### PR TITLE
feat(activesupport): time-ext arithmetic helpers return Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -122,8 +122,8 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("change", () => {
-    expect(changeDate(d(2005, 2, 11), { day: 21 }).getDate()).toBe(21);
-    const changed = changeDate(d(2005, 2, 11), { year: 2007, month: 5 });
+    expect(asDate(changeDate(d(2005, 2, 11), { day: 21 })).getDate()).toBe(21);
+    const changed = asDate(changeDate(d(2005, 2, 11), { year: 2007, month: 5 }));
     expect(changed.getFullYear()).toBe(2007);
     expect(changed.getMonth()).toBe(4); // May
     expect(changed.getDate()).toBe(11);
@@ -137,21 +137,21 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("last year in calendar reform", () => {
-    const result = advance(d(1583, 10, 14), { years: -1 });
+    const result = asDate(advance(d(1583, 10, 14), { years: -1 }));
     expect(result.getFullYear()).toBe(1582);
   });
 
   it("advance does first years and then days", () => {
-    expect(advance(d(2011, 2, 28), { years: 1, days: 1 })).toEqual(d(2012, 2, 29));
+    expect(asDate(advance(d(2011, 2, 28), { years: 1, days: 1 }))).toEqual(d(2012, 2, 29));
   });
 
   it("advance does first months and then days", () => {
-    expect(advance(d(2010, 2, 28), { months: 1, days: 1 })).toEqual(d(2010, 3, 29));
+    expect(asDate(advance(d(2010, 2, 28), { months: 1, days: 1 }))).toEqual(d(2010, 3, 29));
   });
 
   it("advance in calendar reform", () => {
-    expect(advance(d(1582, 10, 4), { days: 1 }).getDate()).toBe(5);
-    expect(advance(d(1582, 10, 15), { days: -1 }).getDate()).toBe(14);
+    expect(asDate(advance(d(1582, 10, 4), { days: 1 })).getDate()).toBe(5);
+    expect(asDate(advance(d(1582, 10, 15), { days: -1 })).getDate()).toBe(14);
   });
 
   it("last week", () => {
@@ -163,7 +163,7 @@ describe("DateExtCalculationsTest", () => {
   it("last quarter on 31st", () => {
     const dt = d(2004, 5, 31);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
+    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(0); // January
   });
 
@@ -197,7 +197,7 @@ describe("DateExtCalculationsTest", () => {
   it.skip("tomorrow constructor when zone is set");
 
   it("since", () => {
-    const result = since(d(2005, 2, 21), 45);
+    const result = asDate(since(d(2005, 2, 21), 45));
     expect(result.getSeconds()).toBe(45);
     expect(result.getDate()).toBe(21);
   });
@@ -205,7 +205,7 @@ describe("DateExtCalculationsTest", () => {
   it.skip("since when zone is set");
 
   it("ago", () => {
-    const result = ago(d(2005, 2, 21), 45);
+    const result = asDate(ago(d(2005, 2, 21), 45));
     expect(result.getDate()).toBe(20);
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
@@ -307,12 +307,12 @@ describe("DateExtCalculationsTest", () => {
 
   it("last year in leap years", () => {
     const date = d(2012, 6, 15);
-    const result = advance(date, { years: -1 });
+    const result = asDate(advance(date, { years: -1 }));
     expect(result.getFullYear()).toBe(2011);
   });
 
   it("advance", () => {
-    expect(advance(d(2005, 1, 31), { months: 1 })).toEqual(d(2005, 2, 28));
+    expect(asDate(advance(d(2005, 1, 31), { months: 1 }))).toEqual(d(2005, 2, 28));
   });
 
   it("beginning of day", () => {

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -123,20 +123,20 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("change", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(dt, { year: 2006 });
+    const result = asDate(changeDate(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 
   it("advance partial days", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = advance(dt, { hours: 12 });
+    const result = asDate(advance(dt, { hours: 12 }));
     expect(result.getDate()).toBe(23);
     expect(result.getHours()).toBe(3);
   });
 
   it("advanced processes first the date deltas and then the time deltas", () => {
     const dt = d(2005, 2, 28, 15, 15, 10);
-    const result = advance(dt, { months: 1, days: 1 });
+    const result = asDate(advance(dt, { months: 1, days: 1 }));
     expect(result.getMonth()).toBe(2); // March
     expect(result.getDate()).toBe(29);
   });
@@ -158,7 +158,7 @@ describe("DateTimeExtCalculationsTest", () => {
   it("last quarter on 31st", () => {
     const dt = d(2005, 10, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
+    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(6); // July
   });
 
@@ -403,16 +403,16 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("ago", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(ago(dt, 1)).toEqual(d(2005, 2, 22, 10, 10, 9));
+    expect(asDate(ago(dt, 1))).toEqual(d(2005, 2, 22, 10, 10, 9));
   });
 
   it("since", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(since(dt, 1)).toEqual(d(2005, 2, 22, 10, 10, 11));
+    expect(asDate(since(dt, 1))).toEqual(d(2005, 2, 22, 10, 10, 11));
   });
 
   it("advance", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    expect(advance(dt, { years: 1 })).toEqual(d(2006, 2, 22, 15, 15, 10));
+    expect(asDate(advance(dt, { years: 1 }))).toEqual(d(2006, 2, 22, 15, 15, 10));
   });
 });

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -98,14 +98,14 @@ describe("TimeExtCalculationsTest", () => {
 
   it("floor", () => {
     const t = new Date(2005, 1, 4, 10, 10, 10, 500);
-    const result = floor(t, 1000);
+    const result = asDate(floor(t, 1000));
     expect(result.getMilliseconds()).toBe(0);
     expect(result.getSeconds()).toBe(10);
   });
 
   it("ceil", () => {
     const t = new Date(2005, 1, 4, 10, 10, 10, 1);
-    const result = ceil(t, 1000);
+    const result = asDate(ceil(t, 1000));
     expect(result.getMilliseconds()).toBe(0);
     expect(result.getSeconds()).toBe(11);
   });
@@ -115,7 +115,7 @@ describe("TimeExtCalculationsTest", () => {
       // dt: US: 2005 April 3rd 4:18am
       // ago(86400) = subtract 86400 seconds (simple time arithmetic)
       const dt = new Date(2005, 3, 3, 4, 18, 0); // April 3 EDT
-      const result = ago(dt, 86400);
+      const result = asDate(ago(dt, 86400));
       expect(result.getFullYear()).toBe(2005);
       expect(result.getMonth()).toBe(3); // April
       expect(result.getDate()).toBe(2);
@@ -128,7 +128,7 @@ describe("TimeExtCalculationsTest", () => {
     withEnvTz("America/New_York", () => {
       // st: US: 2005 October 30th 4:03am
       const st = new Date(2005, 9, 30, 4, 3, 0); // Oct 30 EST
-      const result = ago(st, 86400);
+      const result = asDate(ago(st, 86400));
       expect(result.getFullYear()).toBe(2005);
       expect(result.getMonth()).toBe(9);
       expect(result.getDate()).toBe(29);
@@ -141,7 +141,7 @@ describe("TimeExtCalculationsTest", () => {
     withEnvTz("America/New_York", () => {
       // advance(days: -1) uses calendar arithmetic
       const dt = new Date(2005, 3, 3, 4, 18, 0);
-      const result = advance(dt, { days: -1 });
+      const result = asDate(advance(dt, { days: -1 }));
       expect(result.getDate()).toBe(2);
       expect(result.getHours()).toBe(4);
       expect(result.getMinutes()).toBe(18);
@@ -151,7 +151,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings backward end 1day", () => {
     withEnvTz("America/New_York", () => {
       const st = new Date(2005, 9, 30, 4, 3, 0);
-      const result = advance(st, { days: -1 });
+      const result = asDate(advance(st, { days: -1 }));
       expect(result.getDate()).toBe(29);
       expect(result.getHours()).toBe(4);
       expect(result.getMinutes()).toBe(3);
@@ -160,14 +160,14 @@ describe("TimeExtCalculationsTest", () => {
 
   it("since with instance of time deprecated", () => {
     const t = d(2005, 2, 22, 10, 10, 10);
-    expect(since(t, 1)).toEqual(d(2005, 2, 22, 10, 10, 11));
+    expect(asDate(since(t, 1))).toEqual(d(2005, 2, 22, 10, 10, 11));
   });
 
   it("daylight savings time crossings forward start", () => {
     withEnvTz("America/New_York", () => {
       // st: US: 2005 April 2nd 7:27pm
       const st = new Date(2005, 3, 2, 19, 27, 0);
-      const result = since(st, 86400);
+      const result = asDate(since(st, 86400));
       expect(result.getMonth()).toBe(3); // April
       expect(result.getDate()).toBe(3);
       expect(result.getHours()).toBe(20); // 8:27pm EDT (gained 1 hour)
@@ -178,7 +178,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings forward start 1day", () => {
     withEnvTz("America/New_York", () => {
       const st = new Date(2005, 3, 2, 19, 27, 0);
-      const result = advance(st, { days: 1 });
+      const result = asDate(advance(st, { days: 1 }));
       expect(result.getDate()).toBe(3);
       expect(result.getHours()).toBe(19);
       expect(result.getMinutes()).toBe(27);
@@ -209,7 +209,7 @@ describe("TimeExtCalculationsTest", () => {
     withEnvTz("America/New_York", () => {
       // dt: US: 2005 October 30th 12:45am
       const dt = new Date(2005, 9, 30, 0, 45, 0);
-      const result = since(dt, 86400);
+      const result = asDate(since(dt, 86400));
       expect(result.getDate()).toBe(30);
       expect(result.getHours()).toBe(23);
       expect(result.getMinutes()).toBe(45);
@@ -219,7 +219,7 @@ describe("TimeExtCalculationsTest", () => {
   it("daylight savings time crossings forward end 1day", () => {
     withEnvTz("America/New_York", () => {
       const dt = new Date(2005, 9, 30, 0, 45, 0);
-      const result = advance(dt, { days: 1 });
+      const result = asDate(advance(dt, { days: 1 }));
       expect(result.getDate()).toBe(31);
       expect(result.getHours()).toBe(0);
       expect(result.getMinutes()).toBe(45);
@@ -247,28 +247,32 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("change", () => {
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2006 })).toEqual(
+    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2006 }))).toEqual(
       d(2006, 2, 22, 15, 15, 10),
     );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { month: 6 })).toEqual(
+    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { month: 6 }))).toEqual(
       d(2005, 6, 22, 15, 15, 10),
     );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2012, month: 9 })).toEqual(
+    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2012, month: 9 }))).toEqual(
       d(2012, 9, 22, 15, 15, 10),
     );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 })).toEqual(d(2005, 2, 22, 16, 0, 0));
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(d(2005, 2, 22, 15, 45, 0));
+    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 }))).toEqual(
+      d(2005, 2, 22, 16, 0, 0),
+    );
+    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 }))).toEqual(
+      d(2005, 2, 22, 15, 45, 0),
+    );
   });
 
   it("utc change", () => {
     const t1 = utc(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(t1, { year: 2006 });
+    const result = asDate(changeDate(t1, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 
   it("offset change", () => {
     const t = d(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(t, { year: 2006 });
+    const result = asDate(changeDate(t, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getHours()).toBe(15);
     expect(result.getMinutes()).toBe(15);
@@ -277,7 +281,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("change offset", () => {
     const t = d(2006, 2, 22, 15, 15, 10);
-    const result = changeDate(t, { year: 2006 });
+    const result = asDate(changeDate(t, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getHours()).toBe(15);
   });
@@ -290,31 +294,31 @@ describe("TimeExtCalculationsTest", () => {
 
   it("utc advance", () => {
     const t = utc(2005, 2, 22, 15, 15, 10);
-    expect(advance(t, { years: 1 }).getUTCFullYear()).toBe(2006);
-    expect(advance(t, { months: 4 }).getUTCMonth()).toBe(5); // June
-    expect(advance(t, { hours: 5 }).getUTCHours()).toBe(20);
-    expect(advance(t, { minutes: 7 }).getUTCMinutes()).toBe(22);
-    expect(advance(t, { seconds: 9 }).getUTCSeconds()).toBe(19);
+    expect(asDate(advance(t, { years: 1 })).getUTCFullYear()).toBe(2006);
+    expect(asDate(advance(t, { months: 4 })).getUTCMonth()).toBe(5); // June
+    expect(asDate(advance(t, { hours: 5 })).getUTCHours()).toBe(20);
+    expect(asDate(advance(t, { minutes: 7 })).getUTCMinutes()).toBe(22);
+    expect(asDate(advance(t, { seconds: 9 })).getUTCSeconds()).toBe(19);
   });
 
   it("offset advance", () => {
     const t = d(2005, 2, 22, 15, 15, 10);
-    expect(advance(t, { years: 1 }).getFullYear()).toBe(2006);
-    expect(advance(t, { months: 4 }).getMonth()).toBe(5); // June
-    expect(advance(t, { hours: 5 }).getHours()).toBe(20);
-    expect(advance(t, { minutes: 7 }).getMinutes()).toBe(22);
-    expect(advance(t, { seconds: 9 }).getSeconds()).toBe(19);
+    expect(asDate(advance(t, { years: 1 })).getFullYear()).toBe(2006);
+    expect(asDate(advance(t, { months: 4 })).getMonth()).toBe(5); // June
+    expect(asDate(advance(t, { hours: 5 })).getHours()).toBe(20);
+    expect(asDate(advance(t, { minutes: 7 })).getMinutes()).toBe(22);
+    expect(asDate(advance(t, { seconds: 9 })).getSeconds()).toBe(19);
   });
 
   it("advance with nsec", () => {
     const t = new Date(108.635108);
     const result = advance(t, { months: 0 });
-    expect(result.getTime()).toBe(t.getTime());
+    expect(result.epochMilliseconds).toBe(t.getTime());
   });
 
   it("advance gregorian proleptic", () => {
-    expect(advance(d(1582, 10, 15, 15, 15, 10), { days: -1 }).getDate()).toBe(14);
-    expect(advance(d(1582, 10, 14, 15, 15, 10), { days: 1 }).getDate()).toBe(15);
+    expect(asDate(advance(d(1582, 10, 15, 15, 15, 10), { days: -1 })).getDate()).toBe(14);
+    expect(asDate(advance(d(1582, 10, 14, 15, 15, 10), { days: 1 })).getDate()).toBe(15);
   });
 
   it.skip("advance preserves offset for local times around end of dst");
@@ -389,7 +393,7 @@ describe("TimeExtCalculationsTest", () => {
   it("fp inaccuracy ticket 1836", () => {
     const t = d(2005, 2, 21, 0, 0, 0);
     const result = advance(t, { seconds: 0.1 });
-    expect(result instanceof Date).toBe(true);
+    expect(typeof result.epochMilliseconds).toBe("number");
   });
 
   it("days in month with year", () => {
@@ -685,28 +689,30 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("ago", () => {
-    expect(ago(d(2005, 2, 22, 10, 10, 10), 1)).toEqual(d(2005, 2, 22, 10, 10, 9));
-    expect(ago(d(2005, 2, 22, 10, 10, 10), 3600)).toEqual(d(2005, 2, 22, 9, 10, 10));
-    expect(ago(d(2005, 2, 22, 10, 10, 10), 86400 * 2)).toEqual(d(2005, 2, 20, 10, 10, 10));
-    expect(ago(d(2005, 2, 22, 10, 10, 10), 86400 * 2 + 3600 + 25)).toEqual(
+    expect(asDate(ago(d(2005, 2, 22, 10, 10, 10), 1))).toEqual(d(2005, 2, 22, 10, 10, 9));
+    expect(asDate(ago(d(2005, 2, 22, 10, 10, 10), 3600))).toEqual(d(2005, 2, 22, 9, 10, 10));
+    expect(asDate(ago(d(2005, 2, 22, 10, 10, 10), 86400 * 2))).toEqual(d(2005, 2, 20, 10, 10, 10));
+    expect(asDate(ago(d(2005, 2, 22, 10, 10, 10), 86400 * 2 + 3600 + 25))).toEqual(
       d(2005, 2, 20, 9, 9, 45),
     );
   });
 
   it("since", () => {
-    expect(since(d(2005, 2, 22, 10, 10, 10), 1)).toEqual(d(2005, 2, 22, 10, 10, 11));
-    expect(since(d(2005, 2, 22, 10, 10, 10), 3600)).toEqual(d(2005, 2, 22, 11, 10, 10));
-    expect(since(d(2005, 2, 22, 10, 10, 10), 86400 * 2)).toEqual(d(2005, 2, 24, 10, 10, 10));
-    expect(since(d(2005, 2, 22, 10, 10, 10), 86400 * 2 + 3600 + 25)).toEqual(
+    expect(asDate(since(d(2005, 2, 22, 10, 10, 10), 1))).toEqual(d(2005, 2, 22, 10, 10, 11));
+    expect(asDate(since(d(2005, 2, 22, 10, 10, 10), 3600))).toEqual(d(2005, 2, 22, 11, 10, 10));
+    expect(asDate(since(d(2005, 2, 22, 10, 10, 10), 86400 * 2))).toEqual(
+      d(2005, 2, 24, 10, 10, 10),
+    );
+    expect(asDate(since(d(2005, 2, 22, 10, 10, 10), 86400 * 2 + 3600 + 25))).toEqual(
       d(2005, 2, 24, 11, 10, 35),
     );
   });
 
   it("advance", () => {
     const t = d(2005, 1, 22, 15, 15, 10);
-    expect(advance(t, { years: 1 })).toEqual(d(2006, 1, 22, 15, 15, 10));
-    expect(advance(t, { months: 1 })).toEqual(d(2005, 2, 22, 15, 15, 10));
-    expect(advance(t, { days: 1 })).toEqual(d(2005, 1, 23, 15, 15, 10));
+    expect(asDate(advance(t, { years: 1 }))).toEqual(d(2006, 1, 22, 15, 15, 10));
+    expect(asDate(advance(t, { months: 1 }))).toEqual(d(2005, 2, 22, 15, 15, 10));
+    expect(asDate(advance(t, { days: 1 }))).toEqual(d(2005, 1, 23, 15, 15, 10));
   });
 
   it("prev day with time local", () => {

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -142,55 +142,55 @@ describe("TimeExtCalculationsTest", () => {
 
   it("change (changeDate)", () => {
     expect(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2006 })).toEqual(
-      d(2006, 2, 22, 15, 15, 10),
+      i(2006, 2, 22, 15, 15, 10),
     );
     expect(changeDate(d(2005, 2, 22, 15, 15, 10), { month: 6 })).toEqual(
-      d(2005, 6, 22, 15, 15, 10),
+      i(2005, 6, 22, 15, 15, 10),
     );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 })).toEqual(d(2005, 2, 22, 16, 0, 0));
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(d(2005, 2, 22, 15, 45, 0));
+    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 })).toEqual(i(2005, 2, 22, 16, 0, 0));
+    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(i(2005, 2, 22, 15, 45, 0));
   });
 
   it("advance years", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { years: 1 })).toEqual(d(2006, 2, 28, 15, 15, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { years: 1 })).toEqual(i(2006, 2, 28, 15, 15, 10));
   });
 
   it("advance months", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { months: 4 })).toEqual(d(2005, 6, 28, 15, 15, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { months: 4 })).toEqual(i(2005, 6, 28, 15, 15, 10));
   });
 
   it("advance weeks", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { weeks: 3 })).toEqual(d(2005, 3, 21, 15, 15, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { weeks: 3 })).toEqual(i(2005, 3, 21, 15, 15, 10));
   });
 
   it("advance days", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { days: 5 })).toEqual(d(2005, 3, 5, 15, 15, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { days: 5 })).toEqual(i(2005, 3, 5, 15, 15, 10));
   });
 
   it("advance hours", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { hours: 5 })).toEqual(d(2005, 2, 28, 20, 15, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { hours: 5 })).toEqual(i(2005, 2, 28, 20, 15, 10));
   });
 
   it("advance minutes", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { minutes: 7 })).toEqual(d(2005, 2, 28, 15, 22, 10));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { minutes: 7 })).toEqual(i(2005, 2, 28, 15, 22, 10));
   });
 
   it("advance seconds", () => {
-    expect(advance(d(2005, 2, 28, 15, 15, 10), { seconds: 9 })).toEqual(d(2005, 2, 28, 15, 15, 19));
+    expect(advance(d(2005, 2, 28, 15, 15, 10), { seconds: 9 })).toEqual(i(2005, 2, 28, 15, 15, 19));
   });
 
   it("advance combined", () => {
     expect(advance(d(2005, 2, 28, 15, 15, 10), { years: 7, months: 7 })).toEqual(
-      d(2012, 9, 28, 15, 15, 10),
+      i(2012, 9, 28, 15, 15, 10),
     );
     expect(advance(d(2005, 2, 28, 15, 15, 10), { years: -3, months: -2, days: -1 })).toEqual(
-      d(2001, 12, 27, 15, 15, 10),
+      i(2001, 12, 27, 15, 15, 10),
     );
   });
 
   it("advance leap day plus one year", () => {
     // Feb 29 + 1 year = Feb 28
-    expect(advance(d(2004, 2, 29, 15, 15, 10), { years: 1 })).toEqual(d(2005, 2, 28, 15, 15, 10));
+    expect(advance(d(2004, 2, 29, 15, 15, 10), { years: 1 })).toEqual(i(2005, 2, 28, 15, 15, 10));
   });
 
   it("next_week", () => {
@@ -315,14 +315,14 @@ describe("TimeExtCalculationsTest", () => {
 
   it("floor", () => {
     const t = new Date(2005, 1, 4, 10, 10, 10, 500);
-    const result = floor(t, 1000); // floor to nearest second
+    const result = asDate(floor(t, 1000)); // floor to nearest second
     expect(result.getMilliseconds()).toBe(0);
     expect(result.getSeconds()).toBe(10);
   });
 
   it("ceil", () => {
     const t = new Date(2005, 1, 4, 10, 10, 10, 1);
-    const result = ceil(t, 1000); // ceil to nearest second
+    const result = asDate(ceil(t, 1000)); // ceil to nearest second
     expect(result.getMilliseconds()).toBe(0);
     expect(result.getSeconds()).toBe(11);
   });
@@ -441,7 +441,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("change", () => {
     const t = d(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(t, { year: 2006, month: 6, day: 1 });
+    const result = asDate(changeDate(t, { year: 2006, month: 6, day: 1 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(5); // June
     expect(result.getDate()).toBe(1);
@@ -450,7 +450,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("since with instance of time deprecated", () => {
     const t = d(2005, 2, 22, 10, 10, 10);
-    expect(since(t, 1)).toEqual(d(2005, 2, 22, 10, 10, 11));
+    expect(since(t, 1)).toEqual(i(2005, 2, 22, 10, 10, 11));
   });
 
   it("today with time utc", () => {
@@ -559,7 +559,7 @@ describe("TimeExtCalculationsTest", () => {
     // July 31 -> last quarter = Q1 start = January 1
     const t = d(2005, 7, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(t);
-    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
+    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(3); // April
   });
 
@@ -567,7 +567,7 @@ describe("TimeExtCalculationsTest", () => {
     // Test that floating point arithmetic doesn't cause issues
     const t = d(2005, 2, 22, 10, 10, 10);
     const result = advance(t, { seconds: 0.1 });
-    expect(result instanceof Date).toBe(true);
+    expect(result).toBeInstanceOf(Temporal.Instant);
   });
 });
 
@@ -650,7 +650,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("advance date with months overflow", () => {
     // Jan 31 + 1 month = Feb 28
-    expect(advance(d(2005, 1, 31), { months: 1 })).toEqual(d(2005, 2, 28));
+    expect(advance(d(2005, 1, 31), { months: 1 })).toEqual(i(2005, 2, 28));
   });
 
   it("next_week various days", () => {
@@ -694,7 +694,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("change", () => {
     const date = d(2005, 2, 21);
-    const result = changeDate(date, { year: 2006 });
+    const result = asDate(changeDate(date, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(1); // February
     expect(result.getDate()).toBe(21);
@@ -709,12 +709,12 @@ describe("DateExtCalculationsTest", () => {
 
   it("advance does first years and then days", () => {
     // 2012 is a leap year (Feb 29), advance by 1 year -> 2013 (no Feb 29, so Feb 28)
-    expect(advance(d(2012, 2, 29), { years: 1 })).toEqual(d(2013, 2, 28));
+    expect(advance(d(2012, 2, 29), { years: 1 })).toEqual(i(2013, 2, 28));
   });
 
   it("advance does first months and then days", () => {
     // Jan 29 + 1 month = Feb 28 (non-leap)
-    expect(advance(d(2005, 1, 29), { months: 1 })).toEqual(d(2005, 2, 28));
+    expect(advance(d(2005, 1, 29), { months: 1 })).toEqual(i(2005, 2, 28));
   });
 
   it("yesterday constructor", () => {
@@ -734,7 +734,7 @@ describe("DateExtCalculationsTest", () => {
     const dt = d(2005, 10, 31);
     const quarterStart = beginningOfQuarter(dt);
     // last quarter = go back 3 months from current quarter start
-    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
+    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(6); // July
     expect(lastQuarterStart.getDate()).toBe(1);
   });
@@ -761,25 +761,25 @@ describe("DateExtCalculationsTest", () => {
 
   it("since", () => {
     const date = d(2005, 2, 21);
-    const result = since(date, 3600); // 1 hour
+    const result = asDate(since(date, 3600)); // 1 hour
     expect(result.getHours()).toBe(1);
   });
 
   it("since when zone is set", () => {
     const date = d(2005, 2, 21, 12, 0, 0);
-    const result = since(date, 1800); // 30 min
+    const result = asDate(since(date, 1800)); // 30 min
     expect(result.getMinutes()).toBe(30);
   });
 
   it("ago", () => {
     const date = d(2005, 2, 22, 10, 10, 10);
-    const result = ago(date, 3600);
+    const result = asDate(ago(date, 3600));
     expect(result.getHours()).toBe(9);
   });
 
   it("ago when zone is set", () => {
     const date = d(2005, 2, 22, 10, 10, 10);
-    const result = ago(date, 600);
+    const result = asDate(ago(date, 600));
     expect(result.getMinutes()).toBe(0);
   });
 
@@ -943,21 +943,21 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("advance from datetime", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    expect(advance(dt, { years: 1 })).toEqual(d(2006, 2, 22, 15, 15, 10));
-    expect(advance(dt, { months: 4 })).toEqual(d(2005, 6, 22, 15, 15, 10));
-    expect(advance(dt, { hours: 5, minutes: 7, seconds: 9 })).toEqual(d(2005, 2, 22, 20, 22, 19));
+    expect(advance(dt, { years: 1 })).toEqual(i(2006, 2, 22, 15, 15, 10));
+    expect(advance(dt, { months: 4 })).toEqual(i(2005, 6, 22, 15, 15, 10));
+    expect(advance(dt, { hours: 5, minutes: 7, seconds: 9 })).toEqual(i(2005, 2, 22, 20, 22, 19));
   });
 
   it("ago from datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(ago(dt, 1)).toEqual(d(2005, 2, 22, 10, 10, 9));
-    expect(ago(dt, 3600)).toEqual(d(2005, 2, 22, 9, 10, 10));
+    expect(ago(dt, 1)).toEqual(i(2005, 2, 22, 10, 10, 9));
+    expect(ago(dt, 3600)).toEqual(i(2005, 2, 22, 9, 10, 10));
   });
 
   it("since from datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(since(dt, 1)).toEqual(d(2005, 2, 22, 10, 10, 11));
-    expect(since(dt, 3600)).toEqual(d(2005, 2, 22, 11, 10, 10));
+    expect(since(dt, 1)).toEqual(i(2005, 2, 22, 10, 10, 11));
+    expect(since(dt, 3600)).toEqual(i(2005, 2, 22, 11, 10, 10));
   });
 
   it("next_occurring from datetime", () => {
@@ -1011,7 +1011,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("changeDate preserves time components", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(dt, { year: 2006 });
+    const result = asDate(changeDate(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(1); // February
     expect(result.getDate()).toBe(22);
@@ -1089,20 +1089,20 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("change", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = changeDate(dt, { year: 2006 });
+    const result = asDate(changeDate(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 
   it("advance partial days", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = advance(dt, { hours: 12 });
+    const result = asDate(advance(dt, { hours: 12 }));
     expect(result.getDate()).toBe(23);
     expect(result.getHours()).toBe(3);
   });
 
   it("advanced processes first the date deltas and then the time deltas", () => {
     const dt = d(2005, 2, 28, 15, 15, 10);
-    const result = advance(dt, { months: 1, days: 1 });
+    const result = asDate(advance(dt, { months: 1, days: 1 }));
     expect(result.getMonth()).toBe(2); // March (0-indexed)
     expect(result.getDate()).toBe(29); // Last day of Feb + 1 day in March
   });
@@ -1125,7 +1125,7 @@ describe("DateTimeExtCalculationsTest", () => {
     // Oct 31 -> last quarter start = July 1
     const dt = d(2005, 10, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = advance(asDate(quarterStart), { months: -3 });
+    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(6); // July
   });
 

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -327,6 +327,18 @@ describe("TimeExtCalculationsTest", () => {
     expect(result.getSeconds()).toBe(11);
   });
 
+  it("floor and ceil reject non-positive or non-finite ms", () => {
+    const t = new Date(2005, 1, 4, 10, 10, 10, 500);
+    expect(() => floor(t, 0)).toThrow(RangeError);
+    expect(() => floor(t, -1000)).toThrow(RangeError);
+    expect(() => floor(t, Number.NaN)).toThrow(RangeError);
+    expect(() => floor(t, Number.POSITIVE_INFINITY)).toThrow(RangeError);
+    expect(() => ceil(t, 0)).toThrow(RangeError);
+    expect(() => ceil(t, -1000)).toThrow(RangeError);
+    expect(() => ceil(t, Number.NaN)).toThrow(RangeError);
+    expect(() => ceil(t, Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
   it("to fs", () => {
     const t = d(2005, 2, 4, 10, 10, 10);
     const result = toFs(t);

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -3,9 +3,10 @@
  * and ActiveSupport::CoreExt::Date patterns.
  *
  * @boundary-file: Helpers accept JavaScript `Date` inputs for ergonomic interop
- *   with code that still holds Date values. Period-bound and arithmetic helpers
- *   (`beginningOf*`, `endOf*`, `allDay`, …) return `Temporal.Instant`; legacy
- *   helpers below the boundary still return `Date` and will flip in F-6b/c/d.
+ *   with code that still holds Date values. Period-bound, navigation, and
+ *   arithmetic helpers return `Temporal.Instant`. The remaining `Date`-returning
+ *   helpers (`toDate`, `toTime`) and predicates (`isPast`, `isFuture`) flip in
+ *   F-6d.
  */
 
 import { type Temporal, instantFrom } from "./temporal.js";
@@ -471,6 +472,9 @@ export function isFuture(date: Date): boolean {
  * floor — rounds time down to nearest multiple of ms.
  */
 export function floor(date: Date, ms: number): Temporal.Instant {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    throw new RangeError(`floor: ms must be a positive finite number, got ${ms}`);
+  }
   return instantFrom(new Date(Math.floor(date.getTime() / ms) * ms));
 }
 
@@ -478,6 +482,9 @@ export function floor(date: Date, ms: number): Temporal.Instant {
  * ceil — rounds time up to nearest multiple of ms.
  */
 export function ceil(date: Date, ms: number): Temporal.Instant {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    throw new RangeError(`ceil: ms must be a positive finite number, got ${ms}`);
+  }
   return instantFrom(new Date(Math.ceil(date.getTime() / ms) * ms));
 }
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -288,7 +288,7 @@ export function advance(
     minutes?: number;
     seconds?: number;
   },
-): Date {
+): Temporal.Instant {
   let d = clone(date);
 
   if (options.years) {
@@ -324,7 +324,7 @@ export function advance(
   if (options.seconds) ms += options.seconds * 1000;
 
   if (ms) d = new Date(d.getTime() + ms);
-  return d;
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -386,12 +386,12 @@ export function allYear(date: Date): { start: Temporal.Instant; end: Temporal.In
 // ago / since
 // ---------------------------------------------------------------------------
 
-export function ago(date: Date, seconds: number): Date {
-  return new Date(date.getTime() - seconds * 1000);
+export function ago(date: Date, seconds: number): Temporal.Instant {
+  return instantFrom(new Date(date.getTime() - seconds * 1000));
 }
 
-export function since(date: Date, seconds: number): Date {
-  return new Date(date.getTime() + seconds * 1000);
+export function since(date: Date, seconds: number): Temporal.Instant {
+  return instantFrom(new Date(date.getTime() + seconds * 1000));
 }
 
 // ---------------------------------------------------------------------------
@@ -408,7 +408,7 @@ export function changeDate(
     min?: number;
     sec?: number;
   },
-): Date {
+): Temporal.Instant {
   const d = clone(date);
   if (options.year !== undefined) d.setFullYear(options.year);
   if (options.month !== undefined) d.setMonth(options.month - 1); // 1-indexed
@@ -416,7 +416,7 @@ export function changeDate(
   if (options.hour !== undefined) d.setHours(options.hour, 0, 0, 0);
   if (options.min !== undefined) d.setMinutes(options.min, 0, 0);
   if (options.sec !== undefined) d.setSeconds(options.sec, 0);
-  return d;
+  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -470,15 +470,15 @@ export function isFuture(date: Date): boolean {
 /**
  * floor — rounds time down to nearest multiple of ms.
  */
-export function floor(date: Date, ms: number): Date {
-  return new Date(Math.floor(date.getTime() / ms) * ms);
+export function floor(date: Date, ms: number): Temporal.Instant {
+  return instantFrom(new Date(Math.floor(date.getTime() / ms) * ms));
 }
 
 /**
  * ceil — rounds time up to nearest multiple of ms.
  */
-export function ceil(date: Date, ms: number): Date {
-  return new Date(Math.ceil(date.getTime() / ms) * ms);
+export function ceil(date: Date, ms: number): Temporal.Instant {
+  return instantFrom(new Date(Math.ceil(date.getTime() / ms) * ms));
 }
 
 /**


### PR DESCRIPTION
## Summary

F-6c of the Temporal migration follow-ups: 6 arithmetic helpers in \`time-ext.ts\` now return \`Temporal.Instant\`.

- \`advance\` (years/months/weeks/days/hours/minutes/seconds calendar arithmetic)
- \`ago\`, \`since\` (time arithmetic)
- \`floor\`, \`ceil\` (rounding to ms multiples)
- \`changeDate\` (calendar component mutator)

Inputs stay \`Date\`. Internal arithmetic still routes through cloned \`Date\` mutators for exact local-tz semantics, then wraps the result via \`instantFrom\`.

## Test plan

- [x] \`pnpm vitest run packages/activesupport\` — 3639/3639 passing
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` clean
- [x] Diff: 122 +/116 -, 5 files