### PR TITLE
fix(activerecord): eager adapter registration for subclasses

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -733,9 +733,12 @@ export class Base extends Model {
    * infrastructure. Prefer `establishConnection` for production use.
    */
   static set adapter(adapter: DatabaseAdapter) {
-    // Reassigning the same adapter is a no-op — avoid dropping reflected
-    // columns/types unnecessarily when user code re-sets the same ref.
-    if (this._adapter === adapter) {
+    // Reassigning the same adapter to the same class is a no-op — avoid
+    // dropping reflected columns/types unnecessarily. Use hasOwnProperty so a
+    // subclass that calls `this.adapter = parent.adapter` still fires the hook
+    // and gets registered for table creation, even when the adapter reference
+    // matches what it inherited from the parent class.
+    if (Object.prototype.hasOwnProperty.call(this, "_adapter") && this._adapter === adapter) {
       return;
     }
     this._adapter = adapter;

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -155,7 +155,11 @@ describe("CallbacksTest", () => {
       log.push("before_create");
     });
 
-    class Dog extends Animal {}
+    class Dog extends Animal {
+      static {
+        this.adapter = adapter;
+      }
+    }
     await Dog.create({ name: "Rex" });
     expect(log).toContain("before_create");
   });

--- a/packages/activerecord/src/inherited.test.ts
+++ b/packages/activerecord/src/inherited.test.ts
@@ -17,6 +17,7 @@ describe("InheritedTest", () => {
     }
     class Child extends Parent {
       static {
+        this.adapter = adapter;
         this.beforeCreate(function () {
           log.push("child_before");
         });
@@ -42,6 +43,7 @@ describe("InheritedTest", () => {
     }
     class Child extends Parent {
       static {
+        this.adapter = adapter;
         this.afterCreate(function () {
           log.push("child_after");
         });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1336,7 +1336,11 @@ describe("DefaultScopingTest", () => {
         this.adapter = adp;
       }
     }
-    class Dog extends Animal {}
+    class Dog extends Animal {
+      static {
+        this.adapter = adp;
+      }
+    }
     const dog = (await Dog.create({ name: "Rex", active: true })) as any;
     expect(dog.name).toBe("Rex");
   });

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -972,7 +972,11 @@ describe("NamedScopingTest", () => {
         this.adapter = adp;
       }
     }
-    class Dog extends Animal {}
+    class Dog extends Animal {
+      static {
+        this.adapter = adp;
+      }
+    }
     const dog = (await Dog.create({ name: "Fido" })) as any;
     expect(dog.name).toBe("Fido");
     expect((await Dog.where({ name: "Fido" }).toArray()).length).toBe(1);

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -569,7 +569,11 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
         this.adapter = adapter;
       }
     }
-    class VeryImportantTopic extends ImportantTopic {}
+    class VeryImportantTopic extends ImportantTopic {
+      static {
+        this.adapter = adapter;
+      }
+    }
     serialize(ImportantTopic, "content");
     const payload = { foo: "bar" };
     const t = await VeryImportantTopic.create({

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Base, RecordNotFound } from "./index.js";
+import { Base, RecordNotFound, enableSti, registerSubclass } from "./index.js";
 import { setSignedIdVerifierSecret } from "./signed-id.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -120,11 +120,13 @@ describe("SignedIdTest", () => {
         this.attribute("name", "string");
         this.attribute("type", "string");
         this.adapter = adapter;
+        enableSti(this);
       }
     }
     class Dog extends Animal {
-      // eslint-disable-next-line no-empty-static-block
-      static {}
+      static {
+        registerSubclass(this);
+      }
     }
     const d = await Dog.create({ name: "Rex" });
     const token = await d.signedId();
@@ -147,11 +149,13 @@ describe("SignedIdTest", () => {
         this.attribute("name", "string");
         this.attribute("type", "string");
         this.adapter = adapter;
+        enableSti(this);
       }
     }
     class Car extends Vehicle {
-      // eslint-disable-next-line no-empty-static-block
-      static {}
+      static {
+        registerSubclass(this);
+      }
     }
     const c = await Car.create({ name: "Sedan" });
     const token = await c.signedId();


### PR DESCRIPTION
## Summary

- **`base.ts` infra fix**: the `Base.adapter` setter used `this._adapter === adapter` to skip no-op reassignments, but `this._adapter` resolves via the prototype chain. A subclass calling `this.adapter = parent.adapter` silently matched the inherited reference and returned early — the hook never fired and the subclass table was never registered for test-schema creation. Fixed with `hasOwnProperty` so the guard only applies to own-property assignments.
- **Test fixes**: 7 test files updated to remove reliance on the schema-recovery path being removed in #1205:
  - `inherited.test.ts`: Child classes set `this.adapter = adapter` so their tables are registered
  - `callbacks.test.ts`: Dog subclass sets `this.adapter = adapter`
  - `signed-id.test.ts`: STI tests use `enableSti` + `registerSubclass` (Dog/Car share parent table)
  - `scoping/default-scoping.test.ts`, `scoping/named-scoping.test.ts`: Dog subclasses set adapter
  - `serialized-attribute.test.ts`: VeryImportantTopic sets adapter; `nested-attributes.test.ts`'s SubSubPirate was already calling `this.adapter = adapter` but was silently no-op'd by the old guard — fixed by the infra change

Fixes the following failures surfaced by #1205 on SQLite:
`callbacks.test.ts` (dogs), `inherited.test.ts` (children), `signed-id.test.ts` (dogs, cars), `scoping/default-scoping.test.ts` (dogs), `scoping/named-scoping.test.ts` (dogs), `serialized-attribute.test.ts` (very_important_topics), `nested-attributes.test.ts` (sub_sub_pirates)

Companion PR: #1205 (do not merge before this)

## Test plan

- [ ] Cherry-pick #1205 onto this branch and run the 7 affected test files — all pass
- [ ] Existing tests unaffected (build + typecheck pass)