### PR TITLE
docs: annotate intentional Date boundaries in rack/trailties/website

### DIFF
--- a/packages/rack/src/common-logger.ts
+++ b/packages/rack/src/common-logger.ts
@@ -65,6 +65,8 @@ export class CommonLogger {
     const length = cl && cl !== "0" ? cl : "-";
     const time = elapsed.toFixed(4);
 
+    // boundary: Common Log Format timestamp (`[10/Oct/2000:13:55:36 -0700]`)
+    // is built from JS Date components.
     const now = new Date();
     const months = [
       "Jan",

--- a/packages/rack/src/conditional-get.ts
+++ b/packages/rack/src/conditional-get.ts
@@ -1,3 +1,8 @@
+/**
+ * @boundary-file: parses RFC 7231 HTTP-date strings (`If-Modified-Since`,
+ *   `Last-Modified`) for cache-freshness comparison; JS `Date` is the
+ *   canonical parser for those formats.
+ */
 import { REQUEST_METHOD, ETAG, CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";
 import type { RackApp } from "./mock-request.js";
 

--- a/packages/rack/src/conditional-get.ts
+++ b/packages/rack/src/conditional-get.ts
@@ -1,7 +1,7 @@
 /**
  * @boundary-file: parses RFC 7231 HTTP-date strings (`If-Modified-Since`,
- *   `Last-Modified`) for cache-freshness comparison; JS `Date` is the
- *   canonical parser for those formats.
+ *   `Last-Modified`) for cache-freshness comparison using the runtime's
+ *   `Date` parsing semantics.
  */
 
 import { REQUEST_METHOD, ETAG, CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";

--- a/packages/rack/src/conditional-get.ts
+++ b/packages/rack/src/conditional-get.ts
@@ -3,6 +3,7 @@
  *   `Last-Modified`) for cache-freshness comparison; JS `Date` is the
  *   canonical parser for those formats.
  */
+
 import { REQUEST_METHOD, ETAG, CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";
 import type { RackApp } from "./mock-request.js";
 

--- a/packages/rack/src/files.ts
+++ b/packages/rack/src/files.ts
@@ -1,3 +1,8 @@
+/**
+ * @boundary-file: static-file middleware compares HTTP `If-Modified-Since`
+ *   (RFC 7231 HTTP-date) against the file's mtime; JS `Date` is the
+ *   canonical type for both.
+ */
 import { getFs, getPath } from "@blazetrails/activesupport";
 import type { FsStatResult } from "@blazetrails/activesupport";
 import { CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";

--- a/packages/rack/src/files.ts
+++ b/packages/rack/src/files.ts
@@ -3,6 +3,7 @@
  *   (RFC 7231 HTTP-date) against the file's mtime; JS `Date` is the
  *   canonical type for both.
  */
+
 import { getFs, getPath } from "@blazetrails/activesupport";
 import type { FsStatResult } from "@blazetrails/activesupport";
 import { CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";

--- a/packages/rack/src/mock-response.ts
+++ b/packages/rack/src/mock-response.ts
@@ -3,6 +3,7 @@
  *   RFC 6265 / 6265bis) — `Expires` is an HTTP-date / IMF-fixdate parsed
  *   via JS `Date`; `Max-Age` derives an expiry Date from `Date.now()`.
  */
+
 import { Response } from "./response.js";
 import { SET_COOKIE } from "./constants.js";
 

--- a/packages/rack/src/mock-response.ts
+++ b/packages/rack/src/mock-response.ts
@@ -1,3 +1,8 @@
+/**
+ * @boundary-file: test-only mock parses `Set-Cookie` headers (cookie spec
+ *   RFC 6265 / 6265bis) — `Expires` is an HTTP-date / IMF-fixdate parsed
+ *   via JS `Date`; `Max-Age` derives an expiry Date from `Date.now()`.
+ */
 import { Response } from "./response.js";
 import { SET_COOKIE } from "./constants.js";
 

--- a/packages/rack/src/mock-response.ts
+++ b/packages/rack/src/mock-response.ts
@@ -1,7 +1,8 @@
 /**
  * @boundary-file: test-only mock parses `Set-Cookie` headers (cookie spec
- *   RFC 6265 / 6265bis) — `Expires` is an HTTP-date / IMF-fixdate parsed
- *   via JS `Date`; `Max-Age` derives an expiry Date from `Date.now()`.
+ *   RFC 6265 / 6265bis) — `Expires` uses a cookie-date and is parsed with
+ *   JS `Date` / `Date.parse` semantics; `Max-Age` derives an expiry Date
+ *   from `Date.now()`.
  */
 
 import { Response } from "./response.js";

--- a/packages/rack/src/response.ts
+++ b/packages/rack/src/response.ts
@@ -296,11 +296,13 @@ export class Response {
   cache(duration: number): void {
     if (this.getHeader(CACHE_CONTROL) === "no-cache, must-revalidate") return;
     this.setHeader(CACHE_CONTROL, `public, max-age=${duration}`);
+    // boundary: HTTP Expires header is RFC 7231 HTTP-date, produced by Date#toUTCString.
     this.setHeader(EXPIRES, new Date(Date.now() + duration * 1000).toUTCString());
   }
 
   doNotCache(): void {
     this.setHeader(CACHE_CONTROL, "no-cache, must-revalidate");
+    // boundary: epoch-zero Date is the canonical "already expired" sentinel.
     this.setHeader(EXPIRES, new Date(0).toUTCString());
   }
 

--- a/packages/rack/src/utils.ts
+++ b/packages/rack/src/utils.ts
@@ -496,6 +496,8 @@ function httpDate(date: Date): string {
 }
 
 export function deleteSetCookieHeader(key: string, value: Record<string, any> = {}): string {
+  // boundary: epoch-zero Date is the standard delete-cookie sentinel for the
+  // Set-Cookie `Expires` attribute (RFC 6265 / 6265bis).
   return setCookieHeader(key, { ...value, max_age: "0", expires: new Date(0), value: "" });
 }
 

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -87,6 +87,8 @@ export abstract class GeneratorBase {
 }
 
 export function migrationTimestamp(): string {
+  // boundary: generator timestamp uses local-clock components for the
+  // YYYYMMDDHHMMSS migration filename prefix.
   const now = new Date();
   const y = now.getFullYear().toString();
   const m = (now.getMonth() + 1).toString().padStart(2, "0");

--- a/packages/website/src/lib/frontiers/vfs-generator.ts
+++ b/packages/website/src/lib/frontiers/vfs-generator.ts
@@ -67,6 +67,7 @@ function createVfsFsAdapter(vfs: VirtualFS): FsAdapter {
         isDirectory: () => false,
         isFile: () => entry !== undefined,
         size: content.length,
+        // boundary: epoch-zero placeholder for in-memory VFS file mtime.
         mtime: new Date(0),
       };
     },


### PR DESCRIPTION
## Summary

PR 11e — final sweep of the Temporal migration's incidental-Date audit. Annotates every `new Date` / `instanceof Date` site in `rack`, `trailties`, and `website` source.

### rack — file-level `@boundary-file:` directives

Whole module is HTTP/cookie-spec boundary code:

- `conditional-get.ts` — RFC 7231 `If-Modified-Since` / `Last-Modified` parsing for cache freshness.
- `files.ts` — static-file mtime vs `If-Modified-Since`.
- `mock-response.ts` — test mock parsing `Set-Cookie` per RFC 6265 / 6265bis.

### rack — line-level

- `common-logger.ts` — Common Log Format timestamp built from JS Date components.
- `utils.ts` — epoch-zero delete-cookie sentinel.
- `response.ts` (×2) — HTTP `Expires` header emission via `Date#toUTCString`.

### trailties

- `generators/base.ts` — migration filename `YYYYMMDDHHMMSS` timestamp.

### website

- `lib/frontiers/vfs-generator.ts` — epoch-zero placeholder for in-memory VFS file mtime.

Together with PRs 11a–11d, this completes the audit: every non-test `new Date` / `instanceof Date` in `packages/*/src` is now either migrated to Temporal or annotated as a documented boundary. The **PR 12 ESLint rule** can land safely after this.

## Test plan

- [x] `vitest run packages/rack packages/trailties` — all pass
- [x] `pnpm typecheck`
- [x] Diff size: 24 LOC well under the 300 ceiling