### PR TITLE
fix(activemodel): store live attribute reference in forceChange (P4)

### DIFF
--- a/packages/activemodel/src/attribute-mutation-tracker.test.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.test.ts
@@ -91,15 +91,38 @@ describe("AttributeMutationTracker", () => {
   });
 
   it("forceChange stores the live value reference (in-place mutations are observed)", () => {
+    class ExposedTracker extends AttributeMutationTracker {
+      stored(name: string): unknown {
+        return this.forcedChanges.get(name);
+      }
+    }
     const arr: string[] = ["a", "b"];
     const set = buildSet({ tags: arr });
-    const tracker = new AttributeMutationTracker(set);
+    const tracker = new ExposedTracker(set);
 
     tracker.forceChange("tags");
-    arr.push("c");
+    expect(tracker.stored("tags")).toBe(arr);
 
-    expect(tracker.changedAttributeNames()).toContain("tags");
-    expect(tracker.anyChanges()).toBe(true);
+    arr.push("c");
+    expect(tracker.stored("tags")).toBe(arr);
+    expect(tracker.stored("tags")).toEqual(["a", "b", "c"]);
+  });
+
+  it("forceChange overwrites any previously stored value (Rails parity)", () => {
+    class ExposedTracker extends AttributeMutationTracker {
+      stored(name: string): unknown {
+        return this.forcedChanges.get(name);
+      }
+    }
+    const set = buildSet({ name: "Alice" });
+    const tracker = new ExposedTracker(set);
+
+    tracker.forceChange("name");
+    expect(tracker.stored("name")).toBe("Alice");
+
+    set.writeFromUser("name", "Bob");
+    tracker.forceChange("name");
+    expect(tracker.stored("name")).toBe("Bob");
   });
 
   it("originalValue is sourced from the attribute chain, not the tracker's stored value", () => {

--- a/packages/activemodel/src/attribute-mutation-tracker.test.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.test.ts
@@ -7,12 +7,18 @@ import {
   NullMutationTracker,
 } from "./attribute-mutation-tracker.js";
 import { typeRegistry } from "./type/registry.js";
+import { ValueType } from "./type/value.js";
 
 function buildSet(values: Record<string, unknown>): AttributeSet {
   const attrs = new Map<string, import("./attribute.js").Attribute>();
+  const passthrough = new ValueType();
   for (const [name, value] of Object.entries(values)) {
     const type =
-      typeof value === "number" ? typeRegistry.lookup("integer") : typeRegistry.lookup("string");
+      typeof value === "number"
+        ? typeRegistry.lookup("integer")
+        : typeof value === "string"
+          ? typeRegistry.lookup("string")
+          : passthrough;
     attrs.set(name, Attribute.fromUserWithValue(name, value, value, type));
   }
   return new AttributeSet(attrs);
@@ -82,6 +88,42 @@ describe("AttributeMutationTracker", () => {
     expect(tracker.isChanged("age", { from: "30", to: "31" })).toBe(true);
     expect(tracker.isChanged("age", { from: "29" })).toBe(false);
     expect(tracker.isChanged("age", { to: "32" })).toBe(false);
+  });
+
+  it("forceChange stores the live value reference (in-place mutations are observed)", () => {
+    const arr: string[] = ["a", "b"];
+    const set = buildSet({ tags: arr });
+    const tracker = new AttributeMutationTracker(set);
+
+    tracker.forceChange("tags");
+    arr.push("c");
+
+    expect(tracker.changedAttributeNames()).toContain("tags");
+    expect(tracker.anyChanges()).toBe(true);
+  });
+
+  it("originalValue is sourced from the attribute chain, not the tracker's stored value", () => {
+    const set = buildSet({ name: "Alice" });
+    const tracker = new AttributeMutationTracker(set);
+
+    set.writeFromUser("name", "Bob");
+    tracker.forceChange("name");
+
+    expect(tracker.originalValue("name")).toBe("Alice");
+  });
+
+  it("multiple forced changes don't interfere with each other", () => {
+    const a: string[] = ["x"];
+    const b: string[] = ["y"];
+    const set = buildSet({ a, b });
+    const tracker = new AttributeMutationTracker(set);
+
+    tracker.forceChange("a");
+    tracker.forceChange("b");
+    a.push("z");
+
+    expect(tracker.changedAttributeNames().sort()).toEqual(["a", "b"]);
+    expect(set.fetchValue("b")).toBe(b);
   });
 
   it("changedValues returns original values for changed attrs", () => {

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -112,16 +112,13 @@ export class AttributeMutationTracker {
   }
 
   originalValue(name: string): unknown {
-    if (this.forcedChanges.has(name)) {
-      return this.forcedChanges.get(name);
-    }
     return this.attributes.getAttribute(name).originalValue;
   }
 
   forceChange(name: string): void {
-    if (this.forcedChanges.has(name)) return;
-    const value = this.fetchValue(name);
-    this.forcedChanges.set(name, cloneValue(value));
+    // Intentionally store the live value (no clone) to match Rails:
+    // in-place mutations after forceChange must surface via dirty tracking.
+    this.forcedChanges.set(name, this.fetchValue(name));
   }
 
   protected attributeChanged(name: string): boolean {


### PR DESCRIPTION
Fourth PR in the activemodel attribute-lifecycle chain (P1, P2, P3 already merged). Implements P4 from `docs/activemodel-alignment.md` and resolves audit finding #6 in `docs/activemodel/audit-core.md` §6.

## Why

`AttributeMutationTracker#forceChange` was deep-cloning the recorded value. Rails stores the live value (`forced_changes[attr_name] = fetch_value(attr_name)`). The inverted behavior was a silent footgun: mutating an array/hash/JSON-typed attribute in place after `forceChange` was tracked by Rails dirty-tracking but invisible to ours.

`AttributeMutationTracker#originalValue` was also consulting `forcedChanges`. Rails returns `attributes[attr_name].original_value` unconditionally — only `ForcedMutationTracker` (which already overrides) consults `forced_changes` for `original_value`.

## Changes

- `forceChange` stores the live value, no clone (Rails parity).
- `originalValue` reads from the attribute chain, not `forcedChanges` (Rails parity).
- One non-obvious comment notes the live-ref storage is intentional.

## Test plan

- [x] `pnpm vitest run packages/activemodel/src/attribute-mutation-tracker.test.ts` — 15/15 passing including new tests:
  - in-place mutation after `forceChange` is observed by the tracker
  - `originalValue` is sourced from the attribute chain, not the tracker's stored value
  - multiple forced changes don't interfere with each other
- [x] `pnpm test` — 19813 passed, 0 failed (activerecord dirty-tracking integration still green)
- [x] `pnpm lint`, `pnpm format:check`
- [x] `pnpm api:compare --package activemodel` — 625/625 (100%)