### PR TITLE
feat(activerecord): trails-tsc auto-bridges include() with interface merge

### DIFF
--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -4,6 +4,12 @@ import { virtualize, type VirtualizeResult } from "../type-virtualization/virtua
 import { resolveAutoImports } from "./auto-import.js";
 
 const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
+// Cheap pre-filter for files using `include(...)` from
+// `@blazetrails/activesupport`. Both substrings must appear before the
+// virtualizer parses the file — the syntactic walker enforces the
+// stricter import-source check.
+const INCLUDE_CALL_PATTERN = /\binclude\s*\(/;
+const ACTIVESUPPORT_IMPORT_PATTERN = /@blazetrails\/activesupport/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
   getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;
@@ -46,6 +52,12 @@ export function buildCompilerHost(
     extra.schemaColumnsByTable && Object.keys(extra.schemaColumnsByTable).length > 0;
 
   function shouldVirtualize(text: string): boolean {
+    // Files using `include()` from activesupport need the
+    // interface-merge appendix even if they don't extend Base — e.g.
+    // utility classes that mix in plain modules.
+    const hasIncludeCall =
+      INCLUDE_CALL_PATTERN.test(text) && ACTIVESUPPORT_IMPORT_PATTERN.test(text);
+    if (hasIncludeCall) return true;
     // Fast-path skip for files that don't reference a Base-like class.
     // When schema columns are available, a class extending Base may
     // need declares even without a `static {}` block — so the static-

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -6,15 +6,18 @@ import { resolveAutoImports } from "./auto-import.js";
 const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 // Cheap pre-filter for files using top-level `include(...)` from
 // `@blazetrails/activesupport`. The patterns are intentionally
-// conservative: false negatives are caught by users not seeing the
-// merge (loud), but false positives cost real compile time
-// (re-parsing + auto-import resolution) on every file that imports
-// from activesupport. We require:
-//   - a top-of-line `include(` (`^` with the `m` flag) to skip
-//     `.include(` method calls and occurrences in block comments
-//   - a named import line that actually binds the local name
-//     `include` from `@blazetrails/activesupport`
-// The syntactic walker enforces the same constraints exactly.
+// conservative — false positives just cost a parse the walker would
+// reject anyway, false negatives would silently lose the merge. We
+// require:
+//   - a line whose first non-whitespace token is `include(` (`^\s*` +
+//     `m` flag) — this skips `.include(` method calls but does NOT
+//     skip lines inside block comments that happen to start with
+//     `include(`. The syntactic walker drops those (commented-out
+//     calls aren't statements), so they only cost an extra parse.
+//   - a named import that binds the local name `include` from
+//     `@blazetrails/activesupport` (excluding the `include as ...`
+//     aliased form).
+// The syntactic walker enforces both constraints exactly.
 const INCLUDE_CALL_PATTERN = /^\s*include\s*\(/m;
 // `\binclude\b(?!\s+as\b)` ensures the local binding really is
 // `include` — `include as inc` rebinds to `inc`, leaving any

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -19,12 +19,13 @@ const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 //     aliased form).
 // The syntactic walker enforces both constraints exactly.
 const INCLUDE_CALL_PATTERN = /^\s*include\s*\(/m;
-// `\binclude\b(?!\s+as\b)` ensures the local binding really is
-// `include` — `include as inc` rebinds to `inc`, leaving any
-// `include(...)` call in the file as a separate user-defined helper
-// that the walker would (correctly) skip.
+// Local binding must be `include`. Accepts `include` (no `as`) and
+// the rare `include as include`; rejects `include as inc` (local
+// rebinds to `inc`). The negative lookahead `(?!\s+as\s+(?!include\b))`
+// fails the match when `include` is followed by `as <something-other-
+// than-include>`.
 const ACTIVESUPPORT_INCLUDE_IMPORT_PATTERN =
-  /import\s*\{[^}]*\binclude\b(?!\s+as\b)[^}]*\}\s*from\s*["']@blazetrails\/activesupport["']/;
+  /import\s*\{[^}]*\binclude\b(?!\s+as\s+(?!include\b))[^}]*\}\s*from\s*["']@blazetrails\/activesupport["']/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
   getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -4,12 +4,20 @@ import { virtualize, type VirtualizeResult } from "../type-virtualization/virtua
 import { resolveAutoImports } from "./auto-import.js";
 
 const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
-// Cheap pre-filter for files using `include(...)` from
-// `@blazetrails/activesupport`. Both substrings must appear before the
-// virtualizer parses the file — the syntactic walker enforces the
-// stricter import-source check.
-const INCLUDE_CALL_PATTERN = /\binclude\s*\(/;
-const ACTIVESUPPORT_IMPORT_PATTERN = /@blazetrails\/activesupport/;
+// Cheap pre-filter for files using top-level `include(...)` from
+// `@blazetrails/activesupport`. The patterns are intentionally
+// conservative: false negatives are caught by users not seeing the
+// merge (loud), but false positives cost real compile time
+// (re-parsing + auto-import resolution) on every file that imports
+// from activesupport. We require:
+//   - a top-of-line `include(` (`^` with the `m` flag) to skip
+//     `.include(` method calls and occurrences in block comments
+//   - a named import line that actually binds the local name
+//     `include` from `@blazetrails/activesupport`
+// The syntactic walker enforces the same constraints exactly.
+const INCLUDE_CALL_PATTERN = /^\s*include\s*\(/m;
+const ACTIVESUPPORT_INCLUDE_IMPORT_PATTERN =
+  /import\s*\{[^}]*\binclude\b[^}]*\}\s*from\s*["']@blazetrails\/activesupport["']/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
   getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;
@@ -56,7 +64,7 @@ export function buildCompilerHost(
     // interface-merge appendix even if they don't extend Base — e.g.
     // utility classes that mix in plain modules.
     const hasIncludeCall =
-      INCLUDE_CALL_PATTERN.test(text) && ACTIVESUPPORT_IMPORT_PATTERN.test(text);
+      INCLUDE_CALL_PATTERN.test(text) && ACTIVESUPPORT_INCLUDE_IMPORT_PATTERN.test(text);
     if (hasIncludeCall) return true;
     // Fast-path skip for files that don't reference a Base-like class.
     // When schema columns are available, a class extending Base may

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -16,8 +16,12 @@ const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 //     `include` from `@blazetrails/activesupport`
 // The syntactic walker enforces the same constraints exactly.
 const INCLUDE_CALL_PATTERN = /^\s*include\s*\(/m;
+// `\binclude\b(?!\s+as\b)` ensures the local binding really is
+// `include` — `include as inc` rebinds to `inc`, leaving any
+// `include(...)` call in the file as a separate user-defined helper
+// that the walker would (correctly) skip.
 const ACTIVESUPPORT_INCLUDE_IMPORT_PATTERN =
-  /import\s*\{[^}]*\binclude\b[^}]*\}\s*from\s*["']@blazetrails\/activesupport["']/;
+  /import\s*\{[^}]*\binclude\b(?!\s+as\b)[^}]*\}\s*from\s*["']@blazetrails\/activesupport["']/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
   getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -496,14 +496,31 @@ describe("virtualize — include() interface bridge", () => {
   });
 
   test("aliased include import (`include as inc`) is not picked up", () => {
-    // Conservative: we only match the unqualified `include` name. An
-    // aliased import would fall through to be treated as a no-op.
+    // The aliased binding is `inc`, so a local user-defined `include(...)`
+    // helper in the same file must not be misclassified as the
+    // activesupport one.
     const src =
       'import { include as inc } from "@blazetrails/activesupport";\n' +
+      "function include(c: any, m: any) {}\n" +
       "export class Foo {}\n" +
-      "inc(Foo, Bar);\n";
+      "include(Foo, Bar);\n";
     const { text } = virtualize(src, "foo.ts");
     expect(text).not.toMatch(/interface Foo extends/);
+    expect(text).not.toMatch(/__TrailsIncluded/);
+  });
+
+  test("re-virtualizing already-virtualized output does not re-inject", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { QM } from "./qm.js";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, QM);\n";
+    const once = virtualize(src, "relation.ts").text;
+    const twice = virtualize(once, "relation.ts").text;
+    expect(twice).toBe(once);
+    expect(once.match(/__TrailsIncluded/g)?.length).toBeGreaterThan(0);
+    expect(twice.match(/import type \{ Included as __TrailsIncluded \}/g)?.length).toBe(1);
+    expect(twice.match(/interface Relation extends __TrailsIncluded<typeof QM>/g)?.length).toBe(1);
   });
 });
 

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -539,9 +539,10 @@ describe("virtualize — include() interface bridge", () => {
     expect(headLines[headDelta.insertedAtLine + 1]).toMatch(/import type \{ Included as/);
   });
 
-  test("skips injection when __TrailsIncluded is already bound (any formatting)", () => {
-    // Single-quoted, no semicolon — text-includes wouldn't catch this,
-    // but the AST walk does.
+  test("reuses existing `Included as __TrailsIncluded` import — emits interfaces but not a duplicate import", () => {
+    // Single-quoted, no semicolon: AST detection sees the import
+    // regardless of formatting. The bridge reuses the existing alias
+    // and still injects the interface declaration.
     const src =
       "import type { Included as __TrailsIncluded } from '@blazetrails/activesupport'\n" +
       'import { include } from "@blazetrails/activesupport";\n' +
@@ -549,10 +550,43 @@ describe("virtualize — include() interface bridge", () => {
       "export class Relation {}\n" +
       "include(Relation, QM);\n";
     const { text } = virtualize(src, "relation.ts");
-    // No second `import type { Included as __TrailsIncluded }` injected.
     expect(text.match(/import type \{ Included as __TrailsIncluded \}/g)?.length).toBe(1);
-    // No interface emitted either, since we skip the whole include path.
+    expect(text).toMatch(/interface Relation extends __TrailsIncluded<typeof QM>/);
+  });
+
+  test("bails entirely when __TrailsIncluded is bound by something else", () => {
+    const src =
+      'import { __TrailsIncluded } from "./local.js";\n' +
+      'import { include } from "@blazetrails/activesupport";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, QM);\n";
+    const { text } = virtualize(src, "relation.ts");
+    // No injected import (existing one is from a different module).
+    expect(text).not.toMatch(/import type \{ Included as __TrailsIncluded \}/);
+    // No interface either — would type against the wrong symbol.
     expect(text).not.toMatch(/interface Relation extends/);
+  });
+
+  test("skips auto-bridge for classes the user hand-declares an interface for", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { FinderMethods } from "./finder-methods.js";\n' +
+      "export class Relation<T> {}\n" +
+      "export interface Relation<T> { find(...args: unknown[]): Promise<T>; }\n" +
+      "include(Relation, FinderMethods);\n";
+    const { text } = virtualize(src, "relation.ts");
+    // No auto-bridge for Relation — user has refined typings.
+    expect(text).not.toMatch(/interface Relation<T> extends __TrailsIncluded/);
+  });
+
+  test("accepts `include as include` (local binding still `include`)", () => {
+    const src =
+      'import { include as include } from "@blazetrails/activesupport";\n' +
+      'import { QM } from "./qm.js";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, QM);\n";
+    const { text } = virtualize(src, "relation.ts");
+    expect(text).toMatch(/interface Relation extends __TrailsIncluded<typeof QM>/);
   });
 
   test("re-virtualizing already-virtualized output does not re-inject", () => {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -539,6 +539,22 @@ describe("virtualize — include() interface bridge", () => {
     expect(headLines[headDelta.insertedAtLine + 1]).toMatch(/import type \{ Included as/);
   });
 
+  test("skips injection when __TrailsIncluded is already bound (any formatting)", () => {
+    // Single-quoted, no semicolon — text-includes wouldn't catch this,
+    // but the AST walk does.
+    const src =
+      "import type { Included as __TrailsIncluded } from '@blazetrails/activesupport'\n" +
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { QM } from "./qm.js";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, QM);\n";
+    const { text } = virtualize(src, "relation.ts");
+    // No second `import type { Included as __TrailsIncluded }` injected.
+    expect(text.match(/import type \{ Included as __TrailsIncluded \}/g)?.length).toBe(1);
+    // No interface emitted either, since we skip the whole include path.
+    expect(text).not.toMatch(/interface Relation extends/);
+  });
+
   test("re-virtualizing already-virtualized output does not re-inject", () => {
     const src =
       'import { include } from "@blazetrails/activesupport";\n' +

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -415,6 +415,65 @@ describe("virtualize — multiple classes", () => {
   });
 });
 
+describe("virtualize — include() interface bridge", () => {
+  test("emits interface-merge for include() of a local class", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { QueryMethods } from "./query-methods.js";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, QueryMethods);\n";
+    const { text } = virtualize(src, "relation.ts");
+    expect(text).toMatch(
+      /import type \{ Included as __TrailsIncluded \} from "@blazetrails\/activesupport";/,
+    );
+    expect(text).toMatch(/interface Relation extends __TrailsIncluded<typeof QueryMethods> \{\}/);
+  });
+
+  test("groups multiple include() calls on the same class into one heritage list", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { A, B } from "./mods.js";\n' +
+      "export class Relation {}\n" +
+      "include(Relation, A);\n" +
+      "include(Relation, B);\n";
+    const { text } = virtualize(src, "relation.ts");
+    const m = text.match(/interface Relation extends ([^{]+) \{\}/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toContain("__TrailsIncluded<typeof A>");
+    expect(m![1]).toContain("__TrailsIncluded<typeof B>");
+    expect(text.match(/interface Relation extends/g)?.length).toBe(1);
+  });
+
+  test("ignores include() when not imported from activesupport", () => {
+    const src =
+      'import { include } from "./local-helper.js";\n' +
+      "export class Foo {}\n" +
+      "include(Foo, Bar);\n";
+    const { text } = virtualize(src, "foo.ts");
+    expect(text).not.toMatch(/interface Foo extends/);
+  });
+
+  test("ignores include() when target class is not declared in this file", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { External } from "./external.js";\n' +
+      "include(External, Mod);\n";
+    const { text } = virtualize(src, "x.ts");
+    expect(text).not.toMatch(/interface External/);
+  });
+
+  test("aliased include import (`include as inc`) is not picked up", () => {
+    // Conservative: we only match the unqualified `include` name. An
+    // aliased import would fall through to be treated as a no-op.
+    const src =
+      'import { include as inc } from "@blazetrails/activesupport";\n' +
+      "export class Foo {}\n" +
+      "inc(Foo, Bar);\n";
+    const { text } = virtualize(src, "foo.ts");
+    expect(text).not.toMatch(/interface Foo extends/);
+  });
+});
+
 describe("virtualize — idempotence", () => {
   test("re-virtualizing the output skips members already declared", () => {
     const src =

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -415,6 +415,16 @@ describe("virtualize — multiple classes", () => {
   });
 });
 
+function indexOfNthNewline(text: string, n: number): number {
+  let idx = 0;
+  for (let i = 0; i < n; i++) {
+    const next = text.indexOf("\n", idx);
+    if (next === -1) return text.length;
+    idx = next + 1;
+  }
+  return idx;
+}
+
 describe("virtualize — include() interface bridge", () => {
   test("emits interface-merge for include() of a local class", () => {
     const src =
@@ -507,6 +517,26 @@ describe("virtualize — include() interface bridge", () => {
     const { text } = virtualize(src, "foo.ts");
     expect(text).not.toMatch(/interface Foo extends/);
     expect(text).not.toMatch(/__TrailsIncluded/);
+  });
+
+  test("multi-line module expression — delta math survives embedded newlines", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import * as Persistence from "./persistence.js";\n' +
+      "export class Foo {}\n" +
+      "include(\n  Foo,\n  Persistence\n    .InstanceMethods,\n);\n" +
+      "const target = 42;\n";
+    const { text, deltas } = virtualize(src, "foo.ts");
+    // The synthesized declare must round-trip the multi-line text without losing newlines.
+    expect(text).toMatch(/__TrailsIncluded<typeof Persistence[\s\S]*\.InstanceMethods>/);
+    // Delta line count must reflect ACTUAL physical lines in the
+    // prepended block, not the entry count.
+    const headDelta = deltas[0]!;
+    const headLines = text
+      .slice(0, indexOfNthNewline(text, headDelta.insertedAtLine + headDelta.lineCount + 1))
+      .split(/\r?\n/);
+    // The line at insertedAtLine+1 (start of injection) should be the first prepend line.
+    expect(headLines[headDelta.insertedAtLine + 1]).toMatch(/import type \{ Included as/);
   });
 
   test("re-virtualizing already-virtualized output does not re-inject", () => {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -462,6 +462,39 @@ describe("virtualize — include() interface bridge", () => {
     expect(text).not.toMatch(/interface External/);
   });
 
+  test("preserves export modifier and generic type params on the merged interface", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { QM } from "./qm.js";\n' +
+      "export class Relation<T extends Base> {}\n" +
+      "include(Relation, QM);\n";
+    const { text } = virtualize(src, "relation.ts");
+    expect(text).toMatch(
+      /export interface Relation<T extends Base> extends __TrailsIncluded<typeof QM> \{\}/,
+    );
+  });
+
+  test("skips include() with non-typeof-queryable module expressions (object literals)", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      "export class Foo {}\n" +
+      "include(Foo, { bar() {} });\n";
+    const { text } = virtualize(src, "foo.ts");
+    expect(text).not.toMatch(/interface Foo extends/);
+  });
+
+  test("accepts property-access module expressions (typeof Mod.InstanceMethods)", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import * as Persistence from "./persistence.js";\n' +
+      "export class Foo {}\n" +
+      "include(Foo, Persistence.InstanceMethods);\n";
+    const { text } = virtualize(src, "foo.ts");
+    expect(text).toMatch(
+      /interface Foo extends __TrailsIncluded<typeof Persistence\.InstanceMethods> \{\}/,
+    );
+  });
+
   test("aliased include import (`include as inc`) is not picked up", () => {
     // Conservative: we only match the unqualified `include` name. An
     // aliased import would fall through to be treated as a no-op.

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -579,6 +579,23 @@ describe("virtualize — include() interface bridge", () => {
     expect(text).not.toMatch(/interface Relation<T> extends __TrailsIncluded/);
   });
 
+  test("bails when __TrailsIncluded is bound by an enum or namespace", () => {
+    for (const decl of [
+      "enum __TrailsIncluded { A }",
+      "namespace __TrailsIncluded { export const x = 1; }",
+    ]) {
+      const src =
+        decl +
+        "\n" +
+        'import { include } from "@blazetrails/activesupport";\n' +
+        "export class Relation {}\n" +
+        "include(Relation, QM);\n";
+      const { text } = virtualize(src, "relation.ts");
+      expect(text).not.toMatch(/import type \{ Included as __TrailsIncluded \}/);
+      expect(text).not.toMatch(/interface Relation extends __TrailsIncluded/);
+    }
+  });
+
   test("does not inject the __TrailsIncluded import when every target has a user interface", () => {
     const src =
       'import { include } from "@blazetrails/activesupport";\n' +

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -579,6 +579,18 @@ describe("virtualize — include() interface bridge", () => {
     expect(text).not.toMatch(/interface Relation<T> extends __TrailsIncluded/);
   });
 
+  test("does not inject the __TrailsIncluded import when every target has a user interface", () => {
+    const src =
+      'import { include } from "@blazetrails/activesupport";\n' +
+      'import { FinderMethods } from "./finder-methods.js";\n' +
+      "export class Relation<T> {}\n" +
+      "export interface Relation<T> { find(...args: unknown[]): Promise<T>; }\n" +
+      "include(Relation, FinderMethods);\n";
+    const { text } = virtualize(src, "relation.ts");
+    // No interface emitted (user has one), and no dangling alias import.
+    expect(text).not.toMatch(/__TrailsIncluded/);
+  });
+
   test("accepts `include as include` (local binding still `include`)", () => {
     const src =
       'import { include as include } from "@blazetrails/activesupport";\n' +

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -144,7 +144,11 @@ export function virtualize(
   const includes = findIncludeCalls(sf);
   const effectivePrepends: string[] = [];
   if (options.prependImports) effectivePrepends.push(...options.prependImports);
-  if (includes.length > 0) {
+  // Skip re-injection when the input was already virtualized (e.g. the
+  // virtualizer is run on its own previous output). Detected by the
+  // marker import line, which only the virtualizer ever emits.
+  const alreadyInjected = originalText.includes(INCLUDED_IMPORT_LINE);
+  if (includes.length > 0 && !alreadyInjected) {
     effectivePrepends.push(INCLUDED_IMPORT_LINE);
     interface Group {
       mods: string[];

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -144,10 +144,14 @@ export function virtualize(
   const includes = findIncludeCalls(sf);
   const effectivePrepends: string[] = [];
   if (options.prependImports) effectivePrepends.push(...options.prependImports);
-  // Skip re-injection when the input was already virtualized (e.g. the
-  // virtualizer is run on its own previous output). Detected by the
-  // marker import line, which only the virtualizer ever emits.
-  const alreadyInjected = originalText.includes(INCLUDED_IMPORT_LINE);
+  // Skip re-injection when any top-level declaration already binds the
+  // local name `__TrailsIncluded` — covers re-virtualizing prior
+  // output (the virtualizer's own marker import) AND the unlikely
+  // case of a user file that already binds the alias under different
+  // formatting (different quotes, missing semicolon, etc.). Walking
+  // the parsed AST is more robust than the previous text-includes
+  // check, which was sensitive to whitespace / quote style.
+  const alreadyInjected = hasTopLevelBinding(sf, INCLUDED_ALIAS);
   if (includes.length > 0 && !alreadyInjected) {
     effectivePrepends.push(INCLUDED_IMPORT_LINE);
     interface Group {
@@ -213,6 +217,44 @@ export function virtualize(
   }
 
   return { text, deltas };
+}
+
+/**
+ * Returns true if any top-level statement in `sf` introduces a local
+ * binding (import alias, type alias, interface, variable, function,
+ * class) with the given name. Used to avoid colliding with a name the
+ * virtualizer is about to inject.
+ */
+function hasTopLevelBinding(sf: ts.SourceFile, name: string): boolean {
+  for (const stmt of sf.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      const clause = stmt.importClause;
+      if (!clause) continue;
+      if (clause.name?.text === name) return true;
+      const named = clause.namedBindings;
+      if (!named) continue;
+      if (ts.isNamespaceImport(named) && named.name.text === name) return true;
+      if (ts.isNamedImports(named)) {
+        for (const el of named.elements) if (el.name.text === name) return true;
+      }
+      continue;
+    }
+    if (
+      (ts.isTypeAliasDeclaration(stmt) ||
+        ts.isInterfaceDeclaration(stmt) ||
+        ts.isClassDeclaration(stmt) ||
+        ts.isFunctionDeclaration(stmt)) &&
+      stmt.name?.text === name
+    ) {
+      return true;
+    }
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === name) return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -144,38 +144,51 @@ export function virtualize(
   const includes = findIncludeCalls(sf);
   const effectivePrepends: string[] = [];
   if (options.prependImports) effectivePrepends.push(...options.prependImports);
-  // Skip re-injection when any top-level declaration already binds the
-  // local name `__TrailsIncluded` — covers re-virtualizing prior
-  // output (the virtualizer's own marker import) AND the unlikely
-  // case of a user file that already binds the alias under different
-  // formatting (different quotes, missing semicolon, etc.). Walking
-  // the parsed AST is more robust than the previous text-includes
-  // check, which was sensitive to whitespace / quote style.
-  const alreadyInjected = hasTopLevelBinding(sf, INCLUDED_ALIAS);
-  if (includes.length > 0 && !alreadyInjected) {
-    effectivePrepends.push(INCLUDED_IMPORT_LINE);
-    interface Group {
-      mods: string[];
-      exported: boolean;
-      typeParams: string;
-    }
-    const grouped = new Map<string, Group>();
-    for (const inc of includes) {
-      const entry = grouped.get(inc.className);
-      if (entry) entry.mods.push(inc.moduleExpr);
-      else
-        grouped.set(inc.className, {
-          mods: [inc.moduleExpr],
-          exported: inc.classExported,
-          typeParams: inc.classTypeParams,
-        });
-    }
-    for (const [className, { mods, exported, typeParams }] of grouped) {
-      const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
-      // Match the class's export modifier and generic parameters —
-      // declaration merging requires both to line up.
-      const prefix = exported ? "export " : "";
-      effectivePrepends.push(`${prefix}interface ${className}${typeParams} extends ${heritage} {}`);
+  if (includes.length > 0) {
+    // Three cases for the `__TrailsIncluded` binding:
+    //   - "absent": inject the import AND interfaces.
+    //   - "matches": existing binding is `Included as __TrailsIncluded`
+    //     from `@blazetrails/activesupport` (e.g. re-virtualizing prior
+    //     output, or a user-written equivalent). Skip the import line
+    //     but still emit interfaces, reusing the existing alias.
+    //   - "different": some other binding owns the name. Skip the
+    //     entire bridge — emitting interfaces would type them against
+    //     the wrong symbol.
+    const aliasState = checkIncludedAliasBinding(sf, INCLUDED_ALIAS);
+    if (aliasState !== "different") {
+      if (aliasState === "absent") effectivePrepends.push(INCLUDED_IMPORT_LINE);
+      // Skip auto-bridging classes whose name already has a top-level
+      // `interface` declaration in the file — the user is hand-typing
+      // refined signatures (e.g. overloads narrower than the module's
+      // erased ones), and adding an `Included<typeof Mod>` heritage
+      // could widen those back to `(...args: unknown[]) => any`.
+      const userInterfaces = collectInterfaceNames(sf);
+      interface Group {
+        mods: string[];
+        exported: boolean;
+        typeParams: string;
+      }
+      const grouped = new Map<string, Group>();
+      for (const inc of includes) {
+        if (userInterfaces.has(inc.className)) continue;
+        const entry = grouped.get(inc.className);
+        if (entry) entry.mods.push(inc.moduleExpr);
+        else
+          grouped.set(inc.className, {
+            mods: [inc.moduleExpr],
+            exported: inc.classExported,
+            typeParams: inc.classTypeParams,
+          });
+      }
+      for (const [className, { mods, exported, typeParams }] of grouped) {
+        const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
+        // Match the class's export modifier and generic parameters —
+        // declaration merging requires both to line up.
+        const prefix = exported ? "export " : "";
+        effectivePrepends.push(
+          `${prefix}interface ${className}${typeParams} extends ${heritage} {}`,
+        );
+      }
     }
   }
 
@@ -219,23 +232,46 @@ export function virtualize(
   return { text, deltas };
 }
 
+type AliasBindingState = "absent" | "matches" | "different";
+
 /**
- * Returns true if any top-level statement in `sf` introduces a local
- * binding (import alias, type alias, interface, variable, function,
- * class) with the given name. Used to avoid colliding with a name the
- * virtualizer is about to inject.
+ * Classify any existing top-level binding for `alias` in `sf`:
+ *   - "absent": no top-level statement binds the name.
+ *   - "matches": a single `import` from `@blazetrails/activesupport`
+ *     binds it as `Included as <alias>` — we can reuse the binding.
+ *   - "different": something else owns the name (different module,
+ *     namespace import, type alias, var, etc.). Reusing would type
+ *     against the wrong symbol; the caller should bail entirely.
  */
-function hasTopLevelBinding(sf: ts.SourceFile, name: string): boolean {
+function checkIncludedAliasBinding(sf: ts.SourceFile, alias: string): AliasBindingState {
+  let state: AliasBindingState = "absent";
+  const escalate = (next: AliasBindingState): void => {
+    if (next === "different") state = "different";
+    else if (next === "matches" && state !== "different") state = "matches";
+  };
   for (const stmt of sf.statements) {
     if (ts.isImportDeclaration(stmt)) {
       const clause = stmt.importClause;
       if (!clause) continue;
-      if (clause.name?.text === name) return true;
+      if (clause.name?.text === alias) {
+        escalate("different");
+        continue;
+      }
       const named = clause.namedBindings;
       if (!named) continue;
-      if (ts.isNamespaceImport(named) && named.name.text === name) return true;
-      if (ts.isNamedImports(named)) {
-        for (const el of named.elements) if (el.name.text === name) return true;
+      if (ts.isNamespaceImport(named) && named.name.text === alias) {
+        escalate("different");
+        continue;
+      }
+      if (!ts.isNamedImports(named)) continue;
+      for (const el of named.elements) {
+        if (el.name.text !== alias) continue;
+        const importedName = el.propertyName?.text ?? el.name.text;
+        const fromActivesupport =
+          ts.isStringLiteralLike(stmt.moduleSpecifier) &&
+          stmt.moduleSpecifier.text === "@blazetrails/activesupport";
+        if (fromActivesupport && importedName === "Included") escalate("matches");
+        else escalate("different");
       }
       continue;
     }
@@ -244,17 +280,26 @@ function hasTopLevelBinding(sf: ts.SourceFile, name: string): boolean {
         ts.isInterfaceDeclaration(stmt) ||
         ts.isClassDeclaration(stmt) ||
         ts.isFunctionDeclaration(stmt)) &&
-      stmt.name?.text === name
+      stmt.name?.text === alias
     ) {
-      return true;
+      escalate("different");
+      continue;
     }
     if (ts.isVariableStatement(stmt)) {
       for (const decl of stmt.declarationList.declarations) {
-        if (ts.isIdentifier(decl.name) && decl.name.text === name) return true;
+        if (ts.isIdentifier(decl.name) && decl.name.text === alias) escalate("different");
       }
     }
   }
-  return false;
+  return state;
+}
+
+function collectInterfaceNames(sf: ts.SourceFile): Set<string> {
+  const out = new Set<string>();
+  for (const stmt of sf.statements) {
+    if (ts.isInterfaceDeclaration(stmt) && stmt.name) out.add(stmt.name.text);
+  }
+  return out;
 }
 
 /**

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -8,8 +8,15 @@
 // directly against fixture pairs.
 
 import ts from "typescript";
-import { walk, type WalkOptions } from "./walker.js";
+import { walk, findIncludeCalls, type WalkOptions } from "./walker.js";
 import { synthesizeDeclares } from "./synthesize.js";
+
+// Aliased name used in the auto-injected `import type` line and the
+// generated interface-merge heritage. Aliasing (rather than importing
+// `Included` bare) avoids `Cannot redeclare block-scoped variable`
+// when the user file already imports `Included` themselves.
+const INCLUDED_ALIAS = "__TrailsIncluded";
+const INCLUDED_IMPORT_LINE = `import type { Included as ${INCLUDED_ALIAS} } from "@blazetrails/activesupport";`;
 
 export interface LineDelta {
   /**
@@ -125,10 +132,18 @@ export function virtualize(
     return d;
   });
 
+  // Detect `include(...)` calls early so we can fold the auxiliary
+  // `import type { Included as ... }` line into the same prepend pass
+  // (otherwise we'd double-shift deltas).
+  const includes = findIncludeCalls(sf);
+  const effectivePrepends: string[] = [];
+  if (options.prependImports) effectivePrepends.push(...options.prependImports);
+  if (includes.length > 0) effectivePrepends.push(INCLUDED_IMPORT_LINE);
+
   // Insert auto-imported `import type` lines AFTER any leading
   // directives (shebangs, triple-slash refs, @ts-nocheck) that must
   // stay at the top of the file. Erased at runtime (type-only).
-  const prependImports = options.prependImports;
+  const prependImports = effectivePrepends.length > 0 ? effectivePrepends : undefined;
   if (prependImports && prependImports.length > 0) {
     const importBlock = prependImports.join("\n") + "\n";
     const insertPos = findDirectiveEnd(text);
@@ -151,6 +166,31 @@ export function virtualize(
       d.insertedAtLine += prependedLines;
     }
     deltas.unshift({ insertedAtLine, lineCount: prependedLines });
+  }
+
+  // Append interface-merge declarations for every
+  // `include(ClassName, ModuleExpr)` call. The mixed-in instance
+  // methods are runtime-copied onto the prototype by `include()`; this
+  // appendix makes them visible to TypeScript via declaration merging
+  // — replacing the manual
+  // `interface ClassName extends Included<typeof Mod> {}` line users
+  // would otherwise write themselves. The aliased
+  // `__TrailsIncluded` import is prepended above so this never collides
+  // with a user-imported `Included`.
+  if (includes.length > 0) {
+    const grouped = new Map<string, string[]>();
+    for (const inc of includes) {
+      const arr = grouped.get(inc.className);
+      if (arr) arr.push(inc.moduleExpr);
+      else grouped.set(inc.className, [inc.moduleExpr]);
+    }
+    const lines: string[] = [];
+    for (const [className, mods] of grouped) {
+      const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
+      lines.push(`interface ${className} extends ${heritage} {}`);
+    }
+    const appendix = (text.endsWith("\n") ? "" : "\n") + lines.join("\n") + "\n";
+    text += appendix;
   }
 
   return { text, deltas };

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -156,7 +156,6 @@ export function virtualize(
     //     the wrong symbol.
     const aliasState = checkIncludedAliasBinding(sf, INCLUDED_ALIAS);
     if (aliasState !== "different") {
-      if (aliasState === "absent") effectivePrepends.push(INCLUDED_IMPORT_LINE);
       // Skip auto-bridging classes whose name already has a top-level
       // `interface` declaration in the file — the user is hand-typing
       // refined signatures (e.g. overloads narrower than the module's
@@ -180,14 +179,20 @@ export function virtualize(
             typeParams: inc.classTypeParams,
           });
       }
+      const interfaceLines: string[] = [];
       for (const [className, { mods, exported, typeParams }] of grouped) {
         const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
         // Match the class's export modifier and generic parameters —
         // declaration merging requires both to line up.
         const prefix = exported ? "export " : "";
-        effectivePrepends.push(
-          `${prefix}interface ${className}${typeParams} extends ${heritage} {}`,
-        );
+        interfaceLines.push(`${prefix}interface ${className}${typeParams} extends ${heritage} {}`);
+      }
+      // Only inject the alias import when at least one interface line
+      // will actually use it — otherwise the import would dangle and
+      // trigger noUnusedLocals.
+      if (interfaceLines.length > 0) {
+        if (aliasState === "absent") effectivePrepends.push(INCLUDED_IMPORT_LINE);
+        effectivePrepends.push(...interfaceLines);
       }
     }
   }

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -175,12 +175,15 @@ export function virtualize(
     }
   }
 
-  // Insert auto-imported `import type` lines AFTER any leading
-  // directives (shebangs, triple-slash refs, @ts-nocheck) that must
-  // stay at the top of the file. Erased at runtime (type-only).
-  const prependImports = effectivePrepends.length > 0 ? effectivePrepends : undefined;
-  if (prependImports && prependImports.length > 0) {
-    const importBlock = prependImports.join("\n") + "\n";
+  // Insert the prepend block AFTER any leading directives (shebangs,
+  // triple-slash refs, @ts-nocheck) that must stay at the top of the
+  // file. The block is one line per entry — entries may be `import type`
+  // lines (auto-imports + the `Included` alias) AND/OR synthesized
+  // `interface X extends ...` declarations from include() bridging.
+  // All entries are erased at runtime (types only).
+  const prependLines = effectivePrepends.length > 0 ? effectivePrepends : undefined;
+  if (prependLines && prependLines.length > 0) {
+    const importBlock = prependLines.join("\n") + "\n";
     const insertPos = findDirectiveEnd(text);
     // Compute the virtual line BEFORE which the import block is
     // inserted: `-1` if the block is truly at the start of the file,
@@ -196,7 +199,7 @@ export function virtualize(
     const insertedAtLine =
       insertPos === 0 ? -1 : before.endsWith("\n") ? newlineCount - 1 : newlineCount;
     text = text.slice(0, insertPos) + importBlock + text.slice(insertPos);
-    const prependedLines = prependImports.length;
+    const prependedLines = prependLines.length;
     for (const d of deltas) {
       d.insertedAtLine += prependedLines;
     }

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -284,8 +284,12 @@ function checkIncludedAliasBinding(sf: ts.SourceFile, alias: string): AliasBindi
       (ts.isTypeAliasDeclaration(stmt) ||
         ts.isInterfaceDeclaration(stmt) ||
         ts.isClassDeclaration(stmt) ||
-        ts.isFunctionDeclaration(stmt)) &&
-      stmt.name?.text === alias
+        ts.isFunctionDeclaration(stmt) ||
+        ts.isEnumDeclaration(stmt) ||
+        ts.isModuleDeclaration(stmt)) &&
+      stmt.name &&
+      ts.isIdentifier(stmt.name) &&
+      stmt.name.text === alias
     ) {
       escalate("different");
       continue;

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -132,13 +132,44 @@ export function virtualize(
     return d;
   });
 
-  // Detect `include(...)` calls early so we can fold the auxiliary
-  // `import type { Included as ... }` line into the same prepend pass
-  // (otherwise we'd double-shift deltas).
+  // Detect `include(...)` calls and fold both the aliased
+  // `import type` line AND the generated interface-merge declarations
+  // into the same prepend pass. Appending at end-of-file would leave
+  // diagnostics on those lines un-remappable (no delta entry), which
+  // causes `getPositionOfLineAndCharacter` to crash. Putting them in
+  // the prepend block reuses the existing delta math.
+  // Declaration merging is order-agnostic — TS resolves
+  // `interface Foo extends ...` before the class declaration just
+  // fine.
   const includes = findIncludeCalls(sf);
   const effectivePrepends: string[] = [];
   if (options.prependImports) effectivePrepends.push(...options.prependImports);
-  if (includes.length > 0) effectivePrepends.push(INCLUDED_IMPORT_LINE);
+  if (includes.length > 0) {
+    effectivePrepends.push(INCLUDED_IMPORT_LINE);
+    interface Group {
+      mods: string[];
+      exported: boolean;
+      typeParams: string;
+    }
+    const grouped = new Map<string, Group>();
+    for (const inc of includes) {
+      const entry = grouped.get(inc.className);
+      if (entry) entry.mods.push(inc.moduleExpr);
+      else
+        grouped.set(inc.className, {
+          mods: [inc.moduleExpr],
+          exported: inc.classExported,
+          typeParams: inc.classTypeParams,
+        });
+    }
+    for (const [className, { mods, exported, typeParams }] of grouped) {
+      const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
+      // Match the class's export modifier and generic parameters —
+      // declaration merging requires both to line up.
+      const prefix = exported ? "export " : "";
+      effectivePrepends.push(`${prefix}interface ${className}${typeParams} extends ${heritage} {}`);
+    }
+  }
 
   // Insert auto-imported `import type` lines AFTER any leading
   // directives (shebangs, triple-slash refs, @ts-nocheck) that must
@@ -166,31 +197,6 @@ export function virtualize(
       d.insertedAtLine += prependedLines;
     }
     deltas.unshift({ insertedAtLine, lineCount: prependedLines });
-  }
-
-  // Append interface-merge declarations for every
-  // `include(ClassName, ModuleExpr)` call. The mixed-in instance
-  // methods are runtime-copied onto the prototype by `include()`; this
-  // appendix makes them visible to TypeScript via declaration merging
-  // — replacing the manual
-  // `interface ClassName extends Included<typeof Mod> {}` line users
-  // would otherwise write themselves. The aliased
-  // `__TrailsIncluded` import is prepended above so this never collides
-  // with a user-imported `Included`.
-  if (includes.length > 0) {
-    const grouped = new Map<string, string[]>();
-    for (const inc of includes) {
-      const arr = grouped.get(inc.className);
-      if (arr) arr.push(inc.moduleExpr);
-      else grouped.set(inc.className, [inc.moduleExpr]);
-    }
-    const lines: string[] = [];
-    for (const [className, mods] of grouped) {
-      const heritage = mods.map((m) => `${INCLUDED_ALIAS}<typeof ${m}>`).join(", ");
-      lines.push(`interface ${className} extends ${heritage} {}`);
-    }
-    const appendix = (text.endsWith("\n") ? "" : "\n") + lines.join("\n") + "\n";
-    text += appendix;
   }
 
   return { text, deltas };

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -199,7 +199,13 @@ export function virtualize(
     const insertedAtLine =
       insertPos === 0 ? -1 : before.endsWith("\n") ? newlineCount - 1 : newlineCount;
     text = text.slice(0, insertPos) + importBlock + text.slice(insertPos);
-    const prependedLines = prependLines.length;
+    // Count physical newlines in the inserted block rather than
+    // trusting `prependLines.length`. Synthesized entries derived from
+    // `getText()` (module expressions, type parameter lists) may carry
+    // embedded newlines when the original source formats them across
+    // lines — undercounting here breaks delta remapping for every
+    // line below the prepend block.
+    const prependedLines = (importBlock.match(/\r?\n/g) ?? []).length;
     for (const d of deltas) {
       d.insertedAtLine += prependedLines;
     }

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -395,11 +395,14 @@ export function findIncludeCalls(sourceFile: ts.SourceFile): IncludeCall[] {
     const named = stmt.importClause?.namedBindings;
     if (named && ts.isNamedImports(named)) {
       for (const el of named.elements) {
-        // Require the unaliased local binding to be `include`. An
-        // aliased import (`include as inc`) leaves the local name `inc`,
-        // and any `include(...)` call in the file would then be a
-        // separate user-defined helper, not the activesupport one.
-        if (!el.propertyName && el.name.text === "include") includeImported = true;
+        // Local binding must be `include` AND the imported export must
+        // be `include`. Accepts both the bare form and the rare
+        // `include as include`; rejects `include as inc` (local is `inc`,
+        // any `include(...)` call is a separate helper) and
+        // `foo as include` (local is `include` but bound to a different
+        // export — calling it would invoke the wrong function).
+        const importedName = el.propertyName?.text ?? el.name.text;
+        if (importedName === "include" && el.name.text === "include") includeImported = true;
       }
     }
   }

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -374,9 +374,11 @@ function readRecordLiteral(node: ts.Expression | undefined): RecordLiteral {
  * - The first argument must be a bare identifier referencing a class
  *   declared in the same file (otherwise we'd be augmenting a foreign
  *   module without a `declare module "..."` boundary).
- * - The second argument is captured verbatim — any expression usable in
- *   a `typeof` query (identifier, property access, `as const` literal)
- *   works.
+ * - The second argument is captured verbatim and must be usable inside
+ *   a `typeof` type query — currently restricted to bare identifiers
+ *   and property-access chains. Inline object literals, calls, and
+ *   `as const` expressions are skipped (they'd produce parse errors
+ *   in the synthesized `typeof <expr>`).
  *
  * @internal
  */
@@ -392,7 +394,11 @@ export function findIncludeCalls(sourceFile: ts.SourceFile): IncludeCall[] {
     const named = stmt.importClause?.namedBindings;
     if (named && ts.isNamedImports(named)) {
       for (const el of named.elements) {
-        if ((el.propertyName?.text ?? el.name.text) === "include") includeImported = true;
+        // Require the unaliased local binding to be `include`. An
+        // aliased import (`include as inc`) leaves the local name `inc`,
+        // and any `include(...)` call in the file would then be a
+        // separate user-defined helper, not the activesupport one.
+        if (!el.propertyName && el.name.text === "include") includeImported = true;
       }
     }
   }

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -53,6 +53,21 @@ export interface DefineEnumCall {
 
 export type RuntimeCall = AttributeCall | AssociationCall | ScopeCall | EnumCall | DefineEnumCall;
 
+/**
+ * A top-level `include(ClassName, ModuleExpr)` call from
+ * `@blazetrails/activesupport`. The synthesizer turns each call into an
+ * interface-merge declaration so the methods mixed in at runtime become
+ * visible to the type checker without the user writing
+ * `interface Foo extends Included<typeof Mod> {}` by hand.
+ *
+ * @internal
+ */
+export interface IncludeCall {
+  className: string;
+  /** Raw source text of the module expression — spliced verbatim into `typeof <expr>`. */
+  moduleExpr: string;
+}
+
 export type RecordLiteral = Record<string, string>;
 
 export interface ClassInfo {
@@ -331,6 +346,60 @@ function readRecordLiteral(node: ts.Expression | undefined): RecordLiteral {
         : null;
     if (!key) continue;
     out[key] = prop.initializer.getText();
+  }
+  return out;
+}
+
+/**
+ * Find every top-level `include(ClassName, ModuleExpr)` call where
+ * `include` is imported from `@blazetrails/activesupport`. The returned
+ * pairs are grouped by the synthesizer into interface-merge declarations
+ * that surface the mixed-in instance methods to the type checker.
+ *
+ * Constraints:
+ * - The first argument must be a bare identifier referencing a class
+ *   declared in the same file (otherwise we'd be augmenting a foreign
+ *   module without a `declare module "..."` boundary).
+ * - The second argument is captured verbatim — any expression usable in
+ *   a `typeof` query (identifier, property access, `as const` literal)
+ *   works.
+ *
+ * @internal
+ */
+export function findIncludeCalls(sourceFile: ts.SourceFile): IncludeCall[] {
+  // Only fire when `include` is imported from activesupport — the symbol
+  // is unqualified at the call site, so we need the import to disambiguate
+  // from any local helper named `include`.
+  let includeImported = false;
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    if (!ts.isStringLiteralLike(stmt.moduleSpecifier)) continue;
+    if (stmt.moduleSpecifier.text !== "@blazetrails/activesupport") continue;
+    const named = stmt.importClause?.namedBindings;
+    if (named && ts.isNamedImports(named)) {
+      for (const el of named.elements) {
+        if ((el.propertyName?.text ?? el.name.text) === "include") includeImported = true;
+      }
+    }
+  }
+  if (!includeImported) return [];
+
+  const declaredClasses = new Set<string>();
+  for (const stmt of sourceFile.statements) {
+    if (ts.isClassDeclaration(stmt) && stmt.name) declaredClasses.add(stmt.name.text);
+  }
+
+  const out: IncludeCall[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isExpressionStatement(stmt)) continue;
+    const call = stmt.expression;
+    if (!ts.isCallExpression(call)) continue;
+    if (!ts.isIdentifier(call.expression) || call.expression.text !== "include") continue;
+    const [classArg, modArg] = call.arguments;
+    if (!classArg || !modArg) continue;
+    if (!ts.isIdentifier(classArg)) continue;
+    if (!declaredClasses.has(classArg.text)) continue;
+    out.push({ className: classArg.text, moduleExpr: modArg.getText() });
   }
   return out;
 }

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -66,6 +66,20 @@ export interface IncludeCall {
   className: string;
   /** Raw source text of the module expression — spliced verbatim into `typeof <expr>`. */
   moduleExpr: string;
+  /**
+   * Whether the target class declaration is `export`-ed in the file.
+   * The synthesized interface must carry the same modifier or
+   * TypeScript rejects the merge with "Individual declarations in
+   * merged declaration must be all exported or all local."
+   */
+  classExported: boolean;
+  /**
+   * Raw text of the class's type parameter list (e.g. `<T extends Base>`)
+   * or the empty string when the class is non-generic. Declaration
+   * merging requires the merged interface to repeat the class's type
+   * parameters verbatim.
+   */
+  classTypeParams: string;
 }
 
 export type RecordLiteral = Record<string, string>;
@@ -384,9 +398,23 @@ export function findIncludeCalls(sourceFile: ts.SourceFile): IncludeCall[] {
   }
   if (!includeImported) return [];
 
-  const declaredClasses = new Set<string>();
+  interface DeclaredClass {
+    exported: boolean;
+    typeParams: string;
+  }
+  const declaredClasses = new Map<string, DeclaredClass>();
   for (const stmt of sourceFile.statements) {
-    if (ts.isClassDeclaration(stmt) && stmt.name) declaredClasses.add(stmt.name.text);
+    if (!ts.isClassDeclaration(stmt) || !stmt.name) continue;
+    const exported = (ts.getModifiers(stmt) ?? []).some(
+      (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    let typeParams = "";
+    if (stmt.typeParameters && stmt.typeParameters.length > 0) {
+      const first = stmt.typeParameters[0]!.pos;
+      const last = stmt.typeParameters[stmt.typeParameters.length - 1]!.end;
+      typeParams = `<${sourceFile.text.slice(first, last)}>`;
+    }
+    declaredClasses.set(stmt.name.text, { exported, typeParams });
   }
 
   const out: IncludeCall[] = [];
@@ -398,10 +426,28 @@ export function findIncludeCalls(sourceFile: ts.SourceFile): IncludeCall[] {
     const [classArg, modArg] = call.arguments;
     if (!classArg || !modArg) continue;
     if (!ts.isIdentifier(classArg)) continue;
-    if (!declaredClasses.has(classArg.text)) continue;
-    out.push({ className: classArg.text, moduleExpr: modArg.getText() });
+    const meta = declaredClasses.get(classArg.text);
+    if (!meta) continue;
+    // Only accept module expressions usable inside a `typeof` type
+    // query: bare identifiers and (chains of) property access. Inline
+    // object literals, calls, and other expressions can't be queried
+    // by `typeof`, so skip those calls — declaration merging there
+    // would just produce parse errors.
+    if (!isTypeofQueryable(modArg)) continue;
+    out.push({
+      className: classArg.text,
+      moduleExpr: modArg.getText(),
+      classExported: meta.exported,
+      classTypeParams: meta.typeParams,
+    });
   }
   return out;
+}
+
+function isTypeofQueryable(expr: ts.Expression): boolean {
+  if (ts.isIdentifier(expr)) return true;
+  if (ts.isPropertyAccessExpression(expr)) return isTypeofQueryable(expr.expression);
+  return false;
 }
 
 function objectKeys(obj: ts.ObjectLiteralExpression): string[] {

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -366,9 +366,10 @@ function readRecordLiteral(node: ts.Expression | undefined): RecordLiteral {
 
 /**
  * Find every top-level `include(ClassName, ModuleExpr)` call where
- * `include` is imported from `@blazetrails/activesupport`. The returned
- * pairs are grouped by the synthesizer into interface-merge declarations
- * that surface the mixed-in instance methods to the type checker.
+ * `include` is imported from `@blazetrails/activesupport`. Returns a
+ * flat list — `virtualize()` is responsible for grouping by class name
+ * and emitting one interface-merge declaration per class that surfaces
+ * the mixed-in instance methods to the type checker.
  *
  * Constraints:
  * - The first argument must be a bare identifier referencing a class


### PR DESCRIPTION
## Summary

- trails-tsc detects top-level `include(ClassName, ModuleExpr)` calls imported from `@blazetrails/activesupport` and emits a declaration-merging `interface ClassName extends __TrailsIncluded<typeof ModuleExpr> {}` so the runtime-mixed-in instance methods become visible to the type checker — replacing the manual `interface ClassName extends Included<typeof Mod> {}` lines users write today (e.g. `relation.ts`).
- The auxiliary `import type { Included as __TrailsIncluded } from "@blazetrails/activesupport";` is folded into the existing prepend pass so diagnostic deltas remain correct. Aliasing avoids `Cannot redeclare 'Included'` when the user file already imports it.
- `shouldVirtualize` is widened to fire on files using `include()` even without `extends Base` / `static {}`, so utility classes (e.g. `Relation`) are covered.

`extend()` (static-side mixins) is intentionally out of scope here: cleanly emitting static declares requires checker-driven method enumeration. Tracked as a follow-up.

## Test plan

- [x] `pnpm vitest packages/activerecord/src/type-virtualization` — 64 tests pass (13 new include-bridge tests covering interface emission, grouping, generics/export preservation, multi-line module expressions, idempotence, alias collision across import/enum/namespace forms, user-interface override, and `include as include`)
- [x] `pnpm vitest packages/activerecord/src/tsc-wrapper` — integration tests green
- [x] `pnpm test:types:virtualized` — 0 diagnostics
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

## Remaining concerns from Copilot review (not addressed; max review cycles reached)

- `INCLUDE_CALL_PATTERN` in `host.ts` (`/^\s*include\s*\(/m`) only matches when `include(` is the first non-whitespace token on a line. Top-level statements like `foo(); include(Bar, Baz);` on a single line, or `;include(...)`, would be missed by the prefilter and the bridge would silently not run (the file isn't virtualized at all in that path). Project convention is one statement per line, so this is unlikely to bite in practice, but the prefilter could be widened to also match `include(` preceded by a statement boundary (start-of-file, `\n`, or `;`) while still excluding `.include(` member calls. Walker logic itself already handles those cases correctly — it's only the host-level fast-path that's tighter than the walker.