### PR TITLE
fix(arel): PR 23c — in-array wrap, Table-name Node, PG ESCAPE Node

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -162,7 +162,7 @@ export class Attribute extends Node {
 
   matches(
     pattern: string | { ast: Node },
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ): Matches {
     const right =
@@ -172,7 +172,7 @@ export class Attribute extends Node {
 
   doesNotMatch(
     pattern: string | { ast: Node },
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ): DoesNotMatch {
     const right =

--- a/packages/arel/src/nodes/matches.ts
+++ b/packages/arel/src/nodes/matches.ts
@@ -1,12 +1,13 @@
 import { Binary, NodeOrValue } from "./binary.js";
+import type { Node } from "./node.js";
 
 export class Matches extends Binary {
-  escape: string | null;
+  escape: string | Node | null;
   caseSensitive: boolean;
   constructor(
     left: NodeOrValue,
     right: NodeOrValue,
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ) {
     super(left, right);
@@ -16,12 +17,12 @@ export class Matches extends Binary {
 }
 
 export class DoesNotMatch extends Binary {
-  escape: string | null;
+  escape: string | Node | null;
   caseSensitive: boolean;
   constructor(
     left: NodeOrValue,
     right: NodeOrValue,
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ) {
     super(left, right);

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -110,7 +110,7 @@ export const Predications = {
   matches(
     this: PredicationHost,
     pattern: unknown,
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ): Matches {
     // Rails: `Nodes::Matches.new self, quoted_node(other), ...`.
@@ -122,7 +122,7 @@ export const Predications = {
   doesNotMatch(
     this: PredicationHost,
     pattern: unknown,
-    escape: string | null = null,
+    escape: string | Node | null = null,
     caseSensitive = false,
   ): DoesNotMatch {
     return new DoesNotMatch(

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -414,4 +414,24 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     // GroupingElement itself uses the helper too.
     expect(compile(new Nodes.GroupingElement([users.get("a")]))).toBe('( "users"."a" )');
   });
+
+  describe("Matches ESCAPE", () => {
+    it("hard-quotes a string escape", () => {
+      const node = new Nodes.Matches(users.get("name"), "x%", "!");
+      const sql = new Visitors.PostgreSQL().compile(node);
+      expect(sql).toContain("ESCAPE '!'");
+    });
+
+    it("visits a Node escape", () => {
+      const node = new Nodes.Matches(users.get("name"), "x%", new Nodes.SqlLiteral("'!'"));
+      const sql = new Visitors.PostgreSQL().compile(node);
+      expect(sql).toContain("ESCAPE '!'");
+    });
+
+    it("visits a Node escape on DoesNotMatch", () => {
+      const node = new Nodes.DoesNotMatch(users.get("name"), "x%", new Nodes.SqlLiteral("'!'"));
+      const sql = new Visitors.PostgreSQL().compile(node);
+      expect(sql).toContain("ESCAPE '!'");
+    });
+  });
 });

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -423,13 +423,13 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     });
 
     it("visits a Node escape", () => {
-      const node = new Nodes.Matches(users.get("name"), "x%", new Nodes.SqlLiteral("'!'"));
+      const node = new Nodes.Matches(users.get("name"), "x%", new Nodes.Quoted("!"));
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
 
     it("visits a Node escape on DoesNotMatch", () => {
-      const node = new Nodes.DoesNotMatch(users.get("name"), "x%", new Nodes.SqlLiteral("'!'"));
+      const node = new Nodes.DoesNotMatch(users.get("name"), "x%", new Nodes.Quoted("!"));
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -26,7 +26,12 @@ export class PostgreSQL extends ToSql {
     this.collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");
     this.visitNodeOrValue(node.right);
     if (node.escape) {
-      this.collector.append(` ESCAPE '${node.escape}'`);
+      this.collector.append(" ESCAPE ");
+      if (node.escape instanceof Node) {
+        this.visit(node.escape);
+      } else {
+        this.collector.append(`'${node.escape}'`);
+      }
     }
     return this.collector;
   }
@@ -36,7 +41,12 @@ export class PostgreSQL extends ToSql {
     this.collector.append(node.caseSensitive ? " NOT LIKE " : " NOT ILIKE ");
     this.visitNodeOrValue(node.right);
     if (node.escape) {
-      this.collector.append(` ESCAPE '${node.escape}'`);
+      this.collector.append(" ESCAPE ");
+      if (node.escape instanceof Node) {
+        this.visit(node.escape);
+      } else {
+        this.collector.append(`'${node.escape}'`);
+      }
     }
     return this.collector;
   }

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -25,14 +25,7 @@ export class PostgreSQL extends ToSql {
     this.visitNodeOrValue(node.left);
     this.collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");
     this.visitNodeOrValue(node.right);
-    if (node.escape) {
-      this.collector.append(" ESCAPE ");
-      if (node.escape instanceof Node) {
-        this.visit(node.escape);
-      } else {
-        this.collector.append(`'${node.escape}'`);
-      }
-    }
+    this.appendEscape(node.escape);
     return this.collector;
   }
 
@@ -40,14 +33,7 @@ export class PostgreSQL extends ToSql {
     this.visitNodeOrValue(node.left);
     this.collector.append(node.caseSensitive ? " NOT LIKE " : " NOT ILIKE ");
     this.visitNodeOrValue(node.right);
-    if (node.escape) {
-      this.collector.append(" ESCAPE ");
-      if (node.escape instanceof Node) {
-        this.visit(node.escape);
-      } else {
-        this.collector.append(`'${node.escape}'`);
-      }
-    }
+    this.appendEscape(node.escape);
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1630,4 +1630,24 @@ describe("the to_sql visitor", () => {
       expect(() => visitor.compile(node)).toThrow();
     });
   });
+
+  describe("Table with Node name", () => {
+    it("visits the Node when name is an Arel Node", () => {
+      const tbl = new Table("ignored");
+      (tbl as unknown as { name: Nodes.Node }).name = new Nodes.SqlLiteral("my_subq");
+      expect(new Visitors.ToSql().compile(tbl)).toBe("my_subq");
+    });
+  });
+
+  describe("UpdateManager subselect", () => {
+    it("renders WHERE pk IN (SELECT pk ...) when limit is present", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      um.set([[users.get("name"), "x"]]);
+      um.take(1);
+      um.key = users.get("id");
+      const sql = new Visitors.ToSql().compile(um.ast);
+      expect(sql).toContain('IN (SELECT "users"."id"');
+    });
+  });
 });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1650,4 +1650,15 @@ describe("the to_sql visitor", () => {
       expect(sql).toContain('IN (SELECT "users"."id"');
     });
   });
+
+  describe("DeleteManager subselect", () => {
+    it("renders WHERE pk IN (SELECT pk ...) when limit is present", () => {
+      const dm = new DeleteManager();
+      dm.from(users);
+      dm.take(1);
+      dm.key = users.get("id");
+      const sql = new Visitors.ToSql().compile(dm.ast);
+      expect(sql).toContain('IN (SELECT "users"."id"');
+    });
+  });
 });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -429,7 +429,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       stmt.orders = [];
       const key = this.subselectKey(o.key);
       const columns = new Nodes.Grouping(key);
-      stmt.wheres = [new Nodes.In(columns, this.buildSubselect(key, o))];
+      stmt.wheres = [new Nodes.In(columns, [this.buildSubselect(key, o)])];
       if (this.hasJoinSources(o)) {
         stmt.relation = (o.relation as Nodes.JoinSource).left;
       }
@@ -447,7 +447,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       const rawKey = Array.isArray(o.key) ? o.key[0] : o.key;
       const key = this.subselectKey(rawKey);
       const columns = new Nodes.Grouping(key);
-      stmt.wheres = [new Nodes.In(columns, this.buildSubselect(key, o))];
+      stmt.wheres = [new Nodes.In(columns, [this.buildSubselect(key, o)])];
       if (this.hasJoinSources(o)) {
         stmt.relation = (o.relation as Nodes.JoinSource).left;
       }
@@ -1281,11 +1281,13 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitArelTable(node: Table): SQLString {
-    const quoted = this.quoteTableName(node.name);
-    if (node.tableAlias) {
-      this.collector.append(`${quoted} ${this.quoteTableName(node.tableAlias)}`);
+    if ((node.name as unknown) instanceof Node) {
+      this.visit(node.name as unknown as Node);
     } else {
-      this.collector.append(quoted);
+      this.collector.append(this.quoteTableName(node.name));
+    }
+    if (node.tableAlias) {
+      this.collector.append(` ${this.quoteTableName(node.tableAlias)}`);
     }
     return this.collector;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1207,9 +1207,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     this.visitNodeOrValue(node.left);
     this.collector.append(" LIKE ");
     this.visitNodeOrValue(node.right);
-    if (node.escape) {
-      this.collector.append(` ESCAPE '${node.escape}'`);
-    }
+    this.appendEscape(node.escape);
     return this.collector;
   }
 
@@ -1217,10 +1215,22 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     this.visitNodeOrValue(node.left);
     this.collector.append(" NOT LIKE ");
     this.visitNodeOrValue(node.right);
-    if (node.escape) {
-      this.collector.append(` ESCAPE '${node.escape}'`);
-    }
+    this.appendEscape(node.escape);
     return this.collector;
+  }
+
+  // Mirrors Rails to_sql.rb: when ESCAPE is set, Rails calls `visit
+  // o.escape, collector`. Trails' `escape` is `string | Node | null`; for
+  // Node we visit, for string we route through `quote()` so embedded
+  // quotes are escaped properly.
+  protected appendEscape(escape: string | Node | null): void {
+    if (!escape) return;
+    this.collector.append(" ESCAPE ");
+    if (escape instanceof Node) {
+      this.visit(escape);
+    } else {
+      this.collector.append(this.quote(escape));
+    }
   }
 
   // -- NullsFirst / NullsLast --

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1224,7 +1224,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   // Node we visit, for string we route through `quote()` so embedded
   // quotes are escaped properly.
   protected appendEscape(escape: string | Node | null): void {
-    if (!escape) return;
+    if (escape == null) return;
     this.collector.append(" ESCAPE ");
     if (escape instanceof Node) {
       this.visit(escape);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1281,8 +1281,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitArelTable(node: Table): SQLString {
-    if ((node.name as unknown) instanceof Node) {
-      this.visit(node.name as unknown as Node);
+    // Mirrors Rails visit_Arel_Table (to_sql.rb): if name is a Node, visit
+    // it (subquery-as-table); else quote as identifier. Trails types
+    // `Table.name` as `string`; callers smuggling a Node in must cast.
+    const name = node.name as unknown;
+    if (name instanceof Node) {
+      this.visit(name);
     } else {
       this.collector.append(this.quoteTableName(node.name));
     }


### PR DESCRIPTION
Per [docs/arel-alignment-plan.md](docs/arel-alignment-plan.md) PR 23c.

## Changes

- `to-sql.ts` `prepareUpdateStatement` / `prepareDeleteStatement`: wrap subselect as `new In(columns, [subselect])` to match Rails to_sql.
- `to-sql.ts` `visitArelTable`: branch on `node.name instanceof Node` and visit it; otherwise quote the string. Mirrors Rails `visit_Arel_Table`.
- `postgresql.ts` `visitArelNodesMatches` / `visitArelNodesDoesNotMatch`: when `escape instanceof Node`, visit; else hard-quote. Mirrors Rails Postgres visitor.

## Tests

- `to-sql.test.ts`: Table with Node name; UpdateManager subselect renders `IN (SELECT ...)`.
- `postgres.test.ts`: ESCAPE with string and Node forms; DoesNotMatch ESCAPE with Node.

## Verification

- `pnpm exec vitest run packages/arel` — 1268 passing.
- `tsc --build` clean.