### PR TITLE
feat(activerecord): attributes.rb + aggregations.rb to 100% (Wave 7 PR 28)

### DIFF
--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { reload as persistenceReload } from "./persistence.js";
 import { AggregateReflection } from "./reflection.js";
@@ -67,29 +66,61 @@ export function composedOf(
     ),
   );
 
+  readerMethod(modelClass, name, options.mapping, options.className);
+  writerMethod(modelClass, name, options.mapping, options.className, options.converter);
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Aggregations::ClassMethods#reader_method
+ */
+function readerMethod(
+  modelClass: typeof Base,
+  name: string,
+  mapping: [string, string][],
+  klass: new (...args: any[]) => any,
+): void {
+  const descriptor = (Object.getOwnPropertyDescriptor(modelClass.prototype, name) ??
+    {}) as PropertyDescriptor;
   Object.defineProperty(modelClass.prototype, name, {
+    ...descriptor,
     get(this: Base): unknown {
       const cache = getAggregationCache(this);
       if (cache.has(name)) return cache.get(name);
-
-      const args = options.mapping.map(([modelAttr]) => this.readAttribute(modelAttr));
+      const args = mapping.map(([modelAttr]) => this.readAttribute(modelAttr));
       if (args.every((a) => a === null || a === undefined)) return null;
-
-      const obj = Object.freeze(new options.className(...args));
+      const obj = Object.freeze(new klass(...args));
       cache.set(name, obj);
       return obj;
     },
+    configurable: true,
+  });
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Aggregations::ClassMethods#writer_method
+ */
+function writerMethod(
+  modelClass: typeof Base,
+  name: string,
+  mapping: [string, string][],
+  klass: new (...args: any[]) => any,
+  converter?: (value: unknown) => unknown,
+): void {
+  const descriptor = (Object.getOwnPropertyDescriptor(modelClass.prototype, name) ??
+    {}) as PropertyDescriptor;
+  Object.defineProperty(modelClass.prototype, name, {
+    ...descriptor,
     set(this: Base, value: unknown): void {
       const cache = getAggregationCache(this);
-
       if (value === null || value === undefined) {
-        for (const [modelAttr] of options.mapping) this.writeAttribute(modelAttr, null);
+        for (const [modelAttr] of mapping) this.writeAttribute(modelAttr, null);
         cache.delete(name);
         return;
       }
-
-      if (value instanceof options.className) {
-        for (const [modelAttr, valueAttr] of options.mapping)
+      if (value instanceof klass) {
+        for (const [modelAttr, valueAttr] of mapping)
           this.writeAttribute(modelAttr, (value as any)[valueAttr]);
         cache.set(
           name,
@@ -97,11 +128,10 @@ export function composedOf(
         );
         return;
       }
-
-      if (options.converter) {
-        const converted = options.converter(value);
-        if (converted instanceof options.className) {
-          for (const [modelAttr, valueAttr] of options.mapping)
+      if (converter) {
+        const converted = converter(value);
+        if (converted instanceof klass) {
+          for (const [modelAttr, valueAttr] of mapping)
             this.writeAttribute(modelAttr, (converted as any)[valueAttr]);
           cache.set(
             name,
@@ -148,17 +178,10 @@ export const InstanceMethods = {
   reload,
 };
 
-/** @internal */
-function initInternals(): never {
-  throw new NotImplementedError("ActiveRecord::Aggregations#init_internals is not implemented");
-}
-
-/** @internal */
-function readerMethod(): never {
-  throw new NotImplementedError("ActiveRecord::Aggregations#reader_method is not implemented");
-}
-
-/** @internal */
-function writerMethod(): never {
-  throw new NotImplementedError("ActiveRecord::Aggregations#writer_method is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Aggregations#init_internals
+ */
+function initInternals(this: Base): void {
+  (this as any)._aggregationCache = new Map<string, unknown>();
 }

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -80,10 +80,9 @@ function readerMethod(
   mapping: [string, string][],
   klass: new (...args: any[]) => any,
 ): void {
-  const descriptor = (Object.getOwnPropertyDescriptor(modelClass.prototype, name) ??
-    {}) as PropertyDescriptor;
+  const existing = Object.getOwnPropertyDescriptor(modelClass.prototype, name);
   Object.defineProperty(modelClass.prototype, name, {
-    ...descriptor,
+    enumerable: existing?.enumerable ?? false,
     get(this: Base): unknown {
       const cache = getAggregationCache(this);
       if (cache.has(name)) return cache.get(name);
@@ -108,10 +107,10 @@ function writerMethod(
   klass: new (...args: any[]) => any,
   converter?: (value: unknown) => unknown,
 ): void {
-  const descriptor = (Object.getOwnPropertyDescriptor(modelClass.prototype, name) ??
-    {}) as PropertyDescriptor;
+  const existing = Object.getOwnPropertyDescriptor(modelClass.prototype, name);
   Object.defineProperty(modelClass.prototype, name, {
-    ...descriptor,
+    enumerable: existing?.enumerable ?? false,
+    get: existing?.get,
     set(this: Base, value: unknown): void {
       const cache = getAggregationCache(this);
       if (value === null || value === undefined) {

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -8,18 +8,18 @@
  * Mirrors: ActiveRecord::Attributes
  */
 
-import { NotImplementedError } from "./errors.js";
 import {
   Attribute,
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
-  resetDefaultAttributes,
+  resetDefaultAttributes as amResetDefaultAttributes,
   registerWithSuperclass,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import type { Base } from "./base.js";
 import { applyPendingEncryptions } from "./encryption.js";
+import { lookup as typeLookup } from "./type.js";
 
 type AnyClass = any;
 
@@ -95,7 +95,7 @@ export function defineAttribute(
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
 
-  resetDefaultAttributes(this);
+  amResetDefaultAttributes(this);
   applyPendingEncryptions(this);
 
   // Install prototype accessor so the attribute is readable/writable by name,
@@ -178,26 +178,64 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
   return cacheHost._cachedDefaultAttributes;
 }
 
-/** @internal */
-function reloadSchemaFromCache(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Attributes#reload_schema_from_cache is not implemented",
-  );
+const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#reload_schema_from_cache
+ */
+function reloadSchemaFromCache(this: AnyClass): void {
+  amResetDefaultAttributes(this);
 }
 
-/** @internal */
-function defineDefaultAttribute(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Attributes#define_default_attribute is not implemented",
-  );
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#define_default_attribute
+ */
+function defineDefaultAttribute(
+  this: AnyClass,
+  name: string,
+  value: unknown,
+  type: Type,
+  fromUser: boolean,
+): void {
+  const defaults = _defaultAttributes.call(this);
+  let defaultAttr: Attribute;
+  if (value === NO_DEFAULT_PROVIDED) {
+    defaultAttr = defaults.getAttribute(name).withType(type);
+  } else if (fromUser) {
+    const existing = defaults.getAttribute(name);
+    defaultAttr = existing.withType(type).withUserDefault(value);
+  } else {
+    defaultAttr = Attribute.fromDatabase(name, value, type);
+  }
+  defaults.set(name, defaultAttr);
 }
 
-/** @internal */
-function resolveTypeName(): never {
-  throw new NotImplementedError("ActiveRecord::Attributes#resolve_type_name is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#reset_default_attributes
+ */
+function resetDefaultAttributes(this: AnyClass): void {
+  reloadSchemaFromCache.call(this);
 }
 
-/** @internal */
-function typeForColumn(): never {
-  throw new NotImplementedError("ActiveRecord::Attributes#type_for_column is not implemented");
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#resolve_type_name
+ */
+function resolveTypeName(this: AnyClass, name: string): Type {
+  return typeLookup(name) as Type;
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#type_for_column
+ */
+function typeForColumn(
+  this: AnyClass,
+  _connection: unknown,
+  column: { name: string; type: Type },
+): Type {
+  return column.type;
 }


### PR DESCRIPTION
## Summary

- **attributes.rb 29% → 100%**: implement `reloadSchemaFromCache`, `defineDefaultAttribute`, `resetDefaultAttributes`, `resolveTypeName`, `typeForColumn` — replacing the existing `NotImplementedError` stubs with real logic wired to `amResetDefaultAttributes` (AM's cache reset) and the AR type registry's `lookup`
- **aggregations.rb 50% → 100%**: extract `readerMethod` and `writerMethod` from the monolithic `composedOf` into separate private helpers (which `composedOf` now calls), and implement `initInternals` to initialize `_aggregationCache` as a `Map`
- 161 LOC net, no new files

## Test plan

- [ ] `pnpm api:compare --package activerecord` shows both files at 100% ✓
- [ ] `packages/activerecord/src/attributes.test.ts` — 55 tests pass ✓
- [ ] `packages/activerecord/src/aggregations.test.ts` — 51 tests (21 skipped) pass ✓
- [ ] Full AR test suite: 303 files pass, 1 pre-existing failure in `tsc-wrapper/cli.test.ts` (unrelated)