### PR TITLE
test(arel): PR 28 — BindParam delegation + visitor unboundable wiring tests

### DIFF
--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -39,9 +39,14 @@ describe("BindParam", () => {
       expect(bp.isInfinite()).toBeNull();
     });
 
-    it("delegates to value.isInfinite when present", () => {
+    it("delegates to value.isInfinite when present — positive", () => {
       const bp = new Nodes.BindParam({ isInfinite: () => 1 });
       expect(bp.isInfinite()).toBe(1);
+    });
+
+    it("delegates to value.isInfinite when present — negative", () => {
+      const bp = new Nodes.BindParam({ isInfinite: () => -1 });
+      expect(bp.isInfinite()).toBe(-1);
     });
   });
 

--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -20,4 +20,45 @@ describe("BindParam", () => {
     const b = new Nodes.BindParam(99);
     expect(a.value).not.toBe(b.value);
   });
+
+  describe("valueBeforeTypeCast", () => {
+    it("returns value when value has no valueBeforeTypeCast", () => {
+      const bp = new Nodes.BindParam(42);
+      expect(bp.valueBeforeTypeCast()).toBe(42);
+    });
+
+    it("delegates to value.valueBeforeTypeCast when present", () => {
+      const bp = new Nodes.BindParam({ valueBeforeTypeCast: () => "raw" });
+      expect(bp.valueBeforeTypeCast()).toBe("raw");
+    });
+  });
+
+  describe("isInfinite", () => {
+    it("returns null when value has no isInfinite", () => {
+      const bp = new Nodes.BindParam(42);
+      expect(bp.isInfinite()).toBeNull();
+    });
+
+    it("delegates to value.isInfinite when present", () => {
+      const bp = new Nodes.BindParam({ isInfinite: () => 1 });
+      expect(bp.isInfinite()).toBe(1);
+    });
+  });
+
+  describe("isUnboundable", () => {
+    it("returns false when value has no isUnboundable", () => {
+      const bp = new Nodes.BindParam(42);
+      expect(bp.isUnboundable()).toBe(false);
+    });
+
+    it("delegates to value.isUnboundable when present", () => {
+      const bp = new Nodes.BindParam({ isUnboundable: () => 1 });
+      expect(bp.isUnboundable()).toBe(1);
+    });
+
+    it("propagates negative unboundable sign", () => {
+      const bp = new Nodes.BindParam({ isUnboundable: () => -1 });
+      expect(bp.isUnboundable()).toBe(-1);
+    });
+  });
 });

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -23,8 +23,8 @@ export class BindParam extends Node {
     return typeof v?.isInfinite === "function" ? v.isInfinite() : null;
   }
 
-  isUnboundable(): boolean {
-    const v = this.value as { isUnboundable?: () => boolean } | null | undefined;
+  isUnboundable(): 1 | -1 | false {
+    const v = this.value as { isUnboundable?: () => 1 | -1 | false } | null | undefined;
     return typeof v?.isUnboundable === "function" ? v.isUnboundable() : false;
   }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1204,6 +1204,60 @@ describe("the to_sql visitor", () => {
     });
   });
 
+  describe("BindParam unboundable short-circuit", () => {
+    const unboundable = (sign: 1 | -1) => new Nodes.BindParam({ isUnboundable: () => sign });
+
+    it("GreaterThan short-circuits to 1=0 for positive unboundable", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("GreaterThan short-circuits to 1=1 for negative unboundable", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), unboundable(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("GreaterThanOrEqual short-circuits to 1=0 for positive unboundable", () => {
+      const node = new Nodes.GreaterThanOrEqual(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("GreaterThanOrEqual short-circuits to 1=1 for negative unboundable", () => {
+      const node = new Nodes.GreaterThanOrEqual(users.get("id"), unboundable(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("LessThan short-circuits to 1=1 for positive unboundable", () => {
+      const node = new Nodes.LessThan(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("LessThan short-circuits to 1=0 for negative unboundable", () => {
+      const node = new Nodes.LessThan(users.get("id"), unboundable(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("LessThanOrEqual short-circuits to 1=1 for positive unboundable", () => {
+      const node = new Nodes.LessThanOrEqual(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("LessThanOrEqual short-circuits to 1=0 for negative unboundable", () => {
+      const node = new Nodes.LessThanOrEqual(users.get("id"), unboundable(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("Equality short-circuits to 1=0 for any unboundable", () => {
+      const node = new Nodes.Equality(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("NotEqual short-circuits to 1=1 for any unboundable", () => {
+      const node = new Nodes.NotEqual(users.get("id"), unboundable(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+  });
+
   // Mirrors Rails' to_sql.rb private helpers (sanitize_as_sql_comment,
   // quote_table_name, quote_column_name).
   describe("Rails-mirrored private helpers", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1258,6 +1258,30 @@ describe("the to_sql visitor", () => {
     });
   });
 
+  describe("BindParam infinite short-circuit", () => {
+    const infinite = (sign: 1 | -1) => new Nodes.BindParam({ isInfinite: () => sign });
+
+    it("GreaterThan short-circuits to 1=0 for positive infinite", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), infinite(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("GreaterThan short-circuits to 1=1 for negative infinite", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), infinite(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("LessThan short-circuits to 1=1 for positive infinite", () => {
+      const node = new Nodes.LessThan(users.get("id"), infinite(1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=1");
+    });
+
+    it("LessThan short-circuits to 1=0 for negative infinite", () => {
+      const node = new Nodes.LessThan(users.get("id"), infinite(-1));
+      expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+  });
+
   // Mirrors Rails' to_sql.rb private helpers (sanitize_as_sql_comment,
   // quote_table_name, quote_column_name).
   describe("Rails-mirrored private helpers", () => {


### PR DESCRIPTION
Part of `docs/arel-alignment-followup-prs.md`, PR 28.

## Summary

The `BindParam` delegation methods (`valueBeforeTypeCast`, `isInfinite`, `isUnboundable`) and their wiring into the comparison visitors were already implemented in earlier PRs (#375, #1029). The audit doc flagged them as missing because it was run against an older codebase state. This PR adds the missing test coverage to lock in the behavior.

**`bind-param.test.ts`** — delegation protocol tests:
- `valueBeforeTypeCast` returns raw value or delegates to `value.valueBeforeTypeCast()`
- `isInfinite` returns null or delegates to `value.isInfinite()`
- `isUnboundable` returns false or delegates (including signed -1/1 return values)

**`to-sql.test.ts`** — "BindParam unboundable short-circuit" block:
- `GreaterThan`/`GTE`/`LessThan`/`LTE` collapse to `1=0`/`1=1` per sign
- `Equality` collapses to `1=0` for any unboundable
- `NotEqual` collapses to `1=1` for any unboundable

Mirrors Rails `to_sql.rb:437–484` and `bind_param.rb:26–40`.

## Verification

- `pnpm test` — all pass
- `pnpm api:compare --package arel` — 884/884 (no regressions)