### PR TITLE
feat(activesupport): time-ext period bounds return Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "../temporal.js";
 import {
   beginningOfDay,
   middleOfDay,
@@ -30,6 +31,10 @@ import {
 
 function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(year, month - 1, day, hour, min, sec, ms);
+}
+
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
 }
 
 describe("DateExtBehaviorTest", () => {
@@ -125,7 +130,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("sunday", () => {
-    const result = endOfWeek(d(2008, 2, 29));
+    const result = asDate(endOfWeek(d(2008, 2, 29)));
     expect(result.getDay()).toBe(0); // Sunday
     expect(result.getMonth()).toBe(2); // March
     expect(result.getDate()).toBe(2);
@@ -158,7 +163,7 @@ describe("DateExtCalculationsTest", () => {
   it("last quarter on 31st", () => {
     const dt = d(2004, 5, 31);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(quarterStart, { months: -3 });
+    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
     expect(lastQuarterStart.getMonth()).toBe(0); // January
   });
 
@@ -210,7 +215,7 @@ describe("DateExtCalculationsTest", () => {
   it.skip("ago when zone is set");
 
   it("middle of day", () => {
-    const result = middleOfDay(d(2005, 2, 21));
+    const result = asDate(middleOfDay(d(2005, 2, 21)));
     expect(result.getHours()).toBe(12);
     expect(result.getMinutes()).toBe(0);
   });
@@ -220,41 +225,41 @@ describe("DateExtCalculationsTest", () => {
 
   it("all day", () => {
     const { start, end } = allDay(d(2011, 6, 7));
-    expect(start.getHours()).toBe(0);
-    expect(end.getHours()).toBe(23);
-    expect(end.getMinutes()).toBe(59);
+    expect(asDate(start).getHours()).toBe(0);
+    expect(asDate(end).getHours()).toBe(23);
+    expect(asDate(end).getMinutes()).toBe(59);
   });
 
   it.skip("all day when zone is set");
 
   it("all week", () => {
     const { start, end } = allWeek(d(2011, 6, 7));
-    expect(start.getDay()).toBe(1); // Monday
-    expect(start.getDate()).toBe(6);
-    expect(end.getDay()).toBe(0); // Sunday
-    expect(end.getDate()).toBe(12);
+    expect(asDate(start).getDay()).toBe(1); // Monday
+    expect(asDate(start).getDate()).toBe(6);
+    expect(asDate(end).getDay()).toBe(0); // Sunday
+    expect(asDate(end).getDate()).toBe(12);
   });
 
   it("all month", () => {
     const { start, end } = allMonth(d(2011, 6, 7));
-    expect(start.getDate()).toBe(1);
-    expect(start.getMonth()).toBe(5); // June
-    expect(end.getDate()).toBe(30);
+    expect(asDate(start).getDate()).toBe(1);
+    expect(asDate(start).getMonth()).toBe(5); // June
+    expect(asDate(end).getDate()).toBe(30);
   });
 
   it("all quarter", () => {
     const { start, end } = allQuarter(d(2011, 6, 7));
-    expect(start.getMonth()).toBe(3); // April
-    expect(end.getMonth()).toBe(5); // June
-    expect(end.getDate()).toBe(30);
+    expect(asDate(start).getMonth()).toBe(3); // April
+    expect(asDate(end).getMonth()).toBe(5); // June
+    expect(asDate(end).getDate()).toBe(30);
   });
 
   it("all year", () => {
     const { start, end } = allYear(d(2011, 6, 7));
-    expect(start.getMonth()).toBe(0); // January
-    expect(start.getDate()).toBe(1);
-    expect(end.getMonth()).toBe(11); // December
-    expect(end.getDate()).toBe(31);
+    expect(asDate(start).getMonth()).toBe(0); // January
+    expect(asDate(start).getDate()).toBe(1);
+    expect(asDate(end).getMonth()).toBe(11); // December
+    expect(asDate(end).getDate()).toBe(31);
   });
 
   it("xmlschema", () => {
@@ -289,13 +294,13 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("end of year", () => {
-    const result = endOfYear(d(2005, 6, 15));
+    const result = asDate(endOfYear(d(2005, 6, 15)));
     expect(result.getMonth()).toBe(11); // December
     expect(result.getDate()).toBe(31);
   });
 
   it("end of month", () => {
-    const result = endOfMonth(d(2005, 2, 5));
+    const result = asDate(endOfMonth(d(2005, 2, 5)));
     expect(result.getDate()).toBe(28);
     expect(result.getMonth()).toBe(1);
   });
@@ -312,7 +317,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("beginning of day", () => {
     const date = d(2005, 2, 21, 10, 30, 45);
-    const result = beginningOfDay(date);
+    const result = asDate(beginningOfDay(date));
     expect(result.getHours()).toBe(0);
     expect(result.getMinutes()).toBe(0);
     expect(result.getSeconds()).toBe(0);
@@ -320,7 +325,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("end of day", () => {
     const date = d(2005, 2, 21, 10, 30, 45);
-    const result = endOfDay(date);
+    const result = asDate(endOfDay(date));
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
   });

--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "../temporal.js";
+import type { Temporal } from "../temporal.js";
 import {
   beginningOfDay,
   middleOfDay,

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "../temporal.js";
+import type { Temporal } from "../temporal.js";
 import {
   advance,
   ago,

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "../temporal.js";
 import {
   advance,
   ago,
@@ -29,6 +30,10 @@ import {
   toTime,
   xmlschema,
 } from "../time-ext.js";
+
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
+}
 
 function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(year, month - 1, day, hour, min, sec, ms);
@@ -93,26 +98,26 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("middle of day", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = middleOfDay(dt);
+    const result = asDate(middleOfDay(dt));
     expect(result.getHours()).toBe(12);
     expect(result.getMinutes()).toBe(0);
   });
 
   it("beginning of minute", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = beginningOfMinute(dt);
+    const result = asDate(beginningOfMinute(dt));
     expect(result.getSeconds()).toBe(0);
   });
 
   it("end of minute", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = endOfMinute(dt);
+    const result = asDate(endOfMinute(dt));
     expect(result.getSeconds()).toBe(59);
   });
 
   it("end of month", () => {
     const dt = d(2005, 2, 15, 10, 10, 10);
-    const result = endOfMonth(dt);
+    const result = asDate(endOfMonth(dt));
     expect(result.getDate()).toBe(28);
   });
 
@@ -153,7 +158,7 @@ describe("DateTimeExtCalculationsTest", () => {
   it("last quarter on 31st", () => {
     const dt = d(2005, 10, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(quarterStart, { months: -3 });
+    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
     expect(lastQuarterStart.getMonth()).toBe(6); // July
   });
 
@@ -357,14 +362,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("beginning of hour", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = beginningOfHour(dt);
+    const result = asDate(beginningOfHour(dt));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(0);
   });
 
   it("end of hour", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = endOfHour(dt);
+    const result = asDate(endOfHour(dt));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(59);
   });
@@ -385,13 +390,13 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("beginning of day", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = beginningOfDay(dt);
+    const result = asDate(beginningOfDay(dt));
     expect(result.getHours()).toBe(0);
   });
 
   it("end of day", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = endOfDay(dt);
+    const result = asDate(endOfDay(dt));
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
   });

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { Temporal } from "../temporal.js";
+import type { Temporal } from "../temporal.js";
 import {
   nextDay,
   prevDay,

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { Temporal } from "../temporal.js";
 import {
   nextDay,
   prevDay,
@@ -27,6 +28,10 @@ import {
   isFuture,
   nextWeek,
 } from "../time-ext.js";
+
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
+}
 
 function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(year, month - 1, day, hour, min, sec, ms);
@@ -660,11 +665,11 @@ describe("TimeExtCalculationsTest", () => {
   it("all day with timezone", () => {
     const t = d(2011, 6, 7, 10, 10, 10);
     const { start, end } = allDay(t);
-    expect(start.getHours()).toBe(0);
-    expect(start.getMinutes()).toBe(0);
-    expect(end.getHours()).toBe(23);
-    expect(end.getMinutes()).toBe(59);
-    expect(end.getDate()).toBe(7);
+    expect(asDate(start).getHours()).toBe(0);
+    expect(asDate(start).getMinutes()).toBe(0);
+    expect(asDate(end).getHours()).toBe(23);
+    expect(asDate(end).getMinutes()).toBe(59);
+    expect(asDate(end).getDate()).toBe(7);
   });
 
   it("rfc3339 parse", () => {

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "./temporal.js";
 import {
   beginningOfDay,
   middleOfDay,
@@ -62,6 +63,22 @@ function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0,
   return new Date(year, month - 1, day, hour, min, sec, ms);
 }
 
+// Helpers for Temporal.Instant assertions (period-bound helpers return Instant)
+function i(
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  min = 0,
+  sec = 0,
+  ms = 0,
+): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(d(year, month, day, hour, min, sec, ms).getTime());
+}
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
+}
+
 describe("TimeExtCalculationsTest", () => {
   it("seconds_since_midnight", () => {
     expect(secondsSinceMidnight(d(2005, 1, 1, 0, 0, 1))).toBe(1);
@@ -80,26 +97,26 @@ describe("TimeExtCalculationsTest", () => {
 
   it("beginning_of_day", () => {
     const result = beginningOfDay(d(2005, 2, 4, 10, 10, 10));
-    expect(result).toEqual(d(2005, 2, 4, 0, 0, 0));
+    expect(result).toEqual(i(2005, 2, 4, 0, 0, 0));
   });
 
   it("middle_of_day", () => {
     const result = middleOfDay(d(2005, 2, 4, 10, 10, 10));
-    expect(result).toEqual(d(2005, 2, 4, 12, 0, 0));
+    expect(result).toEqual(i(2005, 2, 4, 12, 0, 0));
   });
 
   it("beginning_of_hour", () => {
     const result = beginningOfHour(d(2005, 2, 4, 19, 30, 10));
-    expect(result).toEqual(d(2005, 2, 4, 19, 0, 0));
+    expect(result).toEqual(i(2005, 2, 4, 19, 0, 0));
   });
 
   it("beginning_of_minute", () => {
     const result = beginningOfMinute(d(2005, 2, 4, 19, 30, 10));
-    expect(result).toEqual(d(2005, 2, 4, 19, 30, 0));
+    expect(result).toEqual(i(2005, 2, 4, 19, 30, 0));
   });
 
   it("end_of_day", () => {
-    const result = endOfDay(d(2007, 8, 12, 10, 10, 10));
+    const result = asDate(endOfDay(d(2007, 8, 12, 10, 10, 10)));
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
     expect(result.getSeconds()).toBe(59);
@@ -110,14 +127,14 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("end_of_hour", () => {
-    const result = endOfHour(d(2005, 2, 4, 19, 30, 10));
+    const result = asDate(endOfHour(d(2005, 2, 4, 19, 30, 10)));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(59);
     expect(result.getSeconds()).toBe(59);
   });
 
   it("end_of_minute", () => {
-    const result = endOfMinute(d(2005, 2, 4, 19, 30, 10));
+    const result = asDate(endOfMinute(d(2005, 2, 4, 19, 30, 10)));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(30);
     expect(result.getSeconds()).toBe(59);
@@ -262,33 +279,33 @@ describe("TimeExtCalculationsTest", () => {
 
   it("all_day", () => {
     const { start, end } = allDay(d(2023, 5, 15, 10, 30, 0));
-    expect(start).toEqual(d(2023, 5, 15, 0, 0, 0));
-    expect(end.getHours()).toBe(23);
-    expect(end.getMinutes()).toBe(59);
+    expect(start).toEqual(i(2023, 5, 15, 0, 0, 0));
+    expect(asDate(end).getHours()).toBe(23);
+    expect(asDate(end).getMinutes()).toBe(59);
   });
 
   it("all_week", () => {
     const { start, end } = allWeek(d(2023, 1, 11)); // Wednesday
-    expect(start.getDay()).toBe(1); // Monday
-    expect(end.getDay()).toBe(0); // Sunday
+    expect(asDate(start).getDay()).toBe(1); // Monday
+    expect(asDate(end).getDay()).toBe(0); // Sunday
   });
 
   it("all_month", () => {
     const { start, end } = allMonth(d(2023, 2, 15));
-    expect(start).toEqual(d(2023, 2, 1, 0, 0, 0));
-    expect(end.getDate()).toBe(28);
+    expect(start).toEqual(i(2023, 2, 1, 0, 0, 0));
+    expect(asDate(end).getDate()).toBe(28);
   });
 
   it("all_quarter", () => {
     const { start, end } = allQuarter(d(2023, 5, 15));
-    expect(start).toEqual(d(2023, 4, 1, 0, 0, 0));
-    expect(end.getMonth()).toBe(5); // June (0-indexed)
+    expect(start).toEqual(i(2023, 4, 1, 0, 0, 0));
+    expect(asDate(end).getMonth()).toBe(5); // June (0-indexed)
   });
 
   it("all_year", () => {
     const { start, end } = allYear(d(2023, 6, 15));
-    expect(start).toEqual(d(2023, 1, 1, 0, 0, 0));
-    expect(end).toEqual(d(2023, 12, 31, 23, 59, 59, 999));
+    expect(start).toEqual(i(2023, 1, 1, 0, 0, 0));
+    expect(end).toEqual(i(2023, 12, 31, 23, 59, 59, 999));
   });
 
   it("sec fraction", () => {
@@ -542,7 +559,7 @@ describe("TimeExtCalculationsTest", () => {
     // July 31 -> last quarter = Q1 start = January 1
     const t = d(2005, 7, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(t);
-    const lastQuarterStart = advance(quarterStart, { months: -3 });
+    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
     expect(lastQuarterStart.getMonth()).toBe(3); // April
   });
 
@@ -577,58 +594,58 @@ describe("DateExtCalculationsTest", () => {
 
   it("beginning_of_week", () => {
     // Wednesday 2023-01-11 -> Monday 2023-01-09
-    const result = beginningOfWeek(d(2023, 1, 11));
+    const result = asDate(beginningOfWeek(d(2023, 1, 11)));
     expect(result.getDay()).toBe(1); // Monday
     expect(result.getDate()).toBe(9);
   });
 
   it("beginning_of_week with sunday start", () => {
     // Wednesday 2023-01-11 -> Sunday 2023-01-08
-    const result = beginningOfWeek(d(2023, 1, 11), 0);
+    const result = asDate(beginningOfWeek(d(2023, 1, 11), 0));
     expect(result.getDay()).toBe(0); // Sunday
     expect(result.getDate()).toBe(8);
   });
 
   it("end_of_week", () => {
     // Wednesday 2023-01-11 -> Sunday 2023-01-15
-    const result = endOfWeek(d(2023, 1, 11));
+    const result = asDate(endOfWeek(d(2023, 1, 11)));
     expect(result.getDay()).toBe(0); // Sunday
     expect(result.getDate()).toBe(15);
   });
 
   it("beginning_of_month", () => {
-    expect(beginningOfMonth(d(2005, 2, 22))).toEqual(d(2005, 2, 1, 0, 0, 0));
+    expect(beginningOfMonth(d(2005, 2, 22))).toEqual(i(2005, 2, 1, 0, 0, 0));
   });
 
   it("end_of_month", () => {
-    const result = endOfMonth(d(2005, 2, 15));
+    const result = asDate(endOfMonth(d(2005, 2, 15)));
     expect(result.getDate()).toBe(28);
     expect(result.getMonth()).toBe(1); // February
   });
 
   it("beginning_of_quarter", () => {
-    expect(beginningOfQuarter(d(2005, 2, 15))).toEqual(d(2005, 1, 1, 0, 0, 0));
-    expect(beginningOfQuarter(d(2005, 5, 15))).toEqual(d(2005, 4, 1, 0, 0, 0));
-    expect(beginningOfQuarter(d(2005, 8, 15))).toEqual(d(2005, 7, 1, 0, 0, 0));
-    expect(beginningOfQuarter(d(2005, 11, 15))).toEqual(d(2005, 10, 1, 0, 0, 0));
+    expect(beginningOfQuarter(d(2005, 2, 15))).toEqual(i(2005, 1, 1, 0, 0, 0));
+    expect(beginningOfQuarter(d(2005, 5, 15))).toEqual(i(2005, 4, 1, 0, 0, 0));
+    expect(beginningOfQuarter(d(2005, 8, 15))).toEqual(i(2005, 7, 1, 0, 0, 0));
+    expect(beginningOfQuarter(d(2005, 11, 15))).toEqual(i(2005, 10, 1, 0, 0, 0));
   });
 
   it("end_of_quarter", () => {
-    const q1End = endOfQuarter(d(2005, 2, 15));
+    const q1End = asDate(endOfQuarter(d(2005, 2, 15)));
     expect(q1End.getMonth()).toBe(2); // March
     expect(q1End.getDate()).toBe(31);
 
-    const q2End = endOfQuarter(d(2005, 5, 15));
+    const q2End = asDate(endOfQuarter(d(2005, 5, 15)));
     expect(q2End.getMonth()).toBe(5); // June
     expect(q2End.getDate()).toBe(30);
   });
 
   it("beginning_of_year", () => {
-    expect(beginningOfYear(d(2005, 6, 15))).toEqual(d(2005, 1, 1, 0, 0, 0));
+    expect(beginningOfYear(d(2005, 6, 15))).toEqual(i(2005, 1, 1, 0, 0, 0));
   });
 
   it("end_of_year", () => {
-    expect(endOfYear(d(2005, 6, 15))).toEqual(d(2005, 12, 31, 23, 59, 59, 999));
+    expect(endOfYear(d(2005, 6, 15))).toEqual(i(2005, 12, 31, 23, 59, 59, 999));
   });
 
   it("advance date with months overflow", () => {
@@ -717,7 +734,7 @@ describe("DateExtCalculationsTest", () => {
     const dt = d(2005, 10, 31);
     const quarterStart = beginningOfQuarter(dt);
     // last quarter = go back 3 months from current quarter start
-    const lastQuarterStart = advance(quarterStart, { months: -3 });
+    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
     expect(lastQuarterStart.getMonth()).toBe(6); // July
     expect(lastQuarterStart.getDate()).toBe(1);
   });
@@ -768,30 +785,30 @@ describe("DateExtCalculationsTest", () => {
 
   it("middle of day", () => {
     const date = d(2005, 2, 21, 10, 30, 45);
-    const result = middleOfDay(date);
+    const result = asDate(middleOfDay(date));
     expect(result.getHours()).toBe(12);
     expect(result.getMinutes()).toBe(0);
   });
 
   it("beginning of day when zone is set", () => {
     const date = d(2005, 2, 21, 10, 30, 45);
-    const result = beginningOfDay(date);
+    const result = asDate(beginningOfDay(date));
     expect(result.getDate()).toBe(21);
     expect(result.getHours()).toBe(0);
   });
 
   it("end of day when zone is set", () => {
     const date = d(2005, 2, 21);
-    const result = endOfDay(date);
+    const result = asDate(endOfDay(date));
     expect(result.getHours()).toBe(23);
   });
 
   it("all day", () => {
     const date = d(2005, 2, 21);
     const { start, end } = allDay(date);
-    expect(start.getHours()).toBe(0);
-    expect(end.getHours()).toBe(23);
-    expect(end.getDate()).toBe(21);
+    expect(asDate(start).getHours()).toBe(0);
+    expect(asDate(end).getHours()).toBe(23);
+    expect(asDate(end).getDate()).toBe(21);
   });
 
   it("yesterday constructor when zone is not set", () => {
@@ -821,37 +838,37 @@ describe("DateExtCalculationsTest", () => {
   it("all day when zone is set", () => {
     const date = d(2005, 2, 21);
     const { start, end } = allDay(date);
-    expect(start.getDate()).toBe(21);
-    expect(end.getDate()).toBe(21);
+    expect(asDate(start).getDate()).toBe(21);
+    expect(asDate(end).getDate()).toBe(21);
   });
 
   it("all week", () => {
     const date = d(2005, 2, 21); // Monday
     const { start, end } = allWeek(date);
-    expect(start.getDay()).toBe(1); // Monday
-    expect(end.getDay()).toBe(0); // Sunday
+    expect(asDate(start).getDay()).toBe(1); // Monday
+    expect(asDate(end).getDay()).toBe(0); // Sunday
   });
 
   it("all month", () => {
     const date = d(2005, 2, 15);
     const { start, end } = allMonth(date);
-    expect(start.getDate()).toBe(1);
-    expect(start.getMonth()).toBe(1); // February
-    expect(end.getDate()).toBe(28);
+    expect(asDate(start).getDate()).toBe(1);
+    expect(asDate(start).getMonth()).toBe(1); // February
+    expect(asDate(end).getDate()).toBe(28);
   });
 
   it("all quarter", () => {
     const date = d(2005, 2, 15); // Q1
     const { start, end } = allQuarter(date);
-    expect(start.getMonth()).toBe(0); // January
-    expect(end.getMonth()).toBe(2); // March
+    expect(asDate(start).getMonth()).toBe(0); // January
+    expect(asDate(end).getMonth()).toBe(2); // March
   });
 
   it("all year", () => {
     const date = d(2005, 6, 15);
     const { start, end } = allYear(date);
-    expect(start.getMonth()).toBe(0); // January
-    expect(end.getMonth()).toBe(11); // December
+    expect(asDate(start).getMonth()).toBe(0); // January
+    expect(asDate(end).getMonth()).toBe(11); // December
   });
 
   it("xmlschema", () => {
@@ -891,7 +908,7 @@ describe("DateExtCalculationsTest", () => {
 describe("DateTimeExtCalculationsTest", () => {
   it("beginning_of_day from datetime", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = beginningOfDay(dt);
+    const result = asDate(beginningOfDay(dt));
     expect(result.getHours()).toBe(0);
     expect(result.getMinutes()).toBe(0);
     expect(result.getSeconds()).toBe(0);
@@ -901,7 +918,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("end_of_day from datetime", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = endOfDay(dt);
+    const result = asDate(endOfDay(dt));
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
     expect(result.getSeconds()).toBe(59);
@@ -910,7 +927,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("beginning_of_hour from datetime", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = beginningOfHour(dt);
+    const result = asDate(beginningOfHour(dt));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(0);
     expect(result.getSeconds()).toBe(0);
@@ -918,7 +935,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("end_of_hour from datetime", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = endOfHour(dt);
+    const result = asDate(endOfHour(dt));
     expect(result.getHours()).toBe(19);
     expect(result.getMinutes()).toBe(59);
     expect(result.getSeconds()).toBe(59);
@@ -969,7 +986,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("beginning_of_week from datetime", () => {
     const dt = d(2005, 2, 4, 10, 10, 10); // Friday
-    const result = beginningOfWeek(dt);
+    const result = asDate(beginningOfWeek(dt));
     expect(result.getDay()).toBe(1); // Monday
     expect(result.getHours()).toBe(0);
   });
@@ -977,9 +994,9 @@ describe("DateTimeExtCalculationsTest", () => {
   it("all_day from datetime", () => {
     const dt = d(2005, 2, 4, 10, 30, 0);
     const { start, end } = allDay(dt);
-    expect(start.getHours()).toBe(0);
-    expect(end.getHours()).toBe(23);
-    expect(end.getDate()).toBe(4);
+    expect(asDate(start).getHours()).toBe(0);
+    expect(asDate(end).getHours()).toBe(23);
+    expect(asDate(end).getDate()).toBe(4);
   });
 
   it("on_weekday from datetime", () => {
@@ -1047,26 +1064,26 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("middle of day", () => {
     const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = middleOfDay(dt);
+    const result = asDate(middleOfDay(dt));
     expect(result.getHours()).toBe(12);
     expect(result.getMinutes()).toBe(0);
   });
 
   it("beginning of minute", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = beginningOfMinute(dt);
+    const result = asDate(beginningOfMinute(dt));
     expect(result.getSeconds()).toBe(0);
   });
 
   it("end of minute", () => {
     const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = endOfMinute(dt);
+    const result = asDate(endOfMinute(dt));
     expect(result.getSeconds()).toBe(59);
   });
 
   it("end of month", () => {
     const dt = d(2005, 2, 15, 10, 10, 10);
-    const result = endOfMonth(dt);
+    const result = asDate(endOfMonth(dt));
     expect(result.getDate()).toBe(28);
   });
 
@@ -1108,7 +1125,7 @@ describe("DateTimeExtCalculationsTest", () => {
     // Oct 31 -> last quarter start = July 1
     const dt = d(2005, 10, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(quarterStart, { months: -3 });
+    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
     expect(lastQuarterStart.getMonth()).toBe(6); // July
   });
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -8,7 +8,7 @@
  *   helpers below the boundary still return `Date` and will flip in F-6b/c/d.
  */
 
-import { Temporal } from "./temporal.js";
+import { Temporal, instantFrom } from "./temporal.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
@@ -22,11 +22,6 @@ function clone(date: Date): Date {
   return new Date(date.getTime());
 }
 
-/** @internal */
-function instantFromDate(d: Date): Temporal.Instant {
-  return Temporal.Instant.fromEpochMilliseconds(d.getTime());
-}
-
 // ---------------------------------------------------------------------------
 // Day boundaries
 // ---------------------------------------------------------------------------
@@ -34,19 +29,19 @@ function instantFromDate(d: Date): Temporal.Instant {
 export function beginningOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(0, 0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function middleOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(12, 0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(23, 59, 59, 999);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -56,13 +51,13 @@ export function endOfDay(date: Date): Temporal.Instant {
 export function beginningOfHour(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMinutes(0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfHour(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMinutes(59, 59, 999);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -72,38 +67,40 @@ export function endOfHour(date: Date): Temporal.Instant {
 export function beginningOfMinute(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setSeconds(0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfMinute(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setSeconds(59, 999);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
 // Week boundaries
-// startDay: 0 = Sunday (default Rails), 1 = Monday
+// startDay: 0 = Sunday, 1 = Monday (default Rails)
 // ---------------------------------------------------------------------------
 
-export function beginningOfWeek(date: Date, startDay = 1): Temporal.Instant {
+/** @internal */
+function _beginningOfWeekDate(date: Date, startDay = 1): Date {
   const d = clone(date);
   const currentDay = d.getDay();
   let diff = currentDay - startDay;
   if (diff < 0) diff += 7;
   d.setDate(d.getDate() - diff);
   d.setHours(0, 0, 0, 0);
-  return instantFromDate(d);
+  return d;
+}
+
+export function beginningOfWeek(date: Date, startDay = 1): Temporal.Instant {
+  return instantFrom(_beginningOfWeekDate(date, startDay));
 }
 
 export function endOfWeek(date: Date, startDay = 1): Temporal.Instant {
-  const d = clone(date);
-  const currentDay = d.getDay();
-  let diff = currentDay - startDay;
-  if (diff < 0) diff += 7;
-  d.setDate(d.getDate() - diff + 6);
+  const d = _beginningOfWeekDate(date, startDay);
+  d.setDate(d.getDate() + 6);
   d.setHours(23, 59, 59, 999);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -114,7 +111,7 @@ export function beginningOfMonth(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setDate(1);
   d.setHours(0, 0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfMonth(date: Date): Temporal.Instant {
@@ -123,7 +120,7 @@ export function endOfMonth(date: Date): Temporal.Instant {
   d.setMonth(d.getMonth() + 1, 1);
   d.setHours(0, 0, 0, 0);
   d.setTime(d.getTime() - 1);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -136,7 +133,7 @@ export function beginningOfQuarter(date: Date): Temporal.Instant {
   const quarterStartMonth = Math.floor(month / 3) * 3;
   d.setMonth(quarterStartMonth, 1);
   d.setHours(0, 0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfQuarter(date: Date): Temporal.Instant {
@@ -146,7 +143,7 @@ export function endOfQuarter(date: Date): Temporal.Instant {
   d.setMonth(quarterEndMonth + 1, 1);
   d.setHours(0, 0, 0, 0);
   d.setTime(d.getTime() - 1);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,29 +154,19 @@ export function beginningOfYear(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMonth(0, 1);
   d.setHours(0, 0, 0, 0);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 export function endOfYear(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMonth(11, 31);
   d.setHours(23, 59, 59, 999);
-  return instantFromDate(d);
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
 // next/prev Week/Month/Year/Day
 // ---------------------------------------------------------------------------
-
-function _beginningOfWeekDate(date: Date, startDay = 1): Date {
-  const d = clone(date);
-  const currentDay = d.getDay();
-  let diff = currentDay - startDay;
-  if (diff < 0) diff += 7;
-  d.setDate(d.getDate() - diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
 
 export function nextWeek(date: Date, day = "monday"): Date {
   const targetDay = dayIndex(day);

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -8,7 +8,7 @@
  *   helpers below the boundary still return `Date` and will flip in F-6b/c/d.
  */
 
-import { Temporal, instantFrom } from "./temporal.js";
+import { type Temporal, instantFrom } from "./temporal.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -2,11 +2,13 @@
  * Time/Date extension functions following Rails' ActiveSupport::CoreExt::Time
  * and ActiveSupport::CoreExt::Date patterns.
  *
- * @boundary-file: All functions operate on JavaScript `Date` objects by Rails
- *   parity — the file mirrors `core_ext/time` / `core_ext/date`, both of which
- *   are Ruby Time/Date-typed in Rails. Temporal-typed equivalents live on
- *   `TimeWithZone` (instant, plain date/time) and `Duration`.
+ * @boundary-file: Helpers accept JavaScript `Date` inputs for ergonomic interop
+ *   with code that still holds Date values. Period-bound and arithmetic helpers
+ *   (`beginningOf*`, `endOf*`, `allDay`, …) return `Temporal.Instant`; legacy
+ *   helpers below the boundary still return `Date` and will flip in F-6b/c/d.
  */
+
+import { Temporal } from "./temporal.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
@@ -20,58 +22,63 @@ function clone(date: Date): Date {
   return new Date(date.getTime());
 }
 
+/** @internal */
+function instantFromDate(d: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(d.getTime());
+}
+
 // ---------------------------------------------------------------------------
 // Day boundaries
 // ---------------------------------------------------------------------------
 
-export function beginningOfDay(date: Date): Date {
+export function beginningOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(0, 0, 0, 0);
-  return d;
+  return instantFromDate(d);
 }
 
-export function middleOfDay(date: Date): Date {
+export function middleOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(12, 0, 0, 0);
-  return d;
+  return instantFromDate(d);
 }
 
-export function endOfDay(date: Date): Date {
+export function endOfDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setHours(23, 59, 59, 999);
-  return d;
+  return instantFromDate(d);
 }
 
 // ---------------------------------------------------------------------------
 // Hour boundaries
 // ---------------------------------------------------------------------------
 
-export function beginningOfHour(date: Date): Date {
+export function beginningOfHour(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMinutes(0, 0, 0);
-  return d;
+  return instantFromDate(d);
 }
 
-export function endOfHour(date: Date): Date {
+export function endOfHour(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setMinutes(59, 59, 999);
-  return d;
+  return instantFromDate(d);
 }
 
 // ---------------------------------------------------------------------------
 // Minute boundaries
 // ---------------------------------------------------------------------------
 
-export function beginningOfMinute(date: Date): Date {
+export function beginningOfMinute(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setSeconds(0, 0);
-  return d;
+  return instantFromDate(d);
 }
 
-export function endOfMinute(date: Date): Date {
+export function endOfMinute(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setSeconds(59, 999);
-  return d;
+  return instantFromDate(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -79,7 +86,92 @@ export function endOfMinute(date: Date): Date {
 // startDay: 0 = Sunday (default Rails), 1 = Monday
 // ---------------------------------------------------------------------------
 
-export function beginningOfWeek(date: Date, startDay = 1): Date {
+export function beginningOfWeek(date: Date, startDay = 1): Temporal.Instant {
+  const d = clone(date);
+  const currentDay = d.getDay();
+  let diff = currentDay - startDay;
+  if (diff < 0) diff += 7;
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return instantFromDate(d);
+}
+
+export function endOfWeek(date: Date, startDay = 1): Temporal.Instant {
+  const d = clone(date);
+  const currentDay = d.getDay();
+  let diff = currentDay - startDay;
+  if (diff < 0) diff += 7;
+  d.setDate(d.getDate() - diff + 6);
+  d.setHours(23, 59, 59, 999);
+  return instantFromDate(d);
+}
+
+// ---------------------------------------------------------------------------
+// Month boundaries
+// ---------------------------------------------------------------------------
+
+export function beginningOfMonth(date: Date): Temporal.Instant {
+  const d = clone(date);
+  d.setDate(1);
+  d.setHours(0, 0, 0, 0);
+  return instantFromDate(d);
+}
+
+export function endOfMonth(date: Date): Temporal.Instant {
+  const d = clone(date);
+  // First day of next month, then go back 1ms
+  d.setMonth(d.getMonth() + 1, 1);
+  d.setHours(0, 0, 0, 0);
+  d.setTime(d.getTime() - 1);
+  return instantFromDate(d);
+}
+
+// ---------------------------------------------------------------------------
+// Quarter boundaries
+// ---------------------------------------------------------------------------
+
+export function beginningOfQuarter(date: Date): Temporal.Instant {
+  const d = clone(date);
+  const month = d.getMonth(); // 0-11
+  const quarterStartMonth = Math.floor(month / 3) * 3;
+  d.setMonth(quarterStartMonth, 1);
+  d.setHours(0, 0, 0, 0);
+  return instantFromDate(d);
+}
+
+export function endOfQuarter(date: Date): Temporal.Instant {
+  const d = clone(date);
+  const month = d.getMonth();
+  const quarterEndMonth = Math.floor(month / 3) * 3 + 2;
+  d.setMonth(quarterEndMonth + 1, 1);
+  d.setHours(0, 0, 0, 0);
+  d.setTime(d.getTime() - 1);
+  return instantFromDate(d);
+}
+
+// ---------------------------------------------------------------------------
+// Year boundaries
+// ---------------------------------------------------------------------------
+
+export function beginningOfYear(date: Date): Temporal.Instant {
+  const d = clone(date);
+  d.setMonth(0, 1);
+  d.setHours(0, 0, 0, 0);
+  return instantFromDate(d);
+}
+
+export function endOfYear(date: Date): Temporal.Instant {
+  const d = clone(date);
+  d.setMonth(11, 31);
+  d.setHours(23, 59, 59, 999);
+  return instantFromDate(d);
+}
+
+// ---------------------------------------------------------------------------
+// next/prev Week/Month/Year/Day
+// ---------------------------------------------------------------------------
+
+function _beginningOfWeekDate(date: Date, startDay = 1): Date {
   const d = clone(date);
   const currentDay = d.getDay();
   let diff = currentDay - startDay;
@@ -89,85 +181,11 @@ export function beginningOfWeek(date: Date, startDay = 1): Date {
   return d;
 }
 
-export function endOfWeek(date: Date, startDay = 1): Date {
-  const d = beginningOfWeek(date, startDay);
-  d.setDate(d.getDate() + 6);
-  d.setHours(23, 59, 59, 999);
-  return d;
-}
-
-// ---------------------------------------------------------------------------
-// Month boundaries
-// ---------------------------------------------------------------------------
-
-export function beginningOfMonth(date: Date): Date {
-  const d = clone(date);
-  d.setDate(1);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-export function endOfMonth(date: Date): Date {
-  const d = clone(date);
-  // First day of next month, then go back 1ms
-  d.setMonth(d.getMonth() + 1, 1);
-  d.setHours(0, 0, 0, 0);
-  d.setTime(d.getTime() - 1);
-  return d;
-}
-
-// ---------------------------------------------------------------------------
-// Quarter boundaries
-// ---------------------------------------------------------------------------
-
-export function beginningOfQuarter(date: Date): Date {
-  const d = clone(date);
-  const month = d.getMonth(); // 0-11
-  const quarterStartMonth = Math.floor(month / 3) * 3;
-  d.setMonth(quarterStartMonth, 1);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-export function endOfQuarter(date: Date): Date {
-  const d = clone(date);
-  const month = d.getMonth();
-  const quarterEndMonth = Math.floor(month / 3) * 3 + 2;
-  d.setMonth(quarterEndMonth + 1, 1);
-  d.setHours(0, 0, 0, 0);
-  d.setTime(d.getTime() - 1);
-  return d;
-}
-
-// ---------------------------------------------------------------------------
-// Year boundaries
-// ---------------------------------------------------------------------------
-
-export function beginningOfYear(date: Date): Date {
-  const d = clone(date);
-  d.setMonth(0, 1);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-export function endOfYear(date: Date): Date {
-  const d = clone(date);
-  d.setMonth(11, 31);
-  d.setHours(23, 59, 59, 999);
-  return d;
-}
-
-// ---------------------------------------------------------------------------
-// next/prev Week/Month/Year/Day
-// ---------------------------------------------------------------------------
-
 export function nextWeek(date: Date, day = "monday"): Date {
   const targetDay = dayIndex(day);
   const d = clone(date);
-  // Move to next week's Monday first (or any day in next week)
   d.setDate(d.getDate() + 7);
-  // Then set to desired day of that week
-  const bow = beginningOfWeek(d, 1); // Monday-based
+  const bow = _beginningOfWeekDate(d, 1); // Monday-based
   const diff = (targetDay - 1 + 7) % 7; // offset from Monday
   bow.setDate(bow.getDate() + diff);
   bow.setHours(0, 0, 0, 0);
@@ -178,7 +196,7 @@ export function prevWeek(date: Date, day = "monday"): Date {
   const targetDay = dayIndex(day);
   const d = clone(date);
   d.setDate(d.getDate() - 7);
-  const bow = beginningOfWeek(d, 1);
+  const bow = _beginningOfWeekDate(d, 1);
   const diff = (targetDay - 1 + 7) % 7;
   bow.setDate(bow.getDate() + diff);
   bow.setHours(0, 0, 0, 0);
@@ -357,23 +375,23 @@ export function daysInYear(year: number): number {
 // all* ranges
 // ---------------------------------------------------------------------------
 
-export function allDay(date: Date): { start: Date; end: Date } {
+export function allDay(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
   return { start: beginningOfDay(date), end: endOfDay(date) };
 }
 
-export function allWeek(date: Date): { start: Date; end: Date } {
+export function allWeek(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
   return { start: beginningOfWeek(date), end: endOfWeek(date) };
 }
 
-export function allMonth(date: Date): { start: Date; end: Date } {
+export function allMonth(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
   return { start: beginningOfMonth(date), end: endOfMonth(date) };
 }
 
-export function allQuarter(date: Date): { start: Date; end: Date } {
+export function allQuarter(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
   return { start: beginningOfQuarter(date), end: endOfQuarter(date) };
 }
 
-export function allYear(date: Date): { start: Date; end: Date } {
+export function allYear(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
   return { start: beginningOfYear(date), end: endOfYear(date) };
 }
 


### PR DESCRIPTION
## Summary

F-6a of the Temporal migration follow-ups: 15 period-bound helpers and 5 range delegators in `time-ext.ts` now return `Temporal.Instant`.

- `beginningOfDay`, `middleOfDay`, `endOfDay`
- `beginningOfHour`, `endOfHour`
- `beginningOfMinute`, `endOfMinute`
- `beginningOfWeek`, `endOfWeek`
- `beginningOfMonth`, `endOfMonth`
- `beginningOfQuarter`, `endOfQuarter`
- `beginningOfYear`, `endOfYear`
- `allDay`, `allWeek`, `allMonth`, `allQuarter`, `allYear`

Inputs remain `Date` for now — F-6b/c/d will flip the rest. Internal arithmetic still routes through cloned `Date` mutators to preserve exact local-tz semantics; the result is wrapped via `Temporal.Instant.fromEpochMilliseconds(d.getTime())`.

`nextWeek` / `prevWeek` (which used `beginningOfWeek` for Date arithmetic) now use a private `_beginningOfWeekDate` helper so they keep returning `Date` until F-6b.

## Test plan

- [x] `pnpm vitest run packages/activesupport` — 3639/3639 passing
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] Diff: 196 +/146 -, 5 files (slightly over the 300 LOC target — scope is the minimum coherent unit since the 20 helpers share test-file infrastructure)