### PR TITLE
feat(activerecord): route schema-statements + PG schema quoting through adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/assert-schema-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/assert-schema-adapter.ts
@@ -1,0 +1,25 @@
+import type { DatabaseAdapter } from "../../adapter.js";
+import type { Quoting } from "./quoting-interface.js";
+
+/**
+ * Assert that `adapter` implements the {@link Quoting} surface
+ * `SchemaStatements` depends on, and narrow its type. Used at the
+ * boundary where callers hold a `DatabaseAdapter` reference but the
+ * concrete adapter is known to mix in `Quoting` at runtime. Throws a
+ * descriptive error rather than failing inside a quoting call later.
+ * @internal
+ */
+export function assertSchemaAdapter(
+  adapter: DatabaseAdapter,
+): asserts adapter is DatabaseAdapter & Quoting {
+  const a = adapter as Partial<Quoting>;
+  if (
+    typeof a.quoteIdentifier !== "function" ||
+    typeof a.quoteTableName !== "function" ||
+    typeof a.quoteDefaultExpression !== "function"
+  ) {
+    throw new Error(
+      `Adapter ${(adapter as { adapterName?: string }).adapterName ?? "<unknown>"} does not implement the Quoting surface required by SchemaStatements (quoteIdentifier / quoteTableName / quoteDefaultExpression)`,
+    );
+  }
+}

--- a/packages/activerecord/src/connection-adapters/abstract/assert-schema-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/assert-schema-adapter.ts
@@ -2,7 +2,17 @@ import type { DatabaseAdapter } from "../../adapter.js";
 import type { Quoting } from "./quoting-interface.js";
 
 /**
- * Assert that `adapter` implements the {@link Quoting} surface
+ * Minimal subset of {@link Quoting} that `SchemaStatements` depends
+ * on. Tightening to this surface lets wrapper adapters forward only
+ * what schema operations actually need. @internal
+ */
+export type SchemaQuoter = Pick<
+  Quoting,
+  "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression"
+>;
+
+/**
+ * Assert that `adapter` implements the {@link SchemaQuoter} surface
  * `SchemaStatements` depends on, and narrow its type. Used at the
  * boundary where callers hold a `DatabaseAdapter` reference but the
  * concrete adapter is known to mix in `Quoting` at runtime. Throws a
@@ -11,8 +21,8 @@ import type { Quoting } from "./quoting-interface.js";
  */
 export function assertSchemaAdapter(
   adapter: DatabaseAdapter,
-): asserts adapter is DatabaseAdapter & Quoting {
-  const a = adapter as Partial<Quoting>;
+): asserts adapter is DatabaseAdapter & SchemaQuoter {
+  const a = adapter as Partial<SchemaQuoter>;
   if (
     typeof a.quoteIdentifier !== "function" ||
     typeof a.quoteTableName !== "function" ||

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -25,10 +25,7 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
-import type { Quoting } from "./quoting-interface.js";
-
-/** Subset of {@link Quoting} that schema-creation needs for identifier and value quoting. @internal */
-type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+import type { SchemaQuoter } from "./assert-schema-adapter.js";
 
 /**
  * Build a fallback quoter from the dialect-name string for the legacy

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -479,7 +479,7 @@ export class TableDefinition {
   readonly comment?: string;
   private _id: boolean | PrimaryKeyType;
   private _adapterName: "sqlite" | "postgres" | "mysql";
-  private _adapter: SchemaQuoter;
+  protected _adapter: SchemaQuoter;
 
   constructor(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -4,11 +4,8 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
-import type { Quoting } from "./quoting-interface.js";
+import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { singularize } from "@blazetrails/activesupport";
-
-/** Subset of {@link Quoting} that schema-definitions needs. @internal */
-type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
 
 /**
  * Build a fallback quoter from the dialect-name string for the legacy

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -35,6 +35,8 @@ import { deduplicate } from "../deduplicable.js";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 
+export { assertSchemaAdapter } from "./assert-schema-adapter.js";
+
 export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -27,7 +27,8 @@ import {
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
-import { quoteIdentifier, quoteDefaultExpression, quoteTableName, quote } from "./quoting.js";
+import { quote } from "./quoting.js";
+import type { Quoting } from "./quoting-interface.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
@@ -38,23 +39,23 @@ export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
   constructor(
-    protected adapter: DatabaseAdapter,
+    protected adapter: DatabaseAdapter & Quoting,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
   ) {}
 
   get schemaCreation(): SchemaCreation {
     if (!this._schemaCreation) {
-      this._schemaCreation = new SchemaCreation(this.adapterName);
+      this._schemaCreation = new SchemaCreation(this.adapterName, this.adapter);
     }
     return this._schemaCreation;
   }
 
   protected _qi(name: string): string {
-    return quoteIdentifier(name, this.adapterName);
+    return this.adapter.quoteIdentifier(name);
   }
 
   protected _qt(tableName: string): string {
-    return quoteTableName(tableName, this.adapterName);
+    return this.adapter.quoteTableName(tableName);
   }
 
   async createTable(
@@ -222,7 +223,7 @@ export class SchemaStatements {
 
     if (this.adapterName === "mysql") {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = quoteDefaultExpression(options.default);
+      const defaultClause = this.adapter.quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -234,12 +235,14 @@ export class SchemaStatements {
         );
       }
       if (options.default !== undefined) {
-        clauses.push(`ALTER COLUMN ${col} SET${quoteDefaultExpression(options.default)}`);
+        clauses.push(
+          `ALTER COLUMN ${col} SET${this.adapter.quoteDefaultExpression(options.default)}`,
+        );
       }
       await this.adapter.executeMutation(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = quoteDefaultExpression(options.default);
+      const defaultClause = this.adapter.quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -302,7 +305,7 @@ export class SchemaStatements {
       typeof options === "object" && options !== null && "to" in (options as any)
         ? (options as any).to
         : options;
-    const clause = quoteDefaultExpression(defaultVal);
+    const clause = this.adapter.quoteDefaultExpression(defaultVal);
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET${clause || " DEFAULT NULL"}`,
     );
@@ -315,7 +318,7 @@ export class SchemaStatements {
     defaultValue?: unknown,
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = quoteDefaultExpression(defaultValue).replace(/^ DEFAULT /, "");
+      const quoted = this.adapter.quoteDefaultExpression(defaultValue).replace(/^ DEFAULT /, "");
       await this.adapter.executeMutation(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
@@ -682,7 +685,7 @@ export class SchemaStatements {
       }
       case "mysql": {
         const rows = await this.adapter.execute(
-          `SHOW INDEX FROM ${quoteIdentifier(tableName, "mysql")} WHERE Key_name != 'PRIMARY'`,
+          `SHOW INDEX FROM ${this.adapter.quoteIdentifier(tableName)} WHERE Key_name != 'PRIMARY'`,
         );
         const indexMap = new Map<string, { unique: boolean; seqs: [number, string][] }>();
         for (const row of rows as any[]) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -28,7 +28,7 @@ import {
 import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
 import { quote } from "./quoting.js";
-import type { Quoting } from "./quoting-interface.js";
+import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
@@ -41,7 +41,7 @@ export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
   constructor(
-    protected adapter: DatabaseAdapter & Quoting,
+    protected adapter: DatabaseAdapter & SchemaQuoter,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
   ) {}
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -687,7 +687,7 @@ export class SchemaStatements {
       }
       case "mysql": {
         const rows = await this.adapter.execute(
-          `SHOW INDEX FROM ${this.adapter.quoteIdentifier(tableName)} WHERE Key_name != 'PRIMARY'`,
+          `SHOW INDEX FROM ${this._qt(tableName)} WHERE Key_name != 'PRIMARY'`,
         );
         const indexMap = new Map<string, { unique: boolean; seqs: [number, string][] }>();
         for (const row of rows as any[]) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3751,7 +3751,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   schemaCreation(): PgSchemaCreation {
-    return new PgSchemaCreation();
+    return new PgSchemaCreation(this);
   }
 
   updateTableDefinition(tableName: string, base: unknown): PgTable {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -7,13 +7,15 @@
 import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import type { ForeignKeyDefinition, ReferentialAction } from "../abstract/schema-definitions.js";
-import { quoteIdentifier, quoteTableName } from "../abstract/quoting.js";
+import type { Quoting } from "../abstract/quoting-interface.js";
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { Utils } from "./utils.js";
 
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+
 export class SchemaCreation extends AbstractSchemaCreation {
-  constructor() {
-    super("postgres");
+  constructor(adapter?: SchemaQuoter) {
+    super("postgres", adapter);
   }
 
   protected override visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
@@ -23,6 +25,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     return sql;
   }
 
+  /** @internal */
   visitAddForeignKey(fromTable: string, toTable: string, options: Record<string, unknown>): string {
     const fromName = Utils.extractSchemaQualifiedName(fromTable);
     const toName = Utils.extractSchemaQualifiedName(toTable);
@@ -30,8 +33,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const primaryKey = (options.primaryKey as string) ?? "id";
     const name = (options.name as string) ?? `fk_rails_${fromName.identifier}_${column}`;
 
-    let sql = `ALTER TABLE ${quoteTableName(fromTable, "postgres")} ADD CONSTRAINT ${quoteIdentifier(name, "postgres")} `;
-    sql += `FOREIGN KEY (${quoteIdentifier(column, "postgres")}) REFERENCES ${quoteTableName(toTable, "postgres")} (${quoteIdentifier(primaryKey, "postgres")})`;
+    let sql = `ALTER TABLE ${this.adapter.quoteTableName(fromTable)} ADD CONSTRAINT ${this.adapter.quoteIdentifier(name)} `;
+    sql += `FOREIGN KEY (${this.adapter.quoteIdentifier(column)}) REFERENCES ${this.adapter.quoteTableName(toTable)} (${this.adapter.quoteIdentifier(primaryKey)})`;
 
     if (options.onDelete) {
       sql += ` ${this.actionSql("DELETE", options.onDelete as ReferentialAction)}`;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -7,11 +7,9 @@
 import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import type { ForeignKeyDefinition, ReferentialAction } from "../abstract/schema-definitions.js";
-import type { Quoting } from "../abstract/quoting-interface.js";
+import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { Utils } from "./utils.js";
-
-type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
 
 export class SchemaCreation extends AbstractSchemaCreation {
   constructor(adapter?: SchemaQuoter) {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -20,7 +20,9 @@ import type {
   ColumnType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
-import { quoteIdentifier } from "../abstract/quoting.js";
+import type { Quoting } from "../abstract/quoting-interface.js";
+
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PostgreSQL {
@@ -176,6 +178,7 @@ export class TableDefinition extends AbstractTableDefinition {
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
+      adapter?: SchemaQuoter;
     } = {},
   ) {
     super(tableName, { ...options, adapterName: "postgres" });
@@ -326,7 +329,7 @@ export class TableDefinition extends AbstractTableDefinition {
 
   private exclusionConstraintSql(ec: ExclusionConstraintDefinition): string {
     const parts: string[] = [];
-    if (ec.name) parts.push("CONSTRAINT", quoteIdentifier(ec.name, "postgres"));
+    if (ec.name) parts.push("CONSTRAINT", this._adapter.quoteIdentifier(ec.name));
     parts.push("EXCLUDE");
     if (ec.using) parts.push(`USING ${ec.using}`);
     parts.push(`(${ec.expression})`);
@@ -338,13 +341,13 @@ export class TableDefinition extends AbstractTableDefinition {
   private uniqueConstraintSql(uc: UniqueConstraintDefinition): string {
     const columns = Array.isArray(uc.column) ? uc.column : [uc.column];
     const parts: string[] = [];
-    if (uc.name) parts.push("CONSTRAINT", quoteIdentifier(uc.name, "postgres"));
+    if (uc.name) parts.push("CONSTRAINT", this._adapter.quoteIdentifier(uc.name));
     parts.push("UNIQUE");
     if (uc.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
     if (uc.usingIndex) {
-      parts.push(`USING INDEX ${quoteIdentifier(uc.usingIndex, "postgres")}`);
+      parts.push(`USING INDEX ${this._adapter.quoteIdentifier(uc.usingIndex)}`);
     } else {
-      parts.push(`(${columns.map((c) => quoteIdentifier(c, "postgres")).join(", ")})`);
+      parts.push(`(${columns.map((c) => this._adapter.quoteIdentifier(c)).join(", ")})`);
     }
     parts.push(...deferrableSql(uc.deferrable));
     return parts.join(" ");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -20,9 +20,7 @@ import type {
   ColumnType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
-import type { Quoting } from "../abstract/quoting-interface.js";
-
-type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PostgreSQL {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2027,6 +2027,10 @@ function mockMigration(): { migration: Migration; sql: string[] } {
     createSavepoint: async () => {},
     releaseSavepoint: async () => {},
     rollbackToSavepoint: async () => {},
+    quoteIdentifier: (n: string) => `"${n.replace(/"/g, '""')}"`,
+    quoteTableName: (n: string) => `"${n.replace(/"/g, '""')}"`,
+    quoteColumnName: (n: string) => `"${n.replace(/"/g, '""')}"`,
+    quoteDefaultExpression: (v: unknown) => (v === undefined ? "" : ` DEFAULT ${String(v)}`),
   };
   return { migration, sql };
 }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -8,6 +8,7 @@ import { Base, MigrationContext, MigrationRunner, Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { createTestAdapter, adapterType } from "./test-adapter.js";
+import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Migration } from "./migration.js";
 import { Logger } from "@blazetrails/activesupport";
@@ -2030,7 +2031,7 @@ function mockMigration(): { migration: Migration; sql: string[] } {
     quoteIdentifier: (n: string) => `"${n.replace(/"/g, '""')}"`,
     quoteTableName: (n: string) => `"${n.replace(/"/g, '""')}"`,
     quoteColumnName: (n: string) => `"${n.replace(/"/g, '""')}"`,
-    quoteDefaultExpression: (v: unknown) => (v === undefined ? "" : ` DEFAULT ${String(v)}`),
+    quoteDefaultExpression: quoteDefaultExpression,
   };
   return { migration, sql };
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -9,8 +9,10 @@ import {
   type ColumnOptions,
   type AddForeignKeyOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
-import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
-import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
+import {
+  SchemaStatements,
+  assertSchemaAdapter,
+} from "./connection-adapters/abstract/schema-statements.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
@@ -171,7 +173,8 @@ export abstract class Migration {
 
   get schema(): SchemaStatements {
     if (!this._schema) {
-      this._schema = new SchemaStatements(this.adapter as DatabaseAdapter & Quoting);
+      assertSchemaAdapter(this.adapter);
+      this._schema = new SchemaStatements(this.adapter);
     }
     return this._schema;
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -10,6 +10,7 @@ import {
   type AddForeignKeyOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
@@ -170,7 +171,7 @@ export abstract class Migration {
 
   get schema(): SchemaStatements {
     if (!this._schema) {
-      this._schema = new SchemaStatements(this.adapter);
+      this._schema = new SchemaStatements(this.adapter as DatabaseAdapter & Quoting);
     }
     return this._schema;
   }

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -598,6 +598,36 @@ describe("QueryCache executor hooks", () => {
     expect(adapter.cache.size).toBe(0);
   });
 
+  it("forwards Quoting methods to inner adapter", () => {
+    const inner = createTestAdapter();
+    const adapter = new QueryCacheAdapter(inner);
+    expect(adapter.quoteIdentifier("users")).toBe(
+      (inner as unknown as { quoteIdentifier(n: string): string }).quoteIdentifier("users"),
+    );
+    expect(adapter.quoteTableName("public.users")).toBe(
+      (inner as unknown as { quoteTableName(n: string): string }).quoteTableName("public.users"),
+    );
+    expect(adapter.quoteColumnName("id")).toBe(
+      (inner as unknown as { quoteColumnName(n: string): string }).quoteColumnName("id"),
+    );
+    expect(adapter.quoteDefaultExpression("foo")).toBe(
+      (inner as unknown as { quoteDefaultExpression(v: unknown): string }).quoteDefaultExpression(
+        "foo",
+      ),
+    );
+  });
+
+  it("Quoting forwarders throw a descriptive error when inner does not implement them", () => {
+    const stub = { adapterName: "stub" } as unknown as ConstructorParameters<
+      typeof QueryCacheAdapter
+    >[0];
+    const adapter = new QueryCacheAdapter(stub);
+    expect(() => adapter.quoteIdentifier("x")).toThrow(/quoteIdentifier/);
+    expect(() => adapter.quoteTableName("x")).toThrow(/quoteTableName/);
+    expect(() => adapter.quoteColumnName("x")).toThrow(/quoteColumnName/);
+    expect(() => adapter.quoteDefaultExpression("x")).toThrow(/quoteDefaultExpression/);
+  });
+
   it("installExecutorHooks wires run/complete to executor", () => {
     const inner = createTestAdapter();
     const adapter = new QueryCacheAdapter(inner);

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -343,6 +343,39 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     );
   }
 
+  quoteIdentifier(name: string): string {
+    const inner = this.inner as { quoteIdentifier?: (n: string) => string };
+    if (typeof inner.quoteIdentifier === "function") return inner.quoteIdentifier(name);
+    throw new Error(
+      `QueryCacheAdapter.quoteIdentifier: wrapped ${this.inner.adapterName} does not implement quoteIdentifier()`,
+    );
+  }
+
+  quoteTableName(name: string): string {
+    const inner = this.inner as { quoteTableName?: (n: string) => string };
+    if (typeof inner.quoteTableName === "function") return inner.quoteTableName(name);
+    throw new Error(
+      `QueryCacheAdapter.quoteTableName: wrapped ${this.inner.adapterName} does not implement quoteTableName()`,
+    );
+  }
+
+  quoteColumnName(name: string): string {
+    const inner = this.inner as { quoteColumnName?: (n: string) => string };
+    if (typeof inner.quoteColumnName === "function") return inner.quoteColumnName(name);
+    throw new Error(
+      `QueryCacheAdapter.quoteColumnName: wrapped ${this.inner.adapterName} does not implement quoteColumnName()`,
+    );
+  }
+
+  quoteDefaultExpression(value: unknown): string {
+    const inner = this.inner as { quoteDefaultExpression?: (v: unknown) => string };
+    if (typeof inner.quoteDefaultExpression === "function")
+      return inner.quoteDefaultExpression(value);
+    throw new Error(
+      `QueryCacheAdapter.quoteDefaultExpression: wrapped ${this.inner.adapterName} does not implement quoteDefaultExpression()`,
+    );
+  }
+
   // --- DatabaseStatements ---
   // Read methods go through this.execute() to leverage the query cache.
   // Write methods go through this.executeMutation() to clear the cache.

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -22,6 +22,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 // cycle that `ReferenceError`s on evaluation order. We lazy-import
 // the implementation inside `AdapterSchemaSource.indexes()` below.
 import type { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
 import { SchemaMigration } from "./schema-migration.js";
 
@@ -313,7 +314,7 @@ class AdapterSchemaSource implements SchemaSource {
   async indexes(tableName: string): Promise<IndexInfo[]> {
     if (!this._schema) {
       const mod = await import("./connection-adapters/abstract/schema-statements.js");
-      this._schema = new mod.SchemaStatements(this._adapter);
+      this._schema = new mod.SchemaStatements(this._adapter as DatabaseAdapter & Quoting);
     }
     const idxs = await this._schema.indexes(tableName);
     return idxs.map((idx) => ({

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -22,7 +22,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 // cycle that `ReferenceError`s on evaluation order. We lazy-import
 // the implementation inside `AdapterSchemaSource.indexes()` below.
 import type { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
-import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
+import { assertSchemaAdapter } from "./connection-adapters/abstract/assert-schema-adapter.js";
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
 import { SchemaMigration } from "./schema-migration.js";
 
@@ -314,7 +314,8 @@ class AdapterSchemaSource implements SchemaSource {
   async indexes(tableName: string): Promise<IndexInfo[]> {
     if (!this._schema) {
       const mod = await import("./connection-adapters/abstract/schema-statements.js");
-      this._schema = new mod.SchemaStatements(this._adapter as DatabaseAdapter & Quoting);
+      assertSchemaAdapter(this._adapter);
+      this._schema = new mod.SchemaStatements(this._adapter);
     }
     const idxs = await this._schema.indexes(tableName);
     return idxs.map((idx) => ({

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -14,8 +14,10 @@
  */
 
 import type { DatabaseAdapter } from "./adapter.js";
-import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
-import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import {
+  SchemaStatements,
+  assertSchemaAdapter,
+} from "./connection-adapters/abstract/schema-statements.js";
 import type { Column } from "./connection-adapters/column.js";
 import type { ForeignKeyDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 
@@ -65,7 +67,8 @@ function schemaStatementsFor(adapter: DatabaseAdapter): SchemaStatements {
   const key = adapter as unknown as object;
   let s = SCHEMA_STATEMENTS.get(key);
   if (!s) {
-    s = new SchemaStatements(adapter as DatabaseAdapter & Quoting);
+    assertSchemaAdapter(adapter);
+    s = new SchemaStatements(adapter);
     SCHEMA_STATEMENTS.set(key, s);
   }
   return s;

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -14,6 +14,7 @@
  */
 
 import type { DatabaseAdapter } from "./adapter.js";
+import type { Quoting } from "./connection-adapters/abstract/quoting-interface.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import type { Column } from "./connection-adapters/column.js";
 import type { ForeignKeyDefinition } from "./connection-adapters/abstract/schema-definitions.js";
@@ -64,7 +65,7 @@ function schemaStatementsFor(adapter: DatabaseAdapter): SchemaStatements {
   const key = adapter as unknown as object;
   let s = SCHEMA_STATEMENTS.get(key);
   if (!s) {
-    s = new SchemaStatements(adapter);
+    s = new SchemaStatements(adapter as DatabaseAdapter & Quoting);
     SCHEMA_STATEMENTS.set(key, s);
   }
   return s;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -760,6 +760,24 @@ class SchemaAdapter implements DatabaseAdapter {
     );
   }
 
+  quoteIdentifier(name: string): string {
+    return (this.inner as { quoteIdentifier(n: string): string }).quoteIdentifier(name);
+  }
+
+  quoteTableName(name: string): string {
+    return (this.inner as { quoteTableName(n: string): string }).quoteTableName(name);
+  }
+
+  quoteColumnName(name: string): string {
+    return (this.inner as { quoteColumnName(n: string): string }).quoteColumnName(name);
+  }
+
+  quoteDefaultExpression(value: unknown): string {
+    return (this.inner as { quoteDefaultExpression(v: unknown): string }).quoteDefaultExpression(
+      value,
+    );
+  }
+
   async cleanup(): Promise<void> {
     await dropAllTables(this.inner);
   }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -761,20 +761,35 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   quoteIdentifier(name: string): string {
-    return (this.inner as { quoteIdentifier(n: string): string }).quoteIdentifier(name);
+    const inner = this.inner as { quoteIdentifier?: (n: string) => string };
+    if (typeof inner.quoteIdentifier === "function") return inner.quoteIdentifier(name);
+    throw new Error(
+      `SchemaAdapter.quoteIdentifier: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quoteIdentifier()`,
+    );
   }
 
   quoteTableName(name: string): string {
-    return (this.inner as { quoteTableName(n: string): string }).quoteTableName(name);
+    const inner = this.inner as { quoteTableName?: (n: string) => string };
+    if (typeof inner.quoteTableName === "function") return inner.quoteTableName(name);
+    throw new Error(
+      `SchemaAdapter.quoteTableName: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quoteTableName()`,
+    );
   }
 
   quoteColumnName(name: string): string {
-    return (this.inner as { quoteColumnName(n: string): string }).quoteColumnName(name);
+    const inner = this.inner as { quoteColumnName?: (n: string) => string };
+    if (typeof inner.quoteColumnName === "function") return inner.quoteColumnName(name);
+    throw new Error(
+      `SchemaAdapter.quoteColumnName: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quoteColumnName()`,
+    );
   }
 
   quoteDefaultExpression(value: unknown): string {
-    return (this.inner as { quoteDefaultExpression(v: unknown): string }).quoteDefaultExpression(
-      value,
+    const inner = this.inner as { quoteDefaultExpression?: (v: unknown) => string };
+    if (typeof inner.quoteDefaultExpression === "function")
+      return inner.quoteDefaultExpression(value);
+    throw new Error(
+      `SchemaAdapter.quoteDefaultExpression: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quoteDefaultExpression()`,
     );
   }
 


### PR DESCRIPTION
## Summary

Phase 3 / PR 7 of the quoting refactor (docs/quoting-refactor.md).

- `abstract/schema-statements.ts`: dispatches identifier / table / default-expression quoting through `this.adapter` (typed as `DatabaseAdapter & Quoting`); `_qi` / `_qt` resolve through the adapter; the `mysql` `SHOW INDEX` site does too. The `schemaCreation` getter now passes `this.adapter` so PR 6's optional-adapter path activates here.
- `postgresql/schema-creation.ts`: constructor takes an optional `SchemaQuoter`; `visitAddForeignKey` routes table/identifier quoting through `this.adapter`.
- `postgresql/schema-definitions.ts`: `TableDefinition` exposes the inherited `_adapter` (now `protected` on the abstract base); the four exclusion/unique constraint identifier quotes now go through `this._adapter.quoteIdentifier`.
- `postgresql-adapter.ts`: `schemaCreation()` constructs `new PgSchemaCreation(this)` so the live adapter is wired.
- Three call sites that instantiate `SchemaStatements` (`migration.ts`, `schema-dumper.ts`, `schema-introspection.ts`) cast to `DatabaseAdapter & Quoting` at the boundary; runtime adapters already implement `Quoting`.
- `test-adapter.ts` (`SchemaAdapter`) and `migration.test.ts` `mockMigration` gain Quoting forwarders so existing tests still pass.

The `adapterName` field stays — type-mapping branches (`"DOUBLE PRECISION"` vs `"REAL"`) are pre-existing trails-specific dispatch and not part of this refactor.

Out of scope: PRs 8–10 (model-schema / internal-metadata / primary-key / migration / alias-tracker / association-scope, and the eventual removal of the `quoterForAdapterName` fallback).

Gates (non-decreasing):
- Data layer: 4190/4503 (93%)
- test:compare: 11833/21679 (54.6%)

LOC (excluding lockfiles/snapshots): ~60.

## Test plan

- [x] pnpm typecheck
- [x] pnpm exec vitest run packages/activerecord/src
- [x] pnpm api:compare (Data layer non-decreasing)
- [x] pnpm test:compare (Overall non-decreasing)