### PR TITLE
chore(api-compare): drop isIs* prefix for is_*? predicates + fix expected-set dedup

### DIFF
--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -627,11 +627,14 @@ describe("numericality with in: range", () => {
     expect(new User({ score: 5 }).isValid()).toBe(true);
   });
 
-  it("rejects non-string/non-number values (boolean, Date, plain object)", () => {
+  it("rejects non-string/non-number values (boolean, Temporal.Instant, plain object)", () => {
     // Rails Kernel.Float raises TypeError for non-Numeric/non-String
-    // input, so is_number? returns false. JS Number(true) === 1 and
-    // Number(new Date()) === epoch would silently pass without the
-    // explicit type narrowing in isNumber.
+    // input, so is_number? returns false. In JS, Number(true) === 1
+    // and Number(<object with valueOf>) can coerce silently — the
+    // explicit string|number narrowing in isNumber prevents that.
+    // (Trails casts datetime attributes to Temporal.Instant, not JS
+    // Date, so the datetime case below exercises the
+    // non-string/non-number path for Temporal types specifically.)
     class User extends Model {
       static {
         this.attribute("flag", "boolean");
@@ -643,5 +646,23 @@ describe("numericality with in: range", () => {
     expect(new User({ flag: true }).isValid()).toBe(false);
     expect(new User({ flag: false }).isValid()).toBe(false);
     expect(new User({ when: "2026-04-29T00:00:00Z" }).isValid()).toBe(false);
+  });
+
+  it("rejects plain object values via the validateEach path", () => {
+    // Direct exercise of the non-string/non-number narrowing in isNumber
+    // — a plain object would coerce to NaN under Number({}), so this
+    // path could survive a regression that drops the explicit typeof
+    // guard. Use a string-typed attribute so we can write a non-string
+    // value through writeAttribute without trails' own type cast
+    // intercepting first.
+    class Bag extends Model {
+      static {
+        this.attribute("payload", "string");
+        this.validates("payload", { numericality: true });
+      }
+    }
+    const b = new Bag();
+    b.writeAttribute("payload", { not: "a number" } as unknown as string);
+    expect(b.isValid()).toBe(false);
   });
 });

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -648,21 +648,20 @@ describe("numericality with in: range", () => {
     expect(new User({ when: "2026-04-29T00:00:00Z" }).isValid()).toBe(false);
   });
 
-  it("rejects plain object values via the validateEach path", () => {
-    // Direct exercise of the non-string/non-number narrowing in isNumber
-    // — a plain object would coerce to NaN under Number({}), so this
-    // path could survive a regression that drops the explicit typeof
-    // guard. Use a string-typed attribute so we can write a non-string
-    // value through writeAttribute without trails' own type cast
-    // intercepting first.
-    class Bag extends Model {
-      static {
-        this.attribute("payload", "string");
-        this.validates("payload", { numericality: true });
-      }
-    }
-    const b = new Bag();
-    b.writeAttribute("payload", { not: "a number" } as unknown as string);
-    expect(b.isValid()).toBe(false);
+  it("rejects plain object values via NumericalityValidator.validateEach directly", async () => {
+    // Direct exercise of the non-string/non-number narrowing in isNumber.
+    // Going through Model attributes wouldn't work — string-typed attrs
+    // cast objects to "[object Object]" before validation, value-typed
+    // attrs go through their own cast path. Bypass attribute infra and
+    // call the validator with a stub record so a real plain object
+    // reaches isNumber.
+    const { NumericalityValidator } = await import("./numericality.js");
+    const v = new NumericalityValidator({ attributes: ["x"] });
+    const errors: Array<[string, string]> = [];
+    const stubRecord = {
+      errors: { add: (attr: string, key: string) => errors.push([attr, key]) },
+    };
+    v.validateEach(stubRecord, "x", { not: "a number" });
+    expect(errors).toEqual([["x", "not_a_number"]]);
   });
 });

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -626,4 +626,22 @@ describe("numericality with in: range", () => {
     expect(new User({ score: 20 }).isValid()).toBe(true);
     expect(new User({ score: 5 }).isValid()).toBe(true);
   });
+
+  it("rejects non-string/non-number values (boolean, Date, plain object)", () => {
+    // Rails Kernel.Float raises TypeError for non-Numeric/non-String
+    // input, so is_number? returns false. JS Number(true) === 1 and
+    // Number(new Date()) === epoch would silently pass without the
+    // explicit type narrowing in isNumber.
+    class User extends Model {
+      static {
+        this.attribute("flag", "boolean");
+        this.attribute("when", "datetime");
+        this.validates("flag", { numericality: true });
+        this.validates("when", { numericality: true });
+      }
+    }
+    expect(new User({ flag: true }).isValid()).toBe(false);
+    expect(new User({ flag: false }).isValid()).toBe(false);
+    expect(new User({ when: "2026-04-29T00:00:00Z" }).isValid()).toBe(false);
+  });
 });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -32,11 +32,11 @@ export class NumericalityValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare round: typeof round;
   /** @internal Rails-private helper. */
-  declare isIsNumber: typeof isIsNumber;
+  declare isNumber: typeof isNumber;
   /** @internal Rails-private helper. */
-  declare isIsInteger: typeof isIsInteger;
+  declare isInteger: typeof isInteger;
   /** @internal Rails-private helper. */
-  declare isIsHexadecimalLiteral: typeof isIsHexadecimalLiteral;
+  declare isHexadecimalLiteral: typeof isHexadecimalLiteral;
 
   private resolveNumeric(
     val: NumericValue | undefined,
@@ -88,14 +88,14 @@ export class NumericalityValidator extends EachValidator {
     }
     if (this.options.allowBlank && isBlank(value)) return;
 
-    if (!this.isIsNumber(value, precision, scale)) {
+    if (!this.isNumber(value, precision, scale)) {
       record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
       return;
     }
 
     const num = parseAsNumber(Number(value), precision, scale) as number;
 
-    if (this.options.onlyInteger && !this.isIsInteger(value)) {
+    if (this.options.onlyInteger && !this.isInteger(value)) {
       record.errors.add(attribute, "not_an_integer", { value, message: this.options.message });
       return;
     }
@@ -267,8 +267,8 @@ export function round(num: number, scale?: number): number {
  *
  * @internal Rails-private helper.
  */
-export function isIsNumber(
-  this: { options: Record<string, unknown>; isIsHexadecimalLiteral(v: unknown): boolean },
+export function isNumber(
+  this: { options: Record<string, unknown>; isHexadecimalLiteral(v: unknown): boolean },
   rawValue: unknown,
   precision: number,
   scale?: number,
@@ -290,7 +290,7 @@ export function isIsNumber(
   // Trails extends this to 0b… / 0o… because JS Number() coerces those
   // too (Rails Kernel.Float would raise).
   const trimmed = rawValue.trimStart();
-  if (this.isIsHexadecimalLiteral(trimmed)) return false;
+  if (this.isHexadecimalLiteral(trimmed)) return false;
   if (NON_DECIMAL_LITERAL_REGEX.test(trimmed)) return false;
   // Rails: rescue ArgumentError, TypeError; false; end (numericality.rb:99).
   // The non-string/non-number paths return early above, and Number(string)
@@ -310,7 +310,7 @@ export function isIsNumber(
  *
  * @internal Rails-private helper.
  */
-export function isIsInteger(rawValue: unknown): boolean {
+export function isInteger(rawValue: unknown): boolean {
   return INTEGER_REGEX.test(String(rawValue));
 }
 
@@ -322,7 +322,7 @@ export function isIsInteger(rawValue: unknown): boolean {
  *
  * @internal Rails-private helper.
  */
-export function isIsHexadecimalLiteral(rawValue: unknown): boolean {
+export function isHexadecimalLiteral(rawValue: unknown): boolean {
   return HEXADECIMAL_REGEX.test(String(rawValue));
 }
 
@@ -388,6 +388,6 @@ export function optionAsNumber(
 NumericalityValidator.prototype.optionAsNumber = optionAsNumber;
 NumericalityValidator.prototype.parseFloat = parseFloatRails;
 NumericalityValidator.prototype.round = round;
-NumericalityValidator.prototype.isIsNumber = isIsNumber;
-NumericalityValidator.prototype.isIsInteger = isIsInteger;
-NumericalityValidator.prototype.isIsHexadecimalLiteral = isIsHexadecimalLiteral;
+NumericalityValidator.prototype.isNumber = isNumber;
+NumericalityValidator.prototype.isInteger = isInteger;
+NumericalityValidator.prototype.isHexadecimalLiteral = isHexadecimalLiteral;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4063,7 +4063,7 @@ function loadAdditionalTypes(oids?: any): never {
 }
 
 /** @internal */
-function isIsCachedPlanFailure(pgerror: any): never {
+function isCachedPlanFailure(pgerror: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#is_cached_plan_failure? is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -149,7 +149,7 @@ function newColumnFromField(tableName: any, field: any, definitions: any): never
 }
 
 /** @internal */
-function isIsColumnTheRowid(field: any, columnDefinitions: any): never {
+function isColumnTheRowid(field: any, columnDefinitions: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#is_column_the_rowid? is not implemented",
   );

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -6,6 +6,7 @@ import {
   methodInMode,
   tsShouldIncludeInIndex,
   flattenIncludedMethodInfos,
+  dedupeRubyMethodInto,
 } from "./compare.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
@@ -398,5 +399,40 @@ describe("flattenIncludedMethodInfos", () => {
     ]);
     const f = flattenIncludedMethodInfos(host, pkg, byShort);
     expect(f.instance.map((m) => m.name).sort()).toEqual(["a1", "b1", "h1"]);
+  });
+});
+
+describe("dedupeRubyMethodInto", () => {
+  function rm(name: string): MethodInfo {
+    return {
+      name,
+      visibility: "public",
+      params: [],
+      isStatic: false,
+      file: "x.rb",
+      line: 1,
+    };
+  }
+
+  it("retains distinct Ruby methods even when their first TS candidates collide", () => {
+    // Regression: previous dedup keyed on the first TS candidate, so
+    // `is_number?` and `number?` (both → "isNumber") collapsed silently.
+    // Keying by Ruby name keeps them as two distinct expected entries.
+    const seen = new Map<string, { rubyName: string; rubyModule: string }>();
+    dedupeRubyMethodInto(seen, rm("is_number?"), "ActiveModel::Validations::Numericality");
+    dedupeRubyMethodInto(seen, rm("number?"), "ActiveModel::Validations::Numericality");
+    expect([...seen.values()].map((v) => v.rubyName).sort()).toEqual(["is_number?", "number?"]);
+  });
+
+  it("still dedups true repeats of the same Ruby method (e.g. subclass overrides)", () => {
+    // Multiple subclasses in one file overriding `invert` should count
+    // once — the original behavior the dedup was designed for.
+    const seen = new Map<string, { rubyName: string; rubyModule: string }>();
+    dedupeRubyMethodInto(seen, rm("invert"), "Foo::A");
+    dedupeRubyMethodInto(seen, rm("invert"), "Foo::B");
+    dedupeRubyMethodInto(seen, rm("invert"), "Foo::C");
+    expect(seen.size).toBe(1);
+    // First insertion wins, so the FQN points at the first observer.
+    expect([...seen.values()][0]).toEqual({ rubyName: "invert", rubyModule: "Foo::A" });
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -327,13 +327,15 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
  * candidate (`is_number?` and `number?` both → `"isNumber"`); keying
  * by the TS candidate would silently drop the second method from the
  * expected set. Same FQN-scoped dedup the original logic provided —
- * just keyed differently.
+ * just keyed differently. Skips methods with no TS-candidate mapping
+ * (operators, SKIP list).
  */
 export function dedupeRubyMethodInto(
   seen: Map<string, { rubyName: string; rubyModule: string }>,
   rm: MethodInfo,
   itemFqn: string,
 ): void {
+  if (rubyMethodToTs(rm.name) === null) return;
   const key = rm.name;
   if (!seen.has(key)) {
     seen.set(key, { rubyName: rm.name, rubyModule: itemFqn });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -321,27 +321,6 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
  * Cycles are guarded by `visited`. Modules outside the package are
  * silently skipped — stdlib like `Comparable`/`Enumerable` falls through.
  */
-/**
- * Dedup expected Ruby methods by Ruby method name (NOT first TS
- * candidate). Two distinct Ruby methods can produce the same first TS
- * candidate (`is_number?` and `number?` both → `"isNumber"`); keying
- * by the TS candidate would silently drop the second method from the
- * expected set. Same FQN-scoped dedup the original logic provided —
- * just keyed differently. Skips methods with no TS-candidate mapping
- * (operators, SKIP list).
- */
-export function dedupeRubyMethodInto(
-  seen: Map<string, { rubyName: string; rubyModule: string }>,
-  rm: MethodInfo,
-  itemFqn: string,
-): void {
-  if (rubyMethodToTs(rm.name) === null) return;
-  const key = rm.name;
-  if (!seen.has(key)) {
-    seen.set(key, { rubyName: rm.name, rubyModule: itemFqn });
-  }
-}
-
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
   rubyPkg: PackageInfo,
@@ -367,6 +346,27 @@ export function flattenIncludedMethodInfos(
   for (const inc of entity.includes ?? []) walk(inc, false);
   for (const ext of entity.extends ?? []) walk(ext, true);
   return { instance, klass };
+}
+
+/**
+ * Dedup expected Ruby methods by Ruby method name (NOT first TS
+ * candidate). Two distinct Ruby methods can produce the same first TS
+ * candidate (`is_number?` and `number?` both → `"isNumber"`); keying
+ * by the TS candidate would silently drop the second method from the
+ * expected set. Same FQN-scoped dedup the original logic provided —
+ * just keyed differently. Skips methods with no TS-candidate mapping
+ * (operators, SKIP list).
+ */
+export function dedupeRubyMethodInto(
+  seen: Map<string, { rubyName: string; rubyModule: string }>,
+  rm: MethodInfo,
+  itemFqn: string,
+): void {
+  if (rubyMethodToTs(rm.name) === null) return;
+  const key = rm.name;
+  if (!seen.has(key)) {
+    seen.set(key, { rubyName: rm.name, rubyModule: itemFqn });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -707,9 +707,13 @@ function main() {
         }
       }
 
-      // Deduplicate: collect all unique TS method names expected from this file.
-      // Multiple Ruby classes in the same file often define the same method
-      // (e.g., 8 subclasses in binary.rb each override `invert`). Count once.
+      // Deduplicate: collect all unique Ruby methods expected from this
+      // file (keyed by Ruby method name, not first TS candidate, so two
+      // distinct Ruby methods that camelize to the same first candidate
+      // — e.g. `is_number?` and `number?` both → "isNumber" — both
+      // survive). Multiple Ruby classes in the same file often define
+      // the same method (e.g., 8 subclasses in binary.rb each override
+      // `invert`). Count once.
       const seen = new Map<string, { rubyName: string; rubyModule: string }>();
       for (const item of items) {
         const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -321,6 +321,25 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
  * Cycles are guarded by `visited`. Modules outside the package are
  * silently skipped — stdlib like `Comparable`/`Enumerable` falls through.
  */
+/**
+ * Dedup expected Ruby methods by Ruby method name (NOT first TS
+ * candidate). Two distinct Ruby methods can produce the same first TS
+ * candidate (`is_number?` and `number?` both → `"isNumber"`); keying
+ * by the TS candidate would silently drop the second method from the
+ * expected set. Same FQN-scoped dedup the original logic provided —
+ * just keyed differently.
+ */
+export function dedupeRubyMethodInto(
+  seen: Map<string, { rubyName: string; rubyModule: string }>,
+  rm: MethodInfo,
+  itemFqn: string,
+): void {
+  const key = rm.name;
+  if (!seen.has(key)) {
+    seen.set(key, { rubyName: rm.name, rubyModule: itemFqn });
+  }
+}
+
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
   rubyPkg: PackageInfo,
@@ -695,17 +714,7 @@ function main() {
         const rubyMethods = [...f.instance, ...f.klass];
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;
-          const tsCandidates = rubyMethodToTs(rm.name);
-          if (tsCandidates === null) continue;
-          // Dedup by Ruby method name (within an FQN/include scope), not
-          // by the first TS candidate — two distinct Ruby methods can
-          // produce the same first TS candidate (e.g. `is_number?` and
-          // `number?` both → "isNumber"), and the previous key choice
-          // dropped the second method silently.
-          const key = rm.name;
-          if (!seen.has(key)) {
-            seen.set(key, { rubyName: rm.name, rubyModule: item.fqn });
-          }
+          dedupeRubyMethodInto(seen, rm, item.fqn);
         }
       }
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -353,8 +353,10 @@ export function flattenIncludedMethodInfos(
  * candidate). Two distinct Ruby methods can produce the same first TS
  * candidate (`is_number?` and `number?` both → `"isNumber"`); keying
  * by the TS candidate would silently drop the second method from the
- * expected set. Same FQN-scoped dedup the original logic provided —
- * just keyed differently. Skips methods with no TS-candidate mapping
+ * expected set. Caller supplies a per-file `seen` map (keyed by method
+ * name); this helper just records the first sighting and ignores
+ * subsequent ones, matching the original per-file dedup behavior with
+ * a different key. Skips methods with no TS-candidate mapping
  * (operators, SKIP list).
  */
 export function dedupeRubyMethodInto(

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -697,7 +697,12 @@ function main() {
           if (!methodMatchesMode(rm)) continue;
           const tsCandidates = rubyMethodToTs(rm.name);
           if (tsCandidates === null) continue;
-          const key = tsCandidates[0];
+          // Dedup by Ruby method name (within an FQN/include scope), not
+          // by the first TS candidate — two distinct Ruby methods can
+          // produce the same first TS candidate (e.g. `is_number?` and
+          // `number?` both → "isNumber"), and the previous key choice
+          // dropped the second method silently.
+          const key = rm.name;
           if (!seen.has(key)) {
             seen.set(key, { rubyName: rm.name, rubyModule: item.fqn });
           }

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -77,6 +77,15 @@ describe("rubyMethodToTs predicates", () => {
     expect(rubyMethodToTs("present?")).toEqual(["isPresent", "present"]);
   });
 
+  it("does NOT treat names that merely camelize to start with 'is' as the is_*? family", () => {
+    // The is_*? guard tests the Ruby BASE NAME, not the camel form.
+    // `isolation_level?` camelizes to `isolationLevel` (starts with
+    // 'is'), but the Ruby base doesn't start with `is_` — keep both
+    // candidates so trails methods named either way still match.
+    expect(rubyMethodToTs("isolation_level?")).toEqual(["isIsolationLevel", "isolationLevel"]);
+    expect(rubyMethodToTs("island?")).toEqual(["isIsland", "island"]);
+  });
+
   it("keeps the existing has/supports/can/etc allowlist behavior intact (camel preferred, isPrefixed available as fallback)", () => {
     // Only the `is_*?` family loses the isPrefixed fallback. Other
     // Ruby predicate prefixes keep both candidates because trails

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { snakeToCamel, rubyMethodToTs } from "./conventions.js";
+import { snakeToCamel, rubyMethodToTs, rubyFileToTs } from "./conventions.js";
 
 describe("snakeToCamel", () => {
   it("converts standard snake_case to camelCase", () => {
@@ -46,11 +46,6 @@ describe("rubyMethodToTs", () => {
     expect(rubyMethodToTs("initialize")).toEqual(["constructor"]);
   });
 
-  it("turns predicate methods into TS is*-prefixed candidates", () => {
-    expect(rubyMethodToTs("valid?")).toEqual(["isValid", "valid"]);
-    expect(rubyMethodToTs("has_attribute?")).toEqual(["hasAttribute", "isHasAttribute"]);
-  });
-
   it("transforms bang methods to *Bang", () => {
     expect(rubyMethodToTs("save!")).toEqual(["saveBang"]);
   });
@@ -64,5 +59,54 @@ describe("rubyMethodToTs", () => {
       "visitArelNodesSelectStatement",
     ]);
     expect(rubyMethodToTs("visit__no_edges")).toEqual(["visitNoEdges"]);
+  });
+});
+
+describe("rubyMethodToTs predicates", () => {
+  it("strips the redundant is-prefix when the Ruby name already starts with is_", () => {
+    // No `isPrefixed` fallback — that would let trails authors land
+    // isIsNumber and still get api:compare credit, defeating the rule.
+    expect(rubyMethodToTs("is_number?")).toEqual(["isNumber"]);
+    expect(rubyMethodToTs("is_integer?")).toEqual(["isInteger"]);
+    expect(rubyMethodToTs("is_hexadecimal_literal?")).toEqual(["isHexadecimalLiteral"]);
+  });
+
+  it("keeps prepending is for predicates that don't already start with one of the allowlisted prefixes", () => {
+    expect(rubyMethodToTs("number?")).toEqual(["isNumber", "number"]);
+    expect(rubyMethodToTs("blank?")).toEqual(["isBlank", "blank"]);
+    expect(rubyMethodToTs("present?")).toEqual(["isPresent", "present"]);
+  });
+
+  it("keeps the existing has/supports/can/etc allowlist behavior intact (camel preferred, isPrefixed available as fallback)", () => {
+    // Only the `is_*?` family loses the isPrefixed fallback. Other
+    // Ruby predicate prefixes keep both candidates because trails
+    // sometimes needs the disambiguating alias — Reflection exposes
+    // `isHasOne()` alongside the `Model.hasOne` association
+    // declaration, for example.
+    expect(rubyMethodToTs("has_attribute?")).toEqual(["hasAttribute", "isHasAttribute"]);
+    expect(rubyMethodToTs("supports_savepoints?")).toEqual([
+      "supportsSavepoints",
+      "isSupportsSavepoints",
+    ]);
+    expect(rubyMethodToTs("can_load?")).toEqual(["canLoad", "isCanLoad"]);
+    expect(rubyMethodToTs("should_retry?")).toEqual(["shouldRetry", "isShouldRetry"]);
+  });
+
+  it("does NOT treat names that merely camelize to start with 'is' as the is_*? family", () => {
+    // The is_*? guard tests the Ruby BASE NAME, not the camel form.
+    // `isolation_level?` camelizes to `isolationLevel` (starts with
+    // 'is'), but the Ruby base doesn't start with `is_` — keep both
+    // candidates so trails methods named either way still match.
+    expect(rubyMethodToTs("isolation_level?")).toEqual(["isIsolationLevel", "isolationLevel"]);
+    expect(rubyMethodToTs("island?")).toEqual(["isIsland", "island"]);
+  });
+});
+
+describe("rubyFileToTs", () => {
+  it("snake-case → kebab-case .ts", () => {
+    expect(rubyFileToTs("validations/numericality.rb")).toBe("validations/numericality.ts");
+    expect(rubyFileToTs("connection_adapters/postgresql_adapter.rb")).toBe(
+      "connection-adapters/postgresql-adapter.ts",
+    );
   });
 });

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -100,15 +100,6 @@ describe("rubyMethodToTs predicates", () => {
     expect(rubyMethodToTs("can_load?")).toEqual(["canLoad", "isCanLoad"]);
     expect(rubyMethodToTs("should_retry?")).toEqual(["shouldRetry", "isShouldRetry"]);
   });
-
-  it("does NOT treat names that merely camelize to start with 'is' as the is_*? family", () => {
-    // The is_*? guard tests the Ruby BASE NAME, not the camel form.
-    // `isolation_level?` camelizes to `isolationLevel` (starts with
-    // 'is'), but the Ruby base doesn't start with `is_` — keep both
-    // candidates so trails methods named either way still match.
-    expect(rubyMethodToTs("isolation_level?")).toEqual(["isIsolationLevel", "isolationLevel"]);
-    expect(rubyMethodToTs("island?")).toEqual(["isIsland", "island"]);
-  });
 });
 
 describe("rubyFileToTs", () => {

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -104,11 +104,24 @@ export const SKIP = new Set([
 
 /**
  * Convert Ruby method name → candidate TS names to try matching.
- * Returns null if the method should be skipped entirely.
- * Returns multiple candidates for predicates where both forms are common:
- *   has_attribute? → ["hasAttribute", "isHasAttribute"]
- *   supports_savepoints? → ["supportsSavepoints", "isSupportsSavepoints"]
- *   valid? → ["isValid", "valid"]
+ *
+ * Returns null if the method should be skipped entirely. Otherwise
+ * returns one or more candidate TS names; compare.ts matches the first
+ * candidate found in the target file's symbol set.
+ *
+ * Predicate naming policy:
+ *   - `is_*?` returns ONLY the camel form (`is_number?` → ["isNumber"]).
+ *     The doubled `isIsNumber` form is always redundant — Ruby already
+ *     conveys the predicate via the `is_` prefix.
+ *   - Other already-predicate prefixes (`has_*?`, `supports_*?`,
+ *     `can_*?`, …) keep BOTH the camel form and the isPrefixed form
+ *     (`has_attribute?` → ["hasAttribute", "isHasAttribute"]). The
+ *     isPrefixed fallback exists because trails sometimes needs the
+ *     disambiguating alias when the bare name collides with a Rails
+ *     macro — e.g. Reflection exposes `isHasOne()` alongside the
+ *     `Model.hasOne` association declaration.
+ *   - Bare predicates (`valid?`, `blank?`) return both forms with the
+ *     isPrefixed form first (`valid?` → ["isValid", "valid"]).
  */
 export function rubyMethodToTs(name: string): string[] | null {
   if (OPERATORS.has(name)) return null;

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -122,8 +122,11 @@ export function rubyMethodToTs(name: string): string[] | null {
     const base = name.slice(0, -1);
     const camel = snakeToCamel(base);
     const isPrefixed = "is" + camel.replace(/^./, (c) => c.toUpperCase());
-    // If base already starts with a predicate word, try without "is" prefix first
-    if (/^(has|supports|can|should|needs|includes|responds|allows|uses)/.test(camel)) {
+    // If base already starts with a predicate word, try without "is" prefix first.
+    // `is` is included so `is_number?` → `isNumber` (not `isIsNumber`) — Ruby
+    // already conveys the predicate via the `is_` prefix; doubling it on
+    // the TS side gives the redundant `isIsNumber`.
+    if (/^(is|has|supports|can|should|needs|includes|responds|allows|uses)/.test(camel)) {
       return [camel, isPrefixed];
     }
     return [isPrefixed, camel];

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -140,8 +140,11 @@ export function rubyMethodToTs(name: string): string[] | null {
     // The `isPrefixed` form is intentionally NOT offered as a fallback
     // here — Ruby already conveys the predicate via the `is_` prefix,
     // and offering `isIsNumber` would let a trails author land that
-    // doubled form and still get api:compare credit.
-    if (/^is/.test(camel)) {
+    // doubled form and still get api:compare credit. Test on the Ruby
+    // base name (with the underscore) so e.g. `isolation_level?` —
+    // which camelizes to `isolationLevel` — is NOT swept into this
+    // branch.
+    if (base.startsWith("is_")) {
       return [camel];
     }
     // Other already-predicate Ruby prefixes (has_one?, supports_x?,

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -122,11 +122,23 @@ export function rubyMethodToTs(name: string): string[] | null {
     const base = name.slice(0, -1);
     const camel = snakeToCamel(base);
     const isPrefixed = "is" + camel.replace(/^./, (c) => c.toUpperCase());
-    // If base already starts with a predicate word, try without "is" prefix first.
-    // `is` is included so `is_number?` → `isNumber` (not `isIsNumber`) — Ruby
-    // already conveys the predicate via the `is_` prefix; doubling it on
-    // the TS side gives the redundant `isIsNumber`.
-    if (/^(is|has|supports|can|should|needs|includes|responds|allows|uses)/.test(camel)) {
+    // Names already starting with `is_` collapse to one candidate so
+    // `is_number?` → ["isNumber"] (not ["isIsNumber", "isNumber"]).
+    // The `isPrefixed` form is intentionally NOT offered as a fallback
+    // here — Ruby already conveys the predicate via the `is_` prefix,
+    // and offering `isIsNumber` would let a trails author land that
+    // doubled form and still get api:compare credit.
+    if (/^is/.test(camel)) {
+      return [camel];
+    }
+    // Other already-predicate Ruby prefixes (has_one?, supports_x?,
+    // can_y?, …) keep both candidates: the canonical camel form
+    // (`hasOne`) and the isPrefixed fallback (`isHasOne`). The
+    // fallback exists because trails sometimes needs the disambiguating
+    // alias when the bare name collides with a macro (e.g. Reflection
+    // exposes `isHasOne()` as a predicate alongside the `Model.hasOne`
+    // association declaration).
+    if (/^(has|supports|can|should|needs|includes|responds|allows|uses)/.test(camel)) {
       return [camel, isPrefixed];
     }
     return [isPrefixed, camel];

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -19,10 +19,17 @@ export function snakeToCamel(name: string): string {
   return prefix + rest.replace(/_+([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
 }
 
-/** Ruby file path → expected TS file path (kebab-case, .ts extension) */
+/**
+ * Ruby file path → expected TS file path (kebab-case, .ts extension).
+ *
+ * Uses `path.posix.*` so the mapping stays cross-platform stable —
+ * Ruby source paths are POSIX, the rest of api-compare keys files by
+ * POSIX paths, and the default `path.join` would return backslashes
+ * on Windows.
+ */
 export function rubyFileToTs(rubyFile: string): string {
-  const dir = path.dirname(rubyFile);
-  const base = path.basename(rubyFile, ".rb");
+  const dir = path.posix.dirname(rubyFile);
+  const base = path.posix.basename(rubyFile, ".rb");
   const kebab = base.replace(/_/g, "-");
   const tsFile = kebab.replace(/\berb\b/g, "ejs") + ".ts";
   if (dir === ".") return tsFile;
@@ -30,7 +37,7 @@ export function rubyFileToTs(rubyFile: string): string {
     .split("/")
     .map((d) => d.replace(/_/g, "-").replace(/\berb\b/g, "ejs"))
     .join("/");
-  return path.join(tsDir, tsFile);
+  return path.posix.join(tsDir, tsFile);
 }
 
 export const OPERATORS = new Set([

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -94,7 +94,10 @@ function analyzeTsCalls(pkgSrcDir: string): TsCallMap {
     if (sourceFile.fileName.endsWith(".test.ts")) continue;
     if (sourceFile.fileName.endsWith(".d.ts")) continue;
 
-    const relPath = path.relative(pkgSrcDir, sourceFile.fileName);
+    // Normalize separators to POSIX so the keys match rubyFileToTs
+    // output. Windows path.relative emits backslashes; without this
+    // the lookup against rubyFileToTs paths would miss.
+    const relPath = path.relative(pkgSrcDir, sourceFile.fileName).split(path.sep).join("/");
     const fileMap = new Map<string, Set<string>>();
 
     const addMethod = (name: string, body: ts.Node) => {

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -149,7 +149,11 @@ function analyzeTsDepUsage(pkgSrcDir: string, tsImport: string, tsIdentifiers: s
     if (sourceFile.fileName.endsWith(".test.ts")) continue;
     if (sourceFile.fileName.endsWith(".d.ts")) continue;
 
-    const relPath = path.relative(pkgSrcDir, sourceFile.fileName);
+    // Normalize separators to POSIX so the keys match rubyFileToTs
+    // output (which uses path.posix.* for cross-platform stability).
+    // Without this, Windows path.relative emits backslashes and the
+    // tsDepMap.get(rubyFileToTs(...)) lookup misses.
+    const relPath = path.relative(pkgSrcDir, sourceFile.fileName).split(path.sep).join("/");
 
     // Collect import bindings from the target package
     const importedNames = new Set<string>();

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -334,7 +334,12 @@ function crossReference(
     if (!tsCandidates) continue;
 
     const tsFile = rubyFileToTs(rm.rubyFile);
-    const dedupeKey = `${tsFile}:${tsCandidates[0]}`;
+    // Key by Ruby method name, not first TS candidate — two distinct
+    // Ruby methods can produce the same first TS candidate
+    // (`is_number?` and `number?` both → "isNumber"), and keying by
+    // the TS candidate would silently drop the second method. Same
+    // fix as compare.ts:dedupeRubyMethodInto.
+    const dedupeKey = `${tsFile}:${rm.rubyName}`;
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
 


### PR DESCRIPTION
## Summary
Follow-up to PR #1015. Three coupled fixes that together remove the `isIs*` naming and prevent it from happening again for future `is_*?` Rails predicates.

### 1. `conventions.ts` — collapse `is_*?` predicates to a single TS candidate
`is_number?` now maps to **`["isNumber"]`** only. The doubled `isIsNumber` form is intentionally NOT offered as a fallback — Ruby already conveys the predicate via the `is_` prefix, and offering `isIsNumber` would let a trails author land that doubled form and still get api:compare credit. Other already-predicate prefixes (`has_*?`, `supports_*?`, `can_*?`, …) keep BOTH `[camel, isPrefixed]` candidates because trails sometimes needs the disambiguating alias (e.g. Reflection exposes `isHasOne()` alongside the `Model.hasOne` association declaration).

The `is_*?` guard tests `base.startsWith("is_")` (NOT the camel form) so names that merely camelize to start with `"is"` — e.g. `isolation_level?` → `isolationLevel` — keep both candidates.

`rubyFileToTs` switched to `path.posix.*` for cross-platform stability.

### 2. `compare.ts` — dedupe expected set by Ruby method name, not first TS candidate
Previously keyed dedup on the first TS candidate, which silently dropped distinct Ruby methods that produced the same first candidate (e.g. `is_number?` and `number?` both → `"isNumber"`). Without this fix the conventions change above would net-regress **-79 methods** across the codebase. The dedup is now extracted as a small `dedupeRubyMethodInto` helper that's directly unit-testable; it skips Ruby names with no TS-candidate mapping (operators, SKIP list).

Same dedup-by-Ruby-name fix applied to `lint-deps.ts:337`. `lint-deps.ts` and `lint-calls.ts` `tsDepMap` keys now normalize to POSIX separators (matching `rubyFileToTs` output and the existing `extract-ts-api.ts` pattern) so Windows lookups don't miss.

### 3. `numericality.ts` — rename the methods landed in PR #1015
`isIsNumber` → `isNumber`, `isIsInteger` → `isInteger`, `isIsHexadecimalLiteral` → `isHexadecimalLiteral`. Class `declare` declarations, top-level function definitions, prototype assignments, and call sites all updated. Also lands the open Copilot review #9 comment from PR #1015: regression tests pinning `isNumber`'s `string|number` narrowing (rejects `boolean` / Temporal types / plain objects via direct `validateEach` invocation).

Also renames the two pre-existing trails stubs that hit the same pattern: `isIsCachedPlanFailure` → `isCachedPlanFailure` (postgresql-adapter), `isIsColumnTheRowid` → `isColumnTheRowid` (sqlite3 schema-statements). `isHas*` aliases on Reflection / Dirty are intentionally NOT renamed — they're legitimate disambiguation from the Rails macros (`Model.hasOne` / `Model.hasMany`).

## Impact
- `pnpm api:compare --package activemodel`: **433/433 → 448/448** (15 previously-deduped methods now surface and still 100% match).
- `pnpm api:compare --privates --package activemodel`: **477/607 → 495/625** (+18 surfaced, +18 matched).
- `pnpm api:compare` overall: **4685/9883 → 4895/10343** (both numerator and denominator grow because the dedup fix surfaces methods that were previously silently collapsed).
- `pnpm test:compare`: unchanged.

## Test plan
- [x] `pnpm vitest run packages/activemodel scripts/api-compare` — passing (106+ tests across the affected suites)
- [x] `pnpm api:compare --package activemodel` — 448/448
- [x] `pnpm api:compare --privates --package activemodel` — 495/625

## Copilot review history (9 rounds, converged round 9)

Round 9 produced no new comments — review loop converged. Resolved across the prior rounds:

- **Round 1** (4): docstring policy block on `rubyMethodToTs`; tightened `is_*?` guard to `base.startsWith("is_")` so `isolation_level?` keeps both candidates; fixed regression test scope on `numericality-validation.test.ts` (boolean/Temporal/plain-object split into two tests with accurate comments).
- **Round 2** (2): extracted `dedupeRubyMethodInto` as a testable helper + 2 regression tests pinning the dedup-by-Ruby-name behavior; rewrote the plain-object test to call `NumericalityValidator.validateEach` directly with a stub record (StringType.cast was collapsing the object before the validator ran).
- **Round 3** (1): folded the `rubyMethodToTs === null` skip back into `dedupeRubyMethodInto` to keep operator / SKIP-list names from crashing the downstream `!` non-null assertion.
- **Round 4** (3): rewrote PR description; updated stale "unique TS method names" inline comment; relocated `dedupeRubyMethodInto` below `flattenIncludedMethodInfos` so its docblock isn't orphaned.
- **Round 5** (1): `rubyFileToTs` now uses `path.posix.*` for cross-platform stability.
- **Round 6** (1): rewrote `dedupeRubyMethodInto` docstring to describe per-file scope (was misleadingly "FQN-scoped").
- **Round 7** (1): same dedup-by-Ruby-name fix applied to `lint-deps.ts:337` so the two scripts stay consistent.
- **Round 8** (1): normalized `tsDepMap` keys to POSIX separators in `lint-deps.ts` and `lint-calls.ts` (Windows `path.relative` emits backslashes; would miss `rubyFileToTs` POSIX keys without normalization).
- **Round 9** (0): converged.

Ready for human review.