### PR TITLE
fix(activemodel): truncate odd/even via Math.trunc + gate raw value on cameFromUser (P16)

### DIFF
--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Model } from "../index.js";
+import { prepareValueForValidation } from "./numericality.js";
 
 describe("NumericalityValidationTest", () => {
   it("validates numericality with greater than or equal using string value", () => {
@@ -746,5 +747,106 @@ describe("numericality with in: range", () => {
     const f = new Person({ score: "5.5" });
     expect(f.isValid()).toBe(false);
     expect(f.errors.get("score")).toContain("must be an integer");
+  });
+
+  it("odd/even truncates float via Math.trunc before checking parity (2.5 → 2, even)", () => {
+    // Rails: value.to_i.even? — truncates toward zero, so 2.5.to_i == 2
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { even: true } });
+      }
+    }
+    expect(new Person({ score: 2.5 }).isValid()).toBe(true); // trunc(2.5)=2, even
+    expect(new Person({ score: 3.5 }).isValid()).toBe(false); // trunc(3.5)=3, odd
+  });
+
+  it("odd/even truncates negative float via Math.trunc (-2.5 → -2, even)", () => {
+    // Ruby: -2.5.to_i == -2 (toward zero), not -3 (Math.floor would give wrong answer)
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { odd: true } });
+      }
+    }
+    expect(new Person({ score: -3.5 }).isValid()).toBe(true); // trunc(-3.5)=-3, odd
+    expect(new Person({ score: -2.5 }).isValid()).toBe(false); // trunc(-2.5)=-2, even
+  });
+
+  it("odd/even truncation: 2.9 is even (truncates to 2, not rounds to 3)", () => {
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { even: true } });
+      }
+    }
+    expect(new Person({ score: 2.9 }).isValid()).toBe(true); // trunc(2.9)=2, even
+    expect(new Person({ score: 3.9 }).isValid()).toBe(false); // trunc(3.9)=3, odd
+  });
+
+  it("cameFromUser absent (AM Model) → falls back to readAttributeBeforeTypeCast, catches raw string", () => {
+    // AM's Model has no cameFromUser — prepareValueForValidation degrades to
+    // the readAttributeBeforeTypeCast path and still catches bad raw input.
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.validates("age", { numericality: true });
+      }
+    }
+    const p = new Person({ age: "abc" });
+    // AM Model does not expose cameFromUser
+    expect(typeof (p as any).cameFromUser).toBe("undefined");
+    // Validator sees "abc" (raw via readAttributeBeforeTypeCast), reports not_a_number
+    expect(p.isValid()).toBe(false);
+    expect(p.errors.get("age")).toContain("is not a number");
+  });
+
+  it("cameFromUser false → validates cast value (readAttribute)", () => {
+    // Mock: cameFromUser returns false, but cast value (readAttribute) is
+    // a valid number — validation should pass.
+    class MockRecord {
+      errors = { add: vi.fn() };
+      cameFromUser(_name: string) {
+        return false;
+      }
+      readAttribute(_name: string) {
+        return 42;
+      }
+      readAttributeBeforeTypeCast(_name: string) {
+        return "not-a-number-string";
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "initial", rec as any, "score");
+    // Should return the cast value (42), not the raw string
+    expect(result).toBe(42);
+  });
+
+  it("cameFromUser absent → falls back to readAttributeBeforeTypeCast", () => {
+    // Non-AR hosts that don't implement cameFromUser degrade gracefully.
+    class MockRecord {
+      errors = { add: vi.fn() };
+      readAttributeBeforeTypeCast(_name: string) {
+        return "raw-value";
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "fallback", rec as any, "score");
+    expect(result).toBe("raw-value");
+  });
+
+  it("cameFromUser false + no readAttributeBeforeTypeCast → readAttribute fallback", () => {
+    class MockRecord {
+      errors = { add: vi.fn() };
+      cameFromUser(_name: string) {
+        return false;
+      }
+      readAttribute(_name: string) {
+        return 99;
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "initial", rec as any, "score");
+    expect(result).toBe(99);
   });
 });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -203,10 +203,10 @@ export class NumericalityValidator extends EachValidator {
         record.errors.add(attribute, "in", withCount(`${min}..${max}`));
       }
     }
-    if (this.options.odd && num % 2 === 0) {
+    if (this.options.odd && Math.trunc(num) % 2 === 0) {
       record.errors.add(attribute, "odd", this.filteredOptions(value));
     }
-    if (this.options.even && num % 2 !== 0) {
+    if (this.options.even && Math.trunc(num) % 2 !== 0) {
       record.errors.add(attribute, "even", this.filteredOptions(value));
     }
   }
@@ -500,6 +500,7 @@ export function isAllowOnlyInteger(
 
 interface RecordWithRawAttribute {
   attributeChangedInPlace?: (name: string) => boolean;
+  cameFromUser?: (name: string) => boolean;
   readAttribute?: (name: string) => unknown;
   readAttributeBeforeTypeCast?: (name: string) => unknown;
   [key: string]: unknown;
@@ -557,10 +558,22 @@ export function prepareValueForValidation(
   // Duck-type the lookup so other hosts implementing the same shape
   // (or AR Base subclasses) work too.
   const r = record as RecordWithRawAttribute;
-  const rawValue =
-    typeof r.readAttributeBeforeTypeCast === "function"
-      ? r.readAttributeBeforeTypeCast(attrName)
-      : undefined;
+  let rawValue: unknown;
+  if (typeof r.cameFromUser === "function") {
+    if (r.cameFromUser(attrName)) {
+      rawValue =
+        typeof r.readAttributeBeforeTypeCast === "function"
+          ? r.readAttributeBeforeTypeCast(attrName)
+          : undefined;
+    } else if (typeof r.readAttribute === "function") {
+      rawValue = r.readAttribute(attrName);
+    }
+  } else {
+    rawValue =
+      typeof r.readAttributeBeforeTypeCast === "function"
+        ? r.readAttributeBeforeTypeCast(attrName)
+        : undefined;
+  }
   // Rails: raw_value || value — Ruby `||` falls back on nil/false. Use
   // the same semantic so `false`/`null` raw values fall through to
   // the cast value rather than being treated as "I read the raw".

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1194,8 +1194,9 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const t = Topic.new({ title: "user-set" }) as any;
-    // newly set attributes come from user
-    expect(t.title).toBe("user-set");
+    expect(t.cameFromUser("title")).toBe(true);
+    t._attributes.writeFromDatabase("title", "db-loaded");
+    expect(t.cameFromUser("title")).toBe(false);
   });
 
   it("accessed_fields", async () => {

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -80,6 +80,7 @@ interface AttributeOwner {
       cameFromUser(): boolean;
     };
   };
+  constructor: { _attributeAliases?: Record<string, string> };
 }
 
 /** @internal */
@@ -94,5 +95,6 @@ function attributeForDatabase(this: AttributeOwner, attrName: string): unknown {
 
 /** @internal */
 export function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
-  return this._attributes.getAttribute(attrName).cameFromUser();
+  const name = this.constructor._attributeAliases?.[attrName] ?? attrName;
+  return this._attributes.getAttribute(name).cameFromUser();
 }

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -93,6 +93,6 @@ function attributeForDatabase(this: AttributeOwner, attrName: string): unknown {
 }
 
 /** @internal */
-function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
+export function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
   return this._attributes.getAttribute(attrName).cameFromUser();
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -110,6 +110,7 @@ import {
 } from "./attribute-methods.js";
 import { toKey as _toKey } from "./attribute-methods/primary-key.js";
 import { _readAttribute as _readAttributeFn } from "./attribute-methods/read.js";
+import { isAttributeCameFromUser as _isAttributeCameFromUser } from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
   _queryAttribute as _queryAttributeFn,
@@ -2732,6 +2733,8 @@ export class Base extends Model {
   /** @internal */
   declare _readAttribute: (name: string) => unknown;
   declare _writeAttribute: (name: string, value: unknown) => void;
+  /** @internal */
+  declare cameFromUser: (name: string) => boolean;
 
   get attributeNamesList(): string[] {
     return _attributeNamesList.call(this as any);
@@ -3091,6 +3094,7 @@ include(Base, {
   _queryAttribute: _queryAttributeFn,
   _readAttribute: _readAttributeFn,
   _writeAttribute: ReadonlyAttributes._writeAttribute,
+  cameFromUser: _isAttributeCameFromUser,
   // PrimaryKey
   toKey: _toKey,
 });

--- a/packages/activerecord/src/validations.test.ts
+++ b/packages/activerecord/src/validations.test.ts
@@ -140,6 +140,40 @@ describe("ValidationsTest", () => {
     expect(t.score).toBe(5);
   });
 
+  it("numericality validates cast value when record loaded from database (cameFromUser false)", async () => {
+    // When an AR record is loaded via writeFromDatabase, cameFromUser returns
+    // false and the validator uses readAttribute (cast value), not the raw
+    // string column. A numeric column loaded as the integer 42 must pass.
+    class Item extends Base {
+      static {
+        this.attribute("price", "integer");
+        this.validates("price", { numericality: { greaterThan: 0 } });
+        this.adapter = adapter;
+      }
+    }
+    const item = Item.new({}) as any;
+    item._attributes.writeFromDatabase("price", 42);
+    expect(item.cameFromUser("price")).toBe(false);
+    expect(await item.isValid()).toBe(true);
+  });
+
+  it("numericality validates raw input when attribute came from user (cameFromUser true)", async () => {
+    // User-assigned string "abc" on an integer column casts to null but the
+    // validator must see the raw "abc" via readAttributeBeforeTypeCast and
+    // reject it — not silently pass because the cast value is null.
+    class Item extends Base {
+      static {
+        this.attribute("price", "integer");
+        this.validates("price", { numericality: true });
+        this.adapter = adapter;
+      }
+    }
+    const item = Item.new({ price: "abc" }) as any;
+    expect(item.cameFromUser("price")).toBe(true);
+    expect(await item.isValid()).toBe(false);
+    expect(item.errors.get("price")).toContain("is not a number");
+  });
+
   it("numericality validator wont be affected by custom getter", async () => {
     const { Topic } = makeModel();
     const t = new Topic({ title: "getter", score: 10 });


### PR DESCRIPTION
Closes audit findings #28 and #29 from `docs/activemodel/audit-validations.md` §15. See `docs/activemodel-alignment.md` P16.

## Changes

**`packages/activemodel/src/validations/numericality.ts`**
- `odd`/`even` now truncate via `Math.trunc` before modulo check, matching Rails `value.to_i.odd?` / `value.to_i.even?` (numericality.rb:51). `Math.trunc(-2.5) === -2` matches Ruby `-2.5.to_i == -2`; `Math.floor` would give -3 (wrong).
- `prepareValueForValidation` now mirrors Rails numericality.rb:120-141: if host exposes `cameFromUser(name)`, branches on it to use `readAttributeBeforeTypeCast` (user input) or `readAttribute` (cast DB value). Hosts without `cameFromUser` fall back to the previous `readAttributeBeforeTypeCast` path — non-AR hosts degrade gracefully.
- `RecordWithRawAttribute` interface gains optional `cameFromUser?(name: string): boolean`.

**`packages/activerecord/src/attribute-methods/before-type-cast.ts`**
- `isAttributeCameFromUser` exported (was unexported private).

**`packages/activerecord/src/base.ts`**
- Imports `isAttributeCameFromUser` and assigns it as `cameFromUser` instance method on Base, wiring the AR AttributeSet's per-attribute `cameFromUser()` flag into the validator dispatch chain.

## Impact

- `2.5` with `even: true` now passes (was incorrectly failing — `2.5 % 2 !== 0` without truncation).
- Records loaded from DB validate against the cast number, not the raw column string.
- 7 new tests; 58 → 65 in numericality-validation.test.ts.
- LOC delta: 127+8 = 135, well within 300-LOC budget.