### PR TITLE
refactor(activerecord): route quoting through adapter in model-schema, internal-metadata, primary-key (PR 8)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -211,6 +211,28 @@ export interface DatabaseAdapter {
   quote?(value: unknown): string;
 
   /**
+   * Quote an identifier (table or column name) for use in SQL.
+   * Abstract and SQLite/PG use double-quotes; MySQL uses backticks.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
+   */
+  quoteIdentifier?(name: string): string;
+
+  /**
+   * Quote a table name for use in SQL.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
+   */
+  quoteTableName?(name: string): string;
+
+  /**
+   * Quote a column name for use in SQL.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
+   */
+  quoteColumnName?(name: string): string;
+
+  /**
    * Cast a value to the primitive form drivers expect for binds.
    * Returns an **unquoted** primitive suitable for passing as a bind
    * value — distinct from `quote()`, which returns a SQL literal

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -208,7 +208,7 @@ export interface DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote
    */
-  quote?(value: unknown): string;
+  quote(value: unknown): string;
 
   /**
    * Quote an identifier (table or column name) for use in SQL.
@@ -216,21 +216,21 @@ export interface DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
    */
-  quoteIdentifier?(name: string): string;
+  quoteIdentifier(name: string): string;
 
   /**
    * Quote a table name for use in SQL.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
    */
-  quoteTableName?(name: string): string;
+  quoteTableName(name: string): string;
 
   /**
    * Quote a column name for use in SQL.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
    */
-  quoteColumnName?(name: string): string;
+  quoteColumnName(name: string): string;
 
   /**
    * Cast a value to the primitive form drivers expect for binds.

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -3,8 +3,6 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey
  */
-import { quoteIdentifier } from "../connection-adapters/abstract/quoting.js";
-import { detectAdapterName } from "../adapter-name.js";
 import { underscore } from "@blazetrails/activesupport";
 import { dangerousAttributeMethods } from "../attribute-methods.js";
 
@@ -112,9 +110,9 @@ export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string):
  */
 export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: any }): string {
   const pk = this.primaryKey;
-  const adapter = this.adapter ? detectAdapterName(this.adapter) : undefined;
-  if (Array.isArray(pk)) return pk.map((k) => quoteIdentifier(k, adapter)).join(", ");
-  return quoteIdentifier(pk, adapter);
+  const quoter = this.adapter;
+  if (Array.isArray(pk)) return pk.map((k) => quoter?.quoteIdentifier(k) ?? `"${k}"`).join(", ");
+  return quoter?.quoteIdentifier(pk) ?? `"${pk}"`;
 }
 
 export function resetPrimaryKey(this: PrimaryKeyHost): void {

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -5,6 +5,7 @@
  */
 import { underscore } from "@blazetrails/activesupport";
 import { dangerousAttributeMethods } from "../attribute-methods.js";
+import type { DatabaseAdapter } from "../adapter.js";
 
 interface PrimaryKeyRecord {
   id: unknown;
@@ -108,7 +109,7 @@ export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string):
 /**
  * Rails: adapter_class.quote_column_name(primary_key)
  */
-export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: any }): string {
+export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: DatabaseAdapter }): string {
   const pk = this.primaryKey;
   const quoter = this.adapter;
   const fallback = (k: string) => `"${k.replace(/"/g, '""')}"`;

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -113,8 +113,8 @@ export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: any }): stri
   const quoter = this.adapter;
   const fallback = (k: string) => `"${k.replace(/"/g, '""')}"`;
   if (Array.isArray(pk))
-    return pk.map((k) => (quoter ? quoter.quoteColumnName!(k) : fallback(k))).join(", ");
-  return quoter ? quoter.quoteColumnName!(pk as string) : fallback(pk as string);
+    return pk.map((k) => (quoter ? quoter.quoteColumnName(k) : fallback(k))).join(", ");
+  return quoter ? quoter.quoteColumnName(pk as string) : fallback(pk as string);
 }
 
 export function resetPrimaryKey(this: PrimaryKeyHost): void {

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -111,8 +111,8 @@ export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string):
 export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: any }): string {
   const pk = this.primaryKey;
   const quoter = this.adapter;
-  if (Array.isArray(pk)) return pk.map((k) => quoter?.quoteIdentifier(k) ?? `"${k}"`).join(", ");
-  return quoter?.quoteIdentifier(pk) ?? `"${pk}"`;
+  if (Array.isArray(pk)) return pk.map((k) => quoter?.quoteColumnName(k) ?? `"${k}"`).join(", ");
+  return quoter?.quoteColumnName(pk) ?? `"${pk}"`;
 }
 
 export function resetPrimaryKey(this: PrimaryKeyHost): void {

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -111,8 +111,10 @@ export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string):
 export function quotedPrimaryKey(this: PrimaryKeyHost & { adapter?: any }): string {
   const pk = this.primaryKey;
   const quoter = this.adapter;
-  if (Array.isArray(pk)) return pk.map((k) => quoter?.quoteColumnName(k) ?? `"${k}"`).join(", ");
-  return quoter?.quoteColumnName(pk) ?? `"${pk}"`;
+  const fallback = (k: string) => `"${k.replace(/"/g, '""')}"`;
+  if (Array.isArray(pk))
+    return pk.map((k) => (quoter ? quoter.quoteColumnName!(k) : fallback(k))).join(", ");
+  return quoter ? quoter.quoteColumnName!(pk as string) : fallback(pk as string);
 }
 
 export function resetPrimaryKey(this: PrimaryKeyHost): void {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -8,7 +8,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { NotImplementedError } from "./errors.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { detectAdapterName } from "./adapter-name.js";
-import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { EnvironmentStorageError } from "./migration.js";
 import {
   Table,
@@ -42,12 +41,8 @@ export class InternalMetadata {
   private _adapter: DatabaseAdapter;
   readonly arelTable: Table;
 
-  private get _adapterName(): "sqlite" | "postgres" | "mysql" {
-    return detectAdapterName(this._adapter);
-  }
-
   private _q(name: string): string {
-    return quoteIdentifier(name, this._adapterName);
+    return (this._adapter as any).quoteIdentifier(name);
   }
 
   get primaryKey(): string {
@@ -82,10 +77,10 @@ export class InternalMetadata {
 
   async createTable(): Promise<void> {
     if (!this._enabled) return;
-    const tsType = this._adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
+    const tsType = detectAdapterName(this._adapter) === "postgres" ? "TIMESTAMP" : "DATETIME";
     const q = (n: string) => this._q(n);
     await this._adapter.executeMutation(
-      `CREATE TABLE IF NOT EXISTS ${quoteTableName(this.tableName, this._adapterName)} (` +
+      `CREATE TABLE IF NOT EXISTS ${(this._adapter as any).quoteTableName(this.tableName)} (` +
         `${q("key")} VARCHAR(255) NOT NULL PRIMARY KEY, ` +
         `${q("value")} VARCHAR(255), ` +
         `${q("created_at")} ${tsType} NOT NULL, ` +
@@ -113,7 +108,7 @@ export class InternalMetadata {
     // config or adapter is actively using.
     if (!this._enabled) return;
     await this._adapter.executeMutation(
-      `DROP TABLE IF EXISTS ${quoteTableName(this.tableName, this._adapterName)}`,
+      `DROP TABLE IF EXISTS ${(this._adapter as any).quoteTableName(this.tableName)}`,
     );
   }
 

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -42,7 +42,7 @@ export class InternalMetadata {
   readonly arelTable: Table;
 
   private _q(name: string): string {
-    return (this._adapter as any).quoteIdentifier(name);
+    return this._adapter.quoteIdentifier!(name);
   }
 
   get primaryKey(): string {
@@ -80,7 +80,7 @@ export class InternalMetadata {
     const tsType = detectAdapterName(this._adapter) === "postgres" ? "TIMESTAMP" : "DATETIME";
     const q = (n: string) => this._q(n);
     await this._adapter.executeMutation(
-      `CREATE TABLE IF NOT EXISTS ${(this._adapter as any).quoteTableName(this.tableName)} (` +
+      `CREATE TABLE IF NOT EXISTS ${this._adapter.quoteTableName!(this.tableName)} (` +
         `${q("key")} VARCHAR(255) NOT NULL PRIMARY KEY, ` +
         `${q("value")} VARCHAR(255), ` +
         `${q("created_at")} ${tsType} NOT NULL, ` +
@@ -108,7 +108,7 @@ export class InternalMetadata {
     // config or adapter is actively using.
     if (!this._enabled) return;
     await this._adapter.executeMutation(
-      `DROP TABLE IF EXISTS ${(this._adapter as any).quoteTableName(this.tableName)}`,
+      `DROP TABLE IF EXISTS ${this._adapter.quoteTableName!(this.tableName)}`,
     );
   }
 

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -42,7 +42,7 @@ export class InternalMetadata {
   readonly arelTable: Table;
 
   private _q(name: string): string {
-    return this._adapter.quoteIdentifier!(name);
+    return this._adapter.quoteIdentifier(name);
   }
 
   get primaryKey(): string {
@@ -80,7 +80,7 @@ export class InternalMetadata {
     const tsType = detectAdapterName(this._adapter) === "postgres" ? "TIMESTAMP" : "DATETIME";
     const q = (n: string) => this._q(n);
     await this._adapter.executeMutation(
-      `CREATE TABLE IF NOT EXISTS ${this._adapter.quoteTableName!(this.tableName)} (` +
+      `CREATE TABLE IF NOT EXISTS ${this._adapter.quoteTableName(this.tableName)} (` +
         `${q("key")} VARCHAR(255) NOT NULL PRIMARY KEY, ` +
         `${q("value")} VARCHAR(255), ` +
         `${q("created_at")} ${tsType} NOT NULL, ` +
@@ -108,7 +108,7 @@ export class InternalMetadata {
     // config or adapter is actively using.
     if (!this._enabled) return;
     await this._adapter.executeMutation(
-      `DROP TABLE IF EXISTS ${this._adapter.quoteTableName!(this.tableName)}`,
+      `DROP TABLE IF EXISTS ${this._adapter.quoteTableName(this.tableName)}`,
     );
   }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -10,7 +10,6 @@ import {
   type Type,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
-import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { applyPendingEncryptions } from "./encryption.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
@@ -55,19 +54,19 @@ export function resolveTableName(this: typeof Base): string {
  */
 export function buildPkWhere(this: typeof Base, idValue: unknown): string {
   const pk = this.primaryKey;
-  const adapter = detectAdapterName(this.adapter);
+  const a = this.adapter as any;
   if (Array.isArray(pk)) {
     if (!Array.isArray(idValue) || idValue.length !== pk.length) return "1=0";
     const conditions: string[] = [];
     for (let i = 0; i < pk.length; i++) {
       const v = idValue[i];
       if (v === undefined || v === null) return "1=0";
-      conditions.push(`${quoteIdentifier(pk[i], adapter)} = ${quote(v)}`);
+      conditions.push(`${a.quoteIdentifier(pk[i])} = ${a.quote(v)}`);
     }
     return conditions.join(" AND ");
   }
   if (idValue === undefined || idValue === null) return "1=0";
-  return `${quoteIdentifier(pk as string, adapter)} = ${quote(idValue)}`;
+  return `${a.quoteIdentifier(pk as string)} = ${a.quote(idValue)}`;
 }
 
 /**
@@ -306,38 +305,39 @@ export async function createTable(this: typeof Base): Promise<void> {
   const isMysql = adapterName === "mysql";
   const isPg = adapterName === "postgres";
   const pkSet = new Set(pks);
+  const a = this.adapter as any;
 
-  await this.adapter.executeMutation(`DROP TABLE IF EXISTS ${quoteTableName(table, adapterName)}`);
+  await this.adapter.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
 
   const colDefs: string[] = [];
   if (pks.length === 1) {
     const pk = pks[0];
     const pkDef = isPg
-      ? `${quoteIdentifier(pk, adapterName)} SERIAL PRIMARY KEY`
+      ? `${a.quoteIdentifier(pk)} SERIAL PRIMARY KEY`
       : isMysql
-        ? `${quoteIdentifier(pk, adapterName)} BIGINT AUTO_INCREMENT PRIMARY KEY`
-        : `${quoteIdentifier(pk, adapterName)} INTEGER PRIMARY KEY AUTOINCREMENT`;
+        ? `${a.quoteIdentifier(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
+        : `${a.quoteIdentifier(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
       const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
-      colDefs.push(`${quoteIdentifier(pk, adapterName)} ${pkType} NOT NULL`);
+      colDefs.push(`${a.quoteIdentifier(pk)} ${pkType} NOT NULL`);
     }
   }
 
   for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
-    colDefs.push(`${quoteIdentifier(name, adapterName)} ${sqlType}`);
+    colDefs.push(`${a.quoteIdentifier(name)} ${sqlType}`);
   }
 
   if (pks.length > 1) {
-    colDefs.push(`PRIMARY KEY (${pks.map((pk) => quoteIdentifier(pk, adapterName)).join(", ")})`);
+    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
   }
 
   await this.adapter.executeMutation(
-    `CREATE TABLE IF NOT EXISTS ${quoteTableName(table, adapterName)} (${colDefs.join(", ")})`,
+    `CREATE TABLE IF NOT EXISTS ${a.quoteTableName(table)} (${colDefs.join(", ")})`,
   );
 }
 
@@ -371,7 +371,7 @@ export function deriveJoinTableName(this: SchemaHost, otherTableName: string): s
 }
 
 export function quotedTableName(this: SchemaHost): string {
-  return quoteTableName(this.tableName, detectAdapterName(this.adapter));
+  return (this.adapter as any).quoteTableName(this.tableName);
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -61,12 +61,12 @@ export function buildPkWhere(this: typeof Base, idValue: unknown): string {
     for (let i = 0; i < pk.length; i++) {
       const v = idValue[i];
       if (v === undefined || v === null) return "1=0";
-      conditions.push(`${a.quoteIdentifier!(pk[i])} = ${a.quote!(v)}`);
+      conditions.push(`${a.quoteIdentifier(pk[i])} = ${a.quote(v)}`);
     }
     return conditions.join(" AND ");
   }
   if (idValue === undefined || idValue === null) return "1=0";
-  return `${a.quoteIdentifier!(pk as string)} = ${a.quote!(idValue)}`;
+  return `${a.quoteIdentifier(pk as string)} = ${a.quote(idValue)}`;
 }
 
 /**
@@ -307,37 +307,37 @@ export async function createTable(this: typeof Base): Promise<void> {
   const pkSet = new Set(pks);
   const a = this.adapter;
 
-  await a.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName!(table)}`);
+  await a.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
 
   const colDefs: string[] = [];
   if (pks.length === 1) {
     const pk = pks[0];
     const pkDef = isPg
-      ? `${a.quoteIdentifier!(pk)} SERIAL PRIMARY KEY`
+      ? `${a.quoteIdentifier(pk)} SERIAL PRIMARY KEY`
       : isMysql
-        ? `${a.quoteIdentifier!(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
-        : `${a.quoteIdentifier!(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
+        ? `${a.quoteIdentifier(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
+        : `${a.quoteIdentifier(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
       const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
-      colDefs.push(`${a.quoteIdentifier!(pk)} ${pkType} NOT NULL`);
+      colDefs.push(`${a.quoteIdentifier(pk)} ${pkType} NOT NULL`);
     }
   }
 
   for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
-    colDefs.push(`${a.quoteIdentifier!(name)} ${sqlType}`);
+    colDefs.push(`${a.quoteIdentifier(name)} ${sqlType}`);
   }
 
   if (pks.length > 1) {
-    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier!(pk)).join(", ")})`);
+    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
   }
 
   await a.executeMutation(
-    `CREATE TABLE IF NOT EXISTS ${a.quoteTableName!(table)} (${colDefs.join(", ")})`,
+    `CREATE TABLE IF NOT EXISTS ${a.quoteTableName(table)} (${colDefs.join(", ")})`,
   );
 }
 
@@ -371,7 +371,7 @@ export function deriveJoinTableName(this: SchemaHost, otherTableName: string): s
 }
 
 export function quotedTableName(this: SchemaHost): string {
-  return this.adapter.quoteTableName!(this.tableName);
+  return this.adapter.quoteTableName(this.tableName);
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -54,19 +54,19 @@ export function resolveTableName(this: typeof Base): string {
  */
 export function buildPkWhere(this: typeof Base, idValue: unknown): string {
   const pk = this.primaryKey;
-  const a = this.adapter as any;
+  const a = this.adapter;
   if (Array.isArray(pk)) {
     if (!Array.isArray(idValue) || idValue.length !== pk.length) return "1=0";
     const conditions: string[] = [];
     for (let i = 0; i < pk.length; i++) {
       const v = idValue[i];
       if (v === undefined || v === null) return "1=0";
-      conditions.push(`${a.quoteIdentifier(pk[i])} = ${a.quote(v)}`);
+      conditions.push(`${a.quoteIdentifier!(pk[i])} = ${a.quote!(v)}`);
     }
     return conditions.join(" AND ");
   }
   if (idValue === undefined || idValue === null) return "1=0";
-  return `${a.quoteIdentifier(pk as string)} = ${a.quote(idValue)}`;
+  return `${a.quoteIdentifier!(pk as string)} = ${a.quote!(idValue)}`;
 }
 
 /**
@@ -305,39 +305,39 @@ export async function createTable(this: typeof Base): Promise<void> {
   const isMysql = adapterName === "mysql";
   const isPg = adapterName === "postgres";
   const pkSet = new Set(pks);
-  const a = this.adapter as any;
+  const a = this.adapter;
 
-  await this.adapter.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
+  await a.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName!(table)}`);
 
   const colDefs: string[] = [];
   if (pks.length === 1) {
     const pk = pks[0];
     const pkDef = isPg
-      ? `${a.quoteIdentifier(pk)} SERIAL PRIMARY KEY`
+      ? `${a.quoteIdentifier!(pk)} SERIAL PRIMARY KEY`
       : isMysql
-        ? `${a.quoteIdentifier(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
-        : `${a.quoteIdentifier(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
+        ? `${a.quoteIdentifier!(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
+        : `${a.quoteIdentifier!(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
       const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
-      colDefs.push(`${a.quoteIdentifier(pk)} ${pkType} NOT NULL`);
+      colDefs.push(`${a.quoteIdentifier!(pk)} ${pkType} NOT NULL`);
     }
   }
 
   for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
-    colDefs.push(`${a.quoteIdentifier(name)} ${sqlType}`);
+    colDefs.push(`${a.quoteIdentifier!(name)} ${sqlType}`);
   }
 
   if (pks.length > 1) {
-    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
+    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier!(pk)).join(", ")})`);
   }
 
-  await this.adapter.executeMutation(
-    `CREATE TABLE IF NOT EXISTS ${a.quoteTableName(table)} (${colDefs.join(", ")})`,
+  await a.executeMutation(
+    `CREATE TABLE IF NOT EXISTS ${a.quoteTableName!(table)} (${colDefs.join(", ")})`,
   );
 }
 
@@ -371,7 +371,7 @@ export function deriveJoinTableName(this: SchemaHost, otherTableName: string): s
 }
 
 export function quotedTableName(this: SchemaHost): string {
-  return (this.adapter as any).quoteTableName(this.tableName);
+  return this.adapter.quoteTableName!(this.tableName);
 }
 
 /**

--- a/packages/website/src/lib/frontiers/sql-js-adapter.ts
+++ b/packages/website/src/lib/frontiers/sql-js-adapter.ts
@@ -48,6 +48,22 @@ export class SqlJsAdapter implements DatabaseAdapter {
     this.db.run(`ROLLBACK TO SAVEPOINT "${name.replace(/"/g, '""')}"`);
   }
 
+  quoteIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+  quoteTableName(name: string): string {
+    return this.quoteIdentifier(name);
+  }
+  quoteColumnName(name: string): string {
+    return this.quoteIdentifier(name);
+  }
+  quote(value: unknown): string {
+    if (value === null || value === undefined) return "NULL";
+    if (typeof value === "boolean") return value ? "1" : "0";
+    if (typeof value === "number" || typeof value === "bigint") return String(value);
+    return `'${String(value).replace(/'/g, "''")}'`;
+  }
+
   async explain(sql: string): Promise<string> {
     const results = this.db.exec(`EXPLAIN QUERY PLAN ${sql}`);
     return results[0]?.values.map((r: any[]) => r.join("|")).join("\n") ?? "";

--- a/packages/website/src/lib/frontiers/sql-js-adapter.ts
+++ b/packages/website/src/lib/frontiers/sql-js-adapter.ts
@@ -51,17 +51,27 @@ export class SqlJsAdapter implements DatabaseAdapter {
   quoteIdentifier(name: string): string {
     return `"${name.replace(/"/g, '""')}"`;
   }
-  quoteTableName(name: string): string {
-    return this.quoteIdentifier(name);
-  }
   quoteColumnName(name: string): string {
     return this.quoteIdentifier(name);
+  }
+  quoteTableName(name: string): string {
+    return name
+      .split(".")
+      .map((part) => this.quoteIdentifier(part))
+      .join(".");
   }
   quote(value: unknown): string {
     if (value === null || value === undefined) return "NULL";
     if (typeof value === "boolean") return value ? "1" : "0";
-    if (typeof value === "number" || typeof value === "bigint") return String(value);
-    return `'${String(value).replace(/'/g, "''")}'`;
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) return `'${value}'`;
+      return String(value);
+    }
+    if (typeof value === "bigint") return String(value);
+    if (typeof value === "string") return `'${value.replace(/'/g, "''")}'`;
+    throw new TypeError(
+      `SqlJsAdapter.quote: unsupported type ${Object.prototype.toString.call(value)}`,
+    );
   }
 
   async explain(sql: string): Promise<string> {


### PR DESCRIPTION
PR 8 of the quoting refactor described in [docs/quoting-refactor.md](docs/quoting-refactor.md).

Routes all identifier/table quoting through the adapter's \`Quoting\` interface in three files, eliminating the remaining \`abstract/quoting\` imports from model-schema.ts, internal-metadata.ts, and attribute-methods/primary-key.ts.

## Changes

- **\`internal-metadata.ts\`** — removes \`quoteIdentifier\`/\`quoteTableName\` imports; \`_adapterName\` getter deleted; \`_q()\` calls \`this._adapter.quoteIdentifier()\`; CREATE/DROP TABLE call \`this._adapter.quoteTableName()\`.
- **\`model-schema.ts\`** — removes \`quote\`/\`quoteIdentifier\`/\`quoteTableName\` imports; \`buildPkWhere\`, \`createTable\`, and \`quotedTableName\` all dispatch through \`this.adapter\`.
- **\`attribute-methods/primary-key.ts\`** — removes \`quoteIdentifier\`/\`detectAdapterName\` imports; \`quotedPrimaryKey\` calls \`this.adapter.quoteColumnName()\` (mirrors Rails \`adapter_class.quote_column_name(primary_key)\`), with an escape-safe double-quote fallback when adapter is absent.
- **\`adapter.ts\`** — promotes \`quote\`, \`quoteIdentifier\`, \`quoteTableName\`, \`quoteColumnName\` from optional to required on \`DatabaseAdapter\`, eliminating runtime surprises for custom adapters and removing the need for non-null assertions at call sites.

## Non-quoting branches preserved

- \`internal-metadata.ts:85\` — \`TIMESTAMP\` vs \`DATETIME\` is SQL-type selection, not quoting. Preserved using \`detectAdapterName(this._adapter) === "postgres"\` (low-churn option from the plan).
- \`model-schema.ts:315–319\` — \`SERIAL\` / \`BIGINT AUTO_INCREMENT\` / \`INTEGER PRIMARY KEY AUTOINCREMENT\` is SQL-type selection. \`isMysql\`/\`isPg\` still derived from \`detectAdapterName\`; only the quoting calls were replaced.

## Test plan

- [x] \`pnpm --filter @blazetrails/activerecord test\` — all AR tests green
- [x] \`pnpm parity:schema\` — 2/2 fixtures unchanged
- [x] Compliance grep: 0 matches of \`from.*abstract/quoting\` in the three changed files
- [x] \`pnpm --filter @blazetrails/activerecord build\` — clean compile
- [x] LOC: well under 300 ceiling