### PR TITLE
feat(test): unpin vitest worker count, add bounded slot retry (PR-P4)

### DIFF
--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -36,6 +36,16 @@ function slotDbUrl(baseUrl: string, slot: number): string {
   return url.toString();
 }
 
+// Bounded retry policy: when all slots are held (possible now that vitest
+// worker count is uncapped), retry with linear backoff. Workers that can't
+// acquire within the window fail loudly rather than silently sharing a DB.
+const SLOT_RETRY_ATTEMPTS = 20;
+const SLOT_RETRY_DELAY_MS = 250; // 20 × 250ms = 5s max wait
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   const forks = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
   if (!Number.isFinite(forks) || forks <= 1) return baseUrl;
@@ -48,24 +58,28 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   const client = new pg.Client(baseUrl);
   await client.connect();
 
-  for (let slot = 1; slot <= forks; slot++) {
-    const res = await client.query<{ locked: boolean }>(
-      "SELECT pg_try_advisory_lock($1) AS locked",
-      [slot],
-    );
-    if (res.rows[0]?.locked) {
-      g.__arAdvisorySlotPg = slot;
-      // Keep client open for the process lifetime; PG drops session locks on
-      // disconnect, so no explicit release is needed on clean exit.
-      process.on("exit", () => void client.end());
-      return slotDbUrl(baseUrl, slot);
+  for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
+    for (let slot = 1; slot <= forks; slot++) {
+      const res = await client.query<{ locked: boolean }>(
+        "SELECT pg_try_advisory_lock($1) AS locked",
+        [slot],
+      );
+      if (res.rows[0]?.locked) {
+        g.__arAdvisorySlotPg = slot;
+        // Keep client open for the process lifetime; PG drops session locks on
+        // disconnect, so no explicit release is needed on clean exit.
+        process.on("exit", () => void client.end());
+        return slotDbUrl(baseUrl, slot);
+      }
     }
+    if (attempt < SLOT_RETRY_ATTEMPTS - 1) await sleep(SLOT_RETRY_DELAY_MS);
   }
 
   await client.end();
   throw new Error(
-    `acquireAdvisorySlotPg: all ${forks} advisory lock slots are held by other workers. ` +
-      `Increase AR_DB_FORKS or wait for a slot to become available.`,
+    `acquireAdvisorySlotPg: all ${forks} advisory lock slots are held after ` +
+      `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s). ` +
+      `Increase AR_DB_FORKS or check for stuck workers.`,
   );
 }
 
@@ -88,24 +102,28 @@ async function acquireAdvisorySlotMysql(baseUrl: string): Promise<string> {
     database: u.pathname.replace(/^\//, "") || undefined,
   });
 
-  for (let slot = 1; slot <= forks; slot++) {
-    const lockName = `ar_test_slot_${slot}`;
-    // GET_LOCK returns 1 when acquired, 0 when timeout (0 s = non-blocking).
-    const [rows] = await conn.query<mysql.RowDataPacket[]>("SELECT GET_LOCK(?, 0) AS acquired", [
-      lockName,
-    ]);
-    if ((rows[0] as { acquired: number }).acquired === 1) {
-      g.__arAdvisorySlotMysql = slot;
-      // Hold the connection open; MariaDB releases GET_LOCK on disconnect.
-      process.on("exit", () => void conn.end());
-      return slotDbUrl(baseUrl, slot);
+  for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
+    for (let slot = 1; slot <= forks; slot++) {
+      const lockName = `ar_test_slot_${slot}`;
+      // GET_LOCK returns 1 when acquired, 0 when timeout (0 s = non-blocking).
+      const [rows] = await conn.query<mysql.RowDataPacket[]>("SELECT GET_LOCK(?, 0) AS acquired", [
+        lockName,
+      ]);
+      if ((rows[0] as { acquired: number }).acquired === 1) {
+        g.__arAdvisorySlotMysql = slot;
+        // Hold the connection open; MariaDB releases GET_LOCK on disconnect.
+        process.on("exit", () => void conn.end());
+        return slotDbUrl(baseUrl, slot);
+      }
     }
+    if (attempt < SLOT_RETRY_ATTEMPTS - 1) await sleep(SLOT_RETRY_DELAY_MS);
   }
 
   await conn.end();
   throw new Error(
-    `acquireAdvisorySlotMysql: all ${forks} GET_LOCK slots are held by other workers. ` +
-      `Increase AR_DB_FORKS or wait for a slot to become available.`,
+    `acquireAdvisorySlotMysql: all ${forks} GET_LOCK slots are held after ` +
+      `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s). ` +
+      `Increase AR_DB_FORKS or check for stuck workers.`,
   );
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,9 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 
-// Number of parallel forks for activerecord tests. Set AR_DB_FORKS=4 in CI
-// after provisioning rails_js_test_2/3/4 alongside the base database. Leave
-// unset (or 0/1) for local runs — workers fall back to the base URL.
-const AR_DB_FORKS = parseInt(process.env.AR_DB_FORKS ?? "0", 10) || undefined;
-
-// When AR_DB_FORKS is unset and a real DB is present, cap to 1 fork so
-// parallel workers don't race on the same PG/MySQL database. SQLite uses
-// :memory: which is isolated per fork, so no cap is needed there.
-const AR_DB_MAX_FORKS =
-  AR_DB_FORKS ?? (process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 1 : undefined);
+// AR_DB_FORKS (read in test-setup-worker-db.ts) sets the advisory-lock slot
+// pool size. Worker count is no longer pinned to it: vitest spawns freely and
+// workers queue on advisory locks when all slots are held.
 
 const SHARED_EXCLUDE = [
   "**/node_modules/**",
@@ -104,10 +97,9 @@ export default defineConfig({
           // regression slips through.
           retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
           pool: "forks",
-          // minForks = maxForks so VITEST_WORKER_ID stays within [1, AR_DB_MAX_FORKS].
-          // Without this each file gets a new fork; IDs wrap mod AR_DB_MAX_FORKS,
-          // so workers share the same DB and race on table mutations mid-test.
-          poolOptions: { forks: { maxForks: AR_DB_MAX_FORKS, minForks: AR_DB_MAX_FORKS } },
+          // Worker count is intentionally uncapped: advisory locks in
+          // test-setup-worker-db.ts bound real DB concurrency to AR_DB_FORKS
+          // slots, so extra workers simply wait for a free slot.
         },
       },
       {


### PR DESCRIPTION
## Summary

- Removes `maxForks=minForks=AR_DB_MAX_FORKS` from the `activerecord` project block in `vitest.config.ts`. Advisory locks (P1/P2, #1223/#1224) already bound real DB concurrency to `AR_DB_FORKS` slots; the worker-count pin was preventing vitest from spawning more workers than slots and added no isolation benefit.
- Adds a bounded retry loop (20 × 250 ms = 5 s max) to both `acquireAdvisorySlotPg` and `acquireAdvisorySlotMysql`. Previously, a worker that found all slots held threw immediately; with the worker count uncapped, transient contention at startup is expected and a short wait is correct.
- Removes the `AR_DB_MAX_FORKS` constant (no longer needed in config; slot pool size is read directly from env in `test-setup-worker-db.ts`).

## Bootstrap connection survivability (open question from plan)

The plan asked: does the bootstrap PG/MariaDB connection survive vitest fork recycling?

**Answer: yes, by construction — but the question is moot for P4.** The bootstrap connection is held in the worker _process_ (via `globalThis.__arAdvisorySlotPg/Mysql` + a `process.on('exit')` handler). `pool: "forks"` recycles worker processes: when vitest retires a fork and spawns a new one, the new process starts fresh, hits `test-setup-worker-db.ts`, and acquires a slot via the retry loop. The old process's connection closes on exit and its PG session lock (or MariaDB `GET_LOCK`) is released automatically.

The retry loop is what makes this safe: the new worker may start before the old one has fully exited (and released its lock). The 5-second window is enough for the exit handler to fire in practice (PG disconnects on `SIGTERM` in <1 s; MariaDB similar).

No empirical long-run was performed because the mechanism is analytically correct and P5 (remove `--no-file-parallelism`) is where real parallel execution — and any empirical signal — begins.

## Prereqs

- P1 advisory-lock PG (#1223)
- P2 advisory-lock MariaDB (#1224)
- P3 advisory default + modulo removed (#1225)

## Test plan

- [ ] CI passes on all three backends (SQLite / PG / MariaDB) with `--no-file-parallelism` still in place (no behaviour change yet — P5 removes that flag)
- [ ] `git grep -n 'AR_DB_MAX_FORKS\|maxForks\|minForks' vitest.config.ts` returns nothing