### PR TITLE
feat(activemodel): port Date/DateTime/TimeValue privates

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -112,11 +112,7 @@ describe("DateTimeTest", () => {
   it("valueFromMultiparameterAssignment reconstructs an Instant from {1..6}", () => {
     class Probe extends Types.DateTimeType {
       call(values: Record<number, unknown>) {
-        return (
-          this as unknown as {
-            valueFromMultiparameterAssignment(v: Record<number, unknown>): unknown;
-          }
-        ).valueFromMultiparameterAssignment(values);
+        return this.valueFromMultiparameterAssignment(values);
       }
     }
     const result = new Probe().call({ 1: 2024, 2: 1, 3: 2, 4: 12, 5: 30, 6: 0 });
@@ -126,11 +122,7 @@ describe("DateTimeTest", () => {
   it("valueFromMultiparameterAssignment throws when keys 1/2/3 missing", () => {
     class Probe extends Types.DateTimeType {
       call(values: Record<number, unknown>) {
-        return (
-          this as unknown as {
-            valueFromMultiparameterAssignment(v: Record<number, unknown>): unknown;
-          }
-        ).valueFromMultiparameterAssignment(values);
+        return this.valueFromMultiparameterAssignment(values);
       }
     }
     expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -133,6 +133,8 @@ describe("DateTimeTest", () => {
         ).valueFromMultiparameterAssignment(values);
       }
     }
-    expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(/necessary keys/);
+    expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(
+      expect.objectContaining({ name: "ArgumentError" }),
+    );
   });
 });

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -108,4 +108,31 @@ describe("DateTimeTest", () => {
     const result = type.cast(pdt);
     expect(result).toBeInstanceOf(Temporal.Instant);
   });
+
+  it("valueFromMultiparameterAssignment reconstructs an Instant from {1..6}", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return (
+          this as unknown as {
+            valueFromMultiparameterAssignment(v: Record<number, unknown>): unknown;
+          }
+        ).valueFromMultiparameterAssignment(values);
+      }
+    }
+    const result = new Probe().call({ 1: 2024, 2: 1, 3: 2, 4: 12, 5: 30, 6: 0 });
+    expect(result).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("valueFromMultiparameterAssignment throws when keys 1/2/3 missing", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return (
+          this as unknown as {
+            valueFromMultiparameterAssignment(v: Record<number, unknown>): unknown;
+          }
+        ).valueFromMultiparameterAssignment(values);
+      }
+    }
+    expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(/necessary keys/);
+  });
 });

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -125,21 +125,8 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * @internal Rails-private helper.
    */
   protected fallbackStringToTime(s: string): Temporal.Instant | null {
-    try {
-      const normalized = s
-        .replace(" ", "T")
-        .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
-      const datetimeString = /^\d{4}-\d{2}-\d{2}$/.test(normalized)
-        ? `${normalized}T00:00:00`
-        : normalized;
-      const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(datetimeString);
-      if (hasOffset) return Temporal.Instant.from(datetimeString);
-      return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-        .toZonedDateTime(configuredTimezone())
-        .toInstant();
-    } catch {
-      return null;
-    }
+    const result = this.parseString(s.trim());
+    return result instanceof Temporal.Instant ? result : null;
   }
 
   /**

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -5,6 +5,7 @@ import {
   type DateInfinity as DateInfinityType,
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
+import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
@@ -129,10 +130,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    */
   protected fallbackStringToTime(s: string): Temporal.Instant | null {
     try {
-      const normalized = s.replace(" ", "T");
-      const hasOffset = /Z$|[+-]\d{2}(?::?\d{2})?$/.test(normalized);
+      const normalized = s
+        .replace(" ", "T")
+        .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+      const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(normalized);
       if (hasOffset) return Temporal.Instant.from(normalized);
-      return Temporal.PlainDateTime.from(normalized)
+      return Temporal.PlainDateTime.from(normalized, { overflow: "reject" })
         .toZonedDateTime(configuredTimezone())
         .toInstant();
     } catch {
@@ -166,7 +169,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   ): DateTimeCastResult | null {
     const missing = [1, 2, 3].filter((k) => !(k in values));
     if (missing.length > 0) {
-      throw new Error(
+      throw new ArgumentError(
         `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
       );
     }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -86,4 +86,89 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   type(): string {
     return this.name;
   }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#microseconds (date_time.rb:62-64).
+   *
+   *   # '0.123456' -> 123456
+   *   # '1.123456' -> 123456
+   *   def microseconds(time)
+   *     time[:sec_fraction] ? (time[:sec_fraction] * 1_000_000).to_i : 0
+   *   end
+   *
+   * Rails parses sub-second precision out of `Date._parse` results as
+   * a `Rational` (e.g. `123456/1000000`); multiplying by 1_000_000
+   * normalizes it to an integer microsecond count.
+   *
+   * @internal Rails-private helper.
+   */
+  protected microseconds(time: { sec_fraction?: number | null }): number {
+    return time.sec_fraction ? Math.trunc(time.sec_fraction * 1_000_000) : 0;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#fallback_string_to_time
+   * (date_time.rb:66-75).
+   *
+   *   def fallback_string_to_time(string)
+   *     time_hash = begin
+   *       ::Date._parse(string)
+   *     rescue ArgumentError
+   *     end
+   *     return unless time_hash
+   *     time_hash[:sec_fraction] = microseconds(time_hash)
+   *     new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
+   *   end
+   *
+   * Trails has no `Date._parse` equivalent; reuse Temporal's
+   * permissive parser plus the configured-zone resolution that
+   * `parseString` already implements. Returns null on parse failure.
+   *
+   * @internal Rails-private helper.
+   */
+  protected fallbackStringToTime(s: string): Temporal.Instant | null {
+    try {
+      const normalized = s.replace(" ", "T");
+      const hasOffset = /Z$|[+-]\d{2}(?::?\d{2})?$/.test(normalized);
+      if (hasOffset) return Temporal.Instant.from(normalized);
+      return Temporal.PlainDateTime.from(normalized)
+        .toZonedDateTime(configuredTimezone())
+        .toInstant();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#value_from_multiparameter_assignment
+   * (date_time.rb:77-83).
+   *
+   *   def value_from_multiparameter_assignment(values_hash)
+   *     missing_parameters = [1, 2, 3].delete_if { |key| values_hash.key?(key) }
+   *     unless missing_parameters.empty?
+   *       raise ArgumentError, "Provided hash #{values_hash} doesn't contain necessary keys: #{missing_parameters}"
+   *     end
+   *     super
+   *   end
+   *
+   * Validates that year/mon/mday (multiparameter keys 1, 2, 3) are
+   * present, then defers to the multiparameter wrapper. Trails routes
+   * the actual reconstruction through `AcceptsMultiparameterTime`
+   * (`helpers/accepts-multiparameter-time.ts`); this helper exists for
+   * Rails parity and as the entry point for callers that want the
+   * key-presence check.
+   *
+   * @internal Rails-private helper.
+   */
+  protected valueFromMultiparameterAssignment(
+    values: Record<number, unknown>,
+  ): DateTimeCastResult | null {
+    const missing = [1, 2, 3].filter((k) => !(k in values));
+    if (missing.length > 0) {
+      throw new Error(
+        `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
+      );
+    }
+    return this.cast(values) as DateTimeCastResult | null;
+  }
 }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -153,7 +153,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): DateTimeCastResult | null {
-    const missing = [1, 2, 3].filter((k) => !(k in values));
+    const missing = [1, 2, 3].filter((k) => !Object.hasOwn(values, k));
     if (missing.length > 0) {
       throw new ArgumentError(
         `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -7,12 +7,8 @@ import {
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
-import { isUtc } from "./helpers/timezone.js";
+import { configuredTimezone } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
-
-function configuredTimezone(): string {
-  return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
-}
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
 
@@ -133,9 +129,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
       const normalized = s
         .replace(" ", "T")
         .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
-      const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(normalized);
-      if (hasOffset) return Temporal.Instant.from(normalized);
-      return Temporal.PlainDateTime.from(normalized, { overflow: "reject" })
+      const datetimeString = /^\d{4}-\d{2}-\d{2}$/.test(normalized)
+        ? `${normalized}T00:00:00`
+        : normalized;
+      const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(datetimeString);
+      if (hasOffset) return Temporal.Instant.from(datetimeString);
+      return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
         .toZonedDateTime(configuredTimezone())
         .toInstant();
     } catch {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -5,6 +5,7 @@ import {
   type DateInfinity as DateInfinityType,
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
+import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
 
@@ -169,6 +170,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
       );
     }
-    return this.cast(values) as DateTimeCastResult | null;
+    return new AcceptsMultiparameterTime(this).cast(values) as DateTimeCastResult | null;
   }
 }

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -63,4 +63,20 @@ describe("DateTest", () => {
   it("typeCastForSchema returns null for null", () => {
     expect(type.typeCastForSchema(null)).toBe("null");
   });
+
+  it("newDate rejects out-of-range components (rescue nil parity)", () => {
+    class Probe extends Types.DateType {
+      newDateFor(y: number, m: number, d: number) {
+        return (
+          this as unknown as {
+            newDate(y: number, m: number, d: number): Temporal.PlainDate | null;
+          }
+        ).newDate(y, m, d);
+      }
+    }
+    const p = new Probe();
+    expect(p.newDateFor(2024, 2, 30)).toBe(null);
+    expect(p.newDateFor(0, 0, 0)).toBe(null);
+    expect(p.newDateFor(2024, 1, 15)?.toString()).toBe("2024-01-15");
+  });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -67,11 +67,7 @@ describe("DateTest", () => {
   it("newDate rejects out-of-range components (rescue nil parity)", () => {
     class Probe extends Types.DateType {
       newDateFor(y: number, m: number, d: number) {
-        return (
-          this as unknown as {
-            newDate(y: number, m: number, d: number): Temporal.PlainDate | null;
-          }
-        ).newDate(y, m, d);
+        return this.newDate(y, m, d);
       }
     }
     const p = new Probe();

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -131,7 +131,10 @@ export class DateType extends ValueType<DateCastResult> {
   ): Temporal.PlainDate | null {
     if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
     try {
-      return Temporal.PlainDate.from({ year, month: mon ?? 1, day: mday ?? 1 });
+      return Temporal.PlainDate.from(
+        { year, month: mon ?? 1, day: mday ?? 1 },
+        { overflow: "reject" },
+      );
     } catch {
       return null;
     }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -130,11 +130,11 @@ export class DateType extends ValueType<DateCastResult> {
     mday: number | null | undefined,
   ): Temporal.PlainDate | null {
     if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
+    // Rails' ::Date.new(year, nil, nil) raises → rescue nil. Treat missing
+    // month/day the same way rather than silently coercing to Jan 1.
+    if (mon == null || mday == null) return null;
     try {
-      return Temporal.PlainDate.from(
-        { year, month: mon ?? 1, day: mday ?? 1 },
-        { overflow: "reject" },
-      );
+      return Temporal.PlainDate.from({ year, month: mon, day: mday }, { overflow: "reject" });
     } catch {
       return null;
     }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -103,7 +103,7 @@ export class DateType extends ValueType<DateCastResult> {
    */
   protected fallbackStringToDate(s: string): Temporal.PlainDate | null {
     try {
-      const pd = Temporal.PlainDate.from(s);
+      const pd = Temporal.PlainDate.from(s, { overflow: "reject" });
       return this.newDate(pd.year, pd.month, pd.day);
     } catch {
       return null;

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -76,6 +76,7 @@ export class DateType extends ValueType<DateCastResult> {
    * @internal Rails-private helper.
    */
   protected fastStringToDate(s: string): Temporal.PlainDate | null {
+    if (s.includes("\n")) return null;
     const m = ISO_DATE.exec(s);
     if (!m) return null;
     return this.newDate(parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10));

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -62,4 +62,106 @@ export class DateType extends ValueType<DateCastResult> {
     if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return "null";
     return JSON.stringify(cast.toString());
   }
+
+  /**
+   * Mirrors: ActiveModel::Type::Date#fast_string_to_date (date.rb:55-58).
+   *
+   *   ISO_DATE = /\A(\d{4})-(\d\d)-(\d\d)\z/
+   *   def fast_string_to_date(string)
+   *     if string =~ ISO_DATE
+   *       new_date $1.to_i, $2.to_i, $3.to_i
+   *     end
+   *   end
+   *
+   * @internal Rails-private helper.
+   */
+  protected fastStringToDate(s: string): Temporal.PlainDate | null {
+    const m = ISO_DATE.exec(s);
+    if (!m) return null;
+    return this.newDate(parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10));
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Date#fallback_string_to_date
+   * (date.rb:60-67).
+   *
+   *   def fallback_string_to_date(string)
+   *     parts = begin
+   *       ::Date._parse(string, false)
+   *     rescue ArgumentError
+   *     end
+   *     new_date(*parts.values_at(:year, :mon, :mday)) if parts
+   *   end
+   *
+   * Trails has no `Date._parse` equivalent; reuses Temporal's
+   * permissive parser, which already accepts the same ISO-leading
+   * forms Rails extracts year/mon/mday from. Falls through to `null`
+   * on parse failure, matching Rails' rescued path.
+   *
+   * @internal Rails-private helper.
+   */
+  protected fallbackStringToDate(s: string): Temporal.PlainDate | null {
+    try {
+      const pd = Temporal.PlainDate.from(s);
+      return this.newDate(pd.year, pd.month, pd.day);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Date#new_date (date.rb:69-73).
+   *
+   *   def new_date(year, mon, mday)
+   *     unless year.nil? || (year == 0 && mon == 0 && mday == 0)
+   *       ::Date.new(year, mon, mday) rescue nil
+   *     end
+   *   end
+   *
+   * `0000-00-00` short-circuits to null per Rails. Out-of-range
+   * components are caught and become null (matches `rescue nil`).
+   *
+   * @internal Rails-private helper.
+   */
+  protected newDate(
+    year: number | null | undefined,
+    mon: number | null | undefined,
+    mday: number | null | undefined,
+  ): Temporal.PlainDate | null {
+    if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
+    try {
+      return Temporal.PlainDate.from({ year, month: mon ?? 1, day: mday ?? 1 });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Date#value_from_multiparameter_assignment
+   * (date.rb:75-78).
+   *
+   *   def value_from_multiparameter_assignment(*)
+   *     time = super
+   *     time && new_date(time.year, time.mon, time.mday)
+   *   end
+   *
+   * The Rails version delegates to `Helpers::AcceptsMultiparameterTime`
+   * for the `Time` reconstruction, then narrows the result to a `::Date`.
+   * Trails routes multiparameter casts through
+   * `AcceptsMultiparameterTime`'s wrapper
+   * (`helpers/accepts-multiparameter-time.ts`); this helper mirrors the
+   * narrowing step so subclasses / consumers can call the Rails-named
+   * hook directly with the `{ 1: year, 2: mon, 3: mday, ... }` form
+   * pulled out of the multiparameter hash.
+   *
+   * @internal Rails-private helper.
+   */
+  protected valueFromMultiparameterAssignment(
+    values: Record<number, number | null | undefined>,
+  ): Temporal.PlainDate | null {
+    return this.newDate(values[1], values[2], values[3]);
+  }
 }
+
+/** Mirrors: ActiveModel::Type::Date::ISO_DATE (date.rb:54). */
+const ISO_DATE = /^(\d{4})-(\d\d)-(\d\d)$/;

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -89,6 +89,13 @@ describe("newTime", () => {
     const i = newTime(2024, 1, 2, 12, 0, 0, 0, 3600);
     expect(i?.toString()).toBe("2024-01-02T11:00:00Z");
   });
+
+  it("splits Ruby microsec (0..999_999) across Temporal millisecond/microsecond", () => {
+    const i = newTime(2024, 1, 2, 12, 0, 0, 123456);
+    const z = i?.toZonedDateTimeISO("UTC");
+    expect(z?.millisecond).toBe(123);
+    expect(z?.microsecond).toBe(456);
+  });
 });
 
 describe("fastStringToTime", () => {

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { applySecondsPrecision } from "./time-value.js";
+import { applySecondsPrecision, fastStringToTime, newTime } from "./time-value.js";
 
 // Mirrors ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
 // (time_value.rb:24-34). Truncation, not rounding — verify each
@@ -76,5 +76,28 @@ describe("applySecondsPrecision", () => {
   it("passes null/undefined through unchanged", () => {
     expect(applySecondsPrecision.call({ precision: 3 }, null)).toBeNull();
     expect(applySecondsPrecision.call({ precision: 3 }, undefined)).toBeUndefined();
+  });
+});
+
+describe("newTime", () => {
+  it("returns null for 0000-00-00 00:00:00 and rejects out-of-range components", () => {
+    expect(newTime(0, 0, 0, 0, 0, 0, 0)).toBeNull();
+    expect(newTime(2024, 2, 30, 0, 0, 0, 0)).toBeNull();
+  });
+
+  it("subtracts offset (in seconds) when offset != 0", () => {
+    const i = newTime(2024, 1, 2, 12, 0, 0, 0, 3600);
+    expect(i?.toString()).toBe("2024-01-02T11:00:00Z");
+  });
+});
+
+describe("fastStringToTime", () => {
+  it("returns null for strings without '-'", () => {
+    expect(fastStringToTime("1234")).toBeNull();
+  });
+
+  it("normalizes Postgres short offset (+00) to (+00:00)", () => {
+    const i = fastStringToTime("2026-04-26 14:23:55.123456+00");
+    expect(i?.toString().startsWith("2026-04-26T14:23:55.123456")).toBe(true);
   });
 });

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -164,6 +164,9 @@ export function newTime(
   // Rails' ::Time.utc(year, nil, nil, ...) raises TypeError → rescue nil.
   // Treat missing month/day the same way rather than silently coercing to Jan 1.
   if (mon == null || mday == null) return null;
+  // Ruby's Time.utc takes microsec as 0..999_999; Temporal splits sub-second
+  // resolution across millisecond (0..999) + microsecond (0..999) fields.
+  const totalMicro = microsec ?? 0;
   const components = {
     year,
     month: mon,
@@ -171,7 +174,8 @@ export function newTime(
     hour: hour ?? 0,
     minute: min ?? 0,
     second: sec ?? 0,
-    microsecond: microsec ?? 0,
+    millisecond: Math.trunc(totalMicro / 1000),
+    microsecond: totalMicro % 1000,
   };
   try {
     if (offset != null) {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -176,10 +176,12 @@ export function newTime(
   };
   try {
     if (offset != null) {
-      const instant = Temporal.PlainDateTime.from(components).toZonedDateTime("UTC").toInstant();
+      const instant = Temporal.PlainDateTime.from(components, { overflow: "reject" })
+        .toZonedDateTime("UTC")
+        .toInstant();
       return offset === 0 ? instant : instant.subtract({ seconds: offset });
     }
-    return Temporal.PlainDateTime.from(components)
+    return Temporal.PlainDateTime.from(components, { overflow: "reject" })
       .toZonedDateTime(configuredTimezone())
       .toInstant();
   } catch {
@@ -212,11 +214,13 @@ export function newTime(
  */
 export function fastStringToTime(s: string): Temporal.Instant | null {
   if (!s.includes("-")) return null;
-  const normalized = s.replace(" ", "T");
-  const hasOffset = /Z$|[+-]\d{2}(?::?\d{2})?$/.test(normalized);
+  const normalized = s
+    .replace(" ", "T")
+    .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+  const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(normalized);
   try {
     if (hasOffset) return Temporal.Instant.from(normalized);
-    return Temporal.PlainDateTime.from(normalized)
+    return Temporal.PlainDateTime.from(normalized, { overflow: "reject" })
       .toZonedDateTime(configuredTimezone())
       .toInstant();
   } catch {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -161,10 +161,13 @@ export function newTime(
   offset?: number | null,
 ): Temporal.Instant | null {
   if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
+  // Rails' ::Time.utc(year, nil, nil, ...) raises TypeError → rescue nil.
+  // Treat missing month/day the same way rather than silently coercing to Jan 1.
+  if (mon == null || mday == null) return null;
   const components = {
     year,
-    month: mon ?? 1,
-    day: mday ?? 1,
+    month: mon,
+    day: mday,
     hour: hour ?? 0,
     minute: min ?? 0,
     second: sec ?? 0,

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,11 +4,7 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { isUtc } from "./timezone.js";
-
-function configuredTimezone(): string {
-  return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
-}
+import { configuredTimezone } from "./timezone.js";
 
 export interface TimeValue {
   precision?: number;
@@ -217,10 +213,13 @@ export function fastStringToTime(s: string): Temporal.Instant | null {
   const normalized = s
     .replace(" ", "T")
     .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
-  const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(normalized);
+  const datetimeString = /^\d{4}-\d{2}-\d{2}$/.test(normalized)
+    ? `${normalized}T00:00:00`
+    : normalized;
+  const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(datetimeString);
   try {
-    if (hasOffset) return Temporal.Instant.from(normalized);
-    return Temporal.PlainDateTime.from(normalized, { overflow: "reject" })
+    if (hasOffset) return Temporal.Instant.from(datetimeString);
+    return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
       .toZonedDateTime(configuredTimezone())
       .toInstant();
   } catch {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,6 +4,11 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { isUtc } from "./timezone.js";
+
+function configuredTimezone(): string {
+  return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
+}
 
 export interface TimeValue {
   precision?: number;
@@ -116,6 +121,104 @@ export function userInputInTimeZone(
   }
   try {
     return Temporal.PlainDateTime.from(str.replace(" ", "T")).toZonedDateTime(zone);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::TimeValue#new_time
+ * (time_value.rb:48-65)
+ *
+ *   def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
+ *     return if year.nil? || (year == 0 && mon == 0 && mday == 0)
+ *     if offset
+ *       time = ::Time.utc(year, mon, mday, hour, min, sec, microsec) rescue nil
+ *       return unless time
+ *       time -= offset unless offset == 0
+ *       is_utc? ? time : time.getlocal
+ *     elsif is_utc?
+ *       ::Time.utc(year, mon, mday, hour, min, sec, microsec) rescue nil
+ *     else
+ *       ::Time.local(year, mon, mday, hour, min, sec, microsec) rescue nil
+ *     end
+ *   end
+ *
+ * Trails returns Temporal.Instant — the closest analogue to Ruby's
+ * `::Time` for the no-zone-info, fixed-instant role this helper plays.
+ * `0000-00-00 00:00:00` short-circuits to null per Rails. With an
+ * offset, build at UTC and subtract the offset (in seconds) to land
+ * the instant; without, interpret the components in the configured
+ * default zone (`isUtc()` → "UTC", else host-local), matching Rails'
+ * `is_utc?` branching.
+ *
+ * @internal Rails-private helper.
+ */
+export function newTime(
+  year: number | null | undefined,
+  mon: number | null | undefined,
+  mday: number | null | undefined,
+  hour: number | null | undefined,
+  min: number | null | undefined,
+  sec: number | null | undefined,
+  microsec: number | null | undefined,
+  offset?: number | null,
+): Temporal.Instant | null {
+  if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
+  const components = {
+    year,
+    month: mon ?? 1,
+    day: mday ?? 1,
+    hour: hour ?? 0,
+    minute: min ?? 0,
+    second: sec ?? 0,
+    microsecond: microsec ?? 0,
+  };
+  try {
+    if (offset != null) {
+      const instant = Temporal.PlainDateTime.from(components).toZonedDateTime("UTC").toInstant();
+      return offset === 0 ? instant : instant.subtract({ seconds: offset });
+    }
+    return Temporal.PlainDateTime.from(components)
+      .toZonedDateTime(configuredTimezone())
+      .toInstant();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::TimeValue#fast_string_to_time
+ * (time_value.rb:79-89, dual definition).
+ *
+ *   def fast_string_to_time(string)
+ *     return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00
+ *     if is_utc?
+ *       ::Time.new(string, in: "UTC")
+ *     else
+ *       ::Time.new(string)
+ *     end
+ *   rescue ArgumentError
+ *     nil
+ *   end
+ *
+ * Returns null for strings that don't look like dates (Rails skips
+ * `"1234"` because Ruby's `Time.new("1234")` would interpret it as
+ * year-only). Trails uses Temporal — strings with an offset go
+ * through `Instant.from`; bare strings fall back to PlainDateTime
+ * in the configured zone (matches Rails' `is_utc?` branching).
+ *
+ * @internal Rails-private helper.
+ */
+export function fastStringToTime(s: string): Temporal.Instant | null {
+  if (!s.includes("-")) return null;
+  const normalized = s.replace(" ", "T");
+  const hasOffset = /Z$|[+-]\d{2}(?::?\d{2})?$/.test(normalized);
+  try {
+    if (hasOffset) return Temporal.Instant.from(normalized);
+    return Temporal.PlainDateTime.from(normalized)
+      .toZonedDateTime(configuredTimezone())
+      .toInstant();
   } catch {
     return null;
   }

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -6,6 +6,8 @@
  * Provides helpers to check if the default timezone is UTC and
  * to retrieve the current default timezone setting.
  */
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
 export interface Timezone {
   isUtc(): boolean;
   defaultTimezone(): "utc" | "local";
@@ -23,4 +25,9 @@ export function defaultTimezone(): "utc" | "local" {
 
 export function setDefaultTimezone(tz: "utc" | "local"): void {
   _defaultTimezone = tz;
+}
+
+/** Resolves to "UTC" when the default timezone is UTC, else the host system zone. */
+export function configuredTimezone(): string {
+  return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
 }


### PR DESCRIPTION
## Summary

Mirrors Rails ActiveModel privates across three time-related type files:

- `type/date.ts` — `fastStringToDate`, `fallbackStringToDate`, `newDate`, `valueFromMultiparameterAssignment` + `ISO_DATE` constant.
- `type/date-time.ts` — `microseconds`, `fallbackStringToTime`, `valueFromMultiparameterAssignment`.
- `type/helpers/time-value.ts` — `newTime`, `fastStringToTime` (standalone exports) + shared `configuredTimezone()` resolver wired through `helpers/timezone.isUtc()`.

Refs `activemodel/lib/active_model/type/date.rb`, `date_time.rb`, `helpers/time_value.rb`.

## Privates report

532/625 (85.1%) → 541/625 (86.6%). type/date 7/7, type/date_time 5/5, type/helpers/time_value 6/6 — all three files at 100%.

Tracks B3 in `docs/activemodel-privates-100-plan.md`.

## Test plan

- [x] `pnpm --filter @blazetrails/activemodel test` — 1621/1621 pass
- [x] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` — +9 matches