### PR TITLE
feat(activerecord): locking/optimistic + counter-cache to 100% api:compare

### DIFF
--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -291,7 +291,7 @@ export async function destroyRow(
     for (const name of counterCachedAssociationNames(this.constructor)) {
       const assoc = this.association(name);
       const dba = this.destroyedByAssociation as any;
-      if (!dba || !is_foreignKeysEqual(dba.foreignKey, assoc.reflection?.foreignKey)) {
+      if (!dba || !isForeignKeysEqual(dba.foreignKey, assoc.reflection?.foreignKey)) {
         await assoc.decrementCounters();
       }
     }
@@ -303,7 +303,7 @@ export async function destroyRow(
  * @internal
  * Mirrors: ActiveRecord::CounterCache#_foreign_keys_equal?
  */
-export function is_foreignKeysEqual(fkey1: unknown, fkey2: unknown): boolean {
+export function isForeignKeysEqual(fkey1: unknown, fkey2: unknown): boolean {
   if (fkey1 === fkey2) return true;
   const arr1 = (Array.isArray(fkey1) ? fkey1 : [fkey1]).map((k) =>
     typeof k === "string" ? k : String(k),

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -252,6 +252,8 @@ export const ClassMethods = {
 type InstanceCounterHost = {
   constructor: typeof Base;
   destroyedByAssociation: unknown;
+  association(name: string): any;
+  counterCachedAssociationNames: string[];
 };
 
 /**
@@ -261,10 +263,11 @@ type InstanceCounterHost = {
 export async function _createRecord(
   this: InstanceCounterHost,
   superFn: () => Promise<unknown>,
-  incrementFn: () => Promise<void>,
 ): Promise<unknown> {
   const id = await superFn();
-  await incrementFn();
+  for (const name of this.counterCachedAssociationNames) {
+    await this.association(name).incrementCounters();
+  }
   return id;
 }
 
@@ -275,14 +278,16 @@ export async function _createRecord(
 export async function destroyRow(
   this: InstanceCounterHost,
   superFn: () => Promise<number>,
-  decrementFn: (assocForeignKey: unknown, reflectionForeignKey: unknown) => Promise<void>,
 ): Promise<number> {
   const affectedRows = await superFn();
   if (affectedRows > 0) {
-    await decrementFn(
-      (this.destroyedByAssociation as any)?.foreignKey,
-      undefined,
-    );
+    for (const name of this.counterCachedAssociationNames) {
+      const assoc = this.association(name);
+      const dba = this.destroyedByAssociation as any;
+      if (!dba || !is_foreignKeysEqual(dba.foreignKey, assoc.reflection?.foreignKey)) {
+        await assoc.decrementCounters();
+      }
+    }
   }
   return affectedRows;
 }

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -253,8 +253,15 @@ type InstanceCounterHost = {
   constructor: typeof Base;
   destroyedByAssociation: unknown;
   association(name: string): any;
-  counterCachedAssociationNames: string[];
 };
+
+function counterCachedAssociationNames(ctor: typeof Base): string[] {
+  const associations: Array<{ type: string; name: string; options: any }> =
+    (ctor as any)._associations ?? [];
+  return associations
+    .filter((a) => a.type === "belongsTo" && a.options?.counterCache)
+    .map((a) => a.name);
+}
 
 /**
  * @internal
@@ -265,7 +272,7 @@ export async function _createRecord(
   superFn: () => Promise<unknown>,
 ): Promise<unknown> {
   const id = await superFn();
-  for (const name of this.counterCachedAssociationNames) {
+  for (const name of counterCachedAssociationNames(this.constructor)) {
     await this.association(name).incrementCounters();
   }
   return id;
@@ -281,7 +288,7 @@ export async function destroyRow(
 ): Promise<number> {
   const affectedRows = await superFn();
   if (affectedRows > 0) {
-    for (const name of this.counterCachedAssociationNames) {
+    for (const name of counterCachedAssociationNames(this.constructor)) {
       const assoc = this.association(name);
       const dba = this.destroyedByAssociation as any;
       if (!dba || !is_foreignKeysEqual(dba.foreignKey, assoc.reflection?.foreignKey)) {

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pendingCounterCacheColumns } from "./counter-cache-state.js";
@@ -250,19 +249,55 @@ export const ClassMethods = {
   isCounterCacheColumn,
 };
 
-/** @internal */
-function _createRecord(attributeNames?: any): never {
-  throw new NotImplementedError("ActiveRecord::CounterCache#_create_record is not implemented");
+type InstanceCounterHost = {
+  constructor: typeof Base;
+  destroyedByAssociation: unknown;
+};
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::CounterCache#_create_record
+ */
+export async function _createRecord(
+  this: InstanceCounterHost,
+  superFn: () => Promise<unknown>,
+  incrementFn: () => Promise<void>,
+): Promise<unknown> {
+  const id = await superFn();
+  await incrementFn();
+  return id;
 }
 
-/** @internal */
-function destroyRow(): never {
-  throw new NotImplementedError("ActiveRecord::CounterCache#destroy_row is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::CounterCache#destroy_row
+ */
+export async function destroyRow(
+  this: InstanceCounterHost,
+  superFn: () => Promise<number>,
+  decrementFn: (assocForeignKey: unknown, reflectionForeignKey: unknown) => Promise<void>,
+): Promise<number> {
+  const affectedRows = await superFn();
+  if (affectedRows > 0) {
+    await decrementFn(
+      (this.destroyedByAssociation as any)?.foreignKey,
+      undefined,
+    );
+  }
+  return affectedRows;
 }
 
-/** @internal */
-function is_foreignKeysEqual(fkey1: any, fkey2: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::CounterCache#_foreign_keys_equal? is not implemented",
+/**
+ * @internal
+ * Mirrors: ActiveRecord::CounterCache#_foreign_keys_equal?
+ */
+export function is_foreignKeysEqual(fkey1: unknown, fkey2: unknown): boolean {
+  if (fkey1 === fkey2) return true;
+  const arr1 = (Array.isArray(fkey1) ? fkey1 : [fkey1]).map((k) =>
+    typeof k === "string" ? k : String(k),
   );
+  const arr2 = (Array.isArray(fkey2) ? fkey2 : [fkey2]).map((k) =>
+    typeof k === "string" ? k : String(k),
+  );
+  return arr1.length === arr2.length && arr1.every((k, i) => k === arr2[i]);
 }

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -3,6 +3,7 @@ import { StaleObjectError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 import { isWillSaveChangeToAttribute, attributeInDatabase } from "../attribute-methods/dirty.js";
 import { queryConstraintsList, _updateRecord as persistenceUpdateRecord } from "../persistence.js";
+import { attributesWithValues } from "../attribute-methods.js";
 
 /**
  * Optimistic locking support for ActiveRecord models.
@@ -159,7 +160,6 @@ type InstanceLockingHost = {
   readAttribute(name: string): unknown;
   writeAttribute(name: string, value: unknown): void;
   clearAttributeChange(name: string): void;
-  attributesWithValues(names: string[]): Record<string, unknown>;
   changes: Record<string, [unknown, unknown]>;
 };
 
@@ -221,7 +221,7 @@ export async function _updateRow(
   try {
     const affectedRows = await persistenceUpdateRecord.call(
       ctor as any,
-      this.attributesWithValues(attributeNames),
+      attributesWithValues.call(this as any, attributeNames),
       updateConstraints,
     );
     if (affectedRows !== 1) throw new StaleObjectError(this, attemptedAction);

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -2,7 +2,7 @@ import type { Base } from "../base.js";
 import { StaleObjectError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 import { isWillSaveChangeToAttribute, attributeInDatabase } from "../attribute-methods/dirty.js";
-import { queryConstraintsList } from "../persistence.js";
+import { queryConstraintsList, _updateRecord as persistenceUpdateRecord } from "../persistence.js";
 
 /**
  * Optimistic locking support for ActiveRecord models.
@@ -211,22 +211,23 @@ export async function _updateRow(
   if (!ctor.lockingEnabled) return superFn(attributeNames, attemptedAction);
 
   const col = ctor.lockingColumn;
-  const lockAttributeWas = (this as any)._attributes?.[col];
+  const lockVersionWas = this.readAttribute(col);
   const baseConstraints = buildBaseConstraints(this, ctor);
   const updateConstraints = { ...baseConstraints, [col]: _lockValueForDatabase.call(this, col) };
 
   attributeNames = [...attributeNames, col];
-  this.writeAttribute(col, ((this.readAttribute(col) as number) ?? 0) + 1);
+  this.writeAttribute(col, (Number(this.readAttribute(col)) || 0) + 1);
 
   try {
-    const affectedRows = await ctor._updateRecord!(
+    const affectedRows = await persistenceUpdateRecord.call(
+      ctor as any,
       this.attributesWithValues(attributeNames),
       updateConstraints,
     );
     if (affectedRows !== 1) throw new StaleObjectError(this, attemptedAction);
     return affectedRows;
   } catch (e) {
-    if (lockAttributeWas !== undefined) (this as any)._attributes[col] = lockAttributeWas;
+    this.writeAttribute(col, lockVersionWas);
     throw e;
   }
 }
@@ -288,7 +289,7 @@ export function _queryConstraintsHash(
  * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#hook_attribute_type
  */
 export function hookAttributeType(this: LockingHost, name: string, castType: Type): Type {
-  if (this.lockOptimistically && name === this._lockingColumn) {
+  if (this.lockOptimistically !== false && name === this._lockingColumn) {
     return new LockingType(castType);
   }
   return castType;

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -99,7 +99,10 @@ interface LockingHost {
   _lockingColumn: string;
   lockOptimistically?: boolean;
   updateCounters?(id: unknown, counters: Record<string, number>): Promise<number>;
-  _updateRecord?(values: Record<string, unknown>, constraints: Record<string, unknown>): Promise<number>;
+  _updateRecord?(
+    values: Record<string, unknown>,
+    constraints: Record<string, unknown>,
+  ): Promise<number>;
 }
 
 /**

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -1,6 +1,8 @@
 import type { Base } from "../base.js";
 import { StaleObjectError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
+import { isWillSaveChangeToAttribute, attributeInDatabase } from "../attribute-methods/dirty.js";
+import { queryConstraintsList } from "../persistence.js";
 
 /**
  * Optimistic locking support for ActiveRecord models.
@@ -70,6 +72,23 @@ function toInt(value: unknown): number {
   return Number.isFinite(n) ? Math.trunc(n) : 0;
 }
 
+function buildBaseConstraints(
+  instance: InstanceLockingHost,
+  ctor: typeof Base,
+): Record<string, unknown> {
+  const constraintsList = queryConstraintsList.call(ctor as any);
+  if (!constraintsList) {
+    const pk = ctor.primaryKey as string;
+    return { [pk]: (instance as any).idInDatabase?.() ?? (instance as any).id };
+  }
+  return Object.fromEntries(
+    constraintsList.map((col: string) => [
+      col,
+      (instance as any).attributeInDatabase?.(col) ?? instance.readAttribute(col),
+    ]),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Class methods — mirrors ActiveRecord::Locking::Optimistic::ClassMethods
 // ---------------------------------------------------------------------------
@@ -80,6 +99,7 @@ interface LockingHost {
   _lockingColumn: string;
   lockOptimistically?: boolean;
   updateCounters?(id: unknown, counters: Record<string, number>): Promise<number>;
+  _updateRecord?(values: Record<string, unknown>, constraints: Record<string, unknown>): Promise<number>;
 }
 
 /**
@@ -132,10 +152,12 @@ export async function updateCounters(
 }
 
 type InstanceLockingHost = {
-  constructor: typeof Base;
+  constructor: typeof Base & LockingHost;
   readAttribute(name: string): unknown;
   writeAttribute(name: string, value: unknown): void;
   clearAttributeChange(name: string): void;
+  attributesWithValues(names: string[]): Record<string, unknown>;
+  changes: Record<string, [unknown, unknown]>;
 };
 
 /**
@@ -167,8 +189,7 @@ export function _touchRow(
 ): unknown {
   const ctor = this.constructor;
   if (ctor.lockingEnabled) {
-    const col = ctor.lockingColumn;
-    if (!touchAttrNames.includes(col)) touchAttrNames = [...touchAttrNames, col];
+    touchAttrNames = [...touchAttrNames, ctor.lockingColumn];
   }
   return superFn(touchAttrNames, time);
 }
@@ -177,19 +198,34 @@ export function _touchRow(
  * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic#_update_row
  */
-export function _updateRow(
+export async function _updateRow(
   this: InstanceLockingHost,
   attributeNames: string[],
   attemptedAction: string,
-  superFn: (names: string[], action: string) => unknown,
-): unknown {
+  superFn: (names: string[], action: string) => Promise<number>,
+): Promise<number> {
   const ctor = this.constructor;
   if (!ctor.lockingEnabled) return superFn(attributeNames, attemptedAction);
+
   const col = ctor.lockingColumn;
-  const currentVersion = (this.readAttribute(col) as number) ?? 0;
-  this.writeAttribute(col, currentVersion + 1);
-  const names = attributeNames.includes(col) ? attributeNames : [...attributeNames, col];
-  return superFn(names, attemptedAction);
+  const lockAttributeWas = (this as any)._attributes?.[col];
+  const baseConstraints = buildBaseConstraints(this, ctor);
+  const updateConstraints = { ...baseConstraints, [col]: _lockValueForDatabase.call(this, col) };
+
+  attributeNames = [...attributeNames, col];
+  this.writeAttribute(col, ((this.readAttribute(col) as number) ?? 0) + 1);
+
+  try {
+    const affectedRows = await ctor._updateRecord!(
+      this.attributesWithValues(attributeNames),
+      updateConstraints,
+    );
+    if (affectedRows !== 1) throw new StaleObjectError(this, attemptedAction);
+    return affectedRows;
+  } catch (e) {
+    if (lockAttributeWas !== undefined) (this as any)._attributes[col] = lockAttributeWas;
+    throw e;
+  }
 }
 
 /**
@@ -213,7 +249,10 @@ export function destroyRow(
  * Mirrors: ActiveRecord::Locking::Optimistic#_lock_value_for_database
  */
 export function _lockValueForDatabase(this: InstanceLockingHost, col: string): unknown {
-  return this.readAttribute(col) ?? 0;
+  if (isWillSaveChangeToAttribute(this as any, col)) {
+    return this.readAttribute(col) ?? 0;
+  }
+  return attributeInDatabase(this as any, col) ?? 0;
 }
 
 /**
@@ -245,7 +284,9 @@ export function _queryConstraintsHash(
  * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#hook_attribute_type
  */
-export function hookAttributeType(name: string, castType: Type, lockCol: string): Type {
-  if (name === lockCol) return new LockingType(castType);
+export function hookAttributeType(this: LockingHost, name: string, castType: Type): Type {
+  if (this.lockOptimistically && name === this._lockingColumn) {
+    return new LockingType(castType);
+  }
   return castType;
 }

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -1,5 +1,5 @@
-import { NotImplementedError } from "../errors.js";
 import type { Base } from "../base.js";
+import { StaleObjectError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 
 /**
@@ -131,52 +131,121 @@ export async function updateCounters(
   return 0;
 }
 
-/** @internal */
-function _createRecord(attributeNames?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Locking::Optimistic#_create_record is not implemented",
-  );
+type InstanceLockingHost = {
+  constructor: typeof Base;
+  readAttribute(name: string): unknown;
+  writeAttribute(name: string, value: unknown): void;
+  clearAttributeChange(name: string): void;
+};
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_create_record
+ */
+export function _createRecord(
+  this: InstanceLockingHost,
+  attributeNames: string[],
+  superFn: (names: string[]) => unknown,
+): unknown {
+  const ctor = this.constructor;
+  if (ctor.lockingEnabled) {
+    const col = ctor.lockingColumn;
+    if (!attributeNames.includes(col)) attributeNames = [...attributeNames, col];
+  }
+  return superFn(attributeNames);
 }
 
-/** @internal */
-function _touchRow(attributeNames: any, time: any): never {
-  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#_touch_row is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_touch_row
+ */
+export function _touchRow(
+  this: InstanceLockingHost,
+  touchAttrNames: string[],
+  time: unknown,
+  superFn: (names: string[], time: unknown) => unknown,
+): unknown {
+  const ctor = this.constructor;
+  if (ctor.lockingEnabled) {
+    const col = ctor.lockingColumn;
+    if (!touchAttrNames.includes(col)) touchAttrNames = [...touchAttrNames, col];
+  }
+  return superFn(touchAttrNames, time);
 }
 
-/** @internal */
-function _updateRow(attributeNames: any, attemptedAction?: any): never {
-  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#_update_row is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_update_row
+ */
+export function _updateRow(
+  this: InstanceLockingHost,
+  attributeNames: string[],
+  attemptedAction: string,
+  superFn: (names: string[], action: string) => unknown,
+): unknown {
+  const ctor = this.constructor;
+  if (!ctor.lockingEnabled) return superFn(attributeNames, attemptedAction);
+  const col = ctor.lockingColumn;
+  const currentVersion = (this.readAttribute(col) as number) ?? 0;
+  this.writeAttribute(col, currentVersion + 1);
+  const names = attributeNames.includes(col) ? attributeNames : [...attributeNames, col];
+  return superFn(names, attemptedAction);
 }
 
-/** @internal */
-function destroyRow(): never {
-  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#destroy_row is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#destroy_row
+ */
+export function destroyRow(
+  this: InstanceLockingHost,
+  superFn: () => number | Promise<number>,
+): number | Promise<number> {
+  const ctor = this.constructor;
+  if (!ctor.lockingEnabled) return superFn();
+  return Promise.resolve(superFn()).then((affected) => {
+    if (affected !== 1) throw new StaleObjectError(this, "destroy");
+    return affected;
+  });
 }
 
-/** @internal */
-function _lockValueForDatabase(lockingColumn: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Locking::Optimistic#_lock_value_for_database is not implemented",
-  );
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_lock_value_for_database
+ */
+export function _lockValueForDatabase(this: InstanceLockingHost, col: string): unknown {
+  return this.readAttribute(col) ?? 0;
 }
 
-/** @internal */
-function _clearLockingColumn(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Locking::Optimistic#_clear_locking_column is not implemented",
-  );
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_clear_locking_column
+ */
+export function _clearLockingColumn(this: InstanceLockingHost): void {
+  const ctor = this.constructor;
+  const col = ctor.lockingColumn;
+  this.writeAttribute(col, null);
+  this.clearAttributeChange(col);
 }
 
-/** @internal */
-function _queryConstraintsHash(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Locking::Optimistic#_query_constraints_hash is not implemented",
-  );
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic#_query_constraints_hash
+ */
+export function _queryConstraintsHash(
+  this: InstanceLockingHost,
+  base: Record<string, unknown>,
+): Record<string, unknown> {
+  const ctor = this.constructor;
+  if (!ctor.lockingEnabled) return base;
+  const col = ctor.lockingColumn;
+  return { ...base, [col]: _lockValueForDatabase.call(this, col) };
 }
 
-/** @internal */
-function hookAttributeType(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Locking::Optimistic#hook_attribute_type is not implemented",
-  );
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#hook_attribute_type
+ */
+export function hookAttributeType(name: string, castType: Type, lockCol: string): Type {
+  if (name === lockCol) return new LockingType(castType);
+  return castType;
 }


### PR DESCRIPTION
## Summary

- Replaces 8 `NotImplementedError` stubs in `locking/optimistic.ts` with exported, real implementations of the Rails private helpers (`_createRecord`, `_touchRow`, `_updateRow`, `destroyRow`, `_lockValueForDatabase`, `_clearLockingColumn`, `_queryConstraintsHash`, `hookAttributeType`)
- Replaces 3 stubs in `counter-cache.ts` with exported implementations (`_createRecord`, `destroyRow`, `_foreignKeysEqual?`)
- `locking/optimistic.ts`: 9/17 → 17/17 (53% → 100%)
- `counter-cache.ts`: 6/9 → 9/9 (67% → 100%)

The api:compare tool skips non-exported stubs that throw `NotImplementedError`. These functions were already stubs; the PR ships real behavior callable by the mixin pattern.

## Test plan

- [ ] `pnpm api:compare --package activerecord` shows both files at 100%
- [ ] `pnpm test --package activerecord -- locking counter-cache` passes
- [ ] LOC: 196 additions+deletions (under 300 limit)