### PR TITLE
test(activerecord): instrument schema-recovery firings (PR 3/4)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -42,8 +42,13 @@ const isMysql = (): boolean => !!MYSQL_TEST_URL;
 
 /**
  * Tracks how many times the regex-based "missing table/column" recovery in
- * `handleMissingSchemaError` fired and patched a real schema mismatch. The
- * recovery path is the historical cause of cross-test drift (PRs #1190,
+ * `handleMissingSchemaError` *would have fired* (i.e. matched a recoverable
+ * error). In soft mode this also reflects DDL that ran; in strict mode the
+ * counter increments but no DDL runs (we throw first). The counter is about
+ * "schema mismatches the recovery path detected", not "schema patches
+ * applied" — both modes count the same event, just with different actions.
+ *
+ * The recovery path is the historical cause of cross-test drift (PRs #1190,
  * #1192, project_test_adapter_drift_fix); it papers over real schema bugs
  * by inferring types from regex parsing of SQL strings.
  *
@@ -105,7 +110,12 @@ function buildRecoveryDiag(
   sql: string,
   strict: boolean,
 ): string {
-  const head = `[test-adapter] schema recovery fired (${kind}): ${msg.slice(0, 200)} | sql=${sql.slice(0, 200)}`;
+  // Collapse all whitespace runs (including newlines) to single spaces so
+  // the diagnostic is one greppable line. Multi-line driver messages and
+  // pretty-printed SQL otherwise break the "one event = one log line"
+  // contract we rely on for `grep -c` in CI.
+  const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
+  const head = `[test-adapter] schema recovery fired (${kind}): ${oneLine(msg).slice(0, 200)} | sql=${oneLine(sql).slice(0, 200)}`;
   if (!strict) return head;
   const guidance =
     kind === "table"

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -72,6 +72,55 @@ export function resetRecoveryFireCount(): void {
   _schemaRecoveryFires = 0;
 }
 
+/**
+ * Classify a DB error message as a recoverable missing-table/missing-column
+ * case based on the same regexes `_handleMissingSchemaErrorInner` uses.
+ * Returns the kind so strict mode can throw with a tailored message before
+ * any DDL runs, and so the soft-mode diagnostic can name what was missing.
+ *
+ * @internal
+ */
+function classifyRecoverableError(msg: string): "column" | "table" | null {
+  if (
+    /column "(\w+)" of relation "(\w+)" does not exist/i.test(msg) ||
+    /Unknown column '(\w+)' in/i.test(msg) ||
+    /table (\w+) has no column named (\w+)/i.test(msg)
+  ) {
+    return "column";
+  }
+  if (
+    /relation "(\w+)" does not exist/i.test(msg) ||
+    /Table '(?:[\w]+\.)?(\w+)' doesn't exist/i.test(msg) ||
+    /no such table: (\w+)/i.test(msg)
+  ) {
+    return "table";
+  }
+  return null;
+}
+
+/** @internal */
+function buildRecoveryDiag(
+  kind: "column" | "table" | "unknown",
+  msg: string,
+  sql: string,
+  strict: boolean,
+): string {
+  const head = `[test-adapter] schema recovery fired (${kind}): ${msg.slice(0, 200)} | sql=${sql.slice(0, 200)}`;
+  if (!strict) return head;
+  const guidance =
+    kind === "table"
+      ? `Recovery patches missing tables by inferring columns from SQL — that's regex SQL parsing, ` +
+        `not a real schema. Register the table at decl time: a Model class via attribute(...), or ` +
+        `a HABTM join table via the association builder (which fires the adapter-set hook).`
+      : kind === "column"
+        ? `Recovery patches schema mismatches with regex-inferred column types — a real bug was ` +
+          `hidden. Declare the missing column on the model via attribute(...) so it gets created ` +
+          `in processPendingModels at adapter-set time.`
+        : `Recovery fired for an unclassified error — extend classifyRecoverableError if this is ` +
+          `a real recoverable case, otherwise surface the underlying bug.`;
+  return `AR_TEST_STRICT_SCHEMA: ${head}\n${guidance}`;
+}
+
 let _sharedAdapter: any = null;
 
 // Schema tracking — what tables/columns have been created in the DB.
@@ -612,6 +661,9 @@ export async function resetTestAdapterState(): Promise<void> {
     _pendingCpk.clear();
     _registeredModelClasses.clear();
     _needsCleanup = false;
+    // Reset the recovery counter so per-test assertions on it don't depend
+    // on execution order. The global beforeEach owns this reset.
+    _schemaRecoveryFires = 0;
   } finally {
     _cleanupPromise = null;
     resolveLock();
@@ -839,26 +891,27 @@ class SchemaAdapter implements DatabaseAdapter {
    * the table or adding the column. Returns true if recovery succeeded.
    *
    * Wrapper around `_handleMissingSchemaErrorInner` that increments the
-   * recovery-fire counter on success, throws in strict mode, and emits a
-   * one-line diagnostic in soft mode so CI logs can be grep'd for tests
-   * that still depend on schema recovery.
+   * recovery-fire counter on success, throws in strict mode (BEFORE any
+   * recovery DDL runs, so the DB stays unmodified), and emits a one-line
+   * diagnostic in soft mode so CI logs can be grep'd for tests that still
+   * depend on schema recovery.
    */
   private async handleMissingSchemaError(e: any, sql: string): Promise<boolean> {
+    const msg = e?.message || e?.sqlMessage || "";
+    const kind = classifyRecoverableError(msg);
+    // Strict mode: detect recoverability from the error text alone and throw
+    // before _handleMissingSchemaErrorInner runs any CREATE/ALTER. Otherwise
+    // strict mode would still patch the DB and only surface the failure
+    // afterwards, masking follow-on behavior in the same process.
+    if (kind && STRICT_SCHEMA) {
+      _schemaRecoveryFires += 1;
+      throw new Error(buildRecoveryDiag(kind, msg, sql, /* strict */ true));
+    }
     const recovered = await this._handleMissingSchemaErrorInner(e, sql);
     if (!recovered) return false;
     _schemaRecoveryFires += 1;
-    const msg = e?.message || e?.sqlMessage || "";
-    const diag = `[test-adapter] schema recovery fired: ${msg.slice(0, 200)} | sql=${sql.slice(0, 200)}`;
-    if (STRICT_SCHEMA) {
-      throw new Error(
-        `AR_TEST_STRICT_SCHEMA: ${diag}\n` +
-          `Recovery patches schema mismatches with regex-inferred column types — a real bug ` +
-          `was hidden. Declare the missing column on the model via attribute(...) so it gets ` +
-          `created in processPendingModels at adapter-set time.`,
-      );
-    }
 
-    console.warn(diag);
+    console.warn(buildRecoveryDiag(kind ?? "unknown", msg, sql, /* strict */ false));
     return true;
   }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -40,6 +40,38 @@ export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
 const isPg = (): boolean => !!PG_TEST_URL;
 const isMysql = (): boolean => !!MYSQL_TEST_URL;
 
+/**
+ * Tracks how many times the regex-based "missing table/column" recovery in
+ * `handleMissingSchemaError` fired and patched a real schema mismatch. The
+ * recovery path is the historical cause of cross-test drift (PRs #1190,
+ * #1192, project_test_adapter_drift_fix); it papers over real schema bugs
+ * by inferring types from regex parsing of SQL strings.
+ *
+ * After PRs #1190 and #1192 made cleanup eager, recovery should never need
+ * to fire — every model declares its attributes via `attribute()`, and
+ * `processPendingModels` creates the table from those declarations before
+ * any query runs.
+ *
+ * Tests can read this counter (`getRecoveryFireCount()`) to assert it stays
+ * at 0; CI can opt into strict mode via `AR_TEST_STRICT_SCHEMA=1` to throw
+ * on any recovery firing. We keep the recovery in default mode for now so
+ * we get a soft-landing if some test path still depends on it; once strict
+ * mode is clean across full PG/MySQL CI, the recovery can be deleted.
+ *
+ * @internal
+ */
+let _schemaRecoveryFires = 0;
+const STRICT_SCHEMA = process.env.AR_TEST_STRICT_SCHEMA === "1";
+
+/** @internal */
+export function getRecoveryFireCount(): number {
+  return _schemaRecoveryFires;
+}
+/** @internal */
+export function resetRecoveryFireCount(): void {
+  _schemaRecoveryFires = 0;
+}
+
 let _sharedAdapter: any = null;
 
 // Schema tracking — what tables/columns have been created in the DB.
@@ -805,8 +837,32 @@ class SchemaAdapter implements DatabaseAdapter {
   /**
    * If the error is about a missing table or column, recover by creating
    * the table or adding the column. Returns true if recovery succeeded.
+   *
+   * Wrapper around `_handleMissingSchemaErrorInner` that increments the
+   * recovery-fire counter on success, throws in strict mode, and emits a
+   * one-line diagnostic in soft mode so CI logs can be grep'd for tests
+   * that still depend on schema recovery.
    */
   private async handleMissingSchemaError(e: any, sql: string): Promise<boolean> {
+    const recovered = await this._handleMissingSchemaErrorInner(e, sql);
+    if (!recovered) return false;
+    _schemaRecoveryFires += 1;
+    const msg = e?.message || e?.sqlMessage || "";
+    const diag = `[test-adapter] schema recovery fired: ${msg.slice(0, 200)} | sql=${sql.slice(0, 200)}`;
+    if (STRICT_SCHEMA) {
+      throw new Error(
+        `AR_TEST_STRICT_SCHEMA: ${diag}\n` +
+          `Recovery patches schema mismatches with regex-inferred column types — a real bug ` +
+          `was hidden. Declare the missing column on the model via attribute(...) so it gets ` +
+          `created in processPendingModels at adapter-set time.`,
+      );
+    }
+
+    console.warn(diag);
+    return true;
+  }
+
+  private async _handleMissingSchemaErrorInner(e: any, sql: string): Promise<boolean> {
     const msg = e?.message || e?.sqlMessage || "";
 
     // Handle missing column: add the column and retry


### PR DESCRIPTION
## Summary

Adds the scaffolding to kill the regex-based `handleMissingSchemaError` recovery path. **Direct removal isn't safe**: 45 firings across the SQLite suite today — mostly HABTM join tables (auto-generated, never registered as Models), STI subclasses, and a few seedPosts patterns. Each is a real test path that would break without recovery and needs its own follow-up fix.

## What ships

- Recovery-fire counter `_schemaRecoveryFires`, exported via `getRecoveryFireCount()` / `resetRecoveryFireCount()`.
- **Soft mode** (default): one-line `console.warn` diagnostic on every recovery firing — CI logs are now grep-friendly:
  ```
  [test-adapter] schema recovery fired: no such table: parrots_pirates | sql=INSERT INTO ...
  ```
- **Strict mode** (`AR_TEST_STRICT_SCHEMA=1`): throw with a message that names the SQL and tells the author exactly how to fix it (declare the column on the model via `attribute(...)`).

## What's next

Future PRs add explicit registration for the offending test-only patterns (HABTM join tables, STI subclasses, abstract-base shadow tables) and shrink the diagnostic count toward 0. Once strict CI is clean, the recovery path can be deleted in a PR-4-followup, and the retry config from #1187 can be reverted.

## Test plan
- [x] Full AR SQLite suite (soft mode): 10203 passed / 3290 skipped
- [x] Strict mode on `finder.test.ts` (no recovery): passes
- [x] Strict mode on `relations.test.ts` (recovery fires): correctly throws and names the SQL
- [ ] PG/MySQL CI: soft mode, no regressions

## Plan context

PR 3 of the 4-PR series following #1190 / #1192. Defers the recovery removal until the underlying registration gaps are closed.