### PR TITLE
fix(arel): take/skip raw amount + null clear; optimizerHints AST node

### DIFF
--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -1,5 +1,6 @@
 import { Node, NodeVisitor } from "./node.js";
 import { JoinSource } from "./join-source.js";
+import type { OptimizerHints } from "./unary.js";
 
 /**
  * SelectCore — the core of a SELECT statement (projections, from, where, etc.).
@@ -15,8 +16,9 @@ export class SelectCore extends Node {
   windows: Node[];
   setQuantifier: Node | null;
   // Mirrors Rails: `@ctx.optimizer_hints` is an `OptimizerHints` node (or
-  // nil) — not a bare array (select_core.rb).
-  optimizerHints: Node | null;
+  // nil) — not a bare array (select_core.rb). Narrowed to the concrete
+  // node type so the SQL visitor can rely on the `/*+ … */` formatting.
+  optimizerHints: OptimizerHints | null;
   comment: Node | null;
 
   constructor(relation: Node | null = null) {

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -14,7 +14,9 @@ export class SelectCore extends Node {
   havings: Node[];
   windows: Node[];
   setQuantifier: Node | null;
-  optimizerHints: string[];
+  // Mirrors Rails: `@ctx.optimizer_hints` is an `OptimizerHints` node (or
+  // nil) — not a bare array (select_core.rb).
+  optimizerHints: Node | null;
   comment: Node | null;
 
   constructor(relation: Node | null = null) {
@@ -26,7 +28,7 @@ export class SelectCore extends Node {
     this.havings = [];
     this.windows = [];
     this.setQuantifier = null;
-    this.optimizerHints = [];
+    this.optimizerHints = null;
     this.comment = null;
   }
 
@@ -47,7 +49,7 @@ export class SelectCore extends Node {
     c.havings = [...this.havings];
     c.windows = [...this.windows];
     c.setQuantifier = this.setQuantifier;
-    c.optimizerHints = [...this.optimizerHints];
+    c.optimizerHints = this.optimizerHints;
     c.comment = this.comment;
     return c;
   }

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -192,6 +192,64 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star).skip(5);
       expect(mgr.toSql()).toContain("OFFSET 5");
     });
+
+    // Mirrors Rails: `skip(amount)` flows the raw value into
+    // `Nodes::Offset.new(amount)` (select_manager.rb), no `Quoted` wrap.
+    it("stores the raw amount on the Offset (no Quoted wrap)", () => {
+      const mgr = new SelectManager(users).skip(5);
+      const offset = mgr.ast.offset as Nodes.Offset;
+      expect(offset).toBeInstanceOf(Nodes.Offset);
+      expect(offset.expr).toBe(5);
+    });
+
+    // Mirrors Rails: `skip(nil)` clears the offset.
+    it("clears the offset when given null", () => {
+      const mgr = new SelectManager(users).skip(5);
+      expect(mgr.ast.offset).not.toBeNull();
+      mgr.skip(null);
+      expect(mgr.ast.offset).toBeNull();
+    });
+  });
+
+  describe("take", () => {
+    it("stores the raw amount on the Limit (no Quoted wrap)", () => {
+      const mgr = new SelectManager(users).take(5);
+      const limit = mgr.ast.limit as Nodes.Limit;
+      expect(limit).toBeInstanceOf(Nodes.Limit);
+      expect(limit.expr).toBe(5);
+    });
+
+    // Mirrors Rails: `take(nil)` clears the limit.
+    it("clears the limit when given null", () => {
+      const mgr = new SelectManager(users).take(5);
+      expect(mgr.ast.limit).not.toBeNull();
+      mgr.take(null);
+      expect(mgr.ast.limit).toBeNull();
+    });
+  });
+
+  // Mirrors Rails: `alias :limit= :take` and `alias :offset= :skip`
+  // (select_manager.rb). The setter form is symmetric with the getter.
+  describe("limit= / offset= setters", () => {
+    it("limit= delegates to take", () => {
+      const mgr = new SelectManager(users);
+      mgr.limit = 7;
+      const limit = mgr.ast.limit as Nodes.Limit;
+      expect(limit).toBeInstanceOf(Nodes.Limit);
+      expect(limit.expr).toBe(7);
+      mgr.limit = null;
+      expect(mgr.ast.limit).toBeNull();
+    });
+
+    it("offset= delegates to skip", () => {
+      const mgr = new SelectManager(users);
+      mgr.offset = 9;
+      const offset = mgr.ast.offset as Nodes.Offset;
+      expect(offset).toBeInstanceOf(Nodes.Offset);
+      expect(offset.expr).toBe(9);
+      mgr.offset = null;
+      expect(mgr.ast.offset).toBeNull();
+    });
   });
 
   describe("offset", () => {
@@ -1220,6 +1278,22 @@ describe("SelectManagerTest", () => {
     it("strips empty hints after sanitization", () => {
       const mgr = new SelectManager(users).project(star).optimizerHints("/* */", "--");
       expect(mgr.toSql()).toBe('SELECT * FROM "users"');
+    });
+
+    // Mirrors Rails: `optimizer_hints(*hints)` builds
+    // `Nodes::OptimizerHints.new(hints)` (select_manager.rb), so the AST
+    // carries an OptimizerHints node — not a bare string array.
+    it("stores hints as an OptimizerHints node on the SelectCore", () => {
+      const mgr = new SelectManager(users).project(star).optimizerHints("X", "Y");
+      expect(mgr.ast.cores[0].optimizerHints).toBeInstanceOf(Nodes.OptimizerHints);
+      expect((mgr.ast.cores[0].optimizerHints as Nodes.OptimizerHints).hints).toEqual(["X", "Y"]);
+    });
+
+    // Mirrors Rails: `optimizer_hints` is a no-op when called with no
+    // arguments (the Rails impl skips the assignment when hints empty).
+    it("is a no-op when called with no hints", () => {
+      const mgr = new SelectManager(users).project(star).optimizerHints();
+      expect(mgr.ast.cores[0].optimizerHints).toBeNull();
     });
   });
 });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -4,14 +4,13 @@ import { SelectStatement } from "./nodes/select-statement.js";
 import { SelectCore } from "./nodes/select-core.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Distinct } from "./nodes/terminal.js";
-import { Offset, Limit, Lock, On, DistinctOn, Group } from "./nodes/unary.js";
+import { Offset, Limit, Lock, On, DistinctOn, Group, OptimizerHints } from "./nodes/unary.js";
 import { CrossJoin, Join } from "./nodes/binary.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
 import { RightOuterJoin } from "./nodes/right-outer-join.js";
 import { FullOuterJoin } from "./nodes/full-outer-join.js";
 import { StringJoin } from "./nodes/string-join.js";
-import { Quoted } from "./nodes/casted.js";
 import { Union, UnionAll, Intersect, Except } from "./nodes/binary.js";
 import { With, WithRecursive } from "./nodes/with.js";
 import { TableAlias } from "./nodes/table-alias.js";
@@ -131,25 +130,23 @@ export class SelectManager extends TreeManager {
 
   /**
    * Set LIMIT.
+   *
+   * Mirrors: Arel::SelectManager#take (select_manager.rb). Pass `null`
+   * to clear; raw amounts flow through `new Limit(amount)` unwrapped.
    */
-  take(amount: number | Node): this {
-    if (amount instanceof Node) {
-      this.ast.limit = amount;
-    } else {
-      this.ast.limit = new Limit(new Quoted(amount));
-    }
+  take(amount: number | Node | null): this {
+    this.ast.limit = amount == null ? null : new Limit(amount);
     return this;
   }
 
   /**
    * Set OFFSET.
+   *
+   * Mirrors: Arel::SelectManager#skip (select_manager.rb). Pass `null`
+   * to clear; raw amounts flow through `new Offset(amount)` unwrapped.
    */
-  skip(amount: number | Node): this {
-    if (amount instanceof Node) {
-      this.ast.offset = amount;
-    } else {
-      this.ast.offset = new Offset(new Quoted(amount));
-    }
+  skip(amount: number | Node | null): this {
+    this.ast.offset = amount == null ? null : new Offset(amount);
     return this;
   }
 
@@ -369,12 +366,26 @@ export class SelectManager extends TreeManager {
   }
 
   /**
+   * Mirrors: Arel::SelectManager `alias limit= take` (select_manager.rb).
+   */
+  set limit(value: number | Node | null) {
+    this.take(value);
+  }
+
+  /**
    * Return the current OFFSET node.
    *
    * Mirrors: Arel::SelectManager#offset
    */
   get offset(): Node | null {
     return this.ast.offset;
+  }
+
+  /**
+   * Mirrors: Arel::SelectManager `alias offset= skip` (select_manager.rb).
+   */
+  set offset(value: number | Node | null) {
+    this.skip(value);
   }
 
   /**
@@ -407,10 +418,14 @@ export class SelectManager extends TreeManager {
   /**
    * Add optimizer hints to the query.
    *
-   * Mirrors: Arel::SelectManager#optimizer_hints
+   * Mirrors: Arel::SelectManager#optimizer_hints (select_manager.rb).
+   * Rails wraps the splat in `Nodes::OptimizerHints.new(hints)` and only
+   * assigns when at least one hint is provided.
    */
   optimizerHints(...hints: string[]): this {
-    this.core.optimizerHints = hints;
+    if (hints.length > 0) {
+      this.core.optimizerHints = new OptimizerHints(hints);
+    }
     return this;
   }
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -422,7 +422,7 @@ export class SelectManager extends TreeManager {
    * Rails wraps the splat in `Nodes::OptimizerHints.new(hints)` and only
    * assigns when at least one hint is provided.
    */
-  optimizerHints(...hints: string[]): this {
+  optimizerHints(...hints: (string | SqlLiteral)[]): this {
     if (hints.length > 0) {
       this.core.optimizerHints = new OptimizerHints(hints);
     }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -292,13 +292,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected emitOptimizerHints(node: Nodes.SelectCore): void {
-    if (node.optimizerHints.length === 0) return;
-    const sanitized = node.optimizerHints
-      .map((h) => this.sanitizeHint(h))
-      .filter((h) => h.length > 0);
-    if (sanitized.length > 0) {
-      this.collector.append(` /*+ ${sanitized.join(" ")} */`);
-    }
+    // Mirrors Rails: `@ctx.optimizer_hints` is now an `OptimizerHints`
+    // node (or null); the visitor delegates to the dedicated visitor
+    // which sanitizes + wraps in `/*+ ... */`.
+    if (node.optimizerHints === null) return;
+    this.visit(node.optimizerHints);
   }
 
   // Mirrors Rails: visit_Arel_Nodes_SelectCore (to_sql.rb:149). Where Rails
@@ -1217,8 +1215,14 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // — this method exists for callers that build an OptimizerHints node
   // explicitly.
   protected visitArelNodesOptimizerHints(node: Nodes.OptimizerHints): SQLString {
-    const hints = node.hints.map((v) => this.sanitizeAsSqlComment(v)).join(" ");
-    this.collector.append(` /*+ ${hints} */`);
+    // Mirrors Rails: hints are sanitized (newlines, comment delimiters,
+    // `--` line comments stripped) and dropped when sanitization yields
+    // an empty string. No output when all hints sanitize away.
+    const sanitized = node.hints
+      .map((h) => this.sanitizeHint(typeof h === "string" ? h : h.value))
+      .filter((h) => h.length > 0);
+    if (sanitized.length === 0) return this.collector;
+    this.collector.append(` /*+ ${sanitized.join(" ")} */`);
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1211,9 +1211,8 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). The
   // OptimizerHints node carries a list of hint strings (Rails' `o.expr` is
   // an array); each hint is sanitized and the joined result wrapped in
-  // /*+ ... */. Trails' SelectCore also stores hints inline as `string[]`
-  // — this method exists for callers that build an OptimizerHints node
-  // explicitly.
+  // /*+ ... */. SelectCore stores its optimizer hints as an OptimizerHints
+  // node and `emitOptimizerHints` delegates here.
   protected visitArelNodesOptimizerHints(node: Nodes.OptimizerHints): SQLString {
     // Mirrors Rails: hints are sanitized (newlines, comment delimiters,
     // `--` line comments stripped) and dropped when sanitization yields

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1549,9 +1549,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   /**
    * Mirrors `to_sql.rb#collect_optimizer_hints`. Rails delegates to
-   * `maybe_visit o.optimizer_hints` since hints are an Arel node;
-   * Trails' SelectCore stores hints inline as `string[]`, so we call into
-   * the existing `emitOptimizerHints` formatter for parity at the seam.
+   * `maybe_visit o.optimizer_hints`; Trails' SelectCore now stores an
+   * `OptimizerHints` node (or null), and `emitOptimizerHints` does the
+   * `maybe_visit` no-op-when-nil dispatch.
    */
   protected collectOptimizerHints(o: Nodes.SelectCore): SQLString {
     this.emitOptimizerHints(o);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1214,11 +1214,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // /*+ ... */. SelectCore stores its optimizer hints as an OptimizerHints
   // node and `emitOptimizerHints` delegates here.
   protected visitArelNodesOptimizerHints(node: Nodes.OptimizerHints): SQLString {
-    // Mirrors Rails: hints are sanitized (newlines, comment delimiters,
-    // `--` line comments stripped) and dropped when sanitization yields
-    // an empty string. No output when all hints sanitize away.
+    // Mirrors Rails: plain string hints are sanitized (newlines, comment
+    // delimiters, `--` line comments stripped) and empty results dropped.
+    // SqlLiteral hints are the explicit escape hatch and pass through
+    // unchanged — same contract as `sanitizeAsSqlComment`.
     const sanitized = node.hints
-      .map((h) => this.sanitizeHint(typeof h === "string" ? h : h.value))
+      .map((h) => (h instanceof Nodes.SqlLiteral ? h.value : this.sanitizeHint(h)))
       .filter((h) => h.length > 0);
     if (sanitized.length === 0) return this.collector;
     this.collector.append(` /*+ ${sanitized.join(" ")} */`);


### PR DESCRIPTION
## Summary

Bundles two coherent SelectManager AST fixes from [`docs/arel-alignment-plan.md`](../blob/main/docs/arel-alignment-plan.md) (PRs 6 + 14). Both write-side; the read-side `limit`/`offset` getter change is the still-deferred PR 7 (wave 3).

- **PR 6** — `take(amount)` / `skip(amount)` now mirror [`select_manager.rb`](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/select_manager.rb): `null` clears `ast.limit`/`offset`; raw amounts flow into `Nodes::Limit` / `Nodes::Offset` directly without a `Quoted` wrap. Adds `limit=` / `offset=` setters per Rails' `alias :limit= :take` / `alias :offset= :skip`.
  - Consumer-visible: `(mgr.ast.limit as Limit).expr` is now a primitive (was `Quoted`). The `mgr.limit` getter still returns the `Limit` node — the breaking getter return-type change is PR 7.
- **PR 14** — `optimizerHints(...hints)` now wraps the values in a `Nodes::OptimizerHints` node and stores it on `SelectCore#optimizerHints` (was a bare `string[]`). `emitOptimizerHints` delegates to the dedicated visitor; sanitization (newlines, comment delimiters, `--` line comments) and empty-hint filtering preserved.

123 insertions / 28 deletions.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1236/1236 (8 new tests under `take`/`skip`/`limit= / offset= setters` + two assertions for the OptimizerHints node shape).
- [x] `pnpm exec vitest run packages/activerecord/` — 9947 passed, no regressions.