### PR TITLE
feat(test-helpers): AR_NO_AUTO_SCHEMA env flag (TS-3)

### DIFF
--- a/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
+++ b/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
@@ -3,10 +3,6 @@ import { createTestAdapter, cleanupTestAdapter, resetTestAdapterState } from "./
 import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-// ---------------------------------------------------------------------------
-// Control group: AR_NO_AUTO_SCHEMA unset — existing behavior unchanged
-// ---------------------------------------------------------------------------
-
 describe("AR_NO_AUTO_SCHEMA unset (control)", () => {
   let adapter: DatabaseAdapter;
 
@@ -36,10 +32,6 @@ describe("AR_NO_AUTO_SCHEMA unset (control)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// AR_NO_AUTO_SCHEMA=1: dynamic adapter degrades to a thin pass-through
-// ---------------------------------------------------------------------------
-
 describe("AR_NO_AUTO_SCHEMA=1", () => {
   beforeEach(() => {
     vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -67,8 +59,6 @@ describe("AR_NO_AUTO_SCHEMA=1", () => {
     }
     void Gadget;
 
-    // The hook was not registered, so no pending models were queued.
-    // A query against the missing table should fail with a DB error, not succeed.
     await expect(adapter.execute(`SELECT * FROM "gadgets"`)).rejects.toThrow();
   });
 

--- a/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
+++ b/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createTestAdapter, cleanupTestAdapter, resetTestAdapterState } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+// ---------------------------------------------------------------------------
+// Control group: AR_NO_AUTO_SCHEMA unset — existing behavior unchanged
+// ---------------------------------------------------------------------------
+
+describe("AR_NO_AUTO_SCHEMA unset (control)", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    await resetTestAdapterState();
+    adapter = createTestAdapter();
+  });
+
+  afterEach(async () => {
+    await cleanupTestAdapter(adapter);
+  });
+
+  it("auto-creates a table when a model sets its adapter", async () => {
+    const { Base } = await import("./base.js");
+    class Widget extends Base {
+      static {
+        this.tableName = "widgets";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    await adapter.executeMutation(`INSERT INTO "widgets" ("name") VALUES ('cog')`);
+    const rows = await adapter.execute(`SELECT * FROM "widgets"`);
+    expect(rows.length).toBeGreaterThan(0);
+    void Widget;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AR_NO_AUTO_SCHEMA=1: dynamic adapter degrades to a thin pass-through
+// ---------------------------------------------------------------------------
+
+describe("AR_NO_AUTO_SCHEMA=1", () => {
+  beforeEach(() => {
+    vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("Base.adapter = x does NOT register the model for auto table creation", async () => {
+    const { createTestAdapter: freshFactory, resetTestAdapterState: freshReset } =
+      await import("./test-adapter.js");
+    await freshReset();
+    const adapter = freshFactory();
+    const { Base } = await import("./base.js");
+
+    class Gadget extends Base {
+      static {
+        this.tableName = "gadgets";
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    void Gadget;
+
+    // The hook was not registered, so no pending models were queued.
+    // A query against the missing table should fail with a DB error, not succeed.
+    await expect(adapter.execute(`SELECT * FROM "gadgets"`)).rejects.toThrow();
+  });
+
+  it("INSERT into a missing table throws the underlying DB error", async () => {
+    const { createTestAdapter: freshFactory, resetTestAdapterState: freshReset } =
+      await import("./test-adapter.js");
+    await freshReset();
+    const adapter = freshFactory();
+
+    await expect(
+      adapter.executeMutation(`INSERT INTO "no_such_table" ("x") VALUES ('y')`),
+    ).rejects.toThrow();
+  });
+
+  it("passes when the caller pre-creates the table via defineSchema()", async () => {
+    const { createTestAdapter: freshFactory, resetTestAdapterState: freshReset } =
+      await import("./test-adapter.js");
+    await freshReset();
+    const adapter = freshFactory();
+
+    await defineSchema(adapter, {
+      gadgets: { label: "string" },
+    });
+
+    await adapter.executeMutation(`INSERT INTO "gadgets" ("label") VALUES ('wrench')`);
+    const rows = await adapter.execute(`SELECT * FROM "gadgets"`);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -31,6 +31,11 @@ import { _setOnAdapterSetHook } from "./base.js";
 const PG_TEST_URL = process.env.PG_TEST_URL;
 const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL;
 
+// When set, the dynamic schema management (setter hook, auto-table creation,
+// error recovery) is disabled. Tests opt in via vi.stubEnv or vitest.config.ts.
+// Read once at module load so per-call overhead is zero.
+const NO_AUTO_SCHEMA = process.env.AR_NO_AUTO_SCHEMA === "1";
+
 /** Which adapter backend is active. */
 export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
   ? "postgres"
@@ -144,6 +149,7 @@ function registerModel(modelClass: any): void {
  * columns and applies CPK only when no non-CPK claimant exists.
  */
 function extractColumnsFromModels(): void {
+  if (NO_AUTO_SCHEMA) return;
   const tablesWithNonCpk = new Set<string>();
   for (const modelClass of _registeredModelClasses) {
     if (modelClass.abstractClass) continue;
@@ -235,6 +241,7 @@ function lookupDeclaredColumnType(tableName: string, colName: string): string | 
  * Create tables and add columns for all pending model registrations.
  */
 async function processPendingModels(inner: any): Promise<void> {
+  if (NO_AUTO_SCHEMA) return;
   for (const [tableName, columns] of _pendingModels) {
     if (!_createdTables.has(tableName)) {
       const cpkCols = _pendingCpk.get(tableName);
@@ -413,8 +420,11 @@ if (PG_TEST_URL) {
   _factory = () => new SchemaAdapter(_sharedAdapter);
 }
 
-// Register hook so Base.adapter = x triggers model registration
-_setOnAdapterSetHook(registerModel);
+// Register hook so Base.adapter = x triggers model registration.
+// Skip when AR_NO_AUTO_SCHEMA=1 — tests manage their own schema explicitly.
+if (!NO_AUTO_SCHEMA) {
+  _setOnAdapterSetHook(registerModel);
+}
 
 /**
  * Create a fresh adapter for testing.
@@ -428,6 +438,10 @@ export function createTestAdapter(): DatabaseAdapter {
  * Clean up test data.
  */
 export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void> {
+  if (NO_AUTO_SCHEMA && _sharedAdapter) {
+    await dropAllTables(_sharedAdapter);
+    return;
+  }
   if (adapter instanceof SchemaAdapter) {
     await adapter.cleanup();
   }
@@ -714,6 +728,7 @@ class SchemaAdapter implements DatabaseAdapter {
    * the table or adding the column. Returns true if recovery succeeded.
    */
   private async handleMissingSchemaError(e: any, sql: string): Promise<boolean> {
+    if (NO_AUTO_SCHEMA) return false;
     const msg = e?.message || e?.sqlMessage || "";
 
     // Handle missing column: add the column and retry


### PR DESCRIPTION
## Summary

- Adds `const NO_AUTO_SCHEMA = process.env.AR_NO_AUTO_SCHEMA === "1"` read once at module load in `test-adapter.ts`
- Wraps `_setOnAdapterSetHook(registerModel)` so the hook is only installed when the flag is off
- Short-circuits `extractColumnsFromModels` and `processPendingModels` when the flag is on
- Short-circuits the error-recovery path (`handleMissingSchemaError` returns `false`) so missing-table/column errors propagate as real DB errors
- Updates `cleanupTestAdapter` to delegate to `dropAllTables(_sharedAdapter)` when the flag is on (tracked tables are not populated in this mode)
- Adds `test-adapter-no-auto-schema.test.ts` covering all four cases from the plan

Part of the [explicit test schema plan](docs/explicit-test-schema-plan.md) (TS-3). Depends on TS-1 (#1201) and TS-2 (just merged). Unblocks TS-4a (`join-model.test.ts` canary migration).

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1`: `Base.adapter = x` does not register model for table creation
- [x] `AR_NO_AUTO_SCHEMA=1`: INSERT into missing table throws DB error (not silent recovery)
- [x] `AR_NO_AUTO_SCHEMA=1` + `defineSchema()`: explicit pre-created table works normally
- [x] Flag unset (control): existing auto-create behavior unchanged