### PR TITLE
feat(activemodel): port Numericality dispatch privates (filteredOptions, isAllowOnlyInteger, prepareValueForValidation, isRecordAttributeChangedInPlace)

### DIFF
--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -686,6 +686,30 @@ describe("numericality with in: range", () => {
     expect(p.errors.get("age")).toContain("is not a number");
   });
 
+  it("validates raw before-type-cast input on UPDATE even when allowNil is true", () => {
+    // Regression: trails' Model.attributeChangedInPlace returns true for
+    // any change-from-snapshot (not just in-place mutation as Rails
+    // means it). So if numericality's prepareValueForValidation
+    // honored the Rails record_attribute_changed_in_place? short-circuit,
+    // a 10 → 'abc' update on an integer attr would skip the raw read
+    // and let allowNil silently pass. Pin the trails behavior: raw
+    // 'abc' is read regardless of dirty state.
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.validates("age", { numericality: { allowNil: true } });
+      }
+    }
+    const p = new Person({ age: 10 });
+    expect(p.isValid()).toBe(true);
+    p.changesApplied(); // baseline = 10
+    p.writeAttribute("age", "abc");
+    expect(p.readAttribute("age")).toBeNull(); // cast failed
+    expect(p.readAttributeBeforeTypeCast("age")).toBe("abc");
+    expect(p.isValid()).toBe(false); // raw 'abc' wins over null cast + allowNil
+    expect(p.errors.get("age")).toContain("is not a number");
+  });
+
   it("validates raw before-type-cast input even when allowNil is true (overridden validate)", () => {
     // EachValidator.validate skips validateEach when allow_nil: true and
     // value is null. Numericality overrides validate so the raw input

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -667,9 +667,11 @@ describe("numericality with in: range", () => {
 
   it("validates against the raw before-type-cast value (prepareValueForValidation)", () => {
     // Rails numericality validates what the user typed, not the cast
-    // value — otherwise integer columns would coerce 'abc' to 0
-    // before the validator sees it. Trails routes the raw read
-    // through readAttributeBeforeTypeCast.
+    // value. In trails, IntegerType.cast returns null for non-numeric
+    // strings — so without prepareValueForValidation, 'abc' would read
+    // as null and slip past via the allowNil short-circuit. The raw
+    // read through readAttributeBeforeTypeCast surfaces the original
+    // 'abc' so it's caught as not_a_number.
     class Person extends Model {
       static {
         this.attribute("age", "integer");

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -686,6 +686,23 @@ describe("numericality with in: range", () => {
     expect(p.errors.get("age")).toContain("is not a number");
   });
 
+  it("validates raw before-type-cast input even when allowNil is true (overridden validate)", () => {
+    // EachValidator.validate skips validateEach when allow_nil: true and
+    // value is null. Numericality overrides validate so the raw input
+    // is read FIRST — 'abc' on an integer column casts to null but
+    // should still be caught as not_a_number even with allowNil: true.
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.validates("age", { numericality: { allowNil: true } });
+      }
+    }
+    expect(new Person({}).isValid()).toBe(true); // genuinely nil → skip
+    const bad = new Person({ age: "abc" });
+    expect(bad.isValid()).toBe(false); // raw 'abc' wins over null cast
+    expect(bad.errors.get("age")).toContain("is not a number");
+  });
+
   it("isAllowOnlyInteger honors a record-method onlyInteger (Ruby truthiness)", () => {
     // Rails: allow_only_integer?(record) returns
     // resolve_value(record, options[:only_integer]). A method name

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -664,4 +664,44 @@ describe("numericality with in: range", () => {
     v.validateEach(stubRecord, "x", { not: "a number" });
     expect(errors).toEqual([["x", "not_a_number"]]);
   });
+
+  it("validates against the raw before-type-cast value (prepareValueForValidation)", () => {
+    // Rails numericality validates what the user typed, not the cast
+    // value — otherwise integer columns would coerce 'abc' to 0
+    // before the validator sees it. Trails routes the raw read
+    // through readAttributeBeforeTypeCast.
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.validates("age", { numericality: true });
+      }
+    }
+    // "abc" can't cast through IntegerType (trails returns null), but
+    // the validator should see the raw "abc" via
+    // readAttributeBeforeTypeCast and reject it as not_a_number — NOT
+    // accidentally pass via the null-then-allow_nil branch.
+    const p = new Person({ age: "abc" });
+    expect(p.readAttributeBeforeTypeCast("age")).toBe("abc");
+    expect(p.isValid()).toBe(false);
+    expect(p.errors.get("age")).toContain("is not a number");
+  });
+
+  it("isAllowOnlyInteger honors a record-method onlyInteger (Ruby truthiness)", () => {
+    // Rails: allow_only_integer?(record) returns
+    // resolve_value(record, options[:only_integer]). A method name
+    // like 'strictMode' resolves to record.strictMode().
+    class Person extends Model {
+      static {
+        this.attribute("score", "string");
+        this.validates("score", { numericality: { onlyInteger: "strictMode" } });
+      }
+      strictMode(): boolean {
+        return true;
+      }
+    }
+    expect(new Person({ score: "5" }).isValid()).toBe(true);
+    const f = new Person({ score: "5.5" });
+    expect(f.isValid()).toBe(false);
+    expect(f.errors.get("score")).toContain("must be an integer");
+  });
 });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -92,19 +92,12 @@ export class NumericalityValidator extends EachValidator {
    */
   override validate(record: AnyRecord): void {
     for (const attribute of this.attributes) {
-      // Same readAttributeForValidation lookup as EachValidator.validate
-      // (validator.ts:90-100). Methods are called directly on `record`
-      // so `this` stays bound — extracting them would unbind and
-      // Model.readAttribute reads this._attributes, which would throw.
-      // The flow runs through prepareValueForValidation BEFORE the
-      // allowNil/allowBlank short-circuits so raw user input ('abc' →
-      // cast null) still gets validated.
-      const cast =
-        typeof record.readAttributeForValidation === "function"
-          ? record.readAttributeForValidation(attribute)
-          : typeof record.readAttribute === "function"
-            ? record.readAttribute(attribute)
-            : record[attribute];
+      // Reuses EachValidator.readAttributeForValidation so the lookup
+      // chain stays in one place. The flow then runs through
+      // prepareValueForValidation BEFORE the allowNil/allowBlank
+      // short-circuits so raw user input ('abc' → cast null) still
+      // gets validated.
+      const cast = this.readAttributeForValidation(record, attribute);
       const value = this.prepareValueForValidation(cast, record, attribute);
       if (value == null && this.options.allowNil === true) continue;
       if (isBlank(value) && this.options.allowBlank === true) continue;
@@ -550,13 +543,13 @@ export function prepareValueForValidation(
   // Rails has an early `return value if record_attribute_changed_in_place?`
   // short-circuit (numericality.rb:121) — in-place mutation means the
   // cast value IS what the user just changed; raw before_type_cast is
-  // stale. Trails skips this optimization today because Model.attribute-
-  // ChangedInPlace returns true for ANY change (not just in-place
-  // mutation), so honoring the short-circuit would let normal
-  // 10 → "abc" updates bypass numericality. The isRecordAttribute-
-  // ChangedInPlace helper is still exported (Rails parity surface),
-  // it just isn't a gate here yet. Revisit once trails grows true
-  // in-place-mutation tracking.
+  // stale. Trails skips this optimization today because
+  // `Model.attributeChangedInPlace` returns true for ANY change (not
+  // just in-place mutation), so honoring the short-circuit would let
+  // normal `10 → "abc"` updates bypass numericality. The
+  // `isRecordAttributeChangedInPlace` helper is still exported (Rails
+  // parity surface), it just isn't a gate here yet. Revisit once
+  // trails grows true in-place-mutation tracking.
   //
   // Trails exposes raw values through the generic
   // `readAttributeBeforeTypeCast(name)` API on Model rather than the

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -534,8 +534,10 @@ interface RecordWithRawAttribute {
  *   end
  *
  * Lets numericality validate against the raw input the user typed
- * (before type-cast) so e.g. "abc" doesn't get cast to 0 by an
- * integer column before the validator sees it.
+ * (before type-cast). In trails, IntegerType.cast returns null for
+ * non-numeric strings — so "abc" on an integer column would otherwise
+ * read as null and slip past via the allowNil short-circuit; this
+ * surfaces the original "abc" so it's caught as not_a_number.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -538,14 +538,22 @@ interface RecordWithRawAttribute {
  * @internal Rails-private helper.
  */
 export function prepareValueForValidation(
-  this: {
-    isRecordAttributeChangedInPlace(record: AnyRecord, attrName: string): boolean;
-  },
+  this: unknown,
   value: unknown,
   record: AnyRecord,
   attrName: string,
 ): unknown {
-  if (this.isRecordAttributeChangedInPlace(record, attrName)) return value;
+  // Rails has an early `return value if record_attribute_changed_in_place?`
+  // short-circuit (numericality.rb:121) — in-place mutation means the
+  // cast value IS what the user just changed; raw before_type_cast is
+  // stale. Trails skips this optimization today because Model.attribute-
+  // ChangedInPlace returns true for ANY change (not just in-place
+  // mutation), so honoring the short-circuit would let normal
+  // 10 → "abc" updates bypass numericality. The isRecordAttribute-
+  // ChangedInPlace helper is still exported (Rails parity surface),
+  // it just isn't a gate here yet. Revisit once trails grows true
+  // in-place-mutation tracking.
+  //
   // Trails exposes raw values through the generic
   // `readAttributeBeforeTypeCast(name)` API on Model rather than the
   // Rails per-attribute generated `${attr}_before_type_cast` methods.

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -82,6 +82,34 @@ export class NumericalityValidator extends EachValidator {
   }
 
   // Rails: validate_each(record, attr_name, value, precision: Float::DIG, scale: nil)
+  /**
+   * Override EachValidator.validate so prepareValueForValidation runs
+   * BEFORE the allow_nil short-circuit. Rails' EachValidator
+   * normally would skip nil values when allow_nil: true, but
+   * Numericality wants to validate what the user actually typed —
+   * an integer column casting "abc" to null mustn't bypass the check
+   * (numericality.rb's validate_each operates on raw input).
+   */
+  override validate(record: AnyRecord): void {
+    for (const attribute of this.attributes) {
+      // Same readAttributeForValidation lookup as EachValidator.validate
+      // (validator.ts:90-100), but routed through prepareValueForValidation
+      // BEFORE the allowNil/allowBlank short-circuits so raw user input
+      // ('abc' → cast null) still gets validated.
+      const r = record as Record<string, unknown>;
+      const cast =
+        typeof r.readAttributeForValidation === "function"
+          ? (r.readAttributeForValidation as (n: string) => unknown)(attribute)
+          : typeof r.readAttribute === "function"
+            ? (r.readAttribute as (n: string) => unknown)(attribute)
+            : r[attribute];
+      const value = this.prepareValueForValidation(cast, record, attribute);
+      if (value == null && this.options.allowNil === true) continue;
+      if (isBlank(value) && this.options.allowBlank === true) continue;
+      this.validateEach(record, attribute, value);
+    }
+  }
+
   validateEach(
     record: AnyRecord,
     attribute: string,
@@ -89,21 +117,15 @@ export class NumericalityValidator extends EachValidator {
     precision = 15,
     scale?: number,
   ): void {
-    // Rails: validate_each operates on the raw user input when one is
-    // available (numericality.rb:36 calls prepare_value_for_validation
-    // implicitly via the *_came_from_user? / *_before_type_cast path).
-    // Trails routes the same idea through readAttributeBeforeTypeCast.
-    value = this.prepareValueForValidation(value, record, attribute);
-
     if (value === null || value === undefined) {
       if (this.options.allowNil !== false) return;
-      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
+      record.errors.add(attribute, "not_a_number", this.filteredOptions(value));
       return;
     }
     if (this.options.allowBlank && isBlank(value)) return;
 
     if (!this.isNumber(value, precision, scale)) {
-      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
+      record.errors.add(attribute, "not_a_number", this.filteredOptions(value));
       return;
     }
 
@@ -113,11 +135,19 @@ export class NumericalityValidator extends EachValidator {
     // raw options[:only_integer] read, so a Proc / method-name option
     // is honored per-record.
     if (this.isAllowOnlyInteger(record) && !this.isInteger(value)) {
-      record.errors.add(attribute, "not_an_integer", { value, message: this.options.message });
+      record.errors.add(attribute, "not_an_integer", this.filteredOptions(value));
       return;
     }
 
-    const msg = this.options.message;
+    // Rails uses filtered_options(value).merge!(count: option_value)
+    // for compare/range branches and filtered_options(value) (no count)
+    // for odd/even. Build a fresh filtered base each branch so non-
+    // reserved validator options (message, if, unless, …) reach i18n.
+    const withCount = (count: unknown): Record<string, unknown> => ({
+      ...this.filteredOptions(value),
+      count,
+    });
+
     const gt = this.resolveNumeric(
       this.options.greaterThan as NumericValue | undefined,
       record,
@@ -125,7 +155,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (gt !== undefined && !(num > gt)) {
-      record.errors.add(attribute, "greater_than", { count: gt, value, message: msg });
+      record.errors.add(attribute, "greater_than", withCount(gt));
     }
     const gte = this.resolveNumeric(
       this.options.greaterThanOrEqualTo as NumericValue | undefined,
@@ -134,7 +164,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (gte !== undefined && !(num >= gte)) {
-      record.errors.add(attribute, "greater_than_or_equal_to", { count: gte, value, message: msg });
+      record.errors.add(attribute, "greater_than_or_equal_to", withCount(gte));
     }
     const lt = this.resolveNumeric(
       this.options.lessThan as NumericValue | undefined,
@@ -143,7 +173,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (lt !== undefined && !(num < lt)) {
-      record.errors.add(attribute, "less_than", { count: lt, value, message: msg });
+      record.errors.add(attribute, "less_than", withCount(lt));
     }
     const lte = this.resolveNumeric(
       this.options.lessThanOrEqualTo as NumericValue | undefined,
@@ -152,7 +182,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (lte !== undefined && !(num <= lte)) {
-      record.errors.add(attribute, "less_than_or_equal_to", { count: lte, value, message: msg });
+      record.errors.add(attribute, "less_than_or_equal_to", withCount(lte));
     }
     const eq = this.resolveNumeric(
       this.options.equalTo as NumericValue | undefined,
@@ -161,7 +191,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (eq !== undefined && num !== eq) {
-      record.errors.add(attribute, "equal_to", { count: eq, value, message: msg });
+      record.errors.add(attribute, "equal_to", withCount(eq));
     }
     const ot = this.resolveNumeric(
       this.options.otherThan as NumericValue | undefined,
@@ -170,23 +200,19 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (ot !== undefined && num === ot) {
-      record.errors.add(attribute, "other_than", { count: ot, value, message: msg });
+      record.errors.add(attribute, "other_than", withCount(ot));
     }
     if (this.options.in !== undefined) {
       const [min, max] = this.options.in as [number, number];
       if (num < min || num > max) {
-        record.errors.add(attribute, "in", {
-          message: msg,
-          value,
-          count: `${min}..${max}`,
-        });
+        record.errors.add(attribute, "in", withCount(`${min}..${max}`));
       }
     }
     if (this.options.odd && num % 2 === 0) {
-      record.errors.add(attribute, "odd", { value, message: msg });
+      record.errors.add(attribute, "odd", this.filteredOptions(value));
     }
     if (this.options.even && num % 2 !== 0) {
-      record.errors.add(attribute, "even", { value, message: msg });
+      record.errors.add(attribute, "even", this.filteredOptions(value));
     }
   }
 }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -93,16 +93,18 @@ export class NumericalityValidator extends EachValidator {
   override validate(record: AnyRecord): void {
     for (const attribute of this.attributes) {
       // Same readAttributeForValidation lookup as EachValidator.validate
-      // (validator.ts:90-100), but routed through prepareValueForValidation
-      // BEFORE the allowNil/allowBlank short-circuits so raw user input
-      // ('abc' → cast null) still gets validated.
-      const r = record as Record<string, unknown>;
+      // (validator.ts:90-100). Methods are called directly on `record`
+      // so `this` stays bound — extracting them would unbind and
+      // Model.readAttribute reads this._attributes, which would throw.
+      // The flow runs through prepareValueForValidation BEFORE the
+      // allowNil/allowBlank short-circuits so raw user input ('abc' →
+      // cast null) still gets validated.
       const cast =
-        typeof r.readAttributeForValidation === "function"
-          ? (r.readAttributeForValidation as (n: string) => unknown)(attribute)
-          : typeof r.readAttribute === "function"
-            ? (r.readAttribute as (n: string) => unknown)(attribute)
-            : r[attribute];
+        typeof record.readAttributeForValidation === "function"
+          ? record.readAttributeForValidation(attribute)
+          : typeof record.readAttribute === "function"
+            ? record.readAttribute(attribute)
+            : record[attribute];
       const value = this.prepareValueForValidation(cast, record, attribute);
       if (value == null && this.options.allowNil === true) continue;
       if (isBlank(value) && this.options.allowBlank === true) continue;

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -89,6 +89,12 @@ export class NumericalityValidator extends EachValidator {
     precision = 15,
     scale?: number,
   ): void {
+    // Rails: validate_each operates on the raw user input when one is
+    // available (numericality.rb:36 calls prepare_value_for_validation
+    // implicitly via the *_came_from_user? / *_before_type_cast path).
+    // Trails routes the same idea through readAttributeBeforeTypeCast.
+    value = this.prepareValueForValidation(value, record, attribute);
+
     if (value === null || value === undefined) {
       if (this.options.allowNil !== false) return;
       record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
@@ -103,7 +109,10 @@ export class NumericalityValidator extends EachValidator {
 
     const num = parseAsNumber(Number(value), precision, scale) as number;
 
-    if (this.options.onlyInteger && !this.isInteger(value)) {
+    // Rails dispatches through allow_only_integer?(record), not the
+    // raw options[:only_integer] read, so a Proc / method-name option
+    // is honored per-record.
+    if (this.isAllowOnlyInteger(record) && !this.isInteger(value)) {
       record.errors.add(attribute, "not_an_integer", { value, message: this.options.message });
       return;
     }
@@ -460,12 +469,18 @@ export function isAllowOnlyInteger(
   },
   record: AnyRecord,
 ): boolean {
-  return Boolean(this.resolveValue(record, this.options.onlyInteger));
+  // Ruby truthiness: only nil/false count as false. Boolean(0) and
+  // Boolean('') would diverge (Ruby treats both as truthy), so use the
+  // explicit nil-or-false check pattern used elsewhere in trails (see
+  // clusivity.ts:delimiter, comparison.ts).
+  const resolved = this.resolveValue(record, this.options.onlyInteger);
+  return resolved !== undefined && resolved !== null && resolved !== false;
 }
 
 interface RecordWithRawAttribute {
   attributeChangedInPlace?: (name: string) => boolean;
   readAttribute?: (name: string) => unknown;
+  readAttributeBeforeTypeCast?: (name: string) => unknown;
   [key: string]: unknown;
 }
 
@@ -505,19 +520,16 @@ export function prepareValueForValidation(
   attrName: string,
 ): unknown {
   if (this.isRecordAttributeChangedInPlace(record, attrName)) return value;
+  // Trails exposes raw values through the generic
+  // `readAttributeBeforeTypeCast(name)` API on Model rather than the
+  // Rails per-attribute generated `${attr}_before_type_cast` methods.
+  // Duck-type the lookup so other hosts implementing the same shape
+  // (or AR Base subclasses) work too.
   const r = record as RecordWithRawAttribute;
-  const cameFromUser = `${attrName}CameFromUser`;
-  const beforeTypeCast = `${attrName}BeforeTypeCast`;
-  let rawValue: unknown;
-  if (typeof r[cameFromUser] === "function") {
-    if ((r[cameFromUser] as () => boolean).call(r)) {
-      rawValue = (r[beforeTypeCast] as (() => unknown) | undefined)?.call(r);
-    } else if (typeof r.readAttribute === "function") {
-      rawValue = r.readAttribute(attrName);
-    }
-  } else if (typeof r[beforeTypeCast] === "function") {
-    rawValue = (r[beforeTypeCast] as () => unknown).call(r);
-  }
+  const rawValue =
+    typeof r.readAttributeBeforeTypeCast === "function"
+      ? r.readAttributeBeforeTypeCast(attrName)
+      : undefined;
   // Rails: raw_value || value — Ruby `||` falls back on nil/false. Use
   // the same semantic so `false`/`null` raw values fall through to
   // the cast value rather than being treated as "I read the raw".

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -37,6 +37,14 @@ export class NumericalityValidator extends EachValidator {
   declare isInteger: typeof isInteger;
   /** @internal Rails-private helper. */
   declare isHexadecimalLiteral: typeof isHexadecimalLiteral;
+  /** @internal Rails-private helper. */
+  declare filteredOptions: typeof filteredOptions;
+  /** @internal Rails-private helper. */
+  declare isAllowOnlyInteger: typeof isAllowOnlyInteger;
+  /** @internal Rails-private helper. */
+  declare prepareValueForValidation: typeof prepareValueForValidation;
+  /** @internal Rails-private helper. */
+  declare isRecordAttributeChangedInPlace: typeof isRecordAttributeChangedInPlace;
 
   private resolveNumeric(
     val: NumericValue | undefined,
@@ -186,6 +194,27 @@ const HEXADECIMAL_REGEX = /^[+-]?0[xX]/;
 // hex check for the elsif-chain semantic Rails would apply, then layer
 // this on for the JS-specific surface.
 const NON_DECIMAL_LITERAL_REGEX = /^[+-]?0[xXbBoO]/;
+
+// Mirrors Rails numericality.rb:16:
+//   RESERVED_OPTIONS = COMPARE_CHECKS.keys + NUMBER_CHECKS.keys + RANGE_CHECKS.keys + [:only_integer, :only_numeric]
+// camelCased for trails option-key conventions.
+const RESERVED_OPTIONS = [
+  // COMPARE_CHECKS keys
+  "greaterThan",
+  "greaterThanOrEqualTo",
+  "equalTo",
+  "lessThan",
+  "lessThanOrEqualTo",
+  "otherThan",
+  // NUMBER_CHECKS keys
+  "odd",
+  "even",
+  // RANGE_CHECKS keys
+  "in",
+  // Misc
+  "onlyInteger",
+  "onlyNumeric",
+] as const;
 
 /**
  * Rails: parse_as_number → branches by Ruby type (Float / BigDecimal /
@@ -385,9 +414,137 @@ export function optionAsNumber(
   return parseAsNumber(numeric, precision, scale);
 }
 
+/**
+ * Mirrors: numericality.rb:110-114
+ *   def filtered_options(value)
+ *     filtered = options.except(*RESERVED_OPTIONS)
+ *     filtered[:value] = value
+ *     filtered
+ *   end
+ *
+ * Builds the i18n interpolation hash for an error: strips the
+ * comparison/range/number-check option keys and merges in :value.
+ *
+ * @internal Rails-private helper.
+ */
+export function filteredOptions(
+  this: { options: Record<string, unknown> },
+  value: unknown,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const key of Object.keys(this.options)) {
+    if (!(RESERVED_OPTIONS as readonly string[]).includes(key)) {
+      filtered[key] = this.options[key];
+    }
+  }
+  filtered.value = value;
+  return filtered;
+}
+
+/**
+ * Mirrors: numericality.rb:116-118
+ *   def allow_only_integer?(record)
+ *     resolve_value(record, options[:only_integer])
+ *   end
+ *
+ * Resolves the :only_integer option per-record, supporting Proc /
+ * symbol-method-name forms via resolveValue. Coerced to boolean to
+ * match Ruby's truthiness expectation at the call site.
+ *
+ * @internal Rails-private helper.
+ */
+export function isAllowOnlyInteger(
+  this: {
+    options: Record<string, unknown>;
+    resolveValue(record: unknown, value: unknown): unknown;
+  },
+  record: AnyRecord,
+): boolean {
+  return Boolean(this.resolveValue(record, this.options.onlyInteger));
+}
+
+interface RecordWithRawAttribute {
+  attributeChangedInPlace?: (name: string) => boolean;
+  readAttribute?: (name: string) => unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Mirrors: numericality.rb:120-138
+ *
+ *   def prepare_value_for_validation(value, record, attr_name)
+ *     return value if record_attribute_changed_in_place?(record, attr_name)
+ *     came_from_user = :"#{attr_name}_came_from_user?"
+ *     if record.respond_to?(came_from_user)
+ *       if record.public_send(came_from_user)
+ *         raw_value = record.public_send(:"#{attr_name}_before_type_cast")
+ *       elsif record.respond_to?(:read_attribute)
+ *         raw_value = record.read_attribute(attr_name)
+ *       end
+ *     else
+ *       before_type_cast = :"#{attr_name}_before_type_cast"
+ *       if record.respond_to?(before_type_cast)
+ *         raw_value = record.public_send(before_type_cast)
+ *       end
+ *     end
+ *     raw_value || value
+ *   end
+ *
+ * Lets numericality validate against the raw input the user typed
+ * (before type-cast) so e.g. "abc" doesn't get cast to 0 by an
+ * integer column before the validator sees it.
+ *
+ * @internal Rails-private helper.
+ */
+export function prepareValueForValidation(
+  this: {
+    isRecordAttributeChangedInPlace(record: AnyRecord, attrName: string): boolean;
+  },
+  value: unknown,
+  record: AnyRecord,
+  attrName: string,
+): unknown {
+  if (this.isRecordAttributeChangedInPlace(record, attrName)) return value;
+  const r = record as RecordWithRawAttribute;
+  const cameFromUser = `${attrName}CameFromUser`;
+  const beforeTypeCast = `${attrName}BeforeTypeCast`;
+  let rawValue: unknown;
+  if (typeof r[cameFromUser] === "function") {
+    if ((r[cameFromUser] as () => boolean).call(r)) {
+      rawValue = (r[beforeTypeCast] as (() => unknown) | undefined)?.call(r);
+    } else if (typeof r.readAttribute === "function") {
+      rawValue = r.readAttribute(attrName);
+    }
+  } else if (typeof r[beforeTypeCast] === "function") {
+    rawValue = (r[beforeTypeCast] as () => unknown).call(r);
+  }
+  // Rails: raw_value || value — Ruby `||` falls back on nil/false. Use
+  // the same semantic so `false`/`null` raw values fall through to
+  // the cast value rather than being treated as "I read the raw".
+  return rawValue !== undefined && rawValue !== null && rawValue !== false ? rawValue : value;
+}
+
+/**
+ * Mirrors: numericality.rb:140-143
+ *   def record_attribute_changed_in_place?(record, attr_name)
+ *     record.respond_to?(:attribute_changed_in_place?) &&
+ *       record.attribute_changed_in_place?(attr_name.to_s)
+ *   end
+ *
+ * @internal Rails-private helper.
+ */
+export function isRecordAttributeChangedInPlace(record: AnyRecord, attrName: string): boolean {
+  const r = record as RecordWithRawAttribute;
+  return typeof r.attributeChangedInPlace === "function" && r.attributeChangedInPlace(attrName);
+}
+
 NumericalityValidator.prototype.optionAsNumber = optionAsNumber;
 NumericalityValidator.prototype.parseFloat = parseFloatRails;
 NumericalityValidator.prototype.round = round;
 NumericalityValidator.prototype.isNumber = isNumber;
 NumericalityValidator.prototype.isInteger = isInteger;
 NumericalityValidator.prototype.isHexadecimalLiteral = isHexadecimalLiteral;
+NumericalityValidator.prototype.filteredOptions = filteredOptions;
+NumericalityValidator.prototype.isAllowOnlyInteger = isAllowOnlyInteger;
+NumericalityValidator.prototype.prepareValueForValidation = prepareValueForValidation;
+NumericalityValidator.prototype.isRecordAttributeChangedInPlace = isRecordAttributeChangedInPlace;

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -87,16 +87,26 @@ export class EachValidator extends Validator {
     this.checkValidity();
   }
 
+  /**
+   * Mirrors: ActiveModel::Validations#read_attribute_for_validation.
+   * Defaults to `send(attr)` (record[attr]); ActiveRecord overrides to
+   * resolve associations. Subclasses that override `validate` (e.g.
+   * NumericalityValidator) reuse this helper so the lookup chain
+   * stays in one place.
+   */
+  protected readAttributeForValidation(record: AnyRecord, attribute: string): unknown {
+    if (typeof record.readAttributeForValidation === "function") {
+      return record.readAttributeForValidation(attribute);
+    }
+    if (typeof record.readAttribute === "function") {
+      return record.readAttribute(attribute);
+    }
+    return record[attribute];
+  }
+
   validate(record: AnyRecord): void {
     for (const attribute of this.attributes) {
-      // Rails: record.read_attribute_for_validation(attribute)
-      // Defaults to send(attr) — AR overrides to resolve associations.
-      const value =
-        typeof record.readAttributeForValidation === "function"
-          ? record.readAttributeForValidation(attribute)
-          : typeof record.readAttribute === "function"
-            ? record.readAttribute(attribute)
-            : record[attribute];
+      const value = this.readAttributeForValidation(record, attribute);
       if (value == null && this.options.allowNil === true) continue;
       if (isBlank(value) && this.options.allowBlank === true) continue;
       this.validateEach(record, attribute, value);


### PR DESCRIPTION
## Summary
Track A4b of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md). Closes the `numericality.rb` privates row at **100%** (15/15). Mirrors the dispatch-side helpers from `ActiveModel::Validations::NumericalityValidator`:

- **`RESERVED_OPTIONS`** — `numericality.rb:16`. `COMPARE_CHECKS` + `NUMBER_CHECKS` + `RANGE_CHECKS` keys + `only_integer` + `only_numeric`, camelCased to trails option-key conventions.
- **`filteredOptions(value)`** — `numericality.rb:110-114`. Strips `RESERVED_OPTIONS` keys from `this.options` and merges in `:value`. **All `errors.add` calls in `validateEach` now build their payload from this** (with `:count` merged via a `withCount` helper for compare/range branches), so non-reserved validator options (`message`, `if`, `unless`, …) reach i18n interpolation.
- **`isAllowOnlyInteger(record)`** — `numericality.rb:116-118`. Resolves `:only_integer` per-record via `this.resolveValue` so a Proc / method-name option is honored. `validateEach` now dispatches through this instead of reading the raw option directly. Uses Ruby-truthy semantics (`null`/`undefined`/`false` = false; `0` and `""` truthy).
- **`prepareValueForValidation(value, record, attrName)`** — `numericality.rb:120-138`. Reads the raw `before_type_cast` value through trails' generic `readAttributeBeforeTypeCast(name)` API on Model (NOT the per-attribute `${attr}_came_from_user?` / `${attr}_before_type_cast` derivations Rails uses — trails exposes the raw read as a single duck-typed method). The Rails `record_attribute_changed_in_place?` short-circuit is intentionally NOT honored here: trails' `Model.attributeChangedInPlace` returns true for any change-from-snapshot (not Rails' in-place-only mutation semantic), so the optimization would let normal `10 → "abc"` updates bypass numericality. Revisit if/when trails grows true in-place-mutation tracking.
- **`isRecordAttributeChangedInPlace(record, attrName)`** — `numericality.rb:140-143`. Duck-typed check via `attributeChangedInPlace`. Exported as Rails-parity surface but not yet a gate (see above).

`NumericalityValidator.validate(record)` is overridden so `prepareValueForValidation` runs BEFORE the `allowNil`/`allowBlank` short-circuits — raw user input wins over the cast value (`"abc"` on an integer column → casts to `null` → still gets caught as `not_a_number` even with `allowNil: true`). Methods on `record` are called directly so `this` stays bound (Model.readAttribute reads `this._attributes`).

All four privates attached to `NumericalityValidator.prototype` with `@internal` JSDoc tags (rails-private-jsdoc rule + super-time bootstrapping pattern from PRs #994 / #1002 / #1009 / #1015).

## Impact
- `pnpm api:compare --privates --package activemodel`: `numericality.rb` 11/15 → **15/15 (100%)** (+4). Overall 495/625 → **499/625 (79.8%)**.
- `pnpm api:compare --package activemodel`: stays **448/448 (100%)**.
- `pnpm test:compare --package activemodel`: stays 959/963.

## Track A status
Track A4 (Numericality privates) now fully complete. Track A5 (Confirmation + Acceptance + Callbacks bundle) is the remaining validator-cluster follow-up.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1604 / 1604 passing
- [x] `pnpm api:compare --package activemodel` — 448/448
- [x] `pnpm api:compare --privates --package activemodel` — 499/625 (+4)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)

Targeted regression tests added:
- Plain-object validation via direct `validateEach` call (bypasses StringType.cast).
- Raw `"abc"` on an integer column rejected as `not_a_number` even with `allowNil: true` (via overridden `validate`).
- 10 → "abc" UPDATE path rejected even with `allowNil: true` (regression for the in-place short-circuit decision).
- `onlyInteger: "methodName"` resolves per-record via `resolveValue`.