### PR TITLE
feat(activemodel): port B7b attribute leaf privates

### DIFF
--- a/packages/activemodel/src/attribute-mutation-tracker.test.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.test.ts
@@ -73,6 +73,17 @@ describe("AttributeMutationTracker", () => {
     expect(tracker.isChanged("name", { to: "Charlie" })).toBe(false);
   });
 
+  it("isChanged type-casts from/to candidates against the attribute type", () => {
+    const set = buildSet({ age: 30 });
+    const tracker = new AttributeMutationTracker(set);
+
+    set.writeFromUser("age", 31);
+    // String "30" / "31" cast to integers should match the typed values.
+    expect(tracker.isChanged("age", { from: "30", to: "31" })).toBe(true);
+    expect(tracker.isChanged("age", { from: "29" })).toBe(false);
+    expect(tracker.isChanged("age", { to: "32" })).toBe(false);
+  });
+
   it("changedValues returns original values for changed attrs", () => {
     const set = buildSet({ name: "Alice", age: 30 });
     const tracker = new AttributeMutationTracker(set);

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -73,7 +73,7 @@ export class AttributeMutationTracker {
 
   changeToAttribute(name: string): [unknown, unknown] | undefined {
     if (this.isChanged(name)) {
-      return [this.originalValue(name), this.attributes.fetchValue(name)];
+      return [this.originalValue(name), this.fetchValue(name)];
     }
     return undefined;
   }
@@ -84,9 +84,17 @@ export class AttributeMutationTracker {
 
   isChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
     if (!this.attributeChanged(name)) return false;
-    if (options && "from" in options && !valuesEqual(this.originalValue(name), options.from))
+    if (
+      options &&
+      "from" in options &&
+      !valuesEqual(this.originalValue(name), this.typeCast(name, options.from))
+    )
       return false;
-    if (options && "to" in options && !valuesEqual(this.attributes.fetchValue(name), options.to))
+    if (
+      options &&
+      "to" in options &&
+      !valuesEqual(this.fetchValue(name), this.typeCast(name, options.to))
+    )
       return false;
     return true;
   }
@@ -112,7 +120,7 @@ export class AttributeMutationTracker {
 
   forceChange(name: string): void {
     if (this.forcedChanges.has(name)) return;
-    const value = this.attributes.fetchValue(name);
+    const value = this.fetchValue(name);
     this.forcedChanges.set(name, cloneValue(value));
   }
 
@@ -124,6 +132,16 @@ export class AttributeMutationTracker {
     const keys = new Set(this.attributes.keys());
     for (const name of this.forcedChanges.keys()) keys.add(name);
     return [...keys];
+  }
+
+  /** @internal */
+  protected fetchValue(name: string): unknown {
+    return this.attributes.fetchValue(name);
+  }
+
+  /** @internal */
+  protected typeCast(name: string, value: unknown): unknown {
+    return this.attributes.getAttribute(name).typeCast(value);
   }
 }
 
@@ -165,17 +183,22 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
     if (this.isChanged(name)) {
       return this.forcedChanges.get(name);
     }
-    return this.attributes.fetchValue(name);
+    return this.fetchValue(name);
   }
 
   forceChange(name: string): void {
     if (this.forcedChanges.has(name)) return;
-    const value = this.attributes.fetchValue(name);
+    const value = this.fetchValue(name);
     this.forcedChanges.set(name, cloneValue(value));
   }
 
   finalizeChanges(): void {
     this.finalizedChanges = this.changes();
+  }
+
+  /** @internal */
+  protected override typeCast(_name: string, value: unknown): unknown {
+    return value;
   }
 }
 

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -42,7 +42,7 @@ export class AttributeSet {
    * Get the Attribute instance for a name.
    */
   getAttribute(name: string): Attribute {
-    return this.attributes.get(name) ?? Attribute.null(name);
+    return this.attributes.get(name) ?? this.defaultAttribute(name);
   }
 
   /**
@@ -52,6 +52,11 @@ export class AttributeSet {
     const attr = this.attributes.get(name);
     if (!attr) return undefined;
     return attr.value;
+  }
+
+  /** @internal */
+  private defaultAttribute(name: string): Attribute {
+    return Attribute.null(name);
   }
 
   set(name: string, attrOrValue: Attribute | unknown): void {

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -55,7 +55,7 @@ export class AttributeSet {
   }
 
   /** @internal */
-  private defaultAttribute(name: string): Attribute {
+  protected defaultAttribute(name: string): Attribute {
     return Attribute.null(name);
   }
 

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -25,7 +25,7 @@ export abstract class Attribute {
   private originalAttribute: Attribute | null;
   private _value: unknown;
   private _hasValue: boolean;
-  private _valueForDatabase: unknown;
+  private _cachedValueForDatabase: unknown;
   private _hasValueForDatabase: boolean;
 
   constructor(
@@ -47,7 +47,7 @@ export abstract class Attribute {
       this._value = undefined;
       this._hasValue = false;
     }
-    this._valueForDatabase = undefined;
+    this._cachedValueForDatabase = undefined;
     this._hasValueForDatabase = false;
   }
 
@@ -72,10 +72,15 @@ export abstract class Attribute {
 
   get valueForDatabase(): unknown {
     if (!this._hasValueForDatabase || this.changedInPlace()) {
-      this._valueForDatabase = this.type.serialize(this.value);
+      this._cachedValueForDatabase = this._valueForDatabase();
       this._hasValueForDatabase = true;
     }
-    return this._valueForDatabase;
+    return this._cachedValueForDatabase;
+  }
+
+  /** @internal */
+  protected _valueForDatabase(): unknown {
+    return this.type.serialize(this.value);
   }
 
   isChanged(): boolean {
@@ -126,8 +131,13 @@ export abstract class Attribute {
   overrideCastValue(value: unknown): void {
     this._value = value;
     this._hasValue = true;
-    this._valueForDatabase = undefined;
+    this._cachedValueForDatabase = undefined;
     this._hasValueForDatabase = false;
+  }
+
+  /** @internal */
+  protected _originalValueForDatabase(): unknown {
+    return this.type.serialize(this.originalValue);
   }
 
   equals(other: Attribute): boolean {
@@ -150,7 +160,7 @@ export abstract class Attribute {
     if (this.originalAttribute !== null) {
       return this.originalAttribute.originalValueForDatabase();
     }
-    return this.type.serialize(this.originalValue);
+    return this._originalValueForDatabase();
   }
 
   withUserDefault(value: unknown): Attribute {
@@ -245,6 +255,11 @@ export class FromDatabase extends Attribute {
   typeCast(value: unknown): unknown {
     return this.type.deserialize(value);
   }
+
+  /** @internal */
+  protected override _originalValueForDatabase(): unknown {
+    return this.valueBeforeTypeCast;
+  }
 }
 
 export class FromUser extends Attribute {
@@ -254,6 +269,15 @@ export class FromUser extends Attribute {
 
   cameFromUser(): boolean {
     return !this.type.isValueConstructedByMassAssignment(this.valueBeforeTypeCast);
+  }
+
+  /** @internal */
+  protected override _valueForDatabase(): unknown {
+    const compatible = this.type.itselfIfSerializeCastValueCompatible();
+    if (compatible === this.type) {
+      return this.type.serializeCastValue(this.value);
+    }
+    return this.type.serialize(this.value);
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the **B7b — Attribute leaves** track from `docs/activemodel-privates-100-plan.md`.

- `Attribute`: introduces `_valueForDatabase()` / `_originalValueForDatabase()` protected indirection mirroring Rails. `FromDatabase` overrides `_originalValueForDatabase` to return `valueBeforeTypeCast` (skips redundant re-serialization). `FromUser` overrides `_valueForDatabase` to use the `serializeCastValue` fast path when the type is compatible (`Type::SerializeCastValue.serialize` parity).
- `AttributeMutationTracker`: adds `fetchValue` and `typeCast` private helpers. `isChanged({from, to})` now type-casts the `from`/`to` candidates against the attribute type before comparing — matching Rails. `ForcedMutationTracker` overrides `typeCast` as a no-op (Rails parity).
- `AttributeSet`: adds `defaultAttribute(name)` private helper, routing `getAttribute` through it.

Renamed the cache field `_valueForDatabase` → `_cachedValueForDatabase` to free up the method name.

## Score

`pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel`:

- Before: **566/625 (90.6%)**
- After: **578/625 (92.5%)**

`attribute.rb`, `attribute_mutation_tracker.rb`, and `attribute_set.rb` are now at 100%. The 4 remaining misses in `attribute_set/builder.rb` (`additionalTypes`, `materialize`, `delegateHash`, `assignDefaultValue`) are out of B7b scope — they require fleshing out `LazyAttributeSet` materialization.

## Test plan

- [x] `pnpm exec vitest run packages/activemodel` — 1631 passed
- [x] `pnpm exec vitest run packages/activerecord/src/dirty` — 85 passed
- [x] `pnpm exec eslint` on touched files clean
- [x] LOC: 65 insertions, 13 deletions