### PR TITLE
test(activerecord): migrate relation.test.ts to defineSchema (TS-4l)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -2,18 +2,27 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { sql, Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
 import { Associations, registerModel, modelRegistry } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
 }
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("isBlank / isPresent", () => {
   it("isBlank returns true when no records exist", async () => {
@@ -24,6 +33,7 @@ describe("isBlank / isPresent", () => {
     User.attribute("id", "integer");
     User.attribute("name", "string");
     User.adapter = adapter;
+    await defineSchema(adapter, { users: { name: "string" } });
 
     expect(await User.all().isBlank()).toBe(true);
     expect(await User.all().isPresent()).toBe(false);
@@ -40,8 +50,28 @@ describe("isBlank / isPresent", () => {
 describe("RelationTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", body: "string", status: "string", author_id: "integer" },
+      developers: { commits: "integer" },
+      orders: { created_at: "string", total: "integer" },
+      books: {
+        author_id: "integer",
+        published_year: "integer",
+        title: "string",
+        active: "boolean",
+      },
+      authors: { name: "string" },
+      comments: { post_id: "integer", author_id: "integer" },
+      users: { name: "string" },
+      eager_comments: { body: "string", eager_article_id: "integer" },
+      eager_articles: { title: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("reload", async () => {
@@ -1170,6 +1200,7 @@ describe("RelationTest", () => {
 
   it("find_by with multi-arg conditions returns the first matching record", async () => {
     const adp = freshAdapter();
+    await defineSchema(adp, { posts: { title: "string", body: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -1486,23 +1517,22 @@ describe("RelationTest", () => {
     expect(matches).not.toBeNull();
   });
 
-  let Post: typeof Base;
+  let SharedPost: typeof Base;
   beforeEach(() => {
-    const adp = createTestAdapter();
     class PostClass extends Base {
       static {
         this.tableName = "posts";
-        this.adapter = adp;
+        this.adapter = adapter;
         this.attribute("title", "string");
         this.attribute("body", "string");
       }
     }
-    Post = PostClass;
+    SharedPost = PostClass;
   });
 
   it("find_by! with multi-arg conditions returns the first matching record", async () => {
-    await Post.create({ title: "multi-arg" });
-    const found = await Post.findByBang({ title: "multi-arg" });
+    await SharedPost.create({ title: "multi-arg" });
+    const found = await SharedPost.findByBang({ title: "multi-arg" });
     expect(found).not.toBeNull();
   });
 

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -1199,13 +1199,11 @@ describe("RelationTest", () => {
   });
 
   it("find_by with multi-arg conditions returns the first matching record", async () => {
-    const adp = freshAdapter();
-    await defineSchema(adp, { posts: { title: "string", body: "string" } });
     class Post extends Base {
       static {
         this.attribute("title", "string");
         this.attribute("body", "string");
-        this.adapter = adp;
+        this.adapter = adapter;
       }
     }
     await Post.create({ title: "t", body: "b" });


### PR DESCRIPTION
## Summary

- Migrates `packages/activerecord/src/relation.test.ts` (1650 lines, 117 tests) to explicit `defineSchema()` + `AR_NO_AUTO_SCHEMA=1`
- Sets the env flag via module-level `beforeAll`/`afterAll` with `vi.stubEnv`/`vi.unstubAllEnvs`
- Adds a superset `defineSchema` in `RelationTest.beforeEach` covering all nine tables used in the file: `posts`, `developers`, `orders`, `books`, `authors`, `comments`, `users`, `eager_comments`, `eager_articles`
- Adds per-call `defineSchema` for the `isBlank/isPresent` test and the `find_by` local-adapter test (line 1172)
- Drops all tables in `RelationTest.afterAll`

## Non-obvious change: `let Post` → `let SharedPost`

Vite renames inner `class Post extends Base` declarations to `Post2` when `let Post: typeof Base` is declared in the enclosing describe scope. This causes `Post.tableName` to resolve to `"post2s"` instead of `"posts"`, breaking all DB-hitting tests. Renaming the describe-scoped variable to `SharedPost` (used by only one test) eliminates the collision. The test name is unchanged.

## LOC budget

+38 / -8 = 46 total changes. Well under the 300 LOC ceiling.