### PR TITLE
feat(activemodel): port Numericality coercion privates (parseFloat, round, isIsNumber, isIsInteger, isIsHexadecimalLiteral, optionAsNumber)

### DIFF
--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -554,4 +554,49 @@ describe("numericality with in: range", () => {
     const u2 = new User({ score: 100 });
     expect(u2.isValid()).toBe(true);
   });
+
+  it("rejects blank and whitespace-only strings", () => {
+    // Rails Kernel.Float raises ArgumentError on "" / whitespace, so
+    // is_number? returns false. JS Number("") would coerce to 0 and
+    // pass — explicit guard required.
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { numericality: true });
+      }
+    }
+    expect(new User({ name: "" }).isValid()).toBe(false);
+    expect(new User({ name: "   " }).isValid()).toBe(false);
+  });
+
+  it("rejects hexadecimal literal strings (with or without leading whitespace)", () => {
+    // Rails parse_as_number's elsif chain skips Kernel.Float when
+    // is_hexadecimal_literal?, so "0x10" is not-a-number even though
+    // JS Number("0x10") === 16.
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { numericality: true });
+      }
+    }
+    expect(new User({ name: "0x10" }).isValid()).toBe(false);
+    expect(new User({ name: "  0x10" }).isValid()).toBe(false);
+    expect(new User({ name: "+0x10" }).isValid()).toBe(false);
+  });
+
+  it("rejects hexadecimal compare-option values", () => {
+    // optionAsNumber should mirror parse_as_number — a hex string
+    // resolved as a compare option must throw, not silently coerce to
+    // its decimal equivalent (would make greaterThan: '0x10' behave as
+    // greaterThan: 16).
+    class User extends Model {
+      static {
+        this.attribute("score", "integer");
+        this.validates("score", { numericality: { greaterThan: "0x10" } });
+      }
+    }
+    expect(() => new User({ score: 20 }).isValid()).toThrow(
+      /Resolved numericality option must be numeric/,
+    );
+  });
 });

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -612,19 +612,18 @@ describe("numericality with in: range", () => {
     expect(new User({ name: "+0x10" }).isValid()).toBe(false);
   });
 
-  it("rejects hexadecimal compare-option values", () => {
-    // optionAsNumber should mirror parse_as_number — a hex string
-    // resolved as a compare option must throw, not silently coerce to
-    // its decimal equivalent (would make greaterThan: '0x10' behave as
-    // greaterThan: 16).
+  it("skips hexadecimal compare-option values (Rails option_as_number returns nil)", () => {
+    // Rails parse_as_number's elsif chain falls through for hex literals
+    // (skips Kernel.Float when is_hexadecimal_literal? matches), so
+    // option_as_number returns nil and the comparison is silently
+    // skipped — neither raises nor coerces "0x10" to 16.
     class User extends Model {
       static {
         this.attribute("score", "integer");
         this.validates("score", { numericality: { greaterThan: "0x10" } });
       }
     }
-    expect(() => new User({ score: 20 }).isValid()).toThrow(
-      /Resolved numericality option must be numeric/,
-    );
+    expect(new User({ score: 20 }).isValid()).toBe(true);
+    expect(new User({ score: 5 }).isValid()).toBe(true);
   });
 });

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -569,6 +569,34 @@ describe("numericality with in: range", () => {
     expect(new User({ name: "   " }).isValid()).toBe(false);
   });
 
+  it("rejects JS binary and octal literal strings", () => {
+    // Rails Kernel.Float rejects 0b… / 0o… (it only accepts decimal +
+    // optional exponent). JS Number("0b10") === 2 / Number("0o10") === 8
+    // would silently pass without an explicit guard.
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { numericality: true });
+      }
+    }
+    expect(new User({ name: "0b10" }).isValid()).toBe(false);
+    expect(new User({ name: "0o10" }).isValid()).toBe(false);
+    expect(new User({ name: "  0b10" }).isValid()).toBe(false);
+    expect(new User({ name: "+0o10" }).isValid()).toBe(false);
+  });
+
+  it("rejects binary/octal compare-option values", () => {
+    class User extends Model {
+      static {
+        this.attribute("score", "integer");
+        this.validates("score", { numericality: { greaterThan: "0b10" } });
+      }
+    }
+    expect(() => new User({ score: 20 }).isValid()).toThrow(
+      /Resolved numericality option must be numeric/,
+    );
+  });
+
   it("rejects hexadecimal literal strings (with or without leading whitespace)", () => {
     // Rails parse_as_number's elsif chain skips Kernel.Float when
     // is_hexadecimal_literal?, so "0x10" is not-a-number even though

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -374,17 +374,18 @@ export function optionAsNumber(
       // option_as_number propagates the error.
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
+    // Rails parse_as_number's elsif chain only falls through for hex
+    // literals when the ANCHORED regex matches (HEXADECIMAL_REGEX uses
+    // \A so leading whitespace doesn't qualify). "  0x10" doesn't
+    // match, falls through to Kernel.Float, and raises — so we should
+    // raise too rather than silently skipping.
+    if (HEXADECIMAL_REGEX.test(resolved)) return undefined;
     const trimmed = resolved.trimStart();
-    // Rails parse_as_number's elsif chain falls through for hex literals
-    // (skips the Kernel.Float branch), returning nil — so option_as_number
-    // returns nil too and the comparison is silently skipped. Mirror that
-    // by returning undefined here rather than raising.
-    if (HEXADECIMAL_REGEX.test(trimmed)) return undefined;
-    // 0b… / 0o… are NOT special-cased in Rails — Kernel.Float just
-    // raises ArgumentError on them — so option_as_number should raise
-    // too. JS Number() would silently coerce, so the explicit guard is
-    // load-bearing on the trails side.
-    if (NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
+    // Anything non-decimal that survives — leading-whitespace hex,
+    // 0b… / 0o… — is rejected by Rails Kernel.Float. JS Number() would
+    // silently coerce 0b/0o, so the explicit guard is load-bearing
+    // on the trails side.
+    if (HEXADECIMAL_REGEX.test(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
   }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -369,18 +369,22 @@ export function optionAsNumber(
     throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
   }
   if (typeof resolved === "string") {
-    // Rails parse_as_number rejects blank strings (Kernel.Float raises)
-    // and hex literals (the elsif chain returns nil). Mirror both so a
-    // misconfigured compare option fails loudly instead of silently
-    // accepting "0x10" as 16.
     if (resolved.trim() === "") {
+      // Rails Kernel.Float raises ArgumentError on blank strings, so
+      // option_as_number propagates the error.
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
     const trimmed = resolved.trimStart();
-    if (HEXADECIMAL_REGEX.test(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
-      // Rails parse_as_number rejects hex via the elsif chain;
-      // additionally guard 0b…/0o… because JS Number() would silently
-      // coerce those (Number("0b10") === 2).
+    // Rails parse_as_number's elsif chain falls through for hex literals
+    // (skips the Kernel.Float branch), returning nil — so option_as_number
+    // returns nil too and the comparison is silently skipped. Mirror that
+    // by returning undefined here rather than raising.
+    if (HEXADECIMAL_REGEX.test(trimmed)) return undefined;
+    // 0b… / 0o… are NOT special-cased in Rails — Kernel.Float just
+    // raises ArgumentError on them — so option_as_number should raise
+    // too. JS Number() would silently coerce, so the explicit guard is
+    // load-bearing on the trails side.
+    if (NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
   }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -174,9 +174,10 @@ export class NumericalityValidator extends EachValidator {
   }
 }
 
-// Rails: /\A[+-]?\d+\z/ — JS `^/$` without the `m` flag is the same
-// as Ruby \A/\z (start/end of string).
-const INTEGER_REGEX = /^[+-]?\d+$/;
+// Rails: /\A[+-]?\d+\z/ — use a true end-of-string check rather than
+// JS `$`, which can match BEFORE a final trailing newline ("1\n" would
+// match `/^[+-]?\d+$/` but is rejected by Ruby's \z).
+const INTEGER_REGEX = /^[+-]?\d+(?![\s\S])/;
 // Rails: /\A[+-]?0[xX]/ — no leading whitespace permitted.
 const HEXADECIMAL_REGEX = /^[+-]?0[xX]/;
 
@@ -276,19 +277,19 @@ export function isIsNumber(
   if (this.options.onlyNumeric && typeof rawValue !== "number") return false;
   if (rawValue === null || rawValue === undefined) return false;
   if (typeof rawValue === "number") return Number.isFinite(rawValue);
-  if (typeof rawValue === "string") {
-    // Rails `Kernel.Float` raises on blank strings — JS Number("")
-    // would coerce to 0 and falsely report true.
-    if (rawValue.trim() === "") return false;
-    // Rails `is_hexadecimal_literal?` is anchored at \A (no whitespace),
-    // but Kernel.Float strips leading whitespace before parsing, so a
-    // string like "  0x1" is still a hex literal that Rails rejects.
-    if (this.isIsHexadecimalLiteral(rawValue.trimStart())) return false;
-  } else if (this.isIsHexadecimalLiteral(rawValue)) {
-    return false;
-  }
-  // Rails: rescue ArgumentError, TypeError; false; end. Number(Symbol)
-  // throws TypeError; mirror Rails' swallow-and-return-false.
+  // Rails Kernel.Float raises TypeError for non-String/non-Numeric input
+  // (Date, true/false, arbitrary objects), so is_number? returns false.
+  // Restrict the coercion path to strings; JS Number(true) === 1 etc.
+  // would otherwise silently pass.
+  if (typeof rawValue !== "string") return false;
+  // Rails `Kernel.Float` raises on blank strings — JS Number("") would
+  // coerce to 0 and falsely report true.
+  if (rawValue.trim() === "") return false;
+  // Rails `is_hexadecimal_literal?` is anchored at \A (no whitespace),
+  // but Kernel.Float strips leading whitespace before parsing, so a
+  // string like "  0x1" is still a hex literal that Rails rejects.
+  if (this.isIsHexadecimalLiteral(rawValue.trimStart())) return false;
+  // Rails: rescue ArgumentError, TypeError; false; end (numericality.rb:99).
   try {
     const coerced = Number(rawValue);
     if (Number.isNaN(coerced)) return false;
@@ -346,6 +347,13 @@ export function optionAsNumber(
 ): number | undefined {
   const resolved = this.resolveValue(record, optionValue);
   if (resolved === undefined || resolved === null) return undefined;
+  // Rails option_as_number → parse_as_number → Kernel.Float would raise
+  // TypeError on non-Numeric/non-String input (Date, boolean, object).
+  // Throw the consistent validator error rather than silently accepting
+  // values that JS Number() happens to coerce (true → 1, Date → epoch).
+  if (typeof resolved !== "number" && typeof resolved !== "string") {
+    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  }
   if (typeof resolved === "string") {
     // Rails parse_as_number rejects blank strings (Kernel.Float raises)
     // and hex literals (the elsif chain returns nil). Mirror both so a
@@ -358,19 +366,7 @@ export function optionAsNumber(
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
   }
-  // Number(Symbol) throws TypeError raw; catch and rethrow with the
-  // consistent validator error so misconfigured procs (e.g. one that
-  // returns a Symbol) fail with the same shape as the other branches.
-  let numeric: number;
-  if (typeof resolved === "number") {
-    numeric = resolved;
-  } else {
-    try {
-      numeric = Number(resolved);
-    } catch {
-      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-    }
-  }
+  const numeric = typeof resolved === "number" ? resolved : Number(resolved);
   if (!Number.isFinite(numeric)) {
     throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
   }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -145,8 +145,11 @@ export class NumericalityValidator extends EachValidator {
   }
 }
 
+// Rails: /\A[+-]?\d+\z/ — JS `^/$` without the `m` flag is the same
+// as Ruby \A/\z (start/end of string).
 const INTEGER_REGEX = /^[+-]?\d+$/;
-const HEXADECIMAL_REGEX = /^\s*[+-]?0[xX]/;
+// Rails: /\A[+-]?0[xX]/ — no leading whitespace permitted.
+const HEXADECIMAL_REGEX = /^[+-]?0[xX]/;
 
 /**
  * Rails: parse_as_number → branches by Ruby type (Float / BigDecimal /
@@ -187,7 +190,7 @@ export function parseAsNumber(num: number, precision: number, scale?: number): n
  * @internal Rails-private helper.
  */
 export function parseFloatRails(num: number, precision: number, scale?: number): number {
-  return +round(round(num, scale)).toPrecision(precision);
+  return +round(num, scale).toPrecision(precision);
 }
 
 /**

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -181,6 +181,12 @@ const INTEGER_REGEX = /^[+-]?\d+(?![\s\S])/;
 // Rails: /\A[+-]?0[xX]/ — no leading whitespace permitted.
 const HEXADECIMAL_REGEX = /^[+-]?0[xX]/;
 
+// Trails-only guard: JS Number() also coerces 0b… (binary) and 0o…
+// (octal) literal strings, which Rails Kernel.Float rejects. Reuse the
+// hex check for the elsif-chain semantic Rails would apply, then layer
+// this on for the JS-specific surface.
+const NON_DECIMAL_LITERAL_REGEX = /^[+-]?0[xXbBoO]/;
+
 /**
  * Rails: parse_as_number → branches by Ruby type (Float / BigDecimal /
  * Numeric / integer-string / non-hex string). In TS we just narrow to
@@ -292,7 +298,11 @@ export function isIsNumber(
   // Rails `is_hexadecimal_literal?` is anchored at \A (no whitespace),
   // but Kernel.Float strips leading whitespace before parsing, so a
   // string like "  0x1" is still a hex literal that Rails rejects.
-  if (this.isIsHexadecimalLiteral(rawValue.trimStart())) return false;
+  // Trails extends this to 0b… / 0o… because JS Number() coerces those
+  // too (Rails Kernel.Float would raise).
+  const trimmed = rawValue.trimStart();
+  if (this.isIsHexadecimalLiteral(trimmed)) return false;
+  if (NON_DECIMAL_LITERAL_REGEX.test(trimmed)) return false;
   // Rails: rescue ArgumentError, TypeError; false; end (numericality.rb:99).
   try {
     const coerced = Number(rawValue);
@@ -366,7 +376,11 @@ export function optionAsNumber(
     if (resolved.trim() === "") {
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
-    if (HEXADECIMAL_REGEX.test(resolved.trimStart())) {
+    const trimmed = resolved.trimStart();
+    if (HEXADECIMAL_REGEX.test(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
+      // Rails parse_as_number rejects hex via the elsif chain;
+      // additionally guard 0b…/0o… because JS Number() would silently
+      // coerce those (Number("0b10") === 2).
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
   }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -38,9 +38,14 @@ export class NumericalityValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isIsHexadecimalLiteral: typeof isIsHexadecimalLiteral;
 
-  private resolveNumeric(val: NumericValue | undefined, record: AnyRecord): number | undefined {
+  private resolveNumeric(
+    val: NumericValue | undefined,
+    record: AnyRecord,
+    precision: number,
+    scale?: number,
+  ): number | undefined {
     if (val === undefined) return undefined;
-    return this.optionAsNumber(record, val, 15, undefined);
+    return this.optionAsNumber(record, val, precision, scale);
   }
 
   override checkValidity(): void {
@@ -96,33 +101,57 @@ export class NumericalityValidator extends EachValidator {
     }
 
     const msg = this.options.message;
-    const gt = this.resolveNumeric(this.options.greaterThan as NumericValue | undefined, record);
+    const gt = this.resolveNumeric(
+      this.options.greaterThan as NumericValue | undefined,
+      record,
+      precision,
+      scale,
+    );
     if (gt !== undefined && !(num > gt)) {
       record.errors.add(attribute, "greater_than", { count: gt, value, message: msg });
     }
     const gte = this.resolveNumeric(
       this.options.greaterThanOrEqualTo as NumericValue | undefined,
       record,
+      precision,
+      scale,
     );
     if (gte !== undefined && !(num >= gte)) {
       record.errors.add(attribute, "greater_than_or_equal_to", { count: gte, value, message: msg });
     }
-    const lt = this.resolveNumeric(this.options.lessThan as NumericValue | undefined, record);
+    const lt = this.resolveNumeric(
+      this.options.lessThan as NumericValue | undefined,
+      record,
+      precision,
+      scale,
+    );
     if (lt !== undefined && !(num < lt)) {
       record.errors.add(attribute, "less_than", { count: lt, value, message: msg });
     }
     const lte = this.resolveNumeric(
       this.options.lessThanOrEqualTo as NumericValue | undefined,
       record,
+      precision,
+      scale,
     );
     if (lte !== undefined && !(num <= lte)) {
       record.errors.add(attribute, "less_than_or_equal_to", { count: lte, value, message: msg });
     }
-    const eq = this.resolveNumeric(this.options.equalTo as NumericValue | undefined, record);
+    const eq = this.resolveNumeric(
+      this.options.equalTo as NumericValue | undefined,
+      record,
+      precision,
+      scale,
+    );
     if (eq !== undefined && num !== eq) {
       record.errors.add(attribute, "equal_to", { count: eq, value, message: msg });
     }
-    const ot = this.resolveNumeric(this.options.otherThan as NumericValue | undefined, record);
+    const ot = this.resolveNumeric(
+      this.options.otherThan as NumericValue | undefined,
+      record,
+      precision,
+      scale,
+    );
     if (ot !== undefined && num === ot) {
       record.errors.add(attribute, "other_than", { count: ot, value, message: msg });
     }
@@ -199,16 +228,25 @@ export function parseFloatRails(num: number, precision: number, scale?: number):
  *     scale ? raw_value.round(scale) : raw_value
  *   end
  *
- * Half-to-even-ish: JS Math.round is half-to-positive-infinity, but
- * matches Ruby's BigDecimal#round default banker's-equivalent for the
- * common decimal cases we hit in validation.
+ * Ruby Float#round is banker's rounding (half-to-even) by default,
+ * matching IEEE 754 round-to-nearest-even. JS Math.round is
+ * half-to-positive-infinity, so a manual implementation is required to
+ * keep tie boundaries (...5) faithful.
  *
  * @internal Rails-private helper.
  */
 export function round(num: number, scale?: number): number {
   if (scale === undefined || scale === null) return num;
   const factor = Math.pow(10, scale);
-  return Math.round(num * factor) / factor;
+  const scaled = num * factor;
+  const floor = Math.floor(scaled);
+  const diff = scaled - floor;
+  // Use a small epsilon to absorb FP residue (e.g. 1.005 * 100 = 100.49999…)
+  const EPS = 1e-9;
+  if (diff < 0.5 - EPS) return floor / factor;
+  if (diff > 0.5 + EPS) return (floor + 1) / factor;
+  // Tie: round to even.
+  return (floor % 2 === 0 ? floor : floor + 1) / factor;
 }
 
 /**
@@ -237,7 +275,17 @@ export function isIsNumber(
   if (this.options.onlyNumeric && typeof rawValue !== "number") return false;
   if (rawValue === null || rawValue === undefined) return false;
   if (typeof rawValue === "number") return Number.isFinite(rawValue);
-  if (this.isIsHexadecimalLiteral(rawValue)) return false;
+  if (typeof rawValue === "string") {
+    // Rails `Kernel.Float` raises on blank strings — JS Number("")
+    // would coerce to 0 and falsely report true.
+    if (rawValue.trim() === "") return false;
+    // Rails `is_hexadecimal_literal?` is anchored at \A (no whitespace),
+    // but Kernel.Float strips leading whitespace before parsing, so a
+    // string like "  0x1" is still a hex literal that Rails rejects.
+    if (this.isIsHexadecimalLiteral(rawValue.trimStart())) return false;
+  } else if (this.isIsHexadecimalLiteral(rawValue)) {
+    return false;
+  }
   const coerced = Number(rawValue);
   if (Number.isNaN(coerced)) return false;
   return parseAsNumber(coerced, precision, scale) !== undefined;
@@ -291,8 +339,17 @@ export function optionAsNumber(
 ): number | undefined {
   const resolved = this.resolveValue(record, optionValue);
   if (resolved === undefined || resolved === null) return undefined;
-  if (typeof resolved === "string" && resolved.trim() === "") {
-    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  if (typeof resolved === "string") {
+    // Rails parse_as_number rejects blank strings (Kernel.Float raises)
+    // and hex literals (the elsif chain returns nil). Mirror both so a
+    // misconfigured compare option fails loudly instead of silently
+    // accepting "0x10" as 16.
+    if (resolved.trim() === "") {
+      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+    }
+    if (HEXADECIMAL_REGEX.test(resolved.trimStart())) {
+      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+    }
   }
   const numeric = typeof resolved === "number" ? resolved : Number(resolved);
   if (!Number.isFinite(numeric)) {

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -1,6 +1,6 @@
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { isBlank, RoundingHelper } from "@blazetrails/activesupport";
 import { errorOptions } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
 
@@ -245,20 +245,9 @@ export function parseFloatRails(num: number, precision: number, scale?: number):
  */
 export function round(num: number, scale?: number): number {
   if (scale === undefined || scale === null) return num;
-  const factor = Math.pow(10, scale);
-  return rubyRound(num * factor) / factor;
-}
-
-/**
- * Half-away-from-zero rounding, with an epsilon adjustment to absorb
- * FP residue (e.g. `1.005 * 100 === 100.49999999999999`). Matches
- * activesupport/src/number-helper/rounding-helper.ts#rubyRound.
- */
-function rubyRound(value: number): number {
-  if (value === 0) return 0;
-  const adjusted = value + (value >= 0 ? Number.EPSILON : -Number.EPSILON);
-  if (adjusted > 0) return Math.floor(adjusted + 0.5);
-  return -Math.floor(-adjusted + 0.5);
+  // Reuse the shared half-away-from-zero rounder so numericality
+  // coercion stays consistent with the rest of the codebase.
+  return new RoundingHelper({ precision: scale }).round(num);
 }
 
 /**
@@ -304,13 +293,13 @@ export function isIsNumber(
   if (this.isIsHexadecimalLiteral(trimmed)) return false;
   if (NON_DECIMAL_LITERAL_REGEX.test(trimmed)) return false;
   // Rails: rescue ArgumentError, TypeError; false; end (numericality.rb:99).
-  try {
-    const coerced = Number(rawValue);
-    if (Number.isNaN(coerced)) return false;
-    return parseAsNumber(coerced, precision, scale) !== undefined;
-  } catch {
-    return false;
-  }
+  // The non-string/non-number paths return early above, and Number(string)
+  // doesn't throw in JS — so the rescue is structurally absent here.
+  // Kept the docstring reference to Rails' rescue for the call-shape
+  // mapping; no try/catch needed.
+  const coerced = Number(rawValue);
+  if (Number.isNaN(coerced)) return false;
+  return parseAsNumber(coerced, precision, scale) !== undefined;
 }
 
 /**

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -6,26 +6,41 @@ import { resolveValue } from "./resolve-value.js";
 
 type NumericValue = number | ((record: AnyRecord) => number) | string;
 
+/**
+ * Mirrors: ActiveModel::Validations::NumericalityValidator (numericality.rb)
+ *
+ *   class NumericalityValidator < EachValidator
+ *     include Comparability
+ *     include ResolveValue
+ *
+ *     INTEGER_REGEX     = /\A[+-]?\d+\z/
+ *     HEXADECIMAL_REGEX = /\A[+-]?0[xX]/
+ *     ...
+ */
 export class NumericalityValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
 
+  // Coercion-pipeline privates declared here, attached to the prototype
+  // below so they're available during EachValidator's super-time
+  // checkValidity() call (same bootstrapping pattern as PRs #994 / #1002 /
+  // #1009). Class fields don't initialize until after super() returns.
+  /** @internal Rails-private helper. */
+  declare optionAsNumber: typeof optionAsNumber;
+  /** @internal Rails-private helper. */
+  declare parseFloat: typeof parseFloatRails;
+  /** @internal Rails-private helper. */
+  declare round: typeof round;
+  /** @internal Rails-private helper. */
+  declare isIsNumber: typeof isIsNumber;
+  /** @internal Rails-private helper. */
+  declare isIsInteger: typeof isIsInteger;
+  /** @internal Rails-private helper. */
+  declare isIsHexadecimalLiteral: typeof isIsHexadecimalLiteral;
+
   private resolveNumeric(val: NumericValue | undefined, record: AnyRecord): number | undefined {
     if (val === undefined) return undefined;
-    const resolved = this.resolveValue(record, val);
-    if (resolved === undefined || resolved === null) return undefined;
-    // Rails parse_as_number → Kernel.Float raises ArgumentError on
-    // non-numeric input (numericality.rb:81-84). Number("") / Number("  ")
-    // coerce to 0 in JS, which would silently accept clearly non-numeric
-    // values, so reject empty/whitespace strings explicitly before coercion.
-    if (typeof resolved === "string" && resolved.trim() === "") {
-      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-    }
-    const numeric = typeof resolved === "number" ? resolved : Number(resolved);
-    if (!Number.isFinite(numeric)) {
-      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-    }
-    return numeric;
+    return this.optionAsNumber(record, val, 15, undefined);
   }
 
   override checkValidity(): void {
@@ -68,21 +83,14 @@ export class NumericalityValidator extends EachValidator {
     }
     if (this.options.allowBlank && isBlank(value)) return;
 
-    if (typeof value === "string" && /^\s*[+-]?0x/i.test(value)) {
+    if (!this.isIsNumber(value, precision, scale)) {
       record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
       return;
     }
 
-    const raw = Number(value);
-    if (isNaN(raw)) {
-      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
-      return;
-    }
+    const num = parseAsNumber(Number(value), precision, scale) as number;
 
-    // Rails: parse_as_number → round(value, scale).to_d(precision)
-    const num = parseAsNumber(raw, precision, scale);
-
-    if (this.options.onlyInteger && !Number.isInteger(num)) {
+    if (this.options.onlyInteger && !this.isIsInteger(value)) {
       record.errors.add(attribute, "not_an_integer", { value, message: this.options.message });
       return;
     }
@@ -137,19 +145,162 @@ export class NumericalityValidator extends EachValidator {
   }
 }
 
+const INTEGER_REGEX = /^[+-]?\d+$/;
+const HEXADECIMAL_REGEX = /^\s*[+-]?0[xX]/;
+
 /**
- * Rails: parse_as_number → round(value, scale).to_d(precision)
+ * Rails: parse_as_number → branches by Ruby type (Float / BigDecimal /
+ * Numeric / integer-string / non-hex string). In TS we just narrow to
+ * number and route through round + parseFloat per Rails:
  *
- * Rounds to scale decimal places, then truncates to precision significant
- * digits. This matches Ruby's BigDecimal(float.round(scale), precision).
+ *   def parse_as_number(raw_value, precision, scale)
+ *     if raw_value.is_a?(Float)
+ *       parse_float(raw_value, precision, scale)
+ *     elsif raw_value.is_a?(Numeric)
+ *       raw_value
+ *     elsif is_integer?(raw_value)
+ *       raw_value.to_i
+ *     elsif !is_hexadecimal_literal?(raw_value)
+ *       parse_float(Kernel.Float(raw_value), precision, scale)
+ *     end
+ *   end
  *
- * @internal
+ * Returns undefined when raw_value isn't parseable (matching Rails'
+ * implicit-nil from the `elsif` chain falling through).
+ *
+ * @internal Rails-private helper.
  */
-function parseAsNumber(num: number, precision: number, scale?: number): number {
-  let result = num;
-  if (scale != null) {
-    const factor = Math.pow(10, scale);
-    result = Math.round(result * factor) / factor;
-  }
-  return +result.toPrecision(precision);
+export function parseAsNumber(num: number, precision: number, scale?: number): number | undefined {
+  if (!Number.isFinite(num)) return undefined;
+  return parseFloatRails(num, precision, scale);
 }
+
+/**
+ * Mirrors: numericality.rb:86-88
+ *   def parse_float(raw_value, precision, scale)
+ *     round(raw_value, scale).to_d(precision)
+ *   end
+ *
+ * Rounds to `scale` decimal places, then truncates to `precision`
+ * significant digits — matches Ruby's `BigDecimal(float.round(scale), precision)`.
+ *
+ * @internal Rails-private helper.
+ */
+export function parseFloatRails(num: number, precision: number, scale?: number): number {
+  return +round(round(num, scale)).toPrecision(precision);
+}
+
+/**
+ * Mirrors: numericality.rb:90-92
+ *   def round(raw_value, scale)
+ *     scale ? raw_value.round(scale) : raw_value
+ *   end
+ *
+ * Half-to-even-ish: JS Math.round is half-to-positive-infinity, but
+ * matches Ruby's BigDecimal#round default banker's-equivalent for the
+ * common decimal cases we hit in validation.
+ *
+ * @internal Rails-private helper.
+ */
+export function round(num: number, scale?: number): number {
+  if (scale === undefined || scale === null) return num;
+  const factor = Math.pow(10, scale);
+  return Math.round(num * factor) / factor;
+}
+
+/**
+ * Mirrors: numericality.rb:94-100
+ *   def is_number?(raw_value, precision, scale)
+ *     if options[:only_numeric] && !raw_value.is_a?(Numeric)
+ *       return false
+ *     end
+ *     !parse_as_number(raw_value, precision, scale).nil?
+ *   rescue ArgumentError, TypeError
+ *     false
+ *   end
+ *
+ * Treats a hex literal as not-a-number (Rails' `parse_as_number`
+ * explicitly skips the `Kernel.Float` branch when `is_hexadecimal_literal?`
+ * is true, so the chain returns nil).
+ *
+ * @internal Rails-private helper.
+ */
+export function isIsNumber(
+  this: { options: Record<string, unknown>; isIsHexadecimalLiteral(v: unknown): boolean },
+  rawValue: unknown,
+  precision: number,
+  scale?: number,
+): boolean {
+  if (this.options.onlyNumeric && typeof rawValue !== "number") return false;
+  if (rawValue === null || rawValue === undefined) return false;
+  if (typeof rawValue === "number") return Number.isFinite(rawValue);
+  if (this.isIsHexadecimalLiteral(rawValue)) return false;
+  const coerced = Number(rawValue);
+  if (Number.isNaN(coerced)) return false;
+  return parseAsNumber(coerced, precision, scale) !== undefined;
+}
+
+/**
+ * Mirrors: numericality.rb:102-104
+ *   def is_integer?(raw_value)
+ *     INTEGER_REGEX.match?(raw_value.to_s)
+ *   end
+ *
+ * @internal Rails-private helper.
+ */
+export function isIsInteger(rawValue: unknown): boolean {
+  return INTEGER_REGEX.test(String(rawValue));
+}
+
+/**
+ * Mirrors: numericality.rb:106-108
+ *   def is_hexadecimal_literal?(raw_value)
+ *     HEXADECIMAL_REGEX.match?(raw_value.to_s)
+ *   end
+ *
+ * @internal Rails-private helper.
+ */
+export function isIsHexadecimalLiteral(rawValue: unknown): boolean {
+  return HEXADECIMAL_REGEX.test(String(rawValue));
+}
+
+/**
+ * Mirrors: numericality.rb:67-69
+ *   def option_as_number(record, option_value, precision, scale)
+ *     parse_as_number(resolve_value(record, option_value), precision, scale)
+ *   end
+ *
+ * The single Rails call site that consumes `resolve_value` for compare
+ * options (numericality.rb:60). With this private in place, validateEach
+ * routes every numeric option through `this.optionAsNumber(...)` rather
+ * than the previous inline resolve+coerce.
+ *
+ * @internal Rails-private helper.
+ */
+export function optionAsNumber(
+  this: {
+    resolveValue(record: unknown, value: unknown): unknown;
+  },
+  record: AnyRecord,
+  optionValue: unknown,
+  precision: number,
+  scale?: number,
+): number | undefined {
+  const resolved = this.resolveValue(record, optionValue);
+  if (resolved === undefined || resolved === null) return undefined;
+  if (typeof resolved === "string" && resolved.trim() === "") {
+    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  }
+  const numeric = typeof resolved === "number" ? resolved : Number(resolved);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  }
+  return parseAsNumber(numeric, precision, scale);
+}
+
+NumericalityValidator.prototype.optionAsNumber = optionAsNumber;
+NumericalityValidator.prototype.parseFloat = parseFloatRails;
+NumericalityValidator.prototype.round = round;
+NumericalityValidator.prototype.isIsNumber = isIsNumber;
+NumericalityValidator.prototype.isIsInteger = isIsInteger;
+NumericalityValidator.prototype.isIsHexadecimalLiteral = isIsHexadecimalLiteral;

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -213,8 +213,9 @@ export function parseAsNumber(num: number, precision: number, scale?: number): n
  *     round(raw_value, scale).to_d(precision)
  *   end
  *
- * Rounds to `scale` decimal places, then truncates to `precision`
+ * Rounds to `scale` decimal places, then rounds to `precision`
  * significant digits — matches Ruby's `BigDecimal(float.round(scale), precision)`.
+ * (Number.prototype.toPrecision performs rounding, not truncation.)
  *
  * @internal Rails-private helper.
  */
@@ -286,9 +287,15 @@ export function isIsNumber(
   } else if (this.isIsHexadecimalLiteral(rawValue)) {
     return false;
   }
-  const coerced = Number(rawValue);
-  if (Number.isNaN(coerced)) return false;
-  return parseAsNumber(coerced, precision, scale) !== undefined;
+  // Rails: rescue ArgumentError, TypeError; false; end. Number(Symbol)
+  // throws TypeError; mirror Rails' swallow-and-return-false.
+  try {
+    const coerced = Number(rawValue);
+    if (Number.isNaN(coerced)) return false;
+    return parseAsNumber(coerced, precision, scale) !== undefined;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -351,7 +358,19 @@ export function optionAsNumber(
       throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
     }
   }
-  const numeric = typeof resolved === "number" ? resolved : Number(resolved);
+  // Number(Symbol) throws TypeError raw; catch and rethrow with the
+  // consistent validator error so misconfigured procs (e.g. one that
+  // returns a Symbol) fail with the same shape as the other branches.
+  let numeric: number;
+  if (typeof resolved === "number") {
+    numeric = resolved;
+  } else {
+    try {
+      numeric = Number(resolved);
+    } catch {
+      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+    }
+  }
   if (!Number.isFinite(numeric)) {
     throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
   }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -230,25 +230,29 @@ export function parseFloatRails(num: number, precision: number, scale?: number):
  *     scale ? raw_value.round(scale) : raw_value
  *   end
  *
- * Ruby Float#round is banker's rounding (half-to-even) by default,
- * matching IEEE 754 round-to-nearest-even. JS Math.round is
- * half-to-positive-infinity, so a manual implementation is required to
- * keep tie boundaries (...5) faithful.
+ * Ruby Float#round defaults to half-away-from-zero (NOT banker's
+ * rounding): 2.5.round == 3, (-2.5).round == -3. Matches the existing
+ * repo helper at activesupport/src/number-helper/rounding-helper.ts
+ * (rubyRound).
  *
  * @internal Rails-private helper.
  */
 export function round(num: number, scale?: number): number {
   if (scale === undefined || scale === null) return num;
   const factor = Math.pow(10, scale);
-  const scaled = num * factor;
-  const floor = Math.floor(scaled);
-  const diff = scaled - floor;
-  // Use a small epsilon to absorb FP residue (e.g. 1.005 * 100 = 100.49999…)
-  const EPS = 1e-9;
-  if (diff < 0.5 - EPS) return floor / factor;
-  if (diff > 0.5 + EPS) return (floor + 1) / factor;
-  // Tie: round to even.
-  return (floor % 2 === 0 ? floor : floor + 1) / factor;
+  return rubyRound(num * factor) / factor;
+}
+
+/**
+ * Half-away-from-zero rounding, with an epsilon adjustment to absorb
+ * FP residue (e.g. `1.005 * 100 === 100.49999999999999`). Matches
+ * activesupport/src/number-helper/rounding-helper.ts#rubyRound.
+ */
+function rubyRound(value: number): number {
+  if (value === 0) return 0;
+  const adjusted = value + (value >= 0 ? Number.EPSILON : -Number.EPSILON);
+  if (adjusted > 0) return Math.floor(adjusted + 0.5);
+  return -Math.floor(-adjusted + 0.5);
 }
 
 /**


### PR DESCRIPTION
## Summary
Track A4a of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md). Mirrors `ActiveModel::Validations::NumericalityValidator` (`numericality.rb`) coercion pipeline:

- `INTEGER_REGEX` (`/^[+-]?\d+(?![\s\S])/` — true `\z`-equivalent, rejects `"1\n"`) + `HEXADECIMAL_REGEX` constants — `numericality.rb:18-20`.
- `parseFloat(num, precision, scale)` — `numericality.rb:86-88`. `round(num, scale)` then `toPrecision`.
- `round(num, scale)` — delegates to activesupport `RoundingHelper` (half-away-from-zero, single source of truth in the repo).
- `isIsNumber(rawValue, precision, scale)` — `numericality.rb:94-100`. Honors `only_numeric`; restricts to `string|number` (Rails `Kernel.Float` raises `TypeError` on Date/boolean/objects); rejects blank, leading-whitespace hex, and `0b…`/`0o…` literals.
- `isIsInteger(rawValue)` — `numericality.rb:102-104`.
- `isIsHexadecimalLiteral(rawValue)` — `numericality.rb:106-108`. Anchored, no leading whitespace.
- `optionAsNumber(record, optionValue, precision, scale)` — `numericality.rb:67-69`. **Closes the `resolveValue` consumption gap** flagged for Numericality in PR #971. Anchored hex returns `undefined` (Rails skip semantic); `0b/0o` and trim-only-hex throw the consistent `Resolved numericality option must be numeric: …` error.

Privates attached to `NumericalityValidator.prototype` (not class fields) so they survive `EachValidator`'s super-time `checkValidity()` call — same bootstrapping pattern as PRs #994 / #1002 / #1009. `@internal` JSDoc tags satisfy `blazetrails/rails-private-jsdoc`. Names follow `extract-ts-api` conventions: `is_number?` → `isIsNumber`, etc. (the doubled `is` prefix is fixed in a follow-up PR — see Outstanding section below).

## Out of scope (Track A4b)
`filtered_options`, `allow_only_integer?`, `prepare_value_for_validation`, `record_attribute_changed_in_place?` — the dispatch-side helpers. Saved for the next PR.

## Impact
- `pnpm api:compare --privates --package activemodel`: `numericality.rb` 5/15 → **11/15 (73%)** (+6). Overall 471/607 → **477/607 (78.6%)**.
- `pnpm api:compare --package activemodel`: stays **433/433 (100%)**.
- `pnpm test:compare --package activemodel`: stays 959/963.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1600 / 1600 passing
- [x] `pnpm api:compare --package activemodel` — 433/433
- [x] `pnpm api:compare --privates --package activemodel` — 477/607 (+6)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)

## Outstanding Copilot feedback (max review cycles hit — flagged for human reviewer)

After **9 Copilot review rounds**, one comment remains unaddressed and is left to the human reviewer to adjudicate:

- **Round 9** — Asks for an explicit test asserting `isIsNumber` rejects `true` / `Date` / arbitrary objects (the new typeof-narrowing branch). Reasonable; would lock in the Rails-faithful no-coercion behavior. Skipped here only because the cycle ceiling was hit; recommend folding into the immediate follow-up PR (the api:compare conventions fix that renames `isIs*` → `is*`).

## Copilot review history (9 rounds, max ceiling)

Resolved across the prior rounds:
- **Round 1** (5 comments): thread `precision`/`scale` through `resolveNumeric`; banker's rounding (later corrected); strict `isIsNumber` blank/hex guards; `optionAsNumber` hex rejection; regression tests.
- **Round 2** (3): rescue raw `TypeError` on `Number()`; accurate `toPrecision` wording; `isIsNumber` try/catch matching Rails `rescue`.
- **Round 3** (3): `INTEGER_REGEX` strict end-of-string `(?![\s\S])`; restrict `isIsNumber` to string/number; `optionAsNumber` typeof guard.
- **Round 4** (1): `round()` realigned to half-away-from-zero matching the in-repo `rubyRound` (Ruby `Float#round` default is NOT banker's — new in-repo evidence).
- **Round 5** (2): reject JS binary/octal literal strings (`0b…` / `0o…`) plus regression tests.
- **Round 6** (2): hex compare options return `undefined` (Rails `parse_as_number` falls through), not throw; test updated to assert skip.
- **Round 7** (1): only `\A`-anchored hex skips silently; trim-only hex (`"  0x10"`) raises (matches Rails `Kernel.Float`).
- **Round 8** (2): reuse activesupport `RoundingHelper`; drop dead `try/catch`.
- **Round 9** (1): test for the new `string|number` narrowing in `isIsNumber` — deferred per max-cycle ceiling.

Ready for human review.