### PR TITLE
fix(arel): PR C — HomogeneousIn#right via attribute.quotedArray (Rails fidelity)

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -583,8 +583,12 @@ export class Attribute extends Node {
    *
    * Mirrors: `OVER` support on Arel expressions.
    */
+  // Mirrors Arel::Predications#quoted_array → delegates to private
+  // `quoted_node`, which is `Nodes.build_quoted(other, self)` — passing
+  // self as the attribute argument so non-Node values become `Casted`
+  // (carrying the type-cast context) rather than bare `Quoted`.
   quotedArray(others: unknown[]): Node[] {
-    return others.map((v) => buildQuoted(v));
+    return others.map((v) => buildQuoted(v, this));
   }
 
   over(window?: Window | NamedWindow | string | null): Over {

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -49,6 +49,38 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
     });
   });
 
+  describe("right (Rails fidelity)", () => {
+    it("non-Node values are wrapped as Casted (carrying the attribute) — not bare Quoted", () => {
+      const node = new Nodes.HomogeneousIn([1, 2, 3], users.get("id"), "in");
+      const right = node.right;
+      expect(right).toHaveLength(3);
+      for (const r of right) {
+        expect(r).toBeInstanceOf(Nodes.Casted);
+        expect((r as Nodes.Casted).attribute).toBe(node.attribute);
+      }
+    });
+
+    it("preserves existing Node values unchanged (build_quoted passthrough)", () => {
+      const inner = new Nodes.SqlLiteral("now()");
+      const node = new Nodes.HomogeneousIn([inner], users.get("created_at"), "in");
+      expect(node.right[0]).toBe(inner);
+    });
+
+    it("delegates to attribute.quotedArray when present (host override participates)", () => {
+      const calls: unknown[][] = [];
+      const fakeAttr = Object.create(users.get("id")) as Nodes.Node & {
+        quotedArray?: (vs: unknown[]) => Nodes.Node[];
+      };
+      fakeAttr.quotedArray = (vs: unknown[]): Nodes.Node[] => {
+        calls.push(vs);
+        return vs.map((v) => new Nodes.SqlLiteral(String(v)));
+      };
+      const node = new Nodes.HomogeneousIn([1, 2], fakeAttr, "in");
+      expect(node.right.every((r) => r instanceof Nodes.SqlLiteral)).toBe(true);
+      expect(calls).toEqual([[1, 2]]);
+    });
+  });
+
   describe("procForBinds", () => {
     it("wraps a value as ActiveModel::Attribute bound to the attribute name", () => {
       const node = new Nodes.HomogeneousIn([1, 2], users.get("id"), "in");

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -1,5 +1,5 @@
 import { Node, NodeVisitor } from "./node.js";
-import { Quoted } from "./casted.js";
+import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 
 // Rails memoizes ActiveModel::Type.default_value as `@default_value ||= Value.new`.
@@ -33,8 +33,20 @@ export class HomogeneousIn extends Node {
     return this.attribute;
   }
 
+  // Mirrors Arel::Nodes::HomogeneousIn#right (homogeneous_in.rb):
+  //   `attribute.quoted_array(values)`
+  // which routes through Predications#quoted_array → quoted_node →
+  // `Nodes.build_quoted(other, attribute)` — non-Node values become
+  // `Casted` (carrying the attribute's type-cast context), not bare
+  // Quoted. Use the attribute's own `quotedArray` when present so any
+  // host-class override participates; otherwise fall through to the
+  // shared buildQuoted with the attribute as the casting context.
   get right(): Node[] {
-    return this.values.map((v) => (v instanceof Node ? v : new Quoted(v)));
+    const attr = this.attribute as Node & { quotedArray?: (vs: unknown[]) => Node[] };
+    if (typeof attr.quotedArray === "function") {
+      return attr.quotedArray(this.values);
+    }
+    return this.values.map((v) => buildQuoted(v, this.attribute));
   }
 
   get castedValues(): unknown[] {


### PR DESCRIPTION
## Summary
Port `Arel::Nodes::HomogeneousIn#right` semantics from Rails 8.0.2 (homogeneous_in.rb).

Rails: `right → attribute.quoted_array(values)` → `Predications#quoted_array` → `quoted_node(v)` → `Nodes.build_quoted(v, attribute)`. Non-Node values become `Casted` carrying the attribute's type-cast context, so the visitor's later `value_for_database()` call actually invokes the attribute's `typeCastForDatabase`.

TS port previously mapped `values.map(v => v instanceof Node ? v : new Quoted(v))` — bypassing the attribute and producing bare `Quoted` nodes that skipped the type-cast pipeline.

This PR:
- `HomogeneousIn#right` delegates to `attribute.quotedArray(values)` when present; falls back to `buildQuoted(v, attribute)` so the attribute is always passed as the casting context.
- `Attribute#quotedArray` fixed to pass `this` to `buildQuoted` (was calling `buildQuoted(v)` with no attribute — same root bug).
- Tests pin: non-Node values produce `Casted` (with attribute pointer); existing Nodes pass through; host-class `quotedArray` override is honored.

For default (identity) type-casters this is a no-op SQL change. For attributes with custom `typeCastForDatabase` (timezones, JSON columns, etc.) the visitor now serializes correctly.

## Test plan
- [x] 3 new HomogeneousIn fidelity tests
- [x] `pnpm vitest run --project other packages/arel` — 1374/1374 passing (was 1371)
- [x] `pnpm vitest run --project activerecord packages/activerecord/src/relation` — 1379 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm api:compare --package arel` — `nodes/homogeneous_in.rb` 12/12; `attributes/attribute.rb` 60/60; overall 884/884
- [x] `pnpm test:compare` — `homogeneous_in_test.rb` 2/2; no delta