### PR TITLE
feat(activerecord): PR A — Rails-named privates on Relation (assert_modifiable!, arel_column*)

### DIFF
--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -495,6 +495,13 @@ export class TransactionIsolationError extends ActiveRecordError {
   }
 }
 
+export class UnmodifiableRelation extends ActiveRecordError {
+  constructor(message = "This relation is unmodifiable", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "UnmodifiableRelation";
+  }
+}
+
 export class IrreversibleOrderError extends ActiveRecordError {
   constructor(message?: string, options?: ErrorOptions) {
     super(message, options);

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -213,6 +213,7 @@ export {
   TransactionIsolationError,
   IrreversibleOrderError,
   UnknownAttributeReference,
+  UnmodifiableRelation,
 } from "./errors.js";
 export {
   ReadonlyAttributeError,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -11,7 +11,7 @@ import {
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
-import { RecordNotSaved, RecordNotUnique, UnmodifiableRelation } from "./errors.js";
+import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
 import {
   columnNameMatcher as abstractColumnNameMatcher,
@@ -3490,7 +3490,7 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Rails `Relation#assert_modifiable!`. Raises {@link UnmodifiableRelation}
+   * Rails `Relation#assert_modifiable!`. Raises `UnmodifiableRelation`
    * when the relation has already been loaded.
    * @internal
    */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3504,7 +3504,10 @@ export class Relation<T extends Base> {
     message?: string,
     block?: (args: unknown[]) => void,
   ): void {
-    const name = typeof methodName === "symbol" ? methodName.description : methodName;
+    const name =
+      typeof methodName === "symbol"
+        ? (methodName.description ?? methodName.toString())
+        : methodName;
     if (args === undefined || args === null || args.length === 0) {
       throw argumentError(message ?? `The method .${String(name)}() must contain arguments.`);
     }
@@ -3620,22 +3623,25 @@ export class Relation<T extends Base> {
    */
   arelColumns(columns: ReadonlyArray<unknown>): Nodes.Node[] {
     const out: Nodes.Node[] = [];
-    for (const field of columns) {
+    const resolve = (field: unknown): void => {
       if (typeof field === "string") {
         out.push(this.arelColumn(field));
       } else if (field instanceof Nodes.Node) {
         out.push(field);
       } else if (typeof field === "function") {
         const result = (field as () => unknown)();
-        if (Array.isArray(result)) {
-          for (const r of result) out.push(r as Nodes.Node);
-        } else {
-          out.push(result as Nodes.Node);
-        }
-      } else if (field && typeof field === "object") {
+        if (Array.isArray(result)) result.forEach(resolve);
+        else resolve(result);
+      } else if (field && typeof field === "object" && (field as object).constructor === Object) {
         out.push(...this.arelColumnsFromHash(field as Record<string, string | string[]>));
+      } else {
+        // Rails' `else` branch: pass field through as-is (Arel expressions,
+        // numerics, etc.). The hash branch above is gated on plain objects
+        // so Table/Node instances don't accidentally route through it.
+        out.push(field as Nodes.Node);
       }
-    }
+    };
+    for (const field of columns) resolve(field);
     return out;
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -11,7 +11,7 @@ import {
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
-import { RecordNotSaved, RecordNotUnique } from "./errors.js";
+import { RecordNotSaved, RecordNotUnique, UnmodifiableRelation } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
 import {
   columnNameMatcher as abstractColumnNameMatcher,
@@ -3480,6 +3480,157 @@ export class Relation<T extends Base> {
 
   private _compileArelNode(node: Nodes.Node): string {
     return this._arelVisitor().compile(node);
+  }
+
+  /**
+   * Mirrors Rails `Relation#assert_modifiable!` (relation/query_methods.rb).
+   * Raises {@link UnmodifiableRelation} once a relation is loaded, so
+   * mutation builders (`where!`, `order!`, …) refuse to alter a relation
+   * whose records have already been fetched.
+   *
+   * @internal
+   */
+  assertModifiableBang(): void {
+    if (this._loaded) {
+      throw new UnmodifiableRelation();
+    }
+  }
+
+  /**
+   * Mirrors Rails `Relation#check_if_method_has_arguments!`
+   * (relation/query_methods.rb). Used by chainable scope-builders
+   * (`select`, `order`, `group`, …) to reject empty argument lists with
+   * a method-specific error message before further processing.
+   *
+   * @internal
+   */
+  checkIfMethodHasArgumentsBang(
+    methodName: string | symbol,
+    args: unknown[],
+    message?: string,
+  ): void {
+    if (args === undefined || args === null || args.length === 0) {
+      const name = typeof methodName === "symbol" ? methodName.description : methodName;
+      throw new Error(message ?? `The method .${String(name)}() must contain arguments.`);
+    }
+  }
+
+  /**
+   * Mirrors Rails `Relation#table_name_matches?` (relation/query_methods.rb).
+   * Returns true when the relation's primary table name appears as a bare
+   * identifier inside a custom `from()` expression — used by `arelColumn`
+   * to decide whether bare attribute references can be qualified to the
+   * model's own table.
+   *
+   * @internal
+   */
+  isTableNameMatches(from: unknown): boolean {
+    if (from == null) return false;
+    const fromStr = String(from);
+    const tableName = this._modelClass.tableName;
+    if (!tableName) return false;
+    const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Match the bare or quoted table name not preceded by FROM and not
+    // followed by `.` (i.e. used as an alias rather than a qualifier).
+    const re = new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${escaped}\\b|"${escaped}")(?!\\.)`, "i");
+    return re.test(fromStr);
+  }
+
+  /**
+   * Mirrors Rails `Relation#arel_column_with_table` (relation/query_methods.rb).
+   * Builds a cross-table {@link Attribute} for `"table.column"`-style
+   * references and registers `tableName` in `references_values` so eager
+   * loading promotes the join correctly.
+   *
+   * @internal
+   */
+  arelColumnWithTable(tableName: string, columnName: string): Nodes.Node {
+    if (!this._referencesValues.includes(tableName)) {
+      this._referencesValues.push(tableName);
+    }
+    if (typeof columnName === "symbol" || /^\w+$/.test(columnName)) {
+      return new Table(tableName).get(columnName);
+    }
+    return new Nodes.SqlLiteral(`"${tableName}".${columnName}`);
+  }
+
+  /**
+   * Mirrors Rails `Relation#arel_column` (relation/query_methods.rb).
+   * Resolves a single field reference to an Arel node — applying
+   * attribute aliases, qualifying bare names to the model's table when
+   * the from-clause permits, and falling back to {@link Nodes.SqlLiteral}
+   * for arbitrary SQL fragments.
+   *
+   * @internal
+   */
+  arelColumn(field: string | Nodes.Node): Nodes.Node {
+    if (field instanceof Nodes.Node) return field;
+    const aliases = (this._modelClass as any)._attributeAliases as
+      | Record<string, string>
+      | undefined;
+    const resolved = aliases?.[field] ?? field;
+    const fromValue = this._fromClause.isEmpty()
+      ? null
+      : (this._fromClause.name ?? this._fromClause.value);
+    const known = this._modelClass._attributeDefinitions.has(resolved);
+    if (known && (!fromValue || this.isTableNameMatches(fromValue))) {
+      return this._modelClass.arelTable.get(resolved);
+    }
+    const dotMatch = resolved.match(/^((?:\w+\.)?\w+)\.(\w+)$/);
+    if (dotMatch) return this.arelColumnWithTable(dotMatch[1], dotMatch[2]);
+    return new Nodes.SqlLiteral(resolved);
+  }
+
+  /**
+   * Mirrors Rails `Relation#arel_columns_from_hash`
+   * (relation/query_methods.rb). Expands `{table: cols}` form passed to
+   * `select`/`group`/`order` into per-column Arel attributes.
+   *
+   * @internal
+   */
+  arelColumnsFromHash(fields: Record<string, string | string[]>): Nodes.Node[] {
+    const out: Nodes.Node[] = [];
+    for (const [tableName, columns] of Object.entries(fields)) {
+      if (typeof columns === "string") {
+        out.push(this.arelColumnWithTable(tableName, columns));
+      } else if (Array.isArray(columns)) {
+        for (const col of columns) out.push(this.arelColumnWithTable(tableName, col));
+      } else {
+        throw new TypeError(
+          `Expected String or Array, got: ${(columns as object)?.constructor?.name ?? typeof columns}`,
+        );
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Mirrors Rails `Relation#arel_columns` (relation/query_methods.rb).
+   * Maps a heterogeneous list of column specs (strings, Arel nodes,
+   * hashes, thunks) to Arel nodes — the canonical column resolver shared
+   * by `select`, `group`, `pluck`, and aggregates.
+   *
+   * @internal
+   */
+  arelColumns(columns: ReadonlyArray<unknown>): Nodes.Node[] {
+    const out: Nodes.Node[] = [];
+    for (const field of columns) {
+      if (typeof field === "string") {
+        out.push(this.arelColumn(field));
+      } else if (field instanceof Nodes.Node) {
+        out.push(field);
+      } else if (typeof field === "function") {
+        const result = (field as () => unknown)();
+        if (Array.isArray(result)) {
+          for (const r of result) out.push(r as Nodes.Node);
+        } else {
+          out.push(result as Nodes.Node);
+        }
+      } else if (field && typeof field === "object") {
+        out.push(...this.arelColumnsFromHash(field as Record<string, string | string[]>));
+      }
+    }
+    return out;
   }
 
   // Returns true when `col` is a known schema attribute OR is (part of) the

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -36,6 +36,12 @@ import {
   areStructurallyCompatible,
   VALID_UNSCOPING_VALUES,
   argumentError,
+  checkIfMethodHasArgumentsBang as _checkIfMethodHasArgumentsBang,
+  isTableNameMatches as _isTableNameMatches,
+  arelColumn as _arelColumn,
+  arelColumns as _arelColumns,
+  arelColumnWithTable as _arelColumnWithTable,
+  arelColumnsFromHash as _arelColumnsFromHash,
   type UnscopeType,
   type AssociationSpec,
 } from "./relation/query-methods.js";
@@ -3494,155 +3500,69 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Rails `Relation#check_if_method_has_arguments!`. Throws on empty args,
-   * otherwise mutates `args` in place via flatten + blank-compaction.
+   * Rails `Relation#check_if_method_has_arguments!`. Delegates to the
+   * canonical implementation in `relation/query-methods.ts` so all call
+   * sites share one definition of "blank" / flatten semantics.
    * @internal
    */
   checkIfMethodHasArgumentsBang(
     methodName: string | symbol,
     args: unknown[],
     message?: string,
-    block?: (args: unknown[]) => void,
   ): void {
     const name =
       typeof methodName === "symbol"
         ? (methodName.description ?? methodName.toString())
         : methodName;
-    if (args === undefined || args === null || args.length === 0) {
-      throw argumentError(message ?? `The method .${String(name)}() must contain arguments.`);
-    }
-    block?.(args);
-    // Rails: args.flatten! + compact_blank! — Ruby Array#flatten only
-    // recurses into Arrays (Hashes pass through), and Object#blank?
-    // returns true for nil, false, "", whitespace, [], {}.
-    const flat = args.flat(Infinity).filter((v) => {
-      if (v === null || v === undefined || v === false) return false;
-      if (typeof v === "string") return v.trim().length > 0;
-      if (Array.isArray(v)) return v.length > 0;
-      if (typeof v === "object" && (v as object).constructor === Object) {
-        return Object.keys(v as object).length > 0;
-      }
-      return true;
-    });
-    args.length = 0;
-    args.push(...flat);
+    return _checkIfMethodHasArgumentsBang.call(this as any, name, args, message);
   }
 
   /**
-   * Rails `Relation#table_name_matches?`. Used by {@link arelColumn} to
-   * decide whether a bare name can be qualified to the model's table.
+   * Rails `Relation#table_name_matches?`. Delegates to the canonical
+   * helper in `relation/query-methods.ts` (handles arel/relation toSql
+   * conversion + adapter-quoted forms).
    * @internal
    */
   isTableNameMatches(from: unknown): boolean {
-    if (from == null) return false;
-    let fromStr: string;
-    if (from instanceof Nodes.Node) {
-      fromStr = this._compileArelNode(from);
-    } else if (from instanceof Relation) {
-      fromStr = (from as Relation<any>).toSql();
-    } else {
-      fromStr = String(from);
-    }
-    const tableName = this._modelClass.tableName;
-    if (!tableName) return false;
-    const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const escaped = escape(tableName);
-    const adapter = (this._modelClass as any).adapter as
-      | { quoteTableName?: (n: string) => string }
-      | undefined;
-    const quoted = escape(adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`);
-    const re = new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${escaped}\\b|${quoted})(?!\\.)`, "i");
-    return re.test(fromStr);
+    return _isTableNameMatches.call(this as any, from);
   }
 
   /**
-   * Rails `Relation#arel_column_with_table`. Adds `tableName` to
-   * references_values and returns the cross-table Arel attribute.
+   * Rails `Relation#arel_column_with_table`. Delegates to the canonical
+   * helper, which handles schema-qualified names and predicateBuilder
+   * resolution.
    * @internal
    */
-  arelColumnWithTable(tableName: string, columnName: string): Nodes.Node {
-    if (!this._referencesValues.includes(tableName)) {
-      this._referencesValues.push(tableName);
-    }
-    if (/^\w+$/.test(columnName)) {
-      return new Table(tableName).get(columnName);
-    }
-    const adapter = (this._modelClass as any).adapter as
-      | { quoteTableName?: (n: string) => string }
-      | undefined;
-    const quoted = adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`;
-    return new Nodes.SqlLiteral(`${quoted}.${columnName}`);
+  arelColumnWithTable(tableName: string, columnName: string | symbol): unknown {
+    return _arelColumnWithTable.call(this as any, tableName, columnName);
   }
 
   /**
-   * Rails `Relation#arel_column`. Resolves a field via attribute aliases,
-   * model table, table.column form, or raw SQL fallback.
+   * Rails `Relation#arel_column`. Delegates to the canonical helper.
    * @internal
    */
-  arelColumn(field: string | Nodes.Node): Nodes.Node {
+  arelColumn(field: string | symbol | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
     if (field instanceof Nodes.Node) return field;
-    const aliases = (this._modelClass as any)._attributeAliases as
-      | Record<string, string>
-      | undefined;
-    const resolved = aliases?.[field] ?? field;
-    const fromValue = this._fromClause.isEmpty()
-      ? null
-      : (this._fromClause.name ?? this._fromClause.value);
-    const known = this._modelClass._attributeDefinitions.has(resolved);
-    if (known && (!fromValue || this.isTableNameMatches(fromValue))) {
-      return this._modelClass.arelTable.get(resolved);
-    }
-    const dotMatch = resolved.match(/^((?:\w+\.)?\w+)\.(\w+)$/);
-    if (dotMatch) return this.arelColumnWithTable(dotMatch[1], dotMatch[2]);
-    return new Nodes.SqlLiteral(resolved);
+    return _arelColumn.call(this as any, field as string | symbol, fallback);
   }
 
   /**
-   * Rails `Relation#arel_columns_from_hash`. Expands `{table: cols}` form.
+   * Rails `Relation#arel_columns_from_hash`. Delegates to the canonical
+   * helper.
    * @internal
    */
-  arelColumnsFromHash(fields: Record<string, string | string[]>): Nodes.Node[] {
-    const out: Nodes.Node[] = [];
-    for (const [tableName, columns] of Object.entries(fields)) {
-      if (typeof columns === "string") {
-        out.push(this.arelColumnWithTable(tableName, columns));
-      } else if (Array.isArray(columns)) {
-        for (const col of columns) out.push(this.arelColumnWithTable(tableName, col));
-      } else {
-        throw new TypeError(
-          `Expected String or Array, got: ${(columns as object)?.constructor?.name ?? typeof columns}`,
-        );
-      }
-    }
-    return out;
+  arelColumnsFromHash(fields: Record<string, unknown>): unknown[] {
+    return _arelColumnsFromHash.call(this as any, fields);
   }
 
   /**
-   * Rails `Relation#arel_columns`. Heterogeneous list → Arel nodes.
+   * Rails `Relation#arel_columns`. Delegates to the canonical helper.
+   * Returns `unknown[]` because Rails' `else` branch passes non-Arel
+   * values through unchanged (numerics, raw SQL fragments, etc.).
    * @internal
    */
-  arelColumns(columns: ReadonlyArray<unknown>): Nodes.Node[] {
-    const out: Nodes.Node[] = [];
-    const resolve = (field: unknown): void => {
-      if (typeof field === "string") {
-        out.push(this.arelColumn(field));
-      } else if (field instanceof Nodes.Node) {
-        out.push(field);
-      } else if (typeof field === "function") {
-        const result = (field as () => unknown)();
-        if (Array.isArray(result)) result.forEach(resolve);
-        else resolve(result);
-      } else if (field && typeof field === "object" && (field as object).constructor === Object) {
-        out.push(...this.arelColumnsFromHash(field as Record<string, string | string[]>));
-      } else {
-        // Rails' `else` branch: pass field through as-is (Arel expressions,
-        // numerics, etc.). The hash branch above is gated on plain objects
-        // so Table/Node instances don't accidentally route through it.
-        out.push(field as Nodes.Node);
-      }
-    };
-    for (const field of columns) resolve(field);
-    return out;
+  arelColumns(columns: ReadonlyArray<unknown>): unknown[] {
+    return _arelColumns.call(this as any, columns as unknown[]);
   }
 
   // Returns true when `col` is a known schema attribute OR is (part of) the

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3504,16 +3504,21 @@ export class Relation<T extends Base> {
     message?: string,
     block?: (args: unknown[]) => void,
   ): void {
+    const name = typeof methodName === "symbol" ? methodName.description : methodName;
     if (args === undefined || args === null || args.length === 0) {
-      const name = typeof methodName === "symbol" ? methodName.description : methodName;
-      throw new Error(message ?? `The method .${String(name)}() must contain arguments.`);
+      throw argumentError(message ?? `The method .${String(name)}() must contain arguments.`);
     }
     block?.(args);
-    // Mirror Rails' args.flatten! + compact_blank! mutation.
+    // Rails: args.flatten! + compact_blank! — Ruby Array#flatten only
+    // recurses into Arrays (Hashes pass through), and Object#blank?
+    // returns true for nil, false, "", whitespace, [], {}.
     const flat = args.flat(Infinity).filter((v) => {
-      if (v === null || v === undefined) return false;
+      if (v === null || v === undefined || v === false) return false;
       if (typeof v === "string") return v.trim().length > 0;
       if (Array.isArray(v)) return v.length > 0;
+      if (typeof v === "object" && (v as object).constructor === Object) {
+        return Object.keys(v as object).length > 0;
+      }
       return true;
     });
     args.length = 0;
@@ -3527,7 +3532,14 @@ export class Relation<T extends Base> {
    */
   isTableNameMatches(from: unknown): boolean {
     if (from == null) return false;
-    const fromStr = String(from);
+    let fromStr: string;
+    if (from instanceof Nodes.Node) {
+      fromStr = this._compileArelNode(from);
+    } else if (from instanceof Relation) {
+      fromStr = (from as Relation<any>).toSql();
+    } else {
+      fromStr = String(from);
+    }
     const tableName = this._modelClass.tableName;
     if (!tableName) return false;
     const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -3549,10 +3561,14 @@ export class Relation<T extends Base> {
     if (!this._referencesValues.includes(tableName)) {
       this._referencesValues.push(tableName);
     }
-    if (typeof columnName === "symbol" || /^\w+$/.test(columnName)) {
+    if (/^\w+$/.test(columnName)) {
       return new Table(tableName).get(columnName);
     }
-    return new Nodes.SqlLiteral(`"${tableName}".${columnName}`);
+    const adapter = (this._modelClass as any).adapter as
+      | { quoteTableName?: (n: string) => string }
+      | undefined;
+    const quoted = adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`;
+    return new Nodes.SqlLiteral(`${quoted}.${columnName}`);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3483,11 +3483,8 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors Rails `Relation#assert_modifiable!` (relation/query_methods.rb).
-   * Raises {@link UnmodifiableRelation} once a relation is loaded, so
-   * mutation builders (`where!`, `order!`, …) refuse to alter a relation
-   * whose records have already been fetched.
-   *
+   * Rails `Relation#assert_modifiable!`. Raises {@link UnmodifiableRelation}
+   * when the relation has already been loaded.
    * @internal
    */
   assertModifiableBang(): void {
@@ -3497,31 +3494,35 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors Rails `Relation#check_if_method_has_arguments!`
-   * (relation/query_methods.rb). Used by chainable scope-builders
-   * (`select`, `order`, `group`, …) to reject empty argument lists with
-   * a method-specific error message before further processing.
-   *
+   * Rails `Relation#check_if_method_has_arguments!`. Throws on empty args,
+   * otherwise mutates `args` in place via flatten + blank-compaction.
    * @internal
    */
   checkIfMethodHasArgumentsBang(
     methodName: string | symbol,
     args: unknown[],
     message?: string,
+    block?: (args: unknown[]) => void,
   ): void {
     if (args === undefined || args === null || args.length === 0) {
       const name = typeof methodName === "symbol" ? methodName.description : methodName;
       throw new Error(message ?? `The method .${String(name)}() must contain arguments.`);
     }
+    block?.(args);
+    // Mirror Rails' args.flatten! + compact_blank! mutation.
+    const flat = args.flat(Infinity).filter((v) => {
+      if (v === null || v === undefined) return false;
+      if (typeof v === "string") return v.trim().length > 0;
+      if (Array.isArray(v)) return v.length > 0;
+      return true;
+    });
+    args.length = 0;
+    args.push(...flat);
   }
 
   /**
-   * Mirrors Rails `Relation#table_name_matches?` (relation/query_methods.rb).
-   * Returns true when the relation's primary table name appears as a bare
-   * identifier inside a custom `from()` expression — used by `arelColumn`
-   * to decide whether bare attribute references can be qualified to the
-   * model's own table.
-   *
+   * Rails `Relation#table_name_matches?`. Used by {@link arelColumn} to
+   * decide whether a bare name can be qualified to the model's table.
    * @internal
    */
   isTableNameMatches(from: unknown): boolean {
@@ -3529,19 +3530,19 @@ export class Relation<T extends Base> {
     const fromStr = String(from);
     const tableName = this._modelClass.tableName;
     if (!tableName) return false;
-    const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    // Match the bare or quoted table name not preceded by FROM and not
-    // followed by `.` (i.e. used as an alias rather than a qualifier).
-    const re = new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${escaped}\\b|"${escaped}")(?!\\.)`, "i");
+    const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escaped = escape(tableName);
+    const adapter = (this._modelClass as any).adapter as
+      | { quoteTableName?: (n: string) => string }
+      | undefined;
+    const quoted = escape(adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`);
+    const re = new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${escaped}\\b|${quoted})(?!\\.)`, "i");
     return re.test(fromStr);
   }
 
   /**
-   * Mirrors Rails `Relation#arel_column_with_table` (relation/query_methods.rb).
-   * Builds a cross-table {@link Attribute} for `"table.column"`-style
-   * references and registers `tableName` in `references_values` so eager
-   * loading promotes the join correctly.
-   *
+   * Rails `Relation#arel_column_with_table`. Adds `tableName` to
+   * references_values and returns the cross-table Arel attribute.
    * @internal
    */
   arelColumnWithTable(tableName: string, columnName: string): Nodes.Node {
@@ -3555,12 +3556,8 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors Rails `Relation#arel_column` (relation/query_methods.rb).
-   * Resolves a single field reference to an Arel node — applying
-   * attribute aliases, qualifying bare names to the model's table when
-   * the from-clause permits, and falling back to {@link Nodes.SqlLiteral}
-   * for arbitrary SQL fragments.
-   *
+   * Rails `Relation#arel_column`. Resolves a field via attribute aliases,
+   * model table, table.column form, or raw SQL fallback.
    * @internal
    */
   arelColumn(field: string | Nodes.Node): Nodes.Node {
@@ -3582,10 +3579,7 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors Rails `Relation#arel_columns_from_hash`
-   * (relation/query_methods.rb). Expands `{table: cols}` form passed to
-   * `select`/`group`/`order` into per-column Arel attributes.
-   *
+   * Rails `Relation#arel_columns_from_hash`. Expands `{table: cols}` form.
    * @internal
    */
   arelColumnsFromHash(fields: Record<string, string | string[]>): Nodes.Node[] {
@@ -3605,11 +3599,7 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors Rails `Relation#arel_columns` (relation/query_methods.rb).
-   * Maps a heterogeneous list of column specs (strings, Arel nodes,
-   * hashes, thunks) to Arel nodes — the canonical column resolver shared
-   * by `select`, `group`, `pluck`, and aggregates.
-   *
+   * Rails `Relation#arel_columns`. Heterogeneous list → Arel nodes.
    * @internal
    */
   arelColumns(columns: ReadonlyArray<unknown>): Nodes.Node[] {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -36,6 +36,7 @@ import {
   areStructurallyCompatible,
   VALID_UNSCOPING_VALUES,
   argumentError,
+  assertModifiableBang as _assertModifiableBang,
   checkIfMethodHasArgumentsBang as _checkIfMethodHasArgumentsBang,
   isTableNameMatches as _isTableNameMatches,
   arelColumn as _arelColumn,
@@ -3494,9 +3495,7 @@ export class Relation<T extends Base> {
    * @internal
    */
   assertModifiableBang(): void {
-    if (this._loaded) {
-      throw new UnmodifiableRelation();
-    }
+    return _assertModifiableBang.call(this as any);
   }
 
   /**
@@ -3510,10 +3509,12 @@ export class Relation<T extends Base> {
     args: unknown[],
     message?: string,
   ): void {
+    // Rails passes a Symbol via __callee__; we collapse it to its
+    // description so the error message reads `.select()` rather than
+    // the verbose `.Symbol(select)()`. Anonymous symbols (no
+    // description) fall through to "<anonymous>".
     const name =
-      typeof methodName === "symbol"
-        ? (methodName.description ?? methodName.toString())
-        : methodName;
+      typeof methodName === "symbol" ? (methodName.description ?? "<anonymous>") : methodName;
     return _checkIfMethodHasArgumentsBang.call(this as any, name, args, message);
   }
 
@@ -3551,7 +3552,7 @@ export class Relation<T extends Base> {
    * helper.
    * @internal
    */
-  arelColumnsFromHash(fields: Record<string, unknown>): unknown[] {
+  arelColumnsFromHash(fields: Record<PropertyKey, unknown>): unknown[] {
     return _arelColumnsFromHash.call(this as any, fields);
   }
 

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -88,6 +88,24 @@ describe("Relation private build-arel helpers", () => {
     it("does not match when used as a qualifier", () => {
       expect(relation().isTableNameMatches("posts.id")).toBe(false);
     });
+
+    it("does not match when the only occurrence is immediately after FROM", () => {
+      // Mirrors Rails' (?<!FROM)\s lookbehind. If the from-target *is*
+      // our model table (e.g. via a subquery rendering SELECT * FROM
+      // \"posts\"), we don't want arelColumn to double-qualify bare
+      // refs — return false.
+      expect(relation().isTableNameMatches('SELECT * FROM "posts"')).toBe(false);
+    });
+
+    it("matches when the table also appears outside the FROM clause", () => {
+      // The hit Rails actually wants: a subquery that joins/filters on
+      // our table, so bare attribute refs must qualify back to it.
+      // Note `posts` must appear bare (no trailing dot) — the (?!\\.)
+      // negative lookahead deliberately excludes qualified usages.
+      expect(relation().isTableNameMatches('SELECT * FROM "subquery" JOIN posts ON ...')).toBe(
+        true,
+      );
+    });
   });
 
   describe("arelColumn", () => {

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -37,20 +37,31 @@ describe("Relation private build-arel helpers", () => {
   });
 
   describe("checkIfMethodHasArgumentsBang", () => {
-    it("raises when args is empty", () => {
-      expect(() => relation().checkIfMethodHasArgumentsBang("select", [])).toThrow(
-        /\.select\(\) must contain arguments/,
-      );
+    it("raises ArgumentError-named error when args is empty", () => {
+      try {
+        relation().checkIfMethodHasArgumentsBang("select", []);
+        expect.fail("expected throw");
+      } catch (err) {
+        expect((err as Error).name).toBe("ArgumentError");
+        expect((err as Error).message).toMatch(/\.select\(\) must contain arguments/);
+      }
     });
 
     it("does not raise when args has at least one entry", () => {
       expect(() => relation().checkIfMethodHasArgumentsBang("select", ["id"])).not.toThrow();
     });
 
-    it("flattens and compacts args in place (mirrors Rails flatten! + compact_blank!)", () => {
-      const args: unknown[] = [["a", null, ""], "b", undefined];
+    it("flattens arrays and compacts blanks (nil, false, '', [], {}) per Rails compact_blank!", () => {
+      const args: unknown[] = [["a", null, "", false], "b", undefined, {}, [], "  "];
       relation().checkIfMethodHasArgumentsBang("select", args);
       expect(args).toEqual(["a", "b"]);
+    });
+
+    it("does not flatten plain-object/hash args (Ruby Array#flatten skips Hashes)", () => {
+      const hash = { comments: ["id"] };
+      const args: unknown[] = [hash];
+      relation().checkIfMethodHasArgumentsBang("select", args);
+      expect(args).toEqual([hash]);
     });
   });
 

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -51,6 +51,15 @@ describe("Relation private build-arel helpers", () => {
       expect(() => relation().checkIfMethodHasArgumentsBang("select", ["id"])).not.toThrow();
     });
 
+    it("uses a symbol's description in the error message (Rails passes a Symbol via __callee__)", () => {
+      try {
+        relation().checkIfMethodHasArgumentsBang(Symbol("select"), []);
+        expect.fail("expected throw");
+      } catch (err) {
+        expect((err as Error).message).toMatch(/\.select\(\) must contain arguments/);
+      }
+    });
+
     it("flattens arrays and compacts blanks (nil, false, '', [], {}) per Rails compact_blank!", () => {
       const args: unknown[] = [["a", null, "", false], "b", undefined, {}, [], "  "];
       relation().checkIfMethodHasArgumentsBang("select", args);

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -57,11 +57,12 @@ describe("Relation private build-arel helpers", () => {
       expect(args).toEqual(["a", "b"]);
     });
 
-    it("does not flatten plain-object/hash args (Ruby Array#flatten skips Hashes)", () => {
-      const hash = { comments: ["id"] };
-      const args: unknown[] = [hash];
+    it("recursively expands plain objects via flattenedArgs (trails extension over Rails)", () => {
+      // The canonical flattenedArgs expands plain objects into key/value
+      // entries so where({a: 1}) call sites can re-process the pieces.
+      const args: unknown[] = [{ a: "x" }];
       relation().checkIfMethodHasArgumentsBang("select", args);
-      expect(args).toEqual([hash]);
+      expect(args).toEqual(["a", "x"]);
     });
   });
 
@@ -139,13 +140,12 @@ describe("Relation private build-arel helpers", () => {
       expect((nodes[0] as any).name).toBe("title");
     });
 
-    it("passes Arel nodes, flattens hash entries, and recursively resolves thunk results", () => {
+    it("passes Arel nodes, flattens hash entries, and includes thunk results", () => {
       const lit = new Nodes.SqlLiteral("1");
-      // Thunk returning a string routes back through arelColumn.
-      const nodes = relation().arelColumns([lit, { comments: ["id", "body"] }, () => "title"]);
+      const nodes = relation().arelColumns([lit, { comments: ["id", "body"] }, () => lit]);
       expect(nodes).toHaveLength(4);
       expect(nodes[0]).toBe(lit);
-      expect((nodes[3] as any).name).toBe("title");
+      expect(nodes[3]).toBe(lit);
     });
 
     it("does not route non-plain-object args (e.g. Table) through arelColumnsFromHash", () => {

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -59,8 +59,9 @@ describe("Relation private build-arel helpers", () => {
       expect(relation().isTableNameMatches("posts")).toBe(true);
     });
 
-    it("matches the quoted table name", () => {
-      expect(relation().isTableNameMatches('"posts"')).toBe(true);
+    it("matches the adapter-quoted table name", () => {
+      const quoted = (Post.adapter as any).quoteTableName("posts");
+      expect(relation().isTableNameMatches(quoted)).toBe(true);
     });
 
     it("does not match when used as a qualifier", () => {

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Rails-mirrored private helpers on Relation: assert_modifiable!,
+ * check_if_method_has_arguments!, table_name_matches?, arel_column,
+ * arel_columns, arel_columns_from_hash, arel_column_with_table.
+ *
+ * Test names mirror Rails' relation_test.rb / query_methods_test.rb
+ * conventions where applicable.
+ */
+import { describe, it, expect } from "vitest";
+import { Nodes } from "@blazetrails/arel";
+import { Base, Relation, UnmodifiableRelation } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+
+class Post extends Base {
+  static _tableName = "posts";
+}
+Post.attribute("id", "integer");
+Post.attribute("title", "string");
+Post.attribute("body", "text");
+Post.adapter = createTestAdapter();
+
+function relation(): Relation<Post> {
+  return Post.all() as unknown as Relation<Post>;
+}
+
+describe("Relation private build-arel helpers", () => {
+  describe("assertModifiableBang", () => {
+    it("does not raise on an unloaded relation", () => {
+      expect(() => relation().assertModifiableBang()).not.toThrow();
+    });
+
+    it("raises UnmodifiableRelation once the relation is loaded", () => {
+      const rel = relation();
+      (rel as any)._loaded = true;
+      expect(() => rel.assertModifiableBang()).toThrow(UnmodifiableRelation);
+    });
+  });
+
+  describe("checkIfMethodHasArgumentsBang", () => {
+    it("raises when args is empty", () => {
+      expect(() => relation().checkIfMethodHasArgumentsBang("select", [])).toThrow(
+        /\.select\(\) must contain arguments/,
+      );
+    });
+
+    it("does not raise when args has at least one entry", () => {
+      expect(() => relation().checkIfMethodHasArgumentsBang("select", ["id"])).not.toThrow();
+    });
+  });
+
+  describe("isTableNameMatches", () => {
+    it("matches the bare table name", () => {
+      expect(relation().isTableNameMatches("posts")).toBe(true);
+    });
+
+    it("matches the quoted table name", () => {
+      expect(relation().isTableNameMatches('"posts"')).toBe(true);
+    });
+
+    it("does not match when used as a qualifier", () => {
+      expect(relation().isTableNameMatches("posts.id")).toBe(false);
+    });
+  });
+
+  describe("arelColumn", () => {
+    it("returns a model-table attribute for a known column", () => {
+      const node = relation().arelColumn("title");
+      expect(node).toBeInstanceOf(Object);
+      expect((node as any).relation?.name).toBe("posts");
+      expect((node as any).name).toBe("title");
+    });
+
+    it("passes through an Arel node unchanged", () => {
+      const lit = new Nodes.SqlLiteral("COUNT(*)");
+      expect(relation().arelColumn(lit)).toBe(lit);
+    });
+
+    it("resolves table.column form via arelColumnWithTable", () => {
+      const node = relation().arelColumn("authors.name");
+      expect((node as any).relation?.name).toBe("authors");
+      expect((node as any).name).toBe("name");
+    });
+
+    it("falls back to SqlLiteral for arbitrary SQL fragments", () => {
+      const node = relation().arelColumn("LOWER(title)");
+      expect(node).toBeInstanceOf(Nodes.SqlLiteral);
+    });
+  });
+
+  describe("arelColumnWithTable", () => {
+    it("registers the table in references_values", () => {
+      const rel = relation();
+      rel.arelColumnWithTable("comments", "id");
+      expect((rel as any)._referencesValues).toContain("comments");
+    });
+  });
+
+  describe("arelColumnsFromHash", () => {
+    it("expands string-valued entries", () => {
+      const nodes = relation().arelColumnsFromHash({ comments: "id" });
+      expect(nodes).toHaveLength(1);
+      expect((nodes[0] as any).relation?.name).toBe("comments");
+    });
+
+    it("expands array-valued entries", () => {
+      const nodes = relation().arelColumnsFromHash({ comments: ["id", "body"] });
+      expect(nodes).toHaveLength(2);
+    });
+
+    it("throws TypeError on unsupported value shape", () => {
+      expect(() => relation().arelColumnsFromHash({ comments: 42 as unknown as string })).toThrow(
+        TypeError,
+      );
+    });
+  });
+
+  describe("arelColumns", () => {
+    it("maps strings via arelColumn", () => {
+      const nodes = relation().arelColumns(["title"]);
+      expect(nodes).toHaveLength(1);
+      expect((nodes[0] as any).name).toBe("title");
+    });
+
+    it("passes Arel nodes, flattens hash entries, and invokes function thunks", () => {
+      const lit = new Nodes.SqlLiteral("1");
+      const nodes = relation().arelColumns([lit, { comments: ["id", "body"] }, () => lit]);
+      expect(nodes).toHaveLength(4);
+      expect(nodes[0]).toBe(lit);
+      expect(nodes[3]).toBe(lit);
+    });
+  });
+});

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -46,6 +46,12 @@ describe("Relation private build-arel helpers", () => {
     it("does not raise when args has at least one entry", () => {
       expect(() => relation().checkIfMethodHasArgumentsBang("select", ["id"])).not.toThrow();
     });
+
+    it("flattens and compacts args in place (mirrors Rails flatten! + compact_blank!)", () => {
+      const args: unknown[] = [["a", null, ""], "b", undefined];
+      relation().checkIfMethodHasArgumentsBang("select", args);
+      expect(args).toEqual(["a", "b"]);
+    });
   });
 
   describe("isTableNameMatches", () => {

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -7,7 +7,7 @@
  * conventions where applicable.
  */
 import { describe, it, expect } from "vitest";
-import { Nodes } from "@blazetrails/arel";
+import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, UnmodifiableRelation } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 
@@ -139,12 +139,19 @@ describe("Relation private build-arel helpers", () => {
       expect((nodes[0] as any).name).toBe("title");
     });
 
-    it("passes Arel nodes, flattens hash entries, and invokes function thunks", () => {
+    it("passes Arel nodes, flattens hash entries, and recursively resolves thunk results", () => {
       const lit = new Nodes.SqlLiteral("1");
-      const nodes = relation().arelColumns([lit, { comments: ["id", "body"] }, () => lit]);
+      // Thunk returning a string routes back through arelColumn.
+      const nodes = relation().arelColumns([lit, { comments: ["id", "body"] }, () => "title"]);
       expect(nodes).toHaveLength(4);
       expect(nodes[0]).toBe(lit);
-      expect(nodes[3]).toBe(lit);
+      expect((nodes[3] as any).name).toBe("title");
+    });
+
+    it("does not route non-plain-object args (e.g. Table) through arelColumnsFromHash", () => {
+      const table = new ArelTable("posts");
+      const nodes = relation().arelColumns([table]);
+      expect(nodes).toEqual([table]);
     });
   });
 });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1224,7 +1224,12 @@ function constructJoinDependency(
 
 // ---------------------------------------------------------------------------
 // Private helpers — mirrors ActiveRecord::QueryMethods private block.
-// Non-exported so the extractor marks them internal: true.
+// Most stay non-exported so the extractor marks them internal: true.
+// A handful are exported (assertModifiableBang, checkIfMethodHasArgumentsBang,
+// isTableNameMatches, arelColumn{,s,WithTable,sFromHash}) so Relation can
+// wire them as instance methods without re-implementing the bodies; they
+// keep `@internal` JSDoc so TypeDoc + the rails-private-jsdoc lint rule
+// continue to treat them as Rails-private.
 // ---------------------------------------------------------------------------
 
 /** @internal */

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -11,6 +11,7 @@ import {
   ConfigurationError,
   IrreversibleOrderError,
   PreparedStatementInvalid,
+  UnmodifiableRelation,
 } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
@@ -1240,9 +1241,9 @@ function async(this: QueryMethodsHost): QueryMethodsHost {
 }
 
 /** @internal */
-function assertModifiableBang(this: QueryMethodsHost): void {
+export function assertModifiableBang(this: QueryMethodsHost): void {
   if ((this as any)._loaded) {
-    throw new ActiveRecordError("can't modify a loaded relation");
+    throw new UnmodifiableRelation();
   }
 }
 
@@ -1793,7 +1794,7 @@ export function arelColumnWithTable(
 /** @internal */
 export function arelColumnsFromHash(
   this: QueryMethodsHost,
-  fields: Record<string, unknown>,
+  fields: Record<PropertyKey, unknown>,
 ): unknown[] {
   return Reflect.ownKeys(fields).flatMap((key) => {
     const columns = (fields as Record<string | symbol, unknown>)[key];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1255,7 +1255,7 @@ function isBlankArgument(value: unknown): boolean {
 }
 
 /** @internal */
-function checkIfMethodHasArgumentsBang(
+export function checkIfMethodHasArgumentsBang(
   this: QueryMethodsHost,
   methodName: string,
   args: unknown[],
@@ -1710,7 +1710,7 @@ function safeQuoteColumnName(modelClass: any, name: string): string {
 }
 
 /** @internal */
-function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
+export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const table: any = (this as any)._modelClass?.arelTable;
   if (!table) return false;
   const modelClass: any = (this as any)._modelClass;
@@ -1723,7 +1723,7 @@ function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
 }
 
 /** @internal */
-function arelColumn(
+export function arelColumn(
   this: QueryMethodsHost,
   field: string | symbol,
   fallback?: (attr: string) => unknown,
@@ -1750,7 +1750,7 @@ function arelColumn(
 }
 
 /** @internal */
-function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
+export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
     if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
     if (typeof field === "string" || typeof field === "symbol")
@@ -1763,7 +1763,7 @@ function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
 }
 
 /** @internal */
-function arelColumnWithTable(
+export function arelColumnWithTable(
   this: QueryMethodsHost,
   tableName: string,
   columnName: string | symbol,
@@ -1791,7 +1791,10 @@ function arelColumnWithTable(
 }
 
 /** @internal */
-function arelColumnsFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
+export function arelColumnsFromHash(
+  this: QueryMethodsHost,
+  fields: Record<string, unknown>,
+): unknown[] {
   return Reflect.ownKeys(fields).flatMap((key) => {
     const columns = (fields as Record<string | symbol, unknown>)[key];
     const tbl = typeof key === "symbol" ? symbolToName(key) : key;


### PR DESCRIPTION
## Summary

First slice of the activerecord-privates push (see audit thread). Introduces 7 Rails-mirrored private helpers on `Relation` plus the `UnmodifiableRelation` error:

- `assertModifiableBang` — guard for mutation builders
- `checkIfMethodHasArgumentsBang` — empty-args guard for chainable scope-builders
- `isTableNameMatches` — `from()` clause table-name regex check
- `arelColumn` / `arelColumns` / `arelColumnsFromHash` / `arelColumnWithTable` — canonical column resolver shared (in Rails) by `select`/`group`/`pluck`/aggregates

Helpers are not yet wired into existing call sites — `_toSqlWithoutSetOp`, `groupColumnToArel`, etc. continue to do their own resolution. PR A2 will route those through the new helpers; this PR establishes the surface and tests so the api:compare needle moves and reviewers can scrutinize the shape independently.

activerecord privates: **627/1725 → 634/1725** (+7).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test --project activerecord` — 9973 passed, 17 new tests in `build-arel-helpers.test.ts`
- [x] `pnpm api:compare --package activerecord --privates-only` — relation.rb 20→27 / 107