### PR TITLE
refactor(trailties): migrate process.* to activesupport processAdapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,45 +195,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
-      - name: Check trailties src does not bypass processAdapter
-        # `process.*` in `packages/trailties/src/**.ts` must go through
-        # @blazetrails/activesupport (PR 0.3 of the trailties build-out plan).
-        # Two exclusions:
-        #   - `*.test.ts` — tests legitimately mock/inspect the host process
-        #   - `app-generator.ts` — template strings emit user-app code that
-        #     runs in the user's app, where direct process.* is fine
-        #
-        # The pattern enforces two syntactic forms:
-        #   1. dotted access:  process.env / process?.env
-        #   2. bracket access: process["env"] / process?.["env"]
-        # The leading `(^|[^[:alnum:]_])` is a portable word boundary
-        # (GNU and BSD grep both honor it; \b semantics differ across
-        # variants). `exitCode` is listed explicitly because `exit\b`
-        # would not match `exitCode` (the trailing `C` is a word char).
-        run: |
-          set -e
-          # Single grep run, OR the two forms together so output is unified.
-          # Form 1: process.PROP / process?.PROP (dotted, optional chaining)
-          # Form 2: process["PROP"] / process?.["PROP"] (bracket, single or double quotes)
-          #
-          # Trailing `($|[^[:alnum:]_])` on Form 1 ensures we match exactly
-          # the listed props — `process.argv0` won't match `argv`. `exitCode`
-          # is listed before `exit` so the alternation tries it first and
-          # matches greedily (avoids an `exit` partial match leaving `Code`
-          # on the right).
-          PROPS='env|cwd|argv|exitCode|exit|stdout|stderr|platform|on'
-          PATTERN="(^|[^[:alnum:]_])process(\??\.(${PROPS})($|[^[:alnum:]_])|(\?\.)?\[['\"](${PROPS})['\"])"
-          violations=$(grep -rEn "$PATTERN" packages/trailties/src \
-            --include='*.ts' \
-            --exclude='*.test.ts' \
-            --exclude='app-generator.ts' || true)
-          if [ -n "$violations" ]; then
-            echo "Found process.* bypasses in packages/trailties/src (excluding *.test.ts, app-generator.ts)."
-            echo "These must go through @blazetrails/activesupport's processAdapter exports:"
-            echo "$violations"
-            exit 1
-          fi
-          echo "OK: no process.* bypasses in packages/trailties/src (excluding *.test.ts, app-generator.ts)"
   prettier:
     name: Prettier
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,27 +195,39 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
-      - name: Check trailties has no process.* references
-        # `process.*` in trailties src must go through @blazetrails/activesupport
-        # (PR 0.3 of the trailties build-out plan). app-generator.ts contains
-        # template strings that emit user-app code; those are exempt.
+      - name: Check trailties src does not bypass processAdapter
+        # `process.*` in `packages/trailties/src/**.ts` must go through
+        # @blazetrails/activesupport (PR 0.3 of the trailties build-out plan).
+        # Two exclusions:
+        #   - `*.test.ts` — tests legitimately mock/inspect the host process
+        #   - `app-generator.ts` — template strings emit user-app code that
+        #     runs in the user's app, where direct process.* is fine
         #
-        # Pattern uses `(^|[^[:alnum:]_])` instead of `\b` for portability
-        # across grep variants. `exitCode` is listed explicitly because the
-        # `exit` alternation alone won't match `process.exitCode` (GNU grep
-        # ERE word boundary requires non-word after `exit`).
+        # Two patterns enforce three syntactic forms:
+        #   1. dotted access:  process.env / process?.env
+        #   2. bracket access: process["env"] / process?.["env"]
+        # The leading `(^|[^[:alnum:]_])` is a portable word boundary
+        # (GNU and BSD grep both honor it; \b semantics differ across
+        # variants). `exitCode` is listed explicitly because `exit\b`
+        # would not match `exitCode` (the trailing `C` is a word char).
         run: |
           set -e
-          violations=$(grep -rEn '(^|[^[:alnum:]_])process\.(env|cwd|argv|exit|exitCode|stdout|stderr|platform|on)' packages/trailties/src \
+          PROPS='env|cwd|argv|exit|exitCode|stdout|stderr|platform|on'
+          # Single grep run, OR the two forms together so output is unified.
+          # Form 1: process.PROP / process?.PROP (dotted, optional chaining)
+          # Form 2: process["PROP"] / process?.["PROP"] (bracket, single or double quotes)
+          PATTERN="(^|[^[:alnum:]_])process(\??\.(${PROPS})|(\?\.)?\[['\"](${PROPS})['\"])"
+          violations=$(grep -rEn "$PATTERN" packages/trailties/src \
             --include='*.ts' \
             --exclude='*.test.ts' \
             --exclude='app-generator.ts' || true)
           if [ -n "$violations" ]; then
-            echo "❌ Found process.* references in trailties src (must go through @blazetrails/activesupport):"
+            echo "Found process.* bypasses in packages/trailties/src (excluding *.test.ts, app-generator.ts)."
+            echo "These must go through @blazetrails/activesupport's processAdapter exports:"
             echo "$violations"
             exit 1
           fi
-          echo "✓ No process.* references in trailties src"
+          echo "OK: no process.* bypasses in packages/trailties/src (excluding *.test.ts, app-generator.ts)"
   prettier:
     name: Prettier
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,16 @@ jobs:
       - run: pnpm lint
       - name: Check trailties has no process.* references
         # `process.*` in trailties src must go through @blazetrails/activesupport
-        # (PR 0.3 of the trailties build-out plan). bin.ts is the single
-        # sanctioned node-flavored entry — but as of PR 0.3 it also routes
-        # through the adapter, so even bin.ts should be clean. app-generator.ts
-        # contains template strings that emit user-app code; those are exempt.
+        # (PR 0.3 of the trailties build-out plan). app-generator.ts contains
+        # template strings that emit user-app code; those are exempt.
+        #
+        # Pattern uses `(^|[^[:alnum:]_])` instead of `\b` for portability
+        # across grep variants. `exitCode` is listed explicitly because the
+        # `exit` alternation alone won't match `process.exitCode` (GNU grep
+        # ERE word boundary requires non-word after `exit`).
         run: |
           set -e
-          violations=$(grep -rEn '\bprocess\.(env|cwd|argv|exit|stdout|stderr|platform|on)\b' packages/trailties/src \
+          violations=$(grep -rEn '(^|[^[:alnum:]_])process\.(env|cwd|argv|exit|exitCode|stdout|stderr|platform|on)' packages/trailties/src \
             --include='*.ts' \
             --exclude='*.test.ts' \
             --exclude='app-generator.ts' || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         #   - `app-generator.ts` — template strings emit user-app code that
         #     runs in the user's app, where direct process.* is fine
         #
-        # Two patterns enforce three syntactic forms:
+        # The pattern enforces two syntactic forms:
         #   1. dotted access:  process.env / process?.env
         #   2. bracket access: process["env"] / process?.["env"]
         # The leading `(^|[^[:alnum:]_])` is a portable word boundary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,11 +212,17 @@ jobs:
         # would not match `exitCode` (the trailing `C` is a word char).
         run: |
           set -e
-          PROPS='env|cwd|argv|exit|exitCode|stdout|stderr|platform|on'
           # Single grep run, OR the two forms together so output is unified.
           # Form 1: process.PROP / process?.PROP (dotted, optional chaining)
           # Form 2: process["PROP"] / process?.["PROP"] (bracket, single or double quotes)
-          PATTERN="(^|[^[:alnum:]_])process(\??\.(${PROPS})|(\?\.)?\[['\"](${PROPS})['\"])"
+          #
+          # Trailing `($|[^[:alnum:]_])` on Form 1 ensures we match exactly
+          # the listed props — `process.argv0` won't match `argv`. `exitCode`
+          # is listed before `exit` so the alternation tries it first and
+          # matches greedily (avoids an `exit` partial match leaving `Code`
+          # on the right).
+          PROPS='env|cwd|argv|exitCode|exit|stdout|stderr|platform|on'
+          PATTERN="(^|[^[:alnum:]_])process(\??\.(${PROPS})($|[^[:alnum:]_])|(\?\.)?\[['\"](${PROPS})['\"])"
           violations=$(grep -rEn "$PATTERN" packages/trailties/src \
             --include='*.ts' \
             --exclude='*.test.ts' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,24 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - name: Check trailties has no process.* references
+        # `process.*` in trailties src must go through @blazetrails/activesupport
+        # (PR 0.3 of the trailties build-out plan). bin.ts is the single
+        # sanctioned node-flavored entry — but as of PR 0.3 it also routes
+        # through the adapter, so even bin.ts should be clean. app-generator.ts
+        # contains template strings that emit user-app code; those are exempt.
+        run: |
+          set -e
+          violations=$(grep -rEn '\bprocess\.(env|cwd|argv|exit|stdout|stderr|platform|on)\b' packages/trailties/src \
+            --include='*.ts' \
+            --exclude='*.test.ts' \
+            --exclude='app-generator.ts' || true)
+          if [ -n "$violations" ]; then
+            echo "❌ Found process.* references in trailties src (must go through @blazetrails/activesupport):"
+            echo "$violations"
+            exit 1
+          fi
+          echo "✓ No process.* references in trailties src"
   prettier:
     name: Prettier
     needs: changes

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import tseslint from "typescript-eslint";
 import unusedImports from "eslint-plugin-unused-imports";
 import vitest from "@vitest/eslint-plugin";
 import noNodeBuiltins from "./eslint/no-node-builtins.mjs";
+import noProcessBypass from "./eslint/no-process-bypass.mjs";
 import railsPrivateJsdoc from "./eslint/rails-private-jsdoc.mjs";
 
 export default defineConfig(
@@ -94,9 +95,26 @@ export default defineConfig(
       blazetrails: {
         rules: {
           "no-node-builtins": noNodeBuiltins,
+          "no-process-bypass": noProcessBypass,
           "rails-private-jsdoc": railsPrivateJsdoc,
         },
       },
+    },
+  },
+
+  // ── no-process-bypass: forbid direct process.* in trailties src ──
+  // process.* must go through @blazetrails/activesupport's processAdapter
+  // so trailties can run on browser/non-Node hosts. app-generator.ts is
+  // exempt because it contains template strings emitting user-app code
+  // (which legitimately uses process.* at runtime in the user's app).
+  {
+    files: ["packages/trailties/src/**/*.ts"],
+    ignores: [
+      "packages/trailties/src/**/*.test.ts",
+      "packages/trailties/src/generators/app-generator.ts",
+    ],
+    rules: {
+      "blazetrails/no-process-bypass": "error",
     },
   },
 

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -160,14 +160,23 @@ function getAccessedProp(node) {
   if (!node.computed && node.property.type === "Identifier") {
     return REPLACEMENTS[node.property.name] ? node.property.name : null;
   }
-  if (
-    node.computed &&
-    node.property.type === "Literal" &&
-    typeof node.property.value === "string"
+  if (!node.computed) return null;
+
+  // Bracket access: `process["env"]` (Literal) and `process[`env`]`
+  // (TemplateLiteral with no expressions) both compile to the same
+  // string property access at runtime; flag both.
+  let key = null;
+  const prop = node.property;
+  if (prop.type === "Literal" && typeof prop.value === "string") {
+    key = prop.value;
+  } else if (
+    prop.type === "TemplateLiteral" &&
+    prop.expressions.length === 0 &&
+    prop.quasis.length === 1
   ) {
-    return REPLACEMENTS[node.property.value] ? node.property.value : null;
+    key = prop.quasis[0].value.cooked;
   }
-  return null;
+  return key && REPLACEMENTS[key] ? key : null;
 }
 
 /**

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -101,8 +101,30 @@ const REPLACEMENTS = {
   },
 };
 
+/**
+ * Unwrap TypeScript wrapper expressions that don't change the runtime
+ * value: non-null assertion (`x!`), type assertions (`x as T`,
+ * `<T>x`), and parenthesized expressions. Without unwrapping, forms
+ * like `process!.env` or `(process as any).env` would silently bypass
+ * the rule.
+ */
+function unwrap(node) {
+  while (
+    node &&
+    (node.type === "TSNonNullExpression" ||
+      node.type === "TSAsExpression" ||
+      node.type === "TSTypeAssertion" ||
+      node.type === "TSSatisfiesExpression" ||
+      node.type === "ParenthesizedExpression")
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
 function isProcessIdentifier(node) {
-  return node && node.type === "Identifier" && node.name === "process";
+  const inner = unwrap(node);
+  return inner && inner.type === "Identifier" && inner.name === "process";
 }
 
 function getAccessedProp(node) {
@@ -165,7 +187,40 @@ const rule = {
     },
   },
   create(context) {
+    /**
+     * Catch destructuring forms: `const { env, cwd } = process;` and
+     * `const { env: e } = process;`. Each disallowed property in the
+     * pattern is reported separately so the message points at the
+     * exact violation.
+     */
+    function checkDestructuring(declarator) {
+      if (!declarator.init) return;
+      if (declarator.id.type !== "ObjectPattern") return;
+      if (!isProcessIdentifier(declarator.init)) return;
+      for (const propNode of declarator.id.properties) {
+        if (propNode.type !== "Property" || propNode.computed) continue;
+        const keyName =
+          propNode.key.type === "Identifier"
+            ? propNode.key.name
+            : propNode.key.type === "Literal" && typeof propNode.key.value === "string"
+              ? propNode.key.value
+              : null;
+        if (!keyName || !REPLACEMENTS[keyName]) continue;
+        const replacement = REPLACEMENTS[keyName];
+        context.report({
+          node: propNode,
+          messageId: "bypass",
+          data: {
+            prop: keyName,
+            importName: replacement.importName,
+            note: replacement.note,
+          },
+        });
+      }
+    }
+
     return {
+      VariableDeclarator: checkDestructuring,
       MemberExpression(node) {
         if (!isProcessIdentifier(node.object)) return;
         const prop = getAccessedProp(node);

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -52,22 +52,29 @@ const REPLACEMENTS = {
     importName: "setExitCode",
     note: "call setExitCode(code) instead",
     fixable: true,
-    // process.exitCode = N → setExitCode(N): rewrite the parent
-    // AssignmentExpression. Only autofix when parent is `=` assignment;
-    // bare reads of process.exitCode are rare enough to leave alone.
+    // process.exitCode = N → setExitCode(N): only autofix when the
+    // assignment is a top-level ExpressionStatement. The assignment's
+    // value is `N` (assignment expressions evaluate to the RHS), so
+    // rewriting `if ((process.exitCode = 1)) ...` to
+    // `if (setExitCode(1)) ...` would silently change the condition
+    // (setExitCode returns void). Bail when the parent isn't a
+    // statement so the user can rewrite by hand.
     rewrite(memberNode, fixer, localName, context) {
-      const parent = memberNode.parent;
+      const assign = memberNode.parent;
       if (
-        parent &&
-        parent.type === "AssignmentExpression" &&
-        parent.operator === "=" &&
-        parent.left === memberNode
+        !assign ||
+        assign.type !== "AssignmentExpression" ||
+        assign.operator !== "=" ||
+        assign.left !== memberNode
       ) {
-        const sourceCode = context.sourceCode || context.getSourceCode();
-        const valueText = sourceCode.getText(parent.right);
-        return [fixer.replaceText(parent, `${localName}(${valueText})`)];
+        return null;
       }
-      return null;
+      if (!assign.parent || assign.parent.type !== "ExpressionStatement") {
+        return null;
+      }
+      const sourceCode = context.sourceCode || context.getSourceCode();
+      const valueText = sourceCode.getText(assign.right);
+      return [fixer.replaceText(assign, `${localName}(${valueText})`)];
     },
   },
   stdout: {
@@ -99,8 +106,25 @@ const REPLACEMENTS = {
     importName: "onSignal",
     note: "call onSignal(name, handler) instead",
     fixable: true,
-    // process.on(...) → onSignal(...): replace `process.on` with `onSignal`.
+    // process.on(name, h) → onSignal(name, h): only autofix when the
+    // first argument is a string literal of a signal name onSignal
+    // accepts. `process.on('exit', h)`, `process.on('message', h)`,
+    // etc. are NOT signals — onSignal would reject them at the type
+    // level. Leave those as a manual rewrite.
     rewrite(memberNode, fixer, localName) {
+      const call = memberNode.parent;
+      if (
+        !call ||
+        call.type !== "CallExpression" ||
+        call.callee !== memberNode ||
+        call.arguments.length === 0
+      ) {
+        return null;
+      }
+      const first = call.arguments[0];
+      const isSignalLiteral =
+        first.type === "Literal" && (first.value === "SIGINT" || first.value === "SIGTERM");
+      if (!isSignalLiteral) return null;
       return [fixer.replaceText(memberNode, localName)];
     },
   },

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -6,21 +6,99 @@
  * Catches both dotted and bracket access, with or without optional
  * chaining. Points the violator at the corresponding adapter export.
  *
+ * Autofix: enabled for properties where the replacement symbol is
+ * unlikely to clash with local code (`setExitCode`, `onSignal`,
+ * `platform`, `exit`, `stdout`, `stderr`). Skipped for `cwd`, `env`,
+ * and `argv` since those names are commonly used as local variables;
+ * the user should pick an alias rather than risk silent shadowing.
+ *
  * Scope: this rule has no allow-list of files. Wire it up in
  * `eslint.config.mjs` only for the directories that should follow the
  * adapter contract (e.g. `packages/trailties/src/**`).
  */
 
+const SOURCE = "@blazetrails/activesupport/process-adapter";
+
+// Each entry describes one disallowed property. `fixable` controls
+// whether autofix runs; `rewrite(node, fixer, localName)` returns the
+// list of fixer ops for the replacement (excluding the import — that
+// is handled centrally).
 const REPLACEMENTS = {
-  cwd: { import: "cwd", note: "call cwd() instead" },
-  env: { import: "env", note: "use the env snapshot; mutate via setEnv()" },
-  argv: { import: "argv", note: "use the argv snapshot" },
-  exit: { import: "exit", note: "call exit(code) instead" },
-  exitCode: { import: "setExitCode", note: "call setExitCode(code) instead" },
-  stdout: { import: "stdout", note: "use stdout.write(...)" },
-  stderr: { import: "stderr", note: "use stderr.write(...)" },
-  platform: { import: "platform", note: "call platform() instead" },
-  on: { import: "onSignal", note: "call onSignal(name, handler) instead" },
+  cwd: {
+    importName: "cwd",
+    note: "call cwd() instead",
+    fixable: false, // local `cwd` variables are too common to autofix safely
+  },
+  env: {
+    importName: "env",
+    note: "use the env snapshot; mutate via setEnv()",
+    fixable: false,
+  },
+  argv: {
+    importName: "argv",
+    note: "use the argv snapshot",
+    fixable: false,
+  },
+  exit: {
+    importName: "exit",
+    note: "call exit(code) instead",
+    fixable: true,
+    // process.exit(c) → exit(c): replace just `process.exit` with `exit`
+    rewrite(memberNode, fixer, localName) {
+      return [fixer.replaceText(memberNode, localName)];
+    },
+  },
+  exitCode: {
+    importName: "setExitCode",
+    note: "call setExitCode(code) instead",
+    fixable: true,
+    // process.exitCode = N → setExitCode(N): rewrite the parent
+    // AssignmentExpression. Only autofix when parent is `=` assignment;
+    // bare reads of process.exitCode are rare enough to leave alone.
+    rewrite(memberNode, fixer, localName, context) {
+      const parent = memberNode.parent;
+      if (parent && parent.type === "AssignmentExpression" && parent.operator === "=" && parent.left === memberNode) {
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        const valueText = sourceCode.getText(parent.right);
+        return [fixer.replaceText(parent, `${localName}(${valueText})`)];
+      }
+      return null;
+    },
+  },
+  stdout: {
+    importName: "stdout",
+    note: "use stdout.write(...)",
+    fixable: true,
+    rewrite(memberNode, fixer, localName) {
+      return [fixer.replaceText(memberNode, localName)];
+    },
+  },
+  stderr: {
+    importName: "stderr",
+    note: "use stderr.write(...)",
+    fixable: true,
+    rewrite(memberNode, fixer, localName) {
+      return [fixer.replaceText(memberNode, localName)];
+    },
+  },
+  platform: {
+    importName: "platform",
+    note: "call platform() instead",
+    fixable: true,
+    // process.platform → platform() — turn the property access into a call.
+    rewrite(memberNode, fixer, localName) {
+      return [fixer.replaceText(memberNode, `${localName}()`)];
+    },
+  },
+  on: {
+    importName: "onSignal",
+    note: "call onSignal(name, handler) instead",
+    fixable: true,
+    // process.on(...) → onSignal(...): replace `process.on` with `onSignal`.
+    rewrite(memberNode, fixer, localName) {
+      return [fixer.replaceText(memberNode, localName)];
+    },
+  },
 };
 
 function isProcessIdentifier(node) {
@@ -28,8 +106,6 @@ function isProcessIdentifier(node) {
 }
 
 function getAccessedProp(node) {
-  // node is a MemberExpression. Returns the accessed property name if it
-  // matches one of the disallowed props, else null.
   if (!node.computed && node.property.type === "Identifier") {
     return REPLACEMENTS[node.property.name] ? node.property.name : null;
   }
@@ -43,10 +119,41 @@ function getAccessedProp(node) {
   return null;
 }
 
+/**
+ * Find an existing `import ... from "@blazetrails/activesupport/process-adapter"`
+ * statement in the file. Returns the ImportDeclaration node or null.
+ */
+function findAdapterImport(programBody) {
+  for (const stmt of programBody) {
+    if (
+      stmt.type === "ImportDeclaration" &&
+      stmt.source.value === SOURCE &&
+      stmt.importKind !== "type"
+    ) {
+      return stmt;
+    }
+  }
+  return null;
+}
+
+/**
+ * If `importDecl` already imports `name` (possibly aliased), return the
+ * local name. Otherwise return null.
+ */
+function findSpecifier(importDecl, name) {
+  for (const spec of importDecl.specifiers) {
+    if (spec.type === "ImportSpecifier" && spec.imported.name === name) {
+      return spec.local.name;
+    }
+  }
+  return null;
+}
+
 /** @type {import("eslint").Rule.RuleModule} */
 const rule = {
   meta: {
     type: "problem",
+    fixable: "code",
     docs: {
       description:
         "Forbid direct process.<prop> access in favor of @blazetrails/activesupport/process-adapter exports",
@@ -58,23 +165,79 @@ const rule = {
     },
   },
   create(context) {
-    function check(node) {
-      if (!isProcessIdentifier(node.object)) return;
-      const prop = getAccessedProp(node);
-      if (!prop) return;
-      const replacement = REPLACEMENTS[prop];
-      context.report({
-        node,
-        messageId: "bypass",
-        data: {
-          prop,
-          importName: replacement.import,
-          note: replacement.note,
-        },
-      });
-    }
     return {
-      MemberExpression: check,
+      MemberExpression(node) {
+        if (!isProcessIdentifier(node.object)) return;
+        const prop = getAccessedProp(node);
+        if (!prop) return;
+        const replacement = REPLACEMENTS[prop];
+        const sourceCode = context.sourceCode || context.getSourceCode();
+
+        const report = {
+          node,
+          messageId: "bypass",
+          data: {
+            prop,
+            importName: replacement.importName,
+            note: replacement.note,
+          },
+        };
+
+        if (replacement.fixable) {
+          report.fix = (fixer) => {
+            const program = sourceCode.ast;
+            const existingImport = findAdapterImport(program.body);
+            const existingLocal = existingImport
+              ? findSpecifier(existingImport, replacement.importName)
+              : null;
+            const localName = existingLocal ?? replacement.importName;
+
+            const rewriteFixes = replacement.rewrite(node, fixer, localName, context);
+            if (!rewriteFixes) return null;
+
+            // Already imported under that name — just rewrite the access.
+            if (existingLocal) return rewriteFixes;
+
+            // No existing import or no specifier — add one.
+            if (existingImport) {
+              // Append to existing import from the same source. Bail if
+              // it uses default/namespace forms (mixed forms are awkward).
+              const onlyNamed = existingImport.specifiers.every(
+                (s) => s.type === "ImportSpecifier",
+              );
+              if (!onlyNamed) return null;
+              if (existingImport.specifiers.length === 0) {
+                // Edge case: `import {} from "..."` — replace whole import
+                return [
+                  fixer.replaceText(
+                    existingImport,
+                    `import { ${replacement.importName} } from "${SOURCE}";`,
+                  ),
+                  ...rewriteFixes,
+                ];
+              }
+              const lastSpec =
+                existingImport.specifiers[existingImport.specifiers.length - 1];
+              return [
+                fixer.insertTextAfter(lastSpec, `, ${replacement.importName}`),
+                ...rewriteFixes,
+              ];
+            }
+
+            // Insert a new import at the top of the file.
+            const firstStmt = program.body[0];
+            const importText = `import { ${replacement.importName} } from "${SOURCE}";\n`;
+            return [
+              firstStmt
+                ? fixer.insertTextBefore(firstStmt, importText)
+                : fixer.insertTextAfterRange([0, 0], importText),
+              ...rewriteFixes,
+            ];
+          };
+        }
+
+        context.report(report);
+      },
     };
   },
 };

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -57,7 +57,12 @@ const REPLACEMENTS = {
     // bare reads of process.exitCode are rare enough to leave alone.
     rewrite(memberNode, fixer, localName, context) {
       const parent = memberNode.parent;
-      if (parent && parent.type === "AssignmentExpression" && parent.operator === "=" && parent.left === memberNode) {
+      if (
+        parent &&
+        parent.type === "AssignmentExpression" &&
+        parent.operator === "=" &&
+        parent.left === memberNode
+      ) {
         const sourceCode = context.sourceCode || context.getSourceCode();
         const valueText = sourceCode.getText(parent.right);
         return [fixer.replaceText(parent, `${localName}(${valueText})`)];
@@ -271,8 +276,7 @@ const rule = {
                   ...rewriteFixes,
                 ];
               }
-              const lastSpec =
-                existingImport.specifiers[existingImport.specifiers.length - 1];
+              const lastSpec = existingImport.specifiers[existingImport.specifiers.length - 1];
               return [
                 fixer.insertTextAfter(lastSpec, `, ${replacement.importName}`),
                 ...rewriteFixes,

--- a/eslint/no-process-bypass.mjs
+++ b/eslint/no-process-bypass.mjs
@@ -1,0 +1,82 @@
+/**
+ * ESLint rule: no-process-bypass
+ *
+ * Forbids direct `process.<prop>` access for the host operations that
+ * trailties routes through `@blazetrails/activesupport`'s processAdapter.
+ * Catches both dotted and bracket access, with or without optional
+ * chaining. Points the violator at the corresponding adapter export.
+ *
+ * Scope: this rule has no allow-list of files. Wire it up in
+ * `eslint.config.mjs` only for the directories that should follow the
+ * adapter contract (e.g. `packages/trailties/src/**`).
+ */
+
+const REPLACEMENTS = {
+  cwd: { import: "cwd", note: "call cwd() instead" },
+  env: { import: "env", note: "use the env snapshot; mutate via setEnv()" },
+  argv: { import: "argv", note: "use the argv snapshot" },
+  exit: { import: "exit", note: "call exit(code) instead" },
+  exitCode: { import: "setExitCode", note: "call setExitCode(code) instead" },
+  stdout: { import: "stdout", note: "use stdout.write(...)" },
+  stderr: { import: "stderr", note: "use stderr.write(...)" },
+  platform: { import: "platform", note: "call platform() instead" },
+  on: { import: "onSignal", note: "call onSignal(name, handler) instead" },
+};
+
+function isProcessIdentifier(node) {
+  return node && node.type === "Identifier" && node.name === "process";
+}
+
+function getAccessedProp(node) {
+  // node is a MemberExpression. Returns the accessed property name if it
+  // matches one of the disallowed props, else null.
+  if (!node.computed && node.property.type === "Identifier") {
+    return REPLACEMENTS[node.property.name] ? node.property.name : null;
+  }
+  if (
+    node.computed &&
+    node.property.type === "Literal" &&
+    typeof node.property.value === "string"
+  ) {
+    return REPLACEMENTS[node.property.value] ? node.property.value : null;
+  }
+  return null;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid direct process.<prop> access in favor of @blazetrails/activesupport/process-adapter exports",
+    },
+    schema: [],
+    messages: {
+      bypass:
+        "Direct `process.{{prop}}` is not allowed here. Import `{{importName}}` from `@blazetrails/activesupport/process-adapter` and {{note}}.",
+    },
+  },
+  create(context) {
+    function check(node) {
+      if (!isProcessIdentifier(node.object)) return;
+      const prop = getAccessedProp(node);
+      if (!prop) return;
+      const replacement = REPLACEMENTS[prop];
+      context.report({
+        node,
+        messageId: "bypass",
+        data: {
+          prop,
+          importName: replacement.import,
+          note: replacement.note,
+        },
+      });
+    }
+    return {
+      MemberExpression: check,
+    };
+  },
+};
+
+export default rule;

--- a/eslint/no-process-bypass.test.mjs
+++ b/eslint/no-process-bypass.test.mjs
@@ -3,42 +3,78 @@ import rule from "./no-process-bypass.mjs";
 
 const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: "module" } });
 
+const SOURCE = "@blazetrails/activesupport/process-adapter";
+
 tester.run("no-process-bypass", rule, {
   valid: [
     // Adapter-routed forms
-    'import { cwd } from "@blazetrails/activesupport/process-adapter"; cwd();',
-    'import { env } from "@blazetrails/activesupport/process-adapter"; env.FOO;',
-    'import { setExitCode } from "@blazetrails/activesupport/process-adapter"; setExitCode(1);',
+    `import { cwd } from "${SOURCE}"; cwd();`,
+    `import { env } from "${SOURCE}"; env.FOO;`,
+    `import { setExitCode } from "${SOURCE}"; setExitCode(1);`,
     // Suffix-match safety: identifiers that share a prefix with `process` are fine
     "const myprocess = {}; myprocess.env;",
     // Unrelated property on process is not flagged (only the listed props)
     "process.versions.node;",
     "process.pid;",
-    // Nested property access on a non-process object that has the same shape
-    "obj.process.env;", // process here is not the global, just a property
+    // `process` as a property name on another object is not flagged
+    "obj.process.env;",
   ],
   invalid: [
-    // Dotted access — every disallowed prop
-    { code: "process.env.FOO;", errors: [{ messageId: "bypass" }] },
-    { code: "process.cwd();", errors: [{ messageId: "bypass" }] },
-    { code: "process.argv;", errors: [{ messageId: "bypass" }] },
-    { code: "process.exit(1);", errors: [{ messageId: "bypass" }] },
-    { code: "process.exitCode = 1;", errors: [{ messageId: "bypass" }] },
-    { code: "process.stdout.write('x');", errors: [{ messageId: "bypass" }] },
-    { code: "process.stderr.write('x');", errors: [{ messageId: "bypass" }] },
-    { code: "process.platform;", errors: [{ messageId: "bypass" }] },
-    { code: "process.on('SIGINT', () => {});", errors: [{ messageId: "bypass" }] },
-    // Optional chaining
-    { code: "process?.env;", errors: [{ messageId: "bypass" }] },
-    { code: "process?.cwd?.();", errors: [{ messageId: "bypass" }] },
-    // Bracket access
-    { code: 'process["env"];', errors: [{ messageId: "bypass" }] },
-    { code: "process['cwd'];", errors: [{ messageId: "bypass" }] },
-    // Optional bracket access
-    { code: 'process?.["env"];', errors: [{ messageId: "bypass" }] },
-    // process.env presence check (in operator)
-    { code: '"FOO" in process.env;', errors: [{ messageId: "bypass" }] },
-    // Assignment is also flagged (env mutation)
-    { code: "process.env.FOO = 'x';", errors: [{ messageId: "bypass" }] },
+    // ── Risky props: flagged but NOT autofixed (local clash risk) ──
+    { code: "process.cwd();", errors: [{ messageId: "bypass" }], output: null },
+    { code: "process.env.FOO;", errors: [{ messageId: "bypass" }], output: null },
+    { code: "process.argv;", errors: [{ messageId: "bypass" }], output: null },
+    { code: "process.argv[0];", errors: [{ messageId: "bypass" }], output: null },
+    { code: "process?.env;", errors: [{ messageId: "bypass" }], output: null },
+    { code: 'process["env"];', errors: [{ messageId: "bypass" }], output: null },
+    { code: "process['cwd'];", errors: [{ messageId: "bypass" }], output: null },
+    { code: 'process?.["env"];', errors: [{ messageId: "bypass" }], output: null },
+    { code: '"FOO" in process.env;', errors: [{ messageId: "bypass" }], output: null },
+    { code: "process.env.FOO = 'x';", errors: [{ messageId: "bypass" }], output: null },
+
+    // ── Autofixable props ──
+    {
+      code: "process.exitCode = 1;",
+      errors: [{ messageId: "bypass" }],
+      output: `import { setExitCode } from "${SOURCE}";\nsetExitCode(1);`,
+    },
+    {
+      code: "process.exit(2);",
+      errors: [{ messageId: "bypass" }],
+      output: `import { exit } from "${SOURCE}";\nexit(2);`,
+    },
+    {
+      code: "process.platform;",
+      errors: [{ messageId: "bypass" }],
+      output: `import { platform } from "${SOURCE}";\nplatform();`,
+    },
+    {
+      code: "process.stdout.write('hi');",
+      errors: [{ messageId: "bypass" }],
+      output: `import { stdout } from "${SOURCE}";\nstdout.write('hi');`,
+    },
+    {
+      code: "process.stderr.write('err');",
+      errors: [{ messageId: "bypass" }],
+      output: `import { stderr } from "${SOURCE}";\nstderr.write('err');`,
+    },
+    {
+      code: "process.on('SIGINT', () => {});",
+      errors: [{ messageId: "bypass" }],
+      output: `import { onSignal } from "${SOURCE}";\nonSignal('SIGINT', () => {});`,
+    },
+
+    // ── Import merging: append to existing import from the same source ──
+    {
+      code: `import { cwd } from "${SOURCE}";\nprocess.exitCode = 0;`,
+      errors: [{ messageId: "bypass" }],
+      output: `import { cwd, setExitCode } from "${SOURCE}";\nsetExitCode(0);`,
+    },
+    // Already-imported (possibly aliased) symbol: reuse the local name.
+    {
+      code: `import { setExitCode as setEC } from "${SOURCE}";\nprocess.exitCode = 1;`,
+      errors: [{ messageId: "bypass" }],
+      output: `import { setExitCode as setEC } from "${SOURCE}";\nsetEC(1);`,
+    },
   ],
 });

--- a/eslint/no-process-bypass.test.mjs
+++ b/eslint/no-process-bypass.test.mjs
@@ -86,6 +86,48 @@ tester.run("no-process-bypass", rule, {
       output: `import { setExitCode as setEC } from "${SOURCE}";\nsetEC(1);`,
     },
 
+    // ── Autofix safety gates ──
+    // exitCode in expression context: flagged but NOT autofixed (semantics
+    // would change — assignment evaluates to the RHS but setExitCode is void)
+    {
+      code: "if ((process.exitCode = 1)) {}",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    {
+      code: "foo(process.exitCode = 1);",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    {
+      code: "const x = process.exitCode = 1;",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // process.on with a non-signal event name: flagged but NOT autofixed
+    {
+      code: "process.on('exit', () => {});",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    {
+      code: "process.on('message', () => {});",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // process.on with dynamic name: flagged but NOT autofixed
+    {
+      code: "process.on(name, () => {});",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // process.on with SIGTERM: autofixed (other supported signal)
+    {
+      code: "process.on('SIGTERM', h);",
+      errors: [{ messageId: "bypass" }],
+      output: `import { onSignal } from "${SOURCE}";\nonSignal('SIGTERM', h);`,
+    },
+
     // ── TypeScript wrapper bypasses ──
     // Non-null assertion: process!.env
     { code: "process!.env;", errors: [{ messageId: "bypass" }], output: null },

--- a/eslint/no-process-bypass.test.mjs
+++ b/eslint/no-process-bypass.test.mjs
@@ -1,7 +1,16 @@
 import { RuleTester } from "eslint";
 import rule from "./no-process-bypass.mjs";
 
-const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: "module" } });
+// Use the TypeScript parser since this rule is enforced on *.ts files.
+// Without it, TS-only bypasses (process!, process as any, etc.) wouldn't
+// even parse in the test, let alone get exercised.
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parser: (await import("typescript-eslint")).parser,
+  },
+});
 
 const SOURCE = "@blazetrails/activesupport/process-adapter";
 
@@ -75,6 +84,52 @@ tester.run("no-process-bypass", rule, {
       code: `import { setExitCode as setEC } from "${SOURCE}";\nprocess.exitCode = 1;`,
       errors: [{ messageId: "bypass" }],
       output: `import { setExitCode as setEC } from "${SOURCE}";\nsetEC(1);`,
+    },
+
+    // ── TypeScript wrapper bypasses ──
+    // Non-null assertion: process!.env
+    { code: "process!.env;", errors: [{ messageId: "bypass" }], output: null },
+    // `as` type assertion: (process as any).cwd()
+    { code: "(process as any).cwd();", errors: [{ messageId: "bypass" }], output: null },
+    // Old-style type assertion: <any>process .env (rarely used in TS files)
+    { code: "(<any>process).env;", errors: [{ messageId: "bypass" }], output: null },
+    // Parenthesized: (process).env
+    { code: "(process).env;", errors: [{ messageId: "bypass" }], output: null },
+    // satisfies: (process satisfies object).env
+    { code: "(process satisfies object).env;", errors: [{ messageId: "bypass" }], output: null },
+    // Combined: ((process as any)!).env
+    { code: "((process as any)!).env;", errors: [{ messageId: "bypass" }], output: null },
+
+    // ── Destructuring ──
+    // Direct destructure of process
+    {
+      code: "const { env } = process;",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // Multiple props in one declarator
+    {
+      code: "const { env, cwd } = process;",
+      errors: [{ messageId: "bypass" }, { messageId: "bypass" }],
+      output: null,
+    },
+    // Renamed destructure
+    {
+      code: "const { env: e } = process;",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // Destructure of an unwrapped TS expression
+    {
+      code: "const { env } = process!;",
+      errors: [{ messageId: "bypass" }],
+      output: null,
+    },
+    // Mix of safe + unsafe props — only the unsafe one is reported
+    {
+      code: "const { pid, env } = process;",
+      errors: [{ messageId: "bypass" }],
+      output: null,
     },
   ],
 });

--- a/eslint/no-process-bypass.test.mjs
+++ b/eslint/no-process-bypass.test.mjs
@@ -1,0 +1,44 @@
+import { RuleTester } from "eslint";
+import rule from "./no-process-bypass.mjs";
+
+const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: "module" } });
+
+tester.run("no-process-bypass", rule, {
+  valid: [
+    // Adapter-routed forms
+    'import { cwd } from "@blazetrails/activesupport/process-adapter"; cwd();',
+    'import { env } from "@blazetrails/activesupport/process-adapter"; env.FOO;',
+    'import { setExitCode } from "@blazetrails/activesupport/process-adapter"; setExitCode(1);',
+    // Suffix-match safety: identifiers that share a prefix with `process` are fine
+    "const myprocess = {}; myprocess.env;",
+    // Unrelated property on process is not flagged (only the listed props)
+    "process.versions.node;",
+    "process.pid;",
+    // Nested property access on a non-process object that has the same shape
+    "obj.process.env;", // process here is not the global, just a property
+  ],
+  invalid: [
+    // Dotted access — every disallowed prop
+    { code: "process.env.FOO;", errors: [{ messageId: "bypass" }] },
+    { code: "process.cwd();", errors: [{ messageId: "bypass" }] },
+    { code: "process.argv;", errors: [{ messageId: "bypass" }] },
+    { code: "process.exit(1);", errors: [{ messageId: "bypass" }] },
+    { code: "process.exitCode = 1;", errors: [{ messageId: "bypass" }] },
+    { code: "process.stdout.write('x');", errors: [{ messageId: "bypass" }] },
+    { code: "process.stderr.write('x');", errors: [{ messageId: "bypass" }] },
+    { code: "process.platform;", errors: [{ messageId: "bypass" }] },
+    { code: "process.on('SIGINT', () => {});", errors: [{ messageId: "bypass" }] },
+    // Optional chaining
+    { code: "process?.env;", errors: [{ messageId: "bypass" }] },
+    { code: "process?.cwd?.();", errors: [{ messageId: "bypass" }] },
+    // Bracket access
+    { code: 'process["env"];', errors: [{ messageId: "bypass" }] },
+    { code: "process['cwd'];", errors: [{ messageId: "bypass" }] },
+    // Optional bracket access
+    { code: 'process?.["env"];', errors: [{ messageId: "bypass" }] },
+    // process.env presence check (in operator)
+    { code: '"FOO" in process.env;', errors: [{ messageId: "bypass" }] },
+    // Assignment is also flagged (env mutation)
+    { code: "process.env.FOO = 'x';", errors: [{ messageId: "bypass" }] },
+  ],
+});

--- a/eslint/no-process-bypass.test.mjs
+++ b/eslint/no-process-bypass.test.mjs
@@ -27,6 +27,9 @@ tester.run("no-process-bypass", rule, {
     "process.pid;",
     // `process` as a property name on another object is not flagged
     "obj.process.env;",
+    // Interpolated template-literal bracket access: dynamic name, not flagged.
+    "process[`${'en' + 'v'}`];",
+    "process[`${dynKey}`];",
   ],
   invalid: [
     // ── Risky props: flagged but NOT autofixed (local clash risk) ──
@@ -127,6 +130,15 @@ tester.run("no-process-bypass", rule, {
       errors: [{ messageId: "bypass" }],
       output: `import { onSignal } from "${SOURCE}";\nonSignal('SIGTERM', h);`,
     },
+
+    // ── Template-literal bracket access (no interpolation) ──
+    // process[`env`] is identical to process["env"] at runtime; flag it.
+    { code: "process[`env`];", errors: [{ messageId: "bypass" }], output: null },
+    { code: "process[`cwd`]();", errors: [{ messageId: "bypass" }], output: null },
+    // Template literals WITH interpolation are dynamic and not flagged
+    // — we can't statically know the property name. Documenting via
+    // an explicit valid case in the suite below would require valid:[]
+    // entries; covered implicitly by absence of error.
 
     // ── TypeScript wrapper bypasses ──
     // Non-null assertion: process!.env

--- a/packages/trailties/src/bin.ts
+++ b/packages/trailties/src/bin.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+import { argv } from "@blazetrails/activesupport";
 import { createProgram } from "./cli.js";
 
 const program = createProgram();
-program.parse(process.argv);
+// `argv` is the process adapter's snapshot of the host argv, populated
+// at activesupport's module load via the eager Node auto-register.
+program.parse(argv as string[]);

--- a/packages/trailties/src/bin.ts
+++ b/packages/trailties/src/bin.ts
@@ -5,4 +5,5 @@ import { createProgram } from "./cli.js";
 const program = createProgram();
 // `argv` is the process adapter's snapshot of the host argv, populated
 // at activesupport's module load via the eager Node auto-register.
-program.parse(argv as string[]);
+// Spread into a fresh mutable array since Commander expects string[].
+program.parse([...argv]);

--- a/packages/trailties/src/bin.ts
+++ b/packages/trailties/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { argv } from "@blazetrails/activesupport";
+import { argv } from "@blazetrails/activesupport/process-adapter";
 import { createProgram } from "./cli.js";
 
 const program = createProgram();

--- a/packages/trailties/src/commands/console.ts
+++ b/packages/trailties/src/commands/console.ts
@@ -1,4 +1,4 @@
-import { cwd } from "@blazetrails/activesupport";
+import { cwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import * as path from "node:path";
 import * as fs from "node:fs";

--- a/packages/trailties/src/commands/console.ts
+++ b/packages/trailties/src/commands/console.ts
@@ -1,3 +1,4 @@
+import { cwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -77,7 +78,7 @@ export function consoleCommand(): Command {
     // Copy globals into the REPL context
     r.context.console = console;
     r.context.process = process;
-    r.context.require = createRequire(path.join(process.cwd(), "package.json"));
+    r.context.require = createRequire(path.join(cwd(), "package.json"));
 
     r.on("exit", async () => {
       if (dbAdapter && typeof dbAdapter.close === "function") {
@@ -95,7 +96,7 @@ export function consoleCommand(): Command {
     }
 
     // Load models from the current project
-    const modelsDir = path.join(process.cwd(), "src", "app", "models");
+    const modelsDir = path.join(cwd(), "src", "app", "models");
     let loadedCount = 0;
     if (fs.existsSync(modelsDir)) {
       const files = fs

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -451,7 +451,7 @@ describe("resolveSchemaFormat", () => {
     // --format="", SCHEMA_FORMAT="", schemaFormat: "" in config all
     // represent an explicitly-set knob; they shouldn't silently fall
     // through to inference. Detection is presence-based (`!== undefined`
-    // / `"KEY" in process.env` / `"schemaFormat" in module`) so a
+    // / `"KEY" in env` / `"schemaFormat" in module`) so a
     // deliberately-empty value reaches the validator.
     await expect(resolveSchemaFormat({ format: "" }, tmpDir)).rejects.toThrow(/Invalid --format/);
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { env, setEnv } from "@blazetrails/activesupport";
+import { env, setEnv } from "@blazetrails/activesupport/process-adapter";
 import { createProgram } from "../cli.js";
 import {
   loadDatabaseConfig,

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { env, setEnv } from "@blazetrails/activesupport";
 import { createProgram } from "../cli.js";
 import {
   loadDatabaseConfig,
@@ -124,31 +125,29 @@ describe("DbCommand", () => {
 });
 
 describe("resolveEnv", () => {
-  const origRailsEnv = process.env.TRAILS_ENV;
-  const origNodeEnv = process.env.NODE_ENV;
+  const origRailsEnv = env.TRAILS_ENV;
+  const origNodeEnv = env.NODE_ENV;
 
   afterEach(() => {
-    if (origRailsEnv === undefined) delete process.env.TRAILS_ENV;
-    else process.env.TRAILS_ENV = origRailsEnv;
-    if (origNodeEnv === undefined) delete process.env.NODE_ENV;
-    else process.env.NODE_ENV = origNodeEnv;
+    setEnv("TRAILS_ENV", origRailsEnv);
+    setEnv("NODE_ENV", origNodeEnv);
   });
 
   it("prefers TRAILS_ENV", () => {
-    process.env.TRAILS_ENV = "staging";
-    process.env.NODE_ENV = "production";
+    setEnv("TRAILS_ENV", "staging");
+    setEnv("NODE_ENV", "production");
     expect(resolveEnv()).toBe("staging");
   });
 
   it("falls back to NODE_ENV", () => {
-    delete process.env.TRAILS_ENV;
-    process.env.NODE_ENV = "production";
+    setEnv("TRAILS_ENV", undefined);
+    setEnv("NODE_ENV", "production");
     expect(resolveEnv()).toBe("production");
   });
 
   it("defaults to development", () => {
-    delete process.env.TRAILS_ENV;
-    delete process.env.NODE_ENV;
+    setEnv("TRAILS_ENV", undefined);
+    setEnv("NODE_ENV", undefined);
     expect(resolveEnv()).toBe("development");
   });
 });
@@ -376,7 +375,7 @@ describe("loadAllDatabaseConfigs", () => {
 
 describe("resolveSchemaFormat", () => {
   let tmpDir: string;
-  const origSchemaFormatEnv = process.env.SCHEMA_FORMAT;
+  const origSchemaFormatEnv = env.SCHEMA_FORMAT;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sf-"));
@@ -385,13 +384,12 @@ describe("resolveSchemaFormat", () => {
     // Phase 6 reads SCHEMA_FORMAT as a Rails-parity override; make sure
     // tests start from a clean slot so a stray env var from the outer
     // process doesn't flip results.
-    delete process.env.SCHEMA_FORMAT;
+    setEnv("SCHEMA_FORMAT", undefined);
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    if (origSchemaFormatEnv === undefined) delete process.env.SCHEMA_FORMAT;
-    else process.env.SCHEMA_FORMAT = origSchemaFormatEnv;
+    setEnv("SCHEMA_FORMAT", origSchemaFormatEnv);
   });
 
   it("prefers an explicit --format flag over everything else", async () => {
@@ -423,7 +421,7 @@ describe("resolveSchemaFormat", () => {
   development: { adapter: "sqlite3", database: ":memory:" },
 };`,
     );
-    process.env.SCHEMA_FORMAT = "sql";
+    setEnv("SCHEMA_FORMAT", "sql");
     // Env wins over config.
     expect(await resolveSchemaFormat({}, tmpDir)).toBe("sql");
     // --format still beats env.
@@ -431,7 +429,7 @@ describe("resolveSchemaFormat", () => {
   });
 
   it("rejects invalid SCHEMA_FORMAT env values", async () => {
-    process.env.SCHEMA_FORMAT = "yaml";
+    setEnv("SCHEMA_FORMAT", "yaml");
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/SCHEMA_FORMAT env var/);
   });
 
@@ -457,9 +455,9 @@ describe("resolveSchemaFormat", () => {
     // deliberately-empty value reaches the validator.
     await expect(resolveSchemaFormat({ format: "" }, tmpDir)).rejects.toThrow(/Invalid --format/);
 
-    process.env.SCHEMA_FORMAT = "";
+    setEnv("SCHEMA_FORMAT", "");
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/SCHEMA_FORMAT env var/);
-    delete process.env.SCHEMA_FORMAT;
+    setEnv("SCHEMA_FORMAT", undefined);
 
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,12 +1,6 @@
 import { Command } from "commander";
-import {
-  env,
-  getFsAsync,
-  getPathAsync,
-  Logger,
-  setExitCode,
-  stdout,
-} from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync, Logger } from "@blazetrails/activesupport";
+import { env, setExitCode, stdout } from "@blazetrails/activesupport/process-adapter";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,5 +1,12 @@
 import { Command } from "commander";
-import { getFsAsync, getPathAsync, Logger } from "@blazetrails/activesupport";
+import {
+  env,
+  getFsAsync,
+  getPathAsync,
+  Logger,
+  setExitCode,
+  stdout,
+} from "@blazetrails/activesupport";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,
@@ -460,7 +467,7 @@ async function runTestLoadSchema(options: {
   const fs = await getFsAsync();
   if (!(await fs.exists(filename))) {
     console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
-    process.exitCode = 1;
+    setExitCode(1);
     return;
   }
   await DatabaseTasks.purge(config);
@@ -603,7 +610,7 @@ async function withMigratorForDb(
   const prevLogger = Migration.logger;
   if (ctx.prefix) {
     Migration.logger = new Logger({
-      write: (s) => process.stdout.write(`${ctx.prefix}${s}`),
+      write: (s) => stdout.write(`${ctx.prefix}${s}`),
     });
   }
   try {
@@ -628,8 +635,7 @@ export function dbCommand(): Command {
       // Rails: ENV["VERSION"] is an alternative to the --version flag
       // for CI scripts that set VERSION=20260101000000. Normalize blank
       // to null so an empty VERSION="" doesn't fail BigInt parsing.
-      const rawVersion =
-        opts.version != null ? String(opts.version).trim() : process.env.VERSION?.trim();
+      const rawVersion = opts.version != null ? String(opts.version).trim() : env.VERSION?.trim();
       const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
       await forEachDatabase(opts, async (ctx) => {
         await withMigratorForDb(
@@ -658,7 +664,7 @@ export function dbCommand(): Command {
       const step = Number(opts.step);
       if (!Number.isInteger(step) || step < 1) {
         console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
-        process.exitCode = 1;
+        setExitCode(1);
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
@@ -677,7 +683,7 @@ export function dbCommand(): Command {
       const step = Number(opts.step);
       if (!Number.isInteger(step) || step < 1) {
         console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
-        process.exitCode = 1;
+        setExitCode(1);
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
@@ -735,7 +741,7 @@ export function dbCommand(): Command {
         await runProtectedEnvCheck(config, envName);
       } catch (error) {
         console.error(error instanceof Error ? error.message : String(error));
-        process.exitCode = 1;
+        setExitCode(1);
       }
     });
 
@@ -771,7 +777,7 @@ export function dbCommand(): Command {
             console.error(`${prefix}  ${version.padStart(4, " ")} ${m.name}`);
           }
           console.error(`${prefix}Run \`trails db migrate\` to resolve this issue.`);
-          process.exitCode = 1;
+          setExitCode(1);
         }
       });
     });
@@ -961,7 +967,7 @@ export function dbCommand(): Command {
       const step = Number(opts.step);
       if (!Number.isInteger(step) || step < 1) {
         console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
-        process.exitCode = 1;
+        setExitCode(1);
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
@@ -1059,7 +1065,7 @@ export function dbCommand(): Command {
           const filename = DatabaseTasks.schemaDumpPath(config);
           if (!(await fs.exists(filename))) {
             console.error(`${prefix}No schema file found at ${filename}`);
-            process.exitCode = 1;
+            setExitCode(1);
             return;
           }
           DatabaseTasks.setAdapter(adapter);

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -1,3 +1,4 @@
+import { cwd as getCwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -13,7 +14,7 @@ export function destroyCommand(): Command {
     .description("Remove a model, its migration, and test")
     .argument("<name>", "Model name")
     .action((name: string) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const fileName = dasherize(name);
       const className = classify(name);
       const tableName = tableize(className);
@@ -38,7 +39,7 @@ export function destroyCommand(): Command {
     .description("Remove a controller and its test")
     .argument("<name>", "Controller name")
     .action((name: string) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const fileName = dasherize(name.replace(/Controller$/i, "")) + "-controller";
       removeFile(cwd, `src/app/controllers/${fileName}.ts`);
       removeFile(cwd, `test/controllers/${fileName}.test.ts`);
@@ -49,7 +50,7 @@ export function destroyCommand(): Command {
     .description("Remove a migration")
     .argument("<name>", "Migration name")
     .action((name: string) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (!fs.existsSync(migrationsDir)) return;
 
@@ -66,7 +67,7 @@ export function destroyCommand(): Command {
     .description("Remove a scaffold (model, controller, migration, tests)")
     .argument("<name>", "Resource name")
     .action((name: string) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const fileName = dasherize(name);
       const className = classify(name);
       const tableName = tableize(className);

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -1,4 +1,4 @@
-import { cwd as getCwd } from "@blazetrails/activesupport";
+import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/trailties/src/commands/generate.ts
+++ b/packages/trailties/src/commands/generate.ts
@@ -1,4 +1,4 @@
-import { cwd } from "@blazetrails/activesupport";
+import { cwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import { ModelGenerator } from "../generators/model-generator.js";
 import { MigrationGenerator } from "../generators/migration-generator.js";

--- a/packages/trailties/src/commands/generate.ts
+++ b/packages/trailties/src/commands/generate.ts
@@ -1,3 +1,4 @@
+import { cwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import { ModelGenerator } from "../generators/model-generator.js";
 import { MigrationGenerator } from "../generators/migration-generator.js";
@@ -23,7 +24,7 @@ export function generateCommand(): Command {
         attributes: string[],
         opts: { migration: boolean; test: boolean; timestamps: boolean },
       ) => {
-        const gen = new ModelGenerator({ cwd: process.cwd(), output: console.log });
+        const gen = new ModelGenerator({ cwd: cwd(), output: console.log });
         gen.run(name, attributes, {
           migration: opts.migration,
           test: opts.test,
@@ -38,7 +39,7 @@ export function generateCommand(): Command {
     .argument("<name>", "Migration name (e.g. AddEmailToUsers)")
     .argument("[columns...]", "Columns as name:type pairs")
     .action((name: string, columns: string[]) => {
-      const gen = new MigrationGenerator({ cwd: process.cwd(), output: console.log });
+      const gen = new MigrationGenerator({ cwd: cwd(), output: console.log });
       gen.run(name, columns);
     });
 
@@ -48,7 +49,7 @@ export function generateCommand(): Command {
     .argument("<name>", "Controller name (e.g. Posts)")
     .argument("[actions...]", "Action names (e.g. index show create)")
     .action((name: string, actions: string[]) => {
-      const gen = new ControllerGenerator({ cwd: process.cwd(), output: console.log });
+      const gen = new ControllerGenerator({ cwd: cwd(), output: console.log });
       gen.run(name, actions);
     });
 
@@ -58,7 +59,7 @@ export function generateCommand(): Command {
     .argument("<name>", "Resource name (e.g. Post)")
     .argument("[attributes...]", "Attributes as name:type pairs")
     .action((name: string, attributes: string[]) => {
-      const gen = new ScaffoldGenerator({ cwd: process.cwd(), output: console.log });
+      const gen = new ScaffoldGenerator({ cwd: cwd(), output: console.log });
       gen.run(name, attributes);
     });
 

--- a/packages/trailties/src/commands/new.ts
+++ b/packages/trailties/src/commands/new.ts
@@ -1,4 +1,4 @@
-import { cwd as getCwd } from "@blazetrails/activesupport";
+import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import path from "node:path";
 import { execSync } from "node:child_process";

--- a/packages/trailties/src/commands/new.ts
+++ b/packages/trailties/src/commands/new.ts
@@ -1,3 +1,4 @@
+import { cwd as getCwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import path from "node:path";
 import { execSync } from "node:child_process";
@@ -14,7 +15,7 @@ export function newCommand(): Command {
     .option("--skip-install", "Skip dependency installation")
     .option("--skip-docker", "Skip Dockerfile creation")
     .action(async (name: string, options) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const gen = new AppGenerator({
         cwd,
         output: console.log,

--- a/packages/trailties/src/commands/routes.ts
+++ b/packages/trailties/src/commands/routes.ts
@@ -1,4 +1,4 @@
-import { cwd as getCwd } from "@blazetrails/activesupport";
+import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/trailties/src/commands/routes.ts
+++ b/packages/trailties/src/commands/routes.ts
@@ -1,3 +1,4 @@
+import { cwd as getCwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -8,7 +9,7 @@ export function routesCommand(): Command {
     .description("Print the application route table")
     .option("-g, --grep <pattern>", "Filter routes by pattern")
     .action(async (options) => {
-      const cwd = process.cwd();
+      const cwd = getCwd();
       const routesFile = path.join(cwd, "src", "config", "routes.ts");
 
       if (!fs.existsSync(routesFile)) {

--- a/packages/trailties/src/commands/server.ts
+++ b/packages/trailties/src/commands/server.ts
@@ -1,4 +1,4 @@
-import { cwd } from "@blazetrails/activesupport";
+import { cwd } from "@blazetrails/activesupport/process-adapter";
 import { Command } from "commander";
 import { DevServer } from "../server/dev-server.js";
 

--- a/packages/trailties/src/commands/server.ts
+++ b/packages/trailties/src/commands/server.ts
@@ -1,3 +1,4 @@
+import { cwd } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import { DevServer } from "../server/dev-server.js";
 
@@ -12,7 +13,7 @@ export function serverCommand(): Command {
       const server = new DevServer({
         port: parseInt(options.port, 10),
         host: options.binding,
-        cwd: process.cwd(),
+        cwd: cwd(),
       });
       await server.start();
     });

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,4 +1,4 @@
-import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { env, getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
@@ -17,7 +17,7 @@ export interface DatabaseConfig {
  * Checks TRAILS_ENV, then NODE_ENV, defaults to "development".
  */
 export function resolveEnv(): string {
-  return process.env.TRAILS_ENV || process.env.NODE_ENV || "development";
+  return env.TRAILS_ENV || env.NODE_ENV || "development";
 }
 
 /**
@@ -377,8 +377,8 @@ export async function resolveSchemaFormat(
   // silently falling through to the next rung.
   if (opts.format !== undefined) return normalize(opts.format, "--format");
 
-  if ("SCHEMA_FORMAT" in process.env) {
-    return normalize(process.env.SCHEMA_FORMAT ?? "", "SCHEMA_FORMAT env var");
+  if ("SCHEMA_FORMAT" in env) {
+    return normalize(env.SCHEMA_FORMAT ?? "", "SCHEMA_FORMAT env var");
   }
 
   // Inspect the config file for a top-level `schemaFormat` key (sibling

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,4 +1,5 @@
-import { env, getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { env } from "@blazetrails/activesupport/process-adapter";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {

--- a/packages/trailties/src/server/vite-plugin.ts
+++ b/packages/trailties/src/server/vite-plugin.ts
@@ -5,7 +5,7 @@
  * falls through to the Rack app — just like Puma sits behind Rack in Rails.
  */
 
-import { cwd as getCwd } from "@blazetrails/activesupport";
+import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
 import type { Plugin, ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { bodyToString } from "@blazetrails/rack";

--- a/packages/trailties/src/server/vite-plugin.ts
+++ b/packages/trailties/src/server/vite-plugin.ts
@@ -5,6 +5,7 @@
  * falls through to the Rack app — just like Puma sits behind Rack in Rails.
  */
 
+import { cwd as getCwd } from "@blazetrails/activesupport";
 import type { Plugin, ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { bodyToString } from "@blazetrails/rack";
@@ -16,7 +17,7 @@ export interface TrailsPluginOptions {
 }
 
 export function trailsPlugin(options: TrailsPluginOptions = {}): Plugin {
-  const cwd = options.cwd || process.cwd();
+  const cwd = options.cwd || getCwd();
   let app: Application;
 
   return {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         __dirname,
         "packages/activesupport/src/glob.ts",
       ),
+      "@blazetrails/activesupport/process-adapter": path.resolve(
+        __dirname,
+        "packages/activesupport/src/process-adapter.ts",
+      ),
       "@blazetrails/activesupport/testing/temporal-helpers": path.resolve(
         __dirname,
         "packages/activesupport/src/testing/temporal-helpers.ts",


### PR DESCRIPTION
## Summary

Mechanical codemod from PR #1017's processAdapter into trailties src, plus an ESLint rule that locks in the constraint and autofixes the safe replacements. Part of the trailties build-out plan (PR 0.3; see \`docs/trailties-plan.md\`).

After this PR, **non-test production source under \`packages/trailties/src/\` contains no \`process.*\` references** outside the two scoped exemptions:

- \`*.test.ts\` — tests legitimately mock or inspect the host process
- \`generators/app-generator.ts\` — template strings emit user-app code that runs in the user's app, where direct \`process.*\` is fine

## Codemod table

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| \`process.cwd()\`                 | \`cwd()\`                        |
| \`process.env.FOO\`               | \`env.FOO\`                      |
| \`process.env.FOO = "x"\`         | \`setEnv("FOO", "x")\`           |
| \`"FOO" in process.env\`          | \`"FOO" in env\`                 |
| \`process.argv\`                  | \`argv\`                         |
| \`process.exitCode = 1\`          | \`setExitCode(1)\`               |
| \`process.stdout.write(s)\`       | \`stdout.write(s)\`              |

All imports come from \`@blazetrails/activesupport/process-adapter\` (the narrow subpath, not the package root) so CLI startup doesn't pull in the full activesupport index.

## Files changed

- \`packages/trailties/src/database.ts\` (env)
- \`packages/trailties/src/commands/console.ts\` (cwd)
- \`packages/trailties/src/commands/db.ts\` (env, setExitCode, stdout)
- \`packages/trailties/src/commands/destroy.ts\` (cwd)
- \`packages/trailties/src/commands/generate.ts\` (cwd)
- \`packages/trailties/src/commands/new.ts\` (cwd)
- \`packages/trailties/src/commands/routes.ts\` (cwd)
- \`packages/trailties/src/commands/server.ts\` (cwd)
- \`packages/trailties/src/server/vite-plugin.ts\` (cwd)
- \`packages/trailties/src/bin.ts\` (argv) — processAdapter auto-registers Node at activesupport module load
- \`packages/trailties/src/commands/db.test.ts\` (\`setEnv()\` for env mutation)
- \`vitest.config.ts\` — alias for the \`/process-adapter\` subpath

## ESLint rule: \`blazetrails/no-process-bypass\`

Replaces the original CI grep gate. AST-based, no regex tuning, no portability footguns.

- **Detects:** dotted access, optional chaining, bracket access (single + double quoted), template-literal bracket access (\`process[\`env\`]\`), optional bracket access, TS wrapper expressions (\`process!.env\`, \`(process as any).env\`, \`<any>process.env\`, \`(process satisfies T).env\`, parenthesized), and destructuring (\`const { env } = process\`).
- **Doesn't false-positive:** suffix matches (\`process.argv0\`, \`process.environ\`, \`myprocess.env\`), unrelated property paths (\`obj.process.env\`), allowed properties (\`process.versions\`, \`process.pid\`), interpolated bracket access (\`process[\`\${dynKey}\`]\`).
- **Autofixes** six replacements where the destination symbol is unlikely to clash with locals:
  - \`process.exit(c)\` → \`exit(c)\`
  - \`process.exitCode = N\` → \`setExitCode(N)\` (only as top-level statement; expression contexts flagged without autofix)
  - \`process.stdout\` → \`stdout\`
  - \`process.stderr\` → \`stderr\`
  - \`process.platform\` → \`platform()\`
  - \`process.on(name, h)\` → \`onSignal(name, h)\` (only when name is a SIGINT/SIGTERM literal)
  - Each fix adds the import or appends to an existing import from the same source; reuses an already-imported (possibly aliased) local name when present.
- **Doesn't autofix** \`cwd\`, \`env\`, \`argv\` because those names are commonly used as local variables; silent shadowing would break compilation. The rule still flags them with a clear pointer at the manual fix.

## Copilot review history

Nine review cycles; hit max review cycles cap on review #9.

### Fixed across reviews #1–#8
- ✅ \`exitCode\` added to alternation (was a real coverage gap)
- ✅ Portable boundary on the original CI grep
- ✅ \`bin.ts\` argv typing (\`[...argv]\` not \`as string[]\`)
- ✅ CI step renaming + clearer failure message
- ✅ Bracket-access bypass coverage (then optional-chaining, drive-relative paths, mid-pattern backslashes, etc.)
- ✅ Stale doc comment in db.test.ts
- ✅ Trailing word boundary on dotted form (\`process.argv0\` no longer matches \`process.argv\`)
- ✅ Narrow subpath imports (\`@blazetrails/activesupport/process-adapter\`) in all 9 trailties files
- ✅ **Replaced CI grep gate with proper ESLint rule** (\`blazetrails/no-process-bypass\`)
- ✅ Autofix for six safe replacements with import injection
- ✅ TS wrapper bypasses (\`process!\`, \`(process as any)\`, etc.)
- ✅ Destructuring detection (\`const { env } = process\`)
- ✅ \`exitCode\` autofix gated to top-level statements (semantics safety)
- ✅ \`process.on\` autofix gated to SIGINT/SIGTERM literals (type safety)
- ✅ Template-literal bracket bypass (\`process[\`env\`]\`)
- ✅ Prettier formatting

### Remaining (review #9, not addressed)

\`globalThis.process.env\` / \`globalThis["process"].cwd()\` / \`global.process.argv\` — accessing the host process via the \`globalThis\` (or \`global\`) namespace bypasses the rule because \`isProcessIdentifier\` only matches the bare \`Identifier("process")\`.

**Decision: defer.** This isn't a syntactic form anyone in the trailties codebase actually uses, and the violations the rule already catches are the practical ones. Adding \`globalThis.process\` / \`global.process\` recognition would expand the rule to walk a small chain (`MemberExpression` whose object is \`Identifier("globalThis"|"global")\` and property resolves to "process"), which is straightforward but also broadens the false-positive surface (e.g. \`globalThis.process\` could legitimately refer to a non-Node process object in browser hosts during testing). If a real consumer ever reaches for the global namespace as a bypass, we can add the check then.

For now, the existing rule covers every form actually used in the codemod and prevents the natural regressions. Documenting the gap so it's discoverable.

## Out of scope

Pre-existing \`node:fs\`, \`node:path\`, \`node:url\`, \`node:module\`, \`node:vm\` imports in trailties src remain. Migrating those to \`fsAdapter\` / \`pathAdapter\` / \`cryptoAdapter\` is a separate PR series — the plan's PR 0.3 scope is explicitly the \`process.*\` codemod only.

## Test plan

- [x] \`pnpm vitest run packages/trailties\` — 239 tests pass, 74 skipped
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` clean (the new ESLint rule fires only on actual violations)
- [x] Rule unit tests cover dotted/optional/bracket/template-bracket/TS-wrapper/destructuring forms plus all 6 autofix paths and the autofix safety gates
- [x] Smoke-tested autofix end-to-end on the real \`database.ts\`: introduced \`process.exitCode\` and \`process.stderr.write\` violations, ran \`pnpm lint --fix\`, confirmed both rewrites and the import injection