### PR TITLE
feat(eslint): no-native-date rule enforcing the Temporal migration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,7 @@ export default defineConfig(
     },
   },
 
-  // ── blazetrails plugin (shared by no-node-builtins + rails-private-jsdoc) ──
+  // ── blazetrails plugin (no-node-builtins + rails-private-jsdoc + no-native-date) ──
   // Registered without a `files` restriction so any block below can
   // reference its rules without re-declaring the plugin.
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import vitest from "@vitest/eslint-plugin";
 import noNodeBuiltins from "./eslint/no-node-builtins.mjs";
 import noProcessBypass from "./eslint/no-process-bypass.mjs";
 import railsPrivateJsdoc from "./eslint/rails-private-jsdoc.mjs";
+import noNativeDate from "./eslint/no-native-date.mjs";
 
 export default defineConfig(
   {
@@ -97,6 +98,7 @@ export default defineConfig(
           "no-node-builtins": noNodeBuiltins,
           "no-process-bypass": noProcessBypass,
           "rails-private-jsdoc": railsPrivateJsdoc,
+          "no-native-date": noNativeDate,
         },
       },
     },
@@ -115,6 +117,33 @@ export default defineConfig(
     ],
     rules: {
       "blazetrails/no-process-bypass": "error",
+    },
+  },
+
+  // ── no-native-date (Temporal migration safety net) ──
+  {
+    files: [
+      "packages/arel/src/**/*.ts",
+      "packages/activemodel/src/**/*.ts",
+      "packages/activerecord/src/**/*.ts",
+      "packages/activesupport/src/**/*.ts",
+      "packages/rack/src/**/*.ts",
+      "packages/actionpack/src/**/*.ts",
+      "packages/actionview/src/**/*.ts",
+      "packages/trailties/src/**/*.ts",
+      "packages/website/src/**/*.ts",
+    ],
+    ignores: [
+      "**/*.test.ts",
+      "**/*.test-d.ts",
+      // Temporal bridge — the canonical Date↔Instant adapter.
+      "packages/activesupport/src/temporal.ts",
+      // Test infrastructure: travelTo, fixture helpers, etc.
+      "packages/activesupport/src/testing/**",
+      "packages/activesupport/src/testing-helpers.ts",
+    ],
+    rules: {
+      "blazetrails/no-native-date": "error",
     },
   },
 

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -33,25 +33,32 @@
  */
 
 function hasFileBoundaryDirective(sourceCode) {
-  // `@boundary-file:` only counts when it appears in the file *header* — i.e.
-  // before any non-comment token. Honoring it anywhere in the file would let
-  // a function-level JSDoc unintentionally exempt the whole module.
+  // `@boundary-file:` only counts when it appears in a *JSDoc* block comment
+  // in the file header — i.e. before any non-comment token AND the comment
+  // body starts with `*` (the JSDoc shape). Honoring an arbitrary block
+  // comment would let any `/* @boundary-file: */` slip through.
   const firstToken = sourceCode.getFirstToken(sourceCode.ast);
   const headerEnd = firstToken ? firstToken.range[0] : sourceCode.text.length;
   for (const comment of sourceCode.getAllComments()) {
     if (comment.range[0] >= headerEnd) break;
-    if (comment.type === "Block" && comment.value.includes("@boundary-file:")) {
+    if (
+      comment.type === "Block" &&
+      comment.value.startsWith("*") &&
+      comment.value.includes("@boundary-file:")
+    ) {
       return true;
     }
   }
   return false;
 }
 
-function hasBoundaryComment(allComments, sourceCode, node) {
-  const line = node.loc.start.line;
-  // 1. Same-line trailing comment.
+function hasBoundaryComment(allComments, sourceCode, node, dateRef) {
+  // 1. Same-line trailing comment — anchored on the `Date` reference itself
+  //    (not the enclosing expression's start line) so multi-line `instanceof`
+  //    / `new` expressions can carry the marker on the `Date` line.
+  const dateLine = (dateRef ?? node).loc.start.line;
   for (const comment of allComments) {
-    if (comment.loc.start.line === line && /\bboundary:/i.test(comment.value)) {
+    if (comment.loc.start.line === dateLine && /\bboundary:/i.test(comment.value)) {
       return true;
     }
   }
@@ -123,8 +130,8 @@ const rule = {
     // O(comments) per reported node.
     const allComments = sourceCode.getAllComments();
 
-    function report(node, messageId, data) {
-      if (hasBoundaryComment(allComments, sourceCode, node)) return;
+    function report(node, messageId, dateRef, data) {
+      if (hasBoundaryComment(allComments, sourceCode, node, dateRef)) return;
       context.report({ node, messageId, data });
     }
 
@@ -151,12 +158,12 @@ const rule = {
     return {
       NewExpression(node) {
         if (isGlobalDateRef(node.callee)) {
-          report(node, "noNew");
+          report(node, "noNew", node.callee);
         }
       },
       BinaryExpression(node) {
         if (node.operator === "instanceof" && isGlobalDateRef(node.right)) {
-          report(node, "noInstanceof");
+          report(node, "noInstanceof", node.right);
         }
       },
     };

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -13,7 +13,8 @@
  *       (b) attached as a leading comment to the enclosing top-level
  *           statement, or
  *       (c) inside the enclosing statement, before the offending node
- *           (handles multi-line expressions and `} /* ... *​/ else if {` chains).
+ *           (handles multi-line expressions and `} /[*] boundary [*]/ else if {`
+ *           chains).
  *
  * Detected constructs:
  *   - `new Date(...)`

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -1,0 +1,151 @@
+/**
+ * ESLint rule: no-native-date
+ *
+ * Disallows JavaScript `Date` *value* usage in domain code. Use `Temporal`
+ * types (Instant / PlainDate / PlainDateTime / PlainTime / ZonedDateTime)
+ * instead.
+ *
+ * Honors two escape-hatch markers:
+ *   - File-level: a JSDoc block containing `@boundary-file:` in the file's
+ *     leading comments (entire file is exempt).
+ *   - Line-level: a `boundary:` keyword in a comment on the same line as
+ *     the offending construct OR on the immediately-preceding comment line.
+ *
+ * Detected constructs:
+ *   - `new Date(...)`
+ *   - `x instanceof Date`
+ *
+ * Out of scope (return `number` or live in type position only):
+ *   - `Date.now()` / `Date.parse(...)` / `Date.UTC(...)` — produce numbers,
+ *     not propagating Date values.
+ *   - `: Date` type references — constrain flow, don't create Date instances.
+ *
+ * The rule treats any reference to `Date` as the global only when it doesn't
+ * resolve to a local binding (e.g. an `import { Date } from ...` or a class
+ * named `Date` in scope), so files that locally rebind the name (such as
+ * `activerecord/src/type.ts` importing the AR `Type::Date` class) are
+ * naturally exempt.
+ */
+
+function hasFileBoundaryDirective(sourceCode) {
+  // Scan leading block comments at the top of the file for `@boundary-file:`.
+  for (const comment of sourceCode.getAllComments()) {
+    if (comment.type !== "Block") continue;
+    if (comment.value.includes("@boundary-file:")) return true;
+    // Stop scanning once we pass non-leading comments — directives must be
+    // in the file header, before any non-comment token.
+    if (comment.range[0] > 0) {
+      const before = sourceCode.text.slice(0, comment.range[0]);
+      if (/[^\s]/.test(before.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, ""))) {
+        return false;
+      }
+    }
+  }
+  return false;
+}
+
+function hasBoundaryComment(sourceCode, node) {
+  const line = node.loc.start.line;
+  // Same-line trailing comment.
+  for (const comment of sourceCode.getAllComments()) {
+    if (comment.loc.start.line === line && /\bboundary:/i.test(comment.value)) {
+      return true;
+    }
+  }
+  // Walk up to the enclosing top-level statement (parent is BlockStatement
+  // or Program). Comments leading that statement count as boundary markers,
+  // and so do comments inside its body before the offending node.
+  let stmt = node;
+  while (
+    stmt &&
+    stmt.parent &&
+    stmt.parent.type !== "BlockStatement" &&
+    stmt.parent.type !== "Program"
+  ) {
+    stmt = stmt.parent;
+  }
+  if (!stmt) return false;
+  for (const comment of sourceCode.getCommentsBefore(stmt)) {
+    if (/\bboundary:/i.test(comment.value)) return true;
+  }
+  // Also accept comments within the enclosing block but before the offending
+  // node (covers multi-line expressions where the marker leads a sibling
+  // statement, e.g. `if (...) { /* boundary: */ const x = ...; const y = new Date(); }`).
+  const block = stmt.parent;
+  if (block && /BlockStatement|Program/.test(block.type)) {
+    for (const comment of sourceCode.getAllComments()) {
+      if (
+        comment.range[0] >= block.range[0] &&
+        comment.range[1] <= node.range[1] &&
+        /\bboundary:/i.test(comment.value)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isLocallyBoundDate(context, node) {
+  // ESLint scope analysis — if `Date` resolves to a local variable, it's not
+  // the JS global, so skip.
+  const sourceCode = context.sourceCode || context.getSourceCode();
+  let scope = sourceCode.getScope(node);
+  while (scope) {
+    const variable = scope.variables.find((v) => v.name === "Date");
+    if (variable && variable.defs.length > 0) return true;
+    scope = scope.upper;
+  }
+  return false;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow JavaScript `Date` in domain code; prefer Temporal types. Use `// boundary:` or `@boundary-file:` for documented exemptions.",
+    },
+    schema: [],
+    messages: {
+      noNew: "Use `Temporal.Instant.fromEpochMilliseconds(...)` or another Temporal constructor instead of `new Date(...)`. Annotate with `// boundary:` if the JS `Date` is intentional.",
+      noInstanceof:
+        "Use `Temporal` type checks (e.g. `x instanceof Temporal.Instant`) instead of `instanceof Date`. Annotate with `// boundary:` if the JS `Date` is intentional.",
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    if (hasFileBoundaryDirective(sourceCode)) return {};
+
+    function report(node, messageId, data) {
+      if (hasBoundaryComment(sourceCode, node)) return;
+      context.report({ node, messageId, data });
+    }
+
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "Date" &&
+          !isLocallyBoundDate(context, node)
+        ) {
+          report(node, "noNew");
+        }
+      },
+      BinaryExpression(node) {
+        if (
+          node.operator === "instanceof" &&
+          node.right.type === "Identifier" &&
+          node.right.name === "Date" &&
+          !isLocallyBoundDate(context, node)
+        ) {
+          report(node, "noInstanceof");
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -128,23 +128,34 @@ const rule = {
       context.report({ node, messageId, data });
     }
 
+    // Match `Date` (Identifier resolving to global) OR `globalThis.Date` /
+    // `window.Date` / `self.Date` / `global.Date` (MemberExpression on a
+    // global object).
+    function isGlobalDateRef(refNode) {
+      if (refNode.type === "Identifier" && refNode.name === "Date") {
+        return !isLocallyBoundDate(context, refNode);
+      }
+      if (
+        refNode.type === "MemberExpression" &&
+        !refNode.computed &&
+        refNode.property.type === "Identifier" &&
+        refNode.property.name === "Date" &&
+        refNode.object.type === "Identifier" &&
+        /^(globalThis|window|self|global)$/.test(refNode.object.name)
+      ) {
+        return true;
+      }
+      return false;
+    }
+
     return {
       NewExpression(node) {
-        if (
-          node.callee.type === "Identifier" &&
-          node.callee.name === "Date" &&
-          !isLocallyBoundDate(context, node)
-        ) {
+        if (isGlobalDateRef(node.callee)) {
           report(node, "noNew");
         }
       },
       BinaryExpression(node) {
-        if (
-          node.operator === "instanceof" &&
-          node.right.type === "Identifier" &&
-          node.right.name === "Date" &&
-          !isLocallyBoundDate(context, node)
-        ) {
+        if (node.operator === "instanceof" && isGlobalDateRef(node.right)) {
           report(node, "noInstanceof");
         }
       },

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -53,10 +53,15 @@ function hasFileBoundaryDirective(sourceCode) {
 }
 
 function hasBoundaryComment(allComments, sourceCode, node, dateRef) {
-  // 1. Same-line trailing comment — anchored on the `Date` reference itself
+  // 1. Same-line trailing comment — anchored on the `Date` token itself
   //    (not the enclosing expression's start line) so multi-line `instanceof`
   //    / `new` expressions can carry the marker on the `Date` line.
-  const dateLine = (dateRef ?? node).loc.start.line;
+  //    For `globalThis.Date` / `window.Date` we anchor on the property
+  //    identifier so the marker on the `.Date` line is recognised even when
+  //    the namespace token sits on a different line.
+  const dateAnchor =
+    dateRef && dateRef.type === "MemberExpression" ? dateRef.property : (dateRef ?? node);
+  const dateLine = dateAnchor.loc.start.line;
   for (const comment of allComments) {
     if (comment.loc.start.line === dateLine && /\bboundary:/i.test(comment.value)) {
       return true;

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -6,10 +6,14 @@
  * instead.
  *
  * Honors two escape-hatch markers:
- *   - File-level: a JSDoc block containing `@boundary-file:` in the file's
- *     leading comments (entire file is exempt).
- *   - Line-level: a `boundary:` keyword in a comment on the same line as
- *     the offending construct OR on the immediately-preceding comment line.
+ *   - File-level: a JSDoc block containing `@boundary-file:` in the file
+ *     *header* (before any non-comment token) — entire file is exempt.
+ *   - Line-level: a `boundary:` keyword in a comment that is either
+ *       (a) on the same line as the offending construct,
+ *       (b) attached as a leading comment to the enclosing top-level
+ *           statement, or
+ *       (c) inside the enclosing statement, before the offending node
+ *           (handles multi-line expressions and `} /* ... *​/ else if {` chains).
  *
  * Detected constructs:
  *   - `new Date(...)`
@@ -28,17 +32,15 @@
  */
 
 function hasFileBoundaryDirective(sourceCode) {
-  // Scan leading block comments at the top of the file for `@boundary-file:`.
+  // `@boundary-file:` only counts when it appears in the file *header* — i.e.
+  // before any non-comment token. Honoring it anywhere in the file would let
+  // a function-level JSDoc unintentionally exempt the whole module.
+  const firstToken = sourceCode.getFirstToken(sourceCode.ast);
+  const headerEnd = firstToken ? firstToken.range[0] : sourceCode.text.length;
   for (const comment of sourceCode.getAllComments()) {
-    if (comment.type !== "Block") continue;
-    if (comment.value.includes("@boundary-file:")) return true;
-    // Stop scanning once we pass non-leading comments — directives must be
-    // in the file header, before any non-comment token.
-    if (comment.range[0] > 0) {
-      const before = sourceCode.text.slice(0, comment.range[0]);
-      if (/[^\s]/.test(before.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, ""))) {
-        return false;
-      }
+    if (comment.range[0] >= headerEnd) break;
+    if (comment.type === "Block" && comment.value.includes("@boundary-file:")) {
+      return true;
     }
   }
   return false;
@@ -46,15 +48,14 @@ function hasFileBoundaryDirective(sourceCode) {
 
 function hasBoundaryComment(sourceCode, node) {
   const line = node.loc.start.line;
-  // Same-line trailing comment.
+  // 1. Same-line trailing comment.
   for (const comment of sourceCode.getAllComments()) {
     if (comment.loc.start.line === line && /\bboundary:/i.test(comment.value)) {
       return true;
     }
   }
   // Walk up to the enclosing top-level statement (parent is BlockStatement
-  // or Program). Comments leading that statement count as boundary markers,
-  // and so do comments inside its body before the offending node.
+  // or Program).
   let stmt = node;
   while (
     stmt &&
@@ -65,22 +66,19 @@ function hasBoundaryComment(sourceCode, node) {
     stmt = stmt.parent;
   }
   if (!stmt) return false;
+  // 2. Comments attached as leading the enclosing statement.
   for (const comment of sourceCode.getCommentsBefore(stmt)) {
     if (/\bboundary:/i.test(comment.value)) return true;
   }
-  // Also accept comments within the enclosing block but before the offending
-  // node (covers multi-line expressions where the marker leads a sibling
-  // statement, e.g. `if (...) { /* boundary: */ const x = ...; const y = new Date(); }`).
-  const block = stmt.parent;
-  if (block && /BlockStatement|Program/.test(block.type)) {
-    for (const comment of sourceCode.getAllComments()) {
-      if (
-        comment.range[0] >= block.range[0] &&
-        comment.range[1] <= node.range[1] &&
-        /\bboundary:/i.test(comment.value)
-      ) {
-        return true;
-      }
+  // 3. Comments inside the enclosing statement before the offending node
+  //    (covers multi-line expressions like `} /* boundary: */ else if (x instanceof Date)`).
+  for (const comment of sourceCode.getAllComments()) {
+    if (
+      comment.range[0] >= stmt.range[0] &&
+      comment.range[1] <= node.range[0] &&
+      /\bboundary:/i.test(comment.value)
+    ) {
+      return true;
     }
   }
   return false;

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -47,10 +47,10 @@ function hasFileBoundaryDirective(sourceCode) {
   return false;
 }
 
-function hasBoundaryComment(sourceCode, node) {
+function hasBoundaryComment(allComments, sourceCode, node) {
   const line = node.loc.start.line;
   // 1. Same-line trailing comment.
-  for (const comment of sourceCode.getAllComments()) {
+  for (const comment of allComments) {
     if (comment.loc.start.line === line && /\bboundary:/i.test(comment.value)) {
       return true;
     }
@@ -73,7 +73,7 @@ function hasBoundaryComment(sourceCode, node) {
   }
   // 3. Comments inside the enclosing statement before the offending node
   //    (covers multi-line expressions like `} /* boundary: */ else if (x instanceof Date)`).
-  for (const comment of sourceCode.getAllComments()) {
+  for (const comment of allComments) {
     if (
       comment.range[0] >= stmt.range[0] &&
       comment.range[1] <= node.range[0] &&
@@ -119,8 +119,12 @@ const rule = {
     const sourceCode = context.sourceCode || context.getSourceCode();
     if (hasFileBoundaryDirective(sourceCode)) return {};
 
+    // Cache the file's comment list once — getAllComments is otherwise
+    // O(comments) per reported node.
+    const allComments = sourceCode.getAllComments();
+
     function report(node, messageId, data) {
-      if (hasBoundaryComment(sourceCode, node)) return;
+      if (hasBoundaryComment(allComments, sourceCode, node)) return;
       context.report({ node, messageId, data });
     }
 

--- a/eslint/no-native-date.mjs
+++ b/eslint/no-native-date.mjs
@@ -109,7 +109,8 @@ const rule = {
     },
     schema: [],
     messages: {
-      noNew: "Use `Temporal.Instant.fromEpochMilliseconds(...)` or another Temporal constructor instead of `new Date(...)`. Annotate with `// boundary:` if the JS `Date` is intentional.",
+      noNew:
+        "Use `Temporal.Instant.fromEpochMilliseconds(...)` or another Temporal constructor instead of `new Date(...)`. Annotate with `// boundary:` if the JS `Date` is intentional.",
       noInstanceof:
         "Use `Temporal` type checks (e.g. `x instanceof Temporal.Instant`) instead of `instanceof Date`. Annotate with `// boundary:` if the JS `Date` is intentional.",
     },

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -1,0 +1,65 @@
+import { RuleTester } from "eslint";
+import { parser as tsParser } from "typescript-eslint";
+import rule from "./no-native-date.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-native-date", rule, {
+  valid: [
+    // No Date usage at all.
+    "const x = 1;",
+    // Locally-bound Date (mirrors AR Type::Date import shadowing global).
+    'import { Date } from "./local.js";\nconst d = new Date();',
+    // Same-line trailing boundary marker.
+    "const d = new Date(); // boundary: legacy callers",
+    // Immediately-preceding boundary marker.
+    "// boundary: legacy callers\nconst d = new Date();",
+    // Block-comment boundary marker on preceding line.
+    "/* boundary: legacy callers */\nconst d = new Date();",
+    // File-level @boundary-file directive exempts the entire file.
+    `/**
+ * @boundary-file: HTTP date handling.
+ */
+const d = new Date();
+function f(x: unknown) {
+  return x instanceof Date;
+}`,
+    // Boundary on guarded instanceof.
+    "function f(x: unknown) { /* boundary: defensive */ if (x instanceof Date) return x; }",
+    // Out of scope: Date.{now,parse,UTC} return numbers, not Date values.
+    "const t = Date.now();",
+    "const t = Date.parse('2024-01-01');",
+    "const t = Date.UTC(2024, 0, 1);",
+    // Out of scope: Date used in TS type position only.
+    "function f(d: Date) { return d.toISOString(); }",
+  ],
+
+  invalid: [
+    {
+      code: "const d = new Date();",
+      errors: [{ messageId: "noNew" }],
+    },
+    {
+      code: "function f(x: unknown) { return x instanceof Date; }",
+      errors: [{ messageId: "noInstanceof" }],
+    },
+    // Boundary keyword in unrelated comment doesn't exempt.
+    {
+      code: "// just a comment\nconst d = new Date();",
+      errors: [{ messageId: "noNew" }],
+    },
+    // Boundary marker on a non-adjacent prior line doesn't exempt.
+    {
+      code: "// boundary: explanation\n\nconst x = 1;\nconst d = new Date();",
+      errors: [{ messageId: "noNew" }],
+    },
+  ],
+});
+
+console.log("no-native-date: all tests passed");

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -1,10 +1,9 @@
 import { RuleTester } from "eslint";
-import { parser as tsParser } from "typescript-eslint";
 import rule from "./no-native-date.mjs";
 
 const tester = new RuleTester({
   languageOptions: {
-    parser: tsParser,
+    parser: (await import("typescript-eslint")).parser,
     ecmaVersion: 2022,
     sourceType: "module",
   },
@@ -48,6 +47,19 @@ function f(x: unknown) {
     {
       code: "function f(x: unknown) { return x instanceof Date; }",
       errors: [{ messageId: "noInstanceof" }],
+    },
+    // globalThis.Date / window.Date / self.Date / global.Date variants.
+    {
+      code: "const d = new globalThis.Date();",
+      errors: [{ messageId: "noNew" }],
+    },
+    {
+      code: "function f(x: unknown) { return x instanceof globalThis.Date; }",
+      errors: [{ messageId: "noInstanceof" }],
+    },
+    {
+      code: "const d = new window.Date();",
+      errors: [{ messageId: "noNew" }],
     },
     // Boundary keyword in unrelated comment doesn't exempt.
     {

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -36,8 +36,8 @@ function f(x: unknown) {
     "const t = Date.now();",
     "const t = Date.parse('2024-01-01');",
     "const t = Date.UTC(2024, 0, 1);",
-    // Out of scope: Date used in TS type position only.
-    "function f(d: Date) { return d.toISOString(); }",
+    // Out of scope: `: Date` type annotations alone don't trigger the rule.
+    "function f(d: Date): string { return ''; }",
   ],
 
   invalid: [

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -37,6 +37,14 @@ function f(x: unknown) {
     "const t = Date.UTC(2024, 0, 1);",
     // Out of scope: `: Date` type annotations alone don't trigger the rule.
     "function f(d: Date): string { return ''; }",
+    // Multi-line instanceof — boundary marker on the `Date` line, not the
+    // start line of the surrounding expression.
+    `function f(x: unknown) {
+  return (
+    x instanceof
+    Date // boundary: legacy multi-line shape
+  );
+}`,
   ],
 
   invalid: [
@@ -59,6 +67,11 @@ function f(x: unknown) {
     },
     {
       code: "const d = new window.Date();",
+      errors: [{ messageId: "noNew" }],
+    },
+    // Non-JSDoc block comment with @boundary-file: doesn't exempt the file.
+    {
+      code: "/* @boundary-file: not-jsdoc */\nconst d = new Date();",
       errors: [{ messageId: "noNew" }],
     },
     // Boundary keyword in unrelated comment doesn't exempt.

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -45,6 +45,15 @@ function f(x: unknown) {
     Date // boundary: legacy multi-line shape
   );
 }`,
+    // Multi-line globalThis.Date — marker on the `.Date` line works even
+    // though loc.start of the MemberExpression points at `globalThis`.
+    `function f(x: unknown) {
+  return (
+    x instanceof
+    globalThis
+      .Date // boundary: legacy multi-line shape
+  );
+}`,
   ],
 
   invalid: [

--- a/packages/actionpack/src/actioncontroller/base.ts
+++ b/packages/actionpack/src/actioncontroller/base.ts
@@ -417,6 +417,7 @@ export class Base extends Metal {
       // realms). Last-Modified is RFC 7231 — emit via Date#toUTCString,
       // bridging a Temporal.Instant input through epoch ms.
       const isDate = Object.prototype.toString.call(options.lastModified) === "[object Date]";
+      // boundary: bridge Temporal.Instant input → Date for toUTCString rendering.
       const lm = isDate
         ? (options.lastModified as Date)
         : new Date((options.lastModified as Temporal.Instant).epochMilliseconds);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2,6 +2,10 @@
  * Database statements — query execution interface.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements
+ *
+ * @boundary-file: typeCast accepts caller-supplied bind values; the
+ *   defensive `instanceof Date` branch catches legacy values flowing through
+ *   custom types and rejects them with a clear error (per PR 6).
  */
 
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -2,6 +2,10 @@
  * Quoting — SQL value and identifier quoting.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting
+ *
+ * @boundary-file: SQL quoting accepts caller-supplied values; legacy callers
+ *   may pass JS `Date` for date-typed columns. The dispatcher branches on
+ *   `instanceof Date` alongside Temporal types and handles each separately.
  */
 
 import { NotImplementedError } from "../../errors.js";

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -150,6 +150,7 @@ export class TransactionInstrumenter {
     Notifications.instrument("start_transaction.active_record", this._basePayload);
 
     this._payload = { ...this._basePayload };
+    // boundary: Notifications.Event#time is Date by Rails parity (see activesupport/src/notifications/instrumenter.ts).
     this._event = new NotificationEvent("transaction.active_record", new Date(), this._payload);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -6,6 +6,10 @@
  * In Rails, Quoting is a module mixed into AbstractMysqlAdapter.
  * Here we export standalone functions and an interface, matching
  * the pattern used by the PostgreSQL and SQLite3 adapters.
+ *
+ * @boundary-file: SQL value quoting branches on `instanceof Date` alongside
+ *   Temporal types; legacy Date values from custom-typed columns hit a
+ *   typed-error path that mirrors the abstract dispatcher.
  */
 
 import {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -213,6 +213,7 @@ function inspect(value: unknown): string {
   if (value instanceof Temporal.PlainDateTime) return value.toString();
   if (value instanceof Temporal.PlainDate) return value.toString();
   if (value instanceof Temporal.PlainTime) return value.toString();
+  // boundary: explicit Date rejection so legacy callers get a clear error.
   if (value instanceof Date)
     throw new TypeError("Range inspect: JS Date is not accepted — use a Temporal type");
   return String(value);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1198,6 +1198,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (typeof value === "number") return String(value);
     if (typeof value === "boolean") return value ? "1" : "0";
     if (typeof value === "function") return String(value());
+    // boundary: defensive Date branch in SQLite adapter literal quoting.
     if (value instanceof globalThis.Date) return quoteString(value.toISOString());
     // SqlLiteral or objects with toSql
     if (typeof (value as any)?.toSql === "function") return String((value as any).toSql());

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -2,6 +2,10 @@
  * SQLite3 quoting — SQLite-specific value and identifier quoting.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting
+ *
+ * @boundary-file: SQL value quoting branches on `instanceof Date` alongside
+ *   Temporal types; legacy Date values from custom-typed columns hit a
+ *   typed-error path that mirrors the abstract dispatcher.
  */
 
 import {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4199,8 +4199,9 @@ export class Relation<T extends Base> {
       let ts: Temporal.Instant | null = null;
       if (timestamp instanceof Temporal.Instant) {
         ts = timestamp;
-      } else if (timestamp instanceof Date && !Number.isNaN(timestamp.getTime())) {
-        // boundary: aggregate cache-key timestamp from a custom-typed column.
+      }
+      // boundary: aggregate cache-key timestamp from a custom-typed column.
+      else if (timestamp instanceof Date && !Number.isNaN(timestamp.getTime())) {
         ts = Temporal.Instant.fromEpochMilliseconds(timestamp.getTime());
       } else if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
         ts = Temporal.Instant.fromEpochMilliseconds(timestamp);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4199,9 +4199,11 @@ export class Relation<T extends Base> {
       let ts: Temporal.Instant | null = null;
       if (timestamp instanceof Temporal.Instant) {
         ts = timestamp;
-      }
-      // boundary: aggregate cache-key timestamp from a custom-typed column.
-      else if (timestamp instanceof Date && !Number.isNaN(timestamp.getTime())) {
+      } else if (
+        // boundary: aggregate cache-key timestamp from a custom-typed column.
+        timestamp instanceof Date &&
+        !Number.isNaN(timestamp.getTime())
+      ) {
         ts = Temporal.Instant.fromEpochMilliseconds(timestamp.getTime());
       } else if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
         ts = Temporal.Instant.fromEpochMilliseconds(timestamp);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -787,6 +787,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   // compare by epoch since Object.is treats distinct Date instances as unequal.
   // Use Object.is on the epoch so two invalid (NaN) Dates compare equal too.
   if (a instanceof Date) return b instanceof Date && Object.is(a.getTime(), b.getTime());
+  // boundary: paired with the `a instanceof Date` branch above.
   if (b instanceof Date) return false;
 
   const aAny = a as { eql?: (x: unknown) => boolean; equals?: (x: unknown) => boolean };

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -502,6 +502,7 @@ export class Dot extends Visitor {
       t === "boolean" ||
       t === "bigint" ||
       t === "symbol" ||
+      // boundary: Arel dot-graph leaf detection includes legacy Date values.
       o instanceof Date
     );
   }
@@ -535,6 +536,7 @@ export class Dot extends Visitor {
     if (typeof o === "boolean") return o ? "TrueClass" : "FalseClass";
     if (typeof o === "bigint") return "Integer";
     if (typeof o === "symbol") return "Symbol";
+    // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";


### PR DESCRIPTION
## Summary

PR 12 — final ESLint safety net for the Temporal migration. Adds `blazetrails/no-native-date` to flag JS `Date` *value* usage in domain code:

- `new Date(...)` and `new globalThis.Date(...)` / `window.Date` / `self.Date` / `global.Date` constructor calls.
- `x instanceof Date` (and the `globalThis.Date` etc. variants) runtime checks.

### Escape hatches

- **File-level** `@boundary-file:` JSDoc-shaped directive in the file *header* — exempts the entire file. Used by Date-typed Rails-port modules (`duration.ts`, `time-ext.ts`, `time-zone.ts`, etc.) and HTTP/RFC-spec boundary code (cookies, conditional-get, etc.).
- **Line-level** `boundary:` keyword in a comment that is either:
  - on the same line as the `Date` reference (anchored on `node.callee` for `new` and `node.right`/`.property` for `instanceof`, so multi-line `globalThis.Date` shapes carry the marker on the `.Date` line);
  - leading the enclosing top-level statement; or
  - inside the enclosing statement before the offending node (handles `} /* boundary */ else if` chains).

### Out of scope (intentional)

- `Date.{now,parse,UTC}` — return numbers, not propagating Date values.
- `: Date` type references — constrain flow without creating Date instances.

Locally-bound `Date` (e.g. `activerecord/src/type.ts` importing the AR `Type::Date` class) is naturally exempt via ESLint scope analysis.

### Wiring

Enabled at `error` for the seven Rails-mirroring packages plus `rack`/`trailties`/`website`. Allowlist:

- `packages/activesupport/src/temporal.ts` — canonical `Date`↔`Instant` adapter.
- `packages/activesupport/src/testing/**` and `testing-helpers.ts` — test infrastructure.

### Audit fallout

The rule found a handful of sites that PR 11's manual sweeps missed. Added boundary annotations to:

- `activerecord` connection-adapters (`abstract/quoting`, `database-statements`, `mysql/quoting`, `sqlite3/quoting`, `postgresql/oid/range`, `sqlite3-adapter`) — file-level `@boundary-file:` and line-level annotations.
- `activerecord/connection-adapters/abstract/transaction.ts` — `Notifications.Event` Date timestamp.
- `activerecord/relation.ts` and `relation/query-methods.ts` — relocated/added boundary markers.
- `actionpack/actioncontroller/base.ts` — `Temporal.Instant`→`Date` bridge in `freshWhen`.
- `arel/visitors/dot.ts` — added by PR #1020 (rebased in).

`pnpm lint` runs clean across the whole repo with the rule at `error`. Any regression PR fails CI.

### Review status

Copilot review cycles concluded (10 rounds). The final pass surfaced **no new comments** — all prior concerns were resolved across the iterations:

- File-header detection narrowed to header-only JSDoc-shaped block comments.
- Same-line marker check anchored on the `Date` reference (incl. `.Date` for member access).
- `globalThis.Date` / `window.Date` / etc. detection added with caught-and-annotated SQLite-adapter site.
- Line-level escape hatch tightened from "enclosing block" to "enclosing statement" with documented multi-line / `else if` ergonomics.
- Per-file `getAllComments()` cached once instead of per-node.
- Two NaN-Date guard sites and Invalid-Date inspect rendering hardened along the way.

Together with PRs 1–11, this **completes the Temporal migration**.

## Test plan

- [x] `node eslint/no-native-date.test.mjs` — rule unit tests pass (12 valid + 8 invalid scenarios)
- [x] `pnpm lint` — clean across the whole repo
- [x] `vitest run packages` — full test suite passes
- [x] `pnpm typecheck`