### PR TITLE
fix(arel): compileUpdate/compileDelete always assign key

### DIFF
--- a/packages/arel/src/crud.test.ts
+++ b/packages/arel/src/crud.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, InsertManager, UpdateManager, DeleteManager } from "./index.js";
+import { Table, InsertManager, UpdateManager, DeleteManager, SelectManager } from "./index.js";
 
 describe("crud", () => {
   const users = new Table("users");
@@ -28,6 +28,23 @@ describe("crud", () => {
       const mgr = new DeleteManager();
       mgr.from(users).where(users.get("id").eq(1));
       expect(mgr.toSql()).toContain('DELETE FROM "users"');
+    });
+  });
+
+  describe("compileUpdate / compileDelete key assignment", () => {
+    // Mirrors Rails Arel::Crud (activerecord/lib/arel/crud.rb): `um.key = key`
+    // and `dm.key = key` are unconditional, so a `null` key clears any prior
+    // value rather than being skipped.
+    it("compileUpdate always assigns key, including null", () => {
+      const mgr = new SelectManager(users);
+      const um = mgr.compileUpdate([[users.get("id"), 1]], null);
+      expect(um.key).toBeNull();
+    });
+
+    it("compileDelete always assigns key, including null", () => {
+      const mgr = new SelectManager(users);
+      const dm = mgr.compileDelete(null);
+      expect(dm.key).toBeNull();
     });
   });
 });

--- a/packages/arel/src/crud.test.ts
+++ b/packages/arel/src/crud.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { Table, InsertManager, UpdateManager, DeleteManager, SelectManager } from "./index.js";
 
 describe("crud", () => {
@@ -38,44 +38,22 @@ describe("crud", () => {
     // because the underlying statement initializes `key` to `null`, so a
     // post-hoc `manager.key === null` check would pass even with the prior
     // `if (key !== null)` guard in place.
-    function spyKeySetter<T extends object>(
-      proto: T,
-    ): {
-      calls: unknown[];
-      restore: () => void;
-    } {
-      const original = Object.getOwnPropertyDescriptor(proto, "key")!;
-      const calls: unknown[] = [];
-      Object.defineProperty(proto, "key", {
-        ...original,
-        set(value: unknown) {
-          calls.push(value);
-          original.set!.call(this, value);
-        },
-      });
-      return { calls, restore: () => Object.defineProperty(proto, "key", original) };
-    }
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
 
     it("compileUpdate always assigns key, including null", () => {
-      const spy = spyKeySetter(UpdateManager.prototype);
-      try {
-        const mgr = new SelectManager(users);
-        mgr.compileUpdate([[users.get("id"), 1]], null);
-        expect(spy.calls).toEqual([null]);
-      } finally {
-        spy.restore();
-      }
+      const setKey = vi.spyOn(UpdateManager.prototype, "key", "set");
+      const mgr = new SelectManager(users);
+      mgr.compileUpdate([[users.get("id"), 1]], null);
+      expect(setKey).toHaveBeenCalledWith(null);
     });
 
     it("compileDelete always assigns key, including null", () => {
-      const spy = spyKeySetter(DeleteManager.prototype);
-      try {
-        const mgr = new SelectManager(users);
-        mgr.compileDelete(null);
-        expect(spy.calls).toEqual([null]);
-      } finally {
-        spy.restore();
-      }
+      const setKey = vi.spyOn(DeleteManager.prototype, "key", "set");
+      const mgr = new SelectManager(users);
+      mgr.compileDelete(null);
+      expect(setKey).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/packages/arel/src/crud.test.ts
+++ b/packages/arel/src/crud.test.ts
@@ -33,18 +33,49 @@ describe("crud", () => {
 
   describe("compileUpdate / compileDelete key assignment", () => {
     // Mirrors Rails Arel::Crud (activerecord/lib/arel/crud.rb): `um.key = key`
-    // and `dm.key = key` are unconditional, so a `null` key clears any prior
-    // value rather than being skipped.
+    // and `dm.key = key` are unconditional for Rails parity, so `null` is
+    // assigned explicitly rather than being skipped. We spy on the setter
+    // because the underlying statement initializes `key` to `null`, so a
+    // post-hoc `manager.key === null` check would pass even with the prior
+    // `if (key !== null)` guard in place.
+    function spyKeySetter<T extends object>(
+      proto: T,
+    ): {
+      calls: unknown[];
+      restore: () => void;
+    } {
+      const original = Object.getOwnPropertyDescriptor(proto, "key")!;
+      const calls: unknown[] = [];
+      Object.defineProperty(proto, "key", {
+        ...original,
+        set(value: unknown) {
+          calls.push(value);
+          original.set!.call(this, value);
+        },
+      });
+      return { calls, restore: () => Object.defineProperty(proto, "key", original) };
+    }
+
     it("compileUpdate always assigns key, including null", () => {
-      const mgr = new SelectManager(users);
-      const um = mgr.compileUpdate([[users.get("id"), 1]], null);
-      expect(um.key).toBeNull();
+      const spy = spyKeySetter(UpdateManager.prototype);
+      try {
+        const mgr = new SelectManager(users);
+        mgr.compileUpdate([[users.get("id"), 1]], null);
+        expect(spy.calls).toEqual([null]);
+      } finally {
+        spy.restore();
+      }
     });
 
     it("compileDelete always assigns key, including null", () => {
-      const mgr = new SelectManager(users);
-      const dm = mgr.compileDelete(null);
-      expect(dm.key).toBeNull();
+      const spy = spyKeySetter(DeleteManager.prototype);
+      try {
+        const mgr = new SelectManager(users);
+        mgr.compileDelete(null);
+        expect(spy.calls).toEqual([null]);
+      } finally {
+        spy.restore();
+      }
     });
   });
 });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -492,7 +492,7 @@ export class SelectManager extends TreeManager {
     um.offset((this.ast.offset as Offset | null)?.expr ?? null);
     um.order(...this.orders);
     um.wheres = this.constraints;
-    if (key !== null) um.key = key;
+    um.key = key;
     if (groupValuesColumns.length > 0) {
       const [first, ...rest] = groupValuesColumns;
       um.group(first, ...rest);
@@ -517,7 +517,7 @@ export class SelectManager extends TreeManager {
     dm.offset((this.ast.offset as Offset | null)?.expr ?? null);
     dm.order(...this.orders);
     dm.wheres = this.constraints;
-    if (key !== null) dm.key = key;
+    dm.key = key;
     if (groupValuesColumns.length > 0) {
       const [first, ...rest] = groupValuesColumns;
       dm.group(first, ...rest);


### PR DESCRIPTION
## Summary

- Drops `if (key !== null)` guards in `SelectManager#compileUpdate` and `#compileDelete` so `key` (including `null`) is always assigned to the resulting `UpdateManager`/`DeleteManager`.
- Matches Rails `Arel::Crud` ([crud.rb](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/crud.rb)) where `um.key = key` and `dm.key = key` are unconditional.

Refs [`docs/arel-alignment-plan.md` PR 17](../blob/main/docs/arel-alignment-plan.md).

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1215/1215 passing, including new `compileUpdate(values, null)` / `compileDelete(null)` assertions verifying `manager.key === null`.