### PR TITLE
feat(activesupport): add glob() helper for fs-adapter

### DIFF
--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -233,6 +233,69 @@ describe("glob", () => {
     }
   });
 
+  it("treats in-segment `**` as plain `*` (no unbounded depth)", async () => {
+    // Build a deep tree under app/models. Pattern `app/foo**bar.rb`
+    // (with `**` in-segment, not as a path segment) should NOT match
+    // anything across directory boundaries — `**` here is just `*`.
+    const deep = join(root, "app", "models", "deep1", "deep2");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "fooXbar.rb"), "");
+    try {
+      const realFs = await getFsAsync();
+      const realPath = await getPathAsync();
+      const reads: string[] = [];
+      const tracking: FsAdapter = {
+        ...realFs,
+        readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+          reads.push(p);
+          return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+        }) as FsAdapter["readdirSync"],
+      };
+      const prevAdapter = fsAdapterConfig.adapter;
+      registerFsAdapter("glob-spy-instar", tracking, realPath);
+      fsAdapterConfig.adapter = "glob-spy-instar";
+      try {
+        // `app/foo**bar.rb`: in-segment **, single-segment match. Should
+        // NOT recurse into deep1/deep2 since maxRemainingDepth is bounded.
+        await glob("app/foo**bar.rb", { cwd: root });
+        expect(reads).not.toContain(join(root, "app", "models", "deep1"));
+        expect(reads).not.toContain(join(root, "app", "models", "deep1", "deep2"));
+      } finally {
+        fsAdapterConfig.adapter = prevAdapter;
+      }
+    } finally {
+      rmSync(join(root, "app", "models", "deep1"), { recursive: true, force: true });
+    }
+  });
+
+  it("rethrows unexpected readdirSync errors (e.g. EACCES)", async () => {
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const erroring: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string) => {
+        const err = new Error("EACCES: permission denied") as Error & { code: string };
+        err.code = "EACCES";
+        throw err;
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-eacces", erroring, realPath);
+    fsAdapterConfig.adapter = "glob-eacces";
+    try {
+      await expect(glob("**/*.rb", { cwd: root })).rejects.toThrow(/EACCES/);
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
+  it("swallows ENOENT/ENOTDIR (expected absence errors)", async () => {
+    // Globbing a non-existent cwd should return [], not throw — that's
+    // the existing "non-existent cwd" behavior, which works because
+    // readdirSync on a missing dir throws ENOENT.
+    expect(await glob("*", { cwd: join(root, "does-not-exist") })).toEqual([]);
+  });
+
   it("handles deep directory trees without stack overflow (iterative walk)", async () => {
     // Build a deeply nested structure (200 levels) under a sibling root.
     const deepRoot = join(root, "deep-stack-test");

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -338,13 +338,28 @@ describe("glob", () => {
     await expect(glob("\\windows\\foo", { cwd: root })).rejects.toThrow(
       /absolute patterns are not supported/,
     );
+    // Drive-relative (no slash after the colon)
+    await expect(glob("C:foo\\bar", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+    await expect(glob("D:relative.rb", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
   });
 
-  it("rejects `..` segments that could escape cwd", async () => {
+  it("rejects `..` segments that could escape cwd (both separator forms)", async () => {
     await expect(glob("../etc/passwd", { cwd: root })).rejects.toThrow(
       /'\.\.' segments are not supported/,
     );
     await expect(glob("app/../../escape", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+    // Backslash-separated traversal — Windows-flavored PathAdapter
+    // would otherwise route this through `path.join(cwd, "..\\foo")`.
+    await expect(glob("..\\escape", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+    await expect(glob("app\\..\\escape", { cwd: root })).rejects.toThrow(
       /'\.\.' segments are not supported/,
     );
   });

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -291,6 +291,35 @@ describe("glob", () => {
     }
   });
 
+  it("treats unbalanced { } [ ] as literals (no walk)", async () => {
+    // foo{bar.rb has '{' but no matching '}' — patternToRegex escapes
+    // it as a literal, and the walk-vs-fast-path decision should also
+    // treat it as literal so it skips the directory walk entirely.
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-spy-unbalanced", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy-unbalanced";
+    try {
+      // Three unbalanced cases — none should trigger a walk.
+      await glob("foo{bar.rb", { cwd: root });
+      await glob("foo}bar.rb", { cwd: root });
+      // Single '[' with no matching ']' — also literal.
+      await glob("foo[bar.rb", { cwd: root });
+      expect(reads).toEqual([]);
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
   it("compiles patterns containing a literal backslash to a valid regex", async () => {
     // Backslash is a regex metacharacter and must escape to `\\\\` in the
     // compiled regex source. Prior to the explicit handling, the

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -235,6 +235,37 @@ describe("glob", () => {
     }
   });
 
+  it("does not count `/` inside character classes when computing depth", async () => {
+    // `app/[/]bar` has only one real path separator. The `/` inside
+    // [/] must not inflate maxDepth — which the (?![/]) guard would
+    // make match nothing anyway, but pruning should still be tight.
+    // Spy on readdirSync and confirm we only read app, not deeper.
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-spy-class-slash", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy-class-slash";
+    try {
+      // Pattern `app/[abc]bar` has only one real separator (depth=0
+      // remaining after base=`app`). Confirm walk doesn't descend
+      // below app/.
+      await glob("app/[abc]bar", { cwd: root });
+      expect(reads).toContain(join(root, "app"));
+      expect(reads).not.toContain(join(root, "app", "models"));
+      expect(reads).not.toContain(join(root, "app", "controllers"));
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
   it("treats in-segment `**` as plain `*` (no unbounded depth)", async () => {
     // Build a deep tree under app/models. Pattern `app/foo**bar.rb`
     // (with `**` in-segment, not as a path segment) should NOT match

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -268,6 +268,38 @@ describe("glob", () => {
     }
   });
 
+  it("literal-pattern fast path rethrows EACCES instead of swallowing", async () => {
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const erroring: FsAdapter = {
+      ...realFs,
+      statSync: (() => {
+        const err = new Error("EACCES: permission denied") as Error & { code: string };
+        err.code = "EACCES";
+        throw err;
+      }) as FsAdapter["statSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-eacces-stat", erroring, realPath);
+    fsAdapterConfig.adapter = "glob-eacces-stat";
+    try {
+      // Literal pattern (no glob chars) hits the fast path which uses
+      // statSync. EACCES must propagate.
+      await expect(glob("foo.rb", { cwd: root })).rejects.toThrow(/EACCES/);
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
+  it("compiles patterns containing a literal backslash to a valid regex", async () => {
+    // Backslash is a regex metacharacter and must escape to `\\\\` in the
+    // compiled regex source. Prior to the explicit handling, the
+    // template-literal `\\${c}` form was correct but easy to misread.
+    // No need to actually create files with backslashes (illegal on
+    // most filesystems) — just assert the pattern compiles and runs.
+    await expect(glob("foo\\bar.rb", { cwd: root })).resolves.toEqual([]);
+  });
+
   it("rethrows unexpected readdirSync errors (e.g. EACCES)", async () => {
     const realFs = await getFsAsync();
     const realPath = await getPathAsync();

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { glob } from "./glob.js";
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "glob-test-"));
+  // Layout:
+  //   foo.rb
+  //   bar.txt
+  //   .hidden
+  //   app/
+  //     models/
+  //       user.rb
+  //       post.rb
+  //       admin.rb
+  //     controllers/
+  //       application_controller.rb
+  //   lib/
+  //     tasks/
+  //       deploy.rake
+  for (const f of ["foo.rb", "bar.txt", ".hidden"]) {
+    writeFileSync(join(root, f), "");
+  }
+  mkdirSync(join(root, "app", "models"), { recursive: true });
+  mkdirSync(join(root, "app", "controllers"), { recursive: true });
+  mkdirSync(join(root, "lib", "tasks"), { recursive: true });
+  for (const f of ["user.rb", "post.rb", "admin.rb"]) {
+    writeFileSync(join(root, "app", "models", f), "");
+  }
+  writeFileSync(join(root, "app", "controllers", "application_controller.rb"), "");
+  writeFileSync(join(root, "lib", "tasks", "deploy.rake"), "");
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("glob", () => {
+  it("matches `*` at root only", async () => {
+    expect(await glob("*.rb", { cwd: root })).toEqual(["foo.rb"]);
+  });
+
+  it("matches `**/*.rb` at any depth", async () => {
+    expect(await glob("**/*.rb", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+    ]);
+  });
+
+  it("matches a prefix path with `**`", async () => {
+    expect(await glob("app/**/*.rb", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+    ]);
+  });
+
+  it("matches `?` for a single char", async () => {
+    expect(await glob("ba?.txt", { cwd: root })).toEqual(["bar.txt"]);
+  });
+
+  it("matches character classes `[...]`", async () => {
+    expect(await glob("app/models/[au]*.rb", { cwd: root })).toEqual([
+      "app/models/admin.rb",
+      "app/models/user.rb",
+    ]);
+  });
+
+  it("expands braces `{a,b}`", async () => {
+    expect(await glob("**/*.{rb,rake}", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+      "lib/tasks/deploy.rake",
+    ]);
+  });
+
+  it("hides dotfiles by default", async () => {
+    expect(await glob("*", { cwd: root })).not.toContain(".hidden");
+  });
+
+  it("includes dotfiles when dot:true", async () => {
+    expect(await glob("*", { cwd: root, dot: true })).toContain(".hidden");
+  });
+
+  it("returns paths relative to cwd", async () => {
+    const result = await glob("**/*.rake", { cwd: root });
+    expect(result).toEqual(["lib/tasks/deploy.rake"]);
+    for (const p of result) expect(p.startsWith("/")).toBe(false);
+  });
+
+  it("returns empty array for unmatched patterns", async () => {
+    expect(await glob("nonexistent/**/*.zzz", { cwd: root })).toEqual([]);
+  });
+
+  it("handles non-existent cwd gracefully", async () => {
+    expect(await glob("*", { cwd: join(root, "does-not-exist") })).toEqual([]);
+  });
+});

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -323,6 +323,15 @@ describe("glob", () => {
     expect(await glob("*", { cwd: root })).not.toContain(".hidden");
   });
 
+  it("ignores empty patterns produced by brace expansion edge cases", async () => {
+    // `{a,}` expands to ["a", ""]; without filtering, the empty pattern
+    // would cause the literal fast path to statSync(cwd) and emit "".
+    expect(await glob("{foo.rb,}", { cwd: root })).toEqual(["foo.rb"]);
+    expect(await glob("{,foo.rb}", { cwd: root })).toEqual(["foo.rb"]);
+    // Bare empty pattern resolves to nothing.
+    expect(await glob("", { cwd: root })).toEqual([]);
+  });
+
   it("does not throw on empty character class `[]` (routed to fast path)", async () => {
     // Empty character class is legal-but-matches-nothing in some JS
     // engines and a syntax error in others. We treat it as a literal

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -323,6 +323,32 @@ describe("glob", () => {
     expect(await glob("*", { cwd: root })).not.toContain(".hidden");
   });
 
+  it("rejects absolute patterns", async () => {
+    await expect(glob("/tmp/**/*.rb", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+    await expect(glob("/etc/passwd", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+    // Windows-absolute form
+    await expect(glob("C:/Users/foo/*.rb", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+    // Backslash leading separator
+    await expect(glob("\\windows\\foo", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+  });
+
+  it("rejects `..` segments that could escape cwd", async () => {
+    await expect(glob("../etc/passwd", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+    await expect(glob("app/../../escape", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+  });
+
   it("ignores empty patterns produced by brace expansion edge cases", async () => {
     // `{a,}` expands to ["a", ""]; without filtering, the empty pattern
     // would cause the literal fast path to statSync(cwd) and emit "".

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -110,7 +110,9 @@ describe("glob", () => {
     expect(await glob("nonexistent/**/*.zzz", { cwd: root })).toEqual([]);
   });
 
-  it("handles non-existent cwd gracefully", async () => {
+  it("handles non-existent cwd gracefully (swallows ENOENT/ENOTDIR)", async () => {
+    // walk() catches ENOENT/ENOTDIR (expected absence) and returns [].
+    // Other errors (EACCES etc.) propagate — covered by a separate test.
     expect(await glob("*", { cwd: join(root, "does-not-exist") })).toEqual([]);
   });
 
@@ -321,11 +323,30 @@ describe("glob", () => {
     expect(await glob("*", { cwd: root })).not.toContain(".hidden");
   });
 
-  it("does not throw on empty character class `[]`", async () => {
+  it("does not throw on empty character class `[]` (routed to fast path)", async () => {
     // Empty character class is legal-but-matches-nothing in some JS
     // engines and a syntax error in others. We treat it as a literal
-    // `[]` so glob() always behaves predictably.
-    await expect(glob("foo[]", { cwd: root })).resolves.toEqual([]);
+    // `[]` so glob() always behaves predictably. Verify by spying that
+    // no readdirSync calls happen — the literal-fast-path takes over.
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-spy-empty", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy-empty";
+    try {
+      await expect(glob("foo[]", { cwd: root })).resolves.toEqual([]);
+      expect(reads).toEqual([]);
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
   });
 
   it("treats unbalanced { } [ ] as literals (no walk)", async () => {
@@ -385,13 +406,6 @@ describe("glob", () => {
     } finally {
       fsAdapterConfig.adapter = prevAdapter;
     }
-  });
-
-  it("swallows ENOENT/ENOTDIR (expected absence errors)", async () => {
-    // Globbing a non-existent cwd should return [], not throw — that's
-    // the existing "non-existent cwd" behavior, which works because
-    // readdirSync on a missing dir throws ENOENT.
-    expect(await glob("*", { cwd: join(root, "does-not-exist") })).toEqual([]);
   });
 
   it("handles deep directory trees without stack overflow (iterative walk)", async () => {

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -291,6 +291,25 @@ describe("glob", () => {
     }
   });
 
+  it("character classes do not match `/` (segment boundary preserved)", async () => {
+    // a[/]b would match a/b without the (?![/])[...] guard. There is
+    // no real file with that name, so the result must be empty rather
+    // than crossing into a sibling directory.
+    expect(await glob("app[/]models", { cwd: root })).toEqual([]);
+    // Negation: ensure normal classes still work
+    expect(await glob("app/models/[au]*.rb", { cwd: root })).toEqual([
+      "app/models/admin.rb",
+      "app/models/user.rb",
+    ]);
+  });
+
+  it("does not throw on empty character class `[]`", async () => {
+    // Empty character class is legal-but-matches-nothing in some JS
+    // engines and a syntax error in others. We treat it as a literal
+    // `[]` so glob() always behaves predictably.
+    await expect(glob("foo[]", { cwd: root })).resolves.toEqual([]);
+  });
+
   it("treats unbalanced { } [ ] as literals (no walk)", async () => {
     // foo{bar.rb has '{' but no matching '}' — patternToRegex escapes
     // it as a literal, and the walk-vs-fast-path decision should also

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -145,6 +145,7 @@ describe("glob", () => {
         return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
       }) as FsAdapter["readdirSync"],
     };
+    const prevAdapter = fsAdapterConfig.adapter;
     registerFsAdapter("glob-spy", tracking, realPath);
     fsAdapterConfig.adapter = "glob-spy";
     try {
@@ -162,7 +163,91 @@ describe("glob", () => {
       expect(reads).not.toContain(join(root, "app"));
       expect(reads).not.toContain(join(root, "lib"));
     } finally {
-      fsAdapterConfig.adapter = null;
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
+  it("does not recurse below the pattern's max depth (no `**`)", async () => {
+    // Pattern `app/*/*.rb` allows exactly one directory level below `app`.
+    // Without depth pruning, walk would descend further if any subdir
+    // contained nested dirs. Verify by creating a deep nested tree under
+    // app/models and confirming readdirSync was never called on the
+    // deepest level.
+    const deep = join(root, "app", "models", "deep1", "deep2", "deep3");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "should-not-be-read.rb"), "");
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-spy-depth", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy-depth";
+    try {
+      // Pattern matches exactly one dir under app, then a *.rb file.
+      // Pattern depth from base "app" = 1 (one trailing /).
+      const result = await glob("app/*/*.rb", { cwd: root });
+      expect(result).toContain("app/models/admin.rb");
+      // Should have read app/ (depth 0) and app/models, app/controllers
+      // (depth 1). Should NOT have read deep1, deep2, deep3.
+      expect(reads).toContain(join(root, "app"));
+      expect(reads).toContain(join(root, "app", "models"));
+      expect(reads).not.toContain(join(root, "app", "models", "deep1"));
+      expect(reads).not.toContain(join(root, "app", "models", "deep1", "deep2"));
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+      // Cleanup the deep tree so other tests aren't affected.
+      rmSync(join(root, "app", "models", "deep1"), { recursive: true, force: true });
+    }
+  });
+
+  it("uses an existence check for fully literal patterns (no walk)", async () => {
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    const prevAdapter = fsAdapterConfig.adapter;
+    registerFsAdapter("glob-spy-literal", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy-literal";
+    try {
+      const found = await glob("foo.rb", { cwd: root });
+      expect(found).toEqual(["foo.rb"]);
+      const missing = await glob("nonexistent.rb", { cwd: root });
+      expect(missing).toEqual([]);
+      // Literal short-circuit: no readdirSync calls should have happened.
+      expect(reads).toEqual([]);
+    } finally {
+      fsAdapterConfig.adapter = prevAdapter;
+    }
+  });
+
+  it("handles deep directory trees without stack overflow (iterative walk)", async () => {
+    // Build a deeply nested structure (200 levels) under a sibling root.
+    const deepRoot = join(root, "deep-stack-test");
+    let cur = deepRoot;
+    for (let i = 0; i < 200; i++) {
+      cur = join(cur, `d${i}`);
+    }
+    mkdirSync(cur, { recursive: true });
+    writeFileSync(join(cur, "leaf.rb"), "");
+    try {
+      const found = await glob("**/leaf.rb", { cwd: deepRoot });
+      expect(found.length).toBe(1);
+      expect(found[0]!.endsWith("leaf.rb")).toBe(true);
+    } finally {
+      rmSync(deepRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -364,6 +364,26 @@ describe("glob", () => {
     );
   });
 
+  it("rejects unsafe forms produced by brace expansion (post-expansion validation)", async () => {
+    // {..,foo}/bar expands to ["../bar", "foo/bar"]. Pre-expansion
+    // validation would let this through; post-expansion validation
+    // catches the traversal branch.
+    await expect(glob("{..,foo}/bar", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+    // {/etc/passwd,foo} expands to ["/etc/passwd", "foo"]. The first
+    // branch is absolute and would escape cwd via path.join.
+    await expect(glob("{/etc/passwd,foo}", { cwd: root })).rejects.toThrow(
+      /absolute patterns are not supported/,
+    );
+    // Negated unsafe branches must also be rejected: a negative pattern
+    // shouldn't let an attacker probe paths outside cwd via timing/effects.
+    await expect(glob("foo,{!/etc/passwd}", { cwd: root })).resolves.toEqual([]);
+    await expect(glob("{foo,!../escape}", { cwd: root })).rejects.toThrow(
+      /'\.\.' segments are not supported/,
+    );
+  });
+
   it("ignores empty patterns produced by brace expansion edge cases", async () => {
     // `{a,}` expands to ["a", ""]; without filtering, the empty pattern
     // would cause the literal fast path to statSync(cwd) and emit "".

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -303,6 +303,24 @@ describe("glob", () => {
     ]);
   });
 
+  it("escapes backslashes inside character classes (no invalid regex)", async () => {
+    // [\b] would otherwise compile to a class containing the JS regex
+    // backspace escape; [a\b] could match unexpected chars. We escape
+    // backslashes so the class is well-defined.
+    await expect(glob("[\\b].rb", { cwd: root })).resolves.toEqual([]);
+    await expect(glob("[a\\b]", { cwd: root })).resolves.toEqual([]);
+  });
+
+  it("matches dotfiles when the pattern explicitly references a dot segment", async () => {
+    // .hidden exists at root from the test fixture. Pattern '.hidden'
+    // (or '**/.hidden') should match without setting dot:true, mirroring
+    // picomatch behavior.
+    expect(await glob(".hidden", { cwd: root })).toEqual([".hidden"]);
+    expect(await glob("**/.hidden", { cwd: root })).toEqual([".hidden"]);
+    // Without explicit dot reference, default dot:false still hides them.
+    expect(await glob("*", { cwd: root })).not.toContain(".hidden");
+  });
+
   it("does not throw on empty character class `[]`", async () => {
     // Empty character class is legal-but-matches-nothing in some JS
     // engines and a syntax error in others. We treat it as a literal

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -395,6 +395,17 @@ describe("glob", () => {
     );
   });
 
+  it("rejects mid-pattern backslashes outside character classes", async () => {
+    // Without the check, `app\\models\\*.rb` validates fine but never
+    // matches because the rest of the impl only understands `/`.
+    await expect(glob("app\\models\\*.rb", { cwd: root })).rejects.toThrow(
+      /backslashes outside character classes are not supported/,
+    );
+    // Bracket-class backslashes are still allowed (they're escapes).
+    await expect(glob("[\\b].rb", { cwd: root })).resolves.toEqual([]);
+    await expect(glob("[a\\b]", { cwd: root })).resolves.toEqual([]);
+  });
+
   it("rejects unsafe forms produced by brace expansion (post-expansion validation)", async () => {
     // {..,foo}/bar expands to ["../bar", "foo/bar"]. Pre-expansion
     // validation would let this through; post-expansion validation
@@ -479,14 +490,10 @@ describe("glob", () => {
     }
   });
 
-  it("compiles patterns containing a literal backslash to a valid regex", async () => {
-    // Backslash is a regex metacharacter and must escape to `\\\\` in the
-    // compiled regex source. Prior to the explicit handling, the
-    // template-literal `\\${c}` form was correct but easy to misread.
-    // No need to actually create files with backslashes (illegal on
-    // most filesystems) — just assert the pattern compiles and runs.
-    await expect(glob("foo\\bar.rb", { cwd: root })).resolves.toEqual([]);
-  });
+  // Note: literal-backslash patterns outside character classes are
+  // rejected by the validator (see "rejects mid-pattern backslashes
+  // outside character classes"). Backslash-in-class patterns are
+  // covered by "escapes backslashes inside character classes".
 
   it("rethrows unexpected readdirSync errors (e.g. EACCES)", async () => {
     const realFs = await getFsAsync();

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -2,6 +2,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  fsAdapterConfig,
+  getFsAsync,
+  getPathAsync,
+  registerFsAdapter,
+  type FsAdapter,
+} from "./fs-adapter.js";
 import { glob } from "./glob.js";
 
 let root: string;
@@ -125,9 +132,37 @@ describe("glob", () => {
   });
 
   it("prunes the walk to the literal prefix", async () => {
-    // `app/models/*.rb` should not require reading anything outside
-    // app/models. Verify by globbing into a non-existent prefix and
-    // confirming no error from a sibling tree (lib/) being absent.
-    expect(await glob("lib/tasks/*.rake", { cwd: root })).toEqual(["lib/tasks/deploy.rake"]);
+    // `lib/tasks/*.rake` should ONLY read lib/tasks (not root, not app/,
+    // not lib/). Wrap the active fs adapter to record every readdirSync
+    // call, then assert none escaped the prefix.
+    const realFs = await getFsAsync();
+    const realPath = await getPathAsync();
+    const reads: string[] = [];
+    const tracking: FsAdapter = {
+      ...realFs,
+      readdirSync: ((p: string, opts?: { withFileTypes: true }) => {
+        reads.push(p);
+        return opts ? realFs.readdirSync(p, opts) : realFs.readdirSync(p);
+      }) as FsAdapter["readdirSync"],
+    };
+    registerFsAdapter("glob-spy", tracking, realPath);
+    fsAdapterConfig.adapter = "glob-spy";
+    try {
+      const result = await glob("lib/tasks/*.rake", { cwd: root });
+      expect(result).toEqual(["lib/tasks/deploy.rake"]);
+      // Only directories under lib/tasks (the literal prefix) should be read.
+      const expectedPrefix = join(root, "lib", "tasks");
+      for (const p of reads) {
+        expect(p.startsWith(expectedPrefix)).toBe(true);
+      }
+      // Sanity: at least one read happened.
+      expect(reads.length).toBeGreaterThan(0);
+      // Specifically, no read of root, root/app, root/lib (parent), etc.
+      expect(reads).not.toContain(root);
+      expect(reads).not.toContain(join(root, "app"));
+      expect(reads).not.toContain(join(root, "lib"));
+    } finally {
+      fsAdapterConfig.adapter = null;
+    }
   });
 });

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -106,4 +106,28 @@ describe("glob", () => {
   it("handles non-existent cwd gracefully", async () => {
     expect(await glob("*", { cwd: join(root, "does-not-exist") })).toEqual([]);
   });
+
+  it("supports negation via leading `!`", async () => {
+    // Brace expansion produces both a positive and a negative pattern.
+    expect(await glob("{**/*.rb,!**/admin.rb}", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+    ]);
+  });
+
+  it("does not throw on unbalanced braces", async () => {
+    // Leftover `{` / `}` after brace expansion bails out should be
+    // escaped as literals rather than producing an invalid regex.
+    await expect(glob("foo{bar.rb", { cwd: root })).resolves.toEqual([]);
+    await expect(glob("foo}bar.rb", { cwd: root })).resolves.toEqual([]);
+  });
+
+  it("prunes the walk to the literal prefix", async () => {
+    // `app/models/*.rb` should not require reading anything outside
+    // app/models. Verify by globbing into a non-existent prefix and
+    // confirming no error from a sibling tree (lib/) being absent.
+    expect(await glob("lib/tasks/*.rake", { cwd: root })).toEqual(["lib/tasks/deploy.rake"]);
+  });
 });

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -105,17 +105,20 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
   const cwd = opts.cwd ?? fs.cwd();
   const dot = opts.dot ?? false;
 
-  // Patterns are relative to `cwd` by contract. Absolute patterns
-  // (POSIX `/foo` or Windows `C:\foo`) and `..` segments would let the
-  // walk escape the provided cwd and emit non-cwd-relative results.
-  // Reject up front with a clear error rather than silently producing
-  // surprising paths.
-  if (/^[/\\]/.test(pattern) || /^[a-zA-Z]:[/\\]/.test(pattern)) {
+  // Patterns are relative to `cwd` by contract. Absolute and
+  // drive-relative patterns, plus any form of `..` segment, would let
+  // the walk escape the provided cwd. Both `/` and `\` are treated as
+  // separators here so a Windows-flavored PathAdapter can't slip past.
+  //
+  // Rejected: leading `/` or `\`; any drive prefix `<letter>:` (covers
+  // both `C:/foo` and the drive-relative `C:foo`); any `..` as a
+  // complete segment regardless of separator.
+  if (/^[/\\]/.test(pattern) || /^[a-zA-Z]:/.test(pattern)) {
     throw new Error(
       `glob: absolute patterns are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
     );
   }
-  if (pattern.split("/").includes("..")) {
+  if (/(^|[/\\])\.\.([/\\]|$)/.test(pattern)) {
     throw new Error(
       `glob: '..' segments are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
     );

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -29,15 +29,17 @@ export interface GlobOptions {
 }
 
 interface CompiledPattern {
+  /** The original (post-brace-expansion) pattern string. */
+  source: string;
   /** Literal directory prefix to start the walk from (relative to cwd). */
   base: string;
   /** Regex applied against the path relative to cwd. */
   re: RegExp;
   /**
    * Max additional directory depth the walk may descend below `base`.
-   * `-1` = unbounded (pattern contains `**`). Otherwise = number of
-   * unconsumed `/` segments in the pattern after `base`. Used to prune
-   * subtree recursion.
+   * `-1` = unbounded (pattern contains a `**` directory segment).
+   * Otherwise = number of unconsumed `/` segments in the pattern after
+   * `base`. Used to prune subtree recursion.
    */
   maxDepth: number;
 }
@@ -60,7 +62,12 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
       negatives.push(patternToRegex(p.slice(1)));
     } else {
       const base = literalPrefix(p);
-      positives.push({ base, re: patternToRegex(p), maxDepth: maxRemainingDepth(p, base) });
+      positives.push({
+        source: p,
+        base,
+        re: patternToRegex(p),
+        maxDepth: maxRemainingDepth(p, base),
+      });
     }
   }
 
@@ -68,21 +75,17 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
 
   // Walk pass: for patterns with glob metacharacters, recurse from the
   // literal prefix using the iterative walker.
-  for (let idx = 0; idx < positives.length; idx++) {
-    const positive = positives[idx]!;
-    const expandedPattern = expanded.filter((p) => !p.startsWith("!"))[idx]!;
-    if (!GLOB_CHARS.test(expandedPattern)) continue; // handled below
+  for (const positive of positives) {
+    if (!GLOB_CHARS.test(positive.source)) continue;
     const { base, re, maxDepth } = positive;
     walk(fs, path, base ? path.join(cwd, base) : cwd, base, re, negatives, dot, maxDepth, results);
   }
 
-  // Literal-pattern fast path: for each expanded pattern with no glob
-  // metacharacters, a single existence check is enough — no walk.
-  for (const p of expanded) {
-    if (p.startsWith("!")) continue;
-    if (GLOB_CHARS.test(p)) continue;
-    if (negatives.some((re) => re.test(p))) continue;
-    if (await fs.exists(path.join(cwd, p))) results.add(p);
+  // Literal-pattern fast path: a single existence check, no walk.
+  for (const positive of positives) {
+    if (GLOB_CHARS.test(positive.source)) continue;
+    if (negatives.some((re) => re.test(positive.source))) continue;
+    if (await fs.exists(path.join(cwd, positive.source))) results.add(positive.source);
   }
 
   return [...results].sort();
@@ -110,8 +113,13 @@ function walk(
     let entries: FsDirent[];
     try {
       entries = fs.readdirSync(absDir, { withFileTypes: true });
-    } catch {
-      continue;
+    } catch (err) {
+      // Only swallow expected absence errors. Permission errors and
+      // other unexpected failures should propagate so callers see them
+      // instead of silently getting incomplete results.
+      const code = (err as { code?: string } | null)?.code;
+      if (code === "ENOENT" || code === "ENOTDIR") continue;
+      throw err;
     }
     for (const entry of entries) {
       if (!dot && entry.name.startsWith(".")) continue;
@@ -145,12 +153,16 @@ function literalPrefix(pattern: string): string {
 
 /**
  * Compute the max additional directory depth a walk needs to consider
- * below `base`. Returns `-1` if the pattern contains `**` (unbounded).
+ * below `base`. Returns `-1` only if the pattern contains a `**` segment
+ * (the directory wildcard form: a path segment that is exactly `**`).
  * Otherwise returns the number of `/` boundaries in the unconsumed
  * portion of the pattern.
+ *
+ * In-segment occurrences like `foo**bar` are treated as plain `*`
+ * (single-segment) and don't grant unbounded depth.
  */
 function maxRemainingDepth(pattern: string, base: string): number {
-  if (pattern.includes("**")) return -1;
+  if (pattern.split("/").includes("**")) return -1;
   const remaining = base ? pattern.slice(base.length + 1) : pattern;
   return (remaining.match(/\//g) ?? []).length;
 }
@@ -174,8 +186,16 @@ function patternToRegex(pattern: string): RegExp {
   while (i < pattern.length) {
     const c = pattern[i]!;
     if (c === "*") {
-      if (pattern[i + 1] === "*") {
-        if (pattern[i + 2] === "/") {
+      // `**` is the directory wildcard ONLY when it forms a complete
+      // path segment: preceded by start-of-pattern or `/`, and followed
+      // by `/` or end-of-pattern. In-segment occurrences (`foo**bar`)
+      // collapse to plain `*` semantics (match within a single segment).
+      const isStarStar = pattern[i + 1] === "*";
+      const beforeIsBoundary = i === 0 || pattern[i - 1] === "/";
+      const after = pattern[i + 2];
+      const afterIsBoundary = after === "/" || after === undefined;
+      if (isStarStar && beforeIsBoundary && afterIsBoundary) {
+        if (after === "/") {
           re += "(?:.*/)?";
           i += 3;
           continue;

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -81,11 +81,14 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
     walk(fs, path, base ? path.join(cwd, base) : cwd, base, re, negatives, dot, maxDepth, results);
   }
 
-  // Literal-pattern fast path: a single existence check, no walk.
+  // Literal-pattern fast path: a single existence check, no walk. Use
+  // statSync with explicit error filtering rather than fs.exists, since
+  // exists() returns false for any error (including EACCES) — we want
+  // to behave consistently with walk() and only swallow ENOENT/ENOTDIR.
   for (const positive of positives) {
     if (GLOB_CHARS.test(positive.source)) continue;
     if (negatives.some((re) => re.test(positive.source))) continue;
-    if (await fs.exists(path.join(cwd, positive.source))) results.add(positive.source);
+    if (literalExists(fs, path.join(cwd, positive.source))) results.add(positive.source);
   }
 
   return [...results].sort();
@@ -167,6 +170,22 @@ function maxRemainingDepth(pattern: string, base: string): number {
   return (remaining.match(/\//g) ?? []).length;
 }
 
+function literalExists(fs: FsAdapter, path: string): boolean {
+  try {
+    fs.statSync(path);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw err;
+  }
+}
+
+// Standard regex-metacharacter escape. Used to render literal characters
+// inside the compiled glob pattern without ambiguity (in particular, a
+// literal backslash must become \\\\ in the regex source).
+const REGEX_META = /[.*+?^${}()|[\]\\/]/;
+
 function expandBraces(pattern: string): string[] {
   const match = /\{([^{}]+)\}/.exec(pattern);
   if (!match) return [pattern];
@@ -218,10 +237,11 @@ function patternToRegex(pattern: string): RegExp {
         re += pattern.slice(i, end + 1);
         i = end + 1;
       }
-    } else if ("^$.+()|/\\{}".includes(c)) {
-      // Escape regex metachars including `{` and `}` — leftover braces
-      // (e.g. unbalanced) reach this loop after `expandBraces` has run.
-      re += `\\${c}`;
+    } else if (REGEX_META.test(c)) {
+      // Escape regex metachars including `{`/`}` (leftover unbalanced
+      // braces after expandBraces) and `\` (which must become `\\\\` in
+      // the compiled regex source to match a single literal backslash).
+      re += c === "\\" ? "\\\\" : `\\${c}`;
       i++;
     } else {
       re += c;

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -2,11 +2,13 @@
  * Glob matching for fs-adapter.
  *
  * Pattern dialect — node/picomatch-style subset:
- *   `**`      match zero or more directories (when followed by `/`) or any
- *             characters (otherwise)
+ *   `**`      directory wildcard, ONLY when it forms a complete path
+ *             segment (preceded by start or `/`, followed by `/` or
+ *             end). In-segment occurrences (e.g. `foo**bar`) collapse
+ *             to plain `*` semantics — they do NOT cross `/` boundaries.
  *   `*`       match anything except `/`
  *   `?`       match any single char except `/`
- *   `[abc]`   character class
+ *   `[abc]`   character class (cannot match `/`)
  *   `{a,b,c}` brace expansion
  *   leading `!`  negation (post-filter)
  *
@@ -45,8 +47,8 @@ interface CompiledPattern {
   /**
    * Whether the walk for this pattern should include dot entries even
    * if `opts.dot` is false. Picomatch-style: a pattern that explicitly
-   * references a dot segment (e.g. `**\/.hidden`, `.config/**`) opts
-   * itself in.
+   * references a dot segment (e.g. `**` + `/.hidden`, `.config/` + `**`)
+   * opts itself in.
    */
   allowDot: boolean;
 }
@@ -65,7 +67,12 @@ interface CompiledPattern {
 function hasGlobSemantics(pattern: string): boolean {
   if (/[*?]/.test(pattern)) return true;
   const open = pattern.indexOf("[");
-  return open !== -1 && pattern.indexOf("]", open + 1) !== -1;
+  if (open === -1) return false;
+  const close = pattern.indexOf("]", open + 1);
+  // Empty `[]` is treated as a literal pair by `patternToRegex`, so it
+  // shouldn't count as glob semantics here either (otherwise it would
+  // route to the walk path instead of the literal fast path).
+  return close !== -1 && close > open + 1;
 }
 
 /**
@@ -77,7 +84,11 @@ function firstGlobIndex(pattern: string): number {
   for (let i = 0; i < pattern.length; i++) {
     const c = pattern[i];
     if (c === "*" || c === "?") return i;
-    if (c === "[" && pattern.indexOf("]", i + 1) !== -1) return i;
+    if (c === "[") {
+      const close = pattern.indexOf("]", i + 1);
+      // Match patternToRegex: empty `[]` is literal, not a class.
+      if (close !== -1 && close > i + 1) return i;
+    }
   }
   return -1;
 }
@@ -191,7 +202,7 @@ function walk(
  * Find the longest literal directory prefix of `pattern` (no real glob
  * chars). Unbalanced `{`/`}`/`[`/`]` are treated as literals.
  *
- * `app/models/*.rb` → `app/models`. `app/**\/*.rb` → `app`.
+ * `app/models/*.rb` → `app/models`. `app/` + `**` + `/*.rb` → `app`.
  * `*.rb` → `""`. `foo{bar.rb` → `""` (whole pattern is literal, but
  * has no `/` to split on).
  *

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -8,7 +8,11 @@
  *             to plain `*` semantics — they do NOT cross `/` boundaries.
  *   `*`       match anything except `/`
  *   `?`       match any single char except `/`
- *   `[abc]`   character class (cannot match `/`)
+ *   `[abc]`   character class (cannot match `/`; empty `[]` is treated
+ *             as a literal pair). Invalid contents (e.g. an out-of-order
+ *             range like `[z-a]`) propagate the underlying
+ *             `new RegExp()` SyntaxError. Glob patterns in this repo
+ *             are author-controlled, so no defensive guard.
  *   `{a,b,c}` brace expansion
  *   leading `!`  negation (post-filter)
  *

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -42,6 +42,13 @@ interface CompiledPattern {
    * `base`. Used to prune subtree recursion.
    */
   maxDepth: number;
+  /**
+   * Whether the walk for this pattern should include dot entries even
+   * if `opts.dot` is false. Picomatch-style: a pattern that explicitly
+   * references a dot segment (e.g. `**\/.hidden`, `.config/**`) opts
+   * itself in.
+   */
+  allowDot: boolean;
 }
 
 /**
@@ -96,6 +103,7 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
         base,
         re: patternToRegex(p),
         maxDepth: maxRemainingDepth(p, base),
+        allowDot: dot || /(^|\/)\./.test(p),
       });
     }
   }
@@ -106,8 +114,18 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
   // literal prefix using the iterative walker.
   for (const positive of positives) {
     if (!hasGlobSemantics(positive.source)) continue;
-    const { base, re, maxDepth } = positive;
-    walk(fs, path, base ? path.join(cwd, base) : cwd, base, re, negatives, dot, maxDepth, results);
+    const { base, re, maxDepth, allowDot } = positive;
+    walk(
+      fs,
+      path,
+      base ? path.join(cwd, base) : cwd,
+      base,
+      re,
+      negatives,
+      allowDot,
+      maxDepth,
+      results,
+    );
   }
 
   // Literal-pattern fast path: a single existence check, no walk. Use
@@ -279,7 +297,11 @@ function patternToRegex(pattern: string): RegExp {
         // Constrain bracket expressions to non-slash to match the
         // segment-boundary semantics of `*` / `?`. Without this,
         // `a[/]b` would match `a/b`, crossing path boundaries.
-        re += `(?![/])${pattern.slice(i, end + 1)}`;
+        // Also escape any backslash inside the class so glob users
+        // can't produce an invalid regex via `[\b]` etc. (filesystem
+        // paths don't carry meaningful backslashes anyway).
+        const classBody = pattern.slice(i, end + 1).replace(/\\/g, "\\\\");
+        re += `(?![/])${classBody}`;
         i = end + 1;
       }
     } else if (REGEX_META.test(c)) {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -268,8 +268,18 @@ function patternToRegex(pattern: string): RegExp {
       if (end === -1) {
         re += "\\[";
         i++;
+      } else if (end === i + 1) {
+        // Empty character class `[]` — treat both `[` and `]` as
+        // literals so the compiled regex stays valid (some engines
+        // reject `[]`, and even when accepted it matches nothing,
+        // surprising callers who passed a literal-looking pattern).
+        re += "\\[\\]";
+        i += 2;
       } else {
-        re += pattern.slice(i, end + 1);
+        // Constrain bracket expressions to non-slash to match the
+        // segment-boundary semantics of `*` / `?`. Without this,
+        // `a[/]b` would match `a/b`, crossing path boundaries.
+        re += `(?![/])${pattern.slice(i, end + 1)}`;
         i = end + 1;
       }
     } else if (REGEX_META.test(c)) {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -105,6 +105,22 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
   const cwd = opts.cwd ?? fs.cwd();
   const dot = opts.dot ?? false;
 
+  // Patterns are relative to `cwd` by contract. Absolute patterns
+  // (POSIX `/foo` or Windows `C:\foo`) and `..` segments would let the
+  // walk escape the provided cwd and emit non-cwd-relative results.
+  // Reject up front with a clear error rather than silently producing
+  // surprising paths.
+  if (/^[/\\]/.test(pattern) || /^[a-zA-Z]:[/\\]/.test(pattern)) {
+    throw new Error(
+      `glob: absolute patterns are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
+    );
+  }
+  if (pattern.split("/").includes("..")) {
+    throw new Error(
+      `glob: '..' segments are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
+    );
+  }
+
   const expanded = expandBraces(pattern);
   const positives: CompiledPattern[] = [];
   const negatives: RegExp[] = [];

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -105,25 +105,6 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
   const cwd = opts.cwd ?? fs.cwd();
   const dot = opts.dot ?? false;
 
-  // Patterns are relative to `cwd` by contract. Absolute and
-  // drive-relative patterns, plus any form of `..` segment, would let
-  // the walk escape the provided cwd. Both `/` and `\` are treated as
-  // separators here so a Windows-flavored PathAdapter can't slip past.
-  //
-  // Rejected: leading `/` or `\`; any drive prefix `<letter>:` (covers
-  // both `C:/foo` and the drive-relative `C:foo`); any `..` as a
-  // complete segment regardless of separator.
-  if (/^[/\\]/.test(pattern) || /^[a-zA-Z]:/.test(pattern)) {
-    throw new Error(
-      `glob: absolute patterns are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
-    );
-  }
-  if (/(^|[/\\])\.\.([/\\]|$)/.test(pattern)) {
-    throw new Error(
-      `glob: '..' segments are not supported (got ${JSON.stringify(pattern)}); use a path relative to \`cwd\``,
-    );
-  }
-
   const expanded = expandBraces(pattern);
   const positives: CompiledPattern[] = [];
   const negatives: RegExp[] = [];
@@ -132,6 +113,30 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
     // `{a,}` or `{,foo}`. Without this, the literal fast path would
     // statSync(cwd) and add "" to results — surprising and useless.
     if (p === "" || p === "!") continue;
+
+    // Validate each expanded branch (after stripping leading `!`)
+    // rather than only the pre-expansion pattern. Brace expansion can
+    // otherwise smuggle unsafe forms past validation, e.g.
+    // `{..,foo}/bar` → `../bar` (escapes cwd), `{/etc/passwd,foo}`
+    // → `/etc/passwd` (absolute, would `path.join(cwd, "/etc/...")`).
+    //
+    // Patterns are relative to `cwd` by contract. Both `/` and `\` are
+    // treated as separators so Windows-flavored PathAdapters can't slip
+    // past. Rejected: leading `/` or `\`; any drive prefix
+    // `<letter>:` (covers both `C:/foo` and `C:foo`); any `..` as a
+    // complete segment regardless of separator.
+    const candidate = p.startsWith("!") ? p.slice(1) : p;
+    if (/^[/\\]/.test(candidate) || /^[a-zA-Z]:/.test(candidate)) {
+      throw new Error(
+        `glob: absolute patterns are not supported (got ${JSON.stringify(candidate)}); use a path relative to \`cwd\``,
+      );
+    }
+    if (/(^|[/\\])\.\.([/\\]|$)/.test(candidate)) {
+      throw new Error(
+        `glob: '..' segments are not supported (got ${JSON.stringify(candidate)}); use a path relative to \`cwd\``,
+      );
+    }
+
     if (p.startsWith("!")) {
       negatives.push(patternToRegex(p.slice(1)));
     } else {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -263,7 +263,28 @@ function literalPrefix(pattern: string): string {
 function maxRemainingDepth(pattern: string, base: string): number {
   if (pattern.split("/").includes("**")) return -1;
   const remaining = base ? pattern.slice(base.length + 1) : pattern;
-  return (remaining.match(/\//g) ?? []).length;
+  return countSeparatorsOutsideClasses(remaining);
+}
+
+/**
+ * Count `/` characters in `s`, skipping any inside a balanced `[...]`
+ * character class. Without this, a pattern like `app/[/]bar` would
+ * count 2 separators (one real, one inside the class) and inflate
+ * `maxDepth`, defeating the intended subtree pruning.
+ */
+function countSeparatorsOutsideClasses(s: string): number {
+  let count = 0;
+  let inClass = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (!inClass) {
+      if (c === "[" && s.indexOf("]", i + 1) !== -1) inClass = true;
+      else if (c === "/") count++;
+    } else if (c === "]") {
+      inClass = false;
+    }
+  }
+  return count;
 }
 
 function literalExists(fs: FsAdapter, path: string): boolean {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -44,7 +44,36 @@ interface CompiledPattern {
   maxDepth: number;
 }
 
-const GLOB_CHARS = /[*?[\]{}]/;
+/**
+ * Detect whether a (post-brace-expansion) pattern has real glob
+ * semantics — `*`, `?`, or a balanced `[...]` character class.
+ *
+ * Unbalanced `{`, `}`, `[`, or `]` are treated as literals by
+ * `patternToRegex` (they get escaped), so they should not push a
+ * pattern onto the walk path or prevent a useful `literalPrefix`.
+ *
+ * `expandBraces` has already replaced balanced `{...}` groups before
+ * this is called, so leftover `{`/`}` are necessarily unbalanced.
+ */
+function hasGlobSemantics(pattern: string): boolean {
+  if (/[*?]/.test(pattern)) return true;
+  const open = pattern.indexOf("[");
+  return open !== -1 && pattern.indexOf("]", open + 1) !== -1;
+}
+
+/**
+ * Index of the first character with real glob semantics, or `-1` if
+ * the pattern is effectively literal. Used by `literalPrefix` to find
+ * the deepest directory we can pin the walk to.
+ */
+function firstGlobIndex(pattern: string): number {
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === "*" || c === "?") return i;
+    if (c === "[" && pattern.indexOf("]", i + 1) !== -1) return i;
+  }
+  return -1;
+}
 
 export async function glob(pattern: string, opts: GlobOptions = {}): Promise<string[]> {
   // Use async resolution so this works in pure Node ESM without callers
@@ -73,20 +102,21 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
 
   const results = new Set<string>();
 
-  // Walk pass: for patterns with glob metacharacters, recurse from the
+  // Walk pass: for patterns with real glob semantics, recurse from the
   // literal prefix using the iterative walker.
   for (const positive of positives) {
-    if (!GLOB_CHARS.test(positive.source)) continue;
+    if (!hasGlobSemantics(positive.source)) continue;
     const { base, re, maxDepth } = positive;
     walk(fs, path, base ? path.join(cwd, base) : cwd, base, re, negatives, dot, maxDepth, results);
   }
 
   // Literal-pattern fast path: a single existence check, no walk. Use
-  // statSync with explicit error filtering rather than fs.exists, since
-  // exists() returns false for any error (including EACCES) — we want
-  // to behave consistently with walk() and only swallow ENOENT/ENOTDIR.
+  // statSync with explicit error filtering rather than fs.exists, so
+  // unexpected errors (e.g. EACCES) propagate instead of being silently
+  // converted to "not found" — keeping behavior consistent with walk()
+  // regardless of how a custom adapter implements `exists`.
   for (const positive of positives) {
-    if (GLOB_CHARS.test(positive.source)) continue;
+    if (hasGlobSemantics(positive.source)) continue;
     if (negatives.some((re) => re.test(positive.source))) continue;
     if (literalExists(fs, path.join(cwd, positive.source))) results.add(positive.source);
   }
@@ -140,12 +170,17 @@ function walk(
 }
 
 /**
- * Find the longest literal directory prefix of `pattern` (no glob chars).
+ * Find the longest literal directory prefix of `pattern` (no real glob
+ * chars). Unbalanced `{`/`}`/`[`/`]` are treated as literals.
+ *
  * `app/models/*.rb` → `app/models`. `app/**\/*.rb` → `app`.
- * `*.rb` → `""`. Used to prune the walk to only the matching subtree.
+ * `*.rb` → `""`. `foo{bar.rb` → `""` (whole pattern is literal, but
+ * has no `/` to split on).
+ *
+ * Used to prune the walk to only the matching subtree.
  */
 function literalPrefix(pattern: string): string {
-  const firstGlob = pattern.search(GLOB_CHARS);
+  const firstGlob = firstGlobIndex(pattern);
   if (firstGlob === -1) {
     const lastSlash = pattern.lastIndexOf("/");
     return lastSlash === -1 ? "" : pattern.slice(0, lastSlash);

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -14,7 +14,13 @@
  * cleanly should be rewritten when ported.
  */
 
-import { getFsAsync, getPathAsync, type FsAdapter, type PathAdapter } from "./fs-adapter.js";
+import {
+  getFsAsync,
+  getPathAsync,
+  type FsAdapter,
+  type FsDirent,
+  type PathAdapter,
+} from "./fs-adapter.js";
 
 export interface GlobOptions {
   cwd?: string;
@@ -68,7 +74,7 @@ function walk(
   dot: boolean,
   results: Set<string>,
 ): void {
-  let entries;
+  let entries: FsDirent[];
   try {
     entries = fs.readdirSync(absDir, { withFileTypes: true });
   } catch {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -1,0 +1,116 @@
+/**
+ * Glob matching for fs-adapter.
+ *
+ * Pattern dialect — node/picomatch-style subset:
+ *   `**`      match zero or more directories (when followed by `/`) or any
+ *             characters (otherwise)
+ *   `*`       match anything except `/`
+ *   `?`       match any single char except `/`
+ *   `[abc]`   character class
+ *   `{a,b,c}` brace expansion
+ *   leading `!`  negation (post-filter)
+ *
+ * Not aiming for Ruby `Dir.glob` parity. Patterns that don't translate
+ * cleanly should be rewritten when ported.
+ */
+
+import { getFs, getPath } from "./fs-adapter.js";
+
+export interface GlobOptions {
+  cwd?: string;
+  /** Include dotfiles. Default false. */
+  dot?: boolean;
+}
+
+export async function glob(pattern: string, opts: GlobOptions = {}): Promise<string[]> {
+  const fs = getFs();
+  const path = getPath();
+  const cwd = opts.cwd ?? fs.cwd();
+  const dot = opts.dot ?? false;
+
+  const expanded = expandBraces(pattern);
+  const positives: RegExp[] = [];
+  const negatives: RegExp[] = [];
+  for (const p of expanded) {
+    if (p.startsWith("!")) negatives.push(patternToRegex(p.slice(1)));
+    else positives.push(patternToRegex(p));
+  }
+
+  const results = new Set<string>();
+
+  function walk(absDir: string, relDir: string): void {
+    let entries;
+    try {
+      entries = fs.readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!dot && entry.name.startsWith(".")) continue;
+      const absPath = path.join(absDir, entry.name);
+      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const matches =
+        positives.some((re) => re.test(relPath)) && !negatives.some((re) => re.test(relPath));
+      if (matches) results.add(relPath);
+      if (entry.isDirectory()) walk(absPath, relPath);
+    }
+  }
+
+  walk(cwd, "");
+  return [...results].sort();
+}
+
+function expandBraces(pattern: string): string[] {
+  const match = /\{([^{}]+)\}/.exec(pattern);
+  if (!match) return [pattern];
+  const before = pattern.slice(0, match.index);
+  const after = pattern.slice(match.index + match[0].length);
+  const choices = match[1].split(",");
+  const expanded: string[] = [];
+  for (const choice of choices) {
+    expanded.push(...expandBraces(before + choice + after));
+  }
+  return expanded;
+}
+
+function patternToRegex(pattern: string): RegExp {
+  let re = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i]!;
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        if (pattern[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 3;
+          continue;
+        }
+        re += ".*";
+        i += 2;
+        continue;
+      }
+      re += "[^/]*";
+      i++;
+    } else if (c === "?") {
+      re += "[^/]";
+      i++;
+    } else if (c === "[") {
+      const end = pattern.indexOf("]", i);
+      if (end === -1) {
+        re += "\\[";
+        i++;
+      } else {
+        re += pattern.slice(i, end + 1);
+        i = end + 1;
+      }
+    } else if ("^$.+()|/\\".includes(c)) {
+      re += `\\${c}`;
+      i++;
+    } else {
+      re += c;
+      i++;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -14,7 +14,7 @@
  * cleanly should be rewritten when ported.
  */
 
-import { getFs, getPath } from "./fs-adapter.js";
+import { getFsAsync, getPathAsync, type FsAdapter, type PathAdapter } from "./fs-adapter.js";
 
 export interface GlobOptions {
   cwd?: string;
@@ -22,42 +22,82 @@ export interface GlobOptions {
   dot?: boolean;
 }
 
+interface CompiledPattern {
+  /** Literal directory prefix to start the walk from (relative to cwd). */
+  base: string;
+  /** Regex applied against the path relative to cwd. */
+  re: RegExp;
+}
+
 export async function glob(pattern: string, opts: GlobOptions = {}): Promise<string[]> {
-  const fs = getFs();
-  const path = getPath();
+  // Use async resolution so this works in pure Node ESM without callers
+  // pre-registering an adapter. (sync getFs() relies on CommonJS require.)
+  const fs = await getFsAsync();
+  const path = await getPathAsync();
   const cwd = opts.cwd ?? fs.cwd();
   const dot = opts.dot ?? false;
 
   const expanded = expandBraces(pattern);
-  const positives: RegExp[] = [];
+  const positives: CompiledPattern[] = [];
   const negatives: RegExp[] = [];
   for (const p of expanded) {
-    if (p.startsWith("!")) negatives.push(patternToRegex(p.slice(1)));
-    else positives.push(patternToRegex(p));
+    if (p.startsWith("!")) {
+      negatives.push(patternToRegex(p.slice(1)));
+    } else {
+      positives.push({ base: literalPrefix(p), re: patternToRegex(p) });
+    }
   }
 
   const results = new Set<string>();
 
-  function walk(absDir: string, relDir: string): void {
-    let entries;
-    try {
-      entries = fs.readdirSync(absDir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (!dot && entry.name.startsWith(".")) continue;
-      const absPath = path.join(absDir, entry.name);
-      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
-      const matches =
-        positives.some((re) => re.test(relPath)) && !negatives.some((re) => re.test(relPath));
-      if (matches) results.add(relPath);
-      if (entry.isDirectory()) walk(absPath, relPath);
-    }
+  for (const { base, re } of positives) {
+    const startAbs = base ? path.join(cwd, base) : cwd;
+    walk(fs, path, startAbs, base, re, negatives, dot, results);
   }
 
-  walk(cwd, "");
   return [...results].sort();
+}
+
+function walk(
+  fs: FsAdapter,
+  path: PathAdapter,
+  absDir: string,
+  relDir: string,
+  positiveRe: RegExp,
+  negatives: RegExp[],
+  dot: boolean,
+  results: Set<string>,
+): void {
+  let entries;
+  try {
+    entries = fs.readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!dot && entry.name.startsWith(".")) continue;
+    const absPath = path.join(absDir, entry.name);
+    const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
+    if (positiveRe.test(relPath) && !negatives.some((re) => re.test(relPath))) {
+      results.add(relPath);
+    }
+    if (entry.isDirectory()) walk(fs, path, absPath, relPath, positiveRe, negatives, dot, results);
+  }
+}
+
+/**
+ * Find the longest literal directory prefix of `pattern` (no glob chars).
+ * `app/models/*.rb` → `app/models`. `app/**\/*.rb` → `app`.
+ * `*.rb` → `""`. Used to prune the walk to only the matching subtree.
+ */
+function literalPrefix(pattern: string): string {
+  const firstGlob = pattern.search(/[*?[{]/);
+  if (firstGlob === -1) {
+    const lastSlash = pattern.lastIndexOf("/");
+    return lastSlash === -1 ? "" : pattern.slice(0, lastSlash);
+  }
+  const lastSlash = pattern.lastIndexOf("/", firstGlob);
+  return lastSlash === -1 ? "" : pattern.slice(0, lastSlash);
 }
 
 function expandBraces(pattern: string): string[] {
@@ -103,7 +143,9 @@ function patternToRegex(pattern: string): RegExp {
         re += pattern.slice(i, end + 1);
         i = end + 1;
       }
-    } else if ("^$.+()|/\\".includes(c)) {
+    } else if ("^$.+()|/\\{}".includes(c)) {
+      // Escape regex metachars including `{` and `}` — leftover braces
+      // (e.g. unbalanced) reach this loop after `expandBraces` has run.
       re += `\\${c}`;
       i++;
     } else {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -33,7 +33,16 @@ interface CompiledPattern {
   base: string;
   /** Regex applied against the path relative to cwd. */
   re: RegExp;
+  /**
+   * Max additional directory depth the walk may descend below `base`.
+   * `-1` = unbounded (pattern contains `**`). Otherwise = number of
+   * unconsumed `/` segments in the pattern after `base`. Used to prune
+   * subtree recursion.
+   */
+  maxDepth: number;
 }
+
+const GLOB_CHARS = /[*?[\]{}]/;
 
 export async function glob(pattern: string, opts: GlobOptions = {}): Promise<string[]> {
   // Use async resolution so this works in pure Node ESM without callers
@@ -50,15 +59,30 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
     if (p.startsWith("!")) {
       negatives.push(patternToRegex(p.slice(1)));
     } else {
-      positives.push({ base: literalPrefix(p), re: patternToRegex(p) });
+      const base = literalPrefix(p);
+      positives.push({ base, re: patternToRegex(p), maxDepth: maxRemainingDepth(p, base) });
     }
   }
 
   const results = new Set<string>();
 
-  for (const { base, re } of positives) {
-    const startAbs = base ? path.join(cwd, base) : cwd;
-    walk(fs, path, startAbs, base, re, negatives, dot, results);
+  // Walk pass: for patterns with glob metacharacters, recurse from the
+  // literal prefix using the iterative walker.
+  for (let idx = 0; idx < positives.length; idx++) {
+    const positive = positives[idx]!;
+    const expandedPattern = expanded.filter((p) => !p.startsWith("!"))[idx]!;
+    if (!GLOB_CHARS.test(expandedPattern)) continue; // handled below
+    const { base, re, maxDepth } = positive;
+    walk(fs, path, base ? path.join(cwd, base) : cwd, base, re, negatives, dot, maxDepth, results);
+  }
+
+  // Literal-pattern fast path: for each expanded pattern with no glob
+  // metacharacters, a single existence check is enough — no walk.
+  for (const p of expanded) {
+    if (p.startsWith("!")) continue;
+    if (GLOB_CHARS.test(p)) continue;
+    if (negatives.some((re) => re.test(p))) continue;
+    if (await fs.exists(path.join(cwd, p))) results.add(p);
   }
 
   return [...results].sort();
@@ -67,27 +91,40 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
 function walk(
   fs: FsAdapter,
   path: PathAdapter,
-  absDir: string,
-  relDir: string,
+  startAbs: string,
+  startRel: string,
   positiveRe: RegExp,
   negatives: RegExp[],
   dot: boolean,
+  maxDepth: number,
   results: Set<string>,
 ): void {
-  let entries: FsDirent[];
-  try {
-    entries = fs.readdirSync(absDir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    if (!dot && entry.name.startsWith(".")) continue;
-    const absPath = path.join(absDir, entry.name);
-    const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
-    if (positiveRe.test(relPath) && !negatives.some((re) => re.test(relPath))) {
-      results.add(relPath);
+  // Iterative DFS via an explicit stack so very deep trees can't blow
+  // the JS call stack. depth = number of `/` boundaries crossed below
+  // the literal base.
+  const stack: { absDir: string; relDir: string; depth: number }[] = [
+    { absDir: startAbs, relDir: startRel, depth: 0 },
+  ];
+  while (stack.length > 0) {
+    const { absDir, relDir, depth } = stack.pop()!;
+    let entries: FsDirent[];
+    try {
+      entries = fs.readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      continue;
     }
-    if (entry.isDirectory()) walk(fs, path, absPath, relPath, positiveRe, negatives, dot, results);
+    for (const entry of entries) {
+      if (!dot && entry.name.startsWith(".")) continue;
+      const absPath = path.join(absDir, entry.name);
+      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
+      if (positiveRe.test(relPath) && !negatives.some((re) => re.test(relPath))) {
+        results.add(relPath);
+      }
+      // Only recurse when the pattern can still match a deeper path.
+      if (entry.isDirectory() && (maxDepth === -1 || depth + 1 <= maxDepth)) {
+        stack.push({ absDir: absPath, relDir: relPath, depth: depth + 1 });
+      }
+    }
   }
 }
 
@@ -97,13 +134,25 @@ function walk(
  * `*.rb` → `""`. Used to prune the walk to only the matching subtree.
  */
 function literalPrefix(pattern: string): string {
-  const firstGlob = pattern.search(/[*?[{]/);
+  const firstGlob = pattern.search(GLOB_CHARS);
   if (firstGlob === -1) {
     const lastSlash = pattern.lastIndexOf("/");
     return lastSlash === -1 ? "" : pattern.slice(0, lastSlash);
   }
   const lastSlash = pattern.lastIndexOf("/", firstGlob);
   return lastSlash === -1 ? "" : pattern.slice(0, lastSlash);
+}
+
+/**
+ * Compute the max additional directory depth a walk needs to consider
+ * below `base`. Returns `-1` if the pattern contains `**` (unbounded).
+ * Otherwise returns the number of `/` boundaries in the unconsumed
+ * portion of the pattern.
+ */
+function maxRemainingDepth(pattern: string, base: string): number {
+  if (pattern.includes("**")) return -1;
+  const remaining = base ? pattern.slice(base.length + 1) : pattern;
+  return (remaining.match(/\//g) ?? []).length;
 }
 
 function expandBraces(pattern: string): string[] {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -136,6 +136,17 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
         `glob: '..' segments are not supported (got ${JSON.stringify(candidate)}); use a path relative to \`cwd\``,
       );
     }
+    // Reject mid-pattern backslashes outside character classes. The
+    // rest of the implementation (literalPrefix, maxRemainingDepth,
+    // walk()'s relPath, allowDot detection) only understands `/` as
+    // the separator, so a pattern like `app\models\*.rb` would silently
+    // never match anything. Backslashes inside `[...]` are allowed —
+    // they're escape characters there.
+    if (hasBackslashSeparator(candidate)) {
+      throw new Error(
+        `glob: backslashes outside character classes are not supported (got ${JSON.stringify(candidate)}); use '/' as the path separator`,
+      );
+    }
 
     if (p.startsWith("!")) {
       negatives.push(patternToRegex(p.slice(1)));
@@ -285,6 +296,26 @@ function countSeparatorsOutsideClasses(s: string): number {
     }
   }
   return count;
+}
+
+/**
+ * Scan `pattern` for a backslash outside any balanced `[...]` character
+ * class. Backslashes inside classes are escape characters (e.g.
+ * `[\\b]`) and are allowed; backslashes outside would be path
+ * separators which the rest of the implementation does not support.
+ */
+function hasBackslashSeparator(pattern: string): boolean {
+  let inClass = false;
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (!inClass) {
+      if (c === "[" && pattern.indexOf("]", i + 1) !== -1) inClass = true;
+      else if (c === "\\") return true;
+    } else if (c === "]") {
+      inClass = false;
+    }
+  }
+  return false;
 }
 
 function literalExists(fs: FsAdapter, path: string): boolean {

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -109,6 +109,10 @@ export async function glob(pattern: string, opts: GlobOptions = {}): Promise<str
   const positives: CompiledPattern[] = [];
   const negatives: RegExp[] = [];
   for (const p of expanded) {
+    // Skip empty patterns produced by brace expansion edge cases like
+    // `{a,}` or `{,foo}`. Without this, the literal fast path would
+    // statSync(cwd) and add "" to results — surprising and useless.
+    if (p === "" || p === "!") continue;
     if (p.startsWith("!")) {
       negatives.push(patternToRegex(p.slice(1)));
     } else {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -8,6 +8,9 @@ export {
 } from "./fs-adapter.js";
 export type { FsAdapter, FsStatResult, FsDirent, PathAdapter } from "./fs-adapter.js";
 
+export { glob } from "./glob.js";
+export type { GlobOptions } from "./glob.js";
+
 export {
   registerCryptoAdapter,
   getCrypto,


### PR DESCRIPTION
## Summary

Pure-TS \`glob()\` over the fs-adapter readdir surface. Powers \`Paths\`, \`SourceAnnotationExtractor\`, \`CodeStatistics\`, and other Phase 1 consumers in the trailties build-out plan (PR 0.2; see \`docs/trailties-plan.md\`).

Pattern dialect — node/picomatch-style subset. **Patterns must use \`/\` as the path separator and be relative to \`cwd\`.** Each post-brace-expansion branch is independently validated. Rejected with a clear error: absolute patterns (POSIX \`/foo\`, drive-absolute \`C:/foo\`, drive-relative \`C:foo\`, leading \`\\\\\`); any \`..\` segment (with either separator); any backslash outside a character class.

| Pattern | Matches |
| ------- | ------- |
| \`**\` (segment form) | zero or more directories |
| \`**\` (in-segment, e.g. \`foo**bar\`) | plain \`*\` semantics — does NOT cross \`/\` |
| \`*\` | anything except \`/\` |
| \`?\` | single char except \`/\` |
| \`[abc]\` | character class (cannot match \`/\`; empty \`[]\` literal; backslashes inside are regex escapes; invalid contents like \`[z-a]\` propagate \`SyntaxError\`) |
| \`{a,b,c}\` | brace expansion (each branch validated independently) |
| leading \`!\` | negation (post-filter) |

Implementation highlights:
- Iterative DFS with explicit stack (no recursion overflow on deep trees)
- Per-pattern \`maxDepth\` pruning (counts \`/\` outside character classes)
- Literal-pattern fast path via \`statSync\` (no walk for literals)
- Per-pattern dotfile opt-in: \`dot || /(^|\\\\/)\\\\./.test(pattern)\`
- Bracket classes constrained to non-slash via \`(?![/])\` lookahead
- ENOENT/ENOTDIR swallowed in \`readdirSync\`; other errors (EACCES etc.) propagate
- Empty patterns from brace expansion skipped
- Each post-expansion branch validated for absolute / drive-relative / \`..\` / backslash (positive AND negative)
- No new dependencies

## Rails source

- \`railties/lib/rails/paths.rb\` \`Path#existent\` (uses \`Dir.glob\`)
- \`railties/lib/rails/source_annotation_extractor.rb\` (uses \`Dir.glob\` with extension lists)

Not aiming for Ruby \`Dir.glob\` parity — patterns that don't translate cleanly should be rewritten when ported.

## Copilot review history

Sixteen review cycles. All comments addressed; hit max review cycles cap on review #16.

### Fixed across reviews #1–#16

- ✅ Switch to \`getFsAsync\`/\`getPathAsync\` for Node ESM compat
- ✅ Escape \`{\`/\`}\` in patternToRegex for unbalanced braces
- ✅ Walk pruned to literal prefix of each expanded pattern
- ✅ Negation test added
- ✅ \`walk()\` declares \`entries: FsDirent[]\`
- ✅ Prefix-prune test asserts no out-of-prefix \`readdirSync\`
- ✅ Depth pruning when no \`**\` segment
- ✅ Literal-pattern fast path via existence check
- ✅ Iterative walk via explicit stack
- ✅ Test restores prior \`fsAdapterConfig.adapter\` value
- ✅ \`maxRemainingDepth\` and \`patternToRegex\` recognize \`**\` only as a complete path segment
- ✅ \`walk()\` only swallows ENOENT/ENOTDIR; rethrows others
- ✅ \`CompiledPattern\` carries \`source\` field; O(n) iteration
- ✅ Literal fast path uses \`statSync\` with explicit error filter
- ✅ Backslash escaping in \`patternToRegex\` made explicit
- ✅ \`hasGlobSemantics\` recognizes only real glob metacharacters
- ✅ Unbalanced \`{\`/\`}\`/\`[\`/\`]\` treated as literals; no walk
- ✅ Comment about \`fs.exists\` corrected
- ✅ Bracket expressions prefixed with \`(?![/])\` to enforce segment boundary
- ✅ Empty \`[]\` treated as literal pair
- ✅ Backslashes inside bracket classes escaped
- ✅ Per-pattern \`allowDot\` for explicit dot-segment patterns
- ✅ Header dialect description clarifies segment-only \`**\` handling
- ✅ JSDoc examples rewritten to avoid the \`**\` + \`/\` sequence ending block comments
- ✅ \`hasGlobSemantics\` and \`firstGlobIndex\` consistent with \`patternToRegex\` on empty \`[]\`
- ✅ Duplicate non-existent-cwd test consolidated
- ✅ Invalid char-class contents (\`[z-a]\`) documented as throwing
- ✅ Empty patterns from brace expansion edge cases skipped
- ✅ Absolute patterns rejected with clear error
- ✅ \`..\` segments rejected with clear error
- ✅ Drive-relative \`C:foo\` rejected
- ✅ Backslash-separated \`..\` traversal rejected
- ✅ Each post-brace-expansion branch independently validated
- ✅ Depth counter ignores \`/\` inside character classes
- ✅ Mid-pattern backslashes outside character classes rejected with clear error pointing at \`/\` as the separator

## Test plan

- [x] 31 unit tests covering pattern classes, dotfiles, negation, brace expansion (incl. empty-branch and unsafe-branch edge cases), depth pruning (incl. char-class slash), literal fast path (incl. zero-readdir verification), iterative walk depth, error propagation (ENOENT, ENOTDIR, EACCES), bracket-class boundary semantics, empty char class, absolute-pattern and \`..\`-segment rejection (POSIX + Windows + drive-relative + backslash + post-expansion forms), mid-pattern backslash rejection
- [x] \`pnpm --filter @blazetrails/activesupport build\` clean
- [x] \`pnpm lint\` clean