### PR TITLE
feat(activesupport): nanosecond-precise TimeWithZone comparison

### DIFF
--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -528,6 +528,28 @@ describe("TimeWithZoneTest", () => {
     expect(a.compareTo(a)).toBe(0);
   });
 
+  it("compareTo distinguishes Temporal.Instant operands at nanosecond precision", () => {
+    const baseNs = 1_700_000_000_000_000_000n;
+    const earlier = new TimeWithZone(Temporal.Instant.fromEpochNanoseconds(baseNs), eastern);
+    const laterByOneNs = Temporal.Instant.fromEpochNanoseconds(baseNs + 1n);
+    expect(earlier.compareTo(laterByOneNs)).toBe(-1);
+    expect(earlier.compareTo(Temporal.Instant.fromEpochNanoseconds(baseNs))).toBe(0);
+  });
+
+  it("minus() preserves nanosecond precision for Temporal.Instant operands", () => {
+    const baseNs = 1_700_000_000_000_000_000n;
+    const a = new TimeWithZone(Temporal.Instant.fromEpochNanoseconds(baseNs), eastern);
+    const b = Temporal.Instant.fromEpochNanoseconds(baseNs - 500n); // 500 ns earlier
+    expect(a.minus(b)).toBeCloseTo(5e-7, 12); // 5e-7 seconds = 500 ns
+  });
+
+  it("eql() is nanosecond-precise for Temporal.Instant operands", () => {
+    const baseNs = 1_700_000_000_000_000_000n;
+    const twz = new TimeWithZone(Temporal.Instant.fromEpochNanoseconds(baseNs), eastern);
+    expect(twz.eql(Temporal.Instant.fromEpochNanoseconds(baseNs))).toBe(true);
+    expect(twz.eql(Temporal.Instant.fromEpochNanoseconds(baseNs + 1n))).toBe(false);
+  });
+
   it("equals() compares same moment regardless of timezone", () => {
     const est = eastern.local(2024, 1, 15, 12, 0, 0);
     const pst = est.inTimeZone(pacific);

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -85,6 +85,23 @@ function daysInMonth(year: number, month: number): number {
   return new Date(year, month, 0).getDate();
 }
 
+const NS_PER_SECOND = 1_000_000_000n;
+
+/** Sign of a BigInt as a Number-typed -1 / 0 / 1. */
+function signOf(diff: bigint): number {
+  return diff < 0n ? -1 : diff > 0n ? 1 : 0;
+}
+
+/**
+ * Convert a nanosecond-difference BigInt to a JS Number of seconds, preserving
+ * sub-second precision via floating-point fractional seconds.
+ */
+function nsDiffToSeconds(diffNs: bigint): number {
+  const wholeSeconds = diffNs / NS_PER_SECOND;
+  const remainderNs = diffNs % NS_PER_SECOND;
+  return Number(wholeSeconds) + Number(remainderNs) / 1e9;
+}
+
 export class TimeWithZone {
   /** The underlying zoned instant */
   private readonly _zoned: Temporal.ZonedDateTime;
@@ -565,7 +582,7 @@ export class TimeWithZone {
   minus(other: TimeWithZone | Date | Temporal.Instant): number;
   minus(arg: number | Duration | TimeWithZone | Date | Temporal.Instant): TimeWithZone | number {
     if (arg instanceof TimeWithZone) {
-      return (this._epochMs - arg._epochMs) / 1000;
+      return nsDiffToSeconds(this._zoned.epochNanoseconds - arg._zoned.epochNanoseconds);
     }
     // boundary: minus accepts Date for backwards compat with Rails' `t1 - t2`
     // overload that takes any Time-like value (including Ruby Time / DateTime).
@@ -573,7 +590,7 @@ export class TimeWithZone {
       return (this._epochMs - arg.getTime()) / 1000;
     }
     if (arg instanceof Temporal.Instant) {
-      return (this._epochMs - arg.epochMilliseconds) / 1000;
+      return nsDiffToSeconds(this._zoned.epochNanoseconds - arg.epochNanoseconds);
     }
     if (arg instanceof Duration) {
       return this.plus(arg.negate());
@@ -692,15 +709,19 @@ export class TimeWithZone {
 
   /**
    * Compare to another TimeWithZone, Date, or Temporal.Instant. Returns -1, 0, or 1.
+   * Comparison is nanosecond-precise for TimeWithZone / Temporal.Instant
+   * arguments; Date arguments compare at millisecond resolution (Date's
+   * native granularity).
    */
   compareTo(other: TimeWithZone | Date | Temporal.Instant): number {
-    const otherMs =
-      other instanceof TimeWithZone
-        ? other._epochMs
-        : other instanceof Temporal.Instant
-          ? other.epochMilliseconds
-          : other.getTime();
+    if (other instanceof TimeWithZone) {
+      return signOf(this._zoned.epochNanoseconds - other._zoned.epochNanoseconds);
+    }
+    if (other instanceof Temporal.Instant) {
+      return signOf(this._zoned.epochNanoseconds - other.epochNanoseconds);
+    }
     const thisMs = this._epochMs;
+    const otherMs = other.getTime();
     if (thisMs < otherMs) return -1;
     if (thisMs > otherMs) return 1;
     return 0;
@@ -720,14 +741,14 @@ export class TimeWithZone {
    */
   eql(other: unknown): boolean {
     if (other instanceof TimeWithZone) {
-      return this._epochMs === other._epochMs;
+      return this._zoned.epochNanoseconds === other._zoned.epochNanoseconds;
     }
     // boundary: eql is duck-typed in Rails (any Time-like); accept Date.
     if (other instanceof Date) {
       return this._epochMs === other.getTime();
     }
     if (other instanceof Temporal.Instant) {
-      return this._epochMs === other.epochMilliseconds;
+      return this._zoned.epochNanoseconds === other.epochNanoseconds;
     }
     return false;
   }


### PR DESCRIPTION
## Summary

F-1 from the Temporal migration follow-ups. PR 8e retired the `_utc: Date` cache, leaving `compareTo` / `minus` / `eql` reading `epochMilliseconds` from incoming `Temporal.Instant` arguments and truncating sub-millisecond precision. Now that storage is `Temporal.ZonedDateTime` end-to-end, these read `epochNanoseconds` (BigInt) for full ns-precision when both sides are `TimeWithZone` or `Temporal.Instant`.

`Date` arguments still compare at millisecond granularity — Date's native resolution.

`minus` returns `Number` seconds; the BigInt-ns difference converts via a `wholeSeconds + remainderNs/1e9` split to avoid BigInt→Number narrowing on values larger than `Number.MAX_SAFE_INTEGER` ns.

## Tests

Three new tests pin the precision contract:

- `compareTo` distinguishes Instants 1 ns apart.
- `minus` preserves a 500 ns difference (5e-7 seconds, asserted within 1e-12 tolerance).
- `eql` is ns-precise.

## Background

Resolves Copilot reviews #1 / #4 on PR #973 — flagged the same issue but were declined at the time because `_utc` was Date-bound.

## Test plan

- [x] `vitest run packages/activesupport` — 3639/3639 pass
- [x] `pnpm typecheck`
- [x] Diff size: 63 LOC under the 300 ceiling