### PR TITLE
feat(activerecord): associations files to 100% Rails parity

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2221,8 +2221,16 @@ function associationInstanceGet(record: Base, name: string): unknown {
  * @internal
  */
 function associationInstanceSet(record: Base, name: string, association: unknown): void {
-  const macro = (association as { reflection?: { macro?: string } } | null)?.reflection?.macro;
-  if (macro === "hasMany" || macro === "hasAndBelongsToMany") {
+  // AssociationDefinition uses `type` (not `macro`) for the association
+  // kind. Look it up on the record's class first; fall back to whatever
+  // the wrapper happens to expose if the definition isn't registered.
+  const ctor = record.constructor as { _associations?: AssociationDefinition[] };
+  const def = ctor._associations?.find((a) => a.name === name);
+  const kind =
+    def?.type ??
+    (association as { reflection?: { type?: string } } | null)?.reflection?.type ??
+    null;
+  if (kind === "hasMany" || kind === "hasAndBelongsToMany") {
     record._collectionProxies.set(name, association);
   } else {
     record._associationInstances.set(name, association as AssociationInstance);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2221,16 +2221,25 @@ function associationInstanceGet(record: Base, name: string): unknown {
  * @internal
  */
 function associationInstanceSet(record: Base, name: string, association: unknown): void {
-  // AssociationDefinition uses `type` (not `macro`) for the association
-  // kind. Look it up on the record's class first; fall back to whatever
-  // the wrapper happens to expose if the definition isn't registered.
+  // AssociationDefinition uses `type` (e.g. "hasMany", "hasManyThrough") for
+  // the macro — look it up on the record's class. If the definition isn't
+  // registered there, fall back to the rich reflection's macro / isCollection
+  // (note: AssociationReflection's `type` field is the polymorphic type
+  // column, not the macro — don't read that).
   const ctor = record.constructor as { _associations?: AssociationDefinition[] };
   const def = ctor._associations?.find((a) => a.name === name);
-  const kind =
-    def?.type ??
-    (association as { reflection?: { type?: string } } | null)?.reflection?.type ??
-    null;
-  if (kind === "hasMany" || kind === "hasAndBelongsToMany" || kind === "hasManyThrough") {
+  const refl = (
+    association as { reflection?: { macro?: string; isCollection?: () => boolean } } | null
+  )?.reflection;
+  const defType = def?.type as string | undefined;
+  const isCollection =
+    defType === "hasMany" ||
+    defType === "hasAndBelongsToMany" ||
+    defType === "hasManyThrough" ||
+    refl?.isCollection?.() ||
+    refl?.macro === "hasMany" ||
+    refl?.macro === "hasAndBelongsToMany";
+  if (isCollection) {
     record._collectionProxies.set(name, association);
   } else {
     record._associationInstances.set(name, association as AssociationInstance);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2194,6 +2194,7 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
 function initInternals(record: Base): void {
   record._associationInstances.clear();
   record._collectionProxies.clear();
+  record._preloadedAssociations.clear();
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2230,7 +2230,7 @@ function associationInstanceSet(record: Base, name: string, association: unknown
     def?.type ??
     (association as { reflection?: { type?: string } } | null)?.reflection?.type ??
     null;
-  if (kind === "hasMany" || kind === "hasAndBelongsToMany") {
+  if (kind === "hasMany" || kind === "hasAndBelongsToMany" || kind === "hasManyThrough") {
     record._collectionProxies.set(name, association);
   } else {
     record._associationInstances.set(name, association as AssociationInstance);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2197,51 +2197,32 @@ function initInternals(record: Base): void {
 }
 
 /**
- * Returns the cached Association wrapper for `name`, or `null` if none has
- * been built yet. Trails' equivalent of Rails' `@association_cache` is split
- * across two maps on the record: `_associationInstances` for singular
- * (belongsTo/hasOne) and `_collectionProxies` for collection
- * (hasMany/habtm) wrappers — check both.
+ * Returns the cached `Association` wrapper for `name`, or `null` if none
+ * has been built yet. Mirrors Rails' `@association_cache[name]` lookup —
+ * always reads `_associationInstances` (the canonical Association cache,
+ * matching how `instance-methods.ts:association()` populates it).
+ * `_collectionProxies` is a separate, Trails-specific user-facing layer
+ * and is intentionally not consulted here.
  *
  * Mirrors: ActiveRecord::Associations#association_instance_get
  *
  * @internal
  */
 function associationInstanceGet(record: Base, name: string): unknown {
-  return record._associationInstances.get(name) ?? record._collectionProxies.get(name) ?? null;
+  return record._associationInstances.get(name) ?? null;
 }
 
 /**
- * Stores `association` in the appropriate cache on `record`. Routes
- * collection wrappers to `_collectionProxies` and singular ones to
- * `_associationInstances`, mirroring Rails' single `@association_cache`.
+ * Stores the built `Association` wrapper for `name` in the canonical
+ * `_associationInstances` cache, mirroring Rails'
+ * `@association_cache[name] = association`. The Trails-specific
+ * `_collectionProxies` wrapper map is populated separately by the
+ * collection-proxy machinery, not here.
  *
  * Mirrors: ActiveRecord::Associations#association_instance_set
  *
  * @internal
  */
 function associationInstanceSet(record: Base, name: string, association: unknown): void {
-  // AssociationDefinition uses `type` (e.g. "hasMany", "hasManyThrough") for
-  // the macro — look it up on the record's class. If the definition isn't
-  // registered there, fall back to the rich reflection's macro / isCollection
-  // (note: AssociationReflection's `type` field is the polymorphic type
-  // column, not the macro — don't read that).
-  const ctor = record.constructor as { _associations?: AssociationDefinition[] };
-  const def = ctor._associations?.find((a) => a.name === name);
-  const refl = (
-    association as { reflection?: { macro?: string; isCollection?: () => boolean } } | null
-  )?.reflection;
-  const defType = def?.type as string | undefined;
-  const isCollection =
-    defType === "hasMany" ||
-    defType === "hasAndBelongsToMany" ||
-    defType === "hasManyThrough" ||
-    refl?.isCollection?.() ||
-    refl?.macro === "hasMany" ||
-    refl?.macro === "hasAndBelongsToMany";
-  if (isCollection) {
-    record._collectionProxies.set(name, association);
-  } else {
-    record._associationInstances.set(name, association as AssociationInstance);
-  }
+  record._associationInstances.set(name, association as AssociationInstance);
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -49,12 +49,7 @@ export async function initializeAssociations(): Promise<void> {
     import("./association-relation.js"),
   ]);
 }
-import {
-  StrictLoadingViolationError,
-  ConfigurationError,
-  Rollback,
-  NotImplementedError,
-} from "./errors.js";
+import { StrictLoadingViolationError, ConfigurationError, Rollback } from "./errors.js";
 import {
   AssociationNotFoundError,
   DeleteRestrictionError,
@@ -64,6 +59,7 @@ import {
 } from "./associations/errors.js";
 import { ForeignAssociation } from "./associations/foreign-association.js";
 import { AssociationScope } from "./associations/association-scope.js";
+import type { Association as AssociationInstance } from "./associations/association.js";
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./inheritance.js";
@@ -2184,21 +2180,51 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
   }
 }
 
-/** @internal */
-function initInternals(): never {
-  throw new NotImplementedError("ActiveRecord::Associations#init_internals is not implemented");
+/**
+ * Per-instance association-cache reset hook. Rails initializes
+ * `@association_cache = {}` here; our equivalents (`_associationInstances`
+ * and `_collectionProxies`) are pre-allocated by the `Base` class fields,
+ * so this only needs to clear them when called on an existing record
+ * (e.g. from `initialize_dup`).
+ *
+ * Mirrors: ActiveRecord::Associations#init_internals
+ *
+ * @internal
+ */
+function initInternals(record: Base): void {
+  record._associationInstances.clear();
+  record._collectionProxies.clear();
 }
 
-/** @internal */
-function associationInstanceGet(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Associations#association_instance_get is not implemented",
-  );
+/**
+ * Returns the cached Association wrapper for `name`, or `null` if none has
+ * been built yet. Trails' equivalent of Rails' `@association_cache` is split
+ * across two maps on the record: `_associationInstances` for singular
+ * (belongsTo/hasOne) and `_collectionProxies` for collection
+ * (hasMany/habtm) wrappers — check both.
+ *
+ * Mirrors: ActiveRecord::Associations#association_instance_get
+ *
+ * @internal
+ */
+function associationInstanceGet(record: Base, name: string): unknown {
+  return record._associationInstances.get(name) ?? record._collectionProxies.get(name) ?? null;
 }
 
-/** @internal */
-function associationInstanceSet(name: any, association: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Associations#association_instance_set is not implemented",
-  );
+/**
+ * Stores `association` in the appropriate cache on `record`. Routes
+ * collection wrappers to `_collectionProxies` and singular ones to
+ * `_associationInstances`, mirroring Rails' single `@association_cache`.
+ *
+ * Mirrors: ActiveRecord::Associations#association_instance_set
+ *
+ * @internal
+ */
+function associationInstanceSet(record: Base, name: string, association: unknown): void {
+  const macro = (association as { reflection?: { macro?: string } } | null)?.reflection?.macro;
+  if (macro === "hasMany" || macro === "hasAndBelongsToMany") {
+    record._collectionProxies.set(name, association);
+  } else {
+    record._associationInstances.set(name, association as AssociationInstance);
+  }
 }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -519,7 +519,14 @@ export class CollectionAssociation extends Association {
     }
   }
 
-  private async nullifyAllRecords(): Promise<void> {
+  /**
+   * Returns the FK/type-column → null map for `dependent: :nullify` bulk
+   * updates. Subclasses (HasManyAssociation) override this to honor the
+   * rich AssociationReflection's foreignKey/foreignType.
+   *
+   * @internal
+   */
+  protected computeNullifiedOwnerAttributes(): Record<string, null> {
     const nullAttrs: Record<string, null> = {};
     for (const fk of this.foreignKeyColumns()) {
       nullAttrs[fk] = null;
@@ -527,6 +534,11 @@ export class CollectionAssociation extends Association {
     if (this.reflection.options.as) {
       nullAttrs[`${underscore(this.reflection.options.as)}_type`] = null;
     }
+    return nullAttrs;
+  }
+
+  protected async nullifyAllRecords(): Promise<void> {
+    const nullAttrs = this.computeNullifiedOwnerAttributes();
 
     // Prefer scope-based bulk update (hits DB even if target isn't loaded)
     const rel = this.scope();

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -3,6 +3,8 @@ import type { AssociationDefinition } from "../associations.js";
 import { loadHasMany } from "../associations.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { CollectionAssociation } from "./collection-association.js";
+import { ForeignAssociation } from "./foreign-association.js";
+import { underscore } from "@blazetrails/activesupport";
 
 /**
  * Proxy that handles a has_many association.
@@ -176,10 +178,14 @@ function intersection(_assoc: HasManyAssociation, a: Base[], b: Base[]): Base[] 
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasManyAssociation): Record<string, null> {
-  const refl = assoc.reflection as unknown as { foreignKey: string | string[]; type?: string };
-  const attrs: Record<string, null> = {};
-  const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
-  for (const fk of fks) attrs[fk] = null;
-  if (refl.type) attrs[refl.type] = null;
-  return attrs;
+  const opts = assoc.reflection.options as {
+    foreignKey?: string | string[];
+    as?: string;
+  };
+  const ctor = assoc.owner.constructor as { name: string };
+  const asName = opts.as;
+  const foreignKey =
+    opts.foreignKey ?? (asName ? `${underscore(asName)}_id` : `${underscore(ctor.name)}_id`);
+  const typeCol = asName ? `${underscore(asName)}_type` : null;
+  return ForeignAssociation.nullifiedOwnerAttributes({ foreignKey, type: typeCol });
 }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -178,14 +178,34 @@ function intersection(_assoc: HasManyAssociation, a: Base[], b: Base[]): Base[] 
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasManyAssociation): Record<string, null> {
-  const opts = assoc.reflection.options as {
-    foreignKey?: string | string[];
-    as?: string;
+  // Resolve the rich reflection so foreignKey expansion (composite PKs,
+  // primaryKey overrides, polymorphic foreignType) matches what the
+  // association itself uses. Fall back to the CollectionAssociation's
+  // own FK column derivation, then to the simple options-based shape.
+  const ctor = assoc.owner.constructor as {
+    name: string;
+    _reflectOnAssociation?: (n: string) => {
+      foreignKey?: string | string[];
+      foreignType?: string;
+    } | null;
   };
-  const ctor = assoc.owner.constructor as { name: string };
-  const asName = opts.as;
-  const foreignKey =
-    opts.foreignKey ?? (asName ? `${underscore(asName)}_id` : `${underscore(ctor.name)}_id`);
-  const typeCol = asName ? `${underscore(asName)}_type` : null;
-  return ForeignAssociation.nullifiedOwnerAttributes({ foreignKey, type: typeCol });
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name) ?? null;
+  let foreignKey: string | string[] | undefined = refl?.foreignKey;
+  const typeCol: string | null = refl?.foreignType ?? null;
+  if (foreignKey == null) {
+    const fks = (assoc as unknown as { foreignKeyColumns?: () => string[] }).foreignKeyColumns?.();
+    if (fks?.length) foreignKey = fks;
+  }
+  if (foreignKey == null) {
+    const opts = assoc.reflection.options as { foreignKey?: string | string[]; as?: string };
+    foreignKey =
+      opts.foreignKey ?? (opts.as ? `${underscore(opts.as)}_id` : `${underscore(ctor.name)}_id`);
+  }
+  const polyType = typeCol ?? deriveAsTypeCol(assoc);
+  return ForeignAssociation.nullifiedOwnerAttributes({ foreignKey, type: polyType });
+}
+
+function deriveAsTypeCol(assoc: { reflection: { options: { as?: string } } }): string | null {
+  const asName = assoc.reflection.options.as;
+  return asName ? `${underscore(asName)}_type` : null;
 }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -97,6 +97,15 @@ export class HasManyAssociation extends CollectionAssociation {
     if (this.reflection.options.through) return;
     super.setOwnerAttributes(record);
   }
+
+  /**
+   * Source the FK/type-column null map from the Rails-named helper so
+   * `dependent: :nullify` honors the rich reflection (custom foreignKey,
+   * polymorphic foreignType, composite PKs).
+   */
+  protected override computeNullifiedOwnerAttributes(): Record<string, null> {
+    return nullifiedOwnerAttributes(this);
+  }
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -165,3 +165,21 @@ function difference(_assoc: HasManyAssociation, a: Base[], b: Base[]): Base[] {
 function intersection(_assoc: HasManyAssociation, a: Base[], b: Base[]): Base[] {
   return a.filter((r) => b.includes(r));
 }
+
+/**
+ * Build the attribute hash that nullifies the owner-side foreign key (and
+ * polymorphic type column, when applicable) on dependent records — used by
+ * `dependent: :nullify` bulk updates to drop the FK without destroying rows.
+ *
+ * Mirrors: ActiveRecord::Associations::ForeignAssociation#nullified_owner_attributes
+ *
+ * @internal
+ */
+function nullifiedOwnerAttributes(assoc: HasManyAssociation): Record<string, null> {
+  const refl = assoc.reflection as unknown as { foreignKey: string | string[]; type?: string };
+  const attrs: Record<string, null> = {};
+  const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
+  for (const fk of fks) attrs[fk] = null;
+  if (refl.type) attrs[refl.type] = null;
+  return attrs;
+}

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -236,13 +236,16 @@ function buildSourceJoinAttributes(
  *
  * @internal
  */
-function transaction(assoc: HasManyThroughAssociation, block: () => Promise<void>): Promise<void> {
+function transaction<R>(
+  assoc: HasManyThroughAssociation,
+  block: (tx?: any) => Promise<R>,
+): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
   const klass = safeKlass(tr) as { transaction?: Function } | null;
   if (klass && typeof klass.transaction === "function") {
-    return klass.transaction(block);
+    return klass.transaction(block) as Promise<R | undefined>;
   }
-  return block();
+  return block() as Promise<R | undefined>;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -292,8 +292,9 @@ function constructJoinAttributes(
   ...records: Base[]
 ): Record<string, unknown> {
   ensureMutable(assoc);
-  const refl = assoc.reflection as any;
-  const sourceRefl = refl.sourceReflection?.() as any;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
+  const sourceRefl = refl?.sourceReflection as any;
   if (!sourceRefl) return {};
   const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
@@ -333,10 +334,11 @@ function constructJoinAttributes(
  * @internal
  */
 function ensureMutable(assoc: HasManyThroughAssociation): void {
-  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as {
-    isBelongsTo?: () => boolean;
-    macro?: string;
-  } | null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
+  const sourceRefl = refl?.sourceReflection as
+    | { isBelongsTo?: () => boolean; macro?: string }
+    | undefined;
   const isBelongs = sourceRefl?.isBelongsTo?.() ?? sourceRefl?.macro === "belongsTo";
   if (!isBelongs) {
     throw new HasManyThroughCantAssociateThroughHasOneOrManyReflection(
@@ -355,8 +357,11 @@ function ensureMutable(assoc: HasManyThroughAssociation): void {
  * @internal
  */
 function ensureNotNested(assoc: HasManyThroughAssociation): void {
-  const refl = assoc.reflection as { isNested?: () => boolean };
-  if (refl.isNested?.()) {
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name) as {
+    isNested?: () => boolean;
+  } | null;
+  if (refl?.isNested?.()) {
     throw new HasManyThroughNestedAssociationsAreReadonly(
       (assoc.owner.constructor as { name: string }).name,
       assoc.reflection.name,

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -5,6 +5,15 @@ import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
   HasManyThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
+import { compositeQueryConstraintsList } from "../persistence.js";
+
+function safeKlass(refl: { klass?: unknown } | null | undefined): any {
+  try {
+    return refl?.klass ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation
@@ -228,9 +237,10 @@ function buildSourceJoinAttributes(
  * @internal
  */
 function transaction(assoc: HasManyThroughAssociation, block: () => Promise<void>): Promise<void> {
-  const tr = throughReflection(assoc) as { klass?: { transaction?: Function } } | null;
-  if (tr?.klass && typeof tr.klass.transaction === "function") {
-    return tr.klass.transaction(block);
+  const tr = throughReflection(assoc) as { klass?: unknown } | null;
+  const klass = safeKlass(tr) as { transaction?: Function } | null;
+  if (klass && typeof klass.transaction === "function") {
+    return klass.transaction(block);
   }
   return block();
 }
@@ -296,9 +306,17 @@ function constructJoinAttributes(
   const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
   const sourceRefl = refl?.sourceReflection as any;
   if (!sourceRefl) return {};
-  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
+  const reflKlass = safeKlass(refl);
+  const assocPk =
+    (typeof sourceRefl.associationPrimaryKeyFor === "function"
+      ? sourceRefl.associationPrimaryKeyFor(reflKlass)
+      : sourceRefl.associationPrimaryKey) ??
+    sourceRefl.primaryKey ??
+    "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
+  const compositeConstraints: string[] = reflKlass
+    ? compositeQueryConstraintsList.call(reflKlass)
+    : [];
 
   let joinAttributes: Record<string, unknown>;
   if (

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -26,7 +26,9 @@ export class HasManyThroughAssociation extends HasManyAssociation {
 
 /** @internal */
 function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base | null {
-  ensureMutable(assoc);
+  // Mutability is enforced inside constructJoinAttributes — keep the
+  // precondition in one place (Rails' build_through_record calls
+  // ensure_mutable once; our equivalent inherits it via the helper).
   const proxy = throughAssociation(assoc) as {
     build?: (attrs: Record<string, unknown>) => Base;
   } | null;
@@ -223,16 +225,19 @@ function transaction<R>(
  * @internal
  */
 function throughReflection(assoc: HasManyThroughAssociation): unknown {
+  // Resolve the rich reflection first — assoc.reflection is the
+  // AssociationDefinition (no throughReflection getter), so we need
+  // ThroughReflection#throughReflection from the registry.
   type Refl = {
     throughReflection?: Refl | null;
     isThroughReflection?: () => boolean;
-    options?: { through?: string };
   };
-  let refl = (assoc.reflection as Refl).throughReflection ?? null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
+  let refl: Refl | null =
+    (ctor._reflectOnAssociation?.(assoc.reflection.name) as Refl | null)?.throughReflection ?? null;
   if (!refl) {
     const throughName = assoc.reflection.options.through as string | undefined;
     if (!throughName) return null;
-    const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
     refl = ctor._reflectOnAssociation?.(throughName) ?? null;
   }
   while (refl?.isThroughReflection?.() && refl.throughReflection) {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -214,3 +214,145 @@ function buildSourceJoinAttributes(
   }
   return joinAttributes;
 }
+
+/**
+ * Wrap `block` in a transaction on the through-reflection's class. Falls
+ * back to invoking the block directly when no through klass is available.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
+ *
+ * @internal
+ */
+function transaction(assoc: HasManyThroughAssociation, block: () => Promise<void>): Promise<void> {
+  const throughName = assoc.reflection.options.through as string | undefined;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  const throughKlass = throughName
+    ? ((ctor._reflectOnAssociation?.(throughName) as { klass?: { transaction?: Function } } | null)
+        ?.klass ?? null)
+    : null;
+  if (throughKlass && typeof throughKlass.transaction === "function") {
+    return throughKlass.transaction(block);
+  }
+  return block();
+}
+
+/**
+ * Resolves the AssociationReflection for the `:through` join model.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#through_reflection
+ *
+ * @internal
+ */
+function throughReflection(assoc: HasManyThroughAssociation): unknown {
+  const refl = assoc.reflection as {
+    throughReflection?: () => unknown;
+    options: { through?: string };
+  };
+  const direct = refl.throughReflection?.();
+  if (direct) return direct;
+  const throughName = refl.options.through;
+  if (!throughName) return null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  return ctor._reflectOnAssociation?.(throughName) ?? null;
+}
+
+/**
+ * Returns the live Association wrapper that owns the join model — i.e.,
+ * `owner.association(throughReflection.name)`.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#through_association
+ *
+ * @internal
+ */
+function throughAssociation(assoc: HasManyThroughAssociation): unknown {
+  const tr = throughReflection(assoc) as { name?: string } | null;
+  if (!tr?.name) return null;
+  return (assoc.owner as unknown as { association?: (n: string) => unknown }).association?.(
+    tr.name,
+  );
+}
+
+/**
+ * Build the join-table attribute hash that pairs `records` with the owner
+ * via the source reflection's foreign key (or the source association name
+ * when the join is composite-keyed). Used when constructing through
+ * records.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#construct_join_attributes
+ *
+ * @internal
+ */
+function constructJoinAttributes(
+  assoc: HasManyThroughAssociation,
+  ...records: Base[]
+): Record<string, unknown> {
+  ensureMutable(assoc);
+  const refl = assoc.reflection as any;
+  const sourceRefl = refl.sourceReflection?.() as any;
+  if (!sourceRefl) return {};
+  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
+  const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
+  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
+
+  let joinAttributes: Record<string, unknown>;
+  if (
+    pkArr.length === compositeConstraints.length &&
+    pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
+    !refl.options?.sourceType
+  ) {
+    joinAttributes = { [sourceRefl.name]: records.length === 1 ? records[0] : records };
+  } else {
+    const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
+    const values = records.map((r: any) =>
+      pkArr.length === 1
+        ? (r.readAttribute?.(pkArr[0]) ?? r.id)
+        : pkArr.map((k: string) => r.readAttribute?.(k)),
+    );
+    joinAttributes = { [fk]: records.length === 1 ? values[0] : values };
+  }
+
+  if (refl.options?.sourceType) {
+    const foreignType: string = sourceRefl.foreignType ?? `${sourceRefl.name}_type`;
+    joinAttributes[foreignType] =
+      records.length === 1 ? refl.options.sourceType : [refl.options.sourceType];
+  }
+  return joinAttributes;
+}
+
+/**
+ * Throws when the source reflection is not a `belongsTo` — Rails treats
+ * such through associations as read-only because mutating the source side
+ * isn't well-defined.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#ensure_mutable
+ *
+ * @internal
+ */
+function ensureMutable(assoc: HasManyThroughAssociation): void {
+  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as { macro?: string } | null;
+  if (sourceRefl && sourceRefl.macro !== "belongsTo") {
+    throw new Error(
+      `Cannot modify association '${assoc.reflection.name}': through associations with a non-belongs-to source are read-only.`,
+    );
+  }
+}
+
+/**
+ * Throws when this through-association points at another through-association
+ * (a "nested through"). Rails treats nested-through chains as read-only.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#ensure_not_nested
+ *
+ * @internal
+ */
+function ensureNotNested(assoc: HasManyThroughAssociation): void {
+  const throughName = assoc.reflection.options.through as string | undefined;
+  if (!throughName) return;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  const throughRefl = ctor._reflectOnAssociation?.(throughName) as {
+    options?: { through?: unknown };
+  } | null;
+  if (throughRefl?.options?.through) {
+    throw new Error(`Nested through associations are read-only.`);
+  }
+}

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -26,12 +26,13 @@ export class HasManyThroughAssociation extends HasManyAssociation {
 
 /** @internal */
 function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base | null {
-  const throughName = assoc.reflection.options.through as string | undefined;
-  if (!throughName) return null;
-  const throughAssoc = (assoc.owner as any).association?.(throughName);
-  if (!throughAssoc) return null;
-  const attrs = buildSourceJoinAttributes(assoc, record);
-  return typeof throughAssoc.build === "function" ? throughAssoc.build(attrs) : null;
+  ensureMutable(assoc);
+  const proxy = throughAssociation(assoc) as {
+    build?: (attrs: Record<string, unknown>) => Base;
+  } | null;
+  if (!proxy) return null;
+  const attrs = constructJoinAttributes(assoc, record);
+  return typeof proxy.build === "function" ? proxy.build(attrs) : null;
 }
 
 /** @internal */
@@ -156,7 +157,7 @@ function throughRecordsFor(assoc: HasManyThroughAssociation, record: Base): Base
 
   // Use constructJoinAttributes to get the FK → PK map for this record,
   // then filter the through-association's in-memory target by those constraints.
-  const joinAttrs = buildSourceJoinAttributes(assoc, record);
+  const joinAttrs = constructJoinAttributes(assoc, record);
   const candidates: Base[] = Array.isArray(throughAssoc.target)
     ? throughAssoc.target
     : throughAssoc.target
@@ -192,40 +193,6 @@ function deleteThroughRecords(assoc: HasManyThroughAssociation, records: Base[])
     }
   }
   return Promise.resolve();
-}
-
-function buildSourceJoinAttributes(
-  assoc: { owner: Base; reflection: any },
-  record: Base,
-): Record<string, unknown> {
-  const refl = assoc.reflection as any;
-  const sourceRefl = refl.sourceReflection?.() as any;
-  if (!sourceRefl) return {};
-  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
-  const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
-
-  let joinAttributes: Record<string, unknown>;
-  if (
-    pkArr.length === compositeConstraints.length &&
-    pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
-    !refl.options?.sourceType
-  ) {
-    joinAttributes = { [sourceRefl.name]: record };
-  } else {
-    const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
-    const pkValues =
-      pkArr.length === 1
-        ? ((record as any).readAttribute?.(pkArr[0]) ?? (record as any).id)
-        : pkArr.map((k: string) => (record as any).readAttribute?.(k));
-    joinAttributes = { [fk]: pkValues };
-  }
-
-  if (refl.options?.sourceType) {
-    const foreignType: string = sourceRefl.foreignType ?? `${sourceRefl.name}_type`;
-    joinAttributes[foreignType] = refl.options.sourceType;
-  }
-  return joinAttributes;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1,6 +1,10 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { HasManyAssociation } from "./has-many-association.js";
+import {
+  HasManyThroughCantAssociateThroughHasOneOrManyReflection,
+  HasManyThroughNestedAssociationsAreReadonly,
+} from "./errors.js";
 
 /**
  * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation
@@ -224,14 +228,9 @@ function buildSourceJoinAttributes(
  * @internal
  */
 function transaction(assoc: HasManyThroughAssociation, block: () => Promise<void>): Promise<void> {
-  const throughName = assoc.reflection.options.through as string | undefined;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  const throughKlass = throughName
-    ? ((ctor._reflectOnAssociation?.(throughName) as { klass?: { transaction?: Function } } | null)
-        ?.klass ?? null)
-    : null;
-  if (throughKlass && typeof throughKlass.transaction === "function") {
-    return throughKlass.transaction(block);
+  const tr = throughReflection(assoc) as { klass?: { transaction?: Function } } | null;
+  if (tr?.klass && typeof tr.klass.transaction === "function") {
+    return tr.klass.transaction(block);
   }
   return block();
 }
@@ -244,16 +243,22 @@ function transaction(assoc: HasManyThroughAssociation, block: () => Promise<void
  * @internal
  */
 function throughReflection(assoc: HasManyThroughAssociation): unknown {
-  const refl = assoc.reflection as {
-    throughReflection?: () => unknown;
-    options: { through?: string };
+  type Refl = {
+    throughReflection?: Refl | null;
+    isThroughReflection?: () => boolean;
+    options?: { through?: string };
   };
-  const direct = refl.throughReflection?.();
-  if (direct) return direct;
-  const throughName = refl.options.through;
-  if (!throughName) return null;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  return ctor._reflectOnAssociation?.(throughName) ?? null;
+  let refl = (assoc.reflection as Refl).throughReflection ?? null;
+  if (!refl) {
+    const throughName = assoc.reflection.options.through as string | undefined;
+    if (!throughName) return null;
+    const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
+    refl = ctor._reflectOnAssociation?.(throughName) ?? null;
+  }
+  while (refl?.isThroughReflection?.() && refl.throughReflection) {
+    refl = refl.throughReflection;
+  }
+  return refl;
 }
 
 /**
@@ -303,10 +308,9 @@ function constructJoinAttributes(
     joinAttributes = { [sourceRefl.name]: records.length === 1 ? records[0] : records };
   } else {
     const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
+    const read = (r: any, k: string) => r._readAttribute?.(k) ?? r.readAttribute?.(k);
     const values = records.map((r: any) =>
-      pkArr.length === 1
-        ? (r.readAttribute?.(pkArr[0]) ?? r.id)
-        : pkArr.map((k: string) => r.readAttribute?.(k)),
+      pkArr.length === 1 ? (read(r, pkArr[0]) ?? r.id) : pkArr.map((k: string) => read(r, k)),
     );
     joinAttributes = { [fk]: records.length === 1 ? values[0] : values };
   }
@@ -329,10 +333,15 @@ function constructJoinAttributes(
  * @internal
  */
 function ensureMutable(assoc: HasManyThroughAssociation): void {
-  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as { macro?: string } | null;
-  if (sourceRefl && sourceRefl.macro !== "belongsTo") {
-    throw new Error(
-      `Cannot modify association '${assoc.reflection.name}': through associations with a non-belongs-to source are read-only.`,
+  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as {
+    isBelongsTo?: () => boolean;
+    macro?: string;
+  } | null;
+  const isBelongs = sourceRefl?.isBelongsTo?.() ?? sourceRefl?.macro === "belongsTo";
+  if (!isBelongs) {
+    throw new HasManyThroughCantAssociateThroughHasOneOrManyReflection(
+      (assoc.owner.constructor as { name: string }).name,
+      assoc.reflection.name,
     );
   }
 }
@@ -346,13 +355,11 @@ function ensureMutable(assoc: HasManyThroughAssociation): void {
  * @internal
  */
 function ensureNotNested(assoc: HasManyThroughAssociation): void {
-  const throughName = assoc.reflection.options.through as string | undefined;
-  if (!throughName) return;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  const throughRefl = ctor._reflectOnAssociation?.(throughName) as {
-    options?: { through?: unknown };
-  } | null;
-  if (throughRefl?.options?.through) {
-    throw new Error(`Nested through associations are read-only.`);
+  const refl = assoc.reflection as { isNested?: () => boolean };
+  if (refl.isNested?.()) {
+    throw new HasManyThroughNestedAssociationsAreReadonly(
+      (assoc.owner.constructor as { name: string }).name,
+      assoc.reflection.name,
+    );
   }
 }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -4,6 +4,7 @@ import { loadHasOne } from "../associations.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { RecordNotSaved } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
+import { ForeignAssociation } from "./foreign-association.js";
 import { SingularAssociation } from "./singular-association.js";
 
 /**
@@ -279,10 +280,14 @@ function transactionIf(
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasOneAssociation): Record<string, null> {
-  const refl = assoc.reflection as unknown as { foreignKey: string | string[]; type?: string };
-  const attrs: Record<string, null> = {};
-  const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
-  for (const fk of fks) attrs[fk] = null;
-  if (refl.type) attrs[refl.type] = null;
-  return attrs;
+  const opts = assoc.reflection.options as {
+    foreignKey?: string | string[];
+    as?: string;
+  };
+  const ctor = assoc.owner.constructor as { name: string };
+  const asName = opts.as;
+  const foreignKey =
+    opts.foreignKey ?? (asName ? `${underscore(asName)}_id` : `${underscore(ctor.name)}_id`);
+  const typeCol = asName ? `${underscore(asName)}_type` : null;
+  return ForeignAssociation.nullifiedOwnerAttributes({ foreignKey, type: typeCol });
 }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -217,23 +217,15 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private nullifyOwnerAttributes(record: Base): void {
-    const fks = Array.isArray(this.reflection.options.foreignKey)
-      ? this.reflection.options.foreignKey
-      : [this.foreignKeyColumn()];
-    for (const fk of fks) {
+    // Source the column list from the Rails-named helper so custom
+    // foreignKey/foreignType (incl. composite PKs and polymorphic `as`)
+    // honor the same derivation rules used by reflection itself.
+    const attrs = nullifiedOwnerAttributes(this);
+    for (const col of Object.keys(attrs)) {
       if (typeof (record as any)._writeAttribute === "function") {
-        (record as any)._writeAttribute(fk, null);
+        (record as any)._writeAttribute(col, null);
       } else {
-        (record as any)[fk] = null;
-      }
-    }
-
-    if (this.reflection.options.as) {
-      const typeCol = `${underscore(this.reflection.options.as)}_type`;
-      if (typeof (record as any)._writeAttribute === "function") {
-        (record as any)._writeAttribute(typeCol, null);
-      } else {
-        (record as any)[typeCol] = null;
+        (record as any)[col] = null;
       }
     }
   }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -268,3 +268,21 @@ function transactionIf(
   }
   return block();
 }
+
+/**
+ * Build the attribute hash that nullifies the owner-side foreign key (and
+ * polymorphic type column, when applicable) on the dependent record — used
+ * by `dependent: :nullify` to drop the FK without destroying the row.
+ *
+ * Mirrors: ActiveRecord::Associations::ForeignAssociation#nullified_owner_attributes
+ *
+ * @internal
+ */
+function nullifiedOwnerAttributes(assoc: HasOneAssociation): Record<string, null> {
+  const refl = assoc.reflection as unknown as { foreignKey: string | string[]; type?: string };
+  const attrs: Record<string, null> = {};
+  const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
+  for (const fk of fks) attrs[fk] = null;
+  if (refl.type) attrs[refl.type] = null;
+  return attrs;
+}

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -280,14 +280,30 @@ function transactionIf(
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasOneAssociation): Record<string, null> {
-  const opts = assoc.reflection.options as {
-    foreignKey?: string | string[];
-    as?: string;
+  // Resolve the rich reflection so foreignKey expansion (composite PKs,
+  // primaryKey overrides, polymorphic foreignType) matches what the
+  // association itself uses. Fall back to the HasOneAssociation's own
+  // foreignKeyColumns() derivation, then to options-based defaults.
+  const ctor = assoc.owner.constructor as {
+    name: string;
+    _reflectOnAssociation?: (n: string) => {
+      foreignKey?: string | string[];
+      foreignType?: string;
+    } | null;
   };
-  const ctor = assoc.owner.constructor as { name: string };
-  const asName = opts.as;
-  const foreignKey =
-    opts.foreignKey ?? (asName ? `${underscore(asName)}_id` : `${underscore(ctor.name)}_id`);
-  const typeCol = asName ? `${underscore(asName)}_type` : null;
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name) ?? null;
+  let foreignKey: string | string[] | undefined = refl?.foreignKey;
+  const reflTypeCol: string | null = refl?.foreignType ?? null;
+  if (foreignKey == null) {
+    const fks = (assoc as unknown as { foreignKeyColumns?: () => string[] }).foreignKeyColumns?.();
+    if (fks?.length) foreignKey = fks;
+  }
+  if (foreignKey == null) {
+    const opts = assoc.reflection.options as { foreignKey?: string | string[]; as?: string };
+    foreignKey =
+      opts.foreignKey ?? (opts.as ? `${underscore(opts.as)}_id` : `${underscore(ctor.name)}_id`);
+  }
+  const asName = assoc.reflection.options.as;
+  const typeCol = reflTypeCol ?? (asName ? `${underscore(asName)}_type` : null);
   return ForeignAssociation.nullifiedOwnerAttributes({ foreignKey, type: typeCol });
 }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -170,8 +170,9 @@ function constructJoinAttributes(
   ...records: Base[]
 ): Record<string, unknown> {
   ensureMutable(assoc);
-  const refl = assoc.reflection as any;
-  const sourceRefl = refl.sourceReflection?.() as any;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
+  const sourceRefl = refl?.sourceReflection as any;
   if (!sourceRefl) return {};
   const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
@@ -211,10 +212,11 @@ function constructJoinAttributes(
  * @internal
  */
 function ensureMutable(assoc: HasOneThroughAssociation): void {
-  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as {
-    isBelongsTo?: () => boolean;
-    macro?: string;
-  } | null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
+  const sourceRefl = refl?.sourceReflection as
+    | { isBelongsTo?: () => boolean; macro?: string }
+    | undefined;
   const isBelongs = sourceRefl?.isBelongsTo?.() ?? sourceRefl?.macro === "belongsTo";
   if (!isBelongs) {
     throw new HasOneThroughCantAssociateThroughHasOneOrManyReflection(
@@ -233,8 +235,11 @@ function ensureMutable(assoc: HasOneThroughAssociation): void {
  * @internal
  */
 function ensureNotNested(assoc: HasOneThroughAssociation): void {
-  const refl = assoc.reflection as { isNested?: () => boolean };
-  if (refl.isNested?.()) {
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name) as {
+    isNested?: () => boolean;
+  } | null;
+  if (refl?.isNested?.()) {
     throw new HasOneThroughNestedAssociationsAreReadonly(
       (assoc.owner.constructor as { name: string }).name,
       assoc.reflection.name,

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -104,13 +104,16 @@ function buildJoinAttributes(
  *
  * @internal
  */
-function transaction(assoc: HasOneThroughAssociation, block: () => Promise<void>): Promise<void> {
+function transaction<R>(
+  assoc: HasOneThroughAssociation,
+  block: (tx?: any) => Promise<R>,
+): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
   const klass = safeKlass(tr) as { transaction?: Function } | null;
   if (klass && typeof klass.transaction === "function") {
-    return klass.transaction(block);
+    return klass.transaction(block) as Promise<R | undefined>;
   }
-  return block();
+  return block() as Promise<R | undefined>;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -1,6 +1,10 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { HasOneAssociation } from "./has-one-association.js";
+import {
+  HasOneThroughCantAssociateThroughHasOneOrManyReflection,
+  HasOneThroughNestedAssociationsAreReadonly,
+} from "./errors.js";
 
 /**
  * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation
@@ -103,14 +107,9 @@ function buildJoinAttributes(
  * @internal
  */
 function transaction(assoc: HasOneThroughAssociation, block: () => Promise<void>): Promise<void> {
-  const throughName = assoc.reflection.options.through as string | undefined;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  const throughKlass = throughName
-    ? ((ctor._reflectOnAssociation?.(throughName) as { klass?: { transaction?: Function } } | null)
-        ?.klass ?? null)
-    : null;
-  if (throughKlass && typeof throughKlass.transaction === "function") {
-    return throughKlass.transaction(block);
+  const tr = throughReflection(assoc) as { klass?: { transaction?: Function } } | null;
+  if (tr?.klass && typeof tr.klass.transaction === "function") {
+    return tr.klass.transaction(block);
   }
   return block();
 }
@@ -123,16 +122,22 @@ function transaction(assoc: HasOneThroughAssociation, block: () => Promise<void>
  * @internal
  */
 function throughReflection(assoc: HasOneThroughAssociation): unknown {
-  const refl = assoc.reflection as {
-    throughReflection?: () => unknown;
-    options: { through?: string };
+  type Refl = {
+    throughReflection?: Refl | null;
+    isThroughReflection?: () => boolean;
+    options?: { through?: string };
   };
-  const direct = refl.throughReflection?.();
-  if (direct) return direct;
-  const throughName = refl.options.through;
-  if (!throughName) return null;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  return ctor._reflectOnAssociation?.(throughName) ?? null;
+  let refl = (assoc.reflection as Refl).throughReflection ?? null;
+  if (!refl) {
+    const throughName = assoc.reflection.options.through as string | undefined;
+    if (!throughName) return null;
+    const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
+    refl = ctor._reflectOnAssociation?.(throughName) ?? null;
+  }
+  while (refl?.isThroughReflection?.() && refl.throughReflection) {
+    refl = refl.throughReflection;
+  }
+  return refl;
 }
 
 /**
@@ -181,10 +186,9 @@ function constructJoinAttributes(
     joinAttributes = { [sourceRefl.name]: records.length === 1 ? records[0] : records };
   } else {
     const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
+    const read = (r: any, k: string) => r._readAttribute?.(k) ?? r.readAttribute?.(k);
     const values = records.map((r: any) =>
-      pkArr.length === 1
-        ? (r.readAttribute?.(pkArr[0]) ?? r.id)
-        : pkArr.map((k: string) => r.readAttribute?.(k)),
+      pkArr.length === 1 ? (read(r, pkArr[0]) ?? r.id) : pkArr.map((k: string) => read(r, k)),
     );
     joinAttributes = { [fk]: records.length === 1 ? values[0] : values };
   }
@@ -207,10 +211,15 @@ function constructJoinAttributes(
  * @internal
  */
 function ensureMutable(assoc: HasOneThroughAssociation): void {
-  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as { macro?: string } | null;
-  if (sourceRefl && sourceRefl.macro !== "belongsTo") {
-    throw new Error(
-      `Cannot modify association '${assoc.reflection.name}': through associations with a non-belongs-to source are read-only.`,
+  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as {
+    isBelongsTo?: () => boolean;
+    macro?: string;
+  } | null;
+  const isBelongs = sourceRefl?.isBelongsTo?.() ?? sourceRefl?.macro === "belongsTo";
+  if (!isBelongs) {
+    throw new HasOneThroughCantAssociateThroughHasOneOrManyReflection(
+      (assoc.owner.constructor as { name: string }).name,
+      assoc.reflection.name,
     );
   }
 }
@@ -224,13 +233,11 @@ function ensureMutable(assoc: HasOneThroughAssociation): void {
  * @internal
  */
 function ensureNotNested(assoc: HasOneThroughAssociation): void {
-  const throughName = assoc.reflection.options.through as string | undefined;
-  if (!throughName) return;
-  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
-  const throughRefl = ctor._reflectOnAssociation?.(throughName) as {
-    options?: { through?: unknown };
-  } | null;
-  if (throughRefl?.options?.through) {
-    throw new Error(`Nested through associations are read-only.`);
+  const refl = assoc.reflection as { isNested?: () => boolean };
+  if (refl.isNested?.()) {
+    throw new HasOneThroughNestedAssociationsAreReadonly(
+      (assoc.owner.constructor as { name: string }).name,
+      assoc.reflection.name,
+    );
   }
 }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -5,6 +5,15 @@ import {
   HasOneThroughCantAssociateThroughHasOneOrManyReflection,
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
+import { compositeQueryConstraintsList } from "../persistence.js";
+
+function safeKlass(refl: { klass?: unknown } | null | undefined): any {
+  try {
+    return refl?.klass ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation
@@ -107,9 +116,10 @@ function buildJoinAttributes(
  * @internal
  */
 function transaction(assoc: HasOneThroughAssociation, block: () => Promise<void>): Promise<void> {
-  const tr = throughReflection(assoc) as { klass?: { transaction?: Function } } | null;
-  if (tr?.klass && typeof tr.klass.transaction === "function") {
-    return tr.klass.transaction(block);
+  const tr = throughReflection(assoc) as { klass?: unknown } | null;
+  const klass = safeKlass(tr) as { transaction?: Function } | null;
+  if (klass && typeof klass.transaction === "function") {
+    return klass.transaction(block);
   }
   return block();
 }
@@ -174,9 +184,17 @@ function constructJoinAttributes(
   const refl = ctor._reflectOnAssociation?.(assoc.reflection.name);
   const sourceRefl = refl?.sourceReflection as any;
   if (!sourceRefl) return {};
-  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
+  const reflKlass = safeKlass(refl);
+  const assocPk =
+    (typeof sourceRefl.associationPrimaryKeyFor === "function"
+      ? sourceRefl.associationPrimaryKeyFor(reflKlass)
+      : sourceRefl.associationPrimaryKey) ??
+    sourceRefl.primaryKey ??
+    "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
+  const compositeConstraints: string[] = reflKlass
+    ? compositeQueryConstraintsList.call(reflKlass)
+    : [];
 
   let joinAttributes: Record<string, unknown>;
   if (

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -30,7 +30,7 @@ async function createThroughRecord(
   record: Base | null,
   save: boolean,
 ): Promise<Base | null> {
-  ensureNotNestedThrough(assoc);
+  ensureNotNested(assoc);
 
   const throughName = assoc.reflection.options.through as string | undefined;
   if (!throughName) return null;
@@ -60,17 +60,6 @@ async function createThroughRecord(
     }
   }
   return record;
-}
-
-function ensureNotNestedThrough(assoc: { reflection: any; owner: Base }): void {
-  if (assoc.reflection.options.through) {
-    const throughRefl = (assoc.owner.constructor as any)._reflectOnAssociation?.(
-      assoc.reflection.options.through,
-    );
-    if (throughRefl?.options?.through) {
-      throw new Error(`Nested through associations are read-only.`);
-    }
-  }
 }
 
 function buildJoinAttributes(

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -45,7 +45,8 @@ async function createThroughRecord(
   }
 
   if (record) {
-    const attrs = buildJoinAttributes(assoc, record);
+    ensureMutable(assoc);
+    const attrs = constructJoinAttributes(assoc, record);
 
     if (throughRecord) {
       if ((throughRecord as any).isNewRecord?.()) {
@@ -60,40 +61,6 @@ async function createThroughRecord(
     }
   }
   return record;
-}
-
-function buildJoinAttributes(
-  assoc: { owner: Base; reflection: any },
-  record: Base,
-): Record<string, unknown> {
-  const refl = assoc.reflection as any;
-  const sourceRefl = refl.sourceReflection?.() as any;
-  if (!sourceRefl) return {};
-  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
-  const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
-
-  let joinAttributes: Record<string, unknown>;
-  if (
-    pkArr.length === compositeConstraints.length &&
-    pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
-    !refl.options?.sourceType
-  ) {
-    joinAttributes = { [sourceRefl.name]: record };
-  } else {
-    const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
-    const pkVal =
-      pkArr.length === 1
-        ? ((record as any).readAttribute?.(pkArr[0]) ?? (record as any).id)
-        : pkArr.map((k: string) => (record as any).readAttribute?.(k));
-    joinAttributes = { [fk]: pkVal };
-  }
-
-  if (refl.options?.sourceType) {
-    const foreignType: string = sourceRefl.foreignType ?? `${sourceRefl.name}_type`;
-    joinAttributes[foreignType] = refl.options.sourceType;
-  }
-  return joinAttributes;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -93,3 +93,144 @@ function buildJoinAttributes(
   }
   return joinAttributes;
 }
+
+/**
+ * Wrap `block` in a transaction on the through-reflection's class. Falls
+ * back to invoking the block directly when no through klass is available.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
+ *
+ * @internal
+ */
+function transaction(assoc: HasOneThroughAssociation, block: () => Promise<void>): Promise<void> {
+  const throughName = assoc.reflection.options.through as string | undefined;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  const throughKlass = throughName
+    ? ((ctor._reflectOnAssociation?.(throughName) as { klass?: { transaction?: Function } } | null)
+        ?.klass ?? null)
+    : null;
+  if (throughKlass && typeof throughKlass.transaction === "function") {
+    return throughKlass.transaction(block);
+  }
+  return block();
+}
+
+/**
+ * Resolves the AssociationReflection for the `:through` join model.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#through_reflection
+ *
+ * @internal
+ */
+function throughReflection(assoc: HasOneThroughAssociation): unknown {
+  const refl = assoc.reflection as {
+    throughReflection?: () => unknown;
+    options: { through?: string };
+  };
+  const direct = refl.throughReflection?.();
+  if (direct) return direct;
+  const throughName = refl.options.through;
+  if (!throughName) return null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  return ctor._reflectOnAssociation?.(throughName) ?? null;
+}
+
+/**
+ * Returns the live Association wrapper that owns the join model — i.e.,
+ * `owner.association(throughReflection.name)`.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#through_association
+ *
+ * @internal
+ */
+function throughAssociation(assoc: HasOneThroughAssociation): unknown {
+  const tr = throughReflection(assoc) as { name?: string } | null;
+  if (!tr?.name) return null;
+  return (assoc.owner as unknown as { association?: (n: string) => unknown }).association?.(
+    tr.name,
+  );
+}
+
+/**
+ * Build the join-table attribute hash pairing `record` with the owner via
+ * the source reflection's foreign key (or the source association name when
+ * the join is composite-keyed). Used when constructing through records.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#construct_join_attributes
+ *
+ * @internal
+ */
+function constructJoinAttributes(
+  assoc: HasOneThroughAssociation,
+  ...records: Base[]
+): Record<string, unknown> {
+  ensureMutable(assoc);
+  const refl = assoc.reflection as any;
+  const sourceRefl = refl.sourceReflection?.() as any;
+  if (!sourceRefl) return {};
+  const assocPk = sourceRefl.associationPrimaryKey?.(refl.klass) ?? sourceRefl.primaryKey ?? "id";
+  const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
+  const compositeConstraints: string[] = refl.klass?.compositeQueryConstraintsList ?? [];
+
+  let joinAttributes: Record<string, unknown>;
+  if (
+    pkArr.length === compositeConstraints.length &&
+    pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
+    !refl.options?.sourceType
+  ) {
+    joinAttributes = { [sourceRefl.name]: records.length === 1 ? records[0] : records };
+  } else {
+    const fk: string = sourceRefl.foreignKey ?? `${sourceRefl.name}_id`;
+    const values = records.map((r: any) =>
+      pkArr.length === 1
+        ? (r.readAttribute?.(pkArr[0]) ?? r.id)
+        : pkArr.map((k: string) => r.readAttribute?.(k)),
+    );
+    joinAttributes = { [fk]: records.length === 1 ? values[0] : values };
+  }
+
+  if (refl.options?.sourceType) {
+    const foreignType: string = sourceRefl.foreignType ?? `${sourceRefl.name}_type`;
+    joinAttributes[foreignType] =
+      records.length === 1 ? refl.options.sourceType : [refl.options.sourceType];
+  }
+  return joinAttributes;
+}
+
+/**
+ * Throws when the source reflection is not a `belongsTo` — through
+ * associations with a non-belongsTo source are read-only because mutating
+ * the source side isn't well-defined.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#ensure_mutable
+ *
+ * @internal
+ */
+function ensureMutable(assoc: HasOneThroughAssociation): void {
+  const sourceRefl = (assoc.reflection as any).sourceReflection?.() as { macro?: string } | null;
+  if (sourceRefl && sourceRefl.macro !== "belongsTo") {
+    throw new Error(
+      `Cannot modify association '${assoc.reflection.name}': through associations with a non-belongs-to source are read-only.`,
+    );
+  }
+}
+
+/**
+ * Throws when this through-association points at another through-association
+ * (a "nested through"). Rails treats nested-through chains as read-only.
+ *
+ * Mirrors: ActiveRecord::Associations::ThroughAssociation#ensure_not_nested
+ *
+ * @internal
+ */
+function ensureNotNested(assoc: HasOneThroughAssociation): void {
+  const throughName = assoc.reflection.options.through as string | undefined;
+  if (!throughName) return;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => unknown };
+  const throughRefl = ctor._reflectOnAssociation?.(throughName) as {
+    options?: { through?: unknown };
+  } | null;
+  if (throughRefl?.options?.through) {
+    throw new Error(`Nested through associations are read-only.`);
+  }
+}

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -45,7 +45,8 @@ async function createThroughRecord(
   }
 
   if (record) {
-    ensureMutable(assoc);
+    // Mutability is enforced inside constructJoinAttributes — keep the
+    // precondition in one place.
     const attrs = constructJoinAttributes(assoc, record);
 
     if (throughRecord) {
@@ -91,16 +92,19 @@ function transaction<R>(
  * @internal
  */
 function throughReflection(assoc: HasOneThroughAssociation): unknown {
+  // Resolve the rich reflection first — assoc.reflection is the
+  // AssociationDefinition (no throughReflection getter), so we need
+  // ThroughReflection#throughReflection from the registry.
   type Refl = {
     throughReflection?: Refl | null;
     isThroughReflection?: () => boolean;
-    options?: { through?: string };
   };
-  let refl = (assoc.reflection as Refl).throughReflection ?? null;
+  const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
+  let refl: Refl | null =
+    (ctor._reflectOnAssociation?.(assoc.reflection.name) as Refl | null)?.throughReflection ?? null;
   if (!refl) {
     const throughName = assoc.reflection.options.through as string | undefined;
     if (!throughName) return null;
-    const ctor = assoc.owner.constructor as { _reflectOnAssociation?: (n: string) => Refl | null };
     refl = ctor._reflectOnAssociation?.(throughName) ?? null;
   }
   while (refl?.isThroughReflection?.() && refl.throughReflection) {


### PR DESCRIPTION
## Summary

Brings 5 association files to 100% on `pnpm api:compare --package activerecord`:

- **associations.rb**: implement `initInternals` (clears `_associationInstances` / `_collectionProxies` / `_preloadedAssociations`), `associationInstanceGet`, `associationInstanceSet` (previously stubs throwing `NotImplementedError`). Both get/set operate on the canonical `_associationInstances` cache only — matches Rails' single `@association_cache` and how `instance-methods.ts:association()` populates it. The Trails-specific `_collectionProxies` map is a separate user-facing layer and is intentionally not consulted from these helpers.
- **has_many_association.rb** + **has_one_association.rb**: add `nullifiedOwnerAttributes`, derived from the rich reflection's `foreignKey` / `foreignType` (with composite-PK / `as` / options fallbacks). Wired into the runtime: `HasOneAssociation.nullifyOwnerAttributes(record)` sources its column list from it, and `HasManyAssociation` overrides `CollectionAssociation.computeNullifiedOwnerAttributes()` so `dependent: :nullify` bulk updates honor it.
- **has_many_through_association.rb** + **has_one_through_association.rb**: add the 6 `ThroughAssociation` methods — `transaction`, `throughReflection`, `throughAssociation`, `constructJoinAttributes`, `ensureMutable`, `ensureNotNested`. The duplicate `buildSourceJoinAttributes` / `buildJoinAttributes` helpers are removed; existing `buildThroughRecord` / `createThroughRecord` / `throughRecordsFor` now route through `constructJoinAttributes` (which enforces `ensureMutable`), and through-association proxies are looked up via `throughAssociation()`.

## Test plan

- [x] `pnpm api:compare --package activerecord` shows all 5 files at 100%
- [x] `pnpm --filter @blazetrails/activerecord build` clean (no new src TS errors)
- [x] has-many/has-one (through + non-through) association tests pass