### PR TITLE
fix(arel): wave-1 fidelity bundle (from/key=/lower/cast/UnaryOperation)

### DIFF
--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -42,6 +42,15 @@ describe("TestFactoryMethods", () => {
     expect(fn.name).toBe("LOWER");
   });
 
+  // Mirrors Rails: `lower(column)` wraps non-Node arguments via
+  // `Nodes.build_quoted` (factory_methods.rb), so a string column resolves
+  // to LOWER('name') rather than rendering "[object Object]".
+  it("lower wraps non-Node arguments via buildQuoted", () => {
+    const fn = users.lower("name");
+    expect(fn.expressions[0]).toBeInstanceOf(Nodes.Quoted);
+    expect(new Visitors.ToSql().compile(fn)).toBe("LOWER('name')");
+  });
+
   it("coalesce", () => {
     const fn = users.coalesce(users.get("name"), new Nodes.Quoted("default"));
     expect(fn).toBeInstanceOf(Nodes.NamedFunction);
@@ -56,6 +65,18 @@ describe("TestFactoryMethods", () => {
     // not a string-interpolated SqlLiteral. The compiled SQL must reference
     // the column properly rather than "[object Object] AS VARCHAR".
     expect(new Visitors.ToSql().compile(fn)).toBe('CAST("users"."age" AS VARCHAR)');
+  });
+
+  // Mirrors Rails: delegating to `name.as(type)` produces an `As` whose
+  // alias is a *retryable* SqlLiteral (factory_methods.rb / alias_predication.rb),
+  // not a plain SqlLiteral.
+  it("cast delegates to .as(type) for a retryable alias", () => {
+    const fn = users.cast(users.get("age"), "VARCHAR");
+    const asNode = fn.expressions[0] as Nodes.As;
+    expect(asNode).toBeInstanceOf(Nodes.As);
+    const right = asNode.right as Nodes.SqlLiteral;
+    expect(right).toBeInstanceOf(Nodes.SqlLiteral);
+    expect(right.retryable).toBe(true);
   });
 
   it("create true", () => {

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -1,6 +1,6 @@
 import type { Node } from "./nodes/node.js";
 import { And } from "./nodes/and.js";
-import { As } from "./nodes/binary.js";
+import { buildQuoted } from "./nodes/casted.js";
 import type { Join } from "./nodes/binary.js";
 import { False } from "./nodes/false.js";
 import { Grouping } from "./nodes/grouping.js";
@@ -42,9 +42,9 @@ export interface FactoryMethodsModule {
   createAnd(clauses: Node[]): And;
   createOn(expr: Node): On;
   grouping(expr: Node): Grouping;
-  lower(column: Node): NamedFunction;
+  lower(column: unknown): NamedFunction;
   coalesce(...exprs: Node[]): NamedFunction;
-  cast(expr: Node, type: string): NamedFunction;
+  cast(expr: Node & { as: (type: string) => Node }, type: string): NamedFunction;
 }
 
 export const FactoryMethods: FactoryMethodsModule = {
@@ -86,19 +86,18 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new Grouping(expr);
   },
 
-  lower(column: Node): NamedFunction {
-    return new NamedFunction("LOWER", [column]);
+  lower(column: unknown): NamedFunction {
+    return new NamedFunction("LOWER", [buildQuoted(column)]);
   },
 
   coalesce(...exprs: Node[]): NamedFunction {
     return new NamedFunction("COALESCE", exprs);
   },
 
-  // Mirrors: Arel::FactoryMethods#cast — `Nodes::NamedFunction.new "CAST",
-  // [name.as(type)]`. Builds an `As` AST node so the visitor compiles it
-  // correctly (`CAST(expr AS type)`); the previous string-interpolation
-  // form stringified Node instances as `"[object Object]"`.
-  cast(expr: Node, type: string): NamedFunction {
-    return new NamedFunction("CAST", [new As(expr, new SqlLiteral(type))]);
+  // Mirrors: Arel::FactoryMethods#cast — `NamedFunction.new "CAST",
+  // [name.as(type)]`. Delegating to `name.as(type)` lets the receiver
+  // build an `As` with a retryable SqlLiteral alias, matching Rails.
+  cast(expr: Node & { as: (type: string) => Node }, type: string): NamedFunction {
+    return new NamedFunction("CAST", [expr.as(type)]);
   },
 };

--- a/packages/arel/src/nodes/unary-operation.test.ts
+++ b/packages/arel/src/nodes/unary-operation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, Nodes } from "../index.js";
+import { Table, Nodes, Visitors } from "../index.js";
 
 describe("TestUnaryOperation", () => {
   const users = new Table("users");
@@ -43,5 +43,13 @@ describe("TestUnaryOperation", () => {
     expect(ordering).toBeInstanceOf(Nodes.Descending);
     expect(ordering.expr).toBe(node);
     expect(ordering.isDescending()).toBe(true);
+  });
+
+  // Mirrors Rails: `visit_Arel_Nodes_UnaryOperation` emits ` #{operator} `
+  // verbatim (visitors/to_sql.rb), so internal whitespace in the operator
+  // is preserved rather than trimmed.
+  it("visitor preserves operator whitespace verbatim", () => {
+    const node = new Nodes.UnaryOperation("- ", users.get("age"));
+    expect(new Visitors.ToSql().compile(node)).toBe(' -  "users"."age"');
   });
 });

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -101,6 +101,22 @@ describe("SelectManagerTest", () => {
         mgr1.from(as);
         expect(mgr1.toSql()).toContain("lol");
       });
+
+      // Mirrors Rails: `from(table)` (select_manager.rb) routes a Join
+      // node to `source.right` so callers can build cross-product FROMs
+      // like `FROM users INNER JOIN posts ON ...` via `from(joinNode)`.
+      it("routes a Join to source.right rather than overwriting source.left", () => {
+        const mgr = new SelectManager();
+        mgr.from(users);
+        const join = new Nodes.InnerJoin(
+          posts,
+          new Nodes.On(users.get("id").eq(posts.get("user_id"))),
+        );
+        mgr.from(join);
+        const core = mgr.ast.cores[0];
+        expect(core.source.left).toBe(users);
+        expect(core.source.right).toContain(join);
+      });
     });
 
     describe("having", () => {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -5,8 +5,7 @@ import { SelectCore } from "./nodes/select-core.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Distinct } from "./nodes/terminal.js";
 import { Offset, Limit, Lock, On, DistinctOn, Group } from "./nodes/unary.js";
-import { CrossJoin } from "./nodes/binary.js";
-import type { Join } from "./nodes/binary.js";
+import { CrossJoin, Join } from "./nodes/binary.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
 import { RightOuterJoin } from "./nodes/right-outer-join.js";
@@ -54,10 +53,11 @@ export class SelectManager extends TreeManager {
    * Set the FROM table.
    */
   from(table: Table | Node | string): this {
-    if (typeof table === "string") {
-      this.core.source.left = new SqlLiteral(table);
+    const node = typeof table === "string" ? new SqlLiteral(table) : table;
+    if (node instanceof Join) {
+      this.core.source.right.push(node);
     } else {
-      this.core.source.left = table;
+      this.core.source.left = node;
     }
     return this;
   }

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -42,7 +42,9 @@ export class StatementMethods {
   }
 
   set key(key: unknown) {
-    (this as unknown as StatementMethodsHost).ast.key = key;
+    (this as unknown as StatementMethodsHost).ast.key = Array.isArray(key)
+      ? key.map((k) => buildQuoted(k))
+      : buildQuoted(key);
   }
 
   get key(): unknown {

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -209,4 +209,35 @@ describe("UpdateManagerTest", () => {
       expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
     });
   });
+
+  // Mirrors Rails: `tree_manager.rb` `key=` calls `Nodes.build_quoted` on
+  // scalar values and maps over arrays, so the AST always holds Quoted
+  // (or pass-through Node) values rather than raw primitives.
+  describe("key=", () => {
+    it("wraps a scalar value in Quoted", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      um.key = 5;
+      expect(um.ast.key).toBeInstanceOf(Nodes.Quoted);
+      expect((um.ast.key as Nodes.Quoted).value).toBe(5);
+    });
+
+    it("maps an array, wrapping each element in Quoted", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      um.key = [1, 2];
+      const arr = um.ast.key as unknown as Nodes.Quoted[];
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.every((q) => q instanceof Nodes.Quoted)).toBe(true);
+      expect(arr.map((q) => q.value)).toEqual([1, 2]);
+    });
+
+    it("passes existing Nodes through unwrapped", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      const lit = new Nodes.SqlLiteral("id");
+      um.key = lit;
+      expect(um.ast.key).toBe(lit);
+    });
+  });
 });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1275,11 +1275,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // -- UnaryOperation --
 
   private visitArelNodesUnaryOperation(node: Nodes.UnaryOperation): SQLString {
-    // Rails emits ` ${operator} ` — space on both sides — so the operator
-    // sits free of surrounding tokens wherever it lands in an expression.
-    // Trim the operator first so callers who construct with decorative
-    // whitespace (e.g. "NOT ") don't get double spaces in the output.
-    this.collector.append(` ${node.operator.trim()} `);
+    // Mirrors Rails: `collector << " #{o.operator} "` (visitors/to_sql.rb).
+    // The operator is emitted verbatim with a space on each side; callers
+    // are responsible for the operator's own whitespace.
+    this.collector.append(` ${node.operator} `);
     this.visit(node.operand);
     return this.collector;
   }


### PR DESCRIPTION
## Summary

Bundles four small Rails-fidelity fixes from [`docs/arel-alignment-plan.md`](../blob/main/docs/arel-alignment-plan.md), all independent and theme-coherent (touch one method each on disjoint files).

- **PR 13** — `SelectManager#from` now routes a `Join` to `core.source.right` rather than overwriting `core.source.left`, matching [`select_manager.rb`'s `case … when Nodes::Join`](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/select_manager.rb).
- **PR 18** — `TreeManager#key=` calls `Nodes.build_quoted` on scalars and maps over arrays, matching `tree_manager.rb`.
- **PR 19** — `FactoryMethods#lower` wraps non-Node arguments via `build_quoted`; `#cast` delegates to `name.as(type)` so the alias is a retryable `SqlLiteral`, matching `factory_methods.rb`.
- **PR 20** — `visit_Arel_Nodes_UnaryOperation` no longer `trim()`s the operator, matching `visitors/to_sql.rb`'s verbatim `" #{operator} "` emission.

99 insertions / 23 deletions.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1222/1222 (added one targeted test per PR).
- [x] `pnpm exec vitest run packages/activerecord/` — 9941 passed, no regressions.
- [x] `pnpm -w build` — clean.