### PR TITLE
feat(activemodel): port _define*ModelCallback helpers + initInternals

### DIFF
--- a/docs/activemodel-privates-100-plan.md
+++ b/docs/activemodel-privates-100-plan.md
@@ -155,14 +155,22 @@ microseconds/fallbackStringToTime (date_time), newTime/fastStringToTime
 (time_value), valueFromMultiparameterAssignment (date+date_time).
 ~9 misses. **Coordinate with Track C1/C2/C3** — same surface.
 
-**PR B5 — Internals callbacks + validation lifecycle (`validations.rb` + `callbacks.rb` + cross-file initInternals)**
-The 3 `_defineXxxModelCallback` methods + `initInternals` +
-`runValidationsBang` + `raiseValidationError` +
-`predicateForValidationContext` + `contextForValidation` +
-`_mergeAttributes`. Mostly one shared cluster surfaced across
-multiple files. ~15-18 misses across `validations.rb`, `callbacks.rb`,
-`model.rb`, `api.rb`, `dirty.rb`. Likely needs splitting into B5a
-(definitions) + B5b (consumption rewiring).
+**PR B5a — Internals callbacks definitions — ✅ done**
+The 3 `_defineXxxModelCallback` helpers extracted from
+`defineModelCallbacks` and re-exposed via `validations.ts` (Rails
+`Validations` extends `Callbacks`). `initInternals` exported from
+`validations.ts` (resets `errors` + `_validationContext`) and
+`dirty.ts` (resets `_dirty`); Model gains an instance hook
+`initInternals()` that chains both, called from the constructor.
+`api.ts` re-exports the validations helper. Closes 10 privates
+misses (callbacks.rb 4/4, +1 each on validations/dirty/model/api).
+
+**PR B5b — Validation lifecycle consumption**
+`runValidationsBang`, `raiseValidationError`,
+`predicateForValidationContext`, `contextForValidation`,
+`_mergeAttributes`. Wires the call sites to the B5a definitions
+and propagates the include-mixed methods across `model.rb`,
+`api.rb`, `dirty.rb`, `attribute_registration.rb`.
 
 **PR B6 — Attribute method dispatch cluster (`attribute_methods.rb` + `attributes.rb` + `attribute_set/builder.rb`)**
 isAttributeMethod, matchedAttributeMethod, missingAttribute,

--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -15,6 +15,17 @@ export interface API {
 }
 
 import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
+import { initInternals as validationsInitInternals } from "./validations.js";
+
+/**
+ * Rails: ActiveModel::API includes Validations (api.rb), so
+ * `init_internals` is part of API's surface as well. Re-export the
+ * canonical Validations helper here so api-compare matches the shape
+ * of `api.rb` and a host that mixes in only API still has the hook.
+ *
+ * @internal Rails-private helper.
+ */
+export const initInternals = validationsInitInternals;
 
 /**
  * Rails: ActiveModel::API includes Validations, which extends Translation,

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -83,61 +83,88 @@ export function defineModelCallbacks(this: any, ...args: unknown[]): void {
 
   const timings: CallbackTiming[] = options.only ?? ["before", "after", "around"];
 
+  // NB: each `_defineXxxModelCallback` passes `fnOrObject` directly to
+  // `register`; `register` already handles `resolveCallback` internally
+  // AND stores the original filter for identity-based removal via
+  // `skip()`. Pre-resolving here would make the stored filter the
+  // wrapper function, breaking `Model.skipCallback(event, timing,
+  // originalObject)` for entries registered through the generated
+  // `beforeX`/`afterX`/`aroundX` helpers.
   for (const event of eventNames) {
-    const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
-
-    // NB: pass `fnOrObject` directly to `register`; `register` already
-    // handles `resolveCallback` internally AND stores the original
-    // filter for identity-based removal via `skip()`. Pre-resolving here
-    // would make the stored filter the wrapper function, breaking
-    // `Model.skipCallback(event, timing, originalObject)` for entries
-    // registered through the generated `beforeX`/`afterX`/`aroundX`
-    // helpers.
-    if (timings.includes("before")) {
-      const methodName = `before${capitalizedEvent}`;
-      Object.defineProperty(this, methodName, {
-        value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
-          if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-            this._callbackChain = this._callbackChain.clone();
-          }
-          this._callbackChain.register("before", event, fnOrObject, conditions);
-        },
-        writable: true,
-        configurable: true,
-      });
-    }
-
-    if (timings.includes("after")) {
-      const methodName = `after${capitalizedEvent}`;
-      Object.defineProperty(this, methodName, {
-        value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
-          if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-            this._callbackChain = this._callbackChain.clone();
-          }
-          this._callbackChain.register("after", event, fnOrObject, conditions);
-        },
-        writable: true,
-        configurable: true,
-      });
-    }
-
-    if (timings.includes("around")) {
-      const methodName = `around${capitalizedEvent}`;
-      Object.defineProperty(this, methodName, {
-        value: function (
-          fnOrObject: AroundCallbackFn | CallbackObject,
-          conditions?: CallbackConditions,
-        ) {
-          if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-            this._callbackChain = this._callbackChain.clone();
-          }
-          this._callbackChain.register("around", event, fnOrObject, conditions);
-        },
-        writable: true,
-        configurable: true,
-      });
-    }
+    if (timings.includes("before")) _defineBeforeModelCallback(this, event);
+    if (timings.includes("after")) _defineAfterModelCallback(this, event);
+    if (timings.includes("around")) _defineAroundModelCallback(this, event);
   }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- mixin host accepts any class constructor */
+type CallbackHost = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Define a `before<Event>` class method that registers a before callback.
+ *
+ * Mirrors: ActiveModel::Callbacks#_define_before_model_callback
+ *
+ * @internal Rails-private helper.
+ */
+export function _defineBeforeModelCallback(klass: CallbackHost, event: string): void {
+  const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
+  Object.defineProperty(klass, `before${capitalizedEvent}`, {
+    value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
+      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
+        this._callbackChain = this._callbackChain.clone();
+      }
+      this._callbackChain.register("before", event, fnOrObject, conditions);
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Define an `around<Event>` class method that registers an around callback.
+ *
+ * Mirrors: ActiveModel::Callbacks#_define_around_model_callback
+ *
+ * @internal Rails-private helper.
+ */
+export function _defineAroundModelCallback(klass: CallbackHost, event: string): void {
+  const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
+  Object.defineProperty(klass, `around${capitalizedEvent}`, {
+    value: function (
+      fnOrObject: AroundCallbackFn | CallbackObject,
+      conditions?: CallbackConditions,
+    ) {
+      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
+        this._callbackChain = this._callbackChain.clone();
+      }
+      this._callbackChain.register("around", event, fnOrObject, conditions);
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Define an `after<Event>` class method that registers an after callback.
+ *
+ * Mirrors: ActiveModel::Callbacks#_define_after_model_callback
+ *
+ * @internal Rails-private helper.
+ */
+export function _defineAfterModelCallback(klass: CallbackHost, event: string): void {
+  const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
+  Object.defineProperty(klass, `after${capitalizedEvent}`, {
+    value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
+      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
+        this._callbackChain = this._callbackChain.clone();
+      }
+      this._callbackChain.register("after", event, fnOrObject, conditions);
+    },
+    writable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -35,6 +35,34 @@ function resolveValue(value: unknown): unknown {
 }
 
 /**
+ * Per-instance reset hook for dirty-tracking state. Mirrors Rails
+ * `ActiveModel::Dirty#init_internals`
+ * (activemodel/lib/active_model/dirty.rb:372-376):
+ *
+ *   def init_internals
+ *     super
+ *     @mutations_before_last_save = nil
+ *     @mutations_from_database = nil
+ *   end
+ *
+ * Trails consolidates Rails' two mutation trackers into a single
+ * `DirtyTracker`, so a fresh tracker is the equivalent reset.
+ * Called from the Model constructor.
+ *
+ * @internal Rails-private helper.
+ */
+export function initInternals(this: DirtyInternalsHost): void {
+  this._dirty = new DirtyTracker();
+}
+
+/**
+ * Host shape consumed by `initInternals`.
+ */
+export interface DirtyInternalsHost {
+  _dirty: DirtyTracker;
+}
+
+/**
  * Dirty tracking mixin — tracks attribute changes on a model.
  *
  * Mirrors: ActiveModel::Dirty

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1193,8 +1193,8 @@ export class Model {
 
   _attributes: AttributeSet = new AttributeSet();
   _accessedFields: Set<string> = new Set();
-  errors: Errors = new Errors(this);
-  _dirty: DirtyTracker = new DirtyTracker();
+  errors!: Errors;
+  _dirty!: DirtyTracker;
 
   /**
    * Per-instance reset hook. Mirrors the Rails chain

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1,12 +1,16 @@
 import { Errors, StrictValidationFailed } from "./errors.js";
-import { ValidationError, ValidationContext } from "./validations.js";
+import {
+  ValidationError,
+  ValidationContext,
+  initInternals as validationsInitInternals,
+} from "./validations.js";
 import { humanize, underscore, dasherize, htmlEscape } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { I18n } from "./i18n.js";
 import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
 import { ModelName } from "./naming.js";
-import { DirtyTracker } from "./dirty.js";
+import { DirtyTracker, initInternals as dirtyInitInternals } from "./dirty.js";
 import {
   CallbackChain,
   CallbackFn,
@@ -1193,6 +1197,22 @@ export class Model {
   _dirty: DirtyTracker = new DirtyTracker();
 
   /**
+   * Per-instance reset hook. Mirrors the Rails chain
+   * `ActiveModel::{Validations,Dirty}#init_internals`
+   * (validations.rb:467-471, dirty.rb:372-376). The Trails
+   * implementation forwards to the per-module helpers exported
+   * from `validations.ts` and `dirty.ts` so each module owns its
+   * own state-reset surface, mirroring how Ruby's `super` chain
+   * walks the include order.
+   *
+   * @internal Rails-private helper.
+   */
+  initInternals(): void {
+    validationsInitInternals.call(this);
+    dirtyInitInternals.call(this);
+  }
+
+  /**
    * Mirrors: ActiveModel::API#initialize → ActiveModel::Attributes#initialize
    *
    * Rails pattern:
@@ -1201,6 +1221,12 @@ export class Model {
    */
   constructor(attrs: Record<string, unknown> = {}) {
     const ctor = this.constructor as typeof Model;
+
+    // Mirrors Rails' init_internals chain (validations.rb:467,
+    // dirty.rb:372). Field initializers above already produce the
+    // same end-state, but routing through the chainable hook keeps
+    // a single point that subclasses (e.g. ActiveRecord) override.
+    this.initInternals();
 
     // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
     this._attributes = ctor._defaultAttributes().deepDup();

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -1,8 +1,66 @@
-import type { Errors } from "./errors.js";
+import { Errors } from "./errors.js";
 import type { ConditionalOptions } from "./validator.js";
 import { I18n } from "./i18n.js";
 
 import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
+import {
+  _defineBeforeModelCallback as _defineBeforeModelCallbackImpl,
+  _defineAroundModelCallback as _defineAroundModelCallbackImpl,
+  _defineAfterModelCallback as _defineAfterModelCallbackImpl,
+} from "./callbacks.js";
+
+/**
+ * Rails: ActiveModel::Validations does `extend ActiveModel::Callbacks`
+ * (validations.rb:42), so the three private callback definers surface
+ * on Validations as well. Re-expose them here so api-compare matches
+ * the shape of `validations.rb` and so a host that mixes in only
+ * Validations still has the helpers available.
+ *
+ * @internal Rails-private helper.
+ */
+export const _defineBeforeModelCallback = _defineBeforeModelCallbackImpl;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const _defineAroundModelCallback = _defineAroundModelCallbackImpl;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const _defineAfterModelCallback = _defineAfterModelCallbackImpl;
+
+/**
+ * Per-instance reset hook for validation state. Mirrors Rails
+ * `ActiveModel::Validations#init_internals`
+ * (activemodel/lib/active_model/validations.rb:467-471):
+ *
+ *   def init_internals
+ *     super
+ *     @errors = nil
+ *     @context_for_validation = nil
+ *   end
+ *
+ * Trails eagerly initializes `errors` (rather than Rails' lazy
+ * `errors_or_create`), so this assigns a fresh `Errors` and clears
+ * the active validation context. Called from the Model constructor.
+ *
+ * @internal Rails-private helper.
+ */
+export function initInternals(this: ValidationsInternalsHost): void {
+  this.errors = new Errors(this);
+  this._validationContext = null;
+}
+
+/**
+ * Host shape consumed by `initInternals`. Kept loose so any class with
+ * the validation-related fields satisfies it without circular imports
+ * back to `Model`.
+ */
+export interface ValidationsInternalsHost {
+  errors: Errors;
+  _validationContext: string | string[] | null;
+}
 
 /**
  * Rails: ActiveModel::Validations extends Translation (validations.rb:43),


### PR DESCRIPTION
## Summary

- Extracts the three private callback definers from `defineModelCallbacks` (callbacks.rb:129-153) into top-level `@internal` helpers `_defineBeforeModelCallback`, `_defineAroundModelCallback`, `_defineAfterModelCallback`. `validations.ts` re-exports them since Rails does `extend ActiveModel::Callbacks` (validations.rb:42).
- Adds `initInternals` exports — `validations.ts` resets `errors` + `_validationContext` (validations.rb:467-471); `dirty.ts` resets the consolidated `_dirty` tracker (dirty.rb:372-376). `Model` gains an instance `initInternals()` that chains both and is called from the constructor — the TS analogue of Rails' `init_internals` super chain. `api.ts` re-exports the Validations helper since API includes Validations.
- B5a from `docs/activemodel-privates-100-plan.md`. Closes 10 privates misses (callbacks.rb 4/4, +1 each on validations/dirty/model/api). activemodel privates: 541/625 → 551/625 (86.6% → 88.2%). Public `api:compare` and 1629/1629 tests unchanged.

## Test plan

- [x] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` → 551/625 (+10)
- [x] `pnpm tsx scripts/api-compare/compare.ts --package activemodel` → unchanged vs main
- [x] `pnpm exec vitest run packages/activemodel` → 1629/1629
- [x] `pnpm --filter @blazetrails/activemodel run build` → clean
- [x] `pnpm lint --fix` → clean