### PR TITLE
feat(test): re-enable AR file-level parallelism (PR-P5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run --no-file-parallelism packages/activerecord
+      - run: pnpm vitest run packages/activerecord
 
   postgres-tests:
     name: PostgreSQL Tests
@@ -294,7 +294,7 @@ jobs:
           for i in 2 3 4; do
             PGPASSWORD=postgres psql -h localhost -U postgres -c "CREATE DATABASE rails_js_test_$i;"
           done
-      - run: pnpm vitest run --no-file-parallelism packages/activerecord
+      - run: pnpm vitest run packages/activerecord
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
           AR_DB_FORKS: 4
@@ -333,7 +333,7 @@ jobs:
             mysql -h 127.0.0.1 -u root -e "CREATE DATABASE rails_js_test_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
           done
           mysql -h 127.0.0.1 -u root -e "ALTER DATABASE rails_js_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
-      - run: pnpm vitest run --no-file-parallelism packages/activerecord
+      - run: pnpm vitest run packages/activerecord
         env:
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
           AR_DB_FORKS: 4


### PR DESCRIPTION
## Summary

Removes \`--no-file-parallelism\` from all three AR vitest run commands in CI (sqlite-tests, postgres-tests, mariadb-tests).

**Why P1–P4 enable this:**
- PR-P1 (#1223): \`pg_try_advisory_lock(slot)\` for PG worker isolation
- PR-P2 (#1224): \`GET_LOCK('ar_test_slot_N', 0)\` for MariaDB worker isolation
- PR-P3 (#1225): \`advisory\` as the default lock mode, removed modulo slot formula
- PR-P4 (#1226): unpinned worker count (removed \`maxForks\`/\`minForks\`); added bounded-retry slot acquisition

**Why now:** \`--no-file-parallelism\` was added in #1222 as a conservative guard while P1–P4 were being built. The cross-worker-leakage-prone test files (\`relation.test.ts\`, \`dirty.test.ts\`, \`associations/join-model.test.ts\`) are all migrated to \`defineSchema\` (TS-4a, TS-4j, TS-4l). This PR turns parallelism back on to observe whether the slot machinery holds under real CI load.

**On worker count vs. slot count:** \`vitest.config.ts\` leaves the fork count uncapped, but GitHub's \`ubuntu-latest\` runners have 2 vCPUs — Vitest will spawn at most 2 workers in practice, well below the 4 slots provisioned. The slot-acquisition path (PR-P4) uses a bounded retry loop, not a one-shot 5-second hard fail, so temporary contention queues cleanly. If GitHub ever upgrades runners to more than 4 vCPUs, \`AR_DB_FORKS\` and the database-creation loops would need to be updated together — that's a deliberate, visible knob rather than a silent cap.

## Empirical bar

The plan calls for **≥20 consecutive green CI runs** before considering this stable. If any job fails with the \`relation X does not exist\` cross-worker pattern, that signals a bug in the P1–P4 slot-acquisition machinery — document it in the PR body rather than applying a hack-fix.

## Test plan

- [ ] sqlite-tests CI job passes with file-level parallelism enabled
- [ ] postgres-tests CI job passes with file-level parallelism enabled
- [ ] mariadb-tests CI job passes with file-level parallelism enabled
- [ ] Accumulate ≥20 consecutive green CI runs before merging