### PR TITLE
test(activerecord): migrate test-databases/defaults/cache-key/token-for/explain/json-serialization to defineSchema (TS-4i)

### DIFF
--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { hexdigest } from "@blazetrails/activesupport";
@@ -8,6 +8,9 @@ import { defineSchema } from "./test-helpers/define-schema.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
 });
 
 function expectedUsec(ts: Temporal.Instant): string {

--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -1,9 +1,14 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { hexdigest } from "@blazetrails/activesupport";
+import { defineSchema } from "./test-helpers/define-schema.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 function expectedUsec(ts: Temporal.Instant): string {
   const dt = ts.toZonedDateTimeISO("UTC");
@@ -25,8 +30,11 @@ function withCollectionCacheVersioning(klass: typeof Base, fn: () => Promise<voi
   });
 }
 
-function makeDeveloper() {
+async function makeDeveloper() {
   const adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    developers: { name: "string", salary: "integer", updated_at: "datetime" },
+  });
   class Developer extends Base {
     static {
       this.attribute("name", "string");
@@ -40,14 +48,14 @@ function makeDeveloper() {
 
 describe("CollectionCacheKeyTest", () => {
   it("collection_cache_key on model", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 100000 });
     const key = await Developer.collectionCacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-\d+-/);
   });
 
   it("cache_key for relation", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const devs = Developer.where({ salary: 100000 }).order({ updated_at: "desc" });
@@ -58,7 +66,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for relation with limit", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const devs = Developer.where({ salary: 100000 }).order({ updated_at: "desc" }).limit(5);
@@ -68,7 +76,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for relation with custom select and limit", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const devs = Developer.where({ salary: 100000 }).order({ updated_at: "desc" }).limit(5);
@@ -79,7 +87,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for loaded relation", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const devs = await Developer.where({ salary: 100000 })
@@ -93,7 +101,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for relation with table alias", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const devs = Developer.where({ salary: 100000 }).order({ updated_at: "desc" });
@@ -102,14 +110,14 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for relation with includes", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 100000 });
     const key = await Developer.where({ salary: 100000 }).cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-\d+/);
   });
 
   it("cache_key for loaded relation with includes", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice" });
     const devs = await Developer.all().load();
     const key = await devs.cacheKey();
@@ -117,7 +125,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("update_all will update cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David", salary: 80000 });
     const devs = Developer.where({ name: "David" });
     const key1 = await devs.cacheKey();
@@ -126,7 +134,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("update_all with includes will update cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David", salary: 80000 });
     const devs = Developer.where({ name: "David" });
     const key1 = await devs.cacheKey();
@@ -135,7 +143,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("delete_all will update cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     await Developer.create({ name: "David" });
     const devs = Developer.where({ name: "David" });
@@ -145,7 +153,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("delete_all with includes will update cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     const devs = Developer.where({ name: "David" });
     const key1 = await devs.cacheKey();
@@ -154,7 +162,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("destroy_all will update cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     const devs = Developer.where({ name: "David" });
     const key1 = await devs.cacheKey();
@@ -163,7 +171,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("it triggers at most one query", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     const devs = Developer.where({ name: "David" });
     const key1 = await devs.cacheKey();
@@ -172,7 +180,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("it doesn't trigger any query if the relation is already loaded", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     const devs = await Developer.where({ name: "David" }).load();
     const key = await devs.cacheKey();
@@ -180,7 +188,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("it doesn't trigger any query if collection_cache_versioning is enabled", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     await withCollectionCacheVersioning(Developer, async () => {
       const devs = Developer.where({ name: "David" });
@@ -191,7 +199,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("relation cache_key changes when the sql query changes", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "David" });
     const devs = Developer.where({ name: "David" });
     const other = Developer.where({ name: "David" }).where("1 = 1");
@@ -199,13 +207,13 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for empty relation", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const key = await Developer.where({ name: "Non Existent Developer" }).cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-0$/);
   });
 
   it("cache_key with custom timestamp column", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-06-15T08:00:00.000Z");
     await Developer.create({ name: "Alice", updated_at: t });
     const key = await Developer.all().cacheKey("updated_at");
@@ -213,7 +221,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key with unknown timestamp column", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice" });
     // Falls back to count-only key when column doesn't exist
     const key = await Developer.all().cacheKey("published_at");
@@ -221,34 +229,34 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("collection proxy provides a cache_key", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 100000 });
     const key = await Developer.where({ salary: 100000 }).cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-\d+-/);
   });
 
   it("cache_key for loaded collection with zero size", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const devs = await Developer.where({ name: "Nobody" }).load();
     const key = await devs.cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-0$/);
   });
 
   it("cache_key for queries with offset which return 0 rows", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const key = await Developer.offset(20).cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-0$/);
   });
 
   it("cache_key with a relation having selected columns", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 80000 });
     const key = await Developer.select("salary").cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-\d+-/);
   });
 
   it("cache_key with a relation having distinct and order", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 80000 });
     const devs = Developer.distinct().order("salary").limit(5);
     const key = await devs.cacheKey();
@@ -257,14 +265,14 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key with a relation having custom select and order", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 80000 });
     const key = await Developer.select("name").order("name DESC").limit(5).cacheKey();
     expect(key).toMatch(/^developers\/query-[0-9a-f]+-\d+-/);
   });
 
   it("cache_key should be stable when using collection_cache_versioning", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice", salary: 100000 });
     await withCollectionCacheVersioning(Developer, async () => {
       const devs = Developer.where({ salary: 100000 });
@@ -275,7 +283,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_version for relation", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     await withCollectionCacheVersioning(Developer, async () => {
@@ -287,7 +295,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("reset will reset cache_version", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     await Developer.create({ name: "Alice" });
     await withCollectionCacheVersioning(Developer, async () => {
       const devs = Developer.all();
@@ -300,7 +308,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key_with_version contains key and version regardless of collection_cache_versioning setting", async () => {
-    const Developer = makeDeveloper();
+    const Developer = await makeDeveloper();
     const t = instant("2024-01-15T10:00:00.000Z");
     await Developer.create({ name: "Alice", salary: 100000, updated_at: t });
     const kv1 = await Developer.all().cacheKeyWithVersion();

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -2,11 +2,17 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -27,8 +33,12 @@ describe("MysqlDefaultExpressionTest", () => {
 
 describe("DefaultNumbersTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { counters: { value: "integer" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {
@@ -61,8 +71,15 @@ describe("DefaultNumbersTest", () => {
 });
 
 describe("DefaultBinaryTest", () => {
+  let adp: DatabaseAdapter;
+  beforeEach(async () => {
+    adp = freshAdapter();
+    await defineSchema(adp, { bin_records: { data: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adp);
+  });
   it("default varbinary string", async () => {
-    const adp = freshAdapter();
     class BinRecord extends Base {
       static {
         this.attribute("data", "string");
@@ -73,7 +90,6 @@ describe("DefaultBinaryTest", () => {
     expect(r.data).toBe("binary_data");
   });
   it("default binary string", async () => {
-    const adp = freshAdapter();
     class BinRecord extends Base {
       static {
         this.attribute("data", "string", { default: "" });
@@ -84,7 +100,6 @@ describe("DefaultBinaryTest", () => {
     expect(r.data).toBe("");
   });
   it("default varbinary string that looks like hex", async () => {
-    const adp = freshAdapter();
     class BinRecord extends Base {
       static {
         this.attribute("data", "string");
@@ -133,8 +148,12 @@ describe("DefaultsTestWithoutTransactionalFixtures", () => {
 
 describe("DefaultTextTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { body: "string", title: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
   it("default texts", async () => {
     class Post extends Base {
@@ -160,8 +179,12 @@ describe("DefaultTextTest", () => {
 
 describe("DefaultStringsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string", body: "string" } });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
   it("default strings", async () => {
     class Post extends Base {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -13,6 +13,9 @@ import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 });
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -2,11 +2,17 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base, registerModel } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -15,8 +21,16 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("ExplainTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", score: "integer" },
+      blogs: { name: "string" },
+      articles: { title: "string", blog_id: "integer" },
+    });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -13,6 +13,9 @@ import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 });
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -13,6 +13,9 @@ import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 });
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -2,11 +2,17 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -17,8 +23,11 @@ describe("JsonSerializationTest", () => {
   let adapter: DatabaseAdapter;
   let Contact: typeof Base;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      contacts: { name: "string", age: "integer", created_at: "string", type: "string" },
+    });
     Contact = class extends Base {};
     Contact._tableName = "contacts";
     Contact.attribute("id", "integer");
@@ -124,12 +133,40 @@ describe("JsonSerializationTest", () => {
     contact.serializableHash(options);
     expect(options.only).toEqual(optionsBefore.only);
   });
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
 });
 
 describe("DatabaseConnectedJsonEncodingTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      post_j1s: { title: "string" },
+      comment_j1s: { body: "string", post_id: "integer" },
+      post_j2s: { title: "string" },
+      comment_j2s: { body: "string", post_id: "integer" },
+      post_j3s: { title: "string" },
+      comment_j3s: { body: "string", post_id: "integer" },
+      reply_j3s: { text: "string", comment_id: "integer" },
+      top_j4s: { val: "string" },
+      mid_j4s: { val: "string" },
+      deep_j4s: { val: "string" },
+      post_j5s: { title: "string", author: "string" },
+      comment_j5s: { body: "string", post_id: "integer" },
+      post_j6s: { title: "string" },
+      author_j7s: { name: "string", age: "integer" },
+      author_j8s: { name: "string", age: "integer" },
+      author_j9s: { name: "string" },
+      book_j9s: { title: "string", author_id: "integer" },
+      author_j10s: { name: "string", age: "integer" },
+      book_j10s: { title: "string", author_id: "integer" },
+      post_j11s: { title: "string" },
+    });
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("includes uses association name", async () => {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
@@ -16,6 +16,10 @@ const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
   vi.spyOn(dc, "configsFor").mockReturnValue(configs as never);
   return dc;
 };
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 describe("TestDatabasesTest", () => {
   let priorCurrent: DatabaseConfigurations | null;

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
@@ -19,6 +19,9 @@ const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("TestDatabasesTest", () => {

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -33,7 +33,7 @@ describe("TokenForTest", () => {
       parents: { name: "string", digest: "string" },
       children: { name: "string", digest: "string" },
       custom_pk_items: { uuid: "string", name: "string" },
-      cpk_items: { shop_id: "integer", id: "integer", name: "string" },
+      cpk_items: { shop_id: "integer", name: "string" },
       no_pk_items: { name: "string" },
     });
     setSignedIdVerifierSecret("blazetrails-test-secret");

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -15,6 +15,9 @@ import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 });
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -29,7 +32,7 @@ describe("TokenForTest", () => {
       users: { name: "string", password_digest: "string" },
       user_short_expiries: { name: "string", password_digest: "string" },
       user2s: { name: "string" },
-      user_xs: { name: "string" },
+      user_xes: { name: "string" },
       parents: { name: "string", digest: "string" },
       children: { name: "string", digest: "string" },
       custom_pk_items: { uuid: "string", name: "string" },
@@ -260,7 +263,7 @@ describe("TokenForTest", () => {
   beforeEach(async () => {
     adapter2 = freshAdapter();
     await defineSchema(adapter2, {
-      users: { id: "integer", name: "string", password_digest: "string" },
+      users: { name: "string", password_digest: "string" },
     });
     setTokenForSecret("blazetrails-test-token-secret");
   });

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -2,13 +2,19 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { generatesTokenFor, setTokenForSecret } from "./generates-token-for.js";
 import { setSignedIdVerifierSecret } from "./signed-id.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -17,14 +23,28 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("TokenForTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", password_digest: "string" },
+      user_short_expiries: { name: "string", password_digest: "string" },
+      user2s: { name: "string" },
+      user_xs: { name: "string" },
+      parents: { name: "string", digest: "string" },
+      children: { name: "string", digest: "string" },
+      custom_pk_items: { uuid: "string", name: "string" },
+      cpk_items: { shop_id: "integer", id: "integer", name: "string" },
+      no_pk_items: { name: "string" },
+    });
     setSignedIdVerifierSecret("blazetrails-test-secret");
     setTokenForSecret("blazetrails-test-token-secret");
   });
 
   afterEach(() => {
     setTokenForSecret(null);
+  });
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {
@@ -186,7 +206,6 @@ describe("TokenForTest", () => {
   });
 
   it("finds record with a custom primary key", async () => {
-    const adapter = freshAdapter();
     class CustomPkItem extends Base {
       static {
         this._primaryKey = "uuid";
@@ -207,7 +226,6 @@ describe("TokenForTest", () => {
     expect(found!.name).toBe("test");
   });
   it("finds record with a composite primary key", async () => {
-    const adapter = freshAdapter();
     class CpkItem extends Base {
       static {
         this.attribute("shop_id", "integer");
@@ -225,7 +243,6 @@ describe("TokenForTest", () => {
     expect(found!.id).toEqual([1, 42]);
   });
   it("raises when no primary key has been declared", async () => {
-    const adapter = freshAdapter();
     class NoPkItem extends Base {
       static {
         this._primaryKey = "";
@@ -239,17 +256,25 @@ describe("TokenForTest", () => {
 });
 
 describe("TokenForTest", () => {
-  beforeEach(() => {
+  let adapter2: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter2 = freshAdapter();
+    await defineSchema(adapter2, {
+      users: { id: "integer", name: "string", password_digest: "string" },
+    });
     setTokenForSecret("blazetrails-test-token-secret");
   });
 
   afterEach(() => {
     setTokenForSecret(null);
   });
+  afterAll(async () => {
+    await dropAllTables(adapter2);
+  });
 
   it("generates and resolves a token", async () => {
     const { generatesTokenFor } = await import("./generates-token-for.js");
-    const adapter = freshAdapter();
+    const adapter = adapter2;
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -275,7 +300,7 @@ describe("TokenForTest", () => {
 
   it("returns null for invalid token", async () => {
     const { generatesTokenFor } = await import("./generates-token-for.js");
-    const adapter = freshAdapter();
+    const adapter = adapter2;
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -290,7 +315,7 @@ describe("TokenForTest", () => {
   });
   it("finds record by token", async () => {
     const { generatesTokenFor } = await import("./generates-token-for.js");
-    const adapter = freshAdapter();
+    const adapter = adapter2;
     class User extends Base {
       static {
         this.attribute("name", "string");
@@ -307,7 +332,7 @@ describe("TokenForTest", () => {
 
   it("does not find record when token is invalid", async () => {
     const { generatesTokenFor } = await import("./generates-token-for.js");
-    const adapter = freshAdapter();
+    const adapter = adapter2;
     class User extends Base {
       static {
         this.attribute("name", "string");


### PR DESCRIPTION
## Summary

Migrates 6 test files to explicit `defineSchema` + `AR_NO_AUTO_SCHEMA=1`, eliminating reliance on the dynamic auto-schema path.

| File | Tables declared |
|------|----------------|
| `test-databases.test.ts` | none (mock-only tests) |
| `defaults.test.ts` | `counters`, `bin_records`, `posts` |
| `collection-cache-key.test.ts` | `developers` |
| `token-for.test.ts` | `users`, `user_short_expiries`, `user2s`, `user_xs`, `parents`, `children`, `custom_pk_items`, `cpk_items`, `no_pk_items` |
| `explain.test.ts` | `posts`, `blogs`, `articles` |
| `json-serialization.test.ts` | `contacts`, `post_j1s`–`post_j11s`, `comment_j*`, `author_j*`, `book_j*`, `reply_j3s`, `*_j4s` (21 tables) |

## Migration notes

- `collection-cache-key.test.ts`: `makeDeveloper()` made async to call `defineSchema` before returning the class; all 30 call sites updated with `await`.
- `token-for.test.ts`: inline per-test adapters for `CustomPkItem`, `CpkItem`, `NoPkItem` consolidated onto the shared `beforeEach` adapter; all their tables pre-declared there.
- `json-serialization.test.ts`: `DatabaseConnectedJsonEncodingTest` pre-declares all 20 J-model tables in a single `beforeEach` `defineSchema` call.
- 219 net LOC (164 add + 55 del), within the 300 LOC ceiling.