### PR TITLE
fix(arel): PR E — reparent Lateral, GroupingElement, Cube, RollUp, GroupingSet to Unary

### DIFF
--- a/packages/arel/src/nodes/unary-reparent.test.ts
+++ b/packages/arel/src/nodes/unary-reparent.test.ts
@@ -25,6 +25,53 @@ describe("Unary reparenting (Rails fidelity)", () => {
     });
   });
 
+  describe("Lateral extends Unary", () => {
+    const inner = new Nodes.Quoted(1);
+    it("instanceof Unary", () => {
+      expect(new Nodes.Lateral(inner)).toBeInstanceOf(Nodes.Unary);
+    });
+
+    it("stores the subquery in expr (Rails: visit reads o.expr)", () => {
+      const lat = new Nodes.Lateral(inner);
+      expect(lat.expr).toBe(inner);
+    });
+
+    it("subquery getter returns expr (back-compat)", () => {
+      const lat = new Nodes.Lateral(inner);
+      expect(lat.subquery).toBe(lat.expr);
+    });
+  });
+
+  describe("GroupingElement / Cube / RollUp / GroupingSet extend Unary", () => {
+    it.each([
+      ["GroupingElement", (vs: Nodes.Node[]) => new Nodes.GroupingElement(vs)],
+      ["Cube", (vs: Nodes.Node[]) => new Nodes.Cube(vs)],
+      ["RollUp", (vs: Nodes.Node[]) => new Nodes.RollUp(vs)],
+      ["GroupingSet", (vs: Nodes.Node[]) => new Nodes.GroupingSet(vs)],
+    ])("%s instanceof Unary", (_name, build) => {
+      const node = build([new Nodes.Quoted(1), new Nodes.Quoted(2)]);
+      expect(node).toBeInstanceOf(Nodes.Unary);
+    });
+
+    it("stores children in expr (Rails: visit reads o.expr)", () => {
+      const a = new Nodes.Quoted(1);
+      const b = new Nodes.Quoted(2);
+      const ge = new Nodes.GroupingElement([a, b]);
+      expect(ge.expr).toEqual([a, b]);
+    });
+
+    it("expressions getter returns expr (back-compat)", () => {
+      const ge = new Nodes.GroupingElement([new Nodes.Quoted(1)]);
+      expect(ge.expressions).toBe(ge.expr);
+    });
+
+    it("normalises a single Node into an array (preserved behaviour)", () => {
+      const single = new Nodes.Quoted(1);
+      const ge = new Nodes.GroupingElement(single);
+      expect(ge.expressions).toEqual([single]);
+    });
+  });
+
   describe("Window framing nodes extend Unary", () => {
     it.each([
       ["Rows", () => new Nodes.Rows(new Nodes.Quoted(1))],

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -32,54 +32,43 @@ export class Not extends Unary {
   }
 }
 
-export class Lateral extends Node {
-  readonly subquery: Node;
-
+// Mirrors Rails: `Lateral < Unary` (unary.rb). The subquery node lives in
+// the inherited `expr` slot — Rails' visit_Arel_Nodes_Lateral reads `o.expr`
+// (postgresql.rb). Keep `subquery` as a back-compat getter for the existing
+// Trails visitor which already reads `node.subquery`.
+export class Lateral extends Unary {
+  declare readonly expr: Node;
   constructor(subquery: Node) {
-    super();
-    this.subquery = subquery;
+    super(subquery);
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+  get subquery(): Node {
+    return this.expr;
   }
 }
 
-export class GroupingElement extends Node {
-  readonly expressions: Node[];
-
+// Mirrors Rails: `GroupingElement < Unary` (unary.rb). Children live in the
+// inherited `expr` slot — Rails' visitors read `o.expr` (postgresql.rb).
+// `expressions` is preserved as a getter for back-compat with the existing
+// Trails visitor accessors. Trails always normalises to an array; Rails'
+// `grouping_array_or_grouping_element` then branches on `is_a? Array`.
+export class GroupingElement extends Unary {
+  declare readonly expr: Node[];
   constructor(expressions: Node | Node[]) {
-    super();
-    this.expressions = Array.isArray(expressions) ? expressions : [expressions];
+    super(Array.isArray(expressions) ? expressions : [expressions]);
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
+  get expressions(): Node[] {
+    return this.expr;
   }
 }
 
-export class Cube extends GroupingElement {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
-
-export class RollUp extends GroupingElement {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class Cube extends GroupingElement {}
+export class RollUp extends GroupingElement {}
+export class GroupingSet extends GroupingElement {}
 
 /** @deprecated Use RollUp (Rails casing) */
 export const Rollup = RollUp;
 /** @deprecated Use RollUp (Rails casing) */
 export type Rollup = RollUp;
-
-export class GroupingSet extends GroupingElement {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
 
 export class Group extends Unary {}
 /**


### PR DESCRIPTION
## Summary
Rails (`unary.rb`) declares all five via `const_set(name, Class.new(Unary))`, so each `< Unary < NodeExpression`. Trails previously had them extend `Node` directly, which (a) skipped the `Predications`/`Math`/`AliasPredication`/`OrderPredications` mixins and (b) stored their child(ren) in dedicated `subquery` / `expressions` fields rather than the inherited `expr` slot that Rails' visitors read via `o.expr` (`postgresql.rb`).

This PR reparents all five to `Unary` while preserving the existing visitor accessors via getters:
- `Lateral.subquery` → getter returning `expr`
- `GroupingElement.expressions` → getter returning `expr` (Cube / RollUp / GroupingSet inherit from GroupingElement)

The single-Node ctor argument is still normalised into an array, so existing visitor sites that iterate `node.expressions` keep working.

This completes the Unary-reparenting work begun in PR D (#1126). `Window` framing nodes done in PR D, `Not` done in PR D, the rest done here.

## Test plan
- [x] New `unary-reparent.test.ts` cases pinning instanceof Unary, `expr` storage, getter back-compat, single-Node→array normalisation
- [x] `pnpm vitest run --project other packages/arel` — 1389 passing
- [x] `pnpm vitest run --project activerecord packages/activerecord/src/relation` — 1379 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm api:compare --package arel` — `unary.rb` 3/3; overall 884/884
- [x] `pnpm test:compare` — delta 0