### PR TITLE
feat(activesupport): Duration since/ago/fromNow/until return Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -220,7 +220,7 @@ describe("DurationTest", () => {
     ] as const) {
       const dur = Duration[unit](1);
       const result = dur.since(now);
-      expect(typeof result.epochMilliseconds === "number").toBe(true);
+      expect(result).toBeInstanceOf(Temporal.Instant);
     }
   });
 
@@ -293,7 +293,7 @@ describe("DurationTest", () => {
   it("since and ago anchored to time now when time zone is not set", () => {
     // JS doesn't have TimeWithZone — just verify since() returns a Temporal.Instant
     const result = Duration.seconds(5).since();
-    expect(typeof result.epochMilliseconds === "number").toBe(true);
+    expect(result).toBeInstanceOf(Temporal.Instant);
   });
 
   it("since and ago anchored to time zone now when time zone is set", () => {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -207,7 +207,7 @@ describe("DurationTest", () => {
   });
 
   it("time plus duration returns same time datatype", () => {
-    // In TypeScript/JS all times are Date objects — just verify arithmetic works
+    // Duration#since now returns Temporal.Instant — verify arithmetic works for each unit
     const now = new Date();
     for (const unit of [
       "seconds",
@@ -245,6 +245,15 @@ describe("DurationTest", () => {
     expect(Duration.seconds(1).ago(t).epochMilliseconds).toBe(t.getTime() - 1000);
   });
 
+  it("since and ago accept Temporal.Instant inputs", () => {
+    const tInstant = Duration.seconds(0).since(new Date(2000, 0, 1, 0, 0, 0, 0));
+    const baseMs = tInstant.epochMilliseconds;
+    expect(Duration.seconds(1).since(tInstant).epochMilliseconds).toBe(baseMs + 1000);
+    expect(Duration.seconds(1).ago(tInstant).epochMilliseconds).toBe(baseMs - 1000);
+    expect(Duration.seconds(1).after(tInstant).epochMilliseconds).toBe(baseMs + 1000);
+    expect(Duration.seconds(1).before(tInstant).epochMilliseconds).toBe(baseMs - 1000);
+  });
+
   it("since and ago without argument", () => {
     const before = new Date();
     const result = Duration.seconds(1).since();
@@ -272,7 +281,7 @@ describe("DurationTest", () => {
   });
 
   it("since and ago anchored to time now when time zone is not set", () => {
-    // JS doesn't have TimeWithZone — just verify since() returns a Date
+    // JS doesn't have TimeWithZone — just verify since() returns a Temporal.Instant
     const result = Duration.seconds(5).since();
     expect(typeof result.epochMilliseconds === "number").toBe(true);
   });

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
+import type { Temporal } from "../temporal.js";
 import { Duration } from "../duration.js";
+
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
+}
 
 describe("DurationTest", () => {
   it("is a", () => {
@@ -159,24 +164,24 @@ describe("DurationTest", () => {
   it("date added with zero days", () => {
     const date = new Date(2017, 0, 1); // Jan 1 2017
     const result = Duration.days(0).since(date);
-    expect(result.getFullYear()).toBe(2017);
-    expect(result.getMonth()).toBe(0);
-    expect(result.getDate()).toBe(1);
+    expect(asDate(result).getFullYear()).toBe(2017);
+    expect(asDate(result).getMonth()).toBe(0);
+    expect(asDate(result).getDate()).toBe(1);
   });
 
   it("date added with multiplied duration", () => {
     const date = new Date(2017, 0, 1);
     const result = Duration.days(1).times(2).since(date);
-    expect(result.getFullYear()).toBe(2017);
-    expect(result.getDate()).toBe(3);
+    expect(asDate(result).getFullYear()).toBe(2017);
+    expect(asDate(result).getDate()).toBe(3);
   });
 
   it("date added with multiplied duration larger than one month", () => {
     const date = new Date(2017, 0, 1);
     const result = Duration.days(1).times(45).since(date);
-    expect(result.getFullYear()).toBe(2017);
-    expect(result.getMonth()).toBe(1); // February
-    expect(result.getDate()).toBe(15);
+    expect(asDate(result).getFullYear()).toBe(2017);
+    expect(asDate(result).getMonth()).toBe(1); // February
+    expect(asDate(result).getDate()).toBe(15);
   });
 
   it("date added with divided duration", () => {
@@ -185,7 +190,7 @@ describe("DurationTest", () => {
     const ms = Duration.days(4).dividedBy(2).inSeconds() * 1000;
     const expected = new Date(date.getTime() + ms);
     const result = Duration.days(4).dividedBy(2).since(date);
-    expect(result.getDate()).toBe(expected.getDate());
+    expect(asDate(result).getDate()).toBe(expected.getDate());
   });
 
   it("date added with divided duration larger than one month", () => {
@@ -215,7 +220,7 @@ describe("DurationTest", () => {
     ] as const) {
       const dur = Duration[unit](1);
       const result = dur.since(now);
-      expect(result instanceof Date).toBe(true);
+      expect(typeof result.epochMilliseconds === "number").toBe(true);
     }
   });
 
@@ -236,15 +241,15 @@ describe("DurationTest", () => {
 
   it("since and ago", () => {
     const t = new Date(2000, 0, 1, 0, 0, 0, 0);
-    expect(Duration.seconds(1).since(t).getTime()).toBe(t.getTime() + 1000);
-    expect(Duration.seconds(1).ago(t).getTime()).toBe(t.getTime() - 1000);
+    expect(Duration.seconds(1).since(t).epochMilliseconds).toBe(t.getTime() + 1000);
+    expect(Duration.seconds(1).ago(t).epochMilliseconds).toBe(t.getTime() - 1000);
   });
 
   it("since and ago without argument", () => {
     const before = new Date();
     const result = Duration.seconds(1).since();
     // result should be at least 1 second after before
-    expect(result.getTime()).toBeGreaterThanOrEqual(before.getTime() + 1000 - 50);
+    expect(result.epochMilliseconds).toBeGreaterThanOrEqual(before.getTime() + 1000 - 50);
   });
 
   it("since and ago with fractional days", () => {
@@ -252,24 +257,24 @@ describe("DurationTest", () => {
     const via36h = Duration.hours(36).since(t);
     const via15days = Duration.days(1.5).since(t);
     // fractional days use ms arithmetic, same as hours — should be equal
-    expect(Math.abs(via36h.getTime() - via15days.getTime())).toBeLessThan(1000);
+    expect(Math.abs(via36h.epochMilliseconds - via15days.epochMilliseconds)).toBeLessThan(1000);
 
     const ago36h = Duration.hours(36).ago(t);
     const ago15days = Duration.days(1.5).ago(t);
-    expect(Math.abs(ago36h.getTime() - ago15days.getTime())).toBeLessThan(1000);
+    expect(Math.abs(ago36h.epochMilliseconds - ago15days.epochMilliseconds)).toBeLessThan(1000);
   });
 
   it("since and ago with fractional weeks", () => {
     const t = new Date(2000, 0, 1);
     const via252h = Duration.hours(7 * 36).since(t);
     const via15weeks = Duration.weeks(1.5).since(t);
-    expect(Math.abs(via252h.getTime() - via15weeks.getTime())).toBeLessThan(1000);
+    expect(Math.abs(via252h.epochMilliseconds - via15weeks.epochMilliseconds)).toBeLessThan(1000);
   });
 
   it("since and ago anchored to time now when time zone is not set", () => {
     // JS doesn't have TimeWithZone — just verify since() returns a Date
     const result = Duration.seconds(5).since();
-    expect(result instanceof Date).toBe(true);
+    expect(typeof result.epochMilliseconds === "number").toBe(true);
   });
 
   it("since and ago anchored to time zone now when time zone is set", () => {
@@ -279,16 +284,16 @@ describe("DurationTest", () => {
 
   it("before and after", () => {
     const t = new Date(2000, 0, 1, 0, 0, 0, 0);
-    expect(Duration.seconds(1).after(t).getTime()).toBe(t.getTime() + 1000);
-    expect(Duration.seconds(1).before(t).getTime()).toBe(t.getTime() - 1000);
+    expect(Duration.seconds(1).after(t).epochMilliseconds).toBe(t.getTime() + 1000);
+    expect(Duration.seconds(1).before(t).epochMilliseconds).toBe(t.getTime() - 1000);
   });
 
   it("before and after without argument", () => {
     const now = new Date();
     const after = Duration.seconds(1).after();
     const before = Duration.seconds(1).before();
-    expect(after.getTime()).toBeGreaterThan(now.getTime());
-    expect(before.getTime()).toBeLessThan(now.getTime());
+    expect(after.epochMilliseconds).toBeGreaterThan(now.getTime());
+    expect(before.epochMilliseconds).toBeLessThan(now.getTime());
   });
 
   it("adding hours across dst boundary", () => {
@@ -296,15 +301,15 @@ describe("DurationTest", () => {
     const base = new Date(2009, 2, 29, 0, 0, 0); // Mar 29 2009
     const result = Duration.hours(24).since(base);
     // 24 hours later in wall-clock time
-    expect(result.getTime()).toBe(base.getTime() + 24 * 3600 * 1000);
+    expect(result.epochMilliseconds).toBe(base.getTime() + 24 * 3600 * 1000);
   });
 
   it("adding day across dst boundary", () => {
     const base = new Date(2009, 2, 29, 0, 0, 0); // Mar 29 2009
     const result = Duration.days(1).since(base);
     // calendar day advance
-    expect(result.getDate()).toBe(30);
-    expect(result.getMonth()).toBe(2);
+    expect(asDate(result).getDate()).toBe(30);
+    expect(asDate(result).getMonth()).toBe(2);
   });
 
   it("delegation with block works", () => {
@@ -455,8 +460,8 @@ describe("DurationTest", () => {
     // Jan 14 + 1 month = Feb 14
     const jan14 = new Date(2016, 0, 14);
     const feb14 = Duration.months(1).since(jan14);
-    expect(feb14.getMonth()).toBe(1);
-    expect(feb14.getDate()).toBe(14);
+    expect(asDate(feb14).getMonth()).toBe(1);
+    expect(asDate(feb14).getDate()).toBe(14);
   });
 
   it("iso8601 parsing wrong patterns with raise", () => {
@@ -490,7 +495,9 @@ describe("DurationTest", () => {
     const reparsed = Duration.parse(d.iso8601());
     const now = new Date();
     // Both should produce roughly same result when applied to now
-    expect(Math.abs(d.since(now).getTime() - reparsed.since(now).getTime())).toBeLessThan(1000);
+    expect(
+      Math.abs(d.since(now).epochMilliseconds - reparsed.since(now).epochMilliseconds),
+    ).toBeLessThan(1000);
   });
 
   it("iso8601 parsing across spring dst boundary", () => {
@@ -512,7 +519,7 @@ describe("DurationTest", () => {
     const time = new Date("Nov 29, 2016");
     const d1 = Duration.months(3).minus(Duration.months(3));
     const d2 = Duration.months(2).minus(Duration.months(2));
-    expect(d1.since(time).getTime()).toBe(d2.since(time).getTime());
+    expect(d1.since(time).epochMilliseconds).toBe(d2.since(time).epochMilliseconds);
   });
 
   it("durations survive yaml serialization", () => {
@@ -549,6 +556,6 @@ describe("DurationTest", () => {
     const time = new Date("Dec 7, 2021");
     const expected = new Date("2021-12-06T23:59:59");
     const d = Duration.seconds(1);
-    expect(d.negate().since(time).getTime()).toBeCloseTo(expected.getTime(), -3);
+    expect(d.negate().since(time).epochMilliseconds).toBeCloseTo(expected.getTime(), -3);
   });
 });

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Temporal } from "../temporal.js";
+import { Temporal } from "../temporal.js";
 import { Duration } from "../duration.js";
 
 function asDate(instant: Temporal.Instant): Date {
@@ -243,6 +243,16 @@ describe("DurationTest", () => {
     const t = new Date(2000, 0, 1, 0, 0, 0, 0);
     expect(Duration.seconds(1).since(t).epochMilliseconds).toBe(t.getTime() + 1000);
     expect(Duration.seconds(1).ago(t).epochMilliseconds).toBe(t.getTime() - 1000);
+  });
+
+  it("since and ago preserve sub-millisecond precision of Temporal.Instant inputs", () => {
+    const baseMs = new Date(2000, 0, 1).getTime();
+    const baseNs = BigInt(baseMs) * 1_000_000n + 123_456n; // 123_456 ns past the ms boundary
+    const t = Temporal.Instant.fromEpochNanoseconds(baseNs);
+    const after = Duration.seconds(1).since(t);
+    expect(after.epochNanoseconds).toBe(baseNs + 1_000_000_000n);
+    const before = Duration.seconds(1).ago(t);
+    expect(before.epochNanoseconds).toBe(baseNs - 1_000_000_000n);
   });
 
   it("since and ago accept Temporal.Instant inputs", () => {

--- a/packages/activesupport/src/core-ext/numeric-ext.test.ts
+++ b/packages/activesupport/src/core-ext/numeric-ext.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { Temporal } from "../temporal.js";
 import { numberToHuman } from "../number-helper.js";
 import { Duration } from "../duration.js";
+
+function asDate(instant: Temporal.Instant): Date {
+  return new Date(instant.epochMilliseconds);
+}
 
 describe("NumericExtTimeAndDateTimeTest", () => {
   it("units", () => {
@@ -15,13 +20,13 @@ describe("NumericExtTimeAndDateTimeTest", () => {
   it("irregular durations", () => {
     const now = new Date(2005, 1, 10, 15, 30, 45); // Feb 10 2005
     const in3000days = Duration.days(3000).since(now);
-    expect(in3000days.getDate()).toBeGreaterThan(0);
+    expect(asDate(in3000days).getDate()).toBeGreaterThan(0);
     // 1 month since Feb → March (month index 2)
     const in1month = Duration.months(1).since(now);
-    expect(in1month.getMonth()).toBe(2); // March (0-indexed)
+    expect(asDate(in1month).getMonth()).toBe(2); // March (0-indexed)
     // until = ago — 1 month before Feb → January (month index 0)
     const minus1month = Duration.months(1).until(now);
-    expect(minus1month.getMonth()).toBe(0); // January
+    expect(asDate(minus1month).getMonth()).toBe(0); // January
   });
 
   it("duration addition", () => {
@@ -31,17 +36,17 @@ describe("NumericExtTimeAndDateTimeTest", () => {
     const expected = new Date(now);
     expected.setDate(expected.getDate() + 1);
     expected.setMonth(expected.getMonth() + 1);
-    expect(combined.getTime()).toBe(expected.getTime());
+    expect(combined.epochMilliseconds).toBe(expected.getTime());
   });
 
   it("time plus duration", () => {
     const now = new Date(2005, 1, 10, 15, 30, 45);
     const plus8 = Duration.seconds(8).since(now);
-    expect(plus8.getTime()).toBe(now.getTime() + 8000);
+    expect(plus8.epochMilliseconds).toBe(now.getTime() + 8000);
     const plus15days = Duration.days(15).since(now);
     const expected15 = new Date(now);
     expected15.setDate(expected15.getDate() + 15);
-    expect(plus15days.getTime()).toBe(expected15.getTime());
+    expect(plus15days.epochMilliseconds).toBe(expected15.getTime());
   });
 
   it("chaining duration operations", () => {
@@ -50,7 +55,7 @@ describe("NumericExtTimeAndDateTimeTest", () => {
     const expected = new Date(now);
     expected.setDate(expected.getDate() + 2);
     expected.setMonth(expected.getMonth() - 3);
-    expect(result.getTime()).toBe(expected.getTime());
+    expect(result.epochMilliseconds).toBe(expected.getTime());
   });
 
   it("duration after conversion is no longer accurate", () => {
@@ -62,9 +67,9 @@ describe("NumericExtTimeAndDateTimeTest", () => {
   it("add one year to leap day", () => {
     const leapDay = new Date(2004, 1, 29, 15, 15, 10);
     const result = Duration.years(1).since(leapDay);
-    expect(result.getFullYear()).toBe(2005);
+    expect(asDate(result).getFullYear()).toBe(2005);
     // JS behavior: setFullYear(2005) on Feb 29 overflows to Mar 1
-    expect(result.getMonth()).toBe(2); // Mar (0-indexed), overflowed from Feb 29
+    expect(asDate(result).getMonth()).toBe(2); // Mar (0-indexed), overflowed from Feb 29
   });
 
   it("in milliseconds", () => {
@@ -76,13 +81,13 @@ describe("NumericExtDateTest", () => {
   it("date plus duration", () => {
     const today = new Date(2005, 1, 10); // Feb 10 2005
     const plus1day = Duration.days(1).since(today);
-    expect(plus1day.getDate()).toBe(11);
+    expect(asDate(plus1day).getDate()).toBe(11);
 
     const plus1month = Duration.months(1).since(today);
-    expect(plus1month.getMonth()).toBe(2); // March
+    expect(asDate(plus1month).getMonth()).toBe(2); // March
 
     const plus1sec = Duration.seconds(1).since(today);
-    expect(plus1sec.getTime()).toBe(today.getTime() + 1000);
+    expect(plus1sec.epochMilliseconds).toBe(today.getTime() + 1000);
   });
 });
 

--- a/packages/activesupport/src/duration.test.ts
+++ b/packages/activesupport/src/duration.test.ts
@@ -47,12 +47,12 @@ describe("Numeric helpers (functional equivalents of Rails numeric extensions)",
 
   it("fromNow returns a future Date", () => {
     const future = minutes(10).fromNow();
-    expect(future.getTime()).toBeGreaterThan(Date.now() + 9 * 60 * 1000);
+    expect(future.epochMilliseconds).toBeGreaterThan(Date.now() + 9 * 60 * 1000);
   });
 
   it("ago returns a past Date", () => {
     const past = hours(1).ago();
-    expect(past.getTime()).toBeLessThan(Date.now() - 59 * 60 * 1000);
+    expect(past.epochMilliseconds).toBeLessThan(Date.now() - 59 * 60 * 1000);
   });
 
   it("Duration.sum adds an array of durations", () => {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -420,7 +420,9 @@ function singular(key: keyof DurationParts): string {
 }
 
 function toDateInput(date: Date | Temporal.Instant): Date {
-  return date instanceof Date ? date : new Date(date.epochMilliseconds);
+  if (date instanceof Date) return date;
+  if (date instanceof Temporal.Instant) return new Date(date.epochMilliseconds);
+  throw new TypeError(`expected a time or date, got ${JSON.stringify(date)}`);
 }
 
 /**

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -180,11 +180,11 @@ export class Duration {
   // ---------------------------------------------------------------------------
 
   since(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
-    return instantFrom(applyDuration(toDateInput(date), this.parts, 1));
+    return applyDurationPreservingNs(date, this.parts, 1);
   }
 
   ago(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
-    return instantFrom(applyDuration(toDateInput(date), this.parts, -1));
+    return applyDurationPreservingNs(date, this.parts, -1);
   }
 
   fromNow(): Temporal.Instant {
@@ -423,6 +423,21 @@ function toDateInput(date: Date | Temporal.Instant): Date {
   if (date instanceof Date) return date;
   if (date instanceof Temporal.Instant) return new Date(date.epochMilliseconds);
   throw new TypeError(`expected a time or date, got ${JSON.stringify(date)}`);
+}
+
+/**
+ * Apply a Duration while preserving the sub-millisecond nanosecond remainder
+ * of a Temporal.Instant input. Calendar math runs at ms precision through
+ * applyDuration; the original ns remainder is re-added to the result.
+ */
+function applyDurationPreservingNs(
+  date: Date | Temporal.Instant,
+  parts: DurationParts,
+  direction: 1 | -1,
+): Temporal.Instant {
+  const nsRemainder = date instanceof Temporal.Instant ? date.epochNanoseconds % 1_000_000n : 0n;
+  const result = instantFrom(applyDuration(toDateInput(date), parts, direction));
+  return nsRemainder === 0n ? result : result.add({ nanoseconds: Number(nsRemainder) });
 }
 
 /**

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -1,11 +1,12 @@
 /**
  * ActiveSupport::Duration — mirrors the Rails API as closely as possible.
  *
- * @boundary-file: This file's public API is Date-typed by Rails parity
- *   (`since`/`ago`/`from_now`/`until`/`after`/`before` all take and return
- *   `Time`-like values, which JS expresses as `Date`). The Temporal flip lives
- *   on `TimeWithZone` instead.
+ * @boundary-file: `since`/`ago`/`from_now`/`until`/`after`/`before` accept
+ *   `Date | Temporal.Instant` (`Date` for ergonomic interop) but return
+ *   `Temporal.Instant`. The default reference is `Temporal.Now.instant()`.
  */
+
+import { Temporal, instantFrom } from "./temporal.js";
 
 export type DurationParts = {
   years: number;
@@ -178,27 +179,27 @@ export class Duration {
   // Date application — applies each part sequentially like Rails does
   // ---------------------------------------------------------------------------
 
-  since(date: Date = new Date()): Date {
-    return applyDuration(date, this.parts, 1);
+  since(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
+    return instantFrom(applyDuration(toDateInput(date), this.parts, 1));
   }
 
-  ago(date: Date = new Date()): Date {
-    return applyDuration(date, this.parts, -1);
+  ago(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
+    return instantFrom(applyDuration(toDateInput(date), this.parts, -1));
   }
 
-  fromNow(): Date {
-    return this.since(new Date());
+  fromNow(): Temporal.Instant {
+    return this.since();
   }
 
-  until(date: Date = new Date()): Date {
+  until(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
     return this.ago(date);
   }
 
-  after(date: Date = new Date()): Date {
+  after(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
     return this.since(date);
   }
 
-  before(date: Date = new Date()): Date {
+  before(date: Date | Temporal.Instant = Temporal.Now.instant()): Temporal.Instant {
     return this.ago(date);
   }
 
@@ -416,6 +417,10 @@ function singular(key: keyof DurationParts): string {
     case "seconds":
       return "second";
   }
+}
+
+function toDateInput(date: Date | Temporal.Instant): Date {
+  return date instanceof Date ? date : new Date(date.epochMilliseconds);
 }
 
 /**


### PR DESCRIPTION
## Summary

Continues the Temporal migration in `activesupport/duration.ts` (F-6e):

- `Duration#since`/`#ago`/`#fromNow`/`#until`/`#after`/`#before` now accept `Date | Temporal.Instant` and return `Temporal.Instant`.
- Default reference flips from `new Date()` to `Temporal.Now.instant()`.
- `@boundary-file` doc updated.

Internal `applyDuration` keeps Date arithmetic for calendar accuracy; the public methods wrap inputs/outputs with `instantFrom`.

## Test plan
- [x] `pnpm exec vitest run packages/activesupport`
- [x] `pnpm --filter @blazetrails/activesupport build`