### PR TITLE
feat(activemodel): port numeric primitives privates (Integer + Decimal + Numeric helper)

### DIFF
--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -26,6 +26,18 @@ describe("DecimalTest", () => {
     expect(result).toBe("42");
   });
 
+  it("convertFloatToBigDecimal: precision rounds significant digits before scale", () => {
+    // Mirrors Rails BigDecimal(value, float_precision) — Type::Decimal.new(precision: 3).cast(1.2346)
+    // rounds the input to 3 significant digits ("1.23") before any scale: pass.
+    const type = new Types.DecimalType({ precision: 3 });
+    expect(type.cast(1.2346)).toBe("1.23");
+    // 1234.5 → 3 significant digits → "1230"
+    expect(type.cast(1234.5)).toBe("1230");
+    // No precision configured: pass through (preserves the existing default).
+    const noPrec = new Types.DecimalType();
+    expect(noPrec.cast(1.2346)).toBe("1.2346");
+  });
+
   it("scale is applied before precision to prevent rounding errors", () => {
     // Rails decimal_test.rb: Type::Decimal.new(precision: 5, scale: 3).cast(1.2346)
     // rounds to BigDecimal("1.235") via apply_scale before storage.

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -86,10 +86,10 @@ export class DecimalType extends ValueType<string> {
    * @internal Rails-private helper.
    */
   protected convertFloatToBigDecimal(value: number): string {
-    if (this.precision !== undefined) {
-      return roundFloatToSignificantDigits(value, this.floatPrecision());
-    }
-    return String(value);
+    if (this.precision === undefined) return String(value);
+    const precision = this.floatPrecision();
+    if (precision <= 0) return String(value);
+    return roundFloatToSignificantDigits(value, precision);
   }
 
   /**

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -61,7 +61,8 @@ export class DecimalType extends ValueType<string> {
   }
 
   /**
-   * Mirrors: ActiveModel::Type::Decimal#convert_float_to_big_decimal
+   * Mirrors the float-conversion portion of
+   * ActiveModel::Type::Decimal#convert_float_to_big_decimal
    * (decimal.rb:75-81).
    *
    *   def convert_float_to_big_decimal(value)
@@ -72,11 +73,15 @@ export class DecimalType extends ValueType<string> {
    *     end
    *   end
    *
-   * Trails has no BigDecimal — decimals are strings — so the
-   * `BigDecimal(value, float_precision)` call translates to "round
-   * to `floatPrecision()` significant digits". When no precision is
-   * configured, fall through to `String(value)` (the same form
-   * `_castWithoutScale` would otherwise emit).
+   * Trails keeps the same overall cast pipeline but applies `scale:`
+   * later via the outer `castValue() → applyScale(...)` step rather
+   * than inside this helper, so the inner `apply_scale(value)` call
+   * Rails makes here is intentionally elided. Trails has no
+   * BigDecimal — decimals are strings — so the precision-sensitive
+   * portion translates to "round to `floatPrecision()` significant
+   * digits". When no precision is configured, fall through to
+   * `String(value)` (the same form `_castWithoutScale` would
+   * otherwise emit).
    *
    * @internal Rails-private helper.
    */
@@ -100,13 +105,16 @@ export class DecimalType extends ValueType<string> {
    *
    * Ruby `::Float::DIG` is 15 on IEEE-754 doubles; cap at 16 so we
    * never request more digits than the underlying representation can
-   * preserve. `precision.to_i` on `nil` gives `0` — matched by
-   * `precision ?? 0`.
+   * preserve. `precision.to_i` on `nil` gives `0`, truncates
+   * fractional values toward zero, and treats non-finite values as
+   * `0` — mirror that exactly so a fractional or NaN `precision:`
+   * doesn't trip `Number#toPrecision`'s integer requirement.
    *
    * @internal Rails-private helper.
    */
   protected floatPrecision(): number {
-    const p = this.precision ?? 0;
+    const raw = this.precision ?? 0;
+    const p = Number.isFinite(raw) ? Math.trunc(raw) : 0;
     return p > 16 ? 16 : p;
   }
 

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -40,9 +40,12 @@ export class DecimalType extends ValueType<string> {
     if (typeof value === "bigint") return value.toString();
     if (typeof value === "number") {
       if (!Number.isFinite(value)) return null;
-      // `String(0.1)` -> "0.1" — as precise as JS can represent the
-      // input. Callers who need full precision should pass a string.
-      return String(value);
+      // Rails dispatches Float through `convert_float_to_big_decimal`
+      // (decimal.rb:75-81). Route every JS number through the same hook
+      // so a configured `precision:` truncates per Rails — for Integer
+      // inputs the result still equals `String(value)` since precision
+      // capping is a no-op on whole numbers.
+      return this.convertFloatToBigDecimal(value);
     }
     if (typeof value === "string") {
       const trimmed = value.trim();
@@ -57,6 +60,56 @@ export class DecimalType extends ValueType<string> {
     return null;
   }
 
+  /**
+   * Mirrors: ActiveModel::Type::Decimal#convert_float_to_big_decimal
+   * (decimal.rb:75-81).
+   *
+   *   def convert_float_to_big_decimal(value)
+   *     if precision
+   *       BigDecimal(apply_scale(value), float_precision)
+   *     else
+   *       value.to_d
+   *     end
+   *   end
+   *
+   * Trails has no BigDecimal — decimals are strings — so the
+   * `BigDecimal(value, float_precision)` call translates to "round
+   * to `floatPrecision()` significant digits". When no precision is
+   * configured, fall through to `String(value)` (the same form
+   * `_castWithoutScale` would otherwise emit).
+   *
+   * @internal Rails-private helper.
+   */
+  protected convertFloatToBigDecimal(value: number): string {
+    if (this.precision !== undefined) {
+      return roundFloatToSignificantDigits(value, this.floatPrecision());
+    }
+    return String(value);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Decimal#float_precision (decimal.rb:83-89).
+   *
+   *   def float_precision
+   *     if precision.to_i > ::Float::DIG + 1
+   *       ::Float::DIG + 1
+   *     else
+   *       precision.to_i
+   *     end
+   *   end
+   *
+   * Ruby `::Float::DIG` is 15 on IEEE-754 doubles; cap at 16 so we
+   * never request more digits than the underlying representation can
+   * preserve. `precision.to_i` on `nil` gives `0` — matched by
+   * `precision ?? 0`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected floatPrecision(): number {
+    const p = this.precision ?? 0;
+    return p > 16 ? 16 : p;
+  }
+
   type(): string {
     return this.name;
   }
@@ -64,6 +117,21 @@ export class DecimalType extends ValueType<string> {
   typeCastForSchema(value: unknown): string {
     return JSON.stringify(value) ?? String(value);
   }
+}
+
+/**
+ * Round a JS number to `precision` significant digits, returning the
+ * decimal string. Used by `convertFloatToBigDecimal` to emulate
+ * Ruby's `BigDecimal(value, precision)`. Returns `String(value)` when
+ * `precision <= 0` (Rails treats `precision: nil` as no rounding).
+ */
+function roundFloatToSignificantDigits(value: number, precision: number): string {
+  if (precision <= 0 || !Number.isFinite(value)) return String(value);
+  // Number#toPrecision returns scientific notation for very small / large
+  // magnitudes; normalize back to plain decimal via Number(...) so the
+  // emitted string matches the rest of the cast pipeline.
+  const rounded = Number(value.toPrecision(precision));
+  return String(rounded);
 }
 
 const MAX_EXPONENT_EXPANSION = 4000;

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -42,9 +42,9 @@ export class DecimalType extends ValueType<string> {
       if (!Number.isFinite(value)) return null;
       // Rails dispatches Float through `convert_float_to_big_decimal`
       // (decimal.rb:75-81). Route every JS number through the same hook
-      // so a configured `precision:` truncates per Rails — for Integer
-      // inputs the result still equals `String(value)` since precision
-      // capping is a no-op on whole numbers.
+      // so a configured `precision:` applies the same significant-digit
+      // rounding per Rails; integer-valued inputs may still change when
+      // the value has more digits than `floatPrecision()` preserves.
       return this.convertFloatToBigDecimal(value);
     }
     if (typeof value === "string") {
@@ -135,11 +135,16 @@ export class DecimalType extends ValueType<string> {
  */
 function roundFloatToSignificantDigits(value: number, precision: number): string {
   if (precision <= 0 || !Number.isFinite(value)) return String(value);
-  // Number#toPrecision returns scientific notation for very small / large
-  // magnitudes; normalize back to plain decimal via Number(...) so the
-  // emitted string matches the rest of the cast pipeline.
+  // Number#toPrecision may emit scientific notation for very small / large
+  // magnitudes. Re-parse to a JS number for canonical rounding, then expand
+  // any exponent form back into a plain decimal string so the emitted value
+  // matches the rest of the cast pipeline (which feeds applyScale's regex
+  // matcher — that one rejects exponent forms).
   const rounded = Number(value.toPrecision(precision));
-  return String(rounded);
+  const parts = splitDecimal(String(rounded));
+  if (!parts) return String(rounded);
+  const { sign, intPart, fracPart } = parts;
+  return fracPart.length > 0 ? `${sign}${intPart}.${fracPart}` : `${sign}${intPart}`;
 }
 
 const MAX_EXPONENT_EXPANSION = 4000;

--- a/packages/activemodel/src/type/helpers/numeric.test.ts
+++ b/packages/activemodel/src/type/helpers/numeric.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { isNonNumericString, isNumberToNonNumber, isEqualNan } from "./numeric.js";
+
+describe("Helpers::Numeric private predicates", () => {
+  describe("isNonNumericString", () => {
+    it("returns false for strings starting with a digit", () => {
+      expect(isNonNumericString("1")).toBe(false);
+      expect(isNonNumericString("1abc")).toBe(false);
+      expect(isNonNumericString("  42")).toBe(false);
+    });
+
+    it("returns false for signed numeric strings", () => {
+      expect(isNonNumericString("+1")).toBe(false);
+      expect(isNonNumericString("-42")).toBe(false);
+      expect(isNonNumericString("  -7")).toBe(false);
+    });
+
+    it("returns true for strings without a leading digit", () => {
+      expect(isNonNumericString("wibble")).toBe(true);
+      expect(isNonNumericString("")).toBe(true);
+      expect(isNonNumericString("abc1")).toBe(true);
+      expect(isNonNumericString(".5")).toBe(true);
+    });
+  });
+
+  describe("isNumberToNonNumber", () => {
+    it("returns false when oldValue is null/undefined", () => {
+      expect(isNumberToNonNumber(null, "wibble")).toBe(false);
+      expect(isNumberToNonNumber(undefined, "wibble")).toBe(false);
+    });
+
+    it("returns false when newValueBeforeTypeCast is numeric", () => {
+      expect(isNumberToNonNumber(5, 7)).toBe(false);
+      expect(isNumberToNonNumber(5, 7n)).toBe(false);
+    });
+
+    it("returns true when oldValue is set and new raw input is non-numeric string", () => {
+      expect(isNumberToNonNumber(5, "wibble")).toBe(true);
+      expect(isNumberToNonNumber(0, "")).toBe(true);
+    });
+
+    it("returns false when new raw input is a numeric string", () => {
+      expect(isNumberToNonNumber(5, "7")).toBe(false);
+      expect(isNumberToNonNumber(5, "-3.14")).toBe(false);
+    });
+  });
+
+  describe("isEqualNan", () => {
+    it("returns true when both values are NaN", () => {
+      expect(isEqualNan(NaN, NaN)).toBe(true);
+    });
+
+    it("returns false when only one side is NaN", () => {
+      expect(isEqualNan(NaN, 0)).toBe(false);
+      expect(isEqualNan(0, NaN)).toBe(false);
+    });
+
+    it("returns false when neither side is NaN", () => {
+      expect(isEqualNan(1, 1)).toBe(false);
+      expect(isEqualNan(1, 2)).toBe(false);
+    });
+
+    it("returns false for non-number inputs", () => {
+      expect(isEqualNan("NaN", "NaN")).toBe(false);
+      expect(isEqualNan(null, null)).toBe(false);
+    });
+  });
+});

--- a/packages/activemodel/src/type/helpers/numeric.ts
+++ b/packages/activemodel/src/type/helpers/numeric.ts
@@ -33,3 +33,71 @@ export const NumericMixin = {
     return oldNum !== newNum;
   },
 };
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::Numeric::NUMERIC_REGEX
+ * (numeric.rb).
+ */
+const NUMERIC_REGEX = /^\s*[+-]?\d/;
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::Numeric#non_numeric_string?
+ * (numeric.rb):
+ *
+ *   def non_numeric_string?(value)
+ *     !NUMERIC_REGEX.match?(value)
+ *   end
+ *
+ * Used to decide whether a string would round-trip through `to_i`/`to_d`
+ * to a meaningful number — Rails treats "wibble" → 0 as a no-op when
+ * comparing dirty state, so this predicate filters those out.
+ *
+ * @internal Rails-private helper.
+ */
+export function isNonNumericString(value: unknown): boolean {
+  return !NUMERIC_REGEX.test(String(value));
+}
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::Numeric#number_to_non_number?
+ * (numeric.rb):
+ *
+ *   def number_to_non_number?(old_value, new_value_before_type_cast)
+ *     old_value != nil && !new_value_before_type_cast.is_a?(::Numeric) &&
+ *       non_numeric_string?(new_value_before_type_cast.to_s)
+ *   end
+ *
+ * @internal Rails-private helper.
+ */
+export function isNumberToNonNumber(oldValue: unknown, newValueBeforeTypeCast: unknown): boolean {
+  if (oldValue === null || oldValue === undefined) return false;
+  if (typeof newValueBeforeTypeCast === "number" || typeof newValueBeforeTypeCast === "bigint") {
+    return false;
+  }
+  return isNonNumericString(newValueBeforeTypeCast);
+}
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::Numeric#equal_nan?
+ * (numeric.rb):
+ *
+ *   def equal_nan?(old_value, new_value)
+ *     (old_value.is_a?(::Float) || old_value.is_a?(BigDecimal)) &&
+ *       old_value.nan? &&
+ *       old_value.instance_of?(new_value.class) &&
+ *       new_value.nan?
+ *   end
+ *
+ * Trails has no BigDecimal class, so the constructor-equality check
+ * collapses to "both are JS numbers and both are NaN".
+ *
+ * @internal Rails-private helper.
+ */
+export function isEqualNan(oldValue: unknown, newValue: unknown): boolean {
+  return (
+    typeof oldValue === "number" &&
+    Number.isNaN(oldValue) &&
+    typeof newValue === "number" &&
+    Number.isNaN(newValue)
+  );
+}

--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -62,6 +62,25 @@ describe("IntegerTest", () => {
     expect(type.cast("")).toBeNull();
   });
 
+  it("serialize raises ActiveModelRangeError for out-of-range values (default 4-byte limit)", () => {
+    // 2**31 — 1 over the default signed 4-byte upper bound
+    expect(() => type.serialize(2147483648)).toThrowError(/out of range for IntegerType/);
+    // -2**31 - 1 — 1 below the default signed 4-byte lower bound
+    expect(() => type.serialize(-2147483649)).toThrowError(/out of range for IntegerType/);
+  });
+
+  it("serialize honors a custom 1-byte limit", () => {
+    const tinyType = new Types.IntegerType({ limit: 1 });
+    expect(tinyType.serialize(127)).toBe(127);
+    expect(tinyType.serialize(-128)).toBe(-128);
+    expect(() => tinyType.serialize(128)).toThrowError(
+      /out of range for IntegerType with limit 1 bytes/,
+    );
+    expect(() => tinyType.serialize(-129)).toThrowError(
+      /out of range for IntegerType with limit 1 bytes/,
+    );
+  });
+
   it("values below int min value are out of range", () => {
     // JavaScript doesn't have the same integer limits as Ruby,
     // but we can test that very negative numbers still cast

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -1,15 +1,14 @@
 import { ValueType } from "./value.js";
 import { ActiveModelRangeError } from "../errors.js";
 
+/** Mirrors: ActiveModel::Type::Integer::DEFAULT_LIMIT (integer.rb:43). */
+const DEFAULT_LIMIT = 4;
+
 export class IntegerType extends ValueType<number> {
   readonly name: string = "integer";
-  private readonly _range: [number, number];
 
   constructor(options?: { precision?: number; scale?: number; limit?: number }) {
     super(options);
-    const byteLimit = this.limit ?? 4;
-    const max = 2 ** (byteLimit * 8 - 1);
-    this._range = [-max, max - 1];
   }
 
   /** @internal Rails-private helper. */
@@ -24,17 +23,7 @@ export class IntegerType extends ValueType<number> {
   }
 
   serialize(value: unknown): unknown {
-    const result = this.cast(value);
-    if (result !== null && (result < this._range[0] || result > this._range[1])) {
-      // Rails message shape
-      // (activemodel/lib/active_model/type/integer.rb:95):
-      //   "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
-      const klass = (this.constructor as { name: string }).name;
-      throw new ActiveModelRangeError(
-        `${result} is out of range for ${klass} with limit ${this.limit ?? 4} bytes`,
-      );
-    }
-    return result;
+    return this.ensureInRange(this.cast(value));
   }
 
   type(): string {
@@ -42,13 +31,96 @@ export class IntegerType extends ValueType<number> {
   }
 
   serializeCastValue(value: number | null): number | null {
-    return value;
+    return this.ensureInRange(value);
   }
 
   isSerializable(value: unknown): boolean {
     if (value === null || value === undefined) return true;
     const num = typeof value === "number" ? value : Number(value);
     if (isNaN(num)) return false;
-    return num >= this._range[0] && num <= this._range[1];
+    return this.isInRange(num);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#range (integer.rb:84).
+   * Rails: `attr_reader :range` over the half-open `min_value...max_value`.
+   * Exposed as a getter so subclasses can override; matches Rails'
+   * `private` accessor visibility.
+   *
+   * @internal Rails-private helper.
+   */
+  protected get range(): [number, number] {
+    return [this.minValue(), this.maxValue() - 1];
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#in_range? (integer.rb:88-90).
+   *   def in_range?(value)
+   *     !value || range.member?(value)
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected isInRange(value: number | null): boolean {
+    if (value == null) return true;
+    const [min, max] = this.range;
+    return value >= min && value <= max;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#ensure_in_range (integer.rb:96-101).
+   *   def ensure_in_range(value)
+   *     unless in_range?(value)
+   *       raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+   *     end
+   *     value
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected ensureInRange(value: number | null): number | null {
+    if (!this.isInRange(value)) {
+      const klass = (this.constructor as { name: string }).name;
+      throw new ActiveModelRangeError(
+        `${value} is out of range for ${klass} with limit ${this._limit()} bytes`,
+      );
+    }
+    return value;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#max_value (integer.rb:103-105).
+   *   def max_value
+   *     1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected maxValue(): number {
+    return 2 ** (this._limit() * 8 - 1);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#min_value (integer.rb:107-109).
+   *   def min_value
+   *     -max_value
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected minValue(): number {
+    return -this.maxValue();
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Integer#_limit (integer.rb:111-113).
+   *   def _limit
+   *     limit || DEFAULT_LIMIT
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected _limit(): number {
+    return this.limit ?? DEFAULT_LIMIT;
   }
 }

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -36,7 +36,18 @@ export class IntegerType extends ValueType<number> {
 
   isSerializable(value: unknown): boolean {
     if (value === null || value === undefined) return true;
-    const num = typeof value === "number" ? value : Number(value);
+    let num: number;
+    if (typeof value === "number") {
+      num = value;
+    } else {
+      // `Number(Symbol())` throws TypeError; catch so callers (e.g.
+      // Attribute.isSerializable) get `false` instead of an exception.
+      try {
+        num = Number(value);
+      } catch {
+        return false;
+      }
+    }
     if (isNaN(num)) return false;
     return this.isInRange(num);
   }


### PR DESCRIPTION
## Summary

Mirrors three Rails source files at `activemodel/lib/active_model/type/`:

- **`integer.rb`**: `range`, `in_range?`, `ensure_in_range`, `max_value`, `min_value`, `_limit`. `IntegerType.serialize` / `serializeCastValue` / `isSerializable` now compose these instead of duplicating the range arithmetic inline. `DEFAULT_LIMIT = 4` lifted as a file-level const.
- **`decimal.rb`**: `convert_float_to_big_decimal`, `float_precision`. Trails has no `BigDecimal`, so `convertFloatToBigDecimal` rounds through `Number#toPrecision(floatPrecision())` — equivalent for the cast pipeline since precisions `<= 0` fall through to `String(value)` (preserves existing default behavior). `_castWithoutScale` dispatches numbers through this hook so a configured `precision:` truncates per Rails. `floatPrecision()` mirrors Ruby's `precision.to_i` exactly: `Math.trunc` plus a `Number.isFinite` guard so a fractional or NaN `precision:` doesn't trip `Number#toPrecision`'s integer requirement.
- **`helpers/numeric.rb`**: `equal_nan?`, `number_to_non_number?`, `non_numeric_string?` exported as standalone predicate functions. `NUMERIC_REGEX` is a file-private const (only the predicate helpers cross the module boundary). Trails' BigDecimal collapse: `isEqualNan` checks `typeof === 'number' && Number.isNaN` for both sides since trails decimals are strings.

**Privates report delta:** activemodel privates 521/625 (83.4%) → 532/625 (85.1%). All three files at 100% (integer 13/13, decimal 6/6, numeric 7/7).

### Track
**B2** of `docs/activemodel-privates-100-plan.md`.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1609/1609 pass (added 2 `serialize`-range regression tests on default + custom `limit:`)
- [x] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` — 532/625 (85.1%)
- [ ] CI green