### PR TITLE
fix(arel)!: SelectManager#limit / #offset return inner expr

### DIFF
--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -209,6 +209,14 @@ describe("SelectManagerTest", () => {
       mgr.skip(null);
       expect(mgr.ast.offset).toBeNull();
     });
+
+    // Mirrors Rails: `def offset; @ast.offset && @ast.offset.expr; end`.
+    it("the offset getter returns the inner expression", () => {
+      const mgr = new SelectManager(users).skip(7);
+      expect(mgr.offset).toBe(7);
+      mgr.skip(null);
+      expect(mgr.offset).toBeNull();
+    });
   });
 
   describe("take", () => {
@@ -225,6 +233,14 @@ describe("SelectManagerTest", () => {
       expect(mgr.ast.limit).not.toBeNull();
       mgr.take(null);
       expect(mgr.ast.limit).toBeNull();
+    });
+
+    // Mirrors Rails: `def limit; @ast.limit && @ast.limit.expr; end`.
+    it("the limit getter returns the inner expression", () => {
+      const mgr = new SelectManager(users).take(5);
+      expect(mgr.limit).toBe(5);
+      mgr.take(null);
+      expect(mgr.limit).toBeNull();
     });
   });
 
@@ -1242,7 +1258,8 @@ describe("SelectManagerTest", () => {
   describe("take", () => {
     it("knows take", () => {
       const mgr = new SelectManager(users).project(star).take(5);
-      expect(mgr.limit).toBeInstanceOf(Nodes.Limit);
+      expect(mgr.ast.limit).toBeInstanceOf(Nodes.Limit);
+      expect(mgr.limit).toBe(5);
       expect(mgr.toSql()).toContain("LIMIT 5");
     });
   });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -362,7 +362,7 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#limit
    */
-  get limit(): unknown {
+  get limit(): Limit["expr"] | null {
     return (this.ast.limit as Limit | null)?.expr ?? null;
   }
 
@@ -379,7 +379,7 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#offset
    */
-  get offset(): unknown {
+  get offset(): Offset["expr"] | null {
     return (this.ast.offset as Offset | null)?.expr ?? null;
   }
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -357,12 +357,13 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * Return the current LIMIT node.
+   * Return the current LIMIT amount (the inner expression of the Limit node),
+   * or null when no limit is set.
    *
    * Mirrors: Arel::SelectManager#limit
    */
-  get limit(): Node | null {
-    return this.ast.limit;
+  get limit(): unknown {
+    return (this.ast.limit as Limit | null)?.expr ?? null;
   }
 
   /**
@@ -373,12 +374,13 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * Return the current OFFSET node.
+   * Return the current OFFSET amount (the inner expression of the Offset node),
+   * or null when no offset is set.
    *
    * Mirrors: Arel::SelectManager#offset
    */
-  get offset(): Node | null {
-    return this.ast.offset;
+  get offset(): unknown {
+    return (this.ast.offset as Offset | null)?.expr ?? null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Aligns `SelectManager#limit` / `#offset` getters with Rails — returns the
inner expression (raw amount) instead of the wrapping `Limit` / `Offset`
node.

Rails (`activerecord/lib/arel/select_manager.rb`):

```ruby
def limit;  @ast.limit  && @ast.limit.expr;  end
def offset; @ast.offset && @ast.offset.expr; end
```

Setters (`limit=` / `offset=`, added in PR 6) are unchanged — still
delegate to `take` / `skip`. AST shape (`mgr.ast.limit`) is unchanged.

## Breaking change

`SelectManager#limit` / `#offset` no longer return a Node. For the node
form, use `mgr.ast.limit` / `mgr.ast.offset`.

In-tree migration: no AR call sites read `mgr.limit` / `mgr.offset` —
arel internals already use `this.ast.limit`. Only one in-package test
assertion (`mgr.limit instanceof Nodes.Limit`) moved to `mgr.ast.limit`.

## Test plan

- [x] `pnpm exec vitest run packages/arel/` — 1246 passed
- [x] `pnpm exec vitest run packages/activerecord/` — 9949 passed
- [x] Diff size: 2 files, +26 / -7

Plan: docs/arel-alignment-plan.md PR 7 (Wave 3).