### PR TITLE
refactor(activerecord): relocate attribute-methods + primary-key + inheritance methods to Rails layout (M2b)

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -410,8 +410,8 @@ export function id(this: any, value?: unknown): unknown {
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#reload */
-export async function reload(this: any): Promise<typeof this> {
-  return _reload.call(this);
+export async function reload<T>(this: T): Promise<T> {
+  return _reload.call(this as any) as unknown as Promise<T>;
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#serializable_hash */

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -410,6 +410,11 @@ export function id(this: any, value?: unknown): unknown {
   const pk = ctor.primaryKey as string | string[];
   if (value !== undefined) {
     if (Array.isArray(pk)) {
+      if (!Array.isArray(value)) {
+        throw new TypeError(
+          `Expected an array for composite primary key [${pk.join(", ")}], got ${value === null ? "null" : typeof value}`,
+        );
+      }
       pk.forEach((col: string, i: number) => this._writeAttribute(col, (value as unknown[])[i]));
     } else {
       this._writeAttribute(pk, value);

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -9,7 +9,8 @@ import { formatForInspect as _formatForInspect } from "./attribute-inspection.js
 import { attributeForInspect as _attrForInspect } from "./core.js";
 import { writeAttribute as _writeAttribute } from "./readonly-attributes.js";
 import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js";
-import { toKey as _toKey, getId, setId } from "./attribute-methods/primary-key.js";
+// toKey/id: inline to avoid a circular dependency (primary-key.ts imports
+// dangerousAttributeMethods from this file)
 import { reload as _reload } from "./persistence.js";
 import {
   serializableHash as _serializableHash,
@@ -397,16 +398,26 @@ export function queryAttribute(this: any, name: string): boolean {
 
 /** Mirrors: ActiveRecord::AttributeMethods#to_key */
 export function toKey(this: any): unknown[] | null {
-  return _toKey.call(this);
+  const pk = this.id;
+  if (pk == null) return null;
+  const arr = Array.isArray(pk) ? pk : [pk];
+  return arr.some((v: unknown) => v == null) ? null : arr;
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#id, id=, id? */
 export function id(this: any, value?: unknown): unknown {
+  const ctor = this.constructor as any;
+  const pk = ctor.primaryKey as string | string[];
   if (value !== undefined) {
-    setId.call(this, value);
+    if (Array.isArray(pk)) {
+      pk.forEach((col: string, i: number) => this._writeAttribute(col, (value as unknown[])[i]));
+    } else {
+      this._writeAttribute(pk, value);
+    }
     return value;
   }
-  return getId.call(this);
+  if (Array.isArray(pk)) return pk.map((col: string) => this._readAttribute(col));
+  return this._readAttribute(pk);
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#reload */

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -378,14 +378,16 @@ export function attributeForInspect(this: any, attr: string): string {
 
 /** Mirrors: ActiveRecord::AttributeMethods#read_attribute */
 export function readAttribute(this: any, name: string): unknown {
-  const pk = (this.constructor as any)?.primaryKey;
-  const resolved = name === "id" && pk && !Array.isArray(pk) ? (pk as string) : name;
+  const aliases = (this.constructor as any)?._attributeAliases ?? {};
+  const resolved = (aliases[name] as string | undefined) ?? name;
   return this._readAttribute(resolved);
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#write_attribute */
 export function writeAttribute(this: any, name: string, value: unknown): void {
-  _writeAttribute.call(this, name, value);
+  const aliases = (this.constructor as any)?._attributeAliases ?? {};
+  const resolved = (aliases[name] as string | undefined) ?? name;
+  _writeAttribute.call(this, resolved, value);
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#query_attribute */

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -6,6 +6,15 @@
 import { isBlank } from "@blazetrails/activesupport";
 import { resolveAliasName } from "@blazetrails/activemodel";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
+import { attributeForInspect as _attrForInspect } from "./core.js";
+import { writeAttribute as _writeAttribute } from "./readonly-attributes.js";
+import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js";
+import { toKey as _toKey, getId, setId } from "./attribute-methods/primary-key.js";
+import { reload as _reload } from "./persistence.js";
+import {
+  serializableHash as _serializableHash,
+  attributeNamesForSerialization as _attrNamesForSerialization,
+} from "./serialization.js";
 // ActiveModel provides aliasAttribute and undefineAttributeMethods on Model.
 // aliasAttribute delegates via the prototype chain. defineAttributeMethods
 // is implemented here since AM doesn't expose it as a static on Model.
@@ -356,4 +365,63 @@ interface AttributeNamesHost {
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
   return [...this._attributeDefinitions.keys()];
+}
+
+// ---------------------------------------------------------------------------
+// Instance methods mirrored from attribute_methods.rb
+// ---------------------------------------------------------------------------
+
+/** Mirrors: ActiveRecord::AttributeMethods#attribute_for_inspect */
+export function attributeForInspect(this: any, attr: string): string {
+  return _attrForInspect.call(this, attr);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#read_attribute */
+export function readAttribute(this: any, name: string): unknown {
+  const pk = (this.constructor as any)?.primaryKey;
+  const resolved = name === "id" && pk && !Array.isArray(pk) ? (pk as string) : name;
+  return this._readAttribute(resolved);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#write_attribute */
+export function writeAttribute(this: any, name: string, value: unknown): void {
+  _writeAttribute.call(this, name, value);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#query_attribute */
+export function queryAttribute(this: any, name: string): boolean {
+  return _queryAttribute.call(this, name);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#to_key */
+export function toKey(this: any): unknown[] | null {
+  return _toKey.call(this);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#id, id=, id? */
+export function id(this: any, value?: unknown): unknown {
+  if (value !== undefined) {
+    setId.call(this, value);
+    return value;
+  }
+  return getId.call(this);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#reload */
+export async function reload(this: any): Promise<typeof this> {
+  return _reload.call(this);
+}
+
+/** Mirrors: ActiveRecord::AttributeMethods#serializable_hash */
+export function serializableHash(this: any, options?: unknown): Record<string, unknown> {
+  return _serializableHash.call(this, options as any);
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods#attribute_names_for_serialization
+ *
+ * @internal
+ */
+export function attributeNamesForSerialization(this: any): string[] {
+  return _attrNamesForSerialization.call(this);
 }

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -404,7 +404,7 @@ export function toKey(this: any): unknown[] | null {
   return arr.some((v: unknown) => v == null) ? null : arr;
 }
 
-/** Mirrors: ActiveRecord::AttributeMethods#id, id=, id? */
+/** Mirrors: ActiveRecord::AttributeMethods#id, id= */
 export function id(this: any, value?: unknown): unknown {
   const ctor = this.constructor as any;
   const pk = ctor.primaryKey as string | string[];

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -172,7 +172,7 @@ export function primaryKey(this: PrimaryKeyHost, value?: string | string[]): str
 }
 
 /**
- * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id, id=, id?
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id, id=
  */
 export function id(this: PrimaryKeyInstance, value?: unknown): unknown {
   if (value !== undefined) {

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -159,6 +159,29 @@ export function isCompositePrimaryKey(this: PrimaryKeyHost): boolean {
   return Array.isArray(this._primaryKey ?? "id");
 }
 
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#primary_key,
+ * primary_key=
+ */
+export function primaryKey(this: PrimaryKeyHost, value?: string | string[]): string | string[] {
+  if (value !== undefined) {
+    setPrimaryKeyAttr.call(this, value);
+    return value;
+  }
+  return getPrimaryKeyAttr.call(this);
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id, id=, id?
+ */
+export function id(this: PrimaryKeyInstance, value?: unknown): unknown {
+  if (value !== undefined) {
+    setId.call(this, value);
+    return value;
+  }
+  return getId.call(this);
+}
+
 export function isInstanceMethodAlreadyImplemented(
   this: PrimaryKeyHost & { prototype: any },
   methodName: string,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2513,7 +2513,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.column_defaults
    */
   static get columnDefaults(): Record<string, unknown> {
-    return this._defaultAttributes().deepDup().toHash();
+    return ModelSchema.columnDefaults.call(this as any);
   }
 
   // -- Strict loading class-level default --

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -190,6 +190,18 @@ export function setAbstractClass(this: typeof Base, value: boolean): void {
 }
 
 /**
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class,
+ * abstract_class=, abstract_class?
+ */
+export function abstractClass(this: typeof Base, value?: boolean): boolean {
+  if (value !== undefined) {
+    setAbstractClass.call(this, value);
+    return value;
+  }
+  return getAbstractClass.call(this);
+}
+
+/**
  * Get the STI base class for a model.
  */
 export function getStiBase(modelClass: typeof Base): typeof Base {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -988,6 +988,11 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
  *   `inheritanceColumn` as a getter/setter.
  * - `loadSchema` — private lifecycle hook in Rails; called automatically
  *   rather than by user code.
+ * - `tableName`, `sequenceName`, `protectedEnvironments`, `ignoredColumns`,
+ *   `inheritanceColumn`, `columnDefaults` — implemented as static
+ *   getter/setter pairs on `Base` directly; adding these to `ClassMethods`
+ *   would cause `extend()` to overwrite the getter descriptor with a plain
+ *   property assignment, breaking lazy-evaluation semantics.
  */
 export const ClassMethods = {
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -357,6 +357,7 @@ interface SchemaHost {
   _ignoredColumns?: string[];
   _protectedEnvironments?: string[];
   _attributeDefinitions: Map<string, any>;
+  _defaultAttributes(): { deepDup(): { toHash(): Record<string, unknown> } };
   _columnsHash?: Record<string, any>;
   _columns?: any[];
   _attributesBuilder?: any;
@@ -958,7 +959,7 @@ export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
 
 /** Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_defaults */
 export function columnDefaults(this: SchemaHost): Record<string, unknown> {
-  return (this as any)._defaultAttributes().deepDup().toHash();
+  return this._defaultAttributes().deepDup().toHash();
 }
 
 export async function tableExists(this: SchemaHost): Promise<boolean> {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -989,10 +989,11 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
  * - `loadSchema` — private lifecycle hook in Rails; called automatically
  *   rather than by user code.
  * - `tableName`, `sequenceName`, `protectedEnvironments`, `ignoredColumns`,
- *   `inheritanceColumn`, `columnDefaults` — implemented as static
- *   getter/setter pairs on `Base` directly; adding these to `ClassMethods`
- *   would cause `extend()` to overwrite the getter descriptor with a plain
- *   property assignment, breaking lazy-evaluation semantics.
+ *   `inheritanceColumn` — implemented as static getter/setter pairs on `Base`
+ *   directly; `columnDefaults` is a getter-only property on `Base`. Adding
+ *   these to `ClassMethods` would cause `extend()` to overwrite the getter
+ *   descriptor with a plain property assignment, breaking lazy-evaluation
+ *   semantics.
  */
 export const ClassMethods = {
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -956,6 +956,11 @@ export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
   return this._ignoredColumns ?? [];
 }
 
+/** Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_defaults */
+export function columnDefaults(this: SchemaHost): Record<string, unknown> {
+  return (this as any)._defaultAttributes().deepDup().toHash();
+}
+
 export async function tableExists(this: SchemaHost): Promise<boolean> {
   const { adapter } = this;
   const cache = adapter.schemaCache;


### PR DESCRIPTION
## Summary

Adds correctly-named exported functions to destination files so `api:compare`'s `directMatch` finds them, fixing 40 total misplaced entries across two commits.

### What this PR does

The M2 PR (#1151) introduced `this`-typed function exports with descriptive-but-non-canonical names (e.g., `getId`/`setId` instead of `id`, `getAbstractClass`/`setAbstractClass` instead of `abstractClass`). The api:compare tool maps Ruby names directly to camelCase TS names (`id`, `primaryKey`, `abstractClass`), so those mis-named exports didn't register as `directMatch`. This PR adds the canonical-named exports.

### Moves grouped by destination

**attribute-methods/primary-key.ts** (5 Ruby methods → 2 TS functions):
- `id` (getter/setter/?) — delegates to existing `getId`/`setId`
- `primaryKey` (getter/setter) — delegates to existing `getPrimaryKeyAttr`/`setPrimaryKeyAttr`

**inheritance.ts** (3 Ruby methods → 1 TS function):
- `abstractClass` (getter/setter/?) — delegates to existing `getAbstractClass`/`setAbstractClass`

**model-schema.ts** (1 Ruby method → 1 TS function):
- `columnDefaults` — moved body from base.ts; base.ts delegates to `ModelSchema.columnDefaults`

**attribute-methods.ts** (14 Ruby methods → 9 TS wrapper functions):
- `attributeForInspect`, `readAttribute`, `writeAttribute`, `queryAttribute`, `toKey`, `id`, `reload`, `serializableHash`, `attributeNamesForSerialization`

### Before/after misplaced+matched counts

| | Before (origin/main) | After M2 (#1151) | After this PR |
|---|---|---|---|
| Misplaced | 176 | 156 | 136 |
| Matched | 3810 | 3854 | 3854 |

Note: matched count doesn't change because misplaced methods were already counted as matched via the include chain. Moving them to `directMatch` removes them from the misplaced report.

### Deferred to M2c

Methods deferred due to **circular import risk** (persistence.ts ↔ transactions.ts/validations.ts, autosave-association.ts ↔ persistence.ts, touch-later.ts ↔ transactions.ts):
- `save`/`saveBang`/`destroy`/`touch` in transactions.ts
- `save`/`saveBang` in validations.ts and suppressor.ts
- `destroy`/`incrementBang` in callbacks.ts
- `reload` in autosave-association.ts and attribute-methods/dirty.ts
- `delete`/`touch` in persistence.ts

Deferred due to **complex overloads** (~130 LOC alone):
- `find`/`findBy`/`findByBang` (core.ts, 3 moves)

### Reference

- Follows pattern from #1151 (M2)
- See [docs/activerecord-100-plan.md](docs/activerecord-100-plan.md) Wave 0 PR M2(b)