### PR TITLE
fix(test-adapter): read AR_NO_AUTO_SCHEMA per-call so vi.stubEnv works (TS-3-fix)

### DIFF
--- a/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
+++ b/packages/activerecord/src/test-adapter-no-auto-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { createTestAdapter, cleanupTestAdapter, resetTestAdapterState } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -29,6 +29,44 @@ describe("AR_NO_AUTO_SCHEMA unset (control)", () => {
     const rows = await adapter.execute(`SELECT * FROM "widgets"`);
     expect(rows.length).toBeGreaterThan(0);
     void Widget;
+  });
+});
+
+// This suite proves the per-call read works WITHOUT vi.resetModules().
+// Before the TS-3-fix, vi.stubEnv in beforeAll was a no-op because
+// NO_AUTO_SCHEMA was captured at module load.
+describe("AR_NO_AUTO_SCHEMA=1 via beforeAll (no module reload)", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeAll(() => {
+    vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  beforeEach(async () => {
+    await resetTestAdapterState();
+    adapter = createTestAdapter();
+  });
+
+  afterEach(async () => {
+    await cleanupTestAdapter(adapter);
+  });
+
+  it("Base.adapter = x does NOT auto-create table when flag is set post-import", async () => {
+    const { Base } = await import("./base.js");
+    class Sprocket extends Base {
+      static {
+        this.tableName = "sprockets";
+        this.attribute("size", "integer");
+        this.adapter = adapter;
+      }
+    }
+    void Sprocket;
+
+    await expect(adapter.execute(`SELECT * FROM "sprockets"`)).rejects.toThrow();
   });
 });
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -33,8 +33,10 @@ const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL;
 
 // When set, the dynamic schema management (setter hook, auto-table creation,
 // error recovery) is disabled. Tests opt in via vi.stubEnv or vitest.config.ts.
-// Read once at module load so per-call overhead is zero.
-const NO_AUTO_SCHEMA = process.env.AR_NO_AUTO_SCHEMA === "1";
+/** @internal Read fresh on each call so vi.stubEnv works in tests. */
+function noAutoSchema(): boolean {
+  return process.env.AR_NO_AUTO_SCHEMA === "1";
+}
 
 /** Which adapter backend is active. */
 export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
@@ -130,8 +132,10 @@ function sqlTypeForAttribute(def: any, isPkCol: boolean): string {
  * We store the model class reference and extract attributes lazily in
  * processPendingModels(), because some tests call this.adapter = x
  * before this.attribute() in their static {} blocks.
+ * Checks noAutoSchema() at call time so vi.stubEnv works after module load.
  */
 function registerModel(modelClass: any): void {
+  if (noAutoSchema()) return;
   _registeredModelClasses.add(modelClass);
 }
 
@@ -149,7 +153,7 @@ function registerModel(modelClass: any): void {
  * columns and applies CPK only when no non-CPK claimant exists.
  */
 function extractColumnsFromModels(): void {
-  if (NO_AUTO_SCHEMA) return;
+  if (noAutoSchema()) return;
   const tablesWithNonCpk = new Set<string>();
   for (const modelClass of _registeredModelClasses) {
     if (modelClass.abstractClass) continue;
@@ -241,7 +245,7 @@ function lookupDeclaredColumnType(tableName: string, colName: string): string | 
  * Create tables and add columns for all pending model registrations.
  */
 async function processPendingModels(inner: any): Promise<void> {
-  if (NO_AUTO_SCHEMA) return;
+  if (noAutoSchema()) return;
   for (const [tableName, columns] of _pendingModels) {
     if (!_createdTables.has(tableName)) {
       const cpkCols = _pendingCpk.get(tableName);
@@ -421,10 +425,9 @@ if (PG_TEST_URL) {
 }
 
 // Register hook so Base.adapter = x triggers model registration.
-// Skip when AR_NO_AUTO_SCHEMA=1 — tests manage their own schema explicitly.
-if (!NO_AUTO_SCHEMA) {
-  _setOnAdapterSetHook(registerModel);
-}
+// The hook itself checks noAutoSchema() on each invocation, so vi.stubEnv
+// works even though _setOnAdapterSetHook runs at module load.
+_setOnAdapterSetHook(registerModel);
 
 /**
  * Create a fresh adapter for testing.
@@ -438,7 +441,7 @@ export function createTestAdapter(): DatabaseAdapter {
  * Clean up test data.
  */
 export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void> {
-  if (NO_AUTO_SCHEMA && _sharedAdapter) {
+  if (noAutoSchema() && _sharedAdapter) {
     await dropAllTables(_sharedAdapter);
     return;
   }
@@ -728,7 +731,7 @@ class SchemaAdapter implements DatabaseAdapter {
    * the table or adding the column. Returns true if recovery succeeded.
    */
   private async handleMissingSchemaError(e: any, sql: string): Promise<boolean> {
-    if (NO_AUTO_SCHEMA) return false;
+    if (noAutoSchema()) return false;
     const msg = e?.message || e?.sqlMessage || "";
 
     // Handle missing column: add the column and retry


### PR DESCRIPTION
## Problem

TS-3 (#1203) added:

\`\`\`ts
const NO_AUTO_SCHEMA = process.env.AR_NO_AUTO_SCHEMA === "1";
\`\`\`

at module load time. Because ES modules are cached after first import, \`vi.stubEnv("AR_NO_AUTO_SCHEMA", "1")\` calls inside \`beforeAll\` hooks ran *after* the module was already loaded — the constant was already \`false\` and never updated. Every TS-4 migration's env flag was silently a no-op: the dynamic adapter kept running alongside explicit \`defineSchema\` calls, the setter hook kept firing, the recovery path kept hitting on missing columns, and cross-file row leakage continued to cause \`join-model.test.ts\` flakes on PG.

## Fix

Replace the module-level constant with a function that reads the env var on each call:

\`\`\`ts
function noAutoSchema(): boolean {
  return process.env.AR_NO_AUTO_SCHEMA === "1";
}
\`\`\`

Two key changes:

1. **All per-call gates** (`extractColumnsFromModels`, `processPendingModels`, `cleanupTestAdapter`, the error-recovery path) now call `noAutoSchema()` instead of reading a stale constant.

2. **Hook registration** — instead of wrapping `_setOnAdapterSetHook(registerModel)` in an `if (!NO_AUTO_SCHEMA)` guard (which only ran once at module load), the hook is now registered unconditionally and the guard is moved *inside* `registerModel` itself. This means `vi.stubEnv` in a `beforeAll` will suppress registration on the next `Base.adapter =` assignment, even though the hook was wired at import time.

## Verification

Added a new `describe` block in `test-adapter-no-auto-schema.test.ts` that sets the flag in `beforeAll` *without* `vi.resetModules()` and asserts that auto table creation is suppressed. Before this fix the test would fail (table was silently created because the captured constant was `false`); after it passes for the right reason.