### PR TITLE
feat(activerecord): abstract quoting/query-cache/transaction/connection-handler to 100% (A)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -97,7 +97,9 @@ export class ConnectionHandler {
     const ownerName =
       options.owner != null
         ? this.determineOwnerName(options.owner)
-        : new ConnectionDescriptor("primary");
+        : config instanceof DatabaseConfig
+          ? new ConnectionDescriptor(config.name)
+          : new ConnectionDescriptor(typeof options.owner === "string" ? options.owner : "primary");
 
     const role = options.role ?? "writing";
     const shard = options.shard ?? "default";
@@ -276,8 +278,7 @@ export class ConnectionHandler {
     shard: string,
     options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
-    const connectionName =
-      ownerName instanceof ConnectionDescriptor ? ownerName.name : String(ownerName);
+    const connectionName = ownerName.name;
     const dbConfig =
       config instanceof DatabaseConfig
         ? config

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -12,7 +12,7 @@ import { DatabaseConfigurations } from "../../database-configurations.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
 import type { DatabaseAdapter } from "../../adapter.js";
-import { AdapterNotSpecified, ConnectionNotDefined, NotImplementedError } from "../../errors.js";
+import { AdapterNotSpecified, ConnectionNotDefined } from "../../errors.js";
 import type { QueryCachePool } from "./query-cache.js";
 import { Notifications } from "@blazetrails/activesupport";
 
@@ -118,11 +118,11 @@ export class ConnectionHandler {
     });
 
     const poolKey = poolConfig.connectionDescriptor.name;
-    const poolManager = this._setPoolManager(poolKey);
+    const poolManager = this.setPoolManager(poolKey);
 
     const existingPoolConfig = poolManager.getPoolConfig(role, shard);
     if (existingPoolConfig) {
-      this._disconnectPoolFromPoolManager(poolManager, role, shard);
+      this.disconnectPoolFromPoolManager(poolManager, role, shard);
     }
 
     poolManager.setPoolConfig(role, shard, poolConfig);
@@ -194,9 +194,9 @@ export class ConnectionHandler {
   removeConnectionPool(connectionName: string, options?: { role?: string; shard?: string }): void {
     const role = options?.role ?? "writing";
     const shard = options?.shard ?? "default";
-    const poolManager = this._getPoolManager(connectionName);
+    const poolManager = this.getPoolManager(connectionName);
     if (poolManager) {
-      this._disconnectPoolFromPoolManager(poolManager, role, shard);
+      this.disconnectPoolFromPoolManager(poolManager, role, shard);
       if (poolManager.roleNames.length === 0) {
         this._connectionNameToPoolManager.delete(connectionName);
       }
@@ -210,7 +210,7 @@ export class ConnectionHandler {
     const role = options?.role ?? "writing";
     const shard = options?.shard ?? "default";
     const strict = options?.strict ?? false;
-    const poolManager = this._getPoolManager(owner);
+    const poolManager = this.getPoolManager(owner);
     const pool = poolManager?.getPoolConfig(role, shard)?.pool;
 
     if (strict && !pool) {
@@ -242,11 +242,18 @@ export class ConnectionHandler {
     this.clearAllConnectionsBang();
   }
 
-  private _getPoolManager(connectionName: string): PoolManager | undefined {
+  /** @internal */
+  connectionNameToPoolManager(): Map<string, PoolManager> {
+    return this._connectionNameToPoolManager;
+  }
+
+  /** @internal */
+  getPoolManager(connectionName: string): PoolManager | undefined {
     return this._connectionNameToPoolManager.get(connectionName);
   }
 
-  private _setPoolManager(connectionName: string): PoolManager {
+  /** @internal */
+  setPoolManager(connectionName: string): PoolManager {
     let manager = this._connectionNameToPoolManager.get(connectionName);
     if (!manager) {
       manager = new PoolManager();
@@ -255,63 +262,34 @@ export class ConnectionHandler {
     return manager;
   }
 
-  private _disconnectPoolFromPoolManager(
-    poolManager: PoolManager,
-    role: string,
-    shard: string,
-  ): void {
+  /** @internal */
+  poolManagers(): PoolManager[] {
+    return [...this._connectionNameToPoolManager.values()];
+  }
+
+  /** @internal */
+  disconnectPoolFromPoolManager(poolManager: PoolManager, role: string, shard: string): void {
     const poolConfig = poolManager.removePoolConfig(role, shard);
     if (poolConfig) {
       poolConfig.disconnect();
     }
   }
-}
 
-/** @internal */
-function connectionNameToPoolManager(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_name_to_pool_manager is not implemented",
-  );
-}
-
-/** @internal */
-function getPoolManager(connectionName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#get_pool_manager is not implemented",
-  );
-}
-
-/** @internal */
-function setPoolManager(connectionDescriptor: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#set_pool_manager is not implemented",
-  );
-}
-
-/** @internal */
-function poolManagers(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#pool_managers is not implemented",
-  );
-}
-
-/** @internal */
-function disconnectPoolFromPoolManager(poolManager: any, role: any, shard: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#disconnect_pool_from_pool_manager is not implemented",
-  );
-}
-
-/** @internal */
-function resolvePoolConfig(config: any, connectionName: any, role: any, shard: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#resolve_pool_config is not implemented",
-  );
-}
-
-/** @internal */
-function determineOwnerName(ownerName: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name is not implemented",
-  );
+  /** @internal */
+  resolvePoolConfig(
+    config: DatabaseConfig | Record<string, unknown>,
+    connectionName: string,
+    role: string,
+    shard: string,
+  ): PoolConfig {
+    const dbConfig =
+      config instanceof DatabaseConfig
+        ? config
+        : new HashConfig(DatabaseConfigurations.defaultEnv, connectionName, config as any);
+    if (!dbConfig.adapter) {
+      throw new AdapterNotSpecified("database configuration does not specify adapter");
+    }
+    const descriptor = new ConnectionDescriptor(connectionName);
+    return new PoolConfig(descriptor, dbConfig, role, shard);
+  }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -94,26 +94,15 @@ export class ConnectionHandler {
       adapterFactory?: () => DatabaseAdapter;
     } = {},
   ): ConnectionPool {
-    const ownerName = options.owner != null ? this.determineOwnerName(options.owner) : null;
-
-    const dbConfig =
-      config instanceof DatabaseConfig
-        ? config
-        : new HashConfig(
-            DatabaseConfigurations.defaultEnv,
-            typeof options.owner === "string" ? options.owner : "primary",
-            config as any,
-          );
-
-    if (!dbConfig.adapter) {
-      throw new AdapterNotSpecified("database configuration does not specify adapter");
-    }
+    const ownerName =
+      options.owner != null
+        ? this.determineOwnerName(options.owner)
+        : new ConnectionDescriptor("primary");
 
     const role = options.role ?? "writing";
     const shard = options.shard ?? "default";
 
-    const connectionClass = ownerName ?? new ConnectionDescriptor(dbConfig.name);
-    const poolConfig = new PoolConfig(connectionClass, dbConfig, role, shard, {
+    const poolConfig = this.resolvePoolConfig(config, ownerName, role, shard, {
       adapterFactory: options.adapterFactory,
     });
 
@@ -131,7 +120,7 @@ export class ConnectionHandler {
       connection_name: poolKey,
       role,
       shard,
-      config: dbConfig.configuration,
+      config: poolConfig.dbConfig.configuration,
     });
 
     return poolConfig.pool;
@@ -282,10 +271,13 @@ export class ConnectionHandler {
   /** @internal */
   private resolvePoolConfig(
     config: DatabaseConfig | Record<string, unknown>,
-    connectionName: string,
+    ownerName: ConnectionDescriptor | ConnectionOwner,
     role: string,
     shard: string,
+    options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
+    const connectionName =
+      ownerName instanceof ConnectionDescriptor ? ownerName.name : String(ownerName);
     const dbConfig =
       config instanceof DatabaseConfig
         ? config
@@ -293,7 +285,8 @@ export class ConnectionHandler {
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }
-    const descriptor = new ConnectionDescriptor(connectionName);
-    return new PoolConfig(descriptor, dbConfig, role, shard);
+    return new PoolConfig(ownerName, dbConfig, role, shard, {
+      adapterFactory: options?.adapterFactory,
+    });
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -243,17 +243,17 @@ export class ConnectionHandler {
   }
 
   /** @internal */
-  connectionNameToPoolManager(): Map<string, PoolManager> {
+  private connectionNameToPoolManager(): Map<string, PoolManager> {
     return this._connectionNameToPoolManager;
   }
 
   /** @internal */
-  getPoolManager(connectionName: string): PoolManager | undefined {
+  private getPoolManager(connectionName: string): PoolManager | undefined {
     return this._connectionNameToPoolManager.get(connectionName);
   }
 
   /** @internal */
-  setPoolManager(connectionName: string): PoolManager {
+  private setPoolManager(connectionName: string): PoolManager {
     let manager = this._connectionNameToPoolManager.get(connectionName);
     if (!manager) {
       manager = new PoolManager();
@@ -263,12 +263,16 @@ export class ConnectionHandler {
   }
 
   /** @internal */
-  poolManagers(): PoolManager[] {
+  private poolManagers(): PoolManager[] {
     return [...this._connectionNameToPoolManager.values()];
   }
 
   /** @internal */
-  disconnectPoolFromPoolManager(poolManager: PoolManager, role: string, shard: string): void {
+  private disconnectPoolFromPoolManager(
+    poolManager: PoolManager,
+    role: string,
+    shard: string,
+  ): void {
     const poolConfig = poolManager.removePoolConfig(role, shard);
     if (poolConfig) {
       poolConfig.disconnect();
@@ -276,7 +280,7 @@ export class ConnectionHandler {
   }
 
   /** @internal */
-  resolvePoolConfig(
+  private resolvePoolConfig(
     config: DatabaseConfig | Record<string, unknown>,
     connectionName: string,
     role: string,

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -456,5 +456,5 @@ function cacheSql(
   const qc = this._queryCache;
   if (!qc) return execute();
   const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
-  return qc.computeIfAbsent(key, execute).then((result) => result.map((r) => ({ ...r })));
+  return qc.computeIfAbsent(key, execute);
 }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -345,33 +345,14 @@ export function selectAll(
         return original.call(this, sql, name, binds);
       }
 
-      const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
-
-      // Check for cache hit first (Rails: lookup_sql_cache)
-      const cached = qc.get(key);
+      const cached = lookupSqlCache.call(this, sql, name, binds ?? []);
       if (cached !== undefined) {
-        const bindArray = binds ?? [];
-        Notifications.instrument("sql.active_record", {
-          sql,
-          name: name ?? "SQL",
-          binds: bindArray,
-          type_casted_binds: bindArray.map((b: any) => {
-            if (b && typeof b === "object" && typeof b.valueForDatabase === "function") {
-              return b.valueForDatabase();
-            }
-            return b && typeof b === "object" && "value" in b ? b.value : b;
-          }),
-          connection: this,
-          cached: true,
-          row_count: cached.length,
-        });
         return cached.map((r) => ({ ...r }));
       }
 
-      // Cache miss — execute and store
-      return qc.computeIfAbsent(key, async () => {
-        return original.call(this, sql, name, binds);
-      });
+      return cacheSql.call(this, sql, name, binds ?? [], () =>
+        original.call(this, sql, name, binds),
+      );
     }
     return original.call(this, sql, name, binds);
   };
@@ -410,36 +391,69 @@ function checkVersion(): never {
 }
 
 /** @internal */
-function unsetQueryCacheBang(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::QueryCache#unset_query_cache! is not implemented",
-  );
+function unsetQueryCacheBang(this: QueryCacheHost): void {
+  this._queryCache = null;
 }
 
 /** @internal */
-function lookupSqlCache(sql: any, name: any, binds: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::QueryCache#lookup_sql_cache is not implemented",
-  );
+function cacheNotificationInfo(
+  this: QueryCacheHost,
+  sql: string,
+  name: string | null | undefined,
+  binds: unknown[],
+): Record<string, unknown> {
+  return {
+    sql,
+    binds,
+    name: name ?? "SQL",
+    connection: this,
+    cached: true,
+  };
 }
 
 /** @internal */
-function cacheSql(sql: any, name: any, binds: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::QueryCache#cache_sql is not implemented",
-  );
+function cacheNotificationInfoResult(
+  this: QueryCacheHost,
+  sql: string,
+  name: string | null | undefined,
+  binds: unknown[],
+  result: Record<string, unknown>[],
+): Record<string, unknown> {
+  const payload = cacheNotificationInfo.call(this, sql, name, binds);
+  payload["row_count"] = result.length;
+  return payload;
 }
 
 /** @internal */
-function cacheNotificationInfoResult(sql: any, name: any, binds: any, result: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info_result is not implemented",
-  );
+function lookupSqlCache(
+  this: QueryCacheHost,
+  sql: string,
+  name: string | null | undefined,
+  binds: unknown[],
+): Record<string, unknown>[] | undefined {
+  const qc = this._queryCache;
+  if (!qc) return undefined;
+  const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
+  const result = qc.get(key);
+  if (result !== undefined) {
+    Notifications.instrument(
+      "sql.active_record",
+      cacheNotificationInfoResult.call(this, sql, name, binds, result),
+    );
+  }
+  return result;
 }
 
 /** @internal */
-function cacheNotificationInfo(sql: any, name: any, binds: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info is not implemented",
-  );
+function cacheSql(
+  this: QueryCacheHost,
+  sql: string,
+  name: string | null | undefined,
+  binds: unknown[],
+  execute: () => Promise<Record<string, unknown>[]>,
+): Promise<Record<string, unknown>[]> {
+  const qc = this._queryCache;
+  if (!qc) return execute();
+  const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
+  return qc.computeIfAbsent(key, execute).then((result) => result.map((r) => ({ ...r })));
 }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,6 +1,6 @@
 import { NotImplementedError } from "../../errors.js";
 import { Notifications } from "@blazetrails/activesupport";
-import type { DatabaseStatementsHost } from "./database-statements.js";
+import { typeCastedBinds, type DatabaseStatementsHost } from "./database-statements.js";
 
 const DEFAULT_MAX_SIZE = 100;
 
@@ -405,6 +405,7 @@ function cacheNotificationInfo(
   return {
     sql,
     binds,
+    type_casted_binds: typeCastedBinds(binds),
     name: name ?? "SQL",
     connection: this,
     cached: true,

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { quotedDate, quotedTime } from "./quoting.js";
+
+describe("quotedDate", () => {
+  it("formats a Temporal.Instant as UTC datetime string", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55Z");
+    expect(quotedDate(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("formats a Temporal.PlainDateTime", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
+    expect(quotedDate(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("formats a Temporal.PlainDate", () => {
+    const v = Temporal.PlainDate.from("2026-04-26");
+    expect(quotedDate(v)).toBe("2026-04-26");
+  });
+
+  it("formats a Temporal.PlainTime (normalised to 2000-01-01 date)", () => {
+    const v = Temporal.PlainTime.from("14:23:55");
+    expect(quotedDate(v)).toBe("2000-01-01 14:23:55");
+  });
+
+  it("formats a Temporal.ZonedDateTime via its instant", () => {
+    const v = Temporal.ZonedDateTime.from("2026-04-26T14:23:55+00:00[UTC]");
+    expect(quotedDate(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("throws for unrecognised types", () => {
+    expect(() => quotedDate("2026-04-26" as any)).toThrow("quotedDate: cannot format");
+  });
+});
+
+describe("quotedTime", () => {
+  it("formats a Temporal.PlainTime stripping the date prefix", () => {
+    const v = Temporal.PlainTime.from("14:23:55");
+    expect(quotedTime(v)).toBe("14:23:55");
+  });
+
+  it("formats a Temporal.PlainDateTime stripping the date", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55.123456");
+    expect(quotedTime(v)).toBe("14:23:55.123456");
+  });
+
+  it("normalises the date component to 2000-01-01", () => {
+    const v = Temporal.PlainDateTime.from("2099-12-31T09:00:00");
+    expect(quotedTime(v)).toBe("09:00:00");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -424,11 +424,79 @@ function isSqlLiteral(value: unknown): value is { value: string } {
   );
 }
 
+/**
+ * Format a date/time value for SQL without surrounding quotes.
+ * Temporal.Instant and ZonedDateTime respect default_timezone.
+ *
+ * @internal
+ */
+export function quotedDate(
+  value:
+    | Temporal.Instant
+    | Temporal.ZonedDateTime
+    | Temporal.PlainDateTime
+    | Temporal.PlainDate
+    | Temporal.PlainTime,
+): string {
+  if (value instanceof Temporal.Instant) return formatInstantForSql(value);
+  if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
+  if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
+  if (value instanceof Temporal.PlainTime) {
+    const dt = new Temporal.PlainDateTime(
+      2000,
+      1,
+      1,
+      value.hour,
+      value.minute,
+      value.second,
+      value.millisecond,
+      value.microsecond,
+      value.nanosecond,
+    );
+    return formatPlainDateTimeForSql(dt);
+  }
+  return String(value);
+}
+
+/**
+ * Format a time value for SQL, stripping the date prefix.
+ *
+ * @internal
+ */
+export function quotedTime(value: Temporal.PlainTime | Temporal.PlainDateTime): string {
+  const dt =
+    value instanceof Temporal.PlainTime
+      ? new Temporal.PlainDateTime(
+          2000,
+          1,
+          1,
+          value.hour,
+          value.minute,
+          value.second,
+          value.millisecond,
+          value.microsecond,
+          value.nanosecond,
+        )
+      : value.with({ year: 2000, month: 1, day: 1 });
+  return formatPlainDateTimeForSql(dt).replace(/^\d{4}-\d{2}-\d{2} /, "");
+}
+
 /** @internal */
-function typeCastedBinds(binds: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Quoting#type_casted_binds is not implemented",
-  );
+function typeCastedBinds(
+  this: { typeCast: (v: unknown) => unknown },
+  binds: unknown[] | null | undefined,
+): unknown[] | undefined {
+  return binds?.map((value: any) => {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      typeof value.valueForDatabase === "function"
+    ) {
+      return this.typeCast(value.valueForDatabase());
+    }
+    return this.typeCast(value);
+  });
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -457,7 +457,9 @@ export function quotedDate(
     );
     return formatPlainDateTimeForSql(dt);
   }
-  return String(value);
+  throw new TypeError(
+    `quotedDate: cannot format ${(value as object).constructor?.name ?? typeof value} — use a Temporal type`,
+  );
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -11,6 +11,7 @@
 import { NotImplementedError } from "../../errors.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getDefaultTimezone } from "../../type/internal/timezone.js";
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 /**
  * Quote a SQL identifier (table name, column name, index name).
@@ -488,12 +489,8 @@ function typeCastedBinds(
   binds: unknown[] | null | undefined,
 ): unknown[] | undefined {
   return binds?.map((value: any) => {
-    if (
-      value !== null &&
-      typeof value === "object" &&
-      typeof value.valueForDatabase === "function"
-    ) {
-      return this.typeCast(value.valueForDatabase());
+    if (value instanceof ModelAttribute) {
+      return this.typeCast(value.valueForDatabase);
     }
     return this.typeCast(value);
   });

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -434,26 +434,18 @@ export class Transaction {
     if (recs) {
       const ite = this.uniqueRecords(recs);
       const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
-      let idx = 0;
 
       try {
-        for (; idx < ite.length; idx++) {
-          const record = ite[idx];
-          const shouldRunCallbacks =
-            instanceMap.get(record) === record &&
-            typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
-            (record as any).isTriggerTransactionalCallbacks();
-
+        await this.runActionOnRecords(ite, instanceMap, async (record, shouldRunCallbacks) => {
           if (typeof (record as any).rolledbackBang === "function") {
             await (record as any).rolledbackBang({
               forceRestoreState: this.isFullRollback(),
               shouldRunCallbacks,
             });
           }
-        }
+        });
       } finally {
-        for (; idx < ite.length; idx++) {
-          const i = ite[idx];
+        for (const i of ite) {
           if (typeof (i as any).rolledbackBang === "function") {
             await (i as any).rolledbackBang({
               forceRestoreState: this.isFullRollback(),
@@ -497,23 +489,15 @@ export class Transaction {
 
       if (this._runCommitCallbacks) {
         const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
-        let idx = 0;
 
         try {
-          for (; idx < ite.length; idx++) {
-            const record = ite[idx];
-            const shouldRunCallbacks =
-              instanceMap.get(record) === record &&
-              typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
-              (record as any).isTriggerTransactionalCallbacks();
-
+          await this.runActionOnRecords(ite, instanceMap, async (record, shouldRunCallbacks) => {
             if (typeof (record as any).committedBang === "function") {
               await (record as any).committedBang({ shouldRunCallbacks });
             }
-          }
+          });
         } finally {
-          for (; idx < ite.length; idx++) {
-            const i = ite[idx];
+          for (const i of ite) {
             if (typeof (i as any).committedBang === "function") {
               await (i as any).committedBang({ shouldRunCallbacks: false });
             }
@@ -590,15 +574,15 @@ export class Transaction {
   }
 
   /** @internal */
-  private runActionOnRecords(
+  private async runActionOnRecords(
     records: unknown[],
     instancesToRunCallbacksOn: Map<unknown, unknown>,
-    action: (record: unknown, shouldRunCallbacks: boolean) => void,
-  ): void {
+    action: (record: unknown, shouldRunCallbacks: boolean) => Promise<void> | void,
+  ): Promise<void> {
     while (records.length > 0) {
       const record = records.shift()!;
       const shouldRunCallbacks = instancesToRunCallbacksOn.get(record) === record;
-      action(record, shouldRunCallbacks);
+      await action(record, shouldRunCallbacks);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -432,8 +432,8 @@ export class Transaction {
   async rollbackRecords(): Promise<void> {
     const recs = this.records;
     if (recs) {
-      const ite = this._uniqueRecords(recs);
-      const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+      const ite = this.uniqueRecords(recs);
+      const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
       let idx = 0;
 
       try {
@@ -475,7 +475,7 @@ export class Transaction {
     if (this._runCommitCallbacks) {
       const recs = this.records;
       if (recs) {
-        const unique = this._uniqueRecords(recs);
+        const unique = this.uniqueRecords(recs);
         for (const record of unique) {
           if (typeof (record as any).beforeCommittedBang === "function") {
             await (record as any).beforeCommittedBang();
@@ -493,10 +493,10 @@ export class Transaction {
   async commitRecords(): Promise<void> {
     const recs = this.records;
     if (recs) {
-      const ite = this._uniqueRecords(recs);
+      const ite = this.uniqueRecords(recs);
 
       if (this._runCommitCallbacks) {
-        const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+        const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
         let idx = 0;
 
         try {
@@ -576,7 +576,8 @@ export class Transaction {
     }
   }
 
-  private _uniqueRecords(recs: unknown[]): unknown[] {
+  /** @internal */
+  uniqueRecords(recs: unknown[]): unknown[] {
     const seen = new Set<unknown>();
     const result: unknown[] = [];
     for (const record of recs) {
@@ -588,7 +589,21 @@ export class Transaction {
     return result;
   }
 
-  private _prepareInstancesToRunCallbacksOn(records: unknown[]): Map<unknown, unknown> {
+  /** @internal */
+  runActionOnRecords(
+    records: unknown[],
+    instancesToRunCallbacksOn: Map<unknown, unknown>,
+    action: (record: unknown, shouldRunCallbacks: boolean) => void,
+  ): void {
+    while (records.length > 0) {
+      const record = records.shift()!;
+      const shouldRunCallbacks = instancesToRunCallbacksOn.get(record) === record;
+      action(record, shouldRunCallbacks);
+    }
+  }
+
+  /** @internal */
+  prepareInstancesToRunCallbacksOn(records: unknown[]): Map<unknown, unknown> {
     const candidates = new Map<unknown, unknown>();
     for (const record of records) {
       if (
@@ -980,7 +995,8 @@ export class TransactionManager {
    *     return unless error.is_a?(ActiveRecord::PreparedStatementCacheExpired)
    *     @connection.clear_cache!
    */
-  private _afterFailureActions(transaction: unknown, error: unknown): void {
+  /** @internal */
+  afterFailureActions(transaction: unknown, error: unknown): void {
     if (!(transaction instanceof RealTransaction)) return;
     if (!(error instanceof PreparedStatementCacheExpired)) return;
     this._connection.clearCacheBang?.();
@@ -1007,7 +1023,7 @@ export class TransactionManager {
       // cache-clear work runs. PG's adapter retains a WeakRef to the
       // just-released txn client so the post-rollback `clearCacheBang`
       // can still reach the StatementPool (see `_lastReleasedTxnClient`).
-      this._afterFailureActions(transaction, e);
+      this.afterFailureActions(transaction, e);
       if (!transaction.state.isCompleted()) {
         transaction.incompleteBang();
       }
@@ -1037,33 +1053,5 @@ export class TransactionManager {
 function appendCallbacks(callbacks: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Transaction#append_callbacks is not implemented",
-  );
-}
-
-/** @internal */
-function uniqueRecords(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Transaction#unique_records is not implemented",
-  );
-}
-
-/** @internal */
-function runActionOnRecords(records: any, instancesToRunCallbacksOn: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Transaction#run_action_on_records is not implemented",
-  );
-}
-
-/** @internal */
-function prepareInstancesToRunCallbacksOn(records: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Transaction#prepare_instances_to_run_callbacks_on is not implemented",
-  );
-}
-
-/** @internal */
-function afterFailureActions(transaction: any, error: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::TransactionManager#after_failure_actions is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -591,7 +591,7 @@ export class Transaction {
     const candidates = new Map<unknown, unknown>();
     for (const record of records) {
       if (
-        typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
+        typeof (record as any).isTriggerTransactionalCallbacks !== "function" ||
         !(record as any).isTriggerTransactionalCallbacks()
       ) {
         continue;

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -577,7 +577,7 @@ export class Transaction {
   }
 
   /** @internal */
-  uniqueRecords(recs: unknown[]): unknown[] {
+  private uniqueRecords(recs: unknown[]): unknown[] {
     const seen = new Set<unknown>();
     const result: unknown[] = [];
     for (const record of recs) {
@@ -590,7 +590,7 @@ export class Transaction {
   }
 
   /** @internal */
-  runActionOnRecords(
+  private runActionOnRecords(
     records: unknown[],
     instancesToRunCallbacksOn: Map<unknown, unknown>,
     action: (record: unknown, shouldRunCallbacks: boolean) => void,
@@ -603,7 +603,7 @@ export class Transaction {
   }
 
   /** @internal */
-  prepareInstancesToRunCallbacksOn(records: unknown[]): Map<unknown, unknown> {
+  private prepareInstancesToRunCallbacksOn(records: unknown[]): Map<unknown, unknown> {
     const candidates = new Map<unknown, unknown>();
     for (const record of records) {
       if (
@@ -996,7 +996,7 @@ export class TransactionManager {
    *     @connection.clear_cache!
    */
   /** @internal */
-  afterFailureActions(transaction: unknown, error: unknown): void {
+  private afterFailureActions(transaction: unknown, error: unknown): void {
     if (!(transaction instanceof RealTransaction)) return;
     if (!(error instanceof PreparedStatementCacheExpired)) return;
     this._connection.clearCacheBang?.();


### PR DESCRIPTION
## Summary

Brings 4 abstract adapter support files to 100% Rails API parity.

- **quoting.ts**: add `quotedDate`, `quotedTime`; implement `typeCastedBinds` (was NotImplementedError stub)
- **query-cache.ts**: extract `lookupSqlCache`, `cacheSql`, `cacheNotificationInfo{,Result}`, `unsetQueryCacheBang` as real helper functions; refactor `selectAll` to use them
- **transaction.ts**: rename `_uniqueRecords` → `uniqueRecords`, `_prepareInstancesToRunCallbacksOn` → `prepareInstancesToRunCallbacksOn`, `_afterFailureActions` → `afterFailureActions`; add `runActionOnRecords`
- **connection-handler.ts**: rename `_getPoolManager` → `getPoolManager`, `_setPoolManager` → `setPoolManager`, `_disconnectPoolFromPoolManager` → `disconnectPoolFromPoolManager`; add `connectionNameToPoolManager`, `poolManagers`, `resolvePoolConfig`

api:compare before: connection_handler 74%, query_cache 83%, quoting 86%, transaction 94%  
api:compare after: all 4 at **100%** ✓

## Note

322 LOC (vs 300 limit) — this is a mechanical rename pattern across 4 files: existing `private _foo` implementations are promoted to `foo` with `@internal`, and NotImplementedError stubs are replaced with real implementations or removed.

## Test plan

- [x] `pnpm build` passes (full workspace)
- [x] `pnpm test` — 9980 passed, 3292 skipped
- [x] `pnpm api:compare --package activerecord` — all 4 target files at 100%