### PR TITLE
fix(arel): Statement ctors take relation; extract wraps in array

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -519,7 +519,8 @@ export class Attribute extends Node {
   // -- Extract --
 
   extract(field: string): Extract {
-    return new Extract(this, field);
+    // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).
+    return new Extract([this], field);
   }
 
   // -- Null handling --

--- a/packages/arel/src/expressions.ts
+++ b/packages/arel/src/expressions.ts
@@ -35,6 +35,7 @@ export const Expressions: ExpressionsModule = {
     return new Avg([this]);
   },
   extract(this: Node, field: string): Extract {
-    return new Extract(this, field);
+    // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).
+    return new Extract([this], field);
   },
 };

--- a/packages/arel/src/nodes/delete-statement.test.ts
+++ b/packages/arel/src/nodes/delete-statement.test.ts
@@ -15,6 +15,15 @@ describe("Arel", () => {
       expect(stmt.wheres.length).toBe(2);
     });
 
+    // Mirrors Rails: `DeleteStatement.new(relation, wheres = [])`
+    // (delete_statement.rb) accepts both args at construction.
+    it("ctor accepts a relation and initial wheres", () => {
+      const eq = users.get("id").eq(1);
+      const stmt = new Nodes.DeleteStatement(users, [eq]);
+      expect(stmt.relation).toBe(users);
+      expect(stmt.wheres).toEqual([eq]);
+    });
+
     describe("equality", () => {
       it("is equal with equal ivars", () => {
         const s1 = new Nodes.DeleteStatement();

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -15,10 +15,10 @@ export class DeleteStatement extends Node {
   offset: Node | null;
   key: Node | Node[] | null;
 
-  constructor(relation: Node | null = null) {
+  constructor(relation: Node | null = null, wheres: Node[] = []) {
     super();
     this.relation = relation;
-    this.wheres = [];
+    this.wheres = wheres;
     this.orders = [];
     this.groups = [];
     this.havings = [];

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -29,7 +29,7 @@ describe("Arel::Nodes::ExtractTest", () => {
     const createdAt = users.get("created_at");
     const node = createdAt.extract("year");
     expect(Array.isArray(node.expr)).toBe(true);
-    expect((node.expr as unknown as Nodes.Node[])[0]).toBe(createdAt);
+    expect((node.expr as Nodes.Node[])[0]).toBe(createdAt);
     expect(new Visitors.ToSql().compile(node)).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
 

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -21,6 +21,18 @@ describe("Arel::Nodes::ExtractTest", () => {
     expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at")');
   });
 
+  // Mirrors Rails: `Expressions#extract` calls `Nodes::Extract.new [self], field`,
+  // wrapping the receiver in an array (expressions.rb). The visitor renders
+  // the array via `inject_join`, so a single-element array still produces
+  // the same SQL as a bare expression.
+  it("expressions.extract wraps the receiver in an array", () => {
+    const createdAt = users.get("created_at");
+    const node = createdAt.extract("year");
+    expect(Array.isArray(node.expr)).toBe(true);
+    expect((node.expr as unknown as Nodes.Node[])[0]).toBe(createdAt);
+    expect(new Visitors.ToSql().compile(node)).toBe('EXTRACT(YEAR FROM "users"."created_at")');
+  });
+
   describe("as", () => {
     it("should alias the extract", () => {
       const createdAt = users.get("created_at");

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -12,7 +12,7 @@ export class Extract extends Unary {
   readonly field: string;
 
   constructor(expr: Node | Node[], field: string) {
-    super(expr as unknown as Node);
+    super(expr);
     this.field = field;
   }
 

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -11,8 +11,8 @@ import { SqlLiteral } from "./sql-literal.js";
 export class Extract extends Unary {
   readonly field: string;
 
-  constructor(expr: Node, field: string) {
-    super(expr);
+  constructor(expr: Node | Node[], field: string) {
+    super(expr as unknown as Node);
     this.field = field;
   }
 

--- a/packages/arel/src/nodes/insert-statement.test.ts
+++ b/packages/arel/src/nodes/insert-statement.test.ts
@@ -15,6 +15,13 @@ describe("Arel", () => {
       expect(stmt.columns.length).toBe(2);
     });
 
+    // Mirrors Rails: `InsertStatement.new(relation)` (insert_statement.rb)
+    // assigns `@relation = relation`, so the AST is constructed pre-bound.
+    it("ctor accepts a relation", () => {
+      const stmt = new Nodes.InsertStatement(users);
+      expect(stmt.relation).toBe(users);
+    });
+
     describe("equality", () => {
       it("is equal with equal ivars", () => {
         const s1 = new Nodes.InsertStatement();

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -11,9 +11,9 @@ export class InsertStatement extends Node {
   values: Node | null;
   select: Node | null;
 
-  constructor() {
+  constructor(relation: Node | null = null) {
     super();
-    this.relation = null;
+    this.relation = relation;
     this.columns = [];
     this.values = null;
     this.select = null;

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -17,9 +17,9 @@ export class SelectCore extends Node {
   optimizerHints: string[];
   comment: Node | null;
 
-  constructor() {
+  constructor(relation: Node | null = null) {
     super();
-    this.source = new JoinSource(null);
+    this.source = new JoinSource(relation);
     this.projections = [];
     this.wheres = [];
     this.groups = [];

--- a/packages/arel/src/nodes/select-statement.test.ts
+++ b/packages/arel/src/nodes/select-statement.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Nodes } from "../index.js";
+import { Nodes, Table } from "../index.js";
 
 describe("Arel", () => {
   describe("select-statement", () => {
@@ -27,6 +27,15 @@ describe("Arel", () => {
         s2.offset = new Nodes.Offset(new Nodes.Quoted(2));
         expect(s1.hash()).not.toBe(s2.hash());
       });
+    });
+
+    // Mirrors Rails: `SelectStatement.new(relation)` (select_statement.rb)
+    // forwards the relation to the seed `SelectCore.new(relation)` so callers
+    // can construct a SELECT pre-bound to a FROM target in one step.
+    it("ctor accepts a relation and seeds source.left", () => {
+      const users = new Table("users");
+      const stmt = new Nodes.SelectStatement(users);
+      expect(stmt.cores[0].source.left).toBe(users);
     });
 
     describe("#clone", () => {

--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -17,9 +17,9 @@ export class SelectStatement extends NodeExpression {
   with: Node | null;
   comment: Comment | null;
 
-  constructor() {
+  constructor(relation: Node | null = null) {
     super();
-    this.cores = [new SelectCore()];
+    this.cores = [new SelectCore(relation)];
     this.orders = [];
     this.limit = null;
     this.offset = null;

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -82,10 +82,9 @@ export class GroupingSet extends GroupingElement {
 export class Group extends Unary {}
 /**
  * Rails' `Arel::Nodes::OptimizerHints` stores `[hint1, hint2, ...]` and the
- * visitor iterates them. The Unary base types `expr` as
- * `Node | string | number | null` — TS won't let us widen `expr` to an array
- * via `declare`, so the hints live in their own typed field and `expr` is
- * left as `null` (consistent with the declared base type).
+ * visitor iterates them. The hints live on a dedicated typed field (rather
+ * than on the now-`Node | Node[] | string | number | null` `expr`) so the
+ * element type can be `string | SqlLiteral` instead of `Node`.
  */
 export class OptimizerHints extends Unary {
   readonly hints: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -2,9 +2,9 @@ import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
 export class Unary extends NodeExpression {
-  readonly expr: Node | string | number | null;
+  readonly expr: Node | Node[] | string | number | null;
 
-  constructor(expr: Node | string | number | null) {
+  constructor(expr: Node | Node[] | string | number | null) {
     super();
     this.expr = expr;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1056,7 +1056,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   private visitArelNodesExtract(node: Nodes.Extract): SQLString {
     this.collector.append(`EXTRACT(${String(node.field).toUpperCase()} FROM `);
-    if (node.expr instanceof Node) {
+    if (Array.isArray(node.expr)) {
+      this.visitArray(node.expr as unknown as Nodes.NodeOrValue[]);
+    } else if (node.expr instanceof Node) {
       this.visit(node.expr);
     } else if (node.expr !== null && node.expr !== undefined) {
       this.collector.append(String(node.expr));

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1057,7 +1057,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   private visitArelNodesExtract(node: Nodes.Extract): SQLString {
     this.collector.append(`EXTRACT(${String(node.field).toUpperCase()} FROM `);
     if (Array.isArray(node.expr)) {
-      this.visitArray(node.expr as unknown as Nodes.NodeOrValue[]);
+      this.visitArray(node.expr);
     } else if (node.expr instanceof Node) {
       this.visit(node.expr);
     } else if (node.expr !== null && node.expr !== undefined) {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1393,6 +1393,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     if (v !== null && v !== undefined && typeof v === "object" && "ast" in v && "toSql" in v) {
       return this.visitArelSelectManager(v as unknown as { ast: Node });
     }
+    if (Array.isArray(v)) {
+      // Mirrors Rails: `visit_Array` (to_sql.rb) — primitives and Nodes in
+      // arrays both flow through here, joined by ", ".
+      return this.visitArray(v);
+    }
     if (v instanceof Node) {
       // Duck-type check to avoid circular dependency (SelectManager → ToSql → SelectManager)
       if ("ast" in v && "toSql" in v) {


### PR DESCRIPTION
## Summary

Bundles two coherent Rails-fidelity fixes (both reshape node ctors). Both are independent and small.

- **PR 21** — Statement ctors take a `relation` arg.
  - `SelectStatement(relation)` / `SelectCore(relation)` mirror [`select_statement.rb`](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/nodes/select_statement.rb) and [`select_core.rb`](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/nodes/select_core.rb): the seed `SelectCore` is constructed pre-bound to a FROM target.
  - `InsertStatement(relation)` mirrors `insert_statement.rb`.
  - `DeleteStatement(relation, wheres = [])` adds the second arg per `delete_statement.rb`.
  - `UpdateStatement` already matched Rails.
- **PR 22** — `Expressions#extract` / `Attribute#extract` now construct `new Extract([self], field)` (single-element array), matching `expressions.rb`'s `Nodes::Extract.new [self], field`. The `visit_Arel_Nodes_Extract` visitor renders an array operand via `inject_join`, so the single-element form produces the same SQL as the prior bare-expression form.

55 insertions / 14 deletions.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1226/1226.
- [x] `pnpm exec vitest run packages/activerecord/` — 9941 passed, no regressions.
- [x] `pnpm -w build` clean.