### PR TITLE
fix(activemodel): StringType.isChangedInPlace returns false for non-string newValue (P18)

### DIFF
--- a/packages/activemodel/src/type/string.test.ts
+++ b/packages/activemodel/src/type/string.test.ts
@@ -35,4 +35,43 @@ describe("StringTest", () => {
     expect(type.toImmutableString().cast(true)).toBe("aye");
     expect(type.toImmutableString().cast(false)).toBe("nay");
   });
+
+  describe("isChangedInPlace", () => {
+    it("non-string new value returns false", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace("42", 42)).toBe(false);
+      expect(type.isChangedInPlace("hello", null)).toBe(false);
+      expect(type.isChangedInPlace("", true)).toBe(false);
+    });
+
+    it("same string returns false", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace("hello", "hello")).toBe(false);
+    });
+
+    it("different string returns true", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace("hello", "world")).toBe(true);
+    });
+
+    it("null rawOldValue with string newValue returns true", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace(null, "hello")).toBe(true);
+    });
+
+    it("undefined rawOldValue with string newValue returns true", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace(undefined, "hello")).toBe(true);
+    });
+
+    it("null rawOldValue with non-string newValue returns false", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace(null, 42)).toBe(false);
+    });
+
+    it("empty string newValue is still a string", () => {
+      const type = new Types.StringType();
+      expect(type.isChangedInPlace("hello", "")).toBe(true);
+    });
+  });
 });

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -21,9 +21,9 @@ export class StringType extends ImmutableStringType {
   }
 
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
-    if (rawOldValue === null || rawOldValue === undefined)
-      return newValue !== null && newValue !== undefined;
-    return String(rawOldValue) !== String(newValue);
+    if (typeof newValue !== "string") return false;
+    if (rawOldValue === null || rawOldValue === undefined) return true;
+    return rawOldValue !== newValue;
   }
 
   toImmutableString(): ImmutableStringType {


### PR DESCRIPTION
## Summary

- Fixes `StringType#isChangedInPlace` to match Rails `string.rb:16-20` exactly: when `newValue` is not a string, returns `false` (Rails returns `nil`, which is falsey — not changed in place)
- Removes the `String()` coercion that caused spurious dirty saves (e.g. assigning `42` to an attribute already holding `"42"` was incorrectly reported as an in-place change)
- Adds 7 unit tests covering the non-string guard, same/different string, null/undefined rawOldValue, and the defensive null+non-string case

Implements P18 from `docs/activemodel-alignment.md`; addresses audit finding #35 from `docs/activemodel/audit-types.md` §3.

**Effect:** eliminates spurious dirty saves on string attributes when the user assigns a non-string value that would normally cast to the same string. The next normal cast + `isChanged` cycle handles real semantic changes.

## Test plan

- [ ] `pnpm --filter @blazetrails/activemodel test` — 1805 passed
- [ ] `pnpm --filter @blazetrails/activerecord test` — 10038 passed
- [ ] `pnpm api:compare --package activemodel` — 624/625 (delta 0)
- [ ] `pnpm format:check` — clean
- [ ] `pnpm typecheck` — clean