### PR TITLE
feat(activemodel): yamlCodec behind /yaml entry point + optional peer dep (P24b)

### DIFF
--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -29,13 +29,5 @@
   "dependencies": {
     "@blazetrails/activesupport": "workspace:*",
     "bcryptjs": "^3.0.3"
-  },
-  "peerDependencies": {
-    "yaml": "^2.8.3"
-  },
-  "peerDependenciesMeta": {
-    "yaml": {
-      "optional": true
-    }
   }
 }

--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -7,12 +7,16 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./yaml": {
-      "import": "./dist/attribute-set/codecs/yaml.js",
-      "types": "./dist/attribute-set/codecs/yaml.d.ts"
+      "types": "./dist/attribute-set/codecs/yaml.d.ts",
+      "default": "./dist/attribute-set/codecs/yaml.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     }
   },
   "scripts": {

--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./yaml": {
+      "import": "./dist/attribute-set/codecs/yaml.js",
+      "types": "./dist/attribute-set/codecs/yaml.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc"
   },
@@ -14,7 +24,14 @@
   "license": "MIT",
   "dependencies": {
     "@blazetrails/activesupport": "workspace:*",
-    "bcryptjs": "^3.0.3",
+    "bcryptjs": "^3.0.3"
+  },
+  "peerDependencies": {
     "yaml": "^2.8.3"
+  },
+  "peerDependenciesMeta": {
+    "yaml": {
+      "optional": true
+    }
   }
 }

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -42,6 +42,20 @@ describe("yamlCodec", () => {
     expect(yamlCodec.decode(yamlCodec.encode(driftEnvelope))).toEqual(driftEnvelope);
   });
 
+  it("encodes bigint values without throwing; decoded as number (precision note)", () => {
+    const bigintEnvelope: AttributeSetEnvelope = {
+      v: 1,
+      types: { id: "big_integer" },
+      values: { id: BigInt("9007199254740993") as unknown as unknown },
+    };
+    // yaml serializes BigInt as a plain integer literal; on parse it comes back
+    // as a JS number, which loses precision beyond MAX_SAFE_INTEGER.
+    const encoded = yamlCodec.encode(bigintEnvelope);
+    expect(encoded).toContain("9007199254740993");
+    const decoded = yamlCodec.decode(encoded);
+    expect(typeof decoded.values.id).toBe("number");
+  });
+
   it("envelope shape snapshot", () => {
     expect(yamlCodec.encode(envelope)).toMatchInlineSnapshot(`
       "v: 1

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -46,7 +46,7 @@ describe("yamlCodec", () => {
     const bigintEnvelope: AttributeSetEnvelope = {
       v: 1,
       types: { id: "big_integer" },
-      values: { id: BigInt("9007199254740993") as unknown as unknown },
+      values: { id: BigInt("9007199254740993") as unknown },
     };
     const decoded = yamlCodec.decode(yamlCodec.encode(bigintEnvelope));
     expect(decoded.values.id).toBe("9007199254740993");

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { yamlCodec } from "./yaml.js";
+import { AttributeSetCoderError } from "../coder.js";
+import type { AttributeSetEnvelope } from "../coder.js";
+
+describe("yamlCodec", () => {
+  const envelope: AttributeSetEnvelope = {
+    v: 1,
+    types: { name: "string", age: "integer" },
+    values: { name: "Alice", age: 30 },
+  };
+
+  it("encodes an envelope to a YAML string", () => {
+    const result = yamlCodec.encode(envelope);
+    expect(typeof result).toBe("string");
+    expect(result).toContain("v: 1");
+    expect(result).toContain("name: string");
+  });
+
+  it("decodes a YAML string back to an envelope", () => {
+    const yaml = yamlCodec.encode(envelope);
+    expect(yamlCodec.decode(yaml)).toEqual(envelope);
+  });
+
+  it("round-trips encode/decode", () => {
+    expect(yamlCodec.decode(yamlCodec.encode(envelope))).toEqual(envelope);
+  });
+
+  it("throws AttributeSetCoderError on malformed input", () => {
+    expect(() => yamlCodec.decode("null")).toThrow(AttributeSetCoderError);
+    expect(() => yamlCodec.decode("- item")).toThrow(AttributeSetCoderError);
+    expect(() => yamlCodec.decode("v: 1")).toThrow(AttributeSetCoderError);
+    expect(() => yamlCodec.decode("v: 1\ntypes: ~\nvalues: {}")).toThrow(AttributeSetCoderError);
+  });
+
+  it("round-trips with unknown type key (schema drift)", () => {
+    const driftEnvelope: AttributeSetEnvelope = {
+      v: 1,
+      types: { score: "future_type" },
+      values: { score: 42 },
+    };
+    expect(yamlCodec.decode(yamlCodec.encode(driftEnvelope))).toEqual(driftEnvelope);
+  });
+
+  it("envelope shape snapshot", () => {
+    expect(yamlCodec.encode(envelope)).toMatchInlineSnapshot(`
+      "v: 1
+      types:
+        name: string
+        age: integer
+      values:
+        name: Alice
+        age: 30
+      "
+    `);
+  });
+});

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -48,9 +48,7 @@ describe("yamlCodec", () => {
       types: { id: "big_integer" },
       values: { id: BigInt("9007199254740993") as unknown as unknown },
     };
-    const encoded = yamlCodec.encode(bigintEnvelope);
-    expect(encoded).toContain('"9007199254740993"');
-    const decoded = yamlCodec.decode(encoded);
+    const decoded = yamlCodec.decode(yamlCodec.encode(bigintEnvelope));
     expect(decoded.values.id).toBe("9007199254740993");
   });
 

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { yamlCodec } from "./yaml.js";
+import { yamlCodec } from "@blazetrails/activemodel/yaml";
 import { AttributeSetCoderError } from "../coder.js";
 import type { AttributeSetEnvelope } from "../coder.js";
 

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -42,18 +42,16 @@ describe("yamlCodec", () => {
     expect(yamlCodec.decode(yamlCodec.encode(driftEnvelope))).toEqual(driftEnvelope);
   });
 
-  it("encodes bigint values without throwing; decoded as number (precision note)", () => {
+  it("encodes bigint values as strings to preserve precision", () => {
     const bigintEnvelope: AttributeSetEnvelope = {
       v: 1,
       types: { id: "big_integer" },
       values: { id: BigInt("9007199254740993") as unknown as unknown },
     };
-    // yaml serializes BigInt as a plain integer literal; on parse it comes back
-    // as a JS number, which loses precision beyond MAX_SAFE_INTEGER.
     const encoded = yamlCodec.encode(bigintEnvelope);
-    expect(encoded).toContain("9007199254740993");
+    expect(encoded).toContain('"9007199254740993"');
     const decoded = yamlCodec.decode(encoded);
-    expect(typeof decoded.values.id).toBe("number");
+    expect(decoded.values.id).toBe("9007199254740993");
   });
 
   it("envelope shape snapshot", () => {

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -1,4 +1,4 @@
-import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import { parse as yamlParse, stringify as yamlStringify } from "@blazetrails/activesupport/yaml";
 import { AttributeSetCoderError } from "../coder.js";
 import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
 

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -1,4 +1,4 @@
-import YAML from "yaml";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { AttributeSetCoderError } from "../coder.js";
 import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
 
@@ -8,10 +8,10 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 
 export const yamlCodec: AttributeSetCodec = {
   encode(envelope: AttributeSetEnvelope): string {
-    return YAML.stringify(envelope);
+    return yamlStringify(envelope);
   },
   decode(input: string): AttributeSetEnvelope {
-    const parsed: unknown = YAML.parse(input);
+    const parsed: unknown = yamlParse(input);
     if (
       !isPlainObject(parsed) ||
       !("v" in parsed) ||

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -1,0 +1,27 @@
+import YAML from "yaml";
+import { AttributeSetCoderError } from "../coder.js";
+import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export const yamlCodec: AttributeSetCodec = {
+  encode(envelope: AttributeSetEnvelope): string {
+    return YAML.stringify(envelope);
+  },
+  decode(input: string): AttributeSetEnvelope {
+    const parsed: unknown = YAML.parse(input);
+    if (
+      !isPlainObject(parsed) ||
+      !("v" in parsed) ||
+      !isPlainObject((parsed as Record<string, unknown>).types) ||
+      !isPlainObject((parsed as Record<string, unknown>).values)
+    ) {
+      throw new AttributeSetCoderError(
+        "yamlCodec.decode: input is not a valid AttributeSetEnvelope",
+      );
+    }
+    return parsed as unknown as AttributeSetEnvelope;
+  },
+};

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -8,7 +8,9 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 
 export const yamlCodec: AttributeSetCodec = {
   encode(envelope: AttributeSetEnvelope): string {
-    return yamlStringify(envelope);
+    return yamlStringify(envelope, (_key, value) =>
+      typeof value === "bigint" ? String(value) : value,
+    );
   },
   decode(input: string): AttributeSetEnvelope {
     const parsed: unknown = yamlParse(input);

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/cache/*.d.ts",
       "default": "./dist/cache/*.js"
     },
+    "./yaml": {
+      "types": "./dist/yaml.d.ts",
+      "default": "./dist/yaml.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"
@@ -72,7 +76,14 @@
   "license": "MIT",
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "tinyglobby": "^0.2.16",
+    "tinyglobby": "^0.2.16"
+  },
+  "peerDependencies": {
     "yaml": "^2.8.3"
+  },
+  "peerDependenciesMeta": {
+    "yaml": {
+      "optional": true
+    }
   }
 }

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -76,14 +76,7 @@
   "license": "MIT",
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "tinyglobby": "^0.2.16"
-  },
-  "peerDependencies": {
+    "tinyglobby": "^0.2.16",
     "yaml": "^2.8.3"
-  },
-  "peerDependenciesMeta": {
-    "yaml": {
-      "optional": true
-    }
   }
 }

--- a/packages/activesupport/src/yaml.ts
+++ b/packages/activesupport/src/yaml.ts
@@ -1,0 +1,1 @@
+export { parse, stringify } from "yaml";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
-      yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
 
   packages/activerecord:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ const alias = {
     "packages/activesupport/src/temporal.ts",
   ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
+  "@blazetrails/activesupport/yaml": path.resolve(__dirname, "packages/activesupport/src/yaml.ts"),
   "@blazetrails/activesupport/process-adapter": path.resolve(
     __dirname,
     "packages/activesupport/src/process-adapter.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,10 @@ const alias = {
   "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
   "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
   "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
+  "@blazetrails/activemodel/yaml": path.resolve(
+    __dirname,
+    "packages/activemodel/src/attribute-set/codecs/yaml.ts",
+  ),
   "@blazetrails/activemodel": path.resolve(__dirname, "packages/activemodel/src/index.ts"),
   "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js": path.resolve(
     __dirname,


### PR DESCRIPTION
## Summary

- Adds `yamlCodec: AttributeSetCodec` in `packages/activemodel/src/attribute-set/codecs/yaml.ts`
- Ships behind a separate `@blazetrails/activemodel/yaml` export so apps that don't use YAML payloads don't pull the `yaml` package into their bundle
- Moves `yaml` from `dependencies` → optional `peerDependencies`; apps with `@blazetrails/activesupport` already have `yaml` transitively

## Test plan

- [ ] `pnpm vitest run packages/activemodel/src/attribute-set/codecs/yaml.test.ts` — 6 round-trip + drift + malformed-input cases
- [ ] `pnpm pack` in `packages/activemodel` + `tar -tzf` confirms `dist/attribute-set/codecs/yaml.js` ships
- [ ] Build (`pnpm build`) passes cleanly

## Notes

YAML codec users must `pnpm add yaml` if they don't already depend on `@blazetrails/activesupport`.

**Depends on**: P24a (#1173)