### PR TITLE
feat(test): MariaDB GET_LOCK advisory slot acquisition (PR-P2)

### DIFF
--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -5,26 +5,33 @@
  *
  * Two modes (selected by AR_DB_LOCK_MODE):
  *
- * "advisory" (PG only): open a bootstrap connection to the base DB and try
- *   pg_try_advisory_lock(N) for N=1..AR_DB_FORKS. Claim the first free slot,
- *   rewrite PG_TEST_URL to that slot's DB, and hold the bootstrap connection
- *   for the life of the process (session lock released automatically on
- *   disconnect). Removes the VITEST_WORKER_ID dependency.
+ * "advisory" (PG + MariaDB): open a bootstrap connection to the base DB and
+ *   try an advisory lock for slot N=1..AR_DB_FORKS. Claim the first free slot,
+ *   rewrite the URL to that slot's DB, and hold the bootstrap connection for
+ *   the life of the process (lock released automatically on disconnect).
+ *   Removes the VITEST_WORKER_ID dependency.
+ *
+ *   PG:      pg_try_advisory_lock(N)
+ *   MariaDB: GET_LOCK('ar_test_slot_N', 0)  — 0-second timeout = non-blocking
  *
  *   Idempotent: the claimed slot is cached on globalThis so re-evaluation
  *   (e.g. hot-module reloading in vitest watch mode) returns the same slot
  *   without opening a second connection or consuming an additional lock.
  *
  * default: legacy modulo formula — (VITEST_WORKER_ID-1) % AR_DB_FORKS + 1.
- *   Used for MariaDB and as the fallback when AR_DB_LOCK_MODE is unset.
+ *   Used as the fallback when AR_DB_LOCK_MODE is unset.
  *
  * AR_DB_FORKS: number of parallel DB slots provisioned in CI (default: 1).
  */
 
 import pg from "pg";
+import mysql from "mysql2/promise";
 
 // Shared by all evaluations of this module within the same worker process.
-const g = globalThis as typeof globalThis & { __arAdvisorySlot?: number };
+const g = globalThis as typeof globalThis & {
+  __arAdvisorySlotPg?: number;
+  __arAdvisorySlotMysql?: number;
+};
 
 function slotDbUrl(baseUrl: string, slot: number): string {
   if (slot === 1) return baseUrl;
@@ -40,8 +47,8 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
 
   // Idempotent: re-evaluation returns the already-claimed slot.
-  if (g.__arAdvisorySlot !== undefined) {
-    return slotDbUrl(baseUrl, g.__arAdvisorySlot);
+  if (g.__arAdvisorySlotPg !== undefined) {
+    return slotDbUrl(baseUrl, g.__arAdvisorySlotPg);
   }
 
   const client = new pg.Client(baseUrl);
@@ -53,7 +60,7 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
       [slot],
     );
     if (res.rows[0]?.locked) {
-      g.__arAdvisorySlot = slot;
+      g.__arAdvisorySlotPg = slot;
       // Keep client open for the process lifetime; PG drops session locks on
       // disconnect, so no explicit release is needed on clean exit.
       process.on("exit", () => void client.end());
@@ -64,6 +71,46 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   await client.end();
   throw new Error(
     `acquireAdvisorySlotPg: all ${forks} advisory lock slots are held by other workers. ` +
+      `Increase AR_DB_FORKS or wait for a slot to become available.`,
+  );
+}
+
+async function acquireAdvisorySlotMysql(baseUrl: string): Promise<string> {
+  const forks = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
+  if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
+
+  // Idempotent: re-evaluation returns the already-claimed slot.
+  if (g.__arAdvisorySlotMysql !== undefined) {
+    return slotDbUrl(baseUrl, g.__arAdvisorySlotMysql);
+  }
+
+  // Parse the mysql:// URL into mysql2 connection options.
+  const u = new URL(baseUrl);
+  const conn = await mysql.createConnection({
+    host: u.hostname,
+    port: u.port ? parseInt(u.port, 10) : 3306,
+    user: u.username || undefined,
+    password: u.password || undefined,
+    database: u.pathname.replace(/^\//, "") || undefined,
+  });
+
+  for (let slot = 1; slot <= forks; slot++) {
+    const lockName = `ar_test_slot_${slot}`;
+    // GET_LOCK returns 1 when acquired, 0 when timeout (0 s = non-blocking).
+    const [rows] = await conn.query<mysql.RowDataPacket[]>("SELECT GET_LOCK(?, 0) AS acquired", [
+      lockName,
+    ]);
+    if ((rows[0] as { acquired: number }).acquired === 1) {
+      g.__arAdvisorySlotMysql = slot;
+      // Hold the connection open; MariaDB releases GET_LOCK on disconnect.
+      process.on("exit", () => void conn.end());
+      return slotDbUrl(baseUrl, slot);
+    }
+  }
+
+  await conn.end();
+  throw new Error(
+    `acquireAdvisorySlotMysql: all ${forks} GET_LOCK slots are held by other workers. ` +
       `Increase AR_DB_FORKS or wait for a slot to become available.`,
   );
 }
@@ -83,9 +130,8 @@ if (lockMode === "advisory") {
   if (process.env.PG_TEST_URL) {
     process.env.PG_TEST_URL = await acquireAdvisorySlotPg(process.env.PG_TEST_URL);
   }
-  // MariaDB falls through to legacy path until PR-P2.
   if (process.env.MYSQL_TEST_URL) {
-    process.env.MYSQL_TEST_URL = legacyWorkerDbUrl(process.env.MYSQL_TEST_URL);
+    process.env.MYSQL_TEST_URL = await acquireAdvisorySlotMysql(process.env.MYSQL_TEST_URL);
   }
 } else {
   if (process.env.PG_TEST_URL) {


### PR DESCRIPTION
## Summary

- Extends \`test-setup-worker-db.ts\` with \`acquireAdvisorySlotMysql\`: opens a bootstrap \`mysql2/promise\` connection to the base \`MYSQL_TEST_URL\` and calls \`GET_LOCK('ar_test_slot_N', 0)\` (0 s = non-blocking) for \`N=1..AR_DB_FORKS\`
- Claims the first free slot, rewrites \`MYSQL_TEST_URL\` to \`<db>_<slot>\`, and holds the connection for the worker's process lifetime — MariaDB releases the lock automatically on disconnect
- Gated behind \`AR_DB_LOCK_MODE=advisory\`; default behaviour (legacy modulo formula) unchanged
- Mirrors PR-P1 (PG \`pg_try_advisory_lock\`); shared helpers deferred to PR-P3

## Test plan

- [ ] Set \`AR_DB_LOCK_MODE=advisory\` + \`AR_DB_FORKS=4\` against a local MariaDB with \`rails_js_test_2..4\` pre-created; run the AR suite and confirm each worker claims a distinct slot
- [ ] Verify \`throw\` path: when all 4 slots are held externally, worker startup fails with the expected error message
- [ ] Default path (\`AR_DB_LOCK_MODE\` unset): suite behaves identically to \`main\`