### PR TITLE
refactor(activerecord): route quoting through adapter in migration, alias-tracker, association-scope (quoting PR 9)

### DIFF
--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -44,8 +44,8 @@ export class AliasTracker {
     return new AliasTracker(tableAliasLength, map, joins, quoter);
   }
 
-  initialCountFor(name: string, tableJoins: any[]): number {
-    const quotedName = this._quoter ? this._quoter.quoteTableName(name) : `"${name}"`;
+  static initialCountFor(quoter: Quoting | undefined, name: string, tableJoins: any[]): number {
+    const quotedName = quoter ? quoter.quoteTableName(name) : `"${name}"`;
     const quotedNameEscaped = quotedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const nameEscaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const pattern = new RegExp(
@@ -72,7 +72,7 @@ export class AliasTracker {
   private _getCount(key: string): number {
     if (this.aliases.has(key)) return this.aliases.get(key)!;
     if (this._joins.length > 0) {
-      const count = this.initialCountFor(key, this._joins);
+      const count = AliasTracker.initialCountFor(this._quoter, key, this._joins);
       this.aliases.set(key, count);
       return count;
     }

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -5,7 +5,7 @@
  */
 import { Table, Nodes } from "@blazetrails/arel";
 import { tableAliasLength as getTableAliasLength } from "../connection-adapters/abstract/database-limits.js";
-import { quoteTableName } from "../connection-adapters/abstract/quoting.js";
+import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 
 const DEFAULT_TABLE_ALIAS_LENGTH = getTableAliasLength();
 
@@ -13,11 +13,18 @@ export class AliasTracker {
   readonly aliases: Map<string, number>;
   private _tableAliasLength: number;
   private _joins: any[];
+  private _quoter?: Quoting;
 
-  constructor(tableAliasLength?: number, aliases?: Map<string, number>, joins?: any[]) {
+  constructor(
+    tableAliasLength?: number,
+    aliases?: Map<string, number>,
+    joins?: any[],
+    quoter?: Quoting,
+  ) {
     this._tableAliasLength = tableAliasLength ?? DEFAULT_TABLE_ALIAS_LENGTH;
     this.aliases = aliases ?? new Map();
     this._joins = joins ?? [];
+    this._quoter = quoter;
   }
 
   static create(
@@ -25,6 +32,7 @@ export class AliasTracker {
     initialTable: string,
     joins: any[],
     aliases?: Map<string, number>,
+    quoter?: Quoting,
   ): AliasTracker {
     const tableAliasLength =
       typeof pool?.withConnection === "function"
@@ -33,11 +41,12 @@ export class AliasTracker {
 
     const map = aliases ? new Map(aliases) : new Map<string, number>();
     map.set(initialTable, 1);
-    return new AliasTracker(tableAliasLength, map, joins);
+    return new AliasTracker(tableAliasLength, map, joins, quoter);
   }
 
-  static initialCountFor(name: string, tableJoins: any[]): number {
-    const quotedNameEscaped = quoteTableName(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  initialCountFor(name: string, tableJoins: any[]): number {
+    const quotedName = this._quoter ? this._quoter.quoteTableName(name) : `"${name}"`;
+    const quotedNameEscaped = quotedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const nameEscaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const pattern = new RegExp(
       `JOIN(?:\\s+\\w+)?\\s+(?:\\S+\\s+)?(?:${quotedNameEscaped}|${nameEscaped})\\s+ON`,
@@ -63,7 +72,7 @@ export class AliasTracker {
   private _getCount(key: string): number {
     if (this.aliases.has(key)) return this.aliases.get(key)!;
     if (this._joins.length > 0) {
-      const count = AliasTracker.initialCountFor(key, this._joins);
+      const count = this.initialCountFor(key, this._joins);
       this.aliases.set(key, count);
       return count;
     }

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1049,8 +1049,10 @@ describe("AssociationScope", () => {
     // (or get dropped) doesn't slip through. PR 3 builds these via
     // _nextChainScope using joinPrimaryKey / joinForeignKey from the
     // chain's pair.
-    expect(sql).toMatch(/ON\s+"hot_settings"\."hot_account_id"\s*=\s*"hot_accounts"\."id"/);
-    expect(sql).toMatch(/"hot_accounts"\."hot_user_id"\s*=\s*5/);
+    expect(sql).toMatch(
+      /ON\s+["`]hot_settings["`]\.["`]hot_account_id["`]\s*=\s*["`]hot_accounts["`]\.["`]id["`]/,
+    );
+    expect(sql).toMatch(/["`]hot_accounts["`]\.["`]hot_user_id["`]\s*=\s*5/);
     expect(sql).toMatch(/LIMIT\s+1/);
   });
 
@@ -1108,7 +1110,9 @@ describe("AssociationScope", () => {
     ).toSql();
     expect(sql).toMatch(/FROM\s+"through_posts"/);
     expect(sql).toMatch(/INNER JOIN\s+"?through_memberships"?/i);
-    expect(sql).toMatch(/"through_posts"\."id"\s*=\s*"through_memberships"\."through_post_id"/);
-    expect(sql).toMatch(/"through_memberships"\."through_author_id"\s*=\s*1/);
+    expect(sql).toMatch(
+      /["`]through_posts["`]\.["`]id["`]\s*=\s*["`]through_memberships["`]\.["`]through_post_id["`]/,
+    );
+    expect(sql).toMatch(/["`]through_memberships["`]\.["`]through_author_id["`]\s*=\s*1/);
   });
 });

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -10,7 +10,7 @@ import {
   polymorphicName,
 } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
-import { quoteTableName, quoteColumnName, quote } from "../connection-adapters/abstract/quoting.js";
+import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -159,6 +159,7 @@ export class ReflectionProxy {
  */
 export class AssociationScope {
   private readonly _valueTransformation: ValueTransformation;
+  private _quoter?: Quoting;
 
   constructor(valueTransformation: ValueTransformation) {
     this._valueTransformation = valueTransformation;
@@ -232,6 +233,7 @@ export class AssociationScope {
    */
   scope(association: AssociationScopeable): unknown {
     const { owner, reflection, klass } = association;
+    this._quoter = klass.adapter as unknown as Quoting;
     // Rails: `klass.unscoped` (association_scope.rb:23). Rails' unscoped
     // bypasses default_scope but STILL applies the STI `type_condition`
     // because `relation()` adds it for `finder_needs_type_condition?`
@@ -254,7 +256,7 @@ export class AssociationScope {
     // default seeding with `klass.arel_table`). The tracker is
     // shared across the chain walk within this call so repeated
     // joins to the same table get unique aliases.
-    const tracker = AliasTracker.create(null, klass.arelTable.name, []);
+    const tracker = AliasTracker.create(null, klass.arelTable.name, [], undefined, this._quoter);
     const chain = this._getChain(reflection, tracker);
     scope = this._addConstraints(scope, owner, chain, klass);
     if (!reflection.isCollection()) {
@@ -497,13 +499,15 @@ export class AssociationScope {
     // Relation is stored as a SQL string and re-wrapped in
     // Nodes.SqlLiteral at apply time, so we still produce a string —
     // but the identifiers/values are escape-safe.
-    const qTable = quoteTableName(table);
-    const qForeignTable = quoteTableName(foreignTable);
+    const q = this._quoter;
+    const qtName = (n: string) => (q ? q.quoteTableName(n) : `"${n}"`);
+    const qcName = (n: string) => (q ? q.quoteColumnName(n) : `"${n}"`);
+    const qVal = (v: unknown) => (q ? q.quote(v) : `'${String(v)}'`);
+    const qTable = qtName(table);
+    const qForeignTable = qtName(foreignTable);
     const conditions: string[] = [];
     for (let i = 0; i < joinPks.length; i++) {
-      conditions.push(
-        `${qTable}.${quoteColumnName(joinPks[i])} = ${qForeignTable}.${quoteColumnName(joinFks[i])}`,
-      );
+      conditions.push(`${qTable}.${qcName(joinPks[i])} = ${qForeignTable}.${qcName(joinFks[i])}`);
     }
     let onClause = conditions.join(" AND ");
     if (r.type) {
@@ -514,7 +518,7 @@ export class AssociationScope {
       // STI) and the value-transformation lambda.
       const nextKlass = (nextReflection as { klass?: typeof Base }).klass;
       const nextName = nextKlass ? polymorphicName(nextKlass) : "";
-      onClause += ` AND ${qTable}.${quoteColumnName(r.type)} = ${quote(this._transformValue(nextName))}`;
+      onClause += ` AND ${qTable}.${qcName(r.type)} = ${qVal(this._transformValue(nextName))}`;
     }
     return (scope as { joins: (table: string, on: string) => unknown }).joins(
       foreignTable,

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -159,7 +159,6 @@ export class ReflectionProxy {
  */
 export class AssociationScope {
   private readonly _valueTransformation: ValueTransformation;
-  private _quoter?: Quoting;
 
   constructor(valueTransformation: ValueTransformation) {
     this._valueTransformation = valueTransformation;
@@ -233,7 +232,7 @@ export class AssociationScope {
    */
   scope(association: AssociationScopeable): unknown {
     const { owner, reflection, klass } = association;
-    this._quoter = klass.adapter as unknown as Quoting;
+    const quoter = klass.adapter as unknown as Quoting;
     // Rails: `klass.unscoped` (association_scope.rb:23). Rails' unscoped
     // bypasses default_scope but STILL applies the STI `type_condition`
     // because `relation()` adds it for `finder_needs_type_condition?`
@@ -256,9 +255,9 @@ export class AssociationScope {
     // default seeding with `klass.arel_table`). The tracker is
     // shared across the chain walk within this call so repeated
     // joins to the same table get unique aliases.
-    const tracker = AliasTracker.create(null, klass.arelTable.name, [], undefined, this._quoter);
+    const tracker = AliasTracker.create(null, klass.arelTable.name, [], undefined, quoter);
     const chain = this._getChain(reflection, tracker);
-    scope = this._addConstraints(scope, owner, chain, klass);
+    scope = this._addConstraints(scope, owner, chain, klass, quoter);
     if (!reflection.isCollection()) {
       scope = (scope as { limit: (n: number) => unknown }).limit(1);
     }
@@ -435,6 +434,7 @@ export class AssociationScope {
     reflection: AbstractReflection | ReflectionProxy,
     nextReflection: AbstractReflection | ReflectionProxy,
     klass?: typeof Base,
+    quoter?: Quoting,
   ): unknown {
     const r = reflection as {
       joinPrimaryKey: string | string[];
@@ -499,15 +499,15 @@ export class AssociationScope {
     // Relation is stored as a SQL string and re-wrapped in
     // Nodes.SqlLiteral at apply time, so we still produce a string —
     // but the identifiers/values are escape-safe.
-    const q = this._quoter;
-    const qtName = (n: string) => (q ? q.quoteTableName(n) : `"${n}"`);
-    const qcName = (n: string) => (q ? q.quoteColumnName(n) : `"${n}"`);
-    const qVal = (v: unknown) => (q ? q.quote(v) : `'${String(v)}'`);
-    const qTable = qtName(table);
-    const qForeignTable = qtName(foreignTable);
+    const q = quoter;
+    if (!q) throw new Error("AssociationScope._nextChainScope requires a quoter");
+    const qTable = q.quoteTableName(table);
+    const qForeignTable = q.quoteTableName(foreignTable);
     const conditions: string[] = [];
     for (let i = 0; i < joinPks.length; i++) {
-      conditions.push(`${qTable}.${qcName(joinPks[i])} = ${qForeignTable}.${qcName(joinFks[i])}`);
+      conditions.push(
+        `${qTable}.${q.quoteColumnName(joinPks[i])} = ${qForeignTable}.${q.quoteColumnName(joinFks[i])}`,
+      );
     }
     let onClause = conditions.join(" AND ");
     if (r.type) {
@@ -518,7 +518,7 @@ export class AssociationScope {
       // STI) and the value-transformation lambda.
       const nextKlass = (nextReflection as { klass?: typeof Base }).klass;
       const nextName = nextKlass ? polymorphicName(nextKlass) : "";
-      onClause += ` AND ${qTable}.${qcName(r.type)} = ${qVal(this._transformValue(nextName))}`;
+      onClause += ` AND ${qTable}.${q.quoteColumnName(r.type)} = ${q.quote(this._transformValue(nextName))}`;
     }
     return (scope as { joins: (table: string, on: string) => unknown }).joins(
       foreignTable,
@@ -539,6 +539,7 @@ export class AssociationScope {
     owner: Base,
     chain: Array<AbstractReflection | ReflectionProxy>,
     klass?: typeof Base,
+    quoter?: Quoting,
   ): unknown {
     const last = chain[chain.length - 1];
     scope = this._lastChainScope(scope, last, owner, klass);
@@ -546,7 +547,7 @@ export class AssociationScope {
     // `chain.each_cons(2) { |r, nr| next_chain_scope(scope, r, nr) }`
     // (association_scope.rb:128-130).
     for (let i = 0; i < chain.length - 1; i++) {
-      scope = this._nextChainScope(scope, chain[i], chain[i + 1], klass);
+      scope = this._nextChainScope(scope, chain[i], chain[i + 1], klass, quoter);
     }
     // Rails' chain.reverse_each over reflection.constraints (Rails:
     // association_scope.rb:131-156) merges scope-chain items into the

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -14,7 +14,6 @@ import {
   assertSchemaAdapter,
 } from "./connection-adapters/abstract/schema-statements.js";
 import { detectAdapterName } from "./adapter-name.js";
-import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
@@ -1291,7 +1290,7 @@ export class MigrationContext {
     const ifNotExistsStr = options?.ifNotExists ? "IF NOT EXISTS " : "";
     const colsStr = cols
       .map((c) => {
-        let col = quoteIdentifier(c, an);
+        let col = this.adapter.quoteIdentifier(c);
         if (an !== "mysql") {
           const ord = options?.order?.[c];
           if (ord) col += ` ${ord.toUpperCase()}`;
@@ -1299,7 +1298,7 @@ export class MigrationContext {
         return col;
       })
       .join(", ");
-    let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${quoteIdentifier(indexName, an)} ON ${quoteTableName(table, an)} (${colsStr})`;
+    let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(table)} (${colsStr})`;
     if (an !== "mysql" && options?.where) sql += ` WHERE ${options.where}`;
     await this.adapter.executeMutation(sql);
     if (!this._indexes.has(table)) this._indexes.set(table, []);


### PR DESCRIPTION
PR 9 of the quoting refactor ([docs/quoting-refactor.md](docs/quoting-refactor.md)). Routes all quoting calls through the connection adapter in three files, removing their direct imports from \`abstract/quoting.js\`.

## Changes

- **\`migration.ts\`** — \`SchemaStatements.createIndex\` now calls \`this.adapter.quoteIdentifier()\` / \`this.adapter.quoteTableName()\` instead of the standalone abstract functions. The \`_adapterName\` getter is retained for the non-quoting dialect branches (\`an !== "mysql"\` checks for ORDER/WHERE clause logic).

- **\`associations/alias-tracker.ts\`** — \`initialCountFor\` remains a static method (Option B, matching Rails' \`def self.initial_count_for(connection, name, table_joins)\`). A \`quoter?: Quoting\` parameter is added as the first argument; \`AliasTracker.create\` gains an optional \`quoter?\` parameter (5th arg, after \`aliases\`) and passes it to the constructor as \`_quoter\`. \`initialCountFor\` uses \`quoter.quoteTableName(name)\` to build the regex pattern; when no quoter is provided the method falls back to \`"${name}"\` (covers callers with empty join lists that never reach this path).

- **\`associations/association-scope.ts\`** — \`AssociationScope\` no longer stores adapter state on the instance. Instead, \`scope()\` derives a local \`quoter\` from \`klass.adapter\` and threads it explicitly through \`_addConstraints(…, quoter)\` → \`_nextChainScope(…, quoter)\`. \`_nextChainScope\` throws if \`quoter\` is absent rather than emitting unsafe fallback SQL. The quoter is also passed to \`AliasTracker.create\`.

## \`initialCountFor\` decision (alias-tracker)

**Option B (static with \`quoter\` param)** was chosen — matches Rails' class-method shape (\`def self.initial_count_for(connection, …)\`). The internal caller \`_getCount\` passes \`this._quoter\`.

## Test plan

- [x] \`pnpm --filter @blazetrails/activerecord test\` — green (exit 0)
- [ ] \`pnpm parity:query\` — cannot run from worktree (packages not built there); baseline on \`origin/main\` shows 2 pre-existing failures (\`ar-01\`, \`ar-130\`), both unrelated to quoting in these files
- [x] Compliance grep (\`abstract/quoting.js\` import removed from all 3 files — remaining matches are for \`quoting-interface.js\` type imports, which are correct and expected)
- [x] \`pnpm --filter @blazetrails/activerecord build\` — no new errors introduced
- [x] LOC: 29 additions + 17 deletions = 46 LOC (well under 300)

> **Note on compliance grep:** The check \`grep -nE 'from.*abstract/quoting'\` matches both \`abstract/quoting.js\` (standalone functions, wrong) and \`abstract/quoting-interface.js\` (the Quoting type, correct). The two remaining matches in the changed files are \`import type { Quoting } from "…/quoting-interface.js"\` — the intended replacement import. The global acceptance criterion's \`grep -v 'connection-adapters/abstract/'\` filter does not cover non-adapter files; \`sanitization.ts\` (merged in PR 3) has the same pattern and is already in main.