### PR TITLE
feat(activerecord): attribute_assignment.rb to 100% (Wave 7 PR 26)

### DIFF
--- a/packages/activerecord/src/attribute-assignment.test.ts
+++ b/packages/activerecord/src/attribute-assignment.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for ActiveRecord::AttributeAssignment
+ * Mirrors: activerecord/test/cases/attribute_assignment_test.rb
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Base } from "./index.js";
+import { typeCastAttributeValue, findParameterPosition } from "./attribute-assignment.js";
+import { createTestAdapter } from "./test-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
+
+// ==========================================================================
+// AttributeAssignmentTest — targets attribute_assignment_test.rb
+// ==========================================================================
+describe("AttributeAssignmentTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
+  it("bulk assign attributes", () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("title", "string");
+        this.attribute("author", "string");
+        this.adapter = adapter;
+      }
+    }
+    const topic = new Topic();
+    topic.assignAttributes({ title: "Hello", author: "World" });
+    expect(topic.readAttribute("title")).toBe("Hello");
+    expect(topic.readAttribute("author")).toBe("World");
+  });
+
+  it("multiparameter date assignment", () => {
+    class Person extends Base {
+      static {
+        this._tableName = "people";
+        this.attribute("born_on", "date");
+        this.adapter = adapter;
+      }
+    }
+    const person = new Person();
+    person.assignAttributes({
+      "born_on(1i)": "1990",
+      "born_on(2i)": "1",
+      "born_on(3i)": "15",
+    });
+    const born = person.readAttribute("born_on");
+    expect(born).toBeInstanceOf(Temporal.PlainDate);
+    const d = born as Temporal.PlainDate;
+    expect(d.year).toBe(1990);
+    expect(d.month).toBe(1);
+    expect(d.day).toBe(15);
+  });
+
+  it("multiparameter datetime assignment", () => {
+    class Event extends Base {
+      static {
+        this._tableName = "events";
+        this.attribute("starts_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    const event = new Event();
+    event.assignAttributes({
+      "starts_at(1i)": "2024",
+      "starts_at(2i)": "6",
+      "starts_at(3i)": "15",
+      "starts_at(4i)": "9",
+      "starts_at(5i)": "30",
+      "starts_at(6i)": "0",
+    });
+    const dt = event.readAttribute("starts_at") as Temporal.Instant;
+    expect(dt).toBeInstanceOf(Temporal.Instant);
+    // Cast goes through DateTimeType: PlainDateTime → Instant in UTC
+    const pdt = dt.toZonedDateTimeISO("UTC").toPlainDateTime();
+    expect(pdt.year).toBe(2024);
+    expect(pdt.month).toBe(6);
+    expect(pdt.day).toBe(15);
+    expect(pdt.hour).toBe(9);
+    expect(pdt.minute).toBe(30);
+  });
+
+  it("all blank multiparameter values sets attribute to null", () => {
+    class Person extends Base {
+      static {
+        this._tableName = "people";
+        this.attribute("born_on", "date");
+        this.adapter = adapter;
+      }
+    }
+    const person = new Person();
+    person.assignAttributes({ "born_on(1i)": "", "born_on(2i)": "", "born_on(3i)": "" });
+    expect(person.readAttribute("born_on")).toBeNull();
+  });
+
+  it("regular and multiparameter keys coexist in same assignAttributes call", () => {
+    class Event extends Base {
+      static {
+        this._tableName = "events";
+        this.attribute("title", "string");
+        this.attribute("starts_on", "date");
+        this.adapter = adapter;
+      }
+    }
+    const event = new Event();
+    event.assignAttributes({
+      title: "Conf",
+      "starts_on(1i)": "2025",
+      "starts_on(2i)": "3",
+      "starts_on(3i)": "10",
+    });
+    expect(event.readAttribute("title")).toBe("Conf");
+    const d = event.readAttribute("starts_on") as Temporal.PlainDate;
+    expect(d.year).toBe(2025);
+  });
+
+  // Helpers
+  describe("typeCastAttributeValue", () => {
+    it("casts integer suffix", () => {
+      expect(typeCastAttributeValue("written_on(1i)", "2004")).toBe(2004);
+    });
+
+    it("casts float suffix", () => {
+      expect(typeCastAttributeValue("amount(1f)", "3.14")).toBeCloseTo(3.14);
+    });
+
+    it("returns string when no type suffix", () => {
+      expect(typeCastAttributeValue("written_on(1)", "2004")).toBe("2004");
+    });
+  });
+
+  describe("findParameterPosition", () => {
+    it("returns position from multiparameter name", () => {
+      expect(findParameterPosition("written_on(1i)")).toBe(1);
+      expect(findParameterPosition("written_on(3)")).toBe(3);
+    });
+  });
+});

--- a/packages/activerecord/src/attribute-assignment.test.ts
+++ b/packages/activerecord/src/attribute-assignment.test.ts
@@ -135,6 +135,14 @@ describe("AttributeAssignmentTest", () => {
     it("returns string when no type suffix", () => {
       expect(typeCastAttributeValue("written_on(1)", "2004")).toBe("2004");
     });
+
+    it("returns 0 for blank integer (mirrors Ruby String#to_i)", () => {
+      expect(typeCastAttributeValue("written_on(1i)", "")).toBe(0);
+    });
+
+    it("returns 0.0 for blank float (mirrors Ruby String#to_f)", () => {
+      expect(typeCastAttributeValue("amount(1f)", "")).toBe(0.0);
+    });
   });
 
   describe("findParameterPosition", () => {

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -1,0 +1,118 @@
+/**
+ * AttributeAssignment — bulk and multiparameter attribute assignment.
+ *
+ * Mirrors: ActiveRecord::AttributeAssignment
+ */
+import {
+  extractMultiparameterCallstack,
+  executeMultiparameterAssignment,
+} from "./multiparameter-attribute-assignment.js";
+
+interface AttributeAssignmentHost {
+  writeAttribute(key: string, value: unknown): void;
+  constructor: unknown;
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
+ */
+export function _assignAttributes(
+  this: AttributeAssignmentHost,
+  attributes: Record<string, unknown>,
+): void {
+  let multiParameterAttributes: Record<string, unknown> | null = null;
+  let nestedParameterAttributes: Record<string, unknown> | null = null;
+
+  for (const [k, v] of Object.entries(attributes)) {
+    if (k.includes("(")) {
+      (multiParameterAttributes ??= {})[k] = v;
+    } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      (nestedParameterAttributes ??= {})[k] = v;
+    } else {
+      this.writeAttribute(k, v);
+    }
+  }
+
+  if (nestedParameterAttributes) {
+    assignNestedParameterAttributes.call(
+      this,
+      nestedParameterAttributes as Record<string, unknown>,
+    );
+  }
+  if (multiParameterAttributes) {
+    assignMultiparameterAttributes.call(this, multiParameterAttributes);
+  }
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes
+ */
+export function assignNestedParameterAttributes(
+  this: AttributeAssignmentHost,
+  pairs: Record<string, unknown>,
+): void {
+  for (const [k, v] of Object.entries(pairs)) {
+    this.writeAttribute(k, v);
+  }
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#assign_multiparameter_attributes
+ */
+export function assignMultiparameterAttributes(
+  this: AttributeAssignmentHost,
+  pairs: Record<string, unknown>,
+): void {
+  const callstack = extractCallstackForMultiparameterAttributes.call(this, pairs);
+  executeCallstackForMultiparameterAttributes.call(this, callstack);
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#execute_callstack_for_multiparameter_attributes
+ */
+export function executeCallstackForMultiparameterAttributes(
+  this: AttributeAssignmentHost,
+  callstack: Record<string, Record<number, unknown>>,
+): void {
+  executeMultiparameterAssignment(
+    this as Parameters<typeof executeMultiparameterAssignment>[0],
+    callstack,
+  );
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#extract_callstack_for_multiparameter_attributes
+ */
+export function extractCallstackForMultiparameterAttributes(
+  this: AttributeAssignmentHost,
+  pairs: Record<string, unknown>,
+): Record<string, Record<number, unknown>> {
+  return extractMultiparameterCallstack(pairs).multiparams;
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#type_cast_attribute_value
+ */
+export function typeCastAttributeValue(multiparameterName: string, value: string): unknown {
+  const match = multiparameterName.match(/\(\d*([if])\)/);
+  if (!match) return value;
+  const flag = match[1];
+  if (flag === "i") return parseInt(value, 10);
+  if (flag === "f") return parseFloat(value);
+  return value;
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeAssignment#find_parameter_position
+ */
+export function findParameterPosition(multiparameterName: string): number {
+  const match = multiparameterName.match(/\((\d+)/);
+  return match ? parseInt(match[1], 10) : 0;
+}

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -110,8 +110,15 @@ export function typeCastAttributeValue(multiparameterName: string, value: string
   const match = multiparameterName.match(/\(\d*([if])\)/);
   if (!match) return value;
   const flag = match[1];
-  if (flag === "i") return parseInt(value, 10);
-  if (flag === "f") return parseFloat(value);
+  // Ruby's String#to_i / #to_f return 0 / 0.0 for blank/invalid input.
+  if (flag === "i") {
+    const n = parseInt(value, 10);
+    return isNaN(n) ? 0 : n;
+  }
+  if (flag === "f") {
+    const n = parseFloat(value);
+    return isNaN(n) ? 0.0 : n;
+  }
   return value;
 }
 

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -2,6 +2,13 @@
  * AttributeAssignment — bulk and multiparameter attribute assignment.
  *
  * Mirrors: ActiveRecord::AttributeAssignment
+ *
+ * Runtime note: the public `assignAttributes` entry-point lives in
+ * `persistence.ts` (wired onto Base), which delegates to the helpers in
+ * `multiparameter-attribute-assignment.ts`. The functions exported here are
+ * the Rails-private layer (`_assign_attributes`, `assign_multiparameter_attributes`,
+ * etc.) that Rails' `assign_attributes` calls internally — they exist here for
+ * Rails-layout parity (`api:compare`) and are @internal.
  */
 import {
   extractMultiparameterCallstack,
@@ -26,9 +33,9 @@ export function _assignAttributes(
 
   for (const [k, v] of Object.entries(attributes)) {
     if (k.includes("(")) {
-      (multiParameterAttributes ??= {})[k] = v;
+      (multiParameterAttributes ??= Object.create(null))[k] = v;
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-      (nestedParameterAttributes ??= {})[k] = v;
+      (nestedParameterAttributes ??= Object.create(null))[k] = v;
     } else {
       this.writeAttribute(k, v);
     }


### PR DESCRIPTION
## Summary

- Creates `packages/activerecord/src/attribute-assignment.ts` mirroring `ActiveRecord::AttributeAssignment`
- Implements all 7 missing methods: `_assignAttributes`, `assignNestedParameterAttributes`, `assignMultiparameterAttributes`, `executeCallstackForMultiparameterAttributes`, `extractCallstackForMultiparameterAttributes`, `typeCastAttributeValue`, `findParameterPosition`
- Delegates multiparameter logic to existing `multiparameter-attribute-assignment.ts` helpers
- 9 tests covering bulk assignment, date/datetime multiparameter, blank values, coexistence of regular + multiparameter keys, and helper unit tests
- `api:compare --package activerecord`: `attribute_assignment.rb` 0% → 100% ✓

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/attribute-assignment.test.ts` — 9/9 pass
- [x] `pnpm api:compare --package activerecord` — attribute_assignment.rb 7/7 (100%)
- [x] `pnpm lint` — clean
- [x] `pnpm build` + `pnpm typecheck` — clean (via pre-commit hook)