### PR TITLE
feat(arel): PR 30 — SelectManager + SqlLiteral ergonomics

### DIFF
--- a/packages/arel/src/nodes/select-core.test.ts
+++ b/packages/arel/src/nodes/select-core.test.ts
@@ -27,6 +27,14 @@ describe("TestSelectCore", () => {
     expect(cloned.wheres).not.toBe(core.wheres);
   });
 
+  it("froms aliases from (Rails select_core.rb:32-33)", () => {
+    const core = new Nodes.SelectCore();
+    expect(core.froms).toBeNull();
+    core.froms = users;
+    expect(core.from).toBe(users);
+    expect(core.froms).toBe(users);
+  });
+
   it("set quantifier", () => {
     const mgr = new SelectManager(users);
     mgr.project(star).distinct();

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -42,6 +42,16 @@ export class SelectCore extends Node {
     this.source.left = value;
   }
 
+  /** @internal */
+  get froms(): Node | null {
+    return this.from;
+  }
+
+  /** @internal */
+  set froms(value: Node | null) {
+    this.from = value;
+  }
+
   clone(): SelectCore {
     const c = new SelectCore();
     c.source = new JoinSource(this.source.left, [...this.source.right]);

--- a/packages/arel/src/nodes/sql-literal.test.ts
+++ b/packages/arel/src/nodes/sql-literal.test.ts
@@ -96,5 +96,13 @@ describe("SqlLiteralTest", () => {
       const sql = new Visitors.ToSql().compile(fragments);
       expect(sql).toBe("foo bar");
     });
+
+    it("plus is an alias for join (Rails sql_literal.rb #+)", () => {
+      const a = new Nodes.SqlLiteral("foo");
+      const b = new Nodes.SqlLiteral("bar");
+      const fragments = a.plus(b);
+      expect(fragments).toBeInstanceOf(Nodes.Fragments);
+      expect(new Visitors.ToSql().compile(fragments)).toBe("foo bar");
+    });
   });
 });

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -44,7 +44,7 @@ export class SqlLiteral extends Node {
 
   /** @internal */
   plus(other: Node): Fragments {
-    return new Fragments([this, other]);
+    return this.join(other);
   }
 
   toYAML(): string {

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -42,6 +42,11 @@ export class SqlLiteral extends Node {
     return new Fragments([this, other]);
   }
 
+  /** @internal */
+  plus(other: Node): Fragments {
+    return new Fragments([this, other]);
+  }
+
   toYAML(): string {
     // Minimal YAML-ish representation for test parity (no external deps).
     const escaped = this.value.replace(/\n/g, "\\n");

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -415,6 +415,11 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star).order("name ASC");
       expect(mgr.toSql()).toContain("ORDER BY name ASC");
     });
+
+    it("accepts symbol and uses description (Rails :sym.to_s == 'sym')", () => {
+      const mgr = users.project(star).order(Symbol("name"));
+      expect(mgr.toSql()).toContain("ORDER BY name");
+    });
   });
 
   describe("order", () => {

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -339,6 +339,14 @@ describe("SelectManagerTest", () => {
     });
   });
 
+  describe("minus", () => {
+    it("minus aliases except", () => {
+      const q1 = users.project(star);
+      const q2 = users.project(star);
+      expect(new Visitors.ToSql().compile(q1.minus(q2))).toContain("EXCEPT");
+    });
+  });
+
   describe("with", () => {
     it("should support basic WITH", () => {
       const cte = users.project(users.get("name")).where(users.get("age").gt(21));
@@ -375,6 +383,12 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star).take(10);
       expect(mgr.limit).not.toBeNull();
     });
+
+    it("taken aliases limit", () => {
+      const mgr = users.project(star).take(5);
+      expect(mgr.taken).toBe(mgr.limit);
+      expect(mgr.taken).toBe(5);
+    });
   });
 
   describe("lock", () => {
@@ -395,6 +409,11 @@ describe("SelectManagerTest", () => {
     it("generates order clauses", () => {
       const mgr = users.project(star).order(users.get("name").asc());
       expect(mgr.toSql()).toContain("ORDER BY");
+    });
+
+    it("accepts string and wraps in SqlLiteral", () => {
+      const mgr = users.project(star).order("name ASC");
+      expect(mgr.toSql()).toContain("ORDER BY name ASC");
     });
   });
 
@@ -435,6 +454,11 @@ describe("SelectManagerTest", () => {
   it("should hand back froms", () => {
     const mgr = users.project(star);
     expect(mgr.froms.length).toBe(1);
+  });
+
+  it("froms filters null — fromless manager returns empty array", () => {
+    const mgr = new SelectManager();
+    expect(mgr.froms).toHaveLength(0);
   });
 
   it("should create and nodes", () => {
@@ -808,6 +832,12 @@ describe("SelectManagerTest", () => {
   describe("where", () => {
     it("knows where", () => {
       const mgr = users.project(star).where(users.get("id").eq(1));
+      expect(mgr.toSql()).toContain("WHERE");
+    });
+
+    it("accepts a TreeManager and unwraps to ast", () => {
+      const sub = users.project(users.get("id")).where(users.get("active").eq(true));
+      const mgr = users.project(star).where(sub);
       expect(mgr.toSql()).toContain("WHERE");
     });
   });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -126,7 +126,11 @@ export class SelectManager extends TreeManager {
   order(...exprs: (Node | string | symbol)[]): this {
     this.ast.orders.push(
       ...exprs.map((x) =>
-        typeof x === "string" || typeof x === "symbol" ? new SqlLiteral(x.toString()) : x,
+        typeof x === "string"
+          ? new SqlLiteral(x)
+          : typeof x === "symbol"
+            ? new SqlLiteral(x.description ?? x.toString())
+            : x,
       ),
     );
     return this;

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -123,8 +123,12 @@ export class SelectManager extends TreeManager {
   /**
    * Add ORDER BY clauses.
    */
-  order(...exprs: (Node | string)[]): this {
-    this.ast.orders.push(...exprs.map((x) => (typeof x === "string" ? new SqlLiteral(x) : x)));
+  order(...exprs: (Node | string | symbol)[]): this {
+    this.ast.orders.push(
+      ...exprs.map((x) =>
+        typeof x === "string" || typeof x === "symbol" ? new SqlLiteral(x.toString()) : x,
+      ),
+    );
     return this;
   }
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -115,16 +115,16 @@ export class SelectManager extends TreeManager {
   /**
    * Add a WHERE condition.
    */
-  where(condition: Node): this {
-    this.core.wheres.push(condition);
+  where(condition: Node | TreeManager): this {
+    this.core.wheres.push(condition instanceof TreeManager ? condition.ast : condition);
     return this;
   }
 
   /**
    * Add ORDER BY clauses.
    */
-  order(...exprs: Node[]): this {
-    this.ast.orders.push(...exprs);
+  order(...exprs: (Node | string)[]): this {
+    this.ast.orders.push(...exprs.map((x) => (typeof x === "string" ? new SqlLiteral(x) : x)));
     return this;
   }
 
@@ -315,6 +315,11 @@ export class SelectManager extends TreeManager {
     return new Except(this.ast, otherAst);
   }
 
+  /** @internal */
+  minus(other: SelectManager | SelectStatement): Node {
+    return this.except(other);
+  }
+
   /**
    * Wrap as EXISTS(subquery).
    */
@@ -349,8 +354,8 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#froms
    */
-  get froms(): (Node | null)[] {
-    return [this.core.source.left];
+  get froms(): Node[] {
+    return this.ast.cores.map((c) => c.from).filter((x): x is Node => x !== null);
   }
 
   /**
@@ -377,6 +382,11 @@ export class SelectManager extends TreeManager {
    */
   set limit(value: number | Node | null) {
     this.take(value);
+  }
+
+  /** @internal */
+  get taken(): Limit["expr"] | null {
+    return this.limit;
   }
 
   /**


### PR DESCRIPTION
Part of `docs/arel-alignment-followup-prs.md`, PR 30.

## Changes

Nine Rails-alignment improvements. Items 8 (Predications#in with SelectManager) and 9 (Attribute#lower → NamedFunction) were already implemented.

| # | Change | Rails source |
|---|--------|-------------|
| 1 | `order()` accepts `string` → wraps in `SqlLiteral` | `select_manager.rb:221` |
| 2 | `where()` accepts `TreeManager` → unwraps to `.ast` | `select_manager.rb:184` |
| 3 | `froms` getter filters null | `select_manager.rb:98` `filter_map` |
| 4 | `taken` getter aliases `limit` | `select_manager.rb:23` |
| 5 | `minus()` aliases `except()` | `select_manager.rb:216` |
| 6 | `SqlLiteral#plus(other)` returns `Fragments` | `sql_literal.rb:28` `#+` |
| 7 | `SelectCore#froms` getter/setter aliases `from` | `select_core.rb:32-33` |

## Verification

- `pnpm test` — all pass
- `pnpm api:compare --package arel` — 884/884 (no regressions)