### PR TITLE
test(activerecord): migrate validations tests to defineSchema (TS-4b)

### DIFF
--- a/packages/activerecord/src/validations/absence-validation.test.ts
+++ b/packages/activerecord/src/validations/absence-validation.test.ts
@@ -2,21 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("AbsenceValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { topics: { title: "string", body: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
   function makeModel() {
     class Topic extends Base {

--- a/packages/activerecord/src/validations/absence-validation.test.ts
+++ b/packages/activerecord/src/validations/absence-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
@@ -12,8 +12,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 
 describe("AbsenceValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
   afterAll(async () => {

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
@@ -13,8 +13,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 
 describe("AssociationValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, {
       posts: { title: "string" },
       comments: { body: "string", post_id: "integer" },

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -2,22 +2,36 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("AssociationValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string" },
+      comments: { body: "string", post_id: "integer" },
+      widgets: { name: "string" },
+      missing_children: { name: "string", parent_id: "integer" },
+      val_bt_parents: { name: "string" },
+      val_bt_children: { title: "string", val_bt_parent_id: "integer" },
+      val_bt_parent2s: { name: "string" },
+      val_bt_child2s: { title: "string", val_bt_parent2_id: "integer" },
+      topic_m_ds: { title: "string" },
+      topic_w_a_ds: { title: "string" },
+      reply_msgs: { title: "string" },
+      reply_ctxs: { title: "string" },
+    });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("validates associated many", async () => {

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
@@ -12,8 +12,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 
 describe("LengthValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string" } });
   });
   afterAll(async () => {

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -2,21 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("LengthValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { topics: { title: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
   function makeModel() {
     class Topic extends Base {

--- a/packages/activerecord/src/validations/numericality-validation.test.ts
+++ b/packages/activerecord/src/validations/numericality-validation.test.ts
@@ -2,22 +2,27 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "../index.js";
 import { NumericalityValidator } from "./numericality.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("NumericalityValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      widgets: { price: "float", quantity: "integer" },
+      widget2s: { price: "float" },
+      decimals: { amount: "decimal" },
+    });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
   function makeModel() {
     class Widget extends Base {

--- a/packages/activerecord/src/validations/numericality-validation.test.ts
+++ b/packages/activerecord/src/validations/numericality-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "../index.js";
 import { NumericalityValidator } from "./numericality.js";
 
@@ -13,8 +13,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 
 describe("NumericalityValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, {
       widgets: { price: "float", quantity: "integer" },
       widget2s: { price: "float" },

--- a/packages/activerecord/src/validations/presence-validation.test.ts
+++ b/packages/activerecord/src/validations/presence-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
@@ -12,8 +12,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 
 describe("PresenceValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
   afterAll(async () => {

--- a/packages/activerecord/src/validations/presence-validation.test.ts
+++ b/packages/activerecord/src/validations/presence-validation.test.ts
@@ -2,21 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("PresenceValidationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { topics: { title: "string", body: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {

--- a/packages/activerecord/src/validations/validations.test.ts
+++ b/packages/activerecord/src/validations/validations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
@@ -8,8 +8,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 describe("Validation Contexts (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     adapter = createTestAdapter();
+  });
+  beforeEach(async () => {
     await defineSchema(adapter, {
       users: { name: "string", terms: "string", change_reason: "string" },
     });

--- a/packages/activerecord/src/validations/validations.test.ts
+++ b/packages/activerecord/src/validations/validations.test.ts
@@ -1,17 +1,21 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("Validation Contexts (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", terms: "string", change_reason: "string" },
+    });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   // Rails: test "validation on: :create"


### PR DESCRIPTION
## Summary

Migrates 6 validations test files from implicit (auto-schema) to explicit `defineSchema()` setup. Part of the TS-4 migration series (TS-1 defineSchema, TS-2 dropAllTables, TS-3 AR_NO_AUTO_SCHEMA env flag all merged).

Each file now:
- Calls `defineSchema(adapter, {...})` in `beforeAll` to explicitly declare the DB schema it needs
- Calls `dropAllTables(adapter)` in `afterAll`
- Uses a shared adapter for the describe block instead of a fresh adapter per test

## Files migrated

| File | Tables declared |
|------|----------------|
| `absence-validation.test.ts` | `topics { title: string, body: string }` |
| `length-validation.test.ts` | `topics { title: string }` |
| `numericality-validation.test.ts` | `widgets { price: float, quantity: integer }`, `widget2s { price: float }`, `decimals { amount: decimal }` |
| `presence-validation.test.ts` | `topics { title: string, body: string }` |
| `association-validation.test.ts` | `posts`, `comments`, `widgets`, `missing_children`, `val_bt_parents`, `val_bt_children`, `val_bt_parent2s`, `val_bt_child2s`, `topic_m_ds`, `topic_w_a_ds`, `reply_msgs`, `reply_ctxs` |
| `validations.test.ts` | `users { name: string, terms: string, change_reason: string }` |

## Not in this PR

- `uniqueness-validation.test.ts` (1625 lines, 99 tests with per-test inline fresh adapters — will be TS-4b-2)
- `i18n-*.test.ts` files (don't use `createTestAdapter`)