### PR TITLE
test(activerecord): retry flaky PG/MySQL tests up to 2x

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,10 +85,12 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-mysql.ts"]
               : []),
           ],
-          // Real-DB tests share a per-worker DB and the module-level test
-          // adapter has known race windows (see project_test_adapter_drift_fix).
-          // Retry intermittent failures on PG/MySQL only; SQLite (:memory:)
-          // is deterministic per fork so retries there would mask real bugs.
+          // Real-DB tests share a per-worker DB; the module-level state in
+          // test-adapter.ts has known race windows (see
+          // project_test_adapter_drift_fix). Retry intermittents on PG/MySQL
+          // only. The SQLite job (retry=0) covers every AR test file too, so
+          // a deterministic regression in a SQLite-only unit test still fails
+          // there — retries here can mask it on PG/MySQL but not in the matrix.
           retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
           pool: "forks",
           // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,6 +85,11 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-mysql.ts"]
               : []),
           ],
+          // Real-DB tests share a per-worker DB and the module-level test
+          // adapter has known race windows (see project_test_adapter_drift_fix).
+          // Retry intermittent failures on PG/MySQL only; SQLite (:memory:)
+          // is deterministic per fork so retries there would mask real bugs.
+          retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
           pool: "forks",
           // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].
           // Without this each file gets a new fork; IDs wrap mod AR_DB_MAX_FORKS,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -88,9 +88,19 @@ export default defineConfig({
           // Real-DB tests share a per-worker DB; the module-level state in
           // test-adapter.ts has known race windows (see PR #1114 for prior
           // _createdTables drift recovery). Retry intermittents on PG/MySQL
-          // only. The SQLite job (retry=0) covers every AR test file too, so
-          // a deterministic regression in a SQLite-only unit test still fails
-          // there — retries here can mask it on PG/MySQL but not in the matrix.
+          // only.
+          //
+          // Tradeoff: this is broader than the known shared-DB flakes — it
+          // also covers describeIfPg/describeIfMysql backend-only tests that
+          // SQLite never exercises, so a flaky-but-real regression in
+          // backend-only code could slip through after a retry. We accept
+          // this because (a) retries only mask non-deterministic failures —
+          // a 100% regression still fails through all attempts, (b) the
+          // observed flake pattern spans 10+ files across the project,
+          // making per-file scoping brittle, and (c) the alternative —
+          // letting CI fail on every transient race — burns more reviewer
+          // time than the rare hidden flake costs. Revisit if a real
+          // regression slips through.
           retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
           pool: "forks",
           // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -86,8 +86,8 @@ export default defineConfig({
               : []),
           ],
           // Real-DB tests share a per-worker DB; the module-level state in
-          // test-adapter.ts has known race windows (see
-          // project_test_adapter_drift_fix). Retry intermittents on PG/MySQL
+          // test-adapter.ts has known race windows (see PR #1114 for prior
+          // _createdTables drift recovery). Retry intermittents on PG/MySQL
           // only. The SQLite job (retry=0) covers every AR test file too, so
           // a deterministic regression in a SQLite-only unit test still fails
           // there — retries here can mask it on PG/MySQL but not in the matrix.


### PR DESCRIPTION
## Summary
- Real-DB AR tests share a per-worker DB with module-level state in `test-adapter.ts` that has known race windows (see prior `_createdTables` drift fix in #1114).
- Recent CI runs show intermittent failures across unrelated tests (`one with destroy`, `to a should dup target`, `last on relation with limit and offset`, `count` returning 0, etc.) — all symptoms of the same races, not bugs in the individual tests.
- Adds vitest `retry: 2` scoped to the activerecord project, gated to PG/MySQL only. SQLite stays at `retry: 0` so deterministic regressions still fail loudly.

## Test plan
- [ ] CI: PostgreSQL Tests pass
- [ ] CI: MariaDB Tests pass
- [ ] CI: SQLite (default) job still runs with no retry