### PR TITLE
feat(activerecord): dispatch database-statements quoting through this

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -249,9 +249,12 @@ describe("DatabaseStatements", () => {
           await fn();
           return undefined;
         },
+        quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+        quoteTableName: (n: string) => `"${n}"`,
+        quoteColumnName: (n: string) => `"${n}"`,
       } as unknown as DatabaseStatementsHost;
 
-      await insertFixturesSet.call(
+      await (insertFixturesSet as unknown as (...args: unknown[]) => Promise<void>).call(
         host,
         {
           users: [{ name: "Alice" }],

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -270,6 +270,56 @@ describe("DatabaseStatements", () => {
     });
   });
 
+  describe("truncate / insertFixture quoter dispatch", () => {
+    type QuoterHost = DatabaseStatementsHost &
+      Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">;
+
+    function makeHost(): {
+      host: QuoterHost;
+      executed: Array<{ sql: string; name?: string | null; receiver: unknown }>;
+    } {
+      const executed: Array<{ sql: string; name?: string | null; receiver: unknown }> = [];
+      const host: QuoterHost = {
+        async execute(sql: string, name?: string | null) {
+          // captures `this` to verify receiver is preserved
+          executed.push({ sql, name, receiver: this });
+        },
+        quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+        quoteTableName: (n: string) => `\`${n}\``,
+        quoteColumnName: (n: string) => `\`${n}\``,
+      };
+      return { host, executed };
+    }
+
+    it("truncate dispatches quoteTableName via this and forwards name to execute", async () => {
+      const { truncate } = await import("./database-statements.js");
+      const { host, executed } = makeHost();
+      await truncate.call(host, "users", "Custom Truncate");
+      expect(executed).toEqual([
+        { sql: "TRUNCATE TABLE `users`", name: "Custom Truncate", receiver: host },
+      ]);
+    });
+
+    it("insertFixture dispatches quote/quoteTableName/quoteColumnName via this", async () => {
+      const { insertFixture } = await import("./database-statements.js");
+      const { host, executed } = makeHost();
+      await insertFixture.call(host, { name: "Alice", id: 1 }, "users");
+      expect(executed).toHaveLength(1);
+      expect(executed[0]).toEqual({
+        sql: "INSERT INTO `users` (`name`, `id`) VALUES ('Alice', 1)",
+        name: "Fixture Insert",
+        receiver: host,
+      });
+    });
+
+    it("insertFixture uses emptyInsertStatementValue when no columns are present", async () => {
+      const { insertFixture } = await import("./database-statements.js");
+      const { host, executed } = makeHost();
+      await insertFixture.call(host, {}, "users");
+      expect(executed[0].sql).toBe("INSERT INTO `users` DEFAULT VALUES");
+    });
+  });
+
   describe("utility methods", () => {
     it("default sequence name returns null", () => {
       expect(defaultSequenceName("users", "id")).toBeNull();

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -26,6 +26,7 @@ import {
   isTransactionOpen,
   type DatabaseStatementsHost,
 } from "./database-statements.js";
+import type { Quoting } from "./quoting-interface.js";
 
 describe("DatabaseStatements", () => {
   describe("toSql", () => {
@@ -240,11 +241,12 @@ describe("DatabaseStatements", () => {
       const executed: string[] = [];
       let transactionUsed = false;
       const { insertFixturesSet } = await import("./database-statements.js");
-      const host = {
+      const host: DatabaseStatementsHost &
+        Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName"> = {
         execute: async (sql: string) => {
           executed.push(sql);
         },
-        transaction: async (fn: (tx?: unknown) => Promise<void> | void) => {
+        transaction: async <T>(fn: (tx?: unknown) => Promise<T> | T) => {
           transactionUsed = true;
           await fn();
           return undefined;
@@ -252,9 +254,9 @@ describe("DatabaseStatements", () => {
         quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
         quoteTableName: (n: string) => `"${n}"`,
         quoteColumnName: (n: string) => `"${n}"`,
-      } as unknown as DatabaseStatementsHost;
+      };
 
-      await (insertFixturesSet as unknown as (...args: unknown[]) => Promise<void>).call(
+      await insertFixturesSet.call(
         host,
         {
           users: [{ name: "Alice" }],

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -14,14 +14,12 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TransactionIsolationError, NotImplementedError } from "../../errors.js";
 import {
-  quote,
-  quoteTableName,
-  quoteColumnName,
   formatInstantForSql,
   formatPlainDateTimeForSql,
   formatPlainDateForSql,
   formatPlainTimeForSql,
 } from "./quoting.js";
+import type { Quoting } from "./quoting-interface.js";
 import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
 import { TransactionManager } from "./transaction.js";
 import { Result } from "../../result.js";
@@ -509,12 +507,12 @@ export { deleteStatement as delete };
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate
  */
 export async function truncate(
-  this: DatabaseStatementsHost | void,
+  this: DatabaseStatementsHost & Pick<Quoting, "quoteTableName">,
   tableName: string,
   name?: string | null,
 ): Promise<unknown> {
-  const sql = `TRUNCATE TABLE ${quoteTableName(tableName)}`;
-  const doExecute = (this as DatabaseStatementsHost)?.execute ?? execute;
+  const sql = `TRUNCATE TABLE ${this.quoteTableName(tableName)}`;
+  const doExecute = this.execute ?? execute;
   return doExecute(sql);
 }
 
@@ -524,7 +522,7 @@ export async function truncate(
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate_tables
  */
 export async function truncateTables(
-  this: DatabaseStatementsHost,
+  this: DatabaseStatementsHost & Pick<Quoting, "quoteTableName">,
   ...tableNames: string[]
 ): Promise<void> {
   const schemaMigrationTable = this.pool?.schemaMigration?.tableName ?? "schema_migrations";
@@ -535,7 +533,7 @@ export async function truncateTables(
 
   if (filtered.length === 0) return;
 
-  const statements = filtered.map((t) => `TRUNCATE TABLE ${quoteTableName(t)}`);
+  const statements = filtered.map((t) => `TRUNCATE TABLE ${this.quoteTableName(t)}`);
 
   const doExecute = this.execute ?? execute;
   const doTruncate = async () => {
@@ -845,21 +843,20 @@ export async function resetSequenceBang(
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#insert_fixture
  */
 export async function insertFixture(
-  this: DatabaseStatementsHost | void,
+  this: DatabaseStatementsHost & Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">,
   fixture: Record<string, unknown>,
   tableName: string,
 ): Promise<unknown> {
-  const host = this as DatabaseStatementsHost;
   const columns = Object.keys(fixture);
-  const values = Object.values(fixture).map((v) => quote(withYamlFallback(v)));
+  const values = Object.values(fixture).map((v) => this.quote(withYamlFallback(v)));
 
-  const emptyValue = host?.emptyInsertStatementValue?.() ?? emptyInsertStatementValue();
+  const emptyValue = this.emptyInsertStatementValue?.() ?? emptyInsertStatementValue();
   const sql =
     columns.length > 0
-      ? `INSERT INTO ${quoteTableName(tableName)} (${columns.map((c) => quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`
-      : `INSERT INTO ${quoteTableName(tableName)} ${emptyValue}`;
+      ? `INSERT INTO ${this.quoteTableName(tableName)} (${columns.map((c) => this.quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`
+      : `INSERT INTO ${this.quoteTableName(tableName)} ${emptyValue}`;
 
-  const doExecute = host?.execute ?? execute;
+  const doExecute = this.execute ?? execute;
   return doExecute(sql);
 }
 
@@ -869,11 +866,11 @@ export async function insertFixture(
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#insert_fixtures_set
  */
 export async function insertFixturesSet(
-  this: DatabaseStatementsHost,
+  this: DatabaseStatementsHost & Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">,
   fixtureSet: Record<string, Record<string, unknown>[]>,
   tablesToDelete: string[] = [],
 ): Promise<void> {
-  const deleteStatements = tablesToDelete.map((t) => `DELETE FROM ${quoteTableName(t)}`);
+  const deleteStatements = tablesToDelete.map((t) => `DELETE FROM ${this.quoteTableName(t)}`);
 
   const insertStatements: string[] = [];
   for (const [tableName, fixtures] of Object.entries(fixtureSet)) {
@@ -882,11 +879,11 @@ export async function insertFixturesSet(
       const columns = Object.keys(fixture);
       if (columns.length === 0) {
         const emptyValue = this.emptyInsertStatementValue?.() ?? emptyInsertStatementValue();
-        insertStatements.push(`INSERT INTO ${quoteTableName(tableName)} ${emptyValue}`);
+        insertStatements.push(`INSERT INTO ${this.quoteTableName(tableName)} ${emptyValue}`);
       } else {
-        const values = Object.values(fixture).map((v) => quote(withYamlFallback(v)));
+        const values = Object.values(fixture).map((v) => this.quote(withYamlFallback(v)));
         insertStatements.push(
-          `INSERT INTO ${quoteTableName(tableName)} (${columns.map((c) => quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`,
+          `INSERT INTO ${this.quoteTableName(tableName)} (${columns.map((c) => this.quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`,
         );
       }
     }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -512,8 +512,7 @@ export async function truncate(
   name?: string | null,
 ): Promise<unknown> {
   const sql = `TRUNCATE TABLE ${this.quoteTableName(tableName)}`;
-  const doExecute = this.execute ?? execute;
-  return doExecute(sql);
+  return (this.execute ?? execute).call(this, sql);
 }
 
 /**
@@ -535,13 +534,13 @@ export async function truncateTables(
 
   const statements = filtered.map((t) => `TRUNCATE TABLE ${this.quoteTableName(t)}`);
 
-  const doExecute = this.execute ?? execute;
+  const exec = this.execute ?? execute;
   const doTruncate = async () => {
     if (this.executeBatch) {
       await this.executeBatch(statements, "Truncate Tables");
     } else {
       for (const stmt of statements) {
-        await doExecute(stmt);
+        await exec.call(this, stmt);
       }
     }
   };
@@ -856,8 +855,7 @@ export async function insertFixture(
       ? `INSERT INTO ${this.quoteTableName(tableName)} (${columns.map((c) => this.quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`
       : `INSERT INTO ${this.quoteTableName(tableName)} ${emptyValue}`;
 
-  const doExecute = this.execute ?? execute;
-  return doExecute(sql);
+  return (this.execute ?? execute).call(this, sql);
 }
 
 /**
@@ -891,13 +889,13 @@ export async function insertFixturesSet(
 
   const allStatements = [...deleteStatements, ...insertStatements];
 
-  const doExecute = this.execute ?? execute;
+  const exec = this.execute ?? execute;
   const doInserts = async () => {
     if (this.executeBatch) {
       await this.executeBatch(allStatements, "Fixtures Load");
     } else {
       for (const stmt of allStatements) {
-        await doExecute(stmt);
+        await exec.call(this, stmt);
       }
     }
   };

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -512,7 +512,8 @@ export async function truncate(
   name?: string | null,
 ): Promise<unknown> {
   const sql = `TRUNCATE TABLE ${this.quoteTableName(tableName)}`;
-  return (this.execute ?? execute).call(this, sql);
+  // Rails: execute(build_truncate_statement(table_name), name)
+  return (this.execute ?? execute).call(this, sql, name);
 }
 
 /**
@@ -855,7 +856,8 @@ export async function insertFixture(
       ? `INSERT INTO ${this.quoteTableName(tableName)} (${columns.map((c) => this.quoteColumnName(c)).join(", ")}) VALUES (${values.join(", ")})`
       : `INSERT INTO ${this.quoteTableName(tableName)} ${emptyValue}`;
 
-  return (this.execute ?? execute).call(this, sql);
+  // Rails: execute(build_fixture_sql(...), "Fixture Insert")
+  return (this.execute ?? execute).call(this, sql, "Fixture Insert");
 }
 
 /**


### PR DESCRIPTION
## Summary

PR 5 of 10 in the quoting refactor (`docs/quoting-refactor.md` Phase 2 — Tier 1 hot path call sites; final Tier 1 PR).

`truncate` / `truncateTables` / `insertFixture` / `insertFixturesSet` now dispatch quoting through `this.quote*` rather than the standalone abstract functions. Adapters always implement the `Quoting` interface (since #1058), so each function's `this:` widens with `Pick<Quoting, …>` to encode the requirement at the type level.

- `truncate` / `truncateTables`: `this.quoteTableName(t)`
- `insertFixture` / `insertFixturesSet`: `this.quote(value)`, `this.quoteTableName(t)`, `this.quoteColumnName(c)`
- `database-statements.ts` no longer imports `quote` / `quoteTableName` / `quoteColumnName` from `abstract/quoting.ts`. Formatters stay (dialect-agnostic).
- Test stub for `insertFixturesSet` now provides `quote`/`quoteTableName`/`quoteColumnName` so the typed call site compiles.

Mirrors Rails' `connection.quote_table_name(...)` / `connection.quote(...)` dispatch in `ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate`, `#insert_fixture`, `#insert_fixtures_set`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/activerecord/src` — 9959 passed
- [x] `pnpm api:compare` — Data layer 4187/4503 (93%), unchanged
- [x] `pnpm test:compare` — Overall 11833/21679 (54.6%), unchanged
- [x] LOC: 21 additions / 21 deletions, well under the 300 ceiling