### PR TITLE
refactor(activerecord): relocate find/findBy/findByBang to core.ts (M2c)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1335,11 +1335,6 @@ export class Base extends Model {
 
   // -- Finders (class methods) --
 
-  /**
-   * Find a record by primary key, or an array of records by primary keys.
-   *
-   * Mirrors: ActiveRecord::Base.find
-   */
   /** @internal Cast a value through an attribute's type, with parseInt fallback for the default PK. */
   static _castAttributeValue(key: string, value: unknown): unknown {
     if (typeof value !== "string") return value;
@@ -1361,159 +1356,28 @@ export class Base extends Model {
   //                       `primaryKey` at the type level, the return is a
   //                       union: callers narrow with `Array.isArray` or cast.
   //   find(id, id, ...) → variadic → array of records
-  static find<T extends typeof Base>(
-    this: T,
-    ids: [unknown, ...unknown[]],
-  ): Promise<InstanceType<T> | InstanceType<T>[]>;
-  static find<T extends typeof Base>(this: T, id: unknown): Promise<InstanceType<T>>;
-  static find<T extends typeof Base>(
-    this: T,
-    id: unknown,
-    ...ids: [unknown, ...unknown[]]
-  ): Promise<InstanceType<T>[]>;
-  static async find(...ids: unknown[]): Promise<any> {
-    if (ids.length === 0) {
-      throw new RecordNotFound(
-        `Couldn't find ${this.name} with an empty list of ids`,
-        this.name,
-        String(this.primaryKey),
-        [],
-      );
-    }
-    // Variadic: User.find(1, 2, 3)
-    if (ids.length > 1) {
-      // Composite primary keys are ambiguous in the variadic-scalar form
-      // (`Model.find(1, 42)` could mean "tuple [1,42]" or "two scalar ids",
-      // neither of which matches the CPK tuple contract). Require an
-      // explicit array form so intent is unambiguous.
-      if (this.compositePrimaryKey && ids.some((i) => !Array.isArray(i))) {
-        throw argumentError(
-          `${this.name} has a composite primary key (${String(this.primaryKey)}); ` +
-            `call find([...tuple]) or find([[...], [...]]) rather than variadic scalars.`,
-        );
-      }
-      return this.find(ids);
-    }
-    const id = ids[0];
+  declare static find: {
+    <T extends typeof Base>(
+      this: T,
+      ids: [unknown, ...unknown[]],
+    ): Promise<InstanceType<T> | InstanceType<T>[]>;
+    <T extends typeof Base>(this: T, id: unknown): Promise<InstanceType<T>>;
+    <T extends typeof Base>(
+      this: T,
+      id: unknown,
+      ...ids: [unknown, ...unknown[]]
+    ): Promise<InstanceType<T>[]>;
+  };
 
-    // CPK: find([shop_id, id]) finds a single record by composite tuple
-    if (this.compositePrimaryKey && Array.isArray(id)) {
-      // Check if this is a single tuple or array of tuples
-      if (id.length > 0 && Array.isArray(id[0])) {
-        // Array of tuples: find([[1,2], [3,4]])
-        const tuples = id as unknown[][];
-        if (tuples.length === 0) {
-          throw new RecordNotFound(
-            `${this.name}: couldn't find all with an empty list of ids`,
-            this.name,
-            String(this.primaryKey),
-            [],
-          );
-        }
-        const whereNodes = tuples.map((tuple) => ModelSchema.buildPkWhereNode.call(this, tuple));
-        const orCondition = whereNodes.reduce((left, right) => new Nodes.Or(left, right));
-        const records = await this.all().where(new Nodes.Grouping(orCondition)).toArray();
-        if (records.length !== tuples.length) {
-          throw new RecordNotFound(
-            `${this.name}: couldn't find all with composite primary key`,
-            this.name,
-            String(this.primaryKey),
-            id,
-          );
-        }
-        return records;
-      }
-      // Single tuple: find([shop_id, id])
-      const pk = this.primaryKey as string[];
-      const whereConditions: Record<string, unknown> = {};
-      pk.forEach((col, i) => {
-        whereConditions[col] = (id as unknown[])[i];
-      });
-      const record = await this.all().where(whereConditions).first();
-      if (!record) {
-        throw new RecordNotFound(
-          `${this.name} with ${this.primaryKey}=[${id}] not found`,
-          this.name,
-          String(this.primaryKey),
-          id,
-        );
-      }
-      return record;
-    }
-
-    // Multiple IDs — return an array
-    if (Array.isArray(id)) {
-      if (id.length === 0) {
-        throw new RecordNotFound(
-          `${this.name}: couldn't find all with an empty list of ids`,
-          this.name,
-          String(this.primaryKey),
-          [],
-        );
-      }
-      const castIds = id.map((i) => this._castAttributeValue(this.primaryKey as string, i));
-      const records = await this.all()
-        .where({ [this.primaryKey as string]: castIds })
-        .toArray();
-      // Ensure all IDs were found
-      if (records.length !== castIds.length) {
-        const foundIds = new Set<unknown>(records.map((r: Base) => r.id));
-        const missing = castIds.filter((i) => !foundIds.has(i));
-        throw new RecordNotFound(
-          `${this.name} with ${this.primaryKey} in [${missing.join(", ")}] not found`,
-          this.name,
-          String(this.primaryKey),
-          id,
-        );
-      }
-      // Return in input order, matching Rails' in_order_of behavior
-      const idToRecord = new Map<unknown, Base>();
-      for (const r of records) idToRecord.set(r.id, r);
-      return castIds.map((cid) => idToRecord.get(cid)!);
-    }
-    // Single ID — cast through PK type, then use all() so STI type filter is applied
-    const castId = this._castAttributeValue(this.primaryKey as string, id);
-    const record = await this.all()
-      .where({ [this.primaryKey as string]: castId })
-      .first();
-    if (!record) {
-      throw new RecordNotFound(
-        `${this.name} with ${this.primaryKey}=${id} not found`,
-        this.name,
-        String(this.primaryKey),
-        id,
-      );
-    }
-    return record;
-  }
-
-  /**
-   * Find the first record matching conditions.
-   *
-   * Mirrors: ActiveRecord::Base.find_by — `delegate :find_by, to: :all`
-   * (querying.rb QUERYING_METHODS). Routing through `all()` picks up
-   * the default scope, current scope (from `scoping()`), and STI type
-   * filter. `createWith` doesn't affect lookups — it's applied only
-   * on downstream create paths like `findOrCreateBy`.
-   */
-  static findBy<T extends typeof Base>(
+  declare static findBy: <T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
-  ): Promise<InstanceType<T> | null> {
-    return this.all().findBy(conditions);
-  }
+  ) => Promise<InstanceType<T> | null>;
 
-  /**
-   * Find the first record matching conditions, or throw.
-   *
-   * Mirrors: ActiveRecord::Base.find_by! — `delegate :find_by!, to: :all`.
-   */
-  static findByBang<T extends typeof Base>(
+  declare static findByBang: <T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
-  ): Promise<InstanceType<T>> {
-    return this.all().findByBang(conditions);
-  }
+  ) => Promise<InstanceType<T>>;
 
   /**
    * Dynamic finder by a single attribute name.
@@ -2890,6 +2754,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
 
 extend(Base, ConnectionHandling.ClassMethods);
 extend(Base, { collectionCacheKey: _collectionCacheKey });
+extend(Base, { find: _Core.find, findBy: _Core.findBy, findByBang: _Core.findByBang });
 extend(Base, Querying);
 extend(Base, {
   belongsTo: _Associations.belongsTo,

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -5,13 +5,15 @@
  */
 
 import { NotImplementedError } from "./errors.js";
+import { RecordNotFound } from "./errors.js";
 import { Notifications, getAsyncContext, ParameterFilter } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { argumentError } from "./relation/query-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
-import { Table } from "@blazetrails/arel";
+import { Table, Nodes } from "@blazetrails/arel";
 import { Map as TypeCasterMap } from "./type-caster/map.js";
+import { buildPkWhereNode } from "./model-schema.js";
 
 /**
  * The Core module interface — methods mixed into every AR model.
@@ -247,6 +249,8 @@ export function fullInspect(this: CoreRecord): string {
 interface CoreHost {
   name: string;
   tableName?: string;
+  primaryKey?: string | string[];
+  compositePrimaryKey?: boolean;
   _filterAttributes?: (string | RegExp | ((key: string, value: unknown) => unknown))[];
   _inspectionFilter?: any;
   _connectionClass?: boolean;
@@ -258,6 +262,8 @@ interface CoreHost {
   _predicateBuilder?: any;
   arelTable?: any;
   prototype: any;
+  all(): any;
+  _castAttributeValue(key: string, value: unknown): unknown;
 }
 
 function parentClass(klass: CoreHost): CoreHost | null {
@@ -600,4 +606,117 @@ function relation(): never {
 /** @internal */
 function cachedFindBy(): never {
   throw new NotImplementedError("ActiveRecord::Core#cached_find_by is not implemented");
+}
+
+export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
+  if (ids.length === 0) {
+    throw new RecordNotFound(
+      `Couldn't find ${this.name} with an empty list of ids`,
+      this.name,
+      String(this.primaryKey),
+      [],
+    );
+  }
+  if (ids.length > 1) {
+    // CPK variadic scalars are ambiguous — require explicit array form
+    if (this.compositePrimaryKey && ids.some((i) => !Array.isArray(i))) {
+      throw argumentError(
+        `${this.name} has a composite primary key (${String(this.primaryKey)}); ` +
+          `call find([...tuple]) or find([[...], [...]]) rather than variadic scalars.`,
+      );
+    }
+    return (this as any).find(ids);
+  }
+  const id = ids[0];
+
+  if (this.compositePrimaryKey && Array.isArray(id)) {
+    if (id.length > 0 && Array.isArray(id[0])) {
+      const tuples = id as unknown[][];
+      if (tuples.length === 0) {
+        throw new RecordNotFound(
+          `${this.name}: couldn't find all with an empty list of ids`,
+          this.name,
+          String(this.primaryKey),
+          [],
+        );
+      }
+      const whereNodes = tuples.map((tuple) => buildPkWhereNode.call(this as any, tuple));
+      const orCondition = whereNodes.reduce((left, right) => new Nodes.Or(left, right));
+      const records = await this.all().where(new Nodes.Grouping(orCondition)).toArray();
+      if (records.length !== tuples.length) {
+        throw new RecordNotFound(
+          `${this.name}: couldn't find all with composite primary key`,
+          this.name,
+          String(this.primaryKey),
+          id,
+        );
+      }
+      return records;
+    }
+    const pk = this.primaryKey as string[];
+    const whereConditions: Record<string, unknown> = {};
+    pk.forEach((col, i) => {
+      whereConditions[col] = (id as unknown[])[i];
+    });
+    const record = await this.all().where(whereConditions).first();
+    if (!record) {
+      throw new RecordNotFound(
+        `${this.name} with ${this.primaryKey}=[${id}] not found`,
+        this.name,
+        String(this.primaryKey),
+        id,
+      );
+    }
+    return record;
+  }
+
+  if (Array.isArray(id)) {
+    if (id.length === 0) {
+      throw new RecordNotFound(
+        `${this.name}: couldn't find all with an empty list of ids`,
+        this.name,
+        String(this.primaryKey),
+        [],
+      );
+    }
+    const castIds = id.map((i) => this._castAttributeValue(this.primaryKey as string, i));
+    const records = await this.all()
+      .where({ [this.primaryKey as string]: castIds })
+      .toArray();
+    if (records.length !== castIds.length) {
+      const foundIds = new Set<unknown>(records.map((r: any) => r.id));
+      const missing = castIds.filter((i) => !foundIds.has(i));
+      throw new RecordNotFound(
+        `${this.name} with ${this.primaryKey} in [${missing.join(", ")}] not found`,
+        this.name,
+        String(this.primaryKey),
+        id,
+      );
+    }
+    // in_order_of: return in input order
+    const idToRecord = new Map<unknown, any>();
+    for (const r of records) idToRecord.set(r.id, r);
+    return castIds.map((cid) => idToRecord.get(cid)!);
+  }
+  const castId = this._castAttributeValue(this.primaryKey as string, id);
+  const record = await this.all()
+    .where({ [this.primaryKey as string]: castId })
+    .first();
+  if (!record) {
+    throw new RecordNotFound(
+      `${this.name} with ${this.primaryKey}=${id} not found`,
+      this.name,
+      String(this.primaryKey),
+      id,
+    );
+  }
+  return record;
+}
+
+export function findBy(this: CoreHost, conditions: Record<string, unknown>): Promise<any> {
+  return this.all().findBy(conditions);
+}
+
+export function findByBang(this: CoreHost, conditions: Record<string, unknown>): Promise<any> {
+  return this.all().findByBang(conditions);
 }


### PR DESCRIPTION
## Methods moved

- `find` (`ActiveRecord::Core::find`) — 3 TypeScript overload signatures preserved via `declare static`
- `findBy` (`ActiveRecord::Core::find_by`)
- `findByBang` (`ActiveRecord::Core::find_by!`)

All three implementations extracted to `core.ts` as `this`-typed exported functions, wired into `Base` via `extend(Base, { find, findBy, findByBang })`. Recursive array-branch in `find` uses `(this as any).find(ids)` per the established M2/M2b dispatch rule.

## Metrics

| | Before | After |
|---|---|---|
| Misplaced | 156 | 153 (-3) |
| Matched | 3854 (75.8%) | 3854 (75.8%) |
| Tests | 10001 passed | 10001 passed |
| LOC | — | +137/-153 = 290 total |

## Deferred

None — all three target methods fit under the 300 LOC ceiling.

## Reference

Wave 0 PR M2c — see [docs/activerecord-100-plan.md](docs/activerecord-100-plan.md). Pattern from #1151 (M2) and #1152 (M2b).