### PR TITLE
fix(arel): Math operand over-quoting + bitwiseNot

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -45,6 +45,8 @@ import {
   BitwiseShiftLeft,
   BitwiseShiftRight,
 } from "../nodes/infix-operation.js";
+import { BitwiseNot } from "../nodes/unary-operation.js";
+import type { NodeOrValue } from "../nodes/binary.js";
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
 import { Predications, type PredicationHost } from "../predications.js";
@@ -372,41 +374,48 @@ export class Attribute extends Node {
   }
 
   // -- Math --
+  //
+  // Mirrors Arel::Math: operands pass through unwrapped. The visitor
+  // renders primitive values via `visitNodeOrValue`.
 
   add(other: unknown): Grouping {
-    return new Grouping(new Addition(this, buildQuoted(other)));
+    return new Grouping(new Addition(this, other as NodeOrValue));
   }
 
   subtract(other: unknown): Grouping {
-    return new Grouping(new Subtraction(this, buildQuoted(other)));
+    return new Grouping(new Subtraction(this, other as NodeOrValue));
   }
 
   multiply(other: unknown): Multiplication {
-    return new Multiplication(this, buildQuoted(other));
+    return new Multiplication(this, other as NodeOrValue);
   }
 
   divide(other: unknown): Division {
-    return new Division(this, buildQuoted(other));
+    return new Division(this, other as NodeOrValue);
   }
 
   bitwiseAnd(other: unknown): Grouping {
-    return new Grouping(new BitwiseAnd(this, buildQuoted(other)));
+    return new Grouping(new BitwiseAnd(this, other as NodeOrValue));
   }
 
   bitwiseOr(other: unknown): Grouping {
-    return new Grouping(new BitwiseOr(this, buildQuoted(other)));
+    return new Grouping(new BitwiseOr(this, other as NodeOrValue));
   }
 
   bitwiseXor(other: unknown): Grouping {
-    return new Grouping(new BitwiseXor(this, buildQuoted(other)));
+    return new Grouping(new BitwiseXor(this, other as NodeOrValue));
   }
 
   bitwiseShiftLeft(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, buildQuoted(other)));
+    return new Grouping(new BitwiseShiftLeft(this, other as NodeOrValue));
   }
 
   bitwiseShiftRight(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, buildQuoted(other)));
+    return new Grouping(new BitwiseShiftRight(this, other as NodeOrValue));
+  }
+
+  bitwiseNot(): BitwiseNot {
+    return new BitwiseNot(this);
   }
 
   // -- Aliasing --

--- a/packages/arel/src/math.test.ts
+++ b/packages/arel/src/math.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "./index.js";
+
+describe("Math", () => {
+  const users = new Table("users");
+  const visitor = new Visitors.ToSql();
+
+  describe("operands pass through raw (no Quoted wrapper)", () => {
+    const arg = new Nodes.SqlLiteral("42");
+
+    it("multiply", () => {
+      const node = users.get("id").multiply(arg) as Nodes.Multiplication;
+      expect(node).toBeInstanceOf(Nodes.Multiplication);
+      expect(node.right).toBe(arg);
+    });
+
+    it("divide", () => {
+      const node = users.get("id").divide(arg) as Nodes.Division;
+      expect(node.right).toBe(arg);
+    });
+
+    it("add", () => {
+      const grouping = users.get("id").add(arg) as Nodes.Grouping;
+      const inner = grouping.expr as Nodes.Addition;
+      expect(inner).toBeInstanceOf(Nodes.Addition);
+      expect(inner.right).toBe(arg);
+    });
+
+    it("subtract", () => {
+      const grouping = users.get("id").subtract(arg) as Nodes.Grouping;
+      const inner = grouping.expr as Nodes.Subtraction;
+      expect(inner.right).toBe(arg);
+    });
+
+    it("bitwiseAnd", () => {
+      const grouping = users.get("id").bitwiseAnd(arg) as Nodes.Grouping;
+      expect((grouping.expr as Nodes.BitwiseAnd).right).toBe(arg);
+    });
+
+    it("bitwiseOr", () => {
+      const grouping = users.get("id").bitwiseOr(arg) as Nodes.Grouping;
+      expect((grouping.expr as Nodes.BitwiseOr).right).toBe(arg);
+    });
+
+    it("bitwiseXor", () => {
+      const grouping = users.get("id").bitwiseXor(arg) as Nodes.Grouping;
+      expect((grouping.expr as Nodes.BitwiseXor).right).toBe(arg);
+    });
+
+    it("bitwiseShiftLeft", () => {
+      const grouping = users.get("id").bitwiseShiftLeft(arg) as Nodes.Grouping;
+      expect((grouping.expr as Nodes.BitwiseShiftLeft).right).toBe(arg);
+    });
+
+    it("bitwiseShiftRight", () => {
+      const grouping = users.get("id").bitwiseShiftRight(arg) as Nodes.Grouping;
+      expect((grouping.expr as Nodes.BitwiseShiftRight).right).toBe(arg);
+    });
+
+    it("primitive numbers also pass through unwrapped", () => {
+      const node = users.get("id").multiply(2) as Nodes.Multiplication;
+      expect(node.right).toBe(2);
+    });
+  });
+
+  describe("bitwiseNot", () => {
+    it("returns a BitwiseNot wrapping the receiver", () => {
+      const attr = users.get("flags");
+      const node = attr.bitwiseNot();
+      expect(node).toBeInstanceOf(Nodes.BitwiseNot);
+      expect(node.operator).toBe("~");
+      expect(node.operand).toBe(attr);
+    });
+
+    it("renders SQL with surrounding spaces around the operator", () => {
+      const sql = visitor.compile(users.get("flags").bitwiseNot());
+      expect(sql).toBe(' ~ "users"."flags"');
+    });
+  });
+});

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -11,42 +11,47 @@ import {
   BitwiseShiftRight,
 } from "./nodes/infix-operation.js";
 import { Grouping } from "./nodes/grouping.js";
-import { buildQuoted } from "./nodes/casted.js";
+import { BitwiseNot } from "./nodes/unary-operation.js";
+import type { NodeOrValue } from "./nodes/binary.js";
 
 /**
  * Math — arithmetic mixin.
  *
- * Mirrors: Arel::Math (activerecord/lib/arel/math.rb). `+` and `-` wrap
- * in Grouping so precedence is preserved when the result is further
- * chained (`a + b - c` becomes `(a + b) - c` via nested Groupings);
- * `*` and `/` do not — same as Rails.
+ * Mirrors: Arel::Math (activerecord/lib/arel/math.rb). `+`/`-` and the
+ * bitwise operators wrap in Grouping so precedence is preserved when the
+ * result is further chained; `*` and `/` do not — same as Rails. The
+ * right-hand operand is passed through raw (Rails does not pre-quote);
+ * the visitor renders primitive values via `visitNodeOrValue`.
  */
 export const Math = {
   add(this: Node, other: unknown): Grouping {
-    return new Grouping(new Addition(this, buildQuoted(other)));
+    return new Grouping(new Addition(this, other as NodeOrValue));
   },
   subtract(this: Node, other: unknown): Grouping {
-    return new Grouping(new Subtraction(this, buildQuoted(other)));
+    return new Grouping(new Subtraction(this, other as NodeOrValue));
   },
   multiply(this: Node, other: unknown): Multiplication {
-    return new Multiplication(this, buildQuoted(other));
+    return new Multiplication(this, other as NodeOrValue);
   },
   divide(this: Node, other: unknown): Division {
-    return new Division(this, buildQuoted(other));
+    return new Division(this, other as NodeOrValue);
   },
   bitwiseAnd(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseAnd(this, buildQuoted(other)));
+    return new Grouping(new BitwiseAnd(this, other as NodeOrValue));
   },
   bitwiseOr(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseOr(this, buildQuoted(other)));
+    return new Grouping(new BitwiseOr(this, other as NodeOrValue));
   },
   bitwiseXor(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseXor(this, buildQuoted(other)));
+    return new Grouping(new BitwiseXor(this, other as NodeOrValue));
   },
   bitwiseShiftLeft(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, buildQuoted(other)));
+    return new Grouping(new BitwiseShiftLeft(this, other as NodeOrValue));
   },
   bitwiseShiftRight(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, buildQuoted(other)));
+    return new Grouping(new BitwiseShiftRight(this, other as NodeOrValue));
+  },
+  bitwiseNot(this: Node): BitwiseNot {
+    return new BitwiseNot(this);
   },
 };

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -1,5 +1,5 @@
 import { Node, NodeVisitor } from "./node.js";
-import { Binary } from "./binary.js";
+import { Binary, type NodeOrValue } from "./binary.js";
 import { As } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { buildQuoted } from "./casted.js";
@@ -15,10 +15,10 @@ import type { Included } from "@blazetrails/activesupport";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class InfixOperation extends Binary {
   readonly operator: string;
-  readonly left: Node;
-  readonly right: Node;
+  readonly left: NodeOrValue;
+  readonly right: NodeOrValue;
 
-  constructor(operator: string, left: Node, right: Node) {
+  constructor(operator: string, left: NodeOrValue, right: NodeOrValue) {
     super(left, right);
     this.operator = operator;
     this.left = left;
@@ -54,81 +54,81 @@ export class InfixOperation extends Binary {
 
 /** Bitwise AND: left & right */
 export class BitwiseAnd extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("&", left, right);
   }
 }
 
 /** Bitwise OR: left | right */
 export class BitwiseOr extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("|", left, right);
   }
 }
 
 /** Bitwise XOR: left ^ right */
 export class BitwiseXor extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("^", left, right);
   }
 }
 
 /** Bitwise Shift Left: left << right */
 export class BitwiseShiftLeft extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("<<", left, right);
   }
 }
 
 /** Bitwise Shift Right: left >> right */
 export class BitwiseShiftRight extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super(">>", left, right);
   }
 }
 
 /** Math operations — these live here to match Rails infix_operation.rb */
 export class Addition extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("+", left, right);
   }
 }
 
 export class Subtraction extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("-", left, right);
   }
 }
 
 export class Multiplication extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("*", left, right);
   }
 }
 
 export class Division extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("/", left, right);
   }
 }
 
 /** String concatenation: left || right */
 export class Concat extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("||", left, right);
   }
 }
 
 /** PostgreSQL @> contains operator */
 export class Contains extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("@>", left, right);
   }
 }
 
 /** PostgreSQL && overlaps operator */
 export class Overlaps extends InfixOperation {
-  constructor(left: Node, right: Node) {
+  constructor(left: NodeOrValue, right: NodeOrValue) {
     super("&&", left, right);
   }
 }

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -98,9 +98,9 @@ export class MySQL extends ToSql {
 
   protected override visitArelNodesConcat(node: Nodes.Concat): SQLString {
     this.collector.append("CONCAT(");
-    this.visit(node.left);
+    this.visitNodeOrValue(node.left);
     this.collector.append(", ");
-    this.visit(node.right);
+    this.visitNodeOrValue(node.right);
     this.collector.append(")");
     return this.collector;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1041,9 +1041,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // -- Concat --
 
   protected visitArelNodesConcat(node: Nodes.Concat): SQLString {
-    this.visit(node.left);
+    this.visitNodeOrValue(node.left);
     this.collector.append(" || ");
-    this.visit(node.right);
+    this.visitNodeOrValue(node.right);
     return this.collector;
   }
 
@@ -1068,9 +1068,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // -- InfixOperation --
 
   private visitArelNodesInfixOperation(node: Nodes.InfixOperation): SQLString {
-    this.visit(node.left);
+    this.visitNodeOrValue(node.left);
     this.collector.append(` ${node.operator} `);
-    this.visit(node.right);
+    this.visitNodeOrValue(node.right);
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary

- Drops `buildQuoted` wrap from all `Arel::Math` operators (`add`, `subtract`, `multiply`, `divide`, `bitwiseAnd|Or|Xor|ShiftLeft|ShiftRight`); operands flow through raw, matching Rails' `math.rb`.
- Adds `bitwiseNot()` (Rails's `~@`) returning `Nodes.BitwiseNot` (already exists as a `UnaryOperation` subclass with operator `~`).
- Updates `visitArelNodesInfixOperation` (and `Concat` in to-sql + mysql visitors) to route operands through `visitNodeOrValue` so primitive scalars still render after the `Quoted` wrapper is gone.
- Mirror change applied to the inline math methods on `Attribute`.

Refs [`docs/arel-alignment-plan.md` PR 11](../blob/main/docs/arel-alignment-plan.md#pr-11--math-over-quoting--bitwisenot-independent).

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1213/1213 passing, including new `packages/arel/src/math.test.ts` raw-operand + bitwiseNot AST/SQL tests.
- [x] Existing `packages/arel/src/attributes/math.test.ts` SQL fixtures unchanged.