### PR TITLE
feat(activerecord): sqlite3_adapter lifecycle/type-map cluster (PR 24b)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -39,7 +39,7 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   // Mirrors: database.yml `pragmas:` — applied via PRAGMA on each connection.
   // Keys must be simple SQLite pragma identifiers (word characters only, e.g. "cache_size").
   // String values must be identifier-like enum words (e.g. "WAL", "NORMAL") — arbitrary
-  // strings are rejected. Numbers and booleans are always accepted (boolean → "1"/"0").
+  // strings are warned and skipped. Numbers and booleans are always accepted (boolean → "1"/"0").
   pragmas?: Record<string, string | number | boolean>;
 }
 

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -36,6 +36,16 @@ export interface TrailsAdapterOptions {
  * Kept separate so MySQL2/SQLite3 destructuring of `TrailsAdapterOptions`
  * never receives — and leaks — these keys into their driver configs.
  */
+/**
+ * SQLite3-specific adapter options that extend the shared base.
+ */
+export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
+  readonly?: boolean;
+  // Mirrors: database.yml `pragmas:` — applied via PRAGMA on each connection.
+  // Keys must be valid SQLite pragma identifiers; values must be scalar.
+  pragmas?: Record<string, string | number | boolean>;
+}
+
 export interface PostgreSQLAdapterOptions extends TrailsAdapterOptions {
   // Mirrors: database.yml `min_messages` — SET client_min_messages on connect (default: "warning")
   minMessages?: string;

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -37,7 +37,9 @@ export interface TrailsAdapterOptions {
 export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   readonly?: boolean;
   // Mirrors: database.yml `pragmas:` — applied via PRAGMA on each connection.
-  // Keys must be valid SQLite pragma identifiers; values must be scalar.
+  // Keys must be simple SQLite pragma identifiers (word characters only, e.g. "cache_size").
+  // String values must be identifier-like enum words (e.g. "WAL", "NORMAL") — arbitrary
+  // strings are rejected. Numbers and booleans are always accepted (boolean → "1"/"0").
   pragmas?: Record<string, string | number | boolean>;
 }
 

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -32,11 +32,6 @@ export interface TrailsAdapterOptions {
 }
 
 /**
- * PostgreSQL-specific adapter options that extend the shared base.
- * Kept separate so MySQL2/SQLite3 destructuring of `TrailsAdapterOptions`
- * never receives — and leaks — these keys into their driver configs.
- */
-/**
  * SQLite3-specific adapter options that extend the shared base.
  */
 export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
@@ -46,6 +41,11 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   pragmas?: Record<string, string | number | boolean>;
 }
 
+/**
+ * PostgreSQL-specific adapter options that extend the shared base.
+ * Kept separate so MySQL2/SQLite3 destructuring of `TrailsAdapterOptions`
+ * never receives — and leaks — these keys into their driver configs.
+ */
 export interface PostgreSQLAdapterOptions extends TrailsAdapterOptions {
   // Mirrors: database.yml `min_messages` — SET client_min_messages on connect (default: "warning")
   minMessages?: string;

--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -603,7 +603,7 @@ describe("SQLite3Adapter._isMemoryFilename", () => {
 });
 
 describe("SQLite3Adapter pragmas option", () => {
-  let adapter: SQLite3Adapter;
+  let adapter: SQLite3Adapter | undefined;
 
   afterEach(() => {
     adapter?.close();

--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -603,52 +603,53 @@ describe("SQLite3Adapter._isMemoryFilename", () => {
 });
 
 describe("SQLite3Adapter pragmas option", () => {
+  let adapter: SQLite3Adapter;
+
+  afterEach(() => {
+    adapter?.close();
+    vi.restoreAllMocks();
+  });
+
   it("applies a valid numeric pragma on construction", () => {
-    const adapter = new SQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
+    adapter = new SQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
     const result = adapter.raw.pragma("cache_size") as Array<{ cache_size: number }>;
     expect(result[0]?.cache_size).toBe(500);
-    adapter.close();
   });
 
   it("converts boolean true to 1 for pragma", () => {
-    const adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
+    adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
     const result = adapter.raw.pragma("foreign_keys") as Array<{ foreign_keys: number }>;
     expect(result[0]?.foreign_keys).toBe(1);
-    adapter.close();
   });
 
   it("converts boolean false to 0 for pragma", () => {
-    const adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
+    adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
     const result = adapter.raw.pragma("foreign_keys") as Array<{ foreign_keys: number }>;
     expect(result[0]?.foreign_keys).toBe(0);
-    adapter.close();
   });
 
   it("applies a valid string enum pragma", () => {
-    const adapter = new SQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
+    adapter = new SQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
     const result = adapter.raw.pragma("synchronous") as Array<{ synchronous: number }>;
     // SQLite returns synchronous as integer: 0=OFF,1=NORMAL,2=FULL,3=EXTRA
     expect(result[0]?.synchronous).toBe(2);
-    adapter.close();
   });
 
   it("warns and skips an invalid pragma name", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const adapter = new SQLite3Adapter(":memory:", {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    adapter = new SQLite3Adapter(":memory:", {
       pragmas: { "bad-name!": 1 } as Record<string, number>,
     });
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("invalid SQLite pragma name"));
-    adapter.close();
-    warn.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid SQLite pragma name"),
+    );
   });
 
   it("warns and skips a string value with unsafe characters", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const adapter = new SQLite3Adapter(":memory:", {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    adapter = new SQLite3Adapter(":memory:", {
       pragmas: { synchronous: "FULL; DROP TABLE users" },
     });
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
-    adapter.close();
-    warn.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import {
   Base,
@@ -599,5 +599,56 @@ describe("SQLite3Adapter._isMemoryFilename", () => {
 
   it("treats a regular file path as on-disk", () => {
     expect(isMemoryFilename("/tmp/test.db")).toBe(false);
+  });
+});
+
+describe("SQLite3Adapter pragmas option", () => {
+  it("applies a valid numeric pragma on construction", () => {
+    const adapter = new SQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
+    const result = adapter.raw.pragma("cache_size") as Array<{ cache_size: number }>;
+    expect(result[0]?.cache_size).toBe(500);
+    adapter.close();
+  });
+
+  it("converts boolean true to 1 for pragma", () => {
+    const adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
+    const result = adapter.raw.pragma("foreign_keys") as Array<{ foreign_keys: number }>;
+    expect(result[0]?.foreign_keys).toBe(1);
+    adapter.close();
+  });
+
+  it("converts boolean false to 0 for pragma", () => {
+    const adapter = new SQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
+    const result = adapter.raw.pragma("foreign_keys") as Array<{ foreign_keys: number }>;
+    expect(result[0]?.foreign_keys).toBe(0);
+    adapter.close();
+  });
+
+  it("applies a valid string enum pragma", () => {
+    const adapter = new SQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
+    const result = adapter.raw.pragma("synchronous") as Array<{ synchronous: number }>;
+    // SQLite returns synchronous as integer: 0=OFF,1=NORMAL,2=FULL,3=EXTRA
+    expect(result[0]?.synchronous).toBe(2);
+    adapter.close();
+  });
+
+  it("warns and skips an invalid pragma name", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = new SQLite3Adapter(":memory:", {
+      pragmas: { "bad-name!": 1 } as Record<string, number>,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("invalid SQLite pragma name"));
+    adapter.close();
+    warn.mockRestore();
+  });
+
+  it("warns and skips a string value with unsafe characters", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = new SQLite3Adapter(":memory:", {
+      pragmas: { synchronous: "FULL; DROP TABLE users" },
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
+    adapter.close();
+    warn.mockRestore();
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1946,9 +1946,17 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     const msg = e instanceof Error ? e.message : String(e);
-    // Wrap non-Error throws so translateException always receives an Error,
-    // but preserve the original thrown value as the cause so it isn't dropped.
-    const exc = e instanceof Error ? e : new Error(msg, { cause: e });
+    // Wrap non-Error throws so translateException always receives an Error.
+    // Preserve the original value as .cause and copy .code so code-based
+    // classification in translateException still works for non-Error throws.
+    let exc: Error;
+    if (e instanceof Error) {
+      exc = e;
+    } else {
+      exc = new Error(msg, { cause: e });
+      const code = (e as any)?.code;
+      if (code !== undefined) (exc as any).code = code;
+    }
     return translateException(exc, msg, sql, binds);
   }
 
@@ -1972,12 +1980,25 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   /** @internal */
   private configureConnection(): void {
     if (!this._readonly) {
-      this.db.pragma("foreign_keys = ON");
-      this.db.pragma("journal_mode = WAL");
-      this.db.pragma("synchronous = NORMAL");
-      this.db.pragma("mmap_size = 134217728");
-      this.db.pragma("journal_size_limit = 67108864");
-      this.db.pragma("cache_size = 2000");
+      // Apply Rails DEFAULT_PRAGMAS best-effort: an unsupported PRAGMA on a
+      // non-standard SQLite build should warn, not abort construction.
+      const defaults: [string, string][] = [
+        ["foreign_keys", "ON"],
+        ["journal_mode", "WAL"],
+        ["synchronous", "NORMAL"],
+        ["mmap_size", "134217728"],
+        ["journal_size_limit", "67108864"],
+        ["cache_size", "2000"],
+      ];
+      for (const [pragma, value] of defaults) {
+        try {
+          this.db.pragma(`${pragma} = ${value}`);
+        } catch (e) {
+          console.warn(
+            `SQLite default pragma '${pragma}' failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      }
     }
     const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -16,6 +16,7 @@ import {
   NotNullViolation,
   ValueTooLong,
   NoDatabaseError,
+  ConnectionNotEstablished,
   DatabaseConnectionError,
   TransactionIsolationError,
   NotImplementedError,
@@ -2165,7 +2166,7 @@ function translateException(
     return new InvalidForeignKey(message, { sql, binds, cause: exception });
   }
   if (/called on a closed database/i.test(msg)) {
-    return new StatementInvalid(message, { sql, binds, cause: exception });
+    return new ConnectionNotEstablished(message, { cause: exception });
   }
   return new StatementInvalid(message, { sql, binds, cause: exception });
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2025,6 +2025,58 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     }
     return new StatementInvalid(msg, { sql, binds, cause });
   }
+
+  /** @internal */
+  private buildStatementPool(): GenericStatementPool<Database.Statement> {
+    return new GenericStatementPool<Database.Statement>(this._statementLimit);
+  }
+
+  /** @internal */
+  private connect(): void {
+    this.db = new Database(this._filename, { readonly: this._readonly });
+  }
+
+  /** @internal */
+  private configureConnection(): void {
+    if (!this._readonly) {
+      this.db.pragma("foreign_keys = ON");
+      this.db.pragma("journal_mode = WAL");
+      this.db.pragma("synchronous = NORMAL");
+      this.db.pragma("mmap_size = 134217728");
+      this.db.pragma("journal_size_limit = 67108864");
+      this.db.pragma("cache_size = 2000");
+    }
+    const pragmas = (this._config as Record<string, unknown>)?.pragmas as
+      | Record<string, unknown>
+      | undefined;
+    if (pragmas) {
+      for (const [pragma, value] of Object.entries(pragmas)) {
+        try {
+          this.db.pragma(`${pragma} = ${String(value)}`);
+        } catch {
+          console.warn(`Unknown SQLite pragma: ${pragma}`);
+        }
+      }
+    }
+  }
+
+  /** @internal */
+  static initializeTypeMap(m: TypeMap): void {
+    const sqlite3Int = (limit?: number) => new IntegerType({ limit: limit ?? 8 });
+    m.registerType("string", new StringType());
+    m.registerType("text", new TextType());
+    m.registerType("integer", sqlite3Int());
+    m.registerType("float", new FloatType());
+    m.registerType("decimal", new DecimalType());
+    m.registerType("boolean", new BooleanType());
+    m.registerType("date", new DateType());
+    m.registerType("datetime", new SQLiteDateTimeType());
+    m.registerType("time", new TimeType());
+    m.registerType("binary", new BinaryType());
+    m.registerType("json", new JsonType());
+    m.registerType(/int/i, undefined, (k) => (/bigint/i.test(k) ? sqlite3Int(8) : sqlite3Int()));
+    m.registerType("bigint", sqlite3Int(8));
+  }
 }
 
 /**
@@ -2063,45 +2115,59 @@ function normalizeReferentialAction(action: string): string {
 }
 
 /** @internal */
-function bindParamsLength(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#bind_params_length is not implemented",
+function bindParamsLength(): number {
+  // https://www.sqlite.org/limits.html — default SQLITE_LIMIT_VARIABLE_NUMBER
+  return 999;
+}
+
+/** @internal */
+function extractValueFromDefault(default_: string | null): unknown {
+  return sqliteExtractValueFromDefault(default_);
+}
+
+/** @internal */
+function extractDefaultFunction(defaultValue: unknown, default_: string): string | undefined {
+  return hasDefaultFunction(defaultValue, default_) ? default_ : undefined;
+}
+
+/** @internal */
+function hasDefaultFunction(defaultValue: unknown, default_: string): boolean {
+  return (
+    !defaultValue && /\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|/.test(default_)
   );
 }
 
 /** @internal */
-function extractValueFromDefault(default_: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#extract_value_from_default is not implemented",
+function isInvalidAlterTableType(type: string, options: Record<string, unknown>): boolean {
+  return (
+    type === "primary_key" ||
+    Boolean(options["primary_key"]) ||
+    (options["null"] === false && options["default"] == null) ||
+    (type === "virtual" && Boolean(options["stored"]))
   );
 }
 
 /** @internal */
-function extractDefaultFunction(defaultValue: any, default_: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#extract_default_function is not implemented",
-  );
-}
-
-/** @internal */
-function hasDefaultFunction(defaultValue: any, default_: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#has_default_function? is not implemented",
-  );
-}
-
-/** @internal */
-function isInvalidAlterTableType(type: any, options: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#invalid_alter_table_type? is not implemented",
-  );
-}
-
-/** @internal */
-function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#translate_exception is not implemented",
-  );
+function translateException(
+  exception: Error,
+  message: string,
+  sql: string,
+  binds: unknown[],
+): Error {
+  const msg = exception.message;
+  if (/(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/i.test(msg)) {
+    return new RecordNotUnique(message, { sql, binds, cause: exception });
+  }
+  if (/(.* may not be NULL|NOT NULL constraint failed: .*)/i.test(msg)) {
+    return new NotNullViolation(message, { sql, binds, cause: exception });
+  }
+  if (/FOREIGN KEY constraint failed/i.test(msg)) {
+    return new InvalidForeignKey(message, { sql, binds, cause: exception });
+  }
+  if (/called on a closed database/i.test(msg)) {
+    return new StatementInvalid(message, { sql, binds, cause: exception });
+  }
+  return new StatementInvalid(message, { sql, binds, cause: exception });
 }
 
 /** @internal */
@@ -2112,36 +2178,8 @@ function arelVisitor(): never {
 }
 
 /** @internal */
-function buildStatementPool(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#build_statement_pool is not implemented",
-  );
-}
-
-/** @internal */
-function connect(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#connect is not implemented",
-  );
-}
-
-/** @internal */
 function reconnect(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#reconnect is not implemented",
-  );
-}
-
-/** @internal */
-function configureConnection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#configure_connection is not implemented",
-  );
-}
-
-/** @internal */
-function initializeTypeMap(m: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize_type_map is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -145,7 +145,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
   private _filename: string;
-  private _statementPool = new GenericStatementPool<Database.Statement>();
+  // _statementLimit must be declared before _statementPool so buildStatementPool()
+  // reads the correct default when the field initializer runs.
+  private _statementLimit = 1000;
+  private _statementPool = this.buildStatementPool();
 
   private static _isMemoryFilename(filename: string): boolean {
     if (filename === ":memory:") return true;
@@ -157,11 +160,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (q === -1) return false;
     return new URLSearchParams(filename.slice(q + 1)).get("mode") === "memory";
   }
-
-  // Rails' `statement_limit` database.yml key. SQLite has a single
-  // connection (no pool), so the adapter owns exactly one pool and the
-  // setter resizes it directly.
-  private _statementLimit = 1000;
 
   /**
    * Maximum prepared statements cached on the single SQLite connection.
@@ -1948,25 +1946,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     const msg = e instanceof Error ? e.message : String(e);
-    const code = (e as any)?.code as string | undefined;
-    const cause = e;
-
-    if (code?.includes("CONSTRAINT_UNIQUE") || msg.includes("UNIQUE constraint failed")) {
-      return new RecordNotUnique(msg, { sql, binds, cause });
-    }
-    if (code?.includes("CONSTRAINT_FOREIGNKEY") || msg.includes("FOREIGN KEY constraint failed")) {
-      return new InvalidForeignKey(msg, { sql, binds, cause });
-    }
-    if (code?.includes("CONSTRAINT_NOTNULL") || msg.includes("NOT NULL constraint failed")) {
-      return new NotNullViolation(msg, { sql, binds, cause });
-    }
-    if (msg.includes("String or BLOB exceeded size limit")) {
-      return new ValueTooLong(msg, { sql, binds, cause });
-    }
-    if (code === "SQLITE_CANTOPEN" || msg.includes("unable to open database file")) {
-      return new NoDatabaseError(msg, { sql, binds, cause });
-    }
-    return new StatementInvalid(msg, { sql, binds, cause });
+    const exc = e instanceof Error ? e : new Error(msg);
+    return translateException(exc, msg, sql, binds);
   }
 
   /** @internal */
@@ -2151,14 +2132,27 @@ function translateException(
   binds: unknown[],
 ): Error {
   const msg = exception.message;
-  if (/(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/i.test(msg)) {
+  const code = (exception as any)?.code as string | undefined;
+  if (
+    code?.includes("CONSTRAINT_UNIQUE") ||
+    /(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/i.test(msg)
+  ) {
     return new RecordNotUnique(message, { sql, binds, cause: exception });
   }
-  if (/(.* may not be NULL|NOT NULL constraint failed: .*)/i.test(msg)) {
+  if (
+    code?.includes("CONSTRAINT_NOTNULL") ||
+    /(.* may not be NULL|NOT NULL constraint failed: .*)/i.test(msg)
+  ) {
     return new NotNullViolation(message, { sql, binds, cause: exception });
   }
-  if (/FOREIGN KEY constraint failed/i.test(msg)) {
+  if (code?.includes("CONSTRAINT_FOREIGNKEY") || /FOREIGN KEY constraint failed/i.test(msg)) {
     return new InvalidForeignKey(message, { sql, binds, cause: exception });
+  }
+  if (msg.includes("String or BLOB exceeded size limit")) {
+    return new ValueTooLong(message, { sql, binds, cause: exception });
+  }
+  if (code === "SQLITE_CANTOPEN" || /unable to open database file/i.test(msg)) {
+    return new NoDatabaseError(message, { sql, binds, cause: exception });
   }
   if (/called on a closed database/i.test(msg)) {
     return new ConnectionNotEstablished(message, { cause: exception });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2033,7 +2033,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   /** @internal */
-  static initializeTypeMap(m: TypeMap): void {
+  private static initializeTypeMap(m: TypeMap): void {
     const sqlite3Int = (limit?: number) => new IntegerType({ limit: limit ?? 8 });
     m.registerType("string", new StringType());
     m.registerType("text", new TextType());

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -631,53 +631,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::SQLite3Integer
   // INTEGER in SQLite can store up to 8 bytes; default _limit to 8 when none given.
   private static _buildTypeMap(): TypeMap {
-    const sqlite3Int = (limit?: number) => new IntegerType({ limit: limit ?? 8 });
     const map = new TypeMap();
-    map.registerType("string", new StringType());
-    map.registerType("text", new TextType());
-    map.registerType("integer", sqlite3Int());
-    map.registerType("float", new FloatType());
-    map.registerType(/decimal|numeric/i, undefined, (sqlType) => {
-      const precisionMatch = /\(\s*(\d+)/.exec(sqlType);
-      const precision = precisionMatch ? parseInt(precisionMatch[1], 10) : undefined;
-      const scaleMatch = /\(\s*\d+\s*,\s*(\d+)\s*\)/.exec(sqlType);
-      // Rails: extract_scale returns 0 when no scale specified; use DecimalWithoutScale
-      const scale = scaleMatch
-        ? parseInt(scaleMatch[1], 10)
-        : precision !== undefined
-          ? 0
-          : undefined;
-      if (scale === 0) return new DecimalWithoutScale({ precision });
-      return new DecimalType({ precision, scale });
-    });
-    map.registerType("decimal", new DecimalType());
-    map.registerType("boolean", new BooleanType());
-    // Date/time types: no driver-level type-parser work needed for Temporal.
-    // better-sqlite3 returns datetime columns as TEXT strings (SQLite has no
-    // native datetime type).  SQLiteDateTimeType converts offset-less strings
-    // to Temporal.Instant using the same timezone as formatInstantForSql
-    // (default_timezone: UTC → UTC, local → host tz).  Writes go through
-    // sqlite3/quoting.ts which formats all Temporal types as :db strings.
-    map.registerType("date", new DateType());
-    map.registerType("datetime", new SQLiteDateTimeType());
-    map.registerType("timestamp", new SQLiteDateTimeType());
-    map.registerType("time", new TimeType());
-    map.registerType("blob", new BinaryType());
-    map.registerType("binary", new BinaryType());
-    map.registerType("json", new JsonType());
-    map.registerType("numeric", new DecimalWithoutScale());
-    // SQLite type affinity — regex matches for flexible type names
-    map.registerType(/int/i, undefined, (lookupKey) => {
-      if (/bigint/i.test(lookupKey)) return sqlite3Int(8);
-      return sqlite3Int();
-    });
-    // Explicit "bigint" registered after /int/i so it takes priority (TypeMap
-    // reverses entries; last registered wins on exact matches vs regex).
-    map.registerType("bigint", sqlite3Int(8));
-    map.registerType(/char/i, undefined, () => new StringType());
-    map.registerType(/clob/i, undefined, () => new TextType());
-    map.registerType(/blob/i, undefined, () => new BinaryType());
-    map.registerType(/real|floa|doub/i, undefined, () => new FloatType());
+    SQLite3Adapter.initializeTypeMap(map);
     return map;
   }
 
@@ -2034,7 +1989,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /** @internal */
   private connect(): void {
-    this.db = new Database(this._filename, { readonly: this._readonly });
+    try {
+      this.db = new Database(this._filename, { readonly: this._readonly });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new DatabaseConnectionError(`Unable to open database '${this._filename}': ${msg}`, {
+        cause: e,
+      });
+    }
   }
 
   /** @internal */
@@ -2051,7 +2013,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       | Record<string, unknown>
       | undefined;
     if (pragmas) {
+      // Validate pragma name is a safe SQLite identifier before interpolating.
+      const SAFE_PRAGMA = /^\w+$/;
       for (const [pragma, value] of Object.entries(pragmas)) {
+        if (!SAFE_PRAGMA.test(pragma)) {
+          console.warn(`Skipping invalid SQLite pragma name: ${pragma}`);
+          continue;
+        }
         try {
           this.db.pragma(`${pragma} = ${String(value)}`);
         } catch {
@@ -2068,15 +2036,38 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     m.registerType("text", new TextType());
     m.registerType("integer", sqlite3Int());
     m.registerType("float", new FloatType());
+    m.registerType(/decimal|numeric/i, undefined, (sqlType) => {
+      const precisionMatch = /\(\s*(\d+)/.exec(sqlType);
+      const precision = precisionMatch ? parseInt(precisionMatch[1], 10) : undefined;
+      const scaleMatch = /\(\s*\d+\s*,\s*(\d+)\s*\)/.exec(sqlType);
+      const scale = scaleMatch
+        ? parseInt(scaleMatch[1], 10)
+        : precision !== undefined
+          ? 0
+          : undefined;
+      if (scale === 0) return new DecimalWithoutScale({ precision });
+      return new DecimalType({ precision, scale });
+    });
     m.registerType("decimal", new DecimalType());
     m.registerType("boolean", new BooleanType());
+    // better-sqlite3 returns datetime columns as TEXT; SQLiteDateTimeType converts
+    // offset-less strings to Temporal.Instant using the configured default_timezone.
     m.registerType("date", new DateType());
     m.registerType("datetime", new SQLiteDateTimeType());
+    m.registerType("timestamp", new SQLiteDateTimeType());
     m.registerType("time", new TimeType());
+    m.registerType("blob", new BinaryType());
     m.registerType("binary", new BinaryType());
     m.registerType("json", new JsonType());
+    m.registerType("numeric", new DecimalWithoutScale());
+    // SQLite type affinity — regex matches for flexible type names
     m.registerType(/int/i, undefined, (k) => (/bigint/i.test(k) ? sqlite3Int(8) : sqlite3Int()));
+    // Explicit "bigint" registered after /int/i so it takes priority on exact matches.
     m.registerType("bigint", sqlite3Int(8));
+    m.registerType(/char/i, undefined, () => new StringType());
+    m.registerType(/clob/i, undefined, () => new TextType());
+    m.registerType(/blob/i, undefined, () => new BinaryType());
+    m.registerType(/real|floa|doub/i, undefined, () => new FloatType());
   }
 }
 
@@ -2134,7 +2125,8 @@ function extractDefaultFunction(defaultValue: unknown, default_: string): string
 /** @internal */
 function hasDefaultFunction(defaultValue: unknown, default_: string): boolean {
   return (
-    !defaultValue && /\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|/.test(default_)
+    defaultValue == null &&
+    /\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|/.test(default_)
   );
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1946,7 +1946,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     const msg = e instanceof Error ? e.message : String(e);
-    const exc = e instanceof Error ? e : new Error(msg);
+    // Wrap non-Error throws so translateException always receives an Error,
+    // but preserve the original thrown value as the cause so it isn't dropped.
+    const exc = e instanceof Error ? e : new Error(msg, { cause: e });
     return translateException(exc, msg, sql, binds);
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -4,7 +4,7 @@ import type {
   AdapterName,
   DatabaseAdapter,
   ExplainOption,
-  TrailsAdapterOptions,
+  SQLite3AdapterOptions,
 } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
@@ -183,10 +183,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     this._statementPool.setMaxSize(value);
   }
 
-  constructor(
-    filename: string | ":memory:" = ":memory:",
-    options: TrailsAdapterOptions & { readonly?: boolean } = {},
-  ) {
+  constructor(filename: string | ":memory:" = ":memory:", options: SQLite3AdapterOptions = {}) {
     super();
     this._config = { ...options };
     this._filename = filename;
@@ -1999,21 +1996,33 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       this.db.pragma("journal_size_limit = 67108864");
       this.db.pragma("cache_size = 2000");
     }
-    const pragmas = (this._config as Record<string, unknown>)?.pragmas as
-      | Record<string, unknown>
-      | undefined;
+    const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {
       // Validate pragma name is a safe SQLite identifier before interpolating.
-      const SAFE_PRAGMA = /^\w+$/;
+      const SAFE_PRAGMA_NAME = /^\w+$/;
+      // Restrict values to identifier-like strings (enum pragmas) or scalars.
+      const SAFE_PRAGMA_VALUE = /^\w+$/;
       for (const [pragma, value] of Object.entries(pragmas)) {
-        if (!SAFE_PRAGMA.test(pragma)) {
+        if (!SAFE_PRAGMA_NAME.test(pragma)) {
           console.warn(`Skipping invalid SQLite pragma name: ${pragma}`);
           continue;
         }
+        const scalar =
+          typeof value === "number" || typeof value === "boolean"
+            ? String(value)
+            : SAFE_PRAGMA_VALUE.test(String(value))
+              ? String(value)
+              : null;
+        if (scalar === null) {
+          console.warn(`Skipping SQLite pragma '${pragma}': value contains unsafe characters`);
+          continue;
+        }
         try {
-          this.db.pragma(`${pragma} = ${String(value)}`);
-        } catch {
-          console.warn(`Unknown SQLite pragma: ${pragma}`);
+          this.db.pragma(`${pragma} = ${scalar}`);
+        } catch (e) {
+          console.warn(
+            `SQLite pragma '${pragma}' failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
         }
       }
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2008,11 +2008,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
           continue;
         }
         const scalar =
-          typeof value === "number" || typeof value === "boolean"
-            ? String(value)
-            : SAFE_PRAGMA_VALUE.test(String(value))
+          typeof value === "boolean"
+            ? value
+              ? "1"
+              : "0"
+            : typeof value === "number"
               ? String(value)
-              : null;
+              : SAFE_PRAGMA_VALUE.test(value)
+                ? value
+                : null;
         if (scalar === null) {
           console.warn(`Skipping SQLite pragma '${pragma}': value contains unsafe characters`);
           continue;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -134,7 +134,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return new Visitors.SQLite(this);
   }
 
-  private db: Database.Database;
+  private db!: Database.Database;
   override get active(): boolean {
     return this.db?.open ?? false;
   }
@@ -199,18 +199,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // Apply adapter-level options FIRST so invalid values fail before
     // the native driver opens a file handle that would otherwise leak.
     if (options.statementLimit !== undefined) this.statementLimit = options.statementLimit;
-    try {
-      this.db = new Database(filename, { readonly: this._readonly });
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      throw new DatabaseConnectionError(`Unable to open database '${filename}': ${msg}`, {
-        cause: e,
-      });
-    }
-    if (!this._readonly) {
-      this.db.pragma("journal_mode = WAL");
-      this.db.pragma("foreign_keys = ON");
-    }
+    this.connect();
+    this.configureConnection();
     this._nativeTypeMap = SQLite3Adapter._buildTypeMap();
   }
 


### PR DESCRIPTION
## Summary

- Implements 10 missing private methods on `SQLite3Adapter`, bringing `sqlite3_adapter.rb` from 86% to 100% (72/72).
- Constructor delegates to `connect()` + `configureConnection()` — single source of truth for connection lifecycle.
- `_buildTypeMap()` delegates to `initializeTypeMap()` — single registration path for both.
- `_translateException` delegates to file-level `translateException` — one error-translation path.
- `_statementPool` constructed via `buildStatementPool()` — single pool constructor.
- `SQLite3AdapterOptions` added to `adapter.ts` with typed `pragmas` option.

**Methods added:**

| Method | Rails | Approach |
|---|---|---|
| `buildStatementPool` | private instance | private instance method |
| `connect` | private instance | private instance method |
| `configureConnection` | private instance | private instance method |
| `initializeTypeMap` | class method | private static method |
| `bindParamsLength` | private | file-level helper |
| `extractValueFromDefault` | private | file-level helper (delegates to quoting.ts) |
| `extractDefaultFunction` | private | file-level helper |
| `hasDefaultFunction` | private | file-level helper |
| `isInvalidAlterTableType` | private | file-level helper |
| `translateException` | private | file-level helper (message + error-code based) |

`configureConnection` applies all six Rails `DEFAULT_PRAGMAS` (`foreign_keys`, `journal_mode`, `synchronous`, `mmap_size`, `journal_size_limit`, `cache_size`) best-effort (each in try/catch). The original constructor only set two; this is a Rails-parity improvement.

## Known open concerns (Copilot cycle limit reached)

1. **Non-finite numeric pragma values not guarded** — `String(NaN)` / `String(Infinity)` would reach `PRAGMA ... = NaN`, which SQLite rejects and triggers the catch/warn path. Harmless at runtime but could be made deterministic with an explicit `Number.isFinite` check and an early warn+skip before interpolation.

2. **`extractDefaultFunction`/`hasDefaultFunction` regex diverges from `schema-statements.ts`** — The file-level `hasDefaultFunction` uses `/\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|/` (no `/i` flag, includes `CURRENT_TIMESTAMP` and `||`). The existing `_extractDefaultFunction` in `sqlite3/schema-statements.ts` uses a different pattern. These are separate call sites: schema-statements uses its helper for column introspection; the file-level one here mirrors Rails `sqlite3_adapter.rb` directly. The regex in `sqlite3_adapter.rb` is `%r{\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|}` — which is exactly what the file-level function implements. Both are correct for their respective Rails source files; centralizing is a refactor for a future PR.

## Test plan

- [x] `pnpm api:compare --package activerecord -- --file sqlite3_adapter.rb` → 72/72 (100%)
- [x] `pnpm vitest run packages/activerecord/src/adapters/sqlite3-adapter.test.ts` → 49/49 pass
- [x] `git diff --shortstat origin/main...HEAD` → < 300 LOC

Follows wave 4, PR 24b from `docs/activerecord-100-plan.md`.