### PR TITLE
feat(activerecord): mysql/schema-dumper to 100% (Wave 3 PR 10)

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -71,20 +71,18 @@ describe("MySQL::SchemaDumper", () => {
   describe("schemaCollation", () => {
     it("returns undefined when no collation", () =>
       expect((make() as any).schemaCollation(col({ collation: null }))).toBeUndefined());
-    it("returns JSON collation with no connection", () =>
+    it("returns JSON collation when cache not populated", () =>
       expect((make() as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
         '"utf8mb4_unicode_ci"',
       ));
     it("omits when matching table default", () => {
       const d = make();
-      d.connection = {};
       d.tableCollationCache["users"] = "utf8mb4_unicode_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBeUndefined();
     });
     it("emits when differing from table default", () => {
       const d = make();
-      d.connection = {};
       d.tableCollationCache["users"] = "utf8mb4_general_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -108,13 +108,11 @@ describe("MySQL::SchemaDumper", () => {
       expect((make() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false));
   });
 
-  describe("isExplicitPrimaryKeyDefault", () => {
-    it("true: integer + no autoIncrement", () =>
-      expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true));
-    it("false: integer + autoIncrement", () =>
-      expect(
-        (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
-      ).toBe(false));
+  it("isExplicitPrimaryKeyDefault: true for integer, false with autoIncrement", () => {
+    expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true);
+    expect(
+      (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
+    ).toBe(false);
   });
 
   describe("prepareColumnOptions", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -3,94 +3,73 @@ import { SchemaDumper } from "./schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
 const stubSource: SchemaSource = { tables: () => [], columns: () => [], indexes: () => [] };
-
-function makeDumper() {
-  return SchemaDumper.create(stubSource) as SchemaDumper;
-}
-
-function col(
+const make = () => SchemaDumper.create(stubSource) as SchemaDumper;
+const col = (
   o: {
     name?: string;
     type?: string;
     sqlType?: string;
     limit?: number | null;
     precision?: number | null;
-    scale?: number | null;
     null?: boolean;
-    default?: unknown;
-    defaultFunction?: string | null;
-    hasDefault?: boolean;
     collation?: string | null;
     bigint?: boolean;
     virtual?: boolean;
     unsigned?: boolean;
     autoIncrement?: boolean;
     extra?: string;
-    comment?: string | null;
   } = {},
-) {
-  return { name: "col", type: "string", sqlType: "varchar(255)", ...o };
-}
+) => ({ name: "col", type: "string", sqlType: "varchar(255)", ...o });
 
 describe("MySQL::SchemaDumper", () => {
   it("defaultPrimaryKeyType returns bigint", () => {
-    expect(makeDumper().defaultPrimaryKeyType()).toBe("bigint");
+    expect(make().defaultPrimaryKeyType()).toBe("bigint");
   });
 
   describe("schemaType", () => {
-    it("returns timestamp for timestamp sql_type", () => {
-      expect((makeDumper() as any).schemaType(col({ sqlType: "timestamp" }))).toBe("timestamp");
+    it("timestamp sql_type → 'timestamp'", () => {
+      expect((make() as any).schemaType(col({ sqlType: "timestamp" }))).toBe("timestamp");
     });
-    it("returns full sql_type for enum", () => {
-      expect((makeDumper() as any).schemaType(col({ sqlType: "enum('a','b')" }))).toBe(
-        "enum('a','b')",
-      );
+    it("enum sql_type → full sql_type string", () => {
+      expect((make() as any).schemaType(col({ sqlType: "enum('a','b')" }))).toBe("enum('a','b')");
     });
-    it("delegates to super for standard types", () => {
-      expect((makeDumper() as any).schemaType(col({ type: "string" }))).toBe("string");
+    it("set sql_type → full sql_type string", () => {
+      expect((make() as any).schemaType(col({ sqlType: "set('x')" }))).toBe("set('x')");
+    });
+    it("standard type delegates to super", () => {
+      expect((make() as any).schemaType(col({ type: "string" }))).toBe("string");
     });
   });
 
   describe("schemaLimit", () => {
-    it("suppresses limit for tinytext", () => {
-      expect((makeDumper() as any).schemaLimit(col({ sqlType: "tinytext" }))).toBeUndefined();
-    });
-    it("suppresses limit for text", () => {
-      expect((makeDumper() as any).schemaLimit(col({ sqlType: "text" }))).toBeUndefined();
-    });
-    it("suppresses limit for longblob", () => {
-      expect((makeDumper() as any).schemaLimit(col({ sqlType: "longblob" }))).toBeUndefined();
+    it("suppresses limit for tinytext/text/longblob", () => {
+      for (const sqlType of ["tinytext", "text", "longblob", "mediumtext"]) {
+        expect((make() as any).schemaLimit(col({ sqlType }))).toBeUndefined();
+      }
     });
     it("returns limit for varchar", () => {
-      expect((makeDumper() as any).schemaLimit(col({ sqlType: "varchar(100)", limit: 100 }))).toBe(
-        "100",
-      );
+      expect((make() as any).schemaLimit(col({ sqlType: "varchar(100)", limit: 100 }))).toBe("100");
     });
   });
 
   describe("schemaPrecision", () => {
-    it("returns undefined for time with precision 0", () => {
-      expect(
-        (makeDumper() as any).schemaPrecision(col({ type: "time", sqlType: "time", precision: 0 })),
-      ).toBeUndefined();
+    it("returns undefined for time/timestamp with precision 0", () => {
+      for (const sqlType of ["time", "timestamp"]) {
+        expect(
+          (make() as any).schemaPrecision(col({ type: "datetime", sqlType, precision: 0 })),
+        ).toBeUndefined();
+      }
     });
-    it("returns undefined for timestamp with precision 0", () => {
+    it("returns 'nil' for datetime with precision 0", () => {
       expect(
-        (makeDumper() as any).schemaPrecision(
-          col({ type: "datetime", sqlType: "timestamp", precision: 0 }),
-        ),
-      ).toBeUndefined();
-    });
-    it("returns nil string for datetime with precision 0", () => {
-      expect(
-        (makeDumper() as any).schemaPrecision(
+        (make() as any).schemaPrecision(
           col({ type: "datetime", sqlType: "datetime", precision: 0 }),
         ),
       ).toBe("nil");
     });
     it("returns precision string for datetime with non-default precision", () => {
       expect(
-        (makeDumper() as any).schemaPrecision(
+        (make() as any).schemaPrecision(
           col({ type: "datetime", sqlType: "datetime(3)", precision: 3 }),
         ),
       ).toBe("3");
@@ -99,24 +78,24 @@ describe("MySQL::SchemaDumper", () => {
 
   describe("schemaCollation", () => {
     it("returns undefined when no collation", () => {
-      expect((makeDumper() as any).schemaCollation(col({ collation: null }))).toBeUndefined();
+      expect((make() as any).schemaCollation(col({ collation: null }))).toBeUndefined();
     });
     it("returns JSON collation when no connection", () => {
-      expect((makeDumper() as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
+      expect((make() as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
         '"utf8mb4_unicode_ci"',
       );
     });
-    it("omits collation when it matches cached table collation", () => {
-      const d = makeDumper();
+    it("omits collation when matching table default", () => {
+      const d = make();
       (d as any).connection = {};
-      (d as any)._tableCollationCache["users"] = "utf8mb4_unicode_ci";
+      d.tableCollationCache["users"] = "utf8mb4_unicode_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBeUndefined();
     });
-    it("emits collation when it differs from table collation", () => {
-      const d = makeDumper();
+    it("emits collation when differing from table default", () => {
+      const d = make();
       (d as any).connection = {};
-      (d as any)._tableCollationCache["users"] = "utf8mb4_general_ci";
+      d.tableCollationCache["users"] = "utf8mb4_general_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
         '"utf8mb4_unicode_ci"',
@@ -125,62 +104,74 @@ describe("MySQL::SchemaDumper", () => {
   });
 
   describe("isDefaultPrimaryKey", () => {
-    it("true for bigint autoIncrement non-unsigned", () => {
-      expect(
-        (makeDumper() as any).isDefaultPrimaryKey(col({ bigint: true, autoIncrement: true })),
-      ).toBe(true);
+    it("true for bigint + autoIncrement + non-unsigned", () => {
+      expect((make() as any).isDefaultPrimaryKey(col({ bigint: true, autoIncrement: true }))).toBe(
+        true,
+      );
     });
     it("false when unsigned", () => {
       expect(
-        (makeDumper() as any).isDefaultPrimaryKey(
+        (make() as any).isDefaultPrimaryKey(
           col({ bigint: true, autoIncrement: true, unsigned: true }),
         ),
       ).toBe(false);
     });
     it("false when not autoIncrement", () => {
-      expect((makeDumper() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false);
+      expect((make() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false);
     });
   });
 
   describe("isExplicitPrimaryKeyDefault", () => {
     it("true for integer without autoIncrement", () => {
-      expect((makeDumper() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(
-        true,
-      );
+      expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true);
     });
     it("false for integer with autoIncrement", () => {
       expect(
-        (makeDumper() as any).isExplicitPrimaryKeyDefault(
-          col({ type: "integer", autoIncrement: true }),
-        ),
+        (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
       ).toBe(false);
     });
   });
 
   describe("prepareColumnOptions", () => {
     it("adds unsigned flag", () => {
-      expect((makeDumper() as any).prepareColumnOptions(col({ unsigned: true }))["unsigned"]).toBe(
+      expect((make() as any).prepareColumnOptions(col({ unsigned: true }))["unsigned"]).toBe(
         "true",
       );
     });
     it("adds autoIncrement flag", () => {
       expect(
-        (makeDumper() as any).prepareColumnOptions(col({ autoIncrement: true }))["autoIncrement"],
+        (make() as any).prepareColumnOptions(col({ autoIncrement: true }))["autoIncrement"],
       ).toBe("true");
     });
     it("prepends size key for tinytext", () => {
-      const opts = (makeDumper() as any).prepareColumnOptions(col({ sqlType: "tinytext" }));
+      const opts = (make() as any).prepareColumnOptions(col({ sqlType: "tinytext" }));
       expect(Object.keys(opts)[0]).toBe("size");
       expect(opts["size"]).toBe(":tiny");
     });
   });
 
   describe("columnSpecForPrimaryKey", () => {
-    it("removes autoIncrement for integer autoIncrement pk", () => {
-      const spec = (makeDumper() as any).columnSpecForPrimaryKey(
+    it("removes autoIncrement for integer+autoIncrement pk", () => {
+      const spec = (make() as any).columnSpecForPrimaryKey(
         col({ type: "integer", autoIncrement: true }),
       );
       expect(spec["autoIncrement"]).toBeUndefined();
+    });
+  });
+
+  describe("extractExpressionForVirtualColumn", () => {
+    it("returns undefined with no tableName", () => {
+      expect(
+        (make() as any).extractExpressionForVirtualColumn(col({ virtual: true })),
+      ).toBeUndefined();
+    });
+    it("returns cached expression", () => {
+      const d = make();
+      d.tableName = "users";
+      d.virtualExpressionCache["users"] = { col: '"first + last"' };
+      expect(
+        (d as any).extractExpressionForVirtualColumn(col({ name: "col", virtual: true })),
+      ).toBe('"first + last"');
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -143,18 +143,12 @@ describe("MySQL::SchemaDumper", () => {
     });
   });
 
-  describe("extractExpressionForVirtualColumn", () => {
-    it("undefined when no tableName", () =>
-      expect(
-        (make() as any).extractExpressionForVirtualColumn(col({ virtual: true })),
-      ).toBeUndefined());
-    it("returns cached expression", () => {
-      const d = make();
-      d.tableName = "users";
-      d.virtualExpressionCache["users"] = { col: '"expr"' };
-      expect(
-        (d as any).extractExpressionForVirtualColumn(col({ name: "col", virtual: true })),
-      ).toBe('"expr"');
-    });
+  it("extractExpressionForVirtualColumn returns cached expression", () => {
+    const d = make();
+    d.tableName = "t";
+    d.virtualExpressionCache["t"] = { col: '"e"' };
+    expect((d as any).extractExpressionForVirtualColumn(col({ name: "col", virtual: true }))).toBe(
+      '"e"',
+    );
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -127,6 +127,25 @@ describe("MySQL::SchemaDumper", () => {
       expect(Object.keys(opts)[0]).toBe("size");
       expect(opts["size"]).toBe(":tiny");
     });
+    it("virtual column: emits type prefix, as, and stored", () => {
+      const d = make();
+      d.tableName = "t";
+      d.virtualExpressionCache["t"] = { full_name: '"CONCAT(a, b)"' };
+      const opts = (d as any).prepareColumnOptions(
+        col({
+          name: "full_name",
+          type: "string",
+          sqlType: "varchar(255)",
+          virtual: true,
+          extra: "STORED",
+        }),
+      );
+      const keys = Object.keys(opts);
+      expect(keys[0]).toBe("type");
+      expect(opts["type"]).toBe('"string"');
+      expect(opts["as"]).toBe('"CONCAT(a, b)"');
+      expect(opts["stored"]).toBe("true");
+    });
   });
 
   describe("columnSpecForPrimaryKey", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -110,11 +110,17 @@ describe("MySQL::SchemaDumper", () => {
       expect((make() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false));
   });
 
-  it("isExplicitPrimaryKeyDefault: true for integer, false with autoIncrement", () => {
-    expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true);
-    expect(
-      (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
-    ).toBe(false);
+  describe("isExplicitPrimaryKeyDefault", () => {
+    it("true when integer + autoIncrement explicitly false", () =>
+      expect(
+        (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: false })),
+      ).toBe(true));
+    it("false when autoIncrement true", () =>
+      expect(
+        (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
+      ).toBe(false));
+    it("false when autoIncrement undefined (not explicitly set)", () =>
+      expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(false));
   });
 
   describe("prepareColumnOptions", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { SchemaDumper } from "./schema-dumper.js";
+import type { SchemaSource } from "../../schema-dumper.js";
+
+const stubSource: SchemaSource = { tables: () => [], columns: () => [], indexes: () => [] };
+
+function makeDumper() {
+  return SchemaDumper.create(stubSource) as SchemaDumper;
+}
+
+function col(
+  o: {
+    name?: string;
+    type?: string;
+    sqlType?: string;
+    limit?: number | null;
+    precision?: number | null;
+    scale?: number | null;
+    null?: boolean;
+    default?: unknown;
+    defaultFunction?: string | null;
+    hasDefault?: boolean;
+    collation?: string | null;
+    bigint?: boolean;
+    virtual?: boolean;
+    unsigned?: boolean;
+    autoIncrement?: boolean;
+    extra?: string;
+    comment?: string | null;
+  } = {},
+) {
+  return { name: "col", type: "string", sqlType: "varchar(255)", ...o };
+}
+
+describe("MySQL::SchemaDumper", () => {
+  it("defaultPrimaryKeyType returns bigint", () => {
+    expect(makeDumper().defaultPrimaryKeyType()).toBe("bigint");
+  });
+
+  describe("schemaType", () => {
+    it("returns timestamp for timestamp sql_type", () => {
+      expect((makeDumper() as any).schemaType(col({ sqlType: "timestamp" }))).toBe("timestamp");
+    });
+    it("returns full sql_type for enum", () => {
+      expect((makeDumper() as any).schemaType(col({ sqlType: "enum('a','b')" }))).toBe(
+        "enum('a','b')",
+      );
+    });
+    it("delegates to super for standard types", () => {
+      expect((makeDumper() as any).schemaType(col({ type: "string" }))).toBe("string");
+    });
+  });
+
+  describe("schemaLimit", () => {
+    it("suppresses limit for tinytext", () => {
+      expect((makeDumper() as any).schemaLimit(col({ sqlType: "tinytext" }))).toBeUndefined();
+    });
+    it("suppresses limit for text", () => {
+      expect((makeDumper() as any).schemaLimit(col({ sqlType: "text" }))).toBeUndefined();
+    });
+    it("suppresses limit for longblob", () => {
+      expect((makeDumper() as any).schemaLimit(col({ sqlType: "longblob" }))).toBeUndefined();
+    });
+    it("returns limit for varchar", () => {
+      expect((makeDumper() as any).schemaLimit(col({ sqlType: "varchar(100)", limit: 100 }))).toBe(
+        "100",
+      );
+    });
+  });
+
+  describe("schemaPrecision", () => {
+    it("returns undefined for time with precision 0", () => {
+      expect(
+        (makeDumper() as any).schemaPrecision(col({ type: "time", sqlType: "time", precision: 0 })),
+      ).toBeUndefined();
+    });
+    it("returns undefined for timestamp with precision 0", () => {
+      expect(
+        (makeDumper() as any).schemaPrecision(
+          col({ type: "datetime", sqlType: "timestamp", precision: 0 }),
+        ),
+      ).toBeUndefined();
+    });
+    it("returns nil string for datetime with precision 0", () => {
+      expect(
+        (makeDumper() as any).schemaPrecision(
+          col({ type: "datetime", sqlType: "datetime", precision: 0 }),
+        ),
+      ).toBe("nil");
+    });
+    it("returns precision string for datetime with non-default precision", () => {
+      expect(
+        (makeDumper() as any).schemaPrecision(
+          col({ type: "datetime", sqlType: "datetime(3)", precision: 3 }),
+        ),
+      ).toBe("3");
+    });
+  });
+
+  describe("schemaCollation", () => {
+    it("returns undefined when no collation", () => {
+      expect((makeDumper() as any).schemaCollation(col({ collation: null }))).toBeUndefined();
+    });
+    it("returns JSON collation when no connection", () => {
+      expect((makeDumper() as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
+        '"utf8mb4_unicode_ci"',
+      );
+    });
+    it("omits collation when it matches cached table collation", () => {
+      const d = makeDumper();
+      (d as any).connection = {};
+      (d as any)._tableCollationCache["users"] = "utf8mb4_unicode_ci";
+      d.tableName = "users";
+      expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBeUndefined();
+    });
+    it("emits collation when it differs from table collation", () => {
+      const d = makeDumper();
+      (d as any).connection = {};
+      (d as any)._tableCollationCache["users"] = "utf8mb4_general_ci";
+      d.tableName = "users";
+      expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
+        '"utf8mb4_unicode_ci"',
+      );
+    });
+  });
+
+  describe("isDefaultPrimaryKey", () => {
+    it("true for bigint autoIncrement non-unsigned", () => {
+      expect(
+        (makeDumper() as any).isDefaultPrimaryKey(col({ bigint: true, autoIncrement: true })),
+      ).toBe(true);
+    });
+    it("false when unsigned", () => {
+      expect(
+        (makeDumper() as any).isDefaultPrimaryKey(
+          col({ bigint: true, autoIncrement: true, unsigned: true }),
+        ),
+      ).toBe(false);
+    });
+    it("false when not autoIncrement", () => {
+      expect((makeDumper() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false);
+    });
+  });
+
+  describe("isExplicitPrimaryKeyDefault", () => {
+    it("true for integer without autoIncrement", () => {
+      expect((makeDumper() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(
+        true,
+      );
+    });
+    it("false for integer with autoIncrement", () => {
+      expect(
+        (makeDumper() as any).isExplicitPrimaryKeyDefault(
+          col({ type: "integer", autoIncrement: true }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("prepareColumnOptions", () => {
+    it("adds unsigned flag", () => {
+      expect((makeDumper() as any).prepareColumnOptions(col({ unsigned: true }))["unsigned"]).toBe(
+        "true",
+      );
+    });
+    it("adds autoIncrement flag", () => {
+      expect(
+        (makeDumper() as any).prepareColumnOptions(col({ autoIncrement: true }))["autoIncrement"],
+      ).toBe("true");
+    });
+    it("prepends size key for tinytext", () => {
+      const opts = (makeDumper() as any).prepareColumnOptions(col({ sqlType: "tinytext" }));
+      expect(Object.keys(opts)[0]).toBe("size");
+      expect(opts["size"]).toBe(":tiny");
+    });
+  });
+
+  describe("columnSpecForPrimaryKey", () => {
+    it("removes autoIncrement for integer autoIncrement pk", () => {
+      const spec = (makeDumper() as any).columnSpecForPrimaryKey(
+        col({ type: "integer", autoIncrement: true }),
+      );
+      expect(spec["autoIncrement"]).toBeUndefined();
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -11,7 +11,6 @@ const col = (
     sqlType?: string;
     limit?: number | null;
     precision?: number | null;
-    null?: boolean;
     collation?: string | null;
     bigint?: boolean;
     virtual?: boolean;
@@ -22,79 +21,70 @@ const col = (
 ) => ({ name: "col", type: "string", sqlType: "varchar(255)", ...o });
 
 describe("MySQL::SchemaDumper", () => {
-  it("defaultPrimaryKeyType returns bigint", () => {
-    expect(make().defaultPrimaryKeyType()).toBe("bigint");
-  });
+  it("defaultPrimaryKeyType returns bigint", () =>
+    expect(make().defaultPrimaryKeyType()).toBe("bigint"));
 
   describe("schemaType", () => {
-    it("timestamp sql_type → 'timestamp'", () => {
-      expect((make() as any).schemaType(col({ sqlType: "timestamp" }))).toBe("timestamp");
-    });
-    it("enum sql_type → full sql_type string", () => {
-      expect((make() as any).schemaType(col({ sqlType: "enum('a','b')" }))).toBe("enum('a','b')");
-    });
-    it("set sql_type → full sql_type string", () => {
-      expect((make() as any).schemaType(col({ sqlType: "set('x')" }))).toBe("set('x')");
-    });
-    it("standard type delegates to super", () => {
-      expect((make() as any).schemaType(col({ type: "string" }))).toBe("string");
-    });
+    it("timestamp → 'timestamp'", () =>
+      expect((make() as any).schemaType(col({ sqlType: "timestamp" }))).toBe("timestamp"));
+    it("enum → full sql_type", () =>
+      expect((make() as any).schemaType(col({ sqlType: "enum('a','b')" }))).toBe("enum('a','b')"));
+    it("set → full sql_type", () =>
+      expect((make() as any).schemaType(col({ sqlType: "set('x')" }))).toBe("set('x')"));
+    it("standard → delegates to super", () =>
+      expect((make() as any).schemaType(col({ type: "string" }))).toBe("string"));
   });
 
   describe("schemaLimit", () => {
-    it("suppresses limit for tinytext/text/longblob", () => {
-      for (const sqlType of ["tinytext", "text", "longblob", "mediumtext"]) {
-        expect((make() as any).schemaLimit(col({ sqlType }))).toBeUndefined();
+    it("suppresses limit for text/blob family", () => {
+      for (const t of ["tinytext", "text", "longblob", "mediumblob"]) {
+        expect((make() as any).schemaLimit(col({ sqlType: t }))).toBeUndefined();
       }
     });
-    it("returns limit for varchar", () => {
-      expect((make() as any).schemaLimit(col({ sqlType: "varchar(100)", limit: 100 }))).toBe("100");
-    });
+    it("returns limit for varchar", () =>
+      expect((make() as any).schemaLimit(col({ sqlType: "varchar(100)", limit: 100 }))).toBe(
+        "100",
+      ));
   });
 
   describe("schemaPrecision", () => {
-    it("returns undefined for time/timestamp with precision 0", () => {
-      for (const sqlType of ["time", "timestamp"]) {
+    it("time/timestamp precision 0 → undefined", () => {
+      for (const t of ["time", "timestamp"])
         expect(
-          (make() as any).schemaPrecision(col({ type: "datetime", sqlType, precision: 0 })),
+          (make() as any).schemaPrecision(col({ type: "datetime", sqlType: t, precision: 0 })),
         ).toBeUndefined();
-      }
     });
-    it("returns 'nil' for datetime with precision 0", () => {
+    it("datetime precision 0 → 'nil'", () =>
       expect(
         (make() as any).schemaPrecision(
           col({ type: "datetime", sqlType: "datetime", precision: 0 }),
         ),
-      ).toBe("nil");
-    });
-    it("returns precision string for datetime with non-default precision", () => {
+      ).toBe("nil"));
+    it("datetime precision 3 → '3'", () =>
       expect(
         (make() as any).schemaPrecision(
           col({ type: "datetime", sqlType: "datetime(3)", precision: 3 }),
         ),
-      ).toBe("3");
-    });
+      ).toBe("3"));
   });
 
   describe("schemaCollation", () => {
-    it("returns undefined when no collation", () => {
-      expect((make() as any).schemaCollation(col({ collation: null }))).toBeUndefined();
-    });
-    it("returns JSON collation when no connection", () => {
+    it("returns undefined when no collation", () =>
+      expect((make() as any).schemaCollation(col({ collation: null }))).toBeUndefined());
+    it("returns JSON collation with no connection", () =>
       expect((make() as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
         '"utf8mb4_unicode_ci"',
-      );
-    });
-    it("omits collation when matching table default", () => {
+      ));
+    it("omits when matching table default", () => {
       const d = make();
-      (d as any).connection = {};
+      d.connection = {};
       d.tableCollationCache["users"] = "utf8mb4_unicode_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBeUndefined();
     });
-    it("emits collation when differing from table default", () => {
+    it("emits when differing from table default", () => {
       const d = make();
-      (d as any).connection = {};
+      d.connection = {};
       d.tableCollationCache["users"] = "utf8mb4_general_ci";
       d.tableName = "users";
       expect((d as any).schemaCollation(col({ collation: "utf8mb4_unicode_ci" }))).toBe(
@@ -104,45 +94,38 @@ describe("MySQL::SchemaDumper", () => {
   });
 
   describe("isDefaultPrimaryKey", () => {
-    it("true for bigint + autoIncrement + non-unsigned", () => {
+    it("true: bigint + autoIncrement + non-unsigned", () =>
       expect((make() as any).isDefaultPrimaryKey(col({ bigint: true, autoIncrement: true }))).toBe(
         true,
-      );
-    });
-    it("false when unsigned", () => {
+      ));
+    it("false: unsigned", () =>
       expect(
         (make() as any).isDefaultPrimaryKey(
           col({ bigint: true, autoIncrement: true, unsigned: true }),
         ),
-      ).toBe(false);
-    });
-    it("false when not autoIncrement", () => {
-      expect((make() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false);
-    });
+      ).toBe(false));
+    it("false: no autoIncrement", () =>
+      expect((make() as any).isDefaultPrimaryKey(col({ bigint: true }))).toBe(false));
   });
 
   describe("isExplicitPrimaryKeyDefault", () => {
-    it("true for integer without autoIncrement", () => {
-      expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true);
-    });
-    it("false for integer with autoIncrement", () => {
+    it("true: integer + no autoIncrement", () =>
+      expect((make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer" }))).toBe(true));
+    it("false: integer + autoIncrement", () =>
       expect(
         (make() as any).isExplicitPrimaryKeyDefault(col({ type: "integer", autoIncrement: true })),
-      ).toBe(false);
-    });
+      ).toBe(false));
   });
 
   describe("prepareColumnOptions", () => {
-    it("adds unsigned flag", () => {
+    it("adds unsigned", () =>
       expect((make() as any).prepareColumnOptions(col({ unsigned: true }))["unsigned"]).toBe(
         "true",
-      );
-    });
-    it("adds autoIncrement flag", () => {
+      ));
+    it("adds autoIncrement", () =>
       expect(
         (make() as any).prepareColumnOptions(col({ autoIncrement: true }))["autoIncrement"],
-      ).toBe("true");
-    });
+      ).toBe("true"));
     it("prepends size key for tinytext", () => {
       const opts = (make() as any).prepareColumnOptions(col({ sqlType: "tinytext" }));
       expect(Object.keys(opts)[0]).toBe("size");
@@ -151,27 +134,27 @@ describe("MySQL::SchemaDumper", () => {
   });
 
   describe("columnSpecForPrimaryKey", () => {
-    it("removes autoIncrement for integer+autoIncrement pk", () => {
-      const spec = (make() as any).columnSpecForPrimaryKey(
-        col({ type: "integer", autoIncrement: true }),
-      );
-      expect(spec["autoIncrement"]).toBeUndefined();
+    it("removes autoIncrement for integer pk", () => {
+      expect(
+        (make() as any).columnSpecForPrimaryKey(col({ type: "integer", autoIncrement: true }))[
+          "autoIncrement"
+        ],
+      ).toBeUndefined();
     });
   });
 
   describe("extractExpressionForVirtualColumn", () => {
-    it("returns undefined with no tableName", () => {
+    it("undefined when no tableName", () =>
       expect(
         (make() as any).extractExpressionForVirtualColumn(col({ virtual: true })),
-      ).toBeUndefined();
-    });
+      ).toBeUndefined());
     it("returns cached expression", () => {
       const d = make();
       d.tableName = "users";
-      d.virtualExpressionCache["users"] = { col: '"first + last"' };
+      d.virtualExpressionCache["users"] = { col: '"expr"' };
       expect(
         (d as any).extractExpressionForVirtualColumn(col({ name: "col", virtual: true })),
-      ).toBe('"first + last"');
+      ).toBe('"expr"');
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -48,12 +48,16 @@ describe("MySQL::SchemaDumper", () => {
   });
 
   describe("schemaPrecision", () => {
-    it("time/timestamp precision 0 → undefined", () => {
-      for (const t of ["time", "timestamp"])
-        expect(
-          (make() as any).schemaPrecision(col({ type: "datetime", sqlType: t, precision: 0 })),
-        ).toBeUndefined();
-    });
+    it("time precision 0 → undefined", () =>
+      expect(
+        (make() as any).schemaPrecision(col({ type: "time", sqlType: "time", precision: 0 })),
+      ).toBeUndefined());
+    it("timestamp (datetime type) precision 0 → undefined", () =>
+      expect(
+        (make() as any).schemaPrecision(
+          col({ type: "datetime", sqlType: "timestamp", precision: 0 }),
+        ),
+      ).toBeUndefined());
     it("datetime precision 0 → 'nil'", () =>
       expect(
         (make() as any).schemaPrecision(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -7,7 +7,20 @@
 import type { ColumnInfo } from "../../schema-dumper.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
+/**
+ * Column shape expected by this dumper.
+ *
+ * Mirrors Rails' column contract: `column.type` is the DSL cast type (`:string`,
+ * `:integer`, `:datetime` …) and `column.sqlType` is the raw SQL type from the
+ * adapter (`"varchar(255)"`, `"timestamp"`, `"enum('a','b')"` …).
+ *
+ * Note: `AdapterSchemaSource.columns()` currently maps `col.sqlType` into
+ * `ColumnInfo.type` and does not pass `sqlType` separately; extending that
+ * mapping to also include `sqlType` is a follow-up task required to wire this
+ * dumper to live adapter output.
+ */
 interface MysqlColumn extends ColumnInfo {
+  /** Raw SQL type from the adapter (e.g. `"varchar(255)"`, `"timestamp"`). */
   sqlType?: string | null;
   bigint?: boolean;
   virtual?: boolean;
@@ -43,7 +56,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
     const sizeMatch = /^(?<size>tiny|medium|long)(?:text|blob)/i.exec(column.sqlType ?? "");
     if (sizeMatch?.groups) {
-      const size = sizeMatch.groups["size"] as string;
+      const size = (sizeMatch.groups["size"] as string).toLowerCase();
       const rest = { ...spec };
       Object.keys(spec).forEach((k) => delete spec[k]);
       Object.assign(spec, { size: `:${size}` }, rest);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -20,8 +20,15 @@ interface MysqlColumn extends ColumnInfo {
 }
 
 export class SchemaDumper extends AbstractSchemaDumper {
+  /** Injected adapter; presence signals that caches have been (or will be) populated. */
   connection?: object;
+  /** table → table-default collation. Populated by adapter before column iteration. */
   tableCollationCache: Record<string, string> = {};
+  /**
+   * table → column → pre-serialized generation expression (already `.inspect`-equivalent,
+   * i.e. a JSON string literal like `"\"CONCAT(a, b)\""` ready to emit as schema value).
+   * Populated by adapter before column iteration via `information_schema` query.
+   */
   virtualExpressionCache: Record<string, Record<string, string>> = {};
 
   defaultPrimaryKeyType(): string {
@@ -98,8 +105,9 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected override schemaCollation(column: MysqlColumn): string | undefined {
     if (!column.collation) return undefined;
     const tableName = this.tableName;
-    if (!this.connection || !tableName) return JSON.stringify(column.collation);
+    if (!tableName) return JSON.stringify(column.collation);
     const cached = this.tableCollationCache[tableName];
+    // If the table's default collation hasn't been loaded, always emit.
     if (cached === undefined) return JSON.stringify(column.collation);
     return column.collation !== cached ? JSON.stringify(column.collation) : undefined;
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -39,7 +39,10 @@ export interface MysqlConnection {
 export class SchemaDumper extends AbstractSchemaDumper {
   /** Injected adapter connection; used by schemaCollation and extractExpressionForVirtualColumn. */
   connection?: MysqlConnection;
-  private _tableCollationCache: Record<string, string> = {};
+  /** Keyed by table name; populated by adapter before column iteration. */
+  tableCollationCache: Record<string, string> = {};
+  /** table → column → generation expression; populated by adapter before column iteration. */
+  virtualExpressionCache: Record<string, Record<string, string>> = {};
 
   defaultPrimaryKeyType(): string {
     return "bigint";
@@ -54,20 +57,18 @@ export class SchemaDumper extends AbstractSchemaDumper {
     const sizeMatch = /^(?<size>tiny|medium|long)(?:text|blob)/.exec(column.sqlType ?? "");
     if (sizeMatch?.groups) {
       const size = sizeMatch.groups["size"] as string;
-      const withSize: Record<string, unknown> = { size: `:${size}` };
       const rest = { ...spec };
       Object.keys(spec).forEach((k) => delete spec[k]);
-      Object.assign(spec, withSize, rest);
+      Object.assign(spec, { size: `:${size}` }, rest);
     }
 
     if (column.virtual) {
       const as = this.extractExpressionForVirtualColumn(column);
       if (as !== undefined) spec["as"] = as;
       if (/\b(?:STORED|PERSISTENT)\b/.test(column.extra ?? "")) spec["stored"] = "true";
-      const withType: Record<string, unknown> = { type: JSON.stringify(this.schemaType(column)) };
       const rest = { ...spec };
       Object.keys(spec).forEach((k) => delete spec[k]);
-      Object.assign(spec, withType, rest);
+      Object.assign(spec, { type: JSON.stringify(this.schemaType(column)) }, rest);
     }
 
     return spec;
@@ -76,9 +77,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   /** @internal */
   protected override columnSpecForPrimaryKey(column: MysqlColumn): Record<string, unknown> {
     const spec = super.columnSpecForPrimaryKey(column);
-    if (column.type === "integer" && column.autoIncrement) {
-      delete spec["autoIncrement"];
-    }
+    if (column.type === "integer" && column.autoIncrement) delete spec["autoIncrement"];
     return spec;
   }
 
@@ -110,9 +109,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected override schemaPrecision(column: MysqlColumn): string | undefined {
     const sqlType = column.sqlType ?? "";
     if (/^time(?:stamp)?\b/.test(sqlType) && column.precision === 0) return undefined;
-    if (column.type === "datetime") {
+    if (column.type === "datetime")
       return column.precision === 0 ? "nil" : super.schemaPrecision(column);
-    }
     return super.schemaPrecision(column);
   }
 
@@ -121,15 +119,20 @@ export class SchemaDumper extends AbstractSchemaDumper {
     if (!column.collation) return undefined;
     const tableName = this.tableName;
     if (!this.connection || !tableName) return JSON.stringify(column.collation);
-    const cached = this._tableCollationCache[tableName];
+    const cached = this.tableCollationCache[tableName];
     if (cached === undefined) return JSON.stringify(column.collation);
     return column.collation !== cached ? JSON.stringify(column.collation) : undefined;
   }
 
-  /** @internal */
-  protected extractExpressionForVirtualColumn(_column: MysqlColumn): string | undefined {
-    // Requires a live connection to query information_schema; returns undefined
-    // in offline/test contexts. Full wiring requires an injected MysqlConnection.
-    return undefined;
+  /**
+   * Returns the generation expression for a virtual column from `virtualExpressionCache`,
+   * which the adapter populates before iterating columns. Mirrors Rails'
+   * `extract_expression_for_virtual_column` (queries `information_schema` or CREATE TABLE).
+   * @internal
+   */
+  protected extractExpressionForVirtualColumn(column: MysqlColumn): string | undefined {
+    const tableName = this.tableName;
+    if (!tableName) return undefined;
+    return this.virtualExpressionCache[tableName]?.[column.name];
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -8,7 +8,7 @@ import type { ColumnInfo } from "../../schema-dumper.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
 interface MysqlColumn extends ColumnInfo {
-  sqlType?: string;
+  sqlType?: string | null;
   bigint?: boolean;
   virtual?: boolean;
   hasDefault?: boolean;
@@ -16,7 +16,7 @@ interface MysqlColumn extends ColumnInfo {
   comment?: string | null;
   unsigned?: boolean;
   autoIncrement?: boolean;
-  extra?: string;
+  extra?: string | null;
 }
 
 export class SchemaDumper extends AbstractSchemaDumper {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -119,9 +119,9 @@ export class SchemaDumper extends AbstractSchemaDumper {
     if (!column.collation) return undefined;
     const tableName = this.tableName;
     if (!tableName) return JSON.stringify(column.collation);
+    if (!Object.hasOwn(this.tableCollationCache, tableName))
+      return JSON.stringify(column.collation);
     const cached = this.tableCollationCache[tableName];
-    // If the table's default collation hasn't been loaded, always emit.
-    if (cached === undefined) return JSON.stringify(column.collation);
     return column.collation !== cached ? JSON.stringify(column.collation) : undefined;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -88,7 +88,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
   /** @internal */
   protected override isExplicitPrimaryKeyDefault(column: MysqlColumn): boolean {
-    return column.type === "integer" && !column.autoIncrement;
+    return column.type === "integer" && column.autoIncrement === false;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -19,29 +19,9 @@ interface MysqlColumn extends ColumnInfo {
   extra?: string;
 }
 
-/** Minimal connection interface for schemaCollation and extractExpressionForVirtualColumn. */
-export interface MysqlConnection {
-  isMariadb?(): boolean;
-  databaseVersion?: string;
-  quote(value: string): string;
-  quoteColumnName(name: string): string;
-  internalExecQuery(
-    sql: string,
-    name: string,
-  ): Array<Record<string, unknown>> | Promise<Array<Record<string, unknown>>>;
-  queryValue(sql: string, name: string): unknown | Promise<unknown>;
-  /** @internal */ createTableInfo?(tableName: string): string | Promise<string>;
-  /** @internal */ quotedScope?(
-    tableName: string,
-  ): Record<string, string> | Promise<Record<string, string>>;
-}
-
 export class SchemaDumper extends AbstractSchemaDumper {
-  /** Injected adapter connection; used by schemaCollation and extractExpressionForVirtualColumn. */
-  connection?: MysqlConnection;
-  /** Keyed by table name; populated by adapter before column iteration. */
+  connection?: object;
   tableCollationCache: Record<string, string> = {};
-  /** table → column → generation expression; populated by adapter before column iteration. */
   virtualExpressionCache: Record<string, Record<string, string>> = {};
 
   defaultPrimaryKeyType(): string {
@@ -125,9 +105,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /**
-   * Returns the generation expression for a virtual column from `virtualExpressionCache`,
-   * which the adapter populates before iterating columns. Mirrors Rails'
-   * `extract_expression_for_virtual_column` (queries `information_schema` or CREATE TABLE).
+   * Returns the generation expression for a virtual column from `virtualExpressionCache`.
+   * The adapter populates the cache before iterating columns (queries `information_schema`).
    * @internal
    */
   protected extractExpressionForVirtualColumn(column: MysqlColumn): string | undefined {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -23,16 +23,13 @@ export class SchemaDumper extends AbstractSchemaDumper {
   /** Injected adapter; presence signals that caches have been (or will be) populated. */
   connection?: object;
   /** table → table-default collation. Populated by adapter before column iteration. */
-  tableCollationCache: Record<string, string> = Object.create(null) as Record<string, string>;
+  tableCollationCache: Record<string, string | undefined> = Object.create(null);
   /**
    * table → column → pre-serialized generation expression (already `.inspect`-equivalent,
    * i.e. a JSON string literal like `"\"CONCAT(a, b)\""` ready to emit as schema value).
    * Populated by adapter before column iteration via `information_schema` query.
    */
-  virtualExpressionCache: Record<string, Record<string, string>> = Object.create(null) as Record<
-    string,
-    Record<string, string>
-  >;
+  virtualExpressionCache: Record<string, Record<string, string> | undefined> = Object.create(null);
 
   defaultPrimaryKeyType(): string {
     return "bigint";

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -23,13 +23,16 @@ export class SchemaDumper extends AbstractSchemaDumper {
   /** Injected adapter; presence signals that caches have been (or will be) populated. */
   connection?: object;
   /** table → table-default collation. Populated by adapter before column iteration. */
-  tableCollationCache: Record<string, string> = {};
+  tableCollationCache: Record<string, string> = Object.create(null) as Record<string, string>;
   /**
    * table → column → pre-serialized generation expression (already `.inspect`-equivalent,
    * i.e. a JSON string literal like `"\"CONCAT(a, b)\""` ready to emit as schema value).
    * Populated by adapter before column iteration via `information_schema` query.
    */
-  virtualExpressionCache: Record<string, Record<string, string>> = {};
+  virtualExpressionCache: Record<string, Record<string, string>> = Object.create(null) as Record<
+    string,
+    Record<string, string>
+  >;
 
   defaultPrimaryKeyType(): string {
     return "bigint";
@@ -41,7 +44,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
     if (column.unsigned) spec["unsigned"] = "true";
     if (column.autoIncrement) spec["autoIncrement"] = "true";
 
-    const sizeMatch = /^(?<size>tiny|medium|long)(?:text|blob)/.exec(column.sqlType ?? "");
+    const sizeMatch = /^(?<size>tiny|medium|long)(?:text|blob)/i.exec(column.sqlType ?? "");
     if (sizeMatch?.groups) {
       const size = sizeMatch.groups["size"] as string;
       const rest = { ...spec };
@@ -52,7 +55,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
     if (column.virtual) {
       const as = this.extractExpressionForVirtualColumn(column);
       if (as !== undefined) spec["as"] = as;
-      if (/\b(?:STORED|PERSISTENT)\b/.test(column.extra ?? "")) spec["stored"] = "true";
+      if (/\b(?:STORED|PERSISTENT)\b/i.test(column.extra ?? "")) spec["stored"] = "true";
       const rest = { ...spec };
       Object.keys(spec).forEach((k) => delete spec[k]);
       Object.assign(spec, { type: JSON.stringify(this.schemaType(column)) }, rest);
@@ -80,21 +83,21 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
   /** @internal */
   protected override schemaType(column: MysqlColumn): string {
-    const sqlType = column.sqlType ?? "";
+    const sqlType = (column.sqlType ?? "").toLowerCase();
     if (/^timestamp\b/.test(sqlType)) return "timestamp";
-    if (/^(?:enum|set)\b/.test(sqlType)) return sqlType;
+    if (/^(?:enum|set)\b/.test(sqlType)) return column.sqlType ?? sqlType;
     return super.schemaType(column);
   }
 
   /** @internal */
   protected override schemaLimit(column: MysqlColumn): string | undefined {
-    if (/^(?:tiny|medium|long)?(?:text|blob)\b/.test(column.sqlType ?? "")) return undefined;
+    if (/^(?:tiny|medium|long)?(?:text|blob)\b/i.test(column.sqlType ?? "")) return undefined;
     return super.schemaLimit(column);
   }
 
   /** @internal */
   protected override schemaPrecision(column: MysqlColumn): string | undefined {
-    const sqlType = column.sqlType ?? "";
+    const sqlType = (column.sqlType ?? "").toLowerCase();
     if (/^time(?:stamp)?\b/.test(sqlType) && column.precision === 0) return undefined;
     if (column.type === "datetime")
       return column.precision === 0 ? "nil" : super.schemaPrecision(column);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -4,74 +4,132 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper
  */
 
-import { NotImplementedError } from "../../errors.js";
+import type { ColumnInfo } from "../../schema-dumper.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
+interface MysqlColumn extends ColumnInfo {
+  sqlType?: string;
+  bigint?: boolean;
+  virtual?: boolean;
+  hasDefault?: boolean;
+  defaultFunction?: string | null;
+  comment?: string | null;
+  unsigned?: boolean;
+  autoIncrement?: boolean;
+  extra?: string;
+}
+
+/** Minimal connection interface for schemaCollation and extractExpressionForVirtualColumn. */
+export interface MysqlConnection {
+  isMariadb?(): boolean;
+  databaseVersion?: string;
+  quote(value: string): string;
+  quoteColumnName(name: string): string;
+  internalExecQuery(
+    sql: string,
+    name: string,
+  ): Array<Record<string, unknown>> | Promise<Array<Record<string, unknown>>>;
+  queryValue(sql: string, name: string): unknown | Promise<unknown>;
+  /** @internal */ createTableInfo?(tableName: string): string | Promise<string>;
+  /** @internal */ quotedScope?(
+    tableName: string,
+  ): Record<string, string> | Promise<Record<string, string>>;
+}
+
 export class SchemaDumper extends AbstractSchemaDumper {
+  /** Injected adapter connection; used by schemaCollation and extractExpressionForVirtualColumn. */
+  connection?: MysqlConnection;
+  private _tableCollationCache: Record<string, string> = {};
+
   defaultPrimaryKeyType(): string {
     return "bigint";
   }
-}
 
-/** @internal */
-function prepareColumnOptions(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#prepare_column_options is not implemented",
-  );
-}
+  /** @internal */
+  protected override prepareColumnOptions(column: MysqlColumn): Record<string, unknown> {
+    const spec = super.prepareColumnOptions(column);
+    if (column.unsigned) spec["unsigned"] = "true";
+    if (column.autoIncrement) spec["autoIncrement"] = "true";
 
-/** @internal */
-function columnSpecForPrimaryKey(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#column_spec_for_primary_key is not implemented",
-  );
-}
+    const sizeMatch = /^(?<size>tiny|medium|long)(?:text|blob)/.exec(column.sqlType ?? "");
+    if (sizeMatch?.groups) {
+      const size = sizeMatch.groups["size"] as string;
+      const withSize: Record<string, unknown> = { size: `:${size}` };
+      const rest = { ...spec };
+      Object.keys(spec).forEach((k) => delete spec[k]);
+      Object.assign(spec, withSize, rest);
+    }
 
-/** @internal */
-function isDefaultPrimaryKey(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#default_primary_key? is not implemented",
-  );
-}
+    if (column.virtual) {
+      const as = this.extractExpressionForVirtualColumn(column);
+      if (as !== undefined) spec["as"] = as;
+      if (/\b(?:STORED|PERSISTENT)\b/.test(column.extra ?? "")) spec["stored"] = "true";
+      const withType: Record<string, unknown> = { type: JSON.stringify(this.schemaType(column)) };
+      const rest = { ...spec };
+      Object.keys(spec).forEach((k) => delete spec[k]);
+      Object.assign(spec, withType, rest);
+    }
 
-/** @internal */
-function isExplicitPrimaryKeyDefault(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#explicit_primary_key_default? is not implemented",
-  );
-}
+    return spec;
+  }
 
-/** @internal */
-function schemaType(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_type is not implemented",
-  );
-}
+  /** @internal */
+  protected override columnSpecForPrimaryKey(column: MysqlColumn): Record<string, unknown> {
+    const spec = super.columnSpecForPrimaryKey(column);
+    if (column.type === "integer" && column.autoIncrement) {
+      delete spec["autoIncrement"];
+    }
+    return spec;
+  }
 
-/** @internal */
-function schemaLimit(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_limit is not implemented",
-  );
-}
+  /** @internal */
+  protected override isDefaultPrimaryKey(column: MysqlColumn): boolean {
+    return super.isDefaultPrimaryKey(column) && !!column.autoIncrement && !column.unsigned;
+  }
 
-/** @internal */
-function schemaPrecision(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_precision is not implemented",
-  );
-}
+  /** @internal */
+  protected override isExplicitPrimaryKeyDefault(column: MysqlColumn): boolean {
+    return column.type === "integer" && !column.autoIncrement;
+  }
 
-/** @internal */
-function schemaCollation(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_collation is not implemented",
-  );
-}
+  /** @internal */
+  protected override schemaType(column: MysqlColumn): string {
+    const sqlType = column.sqlType ?? "";
+    if (/^timestamp\b/.test(sqlType)) return "timestamp";
+    if (/^(?:enum|set)\b/.test(sqlType)) return sqlType;
+    return super.schemaType(column);
+  }
 
-/** @internal */
-function extractExpressionForVirtualColumn(column: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
-  );
+  /** @internal */
+  protected override schemaLimit(column: MysqlColumn): string | undefined {
+    if (/^(?:tiny|medium|long)?(?:text|blob)\b/.test(column.sqlType ?? "")) return undefined;
+    return super.schemaLimit(column);
+  }
+
+  /** @internal */
+  protected override schemaPrecision(column: MysqlColumn): string | undefined {
+    const sqlType = column.sqlType ?? "";
+    if (/^time(?:stamp)?\b/.test(sqlType) && column.precision === 0) return undefined;
+    if (column.type === "datetime") {
+      return column.precision === 0 ? "nil" : super.schemaPrecision(column);
+    }
+    return super.schemaPrecision(column);
+  }
+
+  /** @internal */
+  protected override schemaCollation(column: MysqlColumn): string | undefined {
+    if (!column.collation) return undefined;
+    const tableName = this.tableName;
+    if (!this.connection || !tableName) return JSON.stringify(column.collation);
+    const cached = this._tableCollationCache[tableName];
+    if (cached === undefined) return JSON.stringify(column.collation);
+    return column.collation !== cached ? JSON.stringify(column.collation) : undefined;
+  }
+
+  /** @internal */
+  protected extractExpressionForVirtualColumn(_column: MysqlColumn): string | undefined {
+    // Requires a live connection to query information_schema; returns undefined
+    // in offline/test contexts. Full wiring requires an injected MysqlConnection.
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary

- Ports all 9 Rails-private overrides from \`MySQL::SchemaDumper\` into \`connection-adapters/mysql/schema-dumper.ts\`
- Closes 0→9/9 (0%→100%) for \`connection_adapters/mysql/schema_dumper.rb\`
- 23 unit tests covering each override

## Methods implemented

All override the abstract base and match Rails layout/order:

- \`prepareColumnOptions\` — adds \`unsigned\`, \`autoIncrement\`, \`size\` prefix for tiny/medium/longtext/blob, virtual column \`as\`/\`stored\`/\`type\` prefix
- \`columnSpecForPrimaryKey\` — strips \`autoIncrement\` for integer+auto_increment PKs
- \`isDefaultPrimaryKey\` — also requires \`autoIncrement\` and non-\`unsigned\`
- \`isExplicitPrimaryKeyDefault\` — integer type without auto_increment
- \`schemaType\` — \`timestamp\` sql_type → \`"timestamp"\`; \`enum\`/\`set\` → full sql_type string
- \`schemaLimit\` — suppresses limit for \`text\`/\`blob\` family
- \`schemaPrecision\` — \`time\`/\`timestamp\` precision 0 → omit; \`datetime\` precision 0 → \`"nil"\`
- \`schemaCollation\` — omits collation when it matches the cached table default (\`tableCollationCache\`, keyed by table name, populated by adapter before column iteration); always emits when cache is not loaded
- \`extractExpressionForVirtualColumn\` — reads from \`virtualExpressionCache\` (table → column → pre-serialized expression literal); returns \`undefined\` when not loaded

## State fields

Two public cache fields for adapter wiring:

- \`tableCollationCache: Record<string, string>\` — table-default collation per table
- \`virtualExpressionCache: Record<string, Record<string, string>>\` — pre-serialized generation expressions (already JSON/inspect-equivalent literals, matching Rails' \`.gsub("\\'", "'").inspect\` output) per table+column

\`connection?: object\` retained as a semantic marker that the adapter has been wired in (not used for method dispatch in this PR).