### PR TITLE
feat(activemodel): port validation lifecycle privates (B5b)

### DIFF
--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -15,17 +15,43 @@ export interface API {
 }
 
 import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
-import { initInternals as validationsInitInternals } from "./validations.js";
+import {
+  initInternals as validationsInitInternals,
+  contextForValidation as validationsContextForValidation,
+  runValidationsBang as validationsRunValidationsBang,
+  raiseValidationError as validationsRaiseValidationError,
+  _mergeAttributes as validationsMergeAttributes,
+} from "./validations.js";
 
 /**
- * Rails: ActiveModel::API includes Validations (api.rb), so
- * `init_internals` is part of API's surface as well. Re-export the
- * canonical Validations helper here so api-compare matches the shape
- * of `api.rb` and a host that mixes in only API still has the hook.
+ * Rails: ActiveModel::API includes Validations (api.rb), so the
+ * Validations private surface is part of API as well. Re-export the
+ * canonical helpers so api-compare matches the shape of `api.rb` and
+ * a host that mixes in only API still has the hooks.
  *
  * @internal Rails-private helper.
  */
 export const initInternals = validationsInitInternals;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const contextForValidation = validationsContextForValidation;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const runValidationsBang = validationsRunValidationsBang;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const raiseValidationError = validationsRaiseValidationError;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const _mergeAttributes = validationsMergeAttributes;
 
 /**
  * Rails: ActiveModel::API includes Validations, which extends Translation,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1216,7 +1216,6 @@ export class Model {
   initInternals(): void {
     validationsInitInternals.call(this);
     dirtyInitInternals.call(this);
-    this._contextForValidation = undefined;
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1,8 +1,14 @@
 import { Errors, StrictValidationFailed } from "./errors.js";
 import {
-  ValidationError,
   ValidationContext,
   initInternals as validationsInitInternals,
+  contextForValidation as validationsContextForValidation,
+  runValidationsBang as validationsRunValidationsBang,
+  raiseValidationError as validationsRaiseValidationError,
+  predicateForValidationContext as validationsPredicateForValidationContext,
+  _mergeAttributes as validationsMergeAttributes,
+  _validatesDefaultKeys as validationsValidatesDefaultKeys,
+  _parseValidatesOptions as validationsParseValidatesOptions,
 } from "./validations.js";
 import { humanize, underscore, dasherize, htmlEscape } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -1210,7 +1216,44 @@ export class Model {
   initInternals(): void {
     validationsInitInternals.call(this);
     dirtyInitInternals.call(this);
+    this._contextForValidation = undefined;
   }
+
+  /**
+   * Build the `if`-predicate that gates a validator on a validation
+   * context. Mirrors Rails `predicate_for_validation_context`
+   * (validations.rb:296-306).
+   *
+   * @internal Rails-private helper.
+   */
+  static predicateForValidationContext = validationsPredicateForValidationContext;
+
+  /**
+   * Normalize the trailing options hash from a `validates_each`
+   * argument list and stamp `attributes:` onto it. Mirrors Rails
+   * `Validations::HelperMethods#_merge_attributes`.
+   *
+   * @internal Rails-private helper.
+   */
+  static _mergeAttributes = validationsMergeAttributes;
+
+  /**
+   * Default option keys recognized by `validates(...)`. Subclasses
+   * override to add custom keys. Mirrors Rails
+   * `_validates_default_keys` (validations/validates.rb:162-164).
+   *
+   * @internal Rails-private helper.
+   */
+  static _validatesDefaultKeys = validationsValidatesDefaultKeys;
+
+  /**
+   * Normalize a validator option value into the option hash the
+   * validator constructor expects. Mirrors Rails
+   * `_parse_validates_options` (validations/validates.rb:166-177).
+   *
+   * @internal Rails-private helper.
+   */
+  static _parseValidatesOptions = validationsParseValidatesOptions;
 
   /**
    * Mirrors: ActiveModel::API#initialize → ActiveModel::Attributes#initialize
@@ -1403,6 +1446,45 @@ export class Model {
   // validators all fire. See `validations.rb:361-368` and `:294-306`.
   _validationContext: string | string[] | null = null;
 
+  /**
+   * Lazy-initialized live `ValidationContext` view. Populated on first
+   * call to `contextForValidation()` and cleared by `initInternals()`.
+   *
+   * @internal
+   */
+  _contextForValidation?: ValidationContext;
+
+  /**
+   * Lazy accessor for the active `ValidationContext`. Mirrors Rails
+   * `context_for_validation` (validations.rb:463-465). The returned
+   * object's `.context` property is a live view of `_validationContext`.
+   *
+   * @internal Rails-private helper.
+   */
+  contextForValidation(): ValidationContext {
+    return validationsContextForValidation.call(this);
+  }
+
+  /**
+   * Run the `:validate` callbacks and report whether the model has no
+   * errors. Mirrors Rails `run_validations!` (validations.rb:473-476).
+   *
+   * @internal Rails-private helper.
+   */
+  runValidationsBang(): boolean {
+    return validationsRunValidationsBang.call(this);
+  }
+
+  /**
+   * Throw `ValidationError` for the current model. Mirrors Rails
+   * `raise_validation_error` (validations.rb:478-480).
+   *
+   * @internal Rails-private helper.
+   */
+  raiseValidationError(): never {
+    return validationsRaiseValidationError.call(this);
+  }
+
   isValid(context?: string | string[] | ValidationContext | null): boolean {
     this.errors.clear();
     const ctor = this.constructor as typeof Model;
@@ -1431,7 +1513,7 @@ export class Model {
         "validation",
         this,
         () => {
-          this._runValidateCallbacks();
+          this.runValidationsBang();
         },
         { strict: "sync" },
       );
@@ -1442,7 +1524,8 @@ export class Model {
     }
   }
 
-  private _runValidateCallbacks(): void {
+  /** @internal */
+  _runValidateCallbacks(): void {
     const ctor = this.constructor as typeof Model;
     ctor._callbackChain.runBefore("validate", this, { strict: "sync" });
   }
@@ -2024,7 +2107,7 @@ export class Model {
    */
   validateBang(context?: string | string[] | ValidationContext | null): true {
     if (!this.isValid(context)) {
-      throw new ValidationError(this);
+      this.raiseValidationError();
     }
     return true;
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1100,20 +1100,11 @@ export class Model {
     const parts: Array<(record: AnyRecord) => boolean> = [];
 
     if (options.on !== undefined) {
-      // Rails `predicate_for_validation_context` (validations.rb:294-306):
-      // both the registered `on:` and the model's current
-      // `validation_context` may be Symbols or Arrays of Symbols. A
-      // validator with `on: [:create, :publish]` fires when the model's
-      // context is `:create`, `[:create]`, `[:publish, :foo]`, etc. —
-      // intersection, not equality.
-      const registered = Array.isArray(options.on) ? options.on : [options.on];
-      const registeredSet = new Set(registered);
-      parts.push((record: AnyRecord) => {
-        const ctx = record._validationContext;
-        if (ctx == null) return false;
-        const current = Array.isArray(ctx) ? ctx : [ctx];
-        return current.some((c: unknown) => registeredSet.has(c as string));
-      });
+      // Mirrors Rails (validations.rb:170-172): the `on:` clause is
+      // installed via `predicate_for_validation_context(options[:on])`,
+      // so route through the same module-level cache here. Single
+      // source of truth for the intersection-vs-equality semantics.
+      parts.push(validationsPredicateForValidationContext(options.on));
     }
 
     if (options.if !== undefined) {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1552,10 +1552,12 @@ export class Model {
    *
    * Rails pre-touches `@errors` and `@context_for_validation` so frozen
    * models can still answer `#errors` and `#validation_context` without
-   * tripping their `||=` lazy-init. We mirror that by going through the
-   * public API (`.errors`, `.validationContext`) — that way, if either
-   * becomes lazy in the future, the pre-materialization still runs
-   * without this method coupling to private fields.
+   * tripping their `||=` lazy-init. Trails mirrors that by reading
+   * `errors` and calling `contextForValidation()` to populate its
+   * cached `ValidationContext`. The `validationContext` getter alone
+   * is not enough — it doesn't write to `_contextForValidation`, so a
+   * subsequent `contextForValidation()` call on the frozen instance
+   * would throw on the cache assignment.
    */
   freeze(): this {
     void this.errors;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1559,7 +1559,12 @@ export class Model {
    */
   freeze(): this {
     void this.errors;
-    void this.validationContext;
+    // Pre-materialize the lazy ValidationContext cache so callers can
+    // still invoke `contextForValidation()` on a frozen instance —
+    // Rails does the equivalent at validations.rb:374 by touching
+    // `context_for_validation` inside `freeze`. Touching
+    // `validationContext` alone would not populate the cache.
+    void this.contextForValidation();
     Object.freeze(this);
     return this;
   }

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1162,6 +1162,22 @@ describe("ValidationsTest", () => {
       expect(t.errors).toBeDefined();
       expect(t.validationContext).toBe(null);
     });
+
+    it("contextForValidation is a live view of validationContext", () => {
+      const t = new Topic({ title: "ok" });
+      const vc = t.contextForValidation();
+      vc.context = "create";
+      expect(t.validationContext).toBe("create");
+      // Same instance is returned on subsequent calls (Rails ||= memoization).
+      expect(t.contextForValidation()).toBe(vc);
+    });
+
+    it("contextForValidation is callable on a frozen model", () => {
+      const t = new Topic({ title: "ok" });
+      t.freeze();
+      // freeze() pre-materializes the cache; access must not throw.
+      expect(() => t.contextForValidation()).not.toThrow();
+    });
   });
 
   describe("_validators hash-of-arrays (Rails fidelity)", () => {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -272,14 +272,19 @@ export interface ValidationsContextHost {
 export function contextForValidation(this: ContextForValidationHost): ValidationContext {
   if (this._contextForValidation) return this._contextForValidation;
   const vc = Object.create(ValidationContext.prototype) as ValidationContext;
-  Object.defineProperty(vc, "context", {
+  // Override `context` and the underlying `_context` slot the
+  // prototype's `name` getter reads. Both must be aliased so
+  // `vc.name` / `vc.toString()` stay consistent with the live field.
+  const accessor: PropertyDescriptor = {
     get: (): string | string[] | null => this._validationContext,
     set: (value: string | string[] | null): void => {
       this._validationContext = value;
     },
     configurable: true,
     enumerable: true,
-  });
+  };
+  Object.defineProperty(vc, "context", accessor);
+  Object.defineProperty(vc, "_context", accessor);
   this._contextForValidation = vc;
   return vc;
 }

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -50,6 +50,7 @@ export const _defineAfterModelCallback = _defineAfterModelCallbackImpl;
 export function initInternals(this: ValidationsInternalsHost): void {
   this.errors = new Errors(this);
   this._validationContext = null;
+  this._contextForValidation = undefined;
 }
 
 /**
@@ -60,6 +61,7 @@ export function initInternals(this: ValidationsInternalsHost): void {
 export interface ValidationsInternalsHost {
   errors: Errors;
   _validationContext: string | string[] | null;
+  _contextForValidation?: ValidationContext;
 }
 
 /**

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -273,10 +273,12 @@ export interface ValidationsContextHost {
  */
 export function contextForValidation(this: ContextForValidationHost): ValidationContext {
   if (this._contextForValidation) return this._contextForValidation;
-  const vc = Object.create(ValidationContext.prototype) as ValidationContext;
-  // Override `context` and the underlying `_context` slot the
-  // prototype's `name` getter reads. Both must be aliased so
-  // `vc.name` / `vc.toString()` stay consistent with the live field.
+  // Construct via the real constructor so any future
+  // ValidationContext initialization runs, then replace the
+  // `context` and underlying `_context` slot with a live view of
+  // `_validationContext`. Both must be aliased so `vc.name` /
+  // `vc.toString()` stay consistent with the live field.
+  const vc = new ValidationContext();
   const accessor: PropertyDescriptor = {
     get: (): string | string[] | null => this._validationContext,
     set: (value: string | string[] | null): void => {
@@ -327,7 +329,7 @@ export interface RunValidationsHost {
  *
  * @internal Rails-private helper.
  */
-export function raiseValidationError(this: object): never {
+export function raiseValidationError(this: { errors: Errors }): never {
   throw new ValidationError(this);
 }
 

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -368,8 +368,11 @@ export function _validatesDefaultKeys(): string[] {
  * validator constructor expects. Mirrors Rails
  * `_parse_validates_options(options)`
  * (activemodel/lib/active_model/validations/validates.rb:166-177):
- * `true` → `{}`, plain hash → unchanged, Range/Array → `{ in: options }`,
- * anything else → `{ with: options }`.
+ * `true` → `{}`, plain hash → unchanged, Array → `{ in: options }`,
+ * anything else → `{ with: options }`. Rails also routes `Range` to
+ * `{ in: ... }`; TS has no first-class Range (see the note in
+ * `validations/clusivity.ts`), so a Range-like dispatch slots in
+ * here when one lands.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -285,7 +285,7 @@ export function contextForValidation(this: ContextForValidationHost): Validation
       this._validationContext = value;
     },
     configurable: true,
-    enumerable: true,
+    enumerable: false,
   };
   Object.defineProperty(vc, "context", accessor);
   Object.defineProperty(vc, "_context", accessor);

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -207,3 +207,170 @@ export class ValidationContext {
     return this.name;
   }
 }
+
+/**
+ * Module-level cache for predicate functions keyed by sorted context
+ * arrays. Mirrors Rails `@@predicates_for_validation_contexts = {}`
+ * (activemodel/lib/active_model/validations.rb:294) — a class variable
+ * shared across all hosts that include Validations.
+ *
+ * @internal Rails-private state.
+ */
+const _predicatesForValidationContexts = new Map<
+  string,
+  (model: ValidationsContextHost) => boolean
+>();
+
+/**
+ * Build a predicate that returns whether a model's
+ * `validationContext` matches one of the supplied contexts. Used by
+ * `validates(..., on: :create)` to gate a validator on the active
+ * context. Mirrors Rails
+ * `predicate_for_validation_context(context)`
+ * (activemodel/lib/active_model/validations.rb:296-306).
+ *
+ * @internal Rails-private helper.
+ */
+export function predicateForValidationContext(
+  context: string | string[],
+): (model: ValidationsContextHost) => boolean {
+  const arr = Array.isArray(context) ? [...context].sort() : [context];
+  const key = JSON.stringify(arr);
+  let cached = _predicatesForValidationContexts.get(key);
+  if (!cached) {
+    cached = (model: ValidationsContextHost): boolean => {
+      const mc = model.validationContext;
+      if (Array.isArray(mc)) {
+        return mc.some((c) => arr.includes(c));
+      }
+      return mc !== null && mc !== undefined && arr.includes(mc);
+    };
+    _predicatesForValidationContexts.set(key, cached);
+  }
+  return cached;
+}
+
+/**
+ * Host shape consumed by `predicateForValidationContext`.
+ */
+export interface ValidationsContextHost {
+  readonly validationContext: string | string[] | null;
+}
+
+/**
+ * Lazy per-instance accessor for the active `ValidationContext`.
+ * Mirrors Rails
+ * `def context_for_validation; @context_for_validation ||= ValidationContext.new; end`
+ * (activemodel/lib/active_model/validations.rb:463-465). Trails stores
+ * the active context as `_validationContext: string | string[] | null`
+ * directly; this helper returns a `ValidationContext` whose
+ * `.context` property is a live view of that field, so Rails' pattern
+ * `context_for_validation.context = ctx` still works.
+ *
+ * @internal Rails-private helper.
+ */
+export function contextForValidation(this: ContextForValidationHost): ValidationContext {
+  if (this._contextForValidation) return this._contextForValidation;
+  const vc = Object.create(ValidationContext.prototype) as ValidationContext;
+  Object.defineProperty(vc, "context", {
+    get: (): string | string[] | null => this._validationContext,
+    set: (value: string | string[] | null): void => {
+      this._validationContext = value;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  this._contextForValidation = vc;
+  return vc;
+}
+
+/**
+ * Host shape consumed by `contextForValidation`.
+ */
+export interface ContextForValidationHost {
+  _validationContext: string | string[] | null;
+  _contextForValidation?: ValidationContext;
+}
+
+/**
+ * Run the `:validate` callbacks and report whether the model has no
+ * errors. Mirrors Rails
+ * `def run_validations!; _run_validate_callbacks; errors.empty?; end`
+ * (activemodel/lib/active_model/validations.rb:473-476).
+ *
+ * @internal Rails-private helper.
+ */
+export function runValidationsBang(this: RunValidationsHost): boolean {
+  this._runValidateCallbacks();
+  return this.errors.empty;
+}
+
+/**
+ * Host shape consumed by `runValidationsBang`.
+ */
+export interface RunValidationsHost {
+  errors: Errors;
+  _runValidateCallbacks(): void;
+}
+
+/**
+ * Throw `ValidationError` for the current model. Mirrors Rails
+ * `def raise_validation_error; raise(ValidationError.new(self)); end`
+ * (activemodel/lib/active_model/validations.rb:478-480).
+ *
+ * @internal Rails-private helper.
+ */
+export function raiseValidationError(this: object): never {
+  throw new ValidationError(this);
+}
+
+/**
+ * Normalize the `validates_each` argument list, splitting attribute
+ * names from the trailing options hash and stamping the merged
+ * options with `attributes:`. Mirrors Rails
+ * `Validations::HelperMethods#_merge_attributes`
+ * (activemodel/lib/active_model/validations/helper_methods.rb:7-11).
+ *
+ * @internal Rails-private helper.
+ */
+export function _mergeAttributes(attrNames: unknown[]): Record<string, unknown> {
+  const last = attrNames[attrNames.length - 1];
+  const options: Record<string, unknown> =
+    last !== null && typeof last === "object" && !Array.isArray(last) && last.constructor === Object
+      ? { ...(attrNames.pop() as Record<string, unknown>) }
+      : {};
+  const flat = (attrNames as unknown[]).flat(Infinity).map((n) => String(n));
+  options.attributes = flat;
+  return options;
+}
+
+/**
+ * The default option keys recognized by `validates(...)`. Subclasses
+ * override to add custom keys. Mirrors Rails
+ * `_validates_default_keys`
+ * (activemodel/lib/active_model/validations/validates.rb:162-164).
+ *
+ * @internal Rails-private helper.
+ */
+export function _validatesDefaultKeys(): string[] {
+  return ["if", "unless", "on", "allowBlank", "allowNil", "strict", "exceptOn"];
+}
+
+/**
+ * Normalize a validator option value into the option hash the
+ * validator constructor expects. Mirrors Rails
+ * `_parse_validates_options(options)`
+ * (activemodel/lib/active_model/validations/validates.rb:166-177):
+ * `true` → `{}`, plain hash → unchanged, Range/Array → `{ in: options }`,
+ * anything else → `{ with: options }`.
+ *
+ * @internal Rails-private helper.
+ */
+export function _parseValidatesOptions(options: unknown): Record<string, unknown> {
+  if (options === true) return {};
+  if (Array.isArray(options)) return { in: options };
+  if (options !== null && typeof options === "object" && options.constructor === Object) {
+    return options as Record<string, unknown>;
+  }
+  return { with: options };
+}


### PR DESCRIPTION
## Summary

- Adds the seven Rails-private helpers under `ActiveModel::Validations` that wire the validation lifecycle: `runValidationsBang` (validations.rb:473-476), `raiseValidationError` (:478-480), `contextForValidation` (:463-465), `predicateForValidationContext` (:294-306), `_mergeAttributes` (validations/helper_methods.rb:7-11), `_validatesDefaultKeys` and `_parseValidatesOptions` (validations/validates.rb:162-177).
- `contextForValidation()` returns a lazy `ValidationContext` whose `.context` property is a live view of the existing `_validationContext` field, so Rails' `context_for_validation.context = ctx` pattern works without forcing a wider field-storage refactor. `initInternals()` clears the cached instance.
- Wires `Model.isValid` through `runValidationsBang`, `Model.validateBang` through `raiseValidationError`, and the validator `on:` gate in `_buildValidateConditions` through `predicateForValidationContext` (single source of truth for the cache).
- `api.ts` re-exports five Validations helpers (`initInternals`, `contextForValidation`, `runValidationsBang`, `raiseValidationError`, `_mergeAttributes`) Rails surfaces via `API includes Validations`.
- B5b from \`docs/activemodel-privates-100-plan.md\`. Closes 15 privates misses (validations.rb hits 100% — 48/48); activemodel privates 551/625 → 566/625 (88.2% → 90.6%). Public api:compare also picks up 3 misses (raise_validation_error appearances).

## Test plan

- [x] \`pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel\` → 566/625 (+15)
- [x] \`pnpm tsx scripts/api-compare/compare.ts --package activemodel\` → 451/452 (+3)
- [x] \`pnpm exec vitest run packages/activemodel\` → 1629/1629
- [x] \`pnpm --filter @blazetrails/activemodel run build\` → clean
- [x] \`pnpm lint --fix\` → clean