### PR TITLE
feat(arel): Table#[] resolves model attribute aliases via klass ref

### DIFF
--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1835,3 +1835,31 @@ describe("AttributeMethodsTest", () => {
 // ==========================================================================
 // AttributeMethodsTest — targets attribute_methods_test.rb (continued)
 // ==========================================================================
+
+describe("attribute_alias arelTable integration", () => {
+  const adapter = freshAdapter();
+
+  it("test_attribute_alias_in_where_references_association_name", () => {
+    class User extends Base {
+      static {
+        this.attribute("username", "string");
+        this.aliasAttribute("login", "username");
+        this.adapter = adapter;
+      }
+    }
+    const attr = User.arelTable.get("login");
+    expect(attr.name).toBe("username");
+  });
+
+  it("arelTable.get passthrough for unaliased attribute", () => {
+    class User extends Base {
+      static {
+        this.attribute("username", "string");
+        this.aliasAttribute("login", "username");
+        this.adapter = adapter;
+      }
+    }
+    const attr = User.arelTable.get("username");
+    expect(attr.name).toBe("username");
+  });
+});

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -733,7 +733,7 @@ export class Base extends Model {
    * call since Table is cheap).
    */
   static get arelTable(): Table {
-    return new Table(this.tableName, { typeCaster: new TypeCasterMap(this) });
+    return new Table(this.tableName, { typeCaster: new TypeCasterMap(this), klass: this });
   }
 
   /**

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -262,4 +262,25 @@ describe("TableTest", () => {
       expect(new Visitors.ToSql().compile(attr)).toBe('"u"."id"');
     });
   });
+
+  describe("attribute_aliases", () => {
+    it("resolves an aliased attribute name", () => {
+      const t = new Table("users", { klass: { _attributeAliases: { nickname: "name" } } });
+      const attr = t.get("nickname");
+      expect(attr).toBeInstanceOf(Nodes.Attribute);
+      expect(attr.name).toBe("name");
+    });
+
+    it("passes through an unaliased attribute name", () => {
+      const t = new Table("users", { klass: { _attributeAliases: { nickname: "name" } } });
+      const attr = t.get("name");
+      expect(attr.name).toBe("name");
+    });
+
+    it("passes through when no klass is set", () => {
+      const t = new Table("users");
+      const attr = t.get("nickname");
+      expect(attr.name).toBe("nickname");
+    });
+  });
 });

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -7,6 +7,12 @@ import { InnerJoin } from "./nodes/inner-join.js";
 import type { Join } from "./nodes/binary.js";
 import { TableAlias } from "./nodes/table-alias.js";
 
+/** Structural duck-type for Rails' `@klass.attribute_aliases`.
+ *  Kept minimal so arel does not import activerecord. */
+export interface TableKlass {
+  readonly _attributeAliases?: Record<string, string>;
+}
+
 /**
  * Table — represents a database table.
  *
@@ -18,13 +24,15 @@ export class Table extends Node {
 
   readonly name: string;
   readonly tableAlias: string | null;
+  readonly klass?: TableKlass;
   private typeCaster: unknown;
 
-  constructor(name: string, options?: { as?: string; klass?: unknown; typeCaster?: unknown }) {
+  constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
     super();
     this.name = name;
     const as = options?.as ?? null;
     this.tableAlias = as === name ? null : as;
+    this.klass = options?.klass;
     this.typeCaster = options?.typeCaster ?? null;
   }
 
@@ -61,7 +69,8 @@ export class Table extends Node {
   }
 
   get(name: string, table?: Attribute["relation"]): Attribute {
-    return new Attribute(table ?? this, name);
+    const resolved = this.klass?._attributeAliases?.[name] ?? name;
+    return new Attribute(table ?? this, resolved);
   }
 
   attr(name: string): Attribute {


### PR DESCRIPTION
Part of the [arel alignment plan](docs/arel-alignment-plan.md) — Wave 4, PR 10.

## Summary

- `packages/arel/src/table.ts` — adds a structural `TableKlass` interface (`_attributeAliases?: Record<string, string>`) and an optional `klass` field on `Table`. `get(name)` resolves aliases through `klass._attributeAliases` before constructing the `Attribute`, matching Rails' `Arel::Table#[]`.
- `packages/activerecord/src/base.ts` — `arelTable` passes `klass: this` to the `Table` constructor. `Model` already declares `_attributeAliases` on `activemodel/src/model.ts:93`, satisfying the interface structurally.
- Arel carries zero runtime import of activerecord (duck-typing via the structural interface).

## Rails reference

- `activerecord/lib/arel/table.rb` — `def [](name, table = self)` calls `name = klass.attribute_aliases[name.to_s] || name if klass`
- `activerecord/lib/active_record/model_schema.rb` — `def arel_table` builds `Arel::Table.new(table_name, klass: self)`

## Test plan

- [ ] `pnpm --filter @blazetrails/arel test` — `table.test.ts` includes 3 new `attribute_aliases` cases (alias resolves, passthrough, no-klass)
- [ ] `pnpm test` — `attribute-methods.test.ts` includes 2 new integration tests confirming `arelTable.get("login")` resolves to `"username"` after `aliasAttribute("login", "username")`
- [ ] Pre-existing parity failures are unrelated (schema fixture missing on this machine)