### PR TITLE
fix(arel): InsertManager shape parity

### DIFF
--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -199,7 +199,7 @@ export class SchemaMigration {
       const im = new InsertManager(this.arelTable);
       const rows = toInsert.map((v) => [new Nodes.Quoted(v)]);
       im.ast.columns = [col];
-      im.values(im.createValuesList(rows));
+      im.values = im.createValuesList(rows);
       await this._adapter.executeMutation(im.toSql());
     }
   }

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -9,12 +9,10 @@ describe("InsertManagerTest", () => {
       const mgr = new InsertManager();
       mgr.into(users);
       mgr.ast.columns = [users.get("name"), users.get("age")];
-      mgr.values(
-        new Nodes.ValuesList([
-          [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
-          [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
-        ]),
-      );
+      mgr.values = new Nodes.ValuesList([
+        [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
+        [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
+      ]);
       expect(mgr.toSql()).toBe(
         `INSERT INTO "users" ("name", "age") VALUES ('dean', 30), ('sam', 25)`,
       );
@@ -74,7 +72,7 @@ describe("InsertManagerTest", () => {
       const im = new InsertManager();
       im.into(users);
       const vl = im.createValuesList([[new Nodes.Quoted("alice")], [new Nodes.Quoted("bob")]]);
-      im.values(vl);
+      im.values = vl;
       im.ast.columns = [users.get("name")];
       const sql = im.toSql();
       expect(sql).toContain("VALUES");
@@ -171,12 +169,10 @@ describe("InsertManagerTest", () => {
       const mgr = new InsertManager();
       mgr.into(users);
       mgr.ast.columns = [users.get("name"), users.get("age")];
-      mgr.values(
-        new Nodes.ValuesList([
-          [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
-          [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
-        ]),
-      );
+      mgr.values = new Nodes.ValuesList([
+        [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
+        [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
+      ]);
       expect(mgr.toSql()).toBe(
         `INSERT INTO "users" ("name", "age") VALUES ('dean', 30), ('sam', 25)`,
       );
@@ -214,6 +210,50 @@ describe("InsertManagerTest", () => {
       expect(mgr.into(users)).toBe(mgr);
       expect(mgr.insert([[users.get("name"), "dean"]])).toBe(mgr);
       expect(mgr.toSql()).toContain("INSERT");
+    });
+  });
+
+  // Mirrors Rails: `Arel::InsertManager#insert` (insert_manager.rb).
+  describe("insert (Rails parity)", () => {
+    it("is a no-op for an empty fields array", () => {
+      const mgr = new InsertManager();
+      mgr.insert([]);
+      expect(mgr.ast.values).toBeNull();
+      expect(mgr.ast.relation).toBeNull();
+      expect(mgr.ast.columns).toEqual([]);
+    });
+
+    it("stores a string `fields` value as a SqlLiteral on ast.values", () => {
+      const mgr = new InsertManager(users);
+      mgr.insert("foo");
+      expect(mgr.ast.values).toBeInstanceOf(Nodes.SqlLiteral);
+      expect((mgr.ast.values as Nodes.SqlLiteral).value).toBe("foo");
+    });
+
+    it("infers ast.relation from the first column when not yet set", () => {
+      const mgr = new InsertManager();
+      mgr.insert([[users.get("name"), "alice"]]);
+      expect(mgr.ast.relation).toBe(users);
+    });
+
+    it("preserves an explicit ast.relation rather than inferring", () => {
+      const mgr = new InsertManager(posts);
+      mgr.insert([[users.get("name"), "alice"]]);
+      expect(mgr.ast.relation).toBe(posts);
+    });
+  });
+
+  // Mirrors Rails: `InsertManager#select` stores the manager itself
+  // (insert_manager.rb), not its inner `.ast`. The visitor handles
+  // the SelectManager-shaped duck-type via `visitNodeOrValue`.
+  describe("select (Rails parity)", () => {
+    it("stores the SelectManager itself on ast.select", () => {
+      const mgr = new InsertManager(users);
+      mgr.ast.columns = [users.get("name")];
+      const selectMgr = posts.project(posts.get("title"));
+      mgr.select(selectMgr);
+      expect(mgr.ast.select).toBe(selectMgr);
+      expect(mgr.toSql()).toContain("SELECT");
     });
   });
 });

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -1,9 +1,9 @@
 import { Node } from "./nodes/node.js";
 import { TreeManager } from "./tree-manager.js";
-import { InsertStatement } from "./nodes/insert-statement.js";
+import { InsertStatement, type InsertSelectSource } from "./nodes/insert-statement.js";
 import { Attribute } from "./attributes/attribute.js";
 import { ValuesList } from "./nodes/values-list.js";
-import { Quoted } from "./nodes/casted.js";
+import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Table } from "./table.js";
 
 /**
@@ -16,8 +16,7 @@ export class InsertManager extends TreeManager {
 
   constructor(table?: Table | null) {
     super();
-    this.ast = new InsertStatement();
-    if (table) this.into(table);
+    this.ast = new InsertStatement(table ?? null);
   }
 
   /**
@@ -30,25 +29,44 @@ export class InsertManager extends TreeManager {
 
   /**
    * Set column/value pairs.
+   *
+   * Mirrors: Arel::InsertManager#insert (insert_manager.rb).
+   * - returns early when `fields` is empty (Rails: `return if fields.empty?`)
+   * - string form stores `Nodes::SqlLiteral.new(fields)` on `ast.values`
+   * - infers `ast.relation` from the first column when not yet set
+   *   (Rails: `@ast.relation ||= fields.first.first.relation`)
+   * - values pass through raw — no `Quoted` wrap (Rails preserves them
+   *   for the dialect-specific value visitor to quote)
    */
-  insert(values: [Attribute | Node, unknown][]): this {
-    const columns: Node[] = [];
-    const row: Node[] = [];
-    for (const [col, val] of values) {
-      columns.push(col);
-      row.push(val instanceof Node ? val : new Quoted(val));
+  insert(fields: string | [Attribute | Node, unknown][] | null | undefined): this {
+    if (fields == null) return this;
+
+    if (typeof fields === "string") {
+      this.ast.values = new SqlLiteral(fields);
+      return this;
     }
-    this.ast.columns = columns;
-    this.ast.values = new ValuesList([row]);
+
+    if (fields.length === 0) return this;
+
+    if (this.ast.relation == null) {
+      const first = fields[0]?.[0] as { relation?: Node } | undefined;
+      if (first?.relation) this.ast.relation = first.relation;
+    }
+
+    const row: unknown[] = [];
+    for (const [col, val] of fields) {
+      this.ast.columns.push(col);
+      row.push(val);
+    }
+    this.ast.values = this.createValues(row);
     return this;
   }
 
   /**
-   * Set values from raw rows.
+   * Mirrors: Arel::InsertManager `values=` (insert_manager.rb).
    */
-  values(valuesList: ValuesList): this {
-    this.ast.values = valuesList;
-    return this;
+  set values(val: Node | null) {
+    this.ast.values = val;
   }
 
   /**
@@ -63,10 +81,13 @@ export class InsertManager extends TreeManager {
   /**
    * Set a SelectManager as the source for INSERT ... SELECT.
    *
-   * Mirrors: Arel::InsertManager#select
+   * Mirrors: Arel::InsertManager#select — stores the manager itself
+   * rather than unwrapping to its inner `.ast`. The visitor handles
+   * either shape (raw Node or SelectManager-shaped duck-type) via
+   * `visitNodeOrValue`.
    */
-  select(selectManager: { ast: Node }): this {
-    this.ast.select = selectManager.ast;
+  select(selectManager: InsertSelectSource): this {
+    this.ast.select = selectManager;
     return this;
   }
 
@@ -75,8 +96,8 @@ export class InsertManager extends TreeManager {
    *
    * Mirrors: Arel::InsertManager#create_values
    */
-  createValues(row: Node[], _columns?: Node[]): ValuesList {
-    return new ValuesList([row]);
+  createValues(row: unknown[]): ValuesList {
+    return new ValuesList([row as Node[]]);
   }
 
   /**

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -5,11 +5,18 @@ import { Node, NodeVisitor } from "./node.js";
  *
  * Mirrors: Arel::Nodes::InsertStatement
  */
+/**
+ * Mirrors Rails: `@ast.select = select` in `InsertManager#select` —
+ * Rails stores a `SelectManager` directly (not its inner `.ast`), so
+ * the field type widens to "Node-or-SelectManager-shape-or-null".
+ */
+export type InsertSelectSource = Node | { ast: Node; toSql: () => string } | null;
+
 export class InsertStatement extends Node {
   relation: Node | null;
   columns: Node[];
   values: Node | null;
-  select: Node | null;
+  select: InsertSelectSource;
 
   constructor(relation: Node | null = null) {
     super();

--- a/packages/arel/src/nodes/values-list.ts
+++ b/packages/arel/src/nodes/values-list.ts
@@ -1,15 +1,16 @@
-import { Node } from "./node.js";
 import { Unary } from "./unary.js";
 
 /**
  * ValuesList — VALUES (...), (...), ...
  *
- * Mirrors: Arel::Nodes::ValuesList (extends Unary)
+ * Mirrors: Arel::Nodes::ValuesList (extends Unary). Rails carries
+ * arbitrary value objects in each row; the visitor delegates rendering
+ * to `visitNodeOrValue`, so raw primitives flow through unwrapped.
  */
 export class ValuesList extends Unary {
-  readonly rows: Node[][];
+  readonly rows: unknown[][];
 
-  constructor(rows: Node[][]) {
+  constructor(rows: unknown[][]) {
     super(null);
     this.rows = rows;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -342,12 +342,16 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.collector.append(")");
     }
 
-    if (node.select) {
-      this.collector.append(" ");
-      this.visit(node.select);
-    } else if (node.values) {
+    // Mirrors Rails: prefer `node.values` when both are present
+    // (insert_statement.rb / to_sql.rb pattern). Routes through
+    // `visitNodeOrValue` so a SelectManager-shaped duck-type (the form
+    // `InsertManager#select` stores) lands in `visitArelSelectManager`.
+    if (node.values) {
       this.collector.append(" ");
       this.visit(node.values);
+    } else if (node.select) {
+      this.collector.append(" ");
+      this.visitNodeOrValue(node.select as Nodes.NodeOrValue);
     }
 
     return this.collector;
@@ -1380,7 +1384,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.collector.append("(");
       for (let j = 0; j < node.rows[i].length; j++) {
         if (j > 0) this.collector.append(", ");
-        this.visit(node.rows[i][j]);
+        this.visitNodeOrValue(node.rows[i][j] as Nodes.NodeOrValue);
       }
       this.collector.append(")");
     }


### PR DESCRIPTION
## Summary

PR 12 from [`docs/arel-alignment-plan.md`](../blob/main/docs/arel-alignment-plan.md) — bring `InsertManager` AST in line with Rails ([insert_manager.rb](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/insert_manager.rb)).

- `insert(fields)`:
  - early-returns on `null`/empty (Rails: `return if fields.empty?`)
  - string form stores `Nodes::SqlLiteral.new(fields)` on `ast.values` (was missing)
  - infers `ast.relation` from `fields[0][0].relation` when not yet set (Rails: `@ast.relation ||= fields.first.first.relation`)
  - drops the `Quoted` wrap on values; the visitor's `visitNodeOrValue` path renders raw primitives
- Replaces the prior `values(list)` method with a `set values(val)` setter, matching Rails' `attr_writer :values`. Atomic in-tree migration: AR's `schema-migration.ts` and the `insert-manager.test.ts` suite updated to `mgr.values = …`.
- `select(selectManager)` now stores the manager itself (matching Rails) rather than unwrapping to `.ast`. `InsertStatement#select` widens to `Node | { ast; toSql() } | null`; the visitor routes through `visitNodeOrValue` so the SelectManager-shaped duck-type lands in `visitArelSelectManager`.
- Insert visitor prefers `node.values` over `node.select` when both are present, matching Rails' `to_sql.rb` pattern.
- `ValuesList.rows` widened to `unknown[][]` to carry raw primitives; `visitArelNodesValuesList` uses `visitNodeOrValue` per row cell.

118 insertions / 45 deletions.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1241/1241 (5 new tests under `insert (Rails parity)` and `select (Rails parity)`).
- [x] `pnpm exec vitest run packages/activerecord/` — 9947 passed, no regressions (one site in `schema-migration.ts` updated to the setter form).
- [x] `pnpm -w build` clean.