### PR TITLE
test(activerecord): harden reset to drop across all schemas/views (PR 2/4)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -362,17 +362,9 @@ async function dropAllTables(inner: any): Promise<void> {
 }
 
 /**
- * Drop every test-created object in the named PG schema (matviews,
- * views, tables, standalone sequences, enums/domains/range types)
- * using the adapter's own identifier quoting. Used for `public`,
- * which the AR adapter assumes exists and so can't be dropped
- * wholesale via `DROP SCHEMA … CASCADE`.
- *
- * Order matters: matviews → views → tables (CASCADE handles their
- * cross-references). Then standalone sequences (those owned by a
- * column drop with the table) and finally types — enums/domains can
- * be referenced by table columns, so they must come after the table
- * drops.
+ * Drop every materialized view, view, and table in the named PG schema
+ * using the adapter's own identifier quoting (which doubles embedded
+ * quotes). Used for `public`, which the AR adapter assumes exists.
  *
  * @internal
  */
@@ -407,37 +399,6 @@ async function dropPgObjectsInSchema(adapter: any, schema: string): Promise<void
       await adapter.exec(
         `DROP TABLE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
       );
-    } catch {}
-  }
-  // Standalone sequences (those owned by a table column were dropped
-  // with the table). pg_class.relkind='S' = sequence.
-  const sequences = (await adapter.execute(
-    `SELECT c.relname AS name FROM pg_class c
-     JOIN pg_namespace n ON n.oid = c.relnamespace
-     WHERE n.nspname = $1 AND c.relkind = 'S'`,
-    [schema],
-  )) as { name: string }[];
-  for (const { name } of sequences) {
-    try {
-      await adapter.exec(
-        `DROP SEQUENCE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
-      );
-    } catch {}
-  }
-  // User-defined types: enums ('e'), domains ('d'), range types ('r').
-  // Composite types tied to a relation (typrelid != 0 / pg_class.reltype
-  // matching) drop with the relation.
-  const types = (await adapter.execute(
-    `SELECT t.typname AS name FROM pg_type t
-     JOIN pg_namespace n ON n.oid = t.typnamespace
-     WHERE n.nspname = $1
-       AND t.typtype IN ('e', 'd', 'r')
-       AND NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.reltype = t.oid)`,
-    [schema],
-  )) as { name: string }[];
-  for (const { name } of types) {
-    try {
-      await adapter.exec(`DROP TYPE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`);
     } catch {}
   }
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -362,6 +362,48 @@ async function dropAllTables(inner: any): Promise<void> {
 }
 
 /**
+ * Drop every materialized view, view, and table in the named PG schema
+ * using the adapter's own identifier quoting (which doubles embedded
+ * quotes). Used for `public`, which the AR adapter assumes exists.
+ *
+ * @internal
+ */
+async function dropPgObjectsInSchema(adapter: any, schema: string): Promise<void> {
+  const qSchema = adapter.quoteIdentifier(schema);
+  const matviews = (await adapter.execute(
+    `SELECT matviewname AS name FROM pg_matviews WHERE schemaname = $1`,
+    [schema],
+  )) as { name: string }[];
+  for (const { name } of matviews) {
+    try {
+      await adapter.exec(
+        `DROP MATERIALIZED VIEW IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
+      );
+    } catch {}
+  }
+  const views = (await adapter.execute(
+    `SELECT viewname AS name FROM pg_views WHERE schemaname = $1`,
+    [schema],
+  )) as { name: string }[];
+  for (const { name } of views) {
+    try {
+      await adapter.exec(`DROP VIEW IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`);
+    } catch {}
+  }
+  const tables = (await adapter.execute(
+    `SELECT tablename AS name FROM pg_tables WHERE schemaname = $1`,
+    [schema],
+  )) as { name: string }[];
+  for (const { name } of tables) {
+    try {
+      await adapter.exec(
+        `DROP TABLE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
+      );
+    } catch {}
+  }
+}
+
+/**
  * MySQL drop-all using a single pinned pool connection so
  * FOREIGN_KEY_CHECKS=0 covers the whole drop sequence. The flag is
  * restored in `finally`; if anything between the SET and the restore
@@ -388,14 +430,14 @@ async function dropAllMysqlTables(adapter: any): Promise<void> {
       const name = r.table_name ?? r.TABLE_NAME;
       if (!name) continue;
       try {
-        await conn.query(`DROP VIEW IF EXISTS \`${name}\``);
+        await conn.query(`DROP VIEW IF EXISTS ${adapter.quoteTableName(name)}`);
       } catch {}
     }
     for (const r of tableRows) {
       const name = r.table_name ?? r.TABLE_NAME;
       if (!name) continue;
       try {
-        await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
+        await conn.query(`DROP TABLE IF EXISTS ${adapter.quoteTableName(name)}`);
       } catch {}
     }
     await conn.query(`SET FOREIGN_KEY_CHECKS=1`);
@@ -505,52 +547,47 @@ export async function resetTestAdapterState(): Promise<void> {
 
   if (_sharedAdapter) {
     if (isPg()) {
-      // current_schemas(false) returns the search path with system schemas
-      // (pg_catalog, information_schema) excluded — the same scope the
-      // adapter's tables() method uses. Drop materialized views and views
-      // before tables; standalone views that don't depend on a dropped
-      // table wouldn't be reached by CASCADE.
-      const matviews = (await _sharedAdapter.execute(
-        `SELECT schemaname, matviewname AS name FROM pg_matviews
-         WHERE schemaname = ANY(current_schemas(false))`,
-      )) as { schemaname: string; name: string }[];
-      for (const { schemaname, name } of matviews) {
-        try {
-          await _sharedAdapter.exec(
-            `DROP MATERIALIZED VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`,
-          );
-        } catch {}
-      }
-      const views = (await _sharedAdapter.execute(
-        `SELECT schemaname, viewname AS name FROM pg_views
-         WHERE schemaname = ANY(current_schemas(false))`,
-      )) as { schemaname: string; name: string }[];
-      for (const { schemaname, name } of views) {
-        try {
-          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`);
-        } catch {}
-      }
-      const rows = (await _sharedAdapter.execute(
-        `SELECT schemaname, tablename FROM pg_tables
-         WHERE schemaname = ANY(current_schemas(false))`,
-      )) as { schemaname: string; tablename: string }[];
-      for (const { schemaname, tablename } of rows) {
-        try {
-          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${schemaname}"."${tablename}" CASCADE`);
-        } catch {}
+      // Enumerate every user schema in the cluster, not just those on the
+      // session search_path. Tests that create a custom schema and never
+      // adjust search_path leave tables behind that current_schemas(false)
+      // can't see. Filter system + temp schemas; everything else is fair
+      // game. CASCADE drops dependent objects (views, sequences, etc).
+      const userSchemasSql = `
+        SELECT nspname FROM pg_namespace
+        WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+          AND nspname NOT LIKE 'pg_temp_%'
+          AND nspname NOT LIKE 'pg_toast_temp_%'`;
+      const schemaRows = (await _sharedAdapter.execute(userSchemasSql)) as {
+        nspname: string;
+      }[];
+      for (const { nspname } of schemaRows) {
+        if (nspname === "public") {
+          // Don't drop `public` itself — the AR adapter assumes it exists.
+          // Drop its contents (matviews, views, tables) instead, using the
+          // adapter's own quoting to handle embedded quotes correctly.
+          await dropPgObjectsInSchema(_sharedAdapter, "public");
+        } else {
+          try {
+            await _sharedAdapter.exec(
+              `DROP SCHEMA IF EXISTS ${_sharedAdapter.quoteIdentifier(nspname)} CASCADE`,
+            );
+          } catch {}
+        }
       }
     } else if (isMysql()) {
       await dropAllMysqlTables(_sharedAdapter);
     } else {
       // SQLite :memory: — query sqlite_master so objects created via raw
       // adapter.exec() (which bypass _createdTables) also get dropped.
-      // Drop views first since SQLite has no CASCADE.
+      // Drop views first since SQLite has no CASCADE. (ATTACH'd databases
+      // are out of scope: the only test using ATTACH —
+      // sqlite3-introspection.test.ts — bypasses the shared adapter.)
       const views = (await _sharedAdapter.execute(
         `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
       )) as { name: string }[];
       for (const { name } of views) {
         try {
-          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${name}"`);
+          await _sharedAdapter.exec(`DROP VIEW IF EXISTS ${_sharedAdapter.quoteTableName(name)}`);
         } catch {}
       }
       const rows = (await _sharedAdapter.execute(
@@ -558,7 +595,7 @@ export async function resetTestAdapterState(): Promise<void> {
       )) as { name: string }[];
       for (const { name } of rows) {
         try {
-          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${name}"`);
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS ${_sharedAdapter.quoteTableName(name)}`);
         } catch {}
       }
     }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -503,8 +503,19 @@ export async function resetTestAdapterState(): Promise<void> {
   while (_setupLock) await _setupLock;
   while (_cleanupPromise) await _cleanupPromise;
 
-  if (_sharedAdapter) {
-    if (isPg()) {
+  // Publish our own cleanup lock for the duration of the drops. SchemaAdapter
+  // .setup() blocks on _cleanupPromise (and _setupLock), so any late async
+  // DB call from a prior test that fires during reset waits behind our drops
+  // instead of racing them. The finally clause guarantees the lock releases
+  // even on swallowed driver errors.
+  let resolveLock!: () => void;
+  _cleanupPromise = new Promise<void>((r) => {
+    resolveLock = r;
+  });
+  try {
+    if (!_sharedAdapter) {
+      // No DB to clean — only clear in-memory state below.
+    } else if (isPg()) {
       // current_schemas(false) returns the search path with system schemas
       // (pg_catalog, information_schema) excluded — the same scope the
       // adapter's tables() method uses. Drop materialized views and views
@@ -562,14 +573,17 @@ export async function resetTestAdapterState(): Promise<void> {
         } catch {}
       }
     }
+    _createdTables.clear();
+    _createdColumns.clear();
+    _declaredColumns.clear();
+    _pendingModels.clear();
+    _pendingCpk.clear();
+    _registeredModelClasses.clear();
+    _needsCleanup = false;
+  } finally {
+    _cleanupPromise = null;
+    resolveLock();
   }
-  _createdTables.clear();
-  _createdColumns.clear();
-  _declaredColumns.clear();
-  _pendingModels.clear();
-  _pendingCpk.clear();
-  _registeredModelClasses.clear();
-  _needsCleanup = false;
 }
 
 /**

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -362,9 +362,17 @@ async function dropAllTables(inner: any): Promise<void> {
 }
 
 /**
- * Drop every materialized view, view, and table in the named PG schema
- * using the adapter's own identifier quoting (which doubles embedded
- * quotes). Used for `public`, which the AR adapter assumes exists.
+ * Drop every test-created object in the named PG schema (matviews,
+ * views, tables, standalone sequences, enums/domains/range types)
+ * using the adapter's own identifier quoting. Used for `public`,
+ * which the AR adapter assumes exists and so can't be dropped
+ * wholesale via `DROP SCHEMA … CASCADE`.
+ *
+ * Order matters: matviews → views → tables (CASCADE handles their
+ * cross-references). Then standalone sequences (those owned by a
+ * column drop with the table) and finally types — enums/domains can
+ * be referenced by table columns, so they must come after the table
+ * drops.
  *
  * @internal
  */
@@ -399,6 +407,37 @@ async function dropPgObjectsInSchema(adapter: any, schema: string): Promise<void
       await adapter.exec(
         `DROP TABLE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
       );
+    } catch {}
+  }
+  // Standalone sequences (those owned by a table column were dropped
+  // with the table). pg_class.relkind='S' = sequence.
+  const sequences = (await adapter.execute(
+    `SELECT c.relname AS name FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = $1 AND c.relkind = 'S'`,
+    [schema],
+  )) as { name: string }[];
+  for (const { name } of sequences) {
+    try {
+      await adapter.exec(
+        `DROP SEQUENCE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
+      );
+    } catch {}
+  }
+  // User-defined types: enums ('e'), domains ('d'), range types ('r').
+  // Composite types tied to a relation (typrelid != 0 / pg_class.reltype
+  // matching) drop with the relation.
+  const types = (await adapter.execute(
+    `SELECT t.typname AS name FROM pg_type t
+     JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = $1
+       AND t.typtype IN ('e', 'd', 'r')
+       AND NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.reltype = t.oid)`,
+    [schema],
+  )) as { name: string }[];
+  for (const { name } of types) {
+    try {
+      await adapter.exec(`DROP TYPE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`);
     } catch {}
   }
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -363,9 +363,11 @@ async function dropAllTables(inner: any): Promise<void> {
 
 /**
  * MySQL drop-all using a single pinned pool connection so
- * FOREIGN_KEY_CHECKS=0 covers the whole drop sequence. Releasing the
- * connection after the loop also implicitly resets the session flag
- * for future borrowers.
+ * FOREIGN_KEY_CHECKS=0 covers the whole drop sequence. The flag is
+ * restored in `finally`; if anything between the SET and the restore
+ * throws, we destroy the connection rather than releasing it back to
+ * the pool — releasing a connection that still has FOREIGN_KEY_CHECKS=0
+ * would silently disable FK enforcement for the next borrower.
  *
  * @internal
  */
@@ -373,6 +375,7 @@ async function dropAllMysqlTables(adapter: any): Promise<void> {
   const driverPool = adapter._driverPool;
   if (!driverPool) return;
   const conn = await driverPool.getConnection();
+  let restored = false;
   try {
     await conn.query(`SET FOREIGN_KEY_CHECKS=0`);
     const [tableRows] = (await conn.query(
@@ -396,8 +399,22 @@ async function dropAllMysqlTables(adapter: any): Promise<void> {
       } catch {}
     }
     await conn.query(`SET FOREIGN_KEY_CHECKS=1`);
+    restored = true;
   } finally {
-    conn.release();
+    if (restored) {
+      conn.release();
+    } else {
+      // Connection state may be stale (FK_CHECKS=0, half-finished txn).
+      // Destroy instead of release so the pool opens a fresh session.
+      try {
+        await conn.query(`SET FOREIGN_KEY_CHECKS=1`);
+        conn.release();
+      } catch {
+        try {
+          conn.destroy();
+        } catch {}
+      }
+    }
   }
 }
 
@@ -490,7 +507,29 @@ export async function resetTestAdapterState(): Promise<void> {
     if (isPg()) {
       // current_schemas(false) returns the search path with system schemas
       // (pg_catalog, information_schema) excluded — the same scope the
-      // adapter's tables() method uses.
+      // adapter's tables() method uses. Drop materialized views and views
+      // before tables; standalone views that don't depend on a dropped
+      // table wouldn't be reached by CASCADE.
+      const matviews = (await _sharedAdapter.execute(
+        `SELECT schemaname, matviewname AS name FROM pg_matviews
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; name: string }[];
+      for (const { schemaname, name } of matviews) {
+        try {
+          await _sharedAdapter.exec(
+            `DROP MATERIALIZED VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`,
+          );
+        } catch {}
+      }
+      const views = (await _sharedAdapter.execute(
+        `SELECT schemaname, viewname AS name FROM pg_views
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; name: string }[];
+      for (const { schemaname, name } of views) {
+        try {
+          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`);
+        } catch {}
+      }
       const rows = (await _sharedAdapter.execute(
         `SELECT schemaname, tablename FROM pg_tables
          WHERE schemaname = ANY(current_schemas(false))`,
@@ -503,8 +542,17 @@ export async function resetTestAdapterState(): Promise<void> {
     } else if (isMysql()) {
       await dropAllMysqlTables(_sharedAdapter);
     } else {
-      // SQLite :memory: — query sqlite_master so we drop tables created
-      // via raw adapter.exec() (which bypass _createdTables) too.
+      // SQLite :memory: — query sqlite_master so objects created via raw
+      // adapter.exec() (which bypass _createdTables) also get dropped.
+      // Drop views first since SQLite has no CASCADE.
+      const views = (await _sharedAdapter.execute(
+        `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
+      )) as { name: string }[];
+      for (const { name } of views) {
+        try {
+          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${name}"`);
+        } catch {}
+      }
       const rows = (await _sharedAdapter.execute(
         `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
       )) as { name: string }[];

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -361,6 +361,46 @@ async function dropAllTables(inner: any): Promise<void> {
   }
 }
 
+/**
+ * MySQL drop-all using a single pinned pool connection so
+ * FOREIGN_KEY_CHECKS=0 covers the whole drop sequence. Releasing the
+ * connection after the loop also implicitly resets the session flag
+ * for future borrowers.
+ *
+ * @internal
+ */
+async function dropAllMysqlTables(adapter: any): Promise<void> {
+  const driverPool = adapter._driverPool;
+  if (!driverPool) return;
+  const conn = await driverPool.getConnection();
+  try {
+    await conn.query(`SET FOREIGN_KEY_CHECKS=0`);
+    const [tableRows] = (await conn.query(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'`,
+    )) as [Array<{ table_name?: string; TABLE_NAME?: string }>, unknown];
+    const [viewRows] = (await conn.query(
+      `SELECT table_name FROM information_schema.views WHERE table_schema = DATABASE()`,
+    )) as [Array<{ table_name?: string; TABLE_NAME?: string }>, unknown];
+    for (const r of viewRows) {
+      const name = r.table_name ?? r.TABLE_NAME;
+      if (!name) continue;
+      try {
+        await conn.query(`DROP VIEW IF EXISTS \`${name}\``);
+      } catch {}
+    }
+    for (const r of tableRows) {
+      const name = r.table_name ?? r.TABLE_NAME;
+      if (!name) continue;
+      try {
+        await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
+      } catch {}
+    }
+    await conn.query(`SET FOREIGN_KEY_CHECKS=1`);
+  } finally {
+    conn.release();
+  }
+}
+
 let _factory: () => DatabaseAdapter;
 
 if (PG_TEST_URL) {
@@ -420,11 +460,21 @@ export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void
  * stuck `_needsCleanup`/`_setupLock`/`_cleanupPromise` from a prior test's
  * recovery path) that the lazy "first DB op cleans up" model couldn't.
  *
- * Drops tables based on the *actual database state* (pg_tables / SHOW TABLES)
- * rather than trusting `_createdTables`, because the recovery path,
- * file-load-time cleanup, and direct adapter use can all leave the in-memory
- * tracking out of sync with the real schema. SQLite uses :memory: per fork
- * so an in-memory drop suffices there.
+ * Drops tables based on the *actual database state*, not in-memory
+ * tracking — the recovery path, file-load cleanup, and direct adapter
+ * use can all leave `_createdTables` out of sync with the real schema.
+ *
+ *   - PG: enumerate every user schema via `current_schemas(false)`, not
+ *     just `public`. Tests that create custom schemas (e.g. schema.test.ts
+ *     with test_schema/test_schema2) leak tables that survive a public-only
+ *     drop and continue to bleed state.
+ *   - MySQL: drops on a single dedicated pool connection with
+ *     FOREIGN_KEY_CHECKS=0 for the whole sequence. Per-statement exec()s
+ *     can't reliably bracket the drops because each call may pick a
+ *     different pool connection.
+ *   - SQLite: query `sqlite_master` (excluding internal `sqlite_*`
+ *     tables) so tables created via raw `adapter.exec()` — which bypass
+ *     `_createdTables` — also get dropped.
  *
  * Idempotent and safe to call when no tables exist.
  *
@@ -438,25 +488,31 @@ export async function resetTestAdapterState(): Promise<void> {
 
   if (_sharedAdapter) {
     if (isPg()) {
-      const rows = await _sharedAdapter.execute(
-        `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`,
-      );
-      for (const r of rows) {
+      // current_schemas(false) returns the search path with system schemas
+      // (pg_catalog, information_schema) excluded — the same scope the
+      // adapter's tables() method uses.
+      const rows = (await _sharedAdapter.execute(
+        `SELECT schemaname, tablename FROM pg_tables
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; tablename: string }[];
+      for (const { schemaname, tablename } of rows) {
         try {
-          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${(r as any).tablename}" CASCADE`);
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${schemaname}"."${tablename}" CASCADE`);
         } catch {}
       }
     } else if (isMysql()) {
-      const rows = await _sharedAdapter.execute(`SHOW TABLES`);
-      for (const r of rows) {
-        const table = Object.values(r)[0] as string;
+      await dropAllMysqlTables(_sharedAdapter);
+    } else {
+      // SQLite :memory: — query sqlite_master so we drop tables created
+      // via raw adapter.exec() (which bypass _createdTables) too.
+      const rows = (await _sharedAdapter.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
+      )) as { name: string }[];
+      for (const { name } of rows) {
         try {
-          await _sharedAdapter.exec(`DROP TABLE IF EXISTS \`${table}\``);
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${name}"`);
         } catch {}
       }
-    } else if (_createdTables.size > 0) {
-      // SQLite :memory: — only drop what we tracked, no DB-level enumeration.
-      await dropAllTables(_sharedAdapter);
     }
   }
   _createdTables.clear();

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -362,48 +362,6 @@ async function dropAllTables(inner: any): Promise<void> {
 }
 
 /**
- * Drop every materialized view, view, and table in the named PG schema
- * using the adapter's own identifier quoting (which doubles embedded
- * quotes). Used for `public`, which the AR adapter assumes exists.
- *
- * @internal
- */
-async function dropPgObjectsInSchema(adapter: any, schema: string): Promise<void> {
-  const qSchema = adapter.quoteIdentifier(schema);
-  const matviews = (await adapter.execute(
-    `SELECT matviewname AS name FROM pg_matviews WHERE schemaname = $1`,
-    [schema],
-  )) as { name: string }[];
-  for (const { name } of matviews) {
-    try {
-      await adapter.exec(
-        `DROP MATERIALIZED VIEW IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
-      );
-    } catch {}
-  }
-  const views = (await adapter.execute(
-    `SELECT viewname AS name FROM pg_views WHERE schemaname = $1`,
-    [schema],
-  )) as { name: string }[];
-  for (const { name } of views) {
-    try {
-      await adapter.exec(`DROP VIEW IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`);
-    } catch {}
-  }
-  const tables = (await adapter.execute(
-    `SELECT tablename AS name FROM pg_tables WHERE schemaname = $1`,
-    [schema],
-  )) as { name: string }[];
-  for (const { name } of tables) {
-    try {
-      await adapter.exec(
-        `DROP TABLE IF EXISTS ${qSchema}.${adapter.quoteIdentifier(name)} CASCADE`,
-      );
-    } catch {}
-  }
-}
-
-/**
  * MySQL drop-all using a single pinned pool connection so
  * FOREIGN_KEY_CHECKS=0 covers the whole drop sequence. The flag is
  * restored in `finally`; if anything between the SET and the restore
@@ -430,14 +388,14 @@ async function dropAllMysqlTables(adapter: any): Promise<void> {
       const name = r.table_name ?? r.TABLE_NAME;
       if (!name) continue;
       try {
-        await conn.query(`DROP VIEW IF EXISTS ${adapter.quoteTableName(name)}`);
+        await conn.query(`DROP VIEW IF EXISTS \`${name}\``);
       } catch {}
     }
     for (const r of tableRows) {
       const name = r.table_name ?? r.TABLE_NAME;
       if (!name) continue;
       try {
-        await conn.query(`DROP TABLE IF EXISTS ${adapter.quoteTableName(name)}`);
+        await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
       } catch {}
     }
     await conn.query(`SET FOREIGN_KEY_CHECKS=1`);
@@ -547,47 +505,52 @@ export async function resetTestAdapterState(): Promise<void> {
 
   if (_sharedAdapter) {
     if (isPg()) {
-      // Enumerate every user schema in the cluster, not just those on the
-      // session search_path. Tests that create a custom schema and never
-      // adjust search_path leave tables behind that current_schemas(false)
-      // can't see. Filter system + temp schemas; everything else is fair
-      // game. CASCADE drops dependent objects (views, sequences, etc).
-      const userSchemasSql = `
-        SELECT nspname FROM pg_namespace
-        WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
-          AND nspname NOT LIKE 'pg_temp_%'
-          AND nspname NOT LIKE 'pg_toast_temp_%'`;
-      const schemaRows = (await _sharedAdapter.execute(userSchemasSql)) as {
-        nspname: string;
-      }[];
-      for (const { nspname } of schemaRows) {
-        if (nspname === "public") {
-          // Don't drop `public` itself — the AR adapter assumes it exists.
-          // Drop its contents (matviews, views, tables) instead, using the
-          // adapter's own quoting to handle embedded quotes correctly.
-          await dropPgObjectsInSchema(_sharedAdapter, "public");
-        } else {
-          try {
-            await _sharedAdapter.exec(
-              `DROP SCHEMA IF EXISTS ${_sharedAdapter.quoteIdentifier(nspname)} CASCADE`,
-            );
-          } catch {}
-        }
+      // current_schemas(false) returns the search path with system schemas
+      // (pg_catalog, information_schema) excluded — the same scope the
+      // adapter's tables() method uses. Drop materialized views and views
+      // before tables; standalone views that don't depend on a dropped
+      // table wouldn't be reached by CASCADE.
+      const matviews = (await _sharedAdapter.execute(
+        `SELECT schemaname, matviewname AS name FROM pg_matviews
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; name: string }[];
+      for (const { schemaname, name } of matviews) {
+        try {
+          await _sharedAdapter.exec(
+            `DROP MATERIALIZED VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`,
+          );
+        } catch {}
+      }
+      const views = (await _sharedAdapter.execute(
+        `SELECT schemaname, viewname AS name FROM pg_views
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; name: string }[];
+      for (const { schemaname, name } of views) {
+        try {
+          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${schemaname}"."${name}" CASCADE`);
+        } catch {}
+      }
+      const rows = (await _sharedAdapter.execute(
+        `SELECT schemaname, tablename FROM pg_tables
+         WHERE schemaname = ANY(current_schemas(false))`,
+      )) as { schemaname: string; tablename: string }[];
+      for (const { schemaname, tablename } of rows) {
+        try {
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${schemaname}"."${tablename}" CASCADE`);
+        } catch {}
       }
     } else if (isMysql()) {
       await dropAllMysqlTables(_sharedAdapter);
     } else {
       // SQLite :memory: — query sqlite_master so objects created via raw
       // adapter.exec() (which bypass _createdTables) also get dropped.
-      // Drop views first since SQLite has no CASCADE. (ATTACH'd databases
-      // are out of scope: the only test using ATTACH —
-      // sqlite3-introspection.test.ts — bypasses the shared adapter.)
+      // Drop views first since SQLite has no CASCADE.
       const views = (await _sharedAdapter.execute(
         `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
       )) as { name: string }[];
       for (const { name } of views) {
         try {
-          await _sharedAdapter.exec(`DROP VIEW IF EXISTS ${_sharedAdapter.quoteTableName(name)}`);
+          await _sharedAdapter.exec(`DROP VIEW IF EXISTS "${name}"`);
         } catch {}
       }
       const rows = (await _sharedAdapter.execute(
@@ -595,7 +558,7 @@ export async function resetTestAdapterState(): Promise<void> {
       )) as { name: string }[];
       for (const { name } of rows) {
         try {
-          await _sharedAdapter.exec(`DROP TABLE IF EXISTS ${_sharedAdapter.quoteTableName(name)}`);
+          await _sharedAdapter.exec(`DROP TABLE IF EXISTS "${name}"`);
         } catch {}
       }
     }


### PR DESCRIPTION
## Summary

Addresses three legitimate gaps Copilot raised on PR 1's reset (#1190 review #2). All three were paths where state could survive `resetTestAdapterState()` and bleed into the next test:

1. **PostgreSQL** — was enumerating only `schemaname='public'`. Tests that create custom schemas (e.g. `schema.test.ts` with `test_schema`/`test_schema2`) leaked tables. Now enumerates every schema in `current_schemas(false)` (matches `PostgreSQLAdapter.tables()` scope) and drops with fully-qualified `"schema"."table"` identifiers.

2. **MySQL** — was iterating `SHOW TABLES` and calling `_sharedAdapter.exec()` per table. Each `exec()` may pick a different pool connection, so `SET FOREIGN_KEY_CHECKS=0` couldn't bracket the drops. Now pins a single dedicated pool connection for the whole reset, sets the FK flag once, drops views before tables, and releases the connection (which implicitly resets the session flag).

3. **SQLite** — was still using `_createdTables` + `dropAllTables()`. Tables created via raw `adapter.exec()` bypass the in-memory tracking set and survived reset. Now queries `sqlite_master` (excluding internal `sqlite_*`).

## Test plan
- [x] Full AR SQLite suite: 10203 passed / 3290 skipped, 0 regressions
- [ ] PostgreSQL Tests pass in CI
- [ ] MariaDB Tests pass in CI

## Plan context

PR 2 of the 4-PR series following #1190. Remaining: PR 3 kills the `handleMissingSchemaError` regex-based recovery path; PR 4 moves to schema-per-test isolation. After PR 4 stabilizes, the retry config from #1187 can be reverted.