### PR TITLE
fix(test): re-add --no-file-parallelism to AR CI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run packages/activerecord
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
 
   postgres-tests:
     name: PostgreSQL Tests
@@ -294,7 +294,7 @@ jobs:
           for i in 2 3 4; do
             PGPASSWORD=postgres psql -h localhost -U postgres -c "CREATE DATABASE rails_js_test_$i;"
           done
-      - run: pnpm vitest run packages/activerecord
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
           AR_DB_FORKS: 4
@@ -333,7 +333,7 @@ jobs:
             mysql -h 127.0.0.1 -u root -e "CREATE DATABASE rails_js_test_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
           done
           mysql -h 127.0.0.1 -u root -e "ALTER DATABASE rails_js_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
-      - run: pnpm vitest run packages/activerecord
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
         env:
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
           AR_DB_FORKS: 4


### PR DESCRIPTION
## Root cause

PR #1092 removed the `--no-file-parallelism` CLI flag from the three AR test commands in `.github/workflows/ci.yml`:

```diff
- run: pnpm vitest run --no-file-parallelism packages/activerecord
+ run: pnpm vitest run packages/activerecord
```

…and tried to replace it with config-level knobs (`maxForks`, `minForks`, eventually `singleFork`, `fileParallelism`) plus a per-worker DB URL rewrite (`((VITEST_WORKER_ID - 1) % AR_DB_FORKS) + 1`).

**None of the config-level pool knobs actually serialize files in vitest 3.2.** Verified empirically on this branch's prior commits — every CI run produced 455+ distinct `ARDBG-INIT` lines (one per worker process) despite `maxForks=minForks=1`, `singleFork=true`, and `fileParallelism=false` all set in config.

`VITEST_WORKER_ID` then increments monotonically to ~458, the modulo collides, and multiple alive workers race on the same `rails_js_test*` database — surfacing in `associations/join-model.test.ts` as `relation "X" does not exist` when worker B's `dropAllTables` lands inside worker A's `defineSchema` sequence.

## Fix

Put the CLI flag back. That's the only knob vitest reliably honors.

```diff
- run: pnpm vitest run packages/activerecord
+ run: pnpm vitest run --no-file-parallelism packages/activerecord
```

Three lines (sqlite-tests, postgres-tests, mariadb-tests jobs).

## Tradeoff

Lose the ~3min CI savings PR #1092 added. Gain reliability.

## Follow-up

The per-worker DB scaffolding in `vitest.config.ts` (`AR_DB_FORKS`, `AR_DB_MAX_FORKS`, `maxForks`/`minForks`) and `ci.yml` (the `Create parallel test databases` step + `AR_DB_FORKS: 4` env var) is now harmless dead code. Cleanup in a follow-up.

Re-enabling parallelism properly requires a slot acquisition mechanism that doesn't depend on stable `VITEST_WORKER_ID`s — e.g. PG advisory lock at adapter init.

## Closes / supersedes

- Closes the join-model PG flake blocking #1213, #1217, #1219.
- Supersedes closed #1220 (wrong hypothesis: `vi.unstubAllEnvs` blast radius).
- Effectively reverts the parallelism portion of PR #1092 for PG/MySQL/SQLite.

## Test plan

- [x] Mechanism proven via instrumented CI runs on this branch (455 distinct worker processes per run, three+ concurrent at any moment, racing on same DB)
- [ ] PostgreSQL Tests pass on this branch
- [ ] MariaDB Tests pass on this branch
- [ ] SQLite Tests pass on this branch