### PR TITLE
feat(activesupport): add glob() helper backed by tinyglobby

### DIFF
--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -68,6 +68,7 @@
   "license": "MIT",
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
+    "tinyglobby": "^0.2.16",
     "yaml": "^2.8.3"
   }
 }

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/gzip.d.ts",
       "default": "./dist/gzip.js"
     },
+    "./glob": {
+      "types": "./dist/glob.d.ts",
+      "default": "./dist/glob.js"
+    },
     "./temporal": {
       "types": "./dist/temporal.d.ts",
       "default": "./dist/temporal.js"

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -2,8 +2,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-// glob is a subpath export, not re-exported from activesupport's index
-import { glob } from "./glob.js";
+// Import via the public subpath so the vitest alias is exercised — same
+// pattern other tests use for /message-verifier, /temporal, etc.
+import { glob } from "@blazetrails/activesupport/glob";
 
 let root: string;
 

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+// glob is a subpath export, not re-exported from activesupport's index
 import { glob } from "./glob.js";
 
 let root: string;

--- a/packages/activesupport/src/glob.test.ts
+++ b/packages/activesupport/src/glob.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { glob } from "./glob.js";
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "glob-test-"));
+  // Layout:
+  //   foo.rb
+  //   bar.txt
+  //   .hidden
+  //   app/models/{user,post,admin}.rb
+  //   app/controllers/application_controller.rb
+  //   lib/tasks/deploy.rake
+  for (const f of ["foo.rb", "bar.txt", ".hidden"]) {
+    writeFileSync(join(root, f), "");
+  }
+  mkdirSync(join(root, "app", "models"), { recursive: true });
+  mkdirSync(join(root, "app", "controllers"), { recursive: true });
+  mkdirSync(join(root, "lib", "tasks"), { recursive: true });
+  for (const f of ["user.rb", "post.rb", "admin.rb"]) {
+    writeFileSync(join(root, "app", "models", f), "");
+  }
+  writeFileSync(join(root, "app", "controllers", "application_controller.rb"), "");
+  writeFileSync(join(root, "lib", "tasks", "deploy.rake"), "");
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("glob", () => {
+  it("matches *.ext at root only", async () => {
+    expect(await glob("*.rb", { cwd: root })).toEqual(["foo.rb"]);
+  });
+
+  it("matches **/*.ext at any depth", async () => {
+    expect(await glob("**/*.rb", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+    ]);
+  });
+
+  it("supports a path prefix with **", async () => {
+    expect(await glob("app/**/*.rb", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+    ]);
+  });
+
+  it("supports brace expansion", async () => {
+    expect(await glob("**/*.{rb,rake}", { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/admin.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+      "lib/tasks/deploy.rake",
+    ]);
+  });
+
+  it("supports an array of patterns with negation", async () => {
+    expect(await glob(["**/*.rb", "!**/admin.rb"], { cwd: root })).toEqual([
+      "app/controllers/application_controller.rb",
+      "app/models/post.rb",
+      "app/models/user.rb",
+      "foo.rb",
+    ]);
+  });
+
+  it("hides dotfiles by default", async () => {
+    expect(await glob("*", { cwd: root })).not.toContain(".hidden");
+  });
+
+  it("includes dotfiles when dot:true", async () => {
+    expect(await glob("*", { cwd: root, dot: true })).toContain(".hidden");
+  });
+
+  it("returns empty array for unmatched patterns", async () => {
+    expect(await glob("nonexistent/**/*.zzz", { cwd: root })).toEqual([]);
+  });
+});

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -21,7 +21,10 @@ export interface GlobOptions {
 }
 
 /**
- * Match files relative to `cwd` using picomatch-style patterns.
+ * Match paths (files AND directories) relative to `cwd` using
+ * picomatch-style patterns. Mirrors Ruby `Dir.glob`'s default behavior
+ * of returning both files and directories — needed by Phase 1 consumers
+ * that walk `app/models/*` and similar.
  *
  * Supports `*`, `**`, `?`, `[abc]`, `{a,b}`, leading `!` for negation.
  * Returns paths relative to `cwd`, sorted.

--- a/packages/activesupport/src/glob.ts
+++ b/packages/activesupport/src/glob.ts
@@ -1,0 +1,36 @@
+/**
+ * Glob — thin wrapper around `tinyglobby`.
+ *
+ * Phase 1 trailties consumers (`Paths`, `SourceAnnotationExtractor`,
+ * `CodeStatistics`, app-template DSL) need filesystem globbing. We
+ * delegate to `tinyglobby` (picomatch-based, ~15kB, the same engine
+ * used by fast-glob) rather than re-implementing the matcher.
+ *
+ * Browser support is intentionally deferred — `tinyglobby` uses Node's
+ * `fs` directly. When the browser-adapter PR lands, this file will gain
+ * a runtime branch that swaps in a vfs-aware implementation.
+ */
+
+import { glob as tinyglob } from "tinyglobby";
+
+export interface GlobOptions {
+  /** Directory to glob from. Defaults to the process cwd. */
+  cwd?: string;
+  /** Include dotfiles. Default false. */
+  dot?: boolean;
+}
+
+/**
+ * Match files relative to `cwd` using picomatch-style patterns.
+ *
+ * Supports `*`, `**`, `?`, `[abc]`, `{a,b}`, leading `!` for negation.
+ * Returns paths relative to `cwd`, sorted.
+ */
+export async function glob(patterns: string | string[], opts: GlobOptions = {}): Promise<string[]> {
+  const results = await tinyglob(patterns, {
+    cwd: opts.cwd,
+    dot: opts.dot ?? false,
+    onlyFiles: false,
+  });
+  return results.sort();
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -8,6 +8,9 @@ export {
 } from "./fs-adapter.js";
 export type { FsAdapter, FsStatResult, FsDirent, PathAdapter } from "./fs-adapter.js";
 
+export { glob } from "./glob.js";
+export type { GlobOptions } from "./glob.js";
+
 export {
   registerCryptoAdapter,
   getCrypto,

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -7,9 +7,10 @@ export {
   fsAdapterConfig,
 } from "./fs-adapter.js";
 export type { FsAdapter, FsStatResult, FsDirent, PathAdapter } from "./fs-adapter.js";
-
-export { glob } from "./glob.js";
-export type { GlobOptions } from "./glob.js";
+// Note: glob is intentionally kept as a subpath import
+// (`@blazetrails/activesupport/glob`) so browser bundles that don't need
+// it don't pull tinyglobby's Node-only transitive deps. Mirrors the
+// pattern used by message-verifier, digest, etc.
 
 export {
   registerCryptoAdapter,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -2885,6 +2888,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -3166,6 +3173,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -5514,6 +5525,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -6081,6 +6096,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -6402,6 +6419,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
         __dirname,
         "packages/activesupport/src/temporal.ts",
       ),
+      "@blazetrails/activesupport/glob": path.resolve(
+        __dirname,
+        "packages/activesupport/src/glob.ts",
+      ),
       "@blazetrails/activesupport/testing/temporal-helpers": path.resolve(
         __dirname,
         "packages/activesupport/src/testing/temporal-helpers.ts",


### PR DESCRIPTION
## Summary

Phase 1 trailties consumers (\`Paths\`, \`SourceAnnotationExtractor\`, \`CodeStatistics\`, app-template DSL) need filesystem globbing. This adds a small \`glob()\` helper that delegates to [\`tinyglobby\`](https://www.npmjs.com/package/tinyglobby) — picomatch-based, ~15kB, the same engine used by fast-glob.

This is a redo of #1018 (closed), which tried to re-implement glob matching from scratch. That was the wrong call — there's no reason to reinvent picomatch.

Surface:

\`\`\`ts
glob(patterns: string | string[], opts?: { cwd?: string; dot?: boolean }): Promise<string[]>
\`\`\`

Supports \`*\`, \`**\`, \`?\`, \`[abc]\`, \`{a,b}\`, leading \`!\` for negation. Returns paths relative to \`cwd\`, sorted.

## Browser support

Intentionally deferred. \`tinyglobby\` uses Node's \`fs\` directly. When the browser-adapter PR (3.5) lands, this file will gain a runtime branch that swaps in a vfs-aware implementation.

## Rails source

- \`railties/lib/rails/paths.rb\` \`Path#existent\` (uses \`Dir.glob\`)
- \`railties/lib/rails/source_annotation_extractor.rb\` (uses \`Dir.glob\` with extension lists)

Not aiming for Ruby \`Dir.glob\` parity — patterns that don't translate cleanly should be rewritten when ported.

## Test plan

- [x] 8 unit tests covering star, double-star, prefix, brace expansion, array+negation, dotfiles, missing matches
- [x] \`pnpm --filter @blazetrails/activesupport build\` clean
- [x] \`pnpm lint\` clean