### PR TITLE
fix(activemodel): preserve attribute state through withType/withValueFromUser (P2)

### DIFF
--- a/packages/activemodel/src/attribute.test.ts
+++ b/packages/activemodel/src/attribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Model, Types } from "./index.js";
-import { Attribute } from "./attribute.js";
+import { Attribute, FromUser, UNINITIALIZED_ORIGINAL_VALUE } from "./attribute.js";
+import { UNINITIALIZED_ORIGINAL_VALUE as UNINITIALIZED_FROM_INDEX } from "./index.js";
 import { typeRegistry } from "./type/registry.js";
 import "./attribute/user-provided-default.js";
 
@@ -399,5 +400,51 @@ describe("AttributeTest", () => {
   it("from_database came_from_user? returns false", () => {
     const attr = Attribute.fromDatabase("name", "hello", typeRegistry.lookup("string"));
     expect(attr.cameFromUser()).toBe(false);
+  });
+
+  it("with_type preserves in-place mutations via with_value_from_user chain", () => {
+    const stringType = typeRegistry.lookup("string");
+    const otherType = typeRegistry.lookup("string");
+    class MutableFromUser extends FromUser {
+      override changedInPlace(): boolean {
+        return true;
+      }
+    }
+    const attr = new MutableFromUser("tags", ["a"], stringType, null, ["a", "b"]);
+    const retyped = attr.withType(otherType);
+    expect(retyped.valueBeforeTypeCast).toEqual(["a", "b"]);
+    expect(retyped.type).toBe(otherType);
+  });
+
+  it("with_type preserves originalAttribute when not changed in place", () => {
+    const stringType = typeRegistry.lookup("string");
+    const otherType = typeRegistry.lookup("string");
+    const original = Attribute.fromDatabase("name", "old", stringType);
+    const changed = original.withValueFromUser("new");
+    const retyped = changed.withType(otherType);
+    expect(retyped.getOriginalAttribute()).toBe(original);
+    expect(retyped.type).toBe(otherType);
+    expect(retyped.valueBeforeTypeCast).toBe("new");
+  });
+
+  it("with_value_from_user calls assert_valid_value before constructing", () => {
+    const intType = Object.create(typeRegistry.lookup("integer"));
+    intType.assertValidValue = (v: unknown) => {
+      if (typeof v === "number" && (v < 0 || v > 100)) {
+        throw new RangeError("out of range");
+      }
+    };
+    const attr = Attribute.fromUser("score", 50, intType);
+    expect(() => attr.withValueFromUser(200)).toThrow("out of range");
+    expect(() => attr.withValueFromUser(75)).not.toThrow();
+  });
+
+  it("Uninitialized#originalValue returns the UNINITIALIZED_ORIGINAL_VALUE sentinel", () => {
+    const u = Attribute.uninitialized("name", typeRegistry.lookup("string"));
+    expect(u.originalValue).toBe(UNINITIALIZED_ORIGINAL_VALUE);
+  });
+
+  it("UNINITIALIZED_ORIGINAL_VALUE is a singleton across import paths", () => {
+    expect(UNINITIALIZED_ORIGINAL_VALUE).toBe(UNINITIALIZED_FROM_INDEX);
   });
 });

--- a/packages/activemodel/src/attribute.test.ts
+++ b/packages/activemodel/src/attribute.test.ts
@@ -444,6 +444,24 @@ describe("AttributeTest", () => {
     expect(u.originalValue).toBe(UNINITIALIZED_ORIGINAL_VALUE);
   });
 
+  it("with_type on UserProvidedDefault preserves proc defaults unevaluated", async () => {
+    const { UserProvidedDefault } = await import("./attribute/user-provided-default.js");
+    const stringType = typeRegistry.lookup("string");
+    const otherType = typeRegistry.lookup("string");
+    let calls = 0;
+    const proc = () => {
+      calls++;
+      return `value-${calls}`;
+    };
+    const upd = new UserProvidedDefault("name", proc, stringType, null);
+    const retyped = upd.withType(otherType) as InstanceType<typeof UserProvidedDefault>;
+    expect(retyped).toBeInstanceOf(UserProvidedDefault);
+    expect(retyped.userProvidedValue).toBe(proc);
+    expect(calls).toBe(0);
+    expect(retyped.valueBeforeTypeCast).toBe("value-1");
+    expect(calls).toBe(1);
+  });
+
   it("UNINITIALIZED_ORIGINAL_VALUE is a singleton across import paths", () => {
     expect(UNINITIALIZED_ORIGINAL_VALUE).toBe(UNINITIALIZED_FROM_INDEX);
   });

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -2,6 +2,11 @@ import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 
+// Symbol so identity comparisons work across module copies and can't collide with any user value.
+export const UNINITIALIZED_ORIGINAL_VALUE: unique symbol = Symbol.for(
+  "@blazetrails/activemodel/UNINITIALIZED_ORIGINAL_VALUE",
+);
+
 // Lazy reference to avoid circular import: attribute.ts ↔ user-provided-default.ts
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _UserProvidedDefaultCtor: (new (...args: any[]) => Attribute) | null = null;
@@ -92,6 +97,7 @@ export abstract class Attribute {
   }
 
   withValueFromUser(value: unknown): Attribute {
+    this.type.assertValidValue(value);
     return Attribute.fromUser(this.name, value, this.type, this.originalAttribute ?? this);
   }
 
@@ -104,7 +110,16 @@ export abstract class Attribute {
   }
 
   withType(type: Type): Attribute {
-    return Attribute.withCastValue(this.name, this.value, type);
+    if (this.changedInPlace()) {
+      return this.withValueFromUser(this.value).withType(type);
+    }
+    const Ctor = this.constructor as new (
+      name: string,
+      valueBeforeTypeCast: unknown,
+      type: Type,
+      originalAttribute: Attribute | null,
+    ) => Attribute;
+    return new Ctor(this.name, this._valueBeforeTypeCast, type, this.originalAttribute);
   }
 
   isInitialized(): boolean {
@@ -307,6 +322,10 @@ export class Null extends Attribute {
   withValueFromUser(_value: unknown): Attribute {
     throw new MissingAttributeError(`can't write unknown attribute \`${this.name}\``);
   }
+
+  override withType(type: Type): Attribute {
+    return Attribute.withCastValue(this.name, null, type);
+  }
 }
 
 export class Uninitialized extends Attribute {
@@ -316,6 +335,10 @@ export class Uninitialized extends Attribute {
 
   get value(): unknown {
     return undefined;
+  }
+
+  override get originalValue(): unknown {
+    return UNINITIALIZED_ORIGINAL_VALUE;
   }
 
   get valueForDatabase(): unknown {
@@ -328,6 +351,10 @@ export class Uninitialized extends Attribute {
 
   forgettingAssignment(): Attribute {
     return new Uninitialized(this.name, this.type);
+  }
+
+  override withType(type: Type): Attribute {
+    return new Uninitialized(this.name, type);
   }
 
   typeCast(): unknown {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -119,7 +119,7 @@ export abstract class Attribute {
       type: Type,
       originalAttribute: Attribute | null,
     ) => Attribute;
-    return new Ctor(this.name, this._valueBeforeTypeCast, type, this.originalAttribute);
+    return new Ctor(this.name, this.valueBeforeTypeCast, type, this.originalAttribute);
   }
 
   isInitialized(): boolean {

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -58,6 +58,15 @@ export class UserProvidedDefault extends FromUser {
     return new UserProvidedDefault(this.name, clonedVal, this.type, this.getOriginalAttribute());
   }
 
+  override withType(type: Type): Attribute {
+    return new UserProvidedDefault(
+      this.name,
+      this.userProvidedValue,
+      type,
+      this.getOriginalAttribute(),
+    );
+  }
+
   marshalDump(): [string, unknown, Type, Attribute | null] {
     return [this.name, this.valueBeforeTypeCast, this.type, this.getOriginalAttribute()];
   }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -32,7 +32,13 @@ export {
 } from "./attribute-registration.js";
 export { Attributes } from "./attributes.js";
 export type { AttributeDefinition } from "./attributes.js";
-export { Attribute, FromDatabase, FromUser, WithCastValue } from "./attribute.js";
+export {
+  Attribute,
+  FromDatabase,
+  FromUser,
+  WithCastValue,
+  UNINITIALIZED_ORIGINAL_VALUE,
+} from "./attribute.js";
 export { UserProvidedDefault } from "./attribute/user-provided-default.js";
 export { AttributeSet } from "./attribute-set.js";
 export { LazyAttributeSet, LazyAttributeHash } from "./attribute-set/builder.js";


### PR DESCRIPTION
## Summary

P2 of the activemodel attribute-lifecycle alignment chain. Fixes audit findings #3, #4, #5 from `docs/activemodel/audit-core.md` §8 — three bugs in `attribute.ts` that silently corrupted attribute state. See `docs/activemodel-alignment.md` P2 for the full spec.

- **`withType` drops in-place changes / originalAttribute** → mirror Rails `attribute.rb:91-97`: branch on `changedInPlace()`, route through `withValueFromUser(value).withType(type)` when mutated; otherwise reconstruct via `this.constructor` preserving `originalAttribute`. Previously always re-built via `Attribute.withCastValue`, losing both.
- **`withValueFromUser` skips `assertValidValue`** → mirror Rails `attribute.rb:78-81`: call `this.type.assertValidValue(value)` before constructing the new attribute. Invalid values now throw at assignment time instead of at first read.
- **`Uninitialized#originalValue` returned `undefined`** → mirror Rails `attribute.rb:255-257`: return the new `UNINITIALIZED_ORIGINAL_VALUE` sentinel (`Symbol.for`-based singleton, exported from `attribute.ts` and re-exported from the package index). AR dirty tracking can now identity-check against it.
- Added `Uninitialized#withType` and `Null#withType` overrides to mirror Rails subclass-specific behavior (`attribute.rb:231-233`, `:270-272`).

## Test plan

- [x] `pnpm exec vitest run packages/activemodel` — 1661 / 1661 passing
- [x] `pnpm exec eslint packages/activemodel` — clean
- [x] `pnpm --filter @blazetrails/activemodel build` (typecheck) — clean
- [x] `pnpm api:compare --package activemodel` — 625 / 625 (100%, up from 621)
- [x] `pnpm format:check` — clean
- [x] New tests in `attribute.test.ts`: in-place mutation preserved through `withType`; `originalAttribute` preserved through `withType`; `withValueFromUser` rejects invalid values via `assertValidValue`; `Uninitialized#originalValue === UNINITIALIZED_ORIGINAL_VALUE` (identity); sentinel singleton across import paths.