### PR TITLE
fix(activerecord): eager table creation for migrations and ad-hoc fixtures

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1484,7 +1484,14 @@ describe("HasAndBelongsToManyAssociations", () => {
         this.adapter = adapter;
       }
     }
+    class Project extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
     registerModel(Developer);
+    registerModel(Project);
 
     // Create the join table
     await adapter.executeMutation(

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1041,6 +1041,7 @@ describe("BasicsTest", () => {
       static {
         this.primaryKey = ["shop_id", "id"];
         this.attribute("shop_id", "integer");
+        this.attribute("id", "integer");
         this.attribute("name", "string");
         this.adapter = adapter;
       }

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -399,9 +399,7 @@ describe("Reversible Migrations", () => {
 
     // Down — drops the table
     await migration.run(adapter, "down");
-    // Table was dropped; on MemoryAdapter it returns empty, on real DBs
-    // the SchemaAdapter auto-creates an empty table on missing-table error.
-    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`);
-    expect(afterDrop).toHaveLength(0);
+    // Table was dropped by the reversed migration
+    expect((adapter as any).tables.has("posts")).toBe(false);
   });
 });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -738,6 +738,10 @@ describe("Migration DDL (extended)", () => {
 
   it("reversible renameTable reverses correctly", async () => {
     const adapter = freshAdapter();
+    const ctx = new MigrationContext(adapter);
+    await ctx.createTable("people", {}, (t) => {
+      t.string("name");
+    });
     class RenameUsers extends Migration {
       async change() {
         await this.renameTable("people", "users");
@@ -894,7 +898,8 @@ describe("Rails-guided: migrations", () => {
     expect(await adapter.execute(`SELECT * FROM "widgets"`)).toHaveLength(1);
 
     await m.run(adapter, "down");
-    expect(await adapter.execute(`SELECT * FROM "widgets"`)).toHaveLength(0);
+    // The reversed migration dropped "widgets"; verify it no longer exists
+    expect((adapter as any).tables.has("widgets")).toBe(false);
   });
 
   it("reversible removeColumn with type auto-reverses", async () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -4223,6 +4223,7 @@ describe("RelationTest", () => {
   let adapter: DatabaseAdapter;
   beforeEach(() => {
     adapter = freshAdapter();
+    Post.adapter = adapter;
   });
 
   function makePost() {


### PR DESCRIPTION
## Summary

Removes reliance on the schema-recovery path (removed in #1205) in five test files:

- **`relations.test.ts`**: large `RelationTest` describe block created a fresh adapter each test but never re-assigned `Post.adapter`, leaving the module-level `Post` pointing at a cleaned-up adapter with no tables; add the assignment to `beforeEach`
- **`associations.test.ts`**: `test_habtm_returns_empty_when_no_join_rows` queries the "projects" table but never defined a `Project` model; add a minimal `Project` class so the table is created eagerly
- **`base.test.ts`**: `Order` CPK model declares `primaryKey = ["shop_id","id"]` but omits the `"id"` attribute, causing the `CREATE TABLE` to fail (column in `PRIMARY KEY` but not in column list); add the explicit attribute
- **`migration.test.ts`**: "reversible renameTable" tests renaming a "people" table that was never created; add setup `createTable`. "auto-reverses" test checked `SELECT * FROM widgets` after the migration dropped the table (relied on recovery returning empty rows); assert table absence instead
- **`invertible-migration.test.ts`**: same SELECT-after-drop pattern; assert table absence via adapter's table tracker

Fixes the following failures surfaced by #1205 on SQLite:
`relations.test.ts` (10 × posts), `associations.test.ts` (projects), `base.test.ts` (orders), `migration.test.ts` (people, widgets), `invertible-migration.test.ts` (posts)

Companion PR: #1205 (do not merge before this)

## Test plan

- [ ] Cherry-pick #1205 onto this branch and run the 5 affected test files — all pass
- [ ] Existing tests unaffected (build + typecheck pass)