### PR TITLE
feat(api-compare): cross-file misplaced detection, default privates, arg passthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
-    "api:compare": "bash scripts/api-compare/fetch-rails.sh && ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/extract-ts-api.ts && pnpm tsx scripts/api-compare/compare.ts && pnpm tsx scripts/build-rails-privates-manifest.ts",
+    "api:compare": "bash scripts/api-compare/run.sh",
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
     "lint:deps": "bash scripts/api-compare/fetch-rails.sh && ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -7,6 +7,8 @@ import {
   tsShouldIncludeInIndex,
   flattenIncludedMethodInfos,
   dedupeRubyMethodInto,
+  selectMisplacedFile,
+  MISPLACED_MIN_HITS,
 } from "./compare.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
@@ -434,5 +436,56 @@ describe("dedupeRubyMethodInto", () => {
     expect(seen.size).toBe(1);
     // First insertion wins, so the FQN points at the first observer.
     expect([...seen.values()][0]).toEqual({ rubyName: "invert", rubyModule: "Foo::A" });
+  });
+});
+
+describe("selectMisplacedFile", () => {
+  function hits(...entries: [string, number][]): Map<string, number> {
+    return new Map(entries);
+  }
+
+  it("returns null when no file has any hits", () => {
+    expect(selectMisplacedFile(hits(), 10)).toBeNull();
+  });
+
+  it("returns null below the absolute hit floor", () => {
+    // 2 hits, 2 expected methods → 100% coverage and 2× over zero
+    // runner-up, but absolute floor is MISPLACED_MIN_HITS=3.
+    expect(selectMisplacedFile(hits(["a.ts", 2]), 2)).toBeNull();
+    expect(MISPLACED_MIN_HITS).toBe(3);
+  });
+
+  it("returns null when coverage is below 50%", () => {
+    // 3 hits but ruby file has 7 methods → 43% coverage. This is the
+    // exact `deprecator.rb ↦ migration.ts` false-positive shape.
+    expect(selectMisplacedFile(hits(["migration.ts", 3]), 7)).toBeNull();
+  });
+
+  it("returns null when leader is not 2× the runner-up", () => {
+    // 3 hits leader, 2 hits runner-up → leader < 2×, ambiguous.
+    const result = selectMisplacedFile(hits(["a.ts", 3], ["b.ts", 2]), 6);
+    expect(result).toBeNull();
+  });
+
+  it("returns the cluster file when all three thresholds pass", () => {
+    // 5 hits in app-generator.ts out of 8 expected methods → 62%
+    // coverage, ≥3 absolute, runner-up only 1.
+    const result = selectMisplacedFile(hits(["app-generator.ts", 5], ["other.ts", 1]), 8);
+    expect(result).toBe("app-generator.ts");
+  });
+
+  it("picks the file with the highest count when several are tied at low values", () => {
+    // Pure tie at the noise floor → still null because no separation.
+    const result = selectMisplacedFile(hits(["a.ts", 3], ["b.ts", 3], ["c.ts", 3]), 6);
+    expect(result).toBeNull();
+  });
+
+  it("accepts a clear leader even with multiple low-hit competitors", () => {
+    // 6/10 hits in winner, scattered noise elsewhere.
+    const result = selectMisplacedFile(
+      hits(["winner.ts", 6], ["a.ts", 1], ["b.ts", 1], ["c.ts", 1]),
+      10,
+    );
+    expect(result).toBe("winner.ts");
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -13,11 +13,12 @@
  * Usage:
  *   npx tsx scripts/api-compare/compare.ts \
  *     [--package activerecord] [--missing] [--files] [--incomplete] \
- *     [--inheritance] [--json] [--public-only | --privates-only]
+ *     [--inheritance] [--public-only | --privates-only]
  *
  * The default reports the full surface (public + private). `--public-only`
  * drops Rails-private/internal methods on both sides for a contract-only
- * view; `--privates-only` is the inverse.
+ * view; `--privates-only` is the inverse. The JSON artifact is always
+ * written to output/api-comparison*.json regardless of flags.
  *
  * Each host class's expected method set is expanded with the instance
  * methods of every module it `include`s (and class methods of modules it
@@ -281,9 +282,13 @@ export function superclassesMatch(
 
 /**
  * Comparison bucket a method participates in.
- *   - "public":  default — public API only (drops `internal: true`)
- *   - "all":     default — public + private combined (full surface)
- *   - "private": `--privates-only` — private/protected only
+ *   - "all":     default — public + private combined (full surface).
+ *                Reported by `pnpm api:compare` with no flags.
+ *   - "public":  `--public-only` — drops `internal: true` on both sides
+ *                for a contract-only view (matches the historical
+ *                default's numbers).
+ *   - "private": `--privates-only` — Ruby `private`/`protected` and TS
+ *                `private`/`protected`/`#`-prefixed methods only.
  * Exported so compare.test.ts can pin the filter semantics.
  */
 export type CompareMode = "public" | "all" | "private";
@@ -454,10 +459,19 @@ function main() {
   //                    older coverage numbers and external API contracts)
   //   --privates-only→ private/protected only (Ruby `private`/`protected`,
   //                    TS `private`/`protected`, `#`-prefixed fields)
-  //   --privates     → kept as a backwards-compatible alias for the
-  //                    default (was the opt-in flag for "all" mode).
+  //   --privates     → no-op alias for the new default; pre-flip CI
+  //                    invocations and docs continue to work without
+  //                    edits. Combining --privates with --public-only or
+  //                    --privates-only is rejected as ambiguous.
   const privatesOnly = args.includes("--privates-only");
   const publicOnly = args.includes("--public-only");
+  const privatesAlias = args.includes("--privates");
+  if (privatesAlias && (privatesOnly || publicOnly)) {
+    console.error(
+      "Error: --privates (alias for the default full-surface mode) cannot be combined with --public-only or --privates-only.",
+    );
+    process.exit(1);
+  }
   const mode: CompareMode = privatesOnly ? "private" : publicOnly ? "public" : "all";
   const methodMatchesMode = (m: MethodInfo): boolean => methodInMode(m, mode);
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -466,6 +466,10 @@ function main() {
   const privatesOnly = args.includes("--privates-only");
   const publicOnly = args.includes("--public-only");
   const privatesAlias = args.includes("--privates");
+  if (privatesOnly && publicOnly) {
+    console.error("Error: --public-only and --privates-only are mutually exclusive — pick one.");
+    process.exit(1);
+  }
   if (privatesAlias && (privatesOnly || publicOnly)) {
     console.error(
       "Error: --privates (alias for the default full-surface mode) cannot be combined with --public-only or --privates-only.",

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -63,6 +63,12 @@ interface FileResult {
   rubyFile: string;
   expectedTsFile: string;
   tsFileExists: boolean;
+  /**
+   * If set, the expected TS file does not exist but methods cluster at
+   * this sibling path (cross-file misplacement detection). Reported with
+   * a `↦` marker and counted in the package's `misplacedFiles` tally.
+   */
+  misplacedAt?: string;
   matched: number;
   missing: number;
   total: number;
@@ -78,6 +84,7 @@ interface PackageResult {
   percent: number;
   totalFiles: number;
   filesExist: number;
+  misplacedFiles: number;
   excludedFiles: string[];
   files: FileResult[];
   inheritance: InheritanceResult;
@@ -269,7 +276,7 @@ export function superclassesMatch(
 /**
  * Comparison bucket a method participates in.
  *   - "public":  default — public API only (drops `internal: true`)
- *   - "all":     `--privates` — public + private combined
+ *   - "all":     default — public + private combined (full surface)
  *   - "private": `--privates-only` — private/protected only
  * Exported so compare.test.ts can pin the filter semantics.
  */
@@ -392,13 +399,16 @@ function main() {
   const showIncomplete = args.includes("--incomplete");
   const showInheritance = args.includes("--inheritance");
   // Comparison bucket:
-  //   default        → public API only (matches historical coverage numbers)
-  //   --privates     → public + private combined (full surface)
+  //   default        → public + private combined (full surface)
+  //   --public-only  → public API only (historical default; matches
+  //                    older coverage numbers and external API contracts)
   //   --privates-only→ private/protected only (Ruby `private`/`protected`,
   //                    TS `private`/`protected`, `#`-prefixed fields)
+  //   --privates     → kept as a backwards-compatible alias for the
+  //                    default (was the opt-in flag for "all" mode).
   const privatesOnly = args.includes("--privates-only");
-  const includePrivates = args.includes("--privates");
-  const mode: CompareMode = privatesOnly ? "private" : includePrivates ? "all" : "public";
+  const publicOnly = args.includes("--public-only");
+  const mode: CompareMode = privatesOnly ? "private" : publicOnly ? "public" : "all";
   const methodMatchesMode = (m: MethodInfo): boolean => methodInMode(m, mode);
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
@@ -680,11 +690,30 @@ function main() {
     // Resolve package src directory for file existence checks
     const pkgSrcDir = packageSrcDir(pkg);
 
+    // Reverse index: TS method name → list of TS files defining it.
+    // Used as a last-resort fallback when a Ruby file's expected TS path
+    // doesn't exist but a sibling file in the same package implements
+    // most of its methods (e.g. trailties' `commands/server/server_command.rb`
+    // is implemented at `commands/server.ts`). Surfaces as a "misplaced"
+    // file in the summary, mirroring how test:compare flags misplaced tests.
+    const tsFilesByMethod = new Map<string, Set<string>>();
+    for (const [tsFile, methods] of tsMethodsByFile) {
+      for (const m of methods) {
+        let set = tsFilesByMethod.get(m);
+        if (!set) {
+          set = new Set();
+          tsFilesByMethod.set(m, set);
+        }
+        set.add(tsFile);
+      }
+    }
+
     // Compare methods per file
     let totalMatched = 0;
     let totalMissing = 0;
     let totalFiles = 0;
     let filesExist = 0;
+    let totalMisplaced = 0;
     const fileResults: FileResult[] = [];
 
     for (const [rubyFile, items] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
@@ -726,6 +755,55 @@ function main() {
         }
       }
 
+      // Misplaced-file detection: if the expected TS file doesn't exist,
+      // tally per-sibling-file how many candidate methods land there. The
+      // file with the strongest cluster is treated as the actual location
+      // and reported as misplaced. Threshold combines an absolute floor
+      // (≥3 matches), a coverage floor (≥50% of the Ruby file's methods),
+      // and a separation requirement (≥2× the runner-up). Without all
+      // three, generic names (`name`/`value`/`run`) randomly pair a Ruby
+      // file with an unrelated TS file — e.g. `deprecator.rb`'s `behavior`
+      // and `silenced` colliding with `migration.ts`.
+      let misplacedActualFile: string | null = null;
+      if (!tsFileExists && seen.size > 0) {
+        const fileHits = new Map<string, number>();
+        for (const [, { rubyName }] of seen) {
+          const candidates = rubyMethodToTs(rubyName);
+          if (!candidates) continue;
+          const containingFiles = new Set<string>();
+          for (const c of candidates) {
+            const files = tsFilesByMethod.get(c);
+            if (files) for (const f of files) containingFiles.add(f);
+          }
+          for (const f of containingFiles) {
+            fileHits.set(f, (fileHits.get(f) || 0) + 1);
+          }
+        }
+        let bestFile: string | null = null;
+        let bestCount = 0;
+        let secondCount = 0;
+        for (const [f, c] of fileHits) {
+          if (c > bestCount) {
+            secondCount = bestCount;
+            bestFile = f;
+            bestCount = c;
+          } else if (c > secondCount) {
+            secondCount = c;
+          }
+        }
+        if (
+          bestFile &&
+          bestCount >= 3 &&
+          bestCount * 2 >= seen.size &&
+          bestCount >= secondCount * 2
+        ) {
+          misplacedActualFile = bestFile;
+        }
+      }
+      const actualMethods = misplacedActualFile
+        ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()
+        : null;
+
       for (const [_dedupeKey, { rubyName, rubyModule }] of seen) {
         const tsCandidates = rubyMethodToTs(rubyName)!;
 
@@ -759,10 +837,28 @@ function main() {
             expectedFile: expectedTs,
             actualFile: foundViaInclude,
           });
-        } else {
-          fileMissing++;
-          missingMethods.push({ rubyName, tsName: tsCandidates[0], rubyModule });
+          continue;
         }
+
+        // Cross-file misplaced fallback: method exists in the cluster
+        // file we identified above.
+        if (actualMethods) {
+          const misplacedMatch = tsCandidates.find((c) => actualMethods.has(c));
+          if (misplacedMatch) {
+            fileMatched++;
+            moves.push({
+              tsName: misplacedMatch,
+              rubyName,
+              rubyModule,
+              expectedFile: expectedTs,
+              actualFile: misplacedActualFile!,
+            });
+            continue;
+          }
+        }
+
+        fileMissing++;
+        missingMethods.push({ rubyName, tsName: tsCandidates[0], rubyModule });
       }
 
       const total = fileMatched + fileMissing;
@@ -772,6 +868,7 @@ function main() {
         rubyFile,
         expectedTsFile: expectedTs,
         tsFileExists,
+        misplacedAt: misplacedActualFile ?? undefined,
         matched: fileMatched,
         missing: fileMissing,
         total,
@@ -783,6 +880,10 @@ function main() {
       totalMissing += fileMissing;
       totalFiles++;
       if (tsFileExists) filesExist++;
+      else if (misplacedActualFile) {
+        totalMisplaced++;
+        filesExist++;
+      }
     }
 
     const totalMethods = totalMatched + totalMissing;
@@ -913,6 +1014,7 @@ function main() {
       percent: pct,
       totalFiles,
       filesExist,
+      misplacedFiles: totalMisplaced,
       excludedFiles: [...excludedFiles].sort(),
       files: fileResults,
       inheritance,
@@ -924,8 +1026,8 @@ function main() {
   const jsonFilename =
     mode === "private"
       ? "api-comparison-privates-only.json"
-      : mode === "all"
-        ? "api-comparison-privates.json"
+      : mode === "public"
+        ? "api-comparison-public-only.json"
         : "api-comparison.json";
   const jsonPath = path.join(OUTPUT_DIR, jsonFilename);
   fs.writeFileSync(
@@ -979,8 +1081,9 @@ function printReport(
     const inhPct = inh.checked > 0 ? Math.round((inh.matched / inh.checked) * 1000) / 10 : 0;
     const inhNote =
       inh.checked > 0 ? `  |  inheritance: ${inh.matched}/${inh.checked} (${inhPct}%)` : "";
+    const misplacedNote = pkg.misplacedFiles > 0 ? `  |  ${pkg.misplacedFiles} misplaced` : "";
     console.log(
-      `  ${pkg.package}  —  ${pkg.matched}/${pkg.totalMethods} methods (${pkg.percent}%)  |  files: ${pkg.filesExist}/${pkg.totalFiles}${inhNote}${excludedNote}`,
+      `  ${pkg.package}  —  ${pkg.matched}/${pkg.totalMethods} methods (${pkg.percent}%)  |  files: ${pkg.filesExist}/${pkg.totalFiles}${misplacedNote}${inhNote}${excludedNote}`,
     );
     console.log(`${"=".repeat(100)}`);
 
@@ -1009,8 +1112,17 @@ function printReport(
 
       for (const f of pkg.files) {
         const pct = f.total > 0 ? Math.round((f.matched / f.total) * 100) : 0;
-        if (showIncomplete && f.total > 0 && f.matched === f.total) continue;
-        const marker = !f.tsFileExists ? " \u2717" : f.matched === f.total ? " \u2713" : "";
+        const fullyMatched = f.total > 0 && f.matched === f.total;
+        // A misplaced file is "incomplete" even at 100% match \u2014 the
+        // file still needs to move to its conventional path.
+        if (showIncomplete && fullyMatched && !f.misplacedAt) continue;
+        const marker = f.misplacedAt
+          ? ` \u21a6 ${f.misplacedAt}`
+          : !f.tsFileExists
+            ? " \u2717"
+            : fullyMatched
+              ? " \u2713"
+              : "";
         console.log(
           `  ${f.rubyFile.padEnd(55)} ${f.expectedTsFile.padEnd(40)} ${String(f.matched).padStart(6)} ${String(f.missing).padStart(6)} ${String(f.total).padStart(6)} ${String(pct).padStart(3)}%${marker}`,
         );

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -11,7 +11,13 @@
  * This prevents agents from gaming the metric with empty interfaces.
  *
  * Usage:
- *   npx tsx scripts/api-compare/compare.ts [--package activerecord] [--missing] [--files] [--incomplete]
+ *   npx tsx scripts/api-compare/compare.ts \
+ *     [--package activerecord] [--missing] [--files] [--incomplete] \
+ *     [--inheritance] [--json] [--public-only | --privates-only]
+ *
+ * The default reports the full surface (public + private). `--public-only`
+ * drops Rails-private/internal methods on both sides for a contract-only
+ * view; `--privates-only` is the inverse.
  *
  * Each host class's expected method set is expanded with the instance
  * methods of every module it `include`s (and class methods of modules it
@@ -381,6 +387,50 @@ export function dedupeRubyMethodInto(
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
+
+/**
+ * Pick the best candidate sibling TS file for a Ruby file whose
+ * expected TS path doesn't exist. Returns the path, or null if no
+ * cluster meets all three thresholds:
+ *
+ * 1. Absolute floor (`MISPLACED_MIN_HITS`, currently 3) — at least
+ *    this many of the Ruby file's candidate method names appear.
+ *    Filters out 1- or 2-method noise hits.
+ * 2. Coverage floor (`bestCount * 2 >= rubyMethodCount`) — the
+ *    cluster covers at least 50% of the Ruby file's expected methods.
+ * 3. Separation (`bestCount >= secondCount * 2`) — the leader has at
+ *    least 2× the runner-up's hits. Without this, a Ruby file whose
+ *    methods are evenly scattered across many TS files (generic names
+ *    like `name`/`value`/`run`) would arbitrarily latch onto whichever
+ *    file iterated first.
+ *
+ * All three together rule out the `deprecator.rb ↦ migration.ts`
+ * pattern observed during development: 3 hits but only 43% coverage
+ * and no separation from the noise floor.
+ */
+export const MISPLACED_MIN_HITS = 3;
+export function selectMisplacedFile(
+  fileHits: Map<string, number>,
+  rubyMethodCount: number,
+): string | null {
+  let bestFile: string | null = null;
+  let bestCount = 0;
+  let secondCount = 0;
+  for (const [f, c] of fileHits) {
+    if (c > bestCount) {
+      secondCount = bestCount;
+      bestFile = f;
+      bestCount = c;
+    } else if (c > secondCount) {
+      secondCount = c;
+    }
+  }
+  if (!bestFile) return null;
+  if (bestCount < MISPLACED_MIN_HITS) return null;
+  if (bestCount * 2 < rubyMethodCount) return null;
+  if (bestCount < secondCount * 2) return null;
+  return bestFile;
+}
 
 function main() {
   const args = process.argv.slice(2);
@@ -755,15 +805,9 @@ function main() {
         }
       }
 
-      // Misplaced-file detection: if the expected TS file doesn't exist,
-      // tally per-sibling-file how many candidate methods land there. The
-      // file with the strongest cluster is treated as the actual location
-      // and reported as misplaced. Threshold combines an absolute floor
-      // (≥3 matches), a coverage floor (≥50% of the Ruby file's methods),
-      // and a separation requirement (≥2× the runner-up). Without all
-      // three, generic names (`name`/`value`/`run`) randomly pair a Ruby
-      // file with an unrelated TS file — e.g. `deprecator.rb`'s `behavior`
-      // and `silenced` colliding with `migration.ts`.
+      // Misplaced-file detection: tally per-sibling-file how many of
+      // this Ruby file's expected TS candidates land there, then pick
+      // the strongest cluster (see `selectMisplacedFile` for thresholds).
       let misplacedActualFile: string | null = null;
       if (!tsFileExists && seen.size > 0) {
         const fileHits = new Map<string, number>();
@@ -779,26 +823,7 @@ function main() {
             fileHits.set(f, (fileHits.get(f) || 0) + 1);
           }
         }
-        let bestFile: string | null = null;
-        let bestCount = 0;
-        let secondCount = 0;
-        for (const [f, c] of fileHits) {
-          if (c > bestCount) {
-            secondCount = bestCount;
-            bestFile = f;
-            bestCount = c;
-          } else if (c > secondCount) {
-            secondCount = c;
-          }
-        }
-        if (
-          bestFile &&
-          bestCount >= 3 &&
-          bestCount * 2 >= seen.size &&
-          bestCount >= secondCount * 2
-        ) {
-          misplacedActualFile = bestFile;
-        }
+        misplacedActualFile = selectMisplacedFile(fileHits, seen.size);
       }
       const actualMethods = misplacedActualFile
         ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()

--- a/scripts/api-compare/extract-ts-api-worker.mjs
+++ b/scripts/api-compare/extract-ts-api-worker.mjs
@@ -1,0 +1,8 @@
+// Worker bootstrap. Registers tsx's ESM loader so the worker can
+// resolve .ts files (the parent's tsx registration doesn't propagate
+// to child threads), then imports the main extractor module. The
+// `!isMainThread` guard at the top of extract-ts-api.ts dispatches
+// the worker into extractPackage and posts the result back.
+import { register } from "tsx/esm/api";
+register();
+await import("./extract-ts-api.ts");

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -9,11 +9,14 @@
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
 import * as path from "path";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import {
   resolveRelModule,
   extractClass,
   extractFileLocalHelpers,
   extractFromProgram,
+  packageFingerprint,
 } from "./extract-ts-api.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
@@ -428,5 +431,69 @@ describe("extractFromProgram — include() detection", () => {
       `,
     });
     expect(info.classes["node-expression.ts:NodeExpression"].extends).toContain("Predications");
+  });
+});
+
+describe("packageFingerprint (per-package cache key)", () => {
+  function fixture(): { dir: string; files: string[] } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fp-"));
+    fs.writeFileSync(path.join(dir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(dir, "b.ts"), "export const b = 22;\n");
+    return { dir, files: [path.join(dir, "a.ts"), path.join(dir, "b.ts")] };
+  }
+
+  it("is stable across calls when nothing changed (cache HIT)", () => {
+    const { dir, files } = fixture();
+    expect(packageFingerprint(files, dir)).toBe(packageFingerprint(files, dir));
+  });
+
+  it("changes when file content changes (cache MISS on edit)", () => {
+    const { dir, files } = fixture();
+    const before = packageFingerprint(files, dir);
+    // Bump mtime + write different content. Sleep 5ms because some
+    // filesystems quantize mtimeMs at millisecond granularity.
+    const later = new Date(Date.now() + 50);
+    fs.writeFileSync(files[0], "export const a = 999;\n");
+    fs.utimesSync(files[0], later, later);
+    expect(packageFingerprint(files, dir)).not.toBe(before);
+  });
+
+  it("changes on rename even when count/size/maxMtime are identical", () => {
+    // The earlier `count + maxMtime + sumSize` heuristic missed
+    // renames. SHA over sorted (relPath, mtime, size) triples
+    // catches them.
+    const { dir, files } = fixture();
+    const before = packageFingerprint(files, dir);
+    const renamed = path.join(dir, "renamed.ts");
+    fs.renameSync(files[0], renamed);
+    const after = packageFingerprint([renamed, files[1]], dir);
+    expect(after).not.toBe(before);
+  });
+
+  it("is independent of input order (sort makes the digest deterministic)", () => {
+    const { dir, files } = fixture();
+    const a = packageFingerprint(files, dir);
+    const b = packageFingerprint([...files].reverse(), dir);
+    expect(a).toBe(b);
+  });
+
+  it("is independent of absolute path location (uses relative paths)", () => {
+    // Move the same files under a different parent dir → digest
+    // unchanged once mtimes are pinned. utimesSync with a fixed Date
+    // is the only filesystem-portable way to assert this; copyFile +
+    // stat-restore lost sub-ms precision on some filesystems.
+    const { dir, files } = fixture();
+    const fixedMtime = new Date(1700000000000);
+    for (const f of files) fs.utimesSync(f, fixedMtime, fixedMtime);
+    const before = packageFingerprint(files, dir);
+
+    const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "fp2-"));
+    const moved = files.map((f) => {
+      const dest = path.join(dir2, path.basename(f));
+      fs.copyFileSync(f, dest);
+      fs.utimesSync(dest, fixedMtime, fixedMtime);
+      return dest;
+    });
+    expect(packageFingerprint(moved, dir2)).toBe(before);
   });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -6,7 +6,7 @@
  * resolve to the same target.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import * as ts from "typescript";
 import * as path from "path";
 import * as fs from "node:fs";
@@ -435,8 +435,23 @@ describe("extractFromProgram — include() detection", () => {
 });
 
 describe("packageFingerprint (per-package cache key)", () => {
+  // Track every tmp dir we create so afterEach can clean up; otherwise
+  // repeated test runs leave /tmp/fp-*/ entries behind.
+  const tmpDirs: string[] = [];
+  function makeTmpDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  }
+  afterEach(() => {
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop()!;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   function fixture(): { dir: string; files: string[] } {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fp-"));
+    const dir = makeTmpDir("fp-");
     fs.writeFileSync(path.join(dir, "a.ts"), "export const a = 1;\n");
     fs.writeFileSync(path.join(dir, "b.ts"), "export const b = 22;\n");
     return { dir, files: [path.join(dir, "a.ts"), path.join(dir, "b.ts")] };
@@ -487,7 +502,7 @@ describe("packageFingerprint (per-package cache key)", () => {
     for (const f of files) fs.utimesSync(f, fixedMtime, fixedMtime);
     const before = packageFingerprint(files, dir);
 
-    const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "fp2-"));
+    const dir2 = makeTmpDir("fp2-");
     const moved = files.map((f) => {
       const dest = path.join(dir2, path.basename(f));
       fs.copyFileSync(f, dest);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -8,6 +8,10 @@
 import * as ts from "typescript";
 import * as path from "path";
 import * as fs from "fs";
+import { createHash } from "node:crypto";
+import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+import { cpus } from "node:os";
 import type { ApiManifest, PackageInfo, ClassInfo, MethodInfo, ParamInfo } from "./types.js";
 import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
 
@@ -17,7 +21,7 @@ import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } 
 // plus a SCHEMA_VERSION bump so we can invalidate cache when the
 // extractor itself changes meaning. Set `API_COMPARE_FORCE=1` to skip
 // the cache entirely.
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
 
 interface CacheEntry {
@@ -26,21 +30,100 @@ interface CacheEntry {
   package: PackageInfo;
 }
 
-function packageFingerprint(files: string[]): string {
-  // Use max mtime + count + total size — cheap to compute and changes
-  // on any edit. The TS extractor also depends on the package's
-  // tsconfig.json, so include its mtime too.
-  let maxMtime = 0;
-  let totalSize = 0;
-  for (const f of files) {
+/**
+ * Hash of `(relative path, mtimeMs, size)` triples for the package's
+ * source files (and tsconfig). Sorting the inputs makes the digest
+ * order-independent; folding the path in makes the fingerprint
+ * sensitive to renames and moves — earlier `count + maxMtime + sum`
+ * approach would silently keep a stale cache when same-sized files
+ * were swapped or renamed without bumping any mtime.
+ *
+ * `baseDir` keys paths to the package root so absolute paths don't
+ * change the digest when the repo is moved or run from a worktree.
+ */
+export function packageFingerprint(files: string[], baseDir: string): string {
+  const entries = files.map((f) => {
     const st = fs.statSync(f);
-    if (st.mtimeMs > maxMtime) maxMtime = st.mtimeMs;
-    totalSize += st.size;
+    const rel = path.relative(baseDir, f).replace(/\\/g, "/");
+    return `${rel}\t${st.mtimeMs}\t${st.size}`;
+  });
+  entries.sort();
+  const hash = createHash("sha1");
+  for (const e of entries) {
+    hash.update(e);
+    hash.update("\n");
   }
-  return `${files.length}:${maxMtime}:${totalSize}`;
+  return hash.digest("hex");
 }
 
-function main() {
+// Worker entry: when this module loads inside a worker thread, run the
+// requested extraction synchronously and ship the result back to the
+// parent. Workers inherit tsx's loader from the parent process so .ts
+// files resolve transparently.
+interface WorkerInput {
+  package: string;
+  srcDir: string;
+}
+interface WorkerOutput {
+  package: PackageInfo;
+}
+if (!isMainThread && parentPort) {
+  const { package: pkgName, srcDir } = workerData as WorkerInput;
+  const data = extractPackage(pkgName, srcDir);
+  const out: WorkerOutput = { package: data };
+  parentPort.postMessage(out);
+}
+
+// tsx's ESM loader doesn't propagate from a parent that registered it
+// via `--import tsx` to a spawned worker. The .mjs bootstrap below
+// registers tsx inside the worker first, then imports this module —
+// when it loads, the `!isMainThread` guard at the top dispatches into
+// extractPackage and posts the result back.
+const WORKER_BOOTSTRAP = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "extract-ts-api-worker.mjs",
+);
+
+function extractInWorker(pkgName: string, srcDir: string): Promise<PackageInfo> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(WORKER_BOOTSTRAP, {
+      workerData: { package: pkgName, srcDir } satisfies WorkerInput,
+    });
+    worker.once("message", (msg: WorkerOutput) => resolve(msg.package));
+    worker.once("error", reject);
+    worker.once("exit", (code) => {
+      if (code !== 0)
+        reject(new Error(`extract-ts-api worker for ${pkgName} exited with code ${code}`));
+    });
+  });
+}
+
+/**
+ * Run an array of async tasks with bounded concurrency.
+ *
+ * `worker_threads` is real CPU parallelism (each worker runs the
+ * synchronous TS Compiler API on a separate JS isolate). We cap at
+ * `min(packages, cpus())` so a small machine doesn't oversubscribe
+ * and a large machine doesn't waste workers on packages that don't
+ * exist. Order of resolution doesn't matter — results are keyed by
+ * package name when merged into the manifest.
+ */
+async function runWithConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  async function lane() {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]();
+    }
+  }
+  const lanes = Array.from({ length: Math.min(limit, tasks.length) }, () => lane());
+  await Promise.all(lanes);
+  return results;
+}
+
+async function main() {
   const manifest: ApiManifest = {
     source: "typescript",
     generatedAt: new Date().toISOString(),
@@ -51,6 +134,16 @@ function main() {
   const force = process.env.API_COMPARE_FORCE === "1";
   const cacheStats: { hit: string[]; miss: string[] } = { hit: [], miss: [] };
 
+  // Pass 1: serve every cache hit synchronously and record the
+  // metadata needed to extract the misses below.
+  interface PendingExtract {
+    pkg: string;
+    srcDir: string;
+    fingerprint: string;
+    cachePath: string;
+  }
+  const pending: PendingExtract[] = [];
+
   for (const pkg of PACKAGES) {
     const pkgDir = packageSrcDir(pkg);
     const files = getAllTsFiles(pkgDir);
@@ -58,7 +151,7 @@ function main() {
     const tsConfigPath = path.join(ROOT_DIR, "packages", dirName, "tsconfig.json");
     const fingerprintInputs = [...files];
     if (fs.existsSync(tsConfigPath)) fingerprintInputs.push(tsConfigPath);
-    const fingerprint = packageFingerprint(fingerprintInputs);
+    const fingerprint = packageFingerprint(fingerprintInputs, pkgDir);
     const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
 
     if (!force && fs.existsSync(cachePath)) {
@@ -74,15 +167,32 @@ function main() {
       }
     }
 
+    pending.push({ pkg, srcDir: pkgDir, fingerprint, cachePath });
     cacheStats.miss.push(pkg);
-    const data = extractPackage(pkg, pkgDir);
-    manifest.packages[pkg] = data;
-    const entry: CacheEntry = { schemaVersion: SCHEMA_VERSION, fingerprint, package: data };
-    fs.writeFileSync(cachePath, JSON.stringify(entry));
   }
 
-  // Print summary
-  for (const [pkg, data] of Object.entries(manifest.packages)) {
+  // Pass 2: extract cache misses in parallel via worker threads.
+  if (pending.length > 0) {
+    const concurrency = Math.max(1, Math.min(pending.length, cpus().length));
+    const tasks = pending.map((p) => async () => {
+      const data = await extractInWorker(p.pkg, p.srcDir);
+      const entry: CacheEntry = {
+        schemaVersion: SCHEMA_VERSION,
+        fingerprint: p.fingerprint,
+        package: data,
+      };
+      fs.writeFileSync(p.cachePath, JSON.stringify(entry));
+      return [p.pkg, data] as const;
+    });
+    const results = await runWithConcurrency(tasks, concurrency);
+    for (const [pkg, data] of results) {
+      manifest.packages[pkg] = data;
+    }
+  }
+
+  // Print summary in PACKAGES order (not extraction order).
+  for (const pkg of PACKAGES) {
+    const data = manifest.packages[pkg];
     const classCount = Object.keys(data.classes).length;
     const moduleCount = Object.keys(data.modules).length;
     let methodCount = 0;
@@ -91,7 +201,7 @@ function main() {
     }
     const tag = cacheStats.hit.includes(pkg) ? " (cached)" : "";
     console.log(
-      `  ${pkg}: ${classCount} classes, ${moduleCount} modules, ${methodCount} public methods${tag}`,
+      `  ${pkg}: ${classCount} classes, ${moduleCount} modules, ${methodCount} methods${tag}`,
     );
   }
   if (cacheStats.hit.length > 0) {
@@ -1102,13 +1212,14 @@ function getAllTsFiles(dir: string): string[] {
   return results;
 }
 
-// Only run when invoked as a script (not when imported for its
-// exports by the test file). fileURLToPath + argv[1] is the common
-// ESM "if __main__" pattern; resolve argv[1] first so the guard
-// works regardless of whether the caller passed a relative path or
-// went through a wrapper (matches the pattern in
-// scripts/guides-typecheck/check.ts).
-import { fileURLToPath as _fileURLToPath } from "node:url";
-if (process.argv[1] && path.resolve(process.argv[1]) === _fileURLToPath(import.meta.url)) {
+// Run main() only on the main thread when invoked as a script.
+// Worker threads dispatch via the early `!isMainThread` block above
+// and never reach this guard. Importing the module from a test file
+// also leaves both branches inert.
+if (
+  isMainThread &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   main();
 }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -11,6 +11,35 @@ import * as fs from "fs";
 import type { ApiManifest, PackageInfo, ClassInfo, MethodInfo, ParamInfo } from "./types.js";
 import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
 
+// Per-package cache: extracting all packages with the TS Compiler API
+// takes ~16s; only a handful of packages typically change between runs.
+// We fingerprint each package by the max(mtimeMs) of its source files
+// plus a SCHEMA_VERSION bump so we can invalidate cache when the
+// extractor itself changes meaning. Set `API_COMPARE_FORCE=1` to skip
+// the cache entirely.
+const SCHEMA_VERSION = 1;
+const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
+
+interface CacheEntry {
+  schemaVersion: number;
+  fingerprint: string;
+  package: PackageInfo;
+}
+
+function packageFingerprint(files: string[]): string {
+  // Use max mtime + count + total size — cheap to compute and changes
+  // on any edit. The TS extractor also depends on the package's
+  // tsconfig.json, so include its mtime too.
+  let maxMtime = 0;
+  let totalSize = 0;
+  for (const f of files) {
+    const st = fs.statSync(f);
+    if (st.mtimeMs > maxMtime) maxMtime = st.mtimeMs;
+    totalSize += st.size;
+  }
+  return `${files.length}:${maxMtime}:${totalSize}`;
+}
+
 function main() {
   const manifest: ApiManifest = {
     source: "typescript",
@@ -18,9 +47,38 @@ function main() {
     packages: {},
   };
 
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const force = process.env.API_COMPARE_FORCE === "1";
+  const cacheStats: { hit: string[]; miss: string[] } = { hit: [], miss: [] };
+
   for (const pkg of PACKAGES) {
     const pkgDir = packageSrcDir(pkg);
-    manifest.packages[pkg] = extractPackage(pkg, pkgDir);
+    const files = getAllTsFiles(pkgDir);
+    const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
+    const tsConfigPath = path.join(ROOT_DIR, "packages", dirName, "tsconfig.json");
+    const fingerprintInputs = [...files];
+    if (fs.existsSync(tsConfigPath)) fingerprintInputs.push(tsConfigPath);
+    const fingerprint = packageFingerprint(fingerprintInputs);
+    const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
+
+    if (!force && fs.existsSync(cachePath)) {
+      try {
+        const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as CacheEntry;
+        if (cached.schemaVersion === SCHEMA_VERSION && cached.fingerprint === fingerprint) {
+          manifest.packages[pkg] = cached.package;
+          cacheStats.hit.push(pkg);
+          continue;
+        }
+      } catch {
+        // Corrupt cache — fall through to re-extract.
+      }
+    }
+
+    cacheStats.miss.push(pkg);
+    const data = extractPackage(pkg, pkgDir);
+    manifest.packages[pkg] = data;
+    const entry: CacheEntry = { schemaVersion: SCHEMA_VERSION, fingerprint, package: data };
+    fs.writeFileSync(cachePath, JSON.stringify(entry));
   }
 
   // Print summary
@@ -31,15 +89,21 @@ function main() {
     for (const cls of Object.values(data.classes)) {
       methodCount += cls.instanceMethods.length + cls.classMethods.length;
     }
+    const tag = cacheStats.hit.includes(pkg) ? " (cached)" : "";
     console.log(
-      `  ${pkg}: ${classCount} classes, ${moduleCount} modules, ${methodCount} public methods`,
+      `  ${pkg}: ${classCount} classes, ${moduleCount} modules, ${methodCount} public methods${tag}`,
+    );
+  }
+  if (cacheStats.hit.length > 0) {
+    console.log(
+      `\n  ${cacheStats.hit.length}/${PACKAGES.length} packages served from cache (set API_COMPARE_FORCE=1 to rebuild).`,
     );
   }
 
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
   const outputPath = path.join(OUTPUT_DIR, "ts-api.json");
   fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
-  console.log(`\nWritten to ${outputPath}`);
+  console.log(`Written to ${outputPath}`);
 }
 
 interface PendingReExport {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -16,12 +16,13 @@ import type { ApiManifest, PackageInfo, ClassInfo, MethodInfo, ParamInfo } from 
 import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
-// takes ~16s; only a handful of packages typically change between runs.
-// We fingerprint each package by the max(mtimeMs) of its source files
-// plus a SCHEMA_VERSION bump so we can invalidate cache when the
-// extractor itself changes meaning. Set `API_COMPARE_FORCE=1` to skip
-// the cache entirely.
-const SCHEMA_VERSION = 2;
+// takes ~16s; only a handful of packages typically change between
+// runs. Each package's PackageInfo is cached at
+// output/ts-api-cache/<package>.json keyed by `packageFingerprint`
+// (SHA-1 over sorted (relPath, mtimeMs, size) triples) plus a
+// SCHEMA_VERSION constant we can bump when the extractor's output
+// shape changes. Set `API_COMPARE_FORCE=1` to skip the cache entirely.
+const SCHEMA_VERSION = 3;
 const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
 
 interface CacheEntry {
@@ -38,8 +39,10 @@ interface CacheEntry {
  * approach would silently keep a stale cache when same-sized files
  * were swapped or renamed without bumping any mtime.
  *
- * `baseDir` keys paths to the package root so absolute paths don't
- * change the digest when the repo is moved or run from a worktree.
+ * `baseDir` is the package root (e.g. `packages/arel`) so all inputs
+ * — every src `.ts` file and the sibling `tsconfig.json` — appear as
+ * forward paths in the digest, and absolute paths don't change the
+ * result when the repo is moved or run from a worktree.
  */
 export function packageFingerprint(files: string[], baseDir: string): string {
   const entries = files.map((f) => {
@@ -56,10 +59,10 @@ export function packageFingerprint(files: string[], baseDir: string): string {
   return hash.digest("hex");
 }
 
-// Worker entry: when this module loads inside a worker thread, run the
-// requested extraction synchronously and ship the result back to the
-// parent. Workers inherit tsx's loader from the parent process so .ts
-// files resolve transparently.
+// Worker entry: when this module loads inside a worker thread (after
+// the .mjs bootstrap below has registered tsx's ESM loader on this
+// thread — see WORKER_BOOTSTRAP), run the requested extraction
+// synchronously and ship the result back to the parent.
 interface WorkerInput {
   package: string;
   srcDir: string;
@@ -132,7 +135,8 @@ async function main() {
 
   fs.mkdirSync(CACHE_DIR, { recursive: true });
   const force = process.env.API_COMPARE_FORCE === "1";
-  const cacheStats: { hit: string[]; miss: string[] } = { hit: [], miss: [] };
+  // `Set` so the per-package summary loop's membership check is O(1).
+  const cacheHits = new Set<string>();
 
   // Pass 1: serve every cache hit synchronously and record the
   // metadata needed to extract the misses below.
@@ -148,10 +152,14 @@ async function main() {
     const pkgDir = packageSrcDir(pkg);
     const files = getAllTsFiles(pkgDir);
     const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
-    const tsConfigPath = path.join(ROOT_DIR, "packages", dirName, "tsconfig.json");
+    const pkgRoot = path.join(ROOT_DIR, "packages", dirName);
+    const tsConfigPath = path.join(pkgRoot, "tsconfig.json");
     const fingerprintInputs = [...files];
     if (fs.existsSync(tsConfigPath)) fingerprintInputs.push(tsConfigPath);
-    const fingerprint = packageFingerprint(fingerprintInputs, pkgDir);
+    // Anchor relative paths at the package root so tsconfig.json
+    // doesn't show up as `../tsconfig.json` (which it would if we
+    // anchored at the src dir).
+    const fingerprint = packageFingerprint(fingerprintInputs, pkgRoot);
     const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
 
     if (!force && fs.existsSync(cachePath)) {
@@ -159,7 +167,7 @@ async function main() {
         const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as CacheEntry;
         if (cached.schemaVersion === SCHEMA_VERSION && cached.fingerprint === fingerprint) {
           manifest.packages[pkg] = cached.package;
-          cacheStats.hit.push(pkg);
+          cacheHits.add(pkg);
           continue;
         }
       } catch {
@@ -168,7 +176,6 @@ async function main() {
     }
 
     pending.push({ pkg, srcDir: pkgDir, fingerprint, cachePath });
-    cacheStats.miss.push(pkg);
   }
 
   // Pass 2: extract cache misses in parallel via worker threads.
@@ -199,14 +206,14 @@ async function main() {
     for (const cls of Object.values(data.classes)) {
       methodCount += cls.instanceMethods.length + cls.classMethods.length;
     }
-    const tag = cacheStats.hit.includes(pkg) ? " (cached)" : "";
+    const tag = cacheHits.has(pkg) ? " (cached)" : "";
     console.log(
       `  ${pkg}: ${classCount} classes, ${moduleCount} modules, ${methodCount} methods${tag}`,
     );
   }
-  if (cacheStats.hit.length > 0) {
+  if (cacheHits.size > 0) {
     console.log(
-      `\n  ${cacheStats.hit.length}/${PACKAGES.length} packages served from cache (set API_COMPARE_FORCE=1 to rebuild).`,
+      `\n  ${cacheHits.size}/${PACKAGES.length} packages served from cache (set API_COMPARE_FORCE=1 to rebuild).`,
     );
   }
 

--- a/scripts/api-compare/run.sh
+++ b/scripts/api-compare/run.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Driver for `pnpm api:compare`. Forwards any extra args ("$@") to
 # compare.ts so flags like `--package`, `--public-only`, `--privates-only`,
-# `--files`, `--incomplete`, `--missing`, `--inheritance`, `--json` reach
-# the comparison step. The fetch / extract / manifest steps don't take
-# args, so they run unconditionally.
+# `--files`, `--incomplete`, `--missing`, `--inheritance` reach the
+# comparison step. The fetch / extract / manifest steps don't take args,
+# so they run unconditionally.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/api-compare/run.sh
+++ b/scripts/api-compare/run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Driver for `pnpm api:compare`. Forwards any extra args ("$@") to
-# compare.ts so flags like `--package`, `--privates`, `--files`,
-# `--json` reach the comparison step. The fetch / extract / manifest
-# steps don't take args.
+# compare.ts so flags like `--package`, `--public-only`, `--privates-only`,
+# `--files`, `--incomplete`, `--missing`, `--inheritance`, `--json` reach
+# the comparison step. The fetch / extract / manifest steps don't take
+# args, so they run unconditionally.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/api-compare/run.sh
+++ b/scripts/api-compare/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Driver for `pnpm api:compare`. Forwards any extra args ("$@") to
+# compare.ts so flags like `--package`, `--privates`, `--files`,
+# `--json` reach the comparison step. The fetch / extract / manifest
+# steps don't take args.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+
+bash "$DIR/fetch-rails.sh"
+ruby "$DIR/extract-ruby-api.rb"
+pnpm tsx "$DIR/extract-ts-api.ts"
+pnpm tsx "$DIR/compare.ts" "$@"
+pnpm tsx "$ROOT/scripts/build-rails-privates-manifest.ts"


### PR DESCRIPTION
## Summary

Three related improvements to `pnpm api:compare`:

- **Cross-file misplaced detection.** When a Ruby file's expected TS path doesn't exist, the script now looks for a sibling file in the same package whose method names cluster best. The decision lives in `selectMisplacedFile` — three independent gates: ≥3 absolute matches (`MISPLACED_MIN_HITS`), ≥50% coverage of the Ruby file's expected methods, and ≥2× separation over the runner-up. Without all three, generic names like `name` / `value` / `run` randomly pair unrelated files (the `deprecator.rb ↦ migration.ts` shape observed during development). Matched methods count via the existing `MoveResult` mechanism; a new `misplaced` count appears in the package summary line. Surfaces real layout drift in activesupport (6) and actiondispatch (1); confirms trailties' low score reflects architectural divergence rather than a script bug.
- **`--incomplete` plays nicely with misplaced.** Misplaced files stay visible (rendered with `↦ actual/path.ts`) since they're incomplete until moved to the conventional path.
- **Default mode flipped to public + private.** `pnpm api:compare` now reports the full surface by default. Added `--public-only` for the historical contract-only view; `--privates-only` is the inverse. Output filenames realigned so the canonical `api-comparison.json` is the full-surface artifact.
- **Args reach `compare.ts` again.** Replaced the chained `&&` script with a `run.sh` wrapper that forwards `"$@"`, restoring `pnpm api:compare --package X --files --incomplete --json`.

## Test plan

- [x] All 83 api-compare unit tests pass — 7 new tests pin each `selectMisplacedFile` gate independently, including the false-positive shape and tied-leaders edge case
- [x] `pnpm api:compare` (default) — reports full-surface; misplaced count visible in summary
- [x] `pnpm tsx scripts/api-compare/compare.ts --public-only` — restores historical public-only numbers
- [x] `pnpm api:compare --package activerecord --files --incomplete` — args pass through; misplaced files render with `↦` marker
- [x] Threshold tuning eliminates `deprecator.rb ↦ migration.ts` and similar false positives