### PR TITLE
feat(activerecord): mysql2_adapter.rb to 100% (Wave 4 PR 22)

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -770,11 +770,12 @@ describeIfMysql("Mysql2Adapter", () => {
 
   // -- Connection lifecycle (mirrors mysql2/connection_test.rb) --
   describe("connection lifecycle", () => {
-    it("getFullVersion returns a semver string and populates fullVersion", async () => {
+    it("getFullVersion returns the raw server version string and populates fullVersion", async () => {
       const full = await (adapter as any).getFullVersion();
       expect(typeof full).toBe("string");
       expect(full).toMatch(/\d+\.\d+\.\d+/);
-      expect((adapter as any).fullVersion()).toBe(full.match(/\d+\.\d+\.\d+/)?.[0]);
+      // fullVersion() mirrors Rails' full_version → returns the raw string
+      expect((adapter as any).fullVersion()).toBe(full);
     });
 
     it("isTextType returns true for char/varchar/text, false for int", () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -767,4 +767,36 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
   });
+
+  // -- Connection lifecycle (mirrors mysql2/connection_test.rb) --
+  describe("connection lifecycle", () => {
+    it("getFullVersion returns a semver string and populates fullVersion", async () => {
+      const full = await (adapter as any).getFullVersion();
+      expect(typeof full).toBe("string");
+      expect(full).toMatch(/\d+\.\d+\.\d+/);
+      expect((adapter as any).fullVersion()).toBe(full.match(/\d+\.\d+\.\d+/)?.[0]);
+    });
+
+    it("isTextType returns true for char/varchar/text, false for int", () => {
+      expect((adapter as any).isTextType("varchar(255)")).toBe(true);
+      expect((adapter as any).isTextType("char(10)")).toBe(true);
+      expect((adapter as any).isTextType("text")).toBe(true);
+      expect((adapter as any).isTextType("int")).toBe(false);
+      expect((adapter as any).isTextType("bigint")).toBe(false);
+    });
+
+    it("connect is a no-op and leaves the adapter connected", () => {
+      expect(adapter.isConnected()).toBe(true);
+      (adapter as any).connect();
+      expect(adapter.isConnected()).toBe(true);
+    });
+
+    it("configureConnection is a no-op", () => {
+      expect(() => (adapter as any).configureConnection()).not.toThrow();
+    });
+
+    it("defaultPreparedStatements returns false", () => {
+      expect((adapter as any).defaultPreparedStatements()).toBe(false);
+    });
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -770,12 +770,15 @@ describeIfMysql("Mysql2Adapter", () => {
 
   // -- Connection lifecycle (mirrors mysql2/connection_test.rb) --
   describe("connection lifecycle", () => {
-    it("getFullVersion returns the raw server version string and populates fullVersion", async () => {
+    it("fullVersion returns the real server version string without a prior warm-up call", async () => {
+      const ver = await (adapter as any).fullVersion();
+      expect(typeof ver).toBe("string");
+      expect(ver).toMatch(/\d+\.\d+\.\d+/);
+    });
+
+    it("getFullVersion populates fullVersion cache", async () => {
       const full = await (adapter as any).getFullVersion();
-      expect(typeof full).toBe("string");
-      expect(full).toMatch(/\d+\.\d+\.\d+/);
-      // fullVersion() mirrors Rails' full_version → returns the raw string
-      expect((adapter as any).fullVersion()).toBe(full);
+      expect(await (adapter as any).fullVersion()).toBe(full);
     });
 
     it("isTextType returns true for char/varchar/text, false for int", () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -776,7 +776,29 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(ver).toMatch(/\d+\.\d+\.\d+/);
     });
 
-    it("getFullVersion populates fullVersion cache", async () => {
+    it("getFullVersion returns the full raw string including any server suffix", async () => {
+      const full = await (adapter as any).getFullVersion();
+      // The raw string from SELECT VERSION() may include suffixes like
+      // "-MySQL Community Server - GPL" or "10.x.x-MariaDB". We store it
+      // verbatim so fullVersion() can report it faithfully.
+      expect(full).toBe((adapter as any)._fullVersionString);
+    });
+
+    it("getFullVersion populates _databaseVersion with the parsed semver", async () => {
+      await (adapter as any).getFullVersion();
+      const dv = (adapter as any)._databaseVersion;
+      expect(dv).not.toBeNull();
+      expect(typeof dv.toString()).toBe("string");
+      expect(dv.toString()).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it("getFullVersion sets _mariadb based on version string content", async () => {
+      const full = await (adapter as any).getFullVersion();
+      const expectedMariadb = /mariadb/i.test(full);
+      expect((adapter as any)._mariadb).toBe(expectedMariadb);
+    });
+
+    it("getFullVersion cache: second call via fullVersion returns same value", async () => {
       const full = await (adapter as any).getFullVersion();
       expect(await (adapter as any).fullVersion()).toBe(full);
     });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -811,6 +811,12 @@ describeIfMysql("Mysql2Adapter", () => {
       expect((adapter as any).isTextType("bigint")).toBe(false);
     });
 
+    it("isTextType normalizes case and whitespace like lookupCastType", () => {
+      expect((adapter as any).isTextType("  VARCHAR(255)  ")).toBe(true);
+      expect((adapter as any).isTextType("TEXT")).toBe(true);
+      expect((adapter as any).isTextType("  INT  ")).toBe(false);
+    });
+
     it("connect is a no-op and leaves the adapter connected", () => {
       expect(adapter.isConnected()).toBe(true);
       (adapter as any).connect();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -167,6 +167,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // don't expose it, so we detect once and remember. `undefined` =
   // not yet probed, `true`/`false` = result.
   private _statisticsHasExpression: boolean | undefined;
+  private _fullVersionString: string | null = null;
 
   constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
     super();
@@ -1039,6 +1040,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         unknown,
       ];
       const ver = row?.v ?? "0.0.0";
+      this._fullVersionString = ver;
       this._mariadb = /mariadb/i.test(ver);
       this._databaseVersion = new Version(this.versionString(ver));
       return ver;
@@ -1048,11 +1050,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Return the full version string as stored by the last getFullVersion call.
+   * Return the full raw version string from the last getFullVersion call.
+   * Mirrors Rails' full_version → database_version.full_version_string.
    * @internal
    */
   fullVersion(): string {
-    return this._databaseVersion?.toString() ?? "0.0.0";
+    return this._fullVersionString ?? "0.0.0";
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1,11 +1,13 @@
 import mysql from "mysql2/promise";
 import { Notifications } from "@blazetrails/activesupport";
+import { StringType } from "@blazetrails/activemodel";
 import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import {
   AbstractMysqlAdapter,
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
+import { Version } from "./abstract-adapter.js";
 import { MismatchedForeignKey, NotImplementedError } from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
@@ -14,6 +16,7 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
+import { Text as TextType } from "../type/text.js";
 
 /**
  * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
@@ -1003,6 +1006,60 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return results;
   }
 
+  /** @internal */
+  private isTextType(type: string): boolean {
+    const t = this.nativeTypeMap.lookup(type);
+    return t instanceof StringType || t instanceof TextType;
+  }
+
+  /** @internal */
+  private connect(): void {
+    // Pool is the connection in the Node.js mysql2 model; the pool is
+    // created eagerly in the constructor via newClient. Rails' connect
+    // sets @raw_connection — we have no equivalent single-socket handle.
+  }
+
+  /** @internal */
+  private configureConnection(): void {
+    // In Rails this sets @raw_connection.query_options[:as] = :array and
+    // database_timezone. In our pool model these options are applied via
+    // the pool.on("connection") hook inside newClient — no work here.
+  }
+
+  /**
+   * Fetch the raw version string from the server (e.g. "8.0.28").
+   * Populates _databaseVersion and _mariadb as a side effect.
+   * @internal
+   */
+  async getFullVersion(): Promise<string> {
+    const conn = await this.getConn();
+    try {
+      const [[row]] = (await conn.query("SELECT VERSION() AS v")) as [
+        Array<{ v: string }>,
+        unknown,
+      ];
+      const ver = row?.v ?? "0.0.0";
+      this._mariadb = /mariadb/i.test(ver);
+      this._databaseVersion = new Version(this.versionString(ver));
+      return ver;
+    } finally {
+      this.releaseConn(conn);
+    }
+  }
+
+  /**
+   * Return the full version string as stored by the last getFullVersion call.
+   * @internal
+   */
+  fullVersion(): string {
+    return this._databaseVersion?.toString() ?? "0.0.0";
+  }
+
+  /** @internal */
+  private defaultPreparedStatements(): boolean {
+    return false;
+  }
+
   static newClient(config: mysql.PoolOptions): mysql.Pool {
     // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
     // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
@@ -1049,20 +1106,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 }
 
 /** @internal */
-function isTextType(type: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#text_type? is not implemented",
-  );
-}
-
-/** @internal */
-function connect(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#connect is not implemented",
-  );
-}
-
-/** @internal */
 function reconnect(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#reconnect is not implemented",
@@ -1070,37 +1113,9 @@ function reconnect(): never {
 }
 
 /** @internal */
-function configureConnection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#configure_connection is not implemented",
-  );
-}
-
-/** @internal */
-function fullVersion(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#full_version is not implemented",
-  );
-}
-
-/** @internal */
-function getFullVersion(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#get_full_version is not implemented",
-  );
-}
-
-/** @internal */
 function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#translate_exception is not implemented",
-  );
-}
-
-/** @internal */
-function defaultPreparedStatements(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#default_prepared_statements is not implemented",
   );
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1009,7 +1009,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /** @internal */
   private isTextType(type: string): boolean {
-    const t = this.nativeTypeMap.lookup(type);
+    const t = this.nativeTypeMap.lookup(type.toLowerCase().trim());
     return t instanceof StringType || t instanceof TextType;
   }
 
@@ -1034,6 +1034,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * @internal
    */
   async getFullVersion(): Promise<string> {
+    if (this._fullVersionString) return this._fullVersionString;
     const conn = await this.getConn();
     try {
       const [[row]] = (await conn.query("SELECT VERSION() AS v")) as [

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1050,11 +1050,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Return the full raw version string from the last getFullVersion call.
-   * Mirrors Rails' full_version → database_version.full_version_string.
+   * Return the full raw version string, lazily fetching it if needed.
+   * Mirrors Rails' full_version → database_version.full_version_string,
+   * which always returns the real server version without a separate warm-up.
    * @internal
    */
-  fullVersion(): string {
+  async fullVersion(): Promise<string> {
+    if (!this._fullVersionString) await this.getFullVersion();
     return this._fullVersionString ?? "0.0.0";
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1023,8 +1023,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   /** @internal */
   private configureConnection(): void {
     // In Rails this sets @raw_connection.query_options[:as] = :array and
-    // database_timezone. In our pool model these options are applied via
-    // the pool.on("connection") hook inside newClient — no work here.
+    // database_timezone on the single raw connection. In our pool model
+    // we have no single raw connection to configure here; mysql2's typeCast
+    // handles temporal fields and results are returned as objects (not arrays).
   }
 
   /**


### PR DESCRIPTION
## Summary

- Implements 6 missing private methods on \`Mysql2Adapter\` to bring \`mysql2_adapter.rb\` from 73% (16/22) to 100% (22/22): \`isTextType\`, \`connect\`, \`configureConnection\`, \`getFullVersion\`, \`fullVersion\`, \`defaultPreparedStatements\`
- \`getFullVersion\` queries \`SELECT VERSION()\` to populate \`_databaseVersion\` and detect MariaDB, returning the full raw server version string (e.g. "8.0.28-MySQL Community Server - GPL")
- \`fullVersion\` is async and lazily calls \`getFullVersion\` if not yet cached, mirroring Rails' guarantee that the real version is always returned without a separate warm-up
- \`connect\` and \`configureConnection\` are no-ops in the pool model (pool is created in constructor / connection events handle session config)
- Removes 6 top-level \`NotImplementedError\` stubs and replaces with real class methods
- Adds connection-lifecycle tests mirroring \`mysql2/connection_test.rb\`

## Test plan

- [x] \`pnpm api:compare --package activerecord\` → \`mysql2_adapter.rb\` shows 22/22 100% ✓
- [x] \`git diff --shortstat\` → well under 300 LOC ceiling
- [ ] Run \`pnpm test --filter activerecord mysql2-adapter.test.ts\` against a live MySQL instance to exercise \`getFullVersion\`, \`fullVersion\`, \`isTextType\`, \`connect\`, \`configureConnection\`, \`defaultPreparedStatements\` tests