### PR TITLE
fix(activemodel): compare precision/scale/limit in Type.equals (P19)

### DIFF
--- a/packages/activemodel/src/type/value.test.ts
+++ b/packages/activemodel/src/type/value.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Types } from "../index.js";
+import { Types, ValueType, IntegerType, FloatType, DecimalType, BigIntegerType } from "../index.js";
 
 describe("ValueTest", () => {
   it("type equality", () => {
@@ -14,5 +14,43 @@ describe("ValueTest", () => {
     expect(type.cast("hello")).toBe("hello");
     expect(type.cast(42)).toBe(42);
     expect(type.cast(null)).toBe(null);
+  });
+
+  describe("equals", () => {
+    it("same class, no metadata: equal", () => {
+      expect(new ValueType().equals(new ValueType())).toBe(true);
+    });
+
+    it("different class: not equal", () => {
+      expect(new IntegerType().equals(new FloatType())).toBe(false);
+    });
+
+    it("same class, same precision and scale: equal", () => {
+      expect(
+        new DecimalType({ precision: 8, scale: 2 }).equals(new DecimalType({ precision: 8, scale: 2 }))
+      ).toBe(true);
+    });
+
+    it("same class, different precision: not equal", () => {
+      expect(
+        new DecimalType({ precision: 8 }).equals(new DecimalType({ precision: 4 }))
+      ).toBe(false);
+    });
+
+    it("same class, different scale: not equal", () => {
+      expect(
+        new DecimalType({ scale: 2 }).equals(new DecimalType({ scale: 4 }))
+      ).toBe(false);
+    });
+
+    it("same class, different limit: not equal", () => {
+      expect(
+        new IntegerType({ limit: 8 }).equals(new IntegerType({ limit: 4 }))
+      ).toBe(false);
+    });
+
+    it("subclass and parent: not equal", () => {
+      expect(new IntegerType().equals(new BigIntegerType())).toBe(false);
+    });
   });
 });

--- a/packages/activemodel/src/type/value.test.ts
+++ b/packages/activemodel/src/type/value.test.ts
@@ -27,26 +27,24 @@ describe("ValueTest", () => {
 
     it("same class, same precision and scale: equal", () => {
       expect(
-        new DecimalType({ precision: 8, scale: 2 }).equals(new DecimalType({ precision: 8, scale: 2 }))
+        new DecimalType({ precision: 8, scale: 2 }).equals(
+          new DecimalType({ precision: 8, scale: 2 }),
+        ),
       ).toBe(true);
     });
 
     it("same class, different precision: not equal", () => {
-      expect(
-        new DecimalType({ precision: 8 }).equals(new DecimalType({ precision: 4 }))
-      ).toBe(false);
+      expect(new DecimalType({ precision: 8 }).equals(new DecimalType({ precision: 4 }))).toBe(
+        false,
+      );
     });
 
     it("same class, different scale: not equal", () => {
-      expect(
-        new DecimalType({ scale: 2 }).equals(new DecimalType({ scale: 4 }))
-      ).toBe(false);
+      expect(new DecimalType({ scale: 2 }).equals(new DecimalType({ scale: 4 }))).toBe(false);
     });
 
     it("same class, different limit: not equal", () => {
-      expect(
-        new IntegerType({ limit: 8 }).equals(new IntegerType({ limit: 4 }))
-      ).toBe(false);
+      expect(new IntegerType({ limit: 8 }).equals(new IntegerType({ limit: 4 }))).toBe(false);
     });
 
     it("subclass and parent: not equal", () => {

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -190,6 +190,11 @@ export class ValueType<T = unknown> extends Type<T> {
   readonly name: string = "value";
 
   equals(other: Type): boolean {
-    return this.constructor === other.constructor;
+    return (
+      this.constructor === other.constructor &&
+      this.precision === other.precision &&
+      this.scale === other.scale &&
+      this.limit === other.limit
+    );
   }
 }


### PR DESCRIPTION
## Summary

- `ValueType#equals` now mirrors Rails [`value.rb:121-126`](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/value.rb#L121-L126): class + `precision` + `scale` + `limit` must all match
- Previously, two types of the same class but different metadata (e.g. `DecimalType({ precision: 8 })` vs `DecimalType({ precision: 4 })`) compared equal — the wrong behavior
- Fixes audit finding #34 from `docs/activemodel/audit-types.md` §2 (Critical)

Implements `docs/activemodel-alignment.md` P19. Foundation for P24a's coder type-identity preservation — coder round-trips can now detect when a type's metadata changed, not just its class.

No `hash()` method added — JS Maps/Sets use SameValueZero, not Ruby's hash protocol; cosmetic divergence documented in audit §2.

No `ImmutableStringType` override — P14 (`trueString`/`falseString`) has not yet merged; override lands with or after P14.

## Test plan

- [x] 7 new `equals` tests in `value.test.ts` covering: same-class no-metadata, different class, same precision+scale, different precision, different scale, different limit, subclass vs parent
- [x] Full activemodel suite: 1745 tests passed
- [x] Full activerecord suite: 10001 tests passed (schema cache + attribute-set merge consumers unaffected)
- [x] `pnpm api:compare --package activemodel`: 624/625 (no regression)
- [x] lint: clean
- [x] format:check: clean