### PR TITLE
feat(activemodel): port B8 attribute-assignment cluster privates

### DIFF
--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -22,6 +22,11 @@ import {
   raiseValidationError as validationsRaiseValidationError,
   _mergeAttributes as validationsMergeAttributes,
 } from "./validations.js";
+import {
+  _assignAttributes as attrAssign,
+  _assignAttribute as attrAssignOne,
+  sanitizeForMassAssignment as attrSanitize,
+} from "./attribute-assignment.js";
 
 /**
  * Rails: ActiveModel::API includes Validations (api.rb), so the
@@ -52,6 +57,21 @@ export const raiseValidationError = validationsRaiseValidationError;
  * @internal Rails-private helper.
  */
 export const _mergeAttributes = validationsMergeAttributes;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const _assignAttributes = attrAssign;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const _assignAttribute = attrAssignOne;
+
+/**
+ * @internal Rails-private helper.
+ */
+export const sanitizeForMassAssignment = attrSanitize;
 
 /**
  * Rails: ActiveModel::API includes Validations, which extends Translation,

--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -241,4 +241,23 @@ describe("AttributeAssignmentTest", () => {
     expect(p.readAttribute("name")).toBe("Dave");
     expect(p.readAttribute("role")).toBeNull();
   });
+
+  it("subclass override of _assignAttribute is called by _assignAttributes", () => {
+    const seen: Array<[string, unknown]> = [];
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+      override _assignAttribute(k: string, v: unknown): void {
+        seen.push([k, v]);
+        super._assignAttribute(k, v);
+      }
+    }
+    const p = new Person({});
+    p.assignAttributes({ name: "Eve", age: 5 });
+    expect(seen).toContainEqual(["name", "Eve"]);
+    expect(seen).toContainEqual(["age", 5]);
+    expect(p.readAttribute("name")).toBe("Eve");
+  });
 });

--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -206,4 +206,39 @@ describe("AttributeAssignmentTest", () => {
     p.assignAttributes({ name: "Bob" });
     expect(p.readAttribute("name")).toBe("Bob");
   });
+
+  it("subclass override of _assignAttributes is called by assignAttributes", () => {
+    const called: Record<string, unknown>[] = [];
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+      override _assignAttributes(attrs: Record<string, unknown>): void {
+        called.push(attrs);
+        super._assignAttributes(attrs);
+      }
+    }
+    const p = new Person({});
+    p.assignAttributes({ name: "Carol" });
+    expect(called).toHaveLength(1);
+    expect(called[0]).toEqual({ name: "Carol" });
+    expect(p.readAttribute("name")).toBe("Carol");
+  });
+
+  it("subclass override of sanitizeForMassAssignment is called by assignAttributes", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("role", "string");
+      }
+      override sanitizeForMassAssignment(attrs: Record<string, unknown>): Record<string, unknown> {
+        const { role: _role, ...rest } = attrs;
+        return rest;
+      }
+    }
+    const p = new Person({});
+    p.assignAttributes({ name: "Dave", role: "admin" });
+    expect(p.readAttribute("name")).toBe("Dave");
+    expect(p.readAttribute("role")).toBeNull();
+  });
 });

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -5,8 +5,10 @@ interface PermittedAttributes {
   permitted?(): boolean;
 }
 
-/** @internal */
-function sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown> {
+/** @internal Rails-private helper. */
+export function sanitizeForMassAssignment(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
   const attrs = attributes as Record<string, unknown> & PermittedAttributes;
   if (typeof attrs.permitted === "function") {
     if (!attrs.permitted()) {
@@ -39,10 +41,7 @@ export function assignAttributes(model: AttributeAssignment, newAttributes: unkn
   if (Object.keys(attrs).length === 0) return;
 
   const sanitized = sanitizeForMassAssignment(attrs);
-
-  for (const [key, value] of Object.entries(sanitized)) {
-    assignAttribute(model, key, value);
-  }
+  _assignAttributes(model, sanitized);
 }
 
 /**
@@ -83,7 +82,18 @@ function findSetter(model: object, key: string): ((this: object, value: unknown)
   return null;
 }
 
-function assignAttribute(model: AttributeAssignment, key: string, value: unknown): void {
+/** @internal Rails-private helper. */
+export function _assignAttributes(
+  model: AttributeAssignment,
+  attributes: Record<string, unknown>,
+): void {
+  for (const [k, v] of Object.entries(attributes)) {
+    _assignAttribute(model, k, v);
+  }
+}
+
+/** @internal Rails-private helper. */
+export function _assignAttribute(model: AttributeAssignment, key: string, value: unknown): void {
   const setter = findSetter(model, key);
   if (setter) {
     setter.call(model, value);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -47,7 +47,6 @@ import {
   attributeMissing,
 } from "./attribute-methods.js";
 import {
-  assignAttributes as assignAttrs,
   _assignAttributes as attrAssign,
   _assignAttribute as attrAssignOne,
   sanitizeForMassAssignment as attrSanitize,
@@ -2018,8 +2017,25 @@ export class Model {
    *
    * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
    */
-  assignAttributes(attrs: Record<string, unknown>): void {
-    assignAttrs(this, attrs);
+  assignAttributes(newAttributes: unknown): void {
+    if (
+      typeof newAttributes !== "object" ||
+      newAttributes === null ||
+      Array.isArray(newAttributes)
+    ) {
+      const t =
+        newAttributes === null
+          ? "Null"
+          : Array.isArray(newAttributes)
+            ? "Array"
+            : typeof newAttributes;
+      throw new ArgumentError(
+        `When assigning attributes, you must pass a hash as an argument, ${t.charAt(0).toUpperCase() + t.slice(1)} passed.`,
+      );
+    }
+    const attrs = newAttributes as Record<string, unknown>;
+    if (Object.keys(attrs).length === 0) return;
+    this._assignAttributes(this.sanitizeForMassAssignment(attrs));
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -47,7 +47,6 @@ import {
   attributeMissing,
 } from "./attribute-methods.js";
 import {
-  _assignAttributes as attrAssign,
   _assignAttribute as attrAssignOne,
   sanitizeForMassAssignment as attrSanitize,
   attributeWriterMissing as defaultAttributeWriterMissing,
@@ -2042,7 +2041,9 @@ export class Model {
    * @internal Rails-private helper.
    */
   _assignAttributes(attributes: Record<string, unknown>): void {
-    attrAssign(this, attributes);
+    for (const [k, v] of Object.entries(attributes)) {
+      this._assignAttribute(k, v);
+    }
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -48,6 +48,9 @@ import {
 } from "./attribute-methods.js";
 import {
   assignAttributes as assignAttrs,
+  _assignAttributes as attrAssign,
+  _assignAttribute as attrAssignOne,
+  sanitizeForMassAssignment as attrSanitize,
   attributeWriterMissing as defaultAttributeWriterMissing,
   ArgumentError,
 } from "./attribute-assignment.js";
@@ -1225,7 +1228,9 @@ export class Model {
    *
    * @internal Rails-private helper.
    */
-  static _mergeAttributes = validationsMergeAttributes;
+  static _mergeAttributes(attrNames: unknown[]): Record<string, unknown> {
+    return validationsMergeAttributes(attrNames);
+  }
 
   /**
    * Default option keys recognized by `validates(...)`. Subclasses
@@ -2015,6 +2020,27 @@ export class Model {
    */
   assignAttributes(attrs: Record<string, unknown>): void {
     assignAttrs(this, attrs);
+  }
+
+  /**
+   * @internal Rails-private helper.
+   */
+  _assignAttributes(attributes: Record<string, unknown>): void {
+    attrAssign(this, attributes);
+  }
+
+  /**
+   * @internal Rails-private helper.
+   */
+  _assignAttribute(k: string, v: unknown): void {
+    attrAssignOne(this, k, v);
+  }
+
+  /**
+   * @internal Rails-private helper.
+   */
+  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown> {
+    return attrSanitize(attributes);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Export `_assignAttributes`, `_assignAttribute`, `sanitizeForMassAssignment` from `attribute-assignment.ts` with `@internal` JSDoc
- Re-expose them through `api.ts` and `model.ts` (include-chain re-exports matching Rails' `API includes AttributeAssignment`)
- Fix `static _mergeAttributes` in `model.ts`: was a `PropertyDeclaration` (silently skipped by the `_`-prefix guard in `extract-ts-api.ts`); converted to a `MethodDeclaration` so the compare script finds it

## Result

```
attribute_assignment.rb  60% → 100%
api.rb                   93% → 100%
model.rb                 89% → 100%
Overall: 581/625 (93%) → 590/625 (94.4%)
```

## Test plan

- [ ] `pnpm --filter @blazetrails/activemodel test` — all pass
- [ ] `pnpm build && pnpm typecheck` — clean
- [ ] CI green