### PR TITLE
test(activerecord): register posts table in last RelationTest block beforeEach

### DIFF
--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -4223,6 +4223,7 @@ describe("RelationTest", () => {
   let adapter: DatabaseAdapter;
   beforeEach(() => {
     adapter = freshAdapter();
+    Post.adapter = adapter;
   });
 
   function makePost() {


### PR DESCRIPTION
## Summary

- The `describe("RelationTest")` block at line 4222 of `relations.test.ts` sets `adapter = freshAdapter()` in `beforeEach` but never wires it to the module-level `Post` class.
- Tests that call `Post.create()` directly (rather than defining a local class with `this.adapter = adapter`) found no `posts` table after `resetTestAdapterState()` dropped it.
- Fix: add `Post.adapter = adapter` to that block's `beforeEach`, which triggers `registerModel(Post)` so `setup()` creates the table eagerly — matching the pattern used by `seedPosts()` in the earlier describe blocks.

Unblocks #1205 by registering `relations.test.ts` fixture tables eagerly (10 tests that were silently recovered by `handleMissingSchemaError` now pass without the recovery path).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relations.test.ts` — 675 passed, 9 skipped with cherry-pick of #1205's commit