### PR TITLE
test(activerecord): migrate dirty/store/serialized-attribute to defineSchema (TS-4j)

### DIFF
--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -199,7 +199,13 @@ describe("DirtyTest", () => {
   beforeEach(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
-      posts: { title: "string", views: "integer", count: "integer", meta: "string", author_id: "integer" },
+      posts: {
+        title: "string",
+        views: "integer",
+        count: "integer",
+        meta: "string",
+        author_id: "integer",
+      },
       authors: { name: "string" },
     });
   });

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -2,11 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -19,8 +23,16 @@ function freshAdapter(): DatabaseAdapter {
 describe("DirtyTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      topics: { title: "string" },
+      people: { first_name: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("attribute changes", () => {
@@ -182,13 +194,26 @@ describe("DirtyTest", () => {
 // DirtyTest2 — more targets for dirty_test.rb
 // ==========================================================================
 describe("DirtyTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", views: "integer", count: "integer", meta: "string", author_id: "integer" },
+      authors: { name: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
   it("attribute changes", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
         this.attribute("views", "integer");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "hello", views: 0 })) as any;
@@ -200,11 +225,10 @@ describe("DirtyTest", () => {
   });
 
   it("attribute will change!", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "hello" })) as any;
@@ -213,11 +237,10 @@ describe("DirtyTest", () => {
   });
 
   it("restore attribute!", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -229,11 +252,10 @@ describe("DirtyTest", () => {
   });
 
   it("clear attribute change", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "hello" })) as any;
@@ -245,12 +267,11 @@ describe("DirtyTest", () => {
   });
 
   it("partial update", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
         this.attribute("views", "integer");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original", views: 0 })) as any;
@@ -261,11 +282,10 @@ describe("DirtyTest", () => {
   });
 
   it("dup objects should not copy dirty flag from creator", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -276,11 +296,10 @@ describe("DirtyTest", () => {
   });
 
   it("previous changes", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -290,11 +309,10 @@ describe("DirtyTest", () => {
   });
 
   it("changed attributes should be preserved if save failure", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     Post.validates("title", { presence: true });
@@ -307,11 +325,10 @@ describe("DirtyTest", () => {
   });
 
   it("nullable number not marked as changed if new value is blank", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("views", "integer");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ views: null })) as any;
@@ -320,11 +337,10 @@ describe("DirtyTest", () => {
   });
 
   it("integer zero to string zero not marked as changed", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("count", "integer");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ count: 0 })) as any;
@@ -333,11 +349,10 @@ describe("DirtyTest", () => {
   });
 
   it("string attribute should compare with typecast symbol after update", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "hello" })) as any;
@@ -346,12 +361,11 @@ describe("DirtyTest", () => {
   });
 
   it("save should store serialized attributes even with partial writes", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
         this.attribute("meta", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "test", meta: "data" })) as any;
@@ -362,11 +376,10 @@ describe("DirtyTest", () => {
   });
 
   it("saved changes returns a hash of all the changes that occurred", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -378,18 +391,17 @@ describe("DirtyTest", () => {
   });
 
   it("association assignment changes foreign key", async () => {
-    const adp = freshAdapter();
     class Author extends Base {
       static {
         this.attribute("name", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     class Post extends Base {
       static {
         this.attribute("title", "string");
         this.attribute("author_id", "integer");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const author = (await Author.create({ name: "Alice" })) as any;
@@ -399,11 +411,10 @@ describe("DirtyTest", () => {
   });
 
   it("reverted changes are not dirty after multiple changes", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -414,11 +425,10 @@ describe("DirtyTest", () => {
   });
 
   it("reload should clear changed attributes", async () => {
-    const adp = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     const post = (await Post.create({ title: "original" })) as any;
@@ -434,8 +444,15 @@ describe("DirtyTest", () => {
 // ==========================================================================
 describe("DirtyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("time attributes changes with time zone", () => {
@@ -577,8 +594,15 @@ describe("DirtyTest", () => {
 
 describe("DirtyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      items: { name: "string", age: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("tracks changes from the last save", async () => {
@@ -613,8 +637,19 @@ describe("DirtyTest", () => {
 });
 
 describe("DirtyTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", age: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
   it("attributeInDatabase returns the pre-change value", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -628,7 +663,6 @@ describe("DirtyTest", () => {
   });
 
   it("attributeBeforeLastSave returns value from before last save", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -642,7 +676,6 @@ describe("DirtyTest", () => {
   });
 
   it("changedAttributeNamesToSave returns pending changes", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -659,8 +692,19 @@ describe("DirtyTest", () => {
 });
 
 describe("DirtyTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
   it("returns true for new records", () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -673,7 +717,6 @@ describe("DirtyTest", () => {
   });
 
   it("returns false for persisted unchanged records", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -686,7 +729,6 @@ describe("DirtyTest", () => {
   });
 
   it("returns true for changed records", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -701,9 +743,19 @@ describe("DirtyTest", () => {
 });
 
 describe("DirtyTest", () => {
-  it("attributeChanged with from and to after save", async () => {
-    const adapter = freshAdapter();
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string" },
+    });
+  });
 
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
+  it("attributeChanged with from and to after save", async () => {
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -720,8 +772,6 @@ describe("DirtyTest", () => {
   });
 
   it("savedChangeToAttribute with from/to after save", async () => {
-    const adapter = freshAdapter();
-
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -741,8 +791,16 @@ describe("DirtyTest", () => {
 
 describe("DirtyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", email: "string", age: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   it("attribute changes", async () => {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -26,7 +26,13 @@ describe("SerializedAttributeTest", () => {
       users: { name: "string", preferences: "string" },
       parents: { name: "string", data: "string" },
       topics: { title: "string", content: "string" },
-      posts: { title: "string", settings: "string", tags: "string", meta: "string", data: "string" },
+      posts: {
+        title: "string",
+        settings: "string",
+        tags: "string",
+        meta: "string",
+        data: "string",
+      },
     });
   });
 

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -2,11 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { Base, serialize, SerializationTypeMismatch } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -14,8 +18,23 @@ function freshAdapter(): DatabaseAdapter {
 }
 
 describe("SerializedAttributeTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", preferences: "string" },
+      parents: { name: "string", data: "string" },
+      topics: { title: "string", content: "string" },
+      posts: { title: "string", settings: "string", tags: "string", meta: "string", data: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
   function makeModel() {
-    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("name", "string");
@@ -24,12 +43,11 @@ describe("SerializedAttributeTest", () => {
       }
     }
     serialize(User, "preferences");
-    return { User, adapter };
+    return { User };
   }
 
   it("serialize does not eagerly load columns", () => {
     // Calling serialize should not force column loading; it just registers the serialization
-    const adapter = freshAdapter();
     class LazyUser extends Base {
       static {
         this.attribute("name", "string");
@@ -52,7 +70,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute on alias attribute", () => {
-    const adapter = freshAdapter();
     class AliasUser extends Base {
       static {
         this.attribute("name", "string");
@@ -74,7 +91,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute with default", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -89,7 +105,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute on custom attribute with default", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -104,7 +119,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute in base class", () => {
-    const adapter = freshAdapter();
     class Parent extends Base {
       static {
         this.attribute("name", "string");
@@ -120,7 +134,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attributes from database on subclass", async () => {
-    const adapter = freshAdapter();
     class Parent extends Base {
       static {
         this.attribute("name", "string");
@@ -167,7 +180,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute declared in subclass", () => {
-    const adapter = freshAdapter();
     class Parent extends Base {
       static {
         this.attribute("name", "string");
@@ -228,7 +240,6 @@ describe("SerializedAttributeTest", () => {
     /* needs write-time type validation in serialize (assert_valid_value on dump) */
   });
   it("should raise exception on serialized attribute with type mismatch", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -261,7 +272,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized default class", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -295,7 +305,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialize with coder", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -317,7 +326,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("regression serialized default on text column with null false", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -331,7 +339,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("unexpected serialized type", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -402,7 +409,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("serialized attribute can be defined in abstract classes", () => {
-    const adapter = freshAdapter();
     class AbstractBase extends Base {
       static {
         this.attribute("name", "string");
@@ -425,7 +431,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("hash coder returns empty hash for null", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -440,7 +445,6 @@ describe("SerializedAttributeTest", () => {
   });
 
   it("array coder returns empty array for null", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -492,9 +496,22 @@ describe("SerializedAttributeTest", () => {
 // and re-runs the same tests with use_yaml_unsafe_load=false. In trails we use
 // JSON serialization regardless, so the same assertions apply.
 describe("SerializedAttributeTestWithYamlSafeLoad", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      topics: { title: "string", content: "string" },
+      very_important_topics: { title: "string", content: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
   // Rails test_serialized_attribute: create, assert content, reload, assert again
   it("serialized attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -512,7 +529,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_serialized_attribute_on_alias_attribute: create, reload via alias reads deserialized
   it("serialized attribute on alias attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -531,7 +547,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_serialized_attribute_with_default
   it("serialized attribute with default", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -546,7 +561,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_serialized_attribute_on_custom_attribute_with_default
   it("serialized attribute on custom attribute with default", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -561,7 +575,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_serialized_attributes_from_database_on_subclass: save + reload via subclass
   it("serialized attributes from database on subclass", async () => {
-    const adapter = freshAdapter();
     class ImportantTopic extends Base {
       static {
         this.attribute("title", "string");
@@ -588,7 +601,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_should_raise_exception_on_serialized_attribute_with_type_mismatch
   it("should raise exception on serialized attribute with type mismatch", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -608,7 +620,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_serialize_attribute_via_select_method_when_time_zone_available
   it("serialize attribute via select method when time zone available", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -625,7 +636,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_unexpected_serialized_type: create Hash, switch to Array, reload → mismatch
   it("unexpected serialized type", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -645,7 +655,6 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
   // Rails test_nil_is_always_persisted_as_null: create with data, update to nil, where(content: nil)
   it("nil is always persisted as null", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -670,8 +679,16 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
 
 describe("serialize", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      settings: { data: "string" },
+      prefs: { tags: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("serializes and deserializes JSON data", async () => {
@@ -708,8 +725,15 @@ describe("serialize", () => {
 describe("serialize (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { preferences: "string", roles: "string", settings: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   // Rails: test "serialized attribute"
@@ -775,6 +799,10 @@ describe("SerializedAttributeTest", () => {
 
   beforeEach(() => {
     adapter = freshAdapter();
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
   });
 
   it("serialized attribute — stores and retrieves JSON", async () => {

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -2,11 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { Base, registerModel, store, storedAttributes } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -15,8 +19,15 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("StoreTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { name: "string", settings: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModel() {
@@ -599,8 +610,15 @@ describe("StoreTest", () => {
 describe("StoreTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { settings: "json" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("reading store attributes through accessors", () => {
@@ -713,8 +731,16 @@ describe("StoreTest", () => {
 describe("StoreTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      users: { settings: "json" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   // Rails: test "reading store attributes through accessors"


### PR DESCRIPTION
## Summary

Migrates the three large test files to explicit schema declarations, eliminating cross-file dynamic-adapter contamination.

- **dirty.test.ts** (902 lines → 960): 8 describe blocks; tables `topics`, `people`, `posts`, `authors`, `items`, `users` (name, email, age variants)
- **store.test.ts** (919 lines → 940): 6 describe blocks; tables `users` (string and json settings variants); inline `a2` tests are all in-memory and need no schema
- **serialized-attribute.test.ts** (1024 lines → 1058): 5 describe blocks; tables `users` (preferences), `parents` (data), `topics` (content), `very_important_topics`, `settings`, `prefs`

Each file:
1. Adds `vi.stubEnv("AR_NO_AUTO_SCHEMA", "1")` at module level (requires TS-3-fix #1216)
2. Converts shared-adapter `beforeEach` blocks to async with `defineSchema`
3. Adds `afterAll` with `dropAllTables` per describe; last describe also calls `vi.unstubAllEnvs()`
4. Removes inline `const adapter/adp = freshAdapter()` declarations from tests that had them, hoisting to describe scope

LOC: 193 additions + 81 deletions = 274 total (under 300 ceiling).