### PR TITLE
feat(activerecord): thread quoter through sanitization

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -436,12 +436,12 @@ export class Base extends Model {
 
   // --- Sanitization mixin (wired via extend() after class) ---
   declare static sanitizeSql: typeof Sanitization.ClassMethods.sanitizeSql;
-  declare static sanitizeSqlArray: typeof Sanitization.sanitizeSqlArray;
+  declare static sanitizeSqlArray: typeof Sanitization.ClassMethods.sanitizeSqlArray;
   declare static sanitizeSqlLike: typeof Sanitization.sanitizeSqlLike;
   declare static sanitizeSqlForConditions: typeof Sanitization.ClassMethods.sanitizeSqlForConditions;
   declare static sanitizeSqlForAssignment: typeof Sanitization.ClassMethods.sanitizeSqlForAssignment;
   declare static sanitizeSqlForOrder: typeof Sanitization.ClassMethods.sanitizeSqlForOrder;
-  declare static sanitizeSqlHashForAssignment: typeof Sanitization.sanitizeSqlHashForAssignment;
+  declare static sanitizeSqlHashForAssignment: typeof Sanitization.ClassMethods.sanitizeSqlHashForAssignment;
   declare static disallowRawSqlBang: typeof Sanitization.disallowRawSqlBang;
 
   // --- Associations (wired below after class body) ---

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -1,10 +1,8 @@
-/**
- * Identifier-quoting parity through `sanitizeSqlForAssignment` /
- * `sanitizeSqlHashForAssignment` — verifies the quoter parameter
- * threads dialect-specific identifier quoting through the
- * sanitization helpers, matching Rails' `connection.quote` dispatch.
- */
+// Quoter-threading parity. PG/SQLite drop the table prefix in
+// quote_table_name_for_assignment (Rails sanitization.rb:112,
+// postgresql/quoting.rb:133, sqlite3/quoting.rb:70).
 import { describe, it, expect } from "vitest";
+import { ClassMethods } from "./sanitization.js";
 import {
   sanitizeSqlForAssignment,
   sanitizeSqlHashForAssignment,
@@ -12,48 +10,44 @@ import {
   type Quoter,
 } from "./sanitization.js";
 
+const dq = (n: string) => `"${n.replace(/"/g, '""')}"`;
+const bq = (n: string) => `\`${n.replace(/`/g, "``")}\``;
+const quoteVal = (v: unknown) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v));
+
 const sqliteQuoter: Quoter = {
-  quote: (v) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v)),
-  quoteIdentifier: (n) => `"${n.replace(/"/g, '""')}"`,
-  quoteTableName: (n) =>
-    n
-      .split(".")
-      .map((p) => `"${p.replace(/"/g, '""')}"`)
-      .join("."),
+  quote: quoteVal,
+  quoteIdentifier: dq,
+  quoteTableName: (n) => n.split(".").map(dq).join("."),
+  quoteTableNameForAssignment: (_t, a) => dq(a),
   quoteString: (s) => s.replace(/'/g, "''"),
   castBoundValue: (v) => v,
 };
-
 const pgQuoter: Quoter = { ...sqliteQuoter };
-
 const mysqlQuoter: Quoter = {
-  quote: (v) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v)),
-  quoteIdentifier: (n) => `\`${n.replace(/`/g, "``")}\``,
-  quoteTableName: (n) =>
-    n
-      .split(".")
-      .map((p) => `\`${p.replace(/`/g, "``")}\``)
-      .join("."),
+  quote: quoteVal,
+  quoteIdentifier: bq,
+  quoteTableName: (n) => n.split(".").map(bq).join("."),
+  quoteTableNameForAssignment: (t, a) => `${bq(t)}.${bq(a)}`,
   quoteString: (s) => s.replace(/'/g, "''"),
   castBoundValue: (v) => v,
 };
 
-describe("sanitization quoter threading", () => {
-  it("MySQL quoter emits backtick-quoted identifiers", () => {
+describe("sanitization quoter threading (module-level)", () => {
+  it("MySQL emits backtick-qualified `table`.`column` for hash assignment", () => {
     expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, mysqlQuoter)).toBe(
       "`users`.`name` = 'x'",
     );
   });
 
-  it("PostgreSQL quoter emits double-quoted identifiers", () => {
+  it("PostgreSQL drops the table prefix for hash assignment (Rails parity)", () => {
     expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, pgQuoter)).toBe(
-      '"users"."name" = \'x\'',
+      `"name" = 'x'`,
     );
   });
 
-  it("SQLite quoter emits double-quoted identifiers", () => {
+  it("SQLite drops the table prefix for hash assignment (Rails parity)", () => {
     expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, sqliteQuoter)).toBe(
-      '"users"."name" = \'x\'',
+      `"name" = 'x'`,
     );
   });
 
@@ -65,5 +59,44 @@ describe("sanitization quoter threading", () => {
 
   it("sanitizeSqlForConditions array form threads quoter through `?` binds", () => {
     expect(sanitizeSqlForConditions(["name = ?", "x"], mysqlQuoter)).toBe("name = 'x'");
+  });
+});
+
+describe("sanitization class-method dispatch threads `this.connection()`", () => {
+  const mysqlHost = { connection: () => mysqlQuoter, isConnectedQ: () => true };
+  const pgHost = { connection: () => pgQuoter, isConnectedQ: () => true };
+
+  it("sanitizeSqlHashForAssignment uses MySQL adapter from this.connection()", () => {
+    expect(ClassMethods.sanitizeSqlHashForAssignment.call(mysqlHost, { name: "x" }, "users")).toBe(
+      "`users`.`name` = 'x'",
+    );
+  });
+
+  it("sanitizeSqlHashForAssignment uses PG adapter from this.connection()", () => {
+    expect(ClassMethods.sanitizeSqlHashForAssignment.call(pgHost, { name: "x" }, "users")).toBe(
+      `"name" = 'x'`,
+    );
+  });
+
+  it("sanitizeSqlArray uses dialect quoter for `?` binds", () => {
+    expect(ClassMethods.sanitizeSqlArray.call(mysqlHost, "name = ?", "x")).toBe("name = 'x'");
+  });
+
+  it("falls back to abstract quoter when isConnectedQ() returns false", () => {
+    const host = { connection: () => mysqlQuoter, isConnectedQ: () => false };
+    expect(ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users")).toBe(
+      `"users"."name" = 'x'`,
+    );
+  });
+
+  it("falls back to abstract quoter when host.connection() throws", () => {
+    const host = {
+      connection: () => {
+        throw new Error("ConnectionNotDefined");
+      },
+    };
+    expect(ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users")).toBe(
+      `"users"."name" = 'x'`,
+    );
   });
 });

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -9,6 +9,7 @@ import {
   sanitizeSqlForConditions,
   type Quoter,
 } from "./sanitization.js";
+import { ConnectionNotDefined, ConnectionTimeoutError } from "./errors.js";
 
 const dq = (n: string) => `"${n.replace(/"/g, '""')}"`;
 const bq = (n: string) => `\`${n.replace(/`/g, "``")}\``;
@@ -80,14 +81,25 @@ describe("sanitization class-method dispatch threads `this.connection()`", () =>
     expect(ClassMethods.sanitizeSqlArray.call(mysqlHost, "name = ?", "x")).toBe("name = 'x'");
   });
 
-  it("falls back to abstract quoter when host.connection() throws", () => {
+  it("falls back to abstract quoter when host.connection() throws ConnectionNotDefined", () => {
     const host = {
       connection: () => {
-        throw new Error("ConnectionNotDefined");
+        throw new ConnectionNotDefined("No database connection defined.");
       },
     };
     expect(ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users")).toBe(
       `"users"."name" = 'x'`,
     );
+  });
+
+  it("propagates non-ConnectionNotDefined errors from host.connection()", () => {
+    const host = {
+      connection: () => {
+        throw new ConnectionTimeoutError("connection timed out");
+      },
+    };
+    expect(() =>
+      ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users"),
+    ).toThrow(ConnectionTimeoutError);
   });
 });

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -17,7 +17,6 @@ const quoteVal = (v: unknown) => (typeof v === "string" ? `'${v.replace(/'/g, "'
 const sqliteQuoter: Quoter = {
   quote: quoteVal,
   quoteIdentifier: dq,
-  quoteTableName: (n) => n.split(".").map(dq).join("."),
   quoteTableNameForAssignment: (_t, a) => dq(a),
   quoteString: (s) => s.replace(/'/g, "''"),
   castBoundValue: (v) => v,
@@ -26,7 +25,6 @@ const pgQuoter: Quoter = { ...sqliteQuoter };
 const mysqlQuoter: Quoter = {
   quote: quoteVal,
   quoteIdentifier: bq,
-  quoteTableName: (n) => n.split(".").map(bq).join("."),
   quoteTableNameForAssignment: (t, a) => `${bq(t)}.${bq(a)}`,
   quoteString: (s) => s.replace(/'/g, "''"),
   castBoundValue: (v) => v,
@@ -63,8 +61,8 @@ describe("sanitization quoter threading (module-level)", () => {
 });
 
 describe("sanitization class-method dispatch threads `this.connection()`", () => {
-  const mysqlHost = { connection: () => mysqlQuoter, isConnectedQ: () => true };
-  const pgHost = { connection: () => pgQuoter, isConnectedQ: () => true };
+  const mysqlHost = { connection: () => mysqlQuoter };
+  const pgHost = { connection: () => pgQuoter };
 
   it("sanitizeSqlHashForAssignment uses MySQL adapter from this.connection()", () => {
     expect(ClassMethods.sanitizeSqlHashForAssignment.call(mysqlHost, { name: "x" }, "users")).toBe(
@@ -80,13 +78,6 @@ describe("sanitization class-method dispatch threads `this.connection()`", () =>
 
   it("sanitizeSqlArray uses dialect quoter for `?` binds", () => {
     expect(ClassMethods.sanitizeSqlArray.call(mysqlHost, "name = ?", "x")).toBe("name = 'x'");
-  });
-
-  it("falls back to abstract quoter when isConnectedQ() returns false", () => {
-    const host = { connection: () => mysqlQuoter, isConnectedQ: () => false };
-    expect(ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users")).toBe(
-      `"users"."name" = 'x'`,
-    );
   });
 
   it("falls back to abstract quoter when host.connection() throws", () => {

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Identifier-quoting parity through `sanitizeSqlForAssignment` /
+ * `sanitizeSqlHashForAssignment` — verifies the quoter parameter
+ * threads dialect-specific identifier quoting through the
+ * sanitization helpers, matching Rails' `connection.quote` dispatch.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeSqlForAssignment,
+  sanitizeSqlHashForAssignment,
+  sanitizeSqlForConditions,
+  type Quoter,
+} from "./sanitization.js";
+
+const sqliteQuoter: Quoter = {
+  quote: (v) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v)),
+  quoteIdentifier: (n) => `"${n.replace(/"/g, '""')}"`,
+  quoteTableName: (n) =>
+    n
+      .split(".")
+      .map((p) => `"${p.replace(/"/g, '""')}"`)
+      .join("."),
+  quoteString: (s) => s.replace(/'/g, "''"),
+  castBoundValue: (v) => v,
+};
+
+const pgQuoter: Quoter = { ...sqliteQuoter };
+
+const mysqlQuoter: Quoter = {
+  quote: (v) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v)),
+  quoteIdentifier: (n) => `\`${n.replace(/`/g, "``")}\``,
+  quoteTableName: (n) =>
+    n
+      .split(".")
+      .map((p) => `\`${p.replace(/`/g, "``")}\``)
+      .join("."),
+  quoteString: (s) => s.replace(/'/g, "''"),
+  castBoundValue: (v) => v,
+};
+
+describe("sanitization quoter threading", () => {
+  it("MySQL quoter emits backtick-quoted identifiers", () => {
+    expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, mysqlQuoter)).toBe(
+      "`users`.`name` = 'x'",
+    );
+  });
+
+  it("PostgreSQL quoter emits double-quoted identifiers", () => {
+    expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, pgQuoter)).toBe(
+      '"users"."name" = \'x\'',
+    );
+  });
+
+  it("SQLite quoter emits double-quoted identifiers", () => {
+    expect(sanitizeSqlHashForAssignment({ name: "x" }, "users", undefined, sqliteQuoter)).toBe(
+      '"users"."name" = \'x\'',
+    );
+  });
+
+  it("sanitizeSqlForAssignment hash form threads quoter for MySQL", () => {
+    expect(sanitizeSqlForAssignment({ name: "x" }, "users", mysqlQuoter)).toBe(
+      "`users`.`name` = 'x'",
+    );
+  });
+
+  it("sanitizeSqlForConditions array form threads quoter through `?` binds", () => {
+    expect(sanitizeSqlForConditions(["name = ?", "x"], mysqlQuoter)).toBe("name = 'x'");
+  });
+});

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -9,34 +9,30 @@ import {
   quote as abstractQuote,
   quoteIdentifier as abstractQuoteIdentifier,
   quoteTableName as abstractQuoteTableName,
+  quoteTableNameForAssignment as abstractQuoteTableNameForAssignment,
   quoteString as abstractQuoteString,
   castBoundValue as abstractCastBoundValue,
 } from "./connection-adapters/abstract/quoting.js";
 import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
 import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js";
 
-/**
- * Subset of {@link Quoting} the sanitization helpers need. Adapter
- * classes implement `Quoting`, so any concrete adapter satisfies this.
- *
- * @internal
- */
+/** Subset of {@link Quoting} the sanitization helpers need. @internal */
 export type Quoter = Pick<
   Quoting,
-  "quote" | "quoteIdentifier" | "quoteTableName" | "quoteString" | "castBoundValue"
+  | "quote"
+  | "quoteIdentifier"
+  | "quoteTableName"
+  | "quoteTableNameForAssignment"
+  | "quoteString"
+  | "castBoundValue"
 >;
 
-/**
- * Module-level fallback used when a caller has no adapter to thread
- * through. Delegates to the standalone abstract functions, preserving
- * historic behavior for callers that have not been migrated yet.
- *
- * @internal
- */
+/** Fallback for callers that haven't been migrated to thread an adapter. @internal */
 const ABSTRACT_QUOTER: Quoter = {
   quote: (v) => abstractQuote(v),
   quoteIdentifier: (n) => abstractQuoteIdentifier(n),
   quoteTableName: (n) => abstractQuoteTableName(n),
+  quoteTableNameForAssignment: (t, a) => abstractQuoteTableNameForAssignment(t, a),
   quoteString: (s) => abstractQuoteString(s),
   castBoundValue: (v) => abstractCastBoundValue(v),
 };
@@ -169,8 +165,10 @@ function _sanitizeSqlHashForAssignment(
           if (type.serialize) value = type.serialize(value);
         }
       }
+      // Mirrors Rails sanitization.rb:112 — PG/SQLite override
+      // quote_table_name_for_assignment to drop the table prefix.
       const col = table
-        ? `${quoter.quoteTableName(table)}.${quoter.quoteIdentifier(attr)}`
+        ? quoter.quoteTableNameForAssignment(table, attr)
         : quoter.quoteIdentifier(attr);
       return `${col} = ${quoter.quote(value)}`;
     })
@@ -232,27 +230,29 @@ function sanitizeSqlClassMethod(
 
 /** @internal */
 interface QuoterHost {
-  connection(): unknown;
+  connection?(): unknown;
+  isConnectedQ?(): boolean;
 }
 
-/** @internal */
+/** Probes `isConnectedQ()` first to avoid throwing on the no-connection path. @internal */
 function quoterFor(host: QuoterHost): Quoter {
+  if (typeof host.connection !== "function") return ABSTRACT_QUOTER;
+  if (typeof host.isConnectedQ === "function" && !host.isConnectedQ()) return ABSTRACT_QUOTER;
+  let conn: Partial<Quoter> | null | undefined;
   try {
-    const conn = host.connection() as Partial<Quoter> | null | undefined;
-    if (
-      conn &&
-      typeof conn.quote === "function" &&
-      typeof conn.quoteIdentifier === "function" &&
-      typeof conn.quoteTableName === "function" &&
-      typeof conn.quoteString === "function" &&
-      typeof conn.castBoundValue === "function"
-    ) {
-      return conn as Quoter;
-    }
+    conn = host.connection() as Partial<Quoter> | null | undefined;
   } catch {
-    // Connection may not be configured (e.g. during boot, in tests).
+    return ABSTRACT_QUOTER;
   }
-  return ABSTRACT_QUOTER;
+  return conn &&
+    typeof conn.quote === "function" &&
+    typeof conn.quoteIdentifier === "function" &&
+    typeof conn.quoteTableName === "function" &&
+    typeof conn.quoteTableNameForAssignment === "function" &&
+    typeof conn.quoteString === "function" &&
+    typeof conn.castBoundValue === "function"
+    ? (conn as Quoter)
+    : ABSTRACT_QUOTER;
 }
 
 /**

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -6,13 +6,40 @@
 
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import {
-  quote,
-  quoteIdentifier,
-  quoteTableName,
-  quoteString,
-  castBoundValue,
+  quote as abstractQuote,
+  quoteIdentifier as abstractQuoteIdentifier,
+  quoteTableName as abstractQuoteTableName,
+  quoteString as abstractQuoteString,
+  castBoundValue as abstractCastBoundValue,
 } from "./connection-adapters/abstract/quoting.js";
+import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
 import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js";
+
+/**
+ * Subset of {@link Quoting} the sanitization helpers need. Adapter
+ * classes implement `Quoting`, so any concrete adapter satisfies this.
+ *
+ * @internal
+ */
+export type Quoter = Pick<
+  Quoting,
+  "quote" | "quoteIdentifier" | "quoteTableName" | "quoteString" | "castBoundValue"
+>;
+
+/**
+ * Module-level fallback used when a caller has no adapter to thread
+ * through. Delegates to the standalone abstract functions, preserving
+ * historic behavior for callers that have not been migrated yet.
+ *
+ * @internal
+ */
+const ABSTRACT_QUOTER: Quoter = {
+  quote: (v) => abstractQuote(v),
+  quoteIdentifier: (n) => abstractQuoteIdentifier(n),
+  quoteTableName: (n) => abstractQuoteTableName(n),
+  quoteString: (s) => abstractQuoteString(s),
+  castBoundValue: (v) => abstractCastBoundValue(v),
+};
 
 /**
  * Sanitize a SQL template with bind parameters.
@@ -21,15 +48,20 @@ import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js
  * Mirrors: ActiveRecord::Sanitization::ClassMethods#sanitize_sql_array
  */
 export function sanitizeSqlArray(template: string, ...binds: unknown[]): string {
+  return _sanitizeSqlArray(ABSTRACT_QUOTER, template, binds);
+}
+
+/** @internal */
+function _sanitizeSqlArray(quoter: Quoter, template: string, binds: unknown[]): string {
   const statement = template;
   const [first] = binds;
 
   if (isPlainHash(first) && /:\w+/.test(statement)) {
-    return replaceNamedBindVariables(statement, first as Record<string, unknown>);
+    return replaceNamedBindVariables(quoter, statement, first as Record<string, unknown>);
   }
 
   if (statement.includes("?")) {
-    return replaceBindVariables(statement, binds);
+    return replaceBindVariables(quoter, statement, binds);
   }
 
   if (statement === "") {
@@ -42,7 +74,7 @@ export function sanitizeSqlArray(template: string, ...binds: unknown[]): string 
   if (formatStringCount > 0) {
     raiseIfBindArityMismatch(statement, formatStringCount, binds.length);
     const values = [...binds];
-    return statement.replace(/%s/g, () => quoteString(String(values.shift() ?? "")));
+    return statement.replace(/%s/g, () => quoter.quoteString(String(values.shift() ?? "")));
   }
 
   return statement;
@@ -54,9 +86,14 @@ export function sanitizeSqlArray(template: string, ...binds: unknown[]): string 
  * Mirrors: ActiveRecord::Sanitization::ClassMethods#sanitize_sql
  */
 export function sanitizeSql(input: string | [string, ...unknown[]]): string {
+  return _sanitizeSql(ABSTRACT_QUOTER, input);
+}
+
+/** @internal */
+function _sanitizeSql(quoter: Quoter, input: string | [string, ...unknown[]]): string {
   if (typeof input === "string") return input;
   const [template, ...binds] = input;
-  return sanitizeSqlArray(template, ...binds);
+  return _sanitizeSqlArray(quoter, template, binds);
 }
 
 /**
@@ -64,9 +101,10 @@ export function sanitizeSql(input: string | [string, ...unknown[]]): string {
  */
 export function sanitizeSqlForConditions(
   condition: string | [string, ...unknown[]] | null | undefined,
+  quoter: Quoter = ABSTRACT_QUOTER,
 ): string | null {
   if (!condition || (typeof condition === "string" && condition.trim() === "")) return null;
-  return sanitizeSql(condition);
+  return _sanitizeSql(quoter, condition);
 }
 
 /**
@@ -75,10 +113,11 @@ export function sanitizeSqlForConditions(
 export function sanitizeSqlForAssignment(
   assignments: string | [string, ...unknown[]] | Record<string, unknown>,
   defaultTableName?: string,
+  quoter: Quoter = ABSTRACT_QUOTER,
 ): string {
   if (typeof assignments === "string") return assignments;
-  if (Array.isArray(assignments)) return sanitizeSql(assignments);
-  return sanitizeSqlHashForAssignment(assignments, defaultTableName ?? "");
+  if (Array.isArray(assignments)) return _sanitizeSql(quoter, assignments);
+  return _sanitizeSqlHashForAssignment(quoter, assignments, defaultTableName ?? "");
 }
 
 /**
@@ -86,10 +125,11 @@ export function sanitizeSqlForAssignment(
  */
 export function sanitizeSqlForOrder(
   condition: string | [string, ...unknown[]] | Nodes.Node,
+  quoter: Quoter = ABSTRACT_QUOTER,
 ): string | Nodes.Node {
   if (condition instanceof Nodes.Node) return condition;
   if (Array.isArray(condition) && condition[0]?.toString().includes("?")) {
-    const sanitized = sanitizeSqlArray(condition[0], ...condition.slice(1));
+    const sanitized = _sanitizeSqlArray(quoter, condition[0], condition.slice(1));
     disallowRawSqlBang([sanitized]);
     return arelSql(sanitized);
   }
@@ -100,6 +140,19 @@ export function sanitizeSqlForOrder(
  * Mirrors: ActiveRecord::Sanitization::ClassMethods#sanitize_sql_hash_for_assignment
  */
 export function sanitizeSqlHashForAssignment(
+  attrs: Record<string, unknown>,
+  table: string,
+  typeForAttribute?: (
+    name: string,
+  ) => { cast?(v: unknown): unknown; serialize?(v: unknown): unknown } | undefined,
+  quoter: Quoter = ABSTRACT_QUOTER,
+): string {
+  return _sanitizeSqlHashForAssignment(quoter, attrs, table, typeForAttribute);
+}
+
+/** @internal */
+function _sanitizeSqlHashForAssignment(
+  quoter: Quoter,
   attrs: Record<string, unknown>,
   table: string,
   typeForAttribute?: (
@@ -117,9 +170,9 @@ export function sanitizeSqlHashForAssignment(
         }
       }
       const col = table
-        ? `${quoteTableName(table)}.${quoteIdentifier(attr)}`
-        : quoteIdentifier(attr);
-      return `${col} = ${quote(value)}`;
+        ? `${quoter.quoteTableName(table)}.${quoter.quoteIdentifier(attr)}`
+        : quoter.quoteIdentifier(attr);
+      return `${col} = ${quoter.quote(value)}`;
     })
     .join(", ");
 }
@@ -177,13 +230,50 @@ function sanitizeSqlClassMethod(
   return this.sanitizeSqlArray(template, ...binds);
 }
 
+/** @internal */
+interface QuoterHost {
+  connection(): unknown;
+}
+
+/** @internal */
+function quoterFor(host: QuoterHost): Quoter {
+  try {
+    const conn = host.connection() as Partial<Quoter> | null | undefined;
+    if (
+      conn &&
+      typeof conn.quote === "function" &&
+      typeof conn.quoteIdentifier === "function" &&
+      typeof conn.quoteTableName === "function" &&
+      typeof conn.quoteString === "function" &&
+      typeof conn.castBoundValue === "function"
+    ) {
+      return conn as Quoter;
+    }
+  } catch {
+    // Connection may not be configured (e.g. during boot, in tests).
+  }
+  return ABSTRACT_QUOTER;
+}
+
+/**
+ * Class-method variant of `sanitizeSqlArray` that threads the active
+ * adapter as the quoter, matching Rails' `connection.quote` dispatch.
+ */
+function sanitizeSqlArrayClassMethod(
+  this: QuoterHost,
+  template: string,
+  ...binds: unknown[]
+): string {
+  return _sanitizeSqlArray(quoterFor(this), template, binds);
+}
+
 /**
  * Class-method variant of `sanitizeSqlForConditions` that dispatches
  * through `this.sanitizeSql` (and therefore `this.sanitizeSqlArray`),
  * matching Rails' Ruby `self` dispatch through `ClassMethods`.
  */
 function sanitizeSqlForConditionsClassMethod(
-  this: { sanitizeSql(input: string | [string, ...unknown[]]): string },
+  this: QuoterHost & { sanitizeSql(input: string | [string, ...unknown[]]): string },
   condition: string | [string, ...unknown[]] | null | undefined,
 ): string | null {
   if (!condition || (typeof condition === "string" && condition.trim() === "")) return null;
@@ -196,13 +286,22 @@ function sanitizeSqlForConditionsClassMethod(
  * from `sanitize_sql_for_assignment` → `sanitize_sql_array`.
  */
 function sanitizeSqlForAssignmentClassMethod(
-  this: { sanitizeSql(input: string | [string, ...unknown[]]): string },
+  this: QuoterHost & {
+    sanitizeSql(input: string | [string, ...unknown[]]): string;
+    sanitizeSqlHashForAssignment(
+      attrs: Record<string, unknown>,
+      table: string,
+      typeForAttribute?: (
+        name: string,
+      ) => { cast?(v: unknown): unknown; serialize?(v: unknown): unknown } | undefined,
+    ): string;
+  },
   assignments: string | [string, ...unknown[]] | Record<string, unknown>,
   defaultTableName?: string,
 ): string {
   if (typeof assignments === "string") return assignments;
   if (Array.isArray(assignments)) return this.sanitizeSql(assignments);
-  return sanitizeSqlHashForAssignment(assignments, defaultTableName ?? "");
+  return this.sanitizeSqlHashForAssignment(assignments, defaultTableName ?? "");
 }
 
 /**
@@ -227,17 +326,33 @@ function sanitizeSqlForOrderClassMethod(
 }
 
 /**
+ * Class-method variant of `sanitizeSqlHashForAssignment` that uses the
+ * active adapter as the quoter — so `Model.sanitizeSqlHashForAssignment`
+ * emits dialect-correct identifiers (backticks on MySQL).
+ */
+function sanitizeSqlHashForAssignmentClassMethod(
+  this: QuoterHost,
+  attrs: Record<string, unknown>,
+  table: string,
+  typeForAttribute?: (
+    name: string,
+  ) => { cast?(v: unknown): unknown; serialize?(v: unknown): unknown } | undefined,
+): string {
+  return _sanitizeSqlHashForAssignment(quoterFor(this), attrs, table, typeForAttribute);
+}
+
+/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveRecord::Sanitization::ClassMethods`.
  */
 export const ClassMethods = {
   sanitizeSql: sanitizeSqlClassMethod,
-  sanitizeSqlArray,
+  sanitizeSqlArray: sanitizeSqlArrayClassMethod,
   sanitizeSqlLike,
   sanitizeSqlForConditions: sanitizeSqlForConditionsClassMethod,
   sanitizeSqlForAssignment: sanitizeSqlForAssignmentClassMethod,
   sanitizeSqlForOrder: sanitizeSqlForOrderClassMethod,
-  sanitizeSqlHashForAssignment,
+  sanitizeSqlHashForAssignment: sanitizeSqlHashForAssignmentClassMethod,
   disallowRawSqlBang,
 };
 
@@ -249,11 +364,11 @@ export const ClassMethods = {
  *
  * @internal
  */
-function replaceBindVariables(statement: string, values: unknown[]): string {
+function replaceBindVariables(quoter: Quoter, statement: string, values: unknown[]): string {
   raiseIfBindArityMismatch(statement, statement.match(/\?/g)?.length ?? 0, values.length);
   const bound = [...values];
   let result = statement;
-  result = result.replace(/\?/g, () => replaceBindVariable(bound.shift()));
+  result = result.replace(/\?/g, () => replaceBindVariable(quoter, bound.shift()));
   return result;
 }
 
@@ -265,8 +380,8 @@ function replaceBindVariables(statement: string, values: unknown[]): string {
  *
  * @internal
  */
-function replaceBindVariable(value: unknown): string {
-  return quoteBoundValue(value);
+function replaceBindVariable(quoter: Quoter, value: unknown): string {
+  return quoteBoundValue(quoter, value);
 }
 
 /**
@@ -277,7 +392,11 @@ function replaceBindVariable(value: unknown): string {
  *
  * @internal
  */
-function replaceNamedBindVariables(statement: string, bindVars: Record<string, unknown>): string {
+function replaceNamedBindVariables(
+  quoter: Quoter,
+  statement: string,
+  bindVars: Record<string, unknown>,
+): string {
   let result = statement;
   result = result.replace(
     /([:\\]?):([a-zA-Z]\w*)/g,
@@ -293,7 +412,7 @@ function replaceNamedBindVariables(statement: string, bindVars: Record<string, u
         if (!Object.prototype.hasOwnProperty.call(bindVars, name)) {
           throw new PreparedStatementInvalid(`missing value for :${name} in ${statement}`);
         }
-        return replaceBindVariable(bindVars[name]);
+        return replaceBindVariable(quoter, bindVars[name]);
       }
     },
   );
@@ -309,10 +428,10 @@ function replaceNamedBindVariables(statement: string, bindVars: Record<string, u
  *
  * @internal
  */
-function quoteBoundValue(value: unknown): string {
+function quoteBoundValue(quoter: Quoter, value: unknown): string {
   if (hasIdForDatabase(value)) {
-    const cast = castBoundValue(value.idForDatabase());
-    return quote(cast);
+    const cast = quoter.castBoundValue(value.idForDatabase());
+    return quoter.quote(cast);
   }
 
   // Handle collections recognized by isEnumerable (Array and Set only).
@@ -322,20 +441,20 @@ function quoteBoundValue(value: unknown): string {
   if (isEnumerable(value)) {
     const values = Array.from(value as Iterable<unknown>);
     if (values.length === 0) {
-      const cast = castBoundValue(null);
-      return quote(cast);
+      const cast = quoter.castBoundValue(null);
+      return quoter.quote(cast);
     }
     return values
       .map((v) => {
         const idVal = hasIdForDatabase(v) ? v.idForDatabase() : v;
-        const cast = castBoundValue(idVal);
-        return quote(cast);
+        const cast = quoter.castBoundValue(idVal);
+        return quoter.quote(cast);
       })
       .join(",");
   }
 
-  const cast = castBoundValue(value);
-  return quote(cast);
+  const cast = quoter.castBoundValue(value);
+  return quoter.quote(cast);
 }
 
 function hasIdForDatabase(value: unknown): value is { idForDatabase(): unknown } {

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -13,7 +13,11 @@ import {
   castBoundValue as abstractCastBoundValue,
 } from "./connection-adapters/abstract/quoting.js";
 import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
-import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js";
+import {
+  ConnectionNotDefined,
+  PreparedStatementInvalid,
+  UnknownAttributeReference,
+} from "./errors.js";
 
 /** Subset of {@link Quoting} the sanitization helpers need. @internal */
 export type Quoter = Pick<
@@ -158,8 +162,7 @@ function _sanitizeSqlHashForAssignment(
           if (type.serialize) value = type.serialize(value);
         }
       }
-      // Mirrors Rails sanitization.rb:112 — PG/SQLite override
-      // quote_table_name_for_assignment to drop the table prefix.
+      // Rails sanitization.rb:112 — PG/SQLite drop the table prefix.
       const col = table
         ? quoter.quoteTableNameForAssignment(table, attr)
         : quoter.quoteIdentifier(attr);
@@ -227,18 +230,18 @@ interface QuoterHost {
 }
 
 /**
- * Resolves quoting through `connection()`, falling back to the abstract
- * quoter only when no connection is configured (the call throws). Mirrors
- * Rails' `connection` accessor which lazily establishes a pool/connection.
- * @internal
+ * Resolves quoting through `connection()`. Only `ConnectionNotDefined`
+ * (no pool configured) falls back; other failures propagate to avoid a
+ * silent dialect downgrade. @internal
  */
 function quoterFor(host: QuoterHost): Quoter {
   if (typeof host.connection !== "function") return ABSTRACT_QUOTER;
   let conn: Partial<Quoter> | null | undefined;
   try {
     conn = host.connection() as Partial<Quoter> | null | undefined;
-  } catch {
-    return ABSTRACT_QUOTER;
+  } catch (err) {
+    if (err instanceof ConnectionNotDefined) return ABSTRACT_QUOTER;
+    throw err;
   }
   return conn &&
     typeof conn.quote === "function" &&

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -8,7 +8,6 @@ import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import {
   quote as abstractQuote,
   quoteIdentifier as abstractQuoteIdentifier,
-  quoteTableName as abstractQuoteTableName,
   quoteTableNameForAssignment as abstractQuoteTableNameForAssignment,
   quoteString as abstractQuoteString,
   castBoundValue as abstractCastBoundValue,
@@ -19,19 +18,13 @@ import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js
 /** Subset of {@link Quoting} the sanitization helpers need. @internal */
 export type Quoter = Pick<
   Quoting,
-  | "quote"
-  | "quoteIdentifier"
-  | "quoteTableName"
-  | "quoteTableNameForAssignment"
-  | "quoteString"
-  | "castBoundValue"
+  "quote" | "quoteIdentifier" | "quoteTableNameForAssignment" | "quoteString" | "castBoundValue"
 >;
 
 /** Fallback for callers that haven't been migrated to thread an adapter. @internal */
 const ABSTRACT_QUOTER: Quoter = {
   quote: (v) => abstractQuote(v),
   quoteIdentifier: (n) => abstractQuoteIdentifier(n),
-  quoteTableName: (n) => abstractQuoteTableName(n),
   quoteTableNameForAssignment: (t, a) => abstractQuoteTableNameForAssignment(t, a),
   quoteString: (s) => abstractQuoteString(s),
   castBoundValue: (v) => abstractCastBoundValue(v),
@@ -231,13 +224,16 @@ function sanitizeSqlClassMethod(
 /** @internal */
 interface QuoterHost {
   connection?(): unknown;
-  isConnectedQ?(): boolean;
 }
 
-/** Probes `isConnectedQ()` first to avoid throwing on the no-connection path. @internal */
+/**
+ * Resolves quoting through `connection()`, falling back to the abstract
+ * quoter only when no connection is configured (the call throws). Mirrors
+ * Rails' `connection` accessor which lazily establishes a pool/connection.
+ * @internal
+ */
 function quoterFor(host: QuoterHost): Quoter {
   if (typeof host.connection !== "function") return ABSTRACT_QUOTER;
-  if (typeof host.isConnectedQ === "function" && !host.isConnectedQ()) return ABSTRACT_QUOTER;
   let conn: Partial<Quoter> | null | undefined;
   try {
     conn = host.connection() as Partial<Quoter> | null | undefined;
@@ -247,7 +243,6 @@ function quoterFor(host: QuoterHost): Quoter {
   return conn &&
     typeof conn.quote === "function" &&
     typeof conn.quoteIdentifier === "function" &&
-    typeof conn.quoteTableName === "function" &&
     typeof conn.quoteTableNameForAssignment === "function" &&
     typeof conn.quoteString === "function" &&
     typeof conn.castBoundValue === "function"


### PR DESCRIPTION
## Summary

Phase 2a of the quoting refactor (PR 3 of 10 — see `docs/quoting-refactor.md`). Sanitization helpers now accept an optional `Quoter` (subset of `Quoting`) and the class-method variants thread `this.connection`, so `Model.sanitizeSqlForAssignment({name: "x"}, "users")` on a MySQL-backed model emits `` `users`.`name` = 'x' `` instead of the abstract `"users"."name"` fallback.

- Module-level public exports keep their existing signatures with the abstract standalone as a default fallback, so out-of-scope callers in `query-methods.ts` / `querying.ts` continue to compile unchanged. PRs 4 and 5 migrate those call sites.
- Class-method dispatch through `this.sanitizeSql` / `this.sanitizeSqlArray` is preserved so subclass overrides still take effect; the quoter is resolved at the leaf via `this.connection`.
- New behavioral parity test verifies MySQL backticks vs. PG/SQLite double-quotes through the quoter chain.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/activerecord/src` — 9954 passed
- [x] `pnpm api:compare` — Data layer 4187/4503 (93%), unchanged
- [x] `pnpm test:compare` — Overall 11833/21679 (54.6%), unchanged
- [x] LOC: 226 additions / 38 deletions (under the 300 ceiling)