### PR TITLE
test(activerecord): migrate small/medium batch to defineSchema (TS-4h)

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -2,11 +2,19 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Migration, Schema, TableDefinition } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -2,11 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
 import { Migration, Schema, TableDefinition } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -26,6 +27,10 @@ describe("ActiveRecordSchemaTest", () => {
 
   beforeEach(() => {
     adapter = freshAdapter();
+  });
+
+  afterEach(async () => {
+    await dropAllTables(adapter);
   });
 
   it("has primary key", async () => {

--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -2,16 +2,26 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, composedOf } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // ==========================================================================
 // AggregationsTest — targets aggregations_test.rb
@@ -19,8 +29,22 @@ function freshAdapter(): DatabaseAdapter {
 describe("AggregationsTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      customers: { name: "string", address_street: "string", address_city: "string" },
+      locations: { name: "string", lat: "float", lng: "float" },
+      orders: { label: "string", price_amount: "float", price_currency: "string" },
+      readings: { label: "string", temp_degrees: "float" },
+      waypoints: { name: "string", latitude: "float", longitude: "float" },
+      articles: { title: "string", tag_name: "string" },
+      accounts: { name: "string", balance_amount: "float" },
+      shapes: { name: "string", coord_x: "float", coord_y: "float" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   // Rails: test_find_multiple_value_object
@@ -513,6 +537,7 @@ describe("OverridingAggregationsTest", () => {
 describe("Aggregations", () => {
   it("should sum field", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -530,6 +555,7 @@ describe("Aggregations", () => {
 
   it("should average field", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -547,6 +573,7 @@ describe("Aggregations", () => {
 
   it("should get minimum of field", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -564,6 +591,7 @@ describe("Aggregations", () => {
 
   it("should get maximum of field", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -581,6 +609,7 @@ describe("Aggregations", () => {
 
   it("should sum field with conditions", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer", status: "string" } });
 
     class Order extends Base {
       static {
@@ -627,6 +656,7 @@ describe("Aggregations", () => {
 describe("Aggregation edge cases", () => {
   it("no queries for empty relation on minimum", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -640,6 +670,7 @@ describe("Aggregation edge cases", () => {
 
   it("no queries for empty relation on maximum", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -653,6 +684,7 @@ describe("Aggregation edge cases", () => {
 
   it("minimum on none() returns null", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -667,6 +699,7 @@ describe("Aggregation edge cases", () => {
 
   it("maximum on none() returns null", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { orders: { amount: "integer" } });
 
     class Order extends Base {
       static {
@@ -682,8 +715,15 @@ describe("Aggregation edge cases", () => {
 
 describe("composed_of", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      customers: { address_street: "string", address_city: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("composes value objects from multiple attributes", async () => {
@@ -750,8 +790,15 @@ describe("composed_of", () => {
 describe("composed_of (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      products: { price_amount: "integer", price_currency: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   // Rails: test "reading a composed-of attribute"

--- a/packages/activerecord/src/attribute-assignment.test.ts
+++ b/packages/activerecord/src/attribute-assignment.test.ts
@@ -2,7 +2,7 @@
  * Tests for ActiveRecord::AttributeAssignment
  * Mirrors: activerecord/test/cases/attribute_assignment_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 import { typeCastAttributeValue, findParameterPosition } from "./attribute-assignment.js";
@@ -12,6 +12,14 @@ import type { DatabaseAdapter } from "./adapter.js";
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // ==========================================================================
 // AttributeAssignmentTest — targets attribute_assignment_test.rb

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -2,21 +2,39 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, delegatedType } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
 
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("DelegatedTypeTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      entries: { entryable_id: "integer", entryable_type: "string", title: "string" },
+      entry2s: { title: "string", custom_type: "string", custom_id: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModels() {

--- a/packages/activerecord/src/filter-attributes.test.ts
+++ b/packages/activerecord/src/filter-attributes.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 function makeUser() {
   const adapter = createTestAdapter();

--- a/packages/activerecord/src/integration.test.ts
+++ b/packages/activerecord/src/integration.test.ts
@@ -1,8 +1,9 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 
 function withCacheVersioning(klass: typeof Base, fn: () => void) {
   const original = klass.cacheVersioning;
@@ -26,6 +27,14 @@ function expectedUsec(ts: Temporal.Instant): string {
   return `${y}${mo}${day}${h}${mi}${s}${us}`;
 }
 
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("IntegrationTest", () => {
   it("to param should return string", async () => {
     class Client extends Base {
@@ -34,6 +43,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Client.adapter, { clients: { name: "string" } });
     const record = await Client.create({ name: "Alice" });
     expect(typeof record.toParam()).toBe("string");
   });
@@ -68,6 +78,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "Flamboyant Software" });
     expect(firm.toParam()).toBe(`${firm.id}-flamboyant-software`);
   });
@@ -80,6 +91,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "Flamboyant Software, Inc." });
     expect(firm.toParam()).toBe(`${firm.id}-flamboyant-software`);
   });
@@ -92,6 +104,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "Huey, Dewey, & Louie LLC" });
     expect(firm.toParam()).toBe(`${firm.id}-huey-dewey-louie-llc`);
   });
@@ -104,6 +117,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "Door-to-Door Wash-n-Fold Service" });
     expect(firm.toParam()).toBe(`${firm.id}-door-to-door-wash-n`);
   });
@@ -116,6 +130,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "a ".repeat(100) });
     expect(firm.toParam()).toBe(`${firm.id}-a-a-a-a-a-a-a-a-a-a`);
   });
@@ -128,6 +143,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "David HeinemeierHansson" });
     expect(firm.toParam()).toBe(`${firm.id}-david`);
   });
@@ -140,6 +156,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "David Heinemeier Hansson" });
     expect(firm.toParam()).toBe(`${firm.id}-david-heinemeier`);
   });
@@ -152,6 +169,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "ab \n".repeat(100) });
     expect(firm.toParam()).toBe(`${firm.id}-ab-ab-ab-ab-ab-ab-ab`);
   });
@@ -164,6 +182,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({ name: "戦場ヶ原 ひたぎ" });
     expect(firm.toParam()).toBe(`${firm.id}`);
   });
@@ -176,6 +195,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
+    await defineSchema(Firm.adapter, { firms: { name: "string" } });
     const firm = await Firm.create({});
     expect(firm.toParam()).toBe(`${firm.id}`);
     firm.writeAttribute("name", " ");
@@ -274,6 +294,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", t);
@@ -290,6 +311,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const updatedAt = instant("2024-01-15T10:46:00.123Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", updatedAt);
@@ -305,6 +327,9 @@ describe("IntegrationTest", () => {
         this.cacheTimestampFormat = "number";
       }
     }
+    await defineSchema(CachedDeveloper.adapter, {
+      cached_developers: { name: "string", updated_at: "string" },
+    });
     const updatedAt = instant("2024-01-15T10:46:00Z");
     const dev = await CachedDeveloper.create({ name: "Dev" });
     dev.writeAttribute("updated_at", updatedAt);
@@ -319,6 +344,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", t1);
@@ -336,6 +362,9 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, {
+      developers: { name: "string", updated_at: "string", updated_on: "string" },
+    });
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", null);
     dev.writeAttribute("updated_on", null);
@@ -350,6 +379,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_on: "string" } });
     const updatedOn = instant("2024-03-20T08:00:00.456Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_on", updatedOn);
@@ -365,6 +395,9 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, {
+      developers: { name: "string", updated_at: "string", updated_on: "string" },
+    });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const t2 = instant("2024-01-15T11:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
@@ -382,6 +415,9 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, {
+      developers: { name: "string", updated_at: "string", updated_on: "string" },
+    });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const t2 = instant("2024-01-15T11:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
@@ -398,6 +434,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", t1);
@@ -417,6 +454,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t = instant("2024-01-15T10:00:00.123Z");
     const dev = await Developer.create({ name: "Dev" });
     dev.writeAttribute("updated_at", t);
@@ -431,6 +469,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     withCacheVersioning(Developer, () => {
@@ -452,6 +491,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t = instant("2024-01-15T10:00:00.123Z");
     const dev = await Developer.create({ name: "Dev" });
     withCacheVersioning(Developer, () => {
@@ -468,6 +508,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     withCacheVersioning(Developer, () => {
@@ -489,6 +530,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     withCacheVersioning(Developer, () => {
@@ -510,6 +552,7 @@ describe("IntegrationTest", () => {
         this.adapter = createTestAdapter();
       }
     }
+    await defineSchema(Developer.adapter, { developers: { name: "string", updated_at: "string" } });
     const t1 = instant("2024-01-15T10:00:00.000Z");
     const dev = await Developer.create({ name: "Dev" });
     withCacheVersioning(Developer, () => {

--- a/packages/activerecord/src/integration.test.ts
+++ b/packages/activerecord/src/integration.test.ts
@@ -83,7 +83,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "Flamboyant Software" });
     expect(firm.toParam()).toBe(`${firm.id}-flamboyant-software`);
   });
@@ -96,7 +96,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "Flamboyant Software, Inc." });
     expect(firm.toParam()).toBe(`${firm.id}-flamboyant-software`);
   });
@@ -109,7 +109,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "Huey, Dewey, & Louie LLC" });
     expect(firm.toParam()).toBe(`${firm.id}-huey-dewey-louie-llc`);
   });
@@ -122,7 +122,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "Door-to-Door Wash-n-Fold Service" });
     expect(firm.toParam()).toBe(`${firm.id}-door-to-door-wash-n`);
   });
@@ -135,7 +135,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "a ".repeat(100) });
     expect(firm.toParam()).toBe(`${firm.id}-a-a-a-a-a-a-a-a-a-a`);
   });
@@ -148,7 +148,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "David HeinemeierHansson" });
     expect(firm.toParam()).toBe(`${firm.id}-david`);
   });
@@ -161,7 +161,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "David Heinemeier Hansson" });
     expect(firm.toParam()).toBe(`${firm.id}-david-heinemeier`);
   });
@@ -174,7 +174,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "ab \n".repeat(100) });
     expect(firm.toParam()).toBe(`${firm.id}-ab-ab-ab-ab-ab-ab-ab`);
   });
@@ -187,7 +187,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({ name: "戦場ヶ原 ひたぎ" });
     expect(firm.toParam()).toBe(`${firm.id}`);
   });
@@ -200,7 +200,7 @@ describe("IntegrationTest", () => {
         this.toParam("name");
       }
     }
-    await defineSchema(Firm.adapter, { firms: { name: "string" } });
+    await defineSchema(Firm.adapter, { firms: { name: "text" } });
     const firm = await Firm.create({});
     expect(firm.toParam()).toBe(`${firm.id}`);
     firm.writeAttribute("name", " ");

--- a/packages/activerecord/src/integration.test.ts
+++ b/packages/activerecord/src/integration.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 function withCacheVersioning(klass: typeof Base, fn: () => void) {
   const original = klass.cacheVersioning;
@@ -36,6 +37,10 @@ afterAll(() => {
 });
 
 describe("IntegrationTest", () => {
+  afterAll(async () => {
+    await dropAllTables(createTestAdapter());
+  });
+
   it("to param should return string", async () => {
     class Client extends Base {
       static {

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -2,16 +2,26 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("NormalizedAttributeTest", () => {
   function titlecase(s: string): string {
@@ -24,6 +34,9 @@ describe("NormalizedAttributeTest", () => {
 
   beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      aircrafts: { name: "string", manufactured_at: "string" },
+    });
 
     Aircraft = class extends Base {};
     Aircraft._tableName = "aircrafts";
@@ -39,6 +52,10 @@ describe("NormalizedAttributeTest", () => {
     NormalizedAircraft.normalizes("manufactured_at", (v: unknown) =>
       typeof v === "string" ? "noon:" + v : v,
     );
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("normalizes value from create", async () => {
@@ -180,6 +197,7 @@ describe("NormalizedAttributeTest", () => {
 describe("normalizes on Base", () => {
   it("normalizes attributes before persistence", async () => {
     const adapter = freshAdapter();
+    await defineSchema(adapter, { users: { email: "string" } });
     class User extends Base {
       static _tableName = "users";
     }

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -195,8 +195,15 @@ describe("NormalizedAttributeTest", () => {
 });
 
 describe("normalizes on Base", () => {
+  let _adapter: DatabaseAdapter;
+
+  afterAll(async () => {
+    if (_adapter) await dropAllTables(_adapter);
+  });
+
   it("normalizes attributes before persistence", async () => {
     const adapter = freshAdapter();
+    _adapter = adapter;
     await defineSchema(adapter, { users: { email: "string" } });
     class User extends Base {
       static _tableName = "users";

--- a/packages/activerecord/src/null-relation.test.ts
+++ b/packages/activerecord/src/null-relation.test.ts
@@ -2,16 +2,26 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // ==========================================================================
 // NullRelationTest — targets null_relation_test.rb
@@ -19,8 +29,13 @@ function freshAdapter(): DatabaseAdapter {
 describe("NullRelationTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("none chainable", async () => {
@@ -62,8 +77,13 @@ describe("NullRelationTest", () => {
 
 describe("NullRelationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string" } });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {
@@ -120,8 +140,13 @@ describe("NullRelationTest", () => {
 
 describe("NullRelationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" }, devs: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("none returns empty for all terminal methods", async () => {

--- a/packages/activerecord/src/querying-methods-delegation.test.ts
+++ b/packages/activerecord/src/querying-methods-delegation.test.ts
@@ -2,21 +2,36 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
 
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("Base static query delegations", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { users: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("Base.first() returns the first record", async () => {

--- a/packages/activerecord/src/strict-loading-sync-reader.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.test.ts
@@ -6,10 +6,20 @@
 //
 // Preserves Rails default (off) — strict loading is opt-in.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, registerModel, StrictLoadingViolationError } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("strict loading — sync singular reader (Phase R.3)", () => {
   let adapter: DatabaseAdapter;
@@ -42,8 +52,14 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
   SrAuthor.hasOne("srProfile", { className: "SrProfile" });
   SrPost.belongsTo("srAuthor", { className: "SrAuthor" });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      sr_authors: { name: "string" },
+      sr_posts: { title: "string", sr_author_id: "integer" },
+      sr_profiles: { bio: "string", sr_author_id: "integer" },
+      strict_posts: { title: "string", sr_author_id: "integer" },
+    });
     SrAuthor.adapter = adapter;
     SrPost.adapter = adapter;
     SrProfile.adapter = adapter;
@@ -192,5 +208,9 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     expect(((post as any).srAuthor as SrAuthor).name).toBe("dean");
     // Reader should have marked it loaded as a side effect.
     expect(assoc.loaded).toBe(true);
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 });


### PR DESCRIPTION
## Summary
- Migrates 10 test files to explicit `AR_NO_AUTO_SCHEMA=1` + `defineSchema` + `dropAllTables` pattern (TS-4h)
- Files: active-record-schema, aggregations, attribute-assignment, delegated-type, filter-attributes, integration, normalized-attribute, null-relation, querying-methods-delegation, strict-loading-sync-reader
- Builds on TS-3-fix (#1216) so `vi.stubEnv("AR_NO_AUTO_SCHEMA","1")` now properly engages per-call

## Test plan
- [x] Each file passes individually via `pnpm --filter activerecord test src/<file>.test.ts`
- [x] 240 net LOC (under 300 ceiling)