### PR TITLE
refactor(activerecord): remove adapter? enum from abstract quoting (PR 10 / Phase 5)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -233,6 +233,13 @@ export interface DatabaseAdapter {
   quoteColumnName(name: string): string;
 
   /**
+   * Quote a column default expression for use in DDL.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#quote_default_expression
+   */
+  quoteDefaultExpression(value: unknown): string;
+
+  /**
    * Cast a value to the primitive form drivers expect for binds.
    * Returns an **unquoted** primitive suitable for passing as a bind
    * value — distinct from `quote()`, which returns a SQL literal

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -212,29 +212,7 @@ export interface DatabaseAdapter {
 
   /**
    * Quote an identifier (table or column name) for use in SQL.
-   * Abstract and SQLite/PG use double-quotes; MySQL uses backticks.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
-   */
-  quoteIdentifier(name: string): string;
-
-  /**
-   * Quote a table name for use in SQL.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
-   */
-  quoteTableName(name: string): string;
-
-  /**
-   * Quote a column name for use in SQL.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
-   */
-  quoteColumnName(name: string): string;
-
-  /**
-   * Quote an identifier (table or column name) for use in SQL.
-   * Abstract and SQLite/PG use double-quotes; MySQL uses backticks.
+   * Dispatch is per-adapter: abstract/SQLite/PG use double-quotes; MySQL uses backticks.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
    */

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -233,6 +233,28 @@ export interface DatabaseAdapter {
   quoteColumnName(name: string): string;
 
   /**
+   * Quote an identifier (table or column name) for use in SQL.
+   * Abstract and SQLite/PG use double-quotes; MySQL uses backticks.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
+   */
+  quoteIdentifier?(name: string): string;
+
+  /**
+   * Quote a table name for use in SQL.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
+   */
+  quoteTableName?(name: string): string;
+
+  /**
+   * Quote a column name for use in SQL.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
+   */
+  quoteColumnName?(name: string): string;
+
+  /**
    * Cast a value to the primitive form drivers expect for binds.
    * Returns an **unquoted** primitive suitable for passing as a bind
    * value — distinct from `quote()`, which returns a SQL literal

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -238,21 +238,21 @@ export interface DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_identifier
    */
-  quoteIdentifier?(name: string): string;
+  quoteIdentifier(name: string): string;
 
   /**
    * Quote a table name for use in SQL.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
    */
-  quoteTableName?(name: string): string;
+  quoteTableName(name: string): string;
 
   /**
    * Quote a column name for use in SQL.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
    */
-  quoteColumnName?(name: string): string;
+  quoteColumnName(name: string): string;
 
   /**
    * Cast a value to the primitive form drivers expect for binds.

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -14,14 +14,10 @@ import { getDefaultTimezone } from "../../type/internal/timezone.js";
 
 /**
  * Quote a SQL identifier (table name, column name, index name).
- * Uses double quotes for SQLite/PG, backticks for MySQL.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
  */
-export function quoteIdentifier(name: string, adapter?: "sqlite" | "postgres" | "mysql"): string {
-  if (adapter === "mysql") {
-    return `\`${name.replace(/`/g, "``")}\``;
-  }
+export function quoteIdentifier(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
 }
 
@@ -30,10 +26,10 @@ export function quoteIdentifier(name: string, adapter?: "sqlite" | "postgres" | 
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name
  */
-export function quoteTableName(name: string, adapter?: "sqlite" | "postgres" | "mysql"): string {
+export function quoteTableName(name: string): string {
   return name
     .split(".")
-    .map((part) => quoteIdentifier(part, adapter))
+    .map((part) => quoteIdentifier(part))
     .join(".");
 }
 
@@ -42,11 +38,8 @@ export function quoteTableName(name: string, adapter?: "sqlite" | "postgres" | "
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_column_name
  */
-export function quoteColumnName(
-  columnName: string,
-  adapter?: "sqlite" | "postgres" | "mysql",
-): string {
-  return quoteIdentifier(columnName, adapter);
+export function quoteColumnName(columnName: string): string {
+  return quoteIdentifier(columnName);
 }
 
 /**
@@ -155,12 +148,8 @@ export function quoteString(s: string): string {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name_for_assignment
  */
-export function quoteTableNameForAssignment(
-  table: string,
-  attr: string,
-  adapter?: "sqlite" | "postgres" | "mysql",
-): string {
-  return quoteTableName(`${table}.${attr}`, adapter);
+export function quoteTableNameForAssignment(table: string, attr: string): string {
+  return quoteTableName(`${table}.${attr}`);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -35,8 +35,8 @@ import type { SchemaQuoter } from "./assert-schema-adapter.js";
  */
 function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
   return {
-    quoteIdentifier: (n) => abstractQuoteIdentifier(n, name),
-    quoteTableName: (n) => abstractQuoteTableName(n, name),
+    quoteIdentifier: (n) => abstractQuoteIdentifier(n),
+    quoteTableName: (n) => abstractQuoteTableName(n),
     quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
   };
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -25,10 +25,21 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
+import {
+  quoteIdentifier as mysqlQuoteIdentifier,
+  quoteTableName as mysqlQuoteTableName,
+} from "../mysql/quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 
 /** @internal */
-function quoterForAdapterName(_name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+  if (name === "mysql") {
+    return {
+      quoteIdentifier: (n) => mysqlQuoteIdentifier(n),
+      quoteTableName: (n) => mysqlQuoteTableName(n),
+      quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
+    };
+  }
   return {
     quoteIdentifier: (n) => abstractQuoteIdentifier(n),
     quoteTableName: (n) => abstractQuoteTableName(n),

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -27,13 +27,8 @@ import {
 } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 
-/**
- * Build a fallback quoter from the dialect-name string for the legacy
- * code path where construction sites haven't been migrated to pass an
- * adapter. Each PR in the refactor moves one call site over until this
- * fallback can be removed in PR 10. @internal
- */
-function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+/** @internal */
+function quoterForAdapterName(_name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
   return {
     quoteIdentifier: (n) => abstractQuoteIdentifier(n),
     quoteTableName: (n) => abstractQuoteTableName(n),

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -14,8 +14,8 @@ import { singularize } from "@blazetrails/activesupport";
  */
 function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
   return {
-    quoteIdentifier: (n) => abstractQuoteIdentifier(n, name),
-    quoteTableName: (n) => abstractQuoteTableName(n, name),
+    quoteIdentifier: (n) => abstractQuoteIdentifier(n),
+    quoteTableName: (n) => abstractQuoteTableName(n),
     quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
   };
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -7,12 +7,8 @@ import {
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { singularize } from "@blazetrails/activesupport";
 
-/**
- * Build a fallback quoter from the dialect-name string for the legacy
- * code path where construction sites haven't yet been migrated to pass
- * an adapter. Removed in PR 10. @internal
- */
-function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+/** @internal */
+function quoterForAdapterName(_name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
   return {
     quoteIdentifier: (n) => abstractQuoteIdentifier(n),
     quoteTableName: (n) => abstractQuoteTableName(n),

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -4,11 +4,22 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
+import {
+  quoteIdentifier as mysqlQuoteIdentifier,
+  quoteTableName as mysqlQuoteTableName,
+} from "../mysql/quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { singularize } from "@blazetrails/activesupport";
 
 /** @internal */
-function quoterForAdapterName(_name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
+  if (name === "mysql") {
+    return {
+      quoteIdentifier: (n) => mysqlQuoteIdentifier(n),
+      quoteTableName: (n) => mysqlQuoteTableName(n),
+      quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
+    };
+  }
   return {
     quoteIdentifier: (n) => abstractQuoteIdentifier(n),
     quoteTableName: (n) => abstractQuoteTableName(n),

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -41,7 +41,7 @@ export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
   constructor(
-    protected adapter: DatabaseAdapter & SchemaQuoter,
+    readonly adapter: DatabaseAdapter & SchemaQuoter,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
   ) {}
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -99,7 +99,11 @@ export class SchemaStatements {
       return;
     }
 
-    const td = new TableDefinition(name, { ...options, adapterName: this.adapterName });
+    const td = new TableDefinition(name, {
+      ...options,
+      adapterName: this.adapterName,
+      adapter: this.adapter,
+    });
     if (definer) definer(td);
 
     await this.adapter.executeMutation(td.toSql());
@@ -890,6 +894,7 @@ export class SchemaStatements {
     const td = new TableDefinition(tableName, {
       id: hasCustomPk ? false : options.id,
       adapterName: this.adapterName,
+      adapter: this.adapter,
     });
     if (hasCustomPk) {
       const pkType = (typeof options.id === "string" ? options.id : "primary_key") as ColumnType;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -41,7 +41,7 @@ export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
   constructor(
-    readonly adapter: DatabaseAdapter & SchemaQuoter,
+    protected readonly adapter: DatabaseAdapter & SchemaQuoter,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
   ) {}
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -40,10 +40,11 @@ export { assertSchemaAdapter } from "./assert-schema-adapter.js";
 export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
-  constructor(
-    protected readonly adapter: DatabaseAdapter & SchemaQuoter,
-    protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
-  ) {}
+  constructor(protected readonly adapter: DatabaseAdapter & SchemaQuoter) {}
+
+  protected get adapterName(): "sqlite" | "postgres" | "mysql" {
+    return detectAdapterName(this.adapter);
+  }
 
   get schemaCreation(): SchemaCreation {
     if (!this._schemaCreation) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1068,7 +1068,12 @@ export class MigrationContext {
     if (options?.ifNotExists && this.tableExists(name)) {
       return;
     }
-    const td = new TableDefinition(name, { id: options?.id, adapterName: this._adapterName });
+    const td = new TableDefinition(name, {
+      id: options?.id,
+      adapterName: this._adapterName,
+      adapter: this
+        .adapter as unknown as import("./connection-adapters/abstract/assert-schema-adapter.js").SchemaQuoter,
+    });
     if (fn) fn(td);
     await this.adapter.executeMutation(td.toSql());
     this._tables.add(name);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1068,7 +1068,6 @@ export class MigrationContext {
     if (options?.ifNotExists && this.tableExists(name)) {
       return;
     }
-    assertSchemaAdapter(this.adapter);
     const td = new TableDefinition(name, {
       id: options?.id,
       adapterName: this._adapterName,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1068,11 +1068,11 @@ export class MigrationContext {
     if (options?.ifNotExists && this.tableExists(name)) {
       return;
     }
+    assertSchemaAdapter(this.adapter);
     const td = new TableDefinition(name, {
       id: options?.id,
       adapterName: this._adapterName,
-      adapter: this
-        .adapter as unknown as import("./connection-adapters/abstract/assert-schema-adapter.js").SchemaQuoter,
+      adapter: this.adapter,
     });
     if (fn) fn(td);
     await this.adapter.executeMutation(td.toSql());

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -61,12 +61,12 @@ export function buildPkWhere(this: typeof Base, idValue: unknown): string {
     for (let i = 0; i < pk.length; i++) {
       const v = idValue[i];
       if (v === undefined || v === null) return "1=0";
-      conditions.push(`${a.quoteIdentifier(pk[i])} = ${a.quote(v)}`);
+      conditions.push(`${a.quoteIdentifier!(pk[i])} = ${a.quote!(v)}`);
     }
     return conditions.join(" AND ");
   }
   if (idValue === undefined || idValue === null) return "1=0";
-  return `${a.quoteIdentifier(pk as string)} = ${a.quote(idValue)}`;
+  return `${a.quoteIdentifier!(pk as string)} = ${a.quote!(idValue)}`;
 }
 
 /**
@@ -313,27 +313,27 @@ export async function createTable(this: typeof Base): Promise<void> {
   if (pks.length === 1) {
     const pk = pks[0];
     const pkDef = isPg
-      ? `${a.quoteIdentifier(pk)} SERIAL PRIMARY KEY`
+      ? `${a.quoteIdentifier!(pk)} SERIAL PRIMARY KEY`
       : isMysql
-        ? `${a.quoteIdentifier(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
-        : `${a.quoteIdentifier(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
+        ? `${a.quoteIdentifier!(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
+        : `${a.quoteIdentifier!(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
       const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
-      colDefs.push(`${a.quoteIdentifier(pk)} ${pkType} NOT NULL`);
+      colDefs.push(`${a.quoteIdentifier!(pk)} ${pkType} NOT NULL`);
     }
   }
 
   for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
-    colDefs.push(`${a.quoteIdentifier(name)} ${sqlType}`);
+    colDefs.push(`${a.quoteIdentifier!(name)} ${sqlType}`);
   }
 
   if (pks.length > 1) {
-    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
+    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier!(pk)).join(", ")})`);
   }
 
   await a.executeMutation(

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -61,12 +61,12 @@ export function buildPkWhere(this: typeof Base, idValue: unknown): string {
     for (let i = 0; i < pk.length; i++) {
       const v = idValue[i];
       if (v === undefined || v === null) return "1=0";
-      conditions.push(`${a.quoteIdentifier!(pk[i])} = ${a.quote!(v)}`);
+      conditions.push(`${a.quoteIdentifier(pk[i])} = ${a.quote(v)}`);
     }
     return conditions.join(" AND ");
   }
   if (idValue === undefined || idValue === null) return "1=0";
-  return `${a.quoteIdentifier!(pk as string)} = ${a.quote!(idValue)}`;
+  return `${a.quoteIdentifier(pk as string)} = ${a.quote(idValue)}`;
 }
 
 /**
@@ -313,27 +313,27 @@ export async function createTable(this: typeof Base): Promise<void> {
   if (pks.length === 1) {
     const pk = pks[0];
     const pkDef = isPg
-      ? `${a.quoteIdentifier!(pk)} SERIAL PRIMARY KEY`
+      ? `${a.quoteIdentifier(pk)} SERIAL PRIMARY KEY`
       : isMysql
-        ? `${a.quoteIdentifier!(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
-        : `${a.quoteIdentifier!(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
+        ? `${a.quoteIdentifier(pk)} BIGINT AUTO_INCREMENT PRIMARY KEY`
+        : `${a.quoteIdentifier(pk)} INTEGER PRIMARY KEY AUTOINCREMENT`;
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
       const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
-      colDefs.push(`${a.quoteIdentifier!(pk)} ${pkType} NOT NULL`);
+      colDefs.push(`${a.quoteIdentifier(pk)} ${pkType} NOT NULL`);
     }
   }
 
   for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
-    colDefs.push(`${a.quoteIdentifier!(name)} ${sqlType}`);
+    colDefs.push(`${a.quoteIdentifier(name)} ${sqlType}`);
   }
 
   if (pks.length > 1) {
-    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier!(pk)).join(", ")})`);
+    colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
   }
 
   await a.executeMutation(

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1159,10 +1159,9 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
    * back through adapter.execute).
    */
   function stubAdapter(adapterName: string, versions: string[]) {
+    const lower = adapterName.toLowerCase();
     const isMySQL =
-      adapterName.toLowerCase().includes("mysql") ||
-      adapterName.toLowerCase().includes("trilogy") ||
-      adapterName.toLowerCase().includes("mariadb");
+      lower.includes("mysql") || lower.includes("trilogy") || lower.includes("mariadb");
     return {
       adapterName,
       quoteTableName: (name: string) =>

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1159,8 +1159,22 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
    * adapter.execute).
    */
   function stubAdapter(adapterName: string, versions: string[]) {
+    const isMySQL =
+      adapterName.toLowerCase().includes("mysql") ||
+      adapterName.toLowerCase().includes("trilogy") ||
+      adapterName.toLowerCase().includes("mariadb");
     return {
       adapterName,
+      quoteTableName: (name: string) =>
+        isMySQL
+          ? name
+              .split(".")
+              .map((p) => `\`${p.replace(/`/g, "``")}\``)
+              .join(".")
+          : name
+              .split(".")
+              .map((p) => `"${p.replace(/"/g, '""')}"`)
+              .join("."),
       execute: async (sql: string) => {
         // Both tableExists() and versions() funnel through execute().
         // Return one row to claim the table exists; for the versions

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { DatabaseTasks, DatabaseNotSupported } from "./database-tasks.js";
+import { quoteTableName as mysqlQuoteTableName } from "../connection-adapters/mysql/quoting.js";
+import { quoteTableName as abstractQuoteTableName } from "../connection-adapters/abstract/quoting.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { createTestAdapter } from "../test-adapter.js";
@@ -1165,15 +1167,7 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
     return {
       adapterName,
       quoteTableName: (name: string) =>
-        isMySQL
-          ? name
-              .split(".")
-              .map((p) => `\`${p.replace(/`/g, "``")}\``)
-              .join(".")
-          : name
-              .split(".")
-              .map((p) => `"${p.replace(/"/g, '""')}"`)
-              .join("."),
+        isMySQL ? mysqlQuoteTableName(name) : abstractQuoteTableName(name),
       execute: async (sql: string) => {
         // Both tableExists() and versions() funnel through execute().
         // Return one row to claim the table exists; for the versions

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1154,9 +1154,9 @@ describe("DatabaseTasks schema cache", () => {
 describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
   /**
    * Build the smallest stub that _appendSchemaInformation needs:
-   * an adapterName (for the quoting kind dispatch) and SchemaMigration's
-   * read path (versions + tableExists return values come back through
-   * adapter.execute).
+   * a quoteTableName method (called directly for identifier quoting) and
+   * SchemaMigration's read path (versions + tableExists return values come
+   * back through adapter.execute).
    */
   function stubAdapter(adapterName: string, versions: string[]) {
     const isMySQL =

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -945,9 +945,7 @@ export class DatabaseTasks {
     const versions = await migration.allVersions();
     if (versions.length === 0) return;
 
-    const { quoteTableName } = await import("../connection-adapters/abstract/quoting.js");
-    const adapterKind = this._adapterQuotingKind(adapter);
-    const quotedTable = quoteTableName(migration.tableName, adapterKind);
+    const quotedTable = adapter.quoteTableName(migration.tableName);
     const quoted = versions
       // Rails inserts versions in reverse order so the final row has
       // the highest version — matches `versions.reverse.map`.
@@ -969,25 +967,6 @@ export class DatabaseTasks {
     // result is one blank line between sections, which matches Rails'
     // `f.puts` + `f.print "\n"` shape.
     getFs().appendFileSync(filename, insertSql);
-  }
-
-  /**
-   * Map a DatabaseAdapter instance to the quoting kind expected by the
-   * abstract quoting helpers. Adapter classes report adapterName as
-   * "SQLite" / "PostgreSQL" / "Mysql2"; the helper expects lowercased
-   * "sqlite" / "postgres" / "mysql". Defaults to undefined (which the
-   * helper treats as standard double-quoted identifiers).
-   */
-  private static _adapterQuotingKind(
-    adapter: import("../adapter.js").DatabaseAdapter,
-  ): "sqlite" | "postgres" | "mysql" | undefined {
-    const name = (adapter as { adapterName?: string }).adapterName?.toLowerCase() ?? "";
-    if (name.includes("sqlite")) return "sqlite";
-    if (name.includes("postgres")) return "postgres";
-    if (name.includes("mysql") || name.includes("trilogy") || name.includes("mariadb")) {
-      return "mysql";
-    }
-    return undefined;
   }
 
   static setupInitialDatabaseYaml(): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Removes the `adapter?: "sqlite" | "postgres" | "mysql"` parameter from `quoteIdentifier`, `quoteTableName`, `quoteColumnName`, and `quoteTableNameForAssignment` in `connection-adapters/abstract/quoting.ts`. The MySQL backtick branch inside `quoteIdentifier` is deleted — per-adapter routing was fully wired in PRs 1–9 via the `Quoting` interface on each adapter class.
- Removes the dead `_adapterQuotingKind` helper from `DatabaseTasks` (it was the last caller constructing and passing the enum string) and replaces `quoteTableName(migration.tableName, adapterKind)` with `adapter.quoteTableName(migration.tableName)`.
- Drops the two-arg calls in the legacy `quoterForAdapterName` fallback in `schema-creation.ts` and `schema-definitions.ts` (those fallbacks still exist for non-quoting uses of `adapterName` in those files; the quoting calls now pass no dialect).
- Updates the `stubAdapter` in `database-tasks.test.ts` to provide `quoteTableName` directly, matching the new dispatch path.

Pre-removal grep confirmed 0 external callers passing the enum:
```
grep -rn 'quoteIdentifier\|quoteTableName\|quoteColumnName' \
  packages/activerecord/src --include='*.ts' \
  | grep -v 'connection-adapters/' | grep -v '\.test\.ts' \
  | grep -E '"sqlite"|"postgres"|"mysql"'
# (no output)
```

See `docs/quoting-refactor.md` for the full 10-PR plan.

## Test plan

- [x] Pre-removal grep: 0 callers outside connection-adapters/ passing the enum
- [x] Acceptance criterion: `grep -rn '"sqlite"\|"postgres"\|"mysql"' packages/activerecord/src/connection-adapters/abstract/quoting.ts` → 0 results
- [x] `pnpm --filter @blazetrails/activerecord build` — green
- [x] `pnpm -w run test` — 6 pre-existing parity fixture failures only (no new failures)
- [x] LOC: 92 total (48 added + 44 deleted), well under 300