### PR TITLE
chore(test): remove AR_DB_LOCK_MODE flag + modulo dead code (PR-P6)

### DIFF
--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -36,9 +36,9 @@ function slotDbUrl(baseUrl: string, slot: number): string {
   return url.toString();
 }
 
-// Bounded retry policy: when all slots are held (possible now that vitest
-// worker count is uncapped), retry with linear backoff. Workers that can't
-// acquire within the window fail loudly rather than silently sharing a DB.
+// Bounded retry policy: when all slots are held, retry with linear backoff.
+// Workers that can't acquire within the window fail loudly rather than
+// silently sharing a DB.
 const SLOT_RETRY_ATTEMPTS = 20;
 const SLOT_RETRY_DELAY_MS = 250; // 20 × 250ms = 5s max wait
 


### PR DESCRIPTION
## Summary

Final cleanup pass now that PR-P1 through PR-P5 have stabilised the advisory-lock parallelism system.

- **`AR_DB_LOCK_MODE` flag**: was introduced in PR-P1 (#1223) as a feature gate and removed in PR-P3 (#1225) when advisory became the default and only mode. No live references remain in source or CI — nothing to delete.
- **Modulo slot formula** (`((id-1) % forks) + 1`): removed in PR-P3 (#1225). No residual references remain.
- **Stale rollout comment** (this commit): `test-setup-worker-db.ts` contained a parenthetical `"possible now that vitest worker count is uncapped"` added in PR-P4 (#1226) as temporary context during the rollout. Removed — the uncapped state is now permanent and the parenthetical reads as historical noise.

`AR_DB_FORKS` and the "Create parallel test databases" CI step are preserved (they define the slot pool size).

## Verification

```
grep -rn "AR_DB_LOCK_MODE|% forks|modulo" packages/activerecord/src
# → no output
```