### PR TITLE
feat(lint): blazetrails/sqlite-driver-await guard for sqlite driver calls

### DIFF
--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -1,513 +1,68 @@
-# SQLite driver abstraction plan
+# SQLite Driver Abstraction Plan
 
-Goal: decouple `Sqlite3Adapter` from `better-sqlite3` so the same adapter can
-run on top of any SQLite driver — `node:sqlite`, `expo-sqlite`,
-`@sqlite.org/sqlite-wasm`, `wa-sqlite`, `sql.js`, etc. — by having activerecord
-consume a generic `getSqlite()` accessor from `activesupport`, modeled on
-`getFs()` / `fs-adapter.ts`.
+## Background
 
-## Status (2026-05-06)
+`better-sqlite3` exposes a fully synchronous API. Wrapping it in a
+`SqliteDriver` interface with return type `T | Promise<T>` lets a future async
+driver (e.g. `wa-sqlite` for browser/worker contexts) slot in without touching
+the adapter layer.
 
-- ✅ **Original PR 1 merged** — `packages/activerecord/src/connection-adapters/sqlite3/driver.ts`
-  exists with `SqliteDriver` (the open handle), `SqliteStatement`, `DriverFactory`,
-  and `SqliteConfig` interfaces, plus `drivers/better-sqlite3.ts` wrapping the
-  existing `Database`/`Statement` calls. Note: the rename to `SqliteConnection`
-  (handle) / `SqliteDriver` (registered thing) — described in the "Driver
-  interface" section below — has NOT yet shipped. It lands as part of PR M when
-  the abstraction moves to activesupport; today's code uses the as-merged names.
-- ✅ **Original PR 2 merged** — `Sqlite3Adapter` routes all driver calls through
-  `this.driver.foo()`. Statement pool typed against `SqliteStatement`.
-  `safeIntegers` unified as `setReadBigInts`.
-- 🟡 **PR #1241 in flight** — adds `blazetrails/sqlite-driver-await` ESLint rule
-  scoped to `sqlite3/**` and `sqlite3-adapter.ts`. Flags any `driver.<method>(...)`
-  not wrapped in `await` / `.then` / `.catch`. With async committed everywhere
-  (open question #1 settled below), this rule is no longer a PR 3 _gate_ — it's
-  a permanent regression guard against future drift. Merge it as-is; PR M
-  extends the rule's glob to `packages/activesupport/src/sqlite-adapter.ts` and
-  `sqlite-drivers/**` when the driver code moves.
+## PRs
 
-The driver interface today **lives in activerecord**. The pivot below moves it
-to activesupport so other packages (FileStore, ActionDispatch session store,
-ActiveJob queue adapters) get SQLite for free, and so `node:fs` / `process.env`
-plumbing can be solved once at the activesupport layer instead of re-derived
-inside activerecord.
+### PR 1 — SqliteDriver interface + better-sqlite3 wrapper (#1238)
 
-## Why activesupport
+Added `packages/activerecord/src/connection-adapters/sqlite3/driver.ts`:
 
-The abstraction "open a SQLite handle and run statements" is a generic
-capability, like "read/write a filesystem." Query building, type maps, and
-schema dumping stay in activerecord. Bytes-in/rows-out is a primitive.
+- `SqliteDriver` interface with `open`, `prepare`, `exec`, `pragma`, `close`,
+  `raw`, `setReadBigInts` (sync config setter), `finalize` (optional teardown).
+- `BetterSqlite3Driver` wrapper over the existing `better-sqlite3` `Database`.
+- `SqliteStatement` interface wrapping `better-sqlite3`'s `Statement`.
 
-Concretely, putting the driver in activesupport:
+### PR 2 — Route Sqlite3Adapter through SqliteDriver (#1240)
 
-1. **Pattern parity with `getFs()`.** Same `register*Adapter` / `get*` shape,
-   same lazy-load default, same subpath-export model for non-Node drivers.
-   Consumers already know how to swap `getFs`; swapping `getSqlite` is the
-   same muscle memory.
-2. **Dissolves the carve-out.** The old PR 6 ("remove `node:fs` from the base
-   adapter") existed only because activerecord was tangled with both
-   `better-sqlite3` and `node:fs`. Once the driver lives in activesupport
-   behind `getSqlite()`, activerecord stops touching either. The
-   browser-bundle CI gate moves to activesupport, where `getFs` already needs
-   it.
-3. **Reuse beyond AR.** Rails has `SQLite3CacheStore`, SQLite session stores,
-   SQLite-backed ActiveJob queues. Each of these lands in a different
-   trails package. Putting the driver in activesupport means each consumer
-   takes a dep on activesupport (which they already do) instead of on
-   activerecord.
+Replaced all direct `this.db.*` call sites in `sqlite3-adapter.ts` with
+`this.driver.*`. All calls remain synchronous (the `BetterSqlite3Driver`
+wrapper delegates synchronously to `better-sqlite3`).
 
-## Design
+### Lint guard — `blazetrails/sqlite-driver-await`
 
-### Driver interface
+Sprinkling `async`/`await` through 30+ call sites in PR 3 creates many
+opportunities for a forgotten `await`. With the test suite still migrating to
+`defineSchema` (~50% done), test coverage cannot catch every missed await
+reliably.
 
-`packages/activesupport/src/sqlite-adapter.ts` (moved from
-`packages/activerecord/src/connection-adapters/sqlite3/driver.ts`).
+The `blazetrails/sqlite-driver-await` ESLint rule (`eslint/sqlite-driver-await.mjs`)
+flags any `driver.<method>(...)` call (where `driver` is a local identifier —
+e.g. a helper-function parameter or destructured variable) that is not wrapped
+in `await` or chained with `.then()`/`.catch()`.
 
-**Design principles**
+Whitelisted (always synchronous):
 
-- All methods async-tolerant: return type `T | Promise<T>`. Sync drivers (better-sqlite3) return values directly; async drivers (sqlite-wasm, sqlite-network, expo-sqlite) return Promises. Callers always `await`. This applies to `prepare()` too — sync drivers return the statement immediately and the adapter pays one microtask at the await boundary; async drivers return a Promise. The adapter never assumes one or the other.
-- Driver code is opaque to AR query construction: bytes-in (SQL string + binds), rows-out (raw row values + column metadata). Type-coercion / casting / Date-encoding stay in the AR adapter so PG/MySQL/SQLite share one code path.
-- Driver-thrown errors are not normalized at this layer; AR's `translateException` maps them. Drivers throw whatever the underlying library throws.
-- Statements are reusable across `run` / `get` / `all` / `iterate` calls. Each call independently rebinds.
+| Method                               | Reason                                |
+| ------------------------------------ | ------------------------------------- |
+| `setReadBigInts`                     | synchronous configuration setter      |
+| `finalize`                           | optional teardown, no-op in sync impl |
+| Property access (`driver.raw`, etc.) | not a call; no Promise returned       |
 
-**Bind values**
+`this.driver.<method>()` call sites are **excluded by design** — the rule
+targets local `driver` variables / parameters, which are the likely pattern
+for new helper functions added in and after PR 3. The adapter's own method
+bodies (which use `this.driver`) are covered by the TypeScript compiler once
+the return types move to `Promise<T>`.
 
-```ts
-/** Anything a sqlite driver must accept as a bound parameter. */
-export type SqliteBindValue =
-  | null
-  | string
-  | number
-  | bigint
-  | boolean // drivers MAY coerce to 0/1; AR adapter pre-coerces for parity with PG/MySQL
-  | Uint8Array // BLOB; Buffer (Node) is also valid because Buffer extends Uint8Array
-  | Date; // drivers MAY coerce to ISO string; AR pre-formats for parity
-
-/** Positional or named binds; statement methods accept either form. */
-export type SqliteBinds = readonly SqliteBindValue[] | { readonly [name: string]: SqliteBindValue };
-```
-
-**Driver and statement**
-
-```ts
-export interface SqliteConnection {
-  prepare(sql: string): SqliteStatement | Promise<SqliteStatement>;
-
-  /** Multi-statement DDL/DML. No binds, no return value. */
-  exec(sql: string): void | Promise<void>;
-
-  /**
-   * `PRAGMA <source>;` — returns rows from `prepare("PRAGMA …").all()`.
-   * `simple: true` returns the scalar value of the first column when there's
-   * exactly one row + one column (mirrors better-sqlite3's helper).
-   */
-  pragma(source: string, opts?: { simple?: boolean }): unknown | Promise<unknown>;
-
-  /** Idempotent. After close(), all calls reject / throw. */
-  close(): void | Promise<void>;
-
-  /** True between successful open() and close(). */
-  isOpen(): boolean;
-
-  /** Driver-specific escape hatch (e.g. better-sqlite3 `Database` instance). */
-  readonly raw: unknown;
-}
-
-export interface SqliteStatement {
-  /** INSERT/UPDATE/DELETE/DDL. */
-  run(binds?: SqliteBinds): RunResult | Promise<RunResult>;
-
-  /** First row, or null if none. */
-  get(binds?: SqliteBinds): unknown | Promise<unknown>;
-
-  /** All rows. Drivers MAY stream internally but MUST return a fully-realized array. */
-  all(binds?: SqliteBinds): unknown[] | Promise<unknown[]>;
-
-  /**
-   * Row-at-a-time iteration. Sync drivers return Iterable; async drivers return
-   * AsyncIterable. AR's batch path uses this for large result sets.
-   */
-  iterate(binds?: SqliteBinds): Iterable<unknown> | AsyncIterable<unknown>;
-
-  /** Column metadata for the prepared statement. Stable across calls. */
-  columns(): ColumnInfo[];
-
-  /**
-   * When true, integer columns return as bigint; when false, as number (with
-   * silent loss of precision for values outside Number.MAX_SAFE_INTEGER).
-   * Default: false. Drivers without a per-statement toggle (some WASM ports)
-   * MAY no-op and document the gap.
-   */
-  setReadBigInts(on: boolean): void;
-
-  /**
-   * Release driver resources. Optional — drivers without explicit finalization
-   * (better-sqlite3) leave it undefined; the statement pool calls it when set.
-   */
-  finalize?(): void | Promise<void>;
-}
-
-export interface ColumnInfo {
-  name: string; // result-set column name (alias if any)
-  column: string | null; // source column from the underlying table; null for expressions
-  table: string | null; // source table name; null for expressions
-  database: string | null; // attached-db name; null for expressions or main db
-  type: string | null; // declared sqlite type per sqlite_master, may be null
-}
-
-export interface RunResult {
-  /** Rows affected. SQLite reports this from `sqlite3_changes()`. */
-  changes: number;
-  /**
-   * INSERT rowid. `bigint` when setReadBigInts is on, else `number`.
-   * Caller must check the type if it accepts both modes.
-   */
-  lastInsertRowid: number | bigint;
-}
-```
-
-**Open / driver registration**
-
-```ts
-export interface SqliteOpenConfig {
-  /** File path or special URI (`:memory:`, `file::memory:?cache=shared`). */
-  database: string;
-
-  /** Open in read-only mode. Default false. */
-  readOnly?: boolean;
-
-  /** SQLITE_OPEN_NOMUTEX equivalent — opt-in for single-threaded use. */
-  noMutex?: boolean;
-
-  /** busy_timeout ms for SQLITE_BUSY contention. Default 5000. */
-  timeout?: number;
-
-  /**
-   * Driver-specific options pass-through. Drivers document their own keys;
-   * AR core never inspects this object.
-   */
-  driverOptions?: Record<string, unknown>;
-}
-
-export interface SqliteDriver {
-  readonly name: string;
-
-  /**
-   * Driver self-declared capabilities. Consumers introspect this to decide
-   * whether a given feature path is available without splitting the adapter
-   * into sync/async code paths. The adapter itself always awaits at driver
-   * boundaries (see "Settled decisions" below); capabilities are for
-   * feature-detection, not call-shape branching.
-   */
-  readonly capabilities: SqliteDriverCapabilities;
-
-  open(config: SqliteOpenConfig): Promise<SqliteConnection>;
-
-  /**
-   * Pre-flight check used by `tasks/sqlite_database_tasks.ts` to decide
-   * whether `db:create` should run before connecting. Optional — drivers
-   * that can't statelessly answer (network-backed, ephemeral) leave it
-   * undefined and the task layer falls back to attempt-and-catch.
-   */
-  databaseExists?(config: SqliteOpenConfig): boolean | Promise<boolean>;
-}
-
-export interface SqliteDriverCapabilities {
-  /**
-   * True when prepare/run/get/all return values without yielding to the event
-   * loop (the adapter still awaits at the boundary; this only signals
-   * microtask-only overhead vs. real I/O latency). better-sqlite3 + node:sqlite:
-   * true. WASM, network, expo-sqlite: false.
-   */
-  readonly inProcessSync: boolean;
-
-  /**
-   * True when iterate() yields rows incrementally (vs. collecting then
-   * yielding). Drivers that materialize all rows internally MUST set false
-   * so AR's batch path can pick a different strategy.
-   */
-  readonly streaming: boolean;
-
-  /**
-   * True when SQLite extensions (loadable .so / .dll / .dylib via
-   * `sqlite3_load_extension`) work. node:sqlite: false. better-sqlite3:
-   * true on Node, false on bundled-WASM builds. Adapter paths that need
-   * extensions throw NotImplementedError when this is false.
-   */
-  readonly loadExtension: boolean;
-
-  /**
-   * True when multiple statements can be live on one connection at once
-   * without interfering. better-sqlite3 + node:sqlite: true. Some
-   * older WASM ports: false (must finalize before preparing the next).
-   * AR's statement-cache eviction policy reads this.
-   */
-  readonly concurrentStatements: boolean;
-
-  /**
-   * True when the driver enforces foreign-key constraints by default.
-   * SQLite is opt-in via `PRAGMA foreign_keys = ON`; most drivers default
-   * to ON for AR, but turso/libsql defaults differ. AR's connection setup
-   * uses this to decide whether to issue the PRAGMA.
-   */
-  readonly foreignKeysOnByDefault: boolean;
-
-  /**
-   * True when `BEGIN IMMEDIATE` / `BEGIN EXCLUSIVE` are honored. WAL mode
-   * + standard SQLite: true. Some network-backed drivers serialize
-   * differently and don't accept these. AR's transaction setup falls back
-   * to plain `BEGIN` when false.
-   */
-  readonly immediateTransactions: boolean;
-}
-```
-
-**Capability matrix per driver** (sanity-check that the flag set is right; also drives PR 6's parity allow-list):
-
-| Capability               | better-sqlite3 (Node) | node:sqlite (≥22.5) | sqlite-wasm (browser)      | expo-sqlite (RN) | turso/libsql (network) |
-| ------------------------ | --------------------- | ------------------- | -------------------------- | ---------------- | ---------------------- |
-| `inProcessSync`          | true                  | true                | false (init() async)       | false            | false                  |
-| `streaming`              | true                  | true                | false (collect-then-yield) | false            | false                  |
-| `loadExtension`          | true                  | false               | false                      | false            | false                  |
-| `concurrentStatements`   | true                  | true                | varies                     | true             | true                   |
-| `foreignKeysOnByDefault` | false (PRAGMA needed) | false               | false                      | false            | varies                 |
-| `immediateTransactions`  | true                  | true                | true                       | true             | false (network)        |
-
-**Out of scope for v1** (tracked as future open questions, not blocking):
-custom function/aggregate registration, virtual tables, authorizer hooks, `db.backup()`, online schema-change hooks, encryption (SQLCipher) plumbing. Drivers expose these via `driver.raw` until usage patterns are clear enough to lift into the interface. Capabilities flags can be added incrementally — the interface is open for extension as long as new flags default to `false` (driver presumed not to support).
-
-### Accessor surface (mirrors `fs-adapter.ts`)
-
-```ts
-export function registerSqliteDriver(driver: SqliteDriver): void;
-export function clearSqliteDrivers(): void;
-export function getSqlite(name?: string): SqliteDriver;
-export async function getSqliteAsync(name?: string): Promise<SqliteDriver>;
-```
-
-**Resolution rules** (deterministic; no implicit "first wins"):
-
-- `getSqlite(name)` with an explicit `name` returns the registered driver or throws if missing.
-- `getSqlite()` with no arg:
-  1. If `AR_SQLITE_DRIVER` env var is set (Node only), use it. Throws if the named driver isn't registered.
-  2. Else, if **exactly one** driver is registered, return it.
-  3. Else (zero registered, or two-or-more without an explicit selection), throw with a helpful message naming the registered drivers and the env var to set.
-- `getSqliteAsync()` exists for drivers whose modules are themselves async (WASM bindings that await `init()` before exporting). Same resolution rules as `getSqlite()`. Mirrors the `getFsAsync` precedent.
-- Driver-name collisions overwrite the prior registration with a one-time `console.warn`. Tests use `clearSqliteDrivers()` to swap deterministically.
-
-### Package layout
+The rule is scoped to:
 
 ```
-packages/activesupport/src/
-  sqlite-adapter.ts           # interface + registry + getSqlite/getSqliteAsync
-  sqlite-drivers/
-    better-sqlite3.ts         # imports better-sqlite3 (optional peer dep)
-    node-sqlite.ts            # imports node:sqlite
+packages/activerecord/src/connection-adapters/sqlite3/**/*.ts
+packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
 ```
 
-`@blazetrails/activesupport` `package.json` exports map:
+### PR 3 — Sprinkle async/await (upcoming)
 
-```json
-"./sqlite/better-sqlite3": "./dist/.../sqlite-drivers/better-sqlite3.js",
-"./sqlite/node-sqlite":    "./dist/.../sqlite-drivers/node-sqlite.js"
-```
-
-activerecord's `Sqlite3Adapter` imports the _type_ `SqliteConnection` from
-activesupport and resolves the _instance_ via `getSqlite()`. No driver code
-remains in activerecord.
-
-`better-sqlite3` becomes an `optionalPeerDependency` of activesupport.
-`node:sqlite` is a Node built-in — no install footprint. Consumers using
-neither (browser/RN) register their own driver and never import the
-defaults.
-
-### Config
-
-```ts
-{
-  adapter: "sqlite3",
-  driver: "better-sqlite3", // or "node-sqlite", or a SqliteDriver
-  database: "./dev.sqlite3",
-}
-```
-
-`pool-config` accepts `driver: string | SqliteDriver` and passes it
-through to the sqlite3 adapter, which calls `getSqlite(config.driver)` at
-connect time.
-
-## PR breakdown (revised)
-
-Sized for the project's 300-LOC ceiling. Old PRs 1 and 2 are already merged;
-the remaining work re-homes the abstraction in activesupport, then proceeds
-with async + node:sqlite.
-
-### PR M — Move driver interface from activerecord to activesupport
-
-- Copy `packages/activerecord/src/connection-adapters/sqlite3/driver.ts` →
-  `packages/activesupport/src/sqlite-adapter.ts`. Type-only move; no runtime
-  behavior change.
-- Add `registerSqliteDriver` / `clearSqliteDrivers` / `getSqlite` /
-  `getSqliteAsync` accessors mirroring `fs-adapter.ts`.
-- Move `packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts`
-  → `packages/activesupport/src/sqlite-drivers/better-sqlite3.ts`. Self-registers
-  on import.
-- Add subpath exports in activesupport `package.json`. Move
-  `better-sqlite3` peer-dep declaration from activerecord to activesupport.
-- **No deprecation shims.** Pre-1.0; every consumer of the activerecord-side
-  interfaces is in this monorepo. PR M is the rename — in-flight branches
-  rebase onto main like any other PR.
-- activerecord's `Sqlite3Adapter` constructor now calls
-  `getSqlite(config.driver).open(config)` instead of newing up a
-  `BetterSqlite3Driver` directly.
-- **Back-compat import lives in `packages/activerecord/src/test-setup-ar.ts` only**, NOT `activerecord/index.ts`. Putting it in `index.ts` would pull `better-sqlite3` transitively for every consumer that imports any AR module — defeating the optionalPeerDependency promise. Apps using sqlite explicitly opt in via either (a) `import "@blazetrails/activesupport/sqlite/better-sqlite3"` in their bootstrap, or (b) `driver: betterSqlite3Driver` in their pool config.
-- `pool-config` accepts the `driver` field.
-
-LOC: realistic ~350 (median). The diff covers: type-only move, 4 accessors,
-driver-module move, 2 package.json exports entries, peer-dep migration, adapter
-constructor rewrite, pool-config plumbing, test-setup back-compat import.
-Plan to split as PR Mb (test-setup + back-compat imports) if the main diff
-crosses 300; don't fight to fit in one PR.
-
-**This PR replaces old PRs 1 (already done), 5 (registry), and 6 (carve-out)
-in one move.** The carve-out is implicit: `getFs` calls move with the driver
-into activesupport, and activerecord's adapter stops importing them.
-
-### PR 3 — Async-aware adapter
-
-`blazetrails/sqlite-driver-await` (PR #1241) provides the regression guard:
-missed `await driver.foo()` becomes a CI lint failure. After PR M, extend the
-rule's scope to the activesupport driver paths.
-
-Scope:
-
-- Sprinkle `async`/`await` through `sqlite3-adapter.ts` at every driver
-  call boundary. Public methods that already return promises (`execQuery`,
-  `selectAll`, transaction control) need no signature change. Sync-typed
-  internal helpers (`pragma()`, `_cachedStatement`, introspection helpers,
-  `copyTable`) become async.
-- Audit: `grep` for adapter callers that don't `await`. Most are tests and
-  internal sqlite paths; PG/MySQL parallels are already async.
-- Statement pool gains async finalize on eviction.
-
-**No performance gate.** Async everywhere is the explicit design choice — the
-flexibility to drop in WASM / network / async drivers (sqlite-wasm, expo-sqlite,
-turso) is the whole point of the abstraction. better-sqlite3's microtask-per-call
-overhead is acceptable; if a benchmark elsewhere regresses noticeably, address
-it in that benchmark, not by reverting the async lift.
-
-LOC: ~250–300, plus a focused test pass.
-
-### PR 4 — Consolidate transactions onto the generic path
-
-- Audit any remaining reliance on better-sqlite3's `db.transaction(fn)`.
-  Currently we call `BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT` directly via
-  `db.exec`, so this PR is likely a no-op audit + tests proving
-  nested-transaction parity with PG/MySQL across drivers.
-
-LOC: ~100, mostly tests.
-
-### PR 5 — `node:sqlite` driver
-
-`packages/activesupport/src/sqlite-drivers/node-sqlite.ts` implementing
-`SqliteConnection`. Self-registers as `"node-sqlite"`. Differences from
-better-sqlite3 normalized inside the driver:
-
-- No `.pragma()` helper → implement via `prepare("PRAGMA …").all()`. Mirror
-  better-sqlite3's `[{ pragma_name: value }]` row shape so the adapter sees
-  identical results.
-- `setReadBigInts` exists as a per-statement setter — direct mapping.
-- No `loadExtension` — throw `NotImplementedError` from any adapter path that
-  needs it; document the gap in `docs/sqlite-driver-parity.md` (created in PR 6).
-- Bind handling: node:sqlite uses positional `?` and named `:foo` differently
-  from better-sqlite3 — driver normalizes both forms of `SqliteBinds` into
-  whatever node:sqlite expects.
-- `transaction(fn)` helper absent — already unused; we do explicit
-  `BEGIN`/`COMMIT`.
-- `iterate()` uses node:sqlite's iterator return; sync today, but the
-  interface allows AsyncIterable for future drivers without recompilation.
-- Engine guard: throw at registration time on Node < 22.5 (or whatever
-  version stabilizes `node:sqlite`); link to the version compatibility note
-  in the engine-guard error message.
-
-**Async path validation.** Even though node:sqlite is sync internally, ensure
-the adapter→driver call sites all `await` (relying on the lint guard from
-#1241). Order discipline: PR M → PR 3 (async lift) → PR 5 (node:sqlite). PR 5
-landing before PR 3 means the adapter still wraps everything sync and we'd
-never validate the async path against a real driver. If for any reason PR 5
-ships first, PR 6's CI matrix MUST run node:sqlite under
-`AR_FORCE_ASYNC_DRIVER=1` (a test-only knob the driver wrapper honors by
-returning everything wrapped in `Promise.resolve(...)`) so missed awaits
-surface deterministically.
-
-LOC: ~250.
-
-### PR 6 — CI matrix + parity tests + docs
-
-- Run the existing sqlite test suite under both drivers via
-  `AR_SQLITE_DRIVER=better-sqlite3` and `AR_SQLITE_DRIVER=node-sqlite`.
-- Two CI jobs (or one matrixed job). Expect a small allow-list of
-  known-different behaviors documented in `docs/sqlite-driver-parity.md`
-  (created in this PR).
-- Smoke test exercising both drivers in the same process to catch
-  global-state leaks.
-- Browser-bundle CI test on activesupport: build a minimal entry that
-  imports `getSqlite` (no concrete driver) and runs through `esbuild
---platform=browser --bundle`. Failing on `node:fs` resolution is the
-  regression signal. Catches anyone re-adding `node:*` imports to the base
-  accessor module.
-- Public README section on choosing a driver.
-- Driver authoring guide pointing at the activesupport interface.
-
-LOC: ~250.
-
-## Order and dependencies
-
-- PR M is independent; can land as soon as TS infrastructure is stable.
-- PR 3 depends on PR M (so async lift happens against the activesupport
-  interface, not the soon-to-move activerecord one). Also blocks on
-  TS-final or the lint guard.
-- PR 4 can land any time after PR 3.
-- PR 5 depends on PR M (the registry lives in activesupport). It does
-  _not_ depend on PR 3 — node:sqlite is sync, same as better-sqlite3, and
-  the existing sync wrapping in the adapter still works pre-PR 3. But
-  shipping node:sqlite _before_ PR 3 means we never validate the async
-  path against a real driver, so order PR M → 3 → 5 in practice.
-- PR 6 depends on PR 5.
-
-## Settled decisions
-
-1. **Async everywhere.** Adapter awaits at every driver boundary. Sync drivers
-   (better-sqlite3) cost one microtask per call; the flexibility to swap in
-   async drivers (sqlite-wasm, expo-sqlite, turso, etc.) is worth it. No
-   dual-class fallback.
-2. **better-sqlite3 stays the Node default.** Apps that want `node:sqlite` opt
-   in via `driver: "node-sqlite"` or `AR_SQLITE_DRIVER=node-sqlite`. No silent
-   default switch when `node:sqlite` exits experimental.
-3. **Adapter name is `sqlite3`** regardless of driver (Rails parity); `driver`
-   is a sub-selector.
-4. **Driver-name collisions overwrite with one-time `console.warn`.** Tests
-   use `clearSqliteDrivers()` for deterministic state. Per-connection
-   statement pools already isolate prepared statements across drivers.
-5. **Resolution requires explicit selection when multiple drivers are
-   registered** (see Resolution rules above). No "first registered" wins.
-
-## Open questions
-
-1. **Should FileStore / cache pick up the SQLite driver too?** Out of scope
-   for this plan, but the activesupport home makes it trivial: a
-   `SqliteCacheStore` lives next to `FileStore` and consumes `getSqlite()`
-   the same way `FileStore` consumes `getFs()`. Defer until a concrete
-   consumer needs it.
-
-2. **Custom function / aggregate registration.** The base interface omits
-   `function()` / `aggregate()` because better-sqlite3 and node:sqlite
-   diverge in shape and not every driver supports them (WASM ports often
-   don't). AR's collation needs (e.g. `BINARY` vs `NOCASE`) are SQL-side,
-   not function-side. If we hit a real consumer that needs custom Ruby-style
-   `define_method` callbacks, lift through the `driver.raw` escape hatch
-   first; lift to interface only if multiple drivers benefit.
-
-3. **`databaseExists?` call site.** Today only `tasks/sqlite_database_tasks.ts`
-   needs it (to decide whether `db:create` runs before connecting). The
-   interface marks it optional; drivers that can't statelessly answer
-   leave it undefined. If task layer drift makes it unused, drop it.
+- Make `BetterSqlite3Driver` methods return `Promise<T>` (via
+  `Promise.resolve`).
+- Add `async`/`await` at every `this.driver.*` call site in `sqlite3-adapter.ts`
+  and the `sqlite3/` cluster.
+- The `blazetrails/sqlite-driver-await` lint guard ensures any new helper
+  that passes a `driver` parameter and calls methods on it without `await`
+  is caught at CI time, not at runtime.

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -36,9 +36,13 @@ opportunities for a forgotten `await`. With the test suite still migrating to
 reliably.
 
 The `blazetrails/sqlite-driver-await` ESLint rule (`eslint/sqlite-driver-await.mjs`)
-flags any `driver.<method>(...)` call (where `driver` is a local identifier —
-e.g. a helper-function parameter or destructured variable) that is not wrapped
-in `await` or chained with `.then()`/`.catch()`/`.finally()`.
+flags any `driver.<method>(...)` call — where the callee object is an identifier
+named `driver` (name-based, not scope-analysed; the tight file scope makes false
+positives implausible) — unless the call is:
+
+- wrapped in `await`,
+- chained with `.then()`/`.catch()`/`.finally()`, or
+- returned (`return driver.foo()` — caller takes responsibility for the Promise).
 
 No `SqliteDriver` methods are unconditionally synchronous — every callable
 member returns `T | Promise<T>`. Property accesses (`driver.raw`,

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -34,7 +34,7 @@ reliably.
 The `blazetrails/sqlite-driver-await` ESLint rule (`eslint/sqlite-driver-await.mjs`)
 flags any `driver.<method>(...)` call (where `driver` is a local identifier —
 e.g. a helper-function parameter or destructured variable) that is not wrapped
-in `await` or chained with `.then()`/`.catch()`.
+in `await` or chained with `.then()`/`.catch()`/`.finally()`.
 
 Whitelisted (always synchronous):
 

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -13,10 +13,14 @@ the adapter layer.
 
 Added `packages/activerecord/src/connection-adapters/sqlite3/driver.ts`:
 
-- `SqliteDriver` interface with `open`, `prepare`, `exec`, `pragma`, `close`,
-  `raw`, `setReadBigInts` (sync config setter), `finalize` (optional teardown).
-- `BetterSqlite3Driver` wrapper over the existing `better-sqlite3` `Database`.
-- `SqliteStatement` interface wrapping `better-sqlite3`'s `Statement`.
+- `SqliteDriver` interface: `prepare`, `exec`, `pragma`, `close` (all
+  `T | Promise<T>`), plus readonly `open: boolean` and `raw: unknown`.
+- `SqliteStatement` interface: `run`, `get`, `all` (all `T | Promise<T>`),
+  `columns()`, `setReadBigInts(on)` (sync setter), optional `finalize()`,
+  and readonly `reader: boolean`.
+- `DriverFactory` interface: `name` + `open(config)` (returns
+  `Promise<SqliteDriver>`).
+- `BetterSqlite3Driver` wrapper implementing `SqliteDriver` over `better-sqlite3`.
 
 ### PR 2 — Route Sqlite3Adapter through SqliteDriver (#1240)
 
@@ -36,13 +40,12 @@ flags any `driver.<method>(...)` call (where `driver` is a local identifier —
 e.g. a helper-function parameter or destructured variable) that is not wrapped
 in `await` or chained with `.then()`/`.catch()`/`.finally()`.
 
-Whitelisted (always synchronous):
-
-| Method                               | Reason                                |
-| ------------------------------------ | ------------------------------------- |
-| `setReadBigInts`                     | synchronous configuration setter      |
-| `finalize`                           | optional teardown, no-op in sync impl |
-| Property access (`driver.raw`, etc.) | not a call; no Promise returned       |
+No `SqliteDriver` methods are unconditionally synchronous — every callable
+member returns `T | Promise<T>`. Property accesses (`driver.raw`,
+`driver.open`) are never `CallExpression` nodes and are therefore never
+matched by the rule. (`setReadBigInts` and `finalize` live on
+`SqliteStatement`, not `SqliteDriver`, and cannot appear as
+`driver.<method>()` calls.)
 
 `this.driver.<method>()` call sites are **excluded by design** — the rule
 targets local `driver` variables / parameters, which are the likely pattern

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import noNodeBuiltins from "./eslint/no-node-builtins.mjs";
 import noProcessBypass from "./eslint/no-process-bypass.mjs";
 import railsPrivateJsdoc from "./eslint/rails-private-jsdoc.mjs";
 import noNativeDate from "./eslint/no-native-date.mjs";
+import sqliteDriverAwait from "./eslint/sqlite-driver-await.mjs";
 
 export default defineConfig(
   {
@@ -99,6 +100,7 @@ export default defineConfig(
           "no-process-bypass": noProcessBypass,
           "rails-private-jsdoc": railsPrivateJsdoc,
           "no-native-date": noNativeDate,
+          "sqlite-driver-await": sqliteDriverAwait,
         },
       },
     },
@@ -170,6 +172,18 @@ export default defineConfig(
     ignores: ["**/*.test.ts"],
     rules: {
       "blazetrails/rails-private-jsdoc": "error",
+    },
+  },
+
+  // ── sqlite-driver-await: driver call sites must be awaited ──
+  {
+    files: [
+      "packages/activerecord/src/connection-adapters/sqlite3/**/*.ts",
+      "packages/activerecord/src/connection-adapters/sqlite3-adapter.ts",
+    ],
+    ignores: ["**/*.test.ts"],
+    rules: {
+      "blazetrails/sqlite-driver-await": "error",
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,7 @@ export default defineConfig(
     },
   },
 
-  // ── blazetrails plugin (no-node-builtins + rails-private-jsdoc + no-native-date) ──
+  // ── blazetrails plugin (no-node-builtins + no-process-bypass + rails-private-jsdoc + no-native-date + sqlite-driver-await) ──
   // Registered without a `files` restriction so any block below can
   // reference its rules without re-declaring the plugin.
   {

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -25,12 +25,13 @@
 /**
  * @internal
  * AST node types that are transparent at runtime: they wrap a value without
- * changing it (TS non-null assertion, type assertions, parentheses).
- * Used by both `unwrap` (object-side) and `isSafelyConsumed` (parent-side)
- * so the two helper paths stay in sync.
+ * changing it (TS non-null assertion, type assertions, parentheses, optional
+ * chaining). Used by both `unwrap` (object-side) and `isSafelyConsumed`
+ * (parent-side) so the two helper paths stay in sync.
  */
 const TRANSPARENT_TYPES = new Set([
   "ParenthesizedExpression",
+  "ChainExpression",
   "TSNonNullExpression",
   "TSAsExpression",
   "TSTypeAssertion",

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -42,37 +42,39 @@ function unwrap(node) {
   return node;
 }
 
+/** @internal */
+const TRANSPARENT_TYPES = new Set([
+  "ParenthesizedExpression",
+  "TSNonNullExpression",
+  "TSAsExpression",
+  "TSTypeAssertion",
+  "TSSatisfiesExpression",
+]);
+
 /**
  * @internal
  * Returns true when `node` (a CallExpression whose callee is `driver.<method>`)
  * is safely consumed — either awaited or chained with .then/.catch/.finally.
- * Walks up through transparent wrapper nodes (parentheses, TS assertions) so
- * that `await (driver.run(...))` is correctly recognised as safe.
+ * Walks up through transparent wrapper nodes (parentheses, TS assertions) on
+ * both paths, so `await (driver.run(...))` and `(driver.run()).then(...)` are
+ * both correctly recognised as safe.
  */
 function isSafelyConsumed(node) {
-  let ancestor = node.parent;
-  // Walk up through transparent wrappers (e.g. parenthesized expressions).
-  while (
-    ancestor &&
-    (ancestor.type === "ParenthesizedExpression" ||
-      ancestor.type === "TSNonNullExpression" ||
-      ancestor.type === "TSAsExpression" ||
-      ancestor.type === "TSTypeAssertion" ||
-      ancestor.type === "TSSatisfiesExpression")
-  ) {
-    ancestor = ancestor.parent;
+  // Walk up through transparent wrappers, tracking the last child seen so we
+  // can verify MemberExpression.object === cur for the chain check.
+  let cur = node;
+  let parent = cur.parent;
+  while (parent && TRANSPARENT_TYPES.has(parent.type)) {
+    cur = parent;
+    parent = parent.parent;
   }
-  if (!ancestor) return false;
+  if (!parent) return false;
   // await driver.foo()  /  await (driver.foo())
-  if (ancestor.type === "AwaitExpression") return true;
-  // driver.foo().then(...) / .catch(...) / .finally(...)
-  // The immediate parent of the original node must still be the MemberExpression
-  // callee — don't allow wrappers between the call and the chain accessor.
-  const parent = node.parent;
+  if (parent.type === "AwaitExpression") return true;
+  // (driver.foo()).then(...) / .catch(...) / .finally(...)
   if (
-    parent &&
     parent.type === "MemberExpression" &&
-    parent.object === node &&
+    parent.object === cur &&
     parent.property.type === "Identifier" &&
     (parent.property.name === "then" ||
       parent.property.name === "catch" ||

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -2,12 +2,13 @@
  * ESLint rule: sqlite-driver-await
  *
  * Flags `driver.<method>(...)` call sites — where `driver` is a local
- * identifier (variable or parameter) — that are not wrapped in `await` or
- * chained with `.then()` / `.catch()` / `.finally()`.  The SqliteDriver interface returns
- * `T | Promise<T>` so that the same surface can back both the current
- * synchronous better-sqlite3 implementation and a future async driver.  A
- * forgotten `await` silently discards the Promise when the async path is
- * enabled — this rule turns that into a lint-time (CI) error.
+ * identifier (variable or parameter) — that are not wrapped in `await`,
+ * chained with `.then()` / `.catch()` / `.finally()`, or returned.
+ * The SqliteDriver interface returns `T | Promise<T>` so that the same
+ * surface can back both the current synchronous better-sqlite3 implementation
+ * and a future async driver.  A forgotten `await` silently discards the
+ * Promise when the async path is enabled — this rule turns that into a
+ * lint-time (CI) error.
  *
  * `this.driver.<method>()` is excluded: those call sites use `this` as the
  * receiver and are covered by the TypeScript compiler once return types
@@ -22,27 +23,11 @@
 
 /**
  * @internal
- * Strip TS-only and parenthesized wrapper expressions that don't change the
- * runtime value: non-null assertion (`x!`), type assertions (`x as T`,
- * `<T>x`), satisfies (`x satisfies T`), and parenthesized expressions.
- * Without unwrapping, forms like `driver!.run(...)` or
- * `(driver as SqliteDriver).run(...)` would silently bypass the rule.
+ * AST node types that are transparent at runtime: they wrap a value without
+ * changing it (TS non-null assertion, type assertions, parentheses).
+ * Used by both `unwrap` (object-side) and `isSafelyConsumed` (parent-side)
+ * so the two helper paths stay in sync.
  */
-function unwrap(node) {
-  while (
-    node &&
-    (node.type === "TSNonNullExpression" ||
-      node.type === "TSAsExpression" ||
-      node.type === "TSTypeAssertion" ||
-      node.type === "TSSatisfiesExpression" ||
-      node.type === "ParenthesizedExpression")
-  ) {
-    node = node.expression;
-  }
-  return node;
-}
-
-/** @internal */
 const TRANSPARENT_TYPES = new Set([
   "ParenthesizedExpression",
   "TSNonNullExpression",
@@ -53,8 +38,24 @@ const TRANSPARENT_TYPES = new Set([
 
 /**
  * @internal
+ * Strip TS-only and parenthesized wrapper expressions that don't change the
+ * runtime value: non-null assertion (`x!`), type assertions (`x as T`,
+ * `<T>x`), satisfies (`x satisfies T`), and parenthesized expressions.
+ * Without unwrapping, forms like `driver!.run(...)` or
+ * `(driver as SqliteDriver).run(...)` would silently bypass the rule.
+ */
+function unwrap(node) {
+  while (node && TRANSPARENT_TYPES.has(node.type)) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/**
+ * @internal
  * Returns true when `node` (a CallExpression whose callee is `driver.<method>`)
- * is safely consumed — either awaited or chained with .then/.catch/.finally.
+ * is safely consumed — awaited, chained with .then/.catch/.finally, or
+ * returned (caller takes responsibility for the Promise).
  * Walks up through transparent wrapper nodes (parentheses, TS assertions) on
  * both paths, so `await (driver.run(...))` and `(driver.run()).then(...)` are
  * both correctly recognised as safe.
@@ -71,6 +72,8 @@ function isSafelyConsumed(node) {
   if (!parent) return false;
   // await driver.foo()  /  await (driver.foo())
   if (parent.type === "AwaitExpression") return true;
+  // return driver.foo() — caller takes responsibility for the Promise
+  if (parent.type === "ReturnStatement") return true;
   // (driver.foo()).then(...) / .catch(...) / .finally(...)
   if (
     parent.type === "MemberExpression" &&
@@ -92,12 +95,12 @@ const rule = {
     type: "problem",
     docs: {
       description:
-        "Require await (or .then chain) on sqlite driver calls — interface returns T | Promise<T>.",
+        "Require await, .then/.catch/.finally chain, or return on sqlite driver calls — interface returns T | Promise<T>.",
     },
     schema: [],
     messages: {
       missingAwait:
-        "sqlite driver call must be awaited (interface returns T | Promise<T>); add 'await' or chain '.then'/'.catch'/'.finally'.",
+        "sqlite driver call must be awaited (interface returns T | Promise<T>); add 'await', chain '.then'/'.catch'/'.finally', or return the Promise.",
     },
   },
   create(context) {

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -1,0 +1,77 @@
+/**
+ * ESLint rule: sqlite-driver-await
+ *
+ * Flags `this.driver.<method>(...)` call sites that are not wrapped in
+ * `await` or chained with `.then()` / `.catch()`.  The SqliteDriver
+ * interface returns `T | Promise<T>` so that the same surface can back both
+ * the current synchronous better-sqlite3 implementation and a future async
+ * driver.  A forgotten `await` silently discards the Promise when the async
+ * path is enabled — this rule turns that into a compile-time error.
+ *
+ * Whitelisted (sync by spec):
+ *   - `driver.setReadBigInts(…)` — synchronous configuration setter
+ *   - `driver.finalize(…)`        — optional teardown helper (no-op in sync impl)
+ *   - `driver.raw`                — property access, not a call
+ *
+ * Scoped to sqlite3/** and sqlite3-adapter.ts only (see eslint.config.mjs).
+ */
+
+/** @internal */
+const SYNC_METHODS = new Set(["setReadBigInts", "finalize"]);
+
+/**
+ * @internal
+ * Returns true when `node` (a CallExpression whose callee is `driver.<method>`)
+ * is safely consumed — either awaited or chained.
+ */
+function isSafelyConsumed(node) {
+  const parent = node.parent;
+  if (!parent) return false;
+  // await driver.foo()
+  if (parent.type === "AwaitExpression") return true;
+  // driver.foo().then(...) / .catch(...)
+  if (
+    parent.type === "MemberExpression" &&
+    parent.object === node &&
+    parent.parent?.type === "CallExpression" &&
+    parent.parent.callee === parent
+  ) {
+    return true;
+  }
+  return false;
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require await (or .then chain) on sqlite driver calls — interface returns T | Promise<T>.",
+    },
+    schema: [],
+    messages: {
+      missingAwait:
+        "sqlite driver call must be awaited (interface returns T | Promise<T>); add 'await' or chain '.then'.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        // Match driver.<method>(...) where `driver` is an Identifier (local var or param).
+        // Deliberately excludes `this.driver.<method>()` — those are handled by PR 3's
+        // await-sprinkle pass and do not need a lint guard during the transition.
+        if (callee.type !== "MemberExpression") return;
+        const obj = callee.object;
+        if (obj.type !== "Identifier" || obj.name !== "driver") return;
+        const method = callee.property;
+        if (method.type !== "Identifier") return;
+        if (SYNC_METHODS.has(method.name)) return;
+        if (isSafelyConsumed(node)) return;
+        context.report({ node, messageId: "missingAwait" });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -3,7 +3,7 @@
  *
  * Flags `driver.<method>(...)` call sites — where `driver` is a local
  * identifier (variable or parameter) — that are not wrapped in `await` or
- * chained with `.then()` / `.catch()`.  The SqliteDriver interface returns
+ * chained with `.then()` / `.catch()` / `.finally()`.  The SqliteDriver interface returns
  * `T | Promise<T>` so that the same surface can back both the current
  * synchronous better-sqlite3 implementation and a future async driver.  A
  * forgotten `await` silently discards the Promise when the async path is

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -1,9 +1,10 @@
 /**
  * ESLint rule: sqlite-driver-await
  *
- * Flags `driver.<method>(...)` call sites — where `driver` is a local
- * identifier (variable or parameter) — that are not wrapped in `await`,
- * chained with `.then()` / `.catch()` / `.finally()`, or returned.
+ * Flags `driver.<method>(...)` call sites — where the callee object is an
+ * identifier named `driver` (name-based; the tight file scope makes false
+ * positives implausible) — unless the call is awaited, chained with
+ * `.then()` / `.catch()` / `.finally()`, or returned.
  * The SqliteDriver interface returns `T | Promise<T>` so that the same
  * surface can back both the current synchronous better-sqlite3 implementation
  * and a future async driver.  A forgotten `await` silently discards the
@@ -72,8 +73,11 @@ function isSafelyConsumed(node) {
   if (!parent) return false;
   // await driver.foo()  /  await (driver.foo())
   if (parent.type === "AwaitExpression") return true;
-  // return driver.foo() — caller takes responsibility for the Promise
+  // return driver.foo() — caller takes responsibility for the Promise.
+  // Also covers arrow implicit return: `(driver) => driver.foo()` where the
+  // call is the ArrowFunctionExpression body (no ReturnStatement node).
   if (parent.type === "ReturnStatement") return true;
+  if (parent.type === "ArrowFunctionExpression" && parent.body === cur) return true;
   // (driver.foo()).then(...) / .catch(...) / .finally(...)
   if (
     parent.type === "MemberExpression" &&

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -22,16 +22,55 @@
 
 /**
  * @internal
+ * Strip TS-only and parenthesized wrapper expressions that don't change the
+ * runtime value: non-null assertion (`x!`), type assertions (`x as T`,
+ * `<T>x`), satisfies (`x satisfies T`), and parenthesized expressions.
+ * Without unwrapping, forms like `driver!.run(...)` or
+ * `(driver as SqliteDriver).run(...)` would silently bypass the rule.
+ */
+function unwrap(node) {
+  while (
+    node &&
+    (node.type === "TSNonNullExpression" ||
+      node.type === "TSAsExpression" ||
+      node.type === "TSTypeAssertion" ||
+      node.type === "TSSatisfiesExpression" ||
+      node.type === "ParenthesizedExpression")
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/**
+ * @internal
  * Returns true when `node` (a CallExpression whose callee is `driver.<method>`)
- * is safely consumed — either awaited or chained.
+ * is safely consumed — either awaited or chained with .then/.catch/.finally.
+ * Walks up through transparent wrapper nodes (parentheses, TS assertions) so
+ * that `await (driver.run(...))` is correctly recognised as safe.
  */
 function isSafelyConsumed(node) {
-  const parent = node.parent;
-  if (!parent) return false;
-  // await driver.foo()
-  if (parent.type === "AwaitExpression") return true;
+  let ancestor = node.parent;
+  // Walk up through transparent wrappers (e.g. parenthesized expressions).
+  while (
+    ancestor &&
+    (ancestor.type === "ParenthesizedExpression" ||
+      ancestor.type === "TSNonNullExpression" ||
+      ancestor.type === "TSAsExpression" ||
+      ancestor.type === "TSTypeAssertion" ||
+      ancestor.type === "TSSatisfiesExpression")
+  ) {
+    ancestor = ancestor.parent;
+  }
+  if (!ancestor) return false;
+  // await driver.foo()  /  await (driver.foo())
+  if (ancestor.type === "AwaitExpression") return true;
   // driver.foo().then(...) / .catch(...) / .finally(...)
+  // The immediate parent of the original node must still be the MemberExpression
+  // callee — don't allow wrappers between the call and the chain accessor.
+  const parent = node.parent;
   if (
+    parent &&
     parent.type === "MemberExpression" &&
     parent.object === node &&
     parent.property.type === "Identifier" &&
@@ -63,11 +102,11 @@ const rule = {
     return {
       CallExpression(node) {
         const callee = node.callee;
-        // Match driver.<method>(...) where `driver` is an Identifier (local var or param).
-        // `this.driver.<method>()` has a MemberExpression object, not an Identifier — excluded.
         if (callee.type !== "MemberExpression") return;
-        const obj = callee.object;
-        if (obj.type !== "Identifier" || obj.name !== "driver") return;
+        // Unwrap TS wrappers on the object so `driver!.run()` and
+        // `(driver as SqliteDriver).run()` are caught alongside plain `driver.run()`.
+        const obj = unwrap(callee.object);
+        if (!obj || obj.type !== "Identifier" || obj.name !== "driver") return;
         const method = callee.property;
         if (method.type !== "Identifier") return;
         if (isSafelyConsumed(node)) return;

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -1,12 +1,17 @@
 /**
  * ESLint rule: sqlite-driver-await
  *
- * Flags `this.driver.<method>(...)` call sites that are not wrapped in
- * `await` or chained with `.then()` / `.catch()`.  The SqliteDriver
- * interface returns `T | Promise<T>` so that the same surface can back both
- * the current synchronous better-sqlite3 implementation and a future async
- * driver.  A forgotten `await` silently discards the Promise when the async
- * path is enabled — this rule turns that into a compile-time error.
+ * Flags `driver.<method>(...)` call sites — where `driver` is a local
+ * identifier (variable or parameter) — that are not wrapped in `await` or
+ * chained with `.then()` / `.catch()`.  The SqliteDriver interface returns
+ * `T | Promise<T>` so that the same surface can back both the current
+ * synchronous better-sqlite3 implementation and a future async driver.  A
+ * forgotten `await` silently discards the Promise when the async path is
+ * enabled — this rule turns that into a compile-time error.
+ *
+ * `this.driver.<method>()` is excluded: those call sites use `this` as the
+ * receiver and are covered by the TypeScript compiler once return types
+ * move to `Promise<T>`.
  *
  * Whitelisted (sync by spec):
  *   - `driver.setReadBigInts(…)` — synchronous configuration setter
@@ -59,8 +64,7 @@ const rule = {
       CallExpression(node) {
         const callee = node.callee;
         // Match driver.<method>(...) where `driver` is an Identifier (local var or param).
-        // Deliberately excludes `this.driver.<method>()` — those are handled by PR 3's
-        // await-sprinkle pass and do not need a lint guard during the transition.
+        // `this.driver.<method>()` has a MemberExpression object, not an Identifier — excluded.
         if (callee.type !== "MemberExpression") return;
         const obj = callee.object;
         if (obj.type !== "Identifier" || obj.name !== "driver") return;

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -7,7 +7,7 @@
  * `T | Promise<T>` so that the same surface can back both the current
  * synchronous better-sqlite3 implementation and a future async driver.  A
  * forgotten `await` silently discards the Promise when the async path is
- * enabled — this rule turns that into a compile-time error.
+ * enabled — this rule turns that into a lint-time (CI) error.
  *
  * `this.driver.<method>()` is excluded: those call sites use `this` as the
  * receiver and are covered by the TypeScript compiler once return types
@@ -34,10 +34,14 @@ function isSafelyConsumed(node) {
   if (!parent) return false;
   // await driver.foo()
   if (parent.type === "AwaitExpression") return true;
-  // driver.foo().then(...) / .catch(...)
+  // driver.foo().then(...) / .catch(...) / .finally(...)
   if (
     parent.type === "MemberExpression" &&
     parent.object === node &&
+    parent.property.type === "Identifier" &&
+    (parent.property.name === "then" ||
+      parent.property.name === "catch" ||
+      parent.property.name === "finally") &&
     parent.parent?.type === "CallExpression" &&
     parent.parent.callee === parent
   ) {
@@ -56,7 +60,7 @@ const rule = {
     schema: [],
     messages: {
       missingAwait:
-        "sqlite driver call must be awaited (interface returns T | Promise<T>); add 'await' or chain '.then'.",
+        "sqlite driver call must be awaited (interface returns T | Promise<T>); add 'await' or chain '.then'/'.catch'/'.finally'.",
     },
   },
   create(context) {

--- a/eslint/sqlite-driver-await.mjs
+++ b/eslint/sqlite-driver-await.mjs
@@ -13,16 +13,12 @@
  * receiver and are covered by the TypeScript compiler once return types
  * move to `Promise<T>`.
  *
- * Whitelisted (sync by spec):
- *   - `driver.setReadBigInts(…)` — synchronous configuration setter
- *   - `driver.finalize(…)`        — optional teardown helper (no-op in sync impl)
- *   - `driver.raw`                — property access, not a call
+ * No SqliteDriver methods are unconditionally synchronous — every callable
+ * member returns `T | Promise<T>`.  Property accesses (`driver.raw`,
+ * `driver.open`) are never CallExpressions and therefore never matched.
  *
  * Scoped to sqlite3/** and sqlite3-adapter.ts only (see eslint.config.mjs).
  */
-
-/** @internal */
-const SYNC_METHODS = new Set(["setReadBigInts", "finalize"]);
 
 /**
  * @internal
@@ -74,7 +70,6 @@ const rule = {
         if (obj.type !== "Identifier" || obj.name !== "driver") return;
         const method = callee.property;
         if (method.type !== "Identifier") return;
-        if (SYNC_METHODS.has(method.name)) return;
         if (isSafelyConsumed(node)) return;
         context.report({ node, messageId: "missingAwait" });
       },

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -34,6 +34,8 @@ tester.run("sqlite-driver-await", rule, {
     { code: "async function f(driver: any) { await driver!.run('x'); }" },
     // type assertion, but awaited
     { code: "async function f(driver: any) { await (driver as any).run('x'); }" },
+    // parenthesized call with .then chain
+    { code: "(driver.run('SELECT 1')).then((r: unknown) => r);" },
   ],
   invalid: [
     // bare identifier call

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -36,6 +36,8 @@ tester.run("sqlite-driver-await", rule, {
     { code: "async function f(driver: any) { await (driver as any).run('x'); }" },
     // parenthesized call with .then chain
     { code: "(driver.run('SELECT 1')).then((r: unknown) => r);" },
+    // return — caller takes responsibility for the Promise
+    { code: "function f(driver: any) { return driver.pragma('x'); }" },
   ],
   invalid: [
     // bare identifier call
@@ -51,11 +53,6 @@ tester.run("sqlite-driver-await", rule, {
     // second call in sequence misses await
     {
       code: "async function f(driver: any) { await driver.exec('A'); driver.run('B'); }",
-      errors: [{ messageId: "missingAwait" }],
-    },
-    // returned without await
-    {
-      code: "function f(driver: any) { return driver.pragma('x'); }",
       errors: [{ messageId: "missingAwait" }],
     },
     // arbitrary chain (not then/catch/finally) is not safe

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -45,6 +45,10 @@ tester.run("sqlite-driver-await", rule, {
     { code: "function f(driver: any) { return driver.pragma('x'); }" },
     // arrow implicit return
     { code: "const f = (driver: any) => driver.pragma('x');" },
+    // optional chaining, awaited
+    { code: "async function f(driver: any) { await driver?.run('x'); }" },
+    // optional chaining, returned
+    { code: "function f(driver: any) { return driver?.pragma('x'); }" },
   ],
   invalid: [
     // bare identifier call

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -1,0 +1,51 @@
+import { RuleTester } from "eslint";
+import rule from "./sqlite-driver-await.mjs";
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+tester.run("sqlite-driver-await", rule, {
+  valid: [
+    // awaited call
+    { code: "async function f(driver) { await driver.run('SELECT 1'); }" },
+    // .then() chain
+    { code: "driver.run('SELECT 1').then(r => r);" },
+    // .catch() chain
+    { code: "driver.run('SELECT 1').catch(e => e);" },
+    // property access (no call) — driver.raw
+    { code: "const db = driver.raw;" },
+    // whitelisted sync: setReadBigInts
+    { code: "driver.setReadBigInts(true);" },
+    // whitelisted sync: finalize
+    { code: "driver.finalize();" },
+    // this.driver.exec() — member expression object, not identifier; excluded by design
+    { code: "this.driver.exec('PRAGMA x');" },
+    // deeply nested await
+    { code: "async function f(driver) { const r = await driver.exec('PRAGMA'); }" },
+  ],
+  invalid: [
+    // bare identifier call
+    {
+      code: "driver.run('SELECT 1');",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // assignment without await
+    {
+      code: "const r = driver.prepare('SELECT 1');",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // second call in sequence misses await
+    {
+      code: "async function f(driver) { await driver.exec('A'); driver.run('B'); }",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // returned without await
+    {
+      code: "function f(driver) { return driver.pragma('x'); }",
+      errors: [{ messageId: "missingAwait" }],
+    },
+  ],
+});
+
+console.log("sqlite-driver-await: all tests passed");

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -1,27 +1,39 @@
 import { RuleTester } from "eslint";
 import rule from "./sqlite-driver-await.mjs";
 
+// Use the TypeScript parser — the rule is enforced on *.ts files, and
+// TS-only wrapper forms (driver!, driver as T) must parse to be tested.
 const tester = new RuleTester({
-  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parser: (await import("typescript-eslint")).parser,
+  },
 });
 
 tester.run("sqlite-driver-await", rule, {
   valid: [
     // awaited call
-    { code: "async function f(driver) { await driver.run('SELECT 1'); }" },
+    { code: "async function f(driver: any) { await driver.run('SELECT 1'); }" },
+    // parenthesized await
+    { code: "async function f(driver: any) { await (driver.run('SELECT 1')); }" },
     // .then() chain
-    { code: "driver.run('SELECT 1').then(r => r);" },
+    { code: "driver.run('SELECT 1').then((r: unknown) => r);" },
     // .catch() chain
-    { code: "driver.run('SELECT 1').catch(e => e);" },
+    { code: "driver.run('SELECT 1').catch((e: unknown) => e);" },
     // .finally() chain
     { code: "driver.run('SELECT 1').finally(() => cleanup());" },
     // property access (no call) — driver.raw, driver.open
     { code: "const db = driver.raw;" },
     { code: "const ok = driver.open;" },
-    // this.driver.exec() — member expression object, not identifier; excluded by design
+    // this.driver.exec() — MemberExpression object, not Identifier; excluded by design
     { code: "this.driver.exec('PRAGMA x');" },
     // deeply nested await
-    { code: "async function f(driver) { const r = await driver.exec('PRAGMA'); }" },
+    { code: "async function f(driver: any) { const r = await driver.exec('PRAGMA'); }" },
+    // non-null assertion, but awaited
+    { code: "async function f(driver: any) { await driver!.run('x'); }" },
+    // type assertion, but awaited
+    { code: "async function f(driver: any) { await (driver as any).run('x'); }" },
   ],
   invalid: [
     // bare identifier call
@@ -36,17 +48,27 @@ tester.run("sqlite-driver-await", rule, {
     },
     // second call in sequence misses await
     {
-      code: "async function f(driver) { await driver.exec('A'); driver.run('B'); }",
+      code: "async function f(driver: any) { await driver.exec('A'); driver.run('B'); }",
       errors: [{ messageId: "missingAwait" }],
     },
     // returned without await
     {
-      code: "function f(driver) { return driver.pragma('x'); }",
+      code: "function f(driver: any) { return driver.pragma('x'); }",
       errors: [{ messageId: "missingAwait" }],
     },
     // arbitrary chain (not then/catch/finally) is not safe
     {
       code: "driver.run('SELECT 1').rows;",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // non-null assertion without await
+    {
+      code: "driver!.run('SELECT 1');",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // type assertion without await
+    {
+      code: "(driver as any).run('SELECT 1');",
       errors: [{ messageId: "missingAwait" }],
     },
   ],

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -13,6 +13,8 @@ tester.run("sqlite-driver-await", rule, {
     { code: "driver.run('SELECT 1').then(r => r);" },
     // .catch() chain
     { code: "driver.run('SELECT 1').catch(e => e);" },
+    // .finally() chain
+    { code: "driver.run('SELECT 1').finally(() => cleanup());" },
     // property access (no call) — driver.raw
     { code: "const db = driver.raw;" },
     // whitelisted sync: setReadBigInts
@@ -43,6 +45,11 @@ tester.run("sqlite-driver-await", rule, {
     // returned without await
     {
       code: "function f(driver) { return driver.pragma('x'); }",
+      errors: [{ messageId: "missingAwait" }],
+    },
+    // arbitrary chain (not then/catch/finally) is not safe
+    {
+      code: "driver.run('SELECT 1').rows;",
       errors: [{ messageId: "missingAwait" }],
     },
   ],

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -3,6 +3,11 @@ import rule from "./sqlite-driver-await.mjs";
 
 // Use the TypeScript parser — the rule is enforced on *.ts files, and
 // TS-only wrapper forms (driver!, driver as T) must parse to be tested.
+//
+// The rule is name-based (checks for an identifier named "driver"), not
+// scope-based. Fixtures that use `driver` without a declaration test
+// undeclared/global references; the rule flags them the same as declared
+// locals — intentionally, given the tight file scope.
 const tester = new RuleTester({
   languageOptions: {
     ecmaVersion: 2022,
@@ -38,6 +43,8 @@ tester.run("sqlite-driver-await", rule, {
     { code: "(driver.run('SELECT 1')).then((r: unknown) => r);" },
     // return — caller takes responsibility for the Promise
     { code: "function f(driver: any) { return driver.pragma('x'); }" },
+    // arrow implicit return
+    { code: "const f = (driver: any) => driver.pragma('x');" },
   ],
   invalid: [
     // bare identifier call

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -15,12 +15,9 @@ tester.run("sqlite-driver-await", rule, {
     { code: "driver.run('SELECT 1').catch(e => e);" },
     // .finally() chain
     { code: "driver.run('SELECT 1').finally(() => cleanup());" },
-    // property access (no call) — driver.raw
+    // property access (no call) — driver.raw, driver.open
     { code: "const db = driver.raw;" },
-    // whitelisted sync: setReadBigInts
-    { code: "driver.setReadBigInts(true);" },
-    // whitelisted sync: finalize
-    { code: "driver.finalize();" },
+    { code: "const ok = driver.open;" },
     // this.driver.exec() — member expression object, not identifier; excluded by design
     { code: "this.driver.exec('PRAGMA x');" },
     // deeply nested await


### PR DESCRIPTION
## Summary

- Adds `eslint/sqlite-driver-await.mjs` — ESLint rule `blazetrails/sqlite-driver-await` that flags any `driver.<method>(...)` call (name-based identifier match) not safely consumed via `await`, `.then()`/`.catch()`/`.finally()` chain, or `return`.
- Wires the rule into `eslint.config.mjs` scoped to `sqlite3/**` and `sqlite3-adapter.ts` only.
- Adds `eslint/sqlite-driver-await.test.mjs` with fixture tests using the TypeScript parser, covering: await, return, arrow implicit return, optional chaining, TS non-null/assertion wrappers, parenthesized calls, and arbitrary-chain false-negative.
- Updates `docs/sqlite-driver-abstraction-plan.md` with the lint guard section.

## Motivation

PR 3 will sprinkle `async`/`await` across 30+ call sites in the sqlite3 adapter cluster. A forgotten `await` silently discards the Promise once the async driver path is enabled. With ~50% of test files still migrating to `defineSchema`, test coverage can't catch every missed await reliably. This rule turns that into a CI failure.

`this.driver.<method>()` in the adapter's own methods is excluded by design — those are covered by the TypeScript compiler once return types move to `Promise<T>`. The rule guards the `driver.<method>()` pattern that new helper functions will use in PR 3+.

**Current lint run: zero errors.** The rule is a regression guard, not a correction of existing code.

## Rule evolution during review (9 Copilot cycles)

Improvements merged over review iterations:
- Tightened chain check to `then`/`catch`/`finally` only (arbitrary chains like `.rows` still error)
- Removed erroneous `SYNC_METHODS` whitelist (`setReadBigInts`/`finalize` live on `SqliteStatement`, not `SqliteDriver`)
- Added `unwrap()` for TS wrapper forms on the callee object (`driver!`, `driver as T`)
- Unified wrapper walk in `isSafelyConsumed` so `(driver.run()).then()` and `await (driver.run())` are both safe
- Added `ReturnStatement` + `ArrowFunctionExpression` body as safe consumers
- Added `ChainExpression` to `TRANSPARENT_TYPES` for optional chaining (`await driver?.run()`)
- Switched test fixtures to TypeScript parser

## Remaining Copilot concern (cycle 9, not actioned — already fixed)

Cycle 9 flagged `ChainExpression` not being treated as transparent. This was already fixed in the cycle 8 commit (`a72c49988`); the review was generated against an earlier push. No open concerns remain.

## Test plan

- [x] `node eslint/sqlite-driver-await.test.mjs` — all fixture cases pass
- [x] `pnpm lint` — zero errors
- [x] `pnpm build && pnpm typecheck` — clean