### PR TITLE
feat(activerecord): autosave_association.rb to 100% (Wave 7 PR 30)

### DIFF
--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -526,10 +526,13 @@ function validateHasOneAssociation(this: any, reflection: any): void {
   if (!(record.changedForAutosave?.() ?? false)) return;
   // Mirrors Rails: skip if the inverse belongs_to is currently validating or autosaving
   // to prevent infinite mutual-validation loops.
-  const inverseOf = reflection.inverseOf ?? reflection.inverse_of;
-  if (inverseOf) {
+  const inverse =
+    typeof reflection.inverseOf === "function"
+      ? reflection.inverseOf()
+      : (reflection.inverseOf ?? null);
+  if (inverse) {
     const inverseAssoc =
-      record._cachedAssociations?.get(inverseOf.name) !== undefined ? inverseOf : null;
+      record._cachedAssociations?.get(inverse.name) !== undefined ? inverse : null;
     if (
       inverseAssoc &&
       (record.isValidatingBelongsToFor?.(inverseAssoc) ||
@@ -611,8 +614,8 @@ function aroundSaveCollectionAssociation(this: any, fn: () => void): void {
 }
 
 /** @internal */
-async function saveCollectionAssociation(this: any, reflection: any): Promise<void> {
-  await autosaveHasMany(this, {
+async function saveCollectionAssociation(this: any, reflection: any): Promise<boolean> {
+  return autosaveHasMany(this, {
     name: reflection.name,
     type: "hasMany",
     options: reflection.options ?? {},
@@ -620,8 +623,8 @@ async function saveCollectionAssociation(this: any, reflection: any): Promise<vo
 }
 
 /** @internal */
-async function saveHasOneAssociation(this: any, reflection: any): Promise<void> {
-  await autosaveHasOne(this, {
+async function saveHasOneAssociation(this: any, reflection: any): Promise<boolean> {
+  return autosaveHasOne(this, {
     name: reflection.name,
     type: "hasOne",
     options: reflection.options ?? {},
@@ -657,7 +660,11 @@ function isAssociationForeignKeyChanged(reflection: any, record: any, key: any[]
 
 /** @internal */
 function isInversePolymorphicAssociationChanged(reflection: any, record: any): boolean {
-  if (!reflection.inverseOf?.polymorphic) return false;
+  const inverse =
+    typeof reflection.inverseOf === "function"
+      ? reflection.inverseOf()
+      : (reflection.inverseOf ?? null);
+  if (!inverse?.options?.polymorphic) return false;
   return reflection.activeRecord !== record?.constructor;
 }
 
@@ -683,7 +690,7 @@ function computePrimaryKey(reflection: any, record: any): string | string[] {
 
 /** @internal */
 function _ensureNoDuplicateErrors(this: any): void {
-  if (typeof this.errors?.uniq === "function") this.errors.uniq();
+  if (typeof this.errors?.uniqBang === "function") this.errors.uniqBang();
 }
 
 /** @internal */
@@ -726,11 +733,17 @@ function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any)
 /** @internal */
 function addAutosaveAssociationCallbacks(klass: any, reflection: any): void {
   const saveName = `autosaveAssociatedRecordsFor_${reflection.name}`;
-  if (reflection.collection) {
+  const isCol =
+    typeof reflection.isCollection === "function"
+      ? reflection.isCollection()
+      : !!reflection.collection;
+  const isHasOne =
+    typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
+  if (isCol) {
     defineNonCyclicMethod(klass, saveName, function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
     });
-  } else if (reflection.hasOne) {
+  } else if (isHasOne) {
     defineNonCyclicMethod(klass, saveName, function (this: any) {
       return saveHasOneAssociation.call(this, reflection);
     });
@@ -747,11 +760,17 @@ function defineAutosaveValidationCallbacks(klass: any, reflection: any): void {
   if (!reflection.validate) return;
   const validationName = `validateAssociatedRecordsFor_${reflection.name}`;
   if (typeof klass.prototype?.[validationName] === "function") return;
-  if (reflection.collection) {
+  const isCol =
+    typeof reflection.isCollection === "function"
+      ? reflection.isCollection()
+      : !!reflection.collection;
+  const isHasOne =
+    typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
+  if (isCol) {
     defineNonCyclicMethod(klass, validationName, function (this: any) {
       return validateCollectionAssociation.call(this, reflection);
     });
-  } else if (reflection.hasOne) {
+  } else if (isHasOne) {
     defineNonCyclicMethod(klass, validationName, function (this: any) {
       return validateHasOneAssociation.call(this, reflection);
     });

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -505,8 +505,9 @@ function associatedRecordsToValidateOrSave(
   newRecord: boolean,
   autosave: boolean,
 ): any[] | null {
-  const target: any[] = association?.target;
-  if (!target) return null;
+  const raw = association?.target;
+  if (raw == null) return null;
+  const target: any[] = Array.isArray(raw) ? raw : [raw];
   if (newRecord) return target;
   if (autosave) return target.filter((r: any) => r.changedForAutosave?.() ?? false);
   return target.filter((r: any) => r.isNewRecord?.() ?? false);

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -5,7 +5,6 @@
  * Instance methods are this-typed functions on the module object.
  * The [included] hook registers validateAssociations onto the class.
  */
-import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import type { ValidationContextArg } from "./validations.js";
 import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
@@ -496,134 +495,220 @@ function propagateErrors(parent: Base, child: Base, assocName: string): void {
 }
 
 /** @internal */
-function initInternals(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#init_internals is not implemented",
+function initInternals(this: any): void {
+  this._alreadyCalled = null;
+}
+
+/** @internal */
+function associatedRecordsToValidateOrSave(
+  association: any,
+  newRecord: boolean,
+  autosave: boolean,
+): any[] | null {
+  const target: any[] = association?.target;
+  if (!target) return null;
+  if (newRecord) return target;
+  if (autosave) return target.filter((r: any) => r.changedForAutosave?.() ?? false);
+  return target.filter((r: any) => r.isNewRecord?.() ?? false);
+}
+
+/** @internal */
+function isNestedRecordsChangedForAutosave(this: any): boolean {
+  return _nestedRecordsChangedForAutosave(this);
+}
+
+/** @internal */
+function validateHasOneAssociation(this: any, reflection: any): void {
+  const record =
+    this._cachedAssociations?.get(reflection.name) ??
+    this._preloadedAssociations?.get(reflection.name);
+  if (!record || typeof record !== "object" || Array.isArray(record)) return;
+  if (!(record.changedForAutosave?.() ?? false)) return;
+  isAssociationValid(reflection, record, this);
+}
+
+/** @internal */
+function validateBelongsToAssociation(this: any, reflection: any): void {
+  const record =
+    this._cachedAssociations?.get(reflection.name) ??
+    this._preloadedAssociations?.get(reflection.name);
+  if (!record || typeof record !== "object") return;
+  if (!(record.changedForAutosave?.() ?? false)) return;
+  _setValidatingBelongsToFor(this, reflection, true);
+  try {
+    isAssociationValid(reflection, record, this);
+  } finally {
+    _setValidatingBelongsToFor(this, reflection, false);
+  }
+}
+
+/** @internal */
+function validateCollectionAssociation(this: any, reflection: any): void {
+  const records =
+    this._cachedAssociations?.get(reflection.name) ??
+    this._preloadedAssociations?.get(reflection.name);
+  if (!Array.isArray(records)) return;
+  for (const record of records) {
+    isAssociationValid(reflection, record, this);
+  }
+}
+
+/** @internal */
+function isAssociationValid(reflection: any, record: any, owner: any): boolean {
+  if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
+  if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
+  const isChildValid = typeof record.isValid === "function" ? record.isValid() : true;
+  if (!isChildValid) {
+    const parentErrors = owner?.errors;
+    if (parentErrors && reflection.options?.autosave) {
+      const msgs = (
+        Array.isArray(record.errors?.fullMessages) ? record.errors.fullMessages : []
+      ) as string[];
+      for (const msg of msgs) parentErrors.add("base", "invalid", { message: msg });
+    } else if (parentErrors) {
+      parentErrors.add(reflection.name ?? "base", "invalid");
+    }
+  }
+  return isChildValid;
+}
+
+/** @internal */
+function aroundSaveCollectionAssociation(this: any, fn: () => void): void {
+  const prev = this._newRecordBeforeSave ?? false;
+  this._newRecordBeforeSave =
+    !prev && (typeof this.isNewRecord === "function" ? this.isNewRecord() : false);
+  try {
+    fn();
+  } finally {
+    this._newRecordBeforeSave = prev;
+  }
+}
+
+/** @internal */
+async function saveCollectionAssociation(this: any, reflection: any): Promise<void> {
+  await autosaveHasMany(this, {
+    name: reflection.name,
+    type: "hasMany",
+    options: reflection.options ?? {},
+  });
+}
+
+/** @internal */
+async function saveHasOneAssociation(this: any, reflection: any): Promise<void> {
+  await autosaveHasOne(this, {
+    name: reflection.name,
+    type: "hasOne",
+    options: reflection.options ?? {},
+  });
+}
+
+/** @internal */
+function is_recordChanged(reflection: any, record: any, key: any[]): boolean {
+  return (
+    (typeof record.isNewRecord === "function" ? record.isNewRecord() : false) ||
+    isAssociationForeignKeyChanged(reflection, record, key) ||
+    isInversePolymorphicAssociationChanged(reflection, record) ||
+    (typeof record.willSaveChangeToAttribute === "function"
+      ? record.willSaveChangeToAttribute(reflection.foreignKey)
+      : false)
   );
 }
 
 /** @internal */
-function associatedRecordsToValidateOrSave(association: any, newRecord: any, autosave: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#associated_records_to_validate_or_save is not implemented",
-  );
+function isAssociationForeignKeyChanged(reflection: any, record: any, key: any[]): boolean {
+  if (reflection.throughReflection) return false;
+  const fk: string[] = Array.isArray(reflection.foreignKey)
+    ? reflection.foreignKey
+    : [reflection.foreignKey];
+  if (!fk.every((k: string) => record._hasAttribute?.(k) !== false)) return false;
+  const recordFk = fk.map((k: string) => record._readAttribute?.(k));
+  const keyArr = Array.isArray(key) ? key : [key];
+  return JSON.stringify(recordFk) !== JSON.stringify(keyArr);
 }
 
 /** @internal */
-function isNestedRecordsChangedForAutosave(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#nested_records_changed_for_autosave? is not implemented",
-  );
+function isInversePolymorphicAssociationChanged(reflection: any, record: any): boolean {
+  if (!reflection.inverseOf?.polymorphic) return false;
+  return reflection.activeRecord !== record?.constructor;
 }
 
 /** @internal */
-function validateHasOneAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#validate_has_one_association is not implemented",
-  );
+async function saveBelongsToAssociation(this: any, reflection: any): Promise<boolean> {
+  return _autosaveBelongsTo(this, {
+    name: reflection.name,
+    type: "belongsTo",
+    options: reflection.options ?? {},
+  });
 }
 
 /** @internal */
-function validateBelongsToAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#validate_belongs_to_association is not implemented",
-  );
+function computePrimaryKey(reflection: any, record: any): string | string[] {
+  if (reflection.options?.primaryKey) return reflection.options.primaryKey;
+  const ctor = record?.constructor as any;
+  if (Array.isArray(ctor?.primaryKey)) {
+    const pk: string[] = ctor.primaryKey;
+    return pk.includes("id") ? "id" : pk;
+  }
+  return ctor?.primaryKey ?? "id";
 }
 
 /** @internal */
-function validateCollectionAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#validate_collection_association is not implemented",
-  );
+function _ensureNoDuplicateErrors(this: any): void {
+  if (typeof this.errors?.uniq === "function") this.errors.uniq();
 }
 
 /** @internal */
-function isAssociationValid(association: any, record: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#association_valid? is not implemented",
-  );
+function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any): void {
+  if (typeof klass.prototype?.[name] === "function") return;
+  if (klass.prototype) {
+    klass.prototype[name] = function (this: any) {
+      this._alreadyCalled ??= {};
+      if (this._alreadyCalled[name]) return true;
+      this._alreadyCalled[name] = true;
+      try {
+        return fn.call(this);
+      } finally {
+        this._alreadyCalled[name] = false;
+      }
+    };
+  }
 }
 
 /** @internal */
-function aroundSaveCollectionAssociation(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#around_save_collection_association is not implemented",
-  );
+function addAutosaveAssociationCallbacks(klass: any, reflection: any): void {
+  const saveName = `autosaveAssociatedRecordsFor_${reflection.name}`;
+  if (reflection.collection) {
+    defineNonCyclicMethod(klass, saveName, function (this: any) {
+      return saveCollectionAssociation.call(this, reflection);
+    });
+  } else if (reflection.hasOne) {
+    defineNonCyclicMethod(klass, saveName, function (this: any) {
+      return saveHasOneAssociation.call(this, reflection);
+    });
+  } else {
+    defineNonCyclicMethod(klass, saveName, function (this: any) {
+      return saveBelongsToAssociation.call(this, reflection);
+    });
+  }
+  defineAutosaveValidationCallbacks(klass, reflection);
 }
 
 /** @internal */
-function saveCollectionAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#save_collection_association is not implemented",
-  );
-}
-
-/** @internal */
-function saveHasOneAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#save_has_one_association is not implemented",
-  );
-}
-
-/** @internal */
-function is_recordChanged(reflection: any, record: any, key: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#_record_changed? is not implemented",
-  );
-}
-
-/** @internal */
-function isAssociationForeignKeyChanged(reflection: any, record: any, key: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#association_foreign_key_changed? is not implemented",
-  );
-}
-
-/** @internal */
-function isInversePolymorphicAssociationChanged(reflection: any, record: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#inverse_polymorphic_association_changed? is not implemented",
-  );
-}
-
-/** @internal */
-function saveBelongsToAssociation(reflection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#save_belongs_to_association is not implemented",
-  );
-}
-
-/** @internal */
-function computePrimaryKey(reflection: any, record: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#compute_primary_key is not implemented",
-  );
-}
-
-/** @internal */
-function _ensureNoDuplicateErrors(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#_ensure_no_duplicate_errors is not implemented",
-  );
-}
-
-/** @internal */
-function defineNonCyclicMethod(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#define_non_cyclic_method is not implemented",
-  );
-}
-
-/** @internal */
-function addAutosaveAssociationCallbacks(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#add_autosave_association_callbacks is not implemented",
-  );
-}
-
-/** @internal */
-function defineAutosaveValidationCallbacks(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::AutosaveAssociation#define_autosave_validation_callbacks is not implemented",
-  );
+function defineAutosaveValidationCallbacks(klass: any, reflection: any): void {
+  if (!reflection.validate) return;
+  const validationName = `validateAssociatedRecordsFor_${reflection.name}`;
+  if (typeof klass.prototype?.[validationName] === "function") return;
+  if (reflection.collection) {
+    defineNonCyclicMethod(klass, validationName, function (this: any) {
+      return validateCollectionAssociation.call(this, reflection);
+    });
+  } else if (reflection.hasOne) {
+    defineNonCyclicMethod(klass, validationName, function (this: any) {
+      return validateHasOneAssociation.call(this, reflection);
+    });
+  } else {
+    defineNonCyclicMethod(klass, validationName, function (this: any) {
+      return validateBelongsToAssociation.call(this, reflection);
+    });
+  }
 }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -531,12 +531,12 @@ function validateHasOneAssociation(this: any, reflection: any): void {
       ? reflection.inverseOf()
       : (reflection.inverseOf ?? null);
   if (inverse) {
-    const inverseAssoc =
-      record._cachedAssociations?.get(inverse.name) !== undefined ? inverse : null;
+    const inverseLoaded =
+      record._cachedAssociations?.has(inverse.name) ||
+      record._preloadedAssociations?.has(inverse.name);
     if (
-      inverseAssoc &&
-      (record.isValidatingBelongsToFor?.(inverseAssoc) ||
-        record.isAutosavingBelongsToFor?.(inverseAssoc))
+      inverseLoaded &&
+      (record.isValidatingBelongsToFor?.(inverse) || record.isAutosavingBelongsToFor?.(inverse))
     )
       return;
   }
@@ -578,14 +578,11 @@ function validateCollectionAssociation(this: any, reflection: any): void {
 }
 
 /** @internal */
-function isAssociationValid(
-  reflection: any,
-  record: any,
-  owner: any,
-  context?: ValidationContextArg,
-): boolean {
+function isAssociationValid(reflection: any, record: any, owner: any): boolean {
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
+  // Mirror Rails: read validation_context from the owner when a custom context is active.
+  const context: ValidationContextArg | undefined = owner?._validationContext ?? undefined;
   const isChildValid = typeof record.isValid === "function" ? record.isValid(context) : true;
   if (!isChildValid) {
     const parentErrors = owner?.errors;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -581,8 +581,11 @@ function validateCollectionAssociation(this: any, reflection: any): void {
 function isAssociationValid(reflection: any, record: any, owner: any): boolean {
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
-  // Mirror Rails: read validation_context from the owner when a custom context is active.
-  const context: ValidationContextArg | undefined = owner?._validationContext ?? undefined;
+  // Mirror Rails: only forward a custom (non-:create/:update) validation context.
+  const context: ValidationContextArg | undefined =
+    typeof owner?.customValidationContext === "function" && owner.customValidationContext()
+      ? owner._validationContext
+      : undefined;
   const isChildValid = typeof record.isValid === "function" ? record.isValid(context) : true;
   if (!isChildValid) {
     const parentErrors = owner?.errors;
@@ -599,15 +602,37 @@ function isAssociationValid(reflection: any, record: any, owner: any): boolean {
 }
 
 /** @internal */
-function aroundSaveCollectionAssociation(this: any, fn: () => void): void {
+function aroundSaveCollectionAssociation(
+  this: any,
+  fn: () => void | Promise<any>,
+): void | Promise<any> {
   const prev = this._newRecordBeforeSave ?? false;
   this._newRecordBeforeSave =
     !prev && (typeof this.isNewRecord === "function" ? this.isNewRecord() : false);
-  try {
-    fn();
-  } finally {
+  const restore = () => {
     this._newRecordBeforeSave = prev;
+  };
+  let result: void | Promise<any>;
+  try {
+    result = fn();
+  } catch (e) {
+    restore();
+    throw e;
   }
+  if (result != null && typeof (result as any).then === "function") {
+    return (result as Promise<any>).then(
+      (v) => {
+        restore();
+        return v;
+      },
+      (e) => {
+        restore();
+        throw e;
+      },
+    );
+  }
+  restore();
+  return result;
 }
 
 /** @internal */
@@ -695,7 +720,7 @@ function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any)
   if (typeof klass.prototype?.[name] === "function") return;
   if (klass.prototype) {
     klass.prototype[name] = function (this: any) {
-      this._alreadyCalled ??= {};
+      this._alreadyCalled ??= Object.create(null);
       if (this._alreadyCalled[name]) return true;
       this._alreadyCalled[name] = true;
       const clear = () => {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -524,6 +524,19 @@ function validateHasOneAssociation(this: any, reflection: any): void {
     this._preloadedAssociations?.get(reflection.name);
   if (!record || typeof record !== "object" || Array.isArray(record)) return;
   if (!(record.changedForAutosave?.() ?? false)) return;
+  // Mirrors Rails: skip if the inverse belongs_to is currently validating or autosaving
+  // to prevent infinite mutual-validation loops.
+  const inverseOf = reflection.inverseOf ?? reflection.inverse_of;
+  if (inverseOf) {
+    const inverseAssoc =
+      record._cachedAssociations?.get(inverseOf.name) !== undefined ? inverseOf : null;
+    if (
+      inverseAssoc &&
+      (record.isValidatingBelongsToFor?.(inverseAssoc) ||
+        record.isAutosavingBelongsToFor?.(inverseAssoc))
+    )
+      return;
+  }
   isAssociationValid(reflection, record, this);
 }
 
@@ -544,10 +557,18 @@ function validateBelongsToAssociation(this: any, reflection: any): void {
 
 /** @internal */
 function validateCollectionAssociation(this: any, reflection: any): void {
-  const records =
-    this._cachedAssociations?.get(reflection.name) ??
-    this._preloadedAssociations?.get(reflection.name);
-  if (!Array.isArray(records)) return;
+  // Mirrors Rails: use associatedRecordsToValidateOrSave to filter by new_record/autosave state.
+  const association = {
+    target:
+      this._cachedAssociations?.get(reflection.name) ??
+      this._preloadedAssociations?.get(reflection.name),
+  };
+  const records = associatedRecordsToValidateOrSave(
+    association,
+    typeof this.isNewRecord === "function" ? this.isNewRecord() : false,
+    !!reflection.options?.autosave,
+  );
+  if (!records) return;
   for (const record of records) {
     isAssociationValid(reflection, record, this);
   }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -649,7 +649,7 @@ function isAssociationForeignKeyChanged(reflection: any, record: any, key: any[]
   const fk: string[] = Array.isArray(reflection.foreignKey)
     ? reflection.foreignKey
     : [reflection.foreignKey];
-  if (!fk.every((k: string) => record._hasAttribute?.(k) !== false)) return false;
+  if (!fk.every((k: string) => record.hasAttribute?.(k) !== false)) return false;
   const recordFk = fk.map((k: string) => String(record._readAttribute?.(k) ?? ""));
   const keyArr = (Array.isArray(key) ? key : [key]).map((v) => String(v ?? ""));
   return recordFk.join("\0") !== keyArr.join("\0");

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -575,10 +575,15 @@ function validateCollectionAssociation(this: any, reflection: any): void {
 }
 
 /** @internal */
-function isAssociationValid(reflection: any, record: any, owner: any): boolean {
+function isAssociationValid(
+  reflection: any,
+  record: any,
+  owner: any,
+  context?: ValidationContextArg,
+): boolean {
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
-  const isChildValid = typeof record.isValid === "function" ? record.isValid() : true;
+  const isChildValid = typeof record.isValid === "function" ? record.isValid(context) : true;
   if (!isChildValid) {
     const parentErrors = owner?.errors;
     if (parentErrors && reflection.options?.autosave) {
@@ -625,12 +630,15 @@ async function saveHasOneAssociation(this: any, reflection: any): Promise<void> 
 
 /** @internal */
 function is_recordChanged(reflection: any, record: any, key: any[]): boolean {
+  const fkCols: string[] = Array.isArray(reflection.foreignKey)
+    ? reflection.foreignKey
+    : [reflection.foreignKey];
   return (
     (typeof record.isNewRecord === "function" ? record.isNewRecord() : false) ||
     isAssociationForeignKeyChanged(reflection, record, key) ||
     isInversePolymorphicAssociationChanged(reflection, record) ||
     (typeof record.willSaveChangeToAttribute === "function"
-      ? record.willSaveChangeToAttribute(reflection.foreignKey)
+      ? fkCols.some((col) => record.willSaveChangeToAttribute(col))
       : false)
   );
 }
@@ -642,9 +650,9 @@ function isAssociationForeignKeyChanged(reflection: any, record: any, key: any[]
     ? reflection.foreignKey
     : [reflection.foreignKey];
   if (!fk.every((k: string) => record._hasAttribute?.(k) !== false)) return false;
-  const recordFk = fk.map((k: string) => record._readAttribute?.(k));
-  const keyArr = Array.isArray(key) ? key : [key];
-  return JSON.stringify(recordFk) !== JSON.stringify(keyArr);
+  const recordFk = fk.map((k: string) => String(record._readAttribute?.(k) ?? ""));
+  const keyArr = (Array.isArray(key) ? key : [key]).map((v) => String(v ?? ""));
+  return recordFk.join("\0") !== keyArr.join("\0");
 }
 
 /** @internal */
@@ -686,11 +694,31 @@ function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any)
       this._alreadyCalled ??= {};
       if (this._alreadyCalled[name]) return true;
       this._alreadyCalled[name] = true;
-      try {
-        return fn.call(this);
-      } finally {
+      const clear = () => {
         this._alreadyCalled[name] = false;
+      };
+      let result: any;
+      try {
+        result = fn.call(this);
+      } catch (e) {
+        clear();
+        throw e;
       }
+      // Keep the guard set until async work settles to prevent re-entrant autosave cycles.
+      if (result != null && typeof result.then === "function") {
+        return result.then(
+          (v: any) => {
+            clear();
+            return v;
+          },
+          (e: any) => {
+            clear();
+            throw e;
+          },
+        );
+      }
+      clear();
+      return result;
     };
   }
 }


### PR DESCRIPTION
## Summary

- Replaces 19 \`NotImplementedError\` stubs with real implementations in \`autosave-association.ts\`
- Moves \`autosave_association.rb\` coverage from 34% (10/29) to **100% (29/29)**
- Net diff: ~256 LOC (within 300-LOC ceiling)

## What changed

All 19 private helpers now have real bodies instead of throwing stubs:

**Validation helpers** — \`validateHasOneAssociation\`, \`validateBelongsToAssociation\`, \`validateCollectionAssociation\`, \`isAssociationValid\`: each fetches the cached association, checks \`changedForAutosave\`, guards the belongs_to cycle via \`_setValidatingBelongsToFor\`, and propagates child errors to the parent. \`validateHasOneAssociation\` additionally checks the inverse-association cycle guard (mirrors Rails' \`validating_belongs_to_for?\` / \`autosaving_belongs_to_for?\`). \`validateCollectionAssociation\` filters via \`associatedRecordsToValidateOrSave\`. Validation context is threaded through to \`record.isValid(context)\`.

**Save dispatchers** — \`saveCollectionAssociation\`, \`saveHasOneAssociation\`, \`saveBelongsToAssociation\`: wrappers over the existing \`autosaveHasMany\` / \`autosaveHasOne\` / \`_autosaveBelongsTo\` implementations, adapting the Rails reflection API to the TS assoc definition shape.

**Record-change helpers** — \`is_recordChanged\`, \`isAssociationForeignKeyChanged\`, \`isInversePolymorphicAssociationChanged\`: port the Rails FK-comparison logic. \`isAssociationForeignKeyChanged\` uses element-wise \`String()\` comparison (bigint-safe). \`is_recordChanged\` iterates each FK column for \`willSaveChangeToAttribute\` to handle composite keys.

**Class-level setup** — \`defineNonCyclicMethod\`, \`addAutosaveAssociationCallbacks\`, \`defineAutosaveValidationCallbacks\`: implement the cycle-detection registry (\`_alreadyCalled\` map on instance). The wrapper in \`defineNonCyclicMethod\` is Promise-aware: it keeps the guard set until the async result settles, preventing re-entrant autosave loops during async save callbacks.

**Utility** — \`initInternals\` (clears \`_alreadyCalled\`), \`associatedRecordsToValidateOrSave\` (filters target by new/autosave flags), \`isNestedRecordsChangedForAutosave\` (delegates to existing WeakSet-guarded helper), \`aroundSaveCollectionAssociation\` (tracks \`_newRecordBeforeSave\` per Rails semantics), \`computePrimaryKey\` (composite PK logic), \`_ensureNoDuplicateErrors\` (deduplicates errors).

Also removes the now-unused \`NotImplementedError\` import.

## Known remaining gaps (require infrastructure not yet in scope)

- \`isAssociationValid\` uses \`fullMessages\` strings rather than \`Associations::NestedError\` objects — the NestedError class doesn't exist yet
- \`isInversePolymorphicAssociationChanged\` uses constructor identity instead of \`polymorphic_class_for\` — that resolver doesn't exist yet
- \`saveCollectionAssociation\` / \`saveHasOneAssociation\` delegate to the existing autosave helpers rather than using the association proxy's \`insert_record\` — association proxy objects with that method aren't wired up yet

## Test plan

- [x] \`pnpm api:compare --package activerecord\` → \`autosave_association.rb\` 29/29 100% ✓
- [x] \`pnpm test:compare\` → autosave-association: 138 pass, 0 fail
- [x] \`pnpm lint\` → clean
- [x] Pre-commit hooks pass (build + typecheck)