### PR TITLE
refactor(activerecord): relocate base.ts module methods to Rails layout (M2)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -59,7 +59,6 @@ import {
 } from "./encryption.js";
 import * as CounterCache from "./counter-cache.js";
 import * as ReadonlyAttributes from "./readonly-attributes.js";
-import { Map as TypeCasterMap } from "./type-caster/map.js";
 import {
   defineAttribute as _defineAttribute,
   _defaultAttributes as _arDefaultAttributes,
@@ -138,7 +137,6 @@ import {
   isPresent as _isPresent,
   isBlank as _isBlank,
   filterAttributes as _coreFilterAttributes,
-  inspectionFilter as _coreInspectionFilter,
 } from "./core.js";
 import * as _Core from "./core.js";
 import * as _Persistence from "./persistence.js";
@@ -472,7 +470,7 @@ export class Base extends Model {
   }
 
   static inspectionFilter(): ParameterFilter {
-    return _coreInspectionFilter.call(this);
+    return _Core.inspectionFilter.call(this);
   }
 
   static _adapter: DatabaseAdapter | null = null;
@@ -491,17 +489,12 @@ export class Base extends Model {
   static _protectedEnvironments: string[] = ["production"];
   static _lockingColumn: string = "lock_version";
 
-  /**
-   * List of environments where destructive actions are prohibited.
-   *
-   * Mirrors: ActiveRecord::Base.protected_environments
-   */
   static get protectedEnvironments(): string[] {
-    return this._protectedEnvironments;
+    return ModelSchema.protectedEnvironments.call(this);
   }
 
   static set protectedEnvironments(envs: string[]) {
-    this._protectedEnvironments = envs.map(String);
+    ModelSchema.protectedEnvironments.call(this, envs);
   }
 
   /**
@@ -610,17 +603,12 @@ export class Base extends Model {
     this._tableNameSuffix = suffix;
   }
 
-  /**
-   * Set or get the table name. Inferred from class name if not set.
-   *
-   * Mirrors: ActiveRecord::Base.table_name
-   */
   static get tableName(): string {
-    return ModelSchema.resolveTableName.call(this);
+    return ModelSchema.tableName.call(this);
   }
 
   static set tableName(name: string) {
-    this._tableName = name;
+    ModelSchema.tableName.call(this, name);
   }
 
   /**
@@ -733,7 +721,7 @@ export class Base extends Model {
    * call since Table is cheap).
    */
   static get arelTable(): Table {
-    return new Table(this.tableName, { typeCaster: new TypeCasterMap(this), klass: this });
+    return _Core.arelTable.call(this);
   }
 
   /**
@@ -855,7 +843,7 @@ export class Base extends Model {
   }
 
   static get connectionHandler(): ConnectionHandler {
-    return this._connectionHandler;
+    return _Core.connectionHandler.call(this);
   }
 
   /**
@@ -953,10 +941,11 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.inheritance_column
    */
   static get inheritanceColumn(): string | null {
-    return (this as any)._inheritanceColumn ?? null;
+    return ModelSchema.inheritanceColumn.call(this);
   }
+
   static set inheritanceColumn(col: string | null) {
-    (this as any)._inheritanceColumn = col;
+    ModelSchema.inheritanceColumn.call(this, col);
   }
 
   /**
@@ -1089,46 +1078,23 @@ export class Base extends Model {
   // -- Sequence name --
   static _sequenceName: string | null = null;
 
-  /**
-   * The sequence name used for auto-incrementing the primary key.
-   * Defaults to "${tableName}_${primaryKey}_seq" for PostgreSQL.
-   *
-   * Mirrors: ActiveRecord::Base.sequence_name
-   */
   static get sequenceName(): string | null {
-    const pk = this.primaryKey;
-    if (Array.isArray(pk)) return this._sequenceName;
-    return this._sequenceName ?? `${this.tableName}_${pk}_seq`;
+    return ModelSchema.sequenceName.call(this);
   }
+
   static set sequenceName(name: string | null) {
-    this._sequenceName = name;
+    ModelSchema.sequenceName.call(this, name);
   }
 
   // -- Ignored columns --
   static _ignoredColumns: string[] = [];
 
-  /**
-   * Columns that should be ignored (not loaded from the database).
-   *
-   * Mirrors: ActiveRecord::Base.ignored_columns
-   */
   static get ignoredColumns(): string[] {
-    return this._ignoredColumns;
+    return ModelSchema.ignoredColumns.call(this);
   }
 
   static set ignoredColumns(columns: string[]) {
-    this._ignoredColumns = columns;
-    for (const col of columns) {
-      // Delete own accessor or shadow inherited one with undefined descriptor
-      if (col in this.prototype) {
-        Object.defineProperty(this.prototype, col, {
-          get: undefined,
-          set: undefined,
-          configurable: true,
-        });
-        delete (this.prototype as any)[col];
-      }
-    }
+    ModelSchema.ignoredColumns.call(this, columns);
   }
 
   // -- Readonly attributes --
@@ -1928,27 +1894,9 @@ export class Base extends Model {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (record: InstanceType<T>) => void,
   ): Promise<InstanceType<T> | InstanceType<T>[]> {
-    if (Array.isArray(attrs)) {
-      // Sequential, matching Rails' `attributes.collect { create(attr, &block) }`.
-      // Promise.all would interleave saves and fire callbacks out of order.
-      const records: InstanceType<T>[] = [];
-      for (const a of attrs) {
-        records.push((await (this as T).create(a, block)) as InstanceType<T>);
-      }
-      return records;
-    }
-    const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
-    if (block) block(record);
-    await record.save();
-    return record;
+    return _Persistence.create.call(this, attrs, block);
   }
 
-  /**
-   * Create a record or throw if validation fails.
-   *
-   * Rails: `Base.create!(attributes = nil, &block)` — recurses on arrays
-   * and yields each record to the block before `saveBang()`.
-   */
   static async createBang<T extends typeof Base>(
     this: T,
     attrs: Record<string, unknown>[],
@@ -1964,20 +1912,7 @@ export class Base extends Model {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (record: InstanceType<T>) => void,
   ): Promise<InstanceType<T> | InstanceType<T>[]> {
-    if (Array.isArray(attrs)) {
-      // Sequential + short-circuit on failure: Rails' create! stops at the
-      // first exception, so later elements are never attempted. Promise.all
-      // would fire every save concurrently and partial-write.
-      const records: InstanceType<T>[] = [];
-      for (const a of attrs) {
-        records.push((await (this as T).createBang(a, block)) as InstanceType<T>);
-      }
-      return records;
-    }
-    const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
-    if (block) block(record);
-    await record.saveBang();
-    return record;
+    return _Persistence.createBang.call(this, attrs, block);
   }
 
   // --- Querying mixin (static methods, wired via extend() after class) ---
@@ -2928,12 +2863,7 @@ export class Base extends Model {
   // (bivariant) rather than properties (invariant).
 
   static async tableExists(): Promise<boolean> {
-    const adapter = this.adapter;
-    const cache = adapter.schemaCache;
-    if (!cache || typeof cache.dataSourceExists !== "function") return true;
-    const pool = adapter.pool ?? adapter;
-    const exists = await cache.dataSourceExists(pool, this.tableName);
-    return exists !== false;
+    return ModelSchema.tableExists.call(this);
   }
 
   static hasAttribute(name: string): boolean {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -5,11 +5,13 @@
  */
 
 import { NotImplementedError } from "./errors.js";
-import { Notifications, getAsyncContext } from "@blazetrails/activesupport";
+import { Notifications, getAsyncContext, ParameterFilter } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { argumentError } from "./relation/query-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
+import { Table } from "@blazetrails/arel";
+import { Map as TypeCasterMap } from "./type-caster/map.js";
 
 /**
  * The Core module interface — methods mixed into every AR model.
@@ -33,9 +35,8 @@ export interface Core {
   freeze(): this;
 }
 
-// InspectionMask and inspectionFilter live in attribute-inspection.ts.
-// Re-export so existing importers of core.ts keep working.
-export { InspectionMask, inspectionFilter } from "./attribute-inspection.js";
+export { InspectionMask } from "./attribute-inspection.js";
+import { inspectionFilter as _inspectionFilterImpl } from "./attribute-inspection.js";
 
 // ---------------------------------------------------------------------------
 // Instance-level behavior
@@ -245,9 +246,11 @@ export function fullInspect(this: CoreRecord): string {
 
 interface CoreHost {
   name: string;
+  tableName?: string;
   _filterAttributes?: (string | RegExp | ((key: string, value: unknown) => unknown))[];
   _inspectionFilter?: any;
   _connectionClass?: boolean;
+  _connectionHandler?: any;
   _destroyAssociationAsyncJob?: any;
   _findByStatementCache?: Map<boolean, Map<string, any>>;
   _generatedAssociationMethods?: Set<string>;
@@ -534,6 +537,25 @@ export function cachedFindByStatement(
     cache.set(key, block());
   }
   return cache.get(key);
+}
+
+export function inspectionFilter(this: CoreHost): ParameterFilter {
+  return _inspectionFilterImpl.call(this);
+}
+
+export function connectionHandler(this: CoreHost, value?: any): any {
+  if (value !== undefined) {
+    this._connectionHandler = value;
+    return value;
+  }
+  return this._connectionHandler;
+}
+
+export function arelTable(this: CoreHost): Table {
+  return new Table((this as any).tableName, {
+    typeCaster: new TypeCasterMap(this),
+    klass: this as any,
+  });
 }
 
 /** @internal */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -355,12 +355,14 @@ interface SchemaHost {
   _inheritanceColumn?: string;
   _abstractClass?: boolean;
   _ignoredColumns?: string[];
+  _protectedEnvironments?: string[];
   _attributeDefinitions: Map<string, any>;
   _columnsHash?: Record<string, any>;
   _columns?: any[];
   _attributesBuilder?: any;
   _schemaLoaded?: boolean;
   adapter: any;
+  prototype: any;
   superclass?: SchemaHost;
 }
 
@@ -910,6 +912,57 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (!hash) return false;
   applyColumnsHash(schemaHost, adapter, hash, host);
   return true;
+}
+
+export function tableName(this: SchemaHost, value?: string): string {
+  if (value !== undefined) this._tableName = value;
+  return resolveTableName.call(this as any);
+}
+
+export function protectedEnvironments(this: SchemaHost, value?: string[]): string[] {
+  if (value !== undefined) this._protectedEnvironments = value.map(String);
+  return this._protectedEnvironments ?? ["production"];
+}
+
+export function inheritanceColumn(this: SchemaHost, value?: string | null): string | null {
+  if (value !== undefined) this._inheritanceColumn = value ?? undefined;
+  return this._inheritanceColumn ?? null;
+}
+
+export function sequenceName(this: SchemaHost, value?: string | null): string | null {
+  if (value !== undefined) {
+    this._sequenceName = value;
+    return value;
+  }
+  const pk = this.primaryKey;
+  if (Array.isArray(pk)) return this._sequenceName;
+  return this._sequenceName ?? `${this.tableName}_${pk}_seq`;
+}
+
+export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
+  if (value !== undefined) {
+    this._ignoredColumns = value;
+    for (const col of value) {
+      if (col in this.prototype) {
+        Object.defineProperty(this.prototype, col, {
+          get: undefined,
+          set: undefined,
+          configurable: true,
+        });
+        delete (this.prototype as any)[col];
+      }
+    }
+  }
+  return this._ignoredColumns ?? [];
+}
+
+export async function tableExists(this: SchemaHost): Promise<boolean> {
+  const { adapter } = this;
+  const cache = adapter.schemaCache;
+  if (!cache || typeof cache.dataSourceExists !== "function") return true;
+  const pool = adapter.pool ?? adapter;
+  const exists = await cache.dataSourceExists(pool, this.tableName);
+  return exists !== false;
 }
 
 /**

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -46,6 +46,50 @@ interface PersistenceHost {
 }
 
 /**
+ * Create and save a new record (or array of records).
+ * Mirrors: ActiveRecord::Persistence::ClassMethods#create
+ */
+export async function create(
+  this: PersistenceHost,
+  attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+  block?: (record: any) => void,
+): Promise<any> {
+  if (Array.isArray(attrs)) {
+    const records: any[] = [];
+    for (const a of attrs) {
+      records.push(await create.call(this, a, block));
+    }
+    return records;
+  }
+  const record = new this((this as any)._mergeCurrentScopeAttrs(attrs));
+  if (block) block(record);
+  await record.save();
+  return record;
+}
+
+/**
+ * Create and save, raising on validation failure.
+ * Mirrors: ActiveRecord::Persistence::ClassMethods#create!
+ */
+export async function createBang(
+  this: PersistenceHost,
+  attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+  block?: (record: any) => void,
+): Promise<any> {
+  if (Array.isArray(attrs)) {
+    const records: any[] = [];
+    for (const a of attrs) {
+      records.push(await createBang.call(this, a, block));
+    }
+    return records;
+  }
+  const record = new this((this as any)._mergeCurrentScopeAttrs(attrs));
+  if (block) block(record);
+  await record.saveBang();
+  return record;
+}
+
+/**
  * Build a new instance (or array of instances) without saving.
  * Mirrors: ActiveRecord::Persistence::ClassMethods#build
  */

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -57,7 +57,7 @@ export async function create(
   if (Array.isArray(attrs)) {
     const records: any[] = [];
     for (const a of attrs) {
-      records.push(await create.call(this, a, block));
+      records.push(await (this as any).create(a, block));
     }
     return records;
   }
@@ -79,7 +79,7 @@ export async function createBang(
   if (Array.isArray(attrs)) {
     const records: any[] = [];
     for (const a of attrs) {
-      records.push(await createBang.call(this, a, block));
+      records.push(await (this as any).createBang(a, block));
     }
     return records;
   }


### PR DESCRIPTION
## Summary

Pure mechanical refactor — no new logic, no behavior changes. Moves methods from the `base.ts` monolith into their correct Rails-layout module files, then delegates back via thin getters/setters.

Part of Wave 0 from [docs/activerecord-100-plan.md](docs/activerecord-100-plan.md).

## Methods moved

### → `model-schema.ts` (10 methods)
- `tableName` getter + setter (ActiveRecord::ModelSchema::ClassMethods#table_name, #table_name=)
- `protectedEnvironments` getter + setter (#protected_environments, #protected_environments=)
- `inheritanceColumn` getter + setter (#inheritance_column, #inheritance_column=)
- `sequenceName` getter + setter (#sequence_name, #sequence_name=)
- `ignoredColumns` getter + setter (#ignored_columns, #ignored_columns=)
- `tableExists` async method (#table_exists?)

### → `core.ts` (4 methods)
- `inspectionFilter` (ActiveRecord::Core#inspection_filter)
- `connectionHandler` getter (ActiveRecord::Core#connection_handler)
- `arelTable` getter (ActiveRecord::Core#arel_table)
- (connectionHandler setter not implemented in base.ts — skipped)

### → `persistence.ts` (2 methods)
- `create` class method (ActiveRecord::Persistence::ClassMethods#create)
- `createBang` class method (ActiveRecord::Persistence::ClassMethods#create!)

## Skipped (reason)
- `find`, `findBy`, `findByBang` → complex overloads (~130 LOC), deferred to M2b
- `columnDefaults` → requires `_defaultAttributes()` typing complexity, deferred to M2b
- `touch` (class-level) → implemented in touch-later.ts via include(), not a direct base.ts move
- `connectionHandler` setter → not implemented in base.ts

## Before / after api:compare

| Metric | Before | After |
|---|---|---|
| Overall matched | 3784/5082 (74.5%) | 3828/5082 (75.3%) |
| Methods to relocate (moves.ts) | 176 | 160 |
| base.ts → core.ts moves | 7 | 3 |
| base.ts → model-schema.ts moves | 11 | 1 |
| base.ts → persistence.ts moves | 4 | 2 |

## Verification
- Build: clean
- Type tests: 74/74 passed
- Lint: clean
- Test suite: 9995/9995 passed (no regressions)
- LOC: 141 insertions + 92 deletions = 233 total (well under 300 ceiling)

**M2b follows** (scoping/*, attribute-methods, small modules, remaining skipped methods).

References: docs/activerecord-100-plan.md Wave 0 PR M2