### PR TITLE
test(activerecord): reset shared test-adapter state in beforeEach (PR 1/4)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -413,6 +413,36 @@ export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void
 }
 
 /**
+ * Reset every piece of module-level test-adapter state so the next test
+ * starts from a clean slate. Called from a global `beforeEach` hook in
+ * test-setup.ts — running unconditionally before every test eliminates
+ * cross-test bleed (stale `_declaredColumns`, leaked `_registeredModelClasses`,
+ * stuck `_needsCleanup`/`_setupLock`/`_cleanupPromise` from a prior tests's
+ * recovery path) that the lazy "first DB op cleans up" model couldn't.
+ *
+ * Idempotent and safe to call when no tables exist.
+ *
+ * @internal
+ */
+export async function resetTestAdapterState(): Promise<void> {
+  // Wait for any in-flight cleanup or setup to settle before we tear down,
+  // otherwise we'd race against an already-running drop/create.
+  while (_setupLock) await _setupLock;
+  while (_cleanupPromise) await _cleanupPromise;
+
+  if (_sharedAdapter && _createdTables.size > 0) {
+    await dropAllTables(_sharedAdapter);
+  }
+  _createdTables.clear();
+  _createdColumns.clear();
+  _declaredColumns.clear();
+  _pendingModels.clear();
+  _pendingCpk.clear();
+  _registeredModelClasses.clear();
+  _needsCleanup = false;
+}
+
+/**
  * Thin wrapper around a real database adapter that:
  *   1. Deletes all data on first operation of each test (lazy cleanup)
  *   2. Creates tables from registered model attribute definitions

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -415,10 +415,16 @@ export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void
 /**
  * Reset every piece of module-level test-adapter state so the next test
  * starts from a clean slate. Called from a global `beforeEach` hook in
- * test-setup.ts — running unconditionally before every test eliminates
+ * test-setup-ar.ts — running unconditionally before every test eliminates
  * cross-test bleed (stale `_declaredColumns`, leaked `_registeredModelClasses`,
- * stuck `_needsCleanup`/`_setupLock`/`_cleanupPromise` from a prior tests's
+ * stuck `_needsCleanup`/`_setupLock`/`_cleanupPromise` from a prior test's
  * recovery path) that the lazy "first DB op cleans up" model couldn't.
+ *
+ * Drops tables based on the *actual database state* (pg_tables / SHOW TABLES)
+ * rather than trusting `_createdTables`, because the recovery path,
+ * file-load-time cleanup, and direct adapter use can all leave the in-memory
+ * tracking out of sync with the real schema. SQLite uses :memory: per fork
+ * so an in-memory drop suffices there.
  *
  * Idempotent and safe to call when no tables exist.
  *
@@ -430,8 +436,28 @@ export async function resetTestAdapterState(): Promise<void> {
   while (_setupLock) await _setupLock;
   while (_cleanupPromise) await _cleanupPromise;
 
-  if (_sharedAdapter && _createdTables.size > 0) {
-    await dropAllTables(_sharedAdapter);
+  if (_sharedAdapter) {
+    if (isPg()) {
+      const rows = await _sharedAdapter.execute(
+        `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`,
+      );
+      for (const r of rows) {
+        try {
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${(r as any).tablename}" CASCADE`);
+        } catch {}
+      }
+    } else if (isMysql()) {
+      const rows = await _sharedAdapter.execute(`SHOW TABLES`);
+      for (const r of rows) {
+        const table = Object.values(r)[0] as string;
+        try {
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS \`${table}\``);
+        } catch {}
+      }
+    } else if (_createdTables.size > 0) {
+      // SQLite :memory: — only drop what we tracked, no DB-level enumeration.
+      await dropAllTables(_sharedAdapter);
+    }
   }
   _createdTables.clear();
   _createdColumns.clear();

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -1,0 +1,20 @@
+/**
+ * AR-only vitest setupFile. Wired into the `activerecord` project in
+ * `vitest.config.ts`; the sibling `test-setup.ts` is shared with the
+ * non-AR `other` project, so anything that imports the AR test adapter
+ * (and thus opens a DB connection at module load) belongs here, not
+ * there.
+ */
+
+import { beforeEach } from "vitest";
+import { resetTestAdapterState } from "./test-adapter.js";
+
+// Wipe shared test-adapter state before every test. The previous lazy
+// "clean up on first DB op of next test" model left a window where a
+// prior test's recovery path (handleMissingSchemaError) could mutate
+// _createdTables/_declaredColumns between cleanup and the next test's
+// schema setup, causing intermittent failures (count→0, queries against
+// stale schemas). Eager reset closes that window.
+beforeEach(async () => {
+  await resetTestAdapterState();
+});

--- a/packages/activerecord/src/test-setup.ts
+++ b/packages/activerecord/src/test-setup.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach } from "vitest";
+import { afterEach } from "vitest";
 import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
-import { resetTestAdapterState } from "./test-adapter.js";
 
 // Restore the default Arel visitor after each test so AR tests that set a
 // SQLite (or other dialect) adapter via `Base.adapter = ...` don't leak the
@@ -9,14 +8,4 @@ import { resetTestAdapterState } from "./test-adapter.js";
 // manage it themselves (see node.test.ts's try/finally pattern).
 afterEach(() => {
   setToSqlVisitor(Visitors.ToSql);
-});
-
-// Wipe shared test-adapter state before every test. The previous lazy
-// "clean up on first DB op of next test" model left a window where a
-// prior test's recovery path (handleMissingSchemaError) could mutate
-// _createdTables/_declaredColumns between cleanup and the next test's
-// schema setup, causing intermittent failures (count→0, queries against
-// stale schemas). Eager reset closes that window.
-beforeEach(async () => {
-  await resetTestAdapterState();
 });

--- a/packages/activerecord/src/test-setup.ts
+++ b/packages/activerecord/src/test-setup.ts
@@ -1,5 +1,6 @@
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
+import { resetTestAdapterState } from "./test-adapter.js";
 
 // Restore the default Arel visitor after each test so AR tests that set a
 // SQLite (or other dialect) adapter via `Base.adapter = ...` don't leak the
@@ -8,4 +9,14 @@ import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
 // manage it themselves (see node.test.ts's try/finally pattern).
 afterEach(() => {
   setToSqlVisitor(Visitors.ToSql);
+});
+
+// Wipe shared test-adapter state before every test. The previous lazy
+// "clean up on first DB op of next test" model left a window where a
+// prior test's recovery path (handleMissingSchemaError) could mutate
+// _createdTables/_declaredColumns between cleanup and the next test's
+// schema setup, causing intermittent failures (count→0, queries against
+// stale schemas). Eager reset closes that window.
+beforeEach(async () => {
+  await resetTestAdapterState();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
           setupFiles: [
             "./packages/activerecord/src/test-setup-worker-db.ts",
             "./packages/activerecord/src/test-setup.ts",
+            "./packages/activerecord/src/test-setup-ar.ts",
             ...(process.env.MYSQL_TEST_URL
               ? ["./packages/activerecord/src/test-setup-mysql.ts"]
               : []),


### PR DESCRIPTION
## Summary

The 'fresh adapter' abstraction in `test-adapter.ts` is a lie: each `freshAdapter()` call only flips a `_needsCleanup` flag and returns a wrapper around the same `_sharedAdapter` and same module-level registries (`_createdTables`, `_declaredColumns`, `_registeredModelClasses`, …). Cleanup runs lazily on the next test's first DB op, leaving a window where the prior test's recovery path (`handleMissingSchemaError`) can mutate shared state between cleanup and schema setup.

Observed symptoms (across ~10 unrelated test files): `count()` returning 0 after explicit inserts, queries against stale schemas, `last()` returning null. PR #1187 papered over these with `retry: 2`; this fixes them at the source.

**Change:** add an unconditional global `beforeEach` hook in `test-setup.ts` that drops every tracked table and clears all module-level state before each test. Eager reset replaces the lazy-on-first-DB-op model.

## Plan context

First of 4 PRs. Remaining:
- PR 2: migrate `freshAdapter()` callers to `async`/`await`-aware factory (mechanical, ~169 files).
- PR 3: kill `handleMissingSchemaError` regex-based recovery; require explicit attribute declarations.
- PR 4: schema-per-test isolation (PG `SET search_path` per test).
- After PR 4 lands and flake rate hits 0 over 100 CI runs, revert the retry config from #1187.

## Test plan
- [x] Full AR SQLite suite: 10202 passed / 3290 skipped, 0 regressions
- [ ] PostgreSQL Tests pass in CI
- [ ] MariaDB Tests pass in CI