### PR TITLE
feat(activerecord): Quoting interface + AbstractAdapter implements

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -29,7 +29,26 @@ import {
   DatabaseStatements,
   transaction as dbStatementsTransaction,
 } from "./abstract/database-statements.js";
-import { quote as abstractQuote, typeCast as abstractTypeCast } from "./abstract/quoting.js";
+import {
+  quote as abstractQuote,
+  typeCast as abstractTypeCast,
+  quoteString as abstractQuoteString,
+  quoteIdentifier as abstractQuoteIdentifier,
+  quoteTableName as abstractQuoteTableName,
+  quoteColumnName as abstractQuoteColumnName,
+  quoteTableNameForAssignment as abstractQuoteTableNameForAssignment,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
+  quotedTrue as abstractQuotedTrue,
+  quotedFalse as abstractQuotedFalse,
+  unquotedTrue as abstractUnquotedTrue,
+  unquotedFalse as abstractUnquotedFalse,
+  quotedBinary as abstractQuotedBinary,
+  castBoundValue as abstractCastBoundValue,
+  sanitizeAsSqlComment as abstractSanitizeAsSqlComment,
+  columnNameMatcher as abstractColumnNameMatcher,
+  columnNameWithOrderMatcher as abstractColumnNameWithOrderMatcher,
+} from "./abstract/quoting.js";
+import type { Quoting } from "./abstract/quoting-interface.js";
 import { include } from "@blazetrails/activesupport";
 import type { Result } from "../result.js";
 
@@ -115,7 +134,7 @@ export interface AbstractAdapter {
   ): [unknown, unknown[]];
 }
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class AbstractAdapter {
+export class AbstractAdapter implements Quoting {
   static readonly Version = Version;
 
   private _connection: DatabaseAdapter | null = null;
@@ -195,6 +214,75 @@ export class AbstractAdapter {
    */
   typeCast(value: unknown): unknown {
     return abstractTypeCast(value);
+  }
+
+  /**
+   * Default identifier and bool-literal quoting — delegates to the
+   * abstract quoting module. Concrete adapters override the dialect-
+   * specific methods (PG/SQLite double-quote vs. MySQL backtick;
+   * SQLite `"1"` bools).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting (mixed into
+   * AbstractAdapter).
+   */
+  quoteString(s: string): string {
+    return abstractQuoteString(s);
+  }
+
+  quoteIdentifier(name: string): string {
+    return abstractQuoteIdentifier(name);
+  }
+
+  quoteTableName(name: string): string {
+    return abstractQuoteTableName(name);
+  }
+
+  quoteColumnName(name: string): string {
+    return abstractQuoteColumnName(name);
+  }
+
+  quoteTableNameForAssignment(table: string, attr: string): string {
+    return abstractQuoteTableNameForAssignment(table, attr);
+  }
+
+  quoteDefaultExpression(value: unknown): string {
+    return abstractQuoteDefaultExpression(value);
+  }
+
+  quotedTrue(): string {
+    return abstractQuotedTrue();
+  }
+
+  quotedFalse(): string {
+    return abstractQuotedFalse();
+  }
+
+  unquotedTrue(): boolean | number {
+    return abstractUnquotedTrue();
+  }
+
+  unquotedFalse(): boolean | number {
+    return abstractUnquotedFalse();
+  }
+
+  quotedBinary(value: unknown): string {
+    return abstractQuotedBinary(value);
+  }
+
+  castBoundValue(value: unknown): unknown {
+    return abstractCastBoundValue(value);
+  }
+
+  sanitizeAsSqlComment(value: unknown): string {
+    return abstractSanitizeAsSqlComment(value);
+  }
+
+  columnNameMatcher(): RegExp {
+    return abstractColumnNameMatcher();
+  }
+
+  columnNameWithOrderMatcher(): RegExp {
+    return abstractColumnNameWithOrderMatcher();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -45,8 +45,6 @@ import {
   quotedBinary as abstractQuotedBinary,
   castBoundValue as abstractCastBoundValue,
   sanitizeAsSqlComment as abstractSanitizeAsSqlComment,
-  columnNameMatcher as abstractColumnNameMatcher,
-  columnNameWithOrderMatcher as abstractColumnNameWithOrderMatcher,
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting-interface.js";
 import { include } from "@blazetrails/activesupport";
@@ -275,14 +273,6 @@ export class AbstractAdapter implements Quoting {
 
   sanitizeAsSqlComment(value: unknown): string {
     return abstractSanitizeAsSqlComment(value);
-  }
-
-  columnNameMatcher(): RegExp {
-    return abstractColumnNameMatcher();
-  }
-
-  columnNameWithOrderMatcher(): RegExp {
-    return abstractColumnNameWithOrderMatcher();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -92,6 +92,20 @@ const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
 const ER_TABLE_EXISTS = 1050;
 
+// Hot-path constants for the escape-only `quoteString` override below.
+// Match `MYSQL_ESCAPE_RE` / `MYSQL_ESCAPE_MAP` in `mysql/quoting.ts`
+// (those are module-private). Hoisted here so each call avoids
+// re-allocating the regex and lookup table.
+// eslint-disable-next-line no-control-regex
+const MYSQL_ADAPTER_ESCAPE_RE = /[\\\x00\n\r\x1a]/g;
+const MYSQL_ADAPTER_ESCAPE_MAP: Record<string, string> = {
+  "\\": "\\\\",
+  "\0": "\\0",
+  "\n": "\\n",
+  "\r": "\\r",
+  "\x1a": "\\Z",
+};
+
 export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
 
@@ -620,16 +634,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * wraps with surrounding `'...'` for SQL-literal contexts.
    */
   override quoteString(s: string): string {
-    // eslint-disable-next-line no-control-regex
-    const ESCAPE_RE = /[\\\x00\n\r\x1a]/g;
-    const ESCAPE_MAP: Record<string, string> = {
-      "\\": "\\\\",
-      "\0": "\\0",
-      "\n": "\\n",
-      "\r": "\\r",
-      "\x1a": "\\Z",
-    };
-    return s.replace(/'/g, "''").replace(ESCAPE_RE, (ch) => ESCAPE_MAP[ch] ?? ch);
+    return s
+      .replace(/'/g, "''")
+      .replace(MYSQL_ADAPTER_ESCAPE_RE, (ch) => MYSQL_ADAPTER_ESCAPE_MAP[ch] ?? ch);
   }
 
   /** Retains the literal-quoting helper for legacy callers in this file. */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -33,6 +33,11 @@ import {
   unquoteIdentifier as mysqlUnquoteIdentifier,
   columnNameMatcher as mysqlColumnNameMatcher,
   columnNameWithOrderMatcher as mysqlColumnNameWithOrderMatcher,
+  quoteIdentifier as mysqlQuoteIdentifier,
+  quoteTableName as mysqlQuoteTableName,
+  quoteColumnName as mysqlQuoteColumnName,
+  unquotedTrue as mysqlUnquotedTrue,
+  unquotedFalse as mysqlUnquotedFalse,
 } from "./mysql/quoting.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { TypeMap } from "../type/type-map.js";
@@ -166,6 +171,41 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    */
   override typeCast(value: unknown): unknown {
     return mysqlTypeCast(value);
+  }
+
+  /**
+   * MySQL dialect overrides — backtick identifiers and integer bool
+   * coercion. Matches Rails:
+   *
+   * - `quote_column_name` / `quote_table_name` — backticks
+   *   (`mysql/quoting.rb:48-53`).
+   * - `unquoted_true` / `unquoted_false` → `1` / `0`
+   *   (`mysql/quoting.rb:72-77`). MySQL does NOT override
+   *   `quoted_true`/`quoted_false`; it inherits `"TRUE"`/`"FALSE"` from
+   *   `abstract/quoting.rb:166`. Trails matches that here by NOT
+   *   overriding `quotedTrue`/`quotedFalse` on the adapter — the
+   *   per-module standalones return `"1"`/`"0"` (a pre-existing
+   *   trails-vs-Rails divergence flagged in docs/quoting-refactor.md;
+   *   not addressed in this PR).
+   */
+  override quoteIdentifier(name: string): string {
+    return mysqlQuoteIdentifier(name);
+  }
+
+  override quoteTableName(name: string): string {
+    return mysqlQuoteTableName(name);
+  }
+
+  override quoteColumnName(name: string): string {
+    return mysqlQuoteColumnName(name);
+  }
+
+  override unquotedTrue(): number {
+    return mysqlUnquotedTrue();
+  }
+
+  override unquotedFalse(): number {
+    return mysqlUnquotedFalse();
   }
 
   isMariadb(): boolean {
@@ -571,8 +611,30 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   checkVersion(): void {}
 
-  quoteString(string: string): string {
-    return mysqlQuoteString(string);
+  /**
+   * Escape-only string quoting per the Quoting interface contract
+   * (`abstract/quoting-interface.ts`). Mirrors Rails MySQL
+   * `quote_string` (`mysql/quoting.rb`): doubles `'` and backslash-
+   * escapes the same control chars MySQL's wire protocol requires.
+   * Distinct from the per-module `mysqlQuoteString` standalone, which
+   * wraps with surrounding `'...'` for SQL-literal contexts.
+   */
+  override quoteString(s: string): string {
+    // eslint-disable-next-line no-control-regex
+    const ESCAPE_RE = /[\\\x00\n\r\x1a]/g;
+    const ESCAPE_MAP: Record<string, string> = {
+      "\\": "\\\\",
+      "\0": "\\0",
+      "\n": "\\n",
+      "\r": "\\r",
+      "\x1a": "\\Z",
+    };
+    return s.replace(/'/g, "''").replace(ESCAPE_RE, (ch) => ESCAPE_MAP[ch] ?? ch);
+  }
+
+  /** Retains the literal-quoting helper for legacy callers in this file. */
+  protected _quoteStringLiteral(s: string): string {
+    return mysqlQuoteString(s);
   }
 
   static dbconsole(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -222,6 +222,20 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlUnquotedFalse();
   }
 
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name_for_assignment
+   * (`abstract/quoting.rb:153-155`) — Rails MySQL inherits from
+   * abstract. Dispatching `quote_table_name("#{table}.#{attr}")`
+   * resolves polymorphically to `MySQL::Quoting#quote_table_name` which
+   * splits on `.` and backticks each part. The TS port doesn't get
+   * polymorphic dispatch from the abstract standalone (it would call
+   * the abstract module's `quoteTableName` and emit double quotes), so
+   * we override on the MySQL adapter to route through `this.quoteTableName`.
+   */
+  override quoteTableNameForAssignment(table: string, attr: string): string {
+    return this.quoteTableName(`${table}.${attr}`);
+  }
+
   isMariadb(): boolean {
     return this._mariadb;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -36,6 +36,8 @@ import {
   quoteIdentifier as mysqlQuoteIdentifier,
   quoteTableName as mysqlQuoteTableName,
   quoteColumnName as mysqlQuoteColumnName,
+  quotedTrue as mysqlQuotedTrue,
+  quotedFalse as mysqlQuotedFalse,
   unquotedTrue as mysqlUnquotedTrue,
   unquotedFalse as mysqlUnquotedFalse,
 } from "./mysql/quoting.js";
@@ -194,13 +196,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * - `quote_column_name` / `quote_table_name` — backticks
    *   (`mysql/quoting.rb:48-53`).
    * - `unquoted_true` / `unquoted_false` → `1` / `0`
-   *   (`mysql/quoting.rb:72-77`). MySQL does NOT override
-   *   `quoted_true`/`quoted_false`; it inherits `"TRUE"`/`"FALSE"` from
-   *   `abstract/quoting.rb:166`. Trails matches that here by NOT
-   *   overriding `quotedTrue`/`quotedFalse` on the adapter — the
-   *   per-module standalones return `"1"`/`"0"` (a pre-existing
-   *   trails-vs-Rails divergence flagged in docs/quoting-refactor.md;
-   *   not addressed in this PR).
+   *   (`mysql/quoting.rb:72-77`).
+   *
+   * Note on `quotedTrue`/`quotedFalse`: Rails MySQL does NOT override
+   * these — it inherits `"TRUE"`/`"FALSE"` from `abstract/quoting.rb:166`.
+   * Trails MySQL's per-module standalone returns `"1"`/`"0"` (a
+   * pre-existing trails-vs-Rails divergence flagged in
+   * `docs/quoting-refactor.md`; not addressed here). We override on
+   * the adapter so `quote(true)` and `quotedTrue()` agree (both `"1"`
+   * via the per-module standalone). Without the override the adapter
+   * would inherit AbstractAdapter#quotedTrue (`"TRUE"`) while
+   * `quote()` returns `"1"`, breaking call sites that switch between
+   * the two through the Quoting interface.
    */
   override quoteIdentifier(name: string): string {
     return mysqlQuoteIdentifier(name);
@@ -212,6 +219,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   override quoteColumnName(name: string): string {
     return mysqlQuoteColumnName(name);
+  }
+
+  override quotedTrue(): string {
+    return mysqlQuotedTrue();
+  }
+
+  override quotedFalse(): string {
+    return mysqlQuotedFalse();
   }
 
   override unquotedTrue(): number {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -653,11 +653,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       .replace(MYSQL_ADAPTER_ESCAPE_RE, (ch) => MYSQL_ADAPTER_ESCAPE_MAP[ch] ?? ch);
   }
 
-  /** Retains the literal-quoting helper for legacy callers in this file. */
-  protected _quoteStringLiteral(s: string): string {
-    return mysqlQuoteString(s);
-  }
-
   static dbconsole(
     config: Record<string, unknown>,
     options: Record<string, unknown> = {},

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
@@ -15,7 +15,19 @@ export interface Quoting {
   /** Mirrors: Quoting#quote — SQL-literal form of a value. */
   quote(value: unknown): string;
 
-  /** Mirrors: Quoting#quote_string — escape-only (no surrounding quotes). */
+  /**
+   * Mirrors: Quoting#quote_string — **escape-only**. Doubles `'` and
+   * applies any dialect-specific escape rules (MySQL `\\\0\n\r\Z`; PG
+   * may switch to `E'…'` form for backslashes inside `quote()`). Never
+   * adds surrounding `'`. For a fully-quoted SQL literal use
+   * `quote(value)` instead.
+   *
+   * Note: per-adapter standalone `quoteString` exports in
+   * `{sqlite3,mysql}/quoting.ts` historically wrap with surrounding
+   * `'...'` and are NOT escape-only. Adapter classes override
+   * `quoteString` to honor this contract; the standalones stay as
+   * literal-quoting helpers for legacy call sites.
+   */
   quoteString(s: string): string;
 
   /** Mirrors: Quoting#quote_column_name (identifier-form). PG/SQLite double-quote, MySQL backtick. */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
@@ -1,0 +1,65 @@
+/**
+ * Quoting interface — the contract every connection adapter satisfies
+ * for value/identifier quoting.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting (mixed into
+ * AbstractAdapter; PG/MySQL/SQLite override what differs).
+ *
+ * Call sites depend on this interface — never on the standalone
+ * functions in `abstract/quoting.ts` — so dialect dispatch happens via
+ * the active adapter rather than a string-enum parameter.
+ *
+ * @internal
+ */
+export interface Quoting {
+  /** Mirrors: Quoting#quote — SQL-literal form of a value. */
+  quote(value: unknown): string;
+
+  /** Mirrors: Quoting#quote_string — escape-only (no surrounding quotes). */
+  quoteString(s: string): string;
+
+  /** Mirrors: Quoting#quote_column_name (identifier-form). PG/SQLite double-quote, MySQL backtick. */
+  quoteIdentifier(name: string): string;
+
+  /** Mirrors: Quoting#quote_table_name (handles schema-qualified names). */
+  quoteTableName(name: string): string;
+
+  /** Mirrors: Quoting#quote_column_name. */
+  quoteColumnName(name: string): string;
+
+  /** Mirrors: Quoting#quote_table_name_for_assignment (`UPDATE ... SET col = ...`). */
+  quoteTableNameForAssignment(table: string, attr: string): string;
+
+  /** Mirrors: Quoting#quote_default_expression (DDL DEFAULT clause). */
+  quoteDefaultExpression(value: unknown): string;
+
+  /** Mirrors: Quoting#quoted_true. Abstract/PG/MySQL: `"TRUE"`; SQLite: `"1"`. */
+  quotedTrue(): string;
+
+  /** Mirrors: Quoting#quoted_false. */
+  quotedFalse(): string;
+
+  /** Mirrors: Quoting#unquoted_true. PG: `true`; MySQL/SQLite: `1`. */
+  unquotedTrue(): boolean | number;
+
+  /** Mirrors: Quoting#unquoted_false. */
+  unquotedFalse(): boolean | number;
+
+  /** Mirrors: Quoting#quoted_binary — adapter-specific binary literal. */
+  quotedBinary(value: unknown): string;
+
+  /** Mirrors: Quoting#type_cast — primitive form for bind params. */
+  typeCast(value: unknown): unknown;
+
+  /** Mirrors: Quoting#cast_bound_value — bound-param coercion. */
+  castBoundValue(value: unknown): unknown;
+
+  /** Mirrors: Quoting#sanitize_as_sql_comment — strip comment-close sequences from comment text. */
+  sanitizeAsSqlComment(value: unknown): string;
+
+  /** Mirrors: Quoting::ClassMethods#column_name_matcher — adapter-specific column-list regex. */
+  columnNameMatcher(): RegExp;
+
+  /** Mirrors: Quoting::ClassMethods#column_name_with_order_matcher. */
+  columnNameWithOrderMatcher(): RegExp;
+}

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
@@ -56,10 +56,13 @@ export interface Quoting {
 
   /** Mirrors: Quoting#sanitize_as_sql_comment — strip comment-close sequences from comment text. */
   sanitizeAsSqlComment(value: unknown): string;
-
-  /** Mirrors: Quoting::ClassMethods#column_name_matcher — adapter-specific column-list regex. */
-  columnNameMatcher(): RegExp;
-
-  /** Mirrors: Quoting::ClassMethods#column_name_with_order_matcher. */
-  columnNameWithOrderMatcher(): RegExp;
 }
+
+// `column_name_matcher` / `column_name_with_order_matcher` are deliberately
+// NOT on this interface. In Rails they live in `Quoting::ClassMethods`
+// (active_record/connection_adapters/abstract/quoting.rb:18, :33) — the
+// regexes don't depend on instance state, so they're class methods.
+// Trails mirrors that with `static columnNameMatcher()` on each concrete
+// adapter (e.g. SQLite3Adapter:97). Call sites resolve them via
+// `adapter.constructor.columnNameMatcher()` (relation.ts:211,
+// query-methods.ts:155).

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -15,6 +15,7 @@ import {
   quoteTableName as pgQuoteTableName,
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
+  quoteTableNameForAssignment as pgQuoteTableNameForAssignment,
   quoteDefaultExpression as pgQuoteDefaultExpression,
   columnNameMatcher as pgColumnNameMatcher,
   columnNameWithOrderMatcher as pgColumnNameWithOrderMatcher,
@@ -3271,6 +3272,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   override quoteIdentifier(name: string): string {
     return pgQuoteColumnName(name);
+  }
+
+  /**
+   * Mirrors: PostgreSQL::Quoting#quote_table_name_for_assignment
+   * (`postgresql/quoting.rb:136`) — PG ignores the table and quotes
+   * only the column. Abstract default returns `table.attr`-qualified;
+   * PG overrides because PostgreSQL UPDATE syntax doesn't allow a
+   * table-qualified column on the LHS of `SET`.
+   */
+  override quoteTableNameForAssignment(_table: string, attr: string): string {
+    return pgQuoteTableNameForAssignment(_table, attr);
   }
 
   private quoteSchemaName(name: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -17,6 +17,7 @@ import {
   quoteString as pgQuoteString,
   quoteTableNameForAssignment as pgQuoteTableNameForAssignment,
   quoteDefaultExpression as pgQuoteDefaultExpression,
+  quotedBinary as pgQuotedBinary,
   columnNameMatcher as pgColumnNameMatcher,
   columnNameWithOrderMatcher as pgColumnNameWithOrderMatcher,
 } from "./postgresql/quoting.js";
@@ -3283,6 +3284,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override quoteTableNameForAssignment(_table: string, attr: string): string {
     return pgQuoteTableNameForAssignment(_table, attr);
+  }
+
+  /**
+   * Mirrors: PostgreSQL::Quoting#quoted_binary
+   * (`postgresql/quoting.rb:152`) — `'\\xHEX'` bytea-escape form.
+   * Without this override, the adapter would inherit
+   * AbstractAdapter#quotedBinary (Rails-equivalent
+   * `"'#{quote_string(value.to_s)}'"` from `abstract/quoting.rb:206`)
+   * and emit malformed bytea literals on PG.
+   */
+  override quotedBinary(value: unknown): string {
+    if (value instanceof Uint8Array) return pgQuotedBinary(value);
+    if (value instanceof ArrayBuffer) return pgQuotedBinary(new Uint8Array(value));
+    if (typeof value === "string") return pgQuotedBinary(value);
+    throw new TypeError(
+      `quotedBinary expects Uint8Array, ArrayBuffer, Buffer, or string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
   }
 
   private quoteSchemaName(name: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3269,7 +3269,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return { schema: pgName.schema, table: pgName.identifier };
   }
 
-  private quoteIdentifier(name: string): string {
+  override quoteIdentifier(name: string): string {
     return pgQuoteColumnName(name);
   }
 

--- a/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
+++ b/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import type { Quoting } from "./abstract/quoting-interface.js";
+import { AbstractAdapter } from "./abstract-adapter.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+// Compile-time guard: AbstractAdapter (the base, not a subclass) must
+// itself satisfy Quoting. A subclass-only assignment would let a
+// missing-on-base / present-on-subclass method slip through. This is a
+// pure type-level check — `never` resolves only when the conditional
+// `extends` succeeds, so any failure is a compile error, not a runtime
+// reference.
+type _AbstractAdapterIsQuoting = AbstractAdapter extends Quoting ? true : never;
+const _abstractAdapterIsQuoting: _AbstractAdapterIsQuoting = true;
+void _abstractAdapterIsQuoting;
 
 /**
  * Pin the Quoting contract: every adapter exposes the full surface

--- a/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
+++ b/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
@@ -39,8 +39,6 @@ describe("Quoting interface", () => {
       expect(typeof q.typeCast).toBe("function");
       expect(typeof q.castBoundValue).toBe("function");
       expect(typeof q.sanitizeAsSqlComment).toBe("function");
-      expect(typeof q.columnNameMatcher).toBe("function");
-      expect(typeof q.columnNameWithOrderMatcher).toBe("function");
     } finally {
       adapter.disconnectBang();
     }

--- a/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
+++ b/packages/activerecord/src/connection-adapters/quoting-interface.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import type { Quoting } from "./abstract/quoting-interface.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+/**
+ * Pin the Quoting contract: every adapter exposes the full surface
+ * dispatching to its own dialect. Per-adapter behavioral tests live in
+ * the per-module quoting.test.ts files; this test asserts the
+ * structural contract and dispatches a single value through each
+ * adapter so the whole interface is exercised end-to-end.
+ *
+ * PG/MySQL adapters require a live driver to instantiate, so this
+ * file uses SQLite as the structural witness — the interface is
+ * checked at compile time on AbstractAdapter (which all adapters
+ * extend), and runtime dispatch is exercised on SQLite (the only
+ * adapter that overrides bool literals away from the abstract default).
+ */
+describe("Quoting interface", () => {
+  it("AbstractAdapter implements every Quoting method", () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    try {
+      // Compile-time guard: SQLite3Adapter (extends AbstractAdapter)
+      // is assignable to Quoting. If the interface adds a method that
+      // AbstractAdapter doesn't implement, this assignment fails.
+      const q: Quoting = adapter;
+
+      expect(typeof q.quote).toBe("function");
+      expect(typeof q.quoteString).toBe("function");
+      expect(typeof q.quoteIdentifier).toBe("function");
+      expect(typeof q.quoteTableName).toBe("function");
+      expect(typeof q.quoteColumnName).toBe("function");
+      expect(typeof q.quoteTableNameForAssignment).toBe("function");
+      expect(typeof q.quoteDefaultExpression).toBe("function");
+      expect(typeof q.quotedTrue).toBe("function");
+      expect(typeof q.quotedFalse).toBe("function");
+      expect(typeof q.unquotedTrue).toBe("function");
+      expect(typeof q.unquotedFalse).toBe("function");
+      expect(typeof q.quotedBinary).toBe("function");
+      expect(typeof q.typeCast).toBe("function");
+      expect(typeof q.castBoundValue).toBe("function");
+      expect(typeof q.sanitizeAsSqlComment).toBe("function");
+      expect(typeof q.columnNameMatcher).toBe("function");
+      expect(typeof q.columnNameWithOrderMatcher).toBe("function");
+    } finally {
+      adapter.disconnectBang();
+    }
+  });
+
+  it("SQLite3Adapter dispatches quote/quotedTrue to its own dialect", () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    try {
+      // SQLite is the only adapter whose quotedTrue diverges from the
+      // abstract default. Pinning this here confirms the dispatch
+      // resolves to the SQLite override, not AbstractAdapter's default.
+      expect(adapter.quotedTrue()).toBe("1");
+      expect(adapter.quotedFalse()).toBe("0");
+      expect(adapter.quote(true)).toBe("1");
+      expect(adapter.quoteIdentifier("foo")).toBe('"foo"');
+    } finally {
+      adapter.disconnectBang();
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -39,12 +39,17 @@ import { isWriteQuerySql } from "./sql-classification.js";
 import {
   quote as sqliteQuote,
   typeCast as sqliteTypeCast,
-  quoteString,
+  // Note: the standalone `quoteString` exported by sqlite3/quoting.ts
+  // returns a fully-quoted SQL literal (`'foo'`), not the escape-only
+  // form Rails' `quote_string` returns. The instance override below
+  // implements escape-only inline; the standalone is kept under an
+  // alias here for the few legacy call sites in this file that want
+  // the literal form.
+  quoteString as sqliteQuoteStringLiteral,
   quoteTableName,
   quoteColumnName,
   quoteIdentifier as sqliteQuoteIdentifier,
   quoteTableNameForAssignment as sqliteQuoteTableNameForAssignment,
-  quoteDefaultExpression as sqliteQuoteDefaultExpression,
   quotedTrue as sqliteQuotedTrue,
   unquotedTrue as sqliteUnquotedTrue,
   quotedFalse as sqliteQuotedFalse,
@@ -511,9 +516,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return sqliteQuoteTableNameForAssignment(table, attr);
   }
 
-  override quoteDefaultExpression(value: unknown): string {
-    return sqliteQuoteDefaultExpression(value);
-  }
+  // `quoteDefaultExpression` deliberately not overridden here. The
+  // SQLite standalone (`sqlite3/quoting.ts:114`) returns an unprefixed
+  // expression (`NULL` / `(NOW())`) — Rails-correct — but the abstract
+  // and PG adapters return a `" DEFAULT ..."`-prefixed clause. Until
+  // that contract divergence is reconciled across adapters (Phase 2
+  // call-site work), inheriting the abstract default keeps DDL output
+  // consistent across adapters in this PR.
 
   override quotedTrue(): string {
     return sqliteQuotedTrue();
@@ -1222,12 +1231,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (schema) {
       sql =
         schema.toLowerCase() === "temp"
-          ? `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${quoteString(bare)}`
-          : `SELECT sql FROM ${quoteColumnName(schema)}.sqlite_master WHERE type='table' AND name=${quoteString(bare)}`;
+          ? `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`
+          : `SELECT sql FROM ${quoteColumnName(schema)}.sqlite_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`;
     } else {
-      sql = `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${quoteString(bare)}
+      sql = `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}
              UNION ALL
-             SELECT sql FROM sqlite_master WHERE type='table' AND name=${quoteString(bare)}`;
+             SELECT sql FROM sqlite_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`;
     }
     const row = this.db.prepare(sql).get() as { sql: string } | undefined;
     return row?.sql ?? null;
@@ -1258,15 +1267,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   private quoteDefault(value: unknown): string {
     if (value === null) return "NULL";
-    if (typeof value === "string") return quoteString(value);
+    if (typeof value === "string") return sqliteQuoteStringLiteral(value);
     if (typeof value === "number") return String(value);
     if (typeof value === "boolean") return value ? "1" : "0";
     if (typeof value === "function") return String(value());
     // boundary: defensive Date branch in SQLite adapter literal quoting.
-    if (value instanceof globalThis.Date) return quoteString(value.toISOString());
+    if (value instanceof globalThis.Date) return sqliteQuoteStringLiteral(value.toISOString());
     // SqlLiteral or objects with toSql
     if (typeof (value as any)?.toSql === "function") return String((value as any).toSql());
-    return quoteString(String(value));
+    return sqliteQuoteStringLiteral(String(value));
   }
 
   // --- Schema introspection (drives SchemaCache.addAll) ---
@@ -1329,7 +1338,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   async tableExists(name: string): Promise<boolean> {
     const { sqliteMaster, bare } = this._sqliteMasterFor(name);
     const rows = (await this.execute(
-      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name=${quoteString(bare)}`,
+      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`,
       [],
       "SCHEMA",
     )) as Array<{ one: number }>;
@@ -1339,7 +1348,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   async dataSourceExists(name: string): Promise<boolean> {
     const { sqliteMaster, bare } = this._sqliteMasterFor(name);
     const rows = (await this.execute(
-      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${quoteString(bare)}`,
+      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${sqliteQuoteStringLiteral(bare)}`,
       [],
       "SCHEMA",
     )) as Array<{ one: number }>;
@@ -1659,7 +1668,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       if (idxName.startsWith("sqlite_autoindex_")) continue;
       const createSql = this.db
         .prepare(
-          `SELECT sql FROM ${pragmaPrefix}sqlite_master WHERE type='index' AND name=${quoteString(idxName)}`,
+          `SELECT sql FROM ${pragmaPrefix}sqlite_master WHERE type='index' AND name=${sqliteQuoteStringLiteral(idxName)}`,
         )
         .get() as { sql: string } | undefined;
       if (createSql?.sql) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -541,7 +541,22 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override quotedBinary(value: unknown): string {
-    return sqliteQuotedBinary(value as Uint8Array);
+    // Mirrors: SQLite3::Quoting#quoted_binary (`sqlite3/quoting.rb:79`)
+    // — Rails calls `value.hex` and would NoMethodError on non-Binary
+    // values. The TS standalone iterates the value as a byte source,
+    // so non-binary inputs (strings, plain arrays) silently produce
+    // garbage hex. Validate at the interface boundary.
+    if (value instanceof Uint8Array) {
+      return sqliteQuotedBinary(value);
+    }
+    if (value instanceof ArrayBuffer) {
+      return sqliteQuotedBinary(new Uint8Array(value));
+    }
+    throw new TypeError(
+      `quotedBinary expects a Uint8Array, ArrayBuffer, or Buffer; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -42,6 +42,14 @@ import {
   quoteString,
   quoteTableName,
   quoteColumnName,
+  quoteIdentifier as sqliteQuoteIdentifier,
+  quoteTableNameForAssignment as sqliteQuoteTableNameForAssignment,
+  quoteDefaultExpression as sqliteQuoteDefaultExpression,
+  quotedTrue as sqliteQuotedTrue,
+  unquotedTrue as sqliteUnquotedTrue,
+  quotedFalse as sqliteQuotedFalse,
+  unquotedFalse as sqliteUnquotedFalse,
+  quotedBinary as sqliteQuotedBinary,
 } from "./sqlite3/quoting.js";
 import {
   CheckConstraintDefinition,
@@ -469,6 +477,76 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   override typeCast(value: unknown): unknown {
     return sqliteTypeCast(value);
+  }
+
+  /**
+   * SQLite-specific quoting overrides — route every Quoting interface
+   * method to the per-adapter module so call sites can dispatch via
+   * `connection.quoteX(...)` and get the dialect-correct form
+   * (double-quote identifiers, `"1"`/`"0"` bools, hex binary literals).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting overrides.
+   */
+  override quoteString(s: string): string {
+    // Mirrors: SQLite3::Quoting#quote_string — escape-only (no
+    // surrounding quotes). The standalone sqlite3/quoting.ts
+    // `quoteString` wraps for historical reasons; this override
+    // matches the Rails contract: just `'` → `''`.
+    return s.replace(/'/g, "''");
+  }
+
+  override quoteIdentifier(name: string): string {
+    return sqliteQuoteIdentifier(name);
+  }
+
+  override quoteTableName(name: string): string {
+    return quoteTableName(name);
+  }
+
+  override quoteColumnName(name: string): string {
+    return quoteColumnName(name);
+  }
+
+  override quoteTableNameForAssignment(table: string, attr: string): string {
+    return sqliteQuoteTableNameForAssignment(table, attr);
+  }
+
+  override quoteDefaultExpression(value: unknown): string {
+    return sqliteQuoteDefaultExpression(value);
+  }
+
+  override quotedTrue(): string {
+    return sqliteQuotedTrue();
+  }
+
+  override quotedFalse(): string {
+    return sqliteQuotedFalse();
+  }
+
+  override unquotedTrue(): number {
+    return sqliteUnquotedTrue();
+  }
+
+  override unquotedFalse(): number {
+    return sqliteUnquotedFalse();
+  }
+
+  override quotedBinary(value: unknown): string {
+    return sqliteQuotedBinary(value as Uint8Array);
+  }
+
+  override columnNameMatcher(): RegExp {
+    // Delegate to the static — `disallowRawSqlBang` callers already use
+    // the strict static-method regex (relation.ts:211 and
+    // query-methods.ts:155 walk to `adapter.constructor.columnNameMatcher`).
+    // The per-module `ColumnMatcher` class in sqlite3/quoting.ts is a
+    // looser separate matcher; routing the instance method through the
+    // static keeps the unsafe-sql validation behavior consistent.
+    return SQLite3Adapter.columnNameMatcher();
+  }
+
+  override columnNameWithOrderMatcher(): RegExp {
+    return SQLite3Adapter.columnNameWithOrderMatcher();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -535,20 +535,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return sqliteQuotedBinary(value as Uint8Array);
   }
 
-  override columnNameMatcher(): RegExp {
-    // Delegate to the static — `disallowRawSqlBang` callers already use
-    // the strict static-method regex (relation.ts:211 and
-    // query-methods.ts:155 walk to `adapter.constructor.columnNameMatcher`).
-    // The per-module `ColumnMatcher` class in sqlite3/quoting.ts is a
-    // looser separate matcher; routing the instance method through the
-    // static keeps the unsafe-sql validation behavior consistent.
-    return SQLite3Adapter.columnNameMatcher();
-  }
-
-  override columnNameWithOrderMatcher(): RegExp {
-    return SQLite3Adapter.columnNameWithOrderMatcher();
-  }
-
   /**
    * Close the database connection.
    */


### PR DESCRIPTION
## Summary

Phase 1 of the quoting refactor (`docs/quoting-refactor.md`, PR 2 of 10).

- **New `Quoting` interface** (`connection-adapters/abstract/quoting-interface.ts`) pinning **15 methods** from Rails' `ActiveRecord::ConnectionAdapters::Quoting` (instance surface only — `column_name_matcher` / `column_name_with_order_matcher` live in `Quoting::ClassMethods` per `abstract/quoting.rb:18,33` and stay on the static side). Future call sites (Phases 2–4) depend on this contract instead of standalone functions + `adapter?` enum.
- **`AbstractAdapter implements Quoting`.** Adds the missing instance methods by delegating to the abstract quoting module. Subclasses inherit the full surface and override only what diverges.
- **`SQLite3Adapter` overrides:** `quotedTrue/quotedFalse → "1"/"0"`, double-quote identifiers, hex binary literals (with input-type validation), escape-only `quoteString`. Did not override `quoteDefaultExpression` — sqlite3 standalone returns unprefixed; abstract returns `" DEFAULT ..."`-prefixed; reconciled in Phase 2.
- **`AbstractMysqlAdapter` overrides:** backtick identifiers (`quoteIdentifier`/`quoteTableName`/`quoteColumnName`), `unquotedTrue/False → 1/0`, escape-only `quoteString` with hoisted hot-path constants, `quoteTableNameForAssignment` routed through `this.quoteTableName(...)` to mirror Rails' polymorphic dispatch (`abstract/quoting.rb:153-155`). **`quotedTrue`/`quotedFalse` overridden to delegate to `mysqlQuotedTrue`/`mysqlQuotedFalse` (returns `"1"`/`"0"`)** — restores adapter internal consistency between `quote(true)` and `quotedTrue()`. This is a pre-existing trails-vs-Rails divergence at the per-module level (Rails MySQL inherits `"TRUE"`/`"FALSE"`); flagged separately in `docs/quoting-refactor.md` for a follow-up PR. Within this PR the goal is internal consistency, not full Rails alignment of MySQL booleans.
- **`PostgreSQLAdapter` overrides:** flipped `private quoteIdentifier` to `override quoteIdentifier` (public). Added `override quoteTableNameForAssignment` per `postgresql/quoting.rb:136` — PG ignores the table and quotes only the column. Added `override quotedBinary` per `postgresql/quoting.rb:152` — `'\\xHEX'` bytea-escape form (with input-type validation) — without it the adapter would inherit the abstract default and emit malformed bytea literals.
- **New `quoting-interface.test.ts`** pins the contract via a pure type-level check on `AbstractAdapter` (not a subclass) and exercises end-to-end dispatch on SQLite.

## Rails parity

- Interface mirrors `active_record/connection_adapters/abstract/quoting.rb` instance methods only (15 methods).
- `AbstractAdapter` defaults match `abstract/quoting.rb` (`quoted_true → "TRUE"`, `quoted_binary → "'#{quote_string(value)}'"` per line 206).
- `SQLite3Adapter` overrides match `sqlite3/quoting.rb` (`quoted_true → "1"`).
- `AbstractMysqlAdapter` overrides match `mysql/quoting.rb` (backticks, `unquoted_true → 1`). Booleans diverge: trails standalone returns `"1"` vs. Rails inherited `"TRUE"` — flagged.
- `PostgreSQLAdapter` overrides match `postgresql/quoting.rb` (`quote_table_name_for_assignment` / `quoted_binary`).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec vitest run packages/activerecord/src/connection-adapters` — 631 passed
- [x] `pnpm exec vitest run packages/activerecord/src/unsafe-raw-sql.test.ts` — 36 passed (validation regression check)
- [x] `pnpm api:compare` — data layer 93% (+0.3% from main, no regression)
- [x] `pnpm test:compare` — 54.6% flat
- [ ] CI green