### PR TITLE
fix(activemodel): per-type defaults for AcceptsMultiparameterTime (P21)

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -129,4 +129,20 @@ describe("DateTimeTest", () => {
       expect.objectContaining({ name: "ArgumentError" }),
     );
   });
+
+  it("valueFromMultiparameterAssignment defaults hour/minute to 0 when only date parts given (P21)", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return this.valueFromMultiparameterAssignment(values);
+      }
+    }
+    const result = new Probe().call({ 1: 2025, 2: 7, 3: 4 }) as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(2025);
+    expect(zdt.month).toBe(7);
+    expect(zdt.day).toBe(4);
+    expect(zdt.hour).toBe(0);
+    expect(zdt.minute).toBe(0);
+  });
 });

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -159,6 +159,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
       );
     }
-    return new AcceptsMultiparameterTime(this).cast(values) as DateTimeCastResult | null;
+    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(values) as DateTimeCastResult | null;
   }
 }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -159,6 +159,8 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
       );
     }
-    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(values) as DateTimeCastResult | null;
+    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(
+      values,
+    ) as DateTimeCastResult | null;
   }
 }

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -104,4 +104,16 @@ describe("DateTest", () => {
     expect(result).toBeInstanceOf(Temporal.PlainDate);
     expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
   });
+
+  it("multiparameter hash missing day returns null (no defaults for DateType — P21 regression guard)", () => {
+    // Date has no defaults; year/month/day are all required.
+    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7 });
+    expect(result).toBeNull();
+  });
+
+  it("multiparameter hash with all date parts returns PlainDate (P21 regression guard)", () => {
+    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7, 3: 4 });
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2025-07-04");
+  });
 });

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { Types } from "../../index.js";
+import { AcceptsMultiparameterTime } from "./accepts-multiparameter-time.js";
+
+describe("AcceptsMultiparameterTime defaults", () => {
+  it("defaults fill missing slots", () => {
+    const type = new Types.DateTimeType();
+    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0, "5": 0 });
+    // Only year/month/day provided — hour and minute should default to 0
+    const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4 });
+    expect(result).not.toBeNull();
+  });
+
+  it("user values override defaults", () => {
+    const type = new Types.DateTimeType();
+    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
+    // hour explicitly provided as 15 — default of 0 must not overwrite it
+    const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": 15 });
+    expect(result).not.toBeNull();
+    // The Instant's UTC hour should be 15 (timezone is UTC in test env)
+    const instant = result as import("@blazetrails/activesupport/temporal").Temporal.Instant;
+    expect(instant.toZonedDateTimeISO("UTC").hour).toBe(15);
+  });
+
+  it("empty-string slots get defaults", () => {
+    const type = new Types.DateTimeType();
+    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
+    // hour is empty string — should be treated as missing and filled with 0
+    const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" });
+    expect(result).not.toBeNull();
+    const instant = result as import("@blazetrails/activesupport/temporal").Temporal.Instant;
+    expect(instant.toZonedDateTimeISO("UTC").hour).toBe(0);
+  });
+
+  it("no defaults, only second-slot hash → null (Date-type year-zero guard)", () => {
+    const type = new Types.DateType();
+    const wrapper = new AcceptsMultiparameterTime(type);
+    // Only key "6" (second) present, no defaults → positional year slot gets value 0 → null guard fires.
+    const result = wrapper.cast({ "6": 0 });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -32,10 +32,10 @@ describe("AcceptsMultiparameterTime defaults", () => {
     expect(instant.toZonedDateTimeISO("UTC").hour).toBe(0);
   });
 
-  it("no defaults, only second-slot hash → null (Date-type year-zero guard)", () => {
+  it("no defaults, missing year/month/day keys → null (key-based guard)", () => {
     const type = new Types.DateType();
     const wrapper = new AcceptsMultiparameterTime(type);
-    // Only key "6" (second) present, no defaults → positional year slot gets value 0 → null guard fires.
+    // Only key "6" (second) present, no defaults → keys "1"/"2"/"3" absent → guard fires.
     const result = wrapper.cast({ "6": 0 });
     expect(result).toBeNull();
   });

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -70,15 +70,16 @@ export class AcceptsMultiparameterTime {
     }
 
     // Rails guard: return unless values_hash[1] && values_hash[2] && values_hash[3]
-    // Key-based check (not positional) after defaults are applied.
-    if (!filled["1"] || !filled["2"] || !filled["3"]) return null;
+    // Ruby 0 is truthy, so only nil/"" absence counts — use explicit nil/empty check.
+    const absent = (k: string) => filled[k] === undefined || filled[k] === null || filled[k] === "";
+    if (absent("1") || absent("2") || absent("3")) return null;
 
-    // Extract each slot by key — avoids positional errors with sparse hashes.
+    // Extract each slot by key. Rails uses to_i (non-numeric → 0); mirror that for NaN.
     const num = (key: string, fallback: number): number => {
       const v = filled[key];
       if (v === undefined || v === null || v === "") return fallback;
       const n = typeof v === "number" ? v : Number(v);
-      return Number.isNaN(n) ? fallback : n;
+      return Number.isNaN(n) ? 0 : n;
     };
 
     const year = num("1", 0);

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -14,9 +14,12 @@ import { Type } from "../value.js";
  */
 export class AcceptsMultiparameterTime {
   readonly type: Type;
+  /** @internal */
+  readonly defaults: Record<string, number>;
 
-  constructor(type: Type) {
+  constructor(type: Type, defaults: Record<string, number> = {}) {
     this.type = type;
+    this.defaults = defaults;
   }
 
   cast(value: unknown): unknown {
@@ -57,10 +60,18 @@ export class AcceptsMultiparameterTime {
   }
 
   private castFromMultiparameter(hash: Record<string, unknown>): unknown {
-    const parts = Object.keys(hash)
+    // Apply per-type defaults before the year/month/day guard — mirrors
+    // AcceptsMultiparameterTime#initialize's defaults.each { |k,v| values_hash[k] ||= v }.
+    const filled: Record<string, unknown> = { ...hash };
+    for (const [k, v] of Object.entries(this.defaults)) {
+      if (filled[k] === undefined || filled[k] === null || filled[k] === "") {
+        filled[k] = v;
+      }
+    }
+    const parts = Object.keys(filled)
       .sort((a, b) => Number(a) - Number(b))
       .map((k) => {
-        const v = hash[k];
+        const v = filled[k];
         if (v === undefined || v === null || v === "") return 0;
         return typeof v === "number" ? v : Number(v);
       });

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -68,18 +68,25 @@ export class AcceptsMultiparameterTime {
         filled[k] = v;
       }
     }
-    const parts = Object.keys(filled)
-      .sort((a, b) => Number(a) - Number(b))
-      .map((k) => {
-        const v = filled[k];
-        if (v === undefined || v === null || v === "") return 0;
-        return typeof v === "number" ? v : Number(v);
-      });
 
-    if (parts.some((p) => Number.isNaN(p))) return null;
+    // Rails guard: return unless values_hash[1] && values_hash[2] && values_hash[3]
+    // Key-based check (not positional) after defaults are applied.
+    if (!filled["1"] || !filled["2"] || !filled["3"]) return null;
 
-    const [year = 0, month = 1, day = 1, hour = 0, minute = 0, second = 0] = parts;
-    if (year === 0 && month <= 1 && day <= 1) return null;
+    // Extract each slot by key — avoids positional errors with sparse hashes.
+    const num = (key: string, fallback: number): number => {
+      const v = filled[key];
+      if (v === undefined || v === null || v === "") return fallback;
+      const n = typeof v === "number" ? v : Number(v);
+      return Number.isNaN(n) ? fallback : n;
+    };
+
+    const year = num("1", 0);
+    const month = num("2", 1);
+    const day = num("3", 1);
+    const hour = num("4", 0);
+    const minute = num("5", 0);
+    const second = num("6", 0);
 
     try {
       // Decompose fractional seconds into the three Temporal sub-second

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -138,7 +138,13 @@ describe("TimeTest", () => {
   });
 
   it("valueFromMultiparameterAssignment: full hash with year/month/day/hour still works", () => {
-    const result = (type as any).valueFromMultiparameterAssignment({ "1": 2025, "2": 6, "3": 15, "4": 10, "5": 20 });
+    const result = (type as any).valueFromMultiparameterAssignment({
+      "1": 2025,
+      "2": 6,
+      "3": 15,
+      "4": 10,
+      "5": 20,
+    });
     expect(result).toBeInstanceOf(Temporal.PlainTime);
     expect((result as Temporal.PlainTime).hour).toBe(10);
   });

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -121,4 +121,25 @@ describe("TimeTest", () => {
     expect(result).toBeInstanceOf(Temporal.PlainTime);
     expect((result as Temporal.PlainTime).hour).toBe(19);
   });
+
+  it("valueFromMultiparameterAssignment: hour-only hash returns Time on 2000-01-01 base (P21)", () => {
+    // Regression: was null before P21 because year defaulted to 0 and hit the short-circuit.
+    const result = (type as any).valueFromMultiparameterAssignment({ "4": 15 });
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(15);
+    expect((result as Temporal.PlainTime).minute).toBe(0);
+  });
+
+  it("valueFromMultiparameterAssignment: hour and minute hash returns Time", () => {
+    const result = (type as any).valueFromMultiparameterAssignment({ "4": 15, "5": 30 });
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(15);
+    expect((result as Temporal.PlainTime).minute).toBe(30);
+  });
+
+  it("valueFromMultiparameterAssignment: full hash with year/month/day/hour still works", () => {
+    const result = (type as any).valueFromMultiparameterAssignment({ "1": 2025, "2": 6, "3": 15, "4": 10, "5": 20 });
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(10);
+  });
 });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,5 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
+import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import { ValueType } from "./value.js";
 
 export class TimeType extends ValueType<Temporal.PlainTime> {
@@ -54,6 +55,24 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
 
   type(): string {
     return this.name;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Time includes AcceptsMultiparameterTime.new(defaults: { 1 => 2000, 2 => 1, 3 => 1, 4 => 0, 5 => 0 }).
+   * Rails' base date 2000-01-01 lets hour-only form inputs (e.g. { "4": 15 }) produce a valid Time.
+   *
+   * @internal Rails-private helper.
+   */
+  protected valueFromMultiparameterAssignment(
+    values: Record<string, unknown>,
+  ): Temporal.PlainTime | null {
+    return new AcceptsMultiparameterTime(this, {
+      "1": 2000,
+      "2": 1,
+      "3": 1,
+      "4": 0,
+      "5": 0,
+    }).cast(values) as Temporal.PlainTime | null;
   }
 
   userInputInTimeZone(value: unknown, zone: string = "UTC"): Temporal.ZonedDateTime | null {

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Model } from "../index.js";
+import { prepareValueForValidation } from "./numericality.js";
 
 describe("NumericalityValidationTest", () => {
   it("validates numericality with greater than or equal using string value", () => {
@@ -746,5 +747,106 @@ describe("numericality with in: range", () => {
     const f = new Person({ score: "5.5" });
     expect(f.isValid()).toBe(false);
     expect(f.errors.get("score")).toContain("must be an integer");
+  });
+
+  it("odd/even truncates float via Math.trunc before checking parity (2.5 → 2, even)", () => {
+    // Rails: value.to_i.even? — truncates toward zero, so 2.5.to_i == 2
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { even: true } });
+      }
+    }
+    expect(new Person({ score: 2.5 }).isValid()).toBe(true); // trunc(2.5)=2, even
+    expect(new Person({ score: 3.5 }).isValid()).toBe(false); // trunc(3.5)=3, odd
+  });
+
+  it("odd/even truncates negative float via Math.trunc (-2.5 → -2, even)", () => {
+    // Ruby: -2.5.to_i == -2 (toward zero), not -3 (Math.floor would give wrong answer)
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { odd: true } });
+      }
+    }
+    expect(new Person({ score: -3.5 }).isValid()).toBe(true); // trunc(-3.5)=-3, odd
+    expect(new Person({ score: -2.5 }).isValid()).toBe(false); // trunc(-2.5)=-2, even
+  });
+
+  it("odd/even truncation: 2.9 is even (truncates to 2, not rounds to 3)", () => {
+    class Person extends Model {
+      static {
+        this.attribute("score", "float");
+        this.validates("score", { numericality: { even: true } });
+      }
+    }
+    expect(new Person({ score: 2.9 }).isValid()).toBe(true); // trunc(2.9)=2, even
+    expect(new Person({ score: 3.9 }).isValid()).toBe(false); // trunc(3.9)=3, odd
+  });
+
+  it("cameFromUser absent (AM Model) → falls back to readAttributeBeforeTypeCast, catches raw string", () => {
+    // AM's Model has no cameFromUser — prepareValueForValidation degrades to
+    // the readAttributeBeforeTypeCast path and still catches bad raw input.
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.validates("age", { numericality: true });
+      }
+    }
+    const p = new Person({ age: "abc" });
+    // AM Model does not expose cameFromUser
+    expect(typeof (p as any).cameFromUser).toBe("undefined");
+    // Validator sees "abc" (raw via readAttributeBeforeTypeCast), reports not_a_number
+    expect(p.isValid()).toBe(false);
+    expect(p.errors.get("age")).toContain("is not a number");
+  });
+
+  it("cameFromUser false → validates cast value (readAttribute)", () => {
+    // Mock: cameFromUser returns false, but cast value (readAttribute) is
+    // a valid number — validation should pass.
+    class MockRecord {
+      errors = { add: vi.fn() };
+      cameFromUser(_name: string) {
+        return false;
+      }
+      readAttribute(_name: string) {
+        return 42;
+      }
+      readAttributeBeforeTypeCast(_name: string) {
+        return "not-a-number-string";
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "initial", rec as any, "score");
+    // Should return the cast value (42), not the raw string
+    expect(result).toBe(42);
+  });
+
+  it("cameFromUser absent → falls back to readAttributeBeforeTypeCast", () => {
+    // Non-AR hosts that don't implement cameFromUser degrade gracefully.
+    class MockRecord {
+      errors = { add: vi.fn() };
+      readAttributeBeforeTypeCast(_name: string) {
+        return "raw-value";
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "fallback", rec as any, "score");
+    expect(result).toBe("raw-value");
+  });
+
+  it("cameFromUser false + no readAttributeBeforeTypeCast → readAttribute fallback", () => {
+    class MockRecord {
+      errors = { add: vi.fn() };
+      cameFromUser(_name: string) {
+        return false;
+      }
+      readAttribute(_name: string) {
+        return 99;
+      }
+    }
+    const rec = new MockRecord();
+    const result = prepareValueForValidation.call(undefined, "initial", rec as any, "score");
+    expect(result).toBe(99);
   });
 });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -203,10 +203,10 @@ export class NumericalityValidator extends EachValidator {
         record.errors.add(attribute, "in", withCount(`${min}..${max}`));
       }
     }
-    if (this.options.odd && num % 2 === 0) {
+    if (this.options.odd && Math.trunc(num) % 2 === 0) {
       record.errors.add(attribute, "odd", this.filteredOptions(value));
     }
-    if (this.options.even && num % 2 !== 0) {
+    if (this.options.even && Math.trunc(num) % 2 !== 0) {
       record.errors.add(attribute, "even", this.filteredOptions(value));
     }
   }
@@ -500,6 +500,7 @@ export function isAllowOnlyInteger(
 
 interface RecordWithRawAttribute {
   attributeChangedInPlace?: (name: string) => boolean;
+  cameFromUser?: (name: string) => boolean;
   readAttribute?: (name: string) => unknown;
   readAttributeBeforeTypeCast?: (name: string) => unknown;
   [key: string]: unknown;
@@ -557,10 +558,22 @@ export function prepareValueForValidation(
   // Duck-type the lookup so other hosts implementing the same shape
   // (or AR Base subclasses) work too.
   const r = record as RecordWithRawAttribute;
-  const rawValue =
-    typeof r.readAttributeBeforeTypeCast === "function"
-      ? r.readAttributeBeforeTypeCast(attrName)
-      : undefined;
+  let rawValue: unknown;
+  if (typeof r.cameFromUser === "function") {
+    if (r.cameFromUser(attrName)) {
+      rawValue =
+        typeof r.readAttributeBeforeTypeCast === "function"
+          ? r.readAttributeBeforeTypeCast(attrName)
+          : undefined;
+    } else if (typeof r.readAttribute === "function") {
+      rawValue = r.readAttribute(attrName);
+    }
+  } else {
+    rawValue =
+      typeof r.readAttributeBeforeTypeCast === "function"
+        ? r.readAttributeBeforeTypeCast(attrName)
+        : undefined;
+  }
   // Rails: raw_value || value — Ruby `||` falls back on nil/false. Use
   // the same semantic so `false`/`null` raw values fall through to
   // the cast value rather than being treated as "I read the raw".

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1194,8 +1194,9 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const t = Topic.new({ title: "user-set" }) as any;
-    // newly set attributes come from user
-    expect(t.title).toBe("user-set");
+    expect(t.cameFromUser("title")).toBe(true);
+    t._attributes.writeFromDatabase("title", "db-loaded");
+    expect(t.cameFromUser("title")).toBe(false);
   });
 
   it("accessed_fields", async () => {

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -80,6 +80,7 @@ interface AttributeOwner {
       cameFromUser(): boolean;
     };
   };
+  constructor: { _attributeAliases?: Record<string, string> };
 }
 
 /** @internal */
@@ -94,5 +95,6 @@ function attributeForDatabase(this: AttributeOwner, attrName: string): unknown {
 
 /** @internal */
 export function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
-  return this._attributes.getAttribute(attrName).cameFromUser();
+  const name = this.constructor._attributeAliases?.[attrName] ?? attrName;
+  return this._attributes.getAttribute(name).cameFromUser();
 }

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -93,6 +93,6 @@ function attributeForDatabase(this: AttributeOwner, attrName: string): unknown {
 }
 
 /** @internal */
-function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
+export function isAttributeCameFromUser(this: AttributeOwner, attrName: string): boolean {
   return this._attributes.getAttribute(attrName).cameFromUser();
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -110,6 +110,7 @@ import {
 } from "./attribute-methods.js";
 import { toKey as _toKey } from "./attribute-methods/primary-key.js";
 import { _readAttribute as _readAttributeFn } from "./attribute-methods/read.js";
+import { isAttributeCameFromUser as _isAttributeCameFromUser } from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
   _queryAttribute as _queryAttributeFn,
@@ -2732,6 +2733,8 @@ export class Base extends Model {
   /** @internal */
   declare _readAttribute: (name: string) => unknown;
   declare _writeAttribute: (name: string, value: unknown) => void;
+  /** @internal */
+  declare cameFromUser: (name: string) => boolean;
 
   get attributeNamesList(): string[] {
     return _attributeNamesList.call(this as any);
@@ -3091,6 +3094,7 @@ include(Base, {
   _queryAttribute: _queryAttributeFn,
   _readAttribute: _readAttributeFn,
   _writeAttribute: ReadonlyAttributes._writeAttribute,
+  cameFromUser: _isAttributeCameFromUser,
   // PrimaryKey
   toKey: _toKey,
 });

--- a/packages/activerecord/src/validations.test.ts
+++ b/packages/activerecord/src/validations.test.ts
@@ -140,6 +140,40 @@ describe("ValidationsTest", () => {
     expect(t.score).toBe(5);
   });
 
+  it("numericality validates cast value when record loaded from database (cameFromUser false)", async () => {
+    // When an AR record is loaded via writeFromDatabase, cameFromUser returns
+    // false and the validator uses readAttribute (cast value), not the raw
+    // string column. A numeric column loaded as the integer 42 must pass.
+    class Item extends Base {
+      static {
+        this.attribute("price", "integer");
+        this.validates("price", { numericality: { greaterThan: 0 } });
+        this.adapter = adapter;
+      }
+    }
+    const item = Item.new({}) as any;
+    item._attributes.writeFromDatabase("price", 42);
+    expect(item.cameFromUser("price")).toBe(false);
+    expect(await item.isValid()).toBe(true);
+  });
+
+  it("numericality validates raw input when attribute came from user (cameFromUser true)", async () => {
+    // User-assigned string "abc" on an integer column casts to null but the
+    // validator must see the raw "abc" via readAttributeBeforeTypeCast and
+    // reject it — not silently pass because the cast value is null.
+    class Item extends Base {
+      static {
+        this.attribute("price", "integer");
+        this.validates("price", { numericality: true });
+        this.adapter = adapter;
+      }
+    }
+    const item = Item.new({ price: "abc" }) as any;
+    expect(item.cameFromUser("price")).toBe(true);
+    expect(await item.isValid()).toBe(false);
+    expect(item.errors.get("price")).toContain("is not a number");
+  });
+
   it("numericality validator wont be affected by custom getter", async () => {
     const { Topic } = makeModel();
     const t = new Topic({ title: "getter", score: 10 });


### PR DESCRIPTION
## Summary

- Adds `defaults: Record<string, number>` parameter to `AcceptsMultiparameterTime` constructor, mirroring Rails' `AcceptsMultiparameterTime.new(defaults: {...})` factory pattern
- `DateTimeType` wires `{ "4": 0, "5": 0 }` — hour/minute default to 0 when only date parts are provided
- `TimeType` adds `valueFromMultiparameterAssignment` wired with `{ "1": 2000, "2": 1, "3": 1, "4": 0, "5": 0 }` — hour-only form inputs (e.g. `{ "4": 15 }`) now produce `PlainTime(15:00)` instead of `null`

**User-visible fix:** bare time inputs from HTML forms (e.g. `<input type="time">` submitting `{ "4": 15 }`) previously hit the year-zero short-circuit in `castFromMultiparameter` and silently returned `null`. After P21, `TimeType` defaults year/month/day to the Rails base date `2000-01-01`, satisfying the guard and producing a valid `PlainTime` value.

Refs: docs/activemodel-alignment.md P21 · docs/activemodel/audit-types.md §16 (#42)

## Test plan

- [ ] `pnpm vitest run packages/activemodel/src/type` — 243 tests pass
- [ ] New `accepts-multiparameter-time-defaults.test.ts` — 4 tests covering defaults fill, user override, empty-string slot, and year-zero guard
- [ ] `TimeType.valueFromMultiparameterAssignment` tests: hour-only → PlainTime(15:00), hour+minute → PlainTime(15:30), full hash regression
- [ ] `DateTimeType.valueFromMultiparameterAssignment` test: date-only hash defaults hour/minute to 0
- [ ] `DateType` regression guards: missing day → null, full date parts → PlainDate
- [ ] `pnpm api:compare --package activemodel` → 624/625 (no regression)
- [ ] `pnpm run lint` — no errors
- [ ] `pnpm run typecheck` — clean
- [ ] `pnpm format:check` — clean