### PR TITLE
feat(activemodel): port validator-bundle privates (Confirmation, Acceptance, Callbacks)

### DIFF
--- a/packages/activemodel/src/validations/_accessor.ts
+++ b/packages/activemodel/src/validations/_accessor.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared internal helper for the validator setupBang ports
+ * (acceptance.ts, confirmation.ts). TS-only plumbing — no Rails
+ * counterpart. Walks the prototype chain to capture the first-found
+ * accessor shape for `name` so callers can install only the missing
+ * half of a getter/setter pair without shadowing inherited accessors.
+ */
+
+export interface InheritedAccessor {
+  hasGetter: boolean;
+  hasSetter: boolean;
+  getter?: (this: object) => unknown;
+  setter?: (this: object, value: unknown) => void;
+}
+
+/**
+ * Distinguishes accessor descriptors (`get`/`set`) from data
+ * descriptors (`"value" in desc` — handles the `value: undefined`
+ * case correctly). For data properties, synthesizes a getter that
+ * reads through the captured prototype via `Reflect.get` (avoids
+ * recursing into the accessor the caller is about to install), and a
+ * setter that writes via own-property `defineProperty`.
+ */
+export function inspectAccessor(prototype: object, name: string): InheritedAccessor {
+  let proto: object | null = prototype;
+  while (proto && proto !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (desc) {
+      if ("value" in desc || "writable" in desc) {
+        const inheritedProto = proto;
+        const enumerable = desc.enumerable ?? true;
+        const configurable = desc.configurable ?? true;
+        return {
+          hasGetter: true,
+          hasSetter: desc.writable !== false,
+          getter() {
+            return Reflect.get(inheritedProto, name, this);
+          },
+          setter:
+            desc.writable !== false
+              ? function (this: object, v: unknown) {
+                  Object.defineProperty(this, name, {
+                    value: v,
+                    writable: true,
+                    enumerable,
+                    configurable,
+                  });
+                }
+              : undefined,
+        };
+      }
+      return {
+        hasGetter: typeof desc.get === "function",
+        hasSetter: typeof desc.set === "function",
+        getter: desc.get as ((this: object) => unknown) | undefined,
+        setter: desc.set as ((this: object, v: unknown) => void) | undefined,
+      };
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+  return { hasGetter: false, hasSetter: false };
+}

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -1,5 +1,6 @@
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
+import { inspectAccessor } from "./_accessor.js";
 
 /**
  * Manages lazily-defined virtual attributes for acceptance validation.
@@ -77,8 +78,9 @@ interface AcceptanceHost {
  * Rails lazily materializes attr_reader/attr_writer for the acceptance
  * attributes on first access via method_missing. Trails has no
  * method_missing, so install accessors eagerly on the prototype with
- * a per-instance backing slot. Skips attributes the host already
- * defines.
+ * a per-instance backing slot. Skips attributes that already define
+ * both accessor sides; if only one side exists, defines the missing
+ * half while preserving the existing accessor.
  *
  * @internal Rails-private helper.
  */
@@ -107,64 +109,6 @@ export function setupBang(this: AcceptanceHost, klass: unknown): void {
         },
     });
   }
-}
-
-interface InheritedAccessor {
-  hasGetter: boolean;
-  hasSetter: boolean;
-  getter?: (this: object) => unknown;
-  setter?: (this: object, value: unknown) => void;
-}
-
-/**
- * Walk the prototype chain and capture the first-found accessor
- * shape for `name`. Distinguishes accessor descriptors (`get`/`set`)
- * from data descriptors (`"value" in desc` — handles the
- * `value: undefined` case correctly) and synthesizes a getter/setter
- * pair from a data property so callers can preserve it in a new
- * accessor descriptor.
- */
-function inspectAccessor(prototype: object, name: string): InheritedAccessor {
-  let proto: object | null = prototype;
-  while (proto && proto !== Object.prototype) {
-    const desc = Object.getOwnPropertyDescriptor(proto, name);
-    if (desc) {
-      if ("value" in desc || "writable" in desc) {
-        // Reading `this[name]` would recurse into the accessor we're
-        // about to install — read through the captured proto with
-        // Reflect.get and write as an own property.
-        const inheritedProto = proto;
-        const enumerable = desc.enumerable ?? true;
-        const configurable = desc.configurable ?? true;
-        return {
-          hasGetter: true,
-          hasSetter: desc.writable !== false,
-          getter() {
-            return Reflect.get(inheritedProto, name, this);
-          },
-          setter:
-            desc.writable !== false
-              ? function (this: object, v: unknown) {
-                  Object.defineProperty(this, name, {
-                    value: v,
-                    writable: true,
-                    enumerable,
-                    configurable,
-                  });
-                }
-              : undefined,
-        };
-      }
-      return {
-        hasGetter: typeof desc.get === "function",
-        hasSetter: typeof desc.set === "function",
-        getter: desc.get as ((this: object) => unknown) | undefined,
-        setter: desc.set as ((this: object, v: unknown) => void) | undefined,
-      };
-    }
-    proto = Object.getPrototypeOf(proto);
-  }
-  return { hasGetter: false, hasSetter: false };
 }
 
 /**

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -45,27 +45,15 @@ function isNonStringIterable(value: unknown): value is Iterable<unknown> {
 export class AcceptanceValidator extends EachValidator {
   static readonly lazilyDefineAttributes = new LazilyDefineAttributes([]);
 
+  /** @internal Rails-private helper. */
+  declare setupBang: typeof setupBang;
+  /** @internal Rails-private helper. */
+  declare isAcceptableOption: typeof isAcceptableOption;
+
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
-    // Rails activemodel/lib/active_model/validations/acceptance.rb
-    // `acceptable_option?` calls `Array(options[:accept]).include?(value)`,
-    // so a scalar `accept:` still works. Normalize here with the same shape.
-    // Rails checks key presence via `options.key?(:accept)`, so an explicit
-    // `accept: nil` is treated as `Array(nil) #=> []` (rejects everything)
-    // rather than falling back to the default. Mirror that with a hasOwn
-    // check on this.options.
-    const hasAccept = Object.prototype.hasOwnProperty.call(this.options, "accept");
-    let accepted: unknown[];
-    if (!hasAccept) accepted = ["1", true];
-    else {
-      const rawAccept = this.options.accept;
-      if (rawAccept === null || rawAccept === undefined) accepted = [];
-      else if (Array.isArray(rawAccept)) accepted = rawAccept;
-      else if (isNonStringIterable(rawAccept)) accepted = Array.from(rawAccept);
-      else accepted = [rawAccept];
-    }
-    if (!accepted.includes(value)) {
+    if (!this.isAcceptableOption(value)) {
       record.errors.add(attribute, "accepted", { message: this.options.message });
     }
   }
@@ -74,3 +62,74 @@ export class AcceptanceValidator extends EachValidator {
     return new LazilyDefineAttributes(attributes);
   }
 }
+
+interface AcceptanceHost {
+  attributes: readonly string[];
+}
+
+/**
+ * Mirrors: acceptance.rb:18-22
+ *   def setup!(klass)
+ *     define_attributes = LazilyDefineAttributes.new(attributes)
+ *     klass.include(define_attributes) unless klass.included_modules.include?(define_attributes)
+ *   end
+ *
+ * Rails lazily materializes attr_reader/attr_writer for the acceptance
+ * attributes on first access via method_missing. Trails has no
+ * method_missing, so install accessors eagerly on the prototype with
+ * a per-instance backing slot. Skips attributes the host already
+ * defines.
+ *
+ * @internal Rails-private helper.
+ */
+export function setupBang(this: AcceptanceHost, klass: unknown): void {
+  if (typeof klass !== "function") return;
+  const ctor = klass as { prototype: object };
+  for (const attribute of this.attributes) {
+    if (attribute in ctor.prototype) continue;
+    const slot = `_${attribute}`;
+    Object.defineProperty(ctor.prototype, attribute, {
+      configurable: true,
+      get(this: Record<string, unknown>) {
+        return this[slot] as unknown;
+      },
+      set(this: Record<string, unknown>, v: unknown) {
+        this[slot] = v;
+      },
+    });
+  }
+}
+
+/**
+ * Mirrors: acceptance.rb:24-26
+ *   def acceptable_option?(value)
+ *     Array(options[:accept]).include?(value)
+ *   end
+ *
+ * Rails `Array(options[:accept])` coerces missing → []; scalar → [s];
+ * iterable → flattened. Rails checks `options.key?(:accept)` separately
+ * at the constructor (defaults to `["1", true]` when missing). This
+ * port keeps both behaviors: when the key isn't set the default
+ * applies; when set, explicit `null` collapses to `[]`.
+ *
+ * @internal Rails-private helper.
+ */
+export function isAcceptableOption(
+  this: { options: Record<string, unknown> },
+  value: unknown,
+): boolean {
+  const hasAccept = Object.prototype.hasOwnProperty.call(this.options, "accept");
+  let accepted: unknown[];
+  if (!hasAccept) accepted = ["1", true];
+  else {
+    const rawAccept = this.options.accept;
+    if (rawAccept === null || rawAccept === undefined) accepted = [];
+    else if (Array.isArray(rawAccept)) accepted = rawAccept;
+    else if (isNonStringIterable(rawAccept)) accepted = Array.from(rawAccept);
+    else accepted = [rawAccept];
+  }
+  return accepted.includes(value);
+}
+
+AcceptanceValidator.prototype.setupBang = setupBang;
+AcceptanceValidator.prototype.isAcceptableOption = isAcceptableOption;

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -86,18 +86,47 @@ export function setupBang(this: AcceptanceHost, klass: unknown): void {
   if (typeof klass !== "function") return;
   const ctor = klass as { prototype: object };
   for (const attribute of this.attributes) {
-    if (attribute in ctor.prototype) continue;
+    const { hasGetter, hasSetter } = inspectAccessor(ctor.prototype, attribute);
+    if (hasGetter && hasSetter) continue;
     const slot = `_${attribute}`;
+    // Rails checks reader and writer separately (attribute_method?(name)
+    // vs attribute_method?("#{name}=")). Mirror by installing only the
+    // missing half so a host that pre-defined one accessor isn't
+    // overridden.
+    const existing = Object.getOwnPropertyDescriptor(ctor.prototype, attribute);
     Object.defineProperty(ctor.prototype, attribute, {
       configurable: true,
-      get(this: Record<string, unknown>) {
-        return this[slot] as unknown;
-      },
-      set(this: Record<string, unknown>, v: unknown) {
-        this[slot] = v;
-      },
+      get:
+        existing?.get ??
+        function (this: Record<string, unknown>) {
+          return this[slot] as unknown;
+        },
+      set:
+        existing?.set ??
+        function (this: Record<string, unknown>, v: unknown) {
+          this[slot] = v;
+        },
     });
   }
+}
+
+function inspectAccessor(
+  prototype: object,
+  name: string,
+): { hasGetter: boolean; hasSetter: boolean } {
+  let proto: object | null = prototype;
+  let hasGetter = false;
+  let hasSetter = false;
+  while (proto && proto !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (desc) {
+      if (desc.get || desc.value !== undefined) hasGetter = true;
+      if (desc.set || desc.writable) hasSetter = true;
+      break;
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+  return { hasGetter, hasSetter };
 }
 
 /**

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -130,16 +130,27 @@ function inspectAccessor(prototype: object, name: string): InheritedAccessor {
     const desc = Object.getOwnPropertyDescriptor(proto, name);
     if (desc) {
       if ("value" in desc || "writable" in desc) {
+        // Reading `this[name]` would recurse into the accessor we're
+        // about to install — read through the captured proto with
+        // Reflect.get and write as an own property.
+        const inheritedProto = proto;
+        const enumerable = desc.enumerable ?? true;
+        const configurable = desc.configurable ?? true;
         return {
           hasGetter: true,
           hasSetter: desc.writable !== false,
           getter() {
-            return (this as Record<string, unknown>)[name];
+            return Reflect.get(inheritedProto, name, this);
           },
           setter:
             desc.writable !== false
               ? function (this: object, v: unknown) {
-                  (this as Record<string, unknown>)[name] = v;
+                  Object.defineProperty(this, name, {
+                    value: v,
+                    writable: true,
+                    enumerable,
+                    configurable,
+                  });
                 }
               : undefined,
         };

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -86,23 +86,22 @@ export function setupBang(this: AcceptanceHost, klass: unknown): void {
   if (typeof klass !== "function") return;
   const ctor = klass as { prototype: object };
   for (const attribute of this.attributes) {
-    const { hasGetter, hasSetter } = inspectAccessor(ctor.prototype, attribute);
-    if (hasGetter && hasSetter) continue;
+    const inherited = inspectAccessor(ctor.prototype, attribute);
+    if (inherited.hasGetter && inherited.hasSetter) continue;
     const slot = `_${attribute}`;
     // Rails checks reader and writer separately (attribute_method?(name)
-    // vs attribute_method?("#{name}=")). Mirror by installing only the
-    // missing half so a host that pre-defined one accessor isn't
-    // overridden.
-    const existing = Object.getOwnPropertyDescriptor(ctor.prototype, attribute);
+    // vs attribute_method?("#{name}=")). Install only the missing half.
+    // When one side IS inherited (anywhere in the prototype chain),
+    // reuse it on the new descriptor so overriding doesn't shadow it.
     Object.defineProperty(ctor.prototype, attribute, {
       configurable: true,
       get:
-        existing?.get ??
+        inherited.getter ??
         function (this: Record<string, unknown>) {
           return this[slot] as unknown;
         },
       set:
-        existing?.set ??
+        inherited.setter ??
         function (this: Record<string, unknown>, v: unknown) {
           this[slot] = v;
         },
@@ -110,23 +109,51 @@ export function setupBang(this: AcceptanceHost, klass: unknown): void {
   }
 }
 
-function inspectAccessor(
-  prototype: object,
-  name: string,
-): { hasGetter: boolean; hasSetter: boolean } {
+interface InheritedAccessor {
+  hasGetter: boolean;
+  hasSetter: boolean;
+  getter?: (this: object) => unknown;
+  setter?: (this: object, value: unknown) => void;
+}
+
+/**
+ * Walk the prototype chain and capture the first-found accessor
+ * shape for `name`. Distinguishes accessor descriptors (`get`/`set`)
+ * from data descriptors (`"value" in desc` — handles the
+ * `value: undefined` case correctly) and synthesizes a getter/setter
+ * pair from a data property so callers can preserve it in a new
+ * accessor descriptor.
+ */
+function inspectAccessor(prototype: object, name: string): InheritedAccessor {
   let proto: object | null = prototype;
-  let hasGetter = false;
-  let hasSetter = false;
   while (proto && proto !== Object.prototype) {
     const desc = Object.getOwnPropertyDescriptor(proto, name);
     if (desc) {
-      if (desc.get || desc.value !== undefined) hasGetter = true;
-      if (desc.set || desc.writable) hasSetter = true;
-      break;
+      if ("value" in desc || "writable" in desc) {
+        return {
+          hasGetter: true,
+          hasSetter: desc.writable !== false,
+          getter() {
+            return (this as Record<string, unknown>)[name];
+          },
+          setter:
+            desc.writable !== false
+              ? function (this: object, v: unknown) {
+                  (this as Record<string, unknown>)[name] = v;
+                }
+              : undefined,
+        };
+      }
+      return {
+        hasGetter: typeof desc.get === "function",
+        hasSetter: typeof desc.set === "function",
+        getter: desc.get as ((this: object) => unknown) | undefined,
+        setter: desc.set as ((this: object, v: unknown) => void) | undefined,
+      };
     }
     proto = Object.getPrototypeOf(proto);
   }
-  return { hasGetter, hasSetter };
+  return { hasGetter: false, hasSetter: false };
 }
 
 /**

--- a/packages/activemodel/src/validations/callbacks.ts
+++ b/packages/activemodel/src/validations/callbacks.ts
@@ -12,20 +12,25 @@ import type { CallbackFn, CallbackConditions } from "../callbacks.js";
 export interface CallbacksClassMethods {
   beforeValidation(fn: CallbackFn, conditions?: CallbackConditions): void;
   afterValidation(fn: CallbackFn, conditions?: CallbackConditions): void;
+}
+
+export interface CallbacksInstanceMethods {
   /** @internal Rails-private helper. */
   runValidationsBang(): boolean;
 }
 
-export type Callbacks = CallbacksClassMethods;
+export type Callbacks = CallbacksClassMethods & CallbacksInstanceMethods;
+
+type Conditional = ((record: unknown) => boolean) | string;
 
 interface CallbackOptions {
-  on?: string | string[];
-  if?: Array<((record: unknown) => boolean) | string> | ((record: unknown) => boolean) | string;
-  unless?: Array<((record: unknown) => boolean) | string> | ((record: unknown) => boolean) | string;
+  on?: string | string[] | null;
+  if?: Conditional | Conditional[];
+  unless?: Conditional | Conditional[];
 }
 
 interface CallbackHostRecord {
-  validationContext?: string | string[];
+  validationContext?: string | string[] | null;
 }
 
 /**
@@ -49,20 +54,19 @@ interface CallbackHostRecord {
  */
 export function setOptionsForCallback(options: CallbackOptions): void {
   if (!Object.prototype.hasOwnProperty.call(options, "on")) return;
-  const onArr = Array.isArray(options.on)
-    ? options.on
-    : options.on === undefined
-      ? []
-      : [options.on];
+  // Ruby `Array(nil)` produces `[]` — treat both undefined and null
+  // the same, so `on: null` doesn't accidentally match a `null`
+  // validation context.
+  const onArr = Array.isArray(options.on) ? options.on : options.on == null ? [] : [options.on];
   options.on = onArr;
   const contextGuard = (o: unknown) => {
     const ctx = (o as CallbackHostRecord).validationContext;
-    const ctxArr = ctx === undefined ? [] : Array.isArray(ctx) ? ctx : [ctx];
+    const ctxArr = Array.isArray(ctx) ? ctx : ctx == null ? [] : [ctx];
     return onArr.some((on) => ctxArr.includes(on));
   };
   const existingIf = options.if;
   const existingArr =
-    existingIf === undefined ? [] : Array.isArray(existingIf) ? existingIf : [existingIf];
+    existingIf == null ? [] : Array.isArray(existingIf) ? existingIf : [existingIf];
   options.if = [contextGuard, ...existingArr];
 }
 

--- a/packages/activemodel/src/validations/callbacks.ts
+++ b/packages/activemodel/src/validations/callbacks.ts
@@ -12,6 +12,85 @@ import type { CallbackFn, CallbackConditions } from "../callbacks.js";
 export interface CallbacksClassMethods {
   beforeValidation(fn: CallbackFn, conditions?: CallbackConditions): void;
   afterValidation(fn: CallbackFn, conditions?: CallbackConditions): void;
+  /** @internal Rails-private helper. */
+  runValidationsBang(): boolean;
 }
 
 export type Callbacks = CallbacksClassMethods;
+
+interface CallbackOptions {
+  on?: string | string[];
+  if?: Array<((record: unknown) => boolean) | string> | ((record: unknown) => boolean) | string;
+  unless?: Array<((record: unknown) => boolean) | string> | ((record: unknown) => boolean) | string;
+}
+
+interface CallbackHostRecord {
+  validationContext?: string | string[];
+}
+
+/**
+ * Mirrors: callbacks.rb:99-110
+ *   def set_options_for_callback(options)
+ *     if options.key?(:on)
+ *       options[:on] = Array(options[:on])
+ *       options[:if] = [
+ *         ->(o) { options[:on].intersect?(Array(o.validation_context)) },
+ *         *options[:if]
+ *       ]
+ *     end
+ *   end
+ *
+ * When `on:` is supplied, normalize it to an array and prepend a
+ * context-intersection guard to `if:` so the callback only runs in
+ * the requested validation context(s). Mutates the options hash in
+ * place to match Rails.
+ *
+ * @internal Rails-private helper.
+ */
+export function setOptionsForCallback(options: CallbackOptions): void {
+  if (!Object.prototype.hasOwnProperty.call(options, "on")) return;
+  const onArr = Array.isArray(options.on)
+    ? options.on
+    : options.on === undefined
+      ? []
+      : [options.on];
+  options.on = onArr;
+  const contextGuard = (o: unknown) => {
+    const ctx = (o as CallbackHostRecord).validationContext;
+    const ctxArr = ctx === undefined ? [] : Array.isArray(ctx) ? ctx : [ctx];
+    return onArr.some((on) => ctxArr.includes(on));
+  };
+  const existingIf = options.if;
+  const existingArr =
+    existingIf === undefined ? [] : Array.isArray(existingIf) ? existingIf : [existingIf];
+  options.if = [contextGuard, ...existingArr];
+}
+
+/**
+ * Mirrors: callbacks.rb:113-115
+ *   def run_validations!
+ *     _run_validation_callbacks { super }
+ *   end
+ *
+ * The interface declaration above adds `runValidationsBang()` to the
+ * Callbacks contract — host classes that want before/after validation
+ * dispatch implement the method to wrap their own validation pass in
+ * the callback chain. Trails Model.runValidations already does this
+ * by walking the validation CallbackChain; this export documents the
+ * Rails surface and gives downstream hosts a typed reference.
+ *
+ * @internal Rails-private helper.
+ */
+export function runValidationsBang(this: {
+  _runValidationCallbacks?: (block: () => boolean) => boolean;
+  runValidations?: () => boolean;
+}): boolean {
+  const block = (): boolean => {
+    if (typeof this.runValidations === "function") return this.runValidations();
+    return true;
+  };
+  if (typeof this._runValidationCallbacks === "function") {
+    return this._runValidationCallbacks(block);
+  }
+  return block();
+}

--- a/packages/activemodel/src/validations/callbacks.ts
+++ b/packages/activemodel/src/validations/callbacks.ts
@@ -78,10 +78,10 @@ export function setOptionsForCallback(options: CallbackOptions): void {
  *
  * The interface declaration above adds `runValidationsBang()` to the
  * Callbacks contract — host classes that want before/after validation
- * dispatch implement the method to wrap their own validation pass in
- * the callback chain. Trails Model.runValidations already does this
- * by walking the validation CallbackChain; this export documents the
- * Rails surface and gives downstream hosts a typed reference.
+ * dispatch implement the method to wrap their underlying validation
+ * pass in the callback chain. This export documents the Rails surface
+ * and gives downstream hosts a typed reference for that
+ * callback-wrapping behavior.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -1,6 +1,7 @@
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
 import { humanize } from "@blazetrails/activesupport";
+import { inspectAccessor } from "./_accessor.js";
 
 /**
  * Mirrors: ActiveModel::Validations::ConfirmationValidator (confirmation.rb)
@@ -75,65 +76,6 @@ export function setupBang(this: ConfirmationHost, klass: unknown): void {
         },
     });
   }
-}
-
-interface InheritedAccessor {
-  hasGetter: boolean;
-  hasSetter: boolean;
-  getter?: (this: object) => unknown;
-  setter?: (this: object, value: unknown) => void;
-}
-
-/**
- * Walk the prototype chain and capture the first-found accessor
- * shape for `name`. Distinguishes accessor descriptors (`get`/`set`)
- * from data descriptors (`"value" in desc` — handles the
- * `value: undefined` case correctly) and synthesizes a getter/setter
- * pair from a data property so callers can preserve it in a new
- * accessor descriptor.
- */
-function inspectAccessor(prototype: object, name: string): InheritedAccessor {
-  let proto: object | null = prototype;
-  while (proto && proto !== Object.prototype) {
-    const desc = Object.getOwnPropertyDescriptor(proto, name);
-    if (desc) {
-      if ("value" in desc || "writable" in desc) {
-        // Plain data property — synthesize a getter/setter that reads
-        // through the captured prototype slot via Reflect.get, and
-        // writes via own-property defineProperty. Reading `this[name]`
-        // would recurse into the new accessor we're about to install.
-        const inheritedProto = proto;
-        const enumerable = desc.enumerable ?? true;
-        const configurable = desc.configurable ?? true;
-        return {
-          hasGetter: true,
-          hasSetter: desc.writable !== false,
-          getter() {
-            return Reflect.get(inheritedProto, name, this);
-          },
-          setter:
-            desc.writable !== false
-              ? function (this: object, v: unknown) {
-                  Object.defineProperty(this, name, {
-                    value: v,
-                    writable: true,
-                    enumerable,
-                    configurable,
-                  });
-                }
-              : undefined,
-        };
-      }
-      return {
-        hasGetter: typeof desc.get === "function",
-        hasSetter: typeof desc.set === "function",
-        getter: desc.get as ((this: object) => unknown) | undefined,
-        setter: desc.set as ((this: object, v: unknown) => void) | undefined,
-      };
-    }
-    proto = Object.getPrototypeOf(proto);
-  }
-  return { hasGetter: false, hasSetter: false };
 }
 
 /**

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -53,23 +53,23 @@ export function setupBang(this: ConfirmationHost, klass: unknown): void {
   const ctor = klass as { prototype: object };
   for (const attribute of this.attributes) {
     const confirmationAttr = `${attribute}Confirmation`;
-    const { hasGetter, hasSetter } = inspectAccessor(ctor.prototype, confirmationAttr);
-    if (hasGetter && hasSetter) continue;
+    const inherited = inspectAccessor(ctor.prototype, confirmationAttr);
+    if (inherited.hasGetter && inherited.hasSetter) continue;
     const slot = `_${confirmationAttr}`;
     // Rails checks reader and writer separately (method_defined? for
-    // both `:#{a}_confirmation` and `:#{a}_confirmation=`). Mirror by
-    // installing only the missing half so a host that pre-defined one
-    // accessor isn't overridden.
-    const existing = Object.getOwnPropertyDescriptor(ctor.prototype, confirmationAttr);
+    // both `:#{a}_confirmation` and `:#{a}_confirmation=`). Install
+    // only the missing half. When one side IS inherited (anywhere in
+    // the prototype chain), reuse it on the new descriptor so
+    // overriding doesn't shadow it.
     Object.defineProperty(ctor.prototype, confirmationAttr, {
       configurable: true,
       get:
-        existing?.get ??
+        inherited.getter ??
         function (this: Record<string, unknown>) {
           return this[slot] as unknown;
         },
       set:
-        existing?.set ??
+        inherited.setter ??
         function (this: Record<string, unknown>, v: unknown) {
           this[slot] = v;
         },
@@ -77,25 +77,53 @@ export function setupBang(this: ConfirmationHost, klass: unknown): void {
   }
 }
 
-function inspectAccessor(
-  prototype: object,
-  name: string,
-): { hasGetter: boolean; hasSetter: boolean } {
+interface InheritedAccessor {
+  hasGetter: boolean;
+  hasSetter: boolean;
+  getter?: (this: object) => unknown;
+  setter?: (this: object, value: unknown) => void;
+}
+
+/**
+ * Walk the prototype chain and capture the first-found accessor
+ * shape for `name`. Distinguishes accessor descriptors (`get`/`set`)
+ * from data descriptors (`"value" in desc` — handles the
+ * `value: undefined` case correctly) and synthesizes a getter/setter
+ * pair from a data property so callers can preserve it in a new
+ * accessor descriptor.
+ */
+function inspectAccessor(prototype: object, name: string): InheritedAccessor {
   let proto: object | null = prototype;
-  let hasGetter = false;
-  let hasSetter = false;
   while (proto && proto !== Object.prototype) {
     const desc = Object.getOwnPropertyDescriptor(proto, name);
     if (desc) {
-      if (desc.get || desc.value !== undefined) hasGetter = true;
-      if (desc.set || desc.writable) hasSetter = true;
-      // Plain data properties act as both reader and writer; either way
-      // we've found what's defined at this level — stop walking.
-      break;
+      if ("value" in desc || "writable" in desc) {
+        // Plain data property — synthesize a getter/setter pair that
+        // mirrors the inherited slot semantics.
+        return {
+          hasGetter: true,
+          hasSetter: desc.writable !== false,
+          getter() {
+            return (this as Record<string, unknown>)[name];
+          },
+          setter:
+            desc.writable !== false
+              ? function (this: object, v: unknown) {
+                  (this as Record<string, unknown>)[name] = v;
+                }
+              : undefined,
+        };
+      }
+      return {
+        hasGetter: typeof desc.get === "function",
+        hasSetter: typeof desc.set === "function",
+        getter: desc.get as ((this: object) => unknown) | undefined,
+        setter: desc.set as ((this: object, v: unknown) => void) | undefined,
+      };
     }
     proto = Object.getPrototypeOf(proto);
   }
-  return { hasGetter, hasSetter };
+  return { hasGetter: false, hasSetter: false };
 }
 
 /**

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -98,18 +98,28 @@ function inspectAccessor(prototype: object, name: string): InheritedAccessor {
     const desc = Object.getOwnPropertyDescriptor(proto, name);
     if (desc) {
       if ("value" in desc || "writable" in desc) {
-        // Plain data property — synthesize a getter/setter pair that
-        // mirrors the inherited slot semantics.
+        // Plain data property — synthesize a getter/setter that reads
+        // through the captured prototype slot via Reflect.get, and
+        // writes via own-property defineProperty. Reading `this[name]`
+        // would recurse into the new accessor we're about to install.
+        const inheritedProto = proto;
+        const enumerable = desc.enumerable ?? true;
+        const configurable = desc.configurable ?? true;
         return {
           hasGetter: true,
           hasSetter: desc.writable !== false,
           getter() {
-            return (this as Record<string, unknown>)[name];
+            return Reflect.get(inheritedProto, name, this);
           },
           setter:
             desc.writable !== false
               ? function (this: object, v: unknown) {
-                  (this as Record<string, unknown>)[name] = v;
+                  Object.defineProperty(this, name, {
+                    value: v,
+                    writable: true,
+                    enumerable,
+                    configurable,
+                  });
                 }
               : undefined,
         };

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -53,18 +53,49 @@ export function setupBang(this: ConfirmationHost, klass: unknown): void {
   const ctor = klass as { prototype: object };
   for (const attribute of this.attributes) {
     const confirmationAttr = `${attribute}Confirmation`;
-    if (confirmationAttr in ctor.prototype) continue;
+    const { hasGetter, hasSetter } = inspectAccessor(ctor.prototype, confirmationAttr);
+    if (hasGetter && hasSetter) continue;
     const slot = `_${confirmationAttr}`;
+    // Rails checks reader and writer separately (method_defined? for
+    // both `:#{a}_confirmation` and `:#{a}_confirmation=`). Mirror by
+    // installing only the missing half so a host that pre-defined one
+    // accessor isn't overridden.
+    const existing = Object.getOwnPropertyDescriptor(ctor.prototype, confirmationAttr);
     Object.defineProperty(ctor.prototype, confirmationAttr, {
       configurable: true,
-      get(this: Record<string, unknown>) {
-        return this[slot] as unknown;
-      },
-      set(this: Record<string, unknown>, v: unknown) {
-        this[slot] = v;
-      },
+      get:
+        existing?.get ??
+        function (this: Record<string, unknown>) {
+          return this[slot] as unknown;
+        },
+      set:
+        existing?.set ??
+        function (this: Record<string, unknown>, v: unknown) {
+          this[slot] = v;
+        },
     });
   }
+}
+
+function inspectAccessor(
+  prototype: object,
+  name: string,
+): { hasGetter: boolean; hasSetter: boolean } {
+  let proto: object | null = prototype;
+  let hasGetter = false;
+  let hasSetter = false;
+  while (proto && proto !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (desc) {
+      if (desc.get || desc.value !== undefined) hasGetter = true;
+      if (desc.set || desc.writable) hasSetter = true;
+      // Plain data properties act as both reader and writer; either way
+      // we've found what's defined at this level — stop walking.
+      break;
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+  return { hasGetter, hasSetter };
 }
 
 /**

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -2,19 +2,20 @@ import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
 import { humanize } from "@blazetrails/activesupport";
 
+/**
+ * Mirrors: ActiveModel::Validations::ConfirmationValidator (confirmation.rb)
+ */
 export class ConfirmationValidator extends EachValidator {
+  /** @internal Rails-private helper. */
+  declare setupBang: typeof setupBang;
+  /** @internal Rails-private helper. */
+  declare isConfirmationValueEqual: typeof isConfirmationValueEqual;
+
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const confirmationAttr = `${attribute}Confirmation`;
     const confirmation = record.readAttribute?.(confirmationAttr) ?? record[confirmationAttr];
     if (confirmation == null) return;
-    const caseSensitive = this.options.caseSensitive ?? true;
-    let matches: boolean;
-    if (!caseSensitive && typeof value === "string" && typeof confirmation === "string") {
-      matches = value.toLowerCase() === confirmation.toLowerCase();
-    } else {
-      matches = value === confirmation;
-    }
-    if (!matches) {
+    if (!this.isConfirmationValueEqual(record, attribute, value, confirmation)) {
       const modelClass = (record as AnyRecord).constructor;
       const humanAttr = modelClass?.humanAttributeName
         ? modelClass.humanAttributeName(attribute)
@@ -26,3 +27,71 @@ export class ConfirmationValidator extends EachValidator {
     }
   }
 }
+
+interface ConfirmationHost {
+  attributes: readonly string[];
+}
+
+/**
+ * Mirrors: confirmation.rb:21-29
+ *   def setup!(klass)
+ *     klass.attr_reader(*attributes.filter_map { |a| :"#{a}_confirmation" unless klass.method_defined?(:"#{a}_confirmation") })
+ *     klass.attr_writer(*attributes.filter_map { |a| :"#{a}_confirmation" unless klass.method_defined?(:"#{a}_confirmation=") })
+ *   end
+ *
+ * Defines virtual `${attribute}Confirmation` reader/writer accessors on
+ * the host class so the comparison side of the pair is reachable. In
+ * trails the validator already falls back to `record[confirmationAttr]`
+ * via the existing direct property access path; this helper materializes
+ * matching prototype accessors when a host class explicitly opts in,
+ * keeping a per-instance backing slot under `_${attr}Confirmation`.
+ *
+ * @internal Rails-private helper.
+ */
+export function setupBang(this: ConfirmationHost, klass: unknown): void {
+  if (typeof klass !== "function") return;
+  const ctor = klass as { prototype: object };
+  for (const attribute of this.attributes) {
+    const confirmationAttr = `${attribute}Confirmation`;
+    if (confirmationAttr in ctor.prototype) continue;
+    const slot = `_${confirmationAttr}`;
+    Object.defineProperty(ctor.prototype, confirmationAttr, {
+      configurable: true,
+      get(this: Record<string, unknown>) {
+        return this[slot] as unknown;
+      },
+      set(this: Record<string, unknown>, v: unknown) {
+        this[slot] = v;
+      },
+    });
+  }
+}
+
+/**
+ * Mirrors: confirmation.rb:32-38
+ *   def confirmation_value_equal?(record, attribute, value, confirmed)
+ *     if !options[:case_sensitive] && value.is_a?(String)
+ *       value.casecmp(confirmed) == 0
+ *     else
+ *       value == confirmed
+ *     end
+ *   end
+ *
+ * @internal Rails-private helper.
+ */
+export function isConfirmationValueEqual(
+  this: { options: Record<string, unknown> },
+  _record: AnyRecord,
+  _attribute: string,
+  value: unknown,
+  confirmed: unknown,
+): boolean {
+  const caseSensitive = this.options.caseSensitive ?? true;
+  if (!caseSensitive && typeof value === "string" && typeof confirmed === "string") {
+    return value.toLowerCase() === confirmed.toLowerCase();
+  }
+  return value === confirmed;
+}
+
+ConfirmationValidator.prototype.setupBang = setupBang;
+ConfirmationValidator.prototype.isConfirmationValueEqual = isConfirmationValueEqual;


### PR DESCRIPTION
## Summary
Track A5 of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md) — final validator-cluster track. Closes 6 privates across 3 small files; each row goes 2/4 → **4/4 (100%)**.

### Confirmation (`confirmation.rb` 2/4 → 4/4)
- **`isConfirmationValueEqual(record, attribute, value, confirmed)`** — `confirmation.rb:32-38`. Extracts the inline equality check (case-sensitive vs `casecmp`) and is dispatched through `this.isConfirmationValueEqual` from `validateEach`.
- **`setupBang(klass)`** — `confirmation.rb:21-29`. Defines virtual `${attribute}Confirmation` reader/writer accessors on the host class prototype with a per-instance `_${attr}Confirmation` backing slot; Rails uses `attr_reader`/`attr_writer` the same way.

### Acceptance (`acceptance.rb` 2/4 → 4/4)
- **`isAcceptableOption(value)`** — `acceptance.rb:24-26`. Extracts the `Array(options[:accept]).include?(value)` normalization (with the `hasOwn` check on `accept` that PR #976 established for explicit-`nil` semantics) and is dispatched through `this.isAcceptableOption`.
- **`setupBang(klass)`** — `acceptance.rb:18-22`. Eagerly installs accessors (no `method_missing` in TS), per-instance backing slot, skips attributes the host already defines.

### Callbacks (`callbacks.rb` 2/4 → 4/4)
- **`setOptionsForCallback(options)`** — `callbacks.rb:99-110`. Normalizes `on:` to an array and prepends the validation-context guard to `if:`. In-place mutation matches Rails.
- **`runValidationsBang()`** — `callbacks.rb:113-115`. Wraps a `runValidations()` block in `_runValidationCallbacks`. Surfaces in the `Callbacks` contract; trails Model already does this internally — this gives downstream hosts a typed reference.

All host-class privates attached to the validator prototypes (with `@internal` JSDoc tags) using the super-time bootstrapping pattern from PRs #994 / #1002 / #1009 / #1015 / #1026.

## Impact
- `pnpm api:compare --privates --package activemodel`: confirmation.rb / acceptance.rb / callbacks.rb each 2/4 → **4/4 (100%)** (+6). Overall 499/625 → **505/625 (80.8%)**.
- `pnpm api:compare --package activemodel`: stays **448/448 (100%)**.
- `pnpm test:compare --package activemodel`: stays 959/963.

## Track A status
🎉 **Track A complete.** Validator family (Clusivity / Inclusion / Exclusion / Format / Length / Numericality / Confirmation / Acceptance / Callbacks) all at 100% privates. The next bucket (Track B — privates beyond validators: serialization, type primitives, model.rb / validations.rb) is the next push if you want to keep going.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1604 / 1604 passing
- [x] `pnpm api:compare --package activemodel` — 448/448
- [x] `pnpm api:compare --privates --package activemodel` — 505/625 (+6)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)