### PR TITLE
test(activerecord): migrate small-file batch to defineSchema (TS-4f)

### DIFF
--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -1,20 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
-import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 let adapter: DatabaseAdapter;
 
 beforeAll(() => {
   adapter = createTestAdapter();
-});
-beforeAll(async () => {
-  await defineSchema(adapter, { posts: { title: "string" } });
-});
-afterAll(async () => {
-  await dropAllTables(adapter);
 });
 
 describe("AnnotateTest", () => {

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeAll(async () => {
+  await defineSchema(adapter, { posts: { title: "string" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("AnnotateTest", () => {
   it("annotate wraps content in an inline comment", () => {
-    const adapter = createTestAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -16,7 +30,6 @@ describe("AnnotateTest", () => {
   });
 
   it("annotate is sanitized", () => {
-    const adapter = createTestAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -20,7 +20,7 @@ beforeAll(() => {
   adapter = createTestAdapter();
 });
 beforeEach(async () => {
-  await defineSchema(adapter, { metrics: { score: "string", label: "string" } });
+  await defineSchema(adapter, { metrics: { score: "big_integer", label: "string" } });
 });
 afterAll(async () => {
   await dropAllTables(adapter);

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -5,20 +5,28 @@
  * JSON.stringify, where) with big_integer attributes. Runs on SQLite3
  * by default (no DB); runs on PG/MySQL when *_TEST_URL env vars are set.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
 
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, { metrics: { score: "string", label: "string" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
+
 describe("bigint model round-trip (all adapters)", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    adapter = createTestAdapter();
-  });
-
   function makeModel() {
     class Metric extends Base {
       static {

--- a/packages/activerecord/src/boolean.test.ts
+++ b/packages/activerecord/src/boolean.test.ts
@@ -2,23 +2,27 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, { topics: { title: "string", approved: "boolean" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("BooleanTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   function makeModel() {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/comment.test.ts
+++ b/packages/activerecord/src/comment.test.ts
@@ -4,14 +4,6 @@
  */
 import { describe, it } from "vitest";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
-
 describe("CommentTest", () => {
   it.skip("default primary key comment", () => {
     /* fixture-dependent */

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -1,14 +1,26 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import type { DatabaseAdapter } from "./adapter.js";
 
-function freshAdapter() {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeAll(async () => {
+  await defineSchema(adapter, {
+    posts: { title: "string", lock_version: "integer" },
+  });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("CustomLockingTest", () => {
   it("custom lock", async () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this._tableName = "posts";

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -10,7 +10,7 @@ let adapter: DatabaseAdapter;
 beforeAll(() => {
   adapter = createTestAdapter();
 });
-beforeAll(async () => {
+beforeEach(async () => {
   await defineSchema(adapter, {
     posts: { title: "string", lock_version: "integer" },
   });

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
@@ -11,8 +11,8 @@ let adapter: DatabaseAdapter;
 beforeAll(() => {
   adapter = createTestAdapter();
 });
-beforeAll(async () => {
-  await defineSchema(adapter, { events: { start_date: "string" } });
+beforeEach(async () => {
+  await defineSchema(adapter, { events: { start_date: "date" } });
 });
 afterAll(async () => {
   await dropAllTables(adapter);

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -1,11 +1,25 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeAll(async () => {
+  await defineSchema(adapter, { events: { start_date: "string" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("DateTest", () => {
   it("date with time value", async () => {
-    const adapter = createTestAdapter();
     class Event extends Base {
       static {
         this.attribute("start_date", "date");
@@ -18,7 +32,6 @@ describe("DateTest", () => {
   });
 
   it("date with string value", async () => {
-    const adapter = createTestAdapter();
     class Event extends Base {
       static {
         this.attribute("start_date", "date");

--- a/packages/activerecord/src/delegate.test.ts
+++ b/packages/activerecord/src/delegate.test.ts
@@ -1,20 +1,27 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base, registerModel, delegate } from "./index.js";
 import { Associations } from "./associations.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, {
+    authors: { name: "string", city: "string" },
+    posts: { title: "string", author_id: "integer" },
+  });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("Delegate (Rails-guided)", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   // Rails: test "delegate to association"
   it("delegates attribute reads to a belongs_to association", async () => {
     class Author extends Base {

--- a/packages/activerecord/src/finder-respond-to.test.ts
+++ b/packages/activerecord/src/finder-respond-to.test.ts
@@ -1,23 +1,31 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base, RecordNotFound } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+let adapter: DatabaseAdapter;
+let Topic: typeof Base;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, { topics: { title: "string", author_name: "string" } });
+  Topic = class extends Base {
+    static {
+      this.attribute("title", "string");
+      this.attribute("author_name", "string");
+      this.adapter = adapter;
+    }
+  };
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
+
 describe("FinderRespondToTest", () => {
-  let adapter: DatabaseAdapter;
-  let Topic: typeof Base;
-
-  beforeEach(() => {
-    adapter = createTestAdapter();
-    Topic = class extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("author_name", "string");
-        this.adapter = adapter;
-      }
-    };
-  });
-
   it("should preserve normal respond to behavior on base", () => {
     expect(typeof Base.create).toBe("function");
     expect(typeof Base.find).toBe("function");

--- a/packages/activerecord/src/habtm-destroy-order.test.ts
+++ b/packages/activerecord/src/habtm-destroy-order.test.ts
@@ -1,16 +1,28 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base, association, registerModel } from "./index.js";
 import { Associations, loadHabtm } from "./associations.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-describe("HabtmDestroyOrderTest", () => {
-  let adapter: DatabaseAdapter;
+let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, {
+    students: { name: "string" },
+    lessons: { name: "string" },
+    lessons_students: { lesson_id: "integer", student_id: "integer" },
   });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
+describe("HabtmDestroyOrderTest", () => {
   function makeModels() {
     class Student extends Base {
       static {

--- a/packages/activerecord/src/i18n.test.ts
+++ b/packages/activerecord/src/i18n.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  I18n.reset();
+  await defineSchema(adapter, { topics: { title: "string" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
+
 describe("ActiveRecordI18nTests", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    I18n.reset();
-    adapter = createTestAdapter();
-  });
-
   it("translated model attributes", () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/inherited.test.ts
+++ b/packages/activerecord/src/inherited.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, { parents: { name: "string" } });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("InheritedTest", () => {
   it("super before filter attributes", async () => {
-    const adapter = createTestAdapter();
     const log: string[] = [];
     class Parent extends Base {
       static {
@@ -29,7 +43,6 @@ describe("InheritedTest", () => {
   });
 
   it("super after filter attributes", async () => {
-    const adapter = createTestAdapter();
     const log: string[] = [];
     class Parent extends Base {
       static {

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -2,25 +2,30 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+
+beforeAll(() => {
+  adapter = createTestAdapter();
+});
+beforeEach(async () => {
+  await defineSchema(adapter, {
+    invoices: { amount: "integer", updated_at: "string", created_at: "string" },
+  });
+});
+afterAll(async () => {
+  await dropAllTables(adapter);
+});
 
 describe("TouchLaterTest", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   function makeTouchModel() {
     class Invoice extends Base {
       static {

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 });
 beforeEach(async () => {
   await defineSchema(adapter, {
-    invoices: { amount: "integer", updated_at: "string", created_at: "string" },
+    invoices: { amount: "integer", updated_at: "datetime", created_at: "datetime" },
   });
 });
 afterAll(async () => {


### PR DESCRIPTION
Migrates 12 small test files to explicit \`defineSchema\` + \`dropAllTables\`, completing the TS-4f batch from the explicit-test-schema plan.

Part of the TS-4 migration series (TS-1 #1201, TS-2 #1202, TS-3 #1203, TS-4a #1204, TS-4b #1206, TS-4c #1210 merged).

## Files migrated

| File | Tables |
|------|--------|
| \`custom-locking.test.ts\` | \`posts\` (title, lock_version) |
| \`annotate.test.ts\` | SQL-only (\`toSql()\` — no DB I/O, no schema needed) |
| \`date.test.ts\` | \`events\` (start_date) |
| \`inherited.test.ts\` | \`parents\` (name) |
| \`boolean.test.ts\` | \`topics\` (title, approved) |
| \`comment.test.ts\` | all tests skipped — no schema needed |
| \`finder-respond-to.test.ts\` | \`topics\` (title, author_name) |
| \`habtm-destroy-order.test.ts\` | \`students\` (name), \`lessons\` (name), \`lessons_students\` (lesson_id, student_id) |
| \`bigint-roundtrip.test.ts\` | \`metrics\` (score \`big_integer\`, label) |
| \`delegate.test.ts\` | \`authors\` (name, city), \`posts\` (title, author_id) |
| \`i18n.test.ts\` | \`topics\` (title) |
| \`touch-later.test.ts\` | \`invoices\` (amount, updated_at, created_at) |

## Pattern applied

- \`adapter\` created in \`beforeAll\`
- \`defineSchema\` called in \`beforeEach\` for files that write to the DB (clean table each test); omitted entirely for SQL-only files
- \`dropAllTables\` in \`afterAll\`
- No production code changes