### PR TITLE
fix(arel): align Predications#between / #not_between with Rails range protocol

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -66,7 +66,13 @@ export class RangeHandler {
     if (value.excludeEnd) {
       return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
     }
-    return attribute.notBetween(beginVal, endVal);
+    // Mirrors Rails' AR-level `where.not(col: 1..5)`: the predicate
+    // builder constructs `Between` then `where.not` wraps it in `Not`,
+    // yielding `NOT (col BETWEEN b AND e)`. Don't delegate to
+    // attribute.notBetween — that returns the predications.rb-aligned
+    // `(col < b OR col > e)` shape, which is the right Arel-level
+    // behavior but the wrong AR-level one.
+    return new Nodes.Not(attribute.between(beginVal, endVal));
   }
 
   private get predicateBuilder(): unknown {

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -585,104 +585,7 @@ describe("AttributeTest", () => {
     });
   });
 
-  describe("#not_between", () => {
-    it("can be constructed with a standard range", () => {
-      const node = users.get("age").between(18, 65);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."age" BETWEEN 18 AND 65');
-    });
-
-    it("can be constructed with a range starting from -Infinity", () => {
-      const node = users.get("age").between({ begin: -Infinity, end: 65 });
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."age" <= 65');
-    });
-
-    it("can be constructed with a quoted range starting from -Infinity", () => {
-      const node = users.get("id").lteq(new Nodes.Quoted(100));
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<=");
-    });
-
-    it("can be constructed with an exclusive range starting from -Infinity", () => {
-      const node = users.get("id").lt(100);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<");
-    });
-
-    it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
-      const node = users.get("id").lt(new Nodes.Quoted(100));
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<");
-    });
-
-    it("can be constructed with an infinite range", () => {
-      // -Infinity..Infinity is always true
-      const node = users.get("id").between(-Infinity, Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toBe("TRUE");
-    });
-
-    it("can be constructed with a quoted infinite range", () => {
-      const node = users.get("id").between(-Infinity, Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toBe("TRUE");
-    });
-
-    it("can be constructed with a range ending at Infinity", () => {
-      const node = users.get("id").gteq(1);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain(">=");
-    });
-
-    it("can be constructed with a range implicitly starting at Infinity", () => {
-      const node = users.get("age").notBetween(Infinity, 65);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with a range implicitly ending at Infinity", () => {
-      const node = users.get("age").notBetween(18, Infinity);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with a quoted range starting from -Infinity", () => {
-      const node = users.get("id").notBetween([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with an exclusive range starting from -Infinity", () => {
-      const node = users.get("id").notBetween([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
-      const node = users.get("id").notBetween([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with an infinite range", () => {
-      const node = users.get("id").notBetween([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with a quoted infinite range", () => {
-      const node = users.get("id").notBetween([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-
-    it("can be constructed with a range ending at Infinity", () => {
-      const node = users.get("id").notBetween([1, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.Not);
-    });
-  });
-
   describe("#between", () => {
-    it("can be constructed with an exclusive range implicitly ending at Infinity", () => {
-      const node = users.get("id").lt(Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<");
-    });
-
     it("can be constructed with a standard range", () => {
       const node = users.get("id").between([1, 3]);
       expect(node).toBeInstanceOf(Nodes.Between);
@@ -694,28 +597,28 @@ describe("AttributeTest", () => {
     });
 
     it("can be constructed with a quoted range starting from -Infinity", () => {
-      const node = users.get("id").between([-Infinity, 3]);
+      const node = users.get("id").between({ begin: -Infinity, end: 3 });
       expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
     });
 
     it("can be constructed with an exclusive range starting from -Infinity", () => {
-      const node = users.get("id").between([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
-      const node = users.get("id").between([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("can be constructed with an infinite range", () => {
       const node = users.get("id").between([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.True);
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with a quoted infinite range", () => {
-      const node = users.get("id").between([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.True);
+      const node = users.get("id").between({ begin: -Infinity, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with a range ending at Infinity", () => {
@@ -724,64 +627,123 @@ describe("AttributeTest", () => {
     });
 
     it("can be constructed with a range implicitly starting at Infinity", () => {
-      const node = users.get("id").between([1, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
-    });
-
-    it("can be constructed with a range implicitly ending at Infinity", () => {
-      const node = users.get("id").between([-Infinity, 3]);
+      const node = users.get("id").between({ begin: null, end: 3 });
       expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
     });
 
+    it("can be constructed with a range implicitly ending at Infinity", () => {
+      const node = users.get("id").between({ begin: 1, end: null });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("can be constructed with an exclusive range implicitly ending at Infinity", () => {
+      const node = users.get("id").between({ begin: 1, end: null, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
     it("can be constructed with a quoted range ending at Infinity", () => {
-      const node = users.get("id").between([1, Infinity]);
+      const node = users.get("id").between({ begin: 1, end: Infinity });
       expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
     });
 
     it("can be constructed with an endless range starting from Infinity", () => {
-      const node = users.get("id").between([1, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const node = users.get("id").between({ begin: Infinity, end: null });
+      expect(node).toBeInstanceOf(Nodes.In);
     });
 
     it("can be constructed with a beginless range ending in -Infinity", () => {
-      const node = users.get("id").between([-Infinity, -Infinity]);
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const node = users.get("id").between({ begin: null, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.In);
     });
 
     it("can be constructed with an exclusive range", () => {
-      const node = users.get("id").between([1, 2]);
-      expect(node).toBeInstanceOf(Nodes.Between);
+      const node = users.get("id").between({ begin: 1, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.And);
+    });
+
+    it("can be constructed with a range where the begin and end are equal", () => {
+      const node = users.get("id").between([5, 5]);
+      expect(node).toBeInstanceOf(Nodes.Equality);
     });
   });
 
   describe("#not_between", () => {
+    it("can be constructed with a standard range", () => {
+      const node = users.get("age").notBetween(18, 65);
+      expect(node).toBeInstanceOf(Nodes.Grouping);
+      expect((node as Nodes.Grouping).expr).toBeInstanceOf(Nodes.Or);
+    });
+
+    it("can be constructed with a range starting from -Infinity", () => {
+      const node = users.get("age").notBetween(-Infinity, 65);
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+    });
+
+    it("can be constructed with a quoted range starting from -Infinity", () => {
+      const node = users.get("id").notBetween({ begin: -Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+    });
+
+    it("can be constructed with an exclusive range starting from -Infinity", () => {
+      const node = users.get("id").notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
+      const node = users.get("id").notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("can be constructed with an infinite range", () => {
+      const node = users.get("id").notBetween([-Infinity, Infinity]);
+      expect(node).toBeInstanceOf(Nodes.In);
+    });
+
+    it("can be constructed with a quoted infinite range", () => {
+      const node = users.get("id").notBetween({ begin: -Infinity, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.In);
+    });
+
+    it("can be constructed with a range ending at Infinity", () => {
+      const node = users.get("id").notBetween([1, Infinity]);
+      expect(node).toBeInstanceOf(Nodes.LessThan);
+    });
+
+    it("can be constructed with a range implicitly starting at Infinity", () => {
+      const node = users.get("age").notBetween({ begin: null, end: 0 });
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+    });
+
+    it("can be constructed with a range implicitly ending at Infinity", () => {
+      const node = users.get("age").notBetween({ begin: 0, end: null });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
+    });
+
     it("can be constructed with a quoted range ending at Infinity", () => {
-      const node = users.get("age").notBetween(18, Infinity);
-      expect(node).toBeInstanceOf(Nodes.Not);
+      const node = users.get("age").notBetween({ begin: 18, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("can be constructed with an endless range starting from Infinity", () => {
-      const node = users.get("age").notBetween(Infinity, 100);
-      expect(node).toBeInstanceOf(Nodes.Not);
+      const node = users.get("age").notBetween({ begin: Infinity, end: null });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with a beginless range ending in -Infinity", () => {
-      const node = users.get("age").notBetween(-Infinity, -Infinity);
-      expect(node).toBeInstanceOf(Nodes.Not);
+      const node = users.get("age").notBetween({ begin: null, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with an exclusive range", () => {
-      const node = users.get("age").between(18, 65);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."age" BETWEEN 18 AND 65');
+      const node = users.get("age").notBetween({ begin: 18, end: 65, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.Grouping);
+      const inner = (node as Nodes.Grouping).expr as Nodes.Or;
+      expect(inner.children[1]).toBeInstanceOf(Nodes.GreaterThanOrEqual);
     });
-  });
 
-  describe("#between", () => {
-    it("can be constructed with a range where the begin and end are equal", () => {
-      const node = users.get("id").between([5, 5]);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("BETWEEN");
+    it("can be constructed with a Union", () => {
+      const node = users.get("age").notBetween(1, 100);
+      expect(node).toBeInstanceOf(Nodes.Grouping);
     });
   });
 
@@ -801,7 +763,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a random object", () => {
       const node = users.get("age").notBetween(1, 100);
-      expect(node).toBeInstanceOf(Nodes.Not);
+      expect(node).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("can be constructed with a subquery", () => {
@@ -906,58 +868,53 @@ describe("AttributeTest", () => {
     it("can be constructed with a standard range", () => {
       const node = users.get("age").notBetween(18, 65);
       const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toContain("NOT");
-      expect(visitor.compile(node)).toContain("BETWEEN");
+      const sql = visitor.compile(node);
+      expect(sql).toBe('("users"."age" < 18 OR "users"."age" > 65)');
     });
 
     it("can be constructed with a range starting from -Infinity", () => {
-      const node = users.get("age").between(-Infinity, 65);
+      const node = users.get("age").notBetween(-Infinity, 65);
       const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."age" <= 65');
+      expect(visitor.compile(node)).toBe('"users"."age" > 65');
     });
 
     it("can be constructed with a range implicitly starting at Infinity", () => {
-      const node = users.get("id").gteq(Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain(">=");
+      const node = users.get("id").notBetween({ begin: null, end: 0 });
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
     });
 
     it("can be constructed with a range implicitly ending at Infinity", () => {
-      const node = users.get("id").lteq(Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<=");
+      const node = users.get("id").notBetween({ begin: 0, end: null });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("can be constructed with a quoted range ending at Infinity", () => {
-      const node = users.get("id").gteq(new Nodes.Quoted(1));
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain(">=");
+      const node = users.get("id").notBetween({ begin: 0, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("can be constructed with an endless range starting from Infinity", () => {
-      const node = users.get("id").gteq(Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain(">=");
+      const node = users.get("id").notBetween({ begin: Infinity, end: null });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with a beginless range ending in -Infinity", () => {
-      const node = users.get("id").lteq(-Infinity);
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("<=");
+      const node = users.get("id").notBetween({ begin: null, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with an exclusive range", () => {
-      const node = users.get("age").notBetween(18, 65);
+      const node = users.get("age").notBetween({ begin: 18, end: 65, excludeEnd: true });
       const visitor = new Visitors.ToSql();
       const result = visitor.compile(node);
-      expect(result).toContain("NOT");
+      expect(result).toBe('("users"."age" < 18 OR "users"."age" >= 65)');
     });
   });
 
   describe("#not_between", () => {
     it("can be constructed with a Union", () => {
       const node = users.get("age").notBetween(1, 100);
-      expect(node).toBeInstanceOf(Nodes.Not);
+      expect(node).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("can be constructed with a list", () => {
@@ -967,10 +924,8 @@ describe("AttributeTest", () => {
     });
 
     it("can be constructed with a random object", () => {
-      // Using a quoted value
-      const node = users.get("id").eq(new Nodes.Quoted("random_thing"));
-      const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("'random_thing'");
+      const node = users.get("id").notIn(["random_thing"] as unknown[]);
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("should generate NOT IN in sql", () => {
@@ -1182,8 +1137,9 @@ describe("AttributeTest", () => {
   });
 
   it("notBetween generates NOT BETWEEN", () => {
+    // Mirrors Rails: not_between renders as `(col < begin OR col > end)`.
     expect(users.project(star).where(users.get("age").notBetween(18, 65)).toSql()).toBe(
-      'SELECT * FROM "users" WHERE NOT ("users"."age" BETWEEN 18 AND 65)',
+      'SELECT * FROM "users" WHERE ("users"."age" < 18 OR "users"."age" > 65)',
     );
   });
 
@@ -1597,9 +1553,10 @@ describe("AttributeTest", () => {
 
   describe("#not_between", () => {
     it("can be constructed with a range starting from -Infinity", () => {
+      // Mirrors Rails: not_between(-Inf..end) collapses to gt(end).
       const node = users.get("age").notBetween(-Infinity, 65);
       const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toContain("NOT");
+      expect(visitor.compile(node)).toBe('"users"."age" > 65');
     });
   });
 

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -762,8 +762,8 @@ describe("AttributeTest", () => {
     });
 
     it("can be constructed with a random object", () => {
-      const node = users.get("age").notBetween(1, 100);
-      expect(node).toBeInstanceOf(Nodes.Grouping);
+      const node = users.get("id").notIn(["random_thing"] as unknown[]);
+      expect(node).toBeInstanceOf(Nodes.NotIn);
     });
 
     it("can be constructed with a subquery", () => {
@@ -916,7 +916,9 @@ describe("AttributeTest", () => {
       const node = users.get("age").notBetween(1, 100);
       expect(node).toBeInstanceOf(Nodes.Grouping);
     });
+  });
 
+  describe("#not_in", () => {
     it("can be constructed with a list", () => {
       const node = users.get("id").notIn([1, 2, 3]);
       const visitor = new Visitors.ToSql();

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -5,7 +5,6 @@ import {
   GreaterThanOrEqual,
   LessThan,
   LessThanOrEqual,
-  Between,
   As,
   ATTRIBUTE_BRAND,
 } from "../nodes/binary.js";
@@ -27,12 +26,12 @@ import { Sum, Max, Min, Avg } from "../nodes/function.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
 import { Quoted, Casted, buildQuoted } from "../nodes/casted.js";
+import { parseRange, betweenFromRange, notBetweenFromRange } from "../predications-range.js";
 import { BindParam } from "../nodes/bind-param.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";
 import { Or } from "../nodes/or.js";
-import { Not } from "../nodes/unary.js";
 import { SqlLiteral } from "../nodes/sql-literal.js";
 import { NamedFunction } from "../nodes/named-function.js";
 import { Extract } from "../nodes/extract.js";
@@ -48,7 +47,6 @@ import {
 } from "../nodes/infix-operation.js";
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
-import { True } from "../nodes/true.js";
 import { Predications, type PredicationHost } from "../predications.js";
 
 /**
@@ -202,55 +200,18 @@ export class Attribute extends Node {
     return new NotIn(this, values.map(buildQuoted) as unknown as Node);
   }
 
-  between(range: [unknown, unknown]): Between | LessThanOrEqual | GreaterThanOrEqual | True;
-  between(begin: unknown, end: unknown): Between | LessThanOrEqual | GreaterThanOrEqual | True;
-  between(rangeObj: {
-    begin: unknown;
-    end: unknown;
-  }): Between | LessThanOrEqual | GreaterThanOrEqual | True;
-  between(
-    beginOrRange: unknown,
-    end?: unknown,
-  ): Between | LessThanOrEqual | GreaterThanOrEqual | True {
-    let beginVal: unknown;
-    let endVal: unknown;
-    if (Array.isArray(beginOrRange) && end === undefined) {
-      beginVal = beginOrRange[0];
-      endVal = beginOrRange[1];
-    } else if (
-      typeof beginOrRange === "object" &&
-      beginOrRange !== null &&
-      !Array.isArray(beginOrRange) &&
-      !(beginOrRange instanceof Node) &&
-      "begin" in (beginOrRange as Record<string, unknown>) &&
-      "end" in (beginOrRange as Record<string, unknown>) &&
-      end === undefined
-    ) {
-      beginVal = (beginOrRange as { begin: unknown; end: unknown }).begin;
-      endVal = (beginOrRange as { begin: unknown; end: unknown }).end;
-    } else {
-      beginVal = beginOrRange;
-      endVal = end;
-    }
-    if (beginVal === -Infinity && endVal === Infinity) {
-      return new True();
-    }
-    if (beginVal === -Infinity) {
-      return new LessThanOrEqual(this, buildQuoted(endVal));
-    }
-    if (endVal === Infinity) {
-      return new GreaterThanOrEqual(this, buildQuoted(beginVal));
-    }
-    return new Between(this, new And([buildQuoted(beginVal), buildQuoted(endVal)]));
+  between(range: [unknown, unknown]): Node;
+  between(begin: unknown, end: unknown, excludeEnd?: boolean): Node;
+  between(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
+  between(beginOrRange: unknown, end?: unknown, excludeEnd?: boolean): Node {
+    return betweenFromRange(this, parseRange(beginOrRange, end, excludeEnd));
   }
 
-  notBetween(range: [unknown, unknown]): Not;
-  notBetween(begin: unknown, end: unknown): Not;
-  notBetween(beginOrRange: unknown, end?: unknown): Not {
-    if (Array.isArray(beginOrRange) && end === undefined) {
-      return new Not(this.between(beginOrRange as [unknown, unknown]));
-    }
-    return new Not(this.between(beginOrRange, end!));
+  notBetween(range: [unknown, unknown]): Node;
+  notBetween(begin: unknown, end: unknown, excludeEnd?: boolean): Node;
+  notBetween(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
+  notBetween(beginOrRange: unknown, end?: unknown, excludeEnd?: boolean): Node {
+    return notBetweenFromRange(this, parseRange(beginOrRange, end, excludeEnd));
   }
 
   isNull(): Equality {

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, Nodes } from "./index.js";
+import { Table, Nodes, Visitors } from "./index.js";
 
 // Mirrors Rails' Arel attribute_test.rb #between / #not_between blocks.
 // The Trails port accepts `[begin, end]`, `{ begin, end, excludeEnd? }`,
@@ -69,6 +69,56 @@ describe("Predications range semantics", () => {
     it("begin..null (open end) collapses to GreaterThanOrEqual", () => {
       const node = id.between({ begin: 1, end: null });
       expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+  });
+
+  describe("#between SQL output", () => {
+    const sql = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
+
+    it("inclusive standard range → BETWEEN", () => {
+      expect(sql(id.between({ begin: 1, end: 3 }))).toBe('"users"."id" BETWEEN 1 AND 3');
+    });
+
+    it("exclusive range → >= AND <", () => {
+      expect(sql(id.between({ begin: 1, end: 3, excludeEnd: true }))).toBe(
+        '"users"."id" >= 1 AND "users"."id" < 3',
+      );
+    });
+
+    it("begin == end → equality", () => {
+      expect(sql(id.between({ begin: 5, end: 5 }))).toBe('"users"."id" = 5');
+    });
+
+    it("-Infinity..Infinity → 1=1", () => {
+      expect(sql(id.between({ begin: -Infinity, end: Infinity }))).toBe("1=1");
+    });
+
+    it("Infinity..end (unboundable begin) → 1=0", () => {
+      expect(sql(id.between({ begin: Infinity, end: 3 }))).toBe("1=0");
+    });
+  });
+
+  describe("#not_between SQL output", () => {
+    const sql = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
+
+    it("inclusive range → (col < b OR col > e)", () => {
+      expect(sql(id.notBetween({ begin: 1, end: 3 }))).toBe(
+        '("users"."id" < 1 OR "users"."id" > 3)',
+      );
+    });
+
+    it("exclusive range → (col < b OR col >= e)", () => {
+      expect(sql(id.notBetween({ begin: 1, end: 3, excludeEnd: true }))).toBe(
+        '("users"."id" < 1 OR "users"."id" >= 3)',
+      );
+    });
+
+    it("-Infinity..end → > end (no NOT wrapper)", () => {
+      expect(sql(id.notBetween({ begin: -Infinity, end: 3 }))).toBe('"users"."id" > 3');
+    });
+
+    it("-Infinity..Infinity → 1=0", () => {
+      expect(sql(id.notBetween({ begin: -Infinity, end: Infinity }))).toBe("1=0");
     });
   });
 

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes } from "./index.js";
+
+// Mirrors Rails' Arel attribute_test.rb #between / #not_between blocks.
+// The Trails port accepts `[begin, end]`, `{ begin, end, excludeEnd? }`,
+// and `(begin, end, excludeEnd?)` call shapes; the decision tree
+// (predications.rb) is the same in all cases.
+describe("Predications range semantics", () => {
+  const users = new Table("users");
+  const id = users.get("id");
+
+  describe("#between", () => {
+    it("inclusive standard range builds Between(And(Casted, Casted))", () => {
+      const node = id.between({ begin: 1, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.Between);
+    });
+
+    it("range begin == end collapses to Equality", () => {
+      const node = id.between({ begin: 5, end: 5 });
+      expect(node).toBeInstanceOf(Nodes.Equality);
+    });
+
+    it("exclusive range builds And(GreaterThanOrEqual, LessThan)", () => {
+      const node = id.between({ begin: 1, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.And);
+      const and = node as Nodes.And;
+      expect(and.children[0]).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      expect(and.children[1]).toBeInstanceOf(Nodes.LessThan);
+    });
+
+    it("-Infinity..end inclusive becomes LessThanOrEqual", () => {
+      const node = id.between({ begin: -Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+    });
+
+    it("-Infinity...end exclusive becomes LessThan", () => {
+      const node = id.between({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
+    });
+
+    it("begin..Infinity becomes GreaterThanOrEqual", () => {
+      const node = id.between({ begin: 1, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("-Infinity..Infinity becomes NotIn([])", () => {
+      const node = id.between({ begin: -Infinity, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
+      expect(((node as Nodes.NotIn).right as unknown[]).length).toBe(0);
+    });
+
+    it("Infinity..end (unboundable begin) collapses to In([])", () => {
+      const node = id.between({ begin: Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.In);
+      expect(((node as Nodes.In).right as unknown[]).length).toBe(0);
+    });
+
+    it("begin..-Infinity (unboundable end) collapses to In([])", () => {
+      const node = id.between({ begin: 1, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.In);
+      expect(((node as Nodes.In).right as unknown[]).length).toBe(0);
+    });
+
+    it("null..end (open begin) collapses to LessThanOrEqual", () => {
+      const node = id.between({ begin: null, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+    });
+
+    it("begin..null (open end) collapses to GreaterThanOrEqual", () => {
+      const node = id.between({ begin: 1, end: null });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+  });
+
+  describe("#not_between", () => {
+    it("inclusive standard range builds Grouping(Or(LessThan, GreaterThan))", () => {
+      const node = id.notBetween({ begin: 1, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.Grouping);
+      const inner = (node as Nodes.Grouping).expr as Nodes.Or;
+      expect(inner).toBeInstanceOf(Nodes.Or);
+      expect(inner.children[0]).toBeInstanceOf(Nodes.LessThan);
+      expect(inner.children[1]).toBeInstanceOf(Nodes.GreaterThan);
+    });
+
+    it("exclusive range builds Grouping(Or(LessThan, GreaterThanOrEqual))", () => {
+      const node = id.notBetween({ begin: 1, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.Grouping);
+      const inner = (node as Nodes.Grouping).expr as Nodes.Or;
+      expect(inner.children[0]).toBeInstanceOf(Nodes.LessThan);
+      expect(inner.children[1]).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("-Infinity..end (open begin) becomes GreaterThan", () => {
+      const node = id.notBetween({ begin: -Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+    });
+
+    it("-Infinity...end (open begin, exclusive end) becomes GreaterThanOrEqual", () => {
+      const node = id.notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("begin..Infinity (open end) becomes LessThan", () => {
+      const node = id.notBetween({ begin: 1, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
+    });
+
+    it("-Infinity..Infinity becomes In([])", () => {
+      const node = id.notBetween({ begin: -Infinity, end: Infinity });
+      expect(node).toBeInstanceOf(Nodes.In);
+    });
+
+    it("Infinity..end (unboundable begin) becomes NotIn([])", () => {
+      const node = id.notBetween({ begin: Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
+    });
+
+    it("begin..-Infinity (unboundable end) becomes NotIn([])", () => {
+      const node = id.notBetween({ begin: 1, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
+    });
+  });
+});

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -1,0 +1,121 @@
+import { Node } from "./nodes/node.js";
+import { Quoted } from "./nodes/casted.js";
+import { And } from "./nodes/and.js";
+import { Or } from "./nodes/or.js";
+import { Grouping } from "./nodes/grouping.js";
+import { Between } from "./nodes/binary.js";
+
+/**
+ * Range-protocol helpers shared between `Predications#between` /
+ * `notBetween` (the mixin) and `Attribute#between` / `notBetween` (the
+ * class-side overrides). Mirrors Rails' Predications private helpers
+ * (`infinity?`, `unboundable?`, `open_ended?`) and the public `between`
+ * / `not_between` decision tree (predications.rb).
+ */
+
+export interface RangeLike {
+  begin: unknown;
+  end: unknown;
+  excludeEnd: boolean;
+}
+
+export interface RangeHost {
+  quotedNode(other: unknown): Node;
+  in(values: unknown[]): Node;
+  notIn(values: unknown[]): Node;
+  eq(o: unknown): Node;
+  gt(o: unknown): Node;
+  gteq(o: unknown): Node;
+  lt(o: unknown): Node;
+  lteq(o: unknown): Node;
+}
+
+export function parseRange(beginOrRange: unknown, end: unknown, excludeEnd?: boolean): RangeLike {
+  if (Array.isArray(beginOrRange) && end === undefined) {
+    return { begin: beginOrRange[0], end: beginOrRange[1], excludeEnd: false };
+  }
+  if (
+    typeof beginOrRange === "object" &&
+    beginOrRange !== null &&
+    !(beginOrRange instanceof Node) &&
+    end === undefined &&
+    "begin" in (beginOrRange as Record<string, unknown>) &&
+    "end" in (beginOrRange as Record<string, unknown>)
+  ) {
+    const r = beginOrRange as { begin: unknown; end: unknown; excludeEnd?: boolean };
+    return { begin: r.begin, end: r.end, excludeEnd: r.excludeEnd === true };
+  }
+  return { begin: beginOrRange, end, excludeEnd: excludeEnd === true };
+}
+
+// Mirrors Rails Predications#infinity? — signed infinity check. Trails
+// has no `infinite?` protocol; only +/-Infinity (and Quoted(Infinity))
+// register.
+export function infinitySign(value: unknown): 1 | -1 | 0 {
+  if (value === Infinity) return 1;
+  if (value === -Infinity) return -1;
+  if (value instanceof Quoted) return infinitySign(value.value);
+  return 0;
+}
+
+// Mirrors Rails Predications#unboundable? — Trails has no separate
+// unboundable protocol on user values, so it collapses to infinitySign.
+// Kept named so the decision tree below reads side-by-side with Rails.
+export function unboundableSign(value: unknown): 1 | -1 | 0 {
+  return infinitySign(value);
+}
+
+// Mirrors Rails Predications#open_ended? — null/undefined or any
+// signed-infinity bound counts as "no bound on this side".
+export function isOpenEnded(value: unknown): boolean {
+  return value === null || value === undefined || infinitySign(value) !== 0;
+}
+
+export function betweenFromRange(host: RangeHost, range: RangeLike): Node {
+  if (unboundableSign(range.begin) === 1 || unboundableSign(range.end) === -1) {
+    return host.in([]);
+  }
+  if (isOpenEnded(range.begin)) {
+    if (isOpenEnded(range.end)) {
+      if (infinitySign(range.begin) === 1 || infinitySign(range.end) === -1) {
+        return host.in([]);
+      }
+      return host.notIn([]);
+    }
+    return range.excludeEnd ? host.lt(range.end) : host.lteq(range.end);
+  }
+  if (isOpenEnded(range.end)) {
+    return host.gteq(range.begin);
+  }
+  if (range.excludeEnd) {
+    return new And([host.gteq(range.begin), host.lt(range.end)]);
+  }
+  if (range.begin === range.end) {
+    return host.eq(range.begin);
+  }
+  return new Between(
+    host as unknown as Node,
+    new And([host.quotedNode(range.begin), host.quotedNode(range.end)]),
+  );
+}
+
+export function notBetweenFromRange(host: RangeHost, range: RangeLike): Node {
+  if (unboundableSign(range.begin) === 1 || unboundableSign(range.end) === -1) {
+    return host.notIn([]);
+  }
+  if (isOpenEnded(range.begin)) {
+    if (isOpenEnded(range.end)) {
+      if (infinitySign(range.begin) === 1 || infinitySign(range.end) === -1) {
+        return host.notIn([]);
+      }
+      return host.in([]);
+    }
+    return range.excludeEnd ? host.gteq(range.end) : host.gt(range.end);
+  }
+  if (isOpenEnded(range.end)) {
+    return host.lt(range.begin);
+  }
+  const left = host.lt(range.begin);
+  const right = range.excludeEnd ? host.gteq(range.end) : host.gt(range.end);
+  return new Grouping(new Or([left, right]));
+}

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -10,7 +10,19 @@ import { Between } from "./nodes/binary.js";
  * `notBetween` (the mixin) and `Attribute#between` / `notBetween` (the
  * class-side overrides). Mirrors Rails' Predications private helpers
  * (`infinity?`, `unboundable?`, `open_ended?`) and the public `between`
- * / `not_between` decision tree (predications.rb).
+ * / `not_between` decision tree.
+ *
+ * Source of truth: Rails v8.0.2 `activerecord/lib/arel/predications.rb`
+ *   `between` body — Predications#between
+ *   `not_between` body — Predications#not_between
+ *   `infinity?` / `unboundable?` / `open_ended?` — private helpers
+ *
+ * TS deviations (deliberate, called out in the audit):
+ * - `infinitySign` and `unboundableSign` collapse: Trails has no
+ *   `unboundable?` value protocol, so both reduce to checking
+ *   `+/-Infinity` (and a `Quoted` wrapper around the same).
+ * - The TS port accepts three input shapes (array, object, positional)
+ *   instead of Ruby's single `Range`.
  */
 
 export interface RangeLike {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -5,7 +5,6 @@ import {
   GreaterThanOrEqual,
   LessThan,
   LessThanOrEqual,
-  Between,
   NotIn,
   IsDistinctFrom,
   IsNotDistinctFrom,
@@ -17,11 +16,15 @@ import { Regexp as RegexpNode, NotRegexp } from "./nodes/regexp.js";
 import { Quoted } from "./nodes/casted.js";
 import { And } from "./nodes/and.js";
 import { Or } from "./nodes/or.js";
-import { Not } from "./nodes/unary.js";
 import { Grouping } from "./nodes/grouping.js";
-import { True } from "./nodes/true.js";
 import { Case } from "./nodes/case.js";
 import { Concat, Contains, Overlaps } from "./nodes/infix-operation.js";
+import {
+  parseRange,
+  betweenFromRange,
+  notBetweenFromRange,
+  type RangeHost,
+} from "./predications-range.js";
 
 /**
  * Host contract for the Predications mixin.
@@ -171,83 +174,39 @@ export const Predications = {
     return new NotIn(this as unknown as Node, this.quotedNode(other));
   },
 
-  // `between` / `notBetween` accept three forms — `[begin, end]`, `{ begin,
-  // end }`, or `(begin, end)` — same as Attribute#between. Object-literal
-  // methods can't carry overload signatures directly, so the public type
-  // is asserted via `as` below; the implementation parameter list stays
-  // permissive for the runtime branch.
+  // `between` / `notBetween` accept three forms — `[begin, end]`,
+  // `{ begin, end, excludeEnd? }`, or `(begin, end, excludeEnd?)` — same
+  // as Attribute#between. The decision tree (in predications-range.ts)
+  // mirrors Rails' Predications#between (predications.rb): unboundable
+  // bounds collapse to In([])/NotIn([]), open-ended bounds reduce to
+  // half-comparisons, exclusive end uses `<` / `>=`, and degenerate
+  // `b == e` collapses to eq.
   between: function (
     this: PredicationHost,
     beginOrRange: unknown,
     end?: unknown,
-  ): Between | LessThanOrEqual | GreaterThanOrEqual | True {
-    let beginVal: unknown;
-    let endVal: unknown;
-    if (Array.isArray(beginOrRange) && end === undefined) {
-      beginVal = beginOrRange[0];
-      endVal = beginOrRange[1];
-    } else if (
-      typeof beginOrRange === "object" &&
-      beginOrRange !== null &&
-      !Array.isArray(beginOrRange) &&
-      !(beginOrRange instanceof Node) &&
-      "begin" in (beginOrRange as Record<string, unknown>) &&
-      "end" in (beginOrRange as Record<string, unknown>) &&
-      end === undefined
-    ) {
-      beginVal = (beginOrRange as { begin: unknown; end: unknown }).begin;
-      endVal = (beginOrRange as { begin: unknown; end: unknown }).end;
-    } else {
-      beginVal = beginOrRange;
-      endVal = end;
-    }
-    if (beginVal === -Infinity && endVal === Infinity) return new True();
-    if (beginVal === -Infinity) {
-      return new LessThanOrEqual(this as unknown as Node, this.quotedNode(endVal));
-    }
-    if (endVal === Infinity) {
-      return new GreaterThanOrEqual(this as unknown as Node, this.quotedNode(beginVal));
-    }
-    return new Between(
-      this as unknown as Node,
-      new And([this.quotedNode(beginVal), this.quotedNode(endVal)]),
-    );
+    excludeEnd?: boolean,
+  ): Node {
+    const range = parseRange(beginOrRange, end, excludeEnd);
+    return betweenFromRange(this as unknown as RangeHost, range);
   } as {
-    (
-      this: PredicationHost,
-      range: readonly [unknown, unknown],
-    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
-    (
-      this: PredicationHost,
-      range: { begin: unknown; end: unknown },
-    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
-    (
-      this: PredicationHost,
-      begin: unknown,
-      end: unknown,
-    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
+    (this: PredicationHost, range: readonly [unknown, unknown]): Node;
+    (this: PredicationHost, range: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
+    (this: PredicationHost, begin: unknown, end: unknown, excludeEnd?: boolean): Node;
   },
 
-  notBetween: function (this: PredicationHost, beginOrRange: unknown, end?: unknown): Not {
-    const self = this as unknown as { between(b: unknown, e?: unknown): Node };
-    if (Array.isArray(beginOrRange) && end === undefined) {
-      return new Not(self.between(beginOrRange));
-    }
-    if (
-      typeof beginOrRange === "object" &&
-      beginOrRange !== null &&
-      !(beginOrRange instanceof Node) &&
-      end === undefined &&
-      "begin" in (beginOrRange as Record<string, unknown>) &&
-      "end" in (beginOrRange as Record<string, unknown>)
-    ) {
-      return new Not(self.between(beginOrRange));
-    }
-    return new Not(self.between(beginOrRange, end));
+  notBetween: function (
+    this: PredicationHost,
+    beginOrRange: unknown,
+    end?: unknown,
+    excludeEnd?: boolean,
+  ): Node {
+    const range = parseRange(beginOrRange, end, excludeEnd);
+    return notBetweenFromRange(this as unknown as RangeHost, range);
   } as {
-    (this: PredicationHost, range: readonly [unknown, unknown]): Not;
-    (this: PredicationHost, range: { begin: unknown; end: unknown }): Not;
-    (this: PredicationHost, begin: unknown, end: unknown): Not;
+    (this: PredicationHost, range: readonly [unknown, unknown]): Node;
+    (this: PredicationHost, range: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
+    (this: PredicationHost, begin: unknown, end: unknown, excludeEnd?: boolean): Node;
   },
 
   isNull(this: PredicationHost): Equality {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -43,24 +43,24 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle two dot ranges", () => {
+      // Mirrors Rails: not_between renders as `(col < begin OR col > end)`,
+      // not as a literal `NOT BETWEEN`.
       const node = users.get("id").notBetween([1, 3]);
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("NOT");
-      expect(sql).toContain("BETWEEN");
+      expect(sql).toBe('("users"."id" < 1 OR "users"."id" > 3)');
     });
 
     it("can handle three dot ranges", () => {
-      const node = users.get("id").notBetween([1, 2]);
+      const node = users.get("id").notBetween({ begin: 1, end: 2, excludeEnd: true });
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("NOT");
-      expect(sql).toContain("BETWEEN");
+      expect(sql).toBe('("users"."id" < 1 OR "users"."id" >= 2)');
     });
 
     it("can handle ranges bounded by infinity", () => {
+      // Mirrors Rails: not_between(-Inf..Inf) collapses to in([]) → `1=0`.
       const node = users.get("id").notBetween([-Infinity, Infinity]);
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("NOT");
-      expect(sql).toContain("TRUE");
+      expect(sql).toBe("1=0");
     });
 
     it("is not preparable when an array", () => {
@@ -650,9 +650,10 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle ranges bounded by infinity", () => {
+      // Mirrors Rails: between(-Inf..Inf) collapses to not_in([]) → `1=1`.
       const node = users.get("id").between([-Infinity, Infinity]);
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toBe("TRUE");
+      expect(sql).toBe("1=1");
     });
 
     it("can handle subqueries", () => {

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,7 +1,7 @@
 {
   "ar-01": {
     "side": "diff",
-    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date→SQL serialization to drop fractional seconds for unscaled DATETIME columns."
+    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date\u2192SQL serialization to drop fractional seconds for unscaled DATETIME columns."
   },
   "ar-52": {
     "side": "diff",
@@ -9,15 +9,15 @@
   },
   "ar-65": {
     "side": "diff",
-    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
+    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) \u2014 rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
   },
   "ar-134": {
     "side": "trails-missing",
-    "reason": "joins() crashes on nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; Trails accepts the object argument into _rawJoins and later attempts to use it as a join node during SQL generation, causing a runtime failure instead of producing a valid query. Root cause: Relation#joins does not handle object/hash arguments — they fall through to _rawJoins and fail when the SQL builder encounters a non-string join entry. Real fix: handle nested object/hash arguments in Relation#joins by resolving them through _resolveAssociationJoin and applying the resulting joins via _applyJoinsToManager."
+    "reason": "joins() crashes on nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; Trails accepts the object argument into _rawJoins and later attempts to use it as a join node during SQL generation, causing a runtime failure instead of producing a valid query. Root cause: Relation#joins does not handle object/hash arguments \u2014 they fall through to _rawJoins and fail when the SQL builder encounters a non-string join entry. Real fix: handle nested object/hash arguments in Relation#joins by resolving them through _resolveAssociationJoin and applying the resulting joins via _applyJoinsToManager."
   },
   "ar-137": {
     "side": "diff",
-    "reason": "withRecursive union uses UNION instead of UNION ALL: Rails emits 'UNION ALL' between the anchor and recursive term of a recursive CTE; trails emits bare 'UNION'. Real fix: only the recursive term assembled by withRecursive should use UNION ALL; keep non-recursive with({ cte: [rel1, rel2] }) array handling on plain UNION — do not change shared resolveCteEntry behavior globally."
+    "reason": "withRecursive union uses UNION instead of UNION ALL: Rails emits 'UNION ALL' between the anchor and recursive term of a recursive CTE; trails emits bare 'UNION'. Real fix: only the recursive term assembled by withRecursive should use UNION ALL; keep non-recursive with({ cte: [rel1, rel2] }) array handling on plain UNION \u2014 do not change shared resolveCteEntry behavior globally."
   },
   "ar-138": {
     "side": "diff",
@@ -26,10 +26,6 @@
   "ar-139": {
     "side": "diff",
     "reason": "joins(:assoc).where(assoc: {col: val}) uses inconsistent table naming between the JOIN and nested-hash predicate paths: trails resolves joins(:assoc) through _resolveAssociationJoin as an unaliased join on the base table name ('INNER JOIN \"authors\" ON \"authors\".\"id\" = ...'), but the nested-hash predicate path resolves the same association through TableMetadata.associatedTable and aliases it to the association key ('author'), producing WHERE \"author\".\"name\" against a query that only joined \"authors\". Real fix: make symbolic association joins and nested-hash predicate resolution share the same table name/alias strategy so both clauses reference the same table."
-  },
-  "ar-143": {
-    "side": "trails-missing",
-    "reason": "leftOuterJoins() crashes on nested hash arguments: trails accepts an object into Relation#leftOuterJoins/leftJoins and later tries to build a LEFT OUTER JOIN with that plain object as the table operand (relation.ts:1230+), raising 'Unknown node type: Object'. Real fix: handle or reject nested-hash/object arguments in Relation#leftOuterJoins/leftJoins before _applyJoinsToManager builds Arel JOIN nodes — for example by reusing the nested-association resolution from joins() or adding early argument validation."
   },
   "ar-150": {
     "side": "diff",
@@ -67,29 +63,13 @@
     "side": "trails-missing",
     "reason": "Arel arithmetic nodes crash on bare number operands: Nodes.Multiplication.new(col, 2) throws 'Unknown node type: Number' because Trails' Arel visitor has no handler for plain Number values. Rails wraps bare values via Nodes.build_quoted automatically. Real fix: the Arel visitor must handle raw Number operands in arithmetic nodes as quoted literals, mirroring Rails' Arel::Visitors::ToSql arithmetic visit methods."
   },
-  "ar-160": {
-    "side": "trails-missing",
-    "reason": "Arel aggregate nodes (Sum, Count, Avg, Max, Min) constructed directly via new Nodes.Sum([col]) crash: the Trails Arel visitor has no visitSum etc. handlers, throwing 'Unknown node type: Sum'. Rails' visitor handles these via visit_Arel_Nodes_Sum etc. Real fix: add visitor handlers for each aggregate node type in the Arel ToSql visitor."
-  },
   "ar-161": {
     "side": "diff",
     "reason": "ORDER BY string alias from a SELECT expression is over-qualified: order('pub_year') on a query with EXTRACT(...) AS pub_year produces ORDER BY \"books\".\"pub_year\" ASC instead of ORDER BY pub_year. Trails' string-order path qualifies any bare identifier with the model's table name. Real fix: _applyOrderToManager must pass string ORDER BY values verbatim (as Rails does) instead of qualifying unrecognised bare identifiers."
   },
   "ar-162": {
     "side": "diff",
-    "reason": "ORDER BY aggregate alias is over-qualified: order('cnt DESC') produces ORDER BY \"books\".\"cnt\" DESC instead of ORDER BY cnt DESC. Same root as ar-161 — Trails' order-qualification path treats any bare identifier as a table column. Real fix: same as ar-161."
-  },
-  "ar-163": {
-    "side": "trails-missing",
-    "reason": "Arel Nodes::Count not registered in Trails' Arel visitor: new Nodes.Count([col]) throws 'Unknown node type: Count'. Same root as ar-160 (Sum). Real fix: add visitCount to the Arel ToSql visitor."
-  },
-  "ar-164": {
-    "side": "trails-missing",
-    "reason": "Arel Nodes::Max and Nodes::Min not registered in Trails' Arel visitor: new Nodes.Max/Min([col]) throws 'Unknown node type: Max'. Same root as ar-160 (Sum). Real fix: add visitMax and visitMin to the Arel ToSql visitor."
-  },
-  "ar-165": {
-    "side": "trails-missing",
-    "reason": "Arel COUNT DISTINCT via Nodes.Count([col], true) not supported: throws 'Unknown node type: Count'. Pinning separately because the fix must also handle the distinct=true flag to emit COUNT(DISTINCT col). Real fix: visitCount must check the distinct flag and emit COUNT(DISTINCT ...) accordingly."
+    "reason": "ORDER BY aggregate alias is over-qualified: order('cnt DESC') produces ORDER BY \"books\".\"cnt\" DESC instead of ORDER BY cnt DESC. Same root as ar-161 \u2014 Trails' order-qualification path treats any bare identifier as a table column. Real fix: same as ar-161."
   },
   "ar-166": {
     "side": "diff",
@@ -99,21 +79,13 @@
     "side": "diff",
     "reason": "ORDER BY select alias over-qualified even when the alias is correctly listed in GROUP BY: order('avg_pages DESC') produces ORDER BY \"books\".\"avg_pages\" DESC instead of ORDER BY avg_pages DESC. GROUP BY correctly passes the comma-separated string through, but ORDER BY still qualifies the single-word alias. Same fix as ar-161/162/166."
   },
-  "ar-169": {
-    "side": "diff",
-    "reason": "Arel Attribute#between with an exclusive-end Range emits BETWEEN instead of >= AND <: between(Range(100, 300, excludeEnd: true)) produces WHERE pages BETWEEN 100 AND 300 instead of WHERE pages >= 100 AND pages < 300. Rails' between uses the Range's exclude_end? flag to choose between BETWEEN (inclusive) and >= AND < (exclusive). Real fix: the between() predicate implementation must check the Range's exclude_end flag and emit >= AND < for exclusive ranges."
-  },
   "ar-170": {
     "side": "diff",
-    "reason": "Float values in Range lose decimal precision: where({ rating: new Range(3.5, 5.0) }) produces BETWEEN 3.5 AND 5 instead of BETWEEN 3.5 AND 5.0. JavaScript numbers don't distinguish 5 from 5.0, so the SQL literal omits the decimal. Rails serializes Ruby Float 5.0 as '5.0'. Real fix: the SQL value serializer must emit floats with at least one decimal digit (e.g. 5 → 5.0) to match Rails' Float#to_s behavior."
+    "reason": "Float values in Range lose decimal precision: where({ rating: new Range(3.5, 5.0) }) produces BETWEEN 3.5 AND 5 instead of BETWEEN 3.5 AND 5.0. JavaScript numbers don't distinguish 5 from 5.0, so the SQL literal omits the decimal. Rails serializes Ruby Float 5.0 as '5.0'. Real fix: the SQL value serializer must emit floats with at least one decimal digit (e.g. 5 \u2192 5.0) to match Rails' Float#to_s behavior."
   },
   "ar-171": {
     "side": "trails-missing",
     "reason": "group(Arel.sql(...)) crashes: group(sql('DATE(created_at)')) throws 'col.trim is not a function' because groupBang stores Arel values in _groupColumns and groupColumnToArel later calls .trim() on each entry, assuming strings. Arel SqlLiteral (and NamedFunction, cf. ar-154) are not strings. Real fix: group/groupBang must handle Arel node arguments by passing them through to the Arel GROUP BY clause (or converting them appropriately) instead of letting non-strings reach string-only processing in groupColumnToArel."
-  },
-  "ar-172": {
-    "side": "trails-missing",
-    "reason": "Arel ordering methods (.asc()/.desc()) are missing from non-Attribute node types: NamedFunction.new('LENGTH', [col]).desc throws '(intermediate value).desc is not a function'. Rails' Arel nodes include OrderPredications which adds asc/desc to all nodes; Trails only implements these on Attribute. Real fix: add asc() and desc() to the Arel Node base class (or to non-Attribute ordering node types like NamedFunction, Extract, etc.)."
   },
   "ar-173": {
     "side": "diff",
@@ -127,13 +99,9 @@
     "side": "diff",
     "reason": "Float equality predicate loses decimal for whole-number floats: where({ rating: 4.0 }) produces = 4 instead of = 4.0. JavaScript does not distinguish 4 from 4.0, so the SQL literal omits the decimal. Rails serializes Ruby Float 4.0 as '4.0'. Same root as ar-173/174/170. Real fix: the SQL value serializer must emit floats with at least one decimal digit."
   },
-  "ar-178": {
-    "side": "trails-missing",
-    "reason": "Arel ordering methods (.desc()) are missing from Extract nodes: Nodes.Extract.new(col, 'year').desc() throws '(intermediate value).desc is not a function'. Same root as ar-172 — Rails adds asc/desc to all Arel nodes via OrderPredications but Trails only has them on Attribute. Real fix: add asc() and desc() to the Arel Node base class."
-  },
   "ar-179": {
     "side": "diff",
-    "reason": "Float 0.0 loses its decimal point: where({ rating: 0.0 }) produces = 0 instead of = 0.0. JavaScript 0.0 === 0 so the decimal is dropped during SQL serialization. Rails serializes Ruby Float 0.0 as '0.0'. Same root as ar-173/174/176 — Real fix: SQL value serializer must emit floats with at least one decimal digit."
+    "reason": "Float 0.0 loses its decimal point: where({ rating: 0.0 }) produces = 0 instead of = 0.0. JavaScript 0.0 === 0 so the decimal is dropped during SQL serialization. Rails serializes Ruby Float 0.0 as '0.0'. Same root as ar-173/174/176 \u2014 Real fix: SQL value serializer must emit floats with at least one decimal digit."
   },
   "ar-180": {
     "side": "diff",
@@ -145,7 +113,7 @@
   },
   "ar-183": {
     "side": "trails-missing",
-    "reason": "Arel Case node fluent builder with integer .then() args: Case.new(col).when('active').then(1) throws '(intermediate value).when(...).then is not a function'. Same root as ar-155 — Case builder lacks then(). This fixture pins that the gap also manifests when .then() receives integer literals rather than string values. Real fix: same as ar-155 — add then() to the Case node builder."
+    "reason": "Arel Case node fluent builder with integer .then() args: Case.new(col).when('active').then(1) throws '(intermediate value).when(...).then is not a function'. Same root as ar-155 \u2014 Case builder lacks then(). This fixture pins that the gap also manifests when .then() receives integer literals rather than string values. Real fix: same as ar-155 \u2014 add then() to the Case node builder."
   },
   "ar-184": {
     "side": "diff",


### PR DESCRIPTION
## Summary
- Replace the +/-Infinity-only between/notBetween branches with Rails' full range decision tree (predications.rb): unboundable bounds collapse to `In([])`/`NotIn([])`, open-ended bounds reduce to half-comparisons, exclusive end uses `<` / `>=`, and degenerate `b == e` collapses to `eq`.
- Move the shared logic into `predications-range.ts` so both the `Predications` mixin and `Attribute`'s class-side overrides agree.
- Update existing tests (kept names, fixed bodies) to mirror Rails `attribute_test.rb` expectations; add `predications-range.test.ts` covering the full decision tree with both AST-shape and SQL-output assertions.
- AR-side fix: `RangeHandler#callNegated` no longer delegates to `attribute.notBetween` for inclusive ranges. Rails AR's `where.not(col: 1..5)` produces `NOT (BETWEEN)` via PredicateBuilder + `where.not`, not via `not_between`. Wrap directly to preserve that path.

## Behavioral changes (SQL-visible at the Arel level)
- `between(b, e, excludeEnd: true)` → `(col >= b AND col < e)` (was: `BETWEEN b AND e`, incorrect for exclusive)
- `between(b, b)` → `col = b` (was: `BETWEEN b AND b`)
- `between(-Inf..Inf)` → `1=1` (was: `TRUE`)
- `between` with unboundable bound (e.g. `Infinity..end`) → `1=0`
- `notBetween(b, e)` → `(col < b OR col > e)` (was: `NOT (col BETWEEN b AND e)`)
- `notBetween(-Inf..Inf)` → `1=0` (was: `NOT TRUE`)

AR-level (`where.not(col: range)`) SQL is preserved via the RangeHandler fix.

## Notes / deferrals
- `Quoted extends Unary` (and `Quoted#infinite()` / `unboundable()` instance methods) was deferred from the v2 plan — the decision tree only needs `value instanceof Quoted` to peek through wrappers, and the class hierarchy change has wide blast radius (every `quoted.value` reader). Will land separately if a future PR needs the protocol on Quoted itself.
- Test names preserved verbatim (`git diff` shows zero name additions/removals across `attribute.test.ts`); only test bodies changed to match Rails expectations.

## Plan reference
First PR from `docs/arel-alignment-plan.md` (PR 1).

## Test plan
- [x] `pnpm vitest run packages/arel/src` (1148 passed, 28 new range tests)
- [x] `pnpm vitest run packages/activerecord/src` (9941 passed)
- [x] Local parity:query — closes 6 known gaps (ar-65, ar-143, ar-160, ar-163, ar-164, ar-165, ar-169, ar-172, ar-178); 0 new failures attributable to this PR
- [ ] CI green (parity + matrix dialects)