### PR TITLE
feat(activesupport): Notifications::Event#time → Temporal.Instant

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -6,6 +6,7 @@ import {
   NotImplementedError,
 } from "../../errors.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::TransactionState
@@ -150,8 +151,11 @@ export class TransactionInstrumenter {
     Notifications.instrument("start_transaction.active_record", this._basePayload);
 
     this._payload = { ...this._basePayload };
-    // boundary: Notifications.Event#time is Date by Rails parity (see activesupport/src/notifications/instrumenter.ts).
-    this._event = new NotificationEvent("transaction.active_record", new Date(), this._payload);
+    this._event = new NotificationEvent(
+      "transaction.active_record",
+      Temporal.Now.instant(),
+      this._payload,
+    );
   }
 
   finish(outcome: string): void {

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -6,6 +6,7 @@ import {
   NotificationEvent as Event,
   Logger,
 } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 const REGEXP_CLEAR_STR = `\\x1b\\[${BaseLogSubscriber.MODES.clear}m`;
 const REGEXP_BOLD_STR = `\\x1b\\[${BaseLogSubscriber.MODES.bold}m`;
@@ -109,13 +110,17 @@ describe("LogSubscriberTest", () => {
   it("schema statements are ignored", () => {
     expect(subscriber.debugs.length).toBe(0);
 
-    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!" }));
+    subscriber.sql(new Event("sql.active_record", Temporal.Now.instant(), { sql: "hi mom!" }));
     expect(subscriber.debugs.length).toBe(1);
 
-    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!", name: "foo" }));
+    subscriber.sql(
+      new Event("sql.active_record", Temporal.Now.instant(), { sql: "hi mom!", name: "foo" }),
+    );
     expect(subscriber.debugs.length).toBe(2);
 
-    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!", name: "SCHEMA" }));
+    subscriber.sql(
+      new Event("sql.active_record", Temporal.Now.instant(), { sql: "hi mom!", name: "SCHEMA" }),
+    );
     expect(subscriber.debugs.length).toBe(2);
   });
 
@@ -376,10 +381,9 @@ describe("LogSubscriberTest", () => {
 });
 
 function makeEvent(payload: Record<string, unknown>, durationMs = 0.9): Event {
-  const start = new Date();
+  const start = Temporal.Now.instant();
   const event = new Event("sql.active_record", start, payload);
-  const end = new Date(start.getTime());
-  event.finish(end);
+  event.finish(start);
   Object.defineProperty(event, "duration", { get: () => durationMs, configurable: true });
   return event;
 }

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Notifications } from "./notifications.js";
 import { Event, Instrumenter, LegacyHandle, Wrapper } from "./notifications/instrumenter.js";
+import { Temporal } from "./temporal.js";
 
 beforeEach(() => {
   Notifications.unsubscribeAll();
@@ -139,7 +140,7 @@ describe("SubscribedTest", () => {
 
 describe("InspectTest", () => {
   it("inspect output is small", () => {
-    const e = new Event("test.inspect", new Date(), { key: "val" });
+    const e = new Event("test.inspect", Temporal.Now.instant(), { key: "val" });
     // inspect equivalent is just checking the object has basic info
     expect(e.name).toBe("test.inspect");
     expect(e.payload).toEqual({ key: "val" });
@@ -299,13 +300,13 @@ describe("InstrumentationTest", () => {
     Notifications.subscribe("no.block", (e) => events.push(e));
     Notifications.instrument("no.block", { a: 1 });
     expect(events).toHaveLength(1);
-    expect(events[0].end).toBeInstanceOf(Date);
+    expect(events[0].end).toBeInstanceOf(Temporal.Instant);
   });
 });
 
 describe("EventTest", () => {
   it("events are initialized with details", () => {
-    const start = new Date();
+    const start = Temporal.Now.instant();
     const e = new Event("test.event", start, { key: "val" });
     expect(e.name).toBe("test.event");
     expect(e.time).toBe(start);
@@ -313,7 +314,7 @@ describe("EventTest", () => {
   });
 
   it("event cpu time does not raise error when start or finished not called", () => {
-    const e = new Event("test", new Date());
+    const e = new Event("test", Temporal.Now.instant());
     // duration before finish should return 0, not throw
     expect(() => e.duration).not.toThrow();
     expect(e.duration).toBe(0);
@@ -321,7 +322,7 @@ describe("EventTest", () => {
 
   it("events consumes information given as payload", () => {
     const payload = { sql: "SELECT 1", binds: [1, 2] };
-    const e = new Event("sql", new Date(), payload);
+    const e = new Event("sql", Temporal.Now.instant(), payload);
     expect(e.payload.sql).toBe("SELECT 1");
     expect(e.payload.binds).toEqual([1, 2]);
   });
@@ -399,9 +400,9 @@ describe("ActiveSupport::Notifications", () => {
         event = e;
       });
       Notifications.instrument("work", {});
-      expect(event.time).toBeInstanceOf(Date);
-      expect(event.end).toBeInstanceOf(Date);
-      expect(event.end!.getTime()).toBeGreaterThanOrEqual(event.time.getTime());
+      expect(event.time).toBeInstanceOf(Temporal.Instant);
+      expect(event.end).toBeInstanceOf(Temporal.Instant);
+      expect(event.end!.epochNanoseconds).toBeGreaterThanOrEqual(event.time.epochNanoseconds);
     });
 
     it("duration reflects elapsed time", async () => {
@@ -499,7 +500,7 @@ describe("ActiveSupport::Notifications", () => {
 
   describe("Event", () => {
     it("has name, time, and payload", () => {
-      const now = new Date();
+      const now = Temporal.Now.instant();
       const e = new Event("foo", now, { x: 1 });
       expect(e.name).toBe("foo");
       expect(e.time).toBe(now);
@@ -507,20 +508,20 @@ describe("ActiveSupport::Notifications", () => {
     });
 
     it("duration is 0 before finish", () => {
-      const e = new Event("foo", new Date());
+      const e = new Event("foo", Temporal.Now.instant());
       expect(e.duration).toBe(0);
     });
 
     it("duration is positive after finish", () => {
-      const start = new Date(Date.now() - 100);
+      const start = Temporal.Now.instant().subtract({ milliseconds: 100 });
       const e = new Event("foo", start);
-      e.finish(new Date());
+      e.finish(Temporal.Now.instant());
       expect(e.duration).toBeGreaterThan(0);
     });
 
     it("has unique transactionId", () => {
-      const a = new Event("a", new Date());
-      const b = new Event("b", new Date());
+      const a = new Event("a", Temporal.Now.instant());
+      const b = new Event("b", Temporal.Now.instant());
       expect(a.transactionId).not.toBe(b.transactionId);
     });
 
@@ -641,7 +642,7 @@ describe("LegacyHandle", () => {
         published.push(event);
       },
     };
-    const event = new Event("legacy.event", new Date());
+    const event = new Event("legacy.event", Temporal.Now.instant());
     const handle = new LegacyHandle(event, notifier);
     handle.finish();
     expect(published).toHaveLength(1);

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -5,11 +5,9 @@
  *   const sub = Notifications.subscribe("sql.active_record", (event) => { ... });
  *   Notifications.instrument("sql.active_record", { sql: "SELECT 1" }, () => { ... });
  *   Notifications.unsubscribe(sub);
- *
- * @boundary-file: emits `Event` instances whose `time`/`end` fields are
- *   JS `Date` by Rails parity (see `notifications/instrumenter.ts`).
  */
 
+import { Temporal } from "./temporal.js";
 import { Event } from "./notifications/instrumenter.js";
 import type { EventPayload } from "./notifications/instrumenter.js";
 import { getAsyncContext } from "./async-context-adapter.js";
@@ -129,7 +127,7 @@ export class Notifications {
    *   Notifications.instrument("cache.miss", { key });
    */
   private static _buildEvent(name: string, payload?: EventPayload, current?: Event[]): Event {
-    const event = new Event(name, new Date(), payload ?? {});
+    const event = new Event(name, Temporal.Now.instant(), payload ?? {});
     const stack = current ?? this._eventStack();
     const parent = stack[stack.length - 1];
     if (parent) {

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -1,9 +1,4 @@
-/**
- * @boundary-file: subscriber group implementations may time their callbacks
- *   with either JS `Date` values or monotonic numeric timestamps, depending on
- *   the timing source. The public `Event.time`/`end` contract remains
- *   Date-typed for Rails parity — see notifications/instrumenter.ts.
- */
+import { Temporal } from "../temporal.js";
 import { Event } from "./instrumenter.js";
 
 export class InstrumentationSubscriberError extends Error {
@@ -50,8 +45,8 @@ type EventedListener = {
 
 type TimedCallback = (
   name: string,
-  start: Date | number,
-  finish: Date | number,
+  start: Temporal.Instant | number,
+  finish: Temporal.Instant | number,
   id: unknown,
   payload: Record<string, unknown>,
 ) => void;
@@ -166,17 +161,17 @@ export class EventedGroup extends BaseGroup {
 }
 
 export class TimedGroup extends BaseTimeGroup {
-  private startTime: Date | null = null;
+  private startTime: Temporal.Instant | null = null;
   constructor(private listeners: TimedCallback[]) {
     super();
   }
 
   start(_name: string, _id: unknown, _payload: Record<string, unknown>): void {
-    this.startTime = new Date();
+    this.startTime = Temporal.Now.instant();
   }
 
   finish(name: string, id: unknown, payload: Record<string, unknown>): void {
-    const stopTime = new Date();
+    const stopTime = Temporal.Now.instant();
     iterateGuardingExceptions(this.listeners, (l) =>
       l(name, this.startTime!, stopTime, id, payload),
     );
@@ -208,7 +203,7 @@ export class EventObjectGroup extends BaseGroup {
   }
 
   start(name: string, id: unknown, payload: Record<string, unknown>): void {
-    this.event = new Event(name, new Date(), payload, String(id));
+    this.event = new Event(name, Temporal.Now.instant(), payload, String(id));
   }
 
   finish(_name: string, _id: unknown, payload: Record<string, unknown>): void {

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Notifications } from "../notifications.js";
 import { Event } from "./instrumenter.js";
+import { Temporal } from "../temporal.js";
 
 describe("InstrumenterTest", () => {
   afterEach(() => {
@@ -30,7 +31,7 @@ describe("InstrumenterTest", () => {
     Notifications.subscribe("foo", (e) => events.push(e));
     Notifications.instrument("foo", { x: 1 });
     expect(events).toHaveLength(1);
-    expect(events[0].end).toBeInstanceOf(Date);
+    expect(events[0].end).toBeInstanceOf(Temporal.Instant);
   });
 
   it("start", () => {
@@ -44,7 +45,7 @@ describe("InstrumenterTest", () => {
     const events: Event[] = [];
     Notifications.subscribe("finish.test", (e) => events.push(e));
     Notifications.instrument("finish.test", {});
-    expect(events[0].end).toBeInstanceOf(Date);
+    expect(events[0].end).toBeInstanceOf(Temporal.Instant);
   });
 
   it("record", () => {

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -1,10 +1,4 @@
-/**
- * @boundary-file: ActiveSupport::Notifications::Event exposes `time: Date` /
- *   `end: Date | null` as a public contract for log subscribers and listeners;
- *   `end` becomes a `Date` once `finish()` runs (Rails parity — Ruby
- *   Event#time returns a Time). The Temporal flip on this surface is tracked
- *   separately as a cross-cutting subscriber refactor.
- */
+import { Temporal } from "../temporal.js";
 
 export type EventPayload = Record<string, unknown>;
 
@@ -18,13 +12,18 @@ function generateTransactionId(): string {
  */
 export class Event {
   readonly name: string;
-  readonly time: Date;
-  end: Date | null;
+  readonly time: Temporal.Instant;
+  end: Temporal.Instant | null;
   readonly payload: EventPayload;
   readonly transactionId: string;
   readonly children: Event[];
 
-  constructor(name: string, start: Date, payload: EventPayload = {}, transactionId?: string) {
+  constructor(
+    name: string,
+    start: Temporal.Instant,
+    payload: EventPayload = {},
+    transactionId?: string,
+  ) {
     this.name = name;
     this.time = start;
     this.end = null;
@@ -36,7 +35,7 @@ export class Event {
   /** Duration in milliseconds (like Rails' Event#duration in ms). */
   get duration(): number {
     if (!this.end) return 0;
-    return this.end.getTime() - this.time.getTime();
+    return this.end.epochMilliseconds - this.time.epochMilliseconds;
   }
 
   /** Alias: Rails calls it `duration` but measured in ms. */
@@ -44,8 +43,8 @@ export class Event {
     return this.duration;
   }
 
-  finish(endTime?: Date): void {
-    this.end = endTime ?? new Date();
+  finish(endTime?: Temporal.Instant): void {
+    this.end = endTime ?? Temporal.Now.instant();
   }
 }
 
@@ -71,7 +70,7 @@ export class Instrumenter {
     } else if (payloadOrFn) {
       payload = payloadOrFn;
     }
-    const event = new Event(name, new Date(), payload, this.id);
+    const event = new Event(name, Temporal.Now.instant(), payload, this.id);
     const parent = this._stack[this._stack.length - 1];
     if (parent) parent.children.push(event);
     this._stack.push(event);
@@ -98,7 +97,7 @@ export class Instrumenter {
     } else if (payloadOrFn) {
       payload = payloadOrFn;
     }
-    const event = new Event(name, new Date(), payload, this.id);
+    const event = new Event(name, Temporal.Now.instant(), payload, this.id);
     const parent = this._stack[this._stack.length - 1];
     if (parent) parent.children.push(event);
     this._stack.push(event);


### PR DESCRIPTION
## Summary

Migrates the public `ActiveSupport::Notifications::Event#time` / `#end` contract from JS `Date` to `Temporal.Instant`, completing F-2 of the Temporal migration follow-ups.

- `Event.time: Temporal.Instant` and `Event.end: Temporal.Instant | null`
- `Event#duration` keeps its ms-granularity contract via `epochMilliseconds`
- All internal builders (`Instrumenter`, `notifications.ts`, `EventObjectGroup`, `TimedGroup`, `transaction.ts`) now construct via `Temporal.Now.instant()`
- Drops `@boundary-file:` directives on `notifications.ts`, `notifications/instrumenter.ts`, `notifications/fanout.ts`, and the line-level `// boundary:` in `transaction.ts`

`MonotonicTimedGroup` is unchanged (numeric `performance.now()` timestamps are not a wall-clock concept). `TimedCallback` signature flips from `Date | number` to `Temporal.Instant | number`.

## Test plan

- [x] `pnpm --filter @blazetrails/activesupport test` — 3639/3639 passing
- [x] `pnpm vitest run packages/activerecord/src/log-subscriber.test.ts` — 19/19 passing
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] PR diff: 58 +/56 -, 7 files