### PR TITLE
test(activerecord): migrate medium-file batch to defineSchema (TS-4g)

### DIFF
--- a/packages/activerecord/src/dup.test.ts
+++ b/packages/activerecord/src/dup.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -15,8 +16,9 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("DupTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
 
   function makeModel() {
@@ -167,8 +169,9 @@ describe("DupTest", () => {
 
 describe("DupTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("creates an unsaved copy without primary key", async () => {
@@ -189,8 +192,9 @@ describe("DupTest", () => {
 
 describe("DupTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { animals: { name: "string" }, users: { name: "string" } });
   });
 
   it("transforms a record to another class", async () => {

--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, RecordNotFound, RecordInvalid, ReadOnlyRecord } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -15,8 +16,9 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("ErrorsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
   });
   it("can be instantiated with no args", () => {
     class Post extends Base {
@@ -33,8 +35,14 @@ describe("ErrorsTest", () => {
 
 describe("error classes", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      items: {},
+      widgets: { name: "string" },
+      things: { name: "string" },
+      empties: {},
+    });
   });
 
   it("find throws RecordNotFound with metadata", async () => {
@@ -112,8 +120,9 @@ describe("error classes", () => {
 describe("Error Classes (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { people: { name: "string" } });
   });
 
   // Rails: test "RecordNotFound"

--- a/packages/activerecord/src/excluding.test.ts
+++ b/packages/activerecord/src/excluding.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -19,8 +20,9 @@ function freshAdapter(): DatabaseAdapter {
 describe("ExcludingTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
   });
 
   it("result set does not include single excluded record", async () => {
@@ -50,8 +52,9 @@ describe("ExcludingTest", () => {
 
 describe("ExcludingTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string", score: "integer" } });
   });
 
   function makeModel() {
@@ -145,8 +148,9 @@ describe("ExcludingTest", () => {
 
 describe("excluding() / without()", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("excludes specific records by PK", async () => {
@@ -184,8 +188,9 @@ describe("excluding() / without()", () => {
 
 describe("Excluding (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("excluding removes specific records", async () => {

--- a/packages/activerecord/src/secure-token.test.ts
+++ b/packages/activerecord/src/secure-token.test.ts
@@ -7,6 +7,7 @@ import { Base } from "./index.js";
 import { hasSecureToken, MinimumLengthError } from "./secure-token.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -16,8 +17,12 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("SecureTokenTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", token: "string" },
+      user_with_tokens: { name: "string", token: "string" },
+    });
   });
 
   function makeModel() {
@@ -112,8 +117,12 @@ describe("SecureTokenTest", () => {
 
 describe("has_secure_token", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      api_keys: { token: "string" },
+      sessions: { auth_token: "string" },
+    });
   });
 
   it("auto-generates a token on create", async () => {
@@ -165,8 +174,14 @@ describe("has_secure_token", () => {
 describe("has_secure_token (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { token: "string" },
+      sessions: { session_token: "string" },
+      user1s: { token: "string" },
+      user2s: { token: "string" },
+    });
   });
 
   // Rails: test "generates a token on create"

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -16,6 +17,7 @@ function freshAdapter(): DatabaseAdapter {
 describe("SuppressorTest", () => {
   it("suppresses create", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -30,6 +32,7 @@ describe("SuppressorTest", () => {
 
   it("suppresses update", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -47,6 +50,7 @@ describe("SuppressorTest", () => {
 
   it("suppresses create in callback", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" }, comments: { body: "string" } });
     class Comment extends Base {
       static {
         this.attribute("body", "string");
@@ -70,6 +74,7 @@ describe("SuppressorTest", () => {
 
   it("resumes saving after suppression complete", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -85,6 +90,7 @@ describe("SuppressorTest", () => {
 
   it("suppresses validations on create", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -101,6 +107,7 @@ describe("SuppressorTest", () => {
 
   it("suppresses when nested multiple times", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -119,6 +126,7 @@ describe("SuppressorTest", () => {
 describe("suppress()", () => {
   it("prevents records from being persisted to database", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { users: { name: "string" } });
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -148,6 +156,7 @@ describe("Suppressor.registry", () => {
 
   it("registry reflects active suppression by class name", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { widgets: { name: "string" } });
     class Widget extends Base {
       static {
         this.attribute("name", "string");
@@ -171,6 +180,7 @@ describe("Suppressor.registry", () => {
 
   it("a held reference inside the scope observes the active suppression", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { holdables: { name: "string" } });
     class Holdable extends Base {
       static {
         this.attribute("name", "string");
@@ -187,6 +197,10 @@ describe("Suppressor.registry", () => {
 
   it("isolates registry state across concurrent suppress blocks", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, {
+      concurrent_alphas: { name: "string" },
+      concurrent_betas: { name: "string" },
+    });
     class ConcurrentAlpha extends Base {
       static {
         this.attribute("name", "string");
@@ -222,6 +236,7 @@ describe("Suppressor.registry", () => {
 
   it("registry stays truthy across nested suppress blocks", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { gizmos: { name: "string" } });
     class Gizmo extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, UnknownAttributeReference } from "./index.js";
 import { sql as arelSql } from "@blazetrails/arel";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 function freshAdapter(): DatabaseAdapter {
@@ -17,6 +18,9 @@ describe("UnsafeRawSqlTest", () => {
 
   beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      urs_posts: { title: "string", author_id: "integer", type: "string", tags_count: "integer" },
+    });
 
     class UrsPost extends Base {
       static {


### PR DESCRIPTION
Migrates 6 medium-sized test files to explicit `defineSchema()` calls, matching the pattern established in TS-4a–4c. Each `beforeEach` (or inline adapter creation) now calls `defineSchema` immediately after `freshAdapter()`, so the schema is declared before any model touches the adapter.

The remaining 4 files in scope needed no changes:
- `ordered-options.test.ts` — no DB calls (pure activesupport tests)
- `time-travel.test.ts` — no DB calls (all `vi.useFakeTimers`)
- `schema-columns-dump.test.ts` — explicitly creates tables via `MigrationContext`
- `schema-introspection.test.ts` — explicitly creates tables via `MigrationContext`

## Files migrated

| File | Tables |
|------|--------|
| `dup.test.ts` | `topics` (title, body), `items` (name), `animals` (name), `users` (name) |
| `errors.test.ts` | `posts` (title), `items`, `widgets` (name), `things` (name), `empties`, `people` (name) |
| `excluding.test.ts` | `posts` (title, score), `items` (name) |
| `suppressor.test.ts` | `posts` (title), `comments` (body), `users` (name), `widgets` (name), `holdables` (name), `concurrent_alphas` (name), `concurrent_betas` (name), `gizmos` (name) |
| `secure-token.test.ts` | `users` (name, token), `user_with_tokens` (name, token), `api_keys` (token), `sessions` (auth_token, session_token), `user1s` (token), `user2s` (token) |
| `unsafe-raw-sql.test.ts` | `urs_posts` (title, author_id, type, tags_count) |

78 LOC (65 additions, 13 deletions).