### PR TITLE
fix(arel): UpdateManager#set wraps columns in UnqualifiedColumn

### DIFF
--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -103,6 +103,35 @@ describe("UpdateManagerTest", () => {
       mgr.set(new Nodes.BoundSqlLiteral("name = ?", ["dean"], {}));
       expect(mgr.toSql()).toBe(`UPDATE "users" SET name = 'dean'`);
     });
+
+    // Mirrors Rails: `set` wraps each LHS in `Nodes::UnqualifiedColumn`
+    // (update_manager.rb), so the visitor strips the table qualifier
+    // structurally rather than via a stateful flag.
+    it("wraps each column in an UnqualifiedColumn", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set([[users.get("name"), "dean"]]);
+      const assignment = mgr.ast.values[0] as Nodes.Assignment;
+      expect(assignment).toBeInstanceOf(Nodes.Assignment);
+      expect(assignment.left).toBeInstanceOf(Nodes.UnqualifiedColumn);
+    });
+
+    // Mirrors Rails: values pass through raw (no Quoted wrap); the
+    // visitor's `visitNodeOrValue` quotes primitives.
+    it("stores the raw value on the Assignment (no Quoted wrap)", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set([[users.get("age"), 42]]);
+      const assignment = mgr.ast.values[0] as Nodes.Assignment;
+      expect(assignment.right).toBe(42);
+    });
+
+    it("renders SET col = … without the table qualifier", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set([[users.get("name"), "dean"]]);
+      expect(mgr.toSql()).toBe(`UPDATE "users" SET "name" = 'dean'`);
+    });
   });
 
   describe("table", () => {

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -2,7 +2,7 @@ import { Node } from "./nodes/node.js";
 import { TreeManager, StatementMethods } from "./tree-manager.js";
 import { include } from "@blazetrails/activesupport";
 import { UpdateStatement } from "./nodes/update-statement.js";
-import { Assignment } from "./nodes/binary.js";
+import { Assignment, type NodeOrValue } from "./nodes/binary.js";
 import { UnqualifiedColumn } from "./nodes/unqualified-column.js";
 import { Group } from "./nodes/unary.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
@@ -61,7 +61,7 @@ export class UpdateManager extends TreeManager {
       this.ast.values = [values];
     } else {
       this.ast.values = values.map(
-        ([col, val]) => new Assignment(new UnqualifiedColumn(col), val as Node),
+        ([col, val]) => new Assignment(new UnqualifiedColumn(col), val as NodeOrValue),
       );
     }
     return this;

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -3,7 +3,7 @@ import { TreeManager, StatementMethods } from "./tree-manager.js";
 import { include } from "@blazetrails/activesupport";
 import { UpdateStatement } from "./nodes/update-statement.js";
 import { Assignment } from "./nodes/binary.js";
-import { Quoted } from "./nodes/casted.js";
+import { UnqualifiedColumn } from "./nodes/unqualified-column.js";
 import { Group } from "./nodes/unary.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
@@ -47,15 +47,22 @@ export class UpdateManager extends TreeManager {
    * Mirrors: Arel::UpdateManager#set
    */
   set(values: UpdateValues): this {
+    // Mirrors Arel::UpdateManager#set (update_manager.rb): pairs become
+    // `Assignment(UnqualifiedColumn(col), value)` with the value passed
+    // through raw — the visitor's `visitNodeOrValue` dispatch quotes
+    // primitives. The `UnqualifiedColumn` wrapper strips the table
+    // qualifier so the visitor does not need an `_inUpdateSet` mode flag.
     if (typeof values === "string") {
+      // Trails-only: keep the string form, but stash it as a SqlLiteral
+      // so the AST always contains Nodes (Rails stashes raw strings and
+      // relies on `visit_String`).
       this.ast.values = [new SqlLiteral(values)];
     } else if (values instanceof SqlLiteral || values instanceof BoundSqlLiteral) {
       this.ast.values = [values];
     } else {
-      this.ast.values = values.map(([col, val]) => {
-        const right = val instanceof Node ? val : new Quoted(val);
-        return new Assignment(col, right);
-      });
+      this.ast.values = values.map(
+        ([col, val]) => new Assignment(new UnqualifiedColumn(col), val as Node),
+      );
     }
     return this;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -30,7 +30,6 @@ const DEFAULT_BIND_BLOCK: (index: number) => string = () => "?";
  */
 export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   protected collector!: SQLString;
-  private _inUpdateSet = false;
   protected _extractBinds = false;
 
   compile(node: Node): string {
@@ -365,12 +364,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
     if (node.values.length > 0) {
       this.collector.append(" SET ");
-      this._inUpdateSet = true;
-      try {
-        this.injectJoin(node.values, ", ");
-      } finally {
-        this._inUpdateSet = false;
-      }
+      this.injectJoin(node.values, ", ");
     }
 
     if (node.wheres.length > 0) {
@@ -730,11 +724,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitArelNodesAssignment(node: Nodes.Assignment): SQLString {
-    if (this._inUpdateSet && node.left instanceof Nodes.Attribute) {
-      this.collector.append(this.quoteColumnName(node.left.name));
-    } else {
-      this.visitNodeOrValue(node.left);
-    }
+    // Mirrors Rails: bare `visit(left) = visit(right)`. Column-name
+    // unqualification is the responsibility of `UnqualifiedColumn`,
+    // which `UpdateManager#set` wraps each LHS in.
+    this.visitNodeOrValue(node.left);
     this.collector.append(" = ");
     this.visitNodeOrValue(node.right);
     return this.collector;
@@ -1438,7 +1431,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
         this.collector.append(this.quotedDate(v as { toISOString(): string }));
       }
     } else {
-      this.collector.append(String(v));
+      // Unknown object types (e.g. Temporal.Instant) — defer to `quote()`
+      // so the value is properly escaped/quoted rather than concatenated
+      // raw, matching the visitQuoted path.
+      this.collector.append(this.quote(v));
     }
     return this.collector;
   }


### PR DESCRIPTION
## Summary

PR 8 from [`docs/arel-alignment-plan.md`](../blob/main/docs/arel-alignment-plan.md) — bring `UpdateManager#set` AST in line with Rails ([update_manager.rb](../blob/main/scripts/api-compare/.rails-source/activerecord/lib/arel/update_manager.rb)).

- `UpdateManager#set([[col, val], …])` now produces `Assignment(UnqualifiedColumn(col), value)` with the value passed raw — the visitor's `visitNodeOrValue` quotes primitives.
- Removes the stateful `_inUpdateSet` flag from the `to-sql` visitor. LHS table-qualifier stripping is now structural via `UnqualifiedColumn`. The Assignment visitor reduces to plain `visit(left) = visit(right)`, matching Rails verbatim.

### Side fix (caught by AR regression)

`visitNodeOrValue`'s unknown-object fallback now defers to `quote()` instead of concatenating `String(v)` raw. This matters for non-`Date` date-likes (e.g. `Temporal.Instant` from AR's timestamp helpers) that flow through `UPDATE … SET` assignments without a `Quoted` wrap — the previous fallback inlined them as bare ISO tokens (\`SET "updated_at" = 2026-04-30T19:30:00Z\`), tripping SQLite's `unrecognized token` error. Counter-cache + collection-cache tests now pass.

50 insertions / 18 deletions.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1244/1244 (3 new tests under `set`).
- [x] `pnpm exec vitest run packages/activerecord/` — 9947 passed, no regressions (counter-cache + collection-cache verified).
- [x] `pnpm -w build` clean.