### PR TITLE
feat(activemodel): port Serialization private helpers (+ MessageVerifier expiry fix)

### DIFF
--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -195,6 +195,27 @@ describe("SerializationTest", () => {
     expect((result.comments as any[])[0].text).toBe("Great!");
   });
 
+  it("include accepts mixed array of strings and option hashes", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    const comment = {
+      _attributes: new Map([
+        ["text", "Great!"],
+        ["author", "Bob"],
+      ]),
+    };
+    const tag = { _attributes: new Map([["name", "rails"]]) };
+    (p as any)._preloadedAssociations = new Map<string, unknown>([
+      ["comments", [comment]],
+      ["tags", [tag]],
+    ]);
+    const result = p.serializableHash({
+      include: ["tags", { comments: { only: ["text"] } }],
+    });
+    expect((result.tags as any[])[0].name).toBe("rails");
+    expect((result.comments as any[])[0].text).toBe("Great!");
+    expect((result.comments as any[])[0].author).toBeUndefined();
+  });
+
   it("include with options", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
     const comment = {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -4,6 +4,23 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 type AnyRecord = any;
 
 /**
+ * Set `key` on `target` as an own data property, even when `key` is
+ * `__proto__` (or another magic name that has accessors on
+ * `Object.prototype`). A plain assignment would invoke the inherited
+ * setter and mutate the target's prototype chain. Used everywhere the
+ * key may originate from user input — attribute names, include keys,
+ * association names from a JSON-decoded options bag.
+ */
+function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+/**
  * Serialization mixin contract — provides serializable_hash.
  *
  * Mirrors: ActiveModel::Serialization
@@ -61,9 +78,9 @@ export function serializableHash(
   if (options.methods) {
     for (const method of options.methods) {
       if (typeof record[method] === "function") {
-        result[method] = record[method]();
+        safeSet(result, method, record[method]());
       } else if (method in record) {
-        result[method] = record[method];
+        safeSet(result, method, record[method]);
       } else {
         throw new Error(
           `undefined method '${method}' for an instance of ${record.constructor.name}`,
@@ -74,11 +91,15 @@ export function serializableHash(
 
   serializableAddIncludes(record, options, (assocName, records, opts) => {
     if (Array.isArray(records)) {
-      result[assocName] = records.map((r: AnyRecord) => serializableHash(r, opts));
+      safeSet(
+        result,
+        assocName,
+        records.map((r: AnyRecord) => serializableHash(r, opts)),
+      );
     } else if (records && typeof records === "object" && (records as AnyRecord)._attributes) {
-      result[assocName] = serializableHash(records, opts);
+      safeSet(result, assocName, serializableHash(records, opts));
     } else {
-      result[assocName] = records;
+      safeSet(result, assocName, records);
     }
   });
 
@@ -145,15 +166,17 @@ export function serializableAttributes(
   const attrStore = record._attributes;
   const result: Record<string, unknown> = {};
   for (const key of attributeNames) {
+    let value: unknown;
     if (attrStore && typeof attrStore.fetchValue === "function") {
-      result[key] = attrStore.fetchValue(key);
+      value = attrStore.fetchValue(key);
     } else if (attrStore instanceof Map) {
-      result[key] = attrStore.get(key);
+      value = attrStore.get(key);
     } else if (record.readAttribute) {
-      result[key] = record.readAttribute(key);
+      value = record.readAttribute(key);
     } else {
-      result[key] = record.attributes?.[key];
+      value = record.attributes?.[key];
     }
+    safeSet(result, key, value);
   }
   return result;
 }
@@ -361,19 +384,25 @@ function normalizeIncludes(
     | Array<string | Record<string, SerializeOptions>>
     | string,
 ): Record<string, SerializeOptions> {
+  const result: Record<string, SerializeOptions> = {};
   if (typeof include === "string") {
-    return { [include]: {} };
+    safeSet(result as Record<string, unknown>, include, {});
+    return result;
   }
   if (Array.isArray(include)) {
-    const result: Record<string, SerializeOptions> = {};
     for (const entry of include) {
       if (typeof entry === "string") {
-        result[entry] = {};
+        safeSet(result as Record<string, unknown>, entry, {});
       } else {
-        Object.assign(result, entry);
+        for (const [k, v] of Object.entries(entry)) {
+          safeSet(result as Record<string, unknown>, k, v);
+        }
       }
     }
     return result;
   }
-  return include;
+  for (const [k, v] of Object.entries(include)) {
+    safeSet(result as Record<string, unknown>, k, v);
+  }
+  return result;
 }

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -212,12 +212,19 @@ export function serializableAddIncludes(
 ): void {
   // Rails: `return unless includes = options[:include]` skips on
   // nil/false. Empty string is truthy in Ruby, so JS `!` would
-  // diverge — guard explicitly on null/undefined to mirror Ruby
-  // truthiness. (`SerializeOptions.include` is typed as string /
-  // array / hash, so `false` can't reach this path through the
-  // public API.)
-  if (options.include == null) return;
-  const includes = normalizeIncludes(options.include);
+  // diverge. Guard explicitly on null/undefined/false to mirror
+  // Ruby truthiness without dropping `""`. The `false` branch also
+  // protects against untyped JS callers that bypass the
+  // `SerializeOptions.include` shape.
+  const includeOpt = options.include as
+    | string
+    | Array<string | Record<string, SerializeOptions>>
+    | Record<string, SerializeOptions>
+    | false
+    | null
+    | undefined;
+  if (includeOpt == null || includeOpt === false) return;
+  const includes = normalizeIncludes(includeOpt);
   for (const [assocName, assocOpts] of Object.entries(includes)) {
     const cached =
       record._preloadedAssociations?.get(assocName) ?? record._cachedAssociations?.get(assocName);

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -210,7 +210,13 @@ export function serializableAddIncludes(
   options: SerializeOptions = {},
   callback: (association: string, records: unknown, opts: SerializeOptions) => void,
 ): void {
-  if (!options.include) return;
+  // Rails: `return unless includes = options[:include]` skips on
+  // nil/false. Empty string is truthy in Ruby, so JS `!` would
+  // diverge — guard explicitly on null/undefined to mirror Ruby
+  // truthiness. (`SerializeOptions.include` is typed as string /
+  // array / hash, so `false` can't reach this path through the
+  // public API.)
+  if (options.include == null) return;
   const includes = normalizeIncludes(options.include);
   for (const [assocName, assocOpts] of Object.entries(includes)) {
     const cached =

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -19,7 +19,13 @@ export interface SerializeOptions {
   only?: string[];
   except?: string[];
   methods?: string[];
-  include?: Record<string, SerializeOptions> | string[] | string;
+  // Mirrors Rails `:include` polymorphism: a single name, an array of
+  // names, a hash of name → opts, or — like `include: [:posts, { comments: {} }]`
+  // — an array mixing names and hashes.
+  include?:
+    | Record<string, SerializeOptions>
+    | Array<string | Record<string, SerializeOptions>>
+    | string;
 }
 
 /**
@@ -32,10 +38,11 @@ export function serializableHash(
   record: AnyRecord,
   options: SerializeOptions = {},
 ): Record<string, unknown> {
-  // Prefer an instance-level override (Rails' Model.override semantics)
-  // over the standalone helper. When the host class is a JSON / Serialization
-  // mixin host, its delegator method just bounces back to the function below,
-  // so falling through is safe.
+  // Prefer an instance-level override (Rails' subclass-override
+  // semantics) over the standalone helper. The JSON mixin host's
+  // protected delegator just forwards to the standalone
+  // `attributeNamesForSerialization` function below, so calling it
+  // here is safe and respects any genuine override a Model installs.
   const instanceAttrNames = (record as { attributeNamesForSerialization?: () => string[] })
     .attributeNamesForSerialization;
   let keys =
@@ -177,7 +184,7 @@ export function serializableAttributes(
  */
 export function serializableAddIncludes(
   record: AnyRecord,
-  options: SerializeOptions,
+  options: SerializeOptions = {},
   callback: (association: string, records: unknown, opts: SerializeOptions) => void,
 ): void {
   if (!options.include) return;
@@ -185,7 +192,10 @@ export function serializableAddIncludes(
   for (const [assocName, assocOpts] of Object.entries(includes)) {
     const cached =
       record._preloadedAssociations?.get(assocName) ?? record._cachedAssociations?.get(assocName);
-    if (cached !== undefined) {
+    // Rails: `if records = send(association)` skips on nil. The trails
+    // preloader stores `null` in `_cachedAssociations` for has_one
+    // associations with no row, so guard both null and undefined.
+    if (cached !== null && cached !== undefined) {
       callback(assocName, cached, assocOpts);
     }
   }
@@ -338,16 +348,30 @@ function _coerceForJson(
   return value;
 }
 
+/**
+ * Normalize `:include` to a `{ name → opts }` hash. Mirrors Rails'
+ * `Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]`
+ * — strings/arrays of strings get empty opts, embedded hashes flatten
+ * into the result so `[:posts, { comments: {} }]` becomes
+ * `{ posts: {}, comments: {} }`.
+ */
 function normalizeIncludes(
-  include: Record<string, SerializeOptions> | string[] | string,
+  include:
+    | Record<string, SerializeOptions>
+    | Array<string | Record<string, SerializeOptions>>
+    | string,
 ): Record<string, SerializeOptions> {
   if (typeof include === "string") {
     return { [include]: {} };
   }
   if (Array.isArray(include)) {
     const result: Record<string, SerializeOptions> = {};
-    for (const name of include) {
-      result[name] = {};
+    for (const entry of include) {
+      if (typeof entry === "string") {
+        result[entry] = {};
+      } else {
+        Object.assign(result, entry);
+      }
     }
     return result;
   }

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -26,40 +26,22 @@ export interface SerializeOptions {
  * Serialize a model's attributes to a plain object.
  *
  * Mirrors: ActiveModel::Serialization#serializable_hash
+ * (serialization.rb:111-138)
  */
 export function serializableHash(
   record: AnyRecord,
   options: SerializeOptions = {},
 ): Record<string, unknown> {
-  // Models can override `attributeNamesForSerialization` to scope which
-  // attributes appear (Rails' private `attribute_names_for_serialization`
-  // hook). When absent, fall back to the underlying attribute store.
-  const attrStore = record._attributes;
-  let keys: string[];
-  if (
-    typeof (record as { attributeNamesForSerialization?: () => string[] })
-      .attributeNamesForSerialization === "function"
-  ) {
-    keys = (
-      record as { attributeNamesForSerialization: () => string[] }
-    ).attributeNamesForSerialization();
-  } else if (attrStore && typeof attrStore.keys === "function" && !(attrStore instanceof Map)) {
-    keys = attrStore.keys();
-  } else if (attrStore instanceof Map) {
-    keys = Array.from(attrStore.keys());
-  } else if (record.attributes) {
-    keys = Object.keys(record.attributes);
-  } else {
-    keys = [];
-  }
-
-  // Exclude virtual attributes (e.g., acceptance/confirmation) from serialization
-  const defs = record.constructor?._attributeDefinitions as
-    | Map<string, { virtual?: boolean }>
-    | undefined;
-  if (defs) {
-    keys = keys.filter((k) => !defs.get(k)?.virtual);
-  }
+  // Prefer an instance-level override (Rails' Model.override semantics)
+  // over the standalone helper. When the host class is a JSON / Serialization
+  // mixin host, its delegator method just bounces back to the function below,
+  // so falling through is safe.
+  const instanceAttrNames = (record as { attributeNamesForSerialization?: () => string[] })
+    .attributeNamesForSerialization;
+  let keys =
+    typeof instanceAttrNames === "function"
+      ? instanceAttrNames.call(record)
+      : attributeNamesForSerialization(record);
 
   if (options.only) {
     keys = keys.filter((k) => options.only!.includes(k));
@@ -67,19 +49,7 @@ export function serializableHash(
     keys = keys.filter((k) => !options.except!.includes(k));
   }
 
-  // Read values only for filtered keys
-  const result: Record<string, unknown> = {};
-  for (const key of keys) {
-    if (attrStore && typeof attrStore.fetchValue === "function") {
-      result[key] = attrStore.fetchValue(key);
-    } else if (attrStore instanceof Map) {
-      result[key] = attrStore.get(key);
-    } else if (record.readAttribute) {
-      result[key] = record.readAttribute(key);
-    } else {
-      result[key] = record.attributes?.[key];
-    }
-  }
+  const result = serializableAttributes(record, keys);
 
   if (options.methods) {
     for (const method of options.methods) {
@@ -95,26 +65,130 @@ export function serializableHash(
     }
   }
 
-  // Handle include option for nested associations
-  if (options.include) {
-    const includes = normalizeIncludes(options.include);
-    for (const [assocName, assocOpts] of Object.entries(includes)) {
-      // Check for cached/preloaded associations
-      const cached =
-        record._preloadedAssociations?.get(assocName) ?? record._cachedAssociations?.get(assocName);
-      if (cached !== undefined) {
-        if (Array.isArray(cached)) {
-          result[assocName] = cached.map((r: AnyRecord) => serializableHash(r, assocOpts));
-        } else if (cached && typeof cached === "object" && cached._attributes) {
-          result[assocName] = serializableHash(cached, assocOpts);
-        } else {
-          result[assocName] = cached;
-        }
-      }
+  serializableAddIncludes(record, options, (assocName, records, opts) => {
+    if (Array.isArray(records)) {
+      result[assocName] = records.map((r: AnyRecord) => serializableHash(r, opts));
+    } else if (records && typeof records === "object" && (records as AnyRecord)._attributes) {
+      result[assocName] = serializableHash(records, opts);
+    } else {
+      result[assocName] = records;
     }
-  }
+  });
 
   return result;
+}
+
+/**
+ * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
+ * (serialization.rb:158-160)
+ *
+ *   def attribute_names_for_serialization
+ *     attributes.keys
+ *   end
+ *
+ * Models can override this hook to scope which attributes appear.
+ * Trails has multiple attribute storage shapes (AttributeSet via
+ * `_attributes`, Map, plain object) so the fallback walks them in
+ * order. Virtual attributes (acceptance/confirmation) are filtered
+ * out — they aren't real attributes and shouldn't surface in JSON.
+ *
+ * @internal Rails-private helper.
+ */
+export function attributeNamesForSerialization(record: AnyRecord): string[] {
+  const attrStore = record._attributes;
+  let keys: string[];
+  if (attrStore && typeof attrStore.keys === "function" && !(attrStore instanceof Map)) {
+    keys = attrStore.keys();
+  } else if (attrStore instanceof Map) {
+    keys = Array.from(attrStore.keys());
+  } else if (record.attributes) {
+    keys = Object.keys(record.attributes);
+  } else {
+    keys = [];
+  }
+
+  const defs = record.constructor?._attributeDefinitions as
+    | Map<string, { virtual?: boolean }>
+    | undefined;
+  if (defs) {
+    keys = keys.filter((k) => !defs.get(k)?.virtual);
+  }
+  return keys;
+}
+
+/**
+ * Mirrors: ActiveModel::Serialization#serializable_attributes
+ * (serialization.rb:162-164)
+ *
+ *   def serializable_attributes(attribute_names)
+ *     attribute_names.index_with { |n| read_attribute_for_serialization(n) }
+ *   end
+ *
+ * Builds a `{ name → value }` hash by reading each attribute via the
+ * attribute store fall-through (AttributeSet → Map → readAttribute →
+ * plain attributes). The Rails analogue dispatches through
+ * `read_attribute_for_serialization` (aliased to `send` by default).
+ *
+ * @internal Rails-private helper.
+ */
+export function serializableAttributes(
+  record: AnyRecord,
+  attributeNames: readonly string[],
+): Record<string, unknown> {
+  const attrStore = record._attributes;
+  const result: Record<string, unknown> = {};
+  for (const key of attributeNames) {
+    if (attrStore && typeof attrStore.fetchValue === "function") {
+      result[key] = attrStore.fetchValue(key);
+    } else if (attrStore instanceof Map) {
+      result[key] = attrStore.get(key);
+    } else if (record.readAttribute) {
+      result[key] = record.readAttribute(key);
+    } else {
+      result[key] = record.attributes?.[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * Mirrors: ActiveModel::Serialization#serializable_add_includes
+ * (serialization.rb:171-183)
+ *
+ *   def serializable_add_includes(options = {})
+ *     return unless includes = options[:include]
+ *     unless includes.is_a?(Hash)
+ *       includes = Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]
+ *     end
+ *     includes.each do |association, opts|
+ *       if records = send(association)
+ *         yield association, records, opts
+ *       end
+ *     end
+ *   end
+ *
+ * The trails port resolves associations against the model's preload /
+ * association cache rather than `send`, since trails uses explicit
+ * cache slots instead of Ruby's method-missing-driven association
+ * accessors. The yield contract is identical: `(association, records,
+ * opts)` per included entry.
+ *
+ * @internal Rails-private helper.
+ */
+export function serializableAddIncludes(
+  record: AnyRecord,
+  options: SerializeOptions,
+  callback: (association: string, records: unknown, opts: SerializeOptions) => void,
+): void {
+  if (!options.include) return;
+  const includes = normalizeIncludes(options.include);
+  for (const [assocName, assocOpts] of Object.entries(includes)) {
+    const cached =
+      record._preloadedAssociations?.get(assocName) ?? record._cachedAssociations?.get(assocName);
+    if (cached !== undefined) {
+      callback(assocName, cached, assocOpts);
+    }
+  }
 }
 
 /**

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -1,4 +1,11 @@
-import { serializableHash, coerceForJson, type SerializeOptions } from "../serialization.js";
+import {
+  serializableHash,
+  attributeNamesForSerialization,
+  serializableAttributes,
+  serializableAddIncludes,
+  coerceForJson,
+  type SerializeOptions,
+} from "../serialization.js";
 import { ModelName } from "../naming.js";
 
 function isPlainJsonObject(v: unknown): v is Record<string, unknown> {
@@ -62,6 +69,39 @@ export class JSON {
    */
   serializableHash(options?: SerializeOptions): Record<string, unknown> {
     return serializableHash(this as unknown as Parameters<typeof serializableHash>[0], options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
+   * (serialization.rb:158-160), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected attributeNamesForSerialization(): string[] {
+    return attributeNamesForSerialization(this);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_attributes
+   * (serialization.rb:162-164), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected serializableAttributes(attributeNames: readonly string[]): Record<string, unknown> {
+    return serializableAttributes(this, attributeNames);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_add_includes
+   * (serialization.rb:171-183), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected serializableAddIncludes(
+    options: SerializeOptions,
+    callback: (association: string, records: unknown, opts: SerializeOptions) => void,
+  ): void {
+    serializableAddIncludes(this, options, callback);
   }
 
   /**

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -98,8 +98,8 @@ export class JSON {
    * @internal Rails-private helper.
    */
   protected serializableAddIncludes(
-    options: SerializeOptions,
-    callback: (association: string, records: unknown, opts: SerializeOptions) => void,
+    options: SerializeOptions = {},
+    callback: (association: string, records: unknown, opts: SerializeOptions) => void = () => {},
   ): void {
     serializableAddIncludes(this, options, callback);
   }

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -62,8 +62,14 @@ export class MessageVerifier {
     if (options.expiresAt) {
       payload._expiresAt = options.expiresAt.toString({ smallestUnit: "millisecond" });
     } else if (options.expiresIn !== undefined) {
+      // Temporal.Duration components must be integers, but Rails (and
+      // existing trails callers) pass fractional seconds — e.g. 0.001
+      // for a 1ms expiry. Round to the nearest millisecond so any
+      // sub-second precision is preserved without violating Temporal's
+      // integer-component invariant.
+      const milliseconds = Math.round(options.expiresIn * 1000);
       payload._expiresAt = Temporal.Now.instant()
-        .add({ seconds: options.expiresIn })
+        .add({ milliseconds })
         .toString({ smallestUnit: "millisecond" });
     }
 


### PR DESCRIPTION
## Summary

Mirrors Rails `ActiveModel::Serialization` private helpers (`activemodel/lib/active_model/serialization.rb:158-183`):

- `attribute_names_for_serialization` — returns `attributes.keys` (overridable hook for scoping which attributes serialize).
- `serializable_attributes(attribute_names)` — `index_with { |n| read_attribute_for_serialization(n) }`; builds the name → value hash.
- `serializable_add_includes(options) { |assoc, records, opts| … }` — yields per-association entry from the `:include` option.

`serializableHash` is rebuilt to compose the three helpers in the same order as Rails' `serializable_hash`. The override-aware lookup (`record.attributeNamesForSerialization` if Model overrides it) lives in `serializableHash` itself, while the standalone helper does the unconditional store walk.

`serializers/json.ts` exposes the three helpers as protected delegators on the `JSON` class so api-compare picks them up under `serializers/json.rb` too (Rails surfaces them via `include Serialization`).

Hardens all key writes through a `safeSet` (`Object.defineProperty`) helper to prevent prototype pollution from user-supplied attribute names / association keys / include keys. Widens `SerializeOptions.include` to support Rails' mixed-array form (`include: [:posts, { comments: {} }]`).

### Bundled fix: `MessageVerifier` fractional `expiresIn`

PR #1037 switched `MessageVerifier.generate` to `Temporal.Now.instant().add({ seconds: options.expiresIn })`, but `Temporal.Duration` components must be integers. Existing callers (`token-for.test.ts`) pass `expiresIn: 0.001` for a 1ms expiry — worked under the old `Date.now() + expiresIn * 1000`, broken on main since #1037 with `RangeError: unsupported fractional value 0.001`. Round to milliseconds so sub-second precision survives. Bundled here because it was blocking this PR's CI (and main's data-layer jobs).

**Privates report delta:** 515/625 (82.4%) → 521/625 (83.4%) — closes all 3 misses on `serialization.rb` and all 3 on `serializers/json.rb`.

### Track
**B4** of `docs/activemodel-privates-100-plan.md`.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1607/1607 pass
- [x] `pnpm vitest run packages/activerecord/src/token-for.test.ts` — 20/20 pass (was failing on main)
- [x] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` — 521/625 (83.4%); serialization 4/4, serializers/json 7/7
- [ ] CI green