### PR TITLE
docs(claude): do not reply to Copilot PR comments with text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             # full matrix.
             if [ -z "$files" ]; then
               echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            elif echo "$files" | grep -qvE '^docs/|^README\.md$'; then
+            elif echo "$files" | grep -qvE '^docs/|^README\.md$|^CLAUDE\.md$'; then
               echo "docs_only=false" >> "$GITHUB_OUTPUT"
             else
               echo "docs_only=true" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,9 @@ When NOT to use this:
   notifications (Copilot reviews, CI failures) are delivered to this pane.
   Copilot auto-reviews every PR and push; reviews land at
   `~/.btwhooks/data/github/blazetrailsdev/trails/$PR` — no need to request.
-- Do NOT reply to Copilot PR comments with text. Address feedback via code
-  changes or PR description edits, or discuss in session. Text replies are
-  invisible to Copilot and waste a review cycle.
+- Do NOT reply to Copilot PR comments with text — replies are invisible to
+  Copilot. Address feedback via code changes or PR description edits instead,
+  or discuss in session.
 - Do NOT add code comments that just describe what a line does. Only add
   comments for non-obvious context (hidden bug, broader invariant, etc.).
 - Do NOT add empty stubs or placeholder interfaces. If a feature isn't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ When NOT to use this:
   `~/.btwhooks/data/github/blazetrailsdev/trails/$PR` — no need to request.
 - Do NOT reply to Copilot PR comments with text — replies are invisible to
   Copilot. Address feedback via code changes or PR description edits instead,
-  or discuss in session.
+  or discuss with the user in conversation.
 - Do NOT add code comments that just describe what a line does. Only add
   comments for non-obvious context (hidden bug, broader invariant, etc.).
 - Do NOT add empty stubs or placeholder interfaces. If a feature isn't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,9 @@ When NOT to use this:
   notifications (Copilot reviews, CI failures) are delivered to this pane.
   Copilot auto-reviews every PR and push; reviews land at
   `~/.btwhooks/data/github/blazetrailsdev/trails/$PR` — no need to request.
+- Do NOT reply to Copilot PR comments with text. Address feedback via code
+  changes or PR description edits, or discuss in session. Text replies are
+  invisible to Copilot and waste a review cycle.
 - Do NOT add code comments that just describe what a line does. Only add
   comments for non-obvious context (hidden bug, broader invariant, etc.).
 - Do NOT add empty stubs or placeholder interfaces. If a feature isn't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ When NOT to use this:
   PR body.
 - Do NOT use subagents unless explicitly requested.
 - Do use worktrees for any changes; leave the default worktree for the user.
+  Always use `scripts/start-worktree.sh` to start a worktree.
 - Open new PRs in **draft** status.
 - After opening a PR, run the `/link` skill with the PR number so webhook
   notifications (Copilot reviews, CI failures) are delivered to this pane.


### PR DESCRIPTION
## Summary

- Adds guidance to CLAUDE.md: do not reply to Copilot review comments with text. Address feedback via code changes or PR description edits, or discuss in session. Text replies are invisible to Copilot and waste a review cycle.