### PR TITLE
fix(activemodel): support trueString/falseString + type() returns "string" in ImmutableStringType (P14)

### DIFF
--- a/packages/activemodel/src/type/immutable-string.test.ts
+++ b/packages/activemodel/src/type/immutable-string.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Types } from "../index.js";
+import { ImmutableStringType } from "./immutable-string.js";
 
 describe("ImmutableStringTest", () => {
   it("cast strings are frozen", () => {
@@ -11,7 +12,7 @@ describe("ImmutableStringTest", () => {
 
   it("casts booleans to the PG literal form", () => {
     // Rails type/immutable_string.rb#cast_value:
-    //   case value when true then "t"; when false then "f"; else value.to_s
+    //   case value when true then @true; when false then @false; else value.to_s
     const type = Types.typeRegistry.lookup("immutable_string");
     expect(type.cast(true)).toBe("t");
     expect(type.cast(false)).toBe("f");
@@ -26,5 +27,43 @@ describe("ImmutableStringTest", () => {
     expect(Object.isFrozen(b)).toBe(true);
     expect(a).toBe("hello");
     expect(b).toBe("hello");
+  });
+
+  it("custom trueString is returned for true", () => {
+    const type = new ImmutableStringType({ trueString: "aye" });
+    expect(type.cast(true)).toBe("aye");
+  });
+
+  it("custom falseString is returned for false", () => {
+    const type = new ImmutableStringType({ falseString: "nay" });
+    expect(type.cast(false)).toBe("nay");
+  });
+
+  it("custom trueString and falseString both work", () => {
+    const type = new ImmutableStringType({ trueString: "aye", falseString: "nay" });
+    expect(type.cast(true)).toBe("aye");
+    expect(type.cast(false)).toBe("nay");
+  });
+
+  it("defaults to t/f when no custom strings provided", () => {
+    const type = new ImmutableStringType();
+    expect(type.cast(true)).toBe("t");
+    expect(type.cast(false)).toBe("f");
+  });
+
+  it("type() returns string", () => {
+    const type = new ImmutableStringType();
+    expect(type.type()).toBe("string");
+  });
+
+  it("name stays immutable_string", () => {
+    const type = new ImmutableStringType();
+    expect(type.name).toBe("immutable_string");
+  });
+
+  it("cast then serialize of custom-true value preserves the string", () => {
+    const type = new ImmutableStringType({ trueString: "aye" });
+    const cast = type.cast(true);
+    expect(type.serialize(cast)).toBe("aye");
   });
 });

--- a/packages/activemodel/src/type/immutable-string.test.ts
+++ b/packages/activemodel/src/type/immutable-string.test.ts
@@ -12,7 +12,7 @@ describe("ImmutableStringTest", () => {
 
   it("casts booleans to the PG literal form", () => {
     // Rails type/immutable_string.rb#cast_value:
-    //   case value when true then @true; when false then @false; else value.to_s
+    //   case value when true then @true; when false then @false; else value.to_s.freeze
     const type = Types.typeRegistry.lookup("immutable_string");
     expect(type.cast(true)).toBe("t");
     expect(type.cast(false)).toBe("f");

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -1,10 +1,22 @@
 import { ValueType } from "./value.js";
 
+export interface ImmutableStringTypeOptions {
+  precision?: number;
+  scale?: number;
+  limit?: number;
+  trueString?: string;
+  falseString?: string;
+}
+
 export class ImmutableStringType extends ValueType<string> {
   readonly name: string = "immutable_string";
+  readonly trueString: string;
+  readonly falseString: string;
 
-  constructor(options?: { precision?: number; scale?: number; limit?: number }) {
+  constructor(options?: ImmutableStringTypeOptions) {
     super(options);
+    this.trueString = options?.trueString ?? "t";
+    this.falseString = options?.falseString ?? "f";
   }
 
   /**
@@ -12,16 +24,16 @@ export class ImmutableStringType extends ValueType<string> {
    * (immutable_string.rb):
    *
    *   case value
-   *   when true  then "t"
-   *   when false then "f"
-   *   else value.to_s
+   *   when true  then @true
+   *   when false then @false
+   *   else value.to_s.freeze
    *   end
    *
    * @internal Rails-private helper.
    */
   protected castValue(value: unknown): string | null {
-    if (value === true) return Object.freeze("t") as string;
-    if (value === false) return Object.freeze("f") as string;
+    if (value === true) return Object.freeze(this.trueString) as string;
+    if (value === false) return Object.freeze(this.falseString) as string;
     const str = String(value);
     return Object.freeze(str) as string;
   }
@@ -31,7 +43,7 @@ export class ImmutableStringType extends ValueType<string> {
   }
 
   type(): string {
-    return this.name;
+    return "string";
   }
 
   serializeCastValue(value: string | null): string | null {

--- a/packages/activemodel/src/type/string.test.ts
+++ b/packages/activemodel/src/type/string.test.ts
@@ -29,4 +29,9 @@ describe("StringTest", () => {
     const cast = type.cast(s);
     expect(cast).toBe("foo");
   });
+
+  it("toImmutableString propagates trueString and falseString", () => {
+    const type = new Types.StringType({ trueString: "aye" });
+    expect(type.toImmutableString().cast(true)).toBe("aye");
+  });
 });

--- a/packages/activemodel/src/type/string.test.ts
+++ b/packages/activemodel/src/type/string.test.ts
@@ -31,7 +31,8 @@ describe("StringTest", () => {
   });
 
   it("toImmutableString propagates trueString and falseString", () => {
-    const type = new Types.StringType({ trueString: "aye" });
+    const type = new Types.StringType({ trueString: "aye", falseString: "nay" });
     expect(type.toImmutableString().cast(true)).toBe("aye");
+    expect(type.toImmutableString().cast(false)).toBe("nay");
   });
 });

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -31,6 +31,8 @@ export class StringType extends ImmutableStringType {
       precision: this.precision,
       scale: this.scale,
       limit: this.limit,
+      trueString: this.trueString,
+      falseString: this.falseString,
     });
   }
 }


### PR DESCRIPTION
Implements audit findings #36 and #37 from `docs/activemodel/audit-types.md` §4, per `docs/activemodel-alignment.md` P14.

## Changes

**`ImmutableStringType`**
- Add `trueString`/`falseString` constructor options (defaults `"t"`/`"f"`), mirroring Rails `immutable_string.rb:38-41` `:true`/`:false` kwargs.
  - Named `trueString`/`falseString` (camelCase) rather than bare `true`/`false` — JS reserved-word issues with property access in strict-mode / IDE highlighting. This is the only such rename in the P-series alignment plan.
- `castValue(true)` returns `this.trueString`; `castValue(false)` returns `this.falseString`.
- `type()` now returns `"string"` (was `this.name`), matching Rails `immutable_string.rb:44`. Registry key remains `"immutable_string"` — `type()` is the schema-facing semantic kind; `name` is the registry-facing identifier. Rails makes the same distinction.

**`StringType`**
- `toImmutableString()` propagates `trueString`/`falseString` into the new `ImmutableStringType`.

## Adapter consumer check

Grepped `packages/activemodel/src/` and `packages/activerecord/src/` for callers comparing `type()` to `"immutable_string"` — none found. `ImmutableStringType.type() === "string"` now routes the same as `StringType` in any adapter dispatch.

## Test delta

- `immutable-string.test.ts`: +7 cases (custom strings, defaults regression guard, `type()`, `name`, round-trip)
- `string.test.ts`: +1 case (`toImmutableString()` option propagation)

## api:compare

`activemodel`: 624/625 (99.8%) — unchanged from main (the `type/integer.rb` miss is pre-existing, unrelated to this PR).