### PR TITLE
fix(activemodel): return ValueType fallback for unknown attributeTypes lookups (P3)

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model, Types } from "./index.js";
+import { Model, Types, ValueType } from "./index.js";
 
 describe("AttributeRegistrationTest", () => {
   it("attributes can be registered", () => {
@@ -48,7 +48,31 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.typeForAttribute("unknown")).toBeNull();
+    const fallback = m.typeForAttribute("unknown");
+    expect(fallback).toBeInstanceOf(ValueType);
+    expect(fallback.cast("anything")).toBe("anything");
+  });
+
+  it("attributeTypes returns a fallback ValueType for unknown keys", () => {
+    class MyModel extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const types = MyModel.attributeTypes();
+    expect(types["unknown"]).toBeInstanceOf(ValueType);
+    expect(types["unknown"].cast("hello")).toBe("hello");
+  });
+
+  it("attributeTypes returns the registered type, not the fallback, for known keys", () => {
+    class MyModel extends Model {
+      static {
+        this.attribute("count", "integer");
+      }
+    }
+    const types = MyModel.attributeTypes();
+    expect(types["count"].name).toBe("integer");
+    expect(types["count"].cast("5")).toBe(5);
   });
 
   it("new attributes can be registered at any time", () => {
@@ -267,8 +291,8 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.typeForAttribute("name")).not.toBeNull();
-    expect(p.typeForAttribute("missing_key")).toBeNull();
+    expect(p.typeForAttribute("name").name).toBe("string");
+    expect(p.typeForAttribute("missing_key")).toBeInstanceOf(ValueType);
   });
 
   it("_pendingAttributeModifications queue is populated by attribute()", () => {

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -281,7 +281,8 @@ export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
  * for unknown names (never null), matching Rails' Type.default_value behavior.
  */
 export function typeForAttribute(this: AnyAttributeHost, name: string): Type {
-  return attributeTypes.call(this)[name];
+  const resolved = resolveAttributeName.call(this, name);
+  return attributeTypes.call(this)[resolved];
 }
 
 /**

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -265,7 +265,7 @@ export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
   const cast = _defaultAttributes.call(this).castTypes();
   return new Proxy(cast, {
     get(target, prop, receiver) {
-      if (typeof prop === "string" && !(prop in target)) {
+      if (typeof prop === "string" && !Object.hasOwn(target, prop)) {
         return typeRegistry.lookup("value");
       }
       return Reflect.get(target, prop, receiver);

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -22,7 +22,7 @@ export interface AttributeRegistrationClassMethods {
   _defaultAttributes(): AttributeSet;
   decorateAttributes(names: string[] | null, decorator: (name: string, type: Type) => Type): void;
   attributeTypes(): Record<string, Type>;
-  typeForAttribute(name: string): Type | null;
+  typeForAttribute(name: string): Type;
 }
 
 export type AttributeRegistration = AttributeRegistrationClassMethods;
@@ -257,21 +257,31 @@ export function decorateAttributes(
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#attribute_types
  *
- * Rails: @attribute_types ||= _default_attributes.cast_types
- * Delegates to _defaultAttributes — single codepath.
+ * Rails: @attribute_types ||= _default_attributes.cast_types.tap { |h| h.default = Type.default_value }
+ * Wraps the cast-types record in a Proxy so unknown keys return a fallback
+ * ValueType — same effect as Rails setting `hash.default = Type.default_value`.
  */
 export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
-  return _defaultAttributes.call(this).castTypes();
+  const cast = _defaultAttributes.call(this).castTypes();
+  return new Proxy(cast, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && !(prop in target)) {
+        return typeRegistry.lookup("value");
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 }
 
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#type_for_attribute
  *
  * Rails: attribute_types[attribute_name]
- * Delegates to attributeTypes — single codepath.
+ * Delegates to attributeTypes — single codepath. Returns a fallback ValueType
+ * for unknown names (never null), matching Rails' Type.default_value behavior.
  */
-export function typeForAttribute(this: AnyAttributeHost, name: string): Type | null {
-  return attributeTypes.call(this)[name] ?? null;
+export function typeForAttribute(this: AnyAttributeHost, name: string): Type {
+  return attributeTypes.call(this)[name];
 }
 
 /**

--- a/packages/activemodel/src/attributes.test.ts
+++ b/packages/activemodel/src/attributes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "./index.js";
+import { Model, ValueType } from "./index.js";
 
 describe("AttributesTest", () => {
   // =========================================================================
@@ -376,7 +376,7 @@ describe("typeForAttribute", () => {
       }
     }
     const u = new User({ name: "Alice" });
-    expect(u.typeForAttribute("unknown")).toBeNull();
+    expect(u.typeForAttribute("unknown")).toBeInstanceOf(ValueType);
   });
 });
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2133,7 +2133,7 @@ export class Model {
    *
    * Mirrors: ActiveModel::Attributes#attribute_for_inspect
    */
-  typeForAttribute(name: string): Type | null {
+  typeForAttribute(name: string): Type {
     return (this.constructor as typeof Model).typeForAttribute(name);
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Model, type Type } from "@blazetrails/activemodel";
+import { Model, type Type, typeRegistry } from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
 import {
   Table,
@@ -714,9 +714,9 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::ModelSchema::ClassMethods#type_for_attribute
    */
-  static override typeForAttribute(name: string): Type | null {
+  static override typeForAttribute(name: string): Type {
     (ModelSchema.loadSchema as any).call(this);
-    return (this._attributeDefinitions as any)?.get(name)?.type ?? null;
+    return (this._attributeDefinitions as any)?.get(name)?.type ?? typeRegistry.lookup("value");
   }
 
   /**

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -48,7 +48,7 @@ export class Map {
 
     // Instance-level lookup fallback
     if (typeof klass.typeForAttribute === "function") {
-      return klass.typeForAttribute(name) ?? new ValueType();
+      return klass.typeForAttribute(name);
     }
 
     return new ValueType();


### PR DESCRIPTION
## Summary

Implements P3 from `docs/activemodel-alignment.md` (audit-core §7, finding #11).

`attributeTypes()` previously returned a plain `Record<string, Type>`, so unknown keys read as `undefined` — meaning `attributeTypes(name).cast(value)` blew up with `Cannot read properties of undefined` on any unregistered attribute. Rails sets `hash.default = Type.default_value` on the cast-types hash so unknown lookups return a `Value` instance instead.

We mirror Rails by wrapping the cast-types record in a `Proxy` whose `get` trap returns `typeRegistry.lookup("value")` for any string key that isn't in the underlying record. `typeForAttribute(name)` now consequently returns `Type` (no longer `Type | null`); the AR base override does the same with the same fallback.

Dead `?? new ValueType()` guard removed in `type-caster/map.ts` now that the lookup never returns nullish.

This also unblocks P24a's schema-drift policy (YAML/JSON envelopes can fall back to `value` when the registry doesn't know a type key).

## Changes

- `packages/activemodel/src/attribute-registration.ts` — `attributeTypes()` returns a Proxy with `Type.default_value` fallback; `typeForAttribute()` typed as `Type`.
- `packages/activemodel/src/model.ts` — instance `typeForAttribute` return type tightened.
- `packages/activerecord/src/base.ts` — static override returns ValueType fallback.
- `packages/activerecord/src/type-caster/map.ts` — drop dead `?? new ValueType()` guard.
- Tests updated and added in `attribute-registration.test.ts` / `attributes.test.ts`.

## Test plan

- [x] `pnpm --filter @blazetrails/activemodel test` (1651 tests pass)
- [x] `pnpm --filter @blazetrails/activerecord test` (9956 pass / 3292 skipped)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm api:compare --package activemodel` — 625/625 (100%)
- [x] `pnpm format:check`

## References

- `docs/activemodel-alignment.md` — P3
- `docs/activemodel/audit-core.md` §7 (#11)
- Rails: `activemodel/lib/active_model/attribute_registration.rb:37-51`