### PR TITLE
fix(arel): unboundable short-circuits in ToSql visitor

### DIFF
--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1369,6 +1369,63 @@ describe("the to_sql visitor", () => {
         expect(compile(id.lt(5))).toBe('"users"."id" < 5');
         expect(compile(id.eq(5))).toBe('"users"."id" = 5');
       });
+
+      it("Equality with null still emits IS NULL (not the unboundable branch)", () => {
+        // Regression guard: null is bounded — sign is 0, so the `IS NULL`
+        // path must still fire, not the new `1=0` short-circuit.
+        expect(compile(id.eq(null))).toBe('"users"."id" IS NULL');
+        expect(compile(id.notEq(null))).toBe('"users"."id" IS NOT NULL');
+      });
+
+      it("short-circuits when wrapped directly in Nodes.Quoted (not via buildQuoted)", () => {
+        const eq = new Nodes.Equality(id, new Nodes.Quoted(Infinity));
+        expect(compile(eq)).toBe("1=0");
+        const gt = new Nodes.GreaterThan(id, new Nodes.Quoted(-Infinity));
+        expect(compile(gt)).toBe("1=1");
+      });
+    });
+
+    describe("unboundableSign protocol", () => {
+      interface Internals {
+        unboundableSign(v: unknown): 1 | -1 | 0;
+        isUnboundable(v: unknown): boolean;
+      }
+      const v = () => new Visitors.ToSql() as unknown as Internals;
+
+      it("returns +1 for +Infinity, -1 for -Infinity, 0 otherwise", () => {
+        expect(v().unboundableSign(Infinity)).toBe(1);
+        expect(v().unboundableSign(-Infinity)).toBe(-1);
+        expect(v().unboundableSign(0)).toBe(0);
+        expect(v().unboundableSign(null)).toBe(0);
+        expect(v().unboundableSign(undefined)).toBe(0);
+        expect(v().unboundableSign("foo")).toBe(0);
+      });
+
+      it("unwraps Quoted via isInfinite()", () => {
+        expect(v().unboundableSign(new Nodes.Quoted(Infinity))).toBe(1);
+        expect(v().unboundableSign(new Nodes.Quoted(-Infinity))).toBe(-1);
+        expect(v().unboundableSign(new Nodes.Quoted(5))).toBe(0);
+      });
+
+      it("descends through nodes that expose .value (e.g. Casted)", () => {
+        const tbl = new Table("users");
+        const casted = new Nodes.Casted(Infinity, tbl.get("id"));
+        expect(v().unboundableSign(casted)).toBe(1);
+      });
+
+      it("honours an isUnboundable() protocol returning a sign or boolean", () => {
+        expect(v().unboundableSign({ isUnboundable: () => 1 })).toBe(1);
+        expect(v().unboundableSign({ isUnboundable: () => -1 })).toBe(-1);
+        expect(v().unboundableSign({ isUnboundable: () => true })).toBe(1);
+        expect(v().unboundableSign({ isUnboundable: () => false })).toBe(0);
+      });
+
+      it("isUnboundable is the truthy wrapper of unboundableSign", () => {
+        expect(v().isUnboundable(Infinity)).toBe(true);
+        expect(v().isUnboundable(-Infinity)).toBe(true);
+        expect(v().isUnboundable(5)).toBe(false);
+        expect(v().isUnboundable(null)).toBe(false);
+      });
     });
 
     it("visitArray handles a mix of Node and primitive entries", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1314,6 +1314,63 @@ describe("the to_sql visitor", () => {
       expect(new Visitors.ToSql().compile(elseNode)).toBe("ELSE 0");
     });
 
+    // Mirrors Rails to_sql.rb#visit_Arel_Nodes_{Equality,NotEqual,GreaterThan,
+    // GreaterThanOrEqual,LessThan,LessThanOrEqual,In,NotIn} short-circuits
+    // when the right operand reports `unboundable?` (±Float::INFINITY).
+    describe("unboundable short-circuits", () => {
+      const tbl = new Table("users");
+      const compile = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
+      const id = tbl.get("id");
+
+      it("Equality with +Infinity collapses to 1=0", () => {
+        expect(compile(id.eq(Infinity))).toBe("1=0");
+      });
+      it("Equality with -Infinity collapses to 1=0", () => {
+        expect(compile(id.eq(-Infinity))).toBe("1=0");
+      });
+      it("NotEqual with +Infinity collapses to 1=1", () => {
+        expect(compile(id.notEq(Infinity))).toBe("1=1");
+      });
+      it("NotEqual with -Infinity collapses to 1=1", () => {
+        expect(compile(id.notEq(-Infinity))).toBe("1=1");
+      });
+      it("GreaterThan +Infinity → 1=0; -Infinity → 1=1", () => {
+        expect(compile(id.gt(Infinity))).toBe("1=0");
+        expect(compile(id.gt(-Infinity))).toBe("1=1");
+      });
+      it("GreaterThanOrEqual +Infinity → 1=0; -Infinity → 1=1", () => {
+        expect(compile(id.gteq(Infinity))).toBe("1=0");
+        expect(compile(id.gteq(-Infinity))).toBe("1=1");
+      });
+      it("LessThan +Infinity → 1=1; -Infinity → 1=0", () => {
+        expect(compile(id.lt(Infinity))).toBe("1=1");
+        expect(compile(id.lt(-Infinity))).toBe("1=0");
+      });
+      it("LessThanOrEqual +Infinity → 1=1; -Infinity → 1=0", () => {
+        expect(compile(id.lteq(Infinity))).toBe("1=1");
+        expect(compile(id.lteq(-Infinity))).toBe("1=0");
+      });
+      it("In filters unboundable values; all-unboundable collapses to 1=0", () => {
+        expect(compile(id.in([Infinity, -Infinity]))).toBe("1=0");
+      });
+      it("In retains bounded values when mixed with unboundable", () => {
+        const sql = compile(id.in([1, Infinity, 2]));
+        expect(sql).toBe('"users"."id" IN (1, 2)');
+      });
+      it("NotIn filters unboundable values; all-unboundable collapses to 1=1", () => {
+        expect(compile(id.notIn([Infinity, -Infinity]))).toBe("1=1");
+      });
+      it("NotIn retains bounded values when mixed with unboundable", () => {
+        const sql = compile(id.notIn([1, Infinity, 2]));
+        expect(sql).toBe('"users"."id" NOT IN (1, 2)');
+      });
+      it("bounded comparisons are unaffected", () => {
+        expect(compile(id.gt(5))).toBe('"users"."id" > 5');
+        expect(compile(id.lt(5))).toBe('"users"."id" < 5');
+        expect(compile(id.eq(5))).toBe('"users"."id" = 5');
+      });
+    });
+
     it("visitArray handles a mix of Node and primitive entries", () => {
       const tbl = new Table("users");
       const v = new Visitors.ToSql();

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -89,15 +89,27 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // Per-class dispatch wrappers for shared helpers — mirrors Rails' per-method
   // form (each operator/aggregate has its own visit method).
   protected visitArelNodesGreaterThan(node: Nodes.GreaterThan): SQLString {
+    const sign = this.unboundableSign(node.right);
+    if (sign === 1) return this.collector.append("1=0");
+    if (sign === -1) return this.collector.append("1=1");
     return this.visitBinaryOp(node, ">");
   }
   protected visitArelNodesGreaterThanOrEqual(node: Nodes.GreaterThanOrEqual): SQLString {
+    const sign = this.unboundableSign(node.right);
+    if (sign === 1) return this.collector.append("1=0");
+    if (sign === -1) return this.collector.append("1=1");
     return this.visitBinaryOp(node, ">=");
   }
   protected visitArelNodesLessThan(node: Nodes.LessThan): SQLString {
+    const sign = this.unboundableSign(node.right);
+    if (sign === 1) return this.collector.append("1=1");
+    if (sign === -1) return this.collector.append("1=0");
     return this.visitBinaryOp(node, "<");
   }
   protected visitArelNodesLessThanOrEqual(node: Nodes.LessThanOrEqual): SQLString {
+    const sign = this.unboundableSign(node.right);
+    if (sign === 1) return this.collector.append("1=1");
+    if (sign === -1) return this.collector.append("1=0");
     return this.visitBinaryOp(node, "<=");
   }
   protected visitArelNodesCount(node: Nodes.Count): SQLString {
@@ -575,6 +587,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // -- Predicates --
 
   private visitArelNodesEquality(node: Nodes.Equality): SQLString {
+    if (this.unboundableSign(node.right) !== 0) {
+      return this.collector.append("1=0");
+    }
     if (node.right instanceof Nodes.Quoted && (node.right as Nodes.Quoted).value === null) {
       this.visitNodeOrValue(node.left);
       this.collector.append(" IS NULL");
@@ -587,6 +602,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitArelNodesNotEqual(node: Nodes.NotEqual): SQLString {
+    if (this.unboundableSign(node.right) !== 0) {
+      return this.collector.append("1=1");
+    }
     if (node.right instanceof Nodes.Quoted && (node.right as Nodes.Quoted).value === null) {
       this.visitNodeOrValue(node.left);
       this.collector.append(" IS NOT NULL");
@@ -614,54 +632,66 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitArelNodesIn(node: Nodes.In): SQLString {
-    if (Array.isArray(node.right) && node.right.length === 0) {
-      // Empty IN is always false — Rails uses 1=0
-      this.collector.append("1=0");
-      return this.collector;
+    let values = node.right;
+    if (Array.isArray(values)) {
+      if (values.length > 0) {
+        values = values.filter((v) => this.unboundableSign(v) === 0);
+      }
+      if (values.length === 0) {
+        // Empty IN is always false — Rails uses 1=0
+        this.collector.append("1=0");
+        return this.collector;
+      }
     }
     this.visitNodeOrValue(node.left);
     // Duck-type check for SelectManager subquery - visitNodeOrValue wraps it in parens
     if (
-      node.right &&
-      typeof node.right === "object" &&
-      !Array.isArray(node.right) &&
-      "ast" in (node.right as unknown as Record<string, unknown>) &&
-      "toSql" in (node.right as unknown as Record<string, unknown>)
+      values &&
+      typeof values === "object" &&
+      !Array.isArray(values) &&
+      "ast" in (values as unknown as Record<string, unknown>) &&
+      "toSql" in (values as unknown as Record<string, unknown>)
     ) {
       this.collector.append(" IN ");
-      this.visitNodeOrValue(node.right);
+      this.visitNodeOrValue(values);
       return this.collector;
     }
     this.collector.append(" IN (");
-    if (Array.isArray(node.right)) {
-      for (let i = 0; i < node.right.length; i++) {
+    if (Array.isArray(values)) {
+      for (let i = 0; i < values.length; i++) {
         if (i > 0) this.collector.append(", ");
-        this.visit(node.right[i]);
+        this.visit(values[i]);
       }
     } else {
-      this.visitNodeOrValue(node.right);
+      this.visitNodeOrValue(values);
     }
     this.collector.append(")");
     return this.collector;
   }
 
   private visitArelNodesNotIn(node: Nodes.NotIn): SQLString {
-    if (Array.isArray(node.right) && node.right.length === 0) {
-      // Empty NOT IN is always true — Rails uses 1=1
-      this.collector.append("1=1");
-      return this.collector;
+    let values = node.right;
+    if (Array.isArray(values)) {
+      if (values.length > 0) {
+        values = values.filter((v) => this.unboundableSign(v) === 0);
+      }
+      if (values.length === 0) {
+        // Empty NOT IN is always true — Rails uses 1=1
+        this.collector.append("1=1");
+        return this.collector;
+      }
     }
     this.visitNodeOrValue(node.left);
-    if (Array.isArray(node.right)) {
+    if (Array.isArray(values)) {
       this.collector.append(" NOT IN (");
-      for (let i = 0; i < node.right.length; i++) {
+      for (let i = 0; i < values.length; i++) {
         if (i > 0) this.collector.append(", ");
-        this.visit(node.right[i]);
+        this.visit(values[i]);
       }
       this.collector.append(")");
     } else {
       this.collector.append(" NOT IN (");
-      this.visitNodeOrValue(node.right);
+      this.visitNodeOrValue(values);
       this.collector.append(")");
     }
     return this.collector;
@@ -1592,10 +1622,42 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return DEFAULT_BIND_BLOCK;
   }
 
-  /** Mirrors `to_sql.rb#unboundable?`. */
+  /**
+   * Mirrors `to_sql.rb#unboundable?` returning a sign — `1` for +∞, `-1`
+   * for -∞, `0` for bounded values. Comparison visitors `case` on the
+   * sign; equality/IN visitors use a truthy check (`sign !== 0`).
+   *
+   * Unwraps Quoted/Casted/BindParam to inspect the wrapped value, and
+   * recognises `Float::INFINITY` analogues (`±Infinity`) plus any value
+   * exposing `isInfinite()` / `isUnboundable()`.
+   */
+  protected unboundableSign(value: unknown): 1 | -1 | 0 {
+    if (value === Infinity) return 1;
+    if (value === -Infinity) return -1;
+    if (value && typeof value === "object") {
+      const v = value as {
+        value?: unknown;
+        isInfinite?: () => unknown;
+        isUnboundable?: () => unknown;
+      };
+      if (typeof v.isInfinite === "function") {
+        const r = v.isInfinite();
+        if (r === 1) return 1;
+        if (r === -1) return -1;
+      }
+      if (typeof v.isUnboundable === "function") {
+        const r = v.isUnboundable();
+        if (r === 1 || r === true) return 1;
+        if (r === -1) return -1;
+      }
+      if ("value" in v) return this.unboundableSign(v.value);
+    }
+    return 0;
+  }
+
+  /** Mirrors `to_sql.rb#unboundable?` as a truthy check. */
   protected isUnboundable(value: unknown): boolean {
-    const v = value as { isUnboundable?: () => unknown } | null | undefined;
-    return typeof v?.isUnboundable === "function" ? Boolean(v.isUnboundable()) : false;
+    return this.unboundableSign(value) !== 0;
   }
 
   /** Mirrors `to_sql.rb#has_group_by_and_having?`. */


### PR DESCRIPTION
## Summary

Mirrors Rails `to_sql.rb` where comparison/equality/IN visitors short-circuit when the right operand reports `unboundable?` (±Float::INFINITY). PR 2 of the [arel alignment plan](../blob/main/docs/arel-alignment-plan.md).

## Behavior

| Visitor | RHS = +∞ | RHS = -∞ |
|---|---|---|
| `Equality` | `1=0` | `1=0` |
| `NotEqual` | `1=1` | `1=1` |
| `GreaterThan` / `GreaterThanOrEqual` | `1=0` | `1=1` |
| `LessThan` / `LessThanOrEqual` | `1=1` | `1=0` |
| `In([…])` | filter unboundable; empty → `1=0` | same |
| `NotIn([…])` | filter unboundable; empty → `1=1` | same |

## Rails reference

`scripts/api-compare/.rails-source/activerecord/lib/arel/visitors/to_sql.rb`:
- `visit_Arel_Nodes_Equality` (L643), `NotEqual` (L678)
- `visit_Arel_Nodes_GreaterThan` (L449), `GreaterThanOrEqual` (L437), `LessThan` (L473), `LessThanOrEqual` (L461)
- `visit_Arel_Nodes_In` (L588), `NotIn` (L605)
- `unboundable?` (L905)

## Implementation

- Replaced `isUnboundable(value): boolean` with `unboundableSign(value): 1 | -1 | 0`. Comparisons `case` on the sign; equality/IN use the truthy wrapper `isUnboundable` (now `sign !== 0`).
- `unboundableSign` unwraps `Quoted` / `Casted` / `BindParam` (descends `.value`), recognises `±Infinity` directly, and consults `isInfinite()` / `isUnboundable()` protocols.

## Tests

12 new cases in `to-sql.test.ts > unboundable short-circuits` — one per operator/branch plus mixed-array filtering (`in([1, Inf, 2])` → `IN (1, 2)`) and a guard that bounded comparisons are unaffected. Full arel suite (1170 tests) passes.

## Risk

The legacy `isUnboundable({isUnboundable: () => 1})` test continues to pass — boolean `true` and integer `1` both map to sign `1`.

## Verification

- [x] `pnpm vitest run packages/arel/` (1170 pass)
- [ ] CI: query parity (relies on AR-level paths; should be unaffected since AR `where(col: Inf)` already collapses earlier)

## Depends on

PR #1025 (merged). `Quoted#isInfinite` and the `unboundableSign` semantics were established there.