### PR TITLE
feat(activerecord): encryption serializer/query/filter private methods to 100% (E2)

### DIFF
--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -11,10 +11,16 @@ export class AutoFilteredParameters {
   private _filterParameters: string[];
   private _attributesByClass: Map<any, string[]> = new Map();
   private _collecting = true;
+  private _hookDisposer?: () => void;
 
   constructor(filterParameters: string[]) {
     this._filterParameters = filterParameters;
     this.installCollectingHook();
+  }
+
+  dispose(): void {
+    this._hookDisposer?.();
+    this._hookDisposer = undefined;
   }
 
   enable(): void {
@@ -39,9 +45,11 @@ export class AutoFilteredParameters {
 
   /** @internal */
   private installCollectingHook(): void {
-    Configurable.onEncryptedAttributeDeclared((klass: any, attribute: string) => {
-      this.attributeWasDeclared(klass, attribute);
-    });
+    this._hookDisposer = Configurable.onEncryptedAttributeDeclared(
+      (klass: any, attribute: string) => {
+        this.attributeWasDeclared(klass, attribute);
+      },
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Configurable } from "./configurable.js";
 
@@ -9,12 +8,13 @@ import { Configurable } from "./configurable.js";
  * Mirrors: ActiveRecord::Encryption::AutoFilteredParameters
  */
 export class AutoFilteredParameters {
+  private _filterParameters: string[];
   private _attributesByClass: Map<any, string[]> = new Map();
   private _collecting = true;
-  private _filterParameters: string[];
 
   constructor(filterParameters: string[]) {
     this._filterParameters = filterParameters;
+    this.installCollectingHook();
   }
 
   enable(): void {
@@ -25,13 +25,35 @@ export class AutoFilteredParameters {
 
   /** @internal */
   attributeWasDeclared(klass: any, attribute: string): void {
-    if (!Configurable.config.addToFilterParameters) return;
-    if (Configurable.config.excludeFromFilterParameters.includes(attribute)) return;
-    if (this._collecting) {
+    if (this.isCollecting()) {
       this.collectForLater(klass, attribute);
     } else {
       this.applyFilter(klass, attribute);
     }
+  }
+
+  /** @internal */
+  private get app(): { config: { filter_parameters: string[] } } {
+    return { config: { filter_parameters: this._filterParameters } };
+  }
+
+  /** @internal */
+  private installCollectingHook(): void {
+    Configurable.onEncryptedAttributeDeclared((klass: any, attribute: string) => {
+      this.attributeWasDeclared(klass, attribute);
+    });
+  }
+
+  /** @internal */
+  private isCollecting(): boolean {
+    return this._collecting;
+  }
+
+  /** @internal */
+  private isExcludedFromFilterParameters(filterParameter: string): boolean {
+    return Configurable.config.excludeFromFilterParameters.some(
+      (excluded) => excluded === filterParameter,
+    );
   }
 
   private collectForLater(klass: any, attribute: string): void {
@@ -50,45 +72,16 @@ export class AutoFilteredParameters {
   }
 
   private applyFilter(klass: any, attribute: string): void {
-    const prefix = klass.name ? underscore(klass.name) : "";
+    if (!Configurable.config.addToFilterParameters) return;
+    const prefix = klass?.name ? underscore(klass.name) : "";
     const filter = prefix ? `${prefix}.${attribute}` : attribute;
-    if (!this._filterParameters.includes(filter)) {
-      this._filterParameters.push(filter);
+    if (
+      !this.isExcludedFromFilterParameters(filter) &&
+      !this.isExcludedFromFilterParameters(attribute)
+    ) {
+      if (!this._filterParameters.includes(filter)) {
+        this._filterParameters.push(filter);
+      }
     }
   }
-}
-
-/** @internal */
-function app(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::AutoFilteredParameters#app is not implemented",
-  );
-}
-
-/** @internal */
-function installCollectingHook(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::AutoFilteredParameters#install_collecting_hook is not implemented",
-  );
-}
-
-/** @internal */
-function attributeWasDeclared(klass: any, attribute: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::AutoFilteredParameters#attribute_was_declared is not implemented",
-  );
-}
-
-/** @internal */
-function isCollecting(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::AutoFilteredParameters#collecting? is not implemented",
-  );
-}
-
-/** @internal */
-function isExcludedFromFilterParameters(filterParameter: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::AutoFilteredParameters#excluded_from_filter_parameters? is not implemented",
-  );
 }

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -55,13 +55,10 @@ export class EnvelopeEncryptionKeyProvider {
       | string
       | undefined;
     if (!encryptedDataKey) return null;
-    const keys = this.primaryKeyProvider()
-      .decryptionKeys(encryptedMessage)
-      ?.map((k) => k.secret);
+    const kp = this.primaryKeyProvider();
+    const keys = kp.decryptionKeys(encryptedMessage)?.map((k) => k.secret);
     if (!keys || keys.length === 0) return null;
-    return new Encryptor({ compress: false }).decrypt(encryptedDataKey, {
-      keyProvider: this.primaryKeyProvider(),
-    });
+    return new Encryptor({ compress: false }).decrypt(encryptedDataKey, { keyProvider: kp });
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -56,10 +56,13 @@ export class EnvelopeEncryptionKeyProvider {
       | string
       | undefined;
     if (!encryptedDataKey) return null;
-    const kp = this.primaryKeyProvider();
-    const keys = kp.decryptionKeys(encryptedMessage)?.map((k) => k.secret);
-    if (!keys || keys.length === 0) return null;
-    return new Encryptor({ compress: false }).decrypt(encryptedDataKey, { keyProvider: kp });
+    try {
+      return new Encryptor({ compress: false }).decrypt(encryptedDataKey, {
+        keyProvider: this.primaryKeyProvider(),
+      });
+    } catch {
+      return null;
+    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -11,6 +11,7 @@ import { Encryptor } from "./encryptor.js";
 import { KeyProvider } from "./key-provider.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { Configurable } from "./configurable.js";
+import { DecryptionError } from "./errors.js";
 import type { Message } from "./message.js";
 
 export class EnvelopeEncryptionKeyProvider {
@@ -60,8 +61,9 @@ export class EnvelopeEncryptionKeyProvider {
       return new Encryptor({ compress: false }).decrypt(encryptedDataKey, {
         keyProvider: this.primaryKeyProvider(),
       });
-    } catch {
-      return null;
+    } catch (e) {
+      if (e instanceof DecryptionError) return null;
+      throw e;
     }
   }
 

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -5,79 +5,73 @@
  * Mirrors: ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider
  */
 
-import { NotImplementedError } from "../errors.js";
 import { getCrypto } from "@blazetrails/activesupport";
 import { Key } from "./key.js";
 import { Encryptor } from "./encryptor.js";
 import { KeyProvider } from "./key-provider.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { Configurable } from "./configurable.js";
 import type { Message } from "./message.js";
 
 export class EnvelopeEncryptionKeyProvider {
-  private _primaryKeyProvider: KeyProvider;
-  private _encryptor: Encryptor;
+  private _primaryKeyProviderOverride?: KeyProvider;
   private _activePrimaryKey?: Key;
 
-  constructor(primaryKeyProvider: KeyProvider) {
-    this._primaryKeyProvider = primaryKeyProvider;
-    this._encryptor = new Encryptor({ compress: false });
+  constructor(primaryKeyProvider?: KeyProvider) {
+    this._primaryKeyProviderOverride = primaryKeyProvider;
   }
 
   encryptionKey(): Key {
-    const randomSecret = this.generateRandomEncryptionKey();
+    const randomSecret = this.generateRandomSecret();
     const key = new Key(randomSecret);
-    const primaryKey = this._primaryKeyProvider.encryptionKey();
-    const encryptedSecret = this._encryptor.encrypt(randomSecret, {
-      key: primaryKey.secret,
-    });
-    key.publicTags = { encrypted_data_key: encryptedSecret };
+    key.publicTags = { encrypted_data_key: this.encryptDataKey(randomSecret) };
     return key;
   }
 
   decryptionKeys(message: Message): Key[] {
-    const encryptedDataKey = message.headers.get("encrypted_data_key") as string;
-    if (!encryptedDataKey) {
-      return [];
-    }
-    const secret = this._encryptor.decrypt(encryptedDataKey, {
-      keyProvider: this._primaryKeyProvider,
-    });
-    return [new Key(secret)];
+    const secret = this.decryptDataKey(message);
+    return secret ? [new Key(secret)] : [];
   }
 
   get activePrimaryKey(): Key {
-    this._activePrimaryKey ??= this._primaryKeyProvider.encryptionKey();
+    this._activePrimaryKey ??= this.primaryKeyProvider().encryptionKey();
     return this._activePrimaryKey;
   }
 
   generateRandomEncryptionKey(): string {
+    return this.generateRandomSecret();
+  }
+
+  /** @internal */
+  private encryptDataKey(randomSecret: string): string {
+    return new Encryptor({ compress: false }).encrypt(randomSecret, {
+      key: this.activePrimaryKey.secret,
+    });
+  }
+
+  /** @internal */
+  private decryptDataKey(encryptedMessage: Message): string | null {
+    const encryptedDataKey = encryptedMessage.headers.get("encrypted_data_key") as
+      | string
+      | undefined;
+    if (!encryptedDataKey) return null;
+    const keys = this.primaryKeyProvider()
+      .decryptionKeys(encryptedMessage)
+      ?.map((k) => k.secret);
+    if (!keys || keys.length === 0) return null;
+    return new Encryptor({ compress: false }).decrypt(encryptedDataKey, {
+      keyProvider: this.primaryKeyProvider(),
+    });
+  }
+
+  /** @internal */
+  private primaryKeyProvider(): KeyProvider {
+    if (this._primaryKeyProviderOverride) return this._primaryKeyProviderOverride;
+    return new DerivedSecretKeyProvider(Configurable.config.get("primaryKey") as string);
+  }
+
+  /** @internal */
+  private generateRandomSecret(): string {
     return getCrypto().randomBytes(32).toString("base64");
   }
-}
-
-/** @internal */
-function encryptDataKey(randomSecret: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#encrypt_data_key is not implemented",
-  );
-}
-
-/** @internal */
-function decryptDataKey(encryptedMessage: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#decrypt_data_key is not implemented",
-  );
-}
-
-/** @internal */
-function primaryKeyProvider(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#primary_key_provider is not implemented",
-  );
-}
-
-/** @internal */
-function generateRandomSecret(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#generate_random_secret is not implemented",
-  );
 }

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -15,6 +15,7 @@ import type { Message } from "./message.js";
 
 export class EnvelopeEncryptionKeyProvider {
   private _primaryKeyProviderOverride?: KeyProvider;
+  private _primaryKeyProviderCache?: KeyProvider;
   private _activePrimaryKey?: Key;
 
   constructor(primaryKeyProvider?: KeyProvider) {
@@ -64,7 +65,10 @@ export class EnvelopeEncryptionKeyProvider {
   /** @internal */
   private primaryKeyProvider(): KeyProvider {
     if (this._primaryKeyProviderOverride) return this._primaryKeyProviderOverride;
-    return new DerivedSecretKeyProvider(Configurable.config.get("primaryKey") as string);
+    this._primaryKeyProviderCache ??= new DerivedSecretKeyProvider(
+      Configurable.config.get("primaryKey") as string,
+    );
+    return this._primaryKeyProviderCache;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "../errors.js";
 import { prepend } from "@blazetrails/activesupport";
 import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { getAttributeType } from "./encryptable-record.js";
@@ -159,6 +158,14 @@ export class EncryptedQuery {
     return this.allCiphertextsFor(value, type);
   }
 
+  /** @internal */
+  private static additionalValuesFor(
+    value: unknown,
+    type: EncryptedAttributeType,
+  ): AdditionalValue[] {
+    return type.previousTypes.map((additionalType) => new AdditionalValue(value, additionalType));
+  }
+
   private static allCiphertextsFor(
     plaintext: unknown,
     type: EncryptedAttributeType,
@@ -249,7 +256,12 @@ export class AdditionalValue {
 
   constructor(value: unknown, type: EncryptedAttributeType) {
     this.type = type;
-    this.value = type.serialize(value);
+    this.value = this.process(value);
+  }
+
+  /** @internal */
+  private process(value: unknown): unknown {
+    return this.type.serialize(value);
   }
 
   toString(): string {
@@ -282,18 +294,4 @@ export class ExtendedEncryptableType {
     }
     return originalSerialize(data);
   }
-}
-
-/** @internal */
-function process(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue#process is not implemented",
-  );
-}
-
-/** @internal */
-function additionalValuesFor(value: any, type: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery#additional_values_for is not implemented",
-  );
 }

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -35,11 +35,12 @@ export class KeyGenerator {
       .toString("hex");
   }
 
-  deriveKey(password: string, length: number = 32, salt?: string): string {
+  deriveKey(password: string, length?: number, salt?: string): string {
+    const effectiveLength = length ?? this.keyLength();
     const crypto = getCrypto();
     const effectiveSalt = salt ?? "";
     const digest = this._hashDigestClass.toLowerCase().replace(/-/g, "");
-    const derived = crypto.pbkdf2Sync(password, effectiveSalt, 2 ** 16, length, digest);
+    const derived = crypto.pbkdf2Sync(password, effectiveSalt, 2 ** 16, effectiveLength, digest);
     return derived.toString("base64");
   }
 

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -1,7 +1,5 @@
 /**
- * A message serializer that mirrors Rails'
- * ActiveRecord::Encryption::MessagePackMessageSerializer API but
- * delegates to the JSON-based MessageSerializer.
+ * A message serializer using hash-based encoding.
  *
  * Mirrors: ActiveRecord::Encryption::MessagePackMessageSerializer
  */
@@ -37,15 +35,15 @@ export class MessagePackMessageSerializer {
 
   /** @internal */
   private messageToHash(message: Message): Record<string, unknown> {
-    return {
+    return Object.assign(Object.create(null) as Record<string, unknown>, {
       p: message.payload,
       h: this.headersToHash(message.headers),
-    };
+    });
   }
 
   /** @internal */
   private headersToHash(headers: Properties): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
+    const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
     for (const [key, value] of headers.entries()) {
       result[key] = value instanceof Message ? this.messageToHash(value) : value;
     }
@@ -58,7 +56,14 @@ export class MessagePackMessageSerializer {
     const d = data as Record<string, unknown>;
     const message = new Message(d["p"] as string | null);
     const headers = this.parseProperties(d["h"] as Record<string, unknown> | null, level);
+    let nestedCount = 0;
     for (const [key, value] of headers.entries()) {
+      if (value instanceof Message) {
+        nestedCount++;
+        if (nestedCount > 1) {
+          throw new DecryptionError("Messages can only have one nested message in their headers");
+        }
+      }
       message.headers.set(key, value);
     }
     return message;
@@ -72,7 +77,8 @@ export class MessagePackMessageSerializer {
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
       throw new DecryptionError("Invalid data format: hash without payload");
     }
-    if (!("p" in (data as object))) {
+    const d = data as Record<string, unknown>;
+    if (!("p" in d) || typeof d["p"] !== "string") {
       throw new DecryptionError("Invalid data format: hash without payload");
     }
   }

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -81,6 +81,14 @@ export class MessagePackMessageSerializer {
     if (!("p" in d) || typeof d["p"] !== "string") {
       throw new DecryptionError("Invalid data format: hash without payload");
     }
+    if (
+      "h" in d &&
+      d["h"] !== null &&
+      d["h"] !== undefined &&
+      (typeof d["h"] !== "object" || Array.isArray(d["h"]))
+    ) {
+      throw new DecryptionError("Invalid data format: headers must be an object");
+    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -1,77 +1,97 @@
-import { NotImplementedError } from "../errors.js";
-import { Message } from "./message.js";
-import { MessageSerializer } from "./message-serializer.js";
-
 /**
  * A message serializer that mirrors Rails'
  * ActiveRecord::Encryption::MessagePackMessageSerializer API but
- * currently delegates entirely to the JSON-based MessageSerializer.
- *
- * This implementation does not yet use MessagePack or any binary
- * serialization format; it exists as a compatibility layer so callers
- * can rely on the same interface as Rails while we remain JSON-only.
- *
- * TODO: Optionally integrate a real MessagePack library (e.g.
- * @msgpack/msgpack) in the future for compact binary serialization.
+ * delegates to the JSON-based MessageSerializer.
  *
  * Mirrors: ActiveRecord::Encryption::MessagePackMessageSerializer
  */
+
+import { Message } from "./message.js";
+import { Properties } from "./properties.js";
+import { DecryptionError, ForbiddenClass } from "./errors.js";
+
 export class MessagePackMessageSerializer {
-  private _fallback: MessageSerializer;
-
-  constructor() {
-    this._fallback = new MessageSerializer();
-  }
-
   dump(message: Message): string {
-    return this._fallback.dump(message);
+    if (!(message instanceof Message)) {
+      throw new ForbiddenClass(`Can only serialize Message instances, got ${typeof message}`);
+    }
+    return JSON.stringify(this.messageToHash(message));
   }
 
   load(serialized: string): Message {
-    return this._fallback.load(serialized);
+    if (typeof serialized !== "string") {
+      throw new TypeError(`Expected string, got ${typeof serialized}`);
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(serialized);
+    } catch {
+      throw new DecryptionError("Failed to load MessagePack message");
+    }
+    return this.hashToMessage(data, 1);
   }
 
-  // Rails returns true here because real MessagePack is binary.
-  // This implementation delegates to JSON, so false is correct for
-  // our current output format — the guard in EncryptedAttributeType
-  // that prevents binary data from being stored in text columns must
-  // not fire while we're producing JSON strings.
   isBinary(): boolean {
-    return this._fallback.isBinary();
+    return false;
   }
-}
 
-/** @internal */
-function messageToHash(message: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessagePackMessageSerializer#message_to_hash is not implemented",
-  );
-}
+  /** @internal */
+  private messageToHash(message: Message): Record<string, unknown> {
+    return {
+      p: message.payload,
+      h: this.headersToHash(message.headers),
+    };
+  }
 
-/** @internal */
-function headersToHash(headers: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessagePackMessageSerializer#headers_to_hash is not implemented",
-  );
-}
+  /** @internal */
+  private headersToHash(headers: Properties): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of headers.entries()) {
+      result[key] = value instanceof Message ? this.messageToHash(value) : value;
+    }
+    return result;
+  }
 
-/** @internal */
-function hashToMessage(data: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessagePackMessageSerializer#hash_to_message is not implemented",
-  );
-}
+  /** @internal */
+  private hashToMessage(data: unknown, level: number): Message {
+    this.validateMessageDataFormat(data, level);
+    const d = data as Record<string, unknown>;
+    const message = new Message(d["p"] as string | null);
+    const headers = this.parseProperties(d["h"] as Record<string, unknown> | null, level);
+    for (const [key, value] of headers.entries()) {
+      message.headers.set(key, value);
+    }
+    return message;
+  }
 
-/** @internal */
-function validateMessageDataFormat(data: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessagePackMessageSerializer#validate_message_data_format is not implemented",
-  );
-}
+  /** @internal */
+  private validateMessageDataFormat(data: unknown, level: number): void {
+    if (level > 2) {
+      throw new DecryptionError("More than one level of hash nesting in headers is not supported");
+    }
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      throw new DecryptionError("Invalid data format: hash without payload");
+    }
+    if (!("p" in (data as object))) {
+      throw new DecryptionError("Invalid data format: hash without payload");
+    }
+  }
 
-/** @internal */
-function parseProperties(headers: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessagePackMessageSerializer#parse_properties is not implemented",
-  );
+  /** @internal */
+  private parseProperties(
+    headers: Record<string, unknown> | null | undefined,
+    level: number,
+  ): Properties {
+    const properties = new Properties();
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        const decoded =
+          typeof value === "object" && value !== null && !Array.isArray(value)
+            ? this.hashToMessage(value, level + 1)
+            : value;
+        properties.set(key, decoded);
+      }
+    }
+    return properties;
+  }
 }

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -64,8 +64,12 @@ export class MessageSerializer {
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
       throw new DecryptionError("Invalid data format: hash without payload");
     }
-    if (!("p" in (data as object))) {
+    const d = data as Record<string, unknown>;
+    if (!("p" in d) || typeof d["p"] !== "string") {
       throw new DecryptionError("Invalid data format: hash without payload");
+    }
+    if ("h" in d && d["h"] !== null && d["h"] !== undefined && typeof d["h"] !== "object") {
+      throw new DecryptionError("Invalid data format: headers must be an object");
     }
   }
 
@@ -89,15 +93,15 @@ export class MessageSerializer {
 
   /** @internal */
   private messageToJson(message: Message): Record<string, unknown> {
-    return {
+    return Object.assign(Object.create(null) as Record<string, unknown>, {
       p: this.encodeIfNeeded(message.payload),
       h: this.headersToJson(message.headers),
-    };
+    });
   }
 
   /** @internal */
   private headersToJson(headers: Properties): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
+    const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
     for (const [key, value] of headers.entries()) {
       result[key] =
         value instanceof Message ? this.messageToJson(value) : this.encodeIfNeeded(value);
@@ -108,7 +112,7 @@ export class MessageSerializer {
   /** @internal */
   private encodeIfNeeded(value: unknown): unknown {
     if (typeof value === "string") {
-      return Buffer.from(value, "binary").toString("base64");
+      return Buffer.from(value, "utf-8").toString("base64");
     }
     return value;
   }
@@ -123,7 +127,7 @@ export class MessageSerializer {
         if (normalized !== reencoded) {
           throw new DecryptionError("Invalid base64 encoding");
         }
-        return buf.toString("binary");
+        return buf.toString("utf-8");
       } catch (e) {
         if (e instanceof DecryptionError) throw e;
         throw new DecryptionError("Invalid base64 encoding");

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -68,7 +68,12 @@ export class MessageSerializer {
     if (!("p" in d) || typeof d["p"] !== "string") {
       throw new DecryptionError("Invalid data format: hash without payload");
     }
-    if ("h" in d && d["h"] !== null && d["h"] !== undefined && typeof d["h"] !== "object") {
+    if (
+      "h" in d &&
+      d["h"] !== null &&
+      d["h"] !== undefined &&
+      (typeof d["h"] !== "object" || Array.isArray(d["h"]))
+    ) {
       throw new DecryptionError("Invalid data format: headers must be an object");
     }
   }

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -4,8 +4,8 @@
  * Mirrors: ActiveRecord::Encryption::MessageSerializer
  */
 
-import { NotImplementedError } from "../errors.js";
 import { Message } from "./message.js";
+import { Properties } from "./properties.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
 
 export class MessageSerializer {
@@ -13,138 +13,122 @@ export class MessageSerializer {
     if (!(message instanceof Message)) {
       throw new ForbiddenClass(`Can only serialize Message instances, got ${typeof message}`);
     }
-    const headers: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-    const data: Record<string, unknown> = {
-      p: Buffer.from(message.payload, "utf-8").toString("base64"),
-      h: headers,
-    };
-    for (const [key, value] of message.headers.entries()) {
-      if (value instanceof Message) {
-        headers[key] = JSON.parse(this.dump(value));
-      } else {
-        headers[key] = value;
-      }
-    }
-    return JSON.stringify(data);
+    return JSON.stringify(this.messageToJson(message));
   }
 
   load(serialized: string): Message {
     if (typeof serialized !== "string") {
       throw new TypeError(`Expected string, got ${typeof serialized}`);
     }
-
-    let data: any;
+    let data: unknown;
     try {
       data = JSON.parse(serialized);
     } catch {
       throw new DecryptionError("Failed to deserialize encrypted message");
     }
-
-    if (typeof data !== "object" || data === null || Array.isArray(data)) {
-      throw new DecryptionError("Invalid encrypted message format");
-    }
-
-    if (!("p" in data)) {
-      throw new DecryptionError("Invalid encrypted message format: missing payload");
-    }
-
-    if (typeof data.p !== "string") {
-      throw new DecryptionError("Invalid encrypted message format: payload not base64");
-    }
-    const payloadBuffer = Buffer.from(data.p, "base64");
-    const reencoded = payloadBuffer.toString("base64").replace(/=+$/, "");
-    const normalizedOriginal = data.p.replace(/=+$/, "");
-    if (normalizedOriginal !== reencoded) {
-      throw new DecryptionError("Invalid encrypted message format: payload not base64");
-    }
-    const payload = payloadBuffer.toString("utf-8");
-
-    const message = new Message(payload);
-    const headers = data.h;
-    if (Array.isArray(headers)) {
-      throw new DecryptionError("Invalid encrypted message format: headers must be a JSON object");
-    }
-    if (headers && typeof headers === "object") {
-      const nestedMessages: string[] = [];
-      for (const [key, value] of Object.entries(headers)) {
-        if (
-          typeof value === "object" &&
-          value !== null &&
-          !Array.isArray(value) &&
-          "p" in (value as any)
-        ) {
-          nestedMessages.push(key);
-          if (nestedMessages.length > 1) {
-            throw new DecryptionError("Messages can only have one nested message in their headers");
-          }
-          const nested = this.load(JSON.stringify(value));
-          for (const [, v] of nested.headers.entries()) {
-            if (v instanceof Message) {
-              throw new DecryptionError(
-                "Messages can only have one nested message in their headers",
-              );
-            }
-          }
-          message.headers.set(key, nested);
-        } else {
-          message.headers.set(key, value);
-        }
-      }
-    }
-
-    return message;
+    return this.parseMessage(data, 1);
   }
 
   isBinary(): boolean {
     return false;
   }
-}
 
-/** @internal */
-function parseMessage(data: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#parse_message is not implemented",
-  );
-}
+  /** @internal */
+  private parseMessage(data: unknown, level: number): Message {
+    this.validateMessageDataFormat(data, level);
+    const d = data as Record<string, unknown>;
+    const payload = this.decodeIfNeeded(d["p"]);
+    const headers = this.parseProperties(
+      d["h"] as Record<string, unknown> | null | undefined,
+      level,
+    );
+    const message = new Message(typeof payload === "string" ? payload : null);
+    let nestedCount = 0;
+    for (const [key, value] of headers.entries()) {
+      if (value instanceof Message) {
+        nestedCount++;
+        if (nestedCount > 1) {
+          throw new DecryptionError("Messages can only have one nested message in their headers");
+        }
+      }
+      message.headers.set(key, value);
+    }
+    return message;
+  }
 
-/** @internal */
-function validateMessageDataFormat(data: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#validate_message_data_format is not implemented",
-  );
-}
+  /** @internal */
+  private validateMessageDataFormat(data: unknown, level: number): void {
+    if (level > 2) {
+      throw new DecryptionError("More than one level of hash nesting in headers is not supported");
+    }
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      throw new DecryptionError("Invalid data format: hash without payload");
+    }
+    if (!("p" in (data as object))) {
+      throw new DecryptionError("Invalid data format: hash without payload");
+    }
+  }
 
-/** @internal */
-function parseProperties(headers: any, level: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#parse_properties is not implemented",
-  );
-}
+  /** @internal */
+  private parseProperties(
+    headers: Record<string, unknown> | null | undefined,
+    level: number,
+  ): Properties {
+    const properties = new Properties();
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        const decoded =
+          typeof value === "object" && value !== null && !Array.isArray(value) && "p" in value
+            ? this.parseMessage(value, level + 1)
+            : this.decodeIfNeeded(value);
+        properties.set(key, decoded);
+      }
+    }
+    return properties;
+  }
 
-/** @internal */
-function messageToJson(message: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#message_to_json is not implemented",
-  );
-}
+  /** @internal */
+  private messageToJson(message: Message): Record<string, unknown> {
+    return {
+      p: this.encodeIfNeeded(message.payload),
+      h: this.headersToJson(message.headers),
+    };
+  }
 
-/** @internal */
-function headersToJson(headers: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#headers_to_json is not implemented",
-  );
-}
+  /** @internal */
+  private headersToJson(headers: Properties): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of headers.entries()) {
+      result[key] =
+        value instanceof Message ? this.messageToJson(value) : this.encodeIfNeeded(value);
+    }
+    return result;
+  }
 
-/** @internal */
-function encodeIfNeeded(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#encode_if_needed is not implemented",
-  );
-}
+  /** @internal */
+  private encodeIfNeeded(value: unknown): unknown {
+    if (typeof value === "string") {
+      return Buffer.from(value, "binary").toString("base64");
+    }
+    return value;
+  }
 
-/** @internal */
-function decodeIfNeeded(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::MessageSerializer#decode_if_needed is not implemented",
-  );
+  /** @internal */
+  private decodeIfNeeded(value: unknown): unknown {
+    if (typeof value === "string") {
+      try {
+        const buf = Buffer.from(value, "base64");
+        const reencoded = buf.toString("base64").replace(/=+$/, "");
+        const normalized = value.replace(/=+$/, "");
+        if (normalized !== reencoded) {
+          throw new DecryptionError("Invalid base64 encoding");
+        }
+        return buf.toString("binary");
+      } catch (e) {
+        if (e instanceof DecryptionError) throw e;
+        throw new DecryptionError("Invalid base64 encoding");
+      }
+    }
+    return value;
+  }
 }


### PR DESCRIPTION
## Summary

- Moves private helpers into `@internal` class methods for 5 more encryption files → 100% on `api:compare`
- **MessageSerializer**: `parseMessage`, `validateMessageDataFormat`, `parseProperties`, `messageToJson`, `headersToJson`, `encodeIfNeeded`, `decodeIfNeeded` — refactored `dump`/`load` to delegate to these
- **MessagePackMessageSerializer**: same 5 private methods — own implementation instead of JSON fallback
- **EnvelopeEncryptionKeyProvider**: `encryptDataKey`, `decryptDataKey`, `primaryKeyProvider`, `generateRandomSecret`
- **AutoFilteredParameters**: `app` (private getter), `installCollectingHook`, `isCollecting`, `isExcludedFromFilterParameters`
- **ExtendedDeterministicQueries**: `AdditionalValue#process`, `EncryptedQuery#additionalValuesFor`

Stacks on E1 (#1140).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/encryption` — 270 passed, 10 skipped
- [x] `pnpm test:types` — 74 passed, no type errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm run api:compare --package activerecord` — 5 more encryption files at 100%