### PR TITLE
fix(activemodel): mutable helper round-trips and detects real changes (P12)

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -50,6 +50,8 @@ export { PresenceValidator } from "./validations/presence.js";
 export { LengthValidator } from "./validations/length.js";
 export { NumericalityValidator } from "./validations/numericality.js";
 export { AcceptsMultiparameterTime } from "./type/helpers/accepts-multiparameter-time.js";
+export { MutableModule } from "./type/helpers/mutable.js";
+export type { Mutable } from "./type/helpers/mutable.js";
 export { ModelName } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
 export { CallbackChain } from "./callbacks.js";

--- a/packages/activemodel/src/type/helpers/mutable.test.ts
+++ b/packages/activemodel/src/type/helpers/mutable.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { include } from "@blazetrails/activesupport";
+import { MutableModule } from "./mutable.js";
+import { ValueType } from "../value.js";
+
+class FakeJsonType extends ValueType<unknown> {
+  readonly name = "fake_json";
+
+  override serialize(value: unknown): unknown {
+    if (value === null || value === undefined) return null;
+    return JSON.stringify(value);
+  }
+
+  override deserialize(value: unknown): unknown {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") return JSON.parse(value);
+    return value;
+  }
+}
+
+include(FakeJsonType, MutableModule);
+
+describe("MutableModule", () => {
+  it("included class instances satisfy instanceof the base class", () => {
+    const instance = new FakeJsonType();
+    expect(instance).toBeInstanceOf(FakeJsonType);
+    expect(instance).toBeInstanceOf(ValueType);
+  });
+
+  it("isMutable returns true", () => {
+    expect(new FakeJsonType().isMutable()).toBe(true);
+  });
+
+  it("cast round-trips through serialize/deserialize producing a detached copy", () => {
+    const t = new FakeJsonType();
+    const input = { a: 1 };
+    const result = t.cast(input);
+    expect(result).toEqual({ a: 1 });
+    expect(result).not.toBe(input);
+  });
+
+  it("mutating input after cast does not affect the cast output", () => {
+    const t = new FakeJsonType();
+    const input: Record<string, number> = { a: 1 };
+    const result = t.cast(input) as Record<string, number>;
+    input.a = 99;
+    expect(result.a).toBe(1);
+  });
+
+  it("isChangedInPlace returns false for serialize-equal values", () => {
+    const t = new FakeJsonType();
+    expect(t.isChangedInPlace('{"a":1}', { a: 1 })).toBe(false);
+  });
+
+  it("isChangedInPlace returns true for serialize-different values", () => {
+    const t = new FakeJsonType();
+    expect(t.isChangedInPlace('{"a":1}', { a: 2 })).toBe(true);
+  });
+
+  it("isChangedInPlace returns false when same object reassigned with deep-equal value", () => {
+    const t = new FakeJsonType();
+    const original = { x: 42 };
+    const rawOld = t.serialize(original) as string;
+    const newValue = { x: 42 };
+    expect(t.isChangedInPlace(rawOld, newValue)).toBe(false);
+  });
+});

--- a/packages/activemodel/src/type/helpers/mutable.ts
+++ b/packages/activemodel/src/type/helpers/mutable.ts
@@ -2,24 +2,35 @@
  * Mutable helper — marks a type as mutable for in-place change detection.
  *
  * Mirrors: ActiveModel::Type::Helpers::Mutable
- *
- * Types that include Mutable report mutable?=true, meaning their
- * values can change in-place (e.g. arrays, hashes). changed_in_place?
- * always returns true for mutable types since we can't cheaply detect
- * in-place mutations.
  */
-export interface Mutable {
-  cast(value: unknown): unknown;
-  changedInPlace(rawOldValue: unknown, newValue: unknown): boolean;
-  isMutable(): boolean;
-}
+import { type Included } from "@blazetrails/activesupport";
+import { Type } from "../value.js";
 
-export const MutableMixin = {
-  isMutable(): boolean {
-    return true;
+/**
+ * Mirrors: ActiveModel::Type::Helpers::Mutable (mutable.rb:1-23).
+ *
+ * Include into a type class via `include(MyType, MutableModule)`:
+ * - `cast` round-trips through serialize/deserialize so the returned value
+ *   is detached from the input reference (mutable.rb:7-9)
+ * - `isChangedInPlace` compares serialized forms instead of always returning
+ *   true (mutable.rb:14-16)
+ * - `isMutable` returns true (mutable.rb:18-20)
+ *
+ * @internal Rails-private helper.
+ */
+export const MutableModule = {
+  cast(this: Type, value: unknown): unknown {
+    return this.deserialize(this.serialize(value));
   },
 
-  changedInPlace(_rawOldValue: unknown, _newValue: unknown): boolean {
+  isChangedInPlace(this: Type, rawOldValue: unknown, newValue: unknown): boolean {
+    return rawOldValue !== this.serialize(newValue);
+  },
+
+  isMutable(this: Type): boolean {
     return true;
   },
 };
+
+/** Structural type for types that include MutableModule. */
+export type Mutable = Included<typeof MutableModule>;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts
@@ -21,4 +21,28 @@ describe("PostgreSQL::OID::Jsonb", () => {
     expect(JSON.parse(serialized as string)).toEqual({ a: 1 });
     expect(t.serialize(null)).toBeNull();
   });
+
+  it("isMutable returns true", () => {
+    expect(new Jsonb().isMutable()).toBe(true);
+  });
+
+  it("cast returns a detached copy for object inputs", () => {
+    const t = new Jsonb();
+    const input = { a: 1 };
+    const result = t.cast(input);
+    expect(result).toEqual({ a: 1 });
+    expect(result).not.toBe(input);
+  });
+
+  it("isChangedInPlace returns false for serialize-equal values", () => {
+    const t = new Jsonb();
+    const raw = t.serialize({ a: 1 }) as string;
+    expect(t.isChangedInPlace(raw, { a: 1 })).toBe(false);
+  });
+
+  it("isChangedInPlace returns true for serialize-different values", () => {
+    const t = new Jsonb();
+    const raw = t.serialize({ a: 1 }) as string;
+    expect(t.isChangedInPlace(raw, { a: 2 })).toBe(true);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
@@ -2,11 +2,15 @@
  * PostgreSQL jsonb type — binary JSON storage.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb.
- * Rails: `class Jsonb < Type::Json`. Overrides `type` to return :jsonb; `name`
- * is also set to "jsonb" (Trails-specific property) so call sites that read
- * `type.name` for schema reflection see "jsonb" rather than the inherited "json".
+ * Rails: `class Jsonb < Type::Json; include Helpers::Mutable`. Overrides
+ * `type` to return :jsonb; `name` is also set to "jsonb" (Trails-specific
+ * property). `cast` parses JSON strings directly and round-trips non-string
+ * values through serialize for reference detachment; `isMutable` and
+ * `isChangedInPlace` come from MutableModule.
  */
 
+import { MutableModule } from "@blazetrails/activemodel";
+import { include } from "@blazetrails/activesupport";
 import { Json } from "../../../type/json.js";
 
 export class Jsonb extends Json {
@@ -15,4 +19,12 @@ export class Jsonb extends Json {
   override type(): string {
     return "jsonb";
   }
+
+  override cast(value: unknown): unknown {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") return super.cast(value);
+    return super.cast(this.serialize(value));
+  }
 }
+
+include(Jsonb, MutableModule);


### PR DESCRIPTION
## Summary

Fixes two bugs in `ActiveModel::Type::Helpers::Mutable` per audit-types §17 (#43), documented in `docs/activemodel-alignment.md` P12.

**Bug 1 — no `cast` override:** Rails `mutable.rb:7-9` defines `cast(value) = deserialize(serialize(value))` to produce a value detached from the input reference. The old `MutableMixin` plain-object didn't supply `cast` at all, so mutable types shared the input reference — in-place mutations on the caller's object would leak into the stored attribute value.

**Bug 2 — `changedInPlace` always true:** Rails `mutable.rb:14-16` returns `raw_old_value != serialize(new_value)`. The old mixin returned `true` unconditionally, causing every mutable-typed attribute to dirty-flag on every save cycle even when the value hadn't changed.

**User-visible win:** jsonb attributes re-assigned to a deep-equal value (e.g. re-parsing an API payload to the same structure) no longer trigger a spurious UPDATE on the next `save`.

## Changes

- **`packages/activemodel/src/type/helpers/mutable.ts`** — replaces the broken `MutableMixin` plain-object with `MutableModule` (an `include`-compatible plain object following the activesupport `include()` pattern), plus a `Mutable` type alias. Mirrors `mutable.rb:1-23` exactly.
- **`packages/activemodel/src/index.ts`** — exports `MutableModule` and `Mutable` from the package boundary.
- **`packages/activemodel/src/type/helpers/mutable.test.ts`** — new test file: include application, cast round-trip detachment, `isChangedInPlace` false/true cases, `isMutable` regression guard.
- **`packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts`** — wires `include(Jsonb, MutableModule)` (Rails: `OID::Jsonb includes Helpers::Mutable` via `Type::Json`); adds `cast` override that parses strings directly and round-trips non-string values for reference detachment.
- **`packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts`** — adds coverage for `isMutable`, `isChangedInPlace` (false/true), and `cast` reference detachment.

## Test plan

- [x] `pnpm test` — 20 048 passing, 0 failing
- [x] `pnpm api:compare --package activemodel` — 624/625 (99.8%), inheritance 38/41 (no regression)
- [x] `pnpm api:compare --package activerecord` — 3767/5082 (74.1%), inheritance 198/204 (no regression)
- [x] `pnpm format:check` — passes
- [x] `pnpm lint` — 0 errors
- [x] `tsc --build` — passes (pre-commit hook verified)

## LOC

~132 additions + deletions (excluding lockfiles) — within the 300 LOC ceiling.