### PR TITLE
feat(activerecord): encryptable-record + encrypted-attribute-type to 100% (E4)

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,4 +1,6 @@
 import { Scheme, type SchemeOptions } from "./scheme.js";
+import { getEncryptionContext, withoutEncryption as _withoutEncryption } from "./context.js";
+import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
@@ -287,12 +289,15 @@ export class EncryptableRecord {
   static async decryptAttributes(record: any): Promise<void> {
     this.validateEncryptionAllowed(record);
     const assignments = this.buildDecryptAttributeAssignments(record);
-    await record.updateColumns?.(assignments);
+    await _withoutEncryption(() => record.updateColumns?.(assignments));
   }
 
   /** @internal */
-  static validateEncryptionAllowed(record: any): void {
-    // No-op unless encryption is frozen (read-only mode).
+  static validateEncryptionAllowed(_record: any): void {
+    const ctx = getEncryptionContext();
+    if (ctx.frozenEncryption) {
+      throw new ConfigurationError("can't be modified because it is encrypted");
+    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -214,12 +214,13 @@ export class EncryptableRecord {
 
   /** @internal */
   static overrideAccessorsToPreserveOriginal(
-    modelClass: any,
-    name: string,
-    originalName: string,
+    _modelClass: any,
+    _name: string,
+    _originalName: string,
   ): void {
-    // In TS we can't dynamically override accessors the way Ruby can,
-    // but we record the mapping for consumers that need it.
+    // Rails uses Ruby's `include(Module.new { define_method ... })` to dynamically
+    // override attribute accessors. TS has no equivalent; the ignoreCase
+    // read-original behaviour is handled at the EncryptedAttributeType level.
   }
 
   /** @internal */
@@ -240,10 +241,12 @@ export class EncryptableRecord {
   /** @internal */
   static isEncryptedAttribute(record: any, attributeName: string): boolean {
     const klass = record.constructor as any;
-    if (!klass._encryptedAttributes?.has(attributeName)) return false;
-    const type = getAttributeType(klass, attributeName);
+    // Resolve attribute aliases before checking encrypted set.
+    const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
+    if (!klass._encryptedAttributes?.has(resolvedName)) return false;
+    const type = getAttributeType(klass, resolvedName);
     if (!(type instanceof EncryptedAttributeType)) return false;
-    const raw = record.readAttributeBeforeTypeCast?.(attributeName);
+    const raw = record.readAttributeBeforeTypeCast?.(resolvedName);
     return type.isEncrypted(raw);
   }
 
@@ -252,7 +255,8 @@ export class EncryptableRecord {
     if (this.isEncryptedAttribute(record, attributeName)) {
       return record.readAttributeBeforeTypeCast?.(attributeName);
     }
-    return record.readAttribute?.(attributeName);
+    // For unencrypted attributes return the database-serialized value.
+    return record.readAttributeBeforeTypeCast?.(attributeName);
   }
 
   /** @internal */
@@ -271,11 +275,11 @@ export class EncryptableRecord {
 
   /** @internal */
   static _createRecord(record: any, attributeNames?: string[]): unknown {
-    // Ensure encrypted attributes are always included in persisted column list.
-    const names = attributeNames ?? record.attributeNames ?? [];
-    const encryptedAttrs: Set<string> = record.constructor._encryptedAttributes ?? new Set();
-    const all = [...new Set([...names, ...encryptedAttrs])];
-    return record._createRecord?.(all);
+    // Rails prepends this to force encrypted attrs into the INSERT column list.
+    // In our codebase _createRecord is the ORM callback chain entry point and
+    // ignores attributeNames; encrypted columns are included unconditionally via
+    // _performInsert. This helper exists for api:compare parity only.
+    return record._createRecord?.(attributeNames);
   }
 
   /** @internal */
@@ -305,7 +309,10 @@ export class EncryptableRecord {
     const klass = record.constructor as any;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
-      result[name] = record[name];
+      const type = getAttributeType(klass, name);
+      const value = record[name];
+      // Pre-serialize so updateColumns stores ciphertext, not plaintext.
+      result[name] = type instanceof EncryptedAttributeType ? type.serialize(value) : value;
     }
     return result;
   }
@@ -317,7 +324,12 @@ export class EncryptableRecord {
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
       const type = getAttributeType(klass, name);
       const raw = record.readAttributeBeforeTypeCast?.(name);
-      result[name] = type instanceof EncryptedAttributeType ? type.deserialize(raw) : raw;
+      // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
+      // which returns the raw value when support_unencrypted_data is true.
+      result[name] =
+        type instanceof EncryptedAttributeType && type.isEncrypted(raw)
+          ? type.deserialize(raw)
+          : raw;
     }
     return result;
   }
@@ -325,8 +337,12 @@ export class EncryptableRecord {
   /** @internal */
   static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
     const klass = record.constructor as any;
+    // changedAttributes is a string[] in this codebase (from DirtyTracker).
+    const changed: string[] = Array.isArray(record.changedAttributes)
+      ? record.changedAttributes
+      : [];
     for (const attr of klass._encryptedAttributes ?? new Set<string>()) {
-      if (Object.prototype.hasOwnProperty.call(record.changedAttributes?.() ?? {}, attr)) {
+      if (changed.includes(attr)) {
         record.errors?.add?.(attr, "can't be modified because it is encrypted");
       }
     }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "../errors.js";
 import { Scheme, type SchemeOptions } from "./scheme.js";
 import { LengthValidator } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
@@ -198,6 +197,135 @@ export class EncryptableRecord {
     }
     return result;
   }
+
+  /** @internal */
+  static encryptAttribute(modelClass: any, name: string, options: SchemeOptions = {}): void {
+    this.encrypts(modelClass, name, options);
+  }
+
+  /** @internal */
+  static preserveOriginalEncrypted(modelClass: any, name: string): void {
+    const originalName = `original_${name}`;
+    this.encrypts(modelClass, originalName);
+    this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
+  }
+
+  /** @internal */
+  static overrideAccessorsToPreserveOriginal(
+    modelClass: any,
+    name: string,
+    originalName: string,
+  ): void {
+    // In TS we can't dynamically override accessors the way Ruby can,
+    // but we record the mapping for consumers that need it.
+  }
+
+  /** @internal */
+  static loadSchemaBang(modelClass: any): void {
+    if (Configurable.config.validateColumnSize) {
+      this.addLengthValidationForEncryptedColumns(modelClass);
+    }
+  }
+
+  /** @internal */
+  static addLengthValidationForEncryptedColumns(modelClass: any): void {
+    const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set();
+    for (const name of attrs) {
+      this.validateColumnSize(modelClass, name);
+    }
+  }
+
+  /** @internal */
+  static isEncryptedAttribute(record: any, attributeName: string): boolean {
+    const klass = record.constructor as any;
+    if (!klass._encryptedAttributes?.has(attributeName)) return false;
+    const type = getAttributeType(klass, attributeName);
+    if (!(type instanceof EncryptedAttributeType)) return false;
+    const raw = record.readAttributeBeforeTypeCast?.(attributeName);
+    return type.isEncrypted(raw);
+  }
+
+  /** @internal */
+  static ciphertextFor(record: any, attributeName: string): unknown {
+    if (this.isEncryptedAttribute(record, attributeName)) {
+      return record.readAttributeBeforeTypeCast?.(attributeName);
+    }
+    return record.readAttribute?.(attributeName);
+  }
+
+  /** @internal */
+  static async encrypt(record: any): Promise<void> {
+    if (this.hasEncryptedAttributes(record.constructor)) {
+      await this.encryptAttributes(record);
+    }
+  }
+
+  /** @internal */
+  static async decrypt(record: any): Promise<void> {
+    if (this.hasEncryptedAttributes(record.constructor)) {
+      await this.decryptAttributes(record);
+    }
+  }
+
+  /** @internal */
+  static _createRecord(record: any, attributeNames?: string[]): unknown {
+    // Ensure encrypted attributes are always included in persisted column list.
+    const names = attributeNames ?? record.attributeNames ?? [];
+    const encryptedAttrs: Set<string> = record.constructor._encryptedAttributes ?? new Set();
+    const all = [...new Set([...names, ...encryptedAttrs])];
+    return record._createRecord?.(all);
+  }
+
+  /** @internal */
+  static async encryptAttributes(record: any): Promise<void> {
+    this.validateEncryptionAllowed(record);
+    const assignments = this.buildEncryptAttributeAssignments(record);
+    await record.updateColumns?.(assignments);
+  }
+
+  /** @internal */
+  static async decryptAttributes(record: any): Promise<void> {
+    this.validateEncryptionAllowed(record);
+    const assignments = this.buildDecryptAttributeAssignments(record);
+    await record.updateColumns?.(assignments);
+  }
+
+  /** @internal */
+  static validateEncryptionAllowed(record: any): void {
+    // No-op unless encryption is frozen (read-only mode).
+  }
+
+  /** @internal */
+  static buildEncryptAttributeAssignments(record: any): Record<string, unknown> {
+    const klass = record.constructor as any;
+    const result: Record<string, unknown> = {};
+    for (const name of klass._encryptedAttributes ?? new Set<string>()) {
+      result[name] = record[name];
+    }
+    return result;
+  }
+
+  /** @internal */
+  static buildDecryptAttributeAssignments(record: any): Record<string, unknown> {
+    const klass = record.constructor as any;
+    const result: Record<string, unknown> = {};
+    for (const name of klass._encryptedAttributes ?? new Set<string>()) {
+      const type = getAttributeType(klass, name);
+      const raw = record.readAttributeBeforeTypeCast?.(name);
+      result[name] = type instanceof EncryptedAttributeType ? type.deserialize(raw) : raw;
+    }
+    return result;
+  }
+
+  /** @internal */
+  static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
+    const klass = record.constructor as any;
+    for (const attr of klass._encryptedAttributes ?? new Set<string>()) {
+      if (Object.prototype.hasOwnProperty.call(record.changedAttributes?.() ?? {}, attr)) {
+        record.errors?.add?.(attr, "can't be modified because it is encrypted");
+      }
+    }
+  }
 }
 
 /**
@@ -206,142 +334,4 @@ export class EncryptableRecord {
 export function getAttributeType(klass: any, name: string): unknown {
   const def = klass._attributeDefinitions?.get?.(name);
   return def?.type;
-}
-
-/** @internal */
-function encryptAttribute(
-  name: any,
-  keyProvider?: any,
-  key?: any,
-  deterministic?: any,
-  supportUnencryptedData?: any,
-  downcase?: any,
-  ignoreCase?: any,
-  previous?: any,
-  compress?: any,
-  compressor?: any,
-  contextProperties?: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attribute is not implemented",
-  );
-}
-
-/** @internal */
-function preserveOriginalEncrypted(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#preserve_original_encrypted is not implemented",
-  );
-}
-
-/** @internal */
-function overrideAccessorsToPreserveOriginal(name: any, originalAttributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#override_accessors_to_preserve_original is not implemented",
-  );
-}
-
-/** @internal */
-function loadSchemaBang(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#load_schema! is not implemented",
-  );
-}
-
-/** @internal */
-function addLengthValidationForEncryptedColumns(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#add_length_validation_for_encrypted_columns is not implemented",
-  );
-}
-
-/** @internal */
-function validateColumnSize(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#validate_column_size is not implemented",
-  );
-}
-
-/** @internal */
-function isEncryptedAttribute(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute? is not implemented",
-  );
-}
-
-/** @internal */
-function ciphertextFor(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#ciphertext_for is not implemented",
-  );
-}
-
-/** @internal */
-function encrypt(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt is not implemented",
-  );
-}
-
-/** @internal */
-function decrypt(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#decrypt is not implemented",
-  );
-}
-
-/** @internal */
-function _createRecord(attributeNames?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#_create_record is not implemented",
-  );
-}
-
-/** @internal */
-function encryptAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attributes is not implemented",
-  );
-}
-
-/** @internal */
-function decryptAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#decrypt_attributes is not implemented",
-  );
-}
-
-/** @internal */
-function validateEncryptionAllowed(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#validate_encryption_allowed is not implemented",
-  );
-}
-
-/** @internal */
-function hasEncryptedAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#has_encrypted_attributes? is not implemented",
-  );
-}
-
-/** @internal */
-function buildEncryptAttributeAssignments(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#build_encrypt_attribute_assignments is not implemented",
-  );
-}
-
-/** @internal */
-function buildDecryptAttributeAssignments(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#build_decrypt_attribute_assignments is not implemented",
-  );
-}
-
-/** @internal */
-function cantModifyEncryptedAttributesWhenFrozen(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#cant_modify_encrypted_attributes_when_frozen is not implemented",
-  );
 }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -252,11 +252,9 @@ export class EncryptableRecord {
 
   /** @internal */
   static ciphertextFor(record: any, attributeName: string): unknown {
-    if (this.isEncryptedAttribute(record, attributeName)) {
-      return record.readAttributeBeforeTypeCast?.(attributeName);
-    }
-    // For unencrypted attributes return the database-serialized value.
-    return record.readAttributeBeforeTypeCast?.(attributeName);
+    const klass = record.constructor as any;
+    const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
+    return record.readAttributeBeforeTypeCast?.(resolvedName);
   }
 
   /** @internal */
@@ -310,7 +308,7 @@ export class EncryptableRecord {
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
       const type = getAttributeType(klass, name);
-      const value = record[name];
+      const value = record.readAttribute?.(name) ?? record[name];
       // Pre-serialize so updateColumns stores ciphertext, not plaintext.
       result[name] = type instanceof EncryptedAttributeType ? type.serialize(value) : value;
     }
@@ -326,10 +324,13 @@ export class EncryptableRecord {
       const raw = record.readAttributeBeforeTypeCast?.(name);
       // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
       // which returns the raw value when support_unencrypted_data is true.
-      result[name] =
-        type instanceof EncryptedAttributeType && type.isEncrypted(raw)
-          ? type.deserialize(raw)
-          : raw;
+      if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
+        result[name] = type.deserialize(raw);
+      } else {
+        // Plaintext — return the cast value so typed columns (date, JSON, etc.)
+        // keep their in-memory representation rather than the raw DB string.
+        result[name] = record.readAttribute?.(name) ?? raw;
+      }
     }
     return result;
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -288,7 +288,15 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private buildPreviousTypesFor(schemes: Scheme[]): EncryptedAttributeType[] {
-    return schemes.map((s) => new EncryptedAttributeType({ scheme: s, previousType: true }));
+    return schemes.map(
+      (s) =>
+        new EncryptedAttributeType({
+          scheme: s,
+          castType: this.castType,
+          previousType: true,
+          default: this._default,
+        }),
+    );
   }
 
   /** @internal */
@@ -318,7 +326,10 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private serializeWithOldest(value: unknown): unknown {
-    return this.previousTypes[0]?.serialize(value) ?? value;
+    // Rails uses previous_types.first; our encrypt() uses the last previous scheme.
+    // Match encrypt()'s convention so both helpers stay consistent.
+    const prev = this.previousTypes;
+    return (prev[prev.length - 1] ?? this).serialize(value);
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -340,7 +340,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     const normalized = this.deterministic ? this._applyForcedEncoding(str) : str;
     const toEncrypt =
       this.scheme.downcase || this.scheme.ignoreCase ? normalized.toLowerCase() : normalized;
-    return this.encrypt(toEncrypt);
+    return this.encryptAsText(toEncrypt);
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -326,9 +326,9 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private serializeWithOldest(value: unknown): unknown {
-    // Rails uses previous_types.first; our encrypt() uses the last previous scheme.
-    // Match encrypt()'s convention so both helpers stay consistent.
-    const prev = this.previousTypes;
+    // Use previousTypesWithoutCleanText to avoid the clean-text fallback scheme
+    // being selected when supportUnencryptedData is true.
+    const prev = this.previousTypesWithoutCleanText();
     return (prev[prev.length - 1] ?? this).serialize(value);
   }
 

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "../errors.js";
 import { Type, ValueType, StringType } from "@blazetrails/activemodel";
 import { Scheme } from "./scheme.js";
 import type { EncryptorLike } from "./encryptor.js";
@@ -270,10 +269,97 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   get supportUnencryptedData(): boolean {
     if (this._previousType) return false;
-    // Mirrors Rails' EncryptedAttributeType#support_unencrypted_data? which delegates
-    // directly to scheme.support_unencrypted_data?. The scheme already handles the
-    // per-attribute override vs global config fallback — no extra AND-gate needed here.
     return this.scheme.isSupportUnencryptedData();
+  }
+
+  /** @internal */
+  private previousSchemesIncludingCleanText(): Scheme[] {
+    const schemes = [...(this.scheme.previousSchemes ?? [])];
+    if (this.supportUnencryptedData) {
+      schemes.push(this.cleanTextScheme());
+    }
+    return schemes;
+  }
+
+  /** @internal */
+  private previousTypesWithoutCleanText(): EncryptedAttributeType[] {
+    return this.buildPreviousTypesFor(this.scheme.previousSchemes ?? []);
+  }
+
+  /** @internal */
+  private buildPreviousTypesFor(schemes: Scheme[]): EncryptedAttributeType[] {
+    return schemes.map((s) => new EncryptedAttributeType({ scheme: s, previousType: true }));
+  }
+
+  /** @internal */
+  private isPreviousType(): boolean {
+    return this._previousType;
+  }
+
+  /** @internal */
+  private decryptAsText(value: unknown): unknown {
+    return this.decrypt(value);
+  }
+
+  /** @internal */
+  private tryToDeserializeWithPreviousEncryptedTypes(value: unknown): unknown {
+    return this._tryPreviousTypes(value);
+  }
+
+  /** @internal */
+  private handleDeserializeError(error: BaseEncryptionError, value: unknown): unknown {
+    return this._handleDeserializeError(error, value);
+  }
+
+  /** @internal */
+  private isSerializeWithOldest(): boolean {
+    return this.scheme.isFixed() && (this.scheme.previousSchemes?.length ?? 0) > 0;
+  }
+
+  /** @internal */
+  private serializeWithOldest(value: unknown): unknown {
+    return this.previousTypes[0]?.serialize(value) ?? value;
+  }
+
+  /** @internal */
+  private serializeWithCurrent(value: unknown): unknown {
+    const casted = this.castType.serialize?.(value) ?? value;
+    if (casted === null || casted === undefined) return null;
+    const str = typeof casted === "string" ? casted : String(casted);
+    const normalized = this.deterministic ? this._applyForcedEncoding(str) : str;
+    const toEncrypt =
+      this.scheme.downcase || this.scheme.ignoreCase ? normalized.toLowerCase() : normalized;
+    return this.encrypt(toEncrypt);
+  }
+
+  /** @internal */
+  private encryptAsText(value: string): string {
+    return this._encryptor.encrypt(value, this._encryptionOptionsFor(this.scheme));
+  }
+
+  /** @internal */
+  private get encryptor(): EncryptorLike {
+    return this._encryptor;
+  }
+
+  /** @internal */
+  private encryptionOptions(): Record<string, unknown> {
+    return this._encryptionOptionsFor(this.scheme);
+  }
+
+  /** @internal */
+  private cleanTextScheme(): Scheme {
+    return this._cleanTextScheme();
+  }
+
+  /** @internal */
+  private textToDatabaseType(value: unknown): unknown {
+    return value;
+  }
+
+  /** @internal */
+  private databaseTypeToText(value: unknown): unknown {
+    return value;
   }
 }
 
@@ -290,117 +376,5 @@ function isAdditionalValue(value: unknown): boolean {
     typeof value === "object" &&
     value !== null &&
     (value as Record<symbol, unknown>)[ADDITIONAL_VALUE_BRAND] === true
-  );
-}
-
-/** @internal */
-function previousSchemesIncludingCleanText(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#previous_schemes_including_clean_text is not implemented",
-  );
-}
-
-/** @internal */
-function previousTypesWithoutCleanText(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#previous_types_without_clean_text is not implemented",
-  );
-}
-
-/** @internal */
-function buildPreviousTypesFor(schemes: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#build_previous_types_for is not implemented",
-  );
-}
-
-/** @internal */
-function isPreviousType(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#previous_type? is not implemented",
-  );
-}
-
-/** @internal */
-function decryptAsText(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#decrypt_as_text is not implemented",
-  );
-}
-
-/** @internal */
-function tryToDeserializeWithPreviousEncryptedTypes(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#try_to_deserialize_with_previous_encrypted_types is not implemented",
-  );
-}
-
-/** @internal */
-function handleDeserializeError(error: any, value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#handle_deserialize_error is not implemented",
-  );
-}
-
-/** @internal */
-function isSerializeWithOldest(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_oldest? is not implemented",
-  );
-}
-
-/** @internal */
-function serializeWithOldest(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_oldest is not implemented",
-  );
-}
-
-/** @internal */
-function serializeWithCurrent(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_current is not implemented",
-  );
-}
-
-/** @internal */
-function encryptAsText(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#encrypt_as_text is not implemented",
-  );
-}
-
-/** @internal */
-function encryptor(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#encryptor is not implemented",
-  );
-}
-
-/** @internal */
-function encryptionOptions(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#encryption_options is not implemented",
-  );
-}
-
-/** @internal */
-function cleanTextScheme(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#clean_text_scheme is not implemented",
-  );
-}
-
-/** @internal */
-function textToDatabaseType(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#text_to_database_type is not implemented",
-  );
-}
-
-/** @internal */
-function databaseTypeToText(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptedAttributeType#database_type_to_text is not implemented",
   );
 }


### PR DESCRIPTION
## Summary

Completes all activerecord encryption files to 100% on \`api:compare\` by adding 32 \`@internal\` class methods across two files:

**EncryptedAttributeType** (16 methods): \`previousSchemesIncludingCleanText\`, \`previousTypesWithoutCleanText\`, \`buildPreviousTypesFor\`, \`isPreviousType\`, \`decryptAsText\`, \`tryToDeserializeWithPreviousEncryptedTypes\`, \`handleDeserializeError\`, \`isSerializeWithOldest\`, \`serializeWithOldest\`, \`serializeWithCurrent\`, \`encryptAsText\`, \`encryptor\`, \`encryptionOptions\`, \`cleanTextScheme\`, \`textToDatabaseType\`, \`databaseTypeToText\`

**EncryptableRecord** (16 methods): \`encryptAttribute\`, \`preserveOriginalEncrypted\`, \`overrideAccessorsToPreserveOriginal\`, \`loadSchemaBang\`, \`addLengthValidationForEncryptedColumns\`, \`isEncryptedAttribute\`, \`ciphertextFor\`, \`encrypt\`, \`decrypt\`, \`_createRecord\`, \`encryptAttributes\`, \`decryptAttributes\`, \`validateEncryptionAllowed\`, \`buildEncryptAttributeAssignments\`, \`buildDecryptAttributeAssignments\`, \`cantModifyEncryptedAttributesWhenFrozen\`

Stacks on E3 (#1143).

## Known follow-up concerns (not blocking api:compare parity)

The following are acknowledged limitations raised during review. They apply to the **static** \`EncryptableRecord\` helpers added in this PR, not to the primary model encryption path which lives in \`encryption.ts\` and is unaffected.

- **\`encryptAttributes\` / \`decryptAttributes\` in-memory state**: \`updateColumns()\` writes ciphertext into \`_attributes\`; the plaintext cast values are not restored afterward. The live \`encryptRecord\` / \`decryptRecord\` path in \`encryption.ts\` handles this via \`_attributes.writeCastValue\` + \`changesApplied()\`.
- **\`preserveOriginalEncrypted\` scheme cloning**: declares \`original_<name>\` with the default scheme rather than copying the source attribute's key provider / deterministic / previous-schemes options (minus \`ignoreCase\`/\`downcase\`). The ignore-case wiring in \`encryption.ts\` already does this correctly; a follow-up should consolidate.
- **\`overrideAccessorsToPreserveOriginal\` no-op**: Ruby's \`include Module.new { define_method … }\` has no direct TS equivalent. The ignore-case read/write synchronization is handled at the \`EncryptedAttributeType\` level.
- **\`textToDatabaseType\` / \`databaseTypeToText\` identity**: these are correct for text columns; for binary/JSONB columns a follow-up should delegate to \`castType\`.
- **\`ciphertextFor\` fallback**: returns \`readAttributeBeforeTypeCast\` for all cases. For new/decrypted records \`valuesForDatabase()\` would be more accurate; a follow-up should align with the instance helper in \`encryption.ts\`.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/encryption\` — 270 passed, 10 skipped
- [x] \`pnpm test:types\` — 74 passed, no type errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm run api:compare --package activerecord\` — all encryption files at 100%