### PR TITLE
feat(activerecord): sqlite driver interface + better-sqlite3 wrapper

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
@@ -72,4 +72,16 @@ describe("SqliteDriver — better-sqlite3 round-trip", () => {
     const result = await driver.pragma("journal_mode");
     expect(result).toBeDefined();
   });
+
+  it("driver.open is true while connected", () => {
+    expect(driver.open).toBe(true);
+  });
+
+  it("statement.reader is true for SELECT, false for INSERT", async () => {
+    const sel = await driver.prepare("SELECT 1");
+    expect(sel.reader).toBe(true);
+
+    const ins = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    expect(ins.reader).toBe(false);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { ColumnInfo, SqliteDriver } from "./driver.js";
+import { betterSqlite3DriverFactory } from "./drivers/better-sqlite3.js";
+
+describe("SqliteDriver — better-sqlite3 round-trip", () => {
+  let driver: SqliteDriver;
+
+  beforeAll(async () => {
+    driver = await betterSqlite3DriverFactory.open({ database: ":memory:" });
+    const stmt = await driver.prepare(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, qty INTEGER)",
+    );
+    await stmt.run();
+  });
+
+  afterAll(async () => {
+    await driver.close();
+  });
+
+  it("inserts and retrieves a row", async () => {
+    const insert = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    const result = await insert.run("sprocket", 42);
+    expect(result.changes).toBe(1);
+    expect(
+      typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
+    ).toBe(true);
+
+    const select = await driver.prepare("SELECT id, name, qty FROM widgets WHERE name = ?");
+    const row = (await select.get("sprocket")) as Record<string, unknown>;
+    expect(row["name"]).toBe("sprocket");
+    expect(row["qty"]).toBe(42);
+  });
+
+  it("returns all rows", async () => {
+    const insert = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    await insert.run("gear", 7);
+
+    const select = await driver.prepare("SELECT id, name, qty FROM widgets ORDER BY id");
+    const rows = (await select.all()) as Record<string, unknown>[];
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("columns() matches ColumnInfo shape", async () => {
+    const stmt = await driver.prepare("SELECT id, name, qty FROM widgets");
+    const cols: ColumnInfo[] = stmt.columns();
+    expect(cols.length).toBe(3);
+    for (const col of cols) {
+      expect(typeof col.name).toBe("string");
+      expect(col.column === null || typeof col.column === "string").toBe(true);
+      expect(col.table === null || typeof col.table === "string").toBe(true);
+      expect(col.database === null || typeof col.database === "string").toBe(true);
+      expect(col.type === null || typeof col.type === "string").toBe(true);
+    }
+    expect(cols[0]!.name).toBe("id");
+    expect(cols[1]!.name).toBe("name");
+    expect(cols[2]!.name).toBe("qty");
+  });
+
+  it("setReadBigInts enables bigint returns", async () => {
+    const stmt = await driver.prepare("SELECT qty FROM widgets WHERE name = ?");
+    stmt.setReadBigInts(true);
+    const row = (await stmt.get("sprocket")) as Record<string, unknown>;
+    expect(typeof row["qty"]).toBe("bigint");
+  });
+
+  it("exec runs SQL", async () => {
+    await driver.exec("CREATE TABLE IF NOT EXISTS tmp_exec (x INTEGER)");
+    await driver.exec("DROP TABLE tmp_exec");
+  });
+
+  it("pragma returns a value", async () => {
+    const result = await driver.pragma("journal_mode");
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts
@@ -7,37 +7,42 @@ describe("SqliteDriver — better-sqlite3 round-trip", () => {
 
   beforeAll(async () => {
     driver = await betterSqlite3DriverFactory.open({ database: ":memory:" });
-    const stmt = await driver.prepare(
+    const create = await driver.prepare(
       "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, qty INTEGER)",
     );
-    await stmt.run();
+    await create.run();
+    const insert = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    await insert.run("sprocket", 42);
+    await insert.run("gear", 7);
   });
 
   afterAll(async () => {
     await driver.close();
   });
 
-  it("inserts and retrieves a row", async () => {
-    const insert = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
-    const result = await insert.run("sprocket", 42);
-    expect(result.changes).toBe(1);
-    expect(
-      typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
-    ).toBe(true);
-
+  it("retrieves a row by name", async () => {
     const select = await driver.prepare("SELECT id, name, qty FROM widgets WHERE name = ?");
     const row = (await select.get("sprocket")) as Record<string, unknown>;
     expect(row["name"]).toBe("sprocket");
     expect(row["qty"]).toBe(42);
   });
 
-  it("returns all rows", async () => {
+  it("run() returns changes and lastInsertRowid", async () => {
     const insert = await driver.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
-    await insert.run("gear", 7);
+    const result = await insert.run("bolt", 99);
+    expect(result.changes).toBe(1);
+    expect(
+      typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
+    ).toBe(true);
+  });
 
+  it("returns all rows", async () => {
     const select = await driver.prepare("SELECT id, name, qty FROM widgets ORDER BY id");
     const rows = (await select.all()) as Record<string, unknown>[];
     expect(rows.length).toBeGreaterThanOrEqual(2);
+    const names = rows.map((r) => r["name"]);
+    expect(names).toContain("sprocket");
+    expect(names).toContain("gear");
   });
 
   it("columns() matches ColumnInfo shape", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
@@ -21,6 +21,8 @@ export interface SqliteStatement {
   all(...binds: unknown[]): unknown[] | Promise<unknown[]>;
   columns(): ColumnInfo[];
   setReadBigInts(on: boolean): void;
+  /** True when the statement returns rows (SELECT/PRAGMA that yields rows). */
+  readonly reader: boolean;
   finalize?(): void | Promise<void>;
 }
 
@@ -29,6 +31,8 @@ export interface SqliteDriver {
   exec(sql: string): void | Promise<void>;
   pragma(source: string, opts?: { simple?: boolean }): unknown | Promise<unknown>;
   close(): void | Promise<void>;
+  /** True while the database connection is open. */
+  readonly open: boolean;
   readonly raw: unknown;
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
@@ -1,6 +1,8 @@
-import type { SQLite3AdapterOptions } from "../../adapter.js";
-
-export type SqliteConfig = SQLite3AdapterOptions & { database: string };
+/** Minimal driver-level config — adapter-only knobs live on SQLite3AdapterOptions. */
+export interface SqliteConfig {
+  database: string;
+  readonly?: boolean;
+}
 
 export interface RunResult {
   changes: number;

--- a/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/driver.ts
@@ -1,0 +1,38 @@
+import type { SQLite3AdapterOptions } from "../../adapter.js";
+
+export type SqliteConfig = SQLite3AdapterOptions & { database: string };
+
+export interface RunResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+export interface ColumnInfo {
+  name: string;
+  column: string | null;
+  table: string | null;
+  database: string | null;
+  type: string | null;
+}
+
+export interface SqliteStatement {
+  run(...binds: unknown[]): RunResult | Promise<RunResult>;
+  get(...binds: unknown[]): unknown | Promise<unknown>;
+  all(...binds: unknown[]): unknown[] | Promise<unknown[]>;
+  columns(): ColumnInfo[];
+  setReadBigInts(on: boolean): void;
+  finalize?(): void | Promise<void>;
+}
+
+export interface SqliteDriver {
+  prepare(sql: string): SqliteStatement | Promise<SqliteStatement>;
+  exec(sql: string): void | Promise<void>;
+  pragma(source: string, opts?: { simple?: boolean }): unknown | Promise<unknown>;
+  close(): void | Promise<void>;
+  readonly raw: unknown;
+}
+
+export interface DriverFactory {
+  readonly name: string;
+  open(config: SqliteConfig): Promise<SqliteDriver>;
+}

--- a/packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts
@@ -25,6 +25,10 @@ class BetterSqlite3Statement implements SqliteStatement {
     return this.stmt.all(...binds) as unknown[];
   }
 
+  get reader(): boolean {
+    return this.stmt.reader;
+  }
+
   columns(): ColumnInfo[] {
     return this.stmt.columns().map((c) => ({
       name: c.name,
@@ -55,6 +59,10 @@ class BetterSqlite3Driver implements SqliteDriver {
 
   prepare(sql: string): BetterSqlite3Statement {
     return new BetterSqlite3Statement(this.raw.prepare(sql));
+  }
+
+  get open(): boolean {
+    return this.raw.open;
   }
 
   exec(sql: string): void {

--- a/packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts
@@ -1,0 +1,80 @@
+import Database from "better-sqlite3";
+import type {
+  ColumnInfo,
+  DriverFactory,
+  RunResult,
+  SqliteConfig,
+  SqliteDriver,
+  SqliteStatement,
+} from "../driver.js";
+
+/** @internal */
+class BetterSqlite3Statement implements SqliteStatement {
+  constructor(private readonly stmt: Database.Statement) {}
+
+  run(...binds: unknown[]): RunResult {
+    const result = this.stmt.run(...binds);
+    return { changes: result.changes, lastInsertRowid: result.lastInsertRowid };
+  }
+
+  get(...binds: unknown[]): unknown {
+    return this.stmt.get(...binds);
+  }
+
+  all(...binds: unknown[]): unknown[] {
+    return this.stmt.all(...binds) as unknown[];
+  }
+
+  columns(): ColumnInfo[] {
+    return this.stmt.columns().map((c) => ({
+      name: c.name,
+      column: c.column,
+      table: c.table,
+      database: c.database,
+      type: c.type,
+    }));
+  }
+
+  setReadBigInts(on: boolean): void {
+    this.stmt.safeIntegers(on);
+  }
+
+  finalize(): void {
+    // better-sqlite3 does not expose an explicit finalize — statements are
+    // GC'd automatically. This is a no-op to satisfy the interface.
+  }
+}
+
+/** @internal */
+class BetterSqlite3Driver implements SqliteDriver {
+  readonly raw: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.raw = db;
+  }
+
+  prepare(sql: string): BetterSqlite3Statement {
+    return new BetterSqlite3Statement(this.raw.prepare(sql));
+  }
+
+  exec(sql: string): void {
+    this.raw.exec(sql);
+  }
+
+  pragma(source: string, opts?: { simple?: boolean }): unknown {
+    return this.raw.pragma(source, opts);
+  }
+
+  close(): void {
+    this.raw.close();
+  }
+}
+
+export const betterSqlite3DriverFactory: DriverFactory = {
+  name: "better-sqlite3",
+
+  async open(config: SqliteConfig): Promise<SqliteDriver> {
+    const db = new Database(config.database, { readonly: config.readonly ?? false });
+    return new BetterSqlite3Driver(db);
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `sqlite3/driver.ts` with `SqliteDriver` / `SqliteStatement` / `DriverFactory` / `ColumnInfo` / `RunResult` / `SqliteConfig` interfaces (spec from the sqlite-driver abstraction plan discussed in conversation context)
- Adds `sqlite3/drivers/better-sqlite3.ts` — `BetterSqlite3Driver` and `BetterSqlite3Statement` implement the interfaces as a 1:1 synchronous wrapper; `betterSqlite3DriverFactory` constructs them via `open(config)`
- Adds `sqlite3/driver.test.ts` with a 9-test in-memory round-trip suite (CREATE/INSERT/SELECT, `columns()` shape, `setReadBigInts`, `exec`, `pragma`, `open`, `reader`)
- **No edits to `sqlite3-adapter.ts`** — purely additive; no behavior change

`SqliteConfig` is a minimal driver-level interface `{ database, readonly? }` — adapter-only knobs (`statementLimit`, `preparedStatements`, `pragmas`) live on `SQLite3AdapterOptions` and are not passed through to the driver.

This is PR 1 of the sqlite-driver abstraction plan. PR 2 (mass-rename pass wiring the adapter to use `betterSqlite3DriverFactory`) waits for PR 24b to merge first.

## Test plan

- [x] `pnpm test packages/activerecord/src/connection-adapters/sqlite3/driver.test.ts` — 9/9 pass
- [x] LOC: ~220 additions (budget 300)
- [x] `api:compare` delta: neutral (new files not in Rails manifest)