### PR TITLE
feat(activesupport): time-ext navigation helpers return Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -63,12 +63,12 @@ describe("DateExtBehaviorTest", () => {
 
 describe("DateExtCalculationsTest", () => {
   it("yesterday in calendar reform", () => {
-    const result = prevDay(d(1582, 10, 15));
+    const result = asDate(prevDay(d(1582, 10, 15)));
     expect(result.getDate()).toBe(14);
   });
 
   it("tomorrow in calendar reform", () => {
-    const result = nextDay(d(1582, 10, 4));
+    const result = asDate(nextDay(d(1582, 10, 4)));
     expect(result.getDate()).toBe(5);
   });
 
@@ -101,7 +101,7 @@ describe("DateExtCalculationsTest", () => {
   it("compare to time", () => {
     const ref = d(2023, 6, 15, 12, 0, 0);
     const before = prevDay(ref);
-    expect(before.getTime()).toBeLessThan(ref.getTime());
+    expect(before.epochMilliseconds).toBeLessThan(ref.getTime());
   });
 
   it("to datetime", () => {
@@ -155,7 +155,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("last week", () => {
-    const result = lastWeek(d(2005, 5, 17), "monday");
+    const result = asDate(lastWeek(d(2005, 5, 17), "monday"));
     expect(result.getDate()).toBe(9);
     expect(result.getMonth()).toBe(4); // May
   });

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -143,14 +143,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("last week", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    const result = lastWeek(dt, "monday");
+    const result = asDate(lastWeek(dt, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < dt).toBe(true);
   });
 
   it("date time should have correct last week for leap year", () => {
     const dt = d(2016, 3, 7);
-    const result = lastWeek(dt, "monday");
+    const result = asDate(lastWeek(dt, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < dt).toBe(true);
   });
@@ -171,13 +171,13 @@ describe("DateTimeExtCalculationsTest", () => {
   it("today with offset", () => {
     const now = new Date();
     expect(isToday(now)).toBe(true);
-    expect(isToday(prevDay(now))).toBe(false);
+    expect(isToday(asDate(prevDay(now)))).toBe(false);
   });
 
   it("today without offset", () => {
     const now = new Date();
     expect(isToday(now)).toBe(true);
-    expect(isToday(nextDay(now))).toBe(false);
+    expect(isToday(asDate(nextDay(now)))).toBe(false);
   });
 
   it("yesterday with offset", () => {
@@ -194,7 +194,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("prev day without offset", () => {
     const t = new Date();
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result < t).toBe(true);
   });
 
@@ -212,7 +212,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("next day without offset", () => {
     const t = new Date();
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result > t).toBe(true);
   });
 
@@ -376,14 +376,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("prev day with offset", () => {
     const t = d(2005, 6, 15, 12, 0, 0);
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result.getDate()).toBe(14);
     expect(result.getMonth()).toBe(5);
   });
 
   it("next day with offset", () => {
     const t = d(2005, 6, 15, 12, 0, 0);
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result.getDate()).toBe(16);
     expect(result.getMonth()).toBe(5);
   });

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -188,7 +188,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings forward start tomorrow", () => {
     withEnvTz("America/New_York", () => {
       const st = new Date(2005, 3, 2, 19, 27, 0);
-      const result = nextDay(st);
+      const result = asDate(nextDay(st));
       expect(result.getDate()).toBe(3);
       expect(result.getHours()).toBe(19);
       expect(result.getMinutes()).toBe(27);
@@ -198,7 +198,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings backward start yesterday", () => {
     withEnvTz("America/New_York", () => {
       const dt = new Date(2005, 3, 3, 19, 27, 0);
-      const result = prevDay(dt);
+      const result = asDate(prevDay(dt));
       expect(result.getDate()).toBe(2);
       expect(result.getHours()).toBe(19);
       expect(result.getMinutes()).toBe(27);
@@ -229,7 +229,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings forward end tomorrow", () => {
     withEnvTz("America/New_York", () => {
       const dt = new Date(2005, 9, 30, 0, 45, 0);
-      const result = nextDay(dt);
+      const result = asDate(nextDay(dt));
       expect(result.getDate()).toBe(31);
       expect(result.getHours()).toBe(0);
       expect(result.getMinutes()).toBe(45);
@@ -239,7 +239,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings backward end yesterday", () => {
     withEnvTz("America/New_York", () => {
       const st = new Date(2005, 9, 31, 0, 45, 0);
-      const result = prevDay(st);
+      const result = asDate(prevDay(st));
       expect(result.getDate()).toBe(30);
       expect(result.getHours()).toBe(0);
       expect(result.getMinutes()).toBe(45);
@@ -324,7 +324,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("last week", () => {
     withEnvTz("America/New_York", () => {
-      const result = lastWeek(new Date(2005, 2, 1, 15, 15, 10), "monday");
+      const result = asDate(lastWeek(new Date(2005, 2, 1, 15, 15, 10), "monday"));
       expect(result.getDay()).toBe(1); // Monday
       expect(result.getDate()).toBe(21);
     });
@@ -332,7 +332,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("next week near daylight start", () => {
     withEnvTz("America/New_York", () => {
-      const result = nextWeek(new Date(2006, 3, 2, 23, 1, 0), "monday");
+      const result = asDate(nextWeek(new Date(2006, 3, 2, 23, 1, 0), "monday"));
       expect(result.getDate()).toBe(3);
       expect(result.getMonth()).toBe(3); // April
     });
@@ -340,7 +340,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("next week near daylight end", () => {
     withEnvTz("America/New_York", () => {
-      const result = nextWeek(new Date(2006, 9, 29, 23, 1, 0), "monday");
+      const result = asDate(nextWeek(new Date(2006, 9, 29, 23, 1, 0), "monday"));
       expect(result.getDate()).toBe(30);
       expect(result.getMonth()).toBe(9); // October
     });
@@ -462,7 +462,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("prev day with time utc", () => {
     const t = new Date();
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result < t).toBe(true);
   });
 
@@ -480,7 +480,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("next day with time utc", () => {
     const t = new Date();
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result > t).toBe(true);
   });
 
@@ -711,13 +711,13 @@ describe("TimeExtCalculationsTest", () => {
 
   it("prev day with time local", () => {
     const t = new Date();
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result < t).toBe(true);
   });
 
   it("next day with time local", () => {
     const t = d(2005, 6, 15, 12, 0, 0);
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result.getDate()).toBe(16);
     expect(result.getMonth()).toBe(5);
   });

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -196,55 +196,55 @@ describe("TimeExtCalculationsTest", () => {
   it("next_week", () => {
     // A Monday (2023-01-09) -> next monday = 2023-01-16
     const monday = d(2023, 1, 9);
-    const result = nextWeek(monday, "monday");
+    const result = asDate(nextWeek(monday, "monday"));
     expect(result.getDay()).toBe(1); // Monday
     expect(result > monday).toBe(true);
   });
 
   it("prev_week", () => {
     const monday = d(2023, 1, 16);
-    const result = prevWeek(monday, "monday");
+    const result = asDate(prevWeek(monday, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < monday).toBe(true);
   });
 
   it("next_month", () => {
-    expect(nextMonth(d(2005, 1, 31))).toEqual(d(2005, 2, 28));
-    expect(nextMonth(d(2005, 3, 15))).toEqual(d(2005, 4, 15));
+    expect(nextMonth(d(2005, 1, 31))).toEqual(i(2005, 2, 28));
+    expect(nextMonth(d(2005, 3, 15))).toEqual(i(2005, 4, 15));
   });
 
   it("prev_month", () => {
-    expect(prevMonth(d(2005, 3, 31))).toEqual(d(2005, 2, 28));
-    expect(prevMonth(d(2005, 3, 15))).toEqual(d(2005, 2, 15));
+    expect(prevMonth(d(2005, 3, 31))).toEqual(i(2005, 2, 28));
+    expect(prevMonth(d(2005, 3, 15))).toEqual(i(2005, 2, 15));
   });
 
   it("next_year", () => {
-    expect(nextYear(d(2005, 6, 15))).toEqual(d(2006, 6, 15));
+    expect(nextYear(d(2005, 6, 15))).toEqual(i(2006, 6, 15));
   });
 
   it("prev_year", () => {
-    expect(prevYear(d(2005, 6, 15))).toEqual(d(2004, 6, 15));
+    expect(prevYear(d(2005, 6, 15))).toEqual(i(2004, 6, 15));
   });
 
   it("next_day", () => {
-    expect(nextDay(d(2005, 2, 28))).toEqual(d(2005, 3, 1));
+    expect(nextDay(d(2005, 2, 28))).toEqual(i(2005, 3, 1));
   });
 
   it("prev_day", () => {
-    expect(prevDay(d(2005, 3, 1))).toEqual(d(2005, 2, 28));
+    expect(prevDay(d(2005, 3, 1))).toEqual(i(2005, 2, 28));
   });
 
   it("next_occurring", () => {
     // Monday 2023-01-09, next friday
     const monday = d(2023, 1, 9);
-    const result = nextOccurring(monday, "friday");
+    const result = asDate(nextOccurring(monday, "friday"));
     expect(result.getDay()).toBe(5);
     expect(result > monday).toBe(true);
   });
 
   it("prev_occurring", () => {
     const monday = d(2023, 1, 16);
-    const result = prevOccurring(monday, "friday");
+    const result = asDate(prevOccurring(monday, "friday"));
     expect(result.getDay()).toBe(5);
     expect(result < monday).toBe(true);
   });
@@ -263,8 +263,8 @@ describe("TimeExtCalculationsTest", () => {
   it("is_today, is_tomorrow, is_yesterday", () => {
     const now = new Date();
     expect(isToday(now)).toBe(true);
-    expect(isTomorrow(nextDay(now))).toBe(true);
-    expect(isYesterday(prevDay(now))).toBe(true);
+    expect(isTomorrow(asDate(nextDay(now)))).toBe(true);
+    expect(isYesterday(asDate(prevDay(now)))).toBe(true);
   });
 
   it("is_past", () => {
@@ -347,7 +347,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("last week", () => {
     const t = d(2005, 2, 4, 10, 10, 10); // Friday
-    const result = lastWeek(t, "monday");
+    const result = asDate(lastWeek(t, "monday"));
     expect(result.getDay()).toBe(1); // Monday
     expect(result < t).toBe(true);
   });
@@ -466,7 +466,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("prev day with time utc", () => {
     const t = new Date();
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result < t).toBe(true);
   });
 
@@ -478,7 +478,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("next day with time utc", () => {
     const t = new Date();
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result > t).toBe(true);
   });
 
@@ -656,15 +656,15 @@ describe("DateExtCalculationsTest", () => {
   it("next_week various days", () => {
     // 2023-01-09 (Monday)
     const mon = d(2023, 1, 9);
-    expect(nextWeek(mon, "wednesday").getDay()).toBe(3);
-    expect(nextWeek(mon, "friday").getDay()).toBe(5);
-    expect(nextWeek(mon, "sunday").getDay()).toBe(0);
+    expect(asDate(nextWeek(mon, "wednesday")).getDay()).toBe(3);
+    expect(asDate(nextWeek(mon, "friday")).getDay()).toBe(5);
+    expect(asDate(nextWeek(mon, "sunday")).getDay()).toBe(0);
   });
 
   it("prev_week various days", () => {
     const mon = d(2023, 1, 16);
-    expect(prevWeek(mon, "wednesday").getDay()).toBe(3);
-    expect(prevWeek(mon, "friday").getDay()).toBe(5);
+    expect(asDate(prevWeek(mon, "wednesday")).getDay()).toBe(3);
+    expect(asDate(prevWeek(mon, "friday")).getDay()).toBe(5);
   });
 
   it("to fs", () => {
@@ -702,7 +702,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("last week", () => {
     const date = d(2005, 2, 21);
-    const result = lastWeek(date, "monday");
+    const result = asDate(lastWeek(date, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < date).toBe(true);
   });
@@ -962,14 +962,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("next_occurring from datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10); // Tuesday
-    const result = nextOccurring(dt, "friday");
+    const result = asDate(nextOccurring(dt, "friday"));
     expect(result.getDay()).toBe(5);
     expect(result > dt).toBe(true);
   });
 
   it("prev_occurring from datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10); // Tuesday
-    const result = prevOccurring(dt, "monday");
+    const result = asDate(prevOccurring(dt, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < dt).toBe(true);
   });
@@ -1019,14 +1019,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("next_day from datetime", () => {
     const dt = d(2005, 2, 28, 10, 10, 10);
-    const result = nextDay(dt);
+    const result = asDate(nextDay(dt));
     expect(result.getDate()).toBe(1);
     expect(result.getMonth()).toBe(2); // March
   });
 
   it("prev_day from datetime", () => {
     const dt = d(2005, 3, 1, 10, 10, 10);
-    const result = prevDay(dt);
+    const result = asDate(prevDay(dt));
     expect(result.getDate()).toBe(28);
     expect(result.getMonth()).toBe(1); // February
   });
@@ -1109,14 +1109,14 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("last week", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    const result = lastWeek(dt, "monday");
+    const result = asDate(lastWeek(dt, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < dt).toBe(true);
   });
 
   it("date time should have correct last week for leap year", () => {
     const dt = d(2016, 3, 7); // March 7, 2016 (leap year)
-    const result = lastWeek(dt, "monday");
+    const result = asDate(lastWeek(dt, "monday"));
     expect(result.getDay()).toBe(1);
     expect(result < dt).toBe(true);
   });
@@ -1159,7 +1159,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("prev day without offset", () => {
     const t = new Date();
-    const result = prevDay(t);
+    const result = asDate(prevDay(t));
     expect(result < t).toBe(true);
   });
 
@@ -1177,7 +1177,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("next day without offset", () => {
     const t = new Date();
-    const result = nextDay(t);
+    const result = asDate(nextDay(t));
     expect(result > t).toBe(true);
   });
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -168,7 +168,7 @@ export function endOfYear(date: Date): Temporal.Instant {
 // next/prev Week/Month/Year/Day
 // ---------------------------------------------------------------------------
 
-export function nextWeek(date: Date, day = "monday"): Date {
+export function nextWeek(date: Date, day = "monday"): Temporal.Instant {
   const targetDay = dayIndex(day);
   const d = clone(date);
   d.setDate(d.getDate() + 7);
@@ -176,10 +176,10 @@ export function nextWeek(date: Date, day = "monday"): Date {
   const diff = (targetDay - 1 + 7) % 7; // offset from Monday
   bow.setDate(bow.getDate() + diff);
   bow.setHours(0, 0, 0, 0);
-  return bow;
+  return instantFrom(bow);
 }
 
-export function prevWeek(date: Date, day = "monday"): Date {
+export function prevWeek(date: Date, day = "monday"): Temporal.Instant {
   const targetDay = dayIndex(day);
   const d = clone(date);
   d.setDate(d.getDate() - 7);
@@ -187,10 +187,10 @@ export function prevWeek(date: Date, day = "monday"): Date {
   const diff = (targetDay - 1 + 7) % 7;
   bow.setDate(bow.getDate() + diff);
   bow.setHours(0, 0, 0, 0);
-  return bow;
+  return instantFrom(bow);
 }
 
-export function nextMonth(date: Date): Date {
+export function nextMonth(date: Date): Temporal.Instant {
   const d = clone(date);
   const day = d.getDate();
   d.setMonth(d.getMonth() + 1);
@@ -198,20 +198,20 @@ export function nextMonth(date: Date): Date {
   if (d.getDate() !== day) {
     d.setDate(0); // last day of previous month
   }
-  return d;
+  return instantFrom(d);
 }
 
-export function prevMonth(date: Date): Date {
+export function prevMonth(date: Date): Temporal.Instant {
   const d = clone(date);
   const day = d.getDate();
   d.setMonth(d.getMonth() - 1);
   if (d.getDate() !== day) {
     d.setDate(0);
   }
-  return d;
+  return instantFrom(d);
 }
 
-export function nextYear(date: Date): Date {
+export function nextYear(date: Date): Temporal.Instant {
   const d = clone(date);
   const month = d.getMonth();
   const day = d.getDate();
@@ -223,29 +223,29 @@ export function nextYear(date: Date): Date {
   if (d.getDate() !== day && d.getMonth() === month) {
     d.setDate(0);
   }
-  return d;
+  return instantFrom(d);
 }
 
-export function prevYear(date: Date): Date {
+export function prevYear(date: Date): Temporal.Instant {
   const d = clone(date);
   const month = d.getMonth();
   d.setFullYear(d.getFullYear() - 1);
   if (d.getMonth() !== month) {
     d.setDate(0);
   }
-  return d;
+  return instantFrom(d);
 }
 
-export function nextDay(date: Date): Date {
+export function nextDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setDate(d.getDate() + 1);
-  return d;
+  return instantFrom(d);
 }
 
-export function prevDay(date: Date): Date {
+export function prevDay(date: Date): Temporal.Instant {
   const d = clone(date);
   d.setDate(d.getDate() - 1);
-  return d;
+  return instantFrom(d);
 }
 
 // Alias used in Rails
@@ -255,22 +255,22 @@ export { nextDay as tomorrow, prevDay as yesterday };
 // next/prev occurring
 // ---------------------------------------------------------------------------
 
-export function nextOccurring(date: Date, day: string): Date {
+export function nextOccurring(date: Date, day: string): Temporal.Instant {
   const targetDay = dayIndex(day);
   const d = clone(date);
   let diff = targetDay - d.getDay();
   if (diff <= 0) diff += 7;
   d.setDate(d.getDate() + diff);
-  return d;
+  return instantFrom(d);
 }
 
-export function prevOccurring(date: Date, day: string): Date {
+export function prevOccurring(date: Date, day: string): Temporal.Instant {
   const targetDay = dayIndex(day);
   const d = clone(date);
   let diff = d.getDay() - targetDay;
   if (diff <= 0) diff += 7;
   d.setDate(d.getDate() - diff);
-  return d;
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -442,7 +442,7 @@ export function isToday(date: Date): boolean {
 }
 
 export function isTomorrow(date: Date): boolean {
-  const tomorrow = nextDay(new Date());
+  const tomorrow = new Date(nextDay(new Date()).epochMilliseconds);
   return (
     date.getFullYear() === tomorrow.getFullYear() &&
     date.getMonth() === tomorrow.getMonth() &&
@@ -451,7 +451,7 @@ export function isTomorrow(date: Date): boolean {
 }
 
 export function isYesterday(date: Date): boolean {
-  const yesterday = prevDay(new Date());
+  const yesterday = new Date(prevDay(new Date()).epochMilliseconds);
   return (
     date.getFullYear() === yesterday.getFullYear() &&
     date.getMonth() === yesterday.getMonth() &&
@@ -537,7 +537,7 @@ export function xmlschema(date: Date): string {
 /**
  * lastWeek — returns the start of last week.
  */
-export function lastWeek(date: Date, startDay = "monday"): Date {
+export function lastWeek(date: Date, startDay = "monday"): Temporal.Instant {
   return prevWeek(date, startDay);
 }
 


### PR DESCRIPTION
## Summary

F-6b of the Temporal migration follow-ups: 11 navigation helpers in \`time-ext.ts\` now return \`Temporal.Instant\`.

- \`nextDay\`, \`prevDay\` (+ aliases \`tomorrow\`, \`yesterday\`)
- \`nextWeek\`, \`prevWeek\`, \`lastWeek\`
- \`nextMonth\`, \`prevMonth\`
- \`nextYear\`, \`prevYear\`
- \`nextOccurring\`, \`prevOccurring\`

Inputs stay \`Date\`. Internal arithmetic still routes through cloned \`Date\` mutators for exact local-tz semantics, then wraps the result via \`instantFrom\`. \`isTomorrow\` / \`isYesterday\` updated to read \`epochMilliseconds\` from the now-Instant outputs of \`nextDay\` / \`prevDay\`.

## Test plan

- [x] \`pnpm vitest run packages/activesupport\` — 3639/3639 passing
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` clean
- [x] Diff: 77 +/77 -, 5 files (well under 300 LOC)