### PR TITLE
feat(activesupport): Logger#formatter receives Temporal.Instant

### DIFF
--- a/packages/activesupport/src/broadcast-logger.test.ts
+++ b/packages/activesupport/src/broadcast-logger.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { Logger } from "./logger.js";
 import { BroadcastLogger } from "./broadcast-logger.js";
+import { Temporal } from "./temporal.js";
 
 function makeBuffer() {
   const lines: string[] = [];
@@ -80,7 +81,7 @@ describe("BroadcastLoggerTest", () => {
   });
 
   it("#formatter= assigns to all the loggers", () => {
-    const fmt = (_s: string, _d: Date, _p: string, msg: string) => `FMT: ${msg}\n`;
+    const fmt = (_s: string, _d: Temporal.Instant, _p: string, msg: string) => `FMT: ${msg}\n`;
     logger.formatter = fmt;
     logger.info("hello");
     expect(log1Output.string).toContain("FMT: hello");

--- a/packages/activesupport/src/clean-logger.test.ts
+++ b/packages/activesupport/src/clean-logger.test.ts
@@ -14,7 +14,7 @@ describe("CleanLoggerTest", () => {
     const lines: string[] = [];
     const logger = new Logger({ write: (s) => lines.push(s) });
     logger.formatter = (severity, datetime, _prog, msg) =>
-      `[${datetime.toISOString()}] ${severity}: ${msg}\n`;
+      `[${datetime.toString()}] ${severity}: ${msg}\n`;
     logger.info("test");
     expect(lines[0]).toMatch(/^\[\d{4}-\d{2}-\d{2}/);
   });

--- a/packages/activesupport/src/logger.test.ts
+++ b/packages/activesupport/src/logger.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Logger, taggedLogging, SimpleFormatter } from "./logger.js";
 import { BroadcastLogger } from "./broadcast-logger.js";
+import { Temporal } from "./temporal.js";
 
 function makeBuffer() {
   const lines: string[] = [];
@@ -194,7 +195,8 @@ describe("LoggerTest", () => {
   });
 
   it("formatter can be set via keyword arg", () => {
-    logger.formatter = (_s: string, _d: Date, _p: string, msg: string) => `CUSTOM: ${msg}\n`;
+    logger.formatter = (_s: string, _d: Temporal.Instant, _p: string, msg: string) =>
+      `CUSTOM: ${msg}\n`;
     logger.info("world");
     expect(output.string).toBe("CUSTOM: world\n");
   });
@@ -373,12 +375,12 @@ describe("TaggedLoggingTest", () => {
 describe("SimpleFormatter", () => {
   it("formats a string message with newline", () => {
     const fmt = new SimpleFormatter();
-    expect(fmt.call("INFO", new Date(), null, "hello")).toBe("hello\n");
+    expect(fmt.call("INFO", Temporal.Now.instant(), null, "hello")).toBe("hello\n");
   });
 
   it("formats empty string", () => {
     const fmt = new SimpleFormatter();
-    expect(fmt.call("DEBUG", new Date(), null, "")).toBe("\n");
+    expect(fmt.call("DEBUG", Temporal.Now.instant(), null, "")).toBe("\n");
   });
 });
 

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -93,11 +93,18 @@ export class Logger {
 
   add(severity: number, message?: string | null, progname?: string): boolean {
     if (severity < this.level) return true;
-    const effectiveProgname = progname ?? this.progname;
-    const msg = message != null ? String(message) : effectiveProgname;
+    let msg: string;
+    let formatterProgname: string;
+    if (message != null) {
+      msg = String(message);
+      formatterProgname = progname ?? this.progname;
+    } else {
+      msg = progname ?? this.progname;
+      formatterProgname = this.progname;
+    }
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
     const line = this.formatter
-      ? this.formatter(severityName, Temporal.Now.instant(), effectiveProgname, msg)
+      ? this.formatter(severityName, Temporal.Now.instant(), formatterProgname, msg)
       : `${msg}\n`;
     this.output?.write(line);
     return true;

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -2,6 +2,8 @@
  * Logger and TaggedLogging — mirroring ActiveSupport's logging API.
  */
 
+import { Temporal } from "./temporal.js";
+
 export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "unknown";
 
 export const LOG_LEVELS: Record<LogLevel, number> = {
@@ -33,15 +35,17 @@ export interface LoggerOutput {
 export class Logger {
   progname: string = "trails";
   protected _formatter:
-    | ((severity: string, datetime: Date, progname: string, msg: string) => string)
+    | ((severity: string, datetime: Temporal.Instant, progname: string, msg: string) => string)
     | null = null;
   get formatter():
-    | ((severity: string, datetime: Date, progname: string, msg: string) => string)
+    | ((severity: string, datetime: Temporal.Instant, progname: string, msg: string) => string)
     | null {
     return this._formatter;
   }
   set formatter(
-    value: ((severity: string, datetime: Date, progname: string, msg: string) => string) | null,
+    value:
+      | ((severity: string, datetime: Temporal.Instant, progname: string, msg: string) => string)
+      | null,
   ) {
     this._formatter = value;
   }
@@ -91,10 +95,8 @@ export class Logger {
     if (severity < this.level) return true;
     const msg = message != null ? String(message) : (progname ?? this.progname);
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
-    // boundary: Logger#formatter receives a Date timestamp by Rails parity
-    // (Ruby Logger::Formatter#call(severity, time, progname, msg) — time is a Time).
     const line = this.formatter
-      ? this.formatter(severityName, new Date(), this.progname, msg)
+      ? this.formatter(severityName, Temporal.Now.instant(), this.progname, msg)
       : `${msg}\n`;
     this.output?.write(line);
     return true;
@@ -407,14 +409,19 @@ taggedLogging.logger = function (output: LoggerOutput): TaggedLogger {
 };
 
 export class SimpleFormatter {
-  call(_severity: string, _timestamp: Date, _progname: string | null, msg: string): string {
+  call(
+    _severity: string,
+    _timestamp: Temporal.Instant,
+    _progname: string | null,
+    msg: string,
+  ): string {
     return `${msg}\n`;
   }
 }
 
 export function simpleFormatter(): (
   severity: string,
-  timestamp: Date,
+  timestamp: Temporal.Instant,
   progname: string | null,
   msg: string,
 ) => string {

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -93,10 +93,11 @@ export class Logger {
 
   add(severity: number, message?: string | null, progname?: string): boolean {
     if (severity < this.level) return true;
-    const msg = message != null ? String(message) : (progname ?? this.progname);
+    const effectiveProgname = progname ?? this.progname;
+    const msg = message != null ? String(message) : effectiveProgname;
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
     const line = this.formatter
-      ? this.formatter(severityName, Temporal.Now.instant(), this.progname, msg)
+      ? this.formatter(severityName, Temporal.Now.instant(), effectiveProgname, msg)
       : `${msg}\n`;
     this.output?.write(line);
     return true;

--- a/packages/activesupport/src/tagged-logging.ts
+++ b/packages/activesupport/src/tagged-logging.ts
@@ -5,6 +5,7 @@
 
 import { Logger, taggedLogging as _taggedLogging } from "./logger.js";
 import type { TaggedLogger } from "./logger.js";
+import { Temporal } from "./temporal.js";
 
 export class TagStack {
   private _tags: string[] = [];
@@ -55,7 +56,7 @@ export namespace Formatter {
   export function call(
     tagStack: TagStack,
     severity: string,
-    _timestamp: Date,
+    _timestamp: Temporal.Instant,
     _progname: string | null,
     msg: string,
   ): string {

--- a/packages/activesupport/src/tagged-logging.ts
+++ b/packages/activesupport/src/tagged-logging.ts
@@ -5,7 +5,7 @@
 
 import { Logger, taggedLogging as _taggedLogging } from "./logger.js";
 import type { TaggedLogger } from "./logger.js";
-import { Temporal } from "./temporal.js";
+import type { Temporal } from "./temporal.js";
 
 export class TagStack {
   private _tags: string[] = [];


### PR DESCRIPTION
## Summary

Flips `Logger#formatter` callback signature from `(severity, Date, progname, msg)` to `(severity, Temporal.Instant, progname, msg)`, completing F-3 of the Temporal migration follow-ups.

- `Logger#add` builds the timestamp via `Temporal.Now.instant()` and drops the `// boundary:` annotation
- `SimpleFormatter#call` and `simpleFormatter()` updated to match
- `TaggedLogging.Formatter.call` timestamp type updated to `Temporal.Instant` (kept assignable to `Logger#formatter`)
- `Logger#add` also fixed to follow Ruby stdlib semantics: when `message` is nil, `progname` arg becomes the message and the formatter receives `this.progname`
- Updated `logger.test.ts`, `broadcast-logger.test.ts`, `clean-logger.test.ts` (the latter calls `.toString()` instead of `.toISOString()`)

Rails parity: Ruby's `Logger::Formatter#call(severity, time, progname, msg)` receives a `Time`; `Temporal.Instant` is the modern wall-clock equivalent.

## Test plan

- [x] `pnpm vitest run packages/activesupport` — 3639/3639 passing
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] Files changed: `logger.ts`, `tagged-logging.ts`, `logger.test.ts`, `broadcast-logger.test.ts`, `clean-logger.test.ts`