### PR TITLE
fix(activemodel): cast NaN/Infinity strings to Float specials (P6)

### DIFF
--- a/packages/activemodel/src/type/float.test.ts
+++ b/packages/activemodel/src/type/float.test.ts
@@ -47,4 +47,36 @@ describe("FloatTest", () => {
     expect(type.cast(true)).toBe(1);
     expect(type.cast(false)).toBe(0);
   });
+
+  it('cast "NaN" returns Number.NaN', () => {
+    const type = new Types.FloatType();
+    expect(Number.isNaN(type.cast("NaN"))).toBe(true);
+  });
+
+  it('cast "Infinity" returns Number.POSITIVE_INFINITY', () => {
+    const type = new Types.FloatType();
+    expect(type.cast("Infinity")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('cast "-Infinity" returns Number.NEGATIVE_INFINITY', () => {
+    const type = new Types.FloatType();
+    expect(type.cast("-Infinity")).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("special strings are case-sensitive — lowercase variants cast to null", () => {
+    const type = new Types.FloatType();
+    expect(type.cast("nan")).toBeNull();
+    expect(type.cast("infinity")).toBeNull();
+    expect(type.cast("INFINITY")).toBeNull();
+  });
+
+  it('serialize("NaN") round-trips to Number.NaN via Helpers::Numeric', () => {
+    const type = new Types.FloatType();
+    expect(Number.isNaN(type.serialize("NaN"))).toBe(true);
+  });
+
+  it("typeCastForSchema(NaN) still returns '\"NaN\"'", () => {
+    const type = new Types.FloatType();
+    expect(type.typeCastForSchema(NaN)).toBe('"NaN"');
+  });
 });

--- a/packages/activemodel/src/type/float.ts
+++ b/packages/activemodel/src/type/float.ts
@@ -9,6 +9,10 @@ export class FloatType extends NumericValueType {
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): number | null {
     if (typeof value === "number") return value;
+    // Case-sensitive exact match mirrors Rails float.rb:53-60; "nan"/"infinity" are not valid.
+    if (value === "Infinity") return Number.POSITIVE_INFINITY;
+    if (value === "-Infinity") return Number.NEGATIVE_INFINITY;
+    if (value === "NaN") return Number.NaN;
     const parsed = parseFloat(String(value));
     return isNaN(parsed) ? null : parsed;
   }


### PR DESCRIPTION
## Summary

Implements the three Rails special-string forms for `FloatType#castValue`, closing audit finding #39 from `docs/activemodel/audit-types.md` section 7.

- `"NaN"` -> `Number.NaN`
- `"Infinity"` -> `Number.POSITIVE_INFINITY`
- `"-Infinity"` -> `Number.NEGATIVE_INFINITY`

Match is exact case-sensitive, mirroring `float.rb:53-60`. Lowercase variants (`"nan"`, `"infinity"`, `"INFINITY"`) continue to fall through to `parseFloat` and return `null`.

Since P5's `applyNumericMixin` makes `serialize` call `cast`, the `serialize("NaN")` round-trip to `NaN` also works for free.

References: `docs/activemodel-alignment.md` P6 and `docs/activemodel/audit-types.md` section 7, finding #39.

## Test plan

- [ ] `cast("NaN")` returns `Number.NaN` (checked via `Number.isNaN`)
- [ ] `cast("Infinity")` returns `Number.POSITIVE_INFINITY`
- [ ] `cast("-Infinity")` returns `Number.NEGATIVE_INFINITY`
- [ ] Case sensitivity: `cast("nan")`, `cast("infinity")`, `cast("INFINITY")` return `null`
- [ ] `serialize("NaN")` round-trips to `Number.NaN` (P5+P6 interaction lock-in)
- [ ] `typeCastForSchema(NaN)` still returns `'"NaN"'` (regression guard)
- [ ] `pnpm --filter @blazetrails/activemodel test` — 13/13 pass
- [ ] lint and format:check — clean
- [ ] `pnpm api:compare --package activemodel` — delta >= 0 (float.ts 3/3, 100%)
