### PR TITLE
refactor: move yaml optional peer dep from activemodel to activesupport

### DIFF
--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -29,13 +29,5 @@
   "dependencies": {
     "@blazetrails/activesupport": "workspace:*",
     "bcryptjs": "^3.0.3"
-  },
-  "peerDependencies": {
-    "yaml": "^2.8.3"
-  },
-  "peerDependenciesMeta": {
-    "yaml": {
-      "optional": true
-    }
   }
 }

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -1,4 +1,4 @@
-import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import { parse as yamlParse, stringify as yamlStringify } from "@blazetrails/activesupport/yaml";
 import { AttributeSetCoderError } from "../coder.js";
 import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
 

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/cache/*.d.ts",
       "default": "./dist/cache/*.js"
     },
+    "./yaml": {
+      "types": "./dist/yaml.d.ts",
+      "default": "./dist/yaml.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"
@@ -72,7 +76,14 @@
   "license": "MIT",
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "tinyglobby": "^0.2.16",
+    "tinyglobby": "^0.2.16"
+  },
+  "peerDependencies": {
     "yaml": "^2.8.3"
+  },
+  "peerDependenciesMeta": {
+    "yaml": {
+      "optional": true
+    }
   }
 }

--- a/packages/activesupport/src/yaml.ts
+++ b/packages/activesupport/src/yaml.ts
@@ -1,0 +1,1 @@
+export { parse, stringify } from "yaml";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ const alias = {
     "packages/activesupport/src/temporal.ts",
   ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
+  "@blazetrails/activesupport/yaml": path.resolve(__dirname, "packages/activesupport/src/yaml.ts"),
   "@blazetrails/activesupport/process-adapter": path.resolve(
     __dirname,
     "packages/activesupport/src/process-adapter.ts",


### PR DESCRIPTION
## Summary

- Adds `packages/activesupport/src/yaml.ts` — a thin shim re-exporting `parse`/`stringify` from `"yaml"`
- Moves `yaml` from `dependencies` → `peerDependencies` (optional) in `activesupport/package.json` and adds a `"./yaml"` exports entry
- Updates `activemodel` yaml codec to import via `@blazetrails/activesupport/yaml` instead of `"yaml"` directly; removes `yaml` peer dep from `activemodel/package.json` entirely
- Adds `@blazetrails/activesupport/yaml` alias to `vitest.config.ts` so tests resolve through source

## Test plan
- [ ] `pnpm build` passes (typecheck included via pre-commit hook)
- [ ] `pnpm vitest run packages/activemodel/src/attribute-set/codecs/yaml.test.ts` — 7/7 pass
- [ ] `grep '"yaml"' packages/activemodel/package.json` returns nothing