### PR TITLE
ci: remove self-hosted runner routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,6 @@ jobs:
       parity_sqlite: ${{ steps.filter.outputs.parity_sqlite }}
       parity_postgres: ${{ steps.filter.outputs.parity_postgres }}
       parity_mysql: ${{ steps.filter.outputs.parity_mysql }}
-      # Pure-Node jobs route to self-hosted only for trusted actor + same
-      # repo. Fork PRs and any other actor fall back to ubuntu-latest, so
-      # untrusted code never executes on the self-hosted box. Consumers:
-      # `runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}`.
-      runner: ${{ steps.runner.outputs.value }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,59 +105,12 @@ jobs:
               echo "parity_mysql=false"    >> "$GITHUB_OUTPUT"
               ;;
           esac
-      - id: runner
-        env:
-          EVENT: ${{ github.event_name }}
-          ACTOR: ${{ github.actor }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          REPO: ${{ github.repository }}
-          # Newline-separated allowlist; vars.SELF_HOSTED_ACTORS overrides
-          # the default. Set repo-level via:
-          #   gh variable set SELF_HOSTED_ACTORS --body $'deanmarano'
-          ALLOWLIST: ${{ vars.SELF_HOSTED_ACTORS || 'deanmarano' }}
-        run: |
-          set -euo pipefail
-          # Trust gate: pure-node jobs land on self-hosted iff
-          #   1. the relevant principal is in ALLOWLIST, AND
-          #   2. the code being executed is from this repo (no fork code).
-          # The "principal" depends on event type:
-          #   - pull_request*: the PR author. github.actor on a `labeled`
-          #     event is the labeler (a maintainer labeling a fork PR
-          #     would otherwise pin fork code to self-hosted).
-          #   - push/schedule/workflow_dispatch: github.actor (the pusher
-          #     or dispatcher). HEAD_REPO is empty here; same-repo by
-          #     construction.
-          case "$EVENT" in
-            pull_request|pull_request_target)
-              principal="$PR_AUTHOR"
-              same_repo=$([ "$HEAD_REPO" = "$REPO" ] && echo true || echo false)
-              ;;
-            *)
-              principal="$ACTOR"
-              same_repo=true
-              ;;
-          esac
-          allowed=false
-          while IFS= read -r u; do
-            [ -z "$u" ] && continue
-            [ "$u" = "$principal" ] && { allowed=true; break; }
-          done <<< "$ALLOWLIST"
-          if [ "$allowed" = "true" ] && [ "$same_repo" = "true" ]; then
-            echo 'value=["self-hosted","Linux","X64"]' >> "$GITHUB_OUTPUT"
-            echo "→ self-hosted (event=$EVENT principal=$principal)"
-          else
-            echo 'value="ubuntu-latest"' >> "$GITHUB_OUTPUT"
-            echo "→ ubuntu-latest (event=$EVENT principal=$principal allowed=$allowed same_repo=$same_repo)"
-          fi
 
   build-and-typecheck:
     name: Build & Type Check
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -180,9 +128,7 @@ jobs:
     name: Lint
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -199,9 +145,7 @@ jobs:
     name: Prettier
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -219,9 +163,7 @@ jobs:
     name: Guides Code Type Check
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -240,9 +182,7 @@ jobs:
     name: DX Type Tests
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -260,9 +200,7 @@ jobs:
     name: Virtualized DX Type Tests
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -280,9 +218,7 @@ jobs:
     name: Unit Tests
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
-    # Self-hosted runner can go offline (laptop closed, service crash).
-    # Cap so jobs fail fast instead of queueing for the GitHub default 24h.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,6 @@ jobs:
   prettier:
     name: Prettier
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/docs/actioncontroller-privates-plan.md
+++ b/docs/actioncontroller-privates-plan.md
@@ -3,7 +3,7 @@
 > **Status (2026-05-01):** 252/581 methods (43.4%); files 43/43; inheritance
 > 10/16. No PRs from this plan have shipped yet. Counts below verified
 > against `pnpm tsx scripts/api-compare/compare.ts --package
-> actioncontroller --privates`. Rows where the planned "Missing" count
+actioncontroller --privates`. Rows where the planned "Missing" count
 > drifted from current api:compare are flagged **(re-audit)** — expand
 > the row before opening a PR.
 
@@ -81,34 +81,34 @@ Sequencing rules:
 
 ## Wave 0 — single-file peripherals (remaining)
 
-| PR  | Rails file                          |  Missing | TS file (api:compare row)              | Methods                                                                                                                                                                              |
-| --- | ----------------------------------- | -------: | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P2  | `metal/rate_limiting.rb`            |        2 | `metal/rate-limiting.ts`               | `rateLimit` (class DSL), `rateLimiting` (private instance). Mirror Rails options `to:`, `within:`, `by:`, `with:`, `store:`, `name:`, `only:`/`except:`. Cache backend is divergent. |
-| P3  | `form_builder.rb`                   |        1 | `form-builder.ts`                      | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                       |
-| P4  | `metal/data_streaming.rb` **(re-audit, 10 missing)** |       10 | `metal/data-streaming.ts`              | Originally scoped as `sendFileHeadersBang` only; api:compare now reports 10 missing. Re-list before opening PR. |
-| P5  | `caching.rb`                        |        2 | `caching.ts`                           | `instrumentPayload(key)` → `{ controller, action, key }`; `instrumentName()` → `"action_controller"`. Both private.                                                                  |
-| P7  | `metal/renderers.rb`                |        2 | `metal/renderers.ts`                   | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.           |
-| P9  | `deprecator.rb`                     |        3 | `deprecator.ts`                        | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                           |
+| PR  | Rails file                                           | Missing | TS file (api:compare row) | Methods                                                                                                                                                                              |
+| --- | ---------------------------------------------------- | ------: | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P2  | `metal/rate_limiting.rb`                             |       2 | `metal/rate-limiting.ts`  | `rateLimit` (class DSL), `rateLimiting` (private instance). Mirror Rails options `to:`, `within:`, `by:`, `with:`, `store:`, `name:`, `only:`/`except:`. Cache backend is divergent. |
+| P3  | `form_builder.rb`                                    |       1 | `form-builder.ts`         | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                       |
+| P4  | `metal/data_streaming.rb` **(re-audit, 10 missing)** |      10 | `metal/data-streaming.ts` | Originally scoped as `sendFileHeadersBang` only; api:compare now reports 10 missing. Re-list before opening PR.                                                                      |
+| P5  | `caching.rb`                                         |       2 | `caching.ts`              | `instrumentPayload(key)` → `{ controller, action, key }`; `instrumentName()` → `"action_controller"`. Both private.                                                                  |
+| P7  | `metal/renderers.rb`                                 |       2 | `metal/renderers.ts`      | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.           |
+| P9  | `deprecator.rb`                                      |       3 | `deprecator.ts`           | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                           |
 
 ## Wave 1 — small bundle peripherals
 
 Ship after Wave 0 lands. One PR per row.
 
-| PR  | Rails file                           | Missing | Notes                                                                                                                                              |
-| --- | ------------------------------------ | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P10 | `metal/content_security_policy.rb`   |       4 | `isContentSecurityPolicy?`, `currentContentSecurityPolicy`, `contentSecurityPolicy`, `contentSecurityPolicyReportOnly` — class DSL.                |
-| P11 | `metal/etag_with_template_digest.rb` **(re-audit, 7 missing)** |       7 | Originally 3 methods scoped; api:compare now reports 7 missing. Re-list before opening PR.  |
-| P11.5 | `metal/etag_with_flash.rb` **(new)** |       4 | Not in original plan; api:compare reports 4 missing. Scope before opening PR.                |
-| P12 | `metal/helpers.rb` **(re-audit, 6 missing)** |       6 | Originally 5 methods scoped; api:compare reports 6. Re-list before opening PR.               |
-| P13 | `metal/allow_browser.rb` (privates)  |       9 | `parsedUserAgent`, `isUserAgentVersionReported`, `isUnsupportedBrowser`, `isVersionGuardedBrowser`, `isBot`, `isVersionBelowMinimumRequired`, `minimumBrowserVersionForBrowser`, `expandedVersions`, `normalizedBrowserName` — pure user-agent functions. |
+| PR    | Rails file                                                     | Missing | Notes                                                                                                                                                                                                                                                     |
+| ----- | -------------------------------------------------------------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P10   | `metal/content_security_policy.rb`                             |       4 | `isContentSecurityPolicy?`, `currentContentSecurityPolicy`, `contentSecurityPolicy`, `contentSecurityPolicyReportOnly` — class DSL.                                                                                                                       |
+| P11   | `metal/etag_with_template_digest.rb` **(re-audit, 7 missing)** |       7 | Originally 3 methods scoped; api:compare now reports 7 missing. Re-list before opening PR.                                                                                                                                                                |
+| P11.5 | `metal/etag_with_flash.rb` **(new)**                           |       4 | Not in original plan; api:compare reports 4 missing. Scope before opening PR.                                                                                                                                                                             |
+| P12   | `metal/helpers.rb` **(re-audit, 6 missing)**                   |       6 | Originally 5 methods scoped; api:compare reports 6. Re-list before opening PR.                                                                                                                                                                            |
+| P13   | `metal/allow_browser.rb` (privates)                            |       9 | `parsedUserAgent`, `isUserAgentVersionReported`, `isUnsupportedBrowser`, `isVersionGuardedBrowser`, `isBot`, `isVersionBelowMinimumRequired`, `minimumBrowserVersionForBrowser`, `expandedVersions`, `normalizedBrowserName` — pure user-agent functions. |
 
 ## Wave 2 — medium peripherals
 
-| PR  | Rails file                           | Missing | Notes                                                                                                                                              |
-| --- | ------------------------------------ | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P14 | `metal/redirecting.rb` (privates) **(re-audit, 7 missing)** |       7 | Originally 6 methods scoped; api:compare reports 7. Re-list before opening PR. |
-| P15 | `metal/params_wrapper.rb` (privates) |       8 | `_defaultWrapModel`, `_wrapperKey`, `_wrapperFormats`, `_wrapParameters`, `_extractParameters`, `_isWrapperEnabled`, `_performParameterWrapping`, `_setWrapperOptions`. |
-| P16 | `metal/rendering.rb` (privates)      |       8 | `_processVariant`, `_renderInPriorities`, `_setHtmlContentType`, `_setRenderedContentType`, `_setVaryHeader`, `_normalizeOptions`, `_normalizeText`, `_processOptions`. |
+| PR  | Rails file                                                  | Missing | Notes                                                                                                                                                                   |
+| --- | ----------------------------------------------------------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P14 | `metal/redirecting.rb` (privates) **(re-audit, 7 missing)** |       7 | Originally 6 methods scoped; api:compare reports 7. Re-list before opening PR.                                                                                          |
+| P15 | `metal/params_wrapper.rb` (privates)                        |       8 | `_defaultWrapModel`, `_wrapperKey`, `_wrapperFormats`, `_wrapParameters`, `_extractParameters`, `_isWrapperEnabled`, `_performParameterWrapping`, `_setWrapperOptions`. |
+| P16 | `metal/rendering.rb` (privates)                             |       8 | `_processVariant`, `_renderInPriorities`, `_setHtmlContentType`, `_setRenderedContentType`, `_setVaryHeader`, `_normalizeOptions`, `_normalizeText`, `_processOptions`. |
 
 ## Wave 3 — split-file PRs
 
@@ -117,55 +117,55 @@ the same TS file, so ship them in alphabetical order (a → b → c).
 
 ### `metal/http_authentication.rb` (33 missing) — `metal/http-authentication.ts`
 
-| PR   | Module    | Missing | Methods                                                                                                                                                                                                                          |
-| ---- | --------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P17a | `Basic`   |      13 | `authenticate`, `hasBasicCredentials`, `userNameAndPassword`, `decodeCredentials`, `authScheme`, `authParam`, `encodeCredentials`, `authenticationRequest` + 5 controller-side helpers (`httpBasicAuthenticate*` etc.).        |
-| P17b | `Digest`  |      12 | `validateDigestResponse`, `expectedResponse`, `ha1`, `decodeCredentialsHeader`, `authenticationHeader`, `secretToken`, `nonce`, `validateNonce`, `opaque` + 3 controller-side helpers.                                          |
-| P17c | `Token`   |       8 | `tokenAndOptions`, `tokenParamsFrom`, `paramsArrayFrom`, `rewriteParamValues`, `rawParams` + 3 controller-side helpers.                                                                                                          |
+| PR   | Module   | Missing | Methods                                                                                                                                                                                                                 |
+| ---- | -------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P17a | `Basic`  |      13 | `authenticate`, `hasBasicCredentials`, `userNameAndPassword`, `decodeCredentials`, `authScheme`, `authParam`, `encodeCredentials`, `authenticationRequest` + 5 controller-side helpers (`httpBasicAuthenticate*` etc.). |
+| P17b | `Digest` |      12 | `validateDigestResponse`, `expectedResponse`, `ha1`, `decodeCredentialsHeader`, `authenticationHeader`, `secretToken`, `nonce`, `validateNonce`, `opaque` + 3 controller-side helpers.                                  |
+| P17c | `Token`  |       8 | `tokenAndOptions`, `tokenParamsFrom`, `paramsArrayFrom`, `rewriteParamValues`, `rawParams` + 3 controller-side helpers.                                                                                                 |
 
 ### `metal/live.rb` (24 missing — re-audit; was 22) — `metal/live.ts`
 
-| PR   | Subject               | Missing | Methods                                                                                                                                                                                                                                          |
-| ---- | --------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P18a | `Live::Buffer` class  |      12 | `performWrite`, `queueSize`, `ignoreDisconnect`, `writeln`, `abort`, `isConnected`, `onError`, `callOnError`, `eachChunk`, `buildQueue`, `beforeCommitted`, `buildBuffer`.                                                                       |
-| P18b | `Live` mixin          |      10 | `process`, `responseBody=`, `sendStream`, `newControllerThread`, `cleanUpThreadLocals`, `logError`, `originalNewControllerThread`, `originalCleanUpThreadLocals`, `liveThreadPoolExecutor`, `makeResponseBang`.                                  |
+| PR   | Subject              | Missing | Methods                                                                                                                                                                                                         |
+| ---- | -------------------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P18a | `Live::Buffer` class |      12 | `performWrite`, `queueSize`, `ignoreDisconnect`, `writeln`, `abort`, `isConnected`, `onError`, `callOnError`, `eachChunk`, `buildQueue`, `beforeCommitted`, `buildBuffer`.                                      |
+| P18b | `Live` mixin         |      10 | `process`, `responseBody=`, `sendStream`, `newControllerThread`, `cleanUpThreadLocals`, `logError`, `originalNewControllerThread`, `originalCleanUpThreadLocals`, `liveThreadPoolExecutor`, `makeResponseBang`. |
 
 ### `metal/strong_parameters.rb` (24 missing) — `metal/strong-parameters.ts`
 
-| PR   | Subject                | Missing | Methods                                                                                                                                                                                                                                              |
-| ---- | ---------------------- | ------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P19a | Permit pipeline        |      10 | `permitFilters`, `permitValue`, `permitArrayOfScalars`, `permitArrayOfHashes`, `permitHash`, `permitHashOrArray`, `permitAnyInParameters`, `permitAnyInArray`, `permittedScalarFilter`, `hashFilter`.                                                |
-| P19b | Conversion + nesting   |      10 | `convertParametersToHashes`, `convertHashesToParameters`, `convertValueToParameters`, `_deepTransformKeysInObjectBang`, `isNestedAttributes`, `eachNestedAttribute`, `eachArrayElement`, `isArrayFilter`, `isNonScalar`, `isSpecifyNumericKeys`.    |
-| P19c | Misc + diagnostics     |       4 | `parameters` (private accessor), `newInstanceWithInheritedPermittedStatus`, `unpermittedParametersBang`, `unpermittedKeys`.                                                                                                                          |
+| PR   | Subject              | Missing | Methods                                                                                                                                                                                                                                          |
+| ---- | -------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P19a | Permit pipeline      |      10 | `permitFilters`, `permitValue`, `permitArrayOfScalars`, `permitArrayOfHashes`, `permitHash`, `permitHashOrArray`, `permitAnyInParameters`, `permitAnyInArray`, `permittedScalarFilter`, `hashFilter`.                                            |
+| P19b | Conversion + nesting |      10 | `convertParametersToHashes`, `convertHashesToParameters`, `convertValueToParameters`, `_deepTransformKeysInObjectBang`, `isNestedAttributes`, `eachNestedAttribute`, `eachArrayElement`, `isArrayFilter`, `isNonScalar`, `isSpecifyNumericKeys`. |
+| P19c | Misc + diagnostics   |       4 | `parameters` (private accessor), `newInstanceWithInheritedPermittedStatus`, `unpermittedParametersBang`, `unpermittedKeys`.                                                                                                                      |
 
 ### `metal/request_forgery_protection.rb` (31 missing) — `metal/request-forgery-protection.ts`
 
-| PR   | Subject                              | Missing | Methods                                                                                                                                                                                                                                                                                          |
-| ---- | ------------------------------------ | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR   | Subject                              | Missing | Methods                                                                                                                                                                                                                                                                                             |
+| ---- | ------------------------------------ | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | P20a | Verification predicates              |      10 | `isVerifiedRequest`, `verifySameOriginRequest`, `markForSameOriginVerificationBang`, `isMarkedForSameOriginVerification`, `isNonXhrJavascriptResponse`, `isValidRequestOrigin`, `isProtectAgainstForgery`, `unverifiedRequestWarningMessage`, `normalizeActionPath`, `normalizeRelativeActionPath`. |
-| P20b | Token generation/encoding            |      11 | `generateCsrfToken`, `encodeCsrfToken`, `decodeCsrfToken`, `maskToken`, `unmaskToken`, `maskedAuthenticityToken`, `realCsrfToken`, `perFormCsrfToken`, `globalCsrfToken`, `csrfTokenHmac`, `xorByteStrings`.                                                                                       |
-| P20c | Token validation + strategy plumbing |      10 | `isAnyAuthenticityTokenValid`, `requestAuthenticityTokens`, `isValidAuthenticityToken`, `isValidPerFormCsrfToken`, `compareWithRealToken`, `compareWithGlobalToken`, `formAuthenticityParam`, `protectionMethodClass`, `storageStrategy`, `isIsStorageStrategy`.                                  |
+| P20b | Token generation/encoding            |      11 | `generateCsrfToken`, `encodeCsrfToken`, `decodeCsrfToken`, `maskToken`, `unmaskToken`, `maskedAuthenticityToken`, `realCsrfToken`, `perFormCsrfToken`, `globalCsrfToken`, `csrfTokenHmac`, `xorByteStrings`.                                                                                        |
+| P20c | Token validation + strategy plumbing |      10 | `isAnyAuthenticityTokenValid`, `requestAuthenticityTokens`, `isValidAuthenticityToken`, `isValidPerFormCsrfToken`, `compareWithRealToken`, `compareWithGlobalToken`, `formAuthenticityParam`, `protectionMethodClass`, `storageStrategy`, `isIsStorageStrategy`.                                    |
 
 ### `test_case.rb` (40 missing — re-audit; was 36) — `test-case.ts`
 
-| PR   | Collaborator         | Missing | Methods                                                                                                                                                                                                                                                              |
-| ---- | -------------------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P21a | `TestSession`        |      12 | `isEnabled`, `idWas`, `loadBang`, `keys`, `values`, `destroy`, `dig`, `fetch`, `isExists`, `isSuccess`, `isMissing`, `isError`.                                                                                                                                       |
-| P21b | `TestRequest`/params |      12 | `assignParameters`, `queryString=`, `contentType=`, `shouldMultipart`, `paramsParsers`, `queryParameterNames`, `defaultEnv`, `newSession`, `create`, `controllerClass`, `generatedPath`, `executorAroundEachRequest`.                                                |
-| P21c | Behavior mixin       |      12 | `process`, `controllerClassName`, `setupControllerRequestAndResponse`, `buildResponse`, `setupRequest`, `wrapExecution`, `processControllerResponse`, `scrubEnvBang`, `documentRootElement`, `checkRequiredIvars`, `tests`, `determineDefaultControllerClass`.        |
+| PR   | Collaborator         | Missing | Methods                                                                                                                                                                                                                                                        |
+| ---- | -------------------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P21a | `TestSession`        |      12 | `isEnabled`, `idWas`, `loadBang`, `keys`, `values`, `destroy`, `dig`, `fetch`, `isExists`, `isSuccess`, `isMissing`, `isError`.                                                                                                                                |
+| P21b | `TestRequest`/params |      12 | `assignParameters`, `queryString=`, `contentType=`, `shouldMultipart`, `paramsParsers`, `queryParameterNames`, `defaultEnv`, `newSession`, `create`, `controllerClass`, `generatedPath`, `executorAroundEachRequest`.                                          |
+| P21c | Behavior mixin       |      12 | `process`, `controllerClassName`, `setupControllerRequestAndResponse`, `buildResponse`, `setupRequest`, `wrapExecution`, `processControllerResponse`, `scrubEnvBang`, `documentRootElement`, `checkRequiredIvars`, `tests`, `determineDefaultControllerClass`. |
 
 ## Wave 4 — core (strict serial order: P22 → P23 → P24 → P25 → P26)
 
 These touch the controller backbone and depend on prior peripherals. Do not
 fan out.
 
-| PR  | Rails file                          | Missing | Methods                                                                                                                                                |
-| --- | ----------------------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P22 | `metal/instrumentation.rb`          |       3 | `haltedCallbackHook`, `cleanupViewRuntime`, `appendInfoToPayload`. Hooks render + callback chain.                                                      |
-| P23 | `api/api_rendering.rb` **(re-audit, 12 missing)** |      12 | Originally scoped as `renderToBody` only; api:compare reports 12. Re-list before opening PR. |
-| P24 | `metal/implicit_render.rb` **(re-audit, 4 missing)** |       4 | Originally 3 methods scoped; api:compare reports 4. Re-list before opening PR.            |
-| P25 | `metal.rb` (privates)               |       1 | `buildMiddleware`. Ties to `actiondispatch` middleware stack.                                                                                            |
-| P26 | `base.rb` (privates) **(re-audit, 83 missing)** |      83 | Originally 2 methods scoped; api:compare reports 83 missing. This is no longer one PR — must be split into a sub-plan (likely 4–6 PRs by topic) before any work. |
+| PR  | Rails file                                           | Missing | Methods                                                                                                                                                          |
+| --- | ---------------------------------------------------- | ------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P22 | `metal/instrumentation.rb`                           |       3 | `haltedCallbackHook`, `cleanupViewRuntime`, `appendInfoToPayload`. Hooks render + callback chain.                                                                |
+| P23 | `api/api_rendering.rb` **(re-audit, 12 missing)**    |      12 | Originally scoped as `renderToBody` only; api:compare reports 12. Re-list before opening PR.                                                                     |
+| P24 | `metal/implicit_render.rb` **(re-audit, 4 missing)** |       4 | Originally 3 methods scoped; api:compare reports 4. Re-list before opening PR.                                                                                   |
+| P25 | `metal.rb` (privates)                                |       1 | `buildMiddleware`. Ties to `actiondispatch` middleware stack.                                                                                                    |
+| P26 | `base.rb` (privates) **(re-audit, 83 missing)**      |      83 | Originally 2 methods scoped; api:compare reports 83 missing. This is no longer one PR — must be split into a sub-plan (likely 4–6 PRs by topic) before any work. |
 
 ---
 

--- a/docs/arel-alignment-plan.md
+++ b/docs/arel-alignment-plan.md
@@ -274,7 +274,9 @@ migration matrix entry needed.
        this.left = left;
        this.right = right;
      }
-     accept<T>(visitor: NodeVisitor<T>): T { return visitor.visit(this); }
+     accept<T>(visitor: NodeVisitor<T>): T {
+       return visitor.visit(this);
+     }
    }
 
    // after
@@ -498,7 +500,6 @@ implementation already emits them — no per-visitor override needed.
 3. **Activerecord visitor construction sites** — every place
    that instantiates an arel visitor must pass the connection
    (which already `implements Quoting` per quoting-refactor PR 2):
-
    - `packages/activerecord/src/connection-adapters/abstract-adapter.ts:731`
      `return new Visitors.ToSql();` → `return new Visitors.ToSql(this);`
    - `packages/activerecord/src/connection-adapters/sqlite3-adapter.ts:127`
@@ -617,7 +618,7 @@ subset of Rails.
      (constructor calls — first arg is the SQL string; rename param
      locally if helpful but the positional API doesn't break).
    - `packages/arel/src/update-manager.ts:60` — `instanceof
-     BoundSqlLiteral` branch; no field access, no change needed.
+BoundSqlLiteral` branch; no field access, no change needed.
    - `packages/arel/src/visitors/to-sql.ts:1006` — old visitor reads
      `node.parts`. Replace per step 3.
    - `packages/arel/src/visitors/dot.ts:598` — registered as
@@ -688,7 +689,7 @@ subset of Rails.
 
 4. **`packages/arel/src/errors.ts`** — add or align `BindError`
    class with Rails-shaped message strings (`wrong number of bind
-   variables …` and `missing value for :<name> …`). Existing
+variables …` and `missing value for :<name> …`). Existing
    `Error("Cannot mix positional and named bind parameters")` cases
    in `validate()` retain trails phrasing — Rails doesn't have an
    exact analog there.
@@ -739,11 +740,11 @@ it gains) + ~120 LOC test.
 Pre-release: each PR migrates all in-tree call sites atomically. No
 deprecated aliases, no shims.
 
-| PR  | Surface                                        | Notes                |
-| --- | ---------------------------------------------- | -------------------- |
-| 24  | `Union/Intersect/Except/Join` extends `Binary` | API gain only        |
-| 25b | Visitors accept `Quoting` quoter (MySQL backticks fall out) | curate snapshot diff |
-| 26  | `BoundSqlLiteral` node fields (`parts` → Rails shape) | atomic in-tree migrate |
+| PR  | Surface                                                     | Notes                  |
+| --- | ----------------------------------------------------------- | ---------------------- |
+| 24  | `Union/Intersect/Except/Join` extends `Binary`              | API gain only          |
+| 25b | Visitors accept `Quoting` quoter (MySQL backticks fall out) | curate snapshot diff   |
+| 26  | `BoundSqlLiteral` node fields (`parts` → Rails shape)       | atomic in-tree migrate |
 
 ---
 

--- a/docs/quoting-refactor.md
+++ b/docs/quoting-refactor.md
@@ -281,12 +281,14 @@ instead of a dialect string.
    Class methods (`createTable`, `dropTable`, `quotedTableName`,
    etc.) already have `this.adapter` (or `this.connection`) in
    scope. For each callsite:
+
    ```ts
    // before
    `${quoteIdentifier(pk, adapterName)} INTEGER PRIMARY KEY`
    // after
-   `${this.adapter.quoteIdentifier(pk)} INTEGER PRIMARY KEY`
+   `${this.adapter.quoteIdentifier(pk)} INTEGER PRIMARY KEY`;
    ```
+
    The `detectAdapterName(this.adapter)` line at 305 disappears —
    delete it and any branches that switched purely on the dialect
    string for **identifier quoting**. Type-related branches
@@ -382,7 +384,7 @@ instead of a dialect string.
 - Existing migration / association tests must remain green.
 - `alias-tracker.test.ts` — new test: build a tracker with a MySQL
   quoter, call `initialCountFor("users", joins)` against a join
-  containing `` JOIN `users` ON … ``, assert count = 1. Same with
+  containing ``JOIN `users` ON …``, assert count = 1. Same with
   PG/SQLite (double-quoted identifiers).
 - Mirror Rails test names from
   `scripts/api-compare/.rails-source/activerecord/test/cases/associations/alias_tracker_test.rb`.
@@ -451,18 +453,18 @@ PR 1 ──► PR 2 ──► PR 3, 4, 5  (phase 2, parallel after PR 2)
                               └─► PR 10 (phase 5, after all above)
 ```
 
-| PR  | Phase | Scope                                            | Est. LOC | Status        |
-| --- | ----- | ------------------------------------------------ | -------- | ------------- |
-| 1   | 0     | uniform `quoteIdentifier` across adapter modules | ~50      | merged #1051  |
-| 2   | 1     | `Quoting` interface + adapter `implements`       | ~120     | merged #1058  |
-| 3   | 2     | sanitization through `quoter`                    | ~150     | merged #1065  |
-| 4   | 2     | query-methods + relation neutralize              | ~120     | merged #1068  |
-| 5   | 2     | database-statements `this.quoteX`                | ~80      | merged #1070  |
-| 6   | 3     | abstract schema-creation + schema-definitions    | ~250     | merged #1072  |
-| 7   | 3     | abstract schema-statements + PG schema files     | ~200     | merged #1075  |
-| 8   | 4     | model-schema + internal-metadata + primary-key   | ~200     | open          |
-| 9   | 4     | migration + alias-tracker + association-scope    | ~150     | open          |
-| 10  | 5     | remove `adapter?:` param                         | ~80      | open          |
+| PR  | Phase | Scope                                            | Est. LOC | Status       |
+| --- | ----- | ------------------------------------------------ | -------- | ------------ |
+| 1   | 0     | uniform `quoteIdentifier` across adapter modules | ~50      | merged #1051 |
+| 2   | 1     | `Quoting` interface + adapter `implements`       | ~120     | merged #1058 |
+| 3   | 2     | sanitization through `quoter`                    | ~150     | merged #1065 |
+| 4   | 2     | query-methods + relation neutralize              | ~120     | merged #1068 |
+| 5   | 2     | database-statements `this.quoteX`                | ~80      | merged #1070 |
+| 6   | 3     | abstract schema-creation + schema-definitions    | ~250     | merged #1072 |
+| 7   | 3     | abstract schema-statements + PG schema files     | ~200     | merged #1075 |
+| 8   | 4     | model-schema + internal-metadata + primary-key   | ~200     | open         |
+| 9   | 4     | migration + alias-tracker + association-scope    | ~150     | open         |
+| 10  | 5     | remove `adapter?:` param                         | ~80      | open         |
 
 Total: 10 PRs, all under the 300-LOC ceiling. PRs 8/9 parallel; PR 10
 gates on both.


### PR DESCRIPTION
## Summary

- Removes the self-hosted runner trust gate and `runner` output from the `changes` job
- All jobs now run on `ubuntu-latest`
- Removes the `docs_only` gate from the `prettier` job so formatting is always enforced

Local runners were consuming ~800 GB of bandwidth in 1.5 days (each job was restoring the 1.7 GB pnpm cache from GitHub's remote cache service on every run) and have been turned off.

The three docs files (`actioncontroller-privates-plan.md`, `arel-alignment-plan.md`, `quoting-refactor.md`) are reformatted by `prettier --write` to fix a pre-existing format:check failure that had been silently skipped on docs-only PRs.