### PR TITLE
feat(activerecord): mysql/schema_statements.rb to 100% (Wave 3 PR 11)

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -15,7 +15,13 @@ export class Column extends BaseColumn {
   constructor(
     name: string,
     defaultValue: unknown,
-    sqlTypeMetadata: { sqlType?: string | null; type?: string } = {},
+    sqlTypeMetadata: {
+      sqlType?: string | null;
+      type?: string;
+      limit?: number | null;
+      precision?: number | null;
+      scale?: number | null;
+    } = {},
     null_: boolean = true,
     options: {
       collation?: string | null;
@@ -29,6 +35,9 @@ export class Column extends BaseColumn {
     const meta = new SqlTypeMetadata({
       sqlType: sqlTypeMetadata.sqlType ?? undefined,
       type: sqlTypeMetadata.type,
+      limit: sqlTypeMetadata.limit ?? null,
+      precision: sqlTypeMetadata.precision ?? null,
+      scale: sqlTypeMetadata.scale ?? null,
     });
     super(name, defaultValue, meta, null_, {
       collation: options.collation,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -141,6 +141,11 @@ describe("MySQL::SchemaStatements", () => {
     expect(col.default).toBe("hello world");
   });
 
+  it("fetchTypeMetadata: fallback strips unsigned/zerofill modifiers", () => {
+    expect(fetchTypeMetadata("bigint unsigned").type).toBe("bigint");
+    expect(fetchTypeMetadata("int unsigned zerofill").type).toBe("int");
+  });
+
   it("fetchTypeMetadata wraps sqlType with MySQL TypeMetadata", () => {
     const meta = fetchTypeMetadata("varchar(255)", "auto_increment");
     expect(meta.sqlType).toBe("varchar(255)");
@@ -149,14 +154,14 @@ describe("MySQL::SchemaStatements", () => {
   });
 
   it("fetchTypeMetadata: uses lookupCastType for limit/precision/scale", () => {
-    const lookup = (s: string) => ({ type: "integer", limit: 8, precision: null, scale: null });
+    const lookup = (s: string) => ({ name: "integer", limit: 8, precision: null, scale: null });
     const meta = fetchTypeMetadata("bigint unsigned", "", lookup);
     expect(meta.type).toBe("integer");
     expect(meta.limit).toBe(8);
   });
 
   it("newColumnFromField: limit from lookupCastType is preserved on Column", () => {
-    const lookup = (s: string) => ({ type: "integer", limit: 8, precision: null, scale: null });
+    const lookup = (s: string) => ({ name: "integer", limit: 8, precision: null, scale: null });
     const col = newColumnFromField(
       "t",
       { Field: "id", Type: "bigint", Null: "NO", Default: null, Extra: "" },
@@ -167,7 +172,7 @@ describe("MySQL::SchemaStatements", () => {
   });
 
   it("fetchTypeMetadata: lookupCastType boolean mapping (tinyint(1) emulation)", () => {
-    const lookup = (s: string) => ({ type: "boolean", limit: null, precision: null, scale: null });
+    const lookup = (s: string) => ({ name: "boolean", limit: null, precision: null, scale: null });
     const meta = fetchTypeMetadata("tinyint(1)", "", lookup);
     expect(meta.type).toBe("boolean");
   });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -148,6 +148,19 @@ describe("MySQL::SchemaStatements", () => {
     expect(fetchTypeMetadata("int").extra).toBe("");
   });
 
+  it("fetchTypeMetadata: uses lookupCastType for limit/precision/scale", () => {
+    const lookup = (s: string) => ({ type: "integer", limit: 8, precision: null, scale: null });
+    const meta = fetchTypeMetadata("bigint unsigned", "", lookup);
+    expect(meta.type).toBe("integer");
+    expect(meta.limit).toBe(8);
+  });
+
+  it("fetchTypeMetadata: lookupCastType boolean mapping (tinyint(1) emulation)", () => {
+    const lookup = (s: string) => ({ type: "boolean", limit: null, precision: null, scale: null });
+    const meta = fetchTypeMetadata("tinyint(1)", "", lookup);
+    expect(meta.type).toBe("boolean");
+  });
+
   it("extractForeignKeyAction: RESTRICT → undefined, others normalized", () => {
     expect(extractForeignKeyAction("RESTRICT")).toBeUndefined();
     expect(extractForeignKeyAction("CASCADE")).toBe("cascade");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -8,6 +8,8 @@ import {
   fetchTypeMetadata,
   extractForeignKeyAction,
   addIndexLength,
+  addOptionsForIndexColumns,
+  dataSourceSql,
   quotedScope,
   extractSchemaQualifiedName,
   typeWithSizeToSql,
@@ -18,11 +20,13 @@ import {
 describe("MySQL::SchemaStatements", () => {
   it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", () => {
     expect(isRowFormatDynamicByDefault(true, "10.2.2")).toBe(true);
+    expect(isRowFormatDynamicByDefault(true, "10.10.0")).toBe(true); // numeric, not lexicographic
     expect(isRowFormatDynamicByDefault(true, "10.2.1")).toBe(false);
   });
 
   it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", () => {
     expect(isRowFormatDynamicByDefault(false, "5.7.9")).toBe(true);
+    expect(isRowFormatDynamicByDefault(false, "5.11.0")).toBe(true); // numeric: 11 > 7
     expect(isRowFormatDynamicByDefault(false, "5.7.8")).toBe(false);
   });
 
@@ -75,11 +79,49 @@ describe("MySQL::SchemaStatements", () => {
     expect(result.get("email")).toBe("`email`(20)");
   });
 
+  it("addIndexLength applies scalar length to all columns", () => {
+    const cols = new Map([
+      ["name", "`name`"],
+      ["email", "`email`"],
+    ]);
+    const result = addIndexLength(cols, { length: 10 });
+    expect(result.get("name")).toBe("`name`(10)");
+    expect(result.get("email")).toBe("`email`(10)");
+  });
+
+  it("addOptionsForIndexColumns: applies length and per-column order", () => {
+    const cols = new Map([["name", "`name`"]]);
+    expect(
+      addOptionsForIndexColumns(cols, { length: { name: 5 }, order: { name: "desc" } }).get("name"),
+    ).toBe("`name`(5) DESC");
+  });
+
+  it("addOptionsForIndexColumns: string order applies to all columns", () => {
+    const cols = new Map([
+      ["a", "`a`"],
+      ["b", "`b`"],
+    ]);
+    const result = addOptionsForIndexColumns(cols, { order: "asc" });
+    expect(result.get("a")).toBe("`a` ASC");
+    expect(result.get("b")).toBe("`b` ASC");
+  });
+
   it("extractSchemaQualifiedName splits schema.table", () => {
     expect(extractSchemaQualifiedName("mydb.users")).toEqual(["mydb", "users"]);
     expect(extractSchemaQualifiedName("`mydb`.`users`")).toEqual(["mydb", "users"]);
     expect(extractSchemaQualifiedName("users")).toEqual([null, "users"]);
     expect(extractSchemaQualifiedName(null)).toEqual([null, null]);
+  });
+
+  it("dataSourceSql: generates information_schema query", () => {
+    const sql = dataSourceSql();
+    expect(sql).toContain("SELECT table_name FROM information_schema.tables");
+    expect(sql).toContain("WHERE table_schema = database()");
+    expect(dataSourceSql("users")).toContain("AND table_name = 'users'");
+    expect(dataSourceSql(undefined, "BASE TABLE")).toContain("AND table_type = 'BASE TABLE'");
+    const qualified = dataSourceSql("mydb.users");
+    expect(qualified).toContain("table_schema = 'mydb'");
+    expect(qualified).toContain("table_name = 'users'");
   });
 
   it("quotedScope builds scope hash", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -146,9 +146,10 @@ describe("MySQL::SchemaStatements", () => {
     expect(fetchTypeMetadata("int").extra).toBe("");
   });
 
-  it("extractForeignKeyAction: RESTRICT → undefined, others pass through", () => {
+  it("extractForeignKeyAction: RESTRICT → undefined, others normalized", () => {
     expect(extractForeignKeyAction("RESTRICT")).toBeUndefined();
-    expect(extractForeignKeyAction("CASCADE")).toBe("CASCADE");
+    expect(extractForeignKeyAction("CASCADE")).toBe("cascade");
+    expect(extractForeignKeyAction("SET NULL")).toBe("nullify");
   });
 
   it("addIndexLength appends (N) prefix length to column", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -61,6 +61,7 @@ describe("MySQL::SchemaStatements", () => {
   it("newColumnFromField: builds Column from SHOW COLUMNS field hash", () => {
     const noInfo = () => null;
     const col = newColumnFromField(
+      "users",
       {
         Field: "name",
         Type: "varchar(255)",
@@ -70,7 +71,6 @@ describe("MySQL::SchemaStatements", () => {
         Collation: "utf8_general_ci",
       },
       noInfo,
-      "users",
     );
     expect(col.name).toBe("name");
     expect(col.default).toBe("Dean");
@@ -81,6 +81,7 @@ describe("MySQL::SchemaStatements", () => {
   it("newColumnFromField: CURRENT_TIMESTAMP default becomes defaultFunction on datetime", () => {
     const noInfo = () => null;
     const col = newColumnFromField(
+      "events",
       {
         Field: "created_at",
         Type: "datetime",
@@ -89,7 +90,6 @@ describe("MySQL::SchemaStatements", () => {
         Extra: "",
       },
       noInfo,
-      "events",
     );
     expect(col.default).toBeNull();
     expect(col.defaultFunction).toBe("CURRENT_TIMESTAMP");
@@ -98,6 +98,7 @@ describe("MySQL::SchemaStatements", () => {
   it("newColumnFromField: DEFAULT_GENERATED extra becomes defaultFunction", () => {
     const noInfo = () => null;
     const col = newColumnFromField(
+      "orders",
       {
         Field: "total",
         Type: "decimal(10,2)",
@@ -106,7 +107,6 @@ describe("MySQL::SchemaStatements", () => {
         Extra: "DEFAULT_GENERATED",
       },
       noInfo,
-      "orders",
     );
     expect(col.default).toBeNull();
     expect(col.defaultFunction).toBe("(price * qty)");
@@ -115,9 +115,9 @@ describe("MySQL::SchemaStatements", () => {
   it("newColumnFromField: text default strips surrounding quotes", () => {
     const noInfo = () => null;
     const col = newColumnFromField(
+      "users",
       { Field: "bio", Type: "text", Null: "YES", Default: "'hello world'", Extra: "" },
       noInfo,
-      "users",
     );
     expect(col.default).toBe("hello world");
   });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -22,6 +22,8 @@ describe("MySQL::SchemaStatements", () => {
   it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", () => {
     expect(isRowFormatDynamicByDefault(true, "10.2.2")).toBe(true);
     expect(isRowFormatDynamicByDefault(true, "10.10.0")).toBe(true); // numeric, not lexicographic
+    expect(isRowFormatDynamicByDefault(true, "10.2.2-MariaDB")).toBe(true); // suffix stripped
+    expect(isRowFormatDynamicByDefault(true, "10.2.1-MariaDB")).toBe(false);
     expect(isRowFormatDynamicByDefault(true, "10.2.1")).toBe(false);
   });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  isRowFormatDynamicByDefault,
+  defaultRowFormat,
+  validPrimaryKeyOptions,
+  createTableDefinition,
+  defaultType,
+  fetchTypeMetadata,
+  extractForeignKeyAction,
+  addIndexLength,
+  quotedScope,
+  extractSchemaQualifiedName,
+  typeWithSizeToSql,
+  limitToSize,
+  integerToSql,
+} from "./schema-statements.js";
+
+describe("MySQL::SchemaStatements", () => {
+  it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", () => {
+    expect(isRowFormatDynamicByDefault(true, "10.2.2")).toBe(true);
+    expect(isRowFormatDynamicByDefault(true, "10.2.1")).toBe(false);
+  });
+
+  it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", () => {
+    expect(isRowFormatDynamicByDefault(false, "5.7.9")).toBe(true);
+    expect(isRowFormatDynamicByDefault(false, "5.7.8")).toBe(false);
+  });
+
+  it("defaultRowFormat: null when dynamic by default", () => {
+    expect(defaultRowFormat(false, "8.0.0", true, true)).toBeNull();
+  });
+
+  it("defaultRowFormat: ROW_FORMAT=DYNAMIC when innodb settings set", () => {
+    expect(defaultRowFormat(false, "5.6.0", true, true)).toBe("ROW_FORMAT=DYNAMIC");
+    expect(defaultRowFormat(false, "5.6.0", false, true)).toBeNull();
+  });
+
+  it("validPrimaryKeyOptions includes unsigned and autoIncrement", () => {
+    const opts = validPrimaryKeyOptions();
+    expect(opts).toContain("unsigned");
+    expect(opts).toContain("autoIncrement");
+    expect(opts).toContain("limit");
+  });
+
+  it("createTableDefinition returns MySQL TableDefinition", () => {
+    expect(createTableDefinition("users").tableName).toBe("users");
+  });
+
+  it("defaultType: parses string/integer/function defaults", () => {
+    expect(defaultType("`name` varchar(255) DEFAULT 'admin'", "name")).toBe("string");
+    expect(defaultType("`count` int DEFAULT 42", "count")).toBe("integer");
+    expect(defaultType("`updated_at` datetime DEFAULT NOW", "updated_at")).toBe("function");
+    expect(defaultType(null, "name")).toBeUndefined();
+  });
+
+  it("fetchTypeMetadata wraps sqlType with MySQL TypeMetadata", () => {
+    const meta = fetchTypeMetadata("varchar(255)", "auto_increment");
+    expect(meta.sqlType).toBe("varchar(255)");
+    expect(meta.extra).toBe("auto_increment");
+    expect(fetchTypeMetadata("int").extra).toBe("");
+  });
+
+  it("extractForeignKeyAction: RESTRICT → undefined, others pass through", () => {
+    expect(extractForeignKeyAction("RESTRICT")).toBeUndefined();
+    expect(extractForeignKeyAction("CASCADE")).toBe("CASCADE");
+  });
+
+  it("addIndexLength appends (N) prefix length to column", () => {
+    const cols = new Map([
+      ["name", "`name`"],
+      ["email", "`email`"],
+    ]);
+    const result = addIndexLength(cols, { length: { email: 20 } });
+    expect(result.get("name")).toBe("`name`");
+    expect(result.get("email")).toBe("`email`(20)");
+  });
+
+  it("extractSchemaQualifiedName splits schema.table", () => {
+    expect(extractSchemaQualifiedName("mydb.users")).toEqual(["mydb", "users"]);
+    expect(extractSchemaQualifiedName("`mydb`.`users`")).toEqual(["mydb", "users"]);
+    expect(extractSchemaQualifiedName("users")).toEqual([null, "users"]);
+    expect(extractSchemaQualifiedName(null)).toEqual([null, null]);
+  });
+
+  it("quotedScope builds scope hash", () => {
+    expect(quotedScope().schema).toBe("database()");
+    expect(quotedScope("users").name).toBe("'users'");
+    const q = quotedScope("mydb.users");
+    expect(q.schema).toBe("'mydb'");
+    expect(q.name).toBe("'users'");
+    expect(quotedScope(undefined, { type: "BASE TABLE" }).type).toBe("'BASE TABLE'");
+  });
+
+  it("typeWithSizeToSql: builds prefixed type names", () => {
+    expect(typeWithSizeToSql("text", undefined)).toBe("text");
+    expect(typeWithSizeToSql("text", "tiny")).toBe("tinytext");
+    expect(typeWithSizeToSql("text", "medium")).toBe("mediumtext");
+    expect(typeWithSizeToSql("blob", "long")).toBe("longblob");
+    expect(() => typeWithSizeToSql("text", "huge")).toThrow("invalid :size value");
+  });
+
+  it("limitToSize: maps byte limits for text/blob/binary", () => {
+    expect(limitToSize(255, "text")).toBe("tiny");
+    expect(limitToSize(null, "text")).toBeUndefined();
+    expect(limitToSize(65536, "text")).toBe("medium");
+    expect(limitToSize(16777216, "text")).toBe("long");
+    expect(limitToSize(4, "integer")).toBeUndefined();
+    expect(() => limitToSize(5_000_000_000, "text")).toThrow();
+  });
+
+  it("integerToSql: maps limit to MySQL int types", () => {
+    expect(integerToSql(1)).toBe("tinyint");
+    expect(integerToSql(2)).toBe("smallint");
+    expect(integerToSql(3)).toBe("mediumint");
+    expect(integerToSql(null)).toBe("int");
+    expect(integerToSql(4)).toBe("int");
+    expect(integerToSql(8)).toBe("bigint");
+    expect(() => integerToSql(9)).toThrow("No integer type has byte size");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -5,6 +5,7 @@ import {
   validPrimaryKeyOptions,
   createTableDefinition,
   defaultType,
+  newColumnFromField,
   fetchTypeMetadata,
   extractForeignKeyAction,
   addIndexLength,
@@ -55,6 +56,70 @@ describe("MySQL::SchemaStatements", () => {
     expect(defaultType("`count` int DEFAULT 42", "count")).toBe("integer");
     expect(defaultType("`updated_at` datetime DEFAULT NOW", "updated_at")).toBe("function");
     expect(defaultType(null, "name")).toBeUndefined();
+  });
+
+  it("newColumnFromField: builds Column from SHOW COLUMNS field hash", () => {
+    const noInfo = () => null;
+    const col = newColumnFromField(
+      {
+        Field: "name",
+        Type: "varchar(255)",
+        Null: "YES",
+        Default: "Dean",
+        Extra: "",
+        Collation: "utf8_general_ci",
+      },
+      noInfo,
+      "users",
+    );
+    expect(col.name).toBe("name");
+    expect(col.default).toBe("Dean");
+    expect(col.null).toBe(true);
+    expect(col.collation).toBe("utf8_general_ci");
+  });
+
+  it("newColumnFromField: CURRENT_TIMESTAMP default becomes defaultFunction on datetime", () => {
+    const noInfo = () => null;
+    const col = newColumnFromField(
+      {
+        Field: "created_at",
+        Type: "datetime",
+        Null: "NO",
+        Default: "CURRENT_TIMESTAMP",
+        Extra: "",
+      },
+      noInfo,
+      "events",
+    );
+    expect(col.default).toBeNull();
+    expect(col.defaultFunction).toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("newColumnFromField: DEFAULT_GENERATED extra becomes defaultFunction", () => {
+    const noInfo = () => null;
+    const col = newColumnFromField(
+      {
+        Field: "total",
+        Type: "decimal(10,2)",
+        Null: "YES",
+        Default: "price * qty",
+        Extra: "DEFAULT_GENERATED",
+      },
+      noInfo,
+      "orders",
+    );
+    expect(col.default).toBeNull();
+    expect(col.defaultFunction).toBe("(price * qty)");
+  });
+
+  it("newColumnFromField: text default strips surrounding quotes", () => {
+    const noInfo = () => null;
+    const col = newColumnFromField(
+      { Field: "bio", Type: "text", Null: "YES", Default: "'hello world'", Extra: "" },
+      noInfo,
+      "users",
+    );
+    expect(col.default).toBe("hello world");
   });
 
   it("fetchTypeMetadata wraps sqlType with MySQL TypeMetadata", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -155,6 +155,17 @@ describe("MySQL::SchemaStatements", () => {
     expect(meta.limit).toBe(8);
   });
 
+  it("newColumnFromField: limit from lookupCastType is preserved on Column", () => {
+    const lookup = (s: string) => ({ type: "integer", limit: 8, precision: null, scale: null });
+    const col = newColumnFromField(
+      "t",
+      { Field: "id", Type: "bigint", Null: "NO", Default: null, Extra: "" },
+      () => null,
+      lookup,
+    );
+    expect(col.sqlTypeMetadata?.limit).toBe(8);
+  });
+
   it("fetchTypeMetadata: lookupCastType boolean mapping (tinyint(1) emulation)", () => {
     const lookup = (s: string) => ({ type: "boolean", limit: null, precision: null, scale: null });
     const meta = fetchTypeMetadata("tinyint(1)", "", lookup);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -201,7 +201,9 @@ describe("MySQL::SchemaStatements", () => {
     expect(sql).toContain("SELECT table_name FROM information_schema.tables");
     expect(sql).toContain("WHERE table_schema = database()");
     expect(dataSourceSql("users")).toContain("AND table_name = 'users'");
-    expect(dataSourceSql(undefined, "BASE TABLE")).toContain("AND table_type = 'BASE TABLE'");
+    expect(dataSourceSql(undefined, { type: "BASE TABLE" })).toContain(
+      "AND table_type = 'BASE TABLE'",
+    );
     const qualified = dataSourceSql("mydb.users");
     expect(qualified).toContain("table_schema = 'mydb'");
     expect(qualified).toContain("table_name = 'users'");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -78,6 +78,23 @@ describe("MySQL::SchemaStatements", () => {
     expect(col.collation).toBe("utf8_general_ci");
   });
 
+  it("newColumnFromField: CURRENT_TIMESTAMP default becomes defaultFunction on timestamp (alias for datetime)", () => {
+    const noInfo = () => null;
+    const col = newColumnFromField(
+      "events",
+      {
+        Field: "updated_at",
+        Type: "timestamp",
+        Null: "NO",
+        Default: "CURRENT_TIMESTAMP",
+        Extra: "",
+      },
+      noInfo,
+    );
+    expect(col.default).toBeNull();
+    expect(col.defaultFunction).toBe("CURRENT_TIMESTAMP");
+  });
+
   it("newColumnFromField: CURRENT_TIMESTAMP default becomes defaultFunction on datetime", () => {
     const noInfo = () => null;
     const col = newColumnFromField(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -137,7 +137,7 @@ export function newColumnFromField(
   field: Record<string, string | null>,
   createTableInfoFn: (tableName: string) => string | null,
   lookupCastType?: (sqlType: string) => {
-    type?: string;
+    name: string;
     limit?: number | null;
     precision?: number | null;
     scale?: number | null;
@@ -175,7 +175,7 @@ export function fetchTypeMetadata(
   sqlType: string,
   extra: string = "",
   lookupCastType?: (sqlType: string) => {
-    type?: string;
+    name: string;
     limit?: number | null;
     precision?: number | null;
     scale?: number | null;
@@ -188,18 +188,20 @@ export function fetchTypeMetadata(
 
   if (lookupCastType) {
     const castType = lookupCastType(sqlType);
-    // Normalize timestamp → datetime to match abstract type map alias_type.
-    const raw = (castType.type ?? sqlType).toLowerCase();
+    // Use .name (plain string property on ActiveModel Type).
+    const raw = castType.name.toLowerCase();
     baseType = /^timestamp/.test(raw) ? "datetime" : raw;
     limit = castType.limit ?? null;
     precision = castType.precision ?? null;
     scale = castType.scale ?? null;
   } else {
-    // Fallback: strip modifiers and normalize without adapter context.
+    // Fallback: strip (N) modifiers, then take first whitespace token to drop
+    // trailing modifiers like "unsigned" or "zerofill".
     baseType = sqlType
       .replace(/\(.*\).*$/, "")
       .trim()
-      .toLowerCase();
+      .toLowerCase()
+      .split(/\s+/)[0]!;
     if (/^timestamp/.test(baseType)) baseType = "datetime";
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -85,11 +85,21 @@ export interface SchemaStatements {
 }
 
 /** @internal */
-export function isRowFormatDynamicByDefault(isMariaDb: boolean, databaseVersion: string): boolean {
-  if (isMariaDb) {
-    return databaseVersion >= "10.2.2";
+function versionGte(version: string, threshold: string): boolean {
+  const parse = (v: string) => v.split(".").map(Number);
+  const a = parse(version);
+  const b = parse(threshold);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av > bv;
   }
-  return databaseVersion >= "5.7.9";
+  return true;
+}
+
+/** @internal */
+export function isRowFormatDynamicByDefault(isMariaDb: boolean, databaseVersion: string): boolean {
+  return isMariaDb ? versionGte(databaseVersion, "10.2.2") : versionGte(databaseVersion, "5.7.9");
 }
 
 /** @internal */
@@ -123,9 +133,8 @@ export function defaultType(
   fieldName: string,
 ): "string" | "integer" | "function" | undefined {
   if (!createTableInfo) return undefined;
-  const match = createTableInfo.match(
-    new RegExp("`" + fieldName + "` (.+) DEFAULT ('|\\d+|[A-Za-z]+)"),
-  );
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = createTableInfo.match(new RegExp("`" + escaped + "` (.+) DEFAULT ('|\\d+|[A-z]+)"));
   const defaultPre = match?.[2];
   if (defaultPre === "'") return "string";
   if (defaultPre?.match(/^\d+$/)) return "integer";
@@ -184,11 +193,11 @@ export function addIndexLength(
   options: { length?: Record<string, number> | number } = {},
 ): Map<string, string> {
   if (!options.length) return quotedColumns;
-  const lengths = typeof options.length === "object" ? options.length : {};
+  const lengthMap = typeof options.length === "object" ? options.length : null;
+  const scalar = typeof options.length === "number" ? options.length : null;
   for (const [name, col] of quotedColumns) {
-    if (lengths[name] != null) {
-      quotedColumns.set(name, `${col}(${lengths[name]})`);
-    }
+    const len = lengthMap ? lengthMap[name] : scalar;
+    if (len != null) quotedColumns.set(name, `${col}(${len})`);
   }
   return quotedColumns;
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -136,9 +136,15 @@ export function newColumnFromField(
   tableName: string,
   field: Record<string, string | null>,
   createTableInfoFn: (tableName: string) => string | null,
+  lookupCastType?: (sqlType: string) => {
+    type?: string;
+    limit?: number | null;
+    precision?: number | null;
+    scale?: number | null;
+  },
 ): Column {
   const fieldName = field["Field"] ?? "";
-  const meta = fetchTypeMetadata(field["Type"] ?? "", field["Extra"] ?? "");
+  const meta = fetchTypeMetadata(field["Type"] ?? "", field["Extra"] ?? "", lookupCastType);
   let def: string | null = field["Default"] ?? null;
   let defFn: string | null = null;
 
@@ -165,15 +171,39 @@ export function newColumnFromField(
 }
 
 /** @internal */
-export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMetadata {
-  // Strip modifiers and normalize: "datetime(6)" → "datetime", "timestamp(3)" → "datetime"
-  // (MySQL alias_type maps timestamp → datetime in the abstract type map).
-  let baseType = sqlType
-    .replace(/\(.*\).*$/, "")
-    .trim()
-    .toLowerCase();
-  if (/^timestamp/.test(baseType)) baseType = "datetime";
-  const meta = new SqlTypeMetadata({ sqlType, type: baseType });
+export function fetchTypeMetadata(
+  sqlType: string,
+  extra: string = "",
+  lookupCastType?: (sqlType: string) => {
+    type?: string;
+    limit?: number | null;
+    precision?: number | null;
+    scale?: number | null;
+  },
+): TypeMetadata {
+  let baseType: string;
+  let limit: number | null = null;
+  let precision: number | null = null;
+  let scale: number | null = null;
+
+  if (lookupCastType) {
+    const castType = lookupCastType(sqlType);
+    // Normalize timestamp → datetime to match abstract type map alias_type.
+    const raw = (castType.type ?? sqlType).toLowerCase();
+    baseType = /^timestamp/.test(raw) ? "datetime" : raw;
+    limit = castType.limit ?? null;
+    precision = castType.precision ?? null;
+    scale = castType.scale ?? null;
+  } else {
+    // Fallback: strip modifiers and normalize without adapter context.
+    baseType = sqlType
+      .replace(/\(.*\).*$/, "")
+      .trim()
+      .toLowerCase();
+    if (/^timestamp/.test(baseType)) baseType = "datetime";
+  }
+
+  const meta = new SqlTypeMetadata({ sqlType, type: baseType, limit, precision, scale });
   return new TypeMetadata(meta, { extra });
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -133,9 +133,9 @@ export function defaultType(
 
 /** @internal */
 export function newColumnFromField(
+  tableName: string,
   field: Record<string, string>,
   createTableInfoFn: (tableName: string) => string | null,
-  tableName: string,
 ): Column {
   const fieldName = field["Field"] ?? "";
   const meta = fetchTypeMetadata(field["Type"] ?? "", field["Extra"] ?? "");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -178,9 +178,19 @@ export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMeta
 }
 
 /** @internal */
-export function extractForeignKeyAction(specifier: string): string | undefined {
+export function extractForeignKeyAction(
+  specifier: string,
+): "cascade" | "nullify" | "restrict" | undefined {
+  // RESTRICT is MySQL's default; omit it so FK definitions stay clean.
   if (specifier === "RESTRICT") return undefined;
-  return specifier;
+  switch (specifier) {
+    case "CASCADE":
+      return "cascade";
+    case "SET NULL":
+      return "nullify";
+    default:
+      return undefined;
+  }
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -87,7 +87,7 @@ export interface SchemaStatements {
 
 /** @internal */
 export function isRowFormatDynamicByDefault(isMariaDb: boolean, databaseVersion: string): boolean {
-  const v = new Version(databaseVersion);
+  const v = new Version(databaseVersion.replace(/-.*$/, ""));
   return isMariaDb ? v.gte("10.2.2") : v.gte("5.7.9");
 }
 
@@ -134,7 +134,7 @@ export function defaultType(
 /** @internal */
 export function newColumnFromField(
   tableName: string,
-  field: Record<string, string>,
+  field: Record<string, string | null>,
   createTableInfoFn: (tableName: string) => string | null,
 ): Column {
   const fieldName = field["Field"] ?? "";

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -166,12 +166,13 @@ export function newColumnFromField(
 
 /** @internal */
 export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMetadata {
-  // Strip modifiers (e.g. "datetime(6)" → "datetime", "varchar(255)" → "varchar")
-  // so type-based checks in newColumnFromField fire correctly.
-  const baseType = sqlType
+  // Strip modifiers and normalize: "datetime(6)" → "datetime", "timestamp(3)" → "datetime"
+  // (MySQL alias_type maps timestamp → datetime in the abstract type map).
+  let baseType = sqlType
     .replace(/\(.*\).*$/, "")
     .trim()
     .toLowerCase();
+  if (/^timestamp/.test(baseType)) baseType = "datetime";
   const meta = new SqlTypeMetadata({ sqlType, type: baseType });
   return new TypeMetadata(meta, { extra });
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -111,9 +111,9 @@ export function validPrimaryKeyOptions(): string[] {
 /** @internal */
 export function createTableDefinition(
   name: string,
-  options: Record<string, unknown> = {},
+  options: { id?: boolean | "uuid"; charset?: string | null; collation?: string | null } = {},
 ): TableDefinition {
-  return new TableDefinition(name, options as any);
+  return new TableDefinition(name, options);
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -4,7 +4,13 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (module)
  */
 
-import { NotImplementedError } from "../../errors.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
+import { TypeMetadata } from "./type-metadata.js";
+import { TableDefinition } from "./schema-definitions.js";
+import { Column } from "./column.js";
+import { quoteString } from "./quoting.js";
+
 export interface SchemaStatements {
   createDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
   dropDatabase(name: string): Promise<void>;
@@ -79,113 +85,218 @@ export interface SchemaStatements {
 }
 
 /** @internal */
-function isRowFormatDynamicByDefault(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#row_format_dynamic_by_default? is not implemented",
+export function isRowFormatDynamicByDefault(isMariaDb: boolean, databaseVersion: string): boolean {
+  if (isMariaDb) {
+    return databaseVersion >= "10.2.2";
+  }
+  return databaseVersion >= "5.7.9";
+}
+
+/** @internal */
+export function defaultRowFormat(
+  isMariaDb: boolean,
+  databaseVersion: string,
+  innodbFilePerTable: boolean,
+  innodbFileFormatBarracuda: boolean,
+): string | null {
+  if (isRowFormatDynamicByDefault(isMariaDb, databaseVersion)) return null;
+  if (innodbFilePerTable && innodbFileFormatBarracuda) return "ROW_FORMAT=DYNAMIC";
+  return null;
+}
+
+/** @internal */
+export function validPrimaryKeyOptions(): string[] {
+  return ["limit", "default", "precision", "unsigned", "autoIncrement"];
+}
+
+/** @internal */
+export function createTableDefinition(
+  name: string,
+  options: Record<string, unknown> = {},
+): TableDefinition {
+  return new TableDefinition(name, options as any);
+}
+
+/** @internal */
+export function defaultType(
+  createTableInfo: string | null,
+  fieldName: string,
+): "string" | "integer" | "function" | undefined {
+  if (!createTableInfo) return undefined;
+  const match = createTableInfo.match(
+    new RegExp("`" + fieldName + "` (.+) DEFAULT ('|\\d+|[A-Za-z]+)"),
+  );
+  const defaultPre = match?.[2];
+  if (defaultPre === "'") return "string";
+  if (defaultPre?.match(/^\d+$/)) return "integer";
+  if (defaultPre?.match(/^[A-Za-z]+$/)) return "function";
+  return undefined;
+}
+
+/** @internal */
+export function newColumnFromField(
+  field: Record<string, string>,
+  createTableInfoFn: (tableName: string) => string | null,
+  tableName: string,
+): Column {
+  const fieldName = field["Field"] ?? "";
+  const meta = fetchTypeMetadata(field["Type"] ?? "", field["Extra"] ?? "");
+  let def: string | null = field["Default"] ?? null;
+  let defFn: string | null = null;
+
+  if (meta.type === "datetime" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def ?? "")) {
+    if (/on update CURRENT_TIMESTAMP/i.test(field["Extra"] ?? "")) def = `${def} ON UPDATE ${def}`;
+    [def, defFn] = [null, def];
+  } else if (meta.extra === "DEFAULT_GENERATED") {
+    if (def != null && !def.startsWith("(")) def = `(${def})`;
+    [def, defFn] = [null, def?.replace(/\\'/g, "'") ?? null];
+  } else if (meta.type === "text" && def?.startsWith("'")) {
+    def = def.slice(1, -1).replace(/\\'/g, "'");
+  } else if (def != null && !/^\d/.test(def)) {
+    if (defaultType(createTableInfoFn(tableName), fieldName) === "function")
+      [def, defFn] = [null, def];
+  }
+
+  return new Column(fieldName, def, meta, field["Null"] === "YES", {
+    defaultFunction: defFn ?? undefined,
+    collation: field["Collation"] ?? null,
+    unsigned: /unsigned/i.test(field["Type"] ?? ""),
+    autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
+    virtual: /VIRTUAL GENERATED|STORED GENERATED/i.test(field["Extra"] ?? ""),
+  });
+}
+
+/** @internal */
+export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMetadata {
+  const meta = new SqlTypeMetadata({ sqlType });
+  return new TypeMetadata(meta, { extra });
+}
+
+/** @internal */
+export function extractForeignKeyAction(specifier: string): string | undefined {
+  if (specifier === "RESTRICT") return undefined;
+  return specifier;
+}
+
+/** @internal */
+export function addIndexLength(
+  quotedColumns: Map<string, string>,
+  options: { length?: Record<string, number> | number } = {},
+): Map<string, string> {
+  if (!options.length) return quotedColumns;
+  const lengths = typeof options.length === "object" ? options.length : {};
+  for (const [name, col] of quotedColumns) {
+    if (lengths[name] != null) {
+      quotedColumns.set(name, `${col}(${lengths[name]})`);
+    }
+  }
+  return quotedColumns;
+}
+
+/** @internal */
+export function addOptionsForIndexColumns(
+  quotedColumns: Map<string, string>,
+  options: {
+    length?: Record<string, number> | number;
+    order?: Record<string, string> | string;
+  } = {},
+): Map<string, string> {
+  quotedColumns = addIndexLength(quotedColumns, options);
+  if (options.order) {
+    const orders = typeof options.order === "object" ? options.order : {};
+    for (const [name, col] of quotedColumns) {
+      const dir = typeof options.order === "string" ? options.order : orders[name];
+      if (dir) quotedColumns.set(name, `${col} ${dir.toUpperCase()}`);
+    }
+  }
+  return quotedColumns;
+}
+
+/** @internal */
+export function dataSourceSql(name?: string, type?: string): string {
+  const scope = quotedScope(name, { type });
+  let sql = `SELECT table_name FROM information_schema.tables WHERE table_schema = ${scope.schema}`;
+  if (scope.name) {
+    sql += ` AND table_name = ${scope.name}`;
+    sql += ` AND table_name IN (SELECT table_name FROM information_schema.tables WHERE table_schema = ${scope.schema})`;
+  }
+  if (scope.type) sql += ` AND table_type = ${scope.type}`;
+  return sql;
+}
+
+/** @internal */
+export function quotedScope(
+  name?: string,
+  options: { type?: string } = {},
+): { schema: string; name?: string; type?: string } {
+  const [schema, tableName] = extractSchemaQualifiedName(name);
+  const scope: { schema: string; name?: string; type?: string } = {
+    schema: schema ? quoteString(schema) : "database()",
+  };
+  if (tableName) scope.name = quoteString(tableName);
+  if (options.type) scope.type = quoteString(options.type);
+  return scope;
+}
+
+/** @internal */
+export function extractSchemaQualifiedName(
+  str: string | null | undefined,
+): [string | null, string | null] {
+  const parts = (str ?? "").match(/[^`.\s]+|`[^`]*`/g) ?? [];
+  if (parts.length >= 2) {
+    return [parts[0]!.replace(/^`|`$/g, ""), parts[1]!.replace(/^`|`$/g, "")];
+  }
+  if (parts.length === 1) {
+    return [null, parts[0].replace(/^`|`$/g, "")];
+  }
+  return [null, null];
+}
+
+/** @internal */
+export function typeWithSizeToSql(type: string, size: string | null | undefined): string {
+  const s = size?.toString();
+  if (s === undefined || s === null || s === "tiny" || s === "medium" || s === "long") {
+    return `${s ?? ""}${type}`;
+  }
+  throw new ArgumentError(
+    `${JSON.stringify(size)} is invalid :size value. Only :tiny, :medium, and :long are allowed.`,
   );
 }
 
 /** @internal */
-function defaultRowFormat(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#default_row_format is not implemented",
-  );
+export function limitToSize(limit: number | null | undefined, type: string): string | undefined {
+  switch (type) {
+    case "text":
+    case "blob":
+    case "binary": {
+      if (limit == null || (limit >= 0x100 && limit <= 0xffff)) return undefined;
+      if (limit >= 0 && limit <= 0xff) return "tiny";
+      if (limit >= 0x10000 && limit <= 0xffffff) return "medium";
+      if (limit >= 0x1000000 && limit <= 0xffffffff) return "long";
+      throw new ArgumentError(`No ${type} type has byte size ${limit}`);
+    }
+    default:
+      return undefined;
+  }
 }
 
 /** @internal */
-function validPrimaryKeyOptions(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#valid_primary_key_options is not implemented",
-  );
-}
-
-/** @internal */
-function createTableDefinition(name: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition is not implemented",
-  );
-}
-
-/** @internal */
-function defaultType(tableName: any, fieldName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#default_type is not implemented",
-  );
-}
-
-/** @internal */
-function newColumnFromField(tableName: any, field: any, Definitions: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#new_column_from_field is not implemented",
-  );
-}
-
-/** @internal */
-function fetchTypeMetadata(sqlType: any, extra?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#fetch_type_metadata is not implemented",
-  );
-}
-
-/** @internal */
-function extractForeignKeyAction(specifier: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#extract_foreign_key_action is not implemented",
-  );
-}
-
-/** @internal */
-function addIndexLength(quotedColumns: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_index_length is not implemented",
-  );
-}
-
-/** @internal */
-function addOptionsForIndexColumns(quotedColumns: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_options_for_index_columns is not implemented",
-  );
-}
-
-/** @internal */
-function dataSourceSql(name?: any, type?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#data_source_sql is not implemented",
-  );
-}
-
-/** @internal */
-function quotedScope(name?: any, type?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#quoted_scope is not implemented",
-  );
-}
-
-/** @internal */
-function extractSchemaQualifiedName(string: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#extract_schema_qualified_name is not implemented",
-  );
-}
-
-/** @internal */
-function typeWithSizeToSql(type: any, size: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#type_with_size_to_sql is not implemented",
-  );
-}
-
-/** @internal */
-function limitToSize(limit: any, type: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#limit_to_size is not implemented",
-  );
-}
-
-/** @internal */
-function integerToSql(limit: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#integer_to_sql is not implemented",
-  );
+export function integerToSql(limit: number | null | undefined): string {
+  switch (limit) {
+    case 1:
+      return "tinyint";
+    case 2:
+      return "smallint";
+    case 3:
+      return "mediumint";
+    case null:
+    case undefined:
+    case 4:
+      return "int";
+    default:
+      if (limit >= 5 && limit <= 8) return "bigint";
+      throw new ArgumentError(
+        `No integer type has byte size ${limit}. Use a decimal with scale 0 instead.`,
+      );
+  }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -5,6 +5,7 @@
  */
 
 import { ArgumentError } from "@blazetrails/activemodel";
+import { Version } from "../abstract-adapter.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { TypeMetadata } from "./type-metadata.js";
 import { TableDefinition } from "./schema-definitions.js";
@@ -85,21 +86,9 @@ export interface SchemaStatements {
 }
 
 /** @internal */
-function versionGte(version: string, threshold: string): boolean {
-  const parse = (v: string) => v.split(".").map(Number);
-  const a = parse(version);
-  const b = parse(threshold);
-  for (let i = 0; i < Math.max(a.length, b.length); i++) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    if (av !== bv) return av > bv;
-  }
-  return true;
-}
-
-/** @internal */
 export function isRowFormatDynamicByDefault(isMariaDb: boolean, databaseVersion: string): boolean {
-  return isMariaDb ? versionGte(databaseVersion, "10.2.2") : versionGte(databaseVersion, "5.7.9");
+  const v = new Version(databaseVersion);
+  return isMariaDb ? v.gte("10.2.2") : v.gte("5.7.9");
 }
 
 /** @internal */
@@ -138,7 +127,7 @@ export function defaultType(
   const defaultPre = match?.[2];
   if (defaultPre === "'") return "string";
   if (defaultPre?.match(/^\d+$/)) return "integer";
-  if (defaultPre?.match(/^[A-Za-z]+$/)) return "function";
+  if (defaultPre?.match(/^[A-z]+$/)) return "function";
   return undefined;
 }
 
@@ -177,7 +166,13 @@ export function newColumnFromField(
 
 /** @internal */
 export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMetadata {
-  const meta = new SqlTypeMetadata({ sqlType });
+  // Strip modifiers (e.g. "datetime(6)" → "datetime", "varchar(255)" → "varchar")
+  // so type-based checks in newColumnFromField fire correctly.
+  const baseType = sqlType
+    .replace(/\(.*\).*$/, "")
+    .trim()
+    .toLowerCase();
+  const meta = new SqlTypeMetadata({ sqlType, type: baseType });
   return new TypeMetadata(meta, { extra });
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -228,8 +228,8 @@ export function addOptionsForIndexColumns(
 }
 
 /** @internal */
-export function dataSourceSql(name?: string, type?: string): string {
-  const scope = quotedScope(name, { type });
+export function dataSourceSql(name?: string | null, options: { type?: string } = {}): string {
+  const scope = quotedScope(name, options);
   let sql = `SELECT table_name FROM information_schema.tables WHERE table_schema = ${scope.schema}`;
   if (scope.name) {
     sql += ` AND table_name = ${scope.name}`;
@@ -241,7 +241,7 @@ export function dataSourceSql(name?: string, type?: string): string {
 
 /** @internal */
 export function quotedScope(
-  name?: string,
+  name?: string | null,
   options: { type?: string } = {},
 ): { schema: string; name?: string; type?: string } {
   const [schema, tableName] = extractSchemaQualifiedName(name);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -178,9 +178,7 @@ export function fetchTypeMetadata(sqlType: string, extra: string = ""): TypeMeta
 }
 
 /** @internal */
-export function extractForeignKeyAction(
-  specifier: string,
-): "cascade" | "nullify" | "restrict" | undefined {
+export function extractForeignKeyAction(specifier: string): "cascade" | "nullify" | undefined {
   // RESTRICT is MySQL's default; omit it so FK definitions stay clean.
   if (specifier === "RESTRICT") return undefined;
   switch (specifier) {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -187,7 +187,7 @@ export function addIndexLength(
   quotedColumns: Map<string, string>,
   options: { length?: Record<string, number> | number } = {},
 ): Map<string, string> {
-  if (!options.length) return quotedColumns;
+  if (options.length == null) return quotedColumns;
   const lengthMap = typeof options.length === "object" ? options.length : null;
   const scalar = typeof options.length === "number" ? options.length : null;
   for (const [name, col] of quotedColumns) {
@@ -259,7 +259,7 @@ export function extractSchemaQualifiedName(
 /** @internal */
 export function typeWithSizeToSql(type: string, size: string | null | undefined): string {
   const s = size?.toString();
-  if (s === undefined || s === null || s === "tiny" || s === "medium" || s === "long") {
+  if (s === undefined || s === "tiny" || s === "medium" || s === "long") {
     return `${s ?? ""}${type}`;
   }
   throw new ArgumentError(


### PR DESCRIPTION
## Summary

- Implements all 16 missing Rails-private helpers in \`mysql/schema-statements.ts\`, bringing the file from 38% (10/26) to 100% (26/26)
- Pure utility functions (\`integerToSql\`, \`limitToSize\`, \`typeWithSizeToSql\`, \`extractSchemaQualifiedName\`, \`quotedScope\`, \`dataSourceSql\`, \`extractForeignKeyAction\`) implemented as standalone exports matching Rails logic exactly
- Context-parameterized helpers (\`isRowFormatDynamicByDefault\`, \`defaultRowFormat\`, \`newColumnFromField\`, \`fetchTypeMetadata\`, \`createTableDefinition\`, \`defaultType\`, \`addIndexLength\`, \`addOptionsForIndexColumns\`, \`validPrimaryKeyOptions\`) take explicit parameters in place of \`self\`
- 27 unit tests covering all implemented functions

## Dependencies

PR 8/8b (#1165/#1175) and PR 6 (#1174) — all merged.

## Known trade-offs (intentional Rails fidelity)

- **\`defaultType\` uses \`[A-z]\`** — matches Rails source exactly. The extra ASCII chars between Z–a are unreachable as MySQL DEFAULT values in practice.
- **\`dataSourceSql\` redundant subquery** — the \`AND table_name IN (SELECT ...)\` clause mirrors Rails' \`data_source_sql\` verbatim.
- **\`addOptionsForIndexColumns\` sort-order gating** — \`supportsIndexSortOrder\` is adapter state; gating belongs at the call site. Rails MySQL \`add_options_for_index_columns\` calls \`super\` which owns the gate.
- **\`extractSchemaQualifiedName\` doubled backticks** — Rails \`extract_schema_qualified_name\` has the same limitation.

## Follow-up candidates (not blocking)

- **\`fetchTypeMetadata\` callback shape** — the \`lookupCastType\` callback is typed as returning \`{ type?: string; ... }\`, but ActiveModel \`Type\` instances expose the type name via \`name: string\` (plain property) and \`type(): string\` (method). A caller passing \`adapter.lookupCastType\` directly would get the function reference for \`castType.type\` instead of a string. Fix: use \`castType.name\` instead of \`castType.type\`, and update the callback signature to \`{ name: string; ... }\`.
- **\`fetchTypeMetadata\` fallback modifier stripping** — \`sqlType.replace(/\(.*\).*\$/, "")\` leaves trailing modifiers like \`unsigned\` or \`zerofill\` (e.g. \`"bigint unsigned"\` → \`"bigint unsigned"\`, not \`"bigint"\`). Fix: also split on whitespace and take the first token after stripping the \`(...)\` suffix.

## Test plan

- [x] \`pnpm api:compare --package activerecord\` — \`mysql/schema_statements.rb\` 26/26 (100%) ✓
- [x] \`pnpm vitest run .../mysql/schema-statements.test.ts\` — 27 tests pass
- [x] \`pnpm test:types\` — no type errors
- [x] \`tsc --build\` — clean