### PR TITLE
feat(activerecord): route schema-statements + PG schema quoting through adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -479,7 +479,7 @@ export class TableDefinition {
   readonly comment?: string;
   private _id: boolean | PrimaryKeyType;
   private _adapterName: "sqlite" | "postgres" | "mysql";
-  private _adapter: SchemaQuoter;
+  protected _adapter: SchemaQuoter;
 
   constructor(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -10,6 +10,12 @@
 
 import { NotImplementedError } from "../../errors.js";
 import type { DatabaseAdapter } from "../../adapter.js";
+import type { Quoting } from "./quoting-interface.js";
+import {
+  quoteIdentifier as abstractQuoteIdentifier,
+  quoteTableName as abstractQuoteTableName,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
+} from "./quoting.js";
 import {
   TableDefinition,
   Table,
@@ -27,34 +33,62 @@ import {
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
-import { quoteIdentifier, quoteDefaultExpression, quoteTableName, quote } from "./quoting.js";
+import { quote } from "./quoting.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+
+/**
+ * Build a fallback quoter from the dialect-name string for the legacy
+ * code path where the adapter passed in does not yet implement the
+ * Quoting interface. Removed in PR 10. @internal
+ */
+function isSchemaQuoter(value: unknown): value is SchemaQuoter {
+  const v = value as Partial<SchemaQuoter> | null;
+  return (
+    !!v &&
+    typeof v.quoteIdentifier === "function" &&
+    typeof v.quoteTableName === "function" &&
+    typeof v.quoteDefaultExpression === "function"
+  );
+}
+
+function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+  return {
+    quoteIdentifier: (n) => abstractQuoteIdentifier(n, name),
+    quoteTableName: (n) => abstractQuoteTableName(n, name),
+    quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
+  };
+}
+
 export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
+  protected _quoter: SchemaQuoter;
 
   constructor(
     protected adapter: DatabaseAdapter,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
-  ) {}
+  ) {
+    this._quoter = isSchemaQuoter(adapter) ? adapter : quoterForAdapterName(adapterName);
+  }
 
   get schemaCreation(): SchemaCreation {
     if (!this._schemaCreation) {
-      this._schemaCreation = new SchemaCreation(this.adapterName);
+      this._schemaCreation = new SchemaCreation(this.adapterName, this._quoter);
     }
     return this._schemaCreation;
   }
 
   protected _qi(name: string): string {
-    return quoteIdentifier(name, this.adapterName);
+    return this._quoter.quoteIdentifier(name);
   }
 
   protected _qt(tableName: string): string {
-    return quoteTableName(tableName, this.adapterName);
+    return this._quoter.quoteTableName(tableName);
   }
 
   async createTable(
@@ -222,7 +256,7 @@ export class SchemaStatements {
 
     if (this.adapterName === "mysql") {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = quoteDefaultExpression(options.default);
+      const defaultClause = this._quoter.quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -234,12 +268,14 @@ export class SchemaStatements {
         );
       }
       if (options.default !== undefined) {
-        clauses.push(`ALTER COLUMN ${col} SET${quoteDefaultExpression(options.default)}`);
+        clauses.push(
+          `ALTER COLUMN ${col} SET${this._quoter.quoteDefaultExpression(options.default)}`,
+        );
       }
       await this.adapter.executeMutation(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = quoteDefaultExpression(options.default);
+      const defaultClause = this._quoter.quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -302,7 +338,7 @@ export class SchemaStatements {
       typeof options === "object" && options !== null && "to" in (options as any)
         ? (options as any).to
         : options;
-    const clause = quoteDefaultExpression(defaultVal);
+    const clause = this._quoter.quoteDefaultExpression(defaultVal);
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET${clause || " DEFAULT NULL"}`,
     );
@@ -315,7 +351,7 @@ export class SchemaStatements {
     defaultValue?: unknown,
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = quoteDefaultExpression(defaultValue).replace(/^ DEFAULT /, "");
+      const quoted = this._quoter.quoteDefaultExpression(defaultValue).replace(/^ DEFAULT /, "");
       await this.adapter.executeMutation(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
@@ -682,7 +718,7 @@ export class SchemaStatements {
       }
       case "mysql": {
         const rows = await this.adapter.execute(
-          `SHOW INDEX FROM ${quoteIdentifier(tableName, "mysql")} WHERE Key_name != 'PRIMARY'`,
+          `SHOW INDEX FROM ${this._quoter.quoteIdentifier(tableName)} WHERE Key_name != 'PRIMARY'`,
         );
         const indexMap = new Map<string, { unique: boolean; seqs: [number, string][] }>();
         for (const row of rows as any[]) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3751,7 +3751,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   schemaCreation(): PgSchemaCreation {
-    return new PgSchemaCreation();
+    return new PgSchemaCreation(this);
   }
 
   updateTableDefinition(tableName: string, base: unknown): PgTable {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -7,13 +7,15 @@
 import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import type { ForeignKeyDefinition, ReferentialAction } from "../abstract/schema-definitions.js";
-import { quoteIdentifier, quoteTableName } from "../abstract/quoting.js";
+import type { Quoting } from "../abstract/quoting-interface.js";
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { Utils } from "./utils.js";
 
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
+
 export class SchemaCreation extends AbstractSchemaCreation {
-  constructor() {
-    super("postgres");
+  constructor(adapter?: SchemaQuoter) {
+    super("postgres", adapter);
   }
 
   protected override visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
@@ -23,6 +25,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     return sql;
   }
 
+  /** @internal */
   visitAddForeignKey(fromTable: string, toTable: string, options: Record<string, unknown>): string {
     const fromName = Utils.extractSchemaQualifiedName(fromTable);
     const toName = Utils.extractSchemaQualifiedName(toTable);
@@ -30,8 +33,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const primaryKey = (options.primaryKey as string) ?? "id";
     const name = (options.name as string) ?? `fk_rails_${fromName.identifier}_${column}`;
 
-    let sql = `ALTER TABLE ${quoteTableName(fromTable, "postgres")} ADD CONSTRAINT ${quoteIdentifier(name, "postgres")} `;
-    sql += `FOREIGN KEY (${quoteIdentifier(column, "postgres")}) REFERENCES ${quoteTableName(toTable, "postgres")} (${quoteIdentifier(primaryKey, "postgres")})`;
+    let sql = `ALTER TABLE ${this.adapter.quoteTableName(fromTable)} ADD CONSTRAINT ${this.adapter.quoteIdentifier(name)} `;
+    sql += `FOREIGN KEY (${this.adapter.quoteIdentifier(column)}) REFERENCES ${this.adapter.quoteTableName(toTable)} (${this.adapter.quoteIdentifier(primaryKey)})`;
 
     if (options.onDelete) {
       sql += ` ${this.actionSql("DELETE", options.onDelete as ReferentialAction)}`;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -20,7 +20,9 @@ import type {
   ColumnType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
-import { quoteIdentifier } from "../abstract/quoting.js";
+import type { Quoting } from "../abstract/quoting-interface.js";
+
+type SchemaQuoter = Pick<Quoting, "quoteIdentifier" | "quoteTableName" | "quoteDefaultExpression">;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PostgreSQL {
@@ -176,6 +178,7 @@ export class TableDefinition extends AbstractTableDefinition {
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
+      adapter?: SchemaQuoter;
     } = {},
   ) {
     super(tableName, { ...options, adapterName: "postgres" });
@@ -326,7 +329,7 @@ export class TableDefinition extends AbstractTableDefinition {
 
   private exclusionConstraintSql(ec: ExclusionConstraintDefinition): string {
     const parts: string[] = [];
-    if (ec.name) parts.push("CONSTRAINT", quoteIdentifier(ec.name, "postgres"));
+    if (ec.name) parts.push("CONSTRAINT", this._adapter.quoteIdentifier(ec.name));
     parts.push("EXCLUDE");
     if (ec.using) parts.push(`USING ${ec.using}`);
     parts.push(`(${ec.expression})`);
@@ -338,13 +341,13 @@ export class TableDefinition extends AbstractTableDefinition {
   private uniqueConstraintSql(uc: UniqueConstraintDefinition): string {
     const columns = Array.isArray(uc.column) ? uc.column : [uc.column];
     const parts: string[] = [];
-    if (uc.name) parts.push("CONSTRAINT", quoteIdentifier(uc.name, "postgres"));
+    if (uc.name) parts.push("CONSTRAINT", this._adapter.quoteIdentifier(uc.name));
     parts.push("UNIQUE");
     if (uc.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
     if (uc.usingIndex) {
-      parts.push(`USING INDEX ${quoteIdentifier(uc.usingIndex, "postgres")}`);
+      parts.push(`USING INDEX ${this._adapter.quoteIdentifier(uc.usingIndex)}`);
     } else {
-      parts.push(`(${columns.map((c) => quoteIdentifier(c, "postgres")).join(", ")})`);
+      parts.push(`(${columns.map((c) => this._adapter.quoteIdentifier(c)).join(", ")})`);
     }
     parts.push(...deferrableSql(uc.deferrable));
     return parts.join(" ");


### PR DESCRIPTION
## Summary

Phase 3 / PR 7 of the Quoting refactor (docs/quoting-refactor.md).

- `abstract/schema-statements.ts`: replace standalone `quoteIdentifier` / `quoteTableName` / `quoteDefaultExpression` calls with `this._quoter.*`. The quoter is resolved from the adapter when it implements `Quoting`, otherwise built from the dialect-name string (legacy fallback removed in PR 10). `SchemaCreation` construction now forwards the resolved quoter so PR 6's adapter path becomes active here.
- `postgresql/schema-creation.ts`: accept an optional quoter and route `visitAddForeignKey` identifier/table-name quoting through it.
- `postgresql/schema-definitions.ts`: route exclusion/unique constraint identifier quoting through the inherited `_adapter` quoter (now `protected` on `AbstractTableDefinition`).
- `postgresql-adapter.ts`: pass `this` when constructing `PgSchemaCreation` so the live adapter's `Quoting` impl is used at runtime.

Out of scope: PRs 8–10 (model-schema/internal-metadata/primary-key/migration/alias-tracker/association-scope, and final cleanup of the dialect-name fallback).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/activerecord/src` — 9962 passed, 3372 skipped
- [x] `pnpm api:compare` — Data layer 4190/4503 (93%), unchanged
- [x] `pnpm test:compare` — 11833/21679 (54.6%), unchanged
- [x] `git diff --shortstat` — 5 files, +65/-23 LOC