### PR TITLE
fix(arel): PR D — drop SelectStatement#comment + reparent Unary subclasses

### DIFF
--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -1,12 +1,15 @@
 import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SelectCore } from "./select-core.js";
-import { Comment } from "./comment.js";
 
 /**
  * SelectStatement — the full SELECT with cores, order, limit, offset, lock.
  *
- * Mirrors: Arel::Nodes::SelectStatement
+ * Mirrors: Arel::Nodes::SelectStatement (select_statement.rb).
+ *
+ * Comment lives on `SelectCore`, not here — Rails' attr_accessor list is
+ * `:limit, :orders, :lock, :offset, :with` and only `SelectCore` carries
+ * `:comment`. The visitor emits the comment in `visit_Arel_Nodes_SelectCore`.
  */
 export class SelectStatement extends NodeExpression {
   cores: SelectCore[];
@@ -15,7 +18,6 @@ export class SelectStatement extends NodeExpression {
   offset: Node | null;
   lock: Node | null;
   with: Node | null;
-  comment: Comment | null;
 
   constructor(relation: Node | null = null) {
     super();
@@ -25,7 +27,6 @@ export class SelectStatement extends NodeExpression {
     this.offset = null;
     this.lock = null;
     this.with = null;
-    this.comment = null;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {
@@ -40,7 +41,6 @@ export class SelectStatement extends NodeExpression {
     copy.offset = this.offset;
     copy.lock = this.lock;
     copy.with = this.with;
-    copy.comment = this.comment;
     return copy;
   }
 }

--- a/packages/arel/src/nodes/unary-reparent.test.ts
+++ b/packages/arel/src/nodes/unary-reparent.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { Nodes } from "../index.js";
+
+// Pins Rails-faithful inheritance for nodes that previously extended
+// Node directly. Rails (unary.rb): `Not < Unary`. Rails (window.rb):
+// `Rows < Unary`, `Range < Unary`, `Preceding < Unary`, `Following < Unary`.
+// Inheritance from Unary → NodeExpression brings the Predications/Math
+// /AliasPredication mixins along — pinned indirectly via .as() / .eq().
+describe("Unary reparenting (Rails fidelity)", () => {
+  describe("Not extends Unary", () => {
+    it("instanceof Unary", () => {
+      const n = new Nodes.Not(new Nodes.Quoted(true));
+      expect(n).toBeInstanceOf(Nodes.Unary);
+    });
+
+    it("inherits Predications mixin (.eq)", () => {
+      const n = new Nodes.Not(new Nodes.Quoted(true));
+      expect(typeof (n as unknown as { eq?: unknown }).eq).toBe("function");
+    });
+
+    it("inherits AliasPredication mixin (.as)", () => {
+      const n = new Nodes.Not(new Nodes.Quoted(true));
+      const aliased = (n as unknown as { as: (s: string) => unknown }).as("flag");
+      expect(aliased).toBeInstanceOf(Nodes.As);
+    });
+  });
+
+  describe("Window framing nodes extend Unary", () => {
+    it.each([
+      ["Rows", () => new Nodes.Rows(new Nodes.Quoted(1))],
+      ["Range", () => new Nodes.Range(new Nodes.Quoted(1))],
+      ["Preceding", () => new Nodes.Preceding(new Nodes.Quoted(1))],
+      ["Following", () => new Nodes.Following(new Nodes.Quoted(1))],
+    ])("%s instanceof Unary", (_name, build) => {
+      expect(build()).toBeInstanceOf(Nodes.Unary);
+    });
+
+    it("CurrentRow stays Node-only (Rails: CurrentRow < Node)", () => {
+      const cr = new Nodes.CurrentRow();
+      expect(cr).toBeInstanceOf(Nodes.Node);
+      expect(cr).not.toBeInstanceOf(Nodes.Unary);
+    });
+  });
+});

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -22,16 +22,13 @@ export class DistinctOn extends Unary {}
 export class Bin extends Unary {}
 export class On extends Unary {}
 
-export class Not extends Node {
-  readonly expr: Node;
-
+// Mirrors Rails: `Not < Unary` (unary.rb). Inherits Predications/Math/etc.
+// from NodeExpression. Field type narrowed to `Node` since callers always
+// pass an Arel node.
+export class Not extends Unary {
+  declare readonly expr: Node;
   constructor(expr: Node) {
-    super();
-    this.expr = expr;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(expr);
   }
 }
 

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -1,4 +1,5 @@
 import { Node, NodeVisitor } from "./node.js";
+import { Unary } from "./unary.js";
 
 /**
  * Window — a SQL window specification for OVER clauses.
@@ -65,26 +66,20 @@ export class NamedWindow extends Window {
   }
 }
 
-/** Row-based frame bounds */
-export class Preceding extends Node {
-  readonly expr: Node | null;
+// Row-based frame bounds. Mirrors Rails (window.rb): `Preceding`,
+// `Following`, `Rows`, `Range` all extend Unary; only `CurrentRow`
+// extends Node directly (it carries no expr).
+export class Preceding extends Unary {
+  declare readonly expr: Node | null;
   constructor(expr: Node | null = null) {
-    super();
-    this.expr = expr;
-  }
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(expr);
   }
 }
 
-export class Following extends Node {
-  readonly expr: Node | null;
+export class Following extends Unary {
+  declare readonly expr: Node | null;
   constructor(expr: Node | null = null) {
-    super();
-    this.expr = expr;
-  }
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(expr);
   }
 }
 
@@ -94,24 +89,16 @@ export class CurrentRow extends Node {
   }
 }
 
-export class Rows extends Node {
-  readonly expr: Node | null;
+export class Rows extends Unary {
+  declare readonly expr: Node | null;
   constructor(expr: Node | null = null) {
-    super();
-    this.expr = expr;
-  }
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(expr);
   }
 }
 
-export class Range extends Node {
-  readonly expr: Node | null;
+export class Range extends Unary {
+  declare readonly expr: Node | null;
   constructor(expr: Node | null = null) {
-    super();
-    this.expr = expr;
-  }
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+    super(expr);
   }
 }

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -882,6 +882,23 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star).comment("load users");
       expect(mgr.toSql()).toContain("/* load users */");
     });
+
+    it("stores the Comment node on the SelectCore (Rails fidelity)", () => {
+      const mgr = users.project(star).comment("trace");
+      // Rails: `@ctx.comment = Nodes::Comment.new(values)` — sets on
+      // the core, not the statement. SelectStatement no longer carries
+      // a `comment` field at all.
+      const core = mgr.ast.cores[mgr.ast.cores.length - 1];
+      expect(core.comment).toBeDefined();
+      expect(core.comment).not.toBeNull();
+      expect("comment" in mgr.ast).toBe(false);
+    });
+
+    it("emits the comment exactly once", () => {
+      const sql = users.project(star).comment("once").toSql();
+      const matches = sql.match(/\/\* once \*\//g) ?? [];
+      expect(matches.length).toBe(1);
+    });
   });
 
   it("chains where + order + limit + offset", () => {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -497,9 +497,10 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#comment
    */
   comment(...values: string[]): this {
-    // Mirrors Rails: `comment(*values)` constructs `Nodes::Comment.new(values)`
-    // — a single array arg, not a splat (select_manager.rb).
-    this.ast.comment = new Comment(values);
+    // Mirrors Rails: `@ctx.comment = Nodes::Comment.new(values)`
+    // (select_manager.rb) — sets on the current SelectCore, not on the
+    // statement. `Nodes::Comment.new(values)` takes a single array arg.
+    this.core.comment = new Comment(values);
     return this;
   }
 

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -9,6 +9,20 @@ describe("MysqlTest", () => {
     expect(mgr.toSql()).toContain("LIMIT 10");
   });
 
+  describe("comment emission", () => {
+    it("emits the SelectCore comment in MySQL output", () => {
+      const mgr = new SelectManager(users).project(star).comment("trace=mysql");
+      const sql = new Visitors.MySQL().compile(mgr.ast);
+      expect(sql).toContain("/* trace=mysql */");
+    });
+
+    it("emits the comment exactly once", () => {
+      const mgr = new SelectManager(users).project(star).comment("once");
+      const sql = new Visitors.MySQL().compile(mgr.ast);
+      expect((sql.match(/\/\* once \*\//g) ?? []).length).toBe(1);
+    });
+  });
+
   describe("Nodes::Regexp", () => {
     it("should know how to visit", () => {
       const node = users.get("name").matchesRegexp("bar");

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -48,8 +48,6 @@ export class MySQL extends ToSql {
       this.visit(node.lock);
     }
 
-    this.maybeVisit(node.comment ?? null);
-
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -96,6 +96,12 @@ export class MySQL extends ToSql {
       this.injectJoin(node.windows, ", ");
     }
 
+    // Mirrors base ToSql#visitArelNodesSelectCore — emits the optional
+    // SQL comment after WINDOW. Rails' MySQL visitor (mysql.rb) inherits
+    // the SelectCore visitor from to_sql.rb; Trails overrides for the
+    // FROM DUAL behavior so the comment emission has to be replicated.
+    this.maybeVisit(node.comment ?? null);
+
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -40,8 +40,6 @@ export class SQLite extends ToSql {
 
     // SQLite does not support locking; ignore lock clause entirely.
 
-    this.maybeVisit(node.comment ?? null);
-
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -311,8 +311,6 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.visit(node.lock);
     }
 
-    this.maybeVisit(node.comment ?? null);
-
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary
Two AST-shape fidelity fixes against Rails 8.0.2.

### 1) `SelectStatement` no longer carries `comment`
Rails (`select_statement.rb`) doesn't declare `:comment` in its `attr_accessor` list — it lives on `SelectCore` only. `SelectManager#comment` now sets `core.comment`, mirroring `@ctx.comment = Nodes::Comment.new(values)` (`select_manager.rb`). The `to_sql`/`sqlite`/`mysql` visitors no longer emit the comment at the statement level — the `SelectCore` visitor already handles it (matching Rails' `visit_Arel_Nodes_SelectCore`).

Output identical for typical use; previously the comment was being stored on the statement and emitted via the statement-level visitor while a never-set `core.comment` was being checked twice. Now stored once, on the core.

### 2) Reparent `Not`, `Rows`, `Range`, `Preceding`, `Following` from `Node` to `Unary`
Rails (`unary.rb`): `Not < Unary`. Rails (`window.rb`): `Rows`/`Range`/`Preceding`/`Following` all `< Unary`; only `CurrentRow < Node`. Brings the `Predications`/`Math`/`AliasPredication`/`OrderPredications` mixins along via `NodeExpression` — pinned indirectly via `.eq()` and `.as()` calls on `Not` in the new test.

Deferred to follow-up PR (need field-rename or getter design): `Lateral` (`subquery` field), `GroupingElement`/`Cube`/`RollUp`/`GroupingSet` (`expressions` field).

## Test plan
- [x] New `unary-reparent.test.ts` (8 tests) pinning Unary inheritance + mixin availability
- [x] New `select-manager.test.ts` cases pinning core-level comment storage + once-emit
- [x] `pnpm vitest run --project other packages/arel` — 1384 passing (was 1374)
- [x] `pnpm vitest run --project activerecord packages/activerecord/src/relation` — 1379 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm api:compare --package arel` — 884/884 (select_statement 12/12, select_core 21/21, unary 3/3, window 14/14)
- [x] `pnpm test:compare` — delta 0