### PR TITLE
fix(activemodel): accept non-ISO date/time strings via looseDateParse helper (P13)

### DIFF
--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -75,4 +75,26 @@ describe("DateTest", () => {
     expect(p.newDateFor(0, 0, 0)).toBe(null);
     expect(p.newDateFor(2024, 1, 15)?.toString()).toBe("2024-01-15");
   });
+
+  it("cast month-name string", () => {
+    const result = type.cast("July 4, 2020");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
+
+  it("cast US-slash string", () => {
+    const result = type.cast("7/4/2020");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
+
+  it("cast garbage string returns null", () => {
+    expect(type.cast("garbage")).toBe(null);
+  });
+
+  it("cast ISO string still works (regression guard)", () => {
+    const result = type.cast("2020-07-04");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -97,4 +97,11 @@ describe("DateTest", () => {
     expect(result).toBeInstanceOf(Temporal.PlainDate);
     expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
   });
+
+  it("cast datetime with non-zero offset near midnight preserves local date", () => {
+    // Ruby Date._parse("2020-07-04T00:30:00+02:00") reports mday=4, not the UTC day (3).
+    const result = type.cast("2020-07-04T00:30:00+02:00");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
 });

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -91,10 +91,10 @@ export class DateType extends ValueType<DateCastResult> {
    *     new_date(*parts.values_at(:year, :mon, :mday)) if parts
    *   end
    *
-   * Trails has no `Date._parse` equivalent; reuses Temporal's
-   * permissive parser, which already accepts the same ISO-leading
-   * forms Rails extracts year/mon/mday from. Falls through to `null`
-   * on parse failure, matching Rails' rescued path.
+   * Trails mirrors `Date._parse` breadth via `looseDateParse`: layered
+   * Temporal ISO parsing followed by regex coverage for US-slash, year-first
+   * slash, month-name, and space-separated Postgres wire formats. Falls
+   * through to `null` on parse failure, matching Rails' rescued path.
    *
    * @internal Rails-private helper.
    */

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { looseDateParse } from "./helpers/loose-date-parse.js";
 import {
   DateInfinity,
   DateNegativeInfinity,
@@ -34,11 +35,7 @@ export class DateType extends ValueType<DateCastResult> {
     }
     const str = String(value).trim();
     if (str === "") return null;
-    try {
-      return Temporal.PlainDate.from(str, { overflow: "reject" });
-    } catch {
-      return null;
-    }
+    return this.fastStringToDate(str) ?? this.fallbackStringToDate(str);
   }
 
   serialize(value: unknown): string | null {
@@ -102,12 +99,9 @@ export class DateType extends ValueType<DateCastResult> {
    * @internal Rails-private helper.
    */
   protected fallbackStringToDate(s: string): Temporal.PlainDate | null {
-    try {
-      const pd = Temporal.PlainDate.from(s, { overflow: "reject" });
-      return this.newDate(pd.year, pd.month, pd.day);
-    } catch {
-      return null;
-    }
+    const parts = looseDateParse(s);
+    if (!parts) return null;
+    return this.newDate(parts.year, parts.month, parts.day);
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
@@ -85,4 +85,33 @@ describe("looseDateParse", () => {
   it("out-of-range ISO time returns null", () => {
     expect(looseDateParse("25:61")).toBeNull();
   });
+
+  it("space-separated Postgres wire datetime", () => {
+    const result = looseDateParse("2026-04-26 14:23:55.123456");
+    expect(result).toMatchObject({
+      year: 2026,
+      month: 4,
+      day: 26,
+      hour: 14,
+      minute: 23,
+      second: 55,
+    });
+  });
+
+  it("space-separated Postgres wire datetime with short offset", () => {
+    const result = looseDateParse("2026-04-26 14:23:55.123456+00");
+    expect(result).toMatchObject({
+      year: 2026,
+      month: 4,
+      day: 26,
+      hour: 14,
+      minute: 23,
+      second: 55,
+    });
+  });
+
+  it("out-of-range 12-hour time returns null", () => {
+    expect(looseDateParse("13pm")).toBeNull();
+    expect(looseDateParse("0am")).toBeNull();
+  });
 });

--- a/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { looseDateParse } from "./loose-date-parse.js";
+
+describe("looseDateParse", () => {
+  it("ISO date", () => {
+    expect(looseDateParse("2020-07-04")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("ISO datetime", () => {
+    const result = looseDateParse("2020-07-04T15:30:00");
+    expect(result).toMatchObject({ year: 2020, month: 7, day: 4, hour: 15, minute: 30, second: 0 });
+  });
+
+  it("US slashes MM/DD/YYYY", () => {
+    expect(looseDateParse("7/4/2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("year-first slashes YYYY/MM/DD", () => {
+    expect(looseDateParse("2020/07/04")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("month name with comma", () => {
+    expect(looseDateParse("July 4, 2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("month name without comma", () => {
+    expect(looseDateParse("July 4 2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("day-first month name", () => {
+    expect(looseDateParse("4 July 2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("lowercase month name", () => {
+    expect(looseDateParse("july 4, 2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
+  });
+
+  it("3pm", () => {
+    expect(looseDateParse("3pm")).toMatchObject({ hour: 15 });
+  });
+
+  it("3:30 PM", () => {
+    expect(looseDateParse("3:30 PM")).toMatchObject({ hour: 15, minute: 30 });
+  });
+
+  it("12 AM → hour 0", () => {
+    expect(looseDateParse("12 AM")).toMatchObject({ hour: 0 });
+  });
+
+  it("12 PM → hour 12", () => {
+    expect(looseDateParse("12 PM")).toMatchObject({ hour: 12 });
+  });
+
+  it("24-hour 15:30", () => {
+    expect(looseDateParse("15:30")).toMatchObject({ hour: 15, minute: 30 });
+  });
+
+  it("24-hour with seconds 15:30:45", () => {
+    expect(looseDateParse("15:30:45")).toMatchObject({ hour: 15, minute: 30, second: 45 });
+  });
+
+  it("garbage returns null", () => {
+    expect(looseDateParse("not a date")).toBeNull();
+  });
+
+  it("empty string returns null", () => {
+    expect(looseDateParse("")).toBeNull();
+  });
+
+  it("ISO datetime with timezone Z", () => {
+    const result = looseDateParse("2020-07-04T15:30:00Z");
+    expect(result).toMatchObject({ year: 2020, month: 7, day: 4, hour: 15, minute: 30 });
+  });
+});

--- a/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
@@ -67,8 +67,22 @@ describe("looseDateParse", () => {
     expect(looseDateParse("")).toBeNull();
   });
 
-  it("ISO datetime with timezone Z", () => {
+  it("ISO datetime with timezone Z preserves local fields", () => {
     const result = looseDateParse("2020-07-04T15:30:00Z");
     expect(result).toMatchObject({ year: 2020, month: 7, day: 4, hour: 15, minute: 30 });
+  });
+
+  it("ISO datetime with non-zero offset preserves local fields (not UTC-normalized)", () => {
+    // Ruby Date._parse reports the fields as written; 2020-07-04T00:30:00+02:00 stays day=4, hour=0
+    const result = looseDateParse("2020-07-04T00:30:00+02:00");
+    expect(result).toMatchObject({ year: 2020, month: 7, day: 4, hour: 0, minute: 30 });
+  });
+
+  it("out-of-range ISO date returns null", () => {
+    expect(looseDateParse("2020-13-40")).toBeNull();
+  });
+
+  it("out-of-range ISO time returns null", () => {
+    expect(looseDateParse("25:61")).toBeNull();
   });
 });

--- a/packages/activemodel/src/type/helpers/loose-date-parse.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.ts
@@ -33,10 +33,12 @@ export function looseDateParse(input: string): LooseDateParts | null {
   const s = input.trim();
   if (s === "") return null;
 
-  // Layer 1: ISO datetime (with or without timezone offset)
-  if (/Z$|[+-]\d{2}:\d{2}$/.test(s)) {
+  // Layer 1: ISO datetime — strip offset/Z to preserve local components, matching
+  // Ruby Date._parse which reports the fields as written (offset stored separately).
+  const withoutOffset = stripOffset(s);
+  if (withoutOffset !== null) {
     try {
-      const pdt = Temporal.Instant.from(s).toZonedDateTimeISO("UTC").toPlainDateTime();
+      const pdt = Temporal.PlainDateTime.from(withoutOffset, { overflow: "reject" });
       return toDateTimeParts(pdt);
     } catch {
       // fall through
@@ -44,7 +46,7 @@ export function looseDateParse(input: string): LooseDateParts | null {
   }
 
   try {
-    const pdt = Temporal.PlainDateTime.from(s);
+    const pdt = Temporal.PlainDateTime.from(s, { overflow: "reject" });
     return toDateTimeParts(pdt);
   } catch {
     // fall through
@@ -52,7 +54,7 @@ export function looseDateParse(input: string): LooseDateParts | null {
 
   // Layer 2: ISO date only
   try {
-    const pd = Temporal.PlainDate.from(s);
+    const pd = Temporal.PlainDate.from(s, { overflow: "reject" });
     return { year: pd.year, month: pd.month, day: pd.day };
   } catch {
     // fall through
@@ -60,7 +62,7 @@ export function looseDateParse(input: string): LooseDateParts | null {
 
   // Layer 3: ISO time only
   try {
-    const pt = Temporal.PlainTime.from(s);
+    const pt = Temporal.PlainTime.from(s, { overflow: "reject" });
     return toTimeParts(pt);
   } catch {
     // fall through
@@ -102,11 +104,15 @@ export function looseDateParse(input: string): LooseDateParts | null {
     return parts;
   }
 
-  // 24-hour time: "15:30" or "15:30:45"
+  // 24-hour time: "15:30" or "15:30:45" — validate ranges to reject "25:61"
   m = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(s);
   if (m) {
-    const parts: LooseDateParts = { hour: int(m[1]), minute: int(m[2]) };
-    if (m[3] !== undefined) parts.second = int(m[3]);
+    const hour = int(m[1]);
+    const minute = int(m[2]);
+    const second = m[3] !== undefined ? int(m[3]) : 0;
+    if (hour > 23 || minute > 59 || second > 59) return null;
+    const parts: LooseDateParts = { hour, minute };
+    if (m[3] !== undefined) parts.second = second;
     return parts;
   }
 
@@ -157,4 +163,10 @@ const MONTH_NAMES: Record<string, number> = {
 
 function monthNumber(name: string): number | null {
   return MONTH_NAMES[name.toLowerCase()] ?? null;
+}
+
+/** Strip a trailing Z or numeric offset (+HH:MM / -HH:MM) from an ISO datetime string. */
+function stripOffset(s: string): string | null {
+  const m = /^(.+?)(Z|[+-]\d{2}:\d{2})$/.exec(s);
+  return m ? m[1] : null;
 }

--- a/packages/activemodel/src/type/helpers/loose-date-parse.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.ts
@@ -15,7 +15,8 @@ export interface LooseDateParts {
  * Loosely parse a date/time string, mirroring Ruby's `Date._parse(string, false)`.
  *
  * Supported formats (in evaluation order):
- *   - ISO 8601 datetime:   "2020-07-04T15:30:00", "2020-07-04T15:30:00Z"
+ *   - ISO 8601 datetime:   "2020-07-04T15:30:00", "2020-07-04T15:30:00Z", "2020-07-04T15:30:00+02:00"
+ *   - Space-separated:     "2020-07-04 15:30:00", "2020-07-04 15:30:00.123456+00" (Postgres wire format)
  *   - ISO 8601 date:       "2020-07-04"
  *   - ISO 8601 time:       "15:30", "15:30:45"
  *   - US slashes:          "7/4/2020" (MM/DD/YYYY)
@@ -33,9 +34,13 @@ export function looseDateParse(input: string): LooseDateParts | null {
   const s = input.trim();
   if (s === "") return null;
 
+  // Normalize space separator to T and expand short offsets (+00 → +00:00) so
+  // Temporal can parse Postgres wire-format strings ("2026-04-26 14:23:55.123456+00").
+  const normalized = normalizeDateTime(s);
+
   // Layer 1: ISO datetime — strip offset/Z to preserve local components, matching
   // Ruby Date._parse which reports the fields as written (offset stored separately).
-  const withoutOffset = stripOffset(s);
+  const withoutOffset = stripOffset(normalized);
   if (withoutOffset !== null) {
     try {
       const pdt = Temporal.PlainDateTime.from(withoutOffset, { overflow: "reject" });
@@ -46,7 +51,7 @@ export function looseDateParse(input: string): LooseDateParts | null {
   }
 
   try {
-    const pdt = Temporal.PlainDateTime.from(s, { overflow: "reject" });
+    const pdt = Temporal.PlainDateTime.from(normalized, { overflow: "reject" });
     return toDateTimeParts(pdt);
   } catch {
     // fall through
@@ -92,13 +97,15 @@ export function looseDateParse(input: string): LooseDateParts | null {
     if (month) return { year: int(m[3]), month, day: int(m[1]) };
   }
 
-  // 12-hour time: "3pm", "3:30 PM", "12 AM"
+  // 12-hour time: "3pm", "3:30 PM", "12 AM" — valid hours are 1–12
   m = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(s);
   if (m) {
-    let hour = int(m[1]);
+    const rawHour = int(m[1]);
     const minute = m[2] !== undefined ? int(m[2]) : undefined;
+    if (rawHour < 1 || rawHour > 12 || (minute !== undefined && minute > 59)) return null;
     const ampm = m[3].toLowerCase();
-    hour = ampm === "am" ? (hour === 12 ? 0 : hour) : hour === 12 ? 12 : hour + 12;
+    const hour =
+      ampm === "am" ? (rawHour === 12 ? 0 : rawHour) : rawHour === 12 ? 12 : rawHour + 12;
     const parts: LooseDateParts = { hour };
     if (minute !== undefined) parts.minute = minute;
     return parts;
@@ -165,8 +172,19 @@ function monthNumber(name: string): number | null {
   return MONTH_NAMES[name.toLowerCase()] ?? null;
 }
 
-/** Strip a trailing Z or numeric offset (+HH:MM / -HH:MM) from an ISO datetime string. */
+/**
+ * Normalize a datetime string so Temporal can parse it:
+ * - space separator → T
+ * - short numeric offset (+HH / -HH) → +HH:00
+ */
+function normalizeDateTime(s: string): string {
+  return s
+    .replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T")
+    .replace(/(T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)([-+]\d{2})$/, "$1$2:00");
+}
+
+/** Strip a trailing Z or numeric offset (+HH:MM / +HH / -HH:MM / -HH) from an ISO datetime string. */
 function stripOffset(s: string): string | null {
-  const m = /^(.+?)(Z|[+-]\d{2}:\d{2})$/.exec(s);
+  const m = /^(.+?)(Z|[+-]\d{2}(?::\d{2})?)$/.exec(s);
   return m ? m[1] : null;
 }

--- a/packages/activemodel/src/type/helpers/loose-date-parse.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.ts
@@ -1,0 +1,160 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
+export interface LooseDateParts {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+  millisecond?: number;
+  microsecond?: number;
+}
+
+/**
+ * Loosely parse a date/time string, mirroring Ruby's `Date._parse(string, false)`.
+ *
+ * Supported formats (in evaluation order):
+ *   - ISO 8601 datetime:   "2020-07-04T15:30:00", "2020-07-04T15:30:00Z"
+ *   - ISO 8601 date:       "2020-07-04"
+ *   - ISO 8601 time:       "15:30", "15:30:45"
+ *   - US slashes:          "7/4/2020" (MM/DD/YYYY)
+ *   - Year-first slashes:  "2020/07/04" (YYYY/MM/DD)
+ *   - Month-name day year: "July 4, 2020", "July 4 2020" (case-insensitive)
+ *   - Day-first month:     "4 July 2020" (case-insensitive)
+ *   - 12-hour time:        "3pm", "3:30 PM" (case-insensitive)
+ *   - 24-hour time:        "15:30", "15:30:45"
+ *
+ * Returns `null` for unrecognised input.
+ *
+ * @internal Rails-private helper.
+ */
+export function looseDateParse(input: string): LooseDateParts | null {
+  const s = input.trim();
+  if (s === "") return null;
+
+  // Layer 1: ISO datetime (with or without timezone offset)
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(s)) {
+    try {
+      const pdt = Temporal.Instant.from(s).toZonedDateTimeISO("UTC").toPlainDateTime();
+      return toDateTimeParts(pdt);
+    } catch {
+      // fall through
+    }
+  }
+
+  try {
+    const pdt = Temporal.PlainDateTime.from(s);
+    return toDateTimeParts(pdt);
+  } catch {
+    // fall through
+  }
+
+  // Layer 2: ISO date only
+  try {
+    const pd = Temporal.PlainDate.from(s);
+    return { year: pd.year, month: pd.month, day: pd.day };
+  } catch {
+    // fall through
+  }
+
+  // Layer 3: ISO time only
+  try {
+    const pt = Temporal.PlainTime.from(s);
+    return toTimeParts(pt);
+  } catch {
+    // fall through
+  }
+
+  // Layer 4: regex set for common non-ISO formats
+
+  // US slashes: MM/DD/YYYY
+  let m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  if (m) return { year: int(m[3]), month: int(m[1]), day: int(m[2]) };
+
+  // Year-first slashes: YYYY/MM/DD
+  m = /^(\d{4})\/(\d{1,2})\/(\d{1,2})$/.exec(s);
+  if (m) return { year: int(m[1]), month: int(m[2]), day: int(m[3]) };
+
+  // Month-name day year: "July 4, 2020" or "July 4 2020"
+  m = /^([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})$/.exec(s);
+  if (m) {
+    const month = monthNumber(m[1]);
+    if (month) return { year: int(m[3]), month, day: int(m[2]) };
+  }
+
+  // Day-first month year: "4 July 2020"
+  m = /^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/.exec(s);
+  if (m) {
+    const month = monthNumber(m[2]);
+    if (month) return { year: int(m[3]), month, day: int(m[1]) };
+  }
+
+  // 12-hour time: "3pm", "3:30 PM", "12 AM"
+  m = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(s);
+  if (m) {
+    let hour = int(m[1]);
+    const minute = m[2] !== undefined ? int(m[2]) : undefined;
+    const ampm = m[3].toLowerCase();
+    hour = ampm === "am" ? (hour === 12 ? 0 : hour) : hour === 12 ? 12 : hour + 12;
+    const parts: LooseDateParts = { hour };
+    if (minute !== undefined) parts.minute = minute;
+    return parts;
+  }
+
+  // 24-hour time: "15:30" or "15:30:45"
+  m = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(s);
+  if (m) {
+    const parts: LooseDateParts = { hour: int(m[1]), minute: int(m[2]) };
+    if (m[3] !== undefined) parts.second = int(m[3]);
+    return parts;
+  }
+
+  return null;
+}
+
+function toDateTimeParts(pdt: Temporal.PlainDateTime): LooseDateParts {
+  return {
+    year: pdt.year,
+    month: pdt.month,
+    day: pdt.day,
+    hour: pdt.hour,
+    minute: pdt.minute,
+    second: pdt.second,
+    millisecond: pdt.millisecond,
+    microsecond: pdt.microsecond,
+  };
+}
+
+function toTimeParts(pt: Temporal.PlainTime): LooseDateParts {
+  return {
+    hour: pt.hour,
+    minute: pt.minute,
+    second: pt.second,
+    millisecond: pt.millisecond,
+    microsecond: pt.microsecond,
+  };
+}
+
+function int(s: string): number {
+  return parseInt(s, 10);
+}
+
+const MONTH_NAMES: Record<string, number> = {
+  january: 1,
+  february: 2,
+  march: 3,
+  april: 4,
+  may: 5,
+  june: 6,
+  july: 7,
+  august: 8,
+  september: 9,
+  october: 10,
+  november: 11,
+  december: 12,
+};
+
+function monthNumber(name: string): number | null {
+  return MONTH_NAMES[name.toLowerCase()] ?? null;
+}

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -114,4 +114,11 @@ describe("TimeTest", () => {
     expect(result).toBeInstanceOf(Temporal.PlainTime);
     expect((result as Temporal.PlainTime).hour).toBe(19);
   });
+
+  it("cast datetime with non-zero offset preserves local time (not UTC-normalized)", () => {
+    // Ruby Time._parse reports the local hour written in the string, not the UTC hour.
+    const result = type.cast("2015-02-09T19:45:54+02:00");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(19);
+  });
 });

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -83,4 +83,35 @@ describe("TimeTest", () => {
     const zdt = Temporal.ZonedDateTime.from("2024-01-15T14:30:00[America/New_York]");
     expect(type.userInputInTimeZone(zdt)).toBe(zdt);
   });
+
+  it("cast 3pm returns PlainTime 15:00", () => {
+    const result = type.cast("3pm");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(15);
+    expect((result as Temporal.PlainTime).minute).toBe(0);
+  });
+
+  it("cast 3:30 PM returns PlainTime 15:30", () => {
+    const result = type.cast("3:30 PM");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(15);
+    expect((result as Temporal.PlainTime).minute).toBe(30);
+  });
+
+  it("cast 15:30 returns PlainTime 15:30", () => {
+    const result = type.cast("15:30");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(15);
+    expect((result as Temporal.PlainTime).minute).toBe(30);
+  });
+
+  it("cast garbage string returns null", () => {
+    expect(type.cast("garbage")).toBe(null);
+  });
+
+  it("cast ISO time string still works (regression guard)", () => {
+    const result = type.cast("19:45:54");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(19);
+  });
 });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { looseDateParse } from "./helpers/loose-date-parse.js";
 import { ValueType } from "./value.js";
 
 export class TimeType extends ValueType<Temporal.PlainTime> {
@@ -11,10 +12,19 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
     if (value instanceof Temporal.PlainDateTime) return value.toPlainTime();
     const str = String(value).trim();
     if (str === "") return null;
-    const timeStr = extractTimePortion(str);
-    if (!timeStr) return null;
+    const parts = looseDateParse(str);
+    if (!parts || parts.hour === undefined) return null;
     try {
-      return Temporal.PlainTime.from(timeStr, { overflow: "reject" });
+      return Temporal.PlainTime.from(
+        {
+          hour: parts.hour,
+          minute: parts.minute ?? 0,
+          second: parts.second ?? 0,
+          millisecond: parts.millisecond ?? 0,
+          microsecond: parts.microsecond ?? 0,
+        },
+        { overflow: "reject" },
+      );
     } catch {
       return null;
     }
@@ -70,13 +80,4 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
       return null;
     }
   }
-}
-
-/** Extract the `HH:MM:SS[.ffffff]` portion from a datetime or time-only string. */
-function extractTimePortion(str: string): string | null {
-  // Time-only: "HH:MM" or "HH:MM:SS..." forms
-  if (/^\d{2}:\d{2}/.test(str)) return str;
-  // Full datetime: find the time part after T or space separator
-  const m = /[T ](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:[Z+-]|$)/.exec(str);
-  return m ? m[1] : null;
 }


### PR DESCRIPTION
## Summary

- Implements P13 from `docs/activemodel-alignment.md`; fixes audit finding #41 (`docs/activemodel/audit-types.md` §11 and §13).
- Adds `type/helpers/loose-date-parse.ts` — a layered fallback parser mirroring Ruby's `Date._parse(string, false)` breadth of format support.
- Wires `DateType#fallbackStringToDate` and `TimeType#castValue` through the new helper so non-ISO inputs are accepted.

**User-visible win:** Form inputs with US date format ("7/4/2020"), month-name strings ("July 4, 2020"), and casual times ("3pm", "3:30 PM") no longer silently cast to null.

Supported formats: ISO 8601, US slashes (7/4/2020), year-first slashes (2020/07/04), month-name strings (July 4 2020, 4 July 2020), 12-hour times (3pm, 3:30 PM), 24-hour times (15:30, 15:30:45).

**LOC note:** 328 additions (slightly over the 300 target). The overage is expected — regex set + 26 new tests per P13 spec.

## Test plan

- [ ] 17 new unit tests in `loose-date-parse.test.ts` covering all supported formats and null cases
- [ ] 4 new tests in `date.test.ts` (month-name, US slash, garbage, ISO regression)
- [ ] 5 new tests in `time.test.ts` (3pm, 3:30 PM, 15:30, garbage, ISO regression)
- [ ] `pnpm lint`, `pnpm format:check`, `pnpm typecheck` pass
