### PR TITLE
feat(activemodel): deprecator initializer + auto i18n_customize_full_message (P23)

### DIFF
--- a/docs/activemodel-alignment.md
+++ b/docs/activemodel-alignment.md
@@ -48,7 +48,7 @@ P19 Value#equals precision/scale/limit (independent)
 P20 SecurePassword challenge via _was + password_too_long type (independent)
 P21 Multiparameter time defaults per-type (independent)
 P22 Lint testToKey/testToParam unpersisted-nil + testModelNaming instance↔class (independent)
-P23 Railtie: deprecator initializer + auto-i18n_customize_full_message (independent)
+P23 Railtie: deprecator initializer + auto-i18n_customize_full_message (independent) ✅ #1172
 P24 AttributeSetCoder pluggable codec (JSON default, YAML opt-in) (depends on P1, P2)
 P25 OID layering refactor — drop activemodel uuid/json/array, redirect to AR PG OIDs (independent; touches multiple packages)
 ```
@@ -408,7 +408,7 @@ Suggested merge order (one cluster at a time): **P1 → P2 → P3 → P4** (attr
    **Depends on**: none.
    **Blocks**: none.
 
-### P23 — Railtie: deprecator initializer + auto i18n customize
+### P23 — Railtie: deprecator initializer + auto i18n customize ✅ #1172
 
 **Audit ref**: lifecycle §15.
 **Files**:

--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { env as processEnv, setEnv } from "@blazetrails/activesupport/process-adapter";
-import { Railtie } from "./railtie.js";
+import { Railtie, deprecators } from "./railtie.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
+import { deprecator } from "./deprecator.js";
 
 describe("RailtieTest", () => {
   // Snapshot the global subclasses list so activesupport tests that
   // truncate it can't make this suite order-dependent.
   let savedSubclasses: (typeof BaseRailtie)[];
+  let savedConfig: Record<string, unknown>;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
+    savedConfig = structuredClone ? structuredClone(Railtie.config) : { ...Railtie.config };
   });
 
   afterEach(() => {
@@ -19,6 +22,15 @@ describe("RailtieTest", () => {
     ActiveModelError.i18nCustomizeFullMessage = false;
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
+    // Reset per-class config to saved snapshot
+    for (const key of Object.keys(Railtie.config)) {
+      delete (Railtie.config as Record<string, unknown>)[key];
+    }
+    Object.assign(Railtie.config, savedConfig);
+    // Clear deprecators registry
+    for (const key of Object.keys(deprecators)) {
+      delete deprecators[key];
+    }
   });
 
   it("secure password min_cost is false in the development environment", () => {
@@ -47,6 +59,11 @@ describe("RailtieTest", () => {
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
   });
 
+  it("i18n customize full message can be enabled via nested activeModel config", () => {
+    Railtie.initialize({ activeModel: { i18nCustomizeFullMessage: true } });
+    expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
+  });
+
   it("ActiveModel::Railtie is registered in the global subclasses list", () => {
     // Mirrors Rails::Railtie.subclasses which auto-populates via `inherited`.
     expect(BaseRailtie.subclasses).toContain(Railtie);
@@ -65,5 +82,29 @@ describe("RailtieTest", () => {
     } finally {
       setEnv("TRAILS_ENV", prev);
     }
+  });
+
+  it("runInitializers registers the ActiveModel deprecator", () => {
+    Railtie.runInitializers();
+    expect(deprecators["activeModel"]).toBe(deprecator());
+  });
+
+  it("runInitializers applies i18nCustomizeFullMessage from Railtie.config.activeModel", () => {
+    (Railtie.config as Record<string, unknown>)["activeModel"] = {
+      i18nCustomizeFullMessage: true,
+    };
+    Railtie.runInitializers();
+    expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
+  });
+
+  it("runInitializers applies i18nCustomizeFullMessage from flat Railtie.config (backwards-compat)", () => {
+    (Railtie.config as Record<string, unknown>)["i18nCustomizeFullMessage"] = true;
+    Railtie.runInitializers();
+    expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
+  });
+
+  it("runInitializers defaults i18nCustomizeFullMessage to false when config is absent", () => {
+    Railtie.runInitializers();
+    expect(ActiveModelError.i18nCustomizeFullMessage).toBe(false);
   });
 });

--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -14,7 +14,14 @@ describe("RailtieTest", () => {
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
-    savedConfig = structuredClone ? structuredClone(Railtie.config) : { ...Railtie.config };
+    try {
+      savedConfig =
+        typeof structuredClone === "function"
+          ? structuredClone(Railtie.config)
+          : { ...Railtie.config };
+    } catch {
+      savedConfig = { ...Railtie.config };
+    }
   });
 
   afterEach(() => {

--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { env as processEnv, setEnv } from "@blazetrails/activesupport/process-adapter";
-import { Railtie, deprecators } from "./railtie.js";
+import { Railtie } from "./railtie.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+const { deprecators } = BaseRailtie;
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
 import { deprecator } from "./deprecator.js";

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -45,10 +45,9 @@ export class Railtie extends BaseRailtie {
     });
 
     this.initializer("active_model.i18n_customize_full_message", () => {
-      const cfg = Railtie.config as RailtieConfig;
-      const value =
-        cfg.activeModel?.i18nCustomizeFullMessage ?? cfg.i18nCustomizeFullMessage ?? false;
-      ActiveModelError.i18nCustomizeFullMessage = value;
+      ActiveModelError.i18nCustomizeFullMessage = Railtie.resolveI18nCustomizeFullMessage(
+        Railtie.config as RailtieConfig,
+      );
     });
   }
 
@@ -59,8 +58,11 @@ export class Railtie extends BaseRailtie {
   static initialize(config?: RailtieConfig): void {
     const env = config?.env ?? Railtie.detectEnv();
     SecurePassword.minCost = env === "test";
-    ActiveModelError.i18nCustomizeFullMessage =
-      config?.activeModel?.i18nCustomizeFullMessage ?? config?.i18nCustomizeFullMessage ?? false;
+    ActiveModelError.i18nCustomizeFullMessage = Railtie.resolveI18nCustomizeFullMessage(config);
+  }
+
+  private static resolveI18nCustomizeFullMessage(cfg?: RailtieConfig): boolean {
+    return cfg?.activeModel?.i18nCustomizeFullMessage ?? cfg?.i18nCustomizeFullMessage ?? false;
   }
 
   private static detectEnv(): string {

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -20,7 +20,7 @@ export interface RailtieConfig {
  * Framework-level deprecators registry.
  * Mirrors: `app.deprecators` — a keyed collection of per-framework deprecators.
  */
-export const deprecators: Record<string, Deprecation> = {};
+export const deprecators: Partial<Record<string, Deprecation>> = {};
 
 /**
  * Railtie — initialization hooks for ActiveModel.

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -1,12 +1,26 @@
 import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import type { Deprecation } from "@blazetrails/activesupport";
 import { env as processEnv } from "@blazetrails/activesupport/process-adapter";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
+import { deprecator } from "./deprecator.js";
+
+export interface ActiveModelConfig {
+  i18nCustomizeFullMessage?: boolean;
+}
 
 export interface RailtieConfig {
   env?: string;
+  /** @deprecated Use `activeModel.i18nCustomizeFullMessage` instead. Kept for backwards compat. */
   i18nCustomizeFullMessage?: boolean;
+  activeModel?: ActiveModelConfig;
 }
+
+/**
+ * Framework-level deprecators registry.
+ * Mirrors: `app.deprecators` — a keyed collection of per-framework deprecators.
+ */
+export const deprecators: Record<string, Deprecation> = {};
 
 /**
  * Railtie — initialization hooks for ActiveModel.
@@ -22,8 +36,19 @@ export class Railtie extends BaseRailtie {
   static {
     registerRailtie(this);
 
+    this.initializer("active_model.deprecator", () => {
+      deprecators["activeModel"] = deprecator();
+    });
+
     this.initializer("active_model.secure_password", () => {
       SecurePassword.minCost = Railtie.detectEnv() === "test";
+    });
+
+    this.initializer("active_model.i18n_customize_full_message", () => {
+      const cfg = Railtie.config as RailtieConfig;
+      const value =
+        cfg.activeModel?.i18nCustomizeFullMessage ?? cfg.i18nCustomizeFullMessage ?? false;
+      ActiveModelError.i18nCustomizeFullMessage = value;
     });
   }
 
@@ -34,7 +59,8 @@ export class Railtie extends BaseRailtie {
   static initialize(config?: RailtieConfig): void {
     const env = config?.env ?? Railtie.detectEnv();
     SecurePassword.minCost = env === "test";
-    ActiveModelError.i18nCustomizeFullMessage = config?.i18nCustomizeFullMessage ?? false;
+    ActiveModelError.i18nCustomizeFullMessage =
+      config?.activeModel?.i18nCustomizeFullMessage ?? config?.i18nCustomizeFullMessage ?? false;
   }
 
   private static detectEnv(): string {

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -1,5 +1,4 @@
 import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
-import type { Deprecation } from "@blazetrails/activesupport";
 import { env as processEnv } from "@blazetrails/activesupport/process-adapter";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
@@ -17,12 +16,6 @@ export interface RailtieConfig {
 }
 
 /**
- * Framework-level deprecators registry.
- * Mirrors: `app.deprecators` — a keyed collection of per-framework deprecators.
- */
-export const deprecators: Partial<Record<string, Deprecation>> = {};
-
-/**
  * Railtie — initialization hooks for ActiveModel.
  *
  * Mirrors: ActiveModel::Railtie < ::Rails::Railtie
@@ -37,7 +30,7 @@ export class Railtie extends BaseRailtie {
     registerRailtie(this);
 
     this.initializer("active_model.deprecator", () => {
-      deprecators["activeModel"] = deprecator();
+      BaseRailtie.deprecators["activeModel"] = deprecator();
     });
 
     this.initializer("active_model.secure_password", () => {

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -17,6 +17,15 @@ export class Railtie {
    */
   static readonly subclasses: Array<typeof Railtie> = [];
 
+  /**
+   * Shared registry of per-framework deprecators, keyed by framework name.
+   * Each framework's railtie registers its own deprecator here during
+   * initialization.
+   *
+   * Mirrors: Rails `app.deprecators` (Rails::Application::DeprecatorsProxy)
+   */
+  static readonly deprecators: Partial<Record<string, unknown>> = {};
+
   private static _config: Record<string, unknown> = {};
 
   /**

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -8,6 +8,8 @@
  *
  * Mirrors: Rails::Railtie (railties/lib/rails/railtie.rb)
  */
+import type { Deprecation } from "./deprecation.js";
+
 export class Railtie {
   /**
    * All registered subclasses — tracked so the application can enumerate
@@ -24,7 +26,7 @@ export class Railtie {
    *
    * Mirrors: Rails `app.deprecators` (Rails::Application::DeprecatorsProxy)
    */
-  static readonly deprecators: Partial<Record<string, unknown>> = {};
+  static readonly deprecators: Partial<Record<string, Deprecation>> = {};
 
   private static _config: Record<string, unknown> = {};
 


### PR DESCRIPTION
## Summary

- Registers `active_model.deprecator` initializer that wires the AM deprecator into the `deprecators` registry (mirrors `app.deprecators[:active_model]` in Rails)
- Registers `active_model.i18n_customize_full_message` initializer that reads `Railtie.config.activeModel?.i18nCustomizeFullMessage` and applies it to `Error.i18nCustomizeFullMessage` — no manual `Railtie.initialize()` call needed
- Adds `RailtieConfig.activeModel: { i18nCustomizeFullMessage?: boolean }` nested shape (Rails-style); flat `i18nCustomizeFullMessage` kept for backwards compat

Mirrors: `activemodel/lib/active_model/railtie.rb:12-22`

Closes P23 from `docs/activemodel-alignment.md`.

## Test plan

- [x] `runInitializers()` registers AM deprecator in `deprecators["activeModel"]`
- [x] `runInitializers()` applies `i18nCustomizeFullMessage` from nested `Railtie.config.activeModel`
- [x] `runInitializers()` applies `i18nCustomizeFullMessage` from flat `Railtie.config` (backwards-compat)
- [x] `runInitializers()` defaults `i18nCustomizeFullMessage` to `false` when config absent
- [x] `Railtie.initialize()` accepts nested `activeModel` shape
- [x] All 12 tests pass