### PR TITLE
refactor(arel): collapse Casted/Quoted visitors; drop Date-bind branch

### DIFF
--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -139,7 +139,7 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compileWithBinds(node);
   }
 
-  protected override visitArelNodesCasted(node: Nodes.Casted): SQLString {
+  protected override visitArelNodesCasted(node: Nodes.Casted | Nodes.Quoted): SQLString {
     if (this._extractBinds) {
       this.bindIndex += 1;
       this.collector.addBind(node.valueForDatabase(), () => `$${this.bindIndex}`);

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1571,6 +1571,25 @@ describe("the to_sql visitor", () => {
       const visitor = new Visitors.ToSql();
       expect(visitor.compile(new Nodes.Quoted(42))).toBe("42");
     });
+
+    it("Quoted string binds raw under extractBinds", () => {
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(new Nodes.Quoted("hi"));
+      expect(sql).toBe("?");
+      expect(binds).toEqual(["hi"]);
+    });
+
+    it("Quoted number binds raw under extractBinds", () => {
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(new Nodes.Quoted(42));
+      expect(sql).toBe("?");
+      expect(binds).toEqual([42]);
+    });
+
+    it("Quoted toISOString-bearing object binds raw under extractBinds", () => {
+      const value = { toISOString: () => "2026-04-30T00:00:00.000Z" };
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(new Nodes.Quoted(value));
+      expect(sql).toBe("?");
+      expect(binds).toEqual([value]);
+    });
   });
 
   describe("Nodes::Lock", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   Table,
   star,
@@ -1559,12 +1560,12 @@ describe("the to_sql visitor", () => {
       expect(visitor.compile(new Nodes.Quoted("hi"))).toBe("'hi'");
     });
 
-    it("Quoted Date binds through unified addBind path under extractBinds", () => {
+    it("Quoted Temporal.Instant binds through unified addBind path under extractBinds", () => {
       const visitor = new Visitors.ToSql();
-      const date = new Date("2026-04-30T12:34:56.000Z");
-      const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(date));
+      const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
+      const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(instant));
       expect(sql).toBe("?");
-      expect(binds).toEqual([date]);
+      expect(binds).toEqual([instant]);
     });
 
     it("Quoted non-Date inlines under extractBinds=false", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1565,7 +1565,8 @@ describe("the to_sql visitor", () => {
       const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
       const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(instant));
       expect(sql).toBe("?");
-      expect(binds).toEqual([instant]);
+      expect(binds).toHaveLength(1);
+      expect(binds[0]).toBe(instant);
     });
 
     it("Quoted non-Date inlines under extractBinds=false", () => {
@@ -1589,7 +1590,8 @@ describe("the to_sql visitor", () => {
       const value = { toISOString: () => "2026-04-30T00:00:00.000Z" };
       const [sql, binds] = new Visitors.ToSql().compileWithBinds(new Nodes.Quoted(value));
       expect(sql).toBe("?");
-      expect(binds).toEqual([value]);
+      expect(binds).toHaveLength(1);
+      expect(binds[0]).toBe(value);
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1553,6 +1553,26 @@ describe("the to_sql visitor", () => {
     });
   });
 
+  describe("Quoted/Casted collapse", () => {
+    it("Quoted inlines via quote(valueForDatabase) when not extracting binds", () => {
+      const visitor = new Visitors.ToSql();
+      expect(visitor.compile(new Nodes.Quoted("hi"))).toBe("'hi'");
+    });
+
+    it("Quoted Date binds through unified addBind path under extractBinds", () => {
+      const visitor = new Visitors.ToSql();
+      const date = new Date("2026-04-30T12:34:56.000Z");
+      const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(date));
+      expect(sql).toBe("?");
+      expect(binds).toEqual([date]);
+    });
+
+    it("Quoted non-Date inlines under extractBinds=false", () => {
+      const visitor = new Visitors.ToSql();
+      expect(visitor.compile(new Nodes.Quoted(42))).toBe("42");
+    });
+  });
+
   describe("Nodes::Lock", () => {
     it("visits the inner expr (no FOR UPDATE fallback)", () => {
       const visitor = new Visitors.ToSql();

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1316,7 +1316,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitQuoted(node: Nodes.Quoted): SQLString {
-    return this.visitArelNodesCasted(node as unknown as Nodes.Casted);
+    return this.visitArelNodesCasted(node);
   }
 
   protected visitArelNodesCasted(node: Nodes.Casted | Nodes.Quoted): SQLString {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1316,29 +1316,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitQuoted(node: Nodes.Quoted): SQLString {
-    if (
-      this._extractBinds &&
-      node.value !== null &&
-      node.value !== undefined &&
-      typeof node.value === "object" &&
-      "toISOString" in node.value &&
-      typeof (node.value as { toISOString: unknown }).toISOString === "function"
-    ) {
-      // boundary: bind real Date instances directly (drivers handle them
-      // natively). For other objects with a `toISOString()` method, bind the
-      // formatted string so drivers don't receive an unsupported object type.
-      const bind =
-        node.value instanceof Date
-          ? node.value
-          : this.quotedDate(node.value as { toISOString(): string }).slice(1, -1);
-      this.addDateBind(bind);
-    } else {
-      this.collector.append(this.quote(node.value));
-    }
-    return this.collector;
+    return this.visitArelNodesCasted(node as unknown as Nodes.Casted);
   }
 
-  protected visitArelNodesCasted(node: Nodes.Casted): SQLString {
+  protected visitArelNodesCasted(node: Nodes.Casted | Nodes.Quoted): SQLString {
     const value = node.valueForDatabase();
     if (this._extractBinds) {
       this.collector.addBind(value, this.bindBlock());


### PR DESCRIPTION
## Summary

Slice 23b of plan PR 23. Aligns base ToSql with Rails' \`alias :visit_Arel_Nodes_Quoted :visit_Arel_Nodes_Casted\`:

- \`visitArelNodesCasted\` and \`visitQuoted\` now share one body. The shared method calls \`addBind(o.valueForDatabase(), bindBlock())\` under \`_extractBinds\`, else \`quote(o.valueForDatabase())\`.
- Drops the bespoke Date-bind branch in \`visitQuoted\`. The pre-collapse \`addDateBind\` was already \`addBind(value, bindBlock())\`, so Date binds are unchanged. Custom datetime objects (non-\`Date\` with \`toISOString\`) used to be pre-stringified via \`quotedDate\`; they now bind raw, matching Rails' visitor (driver-layer type_cast handles the conversion).

PR 23c (In-array wrap, Table-name-Node, PostgreSQL ESCAPE) follows.

## Test plan

- [x] \`pnpm exec vitest run packages/arel/\` (1257 + 3 new = 1260 passed)
- [x] \`pnpm exec vitest run packages/activerecord/\` (281 files, 9962 passed, no failures vs main)
- [x] \`pnpm parity:query\` (173/204 — identical to baseline)

Refs \`docs/arel-alignment-plan.md\` PR 23b.