### PR TITLE
feat(activemodel): castValue indirection across Type primitives

### DIFF
--- a/packages/activemodel/src/type/big-integer.ts
+++ b/packages/activemodel/src/type/big-integer.ts
@@ -3,8 +3,8 @@ import { Type } from "./value.js";
 export class BigIntegerType extends Type<bigint> {
   readonly name: string = "big_integer";
 
-  cast(value: unknown): bigint | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): bigint | null {
     if (typeof value === "bigint") return value;
     if (typeof value === "string") {
       try {

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -35,8 +35,8 @@ export class BooleanType extends ValueType<boolean> {
    * policy. "yes", "no", "garbage" all coerce to `true`. Empty string
    * and `null`/`undefined` map to `null`.
    */
-  cast(value: unknown): boolean | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): boolean | null {
     if (value === "") return null;
     return !BooleanType.FALSE_VALUES.has(value);
   }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -17,8 +17,8 @@ export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegat
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
 
-  cast(value: unknown): DateTimeCastResult | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): DateTimeCastResult | null {
     if (value === DateInfinity) return DateInfinity;
     if (value === DateNegativeInfinity) return DateNegativeInfinity;
     if (value instanceof Temporal.Instant) return value;

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -15,8 +15,8 @@ export type DateCastResult = Temporal.PlainDate | DateInfinityType | DateNegativ
 export class DateType extends ValueType<DateCastResult> {
   readonly name: string = "date";
 
-  cast(value: unknown): DateCastResult | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): DateCastResult | null {
     if (value === DateInfinity) return DateInfinity;
     if (value === DateNegativeInfinity) return DateNegativeInfinity;
     if (value instanceof Temporal.PlainDate) return value;

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -10,7 +10,8 @@ export class DecimalType extends ValueType<string> {
   //   - nil      -> nil
   // We mirror the same shape, returning the string form rather than a
   // BigDecimal wrapper.
-  cast(value: unknown): string | null {
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): string | null {
     const casted = this._castWithoutScale(value);
     return this.applyScale(casted);
   }

--- a/packages/activemodel/src/type/float.ts
+++ b/packages/activemodel/src/type/float.ts
@@ -3,8 +3,8 @@ import { ValueType } from "./value.js";
 export class FloatType extends ValueType<number> {
   readonly name = "float";
 
-  cast(value: unknown): number | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): number | null {
     if (typeof value === "number") return value;
     const parsed = parseFloat(String(value));
     return isNaN(parsed) ? null : parsed;

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -7,14 +7,19 @@ export class ImmutableStringType extends ValueType<string> {
     super(options);
   }
 
-  cast(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
-    // Rails type/immutable_string.rb#cast_value:
-    //   case value
-    //   when true  then "t"
-    //   when false then "f"
-    //   else value.to_s
-    //   end
+  /**
+   * Mirrors: ActiveModel::Type::ImmutableString#cast_value
+   * (immutable_string.rb):
+   *
+   *   case value
+   *   when true  then "t"
+   *   when false then "f"
+   *   else value.to_s
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected castValue(value: unknown): string | null {
     if (value === true) return Object.freeze("t") as string;
     if (value === false) return Object.freeze("f") as string;
     const str = String(value);

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -12,8 +12,8 @@ export class IntegerType extends ValueType<number> {
     this._range = [-max, max - 1];
   }
 
-  cast(value: unknown): number | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): number | null {
     if (typeof value === "number") {
       if (isNaN(value)) return null;
       return Math.trunc(value);

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -3,13 +3,13 @@ import { ImmutableStringType } from "./immutable-string.js";
 export class StringType extends ImmutableStringType {
   readonly name: string = "string";
 
-  cast(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): string | null {
     // Rails type/string.rb subclasses immutable_string.rb, so the
     // boolean `true -> "t"` / `false -> "f"` mapping lives in the
     // superclass. Freezing is a no-op on primitive strings, so there's
     // no behavior lost by delegating the bool branch.
-    if (typeof value === "boolean") return super.cast(value);
+    if (typeof value === "boolean") return super.castValue(value);
     return String(value);
   }
 

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -4,8 +4,8 @@ import { ValueType } from "./value.js";
 export class TimeType extends ValueType<Temporal.PlainTime> {
   readonly name = "time";
 
-  cast(value: unknown): Temporal.PlainTime | null {
-    if (value === null || value === undefined) return null;
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): Temporal.PlainTime | null {
     if (value instanceof Temporal.PlainTime) return value;
     // Accept PlainDateTime from multiparameter assignment — extract the time part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainTime();

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -19,7 +19,40 @@ export abstract class Type<T = unknown> {
     return this._scale;
   }
 
-  abstract cast(value: unknown): T | null;
+  /**
+   * Mirrors: ActiveModel::Type::Value#cast (value.rb:53-55)
+   *
+   *   def cast(value)
+   *     cast_value(value) unless value.nil?
+   *   end
+   *
+   * Public coercion entrypoint. Subclasses normally override
+   * {@link castValue} (the protected hook) rather than `cast` itself,
+   * so the `value == null → null` short-circuit lives in one place.
+   * Subclasses with non-Rails-shaped coercion (e.g. Integer's blank
+   * string handling) may still override `cast` directly to match Rails.
+   */
+  cast(value: unknown): T | null {
+    if (value === null || value === undefined) return null;
+    return this.castValue(value);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Value#cast_value (value.rb:155-157)
+   *
+   *   def cast_value(value) # :doc:
+   *     value
+   *   end
+   *
+   * Convenience method for types which do not need separate type
+   * casting behavior for user and database inputs. Called by `cast`
+   * for non-nil values. The default passes the value through.
+   *
+   * @internal Rails-private helper.
+   */
+  protected castValue(value: unknown): T | null {
+    return value as T | null;
+  }
 
   type(): string {
     return this.name;
@@ -155,12 +188,6 @@ export abstract class Type<T = unknown> {
 
 export class ValueType<T = unknown> extends Type<T> {
   readonly name: string = "value";
-
-  cast(value: unknown): T | null {
-    // No-op default: pass the value through. Subclasses narrow by
-    // overriding `cast` with a concrete return type.
-    return value as T | null;
-  }
 
   equals(other: Type): boolean {
     return this.constructor === other.constructor;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -31,15 +31,15 @@ type PgDateTimeResult = Temporal.Instant | DateInfinityType | DateNegativeInfini
 export class DateTime extends DateTimeType {
   override readonly name: string = "datetime";
 
-  override cast(value: unknown): PgDateTimeResult | null {
-    return this.castValue(value);
-  }
-
   /**
    * Rails' `cast_value` — public here so subclasses can call directly
-   * and api:compare matches the Rails method name.
+   * and api:compare matches the Rails method name. Base `cast()`
+   * handles the nil short-circuit and dispatches here, so we fall
+   * through to the parent's `castValue` (NOT `cast`) to avoid the
+   * virtual-dispatch loop that would re-enter this method.
    */
-  castValue(value: unknown): PgDateTimeResult | null {
+  override castValue(value: unknown): PgDateTimeResult | null {
+    if (value === null || value === undefined) return null;
     if (typeof value === "string") {
       if (value === "infinity") return DateInfinity;
       if (value === "-infinity") return DateNegativeInfinity;
@@ -56,7 +56,7 @@ export class DateTime extends DateTimeType {
         }
       }
     }
-    return super.cast(value);
+    return super.castValue(value);
   }
 
   override serialize(value: unknown): string | null {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
@@ -15,7 +15,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   DateType,
-  type DateCastResult,
   DateInfinity,
   DateNegativeInfinity,
   type DateInfinityType,
@@ -26,18 +25,17 @@ import { parsePostgresDate } from "../../abstract/temporal-wire.js";
 export class Date extends DateType {
   override readonly name: string = "date";
 
-  override cast(value: unknown): DateCastResult | null {
-    return this.castValue(value);
-  }
-
   /**
-   * Rails' `cast_value` — the protected hook cast delegates to.
-   * Kept public so subclasses and tests can call it directly, and so
-   * api:compare finds the method name that matches Rails.
+   * Rails' `cast_value` — the hook cast delegates to. Kept public so
+   * subclasses and tests can call it directly. Base `cast()` handles
+   * the nil short-circuit and dispatches here, so we fall through to
+   * the parent's `castValue` (NOT `cast`) to avoid the virtual-dispatch
+   * loop that would re-enter this method.
    */
-  castValue(
+  override castValue(
     value: unknown,
   ): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType | null {
+    if (value === null || value === undefined) return null;
     if (typeof value === "string") {
       if (value === "infinity") return DateInfinity;
       if (value === "-infinity") return DateNegativeInfinity;
@@ -49,7 +47,7 @@ export class Date extends DateType {
         }
       }
     }
-    return super.cast(value);
+    return super.castValue(value);
   }
 
   override serialize(value: unknown): string | null {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
@@ -43,16 +43,16 @@ export class Money extends DecimalType {
    * itself, then delegates to DecimalType via super.cast(...) for
    * numeric casting.
    */
-  override cast(value: unknown): string | null {
-    return this.castValue(value);
-  }
-
   /**
    * Rails' cast_value — exposed publicly so api:compare matches the
-   * Rails method name and callers can invoke the hook directly.
+   * Rails method name and callers can invoke the hook directly. Base
+   * `cast()` now handles the nil short-circuit and dispatches here, so
+   * we only fall through to the parent's `castValue` (NOT `cast`) to
+   * avoid the virtual-dispatch loop that would re-enter this method.
    */
-  castValue(value: unknown): string | null {
-    if (typeof value !== "string") return super.cast(value);
+  override castValue(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+    if (typeof value !== "string") return super.castValue(value);
 
     // (4) (2.55) → -2.55
     let str = value.replace(/^\((.+)\)$/, "-$1");
@@ -65,6 +65,6 @@ export class Money extends DecimalType {
       str = str.replace(/[^\-0-9,]/g, "").replace(/,/g, ".");
     }
 
-    return super.cast(str);
+    return super.castValue(str);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
@@ -28,18 +28,14 @@ export class Uuid extends ValueType<string> {
     return "uuid";
   }
 
-  cast(value: unknown): string | null {
-    return this.castValue(value);
-  }
-
   override deserialize(value: unknown): string | null {
-    return this.castValue(value);
+    return this.cast(value);
   }
 
   // Rails does `alias :serialize :deserialize` — serialize routes through
   // the same casting path as deserialize.
   override serialize(value: unknown): string | null {
-    return this.castValue(value);
+    return this.cast(value);
   }
 
   /**
@@ -57,8 +53,8 @@ export class Uuid extends ValueType<string> {
     return rawOldValue?.constructor !== newValue?.constructor || newValue !== rawOldValue;
   }
 
-  private castValue(value: unknown): string | null {
-    if (value == null) return null;
+  /** @internal Rails-private helper. */
+  protected override castValue(value: unknown): string | null {
     const str = String(value);
     if (!ACCEPTABLE_UUID.test(str)) return null;
     return this.formatUuid(str);

--- a/packages/activerecord/src/type/text.ts
+++ b/packages/activerecord/src/type/text.ts
@@ -3,14 +3,11 @@
  */
 import { StringType } from "@blazetrails/activemodel";
 
-export class Text extends (StringType as new () => Omit<StringType, "name" | "type"> & {
-  name: string;
-  type(): string;
-}) {
-  readonly name = "text";
+export class Text extends StringType {
+  override readonly name: string = "text";
 
   /** Mirrors: ActiveRecord::Type::Text#type */
-  type(): string {
+  override type(): string {
     return "text";
   }
 }


### PR DESCRIPTION
## Summary

Mirrors Rails' `Type::Value#cast` / `#cast_value` split (`activemodel/lib/active_model/type/value.rb:53-55,155-157`):

- `cast(value)` on the base handles the `value == nil → null` short-circuit and dispatches to the protected `castValue(value)` hook.
- `castValue(value)` is the per-type coercion hook subclasses override (default: pass-through).

Updates 10 `Type` subclasses to override `castValue` instead of `cast`, dropping the per-subclass nil-checks that the base now handles.

**Privates report delta:** activemodel privates 505/625 (80.8%) → 515/625 (82.4%). Closes the `castValue` miss in boolean, float, integer, string, immutable_string, big_integer, time, date, date_time, decimal, value (11 sites).

### Side fixes
- `packages/activerecord/src/type/text.ts`: drop the `Omit<StringType, 'name' | 'type'>` cast workaround. Omit operates on the public type only, so the new protected `castValue` would be stripped from the structural type and Text would fail Type<unknown> assignability checks. Standard `extends StringType` + `override readonly name` works.
- `packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts`: rename the pre-existing `private castValue` to `protected override castValue` so it correctly overrides the new base hook. Remove the redundant `cast()` override that just bounced to `castValue` (base handles dispatch now).

### Track
First PR in **B1** of `docs/activemodel-privates-100-plan.md`.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1606/1606 pass
- [x] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` — 515/625 (82.4%)
- [ ] CI green for activerecord (Uuid + Text touched)