### PR TITLE
fix(activemodel): Length :in range object + RESERVED_OPTIONS strip (P17)

### DIFF
--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -2260,6 +2260,17 @@ describe("validates_*_of shorthand methods", () => {
     expect(new User({ name: "ABC" }).isValid()).toBe(true);
   });
 
+  it("validatesSizeOf is an alias for validatesLengthOf", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validatesSizeOf("name", { minimum: 3 });
+      }
+    }
+    expect(new User({ name: "AB" }).isValid()).toBe(false);
+    expect(new User({ name: "ABC" }).isValid()).toBe(true);
+  });
+
   it("validatesNumericalityOf validates numericality", () => {
     class Item extends Model {
       static {

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -18,6 +18,7 @@ export interface HelperMethods {
   validatesFormatOf(attribute: string, options: Record<string, unknown>): void;
   validatesInclusionOf(attribute: string, options: Record<string, unknown>): void;
   validatesLengthOf(attribute: string, options: Record<string, unknown>): void;
+  validatesSizeOf(attribute: string, options: Record<string, unknown>): void;
   validatesNumericalityOf(attribute: string, options?: Record<string, unknown> | boolean): void;
   validatesPresenceOf(...attributes: string[]): void;
 }

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -597,6 +597,18 @@ describe("LengthValidationTest", () => {
     expect(new Person({ title: "a" }).isValid()).toBe(true);
   });
 
+  it("throws at definition time when :in is not a tuple or range object", () => {
+    expect(() => {
+      class Person extends Model {
+        static {
+          this.attribute("title", "string");
+          this.validates("title", { length: { in: "3..10" as unknown as [number, number] } });
+        }
+      }
+      return Person;
+    }).toThrow(/must be a \[min, max\] tuple/);
+  });
+
   it("throws at definition time when constraint is a non-integer", () => {
     expect(() => {
       class Person extends Model {

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -517,6 +517,19 @@ describe("LengthValidationTest", () => {
     expect(new Person({ title: "abcdefghijk" }).isValid()).toBe(false);
   });
 
+  it("accepts :within as a range object { begin, end }", () => {
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { within: { begin: 3, end: 10 } } });
+      }
+    }
+    expect(new Person({ title: "ab" }).isValid()).toBe(false);
+    expect(new Person({ title: "abc" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcdefghij" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcdefghijk" }).isValid()).toBe(false);
+  });
+
   it("accepts :in as a range object with excludeEnd", () => {
     class Person extends Model {
       static {

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -543,7 +543,7 @@ describe("LengthValidationTest", () => {
     expect(new Person({ title: "abcde" }).isValid()).toBe(false);
   });
 
-  it("does not leak reserved keys into errors.add options", () => {
+  it("does not leak reserved keys into errors.add options (minimum/maximum path)", () => {
     class Person extends Model {
       static {
         this.attribute("title", "string");
@@ -551,6 +551,28 @@ describe("LengthValidationTest", () => {
       }
     }
     const p = new Person({ title: "ab" });
+    p.isValid();
+    const err = p.errors.objects[0];
+    expect(err).toBeDefined();
+    expect(err.options).not.toHaveProperty("minimum");
+    expect(err.options).not.toHaveProperty("maximum");
+    expect(err.options).not.toHaveProperty("tooShort");
+    expect(err.options).not.toHaveProperty("tooLong");
+    expect(err.options).not.toHaveProperty("within");
+    expect(err.options).not.toHaveProperty("is");
+    expect(err.options).toHaveProperty("count");
+  });
+
+  it("does not leak reserved keys into errors.add options (is path)", () => {
+    // Rails RESERVED_OPTIONS omits :wrong_length intentionally, so wrongLength
+    // does appear in error options — matching length.rb:13 behaviour.
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { is: 5, wrongLength: "bad length!" } });
+      }
+    }
+    const p = new Person({ title: "abc" });
     p.isValid();
     const err = p.errors.objects[0];
     expect(err).toBeDefined();

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -622,16 +622,6 @@ describe("LengthValidationTest", () => {
     }).toThrow(/minimum must be a non-negative Integer/);
   });
 
-  it("accepts Infinity as a valid maximum constraint", () => {
-    class Person extends Model {
-      static {
-        this.attribute("title", "string");
-        this.validates("title", { length: { minimum: 1, maximum: Infinity } });
-      }
-    }
-    expect(new Person({ title: "x".repeat(10000) }).isValid()).toBe(true);
-  });
-
   it("validates length of with symbol method name", () => {
     // Rails: a Symbol resolves via record.send(:method_name). In TS a
     // string option that names a method on the record is resolved the

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -585,6 +585,18 @@ describe("LengthValidationTest", () => {
     expect(err.options).toHaveProperty("count");
   });
 
+  it("allowBlank: false with only maximum forces minimum of 1", () => {
+    // Mirrors length.rb:22-24: if allow_blank == false && minimum.nil? && is.nil? → minimum = 1
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { maximum: 10, allowBlank: false } });
+      }
+    }
+    expect(new Person({ title: "" }).isValid()).toBe(false);
+    expect(new Person({ title: "a" }).isValid()).toBe(true);
+  });
+
   it("throws at definition time when constraint is a non-integer", () => {
     expect(() => {
       class Person extends Model {

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -504,6 +504,87 @@ describe("LengthValidationTest", () => {
     expect(new Person({ title: "abcdef", limit: 5 }).isValid()).toBe(false);
   });
 
+  it("accepts :in as a range object { begin, end }", () => {
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { in: { begin: 3, end: 10 } } });
+      }
+    }
+    expect(new Person({ title: "ab" }).isValid()).toBe(false);
+    expect(new Person({ title: "abc" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcdefghij" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcdefghijk" }).isValid()).toBe(false);
+  });
+
+  it("accepts :in as a range object with excludeEnd", () => {
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        // { begin: 3, end: 5, excludeEnd: true } → minimum: 3, maximum: 4
+        this.validates("title", { length: { in: { begin: 3, end: 5, excludeEnd: true } } });
+      }
+    }
+    expect(new Person({ title: "abc" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcd" }).isValid()).toBe(true);
+    expect(new Person({ title: "abcde" }).isValid()).toBe(false);
+  });
+
+  it("does not leak reserved keys into errors.add options", () => {
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { in: [3, 5] } });
+      }
+    }
+    const p = new Person({ title: "ab" });
+    p.isValid();
+    const err = p.errors.objects[0];
+    expect(err).toBeDefined();
+    expect(err.options).not.toHaveProperty("minimum");
+    expect(err.options).not.toHaveProperty("maximum");
+    expect(err.options).not.toHaveProperty("tooShort");
+    expect(err.options).not.toHaveProperty("tooLong");
+    expect(err.options).not.toHaveProperty("within");
+    expect(err.options).not.toHaveProperty("is");
+    expect(err.options).toHaveProperty("count");
+  });
+
+  it("throws at definition time when constraint is a non-integer", () => {
+    expect(() => {
+      class Person extends Model {
+        static {
+          this.attribute("title", "string");
+          this.validates("title", { length: { minimum: 2.5 } });
+        }
+      }
+      // reference to suppress unused-class lint
+      return Person;
+    }).toThrow(/minimum must be a non-negative Integer/);
+  });
+
+  it("throws at definition time when constraint is negative", () => {
+    expect(() => {
+      class Person extends Model {
+        static {
+          this.attribute("title", "string");
+          this.validates("title", { length: { minimum: -1 } });
+        }
+      }
+      return Person;
+    }).toThrow(/minimum must be a non-negative Integer/);
+  });
+
+  it("accepts Infinity as a valid maximum constraint", () => {
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { minimum: 1, maximum: Infinity } });
+      }
+    }
+    expect(new Person({ title: "x".repeat(10000) }).isValid()).toBe(true);
+  });
+
   it("validates length of with symbol method name", () => {
     // Rails: a Symbol resolves via record.send(:method_name). In TS a
     // string option that names a method on the record is resolved the

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -149,7 +149,7 @@ export class LengthValidator extends EachValidator {
       if (!valueIsNil || this.skipNilCheck("minimum")) {
         const opts = { ...baseOptions, count: min } as Record<string, unknown>;
         const defaultMsg = this.options.tooShort ?? this.options.message;
-        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
         record.errors.add(attribute, "too_short", opts);
       }
     }
@@ -157,7 +157,7 @@ export class LengthValidator extends EachValidator {
       if (!valueIsNil || this.skipNilCheck("maximum")) {
         const opts = { ...baseOptions, count: max } as Record<string, unknown>;
         const defaultMsg = this.options.tooLong ?? this.options.message;
-        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
         record.errors.add(attribute, "too_long", opts);
       }
     }
@@ -165,7 +165,7 @@ export class LengthValidator extends EachValidator {
       if (!valueIsNil || this.skipNilCheck("is")) {
         const opts = { ...baseOptions, count: is } as Record<string, unknown>;
         const defaultMsg = this.options.wrongLength ?? this.options.message;
-        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
         record.errors.add(attribute, "wrong_length", opts);
       }
     }

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -46,8 +46,12 @@ export class LengthValidator extends EachValidator {
   declare skipNilCheck: typeof skipNilCheck;
 
   constructor(options: Record<string, unknown>) {
+    // Shallow-clone so we don't mutate the caller's object — mirrors Rails
+    // validates_with.rb:93 which passes `options.dup` to each validator.
+    options = { ...options };
+
     // Normalize :in / :within to :minimum / :maximum before super() calls
-    // checkValidity(). We mutate `options` in place, mirroring length.rb:16-20.
+    // checkValidity(), mirroring length.rb:16-20.
     const range = options["in"] ?? options["within"];
     if (range !== undefined) {
       delete options["in"];
@@ -58,8 +62,7 @@ export class LengthValidator extends EachValidator {
       } else if (
         range !== null &&
         typeof range === "object" &&
-        "begin" in range &&
-        "end" in range
+        ("begin" in range || "end" in range)
       ) {
         const r = range as LengthRange;
         if (r.begin !== undefined) options["minimum"] = r.begin;

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -106,7 +106,9 @@ export class LengthValidator extends EachValidator {
       ) {
         continue;
       }
-      throw new Error(`:${key} must be a non-negative Integer, Infinity, Symbol, or Proc`);
+      throw new Error(
+        `:${key} must be a non-negative Integer, Infinity, string (method name), or Proc`,
+      );
     }
   }
 

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -14,8 +14,8 @@ import { resolveValue } from "./resolve-value.js";
 
 /** Rails-style range object accepted by the `:in` / `:within` option. */
 export interface LengthRange {
-  begin: number;
-  end: number;
+  begin?: number;
+  end?: number;
   excludeEnd?: boolean;
 }
 
@@ -67,7 +67,9 @@ export class LengthValidator extends EachValidator {
           options["maximum"] = r.excludeEnd ? r.end - 1 : r.end;
         }
       } else {
-        throw new Error(":in and :within must be a Range or [min, max] tuple");
+        throw new Error(
+          ":in and :within must be a [min, max] tuple or { begin, end, excludeEnd? } object",
+        );
       }
     }
 

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -11,6 +11,30 @@ import { resolveValue } from "./resolve-value.js";
  *     CHECKS = { is: :==, minimum: :>=, maximum: :<= }.freeze
  *     ...
  */
+
+/** Rails-style range object accepted by the `:in` / `:within` option. */
+export interface LengthRange {
+  begin: number;
+  end: number;
+  excludeEnd?: boolean;
+}
+
+/**
+ * Keys stripped from options before forwarding to `errors.add` so they
+ * don't leak as i18n interpolation variables.
+ *
+ * Mirrors: LengthValidator::RESERVED_OPTIONS
+ * @internal
+ */
+export const RESERVED_OPTIONS = [
+  "minimum",
+  "maximum",
+  "within",
+  "is",
+  "tooShort",
+  "tooLong",
+] as const;
+
 export class LengthValidator extends EachValidator {
   // Declarations only — actual functions attached to the prototype below.
   // Prototype attachment (not class fields) so the helpers are present
@@ -21,16 +45,68 @@ export class LengthValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare skipNilCheck: typeof skipNilCheck;
 
-  override checkValidity(): void {
+  constructor(options: Record<string, unknown>) {
+    // Normalize :in / :within to :minimum / :maximum before super() calls
+    // checkValidity(). We mutate `options` in place, mirroring length.rb:16-20.
+    const range = options["in"] ?? options["within"];
+    if (range !== undefined) {
+      delete options["in"];
+      delete options["within"];
+      if (Array.isArray(range) && range.length === 2) {
+        options["minimum"] = range[0];
+        options["maximum"] = range[1];
+      } else if (
+        range !== null &&
+        typeof range === "object" &&
+        "begin" in range &&
+        "end" in range
+      ) {
+        const r = range as LengthRange;
+        if (r.begin !== undefined) options["minimum"] = r.begin;
+        if (r.end !== undefined) {
+          options["maximum"] = r.excludeEnd ? r.end - 1 : r.end;
+        }
+      } else {
+        throw new Error(":in and :within must be a Range or [min, max] tuple");
+      }
+    }
+
+    // allowBlank: false with no minimum/is → minimum defaults to 1 (length.rb:22-24).
     if (
-      this.options.minimum === undefined &&
-      this.options.maximum === undefined &&
-      this.options.is === undefined &&
-      this.options.in === undefined
+      options["allowBlank"] === false &&
+      options["minimum"] === undefined &&
+      options["is"] === undefined
     ) {
+      options["minimum"] = 1;
+    }
+
+    super(options);
+  }
+
+  override checkValidity(): void {
+    const hasCheck =
+      this.options.minimum !== undefined ||
+      this.options.maximum !== undefined ||
+      this.options.is !== undefined;
+
+    if (!hasCheck) {
       throw new Error(
         "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.",
       );
+    }
+
+    for (const key of ["minimum", "maximum", "is"] as const) {
+      const value = this.options[key];
+      if (value === undefined) continue;
+      if (
+        (Number.isInteger(value as number) && (value as number) >= 0) ||
+        value === Infinity ||
+        typeof value === "function" ||
+        typeof value === "string"
+      ) {
+        continue;
+      }
+      throw new Error(`:${key} must be a non-negative Integer, Infinity, Symbol, or Proc`);
     }
   }
 
@@ -54,62 +130,43 @@ export class LengthValidator extends EachValidator {
       length = String(value).length;
     }
 
-    const inOpt = this.options.in as [number, number] | undefined;
-    const rawMin = inOpt ? inOpt[0] : (this.options.minimum as unknown);
-    const rawMax = inOpt ? inOpt[1] : (this.options.maximum as unknown);
+    // Rails length.rb:49 — `errors_options = options.except(*RESERVED_OPTIONS)`
+    const baseOptions = this.filteredErrorOptions([...RESERVED_OPTIONS]);
+
+    // Rails length.rb:51-65 — iterate CHECKS, skip absent constraints.
+    const valueIsNil = value === null || value === undefined;
+
+    const rawMin = this.options.minimum as unknown;
+    const rawMax = this.options.maximum as unknown;
     const rawIs = this.options.is as unknown;
 
     // Rails length.rb:55 — `check_value = resolve_value(record, check_value)`
-    // — so a Proc / method-name option is resolved per-record.
     const min = resolveLengthOpt.call(this, record, rawMin);
     const max = resolveLengthOpt.call(this, record, rawMax);
     const is = resolveLengthOpt.call(this, record, rawIs);
 
-    let effectiveMin = min;
-    if (
-      effectiveMin === undefined &&
-      max === undefined &&
-      this.options.allowBlank === false &&
-      is === undefined &&
-      inOpt === undefined
-    ) {
-      effectiveMin = 1;
-    }
-
-    // Rails length.rb:54 — `!value.nil? || skip_nil_check?(key)`.
-    // Each branch fires the constraint check unless the value is nil AND
-    // skip_nil_check?(key) returns false (meaning Rails would skip nil
-    // for that key). EachValidator's dispatch only short-circuits on
-    // allowNil === true / allowBlank === true; the explicit-false case
-    // and the default case both reach here, so the per-key guard below
-    // is the load-bearing path.
-    const valueIsNil = value === null || value === undefined;
-
-    if (effectiveMin !== undefined && length < effectiveMin) {
+    if (min !== undefined && length < min) {
       if (!valueIsNil || this.skipNilCheck("minimum")) {
-        record.errors.add(attribute, "too_short", {
-          message: (this.options.tooShort ?? this.options.message) as string | undefined,
-          count: effectiveMin,
-          value,
-        });
+        const opts = { ...baseOptions, count: min } as Record<string, unknown>;
+        const defaultMsg = this.options.tooShort ?? this.options.message;
+        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        record.errors.add(attribute, "too_short", opts);
       }
     }
     if (max !== undefined && length > max) {
       if (!valueIsNil || this.skipNilCheck("maximum")) {
-        record.errors.add(attribute, "too_long", {
-          message: (this.options.tooLong ?? this.options.message) as string | undefined,
-          count: max,
-          value,
-        });
+        const opts = { ...baseOptions, count: max } as Record<string, unknown>;
+        const defaultMsg = this.options.tooLong ?? this.options.message;
+        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        record.errors.add(attribute, "too_long", opts);
       }
     }
     if (is !== undefined && length !== is) {
       if (!valueIsNil || this.skipNilCheck("is")) {
-        record.errors.add(attribute, "wrong_length", {
-          message: (this.options.wrongLength ?? this.options.message) as string | undefined,
-          count: is,
-          value,
-        });
+        const opts = { ...baseOptions, count: is } as Record<string, unknown>;
+        const defaultMsg = this.options.wrongLength ?? this.options.message;
+        if (defaultMsg && !opts["message"]) opts["message"] = defaultMsg;
+        record.errors.add(attribute, "wrong_length", opts);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Constructor normalises `:in`/`:within` (tuple `[min, max]` or range object `{ begin, end, excludeEnd? }`) to `minimum`/`maximum` before `super()` calls `checkValidity()`, mirroring `length.rb:15-27`.
- `RESERVED_OPTIONS` const strips `minimum`/`maximum`/`is`/`tooShort`/`tooLong`/`within` from `errors.add` interpolation via `filteredErrorOptions`, mirroring `length.rb:49`.
- `checkValidity` rejects non-integer / negative numeric constraints, mirroring `length.rb:36-44`.
- Adds `validatesSizeOf` alias to `HelperMethods` interface, mirroring `length.rb:127`.

## Test plan

- [ ] `:in: [3, 10]` tuple (existing behaviour preserved)
- [ ] `:in: { begin: 3, end: 10 }` range object — new
- [ ] `:in: { begin: 3, end: 5, excludeEnd: true }` — max becomes 4
- [ ] `errors.objects[0].options` does not contain `minimum`/`maximum`/`tooShort`/`tooLong`/`within`/`is`
- [ ] Non-integer constraint (e.g. `2.5`) throws at class definition time
- [ ] Negative constraint throws at class definition time
- [ ] `Infinity` accepted as valid maximum