### PR TITLE
fix(activemodel): pass through validator options + with.ts arity (P15)

### DIFF
--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -1,5 +1,6 @@
 import { Errors } from "./errors.js";
 import type { ConditionalOptions } from "./validator.js";
+import { VALIDATOR_DEFAULT_KEYS } from "./validator.js";
 import { I18n } from "./i18n.js";
 
 import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
@@ -362,7 +363,7 @@ export function _mergeAttributes(attrNames: unknown[]): Record<string, unknown> 
  * @internal Rails-private helper.
  */
 export function _validatesDefaultKeys(): string[] {
-  return ["if", "unless", "on", "allowBlank", "allowNil", "strict", "exceptOn"];
+  return [...VALIDATOR_DEFAULT_KEYS];
 }
 
 /**

--- a/packages/activemodel/src/validations/absence-validation.test.ts
+++ b/packages/activemodel/src/validations/absence-validation.test.ts
@@ -65,4 +65,16 @@ describe("AbsenceValidationTest", () => {
     expect(p.errors.get("name").length).toBeGreaterThan(0);
     expect(p.errors.get("email").length).toBeGreaterThan(0);
   });
+
+  it("passes custom interpolation vars through to errors.add", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { absence: { message: "must be %{kind}", kind: "empty" } });
+      }
+    }
+    const p = new Person({ name: "Alice" });
+    p.isValid();
+    expect(p.errors.get("name")).toContain("must be empty");
+  });
 });

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -25,7 +25,7 @@ export interface HelperMethods {
 export class AbsenceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (!isBlank(value)) {
-      record.errors.add(attribute, "present", this.filteredOptions());
+      record.errors.add(attribute, "present", this.filteredErrorOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -25,7 +25,7 @@ export interface HelperMethods {
 export class AbsenceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (!isBlank(value)) {
-      record.errors.add(attribute, "present", { message: this.options.message });
+      record.errors.add(attribute, "present", this.filteredOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -195,3 +195,31 @@ describe("acceptance skips nil", () => {
     expect(new Terms({}).isValid()).toBe(true);
   });
 });
+
+describe("acceptance options pass-through", () => {
+  it("passes custom interpolation vars through to errors.add", () => {
+    class Terms extends Model {
+      static {
+        this.attribute("terms", "string");
+        this.validates("terms", {
+          acceptance: { accept: "yes", message: "must be %{kind}", kind: "accepted" },
+        });
+      }
+    }
+    const t = new Terms({ terms: "no" });
+    t.isValid();
+    expect(t.errors.get("terms")).toContain("must be accepted");
+  });
+
+  it("reserved key accept does not appear in error options", () => {
+    class Terms extends Model {
+      static {
+        this.attribute("terms", "string");
+        this.validates("terms", { acceptance: { accept: "yes" } });
+      }
+    }
+    const t = new Terms({ terms: "no" });
+    t.isValid();
+    expect(t.errors.details.find((d) => d.attribute === "terms")?.options?.accept).toBeUndefined();
+  });
+});

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -220,6 +220,7 @@ describe("acceptance options pass-through", () => {
     }
     const t = new Terms({ terms: "no" });
     t.isValid();
+    expect(t.errors.count).toBeGreaterThan(0);
     expect(t.errors.details.find((d) => d.attribute === "terms")?.options?.accept).toBeUndefined();
   });
 });

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -55,7 +55,7 @@ export class AcceptanceValidator extends EachValidator {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
     if (!this.isAcceptableOption(value)) {
-      record.errors.add(attribute, "accepted", this.filteredOptions(["accept", "allowNil"]));
+      record.errors.add(attribute, "accepted", this.filteredErrorOptions(["accept", "allowNil"]));
     }
   }
 

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -55,7 +55,7 @@ export class AcceptanceValidator extends EachValidator {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
     if (!this.isAcceptableOption(value)) {
-      record.errors.add(attribute, "accepted", { message: this.options.message });
+      record.errors.add(attribute, "accepted", this.filteredOptions(["accept", "allowNil"]));
     }
   }
 

--- a/packages/activemodel/src/validations/confirmation-validation.test.ts
+++ b/packages/activemodel/src/validations/confirmation-validation.test.ts
@@ -204,6 +204,7 @@ describe("confirmation options pass-through", () => {
     const u = new User({ title: "alice" });
     u._attributes.set("titleConfirmation", "bob");
     u.isValid();
+    expect(u.errors.count).toBeGreaterThan(0);
     expect(
       u.errors.details.find((d) => d.attribute === "titleConfirmation")?.options?.caseSensitive,
     ).toBeUndefined();

--- a/packages/activemodel/src/validations/confirmation-validation.test.ts
+++ b/packages/activemodel/src/validations/confirmation-validation.test.ts
@@ -177,3 +177,35 @@ describe("ConfirmationValidator caseSensitive", () => {
     expect(u.isValid()).toBe(false);
   });
 });
+
+describe("confirmation options pass-through", () => {
+  it("passes custom interpolation vars through to errors.add", () => {
+    class User extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", {
+          confirmation: { message: "must match %{kind}", kind: "original" },
+        });
+      }
+    }
+    const u = new User({ title: "alice" });
+    u._attributes.set("titleConfirmation", "bob");
+    u.isValid();
+    expect(u.errors.get("titleConfirmation")).toContain("must match original");
+  });
+
+  it("reserved key caseSensitive does not appear in error options", () => {
+    class User extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { confirmation: { caseSensitive: false } });
+      }
+    }
+    const u = new User({ title: "alice" });
+    u._attributes.set("titleConfirmation", "bob");
+    u.isValid();
+    expect(
+      u.errors.details.find((d) => d.attribute === "titleConfirmation")?.options?.caseSensitive,
+    ).toBeUndefined();
+  });
+});

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -22,7 +22,7 @@ export class ConfirmationValidator extends EachValidator {
         ? modelClass.humanAttributeName(attribute)
         : humanize(attribute);
       record.errors.add(confirmationAttr, "confirmation", {
-        ...this.filteredOptions(["caseSensitive"]),
+        ...this.filteredErrorOptions(["caseSensitive"]),
         attribute: humanAttr,
       });
     }

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -22,7 +22,7 @@ export class ConfirmationValidator extends EachValidator {
         ? modelClass.humanAttributeName(attribute)
         : humanize(attribute);
       record.errors.add(confirmationAttr, "confirmation", {
-        message: this.options.message,
+        ...this.filteredOptions(["caseSensitive"]),
         attribute: humanAttr,
       });
     }

--- a/packages/activemodel/src/validations/presence-validation.test.ts
+++ b/packages/activemodel/src/validations/presence-validation.test.ts
@@ -88,4 +88,16 @@ describe("PresenceValidationTest", () => {
     p.isValid();
     expect(p.errors.get("name")).toContain("is required!");
   });
+
+  it("passes custom interpolation vars through to errors.add", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { presence: { message: "is %{kind}", kind: "wrong" } });
+      }
+    }
+    const p = new Person({});
+    p.isValid();
+    expect(p.errors.get("name")).toContain("is wrong");
+  });
 });

--- a/packages/activemodel/src/validations/presence-validation.test.ts
+++ b/packages/activemodel/src/validations/presence-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "../index.js";
+import { Model, StrictValidationFailed } from "../index.js";
 
 describe("PresenceValidationTest", () => {
   it("accepts array arguments", () => {
@@ -99,5 +99,15 @@ describe("PresenceValidationTest", () => {
     const p = new Person({});
     p.isValid();
     expect(p.errors.get("name")).toContain("is wrong");
+  });
+
+  it("strict: true raises StrictValidationFailed via filteredErrorOptions", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validates("name", { presence: { strict: true } });
+      }
+    }
+    expect(() => new Person({}).isValid()).toThrow(StrictValidationFailed);
   });
 });

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -5,7 +5,7 @@ import { isBlank } from "@blazetrails/activesupport";
 export class PresenceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (isBlank(value)) {
-      record.errors.add(attribute, "blank", { message: this.options.message });
+      record.errors.add(attribute, "blank", this.filteredOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -5,7 +5,7 @@ import { isBlank } from "@blazetrails/activesupport";
 export class PresenceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (isBlank(value)) {
-      record.errors.add(attribute, "blank", this.filteredOptions());
+      record.errors.add(attribute, "blank", this.filteredErrorOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -294,12 +294,14 @@ describe("WithValidator arity dispatch", () => {
   });
 
   it("calls one-arity method with attribute name", () => {
-    const spy = vi.fn();
-    const record = { myCheck: spy };
+    let capturedArg: unknown;
+    const record = {
+      myCheck(attr: string) {
+        capturedArg = attr;
+      },
+    };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
-    // Give the spy a declared parameter so Function.length === 1
-    Object.defineProperty(spy, "length", { value: 1 });
     validator.validateEach(record, "name", "value");
-    expect(spy).toHaveBeenCalledWith("name");
+    expect(capturedArg).toBe("name");
   });
 });

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Model } from "../index.js";
+import { WithValidator } from "./with.js";
 
 describe("ValidatesWithTest", () => {
   it("validates_with with options", () => {
@@ -279,5 +280,26 @@ describe("ValidatesWithTest", () => {
     }
     expect(new Person({ name: "ab" }).isValid()).toBe(false);
     expect(new Person({ name: "abcde" }).isValid()).toBe(true);
+  });
+});
+
+describe("WithValidator arity dispatch", () => {
+  it("calls zero-arity method without arguments", () => {
+    const spy = vi.fn();
+    const record = { myCheck: spy };
+    const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
+    validator.validateEach(record, "name", "value");
+    expect(spy).toHaveBeenCalledWith();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls one-arity method with attribute name", () => {
+    const spy = vi.fn();
+    const record = { myCheck: spy };
+    const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
+    // Give the spy a declared parameter so Function.length === 1
+    Object.defineProperty(spy, "length", { value: 1 });
+    validator.validateEach(record, "name", "value");
+    expect(spy).toHaveBeenCalledWith("name");
   });
 });

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -305,10 +305,10 @@ describe("WithValidator arity dispatch", () => {
     expect(capturedArg).toBe("name");
   });
 
-  // JS Function.length excludes rest parameters ((...args) => {} has length 0),
-  // so rest-param methods are dispatched without the attribute — unlike Ruby where
-  // *args gives arity -1 and Rails passes the attribute. Documented divergence;
-  // detecting rest params requires Function.toString() parsing which is fragile.
+  // JS Function.length excludes rest and default parameters (both yield length 0),
+  // so such methods are dispatched without the attribute — unlike Ruby where
+  // *args or optional args give negative arity and Rails passes the attribute.
+  // Documented divergence; detecting these via Function.toString() is fragile.
   it("known divergence: rest-param method called without args (JS length 0 vs Ruby arity -1)", () => {
     const received: unknown[] = [];
     const record = {
@@ -320,5 +320,19 @@ describe("WithValidator arity dispatch", () => {
     validator.validateEach(record, "name", "value");
     // Function.length of a rest-param function is 0, so no arg is passed
     expect(received).toHaveLength(0);
+  });
+
+  it("known divergence: default-param method called without args (JS length 0 vs Ruby arity -1)", () => {
+    let capturedArg: unknown = "not-called";
+    const record = {
+      // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+      myCheck(attr: string = "") {
+        capturedArg = attr;
+      },
+    };
+    const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
+    validator.validateEach(record, "name", "value");
+    // Function.length excludes default params, so length is 0 → called without arg
+    expect(capturedArg).toBe("");
   });
 });

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -304,4 +304,21 @@ describe("WithValidator arity dispatch", () => {
     validator.validateEach(record, "name", "value");
     expect(capturedArg).toBe("name");
   });
+
+  // JS Function.length excludes rest parameters ((...args) => {} has length 0),
+  // so rest-param methods are dispatched without the attribute — unlike Ruby where
+  // *args gives arity -1 and Rails passes the attribute. Documented divergence;
+  // detecting rest params requires Function.toString() parsing which is fragile.
+  it("known divergence: rest-param method called without args (JS length 0 vs Ruby arity -1)", () => {
+    const received: unknown[] = [];
+    const record = {
+      myCheck(...args: unknown[]) {
+        received.push(...args);
+      },
+    };
+    const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
+    validator.validateEach(record, "name", "value");
+    // Function.length of a rest-param function is 0, so no arg is passed
+    expect(received).toHaveLength(0);
+  });
 });

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -20,6 +20,9 @@ export class WithValidator extends EachValidator {
         `WithValidator expected ${methodName} to be a function on the record`,
       );
     }
+    // Mirrors with.rb:8-12: arity == 0 → call without arg, else with attr.
+    // JS divergence: rest-param functions ((...args) => {}) have Function.length 0
+    // and are treated as zero-arity; Ruby gives them arity -1 and passes the attr.
     if (method.length === 0) {
       method.call(record);
     } else {

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -21,8 +21,9 @@ export class WithValidator extends EachValidator {
       );
     }
     // Mirrors with.rb:8-12: arity == 0 → call without arg, else with attr.
-    // JS divergence: rest-param functions ((...args) => {}) have Function.length 0
-    // and are treated as zero-arity; Ruby gives them arity -1 and passes the attr.
+    // JS divergence: rest-param ((...args) => {}) and default-param ((x = "") => {})
+    // functions both have Function.length 0 and are treated as zero-arity; Ruby
+    // gives them negative arity and Rails passes the attr. Documented in tests.
     if (method.length === 0) {
       method.call(record);
     } else {

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -20,6 +20,10 @@ export class WithValidator extends EachValidator {
         `WithValidator expected ${methodName} to be a function on the record`,
       );
     }
-    method.call(record, attribute);
+    if (method.length === 0) {
+      method.call(record);
+    } else {
+      method.call(record, attribute);
+    }
   }
 }

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -159,7 +159,10 @@ export class EachValidator extends Validator {
    * @internal Rails-private helper.
    */
   filteredErrorOptions(additionalReserved: string[] = []): Record<string, unknown> {
-    const reserved = new Set([...(VALIDATOR_DEFAULT_KEYS as readonly string[]), ...additionalReserved]);
+    const reserved = new Set([
+      ...(VALIDATOR_DEFAULT_KEYS as readonly string[]),
+      ...additionalReserved,
+    ]);
     const filtered: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(this.options)) {
       if (!reserved.has(key)) filtered[key] = val;

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -3,6 +3,20 @@ import { isBlank, underscore } from "@blazetrails/activesupport";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyRecord = any;
 
+/**
+ * Universal validator control keys that are never i18n interpolation variables.
+ * Shared by `EachValidator#filteredErrorOptions` and `_validatesDefaultKeys`.
+ */
+export const VALIDATOR_DEFAULT_KEYS = [
+  "if",
+  "unless",
+  "on",
+  "allowBlank",
+  "allowNil",
+  "strict",
+  "exceptOn",
+] as const;
+
 export type ConditionFn = ((record: AnyRecord) => boolean) | string;
 
 export interface ConditionalOptions {
@@ -145,16 +159,7 @@ export class EachValidator extends Validator {
    * @internal Rails-private helper.
    */
   filteredErrorOptions(additionalReserved: string[] = []): Record<string, unknown> {
-    const reserved = new Set([
-      "if",
-      "unless",
-      "on",
-      "allowBlank",
-      "allowNil",
-      "strict",
-      "exceptOn",
-      ...additionalReserved,
-    ]);
+    const reserved = new Set([...(VALIDATOR_DEFAULT_KEYS as readonly string[]), ...additionalReserved]);
     const filtered: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(this.options)) {
       if (!reserved.has(key)) filtered[key] = val;

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -4,8 +4,8 @@ import { isBlank, underscore } from "@blazetrails/activesupport";
 export type AnyRecord = any;
 
 /**
- * Universal validator control keys that are never i18n interpolation variables.
- * Shared by `EachValidator#filteredErrorOptions` and `_validatesDefaultKeys`.
+ * Universal validator control keys recognised by `validates(...)`.
+ * Shared by `_validatesDefaultKeys` and `filteredErrorOptions`.
  */
 export const VALIDATOR_DEFAULT_KEYS = [
   "if",
@@ -16,6 +16,15 @@ export const VALIDATOR_DEFAULT_KEYS = [
   "strict",
   "exceptOn",
 ] as const;
+
+/**
+ * Subset of `VALIDATOR_DEFAULT_KEYS` that must NOT be forwarded to
+ * `errors.add`. `strict` is intentionally absent — `errors.add` reads it
+ * to raise `StrictValidationFailed`, mirroring Rails errors.rb:342-354.
+ */
+const FILTER_FROM_ERROR_OPTIONS = VALIDATOR_DEFAULT_KEYS.filter(
+  (k) => k !== "strict",
+) as readonly string[];
 
 export type ConditionFn = ((record: AnyRecord) => boolean) | string;
 
@@ -159,10 +168,7 @@ export class EachValidator extends Validator {
    * @internal Rails-private helper.
    */
   filteredErrorOptions(additionalReserved: string[] = []): Record<string, unknown> {
-    const reserved = new Set([
-      ...(VALIDATOR_DEFAULT_KEYS as readonly string[]),
-      ...additionalReserved,
-    ]);
+    const reserved = new Set([...FILTER_FROM_ERROR_OPTIONS, ...additionalReserved]);
     const filtered: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(this.options)) {
       if (!reserved.has(key)) filtered[key] = val;

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -134,6 +134,34 @@ export class EachValidator extends Validator {
     throw new Error("Subclasses must implement validateEach(record, attribute, value)");
   }
 
+  /**
+   * Returns `this.options` minus universal validator control keys and any
+   * additional validator-specific reserved keys, for forwarding to
+   * `errors.add` as i18n interpolation variables.
+   *
+   * Mirrors the `options.except(*RESERVED_OPTIONS)` pattern used in Rails
+   * validators (e.g. acceptance.rb:31, confirmation.rb:19).
+   *
+   * @internal Rails-private helper.
+   */
+  filteredOptions(additionalReserved: string[] = []): Record<string, unknown> {
+    const reserved = new Set([
+      "if",
+      "unless",
+      "on",
+      "allowBlank",
+      "allowNil",
+      "strict",
+      "exceptOn",
+      ...additionalReserved,
+    ]);
+    const filtered: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(this.options)) {
+      if (!reserved.has(key)) filtered[key] = val;
+    }
+    return filtered;
+  }
+
   checkValidity(): void {
     // Override in subclasses to validate options
   }

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -144,7 +144,7 @@ export class EachValidator extends Validator {
    *
    * @internal Rails-private helper.
    */
-  filteredOptions(additionalReserved: string[] = []): Record<string, unknown> {
+  filteredErrorOptions(additionalReserved: string[] = []): Record<string, unknown> {
     const reserved = new Set([
       "if",
       "unless",


### PR DESCRIPTION
## Summary

Fixes audit findings #30 (validations §5–§7, §10) and #31 (validations §4) from `docs/activemodel/audit-validations.md`. References `docs/activemodel-alignment.md` P15.

- **`EachValidator#filteredOptions(additionalReserved?)`** — strips universal control keys (`if`/`unless`/`on`/`allowBlank`/`allowNil`/`strict`/`exceptOn`) plus per-validator reserved keys, mirroring Rails `options.except(*RESERVED_OPTIONS)` pattern
- **`presence` / `absence`** — `errors.add` now spreads `filteredOptions()` (no additional reserved keys); custom interpolation vars like `kind:` survive to i18n
- **`acceptance`** — strips `accept` + `allowNil` before `errors.add`, matching `acceptance.rb:31`
- **`confirmation`** — strips `caseSensitive` before `errors.add`, matching `confirmation.rb:19`
- **`with.ts`** — detects `Function.length === 0` and calls method without argument, matching `with.rb:8-16` arity dispatch

## Rails parity

| File | Rails source |
|------|-------------|
| `presence.ts` | `presence.rb:7` — `errors.add(attr_name, :blank, **options)` |
| `absence.ts` | `absence.rb:7-9` |
| `acceptance.ts` | `acceptance.rb:30-32` — `**options.except(:accept, :allow_nil)` |
| `confirmation.ts` | `confirmation.rb:18-20` — `**options.except(:case_sensitive)` |
| `with.ts` | `with.rb:8-16` — arity-aware dispatch |

## Test plan

- [ ] `presence`: custom interpolation var (`kind:`) resolves in error message
- [ ] `absence`: same
- [ ] `acceptance`: custom var resolves; `accept` key stripped from error options
- [ ] `confirmation`: custom var resolves; `caseSensitive` key stripped from error options
- [ ] `with.ts` zero-arity: method called with no args
- [ ] `with.ts` one-arity: method called with attribute name
- [ ] All 1726 activemodel tests pass
- [ ] `api:compare --package activemodel` delta ≥ 0 (624/625)
- [ ] lint, typecheck, format:check pass