### PR TITLE
fix(test): pin worker pool to AR_DB_FORKS to prevent DB slot collisions

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,7 +81,12 @@ export default defineConfig({
               : []),
           ],
           pool: "forks",
-          poolOptions: { forks: { maxForks: AR_DB_MAX_FORKS } },
+          // minForks = maxForks: keep a fixed pool of workers so VITEST_WORKER_ID
+          // stays within [1, AR_DB_FORKS]. Without this, Vitest spawns a new fork
+          // for every test file; IDs wrap modulo AR_DB_FORKS, so workers with IDs
+          // differing by AR_DB_FORKS share the same database and race on table
+          // creation/deletion.
+          poolOptions: { forks: { maxForks: AR_DB_MAX_FORKS, minForks: AR_DB_MAX_FORKS } },
         },
       },
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,11 +81,9 @@ export default defineConfig({
               : []),
           ],
           pool: "forks",
-          // minForks = maxForks: keep a fixed pool of workers so VITEST_WORKER_ID
-          // stays within [1, AR_DB_FORKS]. Without this, Vitest spawns a new fork
-          // for every test file; IDs wrap modulo AR_DB_FORKS, so workers with IDs
-          // differing by AR_DB_FORKS share the same database and race on table
-          // creation/deletion.
+          // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_FORKS].
+          // Without this each file gets a new fork; IDs wrap mod AR_DB_FORKS, so
+          // workers share the same DB and race on table mutations mid-test.
           poolOptions: { forks: { maxForks: AR_DB_MAX_FORKS, minForks: AR_DB_MAX_FORKS } },
         },
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,9 +81,9 @@ export default defineConfig({
               : []),
           ],
           pool: "forks",
-          // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_FORKS].
-          // Without this each file gets a new fork; IDs wrap mod AR_DB_FORKS, so
-          // workers share the same DB and race on table mutations mid-test.
+          // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].
+          // Without this each file gets a new fork; IDs wrap mod AR_DB_MAX_FORKS,
+          // so workers share the same DB and race on table mutations mid-test.
           poolOptions: { forks: { maxForks: AR_DB_MAX_FORKS, minForks: AR_DB_MAX_FORKS } },
         },
       },


### PR DESCRIPTION
## Summary

- Adds `minForks: AR_DB_MAX_FORKS` alongside the existing `maxForks` in the activerecord vitest pool config.

## Root cause

Without `minForks`, Vitest spawns a **new fork process for each test file**. Worker IDs increment globally across all spawned forks. The slot formula `((id-1) % AR_DB_FORKS) + 1` wraps around, so workers with IDs differing by `AR_DB_FORKS` land on the same database (e.g. forks 1 and 5 both hit `rails_js_test`).

`finder.test.ts` is large (~3600 lines, 200+ tests) and runs slowly. While it executes in fork 1, fork 5 is spawned for a smaller file. Fork 5 loads `test-adapter.ts` and its module-load initialization immediately drops **all** existing tables in `rails_js_test` — including the `users` table fork 1 just created. The result is `42P01 relation "users" does not exist` on Charlie's `INSERT` in `finder.test.ts`'s `beforeEach`, since Alice and Bob succeeded before the drop raced in.

## Fix

Setting `minForks = maxForks = AR_DB_FORKS` pre-spawns exactly N workers at startup (IDs 1..N) and reuses them for all test files. IDs never exceed `AR_DB_FORKS`, so every worker maps to a unique DB slot and the race is impossible.

## Test plan

- [ ] PostgreSQL CI job passes without the 42P01 flake on "finds multiple by array of ids"
- [ ] MariaDB CI job unaffected
- [ ] Local SQLite run unaffected (`AR_DB_MAX_FORKS` is `undefined` → `minForks: undefined` → default behavior)