### PR TITLE
fix(activesupport): MessageVerifier fractional expiresIn → milliseconds

### DIFF
--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -62,8 +62,14 @@ export class MessageVerifier {
     if (options.expiresAt) {
       payload._expiresAt = options.expiresAt.toString({ smallestUnit: "millisecond" });
     } else if (options.expiresIn !== undefined) {
+      // Temporal.Duration components must be integers, but Rails (and
+      // existing trails callers) pass fractional seconds — e.g. 0.001
+      // for a 1ms expiry. Round to the nearest millisecond so any
+      // sub-second precision is preserved without violating Temporal's
+      // integer-component invariant.
+      const milliseconds = Math.round(options.expiresIn * 1000);
       payload._expiresAt = Temporal.Now.instant()
-        .add({ seconds: options.expiresIn })
+        .add({ milliseconds })
         .toString({ smallestUnit: "millisecond" });
     }
 


### PR DESCRIPTION
## Summary

PR #1037 switched `MessageVerifier` expiry to `Temporal.Now.instant().add({ seconds: expiresIn })`, but `Temporal.Duration` components must be integers. Existing callers (notably `token-for.test.ts`) pass fractional seconds — e.g. `expiresIn=0.001` for a 1ms expiry — and trip `RangeError: unsupported fractional value 0.001`.

Round to milliseconds so sub-second precision survives without violating Temporal's integer-component invariant.

Unblocks SQLite/PostgreSQL/MariaDB CI on `main` and downstream PRs (#1040, etc.).

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/token-for.test.ts` — 20/20 pass locally
- [ ] CI green on SQLite / PostgreSQL / MariaDB