### PR TITLE
fix(test): swap vi.stubEnv for per-file env save/restore in join-model

### DIFF
--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -45,15 +45,14 @@ async function registerSchemaFor(adapter: DatabaseAdapter, ...models: any[]): Pr
 }
 
 // Disable the dynamic-adapter auto-schema path for this entire file. Must be
-// set before any describe/beforeEach runs so that createTestAdapter() and all
-// SchemaAdapter.setup() calls see the flag immediately.
+// set before any describe/beforeEach runs so createTestAdapter() and every
+// SchemaAdapter.setup() call sees the flag from the first test onward.
 //
-// We mutate process.env directly instead of vi.stubEnv because
-// vi.unstubAllEnvs() is global to the worker — when sibling test files in the
-// same fork (e.g. dirty/store/serialized-attribute after their TS-4 migration)
-// also call unstubAllEnvs in their own afterAll, they wipe this file's stub
-// too, racing this file's tests against an unset flag and producing
-// "relation X does not exist" failures on shared PG/MariaDB workers.
+// Mutate process.env directly instead of vi.stubEnv: vi.unstubAllEnvs() is
+// scoped to the worker, not the file, so a sibling file's afterAll cleanup
+// would wipe this file's stub mid-run and drop us back into the auto-schema
+// path on shared PG/MariaDB workers (manifests as "relation X does not
+// exist"). Direct assignment is invisible to vi's stub registry.
 const _priorNoAutoSchema = process.env.AR_NO_AUTO_SCHEMA;
 process.env.AR_NO_AUTO_SCHEMA = "1";
 

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/associations/join_model_test.rb
  */
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { dbg, dbgPgTables } from "../test-adapter-debug.js";
 import { Base, registerModel, association, enableSti, registerSubclass } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
@@ -101,19 +102,24 @@ describe("AssociationsJoinModelTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeEach(async (ctx) => {
+    dbg("test:beforeEach:enter", {
+      test: ctx.task?.name,
+      env: process.env.AR_NO_AUTO_SCHEMA,
+    });
     adapter = freshAdapter();
+    await dbgPgTables(adapter, "after-freshAdapter");
     Author.adapter = adapter;
     Post.adapter = adapter;
     Tag.adapter = adapter;
     Tagging.adapter = adapter;
-    // AR_NO_AUTO_SCHEMA=1 (stubbed in beforeAll) disables the dynamic
-    // adapter path; tests declare their schema explicitly via
-    // registerSchemaFor instead.
     await registerSchemaFor(adapter, Author, Post, Tag, Tagging);
+    await dbgPgTables(adapter, "after-defineSchema");
+    dbg("test:beforeEach:exit", { test: ctx.task?.name });
   });
 
   it("has many", async () => {
+    await dbgPgTables(adapter, "test-has-many:start");
     const author = await Author.create({ name: "DHH" });
     await Post.create({ author_id: author.id, title: "Intro", body: "Hello" });
     const posts = await loadHasMany(author, "posts", {

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/join_model_test.rb
  */
-import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { Base, registerModel, association, enableSti, registerSubclass } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
@@ -44,10 +44,18 @@ async function registerSchemaFor(adapter: DatabaseAdapter, ...models: any[]): Pr
   for (const M of models) registerModel(M);
 }
 
-// Disable the dynamic-adapter auto-schema path for this entire file.
-// Must be set before any describe/beforeEach runs so that createTestAdapter()
-// and all SchemaAdapter.setup() calls see the flag immediately.
-vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+// Disable the dynamic-adapter auto-schema path for this entire file. Must be
+// set before any describe/beforeEach runs so that createTestAdapter() and all
+// SchemaAdapter.setup() calls see the flag immediately.
+//
+// We mutate process.env directly instead of vi.stubEnv because
+// vi.unstubAllEnvs() is global to the worker — when sibling test files in the
+// same fork (e.g. dirty/store/serialized-attribute after their TS-4 migration)
+// also call unstubAllEnvs in their own afterAll, they wipe this file's stub
+// too, racing this file's tests against an unset flag and producing
+// "relation X does not exist" failures on shared PG/MariaDB workers.
+const _priorNoAutoSchema = process.env.AR_NO_AUTO_SCHEMA;
+process.env.AR_NO_AUTO_SCHEMA = "1";
 
 // ==========================================================================
 // AssociationsJoinModelTest — mirrors join_model_test.rb
@@ -60,7 +68,8 @@ describe("AssociationsJoinModelTest", () => {
     try {
       await dropAllTables(adapter);
     } finally {
-      vi.unstubAllEnvs();
+      if (_priorNoAutoSchema === undefined) delete process.env.AR_NO_AUTO_SCHEMA;
+      else process.env.AR_NO_AUTO_SCHEMA = _priorNoAutoSchema;
     }
   });
 

--- a/packages/activerecord/src/test-adapter-debug.ts
+++ b/packages/activerecord/src/test-adapter-debug.ts
@@ -1,0 +1,37 @@
+/**
+ * Debug instrumentation for the join-model PG flake investigation.
+ *
+ * Emits a structured log line every time the test-adapter mutates its
+ * shared module state, plus a snapshot of pg_tables before/after each
+ * suspicious transition. Output is unconditional so CI captures it.
+ *
+ * Remove this file once the root cause is identified.
+ */
+
+let _seq = 0;
+const _t0 = Date.now();
+
+function ts(): string {
+  return `t+${(Date.now() - _t0).toString().padStart(6, "0")}ms #${(++_seq).toString().padStart(5, "0")}`;
+}
+
+export function dbg(event: string, data?: Record<string, unknown>): void {
+  const payload = data ? ` ${JSON.stringify(data)}` : "";
+  console.log(`[ARDBG ${ts()}] ${event}${payload}`);
+}
+
+export async function dbgPgTables(adapter: any, label: string): Promise<void> {
+  if (adapter?.adapterName !== "postgres" && adapter?.inner?.adapterName !== "postgres") {
+    return;
+  }
+  const inner = adapter.inner ?? adapter;
+  try {
+    const rows = await inner.execute(
+      `SELECT tablename FROM pg_tables WHERE schemaname = current_schema() ORDER BY tablename`,
+    );
+    const names = (rows as { tablename: string }[]).map((r) => r.tablename);
+    dbg(`pgTables[${label}]`, { count: names.length, names });
+  } catch (e: unknown) {
+    dbg(`pgTables[${label}]:error`, { msg: (e as Error).message });
+  }
+}

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -25,6 +25,7 @@ import { include } from "@blazetrails/activesupport";
 import { isWriteQuerySql } from "./connection-adapters/sql-classification.js";
 import type { Result } from "./result.js";
 import { _setOnAdapterSetHook } from "./base.js";
+import { dbg } from "./test-adapter-debug.js";
 
 // process.env.PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
 // test-setup-worker-db.ts (a setupFile that runs before this module loads).
@@ -135,7 +136,14 @@ function sqlTypeForAttribute(def: any, isPkCol: boolean): string {
  * Checks noAutoSchema() at call time so vi.stubEnv works after module load.
  */
 function registerModel(modelClass: any): void {
-  if (noAutoSchema()) return;
+  const noAuto = noAutoSchema();
+  dbg("registerModel", {
+    table: modelClass?.tableName,
+    name: modelClass?.name,
+    noAutoSchema: noAuto,
+    skipped: noAuto,
+  });
+  if (noAuto) return;
   _registeredModelClasses.add(modelClass);
 }
 
@@ -364,6 +372,7 @@ async function execDdlWithSavepoint(inner: any, sql: string): Promise<void> {
  * Drop tables that were created via the SchemaAdapter and reset tracking state.
  */
 async function dropTrackedTables(inner: any): Promise<void> {
+  dbg("dropTrackedTables:enter", { tables: [..._createdTables], adapter: inner?.adapterName });
   // Wait for any in-flight cleanup to finish, then run our own. The previous
   // early-return-after-await pattern was unsound: if another setup() had
   // already re-populated _createdTables between the moment we started waiting
@@ -387,6 +396,7 @@ async function dropTrackedTables(inner: any): Promise<void> {
     }
     _createdTables.clear();
     _createdColumns.clear();
+    dbg("dropTrackedTables:exit");
   } finally {
     _cleanupPromise = null;
     resolve();
@@ -434,6 +444,7 @@ _setOnAdapterSetHook(registerModel);
  */
 export function createTestAdapter(): DatabaseAdapter {
   _needsCleanup = true;
+  dbg("createTestAdapter", { setNeedsCleanup: true });
   return _factory();
 }
 
@@ -479,6 +490,14 @@ export async function cleanupTestAdapter(adapter: DatabaseAdapter): Promise<void
  * @internal
  */
 export async function resetTestAdapterState(): Promise<void> {
+  dbg("resetTestAdapterState:enter", {
+    createdTables: [..._createdTables],
+    pendingModels: [..._pendingModels.keys()],
+    registeredModels: [..._registeredModelClasses].map((m: any) => m?.tableName ?? m?.name),
+    needsCleanup: _needsCleanup,
+    hasSetupLock: !!_setupLock,
+    hasCleanupPromise: !!_cleanupPromise,
+  });
   // Wait for any in-flight cleanup or setup to settle before we tear down,
   // otherwise we'd race against an already-running drop/create.
   while (_setupLock) await _setupLock;
@@ -504,6 +523,7 @@ export async function resetTestAdapterState(): Promise<void> {
     _pendingCpk.clear();
     _registeredModelClasses.clear();
     _needsCleanup = false;
+    dbg("resetTestAdapterState:exit");
   } finally {
     _cleanupPromise = null;
     resolveLock();
@@ -558,12 +578,23 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   private async setup(): Promise<void> {
+    dbg("setup:enter", {
+      needsCleanup: _needsCleanup,
+      registeredModels: _registeredModelClasses.size,
+      pendingModels: _pendingModels.size,
+      createdTables: [..._createdTables],
+      hasSetupLock: !!_setupLock,
+      hasCleanupPromise: !!_cleanupPromise,
+    });
     // Wait for any in-flight setup or cleanup to complete
     while (_setupLock) await _setupLock;
     if (_cleanupPromise) await _cleanupPromise;
 
     // Check if there's any work to do
-    if (!_needsCleanup && _registeredModelClasses.size === 0 && _pendingModels.size === 0) return;
+    if (!_needsCleanup && _registeredModelClasses.size === 0 && _pendingModels.size === 0) {
+      dbg("setup:exit:no-work");
+      return;
+    }
 
     // Acquire module-level lock
     let resolve!: () => void;
@@ -585,6 +616,7 @@ class SchemaAdapter implements DatabaseAdapter {
           await processPendingModels(this.inner);
         }
       }
+      dbg("setup:exit:done", { createdTables: [..._createdTables] });
     } finally {
       _setupLock = null;
       resolve();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -102,7 +102,9 @@ export default defineConfig({
           // letting CI fail on every transient race — burns more reviewer
           // time than the rare hidden flake costs. Revisit if a real
           // regression slips through.
-          retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
+          // TEMP: retries disabled for join-model PG flake investigation —
+          // retries mask the initial failure state. Restore before merging.
+          retry: 0,
           pool: "forks",
           // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].
           // Without this each file gets a new fork; IDs wrap mod AR_DB_MAX_FORKS,


### PR DESCRIPTION
## Status: investigation ongoing — do NOT merge

The vi.stubEnv hypothesis (that `vi.unstubAllEnvs` blast-radius across files in a worker was clearing the flag) **did not hold up under local PG repro**.

### What I confirmed locally on PG

Ran `PG_TEST_URL=... pnpm vitest run --project activerecord <join-model> <dirty>` (with this PR's `process.env.AR_NO_AUTO_SCHEMA = "1"` swap applied):

- 49 failures in join-model.test.ts: `relation "posts" does not exist`, `relation "authors" does not exist`, `column "author_id" of relation "posts" does not exist`, `duplicate key value violates unique constraint "pg_type_typname_nsp_index"`.
- A `console.log` inside `noAutoSchema()` confirmed the flag IS `"1"` during the failing tests — so the env swap is engaged correctly. The recovery path is genuinely off.
- Setting `fileParallelism: false` did NOT resolve it.

### What this tells us

- The failure is **not** caused by env-flag flipping.
- The failure happens even when noAutoSchema is correctly true throughout the failing test.
- Some tests in the file pass and others fail with similar shape — the failing ones are early in the file, later identical tests pass.
- The `pg_type_typname_nsp_index` duplicate-key errors point to **concurrent CREATE TABLE on the shared PG** — multiple sources racing on the same DDL.

### Why this PR's change isn't worthless

The `process.env.X` swap is still strictly safer than `vi.stubEnv` + `vi.unstubAllEnvs()` because the latter IS worker-global. But it doesn't fix the join-model PG failures — those have a different root cause that needs more digging (likely something in `_sharedAdapter` / `_createdTables` / `_pendingModels` shared module state under `AR_DB_FORKS=1`).

### Next steps

- Self-grade: **D** (hypothesis wrong, fix doesn't resolve cited issue).
- Leaving as draft. Will keep investigating the actual cause before reusing this PR or opening a new one.