### PR TITLE
refactor(arel): reparent Union/UnionAll/Intersect/Except/Join to Binary (PR 24)

### DIFF
--- a/packages/arel/src/nodes/binary.test.ts
+++ b/packages/arel/src/nodes/binary.test.ts
@@ -1,8 +1,76 @@
 import { describe, it, expect } from "vitest";
-import { Table, Nodes } from "../index.js";
+import { Table, Nodes, SelectManager, Visitors } from "../index.js";
 
 describe("NodesTest", () => {
   const users = new Table("users");
+
+  describe("set operations extend Binary", () => {
+    it("Union is a Binary", () => {
+      const sm = new SelectManager(users);
+      const union = sm.union(new SelectManager(users));
+      expect(union).toBeInstanceOf(Nodes.Binary);
+    });
+
+    it("Union supports as() from Binary", () => {
+      const sm = new SelectManager(users);
+      const union = sm.union(new SelectManager(users)) as Nodes.Union;
+      expect(union.as("u")).toBeInstanceOf(Nodes.As);
+    });
+
+    it("Union supports and() from Binary", () => {
+      const sm = new SelectManager(users);
+      const union = sm.union(new SelectManager(users)) as Nodes.Union;
+      const other = users.get("id").eq(1);
+      expect(union.and(other)).toBeInstanceOf(Nodes.And);
+    });
+
+    it("UnionAll is a Binary", () => {
+      const sm = new SelectManager(users);
+      const unionAll = sm.unionAll(new SelectManager(users));
+      expect(unionAll).toBeInstanceOf(Nodes.Binary);
+    });
+
+    it("Intersect is a Binary", () => {
+      const sm = new SelectManager(users);
+      const intersect = sm.intersect(new SelectManager(users));
+      expect(intersect).toBeInstanceOf(Nodes.Binary);
+    });
+
+    it("Except is a Binary", () => {
+      const sm = new SelectManager(users);
+      const except = sm.except(new SelectManager(users));
+      expect(except).toBeInstanceOf(Nodes.Binary);
+    });
+  });
+
+  describe("Join extends Binary", () => {
+    it("InnerJoin is a Binary", () => {
+      const join = new Nodes.InnerJoin(users, null);
+      expect(join).toBeInstanceOf(Nodes.Binary);
+    });
+
+    it("OuterJoin is a Binary", () => {
+      const join = new Nodes.OuterJoin(users, null);
+      expect(join).toBeInstanceOf(Nodes.Binary);
+    });
+
+    it("StringJoin is a Binary", () => {
+      const join = new Nodes.StringJoin(new Nodes.SqlLiteral("JOIN foo ON ..."));
+      expect(join).toBeInstanceOf(Nodes.Binary);
+    });
+  });
+
+  describe("dot visitor — union emits left/right edges via Binary fallback", () => {
+    it("Union graph has left and right edges", () => {
+      const sm = new SelectManager(users);
+      const union = sm.union(new SelectManager(users));
+      const dot = new Visitors.Dot();
+      const out = dot.compile(union);
+      expect(out).toMatch(/-> \d+ \[label="left"\]/);
+      expect(out).toMatch(/-> \d+ \[label="right"\]/);
+    });
+  });
+
   describe("Binary", () => {
     it("generates a hash based on its value", () => {
       const a = new Nodes.Equality(users.get("id"), new Nodes.Quoted(1));

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -195,14 +195,12 @@ export class NotIn extends Binary {
 }
 
 /** Join base class — Rails defines via const_set in binary.rb */
-export abstract class Join extends Node {
-  readonly left: Node;
-  readonly right: Node | null;
+export abstract class Join extends Binary {
+  declare readonly left: Node;
+  declare readonly right: Node | null;
 
   constructor(left: Node, right: Node | null = null) {
-    super();
-    this.left = left;
-    this.right = right;
+    super(left, right);
   }
 }
 
@@ -213,48 +211,30 @@ export class CrossJoin extends Join {
 }
 
 /** Set operations — Rails defines via const_set in binary.rb */
-export class Union extends Node {
-  readonly left: Node;
-  readonly right: Node;
+export class Union extends Binary {
+  declare readonly left: Node;
+  declare readonly right: Node;
 
   constructor(left: Node, right: Node) {
-    super();
-    this.left = left;
-    this.right = right;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(left, right);
   }
 }
 
-export class UnionAll extends Node {
-  readonly left: Node;
-  readonly right: Node;
+export class UnionAll extends Binary {
+  declare readonly left: Node;
+  declare readonly right: Node;
 
   constructor(left: Node, right: Node) {
-    super();
-    this.left = left;
-    this.right = right;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(left, right);
   }
 }
 
-export class Intersect extends Node {
-  readonly left: Node;
-  readonly right: Node;
+export class Intersect extends Binary {
+  declare readonly left: Node;
+  declare readonly right: Node;
 
   constructor(left: Node, right: Node) {
-    super();
-    this.left = left;
-    this.right = right;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(left, right);
   }
 }
 
@@ -276,17 +256,11 @@ export interface FetchAttribute {
   fetchAttribute(block: (attr: Node) => unknown): unknown;
 }
 
-export class Except extends Node {
-  readonly left: Node;
-  readonly right: Node;
+export class Except extends Binary {
+  declare readonly left: Node;
+  declare readonly right: Node;
 
   constructor(left: Node, right: Node) {
-    super();
-    this.left = left;
-    this.right = right;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(left, right);
   }
 }


### PR DESCRIPTION
## Summary

- `Union`, `UnionAll`, `Intersect`, `Except` now extend `Binary` (Rails: `const_set ... Binary` in `binary.rb`)
- `Join` now extends `Binary`; join subclasses (`InnerJoin`, `OuterJoin`, etc.) untouched
- `declare readonly` narrowing restores precise types (`left: Node`, `right: Node | null`) at each subclass level with no runtime effect
- Set-op classes each carry an explicit `constructor(left: Node, right: Node)` so the type contract is enforced at construction, not just via `declare`
- `Binary`'s constructor keeps both params required; `Join`'s own constructor handles the optional RHS
- Tests assert `instanceof Binary` for all reparented classes, that `as()`/`and()` chain methods work via inheritance, and that the Dot visitor emits `left`/`right` edges for a Union via the Binary fallback

Part of arel-alignment-plan.md Wave 3.

## Verification

- 67/67 files, 1279/1279 tests passing
- api:compare arel: 884/884 (100%)
- parity:query: no new diffs