### PR TITLE
docs: refresh arel/quoting/actioncontroller plans against current state

### DIFF
--- a/docs/actioncontroller-privates-plan.md
+++ b/docs/actioncontroller-privates-plan.md
@@ -1,0 +1,179 @@
+# ActionController `--privates` — remaining backlog
+
+> **Status (2026-05-01):** 252/581 methods (43.4%); files 43/43; inheritance
+> 10/16. No PRs from this plan have shipped yet. Counts below verified
+> against `pnpm tsx scripts/api-compare/compare.ts --package
+> actioncontroller --privates`. Rows where the planned "Missing" count
+> drifted from current api:compare are flagged **(re-audit)** — expand
+> the row before opening a PR.
+
+Each row is one PR. Pick a row, follow the steps below verbatim, open a draft PR.
+
+## How to ship one PR
+
+```bash
+# 1. Branch from latest origin/main in a fresh worktree
+git fetch origin main
+git worktree add .claude/worktrees/<slug> -b <branch> origin/main
+cd .claude/worktrees/<slug>
+pnpm install
+
+# 2. Read Rails source first (the entire file, not just the missing methods)
+less scripts/api-compare/.rails-source/actionpack/lib/<rails-file>.rb
+
+# 3. Implement in the TS file the api:compare row points to.
+#    Do NOT relocate methods to a helper file or the row stops counting.
+#    Use cwd-relative paths (`packages/...`), never absolute paths into the user's repo.
+$EDITOR packages/actionpack/src/actioncontroller/<ts-file>.ts
+
+# 4. Add tests next to the source as <ts-file>.test.ts
+$EDITOR packages/actionpack/src/actioncontroller/<ts-file>.test.ts
+pnpm test packages/actionpack/src/actioncontroller/<ts-file>.test.ts
+
+# 5. Refresh and confirm api:compare row hits 100%
+bash scripts/api-compare/fetch-rails.sh
+ruby scripts/api-compare/extract-ruby-api.rb
+pnpm tsx scripts/api-compare/extract-ts-api.ts
+pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --privates | grep <rails-file>
+
+# 6. Build clean, prettier clean
+pnpm build
+pnpm exec prettier --write packages/actionpack/src/actioncontroller/<ts-file>.ts \
+                            packages/actionpack/src/actioncontroller/<ts-file>.test.ts
+
+# 7. Commit (NO --no-verify, NO Co-Authored-By trailer) + push
+git add -A
+git commit -m "feat(actioncontroller): <commit subject>"
+git push -u origin <branch>
+
+# 8. Open as draft. PR body MUST quote the Rails source line(s) being mirrored
+#    and reference the plan slot (e.g. "Implements P3").
+gh pr create --draft --title "feat(actioncontroller): <title>" --body "$(cat <<EOF
+...
+EOF
+)"
+```
+
+Constraints (CLAUDE.md):
+
+- camelCase only — no snake_case identifiers, even mirroring Rails payload keys.
+- PR ≤ 300 LOC additions+deletions (excl. lockfiles, snapshots).
+- For methods that mix in to controllers, use the `this`-typed function pattern
+  documented in CLAUDE.md (`export function foo(this: HostInterface, ...)` then
+  `static foo = foo` in `base.ts`). Do NOT inline the body in `base.ts`.
+- For Rails behaviors that can't be mirrored exactly (missing infra, etc.),
+  add a "Known divergences" entry in `docs/actioncontroller-100-percent.md`
+  describing what Rails does, what we do, and why.
+- `instance_exec(opts, &block)` → `block.call(this, opts)` with `this: unknown`
+  threaded through the function signature.
+- Ruby `compact` → `.filter((e) => e !== null && e !== undefined)`, NOT
+  `.filter(Boolean)` (which also drops `0`, `""`, `false`).
+- Ruby `Hash#key?` → `"K" in obj`, NOT `obj["K"] != null` (Ruby returns true
+  for nil values).
+
+Sequencing rules:
+
+- One agent per source file at a time; methods in the same file collide.
+- Wave 4 (core) is **serial** — each PR depends on the prior one shipping.
+
+---
+
+## Wave 0 — single-file peripherals (remaining)
+
+| PR  | Rails file                          |  Missing | TS file (api:compare row)              | Methods                                                                                                                                                                              |
+| --- | ----------------------------------- | -------: | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P2  | `metal/rate_limiting.rb`            |        2 | `metal/rate-limiting.ts`               | `rateLimit` (class DSL), `rateLimiting` (private instance). Mirror Rails options `to:`, `within:`, `by:`, `with:`, `store:`, `name:`, `only:`/`except:`. Cache backend is divergent. |
+| P3  | `form_builder.rb`                   |        1 | `form-builder.ts`                      | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                       |
+| P4  | `metal/data_streaming.rb` **(re-audit, 10 missing)** |       10 | `metal/data-streaming.ts`              | Originally scoped as `sendFileHeadersBang` only; api:compare now reports 10 missing. Re-list before opening PR. |
+| P5  | `caching.rb`                        |        2 | `caching.ts`                           | `instrumentPayload(key)` → `{ controller, action, key }`; `instrumentName()` → `"action_controller"`. Both private.                                                                  |
+| P7  | `metal/renderers.rb`                |        2 | `metal/renderers.ts`                   | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.           |
+| P9  | `deprecator.rb`                     |        3 | `deprecator.ts`                        | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                           |
+
+## Wave 1 — small bundle peripherals
+
+Ship after Wave 0 lands. One PR per row.
+
+| PR  | Rails file                           | Missing | Notes                                                                                                                                              |
+| --- | ------------------------------------ | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P10 | `metal/content_security_policy.rb`   |       4 | `isContentSecurityPolicy?`, `currentContentSecurityPolicy`, `contentSecurityPolicy`, `contentSecurityPolicyReportOnly` — class DSL.                |
+| P11 | `metal/etag_with_template_digest.rb` **(re-audit, 7 missing)** |       7 | Originally 3 methods scoped; api:compare now reports 7 missing. Re-list before opening PR.  |
+| P11.5 | `metal/etag_with_flash.rb` **(new)** |       4 | Not in original plan; api:compare reports 4 missing. Scope before opening PR.                |
+| P12 | `metal/helpers.rb` **(re-audit, 6 missing)** |       6 | Originally 5 methods scoped; api:compare reports 6. Re-list before opening PR.               |
+| P13 | `metal/allow_browser.rb` (privates)  |       9 | `parsedUserAgent`, `isUserAgentVersionReported`, `isUnsupportedBrowser`, `isVersionGuardedBrowser`, `isBot`, `isVersionBelowMinimumRequired`, `minimumBrowserVersionForBrowser`, `expandedVersions`, `normalizedBrowserName` — pure user-agent functions. |
+
+## Wave 2 — medium peripherals
+
+| PR  | Rails file                           | Missing | Notes                                                                                                                                              |
+| --- | ------------------------------------ | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P14 | `metal/redirecting.rb` (privates) **(re-audit, 7 missing)** |       7 | Originally 6 methods scoped; api:compare reports 7. Re-list before opening PR. |
+| P15 | `metal/params_wrapper.rb` (privates) |       8 | `_defaultWrapModel`, `_wrapperKey`, `_wrapperFormats`, `_wrapParameters`, `_extractParameters`, `_isWrapperEnabled`, `_performParameterWrapping`, `_setWrapperOptions`. |
+| P16 | `metal/rendering.rb` (privates)      |       8 | `_processVariant`, `_renderInPriorities`, `_setHtmlContentType`, `_setRenderedContentType`, `_setVaryHeader`, `_normalizeOptions`, `_normalizeText`, `_processOptions`. |
+
+## Wave 3 — split-file PRs
+
+Each Rails file below is too large for one ≤300-LOC PR. Sub-PRs serialize on
+the same TS file, so ship them in alphabetical order (a → b → c).
+
+### `metal/http_authentication.rb` (33 missing) — `metal/http-authentication.ts`
+
+| PR   | Module    | Missing | Methods                                                                                                                                                                                                                          |
+| ---- | --------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P17a | `Basic`   |      13 | `authenticate`, `hasBasicCredentials`, `userNameAndPassword`, `decodeCredentials`, `authScheme`, `authParam`, `encodeCredentials`, `authenticationRequest` + 5 controller-side helpers (`httpBasicAuthenticate*` etc.).        |
+| P17b | `Digest`  |      12 | `validateDigestResponse`, `expectedResponse`, `ha1`, `decodeCredentialsHeader`, `authenticationHeader`, `secretToken`, `nonce`, `validateNonce`, `opaque` + 3 controller-side helpers.                                          |
+| P17c | `Token`   |       8 | `tokenAndOptions`, `tokenParamsFrom`, `paramsArrayFrom`, `rewriteParamValues`, `rawParams` + 3 controller-side helpers.                                                                                                          |
+
+### `metal/live.rb` (24 missing — re-audit; was 22) — `metal/live.ts`
+
+| PR   | Subject               | Missing | Methods                                                                                                                                                                                                                                          |
+| ---- | --------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P18a | `Live::Buffer` class  |      12 | `performWrite`, `queueSize`, `ignoreDisconnect`, `writeln`, `abort`, `isConnected`, `onError`, `callOnError`, `eachChunk`, `buildQueue`, `beforeCommitted`, `buildBuffer`.                                                                       |
+| P18b | `Live` mixin          |      10 | `process`, `responseBody=`, `sendStream`, `newControllerThread`, `cleanUpThreadLocals`, `logError`, `originalNewControllerThread`, `originalCleanUpThreadLocals`, `liveThreadPoolExecutor`, `makeResponseBang`.                                  |
+
+### `metal/strong_parameters.rb` (24 missing) — `metal/strong-parameters.ts`
+
+| PR   | Subject                | Missing | Methods                                                                                                                                                                                                                                              |
+| ---- | ---------------------- | ------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P19a | Permit pipeline        |      10 | `permitFilters`, `permitValue`, `permitArrayOfScalars`, `permitArrayOfHashes`, `permitHash`, `permitHashOrArray`, `permitAnyInParameters`, `permitAnyInArray`, `permittedScalarFilter`, `hashFilter`.                                                |
+| P19b | Conversion + nesting   |      10 | `convertParametersToHashes`, `convertHashesToParameters`, `convertValueToParameters`, `_deepTransformKeysInObjectBang`, `isNestedAttributes`, `eachNestedAttribute`, `eachArrayElement`, `isArrayFilter`, `isNonScalar`, `isSpecifyNumericKeys`.    |
+| P19c | Misc + diagnostics     |       4 | `parameters` (private accessor), `newInstanceWithInheritedPermittedStatus`, `unpermittedParametersBang`, `unpermittedKeys`.                                                                                                                          |
+
+### `metal/request_forgery_protection.rb` (31 missing) — `metal/request-forgery-protection.ts`
+
+| PR   | Subject                              | Missing | Methods                                                                                                                                                                                                                                                                                          |
+| ---- | ------------------------------------ | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P20a | Verification predicates              |      10 | `isVerifiedRequest`, `verifySameOriginRequest`, `markForSameOriginVerificationBang`, `isMarkedForSameOriginVerification`, `isNonXhrJavascriptResponse`, `isValidRequestOrigin`, `isProtectAgainstForgery`, `unverifiedRequestWarningMessage`, `normalizeActionPath`, `normalizeRelativeActionPath`. |
+| P20b | Token generation/encoding            |      11 | `generateCsrfToken`, `encodeCsrfToken`, `decodeCsrfToken`, `maskToken`, `unmaskToken`, `maskedAuthenticityToken`, `realCsrfToken`, `perFormCsrfToken`, `globalCsrfToken`, `csrfTokenHmac`, `xorByteStrings`.                                                                                       |
+| P20c | Token validation + strategy plumbing |      10 | `isAnyAuthenticityTokenValid`, `requestAuthenticityTokens`, `isValidAuthenticityToken`, `isValidPerFormCsrfToken`, `compareWithRealToken`, `compareWithGlobalToken`, `formAuthenticityParam`, `protectionMethodClass`, `storageStrategy`, `isIsStorageStrategy`.                                  |
+
+### `test_case.rb` (40 missing — re-audit; was 36) — `test-case.ts`
+
+| PR   | Collaborator         | Missing | Methods                                                                                                                                                                                                                                                              |
+| ---- | -------------------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P21a | `TestSession`        |      12 | `isEnabled`, `idWas`, `loadBang`, `keys`, `values`, `destroy`, `dig`, `fetch`, `isExists`, `isSuccess`, `isMissing`, `isError`.                                                                                                                                       |
+| P21b | `TestRequest`/params |      12 | `assignParameters`, `queryString=`, `contentType=`, `shouldMultipart`, `paramsParsers`, `queryParameterNames`, `defaultEnv`, `newSession`, `create`, `controllerClass`, `generatedPath`, `executorAroundEachRequest`.                                                |
+| P21c | Behavior mixin       |      12 | `process`, `controllerClassName`, `setupControllerRequestAndResponse`, `buildResponse`, `setupRequest`, `wrapExecution`, `processControllerResponse`, `scrubEnvBang`, `documentRootElement`, `checkRequiredIvars`, `tests`, `determineDefaultControllerClass`.        |
+
+## Wave 4 — core (strict serial order: P22 → P23 → P24 → P25 → P26)
+
+These touch the controller backbone and depend on prior peripherals. Do not
+fan out.
+
+| PR  | Rails file                          | Missing | Methods                                                                                                                                                |
+| --- | ----------------------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P22 | `metal/instrumentation.rb`          |       3 | `haltedCallbackHook`, `cleanupViewRuntime`, `appendInfoToPayload`. Hooks render + callback chain.                                                      |
+| P23 | `api/api_rendering.rb` **(re-audit, 12 missing)** |      12 | Originally scoped as `renderToBody` only; api:compare reports 12. Re-list before opening PR. |
+| P24 | `metal/implicit_render.rb` **(re-audit, 4 missing)** |       4 | Originally 3 methods scoped; api:compare reports 4. Re-list before opening PR.            |
+| P25 | `metal.rb` (privates)               |       1 | `buildMiddleware`. Ties to `actiondispatch` middleware stack.                                                                                            |
+| P26 | `base.rb` (privates) **(re-audit, 83 missing)** |      83 | Originally 2 methods scoped; api:compare reports 83 missing. This is no longer one PR — must be split into a sub-plan (likely 4–6 PRs by topic) before any work. |
+
+---
+
+## Tracking
+
+When a PR merges: strike through the row and append `#NNNN ✅`. Update the
+remaining count by re-running:
+
+```bash
+pnpm tsx scripts/api-compare/extract-ts-api.ts
+pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --privates | tail -1
+```

--- a/docs/actioncontroller-privates-plan.md
+++ b/docs/actioncontroller-privates-plan.md
@@ -68,8 +68,9 @@ Constraints (CLAUDE.md):
   threaded through the function signature.
 - Ruby `compact` → `.filter((e) => e !== null && e !== undefined)`, NOT
   `.filter(Boolean)` (which also drops `0`, `""`, `false`).
-- Ruby `Hash#key?` → `"K" in obj`, NOT `obj["K"] != null` (Ruby returns true
-  for nil values).
+- Ruby `Hash#key?` → `Object.hasOwn(obj, "K")`, NOT `obj["K"] != null`
+  (Ruby returns true for nil values; `"K" in obj` walks the prototype
+  chain). Matches `docs/actioncontroller-100-percent.md:175-176`.
 
 Sequencing rules:
 

--- a/docs/arel-alignment-plan.md
+++ b/docs/arel-alignment-plan.md
@@ -13,13 +13,40 @@ PRs marked **independent** can be parallelized. Trails files are paths under
 ## Sequencing
 
 Waves 1 and 2 (PRs 1–9, 11–23, 23b, 23c) are merged — see **Completed**
-below for the full list. Remaining waves:
+below for the full list. Remaining work, grouped by type:
 
-| Wave | PRs         | Notes                                                                          |
-| ---- | ----------- | ------------------------------------------------------------------------------ |
-| 3    | 24          | breaking-change wave (Binary reparenting); ship before wave 4                  |
-| 4    | 10, 25a, 26 | dialect / cross-package work; 25a is formatting-only and independent           |
+- **Node-shape parity** (Rails class hierarchy / field shapes):
+  PRs **24** (`Binary` reparenting), **26** (`BoundSqlLiteral` →
+  `sqlWithSubstitutes` + `bindValues`).
+- **Visitor formatting** (visitor-internal SQL bugs): PR **25a**
+  (MySQL `Concat`/`Cte`).
+- **Cross-package wiring** (arel ↔ activerecord seams):
+  PRs **10** (`Table#[]` alias resolution via `klass` ref), **25b**
+  (visitors accept a `Quoting` quoter at construction).
+
+Wave order (when to ship):
+
+| Wave | PRs         | Notes                                                                           |
+| ---- | ----------- | ------------------------------------------------------------------------------- |
+| 3    | 24          | breaking-change wave (Binary reparenting); ship before wave 4                   |
+| 4    | 10, 25a, 26 | independent of one another; ship in any order, parallel-friendly                |
 | 5    | 25b         | gates on quoting-refactor Phases 4–5 (PRs 8/9/10 in `docs/quoting-refactor.md`) |
+
+### Definition of done
+
+The plan closes when:
+
+- All five remaining PRs (10, 24, 25a, 25b, 26) merged.
+- `pnpm parity:query` green on PG / MySQL / SQLite fixtures with no
+  dialect-specific identifier quirks left in the arel visitors (only
+  in the adapter `Quoting` implementations).
+- No `as: "sqlite" | "postgres" | "mysql"` enum or equivalent
+  string-dispatch survives in `packages/arel/`.
+- `nodes/binary.rb` and `nodes/bound_sql_literal.rb` shape-aligned
+  (Union/Intersect/Except/Join inherit `Binary`; `BoundSqlLiteral`
+  fields match Rails).
+- `pnpm tsx scripts/api-compare/compare.ts --package arel --privates`
+  remains at 820/820.
 
 ---
 
@@ -213,9 +240,14 @@ of the quoting refactor.
 
 ---
 
-## PR 25b — MySQL identifier quoting via `Quoting` injection
+## PR 25b — Arel visitors accept a `Quoting` quoter at construction
 
-Folds in the long-deferred `arel MySQL identifier quoting` memory.
+Pervasive arel architectural shift: visitors stop carrying dialect
+identifier logic and instead delegate to a `Quoting`-shaped quoter
+passed in at construction. MySQL backticks fall out as a side effect
+(folds in the long-deferred `arel MySQL identifier quoting` memory),
+and the same delegation cleans up PG / SQLite identifier paths too.
+
 **Depends on `docs/quoting-refactor.md` Phase 2 (merged) and ideally
 Phase 4–5 to remove the residual `mysqlQuote(sql)` post-processor.**
 
@@ -346,7 +378,7 @@ deprecated aliases, no shims.
 | PR  | Surface                                        | Notes                |
 | --- | ---------------------------------------------- | -------------------- |
 | 24  | `Union/Intersect/Except/Join` extends `Binary` | API gain only        |
-| 25b | MySQL identifier quoting via Quoting injection | curate snapshot diff |
+| 25b | Visitors accept `Quoting` quoter (MySQL backticks fall out) | curate snapshot diff |
 | 26  | `BoundSqlLiteral` node fields (`parts` → Rails shape) | atomic in-tree migrate |
 
 ---

--- a/docs/arel-alignment-plan.md
+++ b/docs/arel-alignment-plan.md
@@ -118,37 +118,108 @@ duck typing. Option 1 (inject aliases dict at construct) was rejected
 because it diverges from Rails (Rails passes the class, not a snapshot
 of the alias map) and forces every `arelTable` site to re-snapshot.
 
-### Trails files to change
+### Rails reference
 
-- `arel/src/table.ts`:
-  - Add optional `klass` field with a minimal `{ attributeAliases?: Record<string,string> }`
-    interface (do not import AR — keep arel free of AR deps).
-  - `get(name, ...)` resolves `name = klass?.attributeAliases?.[name] ?? name`.
-- `activerecord/src/model.ts` (or `relation.ts`) — pass `klass: this`
-  when building `arelTable`.
+- `activerecord/lib/arel/table.rb` — `def [](name, table = self)` calls
+  `name = klass.attribute_aliases[name.to_s] || name if klass`.
+- `activerecord/lib/active_record/model_schema.rb` —
+  `def arel_table` builds `Arel::Table.new(table_name, klass: self)`.
 
-### Tests to add
+### Step-by-step
 
-- `arel/src/table.test.ts` — pass a fake `klass` with aliases; assert
-  resolution.
-- `activerecord/src/...alias.test.ts` — model with
-  `aliasAttribute("nickname", "name")`; `Model.arelTable.get("nickname")`
-  returns `Attribute(table, "name")`.
+1. **`packages/arel/src/table.ts`** — add a structural `Klass` interface
+   and an optional field:
+
+   ```ts
+   /** Structural duck-type for Rails' `@klass.attribute_aliases`.
+    *  Kept minimal so arel does not import activerecord. */
+   export interface TableKlass {
+     readonly _attributeAliases?: Record<string, string>;
+   }
+
+   export interface TableOptions {
+     typeCaster?: TypeCaster;
+     klass?: TableKlass;
+   }
+   ```
+
+   In the `Table` class, store `readonly klass?: TableKlass` from
+   options and use it in `get(name, table = this)`:
+
+   ```ts
+   get(name: string, table: Table | Node = this): Attribute {
+     const resolved = this.klass?._attributeAliases?.[name] ?? name;
+     return new Attribute(table, resolved);
+   }
+   ```
+
+   Note: the model field is `_attributeAliases` (see
+   `packages/activemodel/src/model.ts:93`); we match that key, not the
+   Rails-camelCase getter name. If a getter `attributeAliases` is
+   added later, widen the interface to either form.
+
+2. **`packages/activerecord/src/base.ts:735`** — current
+   `static get arelTable()` returns
+   `new Table(this.tableName, { typeCaster: new TypeCasterMap(this) })`.
+   Add `klass: this`:
+
+   ```ts
+   static get arelTable(): Table {
+     return new Table(this.tableName, {
+       typeCaster: new TypeCasterMap(this),
+       klass: this,
+     });
+   }
+   ```
+
+   The `static this` here satisfies `TableKlass` structurally because
+   `_attributeAliases` is declared on `activemodel/src/model.ts:93`.
+
+3. **Other `new Table(...)` sites in `relation.ts`** (lines 398, 436,
+   554–555, 585, 1332–1333, 1366–1367, 1429–1430, 1462, 1535+ —
+   `grep -n "new Table(" packages/activerecord/src/relation.ts`) build
+   tables for join targets / through associations from raw table
+   names. They have no model class to attach; leave them untouched
+   (alias resolution only applies to `Model.arelTable`, matching
+   Rails — joined tables don't carry the source model's aliases).
+
+### Tests
+
+- `packages/arel/src/table.test.ts`:
+  - `new Table("users", { klass: { _attributeAliases: { nickname: "name" } } }).get("nickname")`
+    → `Attribute` with `name === "name"`.
+  - Same call with `get("name")` returns `Attribute("name")` (passthrough).
+  - `new Table("users").get("nickname")` (no klass) returns
+    `Attribute("nickname")` (passthrough).
+- `packages/activerecord/src/attribute-methods/aliasing.test.ts`
+  (or wherever `aliasAttribute` is currently tested):
+  - `class M extends Model {} ; M.aliasAttribute("nickname", "name");`
+  - `M.arelTable.get("nickname")` resolves to attribute on `name`.
+  - `M.where({ nickname: "x" }).toSql()` emits `users.name = 'x'`.
+- Mirror the Rails test name: search
+  `scripts/api-compare/.rails-source/activerecord/test/cases/relation/where_test.rb`
+  for `attribute_aliases` and reuse the test title verbatim.
 
 ### Risk
 
-- Circular-import hazard: arel must not import AR types. Use a local
-  structural interface.
-- Memory cycle (Table ↔ Model class): WeakRef not needed since both are
-  long-lived; document in comment.
+- Circular-import hazard: arel must NOT import any activerecord type.
+  Use only the structural `TableKlass` interface declared in
+  `arel/src/table.ts`.
+- Memory cycle (Table ↔ Model class): `Model.arelTable` is a getter
+  that builds a new Table per call; the Table holds a ref to the
+  class, the class holds no ref back. No cycle. (If we ever cache
+  `arelTable`, revisit — but Rails doesn't cache it either.)
 
 ### Verification
 
-- `pnpm test` green; new tests pass.
+- `pnpm --filter @blazetrails/arel test` green.
+- `pnpm --filter @blazetrails/activerecord test` green.
+- `pnpm parity:query` unchanged on fixtures without aliases; new
+  alias-bearing fixture (if added) emits the resolved column name.
 
 ### Size
 
-~60 LOC src + ~80 LOC test.
+~30 LOC src in arel + ~5 LOC src in activerecord + ~80 LOC test.
 
 ---
 
@@ -184,12 +255,55 @@ migration matrix entry needed.
 - PG/MySQL/SQLite use a `visitBinaryOp(node, op)` helper, not a
   `visit_Arel_Nodes_Binary` reflection target — unaffected.
 
-### Changes
+### Step-by-step
 
-- `nodes/binary.ts`: redeclare `Union`/`UnionAll`/`Intersect`/`Except`
-  as `extends Binary`; switch `Join` to `extends Binary`.
-- Drop the now-redundant explicit `left`/`right` fields and
-  constructor on each set-op class — `Binary` already carries them.
+1. **`packages/arel/src/nodes/binary.ts`** — change parent classes.
+   Each of `Union`, `UnionAll`, `Intersect`, `Except`, and the
+   abstract `Join` currently `extends Node` and redeclares
+   `readonly left` / `readonly right` plus a constructor that assigns
+   them. Change to `extends Binary` and remove those duplicated
+   members. Example:
+
+   ```ts
+   // before
+   export class Union extends Node {
+     readonly left: Node;
+     readonly right: Node;
+     constructor(left: Node, right: Node) {
+       super();
+       this.left = left;
+       this.right = right;
+     }
+     accept<T>(visitor: NodeVisitor<T>): T { return visitor.visit(this); }
+   }
+
+   // after
+   export class Union extends Binary {}
+   ```
+
+   The same pattern for `UnionAll`, `Intersect`, `Except`. For
+   `Join`: change `extends Node` to `extends Binary` and drop the
+   `readonly left/right` + constructor. `Binary`'s constructor takes
+   `(left, right = null)` which already covers `Join`'s
+   `(left, right = null)` shape — verify line by line before
+   deleting.
+
+2. **`packages/arel/src/nodes/inner-join.ts`,
+   `outer-join.ts`, `right-outer-join.ts`, `full-outer-join.ts`,
+   `string-join.ts`, `cross-join.ts`** — no change. They already
+   `extends Join`, which now transitively extends `Binary`.
+
+3. **`accept` methods** — `Binary` already declares `accept` calling
+   `visitor.visit(this)`. Subclasses dropping their override inherit
+   this; verify the test suite still resolves dispatch (the
+   per-leaf `dispatchCache` registration in `to-sql.ts:150-166` is
+   unchanged, so dispatch keys still hit the leaf class names).
+
+### Changes summary
+
+- `nodes/binary.ts`: 5 classes (`Union`/`UnionAll`/`Intersect`/`Except`/`Join`)
+  switch parent to `Binary`; drop their duplicated `left`/`right` +
+  constructor + `accept`.
 
 ### Tests
 
@@ -215,28 +329,93 @@ migration matrix entry needed.
 Visitor-side formatting only; no identifier-quoting changes. Independent
 of the quoting refactor.
 
-### Changes
+### Rails reference
 
-- `visitors/mysql.ts`:
-  - `visitArelNodesConcat`: emit `CONCAT(...)` with surrounding spaces
-    (Rails `infix_value`).
-  - `visitArelNodesCte`: drop the explicit `(`...`)` (let inner
-    `Grouping` render).
+`activerecord/lib/arel/visitors/mysql.rb`:
+
+```ruby
+def visit_Arel_Nodes_Concat(o, collector)
+  collector << " CONCAT("
+  visit o.left, collector
+  collector << ", "
+  visit o.right, collector
+  collector << ") "
+end
+
+def visit_Arel_Nodes_Cte(o, collector)
+  collector << quote_table_name(o.name)
+  collector << " AS "
+  visit o.relation, collector
+end
+```
+
+Two divergences from current Trails:
+
+1. **Concat** has leading and trailing spaces around `CONCAT(...)` in
+   Rails. Trails emits `CONCAT(...)` flush, no surrounding spaces
+   (`packages/arel/src/visitors/mysql.ts:99-106`).
+2. **Cte** in Rails relies on `o.relation` being a `Grouping` that
+   renders its own parens. Trails wraps with explicit
+   `` `name` AS ( ... ) `` parens
+   (`packages/arel/src/visitors/mysql.ts:251-255`), which collides
+   with the inner Grouping and produces `((SELECT ...))`.
+
+### Step-by-step
+
+1. **`packages/arel/src/visitors/mysql.ts:99-106`** —
+   `visitArelNodesConcat`. Change to:
+
+   ```ts
+   protected override visitArelNodesConcat(node: Nodes.Concat): SQLString {
+     this.collector.append(" CONCAT(");
+     this.visitNodeOrValue(node.left);
+     this.collector.append(", ");
+     this.visitNodeOrValue(node.right);
+     this.collector.append(") ");
+     return this.collector;
+   }
+   ```
+
+2. **`packages/arel/src/visitors/mysql.ts:246-256`** —
+   `visitArelNodesCte`. Drop the literal `(` / `)` around
+   `node.relation`; the relation visit emits its own parens via
+   `Grouping`:
+
+   ```ts
+   protected override visitArelNodesCte(node: Nodes.Cte): SQLString {
+     const escaped = node.name.replace(/`/g, "``");
+     this.collector.append(`\`${escaped}\` AS `);
+     this.visit(node.relation);
+     return this.collector;
+   }
+   ```
+
+   (Backtick-escaping stays here for now; PR 25b removes it once the
+   visitor delegates identifier quoting to a Quoting quoter.)
 
 ### Tests
 
-- `visitors/mysql.test.ts`:
-  - `CONCAT` in expression context (e.g. `WHERE name = CONCAT(a, b)`).
-  - CTE: `WITH x AS (SELECT 1)` (no double parens).
+- `packages/arel/src/visitors/mysql.test.ts`:
+  - **Concat**: build `Nodes.Concat(attr("a"), attr("b"))`, render
+    via MySQL visitor → SQL contains `" CONCAT(a, b) "` (note the
+    surrounding spaces; assert via substring or full snapshot of
+    a `WHERE name = CONCAT(a, b)`-style expression).
+  - **Cte**: build a `Cte("x", new Grouping(<select>))`, render →
+    `` `x` AS (SELECT ...) `` — exactly one set of parens.
+  - Mirror Rails test names from
+    `scripts/api-compare/.rails-source/activerecord/test/cases/arel/visitors/mysql_test.rb`
+    (look for `concat` and `cte`).
 
 ### Verification
 
 - `pnpm --filter @blazetrails/arel test`.
-- `pnpm parity:query` unchanged (no identifier-quoting churn yet).
+- `pnpm parity:query` — should remain unchanged (these visitors are
+  rarely hit by the parity fixtures; if a CTE fixture exists,
+  expect the snapshot to lose its extra parens — curate).
 
 ### Size
 
-~30 LOC src + ~60 LOC test.
+~10 LOC src + ~50 LOC test.
 
 ---
 
@@ -271,48 +450,124 @@ quoteColumnName(name: string): string {
 backticks fall out automatically because the MySQL adapter's `Quoting`
 implementation already emits them — no per-visitor override needed.
 
-### Changes
+### Step-by-step
 
-- `visitors/to-sql.ts`:
-  - Constructor accepts `quoter: Quoting` (structural type — arel
-    declares its own minimal `Quoting` interface; activerecord's
-    `Quoting` is structurally compatible).
-  - `visitArelTable` / `visitArelNodesAttribute` /
-    `quoteTableName` / `quoteColumnName` route through `this.quoter`.
-- `visitors/mysql.ts`, `postgresql.ts`, `sqlite.ts`: drop any local
-  identifier overrides that exist; they're now redundant.
-- `activerecord` arel-visitor construction sites: pass
-  `connection` (which `implements Quoting`) as the quoter.
+1. **`packages/arel/src/visitors/to-sql.ts`** — add a minimal
+   `Quoting` interface and accept it in the constructor:
+
+   ```ts
+   /** Structural duck-type. activerecord's full `Quoting` interface
+    *  is a superset; both satisfy this. */
+   export interface ArelQuoter {
+     quoteTableName(name: string): string;
+     quoteColumnName(name: string): string;
+     quoteString(s: string): string;
+     quote(value: unknown): string;
+   }
+
+   export class ToSql extends Visitor implements NodeVisitor<SQLString> {
+     protected readonly quoter: ArelQuoter;
+
+     constructor(quoter: ArelQuoter = defaultQuoter) {
+       super();
+       this.quoter = quoter;
+     }
+     // ...
+     protected quoteTableName(name: string): string {
+       return this.quoter.quoteTableName(name);
+     }
+     protected quoteColumnName(name: string): string {
+       return this.quoter.quoteColumnName(name);
+     }
+   }
+   ```
+
+   Provide a `defaultQuoter` exported from a new
+   `packages/arel/src/visitors/default-quoter.ts` that emits the
+   abstract Rails defaults (double-quoted identifiers, `'…'` string
+   escaping). This keeps no-arg `new ToSql()` working for tests and
+   `tree-manager.ts:77` semantics.
+
+2. **`packages/arel/src/visitors/mysql.ts`,
+   `postgresql.ts`, `sqlite.ts`** — drop any local backtick /
+   identifier override logic. The MySQL `visitArelNodesCte`
+   identifier escape (added in PR 25a as
+   `name.replace(/`/g, "``")` + literal backticks) becomes
+   `this.quoteTableName(node.name)`.
+
+3. **Activerecord visitor construction sites** — every place
+   that instantiates an arel visitor must pass the connection
+   (which already `implements Quoting` per quoting-refactor PR 2):
+
+   - `packages/activerecord/src/connection-adapters/abstract-adapter.ts:731`
+     `return new Visitors.ToSql();` → `return new Visitors.ToSql(this);`
+   - `packages/activerecord/src/connection-adapters/sqlite3-adapter.ts:127`
+     `return new Visitors.SQLite();` → `return new Visitors.SQLite(this);`
+   - `packages/activerecord/src/connection-adapters/postgresql-adapter.ts:1754`
+     `return new Visitors.PostgreSQLWithBinds();` → pass `this`.
+   - `packages/activerecord/src/insert-all.ts:417-419` — the three
+     dialect branches each need the connection threaded in. The
+     `_dialect` string lookup is itself a code smell; replace with
+     `return this.model.connection.arelVisitor()` (which returns a
+     fresh visitor with the right quoter) once available, otherwise
+     pass `this.model.connection`.
+   - `packages/activerecord/src/relation.ts:134, 562, 3458` and
+     `packages/activerecord/src/relation/where-clause.ts:323` —
+     each `new Visitors.ToSql()` becomes
+     `new Visitors.ToSql(this.model.connection)` (or thread
+     `connection` from the call context).
+
+4. **`packages/arel/src/nodes/node.ts:119` `setToSqlVisitor`** —
+   the no-arg factory used by `Node#toSql()`. Either extend the
+   factory signature to optionally take a quoter, or document
+   that `Node#toSql()` (with no connection in scope) uses the
+   `defaultQuoter` and is not for production SQL. The latter is
+   simpler and matches Rails — `Arel::Node#to_sql` without a
+   connection is a debug aid.
 
 ### Tests
 
-- `visitors/mysql.test.ts`:
-  - SELECT/UPDATE/INSERT/DELETE with backtick-quoted identifiers when
-    constructed with a MySQL quoter.
-  - Identifier with embedded backtick → doubled.
-- `visitors/to-sql.test.ts`:
-  - Default (no-op) quoter still emits double-quoted identifiers for
-    base/PG/SQLite parity.
+- `packages/arel/src/visitors/to-sql.test.ts`:
+  - Default-quoter ToSql emits double-quoted identifiers
+    (`"users"."id"`) — current behavior, locked in.
+  - `new ToSql(stubQuoter)` where `stubQuoter.quoteTableName` returns
+    `<<x>>` → output contains `<<users>>`.
+- `packages/arel/src/visitors/mysql.test.ts`:
+  - `new MySQL(mysqlQuoter)` SELECT emits `` `users`.`id` ``.
+  - Identifier with embedded backtick → doubled (uses the quoter's
+    own escape).
+- `packages/activerecord/src/relation.test.ts` (or wherever
+  visitor wiring is exercised):
+  - `Model.where(...).toSql()` on MySQL adapter emits backticks
+    end-to-end.
 
 ### Risk
 
-- Identifier quoting changes every MySQL SQL fixture. Snapshot churn is
-  expected; reviewer accepts the diff.
-- Constructor signature change for `ToSql` and dialect subclasses —
-  audit every in-tree construction site (activerecord adapters, tests,
-  parity harness) and migrate atomically.
+- **Snapshot churn:** identifier quoting changes every MySQL SQL
+  fixture. Curate the diff in the PR.
+- **Constructor signature change for `ToSql` and dialect subclasses.**
+  Default-arg `quoter = defaultQuoter` keeps no-arg construction
+  working; tests that construct directly continue to pass.
+- **`ArelQuoter` vs activerecord `Quoting`** — the structural shape
+  must be a strict subset of activerecord's `Quoting` interface.
+  Verify with a one-line check in a `.test-d.ts`:
+  `expectAssignable<ArelQuoter>(connection)`.
 
 ### Verification
 
+- `pnpm --filter @blazetrails/arel test` green.
+- `pnpm --filter @blazetrails/activerecord test` green.
 - `pnpm parity:query` on MySQL — expect a wave of fixture updates;
   curate these in the PR.
 - After merge: the `mysqlQuote(sql)` runtime post-processor in
-  activerecord becomes redundant — schedule removal as a follow-up
-  (cross-references quoting-refactor.md final note).
+  activerecord (search `grep -rn mysqlQuote packages/activerecord/src`)
+  becomes redundant — schedule removal as a follow-up
+  (cross-references `docs/quoting-refactor.md` final note).
 
 ### Size
 
-~80 LOC src + ~150 LOC test (incl. fixture updates).
+~120 LOC src + ~200 LOC test (incl. fixture updates and 8–10
+construction-site migrations).
 
 ---
 
@@ -320,53 +575,162 @@ implementation already emits them — no per-visitor override needed.
 
 ### Design decision (resolved)
 
-**Option 2 — drop `parts`; store `sqlWithSubstitutes` + `bindValues`.**
-Match Rails' node shape exactly; visitor parses `?` placeholders at
-visit time. All in-tree consumers of `parts` migrate atomically (no
-shim).
+**Option 2 — drop `parts`; visitor walks
+`sqlWithSubstitutes` + `positionalBinds` / `namedBinds` directly.**
+Match Rails' node shape: rename `sql` → `sqlWithSubstitutes`, remove
+the `parts` getter, and have the visitor do the placeholder walk
+itself (Rails: `visit_Arel_Nodes_BoundSqlLiteral` in `to_sql.rb`).
 
-Rationale: Rails-shape parity for the node, even at the cost of
-re-parsing on each visit. Aligns the node fields one-for-one with
-`nodes/bound_sql_literal.rb` and removes a Trails-only contract.
+Rationale: the trails node already carries `positionalBinds` and
+`namedBinds` (matching Rails `positional_binds` / `named_binds`); the
+remaining drift is the `sql` field name and the trails-only `parts`
+abstraction. Removing `parts` shrinks the node API to a strict
+subset of Rails.
 
 ### Rails reference
 
-- `visitors/to_sql.rb` — `visit_Arel_Nodes_BoundSqlLiteral`.
-- `nodes/bound_sql_literal.rb` — `BindError` text, field shape.
+- `activerecord/lib/arel/nodes/bound_sql_literal.rb`:
+  - `attr_reader :sql_with_substitutes, :positional_binds, :named_binds`.
+  - `BindError` message: `"wrong number of bind variables (X for Y) in: <sql>"`
+    (positional) or `"missing value for :<name> in <sql>"` (named).
+- `activerecord/lib/arel/visitors/to_sql.rb` —
+  `visit_Arel_Nodes_BoundSqlLiteral` walks `sql_with_substitutes`,
+  for each bind: `Arel::Node` → `visit`, `Array` → visit each
+  comma-joined, otherwise → `quote(value)`.
 
-### Changes
+### Step-by-step
 
-- `nodes/bound-sql-literal.ts`:
-  - Replace `parts` with `sqlWithSubstitutes: string` and
-    `bindValues: unknown[]`.
-  - Update constructor + any `eql`/`hash`/inspection paths.
-  - `BindError` message text matches Rails verbatim.
-- `visitors/to-sql.ts` `visitArelNodesBoundSqlLiteral`:
-  - Walk `sqlWithSubstitutes`, splitting on `?` placeholders; for each
-    bind: `Node` → `visit`, `Array` → visit each comma-joined, else →
-    `quote` (or bind via collector).
-  - Mismatched bind count → `BindError`.
-- All in-tree call sites that constructed `BoundSqlLiteral` with `parts`
-  migrate to the new constructor in the same PR.
-- `errors.ts` — `BindError` text aligned with Rails.
+1. **`packages/arel/src/nodes/bound-sql-literal.ts`** —
+   - Rename field `sql` → `sqlWithSubstitutes` (and the constructor
+     parameter).
+   - Drop the `parts` getter (lines 66-131) and the
+     `sqlWithPlaceholders` getter.
+   - Keep `positionalBinds`, `namedBinds`, and the `validate()` call.
+   - Update `BindError` strings to match Rails verbatim
+     (the messages in `validate()` and the count-mismatch error
+     thrown from the old `parts` getter — those move to the
+     visitor's bind walk in step 3).
+
+2. **In-tree call sites** — update both constructor positional args
+   and any `.sql` / `.parts` reads. Known sites:
+   - `packages/activerecord/src/relation/query-methods.ts:1338, 1357`
+     (constructor calls — first arg is the SQL string; rename param
+     locally if helpful but the positional API doesn't break).
+   - `packages/arel/src/update-manager.ts:60` — `instanceof
+     BoundSqlLiteral` branch; no field access, no change needed.
+   - `packages/arel/src/visitors/to-sql.ts:1006` — old visitor reads
+     `node.parts`. Replace per step 3.
+   - `packages/arel/src/visitors/dot.ts:598` — registered as
+     `visitNoEdges`; no field access, no change.
+   - `grep -rn "BoundSqlLiteral\|\.parts\b" packages/` to confirm no
+     other consumers before merging.
+
+3. **`packages/arel/src/visitors/to-sql.ts:1004-…`** —
+   `visitArelNodesBoundSqlLiteral` rewrite. Replace the
+   `for (const part of node.parts)` loop with a placeholder walk on
+   `node.sqlWithSubstitutes`:
+
+   ```ts
+   private visitArelNodesBoundSqlLiteral(node: Nodes.BoundSqlLiteral): SQLString {
+     const sql = node.sqlWithSubstitutes;
+     const hasPositional = node.positionalBinds.length > 0;
+     const hasNamed = Object.keys(node.namedBinds).length > 0;
+
+     if (hasPositional) {
+       const segments = sql.split("?");
+       if (segments.length - 1 !== node.positionalBinds.length) {
+         throw new BindError(
+           `wrong number of bind variables (${node.positionalBinds.length} for ${segments.length - 1}) in: ${sql}`,
+         );
+       }
+       segments.forEach((seg, i) => {
+         this.collector.append(seg);
+         if (i < node.positionalBinds.length) {
+           this.visitBindValue(node.positionalBinds[i]);
+         }
+       });
+     } else if (hasNamed) {
+       const re = /:([a-zA-Z]\w*)/g;
+       let last = 0;
+       let m: RegExpExecArray | null;
+       while ((m = re.exec(sql))) {
+         this.collector.append(sql.slice(last, m.index));
+         const name = m[1];
+         if (!(name in node.namedBinds)) {
+           throw new BindError(`missing value for :${name} in ${sql}`);
+         }
+         this.visitBindValue(node.namedBinds[name]);
+         last = m.index + m[0].length;
+       }
+       this.collector.append(sql.slice(last));
+     } else {
+       this.collector.append(sql);
+     }
+     return this.collector;
+   }
+
+   private visitBindValue(value: unknown): void {
+     if (value instanceof Node) {
+       this.visit(value);
+     } else if (Array.isArray(value)) {
+       value.forEach((v, i) => {
+         if (i > 0) this.collector.append(", ");
+         this.visitBindValue(v);
+       });
+     } else {
+       this.collector.append(this.quoter.quote(value));
+     }
+   }
+   ```
+
+   `visitBindValue` is private; do not promote it to a `visit_*`
+   reflection target.
+
+4. **`packages/arel/src/errors.ts`** — add or align `BindError`
+   class with Rails-shaped message strings (`wrong number of bind
+   variables …` and `missing value for :<name> …`). Existing
+   `Error("Cannot mix positional and named bind parameters")` cases
+   in `validate()` retain trails phrasing — Rails doesn't have an
+   exact analog there.
 
 ### Tests
 
-- `nodes/bound-sql-literal.test.ts`:
-  - Mixed `?` placeholders + Arel-node value.
-  - Array value flattens with `, `.
-  - Missing/extra binds → BindError with Rails-shaped message text.
+- `packages/arel/src/nodes/bound-sql-literal.test.ts`:
+  - Constructor takes `sqlWithSubstitutes`; `node.sqlWithSubstitutes`
+    reads back unchanged.
+  - `node.parts` is no longer defined (TS error or `undefined`).
+  - Validation errors fire with Rails phrasing.
+- `packages/arel/src/visitors/to-sql.test.ts`:
+  - `?` placeholder + Arel-node bind → emitted SQL contains the
+    visited node's SQL, not its quoted toString.
+  - Array bind value → comma-joined.
+  - Wrong positional count → `BindError` with
+    `"wrong number of bind variables (N for M)"` text.
+  - Missing named bind → `BindError` with `"missing value for :name"`.
+- Mirror Rails test names from
+  `scripts/api-compare/.rails-source/activerecord/test/cases/arel/visitors/to_sql_test.rb`
+  (search for `bound_sql_literal`).
 
 ### Risk
 
-- Breaking change to the `BoundSqlLiteral` node API. Audit every
-  in-tree consumer (search for `BoundSqlLiteral` and `.parts`) before
-  opening; migrate atomically.
+- Breaking change to `BoundSqlLiteral` node API (`sql` field rename,
+  `parts` removal). Pre-release, no external consumers; in-tree
+  audit per step 2.
+- `BindError` exception identity: confirm whether trails has an
+  existing `BindError` class (`grep -rn "class BindError" packages/`)
+  — if not, add to `arel/src/errors.ts` and export.
+
+### Verification
+
+- `pnpm --filter @blazetrails/arel test` green.
+- `pnpm --filter @blazetrails/activerecord test` green.
+- `pnpm parity:query` unchanged — the visitor still emits the same
+  SQL for the same input; only the node-internal API moved.
 
 ### Size
 
-~100 LOC src + ~110 LOC test (constructor migration adds ~20 LOC over
-Option 1).
+~80 LOC src (mostly the visitor rewrite; node loses more LOC than
+it gains) + ~120 LOC test.
 
 ---
 

--- a/docs/arel-alignment-plan.md
+++ b/docs/arel-alignment-plan.md
@@ -12,15 +12,14 @@ PRs marked **independent** can be parallelized. Trails files are paths under
 
 ## Sequencing
 
-PRs 1–5 merged (see Completed below).
+Waves 1 and 2 (PRs 1–9, 11–23, 23b, 23c) are merged — see **Completed**
+below for the full list. Remaining waves:
 
-| Wave | PRs        | Notes                               |
-| ---- | ---------- | ----------------------------------- |
-| 3    | 24         | breaking-change wave; ship serially |
-| 4    | 10, 25, 26 | dialect / cross-package work        |
-
-Waves 1 and 2 are complete. Wave-3 requires sequential merge because
-each one moves AR-visible API.
+| Wave | PRs         | Notes                                                                          |
+| ---- | ----------- | ------------------------------------------------------------------------------ |
+| 3    | 24          | breaking-change wave (Binary reparenting); ship before wave 4                  |
+| 4    | 10, 25a, 26 | dialect / cross-package work; 25a is formatting-only and independent           |
+| 5    | 25b         | gates on quoting-refactor Phases 4–5 (PRs 8/9/10 in `docs/quoting-refactor.md`) |
 
 ---
 
@@ -67,7 +66,7 @@ api:compare` is a chained script — args don't reach `compare.ts`.)
 - PR 7 — `SelectManager#limit` / `#offset` getters return inner expr — merged in #1063.
 - PR 16 — `DeleteStatement` / `InsertStatement` visitor shape — merged in #1066.
 - PR 23 — Visitor leaf alignment (Lock + outer-join guards slice) — merged in #1069.
-- PR 23b — Casted/Quoted visitor collapse + Date-bind branch removal — merged in #1074.
+- PR 23b — Casted/Quoted collapse + Date-bind removal — merged in #1074.
 - PR 23c — In-array wrap, Table-name-Node, PostgreSQL ESCAPE — merged in #1078.
 
 ---
@@ -76,17 +75,21 @@ api:compare` is a chained script — args don't reach `compare.ts`.)
 
 Requires Table↔Model wiring. Larger; can defer if not blocking.
 
-### Pre-PR design decision
+### Design decision (resolved)
 
-Two viable shapes:
+**Option 2 — lazy `klass` ref.** Table holds an optional structural
+`klass?: { attributeAliases?: Record<string, string> }`; `get(name)`
+resolves `klass?.attributeAliases?.[name] ?? name`.
 
-1. **Inject on construct**: `new Table("users", { attributeAliases: {...} })`.
-   AR's `Model.arelTable` populates from `Model.attributeAliases`.
-2. **Lazy lookup**: Table holds an optional `klass` ref;
-   `get(name)` calls `klass?.attributeAliases?.[name] ?? name`.
-
-Recommendation: option 2 — fewer construction sites change, matches
-Rails (`@klass.attribute_aliases`).
+Rationale: literal port of Rails' `@klass.attribute_aliases` duck typing,
+expressed via TS structural typing so arel keeps zero runtime/import
+dependency on activerecord. Merging the packages to mirror Ruby's
+single-gem layout was considered and rejected — the package boundary is
+load-bearing for `api:compare`, the website TypeDoc build, and public
+consumers; structural typing already gives us what Ruby gets from
+duck typing. Option 1 (inject aliases dict at construct) was rejected
+because it diverges from Rails (Rails passes the class, not a snapshot
+of the alias map) and forces every `arelTable` site to re-snapshot.
 
 ### Trails files to change
 
@@ -128,33 +131,51 @@ Rails (`@klass.attribute_aliases`).
 
 - `nodes/binary.rb` — `const_set(:Union, ..., Binary)` etc.
 
+### Decision (audit complete)
+
+Reparent: `Union`, `UnionAll`, `Intersect`, `Except` extend `Binary`
+directly. `Join` (the abstract base in `nodes/binary.ts`) extends
+`Binary`; `InnerJoin`/`OuterJoin`/`RightOuterJoin`/`FullOuterJoin`/
+`StringJoin`/`CrossJoin` keep `extends Join` (one level up only — Rails
+also only changes `Join`'s parent). Pre-release, no consumers, no
+migration matrix entry needed.
+
+### Audit findings (2026-05-01)
+
+- `to-sql.ts` has explicit leaf visitors for every reparented class
+  (`visitArelNodesUnion`/`UnionAll`/`Intersect`/`Except` and all
+  `Join` leaves). Direct dispatch wins over ancestor walk → no
+  behavior change.
+- `dot.ts` defines `visitArelNodesBinary` (walks `left`/`right`) and
+  has **no** leaf visitors for set ops or non-string joins. After
+  reparenting, ancestor walk lands on `Binary` and emits the
+  `left`/`right` edges those nodes already carry — strict improvement
+  over today's generic-Node fallback.
+- `dot.ts` `visitArelNodesStringJoin` (line 151, walks only `left`)
+  remains a direct hit; `Join`'s own leaf in dot doesn't exist, so no
+  conflict.
+- PG/MySQL/SQLite use a `visitBinaryOp(node, op)` helper, not a
+  `visit_Arel_Nodes_Binary` reflection target — unaffected.
+
 ### Changes
 
-- `nodes/binary.ts`: redefine `Union`, `UnionAll`, `Intersect`, `Except`
-  as `extends Binary`.
-- `nodes/inner-join.ts`, `outer-join.ts`, `right-outer-join.ts`,
-  `full-outer-join.ts`, `string-join.ts`: extend `Binary` (they likely
-  extend an abstract `Join`; switch `Join` to extend `Binary`).
-- Audit `visitors/visitor.ts`: per-class dispatch cache is keyed by
-  constructor; the `WeakMap` per `VisitorCtor` doesn't need invalidation
-  because each visitor subclass seeds its dispatch on construction. Each
-  visitor subclass's `dispatchCache` already registers
-  `Union → "visitArelNodesUnion"` etc; verify the registration list still
-  matches.
-- Run dispatch tests on subclass instances — `instance.constructor` is
-  still the leaf class, so direct dispatch hits don't change. Ancestor
-  walk now finds `Binary` if a visitor doesn't register a leaf — confirm
-  no leaf relies on a missing-method fallthrough.
+- `nodes/binary.ts`: redeclare `Union`/`UnionAll`/`Intersect`/`Except`
+  as `extends Binary`; switch `Join` to `extends Binary`.
+- Drop the now-redundant explicit `left`/`right` fields and
+  constructor on each set-op class — `Binary` already carries them.
 
 ### Tests
 
 - `nodes/binary.test.ts`: `union.as("u") instanceof As`,
-  `union.and(other) instanceof And`.
+  `union.and(other) instanceof And`, `union instanceof Binary`.
 - `visitors/to-sql.test.ts`: existing UNION/JOIN snapshots unchanged.
+- `visitors/dot.test.ts`: snapshot a UNION graph — should now show
+  `left`/`right` edges via the Binary fallback.
 
 ### Verification
 
-- Full arel test suite green (smoke for visitor dispatch).
+- `pnpm --filter @blazetrails/arel test`.
+- `pnpm parity:query` unchanged.
 
 ### Size
 
@@ -162,74 +183,140 @@ Rails (`@klass.attribute_aliases`).
 
 ---
 
-## PR 25 — MySQL `Concat` / `Cte` formatting + identifier quoting
+## PR 25a — MySQL `Concat` / `Cte` formatting
 
-Folds in the long-deferred `arel MySQL identifier quoting` memory.
+Visitor-side formatting only; no identifier-quoting changes. Independent
+of the quoting refactor.
 
 ### Changes
 
 - `visitors/mysql.ts`:
   - `visitArelNodesConcat`: emit `CONCAT(...)` with surrounding spaces
-    (Rails infix_value).
-  - `visitArelNodesCte`: drop the explicit `(`...`)` (let inner Grouping
-    render).
-  - Override `quoteTableName` / `quoteColumnName` to backtick-escape:
-    `` `name` `` with embedded backticks doubled.
-  - `visitArelTable` / `visitArelNodesAttribute` already call those
-    overrides; verify.
+    (Rails `infix_value`).
+  - `visitArelNodesCte`: drop the explicit `(`...`)` (let inner
+    `Grouping` render).
 
 ### Tests
 
 - `visitors/mysql.test.ts`:
   - `CONCAT` in expression context (e.g. `WHERE name = CONCAT(a, b)`).
   - CTE: `WITH x AS (SELECT 1)` (no double parens).
-  - SELECT/UPDATE/INSERT/DELETE with backtick-quoted identifiers.
+
+### Verification
+
+- `pnpm --filter @blazetrails/arel test`.
+- `pnpm parity:query` unchanged (no identifier-quoting churn yet).
+
+### Size
+
+~30 LOC src + ~60 LOC test.
+
+---
+
+## PR 25b — MySQL identifier quoting via `Quoting` injection
+
+Folds in the long-deferred `arel MySQL identifier quoting` memory.
+**Depends on `docs/quoting-refactor.md` Phase 2 (merged) and ideally
+Phase 4–5 to remove the residual `mysqlQuote(sql)` post-processor.**
+
+### Design decision (resolved)
+
+The arel visitor must NOT carry dialect identifier logic. Instead, it
+receives a `Quoting`-shaped quoter (the contract introduced in
+quoting-refactor PR 2 / #1058) and delegates identifier emission:
+
+```ts
+// visitors/to-sql.ts — base
+quoteTableName(name: string): string {
+  return this.quoter.quoteTableName(name);
+}
+quoteColumnName(name: string): string {
+  return this.quoter.quoteColumnName(name);
+}
+```
+
+`SubstituteBindCollector` already takes a quoter; same pattern. MySQL
+backticks fall out automatically because the MySQL adapter's `Quoting`
+implementation already emits them — no per-visitor override needed.
+
+### Changes
+
+- `visitors/to-sql.ts`:
+  - Constructor accepts `quoter: Quoting` (structural type — arel
+    declares its own minimal `Quoting` interface; activerecord's
+    `Quoting` is structurally compatible).
+  - `visitArelTable` / `visitArelNodesAttribute` /
+    `quoteTableName` / `quoteColumnName` route through `this.quoter`.
+- `visitors/mysql.ts`, `postgresql.ts`, `sqlite.ts`: drop any local
+  identifier overrides that exist; they're now redundant.
+- `activerecord` arel-visitor construction sites: pass
+  `connection` (which `implements Quoting`) as the quoter.
+
+### Tests
+
+- `visitors/mysql.test.ts`:
+  - SELECT/UPDATE/INSERT/DELETE with backtick-quoted identifiers when
+    constructed with a MySQL quoter.
   - Identifier with embedded backtick → doubled.
+- `visitors/to-sql.test.ts`:
+  - Default (no-op) quoter still emits double-quoted identifiers for
+    base/PG/SQLite parity.
 
 ### Risk
 
 - Identifier quoting changes every MySQL SQL fixture. Snapshot churn is
   expected; reviewer accepts the diff.
+- Constructor signature change for `ToSql` and dialect subclasses —
+  audit every in-tree construction site (activerecord adapters, tests,
+  parity harness) and migrate atomically.
 
 ### Verification
 
 - `pnpm parity:query` on MySQL — expect a wave of fixture updates;
   curate these in the PR.
+- After merge: the `mysqlQuote(sql)` runtime post-processor in
+  activerecord becomes redundant — schedule removal as a follow-up
+  (cross-references quoting-refactor.md final note).
 
 ### Size
 
-~60 LOC src + ~150 LOC test (incl. fixture updates).
+~80 LOC src + ~150 LOC test (incl. fixture updates).
 
 ---
 
 ## PR 26 — `BoundSqlLiteral` visitor parity
 
-### Design decision (must be made before opening PR)
+### Design decision (resolved)
 
-Trails' `BoundSqlLiteral.parts` (pre-parsed) is the current contract. Two
-options:
+**Option 2 — drop `parts`; store `sqlWithSubstitutes` + `bindValues`.**
+Match Rails' node shape exactly; visitor parses `?` placeholders at
+visit time. All in-tree consumers of `parts` migrate atomically (no
+shim).
 
-1. **Keep `parts`**: rewrite the visitor to do per-part dispatch
-   (Arel-node value → visit, Array → recurse, else → quote/bind).
-2. **Drop `parts`, add `sqlWithSubstitutes` + `bindValues`**: parse at
-   visit time. Closer to Rails but breaks the node API.
-
-Recommendation: option 1 (less churn, same SQL).
+Rationale: Rails-shape parity for the node, even at the cost of
+re-parsing on each visit. Aligns the node fields one-for-one with
+`nodes/bound_sql_literal.rb` and removes a Trails-only contract.
 
 ### Rails reference
 
 - `visitors/to_sql.rb` — `visit_Arel_Nodes_BoundSqlLiteral`.
-- `nodes/bound_sql_literal.rb` — `BindError` text.
+- `nodes/bound_sql_literal.rb` — `BindError` text, field shape.
 
 ### Changes
 
+- `nodes/bound-sql-literal.ts`:
+  - Replace `parts` with `sqlWithSubstitutes: string` and
+    `bindValues: unknown[]`.
+  - Update constructor + any `eql`/`hash`/inspection paths.
+  - `BindError` message text matches Rails verbatim.
 - `visitors/to-sql.ts` `visitArelNodesBoundSqlLiteral`:
-  - For each part of the BoundSqlLiteral:
-    - if `part` is an `Arel::Node` (or Trails `Node`) → `visit(part)`.
-    - if `Array.isArray(part)` → visit each, comma-joined.
-    - if `part` is a literal string segment → emit verbatim.
-    - else → quote/bind.
-- `errors.ts` — match Rails BindError messages.
+  - Walk `sqlWithSubstitutes`, splitting on `?` placeholders; for each
+    bind: `Node` → `visit`, `Array` → visit each comma-joined, else →
+    `quote` (or bind via collector).
+  - Mismatched bind count → `BindError`.
+- All in-tree call sites that constructed `BoundSqlLiteral` with `parts`
+  migrate to the new constructor in the same PR.
+- `errors.ts` — `BindError` text aligned with Rails.
 
 ### Tests
 
@@ -238,9 +325,16 @@ Recommendation: option 1 (less churn, same SQL).
   - Array value flattens with `, `.
   - Missing/extra binds → BindError with Rails-shaped message text.
 
+### Risk
+
+- Breaking change to the `BoundSqlLiteral` node API. Audit every
+  in-tree consumer (search for `BoundSqlLiteral` and `.parts`) before
+  opening; migrate atomically.
+
 ### Size
 
-~80 LOC src + ~110 LOC test.
+~100 LOC src + ~110 LOC test (constructor migration adds ~20 LOC over
+Option 1).
 
 ---
 
@@ -252,7 +346,8 @@ deprecated aliases, no shims.
 | PR  | Surface                                        | Notes                |
 | --- | ---------------------------------------------- | -------------------- |
 | 24  | `Union/Intersect/Except/Join` extends `Binary` | API gain only        |
-| 25  | MySQL identifier quoting                       | curate snapshot diff |
+| 25b | MySQL identifier quoting via Quoting injection | curate snapshot diff |
+| 26  | `BoundSqlLiteral` node fields (`parts` → Rails shape) | atomic in-tree migrate |
 
 ---
 

--- a/docs/quoting-refactor.md
+++ b/docs/quoting-refactor.md
@@ -1,17 +1,15 @@
 # Quoting Refactor: Thread Adapter Through All Call Sites
 
-> **Status (2026-04-30):** Adapter classes (`AbstractAdapter`,
-> `PostgreSQLAdapter`, `AbstractMysqlAdapter`, `SQLite3Adapter`) all have
-> a `quote()` instance method, but ~14 call sites outside the adapter
-> layer still import the **standalone** `quote` / `quoteIdentifier` /
-> `quoteTableName` / `quoteDefaultExpression` from
-> `connection-adapters/abstract/quoting.ts` and pass an
-> `adapter?: "sqlite" | "postgres" | "mysql"` string to select dialect.
-> That string-dispatch path duplicates dialect logic and produces wrong
-> SQL when the adapter dispatch on the receiver would diverge from the
-> abstract default — most importantly identifier quoting (MySQL
-> backticks vs. abstract double-quotes) inside `sanitization.ts`,
-> `relation/query-methods.ts`, and the model-schema / migration paths.
+> **Status (2026-05-01):** Phases 0–3 merged
+> (#1051, #1058, #1065, #1068, #1070, #1072, #1075). The hot path
+> (sanitization, query-methods, database-statements) and abstract +
+> PostgreSQL schema layers all route quoting through the adapter's
+> `Quoting` interface. **Remaining:** Phase 4 (model-schema +
+> internal-metadata + primary-key + migration + alias-tracker +
+> association-scope) and Phase 5 (remove the
+> `adapter?: "sqlite" | "postgres" | "mysql"` enum from
+> `abstract/quoting.ts`). Until Phase 5 lands, the enum still exists and
+> the abstract module still has dialect branches.
 
 ## Problem
 
@@ -302,20 +300,21 @@ PR 1 ──► PR 2 ──► PR 3, 4, 5  (phase 2, parallel after PR 2)
                               └─► PR 10 (phase 5, after all above)
 ```
 
-| PR  | Phase | Scope                                            | Est. LOC |
-| --- | ----- | ------------------------------------------------ | -------- |
-| 1   | 0     | uniform `quoteIdentifier` across adapter modules | ~50      |
-| 2   | 1     | `Quoting` interface + adapter `implements`       | ~120     |
-| 3   | 2     | sanitization through `quoter`                    | ~150     |
-| 4   | 2     | query-methods + relation neutralize              | ~120     |
-| 5   | 2     | database-statements `this.quoteX`                | ~80      |
-| 6   | 3     | abstract schema-creation + schema-definitions    | ~250     |
-| 7   | 3     | abstract schema-statements + PG schema files     | ~200     |
-| 8   | 4     | model-schema + internal-metadata + primary-key   | ~200     |
-| 9   | 4     | migration + alias-tracker + association-scope    | ~150     |
-| 10  | 5     | remove `adapter?:` param                         | ~80      |
+| PR  | Phase | Scope                                            | Est. LOC | Status        |
+| --- | ----- | ------------------------------------------------ | -------- | ------------- |
+| 1   | 0     | uniform `quoteIdentifier` across adapter modules | ~50      | merged #1051  |
+| 2   | 1     | `Quoting` interface + adapter `implements`       | ~120     | merged #1058  |
+| 3   | 2     | sanitization through `quoter`                    | ~150     | merged #1065  |
+| 4   | 2     | query-methods + relation neutralize              | ~120     | merged #1068  |
+| 5   | 2     | database-statements `this.quoteX`                | ~80      | merged #1070  |
+| 6   | 3     | abstract schema-creation + schema-definitions    | ~250     | merged #1072  |
+| 7   | 3     | abstract schema-statements + PG schema files     | ~200     | merged #1075  |
+| 8   | 4     | model-schema + internal-metadata + primary-key   | ~200     | open          |
+| 9   | 4     | migration + alias-tracker + association-scope    | ~150     | open          |
+| 10  | 5     | remove `adapter?:` param                         | ~80      | open          |
 
-Total: 10 PRs, all under the 300-LOC ceiling.
+Total: 10 PRs, all under the 300-LOC ceiling. PRs 8/9 parallel; PR 10
+gates on both.
 
 ## Acceptance criteria
 

--- a/docs/quoting-refactor.md
+++ b/docs/quoting-refactor.md
@@ -243,8 +243,159 @@ parameter and pass it as a string to the standalone functions. Replace
 
 **PR split:**
 
-- **PR 8** — model-schema + internal-metadata + primary-key. ~200 LOC.
-- **PR 9** — migration + association-scope + alias-tracker. ~150 LOC.
+### PR 8 — model-schema + internal-metadata + primary-key (~200 LOC)
+
+Common pattern across all three files: replace
+`quoteX(name, this._adapterName)` (or `adapterName` constructor arg)
+with `this._adapter.quoteX(name)`, holding a `Quoting` reference
+instead of a dialect string.
+
+#### Step-by-step
+
+1. **`packages/activerecord/src/internal-metadata.ts`** —
+   - Lines 23–116. The class currently holds `private _adapter` (the
+     adapter instance) and a derived
+     `private get _adapterName(): "sqlite" | "postgres" | "mysql"`
+     (line 45). The `_adapter` field already satisfies `Quoting`
+     after quoting-refactor PR 2.
+   - **Delete** the `_adapterName` getter and every callsite that
+     consumes it (lines 50, 85, 88, 116). Replace with direct calls
+     on `this._adapter`:
+     ```ts
+     // before
+     return quoteIdentifier(name, this._adapterName);
+     // after
+     return this._adapter.quoteIdentifier(name);
+     ```
+   - Line 85 (`_adapterName === "postgres" ? "TIMESTAMP" : "DATETIME"`)
+     is a SQL-type choice, **not quoting** — leave the conditional
+     logic but base it on a different adapter capability check
+     (`this._adapter instanceof PostgreSQLAdapter`, or a typed
+     `adapterCapabilities` getter). If unclear, keep as-is and
+     leave a TODO referencing this plan.
+   - Update the import at line 11 to drop `quoteIdentifier`/
+     `quoteTableName` from `abstract/quoting.js`.
+
+2. **`packages/activerecord/src/model-schema.ts`** —
+   Lines 13, 65, 70, 310, 316, 318–319, 325, 332, 336, 340, 374.
+   Class methods (`createTable`, `dropTable`, `quotedTableName`,
+   etc.) already have `this.adapter` (or `this.connection`) in
+   scope. For each callsite:
+   ```ts
+   // before
+   `${quoteIdentifier(pk, adapterName)} INTEGER PRIMARY KEY`
+   // after
+   `${this.adapter.quoteIdentifier(pk)} INTEGER PRIMARY KEY`
+   ```
+   The `detectAdapterName(this.adapter)` line at 305 disappears —
+   delete it and any branches that switched purely on the dialect
+   string for **identifier quoting**. Type-related branches
+   (lines 316–319, MySQL `BIGINT AUTO_INCREMENT` vs PG `SERIAL`)
+   remain but should switch on `instanceof` or a capability check.
+
+3. **`packages/activerecord/src/attribute-methods/primary-key.ts`** —
+   Lines 6, 116–117.
+   - Line 6: drop the `quoteX from "abstract/quoting.js"` import.
+   - Lines 116–117: helper currently takes `adapter: string`. Change
+     signature to `adapter: Quoting` (or rename the param). Callers
+     are class methods that already have `this.constructor.connection`.
+
+4. **Compliance grep within the changed files** —
+   `grep -nE 'from.*abstract/quoting' packages/activerecord/src/{model-schema,internal-metadata,attribute-methods/primary-key}.ts`
+   should report 0 matches after the change.
+
+#### Tests
+
+- Existing tests for `internal-metadata`, `model-schema`,
+  `primary-key` are sufficient if they pass — the SQL output is
+  identical. Add one new assertion per file confirming the
+  identifier comes from `this._adapter.quoteIdentifier`:
+  ```ts
+  it("uses adapter quoting for table names", () => {
+    const adapter = mockAdapterWith({ quoteIdentifier: () => "<<X>>" });
+    new InternalMetadata(adapter, ...).quotedTableName();
+    expect(...).toContain("<<X>>");
+  });
+  ```
+
+#### Verification
+
+- `pnpm --filter @blazetrails/activerecord test` green.
+- `pnpm parity:schema` unchanged (these files emit DDL; if a fixture
+  changes it's a bug, not expected drift).
+
+---
+
+### PR 9 — migration + association-scope + alias-tracker (~150 LOC)
+
+#### Step-by-step
+
+1. **`packages/activerecord/src/migration.ts`** —
+   Lines 14, 1290, 1298.
+   - Line 14: drop `quoteIdentifier`/`quoteTableName` import from
+     `abstract/quoting.js`.
+   - Lines 1290, 1298: migrations already hold `this.connection`
+     (the adapter). Replace `quoteIdentifier(x, dialect)` with
+     `this.connection.quoteIdentifier(x)`.
+
+2. **`packages/activerecord/src/associations/alias-tracker.ts`** —
+   Lines 8, 40.
+   - Line 8: drop the `quoteTableName` import.
+   - Line 40: the static `initialCountFor(name, tableJoins)` calls
+     `quoteTableName(name)` (no dialect, so it falls through to the
+     abstract default). The method is static, so threading
+     `this.connection` is not an option. Two viable shapes:
+
+     **A.** Make the method instance-bound: move `initialCountFor`
+     onto the `AliasTracker` instance and pass `this._quoter` (a
+     `Quoting` field added to the constructor) to the regex
+     builder.
+
+     **B.** Keep the method static but add a `quoter: Quoting`
+     parameter; callers (search `grep -rn "initialCountFor" packages/`)
+     pass their connection.
+
+     Recommendation: **A**. The constructor at line 17 already
+     accepts a `pool` indirectly via `create(pool, …)` at line 23;
+     thread `pool.withConnection().quoter` (or equivalent) into a
+     `_quoter` field. Confirms the regex anchor uses MySQL backticks
+     for MySQL connections.
+
+3. **`packages/activerecord/src/associations/association-scope.ts`** —
+   Lines 13, 500–517 (~5 sites).
+   - Line 13: drop the abstract-quoting import.
+   - The scope context already carries the connection; replace
+     each `quoteX(name, dialect)` with
+     `scopeContext.connection.quoteX(name)`.
+
+4. **Compliance grep** —
+   ```sh
+   grep -nE 'from.*abstract/quoting' \
+     packages/activerecord/src/migration.ts \
+     packages/activerecord/src/associations/alias-tracker.ts \
+     packages/activerecord/src/associations/association-scope.ts
+   ```
+   should report 0.
+
+#### Tests
+
+- Existing migration / association tests must remain green.
+- `alias-tracker.test.ts` — new test: build a tracker with a MySQL
+  quoter, call `initialCountFor("users", joins)` against a join
+  containing `` JOIN `users` ON … ``, assert count = 1. Same with
+  PG/SQLite (double-quoted identifiers).
+- Mirror Rails test names from
+  `scripts/api-compare/.rails-source/activerecord/test/cases/associations/alias_tracker_test.rb`.
+
+#### Verification
+
+- `pnpm --filter @blazetrails/activerecord test`.
+- `pnpm parity:query` green; MySQL fixtures involving aliased
+  joins should now match the regex correctly under backtick
+  quoting (this is the load-bearing behavior — was previously
+  silently passing because `quoteTableName(name)` defaulted to
+  double-quotes which never matched the backticked SQL produced
+  by the visitor).
 
 ## Phase 5 — Remove the `adapter?:` parameter (PR 10)
 


### PR DESCRIPTION
## Summary

- **arel-alignment-plan**: mark PR 23b (#1074) and 23c (#1078) complete; record decisions for the remaining open questions on PRs 10 (lazy `klass` ref), 24 (Binary reparenting; audit clean — dot graph improves), and 26 (drop `parts`, adopt Rails `sqlWithSubstitutes` + `bindValues`). Split PR 25 into **25a** (Concat/Cte formatting, independent) and **25b** (identifier quoting via `Quoting` interface injection, gates on quoting-refactor Phase 4–5).
- **quoting-refactor**: status header + PR table now reflect Phases 0–3 merged (#1051, #1058, #1065, #1068, #1070, #1072, #1075); PRs 8/9 (Phase 4) and PR 10 (Phase 5, remove `adapter?:` enum) remain.
- **actioncontroller-privates-plan**: newly tracked; status header (252/581, 43.4%); flag rows where the original "Missing" count drifted from current api:compare — most notably `base.rb` (2 → 83), which now needs a sub-plan rather than one PR.
- **Deletes**:
  - `arel-privates-100-plan.md` — 820/820 shipped (PRs #993, #1003, #1008, #1014, #1020).
  - `typedoc-rails-privates-plan.md` — `excludeInternal: true` is in `packages/website/typedoc.json` and `eslint/rails-private-jsdoc.mjs` enforces the `@internal` tag.

Docs-only; no code changes.

## Test plan

- [ ] Reviewer skim — counts match `pnpm tsx scripts/api-compare/compare.ts --package <pkg> --privates`.