### PR TITLE
refactor(arel): align BoundSqlLiteral with Rails node shape (PR 26)

### DIFF
--- a/packages/arel/src/nodes/bound-sql-literal.test.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
+import { BindError } from "../errors.js";
 
 describe("BoundSqlLiteralTest", () => {
   describe("equality", () => {
@@ -14,6 +15,59 @@ describe("BoundSqlLiteralTest", () => {
       const a = new Nodes.BoundSqlLiteral("id = ?", [1]);
       const b = new Nodes.BoundSqlLiteral("id = ?", [2]);
       expect(a.eql(b)).toBe(false);
+    });
+  });
+
+  describe("node shape", () => {
+    it("exposes sqlWithPlaceholders", () => {
+      const node = new Nodes.BoundSqlLiteral("id = ?", [1]);
+      expect(node.sqlWithPlaceholders).toBe("id = ?");
+    });
+
+    it("exposes positionalBinds and namedBinds", () => {
+      const pos = new Nodes.BoundSqlLiteral("id = ?", [42]);
+      expect(pos.positionalBinds).toEqual([42]);
+
+      const named = new Nodes.BoundSqlLiteral("id = :id", [], { id: 1 });
+      expect(named.namedBinds).toEqual({ id: 1 });
+    });
+  });
+
+  describe("refuses mixed binds", () => {
+    it("raises BindError for mixed positional and named", () => {
+      expect(
+        () => new Nodes.BoundSqlLiteral("id = ? AND name = :name", [1], { name: "x" }),
+      ).toThrow(BindError);
+    });
+  });
+
+  describe("requires positional binds to match the placeholders", () => {
+    it("raises BindError when too few binds", () => {
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2])).toThrow(BindError);
+    });
+
+    it("raises BindError when too many binds", () => {
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2, 3, 4])).toThrow(BindError);
+    });
+
+    it("error message matches Rails phrasing", () => {
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2])).toThrow(
+        "wrong number of bind variables (2 for 3) in: id IN (?, ?, ?)",
+      );
+    });
+  });
+
+  describe("requires all named bind params to be supplied", () => {
+    it("raises BindError when a named bind is missing", () => {
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", [], { foo: 1 })).toThrow(
+        BindError,
+      );
+    });
+
+    it("error message matches Rails phrasing", () => {
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", [], { foo: 1 })).toThrow(
+        "missing value for :bar in: id IN (:foo, :bar)",
+      );
     });
   });
 });

--- a/packages/arel/src/nodes/bound-sql-literal.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.ts
@@ -1,7 +1,6 @@
-import { Node, NodeVisitor } from "./node.js";
+import { NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
-import { SqlLiteral } from "./sql-literal.js";
-import { Quoted } from "./casted.js";
+import { BindError } from "../errors.js";
 
 /**
  * BoundSqlLiteral — a SQL literal with bind parameters.
@@ -11,123 +10,51 @@ import { Quoted } from "./casted.js";
  * Mirrors: Arel::Nodes::BoundSqlLiteral
  */
 export class BoundSqlLiteral extends NodeExpression {
-  readonly sql: string;
+  readonly sqlWithPlaceholders: string;
   readonly positionalBinds: unknown[];
   readonly namedBinds: Record<string, unknown>;
 
-  get sqlWithPlaceholders(): string {
-    return this.sql;
-  }
-
   constructor(
-    sql: string,
+    sqlWithPlaceholders: string,
     positionalBinds: unknown[] = [],
     namedBinds: Record<string, unknown> = {},
   ) {
     super();
-    this.sql = sql;
+    this.sqlWithPlaceholders = sqlWithPlaceholders;
     this.positionalBinds = positionalBinds;
     this.namedBinds = namedBinds;
     this.validate();
   }
 
   private validate(): void {
-    const hasPositionalPlaceholders = this.sql.includes("?");
-    const namedMatches = this.sql.match(/:[a-zA-Z]\w*/g) || [];
-    const hasNamedPlaceholders = namedMatches.length > 0;
-    const hasPositionalBinds = this.positionalBinds.length > 0;
-    const hasNamedBinds = Object.keys(this.namedBinds).length > 0;
-
-    // Cannot mix positional and named in the SQL itself
-    if (hasPositionalPlaceholders && hasNamedPlaceholders) {
-      throw new Error("Cannot mix positional and named bind parameters");
-    }
-
-    // Cannot provide named binds with positional placeholders or vice versa
-    if (hasPositionalPlaceholders && hasNamedBinds) {
-      throw new Error("Cannot mix positional and named bind parameters");
-    }
-
-    if (hasNamedPlaceholders && hasPositionalBinds) {
-      throw new Error("Cannot mix positional and named bind parameters");
-    }
-
-    // Named placeholders must have corresponding named binds supplied.
-    if (hasNamedPlaceholders && !hasNamedBinds) {
-      const first = namedMatches[0]?.slice(1) ?? "bind";
-      throw new Error(`Missing named bind parameter: :${first}`);
-    }
-  }
-
-  /**
-   * Get the parts of the SQL split by bind placeholders,
-   * paired with their bound values as Node objects.
-   */
-  get parts(): Node[] {
-    const result: Node[] = [];
+    const sql = this.sqlWithPlaceholders;
     const hasPositional = this.positionalBinds.length > 0;
+    const hasNamed = Object.keys(this.namedBinds).length > 0;
+
+    if (hasPositional && hasNamed) {
+      throw new BindError(`cannot mix positional and named binds`, sql);
+    }
 
     if (hasPositional) {
-      // Positional binds
-      const segments = this.sql.split("?");
-      const count = segments.length - 1;
-      if (this.positionalBinds.length !== count) {
-        throw new Error(
-          `Wrong number of bind variables (${this.positionalBinds.length} for ${count})`,
+      const expected = (sql.match(/\?/g) ?? []).length;
+      if (this.positionalBinds.length !== expected) {
+        throw new BindError(
+          `wrong number of bind variables (${this.positionalBinds.length} for ${expected})`,
+          sql,
         );
       }
-      for (let i = 0; i < segments.length; i++) {
-        if (segments[i]) {
-          result.push(new SqlLiteral(segments[i]));
-        }
-        if (i < this.positionalBinds.length) {
-          const val = this.positionalBinds[i];
-          if (val instanceof Node) {
-            result.push(val);
-          } else {
-            result.push(new Quoted(val));
-          }
-        }
-      }
-    } else if (Object.keys(this.namedBinds).length > 0) {
-      // Named binds
-      const namedPattern = /:[a-zA-Z]\w*/g;
-      const requiredNames = new Set<string>();
-      let match;
-      while ((match = namedPattern.exec(this.sql)) !== null) {
-        requiredNames.add(match[0].slice(1));
-      }
-
-      // Check all required names are supplied
-      for (const name of requiredNames) {
-        if (!(name in this.namedBinds)) {
-          throw new Error(`Missing named bind parameter: :${name}`);
-        }
-      }
-
-      let lastIndex = 0;
-      const pattern = /:[a-zA-Z]\w*/g;
-      while ((match = pattern.exec(this.sql)) !== null) {
-        if (match.index > lastIndex) {
-          result.push(new SqlLiteral(this.sql.slice(lastIndex, match.index)));
-        }
-        const name = match[0].slice(1);
-        const val = this.namedBinds[name];
-        if (val instanceof Node) {
-          result.push(val);
-        } else {
-          result.push(new Quoted(val));
-        }
-        lastIndex = match.index + match[0].length;
-      }
-      if (lastIndex < this.sql.length) {
-        result.push(new SqlLiteral(this.sql.slice(lastIndex)));
-      }
-    } else {
-      result.push(new SqlLiteral(this.sql));
     }
 
-    return result;
+    if (hasNamed) {
+      // Deduplicate tokens (matches Rails `.uniq`) before checking for missing binds.
+      const tokens = [...new Set([...sql.matchAll(/:(?<!::)([a-zA-Z]\w*)/g)].map((m) => m[1]))];
+      const missing = tokens.filter((t) => !(t in this.namedBinds));
+      if (missing.length === 1) {
+        throw new BindError(`missing value for :${missing[0]}`, sql);
+      } else if (missing.length > 1) {
+        throw new BindError(`missing values for ${JSON.stringify(missing)}`, sql);
+      }
+    }
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -400,12 +400,11 @@ describe("the to_sql visitor", () => {
     });
 
     it("requires all named bind params to be supplied", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id = :id", [], {})).toThrow();
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", [], { foo: 1 })).toThrow();
     });
 
     it("requires positional binds to match the placeholders", () => {
-      const node = new Nodes.BoundSqlLiteral("id = ? AND name = ?", [1]);
-      expect(() => new Visitors.ToSql().compile(node)).toThrow();
+      expect(() => new Nodes.BoundSqlLiteral("id = ? AND name = ?", [1])).toThrow();
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -5,7 +5,7 @@ import { Composite } from "../collectors/composite.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
-import { UnsupportedVisitError, NotImplementedError } from "../errors.js";
+import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors.js";
 
 /**
  * Resolve a bind's database value. QueryAttribute exposes
@@ -1005,10 +1005,53 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   private visitArelNodesBoundSqlLiteral(node: Nodes.BoundSqlLiteral): SQLString {
     this.collector.retryable = false;
-    for (const part of node.parts) {
-      this.visit(part);
+    const sql = node.sqlWithPlaceholders;
+
+    if (node.positionalBinds.length > 0) {
+      const segments = sql.split("?");
+      const expected = segments.length - 1;
+      if (node.positionalBinds.length !== expected) {
+        throw new BindError(
+          `wrong number of bind variables (${node.positionalBinds.length} for ${expected})`,
+          sql,
+        );
+      }
+      for (let i = 0; i < segments.length; i++) {
+        if (segments[i]) this.collector.append(segments[i]);
+        if (i < node.positionalBinds.length) this.visitBindValue(node.positionalBinds[i]);
+      }
+    } else if (Object.keys(node.namedBinds).length > 0) {
+      const re = /:(?<!::)([a-zA-Z]\w*)|([^:]+|.)/gy;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(sql)) !== null) {
+        if (m[2] !== undefined) {
+          this.collector.append(m[2]);
+        } else {
+          const name = m[1];
+          if (!(name in node.namedBinds)) {
+            throw new BindError(`missing value for :${name}`, sql);
+          }
+          this.visitBindValue(node.namedBinds[name]);
+        }
+      }
+    } else {
+      this.collector.append(sql);
     }
+
     return this.collector;
+  }
+
+  private visitBindValue(value: unknown): void {
+    if (value instanceof Node) {
+      this.visit(value);
+    } else if (Array.isArray(value)) {
+      value.forEach((v, i) => {
+        if (i > 0) this.collector.append(", ");
+        this.visitBindValue(v);
+      });
+    } else {
+      this.collector.append(this.quote(value));
+    }
   }
 
   // -- Concat --


### PR DESCRIPTION
Part of the arel alignment plan (`docs/arel-alignment-plan.md`), Wave 4 — PR 26.

## Changes

**`BoundSqlLiteral` node** (`nodes/bound-sql-literal.ts`):
- Rename field `sql` → `sqlWithPlaceholders` (mirrors Rails `attr_reader :sql_with_placeholders`)
- Drop the trails-only `parts` getter and `sqlWithPlaceholders` alias getter
- Align `BindError` messages with Rails phrasing: `"wrong number of bind variables (N for M) in: <sql>"`, `"missing value for :<name> in: <sql>"`, `"cannot mix positional and named binds in: <sql>"`
- Validation now fires in the constructor (matches Rails `initialize`)

**Visitor** (`visitors/to-sql.ts`):
- Rewrite `visitArelNodesBoundSqlLiteral` to walk `sqlWithPlaceholders` directly, matching Rails' `visit_Arel_Nodes_BoundSqlLiteral` which scans for `?` / `:name` inline
- Add private `visitBindValue` helper mirroring Rails' `new_bind` lambda: visits Arel nodes, comma-joins arrays, quotes scalars

## Verification

- `pnpm --filter @blazetrails/arel test` — 1269/1269 passed
- `pnpm --filter @blazetrails/activerecord test` — 9964/9964 passed
- `pnpm parity:query` — unchanged (visitor emits same SQL for same input; only internal node API moved)
- `pnpm api:compare --package arel --privates` — 884/884