### PR TITLE
fix(activemodel): pass defaultAttributes through LazyAttributeHash (P1)

### DIFF
--- a/packages/activemodel/src/attribute-set/builder-defaults.test.ts
+++ b/packages/activemodel/src/attribute-set/builder-defaults.test.ts
@@ -31,6 +31,39 @@ describe("LazyAttributeHash defaultAttributes", () => {
     expect(hash.get("age").isInitialized()).toBe(false);
   });
 
+  it("Builder#buildFromDatabase casts a present value using additionalTypes override", () => {
+    const types = new Map([["score", strType]]);
+    const builder = new Builder(types);
+    const additional = new Map([["score", intType]]);
+    const set = builder.buildFromDatabase({ score: "42" }, additional);
+    expect(set.fetchValue("score")).toBe(42);
+  });
+
+  it("LazyAttributeHash uses additionalTypes for present values", () => {
+    const hash = new LazyAttributeHash(
+      new Map([["score", strType]]),
+      { score: "42" },
+      new Map([["score", intType]]),
+    );
+    expect(hash.get("score").value).toBe(42);
+  });
+
+  it("marshalDump/marshalLoad round-trips all five fields", () => {
+    const types = new Map([
+      ["status", strType],
+      ["score", strType],
+    ]);
+    const additional = new Map([["score", intType]]);
+    const defaults = new Map([["status", Attribute.withCastValue("status", "active", strType)]]);
+    const original = new LazyAttributeHash(types, { score: "42" }, additional, defaults);
+    original.get("score");
+
+    const restored = LazyAttributeHash.marshalLoad(original.marshalDump());
+    expect(restored.delegateHash().get("score")!.value).toBe(42);
+    const fresh = LazyAttributeHash.marshalLoad([types, {}, additional, defaults]);
+    expect(fresh.get("status").value).toBe("active");
+  });
+
   it("materialized default is detached from the prototype — mutation does not bleed across AttributeSets", () => {
     const types = new Map([["status", strType]]);
     const defaultProto = Attribute.withCastValue("status", "active", strType);

--- a/packages/activemodel/src/attribute-set/builder-defaults.test.ts
+++ b/packages/activemodel/src/attribute-set/builder-defaults.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { Builder, LazyAttributeHash } from "./builder.js";
+import { Attribute } from "../attribute.js";
+import { typeRegistry } from "../type/registry.js";
+
+describe("LazyAttributeHash defaultAttributes", () => {
+  const strType = typeRegistry.lookup("string");
+  const intType = typeRegistry.lookup("integer");
+
+  it("returns the schema default attribute when key is in defaultAttributes but absent from values", () => {
+    const types = new Map([["status", strType]]);
+    const defaults = new Map([["status", Attribute.withCastValue("status", "active", strType)]]);
+    const hash = new LazyAttributeHash(types, {}, new Map(), defaults);
+
+    const attr = hash.get("status");
+    expect(attr.value).toBe("active");
+  });
+
+  it("user-provided values override defaultAttributes", () => {
+    const types = new Map([["status", strType]]);
+    const defaults = new Map([["status", Attribute.withCastValue("status", "active", strType)]]);
+    const hash = new LazyAttributeHash(types, { status: "archived" }, new Map(), defaults);
+
+    expect(hash.get("status").value).toBe("archived");
+  });
+
+  it("returns Uninitialized when key is absent from both values and defaultAttributes", () => {
+    const types = new Map([["age", intType]]);
+    const hash = new LazyAttributeHash(types, {});
+
+    expect(hash.get("age").isInitialized()).toBe(false);
+  });
+
+  it("materialized default is detached from the prototype — mutation does not bleed across AttributeSets", () => {
+    const types = new Map([["status", strType]]);
+    const defaultProto = Attribute.withCastValue("status", "active", strType);
+    const defaults = new Map([["status", defaultProto]]);
+
+    const builder = new Builder(types, defaults);
+    const setA = builder.buildFromDatabase({});
+    const setB = builder.buildFromDatabase({});
+
+    setA.set("status", setA.getAttribute("status").withValueFromUser("mutated"));
+
+    expect(setA.fetchValue("status")).toBe("mutated");
+    expect(setB.fetchValue("status")).toBe("active");
+    expect(defaultProto.value).toBe("active");
+  });
+});

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -19,7 +19,7 @@ export class Builder {
 
     for (const [name, type] of this.types) {
       const effectiveType = additionalTypes.get(name) ?? type;
-      if (name in values) {
+      if (Object.prototype.hasOwnProperty.call(values, name)) {
         attrs.set(name, Attribute.fromDatabase(name, values[name], effectiveType));
       } else {
         const defaultAttr = this.defaultAttributes.get(name);

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -11,27 +11,40 @@ export class Builder {
     this.defaultAttributes = defaultAttributes;
   }
 
-  buildFromDatabase(values: Record<string, unknown> = {}): AttributeSet {
+  buildFromDatabase(
+    values: Record<string, unknown> = {},
+    additionalTypes: Map<string, Type> = new Map(),
+  ): AttributeSet {
     const attrs = new Map<string, Attribute>();
 
     for (const [name, type] of this.types) {
+      const effectiveType = additionalTypes.get(name) ?? type;
       if (name in values) {
-        attrs.set(name, Attribute.fromDatabase(name, values[name], type));
+        attrs.set(name, Attribute.fromDatabase(name, values[name], effectiveType));
       } else {
         const defaultAttr = this.defaultAttributes.get(name);
         if (defaultAttr) {
-          attrs.set(
-            name,
-            Object.assign(Object.create(Object.getPrototypeOf(defaultAttr)), defaultAttr),
-          );
+          attrs.set(name, dupAttribute(defaultAttr));
         } else {
-          attrs.set(name, Attribute.uninitialized(name, type));
+          attrs.set(name, Attribute.uninitialized(name, effectiveType));
         }
       }
     }
 
     return new AttributeSet(attrs);
   }
+}
+
+/**
+ * Shallow clone of an Attribute that preserves the prototype chain, so
+ * mutations on the clone don't bleed back into the schema-default prototype.
+ *
+ * Mirrors: `default.dup` in ActiveModel::LazyAttributeHash#assign_default_value
+ *
+ * @internal Rails-private helper.
+ */
+function dupAttribute(attr: Attribute): Attribute {
+  return Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
 }
 
 /**
@@ -92,13 +105,24 @@ export class LazyAttributeSet extends AttributeSet {
  * Mirrors: ActiveModel::LazyAttributeHash
  */
 export class LazyAttributeHash {
-  private delegate: Map<string, Attribute> = new Map();
+  private delegate: Map<string, Attribute>;
   private types: Map<string, Type>;
   private values: Record<string, unknown>;
+  private additionalTypes: Map<string, Type>;
+  private defaultAttributes: Map<string, Attribute>;
 
-  constructor(types: Map<string, Type>, values: Record<string, unknown>) {
+  constructor(
+    types: Map<string, Type>,
+    values: Record<string, unknown>,
+    additionalTypes: Map<string, Type> = new Map(),
+    defaultAttributes: Map<string, Attribute> = new Map(),
+    delegateHash: Map<string, Attribute> = new Map(),
+  ) {
     this.types = types;
     this.values = values;
+    this.additionalTypes = additionalTypes;
+    this.defaultAttributes = defaultAttributes;
+    this.delegate = delegateHash;
   }
 
   get(name: string): Attribute {
@@ -128,7 +152,12 @@ export class LazyAttributeHash {
   }
 
   deepDup(): LazyAttributeHash {
-    const copy = new LazyAttributeHash(this.types, { ...this.values });
+    const copy = new LazyAttributeHash(
+      this.types,
+      { ...this.values },
+      this.additionalTypes,
+      this.defaultAttributes,
+    );
     const cache = new Map<Attribute, Attribute>();
     for (const [name, attr] of this.delegate) {
       copy.delegate.set(name, LazyAttributeHash.cloneAttr(attr, cache));
@@ -161,12 +190,26 @@ export class LazyAttributeHash {
     for (const key of allKeys) fn(key);
   }
 
-  marshalDump(): [Map<string, Type>, Record<string, unknown>] {
-    return [this.types, this.values];
+  marshalDump(): [
+    Map<string, Type>,
+    Record<string, unknown>,
+    Map<string, Type>,
+    Map<string, Attribute>,
+    Map<string, Attribute>,
+  ] {
+    return [this.types, this.values, this.additionalTypes, this.defaultAttributes, this.delegate];
   }
 
-  static marshalLoad(data: [Map<string, Type>, Record<string, unknown>]): LazyAttributeHash {
-    return new LazyAttributeHash(data[0], data[1]);
+  static marshalLoad(
+    data: [
+      Map<string, Type>,
+      Record<string, unknown>,
+      (Map<string, Type> | undefined)?,
+      (Map<string, Attribute> | undefined)?,
+      (Map<string, Attribute> | undefined)?,
+    ],
+  ): LazyAttributeHash {
+    return new LazyAttributeHash(data[0], data[1], data[2], data[3], data[4]);
   }
 
   /** @internal Rails-private helper. Mirrors: LazyAttributeHash#delegate_hash (attr_reader) */
@@ -183,14 +226,15 @@ export class LazyAttributeHash {
   }
 
   private assignDefault(name: string): Attribute {
-    const type = this.types.get(name);
+    const type = this.additionalTypes.get(name) ?? this.types.get(name);
     if (Object.prototype.hasOwnProperty.call(this.values, name) && type) {
       const attr = Attribute.fromDatabase(name, this.values[name], type);
       this.delegate.set(name, attr);
       return attr;
     }
-    if (type) {
-      const attr = Attribute.uninitialized(name, type);
+    if (this.types.has(name)) {
+      const defaultAttr = this.defaultAttributes.get(name);
+      const attr = defaultAttr ? dupAttribute(defaultAttr) : Attribute.uninitialized(name, type!);
       this.delegate.set(name, attr);
       return attr;
     }


### PR DESCRIPTION
## Summary

Implements **P1** from `docs/activemodel-alignment.md` (audit-core §12 — highest-severity finding).

Previously `LazyAttributeHash` accepted only `(types, values)`, so on lazy materialize an attribute absent from `values` always became `Uninitialized` — silently dropping schema-level column defaults. This brings the constructor in line with Rails: `(types, values, additionalTypes, defaultAttributes, delegateHash)`.

Lookup precedence on lazy materialize now matches Rails `builder.rb:165-179`:
1. `values[name]` → `Attribute.fromDatabase`
2. `defaultAttributes[name]` → cloned (detached from prototype)
3. `Attribute.uninitialized(name, type)`

`Builder#buildFromDatabase` also gained an optional `additionalTypes` parameter so the eager path mirrors Rails' `LazyAttributeSet` precedence.

## Changes

- `packages/activemodel/src/attribute-set/builder.ts` — extend `LazyAttributeHash` constructor + `assignDefault`, thread `additionalTypes` through `Builder#buildFromDatabase`, update `marshalDump` / `marshalLoad` / `deepDup` for the new fields. Added `dupAttribute` helper (`@internal`).
- `packages/activemodel/src/attribute-set/builder-defaults.test.ts` — new tests covering the four required cases.

## Test plan

- [x] `pnpm --filter @blazetrails/activemodel test` — 1653/1653 pass
- [x] `pnpm api:compare --package activemodel` — **625/625 (100%)**, up from 621/625
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean

## Notes

LOC ~110 — under the 300-LOC ceiling. No `attribute-registration.ts` ripple was needed: `Builder` already accepts `defaultAttributes` in its constructor; the gap was that `LazyAttributeHash` ignored them on materialize.