### PR TITLE
feat(activerecord): migration/join_table.rb to 100% (PR 44)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -9,10 +9,7 @@
  */
 
 import { NotImplementedError } from "../../errors.js";
-import {
-  findJoinTableName as _findJoinTableName,
-  joinTableName as _joinTableName,
-} from "../../migration/join-table.js";
+import { joinTableName as _joinTableName } from "../../migration/join-table.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { tableNameLength, indexNameLength } from "./database-limits.js";
 import type { DatabaseAdapter } from "../../adapter.js";
@@ -1909,7 +1906,7 @@ export class SchemaStatements {
 
   /** @internal */
   findJoinTableName(table1: string, table2: string, options: { tableName?: string } = {}): string {
-    return _findJoinTableName(table1, table2, options);
+    return options.tableName ?? this.joinTableName(table1, table2);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -9,6 +9,10 @@
  */
 
 import { NotImplementedError } from "../../errors.js";
+import {
+  findJoinTableName as _findJoinTableName,
+  joinTableName as _joinTableName,
+} from "../../migration/join-table.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { tableNameLength, indexNameLength } from "./database-limits.js";
 import type { DatabaseAdapter } from "../../adapter.js";
@@ -1905,15 +1909,11 @@ export class SchemaStatements {
 
   /** @internal */
   findJoinTableName(table1: string, table2: string, options: { tableName?: string } = {}): string {
-    return options.tableName ?? this.joinTableName(table1, table2);
+    return _findJoinTableName.call(this, table1, table2, options);
   }
 
   /** @internal */
   joinTableName(table1: string, table2: string): string {
-    // Mirrors ModelSchema.derive_join_table_name:
-    // sort, join with NUL, deduplicate common word+separator prefix, replace NUL with _
-    const joined = [String(table1), String(table2)].sort().join("\0");
-    const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
-    return deduped.replace("\0", "_");
+    return _joinTableName.call(this, table1, table2);
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1909,11 +1909,11 @@ export class SchemaStatements {
 
   /** @internal */
   findJoinTableName(table1: string, table2: string, options: { tableName?: string } = {}): string {
-    return _findJoinTableName.call(this, table1, table2, options);
+    return _findJoinTableName(table1, table2, options);
   }
 
   /** @internal */
   joinTableName(table1: string, table2: string): string {
-    return _joinTableName.call(this, table1, table2);
+    return _joinTableName(table1, table2);
   }
 }

--- a/packages/activerecord/src/migration/join-table.test.ts
+++ b/packages/activerecord/src/migration/join-table.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { findJoinTableName, joinTableName } from "./join-table.js";
+
+const host = {
+  joinTableName(t1: string, t2: string) {
+    return joinTableName.call(this, t1, t2);
+  },
+};
+
+describe("JoinTable#joinTableName", () => {
+  it("sorts table names alphabetically", () => {
+    expect(joinTableName.call(host, "assemblies", "parts")).toBe("assemblies_parts");
+    expect(joinTableName.call(host, "parts", "assemblies")).toBe("assemblies_parts");
+  });
+
+  it("deduplicates common prefix", () => {
+    expect(joinTableName.call(host, "catalog_categories", "catalog_products")).toBe(
+      "catalog_categories_products",
+    );
+  });
+
+  it("handles plain names without common prefix", () => {
+    expect(joinTableName.call(host, "users", "roles")).toBe("roles_users");
+  });
+});
+
+describe("JoinTable#findJoinTableName", () => {
+  it("uses options.tableName when provided", () => {
+    expect(findJoinTableName.call(host, "assemblies", "parts", { tableName: "custom" })).toBe(
+      "custom",
+    );
+  });
+
+  it("falls back to joinTableName", () => {
+    expect(findJoinTableName.call(host, "assemblies", "parts")).toBe("assemblies_parts");
+  });
+});

--- a/packages/activerecord/src/migration/join-table.test.ts
+++ b/packages/activerecord/src/migration/join-table.test.ts
@@ -1,37 +1,29 @@
 import { describe, it, expect } from "vitest";
 import { findJoinTableName, joinTableName } from "./join-table.js";
 
-const host = {
-  joinTableName(t1: string, t2: string) {
-    return joinTableName.call(this, t1, t2);
-  },
-};
-
 describe("JoinTable#joinTableName", () => {
   it("sorts table names alphabetically", () => {
-    expect(joinTableName.call(host, "assemblies", "parts")).toBe("assemblies_parts");
-    expect(joinTableName.call(host, "parts", "assemblies")).toBe("assemblies_parts");
+    expect(joinTableName("assemblies", "parts")).toBe("assemblies_parts");
+    expect(joinTableName("parts", "assemblies")).toBe("assemblies_parts");
   });
 
   it("deduplicates common prefix", () => {
-    expect(joinTableName.call(host, "catalog_categories", "catalog_products")).toBe(
+    expect(joinTableName("catalog_categories", "catalog_products")).toBe(
       "catalog_categories_products",
     );
   });
 
   it("handles plain names without common prefix", () => {
-    expect(joinTableName.call(host, "users", "roles")).toBe("roles_users");
+    expect(joinTableName("users", "roles")).toBe("roles_users");
   });
 });
 
 describe("JoinTable#findJoinTableName", () => {
   it("uses options.tableName when provided", () => {
-    expect(findJoinTableName.call(host, "assemblies", "parts", { tableName: "custom" })).toBe(
-      "custom",
-    );
+    expect(findJoinTableName("assemblies", "parts", { tableName: "custom" })).toBe("custom");
   });
 
   it("falls back to joinTableName", () => {
-    expect(findJoinTableName.call(host, "assemblies", "parts")).toBe("assemblies_parts");
+    expect(findJoinTableName("assemblies", "parts")).toBe("assemblies_parts");
   });
 });

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -17,5 +17,5 @@ export function findJoinTableName(
 export function joinTableName(table1: string, table2: string): string {
   const joined = [String(table1), String(table2)].sort().join("\0");
   const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
-  return deduped.replace("\0", "_");
+  return deduped.replaceAll("\0", "_");
 }

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -1,0 +1,27 @@
+/**
+ * JoinTable — helpers for deriving HABTM join table names.
+ *
+ * Mirrors: ActiveRecord::Migration::JoinTable
+ */
+
+export interface JoinTableHost {
+  /** @internal */
+  joinTableName(table1: string, table2: string): string;
+}
+
+/** @internal */
+export function findJoinTableName(
+  this: JoinTableHost,
+  table1: string,
+  table2: string,
+  options: { tableName?: string } = {},
+): string {
+  return options.tableName ?? this.joinTableName(table1, table2);
+}
+
+/** @internal */
+export function joinTableName(this: JoinTableHost, table1: string, table2: string): string {
+  const joined = [String(table1), String(table2)].sort().join("\0");
+  const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
+  return deduped.replace("\0", "_");
+}

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -4,23 +4,17 @@
  * Mirrors: ActiveRecord::Migration::JoinTable
  */
 
-interface JoinTableHost {
-  /** @internal */
-  joinTableName(table1: string, table2: string): string;
-}
-
 /** @internal */
 export function findJoinTableName(
-  this: JoinTableHost,
   table1: string,
   table2: string,
   options: { tableName?: string } = {},
 ): string {
-  return options.tableName ?? this.joinTableName(table1, table2);
+  return options.tableName ?? joinTableName(table1, table2);
 }
 
 /** @internal */
-export function joinTableName(this: JoinTableHost, table1: string, table2: string): string {
+export function joinTableName(table1: string, table2: string): string {
   const joined = [String(table1), String(table2)].sort().join("\0");
   const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
   return deduped.replace("\0", "_");

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Migration::JoinTable
  */
 
-export interface JoinTableHost {
+interface JoinTableHost {
   /** @internal */
   joinTableName(table1: string, table2: string): string;
 }


### PR DESCRIPTION
## Summary

- Creates `migration/join-table.ts` matching Rails layout (`ActiveRecord::Migration::JoinTable`)
- Exports `findJoinTableName` and `joinTableName` as plain functions (the canonical logic lives here, satisfying `api:compare`)
- `SchemaStatements#joinTableName` delegates to `_joinTableName` from the module
- `SchemaStatements#findJoinTableName` is a one-liner (`options.tableName ?? this.joinTableName(...)`) that calls via `this` so subclass overrides of `joinTableName` are respected — identical semantics to Rails' `self.join_table_name` call
- 2/2 methods at 100%

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/migration/join-table.test.ts` — 5 tests pass
- [ ] `pnpm api:compare --package activerecord` — `migration/join_table.rb` 2/2 100% ✓
- [ ] Build + typecheck pass (pre-commit hook)