### PR TITLE
fix(arel): wire set-op visitors through infixValueWithParen + flatten

### DIFF
--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -77,31 +77,40 @@ describe("SqliteTest", () => {
       const sql = new Visitors.SQLite().compile(node);
       expect(sql).not.toContain("((");
       expect(sql).toContain("UNION");
-      expect(sql).toBe('(SELECT * FROM "users" UNION SELECT * FROM "users")');
+      expect(sql).toBe('( SELECT * FROM "users" UNION SELECT * FROM "users" )');
     });
 
     it("UNION ALL strips Grouping wrapped operands", () => {
       const node = new Nodes.UnionAll(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toBe('(SELECT * FROM "users" UNION ALL SELECT * FROM "users")');
+      expect(sql).toBe('( SELECT * FROM "users" UNION ALL SELECT * FROM "users" )');
     });
 
     it("INTERSECT strips Grouping wrapped operands", () => {
       const node = new Nodes.Intersect(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toBe('(SELECT * FROM "users" INTERSECT SELECT * FROM "users")');
+      expect(sql).toBe('( SELECT * FROM "users" INTERSECT SELECT * FROM "users" )');
     });
 
     it("EXCEPT strips Grouping wrapped operands", () => {
       const node = new Nodes.Except(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toBe('(SELECT * FROM "users" EXCEPT SELECT * FROM "users")');
+      expect(sql).toBe('( SELECT * FROM "users" EXCEPT SELECT * FROM "users" )');
     });
 
     it("UNION without Grouping operands renders bare SELECTs", () => {
       const node = new Nodes.Union(q1().ast, q2().ast);
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toBe('(SELECT * FROM "users" UNION SELECT * FROM "users")');
+      expect(sql).toBe('( SELECT * FROM "users" UNION SELECT * FROM "users" )');
+    });
+
+    it("nested unions are flattened (Rails-style)", () => {
+      const q3 = users.project(star);
+      const node = new Nodes.Union(q1().ast, new Nodes.Union(q2().ast, q3.ast));
+      const sql = new Visitors.SQLite().compile(node);
+      expect(sql).toBe(
+        '( SELECT * FROM "users" UNION SELECT * FROM "users" UNION SELECT * FROM "users" )',
+      );
     });
 
     it("union via SelectManager omits inner parens", () => {

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -80,32 +80,33 @@ export class SQLite extends ToSql {
   }
 
   /**
-   * Mirrors `sqlite.rb#infix_value_with_paren`: SQLite rejects parens around
-   * SELECT operands of UNION/INTERSECT/EXCEPT. Strip a `Grouping` wrapper from
-   * each operand so a SELECT visits raw inside the set-op.
+   * Mirrors `sqlite.rb#infix_value_with_paren`. SQLite rejects parens around
+   * SELECT operands of UNION/INTERSECT/EXCEPT — strip a `Grouping` wrapper
+   * from each operand before recursing/visiting.
    */
-  protected override visitArelNodesUnion(node: Nodes.Union): SQLString {
-    return this.visitSetOperation(node, " UNION ");
-  }
+  protected override infixValueWithParen(
+    o: Node & { left: Node; right: Node },
+    value: string,
+    suppressParens = false,
+  ): SQLString {
+    const sameClass = (child: Node): child is typeof o =>
+      Object.getPrototypeOf(child) === Object.getPrototypeOf(o);
 
-  protected override visitArelNodesUnionAll(node: Nodes.UnionAll): SQLString {
-    return this.visitSetOperation(node, " UNION ALL ");
-  }
-
-  protected override visitArelNodesIntersect(node: Nodes.Intersect): SQLString {
-    return this.visitSetOperation(node, " INTERSECT ");
-  }
-
-  protected override visitArelNodesExcept(node: Nodes.Except): SQLString {
-    return this.visitSetOperation(node, " EXCEPT ");
-  }
-
-  private visitSetOperation(node: { left: Node; right: Node }, op: string): SQLString {
-    this.collector.append("(");
-    this.visit(this.unwrapGrouping(node.left));
-    this.collector.append(op);
-    this.visit(this.unwrapGrouping(node.right));
-    this.collector.append(")");
+    if (!suppressParens) this.collector.append("( ");
+    const left = this.unwrapGrouping(o.left);
+    if (sameClass(left)) {
+      this.infixValueWithParen(left, value, true);
+    } else {
+      this.groupingParentheses(left, false);
+    }
+    this.collector.append(value);
+    const right = this.unwrapGrouping(o.right);
+    if (sameClass(right)) {
+      this.infixValueWithParen(right, value, true);
+    } else {
+      this.groupingParentheses(right, false);
+    }
+    if (!suppressParens) this.collector.append(" )");
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -891,6 +891,36 @@ describe("the to_sql visitor", () => {
     });
   });
 
+  describe("Nodes::Union with ORDER/LIMIT/OFFSET operands", () => {
+    // Mirrors Rails `grouping_parentheses(..., false)` + `require_parentheses?`:
+    // SELECTs that carry orders/limit/offset are wrapped to disambiguate.
+    it("wraps a SELECT operand with ORDER BY", () => {
+      const a = users.project(star);
+      const b = users.project(star).order(users.get("id"));
+      const node = new Nodes.Union(a.ast, b.ast);
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe(
+        '( SELECT * FROM "users" UNION (SELECT * FROM "users" ORDER BY "users"."id") )',
+      );
+    });
+
+    it("wraps a SELECT operand with LIMIT", () => {
+      const a = users.project(star);
+      const b = users.project(star).take(5);
+      const node = new Nodes.Union(a.ast, b.ast);
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe('( SELECT * FROM "users" UNION (SELECT * FROM "users" LIMIT 5) )');
+    });
+
+    it("wraps a SELECT operand with OFFSET", () => {
+      const a = users.project(star);
+      const b = users.project(star).skip(10);
+      const node = new Nodes.Union(a.ast, b.ast);
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe('( SELECT * FROM "users" UNION (SELECT * FROM "users" OFFSET 10) )');
+    });
+  });
+
   describe("Nodes::Intersect", () => {
     it("flattens nested intersects", () => {
       const a = users.project(star);

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -864,7 +864,9 @@ describe("the to_sql visitor", () => {
       const c = users.project(star);
       const node = new Nodes.UnionAll(a.ast, new Nodes.UnionAll(b.ast, c.ast));
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("UNION ALL");
+      expect(sql).toBe(
+        '( SELECT * FROM "users" UNION ALL SELECT * FROM "users" UNION ALL SELECT * FROM "users" )',
+      );
     });
   });
 
@@ -875,7 +877,9 @@ describe("the to_sql visitor", () => {
       const c = users.project(star);
       const node = new Nodes.Union(a.ast, new Nodes.Union(b.ast, c.ast));
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("UNION");
+      expect(sql).toBe(
+        '( SELECT * FROM "users" UNION SELECT * FROM "users" UNION SELECT * FROM "users" )',
+      );
     });
 
     it("encloses SELECT statements with parentheses", () => {
@@ -883,8 +887,33 @@ describe("the to_sql visitor", () => {
       const m2 = users.project(star);
       const node = new Nodes.Union(m1.ast, m2.ast);
       const sql = new Visitors.ToSql().compile(node);
-      expect(sql).toContain("UNION");
-      expect(sql).toContain("(");
+      expect(sql).toBe('( SELECT * FROM "users" UNION SELECT * FROM "users" )');
+    });
+  });
+
+  describe("Nodes::Intersect", () => {
+    it("flattens nested intersects", () => {
+      const a = users.project(star);
+      const b = users.project(star);
+      const c = users.project(star);
+      const node = new Nodes.Intersect(a.ast, new Nodes.Intersect(b.ast, c.ast));
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe(
+        '( SELECT * FROM "users" INTERSECT SELECT * FROM "users" INTERSECT SELECT * FROM "users" )',
+      );
+    });
+  });
+
+  describe("Nodes::Except", () => {
+    it("flattens nested excepts", () => {
+      const a = users.project(star);
+      const b = users.project(star);
+      const c = users.project(star);
+      const node = new Nodes.Except(a.ast, new Nodes.Except(b.ast, c.ast));
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe(
+        '( SELECT * FROM "users" EXCEPT SELECT * FROM "users" EXCEPT SELECT * FROM "users" )',
+      );
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1077,39 +1077,19 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // -- Set operations --
 
   protected visitArelNodesUnion(node: Nodes.Union): SQLString {
-    this.collector.append("(");
-    this.visit(node.left);
-    this.collector.append(" UNION ");
-    this.visit(node.right);
-    this.collector.append(")");
-    return this.collector;
+    return this.infixValueWithParen(node, " UNION ");
   }
 
   protected visitArelNodesUnionAll(node: Nodes.UnionAll): SQLString {
-    this.collector.append("(");
-    this.visit(node.left);
-    this.collector.append(" UNION ALL ");
-    this.visit(node.right);
-    this.collector.append(")");
-    return this.collector;
+    return this.infixValueWithParen(node, " UNION ALL ");
   }
 
   protected visitArelNodesIntersect(node: Nodes.Intersect): SQLString {
-    this.collector.append("(");
-    this.visit(node.left);
-    this.collector.append(" INTERSECT ");
-    this.visit(node.right);
-    this.collector.append(")");
-    return this.collector;
+    return this.infixValueWithParen(node, " INTERSECT ");
   }
 
   protected visitArelNodesExcept(node: Nodes.Except): SQLString {
-    this.collector.append("(");
-    this.visit(node.left);
-    this.collector.append(" EXCEPT ");
-    this.visit(node.right);
-    this.collector.append(")");
-    return this.collector;
+    return this.infixValueWithParen(node, " EXCEPT ");
   }
 
   // -- CTE --


### PR DESCRIPTION
## Summary

Base `ToSql` Union/UnionAll/Intersect/Except visitors now delegate to the existing `infixValueWithParen` helper, mirroring `to_sql.rb#visit_Arel_Nodes_Union` and friends. Output shape becomes the Rails-faithful `( a UNION b UNION c )` — flat, single outer pair of parens, inner SELECT operands visited via `groupingParentheses(false)`.

The SQLite visitor now overrides `infixValueWithParen` itself (mirroring `sqlite.rb#infix_value_with_paren`) instead of the four set-op visitors. Same end behavior as PR #1034, but matches Rails' inheritance shape and inherits flatten-by-class for free.

## Test plan

- [x] `pnpm vitest run packages/arel` — 1196 passing
- [x] Spot-checked AR relations + relation/with tests — green
- [x] New strict-shape tests for nested UNION/UNION ALL/INTERSECT/EXCEPT in `to-sql.test.ts`
- [x] SQLite test for nested unions