### PR TITLE
feat(activerecord): advisory-lock slot acquisition for PG (PR-P1)

### DIFF
--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -3,34 +3,80 @@
  * database suffix to PG_TEST_URL and MYSQL_TEST_URL before any test code
  * or import runs.
  *
- * Mutating process.env here ensures every consumer in this fork — including
- * adapter test helpers that read process.env directly — connects to the
- * correct per-worker database rather than all sharing the base database.
+ * Two modes (selected by AR_DB_LOCK_MODE):
+ *
+ * "advisory" (PG only): open a bootstrap connection to the base DB and try
+ *   pg_try_advisory_lock(N) for N=1..AR_DB_FORKS. Claim the first free slot,
+ *   rewrite PG_TEST_URL to that slot's DB, and hold the bootstrap connection
+ *   for the life of the process (session lock released automatically on
+ *   disconnect). Removes the VITEST_WORKER_ID dependency.
+ *
+ * default: legacy modulo formula — (VITEST_WORKER_ID-1) % AR_DB_FORKS + 1.
+ *   Used for MariaDB and as the fallback when AR_DB_LOCK_MODE is unset.
  *
  * AR_DB_FORKS: number of parallel DB slots provisioned in CI (default: 1).
- * VITEST_WORKER_ID: global incrementing fork ID assigned by vitest.
- *   Consecutive IDs are assigned to concurrent forks, so (id-1) % forks + 1
- *   maps each concurrent fork to a distinct slot with no overlap.
  */
 
-function workerDbUrl(baseUrl: string): string {
+import pg from "pg";
+
+function slotDbUrl(baseUrl: string, slot: number): string {
+  if (slot === 1) return baseUrl;
+  const url = new URL(baseUrl);
+  const db = url.pathname.replace(/^\//, "");
+  if (!db) throw new Error(`slotDbUrl: no database name in URL: ${baseUrl}`);
+  url.pathname = `/${db}_${slot}`;
+  return url.toString();
+}
+
+async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
+  const forks = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
+  if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
+
+  const client = new pg.Client(baseUrl);
+  await client.connect();
+
+  for (let slot = 1; slot <= forks; slot++) {
+    const res = await client.query<{ locked: boolean }>(
+      "SELECT pg_try_advisory_lock($1) AS locked",
+      [slot],
+    );
+    if (res.rows[0]?.locked) {
+      // Keep client open for the process lifetime; PG drops session locks on
+      // disconnect, so no explicit release is needed on clean exit.
+      process.on("exit", () => void client.end());
+      return slotDbUrl(baseUrl, slot);
+    }
+  }
+
+  // All slots busy — fall back to slot 1 (serialised, never races with itself).
+  await client.end();
+  return baseUrl;
+}
+
+function legacyWorkerDbUrl(baseUrl: string): string {
   const forks = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
   if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
 
   const raw = parseInt(process.env.VITEST_WORKER_ID ?? "1", 10);
   const slot = ((raw - 1) % forks) + 1;
-  if (slot === 1) return baseUrl;
-
-  const url = new URL(baseUrl);
-  const db = url.pathname.replace(/^\//, "");
-  if (!db) throw new Error(`workerDbUrl: no database name in URL: ${baseUrl}`);
-  url.pathname = `/${db}_${slot}`;
-  return url.toString();
+  return slotDbUrl(baseUrl, slot);
 }
 
-if (process.env.PG_TEST_URL) {
-  process.env.PG_TEST_URL = workerDbUrl(process.env.PG_TEST_URL);
-}
-if (process.env.MYSQL_TEST_URL) {
-  process.env.MYSQL_TEST_URL = workerDbUrl(process.env.MYSQL_TEST_URL);
+const lockMode = process.env.AR_DB_LOCK_MODE;
+
+if (lockMode === "advisory") {
+  if (process.env.PG_TEST_URL) {
+    process.env.PG_TEST_URL = await acquireAdvisorySlotPg(process.env.PG_TEST_URL);
+  }
+  // MariaDB falls through to legacy path until PR-P2.
+  if (process.env.MYSQL_TEST_URL) {
+    process.env.MYSQL_TEST_URL = legacyWorkerDbUrl(process.env.MYSQL_TEST_URL);
+  }
+} else {
+  if (process.env.PG_TEST_URL) {
+    process.env.PG_TEST_URL = legacyWorkerDbUrl(process.env.PG_TEST_URL);
+  }
+  if (process.env.MYSQL_TEST_URL) {
+    process.env.MYSQL_TEST_URL = legacyWorkerDbUrl(process.env.MYSQL_TEST_URL);
+  }
 }

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -11,6 +11,10 @@
  *   for the life of the process (session lock released automatically on
  *   disconnect). Removes the VITEST_WORKER_ID dependency.
  *
+ *   Idempotent: the claimed slot is cached on globalThis so re-evaluation
+ *   (e.g. hot-module reloading in vitest watch mode) returns the same slot
+ *   without opening a second connection or consuming an additional lock.
+ *
  * default: legacy modulo formula — (VITEST_WORKER_ID-1) % AR_DB_FORKS + 1.
  *   Used for MariaDB and as the fallback when AR_DB_LOCK_MODE is unset.
  *
@@ -18,6 +22,9 @@
  */
 
 import pg from "pg";
+
+// Shared by all evaluations of this module within the same worker process.
+const g = globalThis as typeof globalThis & { __arAdvisorySlot?: number };
 
 function slotDbUrl(baseUrl: string, slot: number): string {
   if (slot === 1) return baseUrl;
@@ -32,6 +39,11 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   const forks = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
   if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
 
+  // Idempotent: re-evaluation returns the already-claimed slot.
+  if (g.__arAdvisorySlot !== undefined) {
+    return slotDbUrl(baseUrl, g.__arAdvisorySlot);
+  }
+
   const client = new pg.Client(baseUrl);
   await client.connect();
 
@@ -41,6 +53,7 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
       [slot],
     );
     if (res.rows[0]?.locked) {
+      g.__arAdvisorySlot = slot;
       // Keep client open for the process lifetime; PG drops session locks on
       // disconnect, so no explicit release is needed on clean exit.
       process.on("exit", () => void client.end());
@@ -48,9 +61,11 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
     }
   }
 
-  // All slots busy — fall back to slot 1 (serialised, never races with itself).
   await client.end();
-  return baseUrl;
+  throw new Error(
+    `acquireAdvisorySlotPg: all ${forks} advisory lock slots are held by other workers. ` +
+      `Increase AR_DB_FORKS or wait for a slot to become available.`,
+  );
 }
 
 function legacyWorkerDbUrl(baseUrl: string): string {


### PR DESCRIPTION
## Summary

- Adds `AR_DB_LOCK_MODE=advisory` mode to `test-setup-worker-db.ts`
- When set, each worker opens a bootstrap PG connection to the base database and claims the first free slot via `pg_try_advisory_lock(1..AR_DB_FORKS)`
- `PG_TEST_URL` is rewritten to the claimed slot's database (`rails_js_test_N`)
- Bootstrap connection is held for the process lifetime; PG drops the session lock automatically on disconnect (crash-safe)
- Legacy `VITEST_WORKER_ID` modulo formula is unchanged and remains the default

## Test plan

- [ ] Set `AR_DB_LOCK_MODE=advisory` + `AR_DB_FORKS=4` locally with PG and verify each worker connects to a distinct DB
- [ ] Verify that when all slots are busy, the fallback returns to slot 1 (no crash)
- [ ] Verify MariaDB still uses the legacy path
- [ ] CI passes with existing `AR_DB_LOCK_MODE` unset (default path unchanged)

Part of the advisory-lock parallelism plan (docs/ar-test-parallelism-plan.md). PR-P2 adds the MariaDB `GET_LOCK` path; PR-P3 flips the default.