### PR TITLE
fix(activerecord): align SQLite3Adapter._isMemoryFilename with URLSearchParams parsing

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -574,30 +574,30 @@ describe("SqliteAdapter", () => {
   });
 });
 
-describe("SQLite3Adapter._isMemoryFilename (via supportsConcurrentConnections)", () => {
-  it("treats :memory: as in-memory (no concurrent connections)", () => {
-    const a = new SQLite3Adapter(":memory:");
-    expect(a.supportsConcurrentConnections()).toBe(false);
+describe("SQLite3Adapter._isMemoryFilename", () => {
+  // Access the private static via `as any` — avoids opening any real DB connection.
+  const isMemoryFilename = (SQLite3Adapter as any)._isMemoryFilename.bind(SQLite3Adapter) as (
+    filename: string,
+  ) => boolean;
+
+  it("treats :memory: as in-memory", () => {
+    expect(isMemoryFilename(":memory:")).toBe(true);
   });
 
   it("treats file::memory: URI as in-memory", () => {
-    const a = new SQLite3Adapter("file::memory:?cache=shared");
-    expect(a.supportsConcurrentConnections()).toBe(false);
+    expect(isMemoryFilename("file::memory:?cache=shared")).toBe(true);
   });
 
   it("treats file:?mode=memory URI as in-memory", () => {
-    const a = new SQLite3Adapter("file:memdb1?mode=memory&cache=shared");
-    expect(a.supportsConcurrentConnections()).toBe(false);
+    expect(isMemoryFilename("file:memdb1?mode=memory&cache=shared")).toBe(true);
   });
 
   it("does NOT treat a path containing mode=memory text as in-memory", () => {
     // file:/tmp/mode=memory.db has the text but not as a query param
-    const a = new SQLite3Adapter("file:/tmp/mode=memory.db");
-    expect(a.supportsConcurrentConnections()).toBe(true);
+    expect(isMemoryFilename("file:/tmp/mode=memory.db")).toBe(false);
   });
 
-  it("treats a regular file path as on-disk (concurrent connections ok)", () => {
-    const a = new SQLite3Adapter("/tmp/test.db");
-    expect(a.supportsConcurrentConnections()).toBe(true);
+  it("treats a regular file path as on-disk", () => {
+    expect(isMemoryFilename("/tmp/test.db")).toBe(false);
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -573,3 +573,31 @@ describe("SqliteAdapter", () => {
     });
   });
 });
+
+describe("SQLite3Adapter._isMemoryFilename (via supportsConcurrentConnections)", () => {
+  it("treats :memory: as in-memory (no concurrent connections)", () => {
+    const a = new SQLite3Adapter(":memory:");
+    expect(a.supportsConcurrentConnections()).toBe(false);
+  });
+
+  it("treats file::memory: URI as in-memory", () => {
+    const a = new SQLite3Adapter("file::memory:?cache=shared");
+    expect(a.supportsConcurrentConnections()).toBe(false);
+  });
+
+  it("treats file:?mode=memory URI as in-memory", () => {
+    const a = new SQLite3Adapter("file:memdb1?mode=memory&cache=shared");
+    expect(a.supportsConcurrentConnections()).toBe(false);
+  });
+
+  it("does NOT treat a path containing mode=memory text as in-memory", () => {
+    // file:/tmp/mode=memory.db has the text but not as a query param
+    const a = new SQLite3Adapter("file:/tmp/mode=memory.db");
+    expect(a.supportsConcurrentConnections()).toBe(true);
+  });
+
+  it("treats a regular file path as on-disk (concurrent connections ok)", () => {
+    const a = new SQLite3Adapter("/tmp/test.db");
+    expect(a.supportsConcurrentConnections()).toBe(true);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -130,7 +130,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private static _isMemoryFilename(filename: string): boolean {
     if (filename === ":memory:") return true;
     if (!filename.startsWith("file:")) return false;
-    return filename.startsWith("file::memory:") || filename.includes("mode=memory");
+    if (filename.startsWith("file::memory:")) return true;
+    // Parse query string so a path containing the text "mode=memory" isn't
+    // misclassified (e.g. /tmp/mode=memory.db). Mirrors SQLiteDatabaseTasks.
+    const q = filename.indexOf("?");
+    if (q === -1) return false;
+    return new URLSearchParams(filename.slice(q + 1)).get("mode") === "memory";
   }
 
   // Rails' `statement_limit` database.yml key. SQLite has a single

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -132,7 +132,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (!filename.startsWith("file:")) return false;
     if (filename.startsWith("file::memory:")) return true;
     // Parse query string so a path containing the text "mode=memory" isn't
-    // misclassified (e.g. /tmp/mode=memory.db). Mirrors SQLiteDatabaseTasks.
+    // misclassified (e.g. file:/tmp/mode=memory.db). Mirrors SQLiteDatabaseTasks.
     const q = filename.indexOf("?");
     if (q === -1) return false;
     return new URLSearchParams(filename.slice(q + 1)).get("mode") === "memory";


### PR DESCRIPTION
Deferred from #975. Aligns `SQLite3Adapter._isMemoryFilename` with the stricter `isInMemoryDatabase` logic in `SQLiteDatabaseTasks` — uses `URLSearchParams` to parse the `mode=memory` query parameter rather than `includes('mode=memory')`, avoiding false positives for paths like `/tmp/mode=memory.db`.