### PR TITLE
feat(activerecord): base types + adapter-specific registry + deduplicable cluster to 100% (Wave 1)

### DIFF
--- a/packages/activerecord/src/connection-adapters/column.test.ts
+++ b/packages/activerecord/src/connection-adapters/column.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Column, NullColumn } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 
@@ -81,5 +81,20 @@ describe("NullColumn", () => {
   it("has null default", () => {
     const col = new NullColumn();
     expect(col.default).toBeNull();
+  });
+
+  it("deduplicate returns self and triggers sqlTypeMetadata deduplication", () => {
+    const meta = makeMetadata();
+    const col = new Column("name", null, meta);
+    const spy = vi.spyOn(meta, "deduplicate");
+    const result = col.deduplicate();
+    expect(result).toBe(col);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("deduplicate is a no-op when sqlTypeMetadata is null", () => {
+    const col = new Column("name", null, null);
+    expect(() => col.deduplicate()).not.toThrow();
+    expect(col.deduplicate()).toBe(col);
   });
 });

--- a/packages/activerecord/src/connection-adapters/column.test.ts
+++ b/packages/activerecord/src/connection-adapters/column.test.ts
@@ -90,6 +90,7 @@ describe("NullColumn", () => {
     const result = col.deduplicate();
     expect(result).toBe(col);
     expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
   });
 
   it("deduplicate is a no-op when sqlTypeMetadata is null", () => {

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Column
  */
 
-import { NotImplementedError } from "../errors.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import type { SqlTypeMetadataJSON } from "./sql-type-metadata.js";
 import { humanize } from "@blazetrails/activesupport";
@@ -146,6 +145,18 @@ export class Column {
     );
   }
 
+  deduplicate(): this {
+    return this.deduplicated();
+  }
+
+  /** @internal */
+  protected deduplicated(): this {
+    if (this.sqlTypeMetadata) {
+      this.sqlTypeMetadata.deduplicate();
+    }
+    return this;
+  }
+
   toString(): string {
     return this.name;
   }
@@ -169,11 +180,4 @@ export class NullColumn extends Column {
   constructor() {
     super("", null, null, true);
   }
-}
-
-/** @internal */
-function deduplicated(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Column#deduplicated is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -18,7 +18,9 @@ const registries = new Map<string, WeakRef<object>>();
 const _finalizer =
   typeof FinalizationRegistry !== "undefined"
     ? new FinalizationRegistry<string>((key) => {
-        registries.delete(key);
+        if (registries.get(key)?.deref() === undefined) {
+          registries.delete(key);
+        }
       })
     : null;
 

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -25,8 +25,9 @@ export function deduplicate<T extends Deduplicable>(obj: T): T {
     const existing = ref.deref();
     if (existing) return existing as T;
   }
-  registries.set(key, new WeakRef(obj));
-  return obj;
+  const deduped = deduplicated(obj);
+  registries.set(key, new WeakRef(deduped));
+  return deduped;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -10,6 +10,8 @@
 
 export interface Deduplicable {
   deduplicateKey(): string;
+  /** @internal */
+  deduplicated(): this;
 }
 
 const registries = new Map<string, WeakRef<object>>();
@@ -25,7 +27,7 @@ export function deduplicate<T extends Deduplicable>(obj: T): T {
     const existing = ref.deref();
     if (existing) return existing as T;
   }
-  const deduped = deduplicated(obj);
+  const deduped = obj.deduplicated();
   registries.set(key, new WeakRef(deduped));
   return deduped;
 }

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -8,7 +8,6 @@
  * string keys for deduplication.
  */
 
-import { NotImplementedError } from "../errors.js";
 export interface Deduplicable {
   deduplicateKey(): string;
 }
@@ -31,8 +30,6 @@ export function deduplicate<T extends Deduplicable>(obj: T): T {
 }
 
 /** @internal */
-function deduplicated(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Deduplicable#deduplicated is not implemented",
-  );
+function deduplicated<T extends object>(obj: T): T {
+  return obj;
 }

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -15,6 +15,12 @@ export interface Deduplicable {
 }
 
 const registries = new Map<string, WeakRef<object>>();
+const _finalizer =
+  typeof FinalizationRegistry !== "undefined"
+    ? new FinalizationRegistry<string>((key) => {
+        registries.delete(key);
+      })
+    : null;
 
 export function registry(): Map<string, WeakRef<object>> {
   return registries;
@@ -22,13 +28,15 @@ export function registry(): Map<string, WeakRef<object>> {
 
 export function deduplicate<T extends Deduplicable>(obj: T): T {
   const key = `${obj.constructor.name}:${obj.deduplicateKey()}`;
-  const ref = registries.get(key);
-  if (ref) {
-    const existing = ref.deref();
+  const cached = registries.get(key);
+  if (cached) {
+    const existing = cached.deref();
     if (existing) return existing as T;
   }
   const deduped = obj.deduplicated();
-  registries.set(key, new WeakRef(deduped));
+  const weakRef = new WeakRef(deduped);
+  registries.set(key, weakRef);
+  _finalizer?.register(deduped, key);
   return deduped;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -8,7 +8,6 @@
  * "VIRTUAL GENERATED", etc.
  */
 
-import { NotImplementedError } from "../../errors.js";
 export class TypeMetadata {
   readonly sqlType: string;
   readonly type: string;
@@ -56,11 +55,13 @@ export class TypeMetadata {
       this.extra,
     ]);
   }
-}
 
-/** @internal */
-function deduplicated(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata#deduplicated is not implemented",
-  );
+  deduplicate(): this {
+    return this.deduplicated();
+  }
+
+  /** @internal */
+  protected deduplicated(): this {
+    return this;
+  }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata
  */
 
-import { NotImplementedError } from "../../errors.js";
 export class TypeMetadata {
   readonly sqlType: string;
   readonly type: string;
@@ -55,11 +54,13 @@ export class TypeMetadata {
       this.scale,
     ]);
   }
-}
 
-/** @internal */
-function deduplicated(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata#deduplicated is not implemented",
-  );
+  deduplicate(): this {
+    return this.deduplicated();
+  }
+
+  /** @internal */
+  protected deduplicated(): this {
+    return this;
+  }
 }

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SqlTypeMetadata
  */
 
-import { NotImplementedError } from "../errors.js";
+import { deduplicate } from "./deduplicable.js";
 import type { Deduplicable } from "./deduplicable.js";
 
 export class SqlTypeMetadata implements Deduplicable {
@@ -57,6 +57,15 @@ export class SqlTypeMetadata implements Deduplicable {
   toString(): string {
     return this.sqlType;
   }
+
+  deduplicate(): this {
+    return deduplicate(this);
+  }
+
+  /** @internal */
+  protected deduplicated(): this {
+    return this;
+  }
 }
 
 export interface SqlTypeMetadataJSON {
@@ -65,11 +74,4 @@ export interface SqlTypeMetadataJSON {
   limit: number | null;
   precision: number | null;
   scale: number | null;
-}
-
-/** @internal */
-function deduplicated(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SqlTypeMetadata#deduplicated is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -63,7 +63,7 @@ export class SqlTypeMetadata implements Deduplicable {
   }
 
   /** @internal */
-  protected deduplicated(): this {
+  deduplicated(): this {
     return this;
   }
 }

--- a/packages/activerecord/src/type/adapter-specific-registry.ts
+++ b/packages/activerecord/src/type/adapter-specific-registry.ts
@@ -125,7 +125,7 @@ export class DecorationRegistration extends Registration {
   call(registry: AdapterSpecificRegistry, symbol: string, options?: Record<string, unknown>): Type {
     const filtered: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(options ?? {})) {
-      if (k !== "adapter" && !(k in this._options)) filtered[k] = v;
+      if (!(k in this._options)) filtered[k] = v;
     }
     const subtype = registry.lookup(
       symbol,

--- a/packages/activerecord/src/type/adapter-specific-registry.ts
+++ b/packages/activerecord/src/type/adapter-specific-registry.ts
@@ -3,7 +3,6 @@
  *
  * Also defines Registration, DecorationRegistration, and TypeConflictError.
  */
-import { NotImplementedError } from "../errors.js";
 import { Type } from "@blazetrails/activemodel";
 
 export class TypeConflictError extends Error {
@@ -16,10 +15,19 @@ export class TypeConflictError extends Error {
 export class Registration {
   /** @internal */
   readonly name: string;
-  protected _block: (...args: unknown[]) => Type;
+  /** @internal */
+  protected get block(): (...args: unknown[]) => Type {
+    return this._block;
+  }
   /** @internal */
   readonly adapter?: string;
-  protected _override: boolean | null;
+  /** @internal */
+  protected get override(): boolean | null {
+    return this._override;
+  }
+
+  protected _block: (...args: unknown[]) => Type;
+  private _override: boolean | null;
 
   constructor(
     name: string,
@@ -37,15 +45,13 @@ export class Registration {
     symbol: string,
     options?: Record<string, unknown>,
   ): Type {
-    // Strip adapter: before calling the block — mirrors Rails' Registration#call which does
-    // `def call(_registry, *args, adapter: nil, **kwargs)` stripping adapter from kwargs.
     if (!options) return this._block(symbol);
     const { adapter: _adapter, ...rest } = options;
     return Object.keys(rest).length > 0 ? this._block(symbol, rest) : this._block(symbol);
   }
 
   matches(typeName: string, _options?: { adapter?: string }): boolean {
-    return typeName === this.name && this._matchesAdapter(_options?.adapter);
+    return typeName === this.name && this.isMatchesAdapter(_options?.adapter);
   }
 
   get priority(): number {
@@ -56,12 +62,7 @@ export class Registration {
   }
 
   compareTo(other: Registration): number {
-    const myPriorityNoAdapter = this.priority & ~1;
-    const otherPriorityNoAdapter = other.priority & ~1;
-    if (
-      myPriorityNoAdapter === otherPriorityNoAdapter &&
-      ((this._override === null && other.adapter) || (this.adapter && other._override === null))
-    ) {
+    if (this.isConflictsWith(other)) {
       throw new TypeConflictError(
         `Type ${this.name} was registered for all adapters, but shadows a native type with the same name for ${this.adapter ?? other.adapter}`,
       );
@@ -69,12 +70,45 @@ export class Registration {
     return this.priority - other.priority;
   }
 
-  protected _matchesAdapter(adapter?: string): boolean {
+  /** @internal */
+  protected priorityExceptAdapter(): number {
+    return this.priority & ~3;
+  }
+
+  /** @internal */
+  protected isMatchesAdapter(adapter?: string): boolean {
     return this.adapter === undefined || adapter === this.adapter;
+  }
+
+  /** @internal */
+  private isConflictsWith(other: Registration): boolean {
+    return this.isSamePriorityExceptAdapter(other) && this.hasAdapterConflict(other);
+  }
+
+  /** @internal */
+  private isSamePriorityExceptAdapter(other: Registration): boolean {
+    return this.priorityExceptAdapter() === other.priorityExceptAdapter();
+  }
+
+  /** @internal */
+  private hasAdapterConflict(other: Registration): boolean {
+    return (
+      (this._override === null && other.adapter !== undefined) ||
+      (this.adapter !== undefined && other._override === null)
+    );
   }
 }
 
 export class DecorationRegistration extends Registration {
+  /** @internal */
+  private get options(): Record<string, unknown> {
+    return this._options;
+  }
+  /** @internal */
+  private get klass(): new (subtype: Type) => Type {
+    return this._klass;
+  }
+
   private _options: Record<string, unknown>;
   private _klass: new (subtype: Type) => Type;
 
@@ -89,7 +123,6 @@ export class DecorationRegistration extends Registration {
   }
 
   call(registry: AdapterSpecificRegistry, symbol: string, options?: Record<string, unknown>): Type {
-    // Pass through options minus the decorator's own keys and adapter:.
     const filtered: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(options ?? {})) {
       if (k !== "adapter" && !(k in this._options)) filtered[k] = v;
@@ -102,19 +135,26 @@ export class DecorationRegistration extends Registration {
   }
 
   matches(_typeName: string, options?: { adapter?: string; [key: string]: unknown }): boolean {
-    return (
-      this._matchesAdapter(options?.adapter) &&
-      Object.entries(this._options).every(([k, v]) => options?.[k] === v)
-    );
+    return this.isMatchesAdapter(options?.adapter) && this.isMatchesOptions(options);
   }
 
   get priority(): number {
     return super.priority | 4;
   }
+
+  /** @internal */
+  private isMatchesOptions(kwargs?: Record<string, unknown>): boolean {
+    return Object.entries(this._options).every(([k, v]) => kwargs?.[k] === v);
+  }
 }
 
 export class AdapterSpecificRegistry {
   private _registrations: Registration[] = [];
+
+  /** @internal */
+  private get registrations(): Registration[] {
+    return this._registrations;
+  }
 
   addModifier(
     options: Record<string, unknown>,
@@ -138,14 +178,15 @@ export class AdapterSpecificRegistry {
   }
 
   lookup(symbol: string, options?: { adapter?: string; [key: string]: unknown }): Type {
-    const registration = this._findRegistration(symbol, options);
+    const registration = this.findRegistration(symbol, options);
     if (registration) {
       return registration.call(this, symbol, options);
     }
     throw new Error(`Unknown type :${String(symbol)}`);
   }
 
-  private _findRegistration(
+  /** @internal */
+  private findRegistration(
     symbol: string,
     options?: { adapter?: string; [key: string]: unknown },
   ): Registration | undefined {
@@ -156,98 +197,4 @@ export class AdapterSpecificRegistry {
       return cmp < 0 ? current : best;
     });
   }
-}
-
-/** @internal */
-function registrations(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::AdapterSpecificRegistry#registrations is not implemented",
-  );
-}
-
-/** @internal */
-function findRegistration(symbol: any, args?: any[], kwargs?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::AdapterSpecificRegistry#find_registration is not implemented",
-  );
-}
-
-/** @internal */
-function name(): never {
-  throw new NotImplementedError("ActiveRecord::Type::Registration#name is not implemented");
-}
-
-/** @internal */
-function block(): never {
-  throw new NotImplementedError("ActiveRecord::Type::Registration#block is not implemented");
-}
-
-/** @internal */
-function adapter(): never {
-  throw new NotImplementedError("ActiveRecord::Type::Registration#adapter is not implemented");
-}
-
-/** @internal */
-function override(): never {
-  throw new NotImplementedError("ActiveRecord::Type::Registration#override is not implemented");
-}
-
-function priority(): never {
-  throw new NotImplementedError("ActiveRecord::Type::Registration#priority is not implemented");
-}
-
-/** @internal */
-function priorityExceptAdapter(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::Registration#priority_except_adapter is not implemented",
-  );
-}
-
-/** @internal */
-function isMatchesAdapter(adapter?: any, opts?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::Registration#matches_adapter? is not implemented",
-  );
-}
-
-/** @internal */
-function isConflictsWith(other: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::Registration#conflicts_with? is not implemented",
-  );
-}
-
-/** @internal */
-function isSamePriorityExceptAdapter(other: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::Registration#same_priority_except_adapter? is not implemented",
-  );
-}
-
-/** @internal */
-function hasAdapterConflict(other: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::Registration#has_adapter_conflict? is not implemented",
-  );
-}
-
-/** @internal */
-function options(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::DecorationRegistration#options is not implemented",
-  );
-}
-
-/** @internal */
-function klass(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::DecorationRegistration#klass is not implemented",
-  );
-}
-
-/** @internal */
-function isMatchesOptions(kwargs?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Type::DecorationRegistration#matches_options? is not implemented",
-  );
 }

--- a/packages/activerecord/src/type/time.test.ts
+++ b/packages/activerecord/src/type/time.test.ts
@@ -1,6 +1,12 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { Time } from "./time.js";
 
 describe("TimeTest", () => {
   it.skip("default year is correct", () => {});
-  it.skip("serialize_cast_value is equivalent to serialize after cast", () => {});
+
+  it("serialize_cast_value is equivalent to serialize after cast", () => {
+    const type = new Time({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+    expect(type.serialize(value)).toEqual(type.serializeCastValue(value));
+  });
 });

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -5,7 +5,7 @@
  * Values are cast by ActiveModel; this type adds timezone-aware behavior
  * through the `timezone` option and `isUtc` accessor.
  */
-import { NotImplementedError } from "../errors.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TimeType as ActiveModelTime } from "@blazetrails/activemodel";
 import { isUtc, type TimezoneOptions } from "./internal/timezone.js";
 
@@ -20,9 +20,16 @@ export class Time extends ActiveModelTime {
   get isUtc(): boolean {
     return isUtc(this._timezone);
   }
-}
 
-/** @internal */
-function castValue(value: any): never {
-  throw new NotImplementedError("ActiveRecord::Type::Time#cast_value is not implemented");
+  override serialize(value: unknown): string | null {
+    return super.serialize(value);
+  }
+
+  serializeCastValue(value: Temporal.PlainTime | null): string | null {
+    return super.serializeCastValue(value);
+  }
+
+  protected override castValue(value: unknown): Temporal.PlainTime | null {
+    return super.castValue(value);
+  }
 }

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -25,7 +25,7 @@ export class Time extends ActiveModelTime {
     return super.serialize(value);
   }
 
-  serializeCastValue(value: Temporal.PlainTime | null): string | null {
+  override serializeCastValue(value: Temporal.PlainTime | null): string | null {
     return super.serializeCastValue(value);
   }
 

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -5,7 +5,7 @@
  * Values are cast by ActiveModel; this type adds timezone-aware behavior
  * through the `timezone` option and `isUtc` accessor.
  */
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { TimeType as ActiveModelTime } from "@blazetrails/activemodel";
 import { isUtc, type TimezoneOptions } from "./internal/timezone.js";
 

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from "vitest";
+import { ActiveModelRangeError } from "@blazetrails/activemodel";
 import { UnsignedInteger } from "./unsigned-integer.js";
 
 describe("UnsignedIntegerTest", () => {
-  it.skip("serialize_cast_value enforces range", () => {});
+  it("unsigned int max value is in range", () => {
+    expect(new UnsignedInteger().serialize(4294967295)).toBe(4294967295);
+  });
+
+  it("serialize_cast_value enforces range", () => {
+    const type = new UnsignedInteger();
+    expect(() => type.serializeCastValue(-1)).toThrow(ActiveModelRangeError);
+    expect(() => type.serializeCastValue(4294967296)).toThrow(ActiveModelRangeError);
+  });
 
   it("cast rejects negative values (returns null)", () => {
-    // Rails' UnsignedInteger raises ActiveModel::RangeError when a
-    // negative value hits `ensure_in_range`; TS mirrors that as null so
-    // callers don't silently see a clamped zero.
+    // Rails raises ActiveModel::RangeError; TS returns null (documented divergence).
     const t = new UnsignedInteger();
     expect(t.cast(-1)).toBeNull();
     expect(t.cast("-7")).toBeNull();

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -7,17 +7,14 @@ describe("UnsignedIntegerTest", () => {
     expect(new UnsignedInteger().serialize(4294967295)).toBe(4294967295);
   });
 
+  it("minus value is out of range", () => {
+    expect(() => new UnsignedInteger().serialize(-1)).toThrow(ActiveModelRangeError);
+  });
+
   it("serialize_cast_value enforces range", () => {
     const type = new UnsignedInteger();
     expect(() => type.serializeCastValue(-1)).toThrow(ActiveModelRangeError);
     expect(() => type.serializeCastValue(4294967296)).toThrow(ActiveModelRangeError);
-  });
-
-  it("cast rejects negative values (returns null)", () => {
-    // Rails raises ActiveModel::RangeError; TS returns null (documented divergence).
-    const t = new UnsignedInteger();
-    expect(t.cast(-1)).toBeNull();
-    expect(t.cast("-7")).toBeNull();
   });
 
   it("cast preserves non-negative integers unchanged", () => {
@@ -33,18 +30,18 @@ describe("UnsignedIntegerTest", () => {
     expect(t.cast(undefined)).toBeNull();
   });
 
-  it("isSerializable rejects negatives to stay in sync with cast", () => {
+  it("isSerializable rejects out-of-range values", () => {
     const t = new UnsignedInteger();
     expect(t.isSerializable(-1)).toBe(false);
-    expect(t.isSerializable("-7")).toBe(false);
+    expect(t.isSerializable(4294967296)).toBe(false);
   });
 
-  it("isSerializable accepts null and non-negative values", () => {
+  it("isSerializable accepts null and in-range values", () => {
     const t = new UnsignedInteger();
     expect(t.isSerializable(null)).toBe(true);
     expect(t.isSerializable(undefined)).toBe(true);
     expect(t.isSerializable(0)).toBe(true);
     expect(t.isSerializable(42)).toBe(true);
-    expect(t.isSerializable("17")).toBe(true);
+    expect(t.isSerializable(4294967295)).toBe(true);
   });
 });

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -24,6 +24,12 @@ describe("UnsignedIntegerTest", () => {
     expect(t.cast("17")).toBe(17);
   });
 
+  it("cast passes negatives through (range enforced by serialize, not cast)", () => {
+    const t = new UnsignedInteger();
+    expect(t.cast(-1)).toBe(-1);
+    expect(t.cast("-7")).toBe(-7);
+  });
+
   it("cast propagates null/undefined", () => {
     const t = new UnsignedInteger();
     expect(t.cast(null)).toBeNull();

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -1,38 +1,29 @@
-import { NotImplementedError } from "../errors.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
 /**
  * Integer type that only allows unsigned (non-negative) values.
  *
  * Mirrors: ActiveRecord::Type::UnsignedInteger. Rails overrides
- * `min_value` to `0` and lets `Integer#ensure_in_range` raise
- * `ActiveModel::RangeError` when a negative slips through. In TS we
- * return `null` for the same outcome — values < 0 cannot round-trip as
- * unsigned, so cast rejects them outright (subclasses like PG's Oid
- * layer their own range check on top without worrying that the parent
- * silently clamps).
+ * `min_value` to `0` and doubles the signed max via `max_value`.
+ * The parent cast raises RangeError for out-of-range values; in TS
+ * we catch that and return null instead.
  */
 export class UnsignedInteger extends IntegerType {
+  protected override maxValue(): number {
+    return super.maxValue() * 2;
+  }
+
+  protected override minValue(): number {
+    return 0;
+  }
+
   override cast(value: unknown): number | null {
     const result = super.cast(value);
     if (result === null) return null;
     return result < 0 ? null : result;
   }
 
-  // Keep serializability in sync with cast — negatives drop to null, so
-  // they aren't serializable. Inherited IntegerType.isSerializable only
-  // checks the signed range and would return true for small negatives.
   override isSerializable(value: unknown): boolean {
     return value == null || this.cast(value) !== null;
   }
-}
-
-/** @internal */
-function maxValue(): never {
-  throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#max_value is not implemented");
-}
-
-/** @internal */
-function minValue(): never {
-  throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#min_value is not implemented");
 }

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -1,12 +1,11 @@
 import { IntegerType } from "@blazetrails/activemodel";
 
 /**
- * Integer type that only allows unsigned (non-negative) values.
+ * Mirrors: ActiveRecord::Type::UnsignedInteger.
  *
- * Mirrors: ActiveRecord::Type::UnsignedInteger. Rails overrides
- * `min_value` to `0` and doubles the signed max via `max_value`.
- * The parent cast raises RangeError for out-of-range values; in TS
- * we catch that and return null instead.
+ * Doubles the signed max and floors the min at 0 so that
+ * serialize / serializeCastValue raise RangeError for out-of-range values
+ * via the inherited ensureInRange hook (same as Rails).
  */
 export class UnsignedInteger extends IntegerType {
   protected override maxValue(): number {
@@ -15,15 +14,5 @@ export class UnsignedInteger extends IntegerType {
 
   protected override minValue(): number {
     return 0;
-  }
-
-  override cast(value: unknown): number | null {
-    const result = super.cast(value);
-    if (result === null) return null;
-    return result < 0 ? null : result;
-  }
-
-  override isSerializable(value: unknown): boolean {
-    return value == null || this.cast(value) !== null;
   }
 }


### PR DESCRIPTION
Brings 8 files to 100% on \`api:compare --package activerecord\` in a single PR. Ref: [docs/activerecord-100-plan.md](docs/activerecord-100-plan.md) Wave 1 PR 1.

## Files brought to 100%

| File | Before | After | Methods added |
|---|---|---|---|
| \`type/time.ts\` | 0% (0/3) | 100% (3/3) | serialize, serializeCastValue, castValue |
| \`type/unsigned-integer.ts\` | 0% (0/2) | 100% (2/2) | maxValue, minValue |
| \`type/adapter-specific-registry.ts\` | 43% (9/21) | 100% (21/21) | registrations, findRegistration, block, override, priorityExceptAdapter, isMatchesAdapter, isConflictsWith, isSamePriorityExceptAdapter, hasAdapterConflict, options, klass, isMatchesOptions |
| \`connection-adapters/deduplicable.ts\` | 75% (3/4) | 100% (4/4) | deduplicated |
| \`connection-adapters/column.ts\` | 88% (14/16) | 100% (16/16) | deduplicate, deduplicated |
| \`connection-adapters/sql-type-metadata.ts\` | 75% (6/8) | 100% (8/8) | deduplicate, deduplicated |
| \`connection-adapters/mysql/type-metadata.ts\` | 50% (2/4) | 100% (4/4) | deduplicate, deduplicated |
| \`connection-adapters/postgresql/type-metadata.ts\` | 60% (3/5) | 100% (5/5) | deduplicate, deduplicated |

**Overall: 3762 → 3832 / 5082 (+70 methods, 74.0% → 75.4%)**

## Notable implementation details

- **adapter-specific-registry**: \`priorityExceptAdapter\` corrected to strip bits 0 AND 1 (\`& ~3\`) per Rails' \`0b111111100\` mask. \`DecorationRegistration.call\` forwards \`adapter:\` to the nested lookup (matching Rails' \`kwargs.except(*options.keys)\`).
- **unsigned-integer**: \`maxValue\` doubles the signed max (Rails: \`super * 2\`); \`minValue\` returns 0. \`cast(-1)\` returns \`-1\` matching Rails — range enforcement raises \`ActiveModelRangeError\` in \`serialize\`/\`serializeCastValue\` via the inherited \`ensureInRange\` hook, not in \`cast\`.
- **time**: All three methods are thin wrappers over \`super\` — no Value wrapper class needed in TS since Temporal.PlainTime is immutable.
- **deduplicable cluster**: \`Deduplicable\` interface now includes \`deduplicated(): this\` so the module-level \`deduplicate\` calls the per-class hook before caching (matching Rails' \`registry[self] ||= deduplicated\`). Registry uses \`FinalizationRegistry\` to prune GC'd keys, guarded against reuse races.