### PR TITLE
feat(activesupport): time-travel clock sources Temporal.Now; add currentTimeInstant

### DIFF
--- a/packages/activesupport/src/time-travel.test.ts
+++ b/packages/activesupport/src/time-travel.test.ts
@@ -199,7 +199,8 @@ describe("TimeTravelTest", () => {
     try {
       const traveled = currentTimeInstant().epochNanoseconds;
       const drift = traveled - before - offsetNs;
-      expect(drift >= -1_000_000_000n && drift <= 1_000_000_000n).toBe(true);
+      expect(drift).toBeGreaterThanOrEqual(-1_000_000_000n);
+      expect(drift).toBeLessThanOrEqual(1_000_000_000n);
     } finally {
       setTimeOffsetNs(0n);
     }

--- a/packages/activesupport/src/time-travel.test.ts
+++ b/packages/activesupport/src/time-travel.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 
+import { Temporal } from "./temporal.js";
 import { travelTo, travelBack, travel, freezeTime, currentTime } from "./testing-helpers.js";
+import { currentTimeInstant, setFrozenInstant, setTimeOffsetNs } from "./time-travel.js";
 
 describe("TimeTravelTest", () => {
   afterEach(() => {
@@ -172,5 +174,34 @@ describe("TimeTravelTest", () => {
     freezeTime();
     travelBack();
     expect(Math.abs(currentTime().getTime() - Date.now())).toBeLessThan(100);
+  });
+
+  it("currentTimeInstant returns Temporal.Instant", () => {
+    expect(currentTimeInstant()).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("currentTimeInstant respects frozen instant at nanosecond precision", () => {
+    const baseMs = Date.UTC(2030, 0, 1, 0, 0, 0);
+    const baseNs = BigInt(baseMs) * 1_000_000n + 123_456n;
+    const frozen = Temporal.Instant.fromEpochNanoseconds(baseNs);
+    setFrozenInstant(frozen);
+    try {
+      expect(currentTimeInstant().epochNanoseconds).toBe(baseNs);
+    } finally {
+      setFrozenInstant(null);
+    }
+  });
+
+  it("currentTimeInstant respects nanosecond time offset", () => {
+    const offsetNs = 365n * 24n * 3600n * 1_000_000_000n + 42n; // ~1 year + 42 ns
+    const before = Temporal.Now.instant().epochNanoseconds;
+    setTimeOffsetNs(offsetNs);
+    try {
+      const traveled = currentTimeInstant().epochNanoseconds;
+      const drift = traveled - before - offsetNs;
+      expect(drift >= -1_000_000_000n && drift <= 1_000_000_000n).toBe(true);
+    } finally {
+      setTimeOffsetNs(0n);
+    }
   });
 });

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -19,7 +19,13 @@ let _frozenInstant: Temporal.Instant | null = null;
 let _timeOffsetNs: bigint = 0n;
 
 export function setFrozenTime(time: Date | null): void {
-  _frozenInstant = time === null ? null : Temporal.Instant.fromEpochMilliseconds(time.getTime());
+  if (time === null) {
+    _frozenInstant = null;
+    return;
+  }
+  const ms = time.getTime();
+  if (Number.isNaN(ms)) throw new RangeError("`time` must be a valid Date");
+  _frozenInstant = Temporal.Instant.fromEpochMilliseconds(ms);
 }
 
 export function setFrozenInstant(instant: Temporal.Instant | null): void {
@@ -27,6 +33,7 @@ export function setFrozenInstant(instant: Temporal.Instant | null): void {
 }
 
 export function setTimeOffset(offsetMs: number): void {
+  if (!Number.isFinite(offsetMs)) throw new TypeError("offsetMs must be a finite number");
   _timeOffsetNs = BigInt(Math.trunc(offsetMs)) * 1_000_000n;
 }
 

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -34,7 +34,9 @@ export function setFrozenInstant(instant: Temporal.Instant | null): void {
 
 export function setTimeOffset(offsetMs: number): void {
   if (!Number.isFinite(offsetMs)) throw new TypeError("offsetMs must be a finite number");
-  _timeOffsetNs = BigInt(Math.trunc(offsetMs)) * 1_000_000n;
+  const wholeMs = Math.trunc(offsetMs);
+  const fracNs = Math.round((offsetMs - wholeMs) * 1_000_000);
+  _timeOffsetNs = BigInt(wholeMs) * 1_000_000n + BigInt(fracNs);
 }
 
 export function setTimeOffsetNs(offsetNs: bigint): void {

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -22,8 +22,16 @@ export function setFrozenTime(time: Date | null): void {
   _frozenInstant = time === null ? null : Temporal.Instant.fromEpochMilliseconds(time.getTime());
 }
 
+export function setFrozenInstant(instant: Temporal.Instant | null): void {
+  _frozenInstant = instant;
+}
+
 export function setTimeOffset(offsetMs: number): void {
   _timeOffsetNs = BigInt(Math.trunc(offsetMs)) * 1_000_000n;
+}
+
+export function setTimeOffsetNs(offsetNs: bigint): void {
+  _timeOffsetNs = offsetNs;
 }
 
 /**

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -7,25 +7,41 @@
  *
  * @boundary-file: `currentTime()` returns a JS `Date` because most consumers
  *   (legacy Rails-port code in `time-ext`, `duration`, etc.) are Date-typed.
- *   Callers that want Temporal use `Temporal.Now.instant()` directly or bridge
- *   via `instantFrom(currentTime())`.
+ *   The clock source is `Temporal.Now.instant()`; the offset is stored in
+ *   nanoseconds so sub-millisecond travel is preserved on the
+ *   `currentTimeInstant()` path. Callers that want Temporal use
+ *   `currentTimeInstant()` (or `Temporal.Now.instant()` directly).
  */
 
-let _frozenTime: Date | null = null;
-let _timeOffset: number = 0;
+import { Temporal } from "./temporal.js";
+
+let _frozenInstant: Temporal.Instant | null = null;
+let _timeOffsetNs: bigint = 0n;
 
 export function setFrozenTime(time: Date | null): void {
-  _frozenTime = time;
+  _frozenInstant = time === null ? null : Temporal.Instant.fromEpochMilliseconds(time.getTime());
 }
 
-export function setTimeOffset(offset: number): void {
-  _timeOffset = offset;
+export function setTimeOffset(offsetMs: number): void {
+  _timeOffsetNs = BigInt(Math.trunc(offsetMs)) * 1_000_000n;
+}
+
+/**
+ * Returns the current time as a `Temporal.Instant`, respecting any active
+ * time travel. Preserves nanosecond precision for both the frozen-time and
+ * offset paths.
+ */
+export function currentTimeInstant(): Temporal.Instant {
+  if (_frozenInstant) return _frozenInstant;
+  if (_timeOffsetNs === 0n) return Temporal.Now.instant();
+  return Temporal.Instant.fromEpochNanoseconds(
+    Temporal.Now.instant().epochNanoseconds + _timeOffsetNs,
+  );
 }
 
 /**
  * Returns the current time, respecting any active time travel.
  */
 export function currentTime(): Date {
-  if (_frozenTime) return new Date(_frozenTime);
-  return new Date(Date.now() + _timeOffset);
+  return new Date(currentTimeInstant().epochMilliseconds);
 }


### PR DESCRIPTION
## Summary

F-6g of the Temporal migration:

- `currentTime()` no longer calls `Date.now()`; it reads the clock through `Temporal.Now.instant()`.
- The travel offset moves from millisecond `number` to nanosecond `bigint` storage.
- New `currentTimeInstant()` returns `Temporal.Instant` so callers can use the time-travel mock at full nanosecond precision.
- `currentTime()` keeps its `Date` return shape — no consumer churn.

## Test plan
- [x] `pnpm exec vitest run packages/activesupport`
- [x] `pnpm --filter @blazetrails/activesupport build`