### PR TITLE
feat(activesupport): MessageVerifier expiry uses Temporal.Instant

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2795,7 +2795,7 @@ export class Base extends Model {
   async signedId(options?: {
     purpose?: string;
     expiresIn?: number;
-    expiresAt?: Date;
+    expiresAt?: Temporal.Instant;
   }): Promise<string> {
     const SignedIdModule = await loadSignedId();
     return SignedIdModule.signedId(this, options);

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base, RecordNotFound } from "./index.js";
 import { setSignedIdVerifierSecret } from "./signed-id.js";
 
@@ -49,7 +50,7 @@ describe("SignedIdTest", () => {
   it("fail to find signed record within expiration duration", async () => {
     const { User } = makeModel();
     const u = await User.create({ name: "Bob" });
-    const token = await u.signedId({ expiresAt: new Date(Date.now() - 1000) });
+    const token = await u.signedId({ expiresAt: Temporal.Now.instant().subtract({ seconds: 1 }) });
     const result = await User.findSigned(token);
     expect(result).toBeNull();
   });
@@ -170,7 +171,7 @@ describe("SignedIdTest", () => {
   it("fail to find signed record within expiration time", async () => {
     const { User } = makeModel();
     const u = await User.create({ name: "Expired" });
-    const token = await u.signedId({ expiresAt: new Date(Date.now() - 1000) });
+    const token = await u.signedId({ expiresAt: Temporal.Now.instant().subtract({ seconds: 1 }) });
     const result = await User.findSigned(token);
     expect(result).toBeNull();
   });
@@ -190,7 +191,7 @@ describe("SignedIdTest", () => {
       }
     }
     const u = await UserShort.create({ name: "Jake" });
-    const token = await u.signedId({ expiresAt: new Date(Date.now() - 1000) });
+    const token = await u.signedId({ expiresAt: Temporal.Now.instant().subtract({ seconds: 1 }) });
     await expect(UserShort.findSignedBang(token)).rejects.toThrow(
       /Expired message|InvalidSignature/,
     );

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -1,6 +1,7 @@
 import type { Base } from "./base.js";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { underscore } from "@blazetrails/activesupport";
+import type { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
  * Signed ID generation and lookup for ActiveRecord models.
@@ -78,7 +79,7 @@ function combinePurposes(modelClass: typeof Base, purpose?: string): string | un
  */
 export function signedId(
   instance: Base,
-  options?: { purpose?: string; expiresIn?: number; expiresAt?: Date },
+  options?: { purpose?: string; expiresIn?: number; expiresAt?: Temporal.Instant },
 ): string {
   if (!instance.isPersisted()) {
     throw new Error("Cannot generate a signed_id for a new record");

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -103,7 +103,7 @@ export class MessageVerifier {
 
       if (payload._expiresAt) {
         const expiresAt = Temporal.Instant.from(payload._expiresAt as string);
-        if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) < 0) {
+        if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) <= 0) {
           throw new InvalidSignature("Expired message");
         }
       }

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -60,9 +60,11 @@ export class MessageVerifier {
     const payload: Record<string, unknown> = { value };
 
     if (options.expiresAt) {
-      payload._expiresAt = options.expiresAt.toString();
+      payload._expiresAt = options.expiresAt.toString({ smallestUnit: "millisecond" });
     } else if (options.expiresIn !== undefined) {
-      payload._expiresAt = Temporal.Now.instant().add({ seconds: options.expiresIn }).toString();
+      payload._expiresAt = Temporal.Now.instant()
+        .add({ seconds: options.expiresIn })
+        .toString({ smallestUnit: "millisecond" });
     }
 
     if (options.purpose) {

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -4,6 +4,7 @@
  */
 
 import { getCrypto } from "./crypto-adapter.js";
+import { Temporal } from "./temporal.js";
 
 export class InvalidSignature extends Error {
   constructor(message = "Invalid signature") {
@@ -34,7 +35,7 @@ interface MessageVerifierOptions {
 
 interface GenerateOptions {
   expiresIn?: number; // seconds
-  expiresAt?: Date;
+  expiresAt?: Temporal.Instant;
   purpose?: string;
 }
 
@@ -59,10 +60,9 @@ export class MessageVerifier {
     const payload: Record<string, unknown> = { value };
 
     if (options.expiresAt) {
-      payload._expiresAt = options.expiresAt.toISOString();
+      payload._expiresAt = options.expiresAt.toString();
     } else if (options.expiresIn !== undefined) {
-      // boundary: ISO timestamp serialized into the signed payload.
-      payload._expiresAt = new Date(Date.now() + options.expiresIn * 1000).toISOString();
+      payload._expiresAt = Temporal.Now.instant().add({ seconds: options.expiresIn }).toString();
     }
 
     if (options.purpose) {
@@ -101,9 +101,11 @@ export class MessageVerifier {
 
       const payload = parsed as Record<string, unknown>;
 
-      // boundary: parse the embedded ISO timestamp and compare to wall clock.
-      if (payload._expiresAt && new Date(payload._expiresAt as string) < new Date()) {
-        throw new InvalidSignature("Expired message");
+      if (payload._expiresAt) {
+        const expiresAt = Temporal.Instant.from(payload._expiresAt as string);
+        if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) < 0) {
+          throw new InvalidSignature("Expired message");
+        }
       }
 
       if (options.purpose && payload._purpose !== options.purpose) {

--- a/packages/activesupport/src/messages/message-verifier-metadata.test.ts
+++ b/packages/activesupport/src/messages/message-verifier-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { MessageVerifier } from "../message-verifier.js";
+import { Temporal } from "../temporal.js";
 
 describe("MessageVerifierMetadataTest", () => {
   it("#verify raises when :purpose does not match", () => {
@@ -10,7 +11,7 @@ describe("MessageVerifierMetadataTest", () => {
 
   it("#verify raises when message is expired via :expires_at", () => {
     const verifier = new MessageVerifier("secret");
-    const pastDate = new Date(Date.now() - 1000);
+    const pastDate = Temporal.Now.instant().subtract({ seconds: 1 });
     const message = verifier.generate("data", { expiresAt: pastDate });
     expect(() => verifier.verify(message)).toThrow();
   });


### PR DESCRIPTION
## Summary

Switches `MessageVerifier` token expiry from `Date` to `Temporal.Instant`, completing F-4 of the Temporal migration follow-ups.

- `generate({ expiresAt })` now accepts `Temporal.Instant`
- `expiresIn` path uses `Temporal.Now.instant().add({ seconds })`
- Verification compares via `Temporal.Instant.compare(expiresAt, Temporal.Now.instant())`
- Drops two `// boundary:` annotations
- `signedId` (activerecord) and `Base#signedId` thread the type change
- Wire format unchanged — ISO-8601 instant string in the signed payload remains compatible with previously issued tokens

## Test plan

- [x] `pnpm vitest run packages/activesupport/src/messages/message-verifier-metadata packages/activerecord/src/signed-id` — passing
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] Diff: 18 +/13 -, 5 files