### PR TITLE
fix(arel)!: visitor leaf alignment — Lock + outer-join guards

### DIFF
--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -994,14 +994,14 @@ describe("SelectManagerTest", () => {
   it("rightOuterJoin with string table name", () => {
     const mgr = new SelectManager(users);
     mgr.project(star);
-    mgr.rightOuterJoin("posts");
+    mgr.rightOuterJoin("posts", users.get("id").eq(new Nodes.SqlLiteral("posts.user_id")));
     expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
   });
 
   it("fullOuterJoin with string table name", () => {
     const mgr = new SelectManager(users);
     mgr.project(star);
-    mgr.fullOuterJoin("posts");
+    mgr.fullOuterJoin("posts", users.get("id").eq(new Nodes.SqlLiteral("posts.user_id")));
     expect(mgr.toSql()).toContain("FULL OUTER JOIN");
   });
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -256,8 +256,14 @@ export class SelectManager extends TreeManager {
   /**
    * Add a lock clause (FOR UPDATE by default).
    */
-  lock(lockClause?: string): this {
-    this.ast.lock = new Lock(lockClause ?? null);
+  lock(lockClause?: string | Node): this {
+    const expr =
+      lockClause === undefined
+        ? new SqlLiteral("FOR UPDATE")
+        : typeof lockClause === "string"
+          ? new SqlLiteral(lockClause)
+          : lockClause;
+    this.ast.lock = new Lock(expr);
     return this;
   }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1572,19 +1572,19 @@ describe("the to_sql visitor", () => {
   describe("OuterJoin guard", () => {
     it("OuterJoin without an ON throws", () => {
       const visitor = new Visitors.ToSql();
-      const node = new Nodes.OuterJoin(users, null as unknown as Nodes.On);
+      const node = new Nodes.OuterJoin(users, null);
       expect(() => visitor.compile(node)).toThrow();
     });
 
     it("RightOuterJoin without an ON throws", () => {
       const visitor = new Visitors.ToSql();
-      const node = new Nodes.RightOuterJoin(users, null as unknown as Nodes.On);
+      const node = new Nodes.RightOuterJoin(users, null);
       expect(() => visitor.compile(node)).toThrow();
     });
 
     it("FullOuterJoin without an ON throws", () => {
       const visitor = new Visitors.ToSql();
-      const node = new Nodes.FullOuterJoin(users, null as unknown as Nodes.On);
+      const node = new Nodes.FullOuterJoin(users, null);
       expect(() => visitor.compile(node)).toThrow();
     });
   });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1552,4 +1552,40 @@ describe("the to_sql visitor", () => {
       );
     });
   });
+
+  describe("Nodes::Lock", () => {
+    it("visits the inner expr (no FOR UPDATE fallback)", () => {
+      const visitor = new Visitors.ToSql();
+      const node = new Nodes.Lock(new Nodes.SqlLiteral("FOR SHARE"));
+      expect(visitor.compile(node)).toBe("FOR SHARE");
+    });
+
+    it("SelectManager#lock wraps default in SqlLiteral", () => {
+      expect(users.project(star).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
+    });
+
+    it("SelectManager#lock with custom string wraps in SqlLiteral", () => {
+      expect(users.project(star).lock("FOR SHARE").toSql()).toBe('SELECT * FROM "users" FOR SHARE');
+    });
+  });
+
+  describe("OuterJoin guard", () => {
+    it("OuterJoin without an ON throws", () => {
+      const visitor = new Visitors.ToSql();
+      const node = new Nodes.OuterJoin(users, null as unknown as Nodes.On);
+      expect(() => visitor.compile(node)).toThrow();
+    });
+
+    it("RightOuterJoin without an ON throws", () => {
+      const visitor = new Visitors.ToSql();
+      const node = new Nodes.RightOuterJoin(users, null as unknown as Nodes.On);
+      expect(() => visitor.compile(node)).toThrow();
+    });
+
+    it("FullOuterJoin without an ON throws", () => {
+      const visitor = new Visitors.ToSql();
+      const node = new Nodes.FullOuterJoin(users, null as unknown as Nodes.On);
+      expect(() => visitor.compile(node)).toThrow();
+    });
+  });
 });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -524,30 +524,24 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   private visitArelNodesOuterJoin(node: Nodes.OuterJoin): SQLString {
     this.collector.append("LEFT OUTER JOIN ");
     this.visit(node.left);
-    if (node.right) {
-      this.collector.append(" ");
-      this.visit(node.right);
-    }
+    this.collector.append(" ");
+    this.visit(node.right as Node);
     return this.collector;
   }
 
   private visitArelNodesRightOuterJoin(node: Nodes.RightOuterJoin): SQLString {
     this.collector.append("RIGHT OUTER JOIN ");
     this.visit(node.left);
-    if (node.right) {
-      this.collector.append(" ");
-      this.visit(node.right);
-    }
+    this.collector.append(" ");
+    this.visit(node.right as Node);
     return this.collector;
   }
 
   private visitArelNodesFullOuterJoin(node: Nodes.FullOuterJoin): SQLString {
     this.collector.append("FULL OUTER JOIN ");
     this.visit(node.left);
-    if (node.right) {
-      this.collector.append(" ");
-      this.visit(node.right);
-    }
+    this.collector.append(" ");
+    this.visit(node.right as Node);
     return this.collector;
   }
 
@@ -813,13 +807,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected visitArelNodesLock(node: Nodes.Lock): SQLString {
-    if (node.expr instanceof Node) {
-      this.visit(node.expr);
-    } else if (typeof node.expr === "string") {
-      this.collector.append(node.expr);
-    } else {
-      this.collector.append("FOR UPDATE");
-    }
+    this.visit(node.expr as Node);
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary

First slice of plan PR 23. Aligns two visitor leaves with Rails:

- **Lock**: `visitArelNodesLock` now just calls `visit(node.expr)`, dropping the `"FOR UPDATE"` fallback. To preserve default behavior, `SelectManager#lock` wraps the default (and any string argument) in `SqlLiteral`, matching Rails' `lock(locking = Arel.sql("FOR UPDATE"))`.
- **OuterJoin / RightOuterJoin / FullOuterJoin**: drop the `if (node.right)` guard. An outer join with no ON now throws via the visitor — intentional, matches Rails behavior.

Casted/Quoted collapse + Date-bind removal, In-array subselect wrap, Table-name-Node visit, and PostgreSQL ESCAPE rendering follow in 23b/23c (split per `docs/arel-alignment-plan.md` heuristic — Date-bind removal interacts with `_extractBinds` and `PostgreSQLWithBinds`, warrants its own PR).

## Test plan

- [x] `pnpm exec vitest run packages/arel/` (1257 passed)
- [x] `pnpm exec vitest run packages/activerecord/` (no new failures vs main; pre-existing tsc-wrapper timeouts unrelated)
- [x] `pnpm parity:query` (53/204 unchanged from baseline)

Refs `docs/arel-alignment-plan.md` PR 23.