### PR TITLE
docs: annotate intentional Date boundaries in activemodel/arel/actionpack

### DIFF
--- a/packages/actionpack/src/actioncontroller/base.ts
+++ b/packages/actionpack/src/actioncontroller/base.ts
@@ -413,8 +413,9 @@ export class Base extends Metal {
       this.setHeader("etag", etag);
     }
     if (options.lastModified) {
-      // Realm-safe Date check: instanceof breaks across realms (vm/iframe)
-      // for both Date and Temporal.Instant. Use the brand string instead.
+      // boundary: Realm-safe Date check (instanceof breaks across vm/iframe
+      // realms). Last-Modified is RFC 7231 — emit via Date#toUTCString,
+      // bridging a Temporal.Instant input through epoch ms.
       const isDate = Object.prototype.toString.call(options.lastModified) === "[object Date]";
       const lm = isDate
         ? (options.lastModified as Date)
@@ -579,6 +580,8 @@ export class Base extends Metal {
       return ifNoneMatch === etag;
     }
     if (ifModifiedSince && lastModified) {
+      // boundary: HTTP If-Modified-Since / Last-Modified are RFC 7231 date
+      // strings; parse via Date.parse semantics for comparison.
       return new Date(ifModifiedSince) >= new Date(lastModified);
     }
     return false;

--- a/packages/actionpack/src/actioncontroller/caching.ts
+++ b/packages/actionpack/src/actioncontroller/caching.ts
@@ -29,6 +29,7 @@ function stableStringify(obj: unknown): string {
     return json === undefined ? String(obj) : json;
   }
   if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+  // boundary: stable cache-key stringification handles legacy Date values.
   if (obj instanceof Date) return JSON.stringify(obj.toISOString());
 
   const record = obj as Record<string, unknown>;

--- a/packages/actionpack/src/actioncontroller/metal/conditional-get.ts
+++ b/packages/actionpack/src/actioncontroller/metal/conditional-get.ts
@@ -37,6 +37,7 @@ export function isFresh(
     return clientTags.some((t) => t === etag || t.replace(/^W\//, "") === normalizedEtag);
   }
   if (ifModifiedSince && lastModified) {
+    // boundary: HTTP RFC 7231 date string parsing for cache freshness check.
     return new Date(ifModifiedSince) >= new Date(lastModified);
   }
   return false;

--- a/packages/actionpack/src/actioncontroller/metal/conditional-get.ts
+++ b/packages/actionpack/src/actioncontroller/metal/conditional-get.ts
@@ -3,6 +3,9 @@
  *
  * Provides fresh_when, stale?, expires_in, expires_now, http_cache_forever, no_store.
  * @see https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html
+ *
+ * @boundary-file: parses RFC 7231 `If-Modified-Since` / `Last-Modified` header
+ *   strings via JS `Date.parse` semantics for the freshness comparison.
  */
 
 import { getCrypto } from "@blazetrails/activesupport";
@@ -37,7 +40,6 @@ export function isFresh(
     return clientTags.some((t) => t === etag || t.replace(/^W\//, "") === normalizedEtag);
   }
   if (ifModifiedSince && lastModified) {
-    // boundary: HTTP RFC 7231 date string parsing for cache freshness check.
     return new Date(ifModifiedSince) >= new Date(lastModified);
   }
   return false;

--- a/packages/actionpack/src/actiondispatch/cookies.ts
+++ b/packages/actionpack/src/actiondispatch/cookies.ts
@@ -11,6 +11,8 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 export type CookieExpires = Date | Temporal.Instant;
 
 function toUTCString(expires: CookieExpires): string {
+  // boundary: RFC 7231 cookie expiry strings are produced by Date#toUTCString;
+  // bridge a Temporal.Instant input via epoch ms.
   return expires instanceof Temporal.Instant
     ? new Date(expires.epochMilliseconds).toUTCString()
     : expires.toUTCString();
@@ -193,6 +195,7 @@ export class PermanentCookieJar {
   }
 
   set(key: string, valueOrOptions: string | SetCookieOptions): void {
+    // boundary: PermanentCookieJar fixes a far-future expiry in JS Date form.
     const expires = new Date(Date.now() + PermanentCookieJar.TWENTY_YEARS_MS);
     if (typeof valueOrOptions === "string") {
       this.jar.set(key, { value: valueOrOptions, expires });

--- a/packages/actionpack/src/actiondispatch/cookies.ts
+++ b/packages/actionpack/src/actiondispatch/cookies.ts
@@ -3,10 +3,11 @@
  *
  * Cookie jar implementation mirroring Rails cookie handling.
  *
- * @boundary-file: HTTP `Set-Cookie` `expires=` is RFC 7231 by spec — JS
- *   `Date#toUTCString` produces exactly that format. The jar accepts
- *   `Date | Temporal.Instant` from Rails-aware callers and bridges Temporal
- *   inputs to Date for on-wire serialization.
+ * @boundary-file: HTTP `Set-Cookie` `Expires` is defined by the cookie spec
+ *   (RFC 6265 / 6265bis); its on-wire date value aligns with HTTP-date /
+ *   IMF-fixdate from RFC 7231, which JS `Date#toUTCString` produces. The
+ *   jar accepts `Date | Temporal.Instant` from Rails-aware callers and
+ *   bridges Temporal inputs to Date for on-wire serialization.
  */
 
 import { getCrypto } from "@blazetrails/activesupport";

--- a/packages/actionpack/src/actiondispatch/cookies.ts
+++ b/packages/actionpack/src/actiondispatch/cookies.ts
@@ -2,6 +2,11 @@
  * ActionDispatch::Cookies
  *
  * Cookie jar implementation mirroring Rails cookie handling.
+ *
+ * @boundary-file: HTTP `Set-Cookie` `expires=` is RFC 7231 by spec — JS
+ *   `Date#toUTCString` produces exactly that format. The jar accepts
+ *   `Date | Temporal.Instant` from Rails-aware callers and bridges Temporal
+ *   inputs to Date for on-wire serialization.
  */
 
 import { getCrypto } from "@blazetrails/activesupport";
@@ -11,8 +16,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 export type CookieExpires = Date | Temporal.Instant;
 
 function toUTCString(expires: CookieExpires): string {
-  // boundary: RFC 7231 cookie expiry strings are produced by Date#toUTCString;
-  // bridge a Temporal.Instant input via epoch ms.
   return expires instanceof Temporal.Instant
     ? new Date(expires.epochMilliseconds).toUTCString()
     : expires.toUTCString();
@@ -195,7 +198,6 @@ export class PermanentCookieJar {
   }
 
   set(key: string, valueOrOptions: string | SetCookieOptions): void {
-    // boundary: PermanentCookieJar fixes a far-future expiry in JS Date form.
     const expires = new Date(Date.now() + PermanentCookieJar.TWENTY_YEARS_MS);
     if (typeof valueOrOptions === "string") {
       this.jar.set(key, { value: valueOrOptions, expires });

--- a/packages/actionpack/src/actiondispatch/response.ts
+++ b/packages/actionpack/src/actiondispatch/response.ts
@@ -141,6 +141,7 @@ export class Response {
   deleteCookie(name: string, options: Partial<CookieOptions> = {}): void {
     this._cookies.set(name, {
       value: "",
+      // boundary: epoch-zero Date is the standard delete-cookie sentinel.
       expires: new Date(0),
       ...options,
     });

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -4,7 +4,8 @@ import { AttributeSet } from "./attribute-set.js";
 /** @internal */
 function cloneValue(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value;
-  // Date is mutable — clone it to protect dirty tracking during the dual-typed window.
+  // boundary: Date is mutable — clone to protect dirty tracking when a legacy
+  // caller hands in a Date attribute value. Temporal types are immutable.
   if (value instanceof Date) return new Date(value.getTime());
   // Temporal types are immutable — no clone needed
   if (

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1825,11 +1825,11 @@ export class Model {
       const tag = dasherize(key);
       if (value === null || value === undefined) {
         xml += `${indent}<${tag} nil="true"/>\n`;
-        // boundary: exclude Date and Temporal types from the plain-object branch
-        // so they hit their dedicated XML serialization arms below.
       } else if (
         typeof value === "object" &&
         !Array.isArray(value) &&
+        // boundary: exclude Date and Temporal types from the plain-object
+        // branch so they hit dedicated serialization arms below.
         !(value instanceof Date) &&
         !(value instanceof Temporal.Instant) &&
         !(value instanceof Temporal.PlainDateTime) &&

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1825,6 +1825,8 @@ export class Model {
       const tag = dasherize(key);
       if (value === null || value === undefined) {
         xml += `${indent}<${tag} nil="true"/>\n`;
+        // boundary: exclude Date and Temporal types from the plain-object branch
+        // so they hit their dedicated XML serialization arms below.
       } else if (
         typeof value === "object" &&
         !Array.isArray(value) &&
@@ -1836,8 +1838,8 @@ export class Model {
         !(value instanceof Temporal.ZonedDateTime)
       ) {
         xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ")}${indent}</${tag}>\n`;
+        // boundary: legacy Date values serialize as ISO 8601 dateTime XML.
       } else if (value instanceof Date) {
-        // Dual-typed window: Date values still serialize as ISO 8601 dateTime.
         xml += `${indent}<${tag} type="dateTime">${Number.isNaN(value.getTime()) ? "" : value.toISOString()}</${tag}>\n`;
       } else if (Array.isArray(value)) {
         xml += `${indent}<${tag} type="array">\n`;

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -188,10 +188,10 @@ function _coerceForJson(
   // its description would misrepresent its role. Leave symbols alone;
   // `JSON.stringify` already drops them per spec, which correctly
   // signals "this doesn't serialize".
+  // boundary: defensive ISO 8601 emission for any Date attribute value supplied
+  // by a custom (non-Temporal-cast) type. Invalid Dates coerce to null like
+  // Date#toJSON does, keeping asJson safe for downstream JSON.stringify.
   if (value instanceof Date) {
-    // Preserve stable ISO 8601 output for any Date values still in flight
-    // during the dual-typed window (removed in PR 6). Invalid Dates must
-    // coerce like Date#toJSON (returns null) so asJson stays JSON.stringify-safe.
     if (Number.isNaN(value.getTime())) return null;
     return value.toISOString();
   }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -22,7 +22,8 @@ export class DateType extends ValueType<DateCastResult> {
     if (value instanceof Temporal.PlainDate) return value;
     // Accept PlainDateTime from multiparameter assignment — extract the date part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();
-    // Dual-typed window: pg driver still returns Date until PR 5a.
+    // boundary: cast accepts Date input from legacy callers / custom types
+    // and bridges into Temporal.PlainDate via the UTC calendar components.
     if (value instanceof Date) {
       if (Number.isNaN(value.getTime())) return null;
       return Temporal.PlainDate.from({

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -42,6 +42,7 @@ export class ComparisonValidator extends EachValidator {
       return Temporal.ZonedDateTime.compare(a, b);
     if (typeof a === "number" && typeof b === "number") return a - b;
     if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
+    // boundary: comparison validator accepts Date pairs by Rails parity.
     if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
     // Match Rails ArgumentError format from value.public_send(op, other):
     //   "comparison of Integer with String failed"

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -139,6 +139,7 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
   if (t === "symbol") return "symbol";
   if (t === "function") return "function";
 
+  // boundary: Arel inspect output recognizes legacy Date values.
   if (value instanceof Date) return `Date(${value.toISOString()})`;
 
   if (typeof value === "object") {

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -10,6 +10,7 @@ export function quoteArrayLiteral(arr: unknown[]): string {
     if (Array.isArray(v)) return quoteArrayLiteral(v);
     if (typeof v === "number") return String(v);
     if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+    // boundary: defensive Date quoting for caller-supplied array literals.
     if (v instanceof Date) {
       return `"${v.toISOString()}"`;
     }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1329,7 +1329,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       typeof (node.value as { toISOString: unknown }).toISOString === "function"
     ) {
       // boundary: bind real Date instances directly (drivers handle them
-      // natively). For non-Date date-like objects (Temporal types), bind the
+      // natively). For other objects with a `toISOString()` method, bind the
       // formatted string so drivers don't receive an unsupported object type.
       const bind =
         node.value instanceof Date
@@ -1404,7 +1404,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     ) {
       if (this._extractBinds) {
         // boundary: see addDateBind branch above — Date binds pass through
-        // natively; Temporal/date-like values stringify first.
+        // natively; non-Date values with toISOString() stringify first.
         const bind =
           v instanceof Date ? v : this.quotedDate(v as { toISOString(): string }).slice(1, -1);
         this.addDateBind(bind);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1328,9 +1328,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       "toISOString" in node.value &&
       typeof (node.value as { toISOString: unknown }).toISOString === "function"
     ) {
-      // Bind real Date instances directly (drivers handle them natively).
-      // For non-Date date-like objects, bind the formatted string so drivers
-      // don't receive an unsupported object type.
+      // boundary: bind real Date instances directly (drivers handle them
+      // natively). For non-Date date-like objects (Temporal types), bind the
+      // formatted string so drivers don't receive an unsupported object type.
       const bind =
         node.value instanceof Date
           ? node.value
@@ -1403,6 +1403,8 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       typeof (v as { toISOString: unknown }).toISOString === "function"
     ) {
       if (this._extractBinds) {
+        // boundary: see addDateBind branch above — Date binds pass through
+        // natively; Temporal/date-like values stringify first.
         const bind =
           v instanceof Date ? v : this.quotedDate(v as { toISOString(): string }).slice(1, -1);
         this.addDateBind(bind);


### PR DESCRIPTION
## Summary

PR 11d of the Temporal migration's incidental-Date audit. Annotates every `new Date` / `instanceof Date` site across **activemodel**, **arel**, and **actionpack** source (outside test files and testing helpers) so the PR 12 lint rule has explicit per-line escape hatches.

### activemodel

- `attribute-mutation-tracker.ts` — clone Date for dirty tracking (Temporal types are immutable).
- `serialization.ts` — defensive ISO 8601 emission for legacy Date attribute values.
- `type/date.ts` — cast bridges Date input to `Temporal.PlainDate`.
- `validations/comparison.ts` — comparison validator accepts Date pairs by Rails parity.
- `model.ts` (×2) — XML serialization of legacy Date values.

### arel

- `quote-array.ts` — defensive Date quoting for array literals.
- `visitors/to-sql.ts` (×2) — Date binds pass through to drivers natively; Temporal date-likes stringify first.
- `nodes/node.ts` — Arel inspect output for Date values.

### actionpack

- `actioncontroller/base.ts` (×2) — RFC 7231 `If-Modified-Since` / `Last-Modified` comparison and emission.
- `actioncontroller/metal/conditional-get.ts` — RFC 7231 freshness check.
- `actioncontroller/caching.ts` — stable cache-key Date stringification.
- `actiondispatch/cookies.ts` (×2) — RFC 7231 cookie-expires emission and `PermanentCookieJar` far-future expiry.
- `actiondispatch/response.ts` — epoch-zero delete-cookie sentinel.

Comments-only; no behavior change.

## Test plan

- [x] `vitest run packages/activemodel packages/arel packages/actionpack` — 4491/4491 pass
- [x] `pnpm typecheck`
- [x] Diff size: 40 LOC well under the 300 ceiling