### PR TITLE
fix(arel): DeleteStatement/InsertStatement visitor shape

### DIFF
--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -604,10 +604,15 @@ describe("the to_sql visitor", () => {
 
     it("renders TableAlias on the left when join sources are present", () => {
       const aliased = new Nodes.TableAlias(users, "u");
-      const stmt = new Nodes.DeleteStatement(new Nodes.JoinSource(aliased));
+      const join = new Nodes.InnerJoin(
+        posts,
+        new Nodes.On(new Nodes.Equality(posts.get("user_id"), users.get("id"))),
+      );
+      const stmt = new Nodes.DeleteStatement(new Nodes.JoinSource(aliased, [join]));
       stmt.wheres.push(new Nodes.Equality(users.get("id"), 1));
       const sql = new Visitors.ToSql().compile(stmt);
       expect(sql).toContain('DELETE "users" "u" FROM "users" "u"');
+      expect(sql).toContain("INNER JOIN");
       expect(sql).toContain("WHERE");
     });
   });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -595,6 +595,43 @@ describe("the to_sql visitor", () => {
     expect(collector.retryable).toBe(false);
   });
 
+  describe("Nodes::DeleteStatement", () => {
+    it("renders DELETE FROM via the table visitor", () => {
+      const stmt = new DeleteManager().from(users).ast;
+      const sql = new Visitors.ToSql().compile(stmt);
+      expect(sql).toBe('DELETE FROM "users"');
+    });
+
+    it("renders TableAlias on the left when join sources are present", () => {
+      const aliased = new Nodes.TableAlias(users, "u");
+      const stmt = new Nodes.DeleteStatement(new Nodes.JoinSource(aliased));
+      stmt.wheres.push(new Nodes.Equality(users.get("id"), 1));
+      const sql = new Visitors.ToSql().compile(stmt);
+      expect(sql).toContain('DELETE "users" "u" FROM "users" "u"');
+      expect(sql).toContain("WHERE");
+    });
+  });
+
+  describe("Nodes::InsertStatement", () => {
+    it("prefers values over select when both are present", () => {
+      const mgr = new InsertManager(users);
+      mgr.insert([[users.get("name"), "dean"]]);
+      const sub = users.project(users.get("name"));
+      mgr.ast.select = sub.ast;
+      const sql = new Visitors.ToSql().compile(mgr.ast);
+      expect(sql).toContain("VALUES");
+      expect(sql).toContain("'dean'");
+      expect(sql).not.toContain("SELECT");
+    });
+
+    it("routes column names through quoteColumnName", () => {
+      const mgr = new InsertManager(users);
+      mgr.insert([[users.get("name"), "dean"]]);
+      const sql = new Visitors.ToSql().compile(mgr.ast);
+      expect(sql).toContain('("name")');
+    });
+  });
+
   it("should mark collector as non-retryable when visiting named function", () => {
     const fn = users.get("name").lower();
     const collector = new Visitors.ToSql().compileWithCollector(fn);

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -602,6 +602,15 @@ describe("the to_sql visitor", () => {
       expect(sql).toBe('DELETE FROM "users"');
     });
 
+    it("treats a JoinSource with no joins as no-join-source (Rails has_join_sources?)", () => {
+      // Mirrors Rails: `has_join_sources?` requires non-empty `right`.
+      // A bare JoinSource(table) renders via the plain `DELETE FROM` path,
+      // identical to passing the table directly.
+      const stmt = new Nodes.DeleteStatement(new Nodes.JoinSource(users));
+      const sql = new Visitors.ToSql().compile(stmt);
+      expect(sql).toBe('DELETE FROM "users"');
+    });
+
     it("renders TableAlias on the left when join sources are present", () => {
       const aliased = new Nodes.TableAlias(users, "u");
       const join = new Nodes.InnerJoin(

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -333,9 +333,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     if (node.columns.length > 0) {
       this.collector.append(" (");
       const colNames = node.columns.map((c) => {
-        if (c instanceof Nodes.Attribute) return `"${c.name}"`;
         if (c instanceof Nodes.SqlLiteral) return c.value;
-        return String(c);
+        const name =
+          c instanceof Nodes.Attribute ? c.name : String((c as { name?: string }).name ?? c);
+        return this.quoteColumnName(name);
       });
       this.collector.append(colNames.join(", "));
       this.collector.append(")");
@@ -389,26 +390,15 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   protected visitArelNodesDeleteStatement(o: Nodes.DeleteStatement): SQLString {
     const node = this.prepareDeleteStatement(o);
     this.collector.retryable = false;
-    this.collector.append("DELETE ");
-    if (this.hasJoinSources(node)) {
-      const joinSource = node.relation as Nodes.JoinSource;
-      if (joinSource.left) {
-        const table = joinSource.left;
-        if (table instanceof Nodes.TableAlias) {
-          this.collector.append(`"${table.name}"`);
-        } else if (table instanceof Table && table.tableAlias) {
-          this.collector.append(`"${table.tableAlias}"`);
-        } else if (table instanceof Table) {
-          this.collector.append(`"${table.name}"`);
-        } else {
-          this.visit(table);
-        }
-        this.collector.append(" FROM ");
-      } else {
-        this.collector.append("FROM ");
-      }
+    const joinSourceLeft = this.hasJoinSources(node)
+      ? (node.relation as Nodes.JoinSource).left
+      : null;
+    if (joinSourceLeft) {
+      this.collector.append("DELETE ");
+      this.visit(joinSourceLeft);
+      this.collector.append(" FROM ");
     } else {
-      this.collector.append("FROM ");
+      this.collector.append("DELETE FROM ");
     }
     if (node.relation) this.visit(node.relation);
 


### PR DESCRIPTION
PR 16 of [docs/arel-alignment-plan.md](../blob/main/docs/arel-alignment-plan.md) (Wave 3).

## Summary

- `visitArelNodesDeleteStatement`: route the join-source `left` through
  `visit()` so a `TableAlias` renders as `"users" "u"` instead of the
  hardcoded bare `"u"`. Mirrors Rails `visit_Arel_Nodes_DeleteStatement`.
- `visitArelNodesInsertStatement`: column names go through
  `this.quoteColumnName(name)` so the MySQL backtick override (PR 25)
  will apply once it lands. The values-vs-select preference already
  matched Rails.

## Test plan

- [x] `pnpm exec vitest run packages/arel/`
- [x] `pnpm exec vitest run packages/activerecord/`