### PR TITLE
feat(arel): Table self-alias normalization + 2-arg get overload

### DIFF
--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -271,6 +271,7 @@ describe("TableTest", () => {
       const aliased = users.as("u");
       const attr = users.get("id", aliased);
       expect(attr.relation).toBe(aliased);
+      expect(new Visitors.ToSql().compile(attr)).toBe('"u"."id"');
     });
   });
 });

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -246,18 +246,6 @@ describe("TableTest", () => {
     expect(t.name).toBe("widgets");
   });
 
-  describe("self-alias normalization", () => {
-    it("drops table_alias when as equals name", () => {
-      const t = new Table("users", { as: "users" });
-      expect(t.tableAlias).toBeNull();
-    });
-
-    it("preserves table_alias when as differs from name", () => {
-      const t = new Table("users", { as: "u" });
-      expect(t.tableAlias).toBe("u");
-    });
-  });
-
   describe("[] (get) with explicit table", () => {
     it("builds an attribute on the provided table", () => {
       const other = new Table("others");

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -83,8 +83,8 @@ describe("TableTest", () => {
 
     it("ignores as if it equals name", () => {
       const t = new Table("users", { as: "users" });
-      // tableAlias is set to 'users' -- just proves it accepts the option
       expect(t.name).toBe("users");
+      expect(t.tableAlias).toBeNull();
     });
 
     it("should accept literal SQL", () => {

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -245,4 +245,32 @@ describe("TableTest", () => {
     const t = new Table("widgets");
     expect(t.name).toBe("widgets");
   });
+
+  describe("self-alias normalization", () => {
+    it("drops table_alias when as equals name", () => {
+      const t = new Table("users", { as: "users" });
+      expect(t.tableAlias).toBeNull();
+    });
+
+    it("preserves table_alias when as differs from name", () => {
+      const t = new Table("users", { as: "u" });
+      expect(t.tableAlias).toBe("u");
+    });
+  });
+
+  describe("[] (get) with explicit table", () => {
+    it("builds an attribute on the provided table", () => {
+      const other = new Table("others");
+      const attr = users.get("id", other);
+      expect(attr).toBeInstanceOf(Nodes.Attribute);
+      expect(attr.relation).toBe(other);
+      expect(attr.name).toBe("id");
+    });
+
+    it("builds an attribute on a TableAlias", () => {
+      const aliased = users.as("u");
+      const attr = users.get("id", aliased);
+      expect(attr.relation).toBe(aliased);
+    });
+  });
 });

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -23,7 +23,8 @@ export class Table extends Node {
   constructor(name: string, options?: { as?: string; klass?: unknown; typeCaster?: unknown }) {
     super();
     this.name = name;
-    this.tableAlias = options?.as ?? null;
+    const as = options?.as ?? null;
+    this.tableAlias = as != null && as === name ? null : as;
     this.typeCaster = options?.typeCaster ?? null;
   }
 
@@ -59,8 +60,8 @@ export class Table extends Node {
     return this.typeCaster != null;
   }
 
-  get(name: string): Attribute {
-    return new Attribute(this, name);
+  get(name: string, table?: Table | TableAlias): Attribute {
+    return new Attribute(table ?? this, name);
   }
 
   attr(name: string): Attribute {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -60,7 +60,7 @@ export class Table extends Node {
     return this.typeCaster != null;
   }
 
-  get(name: string, table?: Table | TableAlias): Attribute {
+  get(name: string, table?: Attribute["relation"]): Attribute {
     return new Attribute(table ?? this, name);
   }
 

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -24,7 +24,7 @@ export class Table extends Node {
     super();
     this.name = name;
     const as = options?.as ?? null;
-    this.tableAlias = as != null && as === name ? null : as;
+    this.tableAlias = as === name ? null : as;
     this.typeCaster = options?.typeCaster ?? null;
   }
 


### PR DESCRIPTION
PR 9 of [docs/arel-alignment-plan.md](../blob/main/docs/arel-alignment-plan.md).

Two small Rails-fidelity tweaks in `packages/arel/src/table.ts` (Rails ref: `arel/table.rb`):

- Constructor drops `tableAlias` when the `as` option equals the table name. AR sometimes passes `as:` to signal aliasing without changing the name; Rails normalizes that to `nil`.
- `Table#get(name, table?)` adds an optional second argument so the attribute can be built on a different relation (e.g., a `TableAlias`), matching Rails' `users[:id, other]`.

## Test plan
- [x] `pnpm exec vitest run packages/arel/` (1203 passing)
- [x] New `table.test.ts` cases cover both the self-alias drop and the 2-arg `get` overload (Table + TableAlias).