### PR TITLE
fix(activemodel): lint parity — toKey/toParam unpersisted + modelName delegation (P22)

### DIFF
--- a/packages/activemodel/src/lint.test.ts
+++ b/packages/activemodel/src/lint.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { testErrorsAref, testModelNaming, testToKey, testToParam } from "./lint.js";
+
+type KeyFixture = {
+  isPersisted(): boolean;
+  toKey(): unknown[] | null;
+};
+
+function buildKeyFixture(): KeyFixture {
+  const fixture: KeyFixture = {
+    isPersisted() {
+      return true;
+    },
+    toKey(this: KeyFixture) {
+      return this.isPersisted() ? [1] : null;
+    },
+  };
+  return fixture;
+}
+
+describe("Lint::Tests", () => {
+  describe("testToKey", () => {
+    it("passes when persisted returns key and unpersisted returns null", () => {
+      expect(() => testToKey(buildKeyFixture())).not.toThrow();
+    });
+
+    it("throws when toKey returns non-null while unpersisted", () => {
+      const broken: KeyFixture = {
+        isPersisted: () => true,
+        toKey: () => [1],
+      };
+      expect(() => testToKey(broken)).toThrow(/null when `isPersisted` returns false/);
+    });
+
+    it("restores isPersisted after running", () => {
+      const fixture = buildKeyFixture();
+      const before = fixture.isPersisted;
+      testToKey(fixture);
+      expect(fixture.isPersisted).toBe(before);
+      expect(fixture.isPersisted()).toBe(true);
+    });
+  });
+
+  describe("testToParam", () => {
+    it("passes when toParam returns null in unpersisted branch", () => {
+      type ParamFixture = {
+        isPersisted(): boolean;
+        toKey(): unknown[] | null;
+        toParam(): string | null;
+      };
+      const fixture: ParamFixture = {
+        isPersisted() {
+          return true;
+        },
+        toKey(this: ParamFixture) {
+          return this.isPersisted() ? [1] : null;
+        },
+        toParam(this: ParamFixture) {
+          if (!this.isPersisted()) return null;
+          const key = this.toKey();
+          return key === null ? null : String(key[0]);
+        },
+      };
+      expect(() => testToParam(fixture)).not.toThrow();
+      expect(fixture.isPersisted()).toBe(true);
+    });
+
+    it("throws when toParam is non-null while unpersisted", () => {
+      const broken = {
+        isPersisted: () => true,
+        toKey: () => [1] as unknown[],
+        toParam: () => "1",
+      };
+      expect(() => testToParam(broken)).toThrow(/null when `isPersisted` returns false/);
+    });
+  });
+
+  describe("testModelNaming", () => {
+    const goodName = { human: "Foo", singular: "foo", plural: "foos" };
+
+    it("passes when instance.modelName === constructor.modelName", () => {
+      const fixture = { modelName: goodName, constructor: { modelName: goodName } };
+      expect(() => testModelNaming(fixture)).not.toThrow();
+    });
+
+    it("throws when instance.modelName diverges from constructor.modelName", () => {
+      const fixture = {
+        modelName: { ...goodName },
+        constructor: { modelName: goodName },
+      };
+      expect(() => testModelNaming(fixture)).toThrow(
+        /modelName must equal model\.constructor\.modelName/,
+      );
+    });
+  });
+
+  describe("testErrorsAref", () => {
+    it("passes when errors.get returns an array", () => {
+      expect(() => testErrorsAref({ errors: { get: () => [] } })).not.toThrow();
+    });
+
+    it("throws when errors.get returns a non-array", () => {
+      const broken = { errors: { get: () => "nope" as unknown as string[] } };
+      expect(() => testErrorsAref(broken)).toThrow(/must return an array/);
+    });
+  });
+});

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -112,7 +112,7 @@ export namespace Tests {
   }
 
   type ModelNamingHost = {
-    modelName?: { human: string; singular: string; plural: string };
+    modelName: { human: string; singular: string; plural: string };
     constructor: { modelName?: { human: string; singular: string; plural: string } };
   };
   export function testModelNaming(model: ModelNamingHost): void {

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -54,15 +54,38 @@ export namespace Tests {
     if (persisted && key === null) {
       throw new Error("toKey must not return null when the model is persisted");
     }
+
+    withPatchedPersistedFalse(m, () => {
+      if (m.toKey() !== null) {
+        throw new Error("toKey should return null when `isPersisted` returns false");
+      }
+    });
   }
 
-  type ToParamHost = { toParam(): string | null; toKey(): unknown[] | null };
+  type ToParamHost = {
+    toParam(): string | null;
+    toKey(): unknown[] | null;
+    isPersisted(): boolean;
+  };
   export function testToParam(input: ToParamHost | { toModel(): ToParamHost }): void {
     const m = model(input);
     const param = m.toParam();
     if (param !== null && typeof param !== "string") {
       throw new Error("toParam must return null or a string");
     }
+
+    withPatched(
+      m,
+      "toKey",
+      () => [1],
+      () => {
+        withPatchedPersistedFalse(m, () => {
+          if (m.toParam() !== null) {
+            throw new Error("toParam should return null when `isPersisted` returns false");
+          }
+        });
+      },
+    );
   }
 
   type ToPartialPathHost = { toPartialPath(): string };
@@ -88,30 +111,74 @@ export namespace Tests {
     }
   }
 
-  export function testModelNaming(model: {
+  type ModelNamingHost = {
+    modelName?: { human: string; singular: string; plural: string };
     constructor: { modelName?: { human: string; singular: string; plural: string } };
-  }): void {
-    const modelName = model.constructor.modelName;
-    if (!modelName) {
+  };
+  export function testModelNaming(model: ModelNamingHost): void {
+    const classModelName = model.constructor.modelName;
+    if (!classModelName) {
       throw new Error("model.constructor.modelName must be defined");
     }
-    if (typeof modelName.human !== "string") {
+    if (typeof classModelName.human !== "string") {
       throw new Error("modelName.human must return a string");
     }
-    if (typeof modelName.singular !== "string") {
+    if (typeof classModelName.singular !== "string") {
       throw new Error("modelName.singular must return a string");
     }
-    if (typeof modelName.plural !== "string") {
+    if (typeof classModelName.plural !== "string") {
       throw new Error("modelName.plural must return a string");
+    }
+    if (model.modelName !== classModelName) {
+      throw new Error("model.modelName must equal model.constructor.modelName");
     }
   }
 
+  /**
+   * Trails uses `errors.get(name)` rather than Ruby's `errors[:name]`
+   * array-access syntax. Behavior matches Rails: must return an array
+   * (empty when no errors are present for the attribute).
+   */
   export function testErrorsAref(model: { errors: { get(attribute: string): string[] } }): void {
     const result = model.errors.get("attribute");
     if (!Array.isArray(result)) {
       throw new Error("errors.get(attribute) must return an array");
     }
   }
+}
+
+/**
+ * Temporarily replace a method on `target` with `fn` for the duration of `body`.
+ * Restores the original property descriptor in a `finally`.
+ *
+ * @internal Rails-private helper — mirrors `def model.foo() ... end` patches in lint.rb.
+ */
+function withPatched<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  fn: T[K],
+  body: () => void,
+): void {
+  const original = Object.getOwnPropertyDescriptor(target, key);
+  Object.defineProperty(target, key, {
+    value: fn,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    body();
+  } finally {
+    if (original) {
+      Object.defineProperty(target, key, original);
+    } else {
+      delete (target as Record<PropertyKey, unknown>)[key as PropertyKey];
+    }
+  }
+}
+
+/** @internal Rails-private helper. */
+function withPatchedPersistedFalse(target: { isPersisted(): boolean }, body: () => void): void {
+  withPatched(target, "isPersisted", () => false, body);
 }
 
 export const {


### PR DESCRIPTION
## Summary

- `testToKey`: asserts `toKey()` returns `null` when `isPersisted()` is `false` (mirrors Rails lint.rb patch pattern)
- `testToParam`: same — patches `toKey` to return `[1]` then patches `isPersisted→false`, asserts `toParam()` is `null`
- `testModelNaming`: asserts `model.modelName === model.constructor.modelName` (instance delegates to class)
- `testErrorsAref`: kept as-is with a JSDoc note explaining `.get()` vs Ruby's `[]` syntax
- Adds `withPatched` / `withPatchedPersistedFalse` private helpers that swap methods for the duration of an assertion and restore in `finally`
- New `lint.test.ts`: 9 tests covering the happy path and each failure branch

## Test plan

- [x] `pnpm test` passes (9/9 lint tests green)
- [x] `tsc --build` clean
- [x] 185 LOC additions — under 300 ceiling