### PR TITLE
feat(activesupport): drop TimeWithZone#_toDate; TimeZone helpers accept Temporal

### DIFF
--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -118,11 +118,9 @@ export class TimeWithZone {
     return this._zoned.epochMilliseconds;
   }
 
-  /** Build a Date snapshot for legacy Date-based helpers and formatters. */
-  private _toDate(): Date {
-    // boundary: bridges Temporal-backed state to still-Date-typed TimeZone
-    // helpers and time-ext/duration arithmetic.
-    return new Date(this._epochMs);
+  /** UTC-zoned snapshot of the underlying instant for component access. */
+  private get _utc(): Temporal.PlainDateTime {
+    return this._zoned.withTimeZone("UTC").toPlainDateTime();
   }
 
   // ---------------------------------------------------------------------------
@@ -141,12 +139,12 @@ export class TimeWithZone {
 
   /** Timezone abbreviation (e.g., "EST", "EDT") */
   get zone(): string {
-    return this._timeZone.abbreviation(this._toDate());
+    return this._timeZone.abbreviation(this._zoned.toInstant());
   }
 
   /** UTC offset in seconds */
   get utcOffset(): number {
-    return this._timeZone.utcOffsetAt(this._toDate());
+    return this._timeZone.utcOffsetAt(this._zoned.toInstant());
   }
 
   /** Alias for utcOffset */
@@ -156,7 +154,7 @@ export class TimeWithZone {
 
   /** Whether DST is in effect */
   dst(): boolean {
-    return this._timeZone.isDst(this._toDate());
+    return this._timeZone.isDst(this._zoned.toInstant());
   }
 
   /** Alias for dst() */
@@ -478,11 +476,11 @@ export class TimeWithZone {
 
   /** HTTP date format */
   httpdate(): string {
-    const u = this._toDate();
+    const u = this._utc;
     return (
-      `${SHORT_DAY_NAMES[u.getUTCDay()]}, ${pad2(u.getUTCDate())} ` +
-      `${SHORT_MONTH_NAMES[u.getUTCMonth()]} ${u.getUTCFullYear()} ` +
-      `${pad2(u.getUTCHours())}:${pad2(u.getUTCMinutes())}:${pad2(u.getUTCSeconds())} GMT`
+      `${SHORT_DAY_NAMES[u.dayOfWeek % 7]}, ${pad2(u.day)} ` +
+      `${SHORT_MONTH_NAMES[u.month - 1]} ${u.year} ` +
+      `${pad2(u.hour)}:${pad2(u.minute)}:${pad2(u.second)} GMT`
     );
   }
 
@@ -490,10 +488,10 @@ export class TimeWithZone {
   toFs(format: string = "default"): string {
     switch (format) {
       case "db": {
-        const u = this._toDate();
+        const u = this._utc;
         return (
-          `${u.getUTCFullYear()}-${pad2(u.getUTCMonth() + 1)}-${pad2(u.getUTCDate())} ` +
-          `${pad2(u.getUTCHours())}:${pad2(u.getUTCMinutes())}:${pad2(u.getUTCSeconds())}`
+          `${u.year}-${pad2(u.month)}-${pad2(u.day)} ` +
+          `${pad2(u.hour)}:${pad2(u.minute)}:${pad2(u.second)}`
         );
       }
       case "long":

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -172,6 +172,10 @@ const zoneCache = new Map<string, TimeZone>();
 /**
  * Get timezone abbreviation and offset for a given IANA zone at a specific instant.
  */
+function toDate(at: Date | Temporal.Instant): Date {
+  return at instanceof Date ? at : new Date(at.epochMilliseconds);
+}
+
 function getZoneInfo(
   ianaName: string,
   date: Date,
@@ -665,8 +669,8 @@ export class TimeZone {
   /**
    * UTC offset at a specific instant.
    */
-  utcOffsetAt(date: Date): number {
-    return getZoneInfo(this.tzinfo, date).utcOffsetSeconds;
+  utcOffsetAt(date: Date | Temporal.Instant): number {
+    return getZoneInfo(this.tzinfo, toDate(date)).utcOffsetSeconds;
   }
 
   /**
@@ -684,15 +688,16 @@ export class TimeZone {
   /**
    * Whether DST is in effect at the given instant.
    */
-  isDst(date: Date = new Date()): boolean {
+  isDst(date: Date | Temporal.Instant = Temporal.Now.instant()): boolean {
     // Compare offset at this date vs January (standard time for Northern hemisphere)
     // and July (standard time for Southern hemisphere). If current offset differs
     // from the minimum offset, DST is in effect.
-    const jan = new Date(date.getFullYear(), 0, 1);
-    const jul = new Date(date.getFullYear(), 6, 1);
+    const d = toDate(date);
+    const jan = new Date(d.getFullYear(), 0, 1);
+    const jul = new Date(d.getFullYear(), 6, 1);
     const janOffset = getZoneInfo(this.tzinfo, jan).utcOffsetSeconds;
     const julOffset = getZoneInfo(this.tzinfo, jul).utcOffsetSeconds;
-    const currentOffset = getZoneInfo(this.tzinfo, date).utcOffsetSeconds;
+    const currentOffset = getZoneInfo(this.tzinfo, d).utcOffsetSeconds;
     const standardOffset = Math.min(janOffset, julOffset);
     return currentOffset !== standardOffset;
   }
@@ -700,8 +705,8 @@ export class TimeZone {
   /**
    * Timezone abbreviation at a given instant.
    */
-  abbreviation(date: Date = new Date()): string {
-    return getZoneInfo(this.tzinfo, date).abbreviation;
+  abbreviation(date: Date | Temporal.Instant = Temporal.Now.instant()): string {
+    return getZoneInfo(this.tzinfo, toDate(date)).abbreviation;
   }
 
   /**


### PR DESCRIPTION
## Summary

F-6f of the Temporal migration:

- `TimeZone#abbreviation`/`#utcOffsetAt`/`#isDst` accept `Date | Temporal.Instant`. Defaults flip from `new Date()` to `Temporal.Now.instant()`.
- `TimeWithZone` calls them with `this._zoned.toInstant()` instead of building a `Date` snapshot.
- The two UTC-component formatters (`httpdate`, `toFs("db")`) read components off `_zoned.withTimeZone("UTC").toPlainDateTime()` instead of `getUTC*` on a `Date`.
- `private _toDate()` deleted; one Date emission point in activesupport gone.

## Test plan
- [x] `pnpm exec vitest run packages/activesupport`
- [x] `pnpm --filter @blazetrails/activesupport build`