### PR TITLE
feat(activemodel): B9 — attribute-registration.ts privates to 100%

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -308,7 +308,8 @@ export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#resolve_attribute_name
  *
- * Coerces an attribute name to a string.
+ * Returns the attribute name as-is. Rails calls name.to_s here; our public
+ * API already enforces string, so no coercion is needed.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -169,10 +169,7 @@ export function applyPendingAttributeModifications(
  * Mirrors: the PendingType push inside ActiveModel::AttributeRegistration#attribute
  */
 export function pushPendingType(cls: AnyAttributeHost, name: string, type: Type): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")) {
-    cls._pendingAttributeModifications = [];
-  }
-  cls._pendingAttributeModifications.push(new PendingType(name, type));
+  pendingAttributeModifications.call(cls).push(new PendingType(name, type));
 }
 
 /**
@@ -182,10 +179,7 @@ export function pushPendingType(cls: AnyAttributeHost, name: string, type: Type)
  * Mirrors: the PendingDefault push inside ActiveModel::AttributeRegistration#attribute
  */
 export function pushPendingDefault(cls: AnyAttributeHost, name: string, value: unknown): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")) {
-    cls._pendingAttributeModifications = [];
-  }
-  cls._pendingAttributeModifications.push(new PendingDefault(name, value));
+  pendingAttributeModifications.call(cls).push(new PendingDefault(name, value));
 }
 
 /**
@@ -199,10 +193,7 @@ export function pushPendingDecorator(
   names: string[] | null,
   decorator: (name: string, type: Type) => Type,
 ): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")) {
-    cls._pendingAttributeModifications = [];
-  }
-  cls._pendingAttributeModifications.push(new PendingDecorator(names, decorator));
+  pendingAttributeModifications.call(cls).push(new PendingDecorator(names, decorator));
 }
 
 /**

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,5 +1,6 @@
 import { DescendantsTracker } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
+import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
 
@@ -39,7 +40,8 @@ interface PendingModification {
   applyTo(attributeSet: AttributeSet): void;
 }
 
-class PendingType implements PendingModification {
+/** @internal Rails-private helper. */
+export class PendingType implements PendingModification {
   constructor(
     readonly name: string,
     readonly type: Type,
@@ -52,7 +54,8 @@ class PendingType implements PendingModification {
   }
 }
 
-class PendingDefault implements PendingModification {
+/** @internal Rails-private helper. */
+export class PendingDefault implements PendingModification {
   constructor(
     readonly name: string,
     readonly default_: unknown,
@@ -65,7 +68,8 @@ class PendingDefault implements PendingModification {
   }
 }
 
-class PendingDecorator implements PendingModification {
+/** @internal Rails-private helper. */
+export class PendingDecorator implements PendingModification {
   constructor(
     readonly names: string[] | null,
     readonly decorator: (name: string, type: Type) => Type,
@@ -284,4 +288,69 @@ export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
  */
 export function typeForAttribute(this: AnyAttributeHost, name: string): Type | null {
   return attributeTypes.call(this)[name] ?? null;
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#pending_attribute_modifications
+ *
+ * Lazily initializes the own-class pending-modification queue and returns it.
+ *
+ * @internal Rails-private helper.
+ */
+export function pendingAttributeModifications(this: AnyAttributeHost): PendingModification[] {
+  if (!Object.prototype.hasOwnProperty.call(this, "_pendingAttributeModifications")) {
+    this._pendingAttributeModifications = [];
+  }
+  return this._pendingAttributeModifications as PendingModification[];
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#reset_default_attributes!
+ *
+ * Clears only the cached state on this class (no subclass cascade).
+ * resetDefaultAttributes() calls this first, then recurses.
+ *
+ * @internal Rails-private helper.
+ */
+export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
+  this._cachedDefaultAttributes = null;
+  this._attributesBuilder = undefined;
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#resolve_attribute_name
+ *
+ * Coerces an attribute name to a string.
+ *
+ * @internal Rails-private helper.
+ */
+export function resolveAttributeName(this: AnyAttributeHost, name: string | symbol): string {
+  return String(name);
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#resolve_type_name
+ *
+ * Looks up a registered Type by symbolic name.
+ *
+ * @internal Rails-private helper.
+ */
+export function resolveTypeName(
+  this: AnyAttributeHost,
+  name: string,
+  _options?: Record<string, unknown>,
+): Type {
+  return typeRegistry.lookup(name);
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#hook_attribute_type
+ *
+ * Extension point for other modules (e.g. AR encryption) to decorate a
+ * type immediately after resolution. Base implementation is a pass-through.
+ *
+ * @internal Rails-private helper.
+ */
+export function hookAttributeType(this: AnyAttributeHost, _attribute: string, type: Type): Type {
+  return type;
 }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -312,8 +312,8 @@ export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
  *
  * @internal Rails-private helper.
  */
-export function resolveAttributeName(this: AnyAttributeHost, name: string | symbol): string {
-  return String(name);
+export function resolveAttributeName(this: AnyAttributeHost, name: string): string {
+  return name;
 }
 
 /**

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -35,7 +35,8 @@ type AnyAttributeHost = any;
 // Mirrors: ActiveModel::AttributeRegistration::ClassMethods private structs
 // ---------------------------------------------------------------------------
 
-interface PendingModification {
+/** @internal Rails-private helper. */
+export interface PendingModification {
   /** @internal */
   applyTo(attributeSet: AttributeSet): void;
 }
@@ -124,15 +125,7 @@ export function registerWithSuperclass(cls: AnyAttributeHost): void {
  * @internal
  */
 export function resetDefaultAttributes(cls: AnyAttributeHost): void {
-  cls._cachedDefaultAttributes = null;
-  // _attributesBuilder is an AR-specific derived cache. Unconditionally
-  // shadow it with undefined so prototype-chain lookup never returns a stale
-  // superclass builder after this class's attributes change. For STI
-  // subclasses, attributesBuilder() removes the shadow after writing the
-  // fresh builder to cacheHost, restoring normal prototype-chain access.
-  // AM-only classes that never call attributesBuilder() carry the undefined
-  // own property harmlessly (a single extra slot per class).
-  cls._attributesBuilder = undefined;
+  resetDefaultAttributesBang.call(cls);
   for (const sub of DescendantsTracker.subclasses(cls)) {
     resetDefaultAttributes(sub);
   }
@@ -314,6 +307,10 @@ export function pendingAttributeModifications(this: AnyAttributeHost): PendingMo
  */
 export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
   this._cachedDefaultAttributes = null;
+  // _attributesBuilder is an AR-specific derived cache. Shadow with undefined
+  // so prototype-chain lookup never returns a stale superclass builder after
+  // this class's attributes change. STI subclasses remove the shadow after
+  // writing the fresh builder; AM-only classes carry it harmlessly.
   this._attributesBuilder = undefined;
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -137,7 +137,7 @@ export class Model {
   }
 
   /** @internal Rails-private helper. */
-  static resolveAttributeName(name: string | symbol): string {
+  static resolveAttributeName(name: string): string {
     return _resolveAttributeNameHelper.call(this, name);
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -69,6 +69,11 @@ import {
   attributeTypes,
   typeForAttribute as staticTypeForAttribute,
   decorateAttributes,
+  pendingAttributeModifications as _pendingAttributeModificationsHelper,
+  resetDefaultAttributesBang as _resetDefaultAttributesBangHelper,
+  resolveAttributeName as _resolveAttributeNameHelper,
+  resolveTypeName as _resolveTypeNameHelper,
+  hookAttributeType as _hookAttributeTypeHelper,
 } from "./attribute-registration.js";
 import { _toPartialPath } from "./conversion.js";
 
@@ -120,6 +125,37 @@ export class Model {
   static attributeTypes = attributeTypes;
   static typeForAttribute = staticTypeForAttribute;
   static _toPartialPath = _toPartialPath;
+
+  /** @internal Rails-private helper. */
+  static pendingAttributeModifications(): ReturnType<typeof _pendingAttributeModificationsHelper> {
+    return _pendingAttributeModificationsHelper.call(this);
+  }
+
+  /** @internal Rails-private helper. */
+  static resetDefaultAttributesBang(): void {
+    _resetDefaultAttributesBangHelper.call(this);
+  }
+
+  /** @internal Rails-private helper. */
+  static resolveAttributeName(name: string | symbol): string {
+    return _resolveAttributeNameHelper.call(this, name);
+  }
+
+  /** @internal Rails-private helper. */
+  static resolveTypeName(
+    name: string,
+    options?: Record<string, unknown>,
+  ): import("./type/value.js").Type {
+    return _resolveTypeNameHelper.call(this, name, options);
+  }
+
+  /** @internal Rails-private helper. */
+  static hookAttributeType(
+    attribute: string,
+    type: import("./type/value.js").Type,
+  ): import("./type/value.js").Type {
+    return _hookAttributeTypeHelper.call(this, attribute, type);
+  }
 
   static attributeNames(): string[] {
     return Array.from(this._attributeDefinitions.entries())


### PR DESCRIPTION
## Summary

- Export `PendingType`, `PendingDefault`, `PendingDecorator` so their `applyTo` methods are visible to the TS API extractor
- Add 5 this-typed exported functions: `pendingAttributeModifications`, `resetDefaultAttributesBang`, `resolveAttributeName`, `resolveTypeName`, `hookAttributeType`
- Wire all 5 as `MethodDeclaration` statics on `Model`

`attribute-registration.ts`: 7/13 → 13/13 (100%)  
activemodel privates overall: 581/625 → 587/625 (93.9%)

## Test plan

- [ ] `pnpm tsx scripts/api-compare/compare.ts --privates --package activemodel` shows attribute-registration.ts 100%
- [ ] `pnpm test` — same pass/fail counts as main (2 pre-existing failures in parity/query tests)
- [ ] Build and typecheck pass (enforced by pre-commit hook)