### PR TITLE
fix(arel): MySQL prepareUpdateStatement / buildSubselect

### DIFF
--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -250,6 +250,110 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
     expect(compile(node)).toBe('"users"."name" NOT REGEXP \'^a\'');
   });
 
+  describe("prepareUpdateStatement / prepareDeleteStatement (MySQL)", () => {
+    const posts = new Table("posts");
+    const visitor = new Visitors.MySQL();
+    type WithPrepare = {
+      prepareUpdateStatement(o: Nodes.UpdateStatement): Nodes.UpdateStatement;
+      prepareDeleteStatement(o: Nodes.DeleteStatement): Nodes.DeleteStatement;
+    };
+    const prep = visitor as unknown as WithPrepare;
+
+    const buildUpdate = (opts: {
+      withJoin?: boolean;
+      limit?: boolean;
+      offset?: boolean;
+      orders?: boolean;
+      groups?: boolean;
+      havings?: boolean;
+    }): Nodes.UpdateStatement => {
+      const stmt = new Nodes.UpdateStatement();
+      const relation = opts.withJoin
+        ? new Nodes.JoinSource(users, [
+            new Nodes.InnerJoin(posts, new Nodes.On(new Nodes.SqlLiteral("1=1"))),
+          ])
+        : new Nodes.JoinSource(users);
+      stmt.relation = relation;
+      stmt.key = users.get("id");
+      if (opts.limit) stmt.limit = new Nodes.Limit(new Nodes.SqlLiteral("1"));
+      if (opts.offset) stmt.offset = new Nodes.Offset(new Nodes.SqlLiteral("1"));
+      if (opts.orders) stmt.orders = [users.get("id")];
+      if (opts.groups) stmt.groups = [users.get("id")];
+      if (opts.havings) stmt.havings = [new Nodes.SqlLiteral("1=1")];
+      return stmt;
+    };
+
+    it("UPDATE with JOIN but no LIMIT/OFFSET/ORDER returns the original statement (no subselect)", () => {
+      const stmt = buildUpdate({ withJoin: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).toBe(stmt);
+    });
+
+    it("UPDATE without JOIN and without OFFSET returns original even with LIMIT/ORDER", () => {
+      const stmt = buildUpdate({ limit: true, orders: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).toBe(stmt);
+    });
+
+    it("UPDATE with JOIN + LIMIT triggers subselect rewrite", () => {
+      const stmt = buildUpdate({ withJoin: true, limit: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).not.toBe(stmt);
+      expect(out.wheres.length).toBe(1);
+      expect(out.wheres[0]).toBeInstanceOf(Nodes.In);
+    });
+
+    it("UPDATE with OFFSET (no JOIN) triggers subselect rewrite", () => {
+      const stmt = buildUpdate({ offset: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).not.toBe(stmt);
+    });
+
+    it("UPDATE with JOIN + GROUP BY + HAVING triggers subselect rewrite", () => {
+      const stmt = buildUpdate({ withJoin: true, groups: true, havings: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).not.toBe(stmt);
+    });
+
+    it("UPDATE with GROUP BY only (no HAVING) does NOT trigger rewrite", () => {
+      const stmt = buildUpdate({ groups: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      expect(out).toBe(stmt);
+    });
+
+    it("DELETE follows the same rules (alias of prepareUpdateStatement)", () => {
+      const stmt = new Nodes.DeleteStatement(
+        new Nodes.JoinSource(users, [
+          new Nodes.InnerJoin(posts, new Nodes.On(new Nodes.SqlLiteral("1=1"))),
+        ]),
+      );
+      stmt.key = users.get("id");
+      stmt.limit = new Nodes.Limit(new Nodes.SqlLiteral("1"));
+      const out = prep.prepareDeleteStatement(stmt);
+      expect(out).not.toBe(stmt);
+      expect(out.wheres[0]).toBeInstanceOf(Nodes.In);
+    });
+
+    it("buildSubselect adds DISTINCT when the subselect has no LIMIT/OFFSET/ORDER", () => {
+      // JOIN + GROUP BY + HAVING (no LIMIT/OFFSET/ORDER): super clones
+      // and clears limit/offset/orders on the rewritten stmt, build_subselect
+      // sees an `o` with none of those → MySQL adds DISTINCT to materialize.
+      const stmt = buildUpdate({ withJoin: true, groups: true, havings: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      const sql = visitor.compile(out);
+      expect(sql).toContain("__active_record_temp");
+      expect(sql).toContain("DISTINCT");
+    });
+
+    it("buildSubselect skips DISTINCT when subselect already carries LIMIT", () => {
+      const stmt = buildUpdate({ withJoin: true, limit: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      const sql = visitor.compile(out);
+      expect(sql).toContain("__active_record_temp");
+      expect(sql).not.toContain("DISTINCT");
+    });
+  });
+
   it("Cte uses backtick-quoted identifiers (not double quotes)", () => {
     const inner = new SelectManager(users).project(users.get("id"));
     const cte = new Nodes.Cte("recent", inner.ast);

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -352,6 +352,20 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
       expect(sql).toContain("__active_record_temp");
       expect(sql).not.toContain("DISTINCT");
     });
+
+    // Full-shape regression for the JOIN+GROUP+HAVING path: pins the
+    // exact subselect wrapping (DISTINCT, `__active_record_temp` alias,
+    // outer projection of the quoted key column) so any future
+    // visitor change that drifts from Rails will be caught here.
+    it("JOIN + GROUP BY + HAVING produces the full Rails-shaped subselect", () => {
+      const stmt = buildUpdate({ withJoin: true, groups: true, havings: true });
+      const out = prep.prepareUpdateStatement(stmt);
+      const sql = visitor.compile(out);
+      expect(sql).toContain('IN (SELECT "id" FROM (SELECT DISTINCT "users"."id" FROM "users"');
+      expect(sql).toContain('INNER JOIN "posts" ON 1=1');
+      expect(sql).toContain('GROUP BY "users"."id" HAVING 1=1');
+      expect(sql).toContain(") AS __active_record_temp)");
+    });
   });
 
   it("Cte uses backtick-quoted identifiers (not double quotes)", () => {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -187,6 +187,62 @@ export class MySQL extends ToSql {
     return this.collector;
   }
 
+  // In the simple case, MySQL allows JOINs directly in UPDATE/DELETE
+  // queries. LIMIT/OFFSET/ORDER need a subquery. Mirrors Rails MySQL's
+  // `prepare_update_statement` / `prepare_delete_statement` (aliased).
+  protected override prepareUpdateStatement(o: Nodes.UpdateStatement): Nodes.UpdateStatement {
+    if (
+      o.offset ||
+      this.hasGroupByAndHaving(o) ||
+      (this.hasJoinSources(o) && this.hasLimitOrOffsetOrOrders(o))
+    ) {
+      return super.prepareUpdateStatement(o);
+    }
+    return o;
+  }
+
+  protected override prepareDeleteStatement(o: Nodes.DeleteStatement): Nodes.DeleteStatement {
+    if (
+      o.offset ||
+      this.hasGroupByAndHaving(o) ||
+      (this.hasJoinSources(o) && this.hasLimitOrOffsetOrOrders(o))
+    ) {
+      return super.prepareDeleteStatement(o);
+    }
+    return o;
+  }
+
+  // MySQL doesn't auto-create a temp table for the subquery; force it by
+  // adding DISTINCT (when LIMIT/OFFSET/ORDER doesn't already materialize)
+  // and wrapping the subselect in another SELECT aliased as
+  // `__active_record_temp`. Mirrors Rails MySQL's `build_subselect`.
+  protected override buildSubselect(
+    key: Node,
+    o: {
+      relation: Node | null;
+      wheres: Node[];
+      groups: Node[];
+      havings: Node[];
+      limit: Node | null;
+      offset: Node | null;
+      orders: Node[];
+    },
+  ): Nodes.SelectStatement {
+    const subselect = super.buildSubselect(key, o);
+
+    if (!this.hasLimitOrOffsetOrOrders(subselect)) {
+      const subCore = subselect.cores[subselect.cores.length - 1];
+      subCore.setQuantifier = new Nodes.Distinct();
+    }
+
+    const stmt = new Nodes.SelectStatement();
+    const core = stmt.cores[stmt.cores.length - 1];
+    const keyName = (key as unknown as { name: string }).name;
+    core.source = new Nodes.JoinSource(new Nodes.Grouping(subselect).as("__active_record_temp"));
+    core.projections = [new Nodes.SqlLiteral(this.quoteColumnName(keyName), { retryable: true })];
+    return stmt;
+  }
+
   protected override visitArelNodesCte(node: Nodes.Cte): SQLString {
     // MySQL identifiers are backtick-quoted, not double-quoted, and the
     // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -470,7 +470,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return o;
   }
 
-  private buildSubselect(
+  protected buildSubselect(
     key: Node,
     o: {
       relation: Node | null;
@@ -502,11 +502,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return key;
   }
 
-  private hasJoinSources(o: { relation: Node | null }): boolean {
+  protected hasJoinSources(o: { relation: Node | null }): boolean {
     return o.relation instanceof Nodes.JoinSource && o.relation.right.length > 0;
   }
 
-  private hasLimitOrOffsetOrOrders(o: {
+  protected hasLimitOrOffsetOrOrders(o: {
     limit: Node | null;
     offset: Node | null;
     orders: Node[];


### PR DESCRIPTION
## Summary
- Override `prepareUpdateStatement` / `prepareDeleteStatement` on the MySQL visitor to gate the subquery rewrite per Rails (`o.offset || hasGroupByAndHaving || (joins && limit/offset/orders)`).
- Override `buildSubselect` to wrap the inner SELECT in a `Grouping(...).as("__active_record_temp")` with `Distinct` applied when the subselect lacks LIMIT/OFFSET/ORDER (forcing MySQL 5.7.6+ to materialize the derived table).
- Loosen base `to-sql.ts` visibility on `buildSubselect` / `hasJoinSources` / `hasLimitOrOffsetOrOrders` from private to protected so the MySQL subclass can call/override them.

Mirrors `Arel::Visitors::MySQL#prepare_update_statement` and `#build_subselect` (activerecord/lib/arel/visitors/mysql.rb).

## Test plan
- [x] `pnpm vitest run packages/arel` — 1186/1186 pass
- [x] New tests cover: JOIN-only no rewrite, OFFSET triggers rewrite, JOIN+LIMIT triggers rewrite + DISTINCT skipped, JOIN+GROUP+HAVING triggers rewrite + DISTINCT applied, DELETE symmetric, GROUP-only does not trigger