### PR TITLE
refactor(activerecord): relocate scoping + attribute-methods + small-module methods to Rails layout (M2b)

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -344,3 +344,16 @@ function pkAttribute(this: any, name: string): boolean {
   const pk = (this.constructor as any)?.primaryKey ?? this._primaryKey;
   return Array.isArray(pk) ? pk.includes(name) : name === pk;
 }
+
+interface AttributeNamesHost {
+  _attributeDefinitions: { keys(): Iterable<string> };
+}
+
+/**
+ * Returns the list of attribute names for the model class.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::ClassMethods#attribute_names
+ */
+export function attributeNames(this: AttributeNamesHost): string[] {
+  return [...this._attributeDefinitions.keys()];
+}

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -86,6 +86,46 @@ export function idForDatabase(this: PrimaryKeyRecord): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Instance accessor methods
+// ---------------------------------------------------------------------------
+
+interface PrimaryKeyInstance {
+  constructor: unknown;
+  _readAttribute(name: string): unknown;
+  _writeAttribute(name: string, value: unknown): void;
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id
+ * @internal
+ */
+export function getId(this: PrimaryKeyInstance): unknown {
+  const ctor = this.constructor as any;
+  const pk = ctor.primaryKey as string | string[];
+  if (Array.isArray(pk)) return pk.map((col) => this._readAttribute(col));
+  return this._readAttribute(pk);
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id=
+ * @internal
+ */
+export function setId(this: PrimaryKeyInstance, value: unknown): void {
+  const ctor = this.constructor as any;
+  const pk = ctor.primaryKey as string | string[];
+  if (Array.isArray(pk)) {
+    if (!Array.isArray(value)) {
+      throw new TypeError(
+        `Expected an array for composite primary key [${pk.join(", ")}], got ${value === null ? "null" : typeof value}`,
+      );
+    }
+    pk.forEach((col, i) => this._writeAttribute(col, (value as unknown[])[i]));
+  } else {
+    this._writeAttribute(pk, value);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Class methods
 // ---------------------------------------------------------------------------
 
@@ -93,6 +133,30 @@ interface PrimaryKeyHost {
   primaryKey: string | string[];
   _primaryKey?: string | string[];
   name: string;
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#primary_key
+ * @internal
+ */
+export function getPrimaryKeyAttr(this: PrimaryKeyHost): string | string[] {
+  return this._primaryKey ?? "id";
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#primary_key=
+ * @internal
+ */
+export function setPrimaryKeyAttr(this: PrimaryKeyHost, key: string | string[]): void {
+  this._primaryKey = key;
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#composite_primary_key?
+ * @internal
+ */
+export function isCompositePrimaryKey(this: PrimaryKeyHost): boolean {
+  return Array.isArray(this._primaryKey ?? "id");
 }
 
 export function isInstanceMethodAlreadyImplemented(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -26,6 +26,9 @@ import {
   stiClassFor,
   polymorphicClassFor,
   initializeInternalsCallback as inheritanceInitializeInternalsCallback,
+  baseClass as _inheritanceBaseClass,
+  getAbstractClass as _getAbstractClass,
+  setAbstractClass as _setAbstractClass,
 } from "./inheritance.js";
 import {
   NotImplementedError,
@@ -106,8 +109,16 @@ import {
   accessedFields as _accessedFields,
   attributesForCreate as _attributesForCreate,
   attributesForUpdate as _attributesForUpdate,
+  attributeNames as _attributeNames,
 } from "./attribute-methods.js";
-import { toKey as _toKey } from "./attribute-methods/primary-key.js";
+import {
+  toKey as _toKey,
+  getId as _getId,
+  setId as _setId,
+  getPrimaryKeyAttr as _getPrimaryKeyAttr,
+  setPrimaryKeyAttr as _setPrimaryKeyAttr,
+  isCompositePrimaryKey as _isCompositePrimaryKey,
+} from "./attribute-methods/primary-key.js";
 import { _readAttribute as _readAttributeFn } from "./attribute-methods/read.js";
 import {
   queryAttribute as _queryAttribute,
@@ -497,20 +508,12 @@ export class Base extends Model {
     ModelSchema.protectedEnvironments.call(this, envs);
   }
 
-  /**
-   * Mark this class as abstract — it won't have its own table.
-   * Does not inherit from parent: only true if explicitly set on this class.
-   *
-   * Mirrors: ActiveRecord::Base.abstract_class
-   */
   static get abstractClass(): boolean {
-    return Object.prototype.hasOwnProperty.call(this, "_abstractClass")
-      ? this._abstractClass
-      : false;
+    return _getAbstractClass.call(this);
   }
 
   static set abstractClass(value: boolean) {
-    this._abstractClass = value;
+    _setAbstractClass.call(this, value);
   }
 
   static _requireConcreteClass(): void {
@@ -611,17 +614,12 @@ export class Base extends Model {
     ModelSchema.tableName.call(this, name);
   }
 
-  /**
-   * Set or get the primary key. Defaults to "id".
-   *
-   * Mirrors: ActiveRecord::Base.primary_key
-   */
   static get primaryKey(): string | string[] {
-    return this._primaryKey;
+    return _getPrimaryKeyAttr.call(this);
   }
 
   static set primaryKey(key: string | string[]) {
-    this._primaryKey = key;
+    _setPrimaryKeyAttr.call(this, key);
   }
 
   /**
@@ -641,13 +639,8 @@ export class Base extends Model {
     return LockingOptimistic.lockingEnabled(this);
   }
 
-  /**
-   * Returns true if this model uses a composite primary key.
-   *
-   * Mirrors: ActiveRecord::Base.composite_primary_key?
-   */
   static get compositePrimaryKey(): boolean {
-    return Array.isArray(this._primaryKey);
+    return _isCompositePrimaryKey.call(this);
   }
 
   /**
@@ -948,13 +941,8 @@ export class Base extends Model {
     ModelSchema.inheritanceColumn.call(this, col);
   }
 
-  /**
-   * Return the base class in an STI hierarchy.
-   *
-   * Mirrors: ActiveRecord::Base.base_class
-   */
   static get baseClass(): typeof Base {
-    return getStiBase(this);
+    return _inheritanceBaseClass.call(this);
   }
 
   /** @internal */
@@ -2215,36 +2203,12 @@ export class Base extends Model {
 
   declare writeAttribute: typeof ReadonlyAttributes.writeAttribute;
 
-  /**
-   * The primary key value. When the concrete PK type is known, narrow it at
-   * the use site (e.g. `record.id as number`) rather than redeclaring `id`
-   * on a subclass — `id` is defined here as an accessor and TS forbids
-   * overriding an accessor with a differently-typed instance property.
-   *
-   * Mirrors: ActiveRecord::Base#id
-   */
   get id(): PrimaryKeyValue {
-    const ctor = this.constructor as typeof Base;
-    const pk = ctor.primaryKey;
-    if (Array.isArray(pk)) {
-      return pk.map((col) => this._readAttribute(col)) as PrimaryKeyValue;
-    }
-    return this._readAttribute(pk) as PrimaryKeyValue;
+    return _getId.call(this) as PrimaryKeyValue;
   }
 
   set id(value: PrimaryKeyValue) {
-    const ctor = this.constructor as typeof Base;
-    const pk = ctor.primaryKey;
-    if (Array.isArray(pk)) {
-      if (!Array.isArray(value)) {
-        throw new TypeError(
-          `Expected an array for composite primary key [${pk.join(", ")}], got ${value === null ? "null" : typeof value}`,
-        );
-      }
-      pk.forEach((col, i) => this._writeAttribute(col, value[i]));
-    } else {
-      this._writeAttribute(pk, value);
-    }
+    _setId.call(this, value);
   }
 
   // increment/decrement/toggle + bang variants wired via include() below;
@@ -2672,13 +2636,8 @@ export class Base extends Model {
     return _attributeNamesList.call(this as any);
   }
 
-  /**
-   * Returns the list of attribute names.
-   *
-   * Mirrors: ActiveRecord::Base.attribute_names
-   */
   static attributeNames(): string[] {
-    return [...this._attributeDefinitions.keys()];
+    return _attributeNames.call(this);
   }
 
   /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -164,6 +164,32 @@ export function isStiSubclass(modelClass: typeof Base): boolean {
 }
 
 /**
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#base_class
+ * @internal
+ */
+export function baseClass(this: typeof Base): typeof Base {
+  return getStiBase(this);
+}
+
+/**
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class
+ * @internal
+ */
+export function getAbstractClass(this: typeof Base): boolean {
+  return Object.prototype.hasOwnProperty.call(this, "_abstractClass")
+    ? (this as any)._abstractClass
+    : false;
+}
+
+/**
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class=
+ * @internal
+ */
+export function setAbstractClass(this: typeof Base, value: boolean): void {
+  (this as any)._abstractClass = value;
+}
+
+/**
  * Get the STI base class for a model.
  */
 export function getStiBase(modelClass: typeof Base): typeof Base {


### PR DESCRIPTION
## Summary

Second half of Wave 0 base.ts module moves (M2b), following the this-typed-function + delegation pattern established in #1151 (M2).

## Moves (by destination)

**`attribute-methods/primary-key.ts`** (6 methods via 3 pairs):
- `id` getter/setter (`AttributeMethods::PrimaryKey#id`, `#id=`)
- `primaryKey` getter/setter (`PrimaryKey::ClassMethods#primary_key`, `#primary_key=`)
- `compositePrimaryKey` getter (`PrimaryKey::ClassMethods#composite_primary_key?`)

**`inheritance.ts`** (3 methods via 3 items):
- `baseClass` getter (`Inheritance::ClassMethods#base_class`)
- `abstractClass` getter (`Inheritance::ClassMethods#abstract_class`)
- `abstractClass` setter (`Inheritance::ClassMethods#abstract_class=`)

**`attribute-methods.ts`** (1 method):
- `attributeNames` static (`AttributeMethods::ClassMethods#attribute_names`)

## Metrics

| | Before | After |
|---|---|---|
| Misplaced | 176 | 156 (-20) |
| Matched | 3810 (75.0%) | 3854 (75.8%) |
| Tests | 10001 passed | 10001 passed |
| LOC | — | +124/-62 = 186 total |

No files regressed from 100%.

## Deferred

The remaining base.ts misplacements (`save`/`saveBang`/`destroy`/`touch` attributed to transactions, callbacks, suppressor, validations) are not mechanical moves — Rails' multi-module include layering can't be replicated without architectural work. Deferred to a dedicated PR.

Relation.ts misplacements (40 query-methods, 27 finder-methods, etc.) are separate from Wave 0 scope per CLAUDE.md ("Do NOT touch relation.ts or relation/*").

## Reference

Wave 0 PR M2 (b) — see [docs/activerecord-100-plan.md](docs/activerecord-100-plan.md). Pattern from #1151.