### PR TITLE
fix(arel): SQLite strips Grouping operands from set operations

### DIFF
--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -65,4 +65,49 @@ describe("SqliteTest", () => {
       expect(sql).toContain('"posts"."user_id"');
     });
   });
+
+  describe("set operations", () => {
+    // SQLite rejects parens around SELECT operands of UNION/INTERSECT/EXCEPT.
+    // Mirrors `sqlite.rb#infix_value_with_paren` — strip Grouping wrappers.
+    const q1 = () => users.project(star);
+    const q2 = () => users.project(star);
+
+    it("UNION strips Grouping wrapped operands", () => {
+      const node = new Nodes.Union(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).not.toContain("((");
+      expect(sql).toContain("UNION");
+      expect(sql).toBe('(SELECT * FROM "users" UNION SELECT * FROM "users")');
+    });
+
+    it("UNION ALL strips Grouping wrapped operands", () => {
+      const node = new Nodes.UnionAll(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).toBe('(SELECT * FROM "users" UNION ALL SELECT * FROM "users")');
+    });
+
+    it("INTERSECT strips Grouping wrapped operands", () => {
+      const node = new Nodes.Intersect(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).toBe('(SELECT * FROM "users" INTERSECT SELECT * FROM "users")');
+    });
+
+    it("EXCEPT strips Grouping wrapped operands", () => {
+      const node = new Nodes.Except(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).toBe('(SELECT * FROM "users" EXCEPT SELECT * FROM "users")');
+    });
+
+    it("UNION without Grouping operands renders bare SELECTs", () => {
+      const node = new Nodes.Union(q1().ast, q2().ast);
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).toBe('(SELECT * FROM "users" UNION SELECT * FROM "users")');
+    });
+
+    it("union via SelectManager omits inner parens", () => {
+      const sql = new Visitors.SQLite().compile(q1().union(q2()));
+      expect(sql).not.toContain("((");
+      expect(sql).toContain("UNION");
+    });
+  });
 });

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -1,4 +1,5 @@
 import * as Nodes from "../nodes/index.js";
+import { Node } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql } from "./to-sql.js";
 
@@ -76,5 +77,42 @@ export class SQLite extends ToSql {
 
   protected override visitArelNodesIsNotDistinctFrom(node: Nodes.IsNotDistinctFrom): SQLString {
     return this.visitBinaryOp(node, "IS");
+  }
+
+  /**
+   * Mirrors `sqlite.rb#infix_value_with_paren`: SQLite rejects parens around
+   * SELECT operands of UNION/INTERSECT/EXCEPT. Strip a `Grouping` wrapper from
+   * each operand so a SELECT visits raw inside the set-op.
+   */
+  protected override visitArelNodesUnion(node: Nodes.Union): SQLString {
+    return this.visitSetOperation(node, " UNION ");
+  }
+
+  protected override visitArelNodesUnionAll(node: Nodes.UnionAll): SQLString {
+    return this.visitSetOperation(node, " UNION ALL ");
+  }
+
+  protected override visitArelNodesIntersect(node: Nodes.Intersect): SQLString {
+    return this.visitSetOperation(node, " INTERSECT ");
+  }
+
+  protected override visitArelNodesExcept(node: Nodes.Except): SQLString {
+    return this.visitSetOperation(node, " EXCEPT ");
+  }
+
+  private visitSetOperation(node: { left: Node; right: Node }, op: string): SQLString {
+    this.collector.append("(");
+    this.visit(this.unwrapGrouping(node.left));
+    this.collector.append(op);
+    this.visit(this.unwrapGrouping(node.right));
+    this.collector.append(")");
+    return this.collector;
+  }
+
+  private unwrapGrouping(node: Node): Node {
+    if (node instanceof Nodes.Grouping && node.expr && typeof node.expr === "object") {
+      return node.expr as Node;
+    }
+    return node;
   }
 }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1076,7 +1076,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   // -- Set operations --
 
-  private visitArelNodesUnion(node: Nodes.Union): SQLString {
+  protected visitArelNodesUnion(node: Nodes.Union): SQLString {
     this.collector.append("(");
     this.visit(node.left);
     this.collector.append(" UNION ");
@@ -1085,7 +1085,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitArelNodesUnionAll(node: Nodes.UnionAll): SQLString {
+  protected visitArelNodesUnionAll(node: Nodes.UnionAll): SQLString {
     this.collector.append("(");
     this.visit(node.left);
     this.collector.append(" UNION ALL ");
@@ -1094,7 +1094,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitArelNodesIntersect(node: Nodes.Intersect): SQLString {
+  protected visitArelNodesIntersect(node: Nodes.Intersect): SQLString {
     this.collector.append("(");
     this.visit(node.left);
     this.collector.append(" INTERSECT ");
@@ -1103,7 +1103,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitArelNodesExcept(node: Nodes.Except): SQLString {
+  protected visitArelNodesExcept(node: Nodes.Except): SQLString {
     this.collector.append("(");
     this.visit(node.left);
     this.collector.append(" EXCEPT ");


### PR DESCRIPTION
## Summary

SQLite rejects parens around SELECT operands of UNION/INTERSECT/EXCEPT. This mirrors Rails' `Arel::Visitors::SQLite#infix_value_with_paren` (sqlite.rb:39-60) by overriding the four set-op visitors in the SQLite visitor to unwrap a `Grouping` wrapper from each operand before visiting.

Relaxes the four base set-op visitors in `to-sql.ts` from `private` to `protected` so the SQLite subclass can override them.

## Test plan

- [x] `pnpm vitest run packages/arel` — 1193 passing
- [x] New tests cover Union/UnionAll/Intersect/Except with and without Grouping wrappers