### PR TITLE
feat(activerecord): route schema-creation/definitions quoting through adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -20,7 +20,29 @@ import {
   CheckConstraintDefinition,
   TableDefinition,
 } from "./schema-definitions.js";
-import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "./quoting.js";
+import {
+  quoteIdentifier as abstractQuoteIdentifier,
+  quoteTableName as abstractQuoteTableName,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
+} from "./quoting.js";
+import type { Quoting } from "./quoting-interface.js";
+
+/** Subset of {@link Quoting} that schema-creation needs for identifier and value quoting. @internal */
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+
+/**
+ * Build a fallback quoter from the dialect-name string for the legacy
+ * code path where construction sites haven't been migrated to pass an
+ * adapter. Each PR in the refactor moves one call site over until this
+ * fallback can be removed in PR 10. @internal
+ */
+function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+  return {
+    quoteIdentifier: (n) => abstractQuoteIdentifier(n, name),
+    quoteTableName: (n) => abstractQuoteTableName(n, name),
+    quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
+  };
+}
 
 type Definition =
   | TableDefinition
@@ -32,7 +54,15 @@ type Definition =
   | CheckConstraintDefinition;
 
 export class SchemaCreation {
-  constructor(protected adapterName: "sqlite" | "postgres" | "mysql") {}
+  /** Quoter used for identifier/table/default-expression quoting. */
+  protected adapter: SchemaQuoter;
+
+  constructor(
+    protected adapterName: "sqlite" | "postgres" | "mysql",
+    adapter?: SchemaQuoter,
+  ) {
+    this.adapter = adapter ?? quoterForAdapterName(adapterName);
+  }
 
   protected supportsPartialIndex(): boolean {
     return this.adapterName !== "mysql";
@@ -67,7 +97,7 @@ export class SchemaCreation {
 
   protected visitTableDefinition(o: TableDefinition): string {
     let sql = "CREATE TABLE ";
-    sql += `${quoteTableName(o.tableName, this.adapterName)} `;
+    sql += `${this.adapter.quoteTableName(o.tableName)} `;
 
     const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
 
@@ -80,7 +110,7 @@ export class SchemaCreation {
 
   protected visitColumnDefinition(o: ColumnDefinition): string {
     const sqlType = o.sqlType ?? this.typeToSql(o.type, o.options);
-    let sql = `${quoteIdentifier(o.name, this.adapterName)} ${sqlType}`;
+    let sql = `${this.adapter.quoteIdentifier(o.name)} ${sqlType}`;
     if (o.type !== "primary_key") {
       sql = this.addColumnOptions(sql, o.options);
     }
@@ -92,7 +122,7 @@ export class SchemaCreation {
   }
 
   protected visitAlterTable(o: AlterTable): string {
-    const table = quoteTableName(o.name, this.adapterName);
+    const table = this.adapter.quoteTableName(o.name);
     const parts: string[] = [];
 
     for (const add of o.adds) {
@@ -102,23 +132,25 @@ export class SchemaCreation {
       parts.push(`ADD ${this.visitForeignKeyDefinition(fk)}`);
     }
     for (const name of o.foreignKeyDrops) {
-      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
     }
     for (const chk of o.checkConstraintAdds) {
       parts.push(`ADD ${this.visitCheckConstraintDefinition(chk)}`);
     }
     for (const name of o.checkConstraintDrops) {
-      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
     }
     for (const name of o.constraintDrops) {
-      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
     }
     for (const change of o.columnDefaultChanges) {
-      const col = quoteIdentifier(change.columnName, this.adapterName);
+      const col = this.adapter.quoteIdentifier(change.columnName);
       if (change.defaultValue == null) {
         parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
       } else {
-        parts.push(`ALTER COLUMN ${col} SET${quoteDefaultExpression(change.defaultValue)}`);
+        parts.push(
+          `ALTER COLUMN ${col} SET${this.adapter.quoteDefaultExpression(change.defaultValue)}`,
+        );
       }
     }
 
@@ -134,11 +166,11 @@ export class SchemaCreation {
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
     if (index.type) parts.push(index.type.toUpperCase());
     parts.push(
-      `${quoteIdentifier(index.name, this.adapterName)} ON ${quoteTableName(index.table, this.adapterName)}`,
+      `${this.adapter.quoteIdentifier(index.name)} ON ${this.adapter.quoteTableName(index.table)}`,
     );
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     const columnsSql = index.columns.map((c) => {
-      let col = quoteIdentifier(c, this.adapterName);
+      let col = this.adapter.quoteIdentifier(c);
       if (index.lengths[c]) col += `(${index.lengths[c]})`;
       if (this.supportsIndexSortOrder()) {
         const order = index.orders[c];
@@ -149,7 +181,7 @@ export class SchemaCreation {
     });
     parts.push(`(${columnsSql.join(", ")})`);
     if (this.supportsIndexInclude() && index.include && index.include.length > 0) {
-      const includeCols = index.include.map((c) => quoteIdentifier(c, this.adapterName));
+      const includeCols = index.include.map((c) => this.adapter.quoteIdentifier(c));
       parts.push(`INCLUDE (${includeCols.join(", ")})`);
     }
     if (this.supportsNullsNotDistinct() && index.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
@@ -158,16 +190,16 @@ export class SchemaCreation {
   }
 
   protected visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
-    let sql = `CONSTRAINT ${quoteIdentifier(o.name, this.adapterName)} `;
-    sql += `FOREIGN KEY (${quoteIdentifier(o.column, this.adapterName)}) `;
-    sql += `REFERENCES ${quoteTableName(o.toTable, this.adapterName)} (${quoteIdentifier(o.primaryKey, this.adapterName)})`;
+    let sql = `CONSTRAINT ${this.adapter.quoteIdentifier(o.name)} `;
+    sql += `FOREIGN KEY (${this.adapter.quoteIdentifier(o.column)}) `;
+    sql += `REFERENCES ${this.adapter.quoteTableName(o.toTable)} (${this.adapter.quoteIdentifier(o.primaryKey)})`;
     if (o.onDelete) sql += ` ${this.actionSql("DELETE", o.onDelete)}`;
     if (o.onUpdate) sql += ` ${this.actionSql("UPDATE", o.onUpdate)}`;
     return sql;
   }
 
   protected visitCheckConstraintDefinition(o: CheckConstraintDefinition): string {
-    let sql = `CONSTRAINT ${quoteIdentifier(o.name, this.adapterName)} CHECK (${o.expression})`;
+    let sql = `CONSTRAINT ${this.adapter.quoteIdentifier(o.name)} CHECK (${o.expression})`;
     if (!o.validate) {
       if (this.adapterName !== "postgres") {
         throw new Error("Check constraint validate: false is only supported on PostgreSQL");
@@ -179,7 +211,7 @@ export class SchemaCreation {
 
   addColumnOptions(sql: string, options: ColumnOptions): string {
     if (options.default !== undefined) {
-      sql += quoteDefaultExpression(options.default);
+      sql += this.adapter.quoteDefaultExpression(options.default);
     }
     if (options.null === false) {
       sql += " NOT NULL";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,6 +1,27 @@
 import { NotImplementedError } from "../../errors.js";
-import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "./quoting.js";
+import {
+  quoteIdentifier as abstractQuoteIdentifier,
+  quoteTableName as abstractQuoteTableName,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
+} from "./quoting.js";
+import type { Quoting } from "./quoting-interface.js";
 import { singularize } from "@blazetrails/activesupport";
+
+/** Subset of {@link Quoting} that schema-definitions needs. @internal */
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+
+/**
+ * Build a fallback quoter from the dialect-name string for the legacy
+ * code path where construction sites haven't yet been migrated to pass
+ * an adapter. Removed in PR 10. @internal
+ */
+function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+  return {
+    quoteIdentifier: (n) => abstractQuoteIdentifier(n, name),
+    quoteTableName: (n) => abstractQuoteTableName(n, name),
+    quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
+  };
+}
 
 /**
  * Column type mapping.
@@ -458,12 +479,14 @@ export class TableDefinition {
   readonly comment?: string;
   private _id: boolean | PrimaryKeyType;
   private _adapterName: "sqlite" | "postgres" | "mysql";
+  private _adapter: SchemaQuoter;
 
   constructor(
     tableName: string,
     tdOptions: {
       id?: boolean | PrimaryKeyType;
       adapterName?: "sqlite" | "postgres" | "mysql";
+      adapter?: SchemaQuoter;
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
@@ -473,6 +496,7 @@ export class TableDefinition {
   ) {
     this.tableName = tableName;
     this._adapterName = tdOptions.adapterName ?? "sqlite";
+    this._adapter = tdOptions.adapter ?? quoterForAdapterName(this._adapterName);
     this._id = tdOptions.id ?? true;
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
@@ -734,7 +758,7 @@ export class TableDefinition {
    */
   toSql(): string {
     const columnDefs = this.columns.map((col) => {
-      const parts = [quoteIdentifier(col.name, this._adapterName)];
+      const parts = [this._adapter.quoteIdentifier(col.name)];
 
       switch (col.type) {
         case "primary_key":
@@ -810,7 +834,7 @@ export class TableDefinition {
       }
 
       if (col.options.collation && this._adapterName === "sqlite") {
-        parts.push(`COLLATE ${quoteIdentifier(col.options.collation, this._adapterName)}`);
+        parts.push(`COLLATE ${this._adapter.quoteIdentifier(col.options.collation)}`);
       }
 
       if (col.options.array && col.type !== "primary_key") {
@@ -827,7 +851,7 @@ export class TableDefinition {
       }
 
       if (col.options.default !== undefined) {
-        const clause = quoteDefaultExpression(col.options.default);
+        const clause = this._adapter.quoteDefaultExpression(col.options.default);
         if (clause) parts.push(clause.trimStart());
       }
 
@@ -838,14 +862,14 @@ export class TableDefinition {
     if (this.temporary) sql += " TEMPORARY";
     sql += " TABLE";
     if (this.ifNotExists) sql += " IF NOT EXISTS";
-    sql += ` ${quoteTableName(this.tableName, this._adapterName)}`;
+    sql += ` ${this._adapter.quoteTableName(this.tableName)}`;
 
     if (this.as) {
       sql += ` AS ${this.as}`;
     } else {
       const tableElements = [...columnDefs];
       for (const chk of this.checkConstraints) {
-        let chkSql = `CONSTRAINT ${quoteIdentifier(chk.name, this._adapterName)} CHECK (${chk.expression})`;
+        let chkSql = `CONSTRAINT ${this._adapter.quoteIdentifier(chk.name)} CHECK (${chk.expression})`;
         if (!chk.validate) {
           if (this._adapterName !== "postgres") {
             throw new Error("Check constraint validate: false is only supported on PostgreSQL");
@@ -855,7 +879,7 @@ export class TableDefinition {
         tableElements.push(chkSql);
       }
       for (const fk of this.foreignKeys) {
-        let fkSql = `CONSTRAINT ${quoteIdentifier(fk.name, this._adapterName)} FOREIGN KEY (${quoteIdentifier(fk.column, this._adapterName)}) REFERENCES ${quoteTableName(fk.toTable, this._adapterName)} (${quoteIdentifier(fk.primaryKey, this._adapterName)})`;
+        let fkSql = `CONSTRAINT ${this._adapter.quoteIdentifier(fk.name)} FOREIGN KEY (${this._adapter.quoteIdentifier(fk.column)}) REFERENCES ${this._adapter.quoteTableName(fk.toTable)} (${this._adapter.quoteIdentifier(fk.primaryKey)})`;
         if (fk.onDelete)
           fkSql += ` ON DELETE ${fk.onDelete.toUpperCase().replace("NULLIFY", "SET NULL").replace("NO_ACTION", "NO ACTION")}`;
         if (fk.onUpdate)


### PR DESCRIPTION
## Summary

PR 6 of 10 in the quoting refactor (`docs/quoting-refactor.md` Phase 3 — Tier 2 DDL/schema).

`abstract/schema-creation.ts` and `abstract/schema-definitions.ts` now route identifier, table-name, and default-expression quoting through a `SchemaQuoter` (subset of the `Quoting` interface). When a real adapter is passed, dialect-specific overrides take effect (MySQL backticks, PG `quoteDefaultExpression`, etc.); otherwise a synthetic quoter built from the dialect-name string preserves the legacy behavior so existing construction sites in the test suite and downstream packages don't break.

- `SchemaCreation` now takes `(adapterName, adapter?)` — adapter optional for now; PR 7 wires the live adapter through `schema-statements`.
- `TableDefinition` options gain an optional `adapter?` alongside the existing `adapterName`.
- The 18 `quoteIdentifier` / `quoteTableName` / `quoteDefaultExpression` call sites in schema-creation and the 7 in schema-definitions now go through `this.adapter` / `this._adapter`.
- `adapterName` is retained for the dialect-dispatch type-mapping branches (e.g. `"DOUBLE PRECISION"` vs `"REAL"`) — not part of the Quoting refactor; out of scope here.

Mirrors Rails' `connection.quote_*` dispatch in `ActiveRecord::ConnectionAdapters::SchemaCreation` and `TableDefinition`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/activerecord/src` — 9962 passed (+3 vs main)
- [x] `pnpm api:compare` — Data layer 4190/4503 (93%, +3 methods)
- [x] `pnpm test:compare` — Overall 11833/21679 (54.6%), unchanged
- [x] LOC: 81 additions / 25 deletions, well under the 300 ceiling