### PR TITLE
feat(activesupport): time-ext predicates & coercions return Temporal

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -94,8 +94,7 @@ describe("DateExtCalculationsTest", () => {
   it("to time", () => {
     const date = d(2005, 2, 21);
     const result = toTime(date);
-    expect(result instanceof Date).toBe(true);
-    expect(result.getFullYear()).toBe(2005);
+    expect(asDate(result).getFullYear()).toBe(2005);
   });
 
   it("compare to time", () => {
@@ -107,18 +106,18 @@ describe("DateExtCalculationsTest", () => {
   it("to datetime", () => {
     const date = d(2005, 2, 21);
     const result = toTime(date);
-    expect(result.getFullYear()).toBe(2005);
-    expect(result.getMonth()).toBe(1); // February
-    expect(result.getDate()).toBe(21);
+    const back = asDate(result);
+    expect(back.getFullYear()).toBe(2005);
+    expect(back.getMonth()).toBe(1); // February
+    expect(back.getDate()).toBe(21);
   });
 
   it("to date", () => {
     const date = d(2005, 2, 21, 10, 30);
     const result = toDate(date);
-    expect(result.getFullYear()).toBe(2005);
-    expect(result.getMonth()).toBe(1);
-    expect(result.getDate()).toBe(21);
-    expect(result.getHours()).toBe(0);
+    expect(result.year).toBe(2005);
+    expect(result.month).toBe(2);
+    expect(result.day).toBe(21);
   });
 
   it("change", () => {

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -72,26 +72,26 @@ describe("DateTimeExtCalculationsTest", () => {
   it("to date", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toDate(dt);
-    expect(result.getHours()).toBe(0);
-    expect(result.getDate()).toBe(22);
+    expect(result.day).toBe(22);
+    expect(result.month).toBe(2);
   });
 
   it("to datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toTime(dt);
-    expect(result.getTime()).toBe(dt.getTime());
+    expect(result.epochMilliseconds).toBe(dt.getTime());
   });
 
   it("to time", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toTime(dt);
-    expect(result instanceof Date).toBe(true);
+    expect(result.epochMilliseconds).toBe(dt.getTime());
   });
 
   it("to time preserves fractional seconds", () => {
     const dt = new Date(2005, 1, 22, 10, 10, 10, 500);
     const result = toTime(dt);
-    expect(result.getMilliseconds()).toBe(500);
+    expect(asDate(result).getMilliseconds()).toBe(500);
   });
 
   it.skip("civil from format");

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -371,23 +371,21 @@ describe("TimeExtCalculationsTest", () => {
   it("to date", () => {
     const t = d(2005, 2, 21, 17, 44, 30);
     const result = toDate(t);
-    expect(result.getFullYear()).toBe(2005);
-    expect(result.getMonth()).toBe(1); // February
-    expect(result.getDate()).toBe(21);
-    expect(result.getHours()).toBe(0);
+    expect(result.year).toBe(2005);
+    expect(result.month).toBe(2);
+    expect(result.day).toBe(21);
   });
 
   it("to datetime", () => {
     const t = d(2005, 2, 21, 17, 44, 30);
     const result = toTime(t);
-    expect(result.getTime()).toBe(t.getTime());
+    expect(result.epochMilliseconds).toBe(t.getTime());
   });
 
   it("to time", () => {
     const t = d(2005, 2, 21, 17, 44, 30);
     const result = toTime(t);
-    expect(result instanceof Date).toBe(true);
-    expect(result.getTime()).toBe(t.getTime());
+    expect(result.epochMilliseconds).toBe(t.getTime());
   });
 
   it("fp inaccuracy ticket 1836", () => {

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -367,24 +367,21 @@ describe("TimeExtCalculationsTest", () => {
   it("to date", () => {
     const t = d(2005, 2, 4, 10, 10, 10);
     const result = toDate(t);
-    expect(result.getFullYear()).toBe(2005);
-    expect(result.getMonth()).toBe(1); // February
-    expect(result.getDate()).toBe(4);
-    expect(result.getHours()).toBe(0);
+    expect(result.year).toBe(2005);
+    expect(result.month).toBe(2);
+    expect(result.day).toBe(4);
   });
 
   it("to datetime", () => {
     const t = d(2005, 2, 4, 10, 10, 10);
-    const result = toTime(t); // datetime = time in TS
-    expect(result.getFullYear()).toBe(2005);
-    expect(result.getTime()).toBe(t.getTime());
+    const result = toTime(t);
+    expect(result.epochMilliseconds).toBe(t.getTime());
   });
 
   it("to time", () => {
     const t = d(2005, 2, 4, 10, 10, 10);
     const result = toTime(t);
-    expect(result instanceof Date).toBe(true);
-    expect(result.getTime()).toBe(t.getTime());
+    expect(result.epochMilliseconds).toBe(t.getTime());
   });
 
   it("formatted offset with utc", () => {
@@ -688,20 +685,20 @@ describe("DateExtCalculationsTest", () => {
   it("to time", () => {
     const date = d(2005, 2, 21);
     const result = toTime(date);
-    expect(result instanceof Date).toBe(true);
+    expect(result.epochMilliseconds).toBe(date.getTime());
   });
 
   it("to datetime", () => {
     const date = d(2005, 2, 21);
     const result = toTime(date);
-    expect(result.getFullYear()).toBe(2005);
+    expect(asDate(result).getFullYear()).toBe(2005);
   });
 
   it("to date", () => {
     const date = d(2005, 2, 21, 10, 20, 30);
     const result = toDate(date);
-    expect(result.getHours()).toBe(0);
-    expect(result.getDate()).toBe(21);
+    expect(result.day).toBe(21);
+    expect(result.month).toBe(2);
   });
 
   it("change", () => {
@@ -1052,26 +1049,26 @@ describe("DateTimeExtCalculationsTest", () => {
   it("to date", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toDate(dt);
-    expect(result.getHours()).toBe(0);
-    expect(result.getDate()).toBe(22);
+    expect(result.day).toBe(22);
+    expect(result.month).toBe(2);
   });
 
   it("to datetime", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toTime(dt);
-    expect(result.getTime()).toBe(dt.getTime());
+    expect(result.epochMilliseconds).toBe(dt.getTime());
   });
 
   it("to time", () => {
     const dt = d(2005, 2, 22, 10, 10, 10);
     const result = toTime(dt);
-    expect(result instanceof Date).toBe(true);
+    expect(result.epochMilliseconds).toBe(dt.getTime());
   });
 
   it("to time preserves fractional seconds", () => {
     const dt = new Date(2005, 1, 22, 10, 10, 10, 500);
     const result = toTime(dt);
-    expect(result.getMilliseconds()).toBe(500);
+    expect(asDate(result).getMilliseconds()).toBe(500);
   });
 
   it("middle of day", () => {

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -272,9 +272,29 @@ describe("TimeExtCalculationsTest", () => {
     expect(isPast(d(2099, 1, 1))).toBe(false);
   });
 
+  it("is_past accepts Temporal.Instant with sub-millisecond precision", () => {
+    expect(isPast(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(true);
+    expect(isPast(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(false);
+    const now = Temporal.Now.instant();
+    const oneNsBefore = now.subtract({ nanoseconds: 1 });
+    const oneNsAfter = now.add({ nanoseconds: 1_000_000_000 });
+    expect(isPast(oneNsBefore)).toBe(true);
+    expect(isPast(oneNsAfter)).toBe(false);
+  });
+
   it("is_future", () => {
     expect(isFuture(d(2099, 1, 1))).toBe(true);
     expect(isFuture(d(2000, 1, 1))).toBe(false);
+  });
+
+  it("is_future accepts Temporal.Instant with sub-millisecond precision", () => {
+    expect(isFuture(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(true);
+    expect(isFuture(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(false);
+    const now = Temporal.Now.instant();
+    const oneNsAfter = now.add({ nanoseconds: 1_000_000_000 });
+    const oneNsBefore = now.subtract({ nanoseconds: 1 });
+    expect(isFuture(oneNsAfter)).toBe(true);
+    expect(isFuture(oneNsBefore)).toBe(false);
   });
 
   it("all_day", () => {

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Temporal } from "./temporal.js";
 import {
   beginningOfDay,
@@ -273,13 +273,16 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("is_past accepts Temporal.Instant with sub-millisecond precision", () => {
-    expect(isPast(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(true);
-    expect(isPast(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(false);
-    const now = Temporal.Now.instant();
-    const oneNsBefore = now.subtract({ nanoseconds: 1 });
-    const oneNsAfter = now.add({ nanoseconds: 1_000_000_000 });
-    expect(isPast(oneNsBefore)).toBe(true);
-    expect(isPast(oneNsAfter)).toBe(false);
+    const fixed = Temporal.Instant.from("2025-06-15T12:00:00.000Z");
+    const spy = vi.spyOn(Temporal.Now, "instant").mockReturnValue(fixed);
+    try {
+      expect(isPast(fixed.subtract({ nanoseconds: 1 }))).toBe(true);
+      expect(isPast(fixed.add({ nanoseconds: 1 }))).toBe(false);
+      expect(isPast(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(true);
+      expect(isPast(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("is_future", () => {
@@ -288,13 +291,16 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("is_future accepts Temporal.Instant with sub-millisecond precision", () => {
-    expect(isFuture(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(true);
-    expect(isFuture(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(false);
-    const now = Temporal.Now.instant();
-    const oneNsAfter = now.add({ nanoseconds: 1_000_000_000 });
-    const oneNsBefore = now.subtract({ nanoseconds: 1 });
-    expect(isFuture(oneNsAfter)).toBe(true);
-    expect(isFuture(oneNsBefore)).toBe(false);
+    const fixed = Temporal.Instant.from("2025-06-15T12:00:00.000Z");
+    const spy = vi.spyOn(Temporal.Now, "instant").mockReturnValue(fixed);
+    try {
+      expect(isFuture(fixed.add({ nanoseconds: 1 }))).toBe(true);
+      expect(isFuture(fixed.subtract({ nanoseconds: 1 }))).toBe(false);
+      expect(isFuture(Temporal.Instant.from("2099-01-01T00:00:00Z"))).toBe(true);
+      expect(isFuture(Temporal.Instant.from("2000-01-01T00:00:00Z"))).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("all_day", () => {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -3,13 +3,13 @@
  * and ActiveSupport::CoreExt::Date patterns.
  *
  * @boundary-file: Helpers accept JavaScript `Date` inputs for ergonomic interop
- *   with code that still holds Date values. Period-bound, navigation, and
- *   arithmetic helpers return `Temporal.Instant`. The remaining `Date`-returning
- *   helpers (`toDate`, `toTime`) and predicates (`isPast`, `isFuture`) flip in
- *   F-6d.
+ *   with code that still holds Date values. Period-bound, navigation,
+ *   arithmetic, and coercion helpers all return `Temporal.*` types
+ *   (`Temporal.Instant` for time-of-day helpers, `Temporal.PlainDate` for
+ *   `toDate`). Predicates (`isPast`, `isFuture`) accept `Date | Temporal.Instant`.
  */
 
-import { type Temporal, instantFrom } from "./temporal.js";
+import { Temporal, instantFrom } from "./temporal.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
@@ -460,12 +460,14 @@ export function isYesterday(date: Date): boolean {
   );
 }
 
-export function isPast(date: Date): boolean {
-  return date.getTime() < Date.now();
+export function isPast(date: Date | Temporal.Instant): boolean {
+  const ms = date instanceof Date ? date.getTime() : date.epochMilliseconds;
+  return ms < Temporal.Now.instant().epochMilliseconds;
 }
 
-export function isFuture(date: Date): boolean {
-  return date.getTime() > Date.now();
+export function isFuture(date: Date | Temporal.Instant): boolean {
+  const ms = date instanceof Date ? date.getTime() : date.epochMilliseconds;
+  return ms > Temporal.Now.instant().epochMilliseconds;
 }
 
 /**
@@ -549,17 +551,21 @@ export function lastWeek(date: Date, startDay = "monday"): Temporal.Instant {
 }
 
 /**
- * toDate — returns a Date object representing just the date portion.
+ * toDate — Rails `Time#to_date`. Returns the calendar date in local time.
  */
-export function toDate(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+export function toDate(date: Date): Temporal.PlainDate {
+  return Temporal.PlainDate.from({
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+  });
 }
 
 /**
- * toTime — alias, returns same date (in TS, Date represents both date and time).
+ * toTime — Rails `Time#to_time`. Returns the instant the Date refers to.
  */
-export function toTime(date: Date): Date {
-  return new Date(date.getTime());
+export function toTime(date: Date): Temporal.Instant {
+  return instantFrom(date);
 }
 
 /**

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -461,13 +461,13 @@ export function isYesterday(date: Date): boolean {
 }
 
 export function isPast(date: Date | Temporal.Instant): boolean {
-  const ms = date instanceof Date ? date.getTime() : date.epochMilliseconds;
-  return ms < Temporal.Now.instant().epochMilliseconds;
+  const instant = date instanceof Date ? instantFrom(date) : date;
+  return Temporal.Instant.compare(instant, Temporal.Now.instant()) < 0;
 }
 
 export function isFuture(date: Date | Temporal.Instant): boolean {
-  const ms = date instanceof Date ? date.getTime() : date.epochMilliseconds;
-  return ms > Temporal.Now.instant().epochMilliseconds;
+  const instant = date instanceof Date ? instantFrom(date) : date;
+  return Temporal.Instant.compare(instant, Temporal.Now.instant()) > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Continues the Temporal migration in `activesupport/time-ext.ts` (F-6d):

- `isPast`/`isFuture` now accept `Date | Temporal.Instant` and compare via `Temporal.Now.instant()`.
- `toDate` returns `Temporal.PlainDate` (Rails `Time#to_date`).
- `toTime` returns `Temporal.Instant` (Rails `Time#to_time`).
- `@boundary-file` doc updated.

After this lands, the only remaining `Date`-returning helpers in `time-ext.ts` are the `isToday`/`isTomorrow`/`isYesterday` predicates (which still take `Date` input — covered by F-6 follow-ups).

## Test plan
- [x] `pnpm exec vitest run packages/activesupport/src/time-ext.test.ts packages/activesupport/src/core-ext/{date,date-time,time}-ext.test.ts`
- [x] `pnpm --filter @blazetrails/activesupport build`
- [x] `pnpm lint`