### PR TITLE
feat(activerecord): abstract schema_creation + schema_dumper to 100% (B)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -7,7 +7,6 @@
  * visit methods for dialect-specific SQL generation.
  */
 
-import { NotImplementedError } from "../../errors.js";
 import {
   type ColumnType,
   type ColumnOptions,
@@ -299,6 +298,54 @@ export class SchemaCreation {
   }
 
   /** @internal */
+  protected visitPrimaryKeyDefinition(o: { name: string[] }): string {
+    return `PRIMARY KEY (${o.name.map((n) => this.adapter.quoteIdentifier(n)).join(", ")})`;
+  }
+
+  /** @internal */
+  protected visitDropConstraint(name: string): string {
+    return `DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`;
+  }
+
+  /** @internal */
+  protected visitAddCheckConstraint(o: CheckConstraintDefinition): string {
+    return `ADD ${this.visitCheckConstraintDefinition(o)}`;
+  }
+
+  /** @internal */
+  protected quotedColumns(o: { columns: string | string[] }): string {
+    if (typeof o.columns === "string") return o.columns;
+    return o.columns.map((c) => this.adapter.quoteIdentifier(c)).join(", ");
+  }
+
+  /** @internal */
+  protected addTableOptionsBang(sql: string, o: TableDefinition): string {
+    if (o.options) sql += ` ${o.options}`;
+    return sql;
+  }
+
+  /** @internal */
+  protected columnOptions(o: ColumnDefinition): Record<string, unknown> {
+    return { ...o.options, column: o };
+  }
+
+  /** @internal */
+  protected addColumnOptionsBang(sql: string, options: ColumnOptions): string {
+    return this.addColumnOptions(sql, options);
+  }
+
+  /** @internal */
+  protected toSql(sql: unknown): string {
+    if (sql && typeof (sql as any).toSql === "function") return (sql as any).toSql();
+    return String(sql);
+  }
+
+  /** @internal */
+  protected tableModifierInCreate(o: TableDefinition): string {
+    return o.temporary ? " TEMPORARY" : "";
+  }
+
+  /** @internal */
   actionSql(action: string, dependency: ReferentialAction): string {
     switch (dependency) {
       case "cascade":
@@ -321,127 +368,6 @@ export class SchemaCreation {
 }
 
 /** @internal */
-function visit_AlterTable(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AlterTable is not implemented",
-  );
-}
-
-/** @internal */
-function visit_ColumnDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_ColumnDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_AddColumnDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddColumnDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_TableDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_TableDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_PrimaryKeyDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_PrimaryKeyDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_ForeignKeyDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_ForeignKeyDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_AddForeignKey(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddForeignKey is not implemented",
-  );
-}
-
-/** @internal */
-function visit_DropConstraint(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_DropConstraint is not implemented",
-  );
-}
-
-/** @internal */
-function visit_CreateIndexDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_CreateIndexDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_CheckConstraintDefinition(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_CheckConstraintDefinition is not implemented",
-  );
-}
-
-/** @internal */
-function visit_AddCheckConstraint(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddCheckConstraint is not implemented",
-  );
-}
-
-/** @internal */
-function quotedColumns(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#quoted_columns is not implemented",
-  );
-}
-
-/** @internal */
-function addTableOptionsBang(createSql: any, o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#add_table_options! is not implemented",
-  );
-}
-
-/** @internal */
-function columnOptions(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#column_options is not implemented",
-  );
-}
-
-/** @internal */
-function addColumnOptionsBang(sql: any, options: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#add_column_options! is not implemented",
-  );
-}
-
-/** @internal */
-function toSql(sql: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#to_sql is not implemented",
-  );
-}
-
-/** @internal */
-function tableModifierInCreate(o: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#table_modifier_in_create is not implemented",
-  );
-}
-
-/** @internal */
-function actionSql(action: any, dependency: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaCreation#action_sql is not implemented",
-  );
+function visitAddForeignKey(this: SchemaCreation, o: ForeignKeyDefinition): string {
+  return `ADD ${this.visitForeignKeyDefinition(o)}`;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -131,19 +131,19 @@ export class SchemaCreation {
       parts.push(this.visitAddColumnDefinition(add));
     }
     for (const fk of o.foreignKeyAdds) {
-      parts.push(`ADD ${this.visitForeignKeyDefinition(fk)}`);
+      parts.push(visitAddForeignKey.call(this, fk));
     }
     for (const name of o.foreignKeyDrops) {
-      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
+      parts.push(this.visitDropConstraint(name));
     }
     for (const chk of o.checkConstraintAdds) {
-      parts.push(`ADD ${this.visitCheckConstraintDefinition(chk)}`);
+      parts.push(this.visitAddCheckConstraint(chk));
     }
     for (const name of o.checkConstraintDrops) {
-      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
+      parts.push(this.visitDropConstraint(name));
     }
     for (const name of o.constraintDrops) {
-      parts.push(`DROP CONSTRAINT ${this.adapter.quoteIdentifier(name)}`);
+      parts.push(this.visitDropConstraint(name));
     }
     for (const change of o.columnDefaultChanges) {
       const col = this.adapter.quoteIdentifier(change.columnName);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -30,12 +30,12 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private columnSpec(column: Column): [symbol | string, Record<string, unknown>] {
+  protected columnSpec(column: Column): [symbol | string, Record<string, unknown>] {
     return [this.schemaTypeWithVirtual(column), this.prepareColumnOptions(column)];
   }
 
   /** @internal */
-  private columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
+  protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
     const spec: Record<string, unknown> = {};
     if (!this.isDefaultPrimaryKey(column)) {
       spec["id"] = String(this.schemaType(column));
@@ -50,7 +50,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private prepareColumnOptions(column: Column): Record<string, unknown> {
+  protected prepareColumnOptions(column: Column): Record<string, unknown> {
     const spec: Record<string, unknown> = {};
     const limit = this.schemaLimit(column);
     if (limit !== undefined) spec["limit"] = limit;
@@ -68,29 +68,29 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private isDefaultPrimaryKey(column: Column): boolean {
+  protected isDefaultPrimaryKey(column: Column): boolean {
     return this.schemaType(column) === "bigint";
   }
 
   /** @internal */
-  private isExplicitPrimaryKeyDefault(_column: Column): boolean {
+  protected isExplicitPrimaryKeyDefault(_column: Column): boolean {
     return false;
   }
 
   /** @internal */
-  private schemaTypeWithVirtual(column: Column): string {
+  protected schemaTypeWithVirtual(column: Column): string {
     if (column.virtual) return "virtual";
     return this.schemaType(column);
   }
 
   /** @internal */
-  private schemaType(column: Column): string {
+  protected schemaType(column: Column): string {
     if (column.bigint || column.type === "bigint") return "bigint";
     return column.type;
   }
 
   /** @internal */
-  private schemaLimit(column: Column): string | undefined {
+  protected schemaLimit(column: Column): string | undefined {
     if (column.bigint || column.type === "bigint") return undefined;
     const limit = column.limit;
     if (limit == null) return undefined;
@@ -98,7 +98,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private schemaPrecision(column: Column): string | undefined {
+  protected schemaPrecision(column: Column): string | undefined {
     if (column.type === "datetime") {
       if (column.precision == null) return "nil";
       if (column.precision === DEFAULT_DATETIME_PRECISION) return undefined;
@@ -109,13 +109,13 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private schemaScale(column: Column): string | undefined {
+  protected schemaScale(column: Column): string | undefined {
     if (column.scale != null) return String(column.scale);
     return undefined;
   }
 
   /** @internal */
-  private schemaDefault(column: Column): string | undefined {
+  protected schemaDefault(column: Column): string | undefined {
     if (!column.hasDefault && column.default === undefined) return undefined;
     if (column.default == null) return this.schemaExpression(column);
     // Represent the default as its schema literal
@@ -124,13 +124,13 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  private schemaExpression(column: Column): string | undefined {
+  protected schemaExpression(column: Column): string | undefined {
     if (column.defaultFunction) return `-> { ${JSON.stringify(column.defaultFunction)} }`;
     return undefined;
   }
 
   /** @internal */
-  private schemaCollation(column: Column): string | undefined {
+  protected schemaCollation(column: Column): string | undefined {
     if (column.collation) return JSON.stringify(column.collation);
     return undefined;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -2,19 +2,23 @@
  * Connection-adapters-layer SchemaDumper. Mirrors Rails'
  * `ActiveRecord::ConnectionAdapters::SchemaDumper < SchemaDumper`
  * (connection_adapters/abstract/schema_dumper.rb) — the adapter
- * subclass of the base dumper. Rails uses this class to add
- * adapter-specific column-spec helpers (schema_type, schema_limit,
- * schema_precision, schema_default, etc.); our dump loop currently
- * inlines the equivalent logic in the base, so the subclass is
- * effectively empty. The extends edge is still what adapter-
- * specific subclasses (postgres/sqlite/mysql) build on top of, so
- * keeping it wired is important for Rails-parity and for future
- * column-spec hooks.
+ * subclass of the base dumper that adds column-spec helpers used by
+ * `schema_type`, `schema_limit`, `schema_default`, etc.
  */
 
-import { NotImplementedError } from "../../errors.js";
-import type { SchemaSource } from "../../schema-dumper.js";
+import type { SchemaSource, ColumnInfo } from "../../schema-dumper.js";
 import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
+
+const DEFAULT_DATETIME_PRECISION = 6;
+
+/** Column-shaped interface this dumper depends on. */
+interface Column extends ColumnInfo {
+  bigint?: boolean;
+  virtual?: boolean;
+  hasDefault?: boolean;
+  defaultFunction?: string | null;
+  comment?: string | null;
+}
 
 export class SchemaDumper extends BaseSchemaDumper {
   static override create<T extends typeof BaseSchemaDumper>(
@@ -24,95 +28,110 @@ export class SchemaDumper extends BaseSchemaDumper {
   ): InstanceType<T> {
     return new this(source, options) as InstanceType<T>;
   }
-}
 
-/** @internal */
-function columnSpec(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#column_spec is not implemented",
-  );
-}
+  /** @internal */
+  private columnSpec(column: Column): [symbol | string, Record<string, unknown>] {
+    return [this.schemaTypeWithVirtual(column), this.prepareColumnOptions(column)];
+  }
 
-/** @internal */
-function columnSpecForPrimaryKey(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#column_spec_for_primary_key is not implemented",
-  );
-}
+  /** @internal */
+  private columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
+    const spec: Record<string, unknown> = {};
+    if (!this.isDefaultPrimaryKey(column)) {
+      spec["id"] = String(this.schemaType(column));
+    }
+    const colOpts = this.prepareColumnOptions(column);
+    delete colOpts["null"];
+    Object.assign(spec, colOpts);
+    if (this.isExplicitPrimaryKeyDefault(column)) {
+      spec["default"] ??= "nil";
+    }
+    return spec;
+  }
 
-/** @internal */
-function prepareColumnOptions(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#prepare_column_options is not implemented",
-  );
-}
+  /** @internal */
+  private prepareColumnOptions(column: Column): Record<string, unknown> {
+    const spec: Record<string, unknown> = {};
+    const limit = this.schemaLimit(column);
+    if (limit !== undefined) spec["limit"] = limit;
+    const precision = this.schemaPrecision(column);
+    if (precision !== undefined) spec["precision"] = precision;
+    const scale = this.schemaScale(column);
+    if (scale !== undefined) spec["scale"] = scale;
+    const def = this.schemaDefault(column);
+    if (def !== undefined) spec["default"] = def;
+    if (column.null === false) spec["null"] = "false";
+    const collation = this.schemaCollation(column);
+    if (collation !== undefined) spec["collation"] = collation;
+    if (column.comment) spec["comment"] = JSON.stringify(column.comment);
+    return spec;
+  }
 
-/** @internal */
-function isDefaultPrimaryKey(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#default_primary_key? is not implemented",
-  );
-}
+  /** @internal */
+  private isDefaultPrimaryKey(column: Column): boolean {
+    return this.schemaType(column) === "bigint";
+  }
 
-/** @internal */
-function isExplicitPrimaryKeyDefault(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#explicit_primary_key_default? is not implemented",
-  );
-}
+  /** @internal */
+  private isExplicitPrimaryKeyDefault(_column: Column): boolean {
+    return false;
+  }
 
-/** @internal */
-function schemaTypeWithVirtual(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_type_with_virtual is not implemented",
-  );
-}
+  /** @internal */
+  private schemaTypeWithVirtual(column: Column): string {
+    if (column.virtual) return "virtual";
+    return this.schemaType(column);
+  }
 
-/** @internal */
-function schemaType(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_type is not implemented",
-  );
-}
+  /** @internal */
+  private schemaType(column: Column): string {
+    if (column.bigint || column.type === "bigint") return "bigint";
+    return column.type;
+  }
 
-/** @internal */
-function schemaLimit(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_limit is not implemented",
-  );
-}
+  /** @internal */
+  private schemaLimit(column: Column): string | undefined {
+    if (column.bigint || column.type === "bigint") return undefined;
+    const limit = column.limit;
+    if (limit == null) return undefined;
+    return String(limit);
+  }
 
-/** @internal */
-function schemaPrecision(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_precision is not implemented",
-  );
-}
+  /** @internal */
+  private schemaPrecision(column: Column): string | undefined {
+    if (column.type === "datetime") {
+      if (column.precision == null) return "nil";
+      if (column.precision === DEFAULT_DATETIME_PRECISION) return undefined;
+      return String(column.precision);
+    }
+    if (column.precision != null) return String(column.precision);
+    return undefined;
+  }
 
-/** @internal */
-function schemaScale(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_scale is not implemented",
-  );
-}
+  /** @internal */
+  private schemaScale(column: Column): string | undefined {
+    if (column.scale != null) return String(column.scale);
+    return undefined;
+  }
 
-/** @internal */
-function schemaDefault(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_default is not implemented",
-  );
-}
+  /** @internal */
+  private schemaDefault(column: Column): string | undefined {
+    if (!column.hasDefault && column.default === undefined) return undefined;
+    if (column.default == null) return this.schemaExpression(column);
+    // Represent the default as its schema literal
+    if (typeof column.default === "string") return JSON.stringify(column.default);
+    return String(column.default);
+  }
 
-/** @internal */
-function schemaExpression(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_expression is not implemented",
-  );
-}
+  /** @internal */
+  private schemaExpression(column: Column): string | undefined {
+    if (column.defaultFunction) return `-> { ${JSON.stringify(column.defaultFunction)} }`;
+    return undefined;
+  }
 
-/** @internal */
-function schemaCollation(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_collation is not implemented",
-  );
+  /** @internal */
+  private schemaCollation(column: Column): string | undefined {
+    if (column.collation) return JSON.stringify(column.collation);
+    return undefined;
+  }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -9,8 +9,6 @@
 import type { SchemaSource, ColumnInfo } from "../../schema-dumper.js";
 import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
 
-const DEFAULT_DATETIME_PRECISION = 6;
-
 /** Column-shaped interface this dumper depends on. */
 interface Column extends ColumnInfo {
   bigint?: boolean;
@@ -101,7 +99,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   protected schemaPrecision(column: Column): string | undefined {
     if (column.type === "datetime") {
       if (column.precision == null) return "nil";
-      if (column.precision === DEFAULT_DATETIME_PRECISION) return undefined;
+      if (column.precision === BaseSchemaDumper.DEFAULT_DATETIME_PRECISION) return undefined;
       return String(column.precision);
     }
     if (column.precision != null) return String(column.precision);


### PR DESCRIPTION
## Summary

Brings 2 more abstract adapter files to 100% Rails API parity.

**schema-creation.ts** 52% → 100%:
- Add `visitPrimaryKeyDefinition`, `visitDropConstraint`, `visitAddCheckConstraint`, `quotedColumns`, `addTableOptionsBang`, `columnOptions`, `addColumnOptionsBang`, `toSql`, `tableModifierInCreate` as `protected` class methods
- `visitAddForeignKey` kept as file-local helper (subclasses have a legacy `(fromTable, toTable, options)` signature incompatible with Rails' `(o: ForeignKeyDefinition)`, so adding it as a class method causes a TS override conflict); wired into `visitAlterTable` via `.call(this, fk)`
- `visitDropConstraint` and `visitAddCheckConstraint` now routed through their named methods in `visitAlterTable` (matching Rails' `visit_AlterTable` dispatch)
- Remove all NotImplementedError stubs

**schema-dumper.ts** 7% → 100%:
- Implement all 13 column-spec helpers (`columnSpec`, `columnSpecForPrimaryKey`, `prepareColumnOptions`, `schemaType`, `schemaTypeWithVirtual`, `schemaLimit`, `schemaPrecision`, `schemaScale`, `schemaDefault`, `schemaExpression`, `schemaCollation`, `isDefaultPrimaryKey`, `isExplicitPrimaryKeyDefault`) as **protected** class methods — `protected` so MySQL/PostgreSQL/SQLite3 SchemaDumper subclasses can override them, mirroring Rails where these are overridden by each adapter
- References `BaseSchemaDumper.DEFAULT_DATETIME_PRECISION` instead of duplicating the constant

## Test plan

- [x] `pnpm build` clean
- [x] 9992 tests pass (3292 skipped)
- [x] `api:compare`: schema_creation 100% ✓, schema_dumper 100% ✓

Note: 369 LOC vs 300 limit — two cohesive files, all `@internal` helper methods, no public API changes.