### PR TITLE
feat(activerecord): abstract_mysql_adapter.rb query/schema helpers (Wave 4 PR 21b)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -41,7 +41,7 @@ import {
   unquotedTrue as mysqlUnquotedTrue,
   unquotedFalse as mysqlUnquotedFalse,
 } from "./mysql/quoting.js";
-import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import { ForeignKeyDefinition, IndexDefinition } from "./abstract/schema-definitions.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -1111,10 +1111,33 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): string {
-    void tableName;
-    void columnName;
-    void options;
-    throw new Error("addIndexForAlter: not yet wired (requires SchemaStatements.addIndexOptions)");
+    const columnNames = Array.isArray(columnName) ? columnName : [columnName];
+    const indexName =
+      (options.name as string | undefined) ?? `index_${tableName}_on_${columnNames.join("_and_")}`;
+    const algorithmKey = (options.algorithm as string | undefined)?.toLowerCase();
+    const algorithmSql = algorithmKey
+      ? (this.indexAlgorithms() as Record<string, string>)[algorithmKey]
+      : undefined;
+    const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
+      where: options.where as string | undefined,
+      using: options.using as string | undefined,
+      type: options.type as string | undefined,
+      lengths: (options.length ?? {}) as Record<string, number>,
+      orders: (options.order ?? {}) as Record<string, string>,
+      include: options.include as string[] | undefined,
+    });
+    // Mirrors visit_IndexDefinition(o, create=false): no ON clause, no CREATE prefix.
+    // Algorithm appended with ", " separator per Rails' add_index_for_alter.
+    const indexType = idx.type?.toUpperCase() ?? (idx.unique ? "UNIQUE" : undefined);
+    const parts: string[] = [];
+    if (indexType) parts.push(indexType);
+    parts.push("INDEX");
+    parts.push(this.quoteIdentifier(idx.name));
+    if (idx.using) parts.push(`USING ${idx.using}`);
+    const quotedCols = columnNames.map((c) => this.quoteColumnName(c)).join(", ");
+    parts.push(`(${quotedCols})`);
+    const idxSql = parts.join(" ");
+    return algorithmSql ? `ADD ${idxSql}, ${algorithmSql}` : `ADD ${idxSql}`;
   }
 
   /** @internal */
@@ -1124,11 +1147,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     options: Record<string, unknown> = {},
   ): string {
     void tableName;
-    void columnName;
-    void options;
-    throw new Error(
-      "removeIndexForAlter: not yet wired (requires SchemaStatements.indexNameForRemove)",
-    );
+    const indexName =
+      (options.name as string | undefined) ??
+      (columnName
+        ? `index_${tableName}_on_${Array.isArray(columnName) ? columnName.join("_and_") : columnName}`
+        : undefined);
+    if (!indexName) throw new Error("removeIndexForAlter: no name or column provided");
+    return `DROP INDEX ${this.quoteColumnName(indexName)}`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1127,14 +1127,26 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       include: options.include as string[] | undefined,
     });
     // Mirrors visit_IndexDefinition(o, create=false): no ON clause, no CREATE prefix.
+    // Lengths applied per MySQL's add_index_length: col(N) for prefix indexes.
     // Algorithm appended with ", " separator per Rails' add_index_for_alter.
+    const lengths = idx.lengths as Record<string, number> | number | undefined;
     const indexType = idx.type?.toUpperCase() ?? (idx.unique ? "UNIQUE" : undefined);
     const parts: string[] = [];
     if (indexType) parts.push(indexType);
     parts.push("INDEX");
     parts.push(this.quoteIdentifier(idx.name));
     if (idx.using) parts.push(`USING ${idx.using}`);
-    const quotedCols = columnNames.map((c) => this.quoteColumnName(c)).join(", ");
+    const quotedCols = columnNames
+      .map((c) => {
+        const len =
+          typeof lengths === "number"
+            ? lengths
+            : typeof lengths === "object"
+              ? lengths[c]
+              : undefined;
+        return len ? `${this.quoteColumnName(c)}(${len})` : this.quoteColumnName(c);
+      })
+      .join(", ");
     parts.push(`(${quotedCols})`);
     const idxSql = parts.join(" ");
     return algorithmSql ? `ADD ${idxSql}, ${algorithmSql}` : `ADD ${idxSql}`;
@@ -1146,7 +1158,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName?: string | string[],
     options: Record<string, unknown> = {},
   ): string {
-    void tableName;
     const indexName =
       (options.name as string | undefined) ??
       (columnName

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1103,9 +1103,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (this.supportsRenameColumn()) {
       return `RENAME COLUMN ${this.quoteIdentifier(columnName)} TO ${this.quoteIdentifier(newColumnName)}`;
     }
-    // Fallback: SHOW COLUMNS + recreate; requires DB access — must be overridden by driver subclass
+    // TODO: implement CHANGE-column fallback for older MySQL/MariaDB
+    //   (matches abstract_mysql_adapter.rb:rename_column_for_alter when !supports_rename_column?).
+    //   Requires fetching the existing column type via columnDefinitions() and building a
+    //   ChangeColumnDefinition. Safe to skip for modern servers: MySQL ≥8.0.3 and
+    //   MariaDB ≥10.5.2 always hit the fast path above.
     throw new Error(
-      "renameColumnForAlter fallback path requires driver-level DB access; override in subclass",
+      "renameColumnForAlter fallback path (CHANGE clause for older MySQL/MariaDB) not yet implemented",
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -23,6 +23,7 @@ import {
 } from "../errors.js";
 import { sql as arelSql, type Nodes, Visitors } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
+import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import {
   quoteString as mysqlQuoteString,
   quote as mysqlQuote,
@@ -1088,17 +1089,20 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     options: Record<string, unknown> = {},
   ): string {
     const cd = this.buildChangeColumnDefinition(tableName, columnName, type, options);
-    return (
-      this as unknown as { schemaCreation: { accept(o: unknown): string } }
-    ).schemaCreation.accept(cd);
+    return new MysqlSchemaCreation().accept(
+      cd as unknown as Parameters<MysqlSchemaCreation["accept"]>[0],
+    );
   }
 
   /** @internal */
   renameColumnForAlter(tableName: string, columnName: string, newColumnName: string): string {
-    void tableName;
-    void columnName;
-    void newColumnName;
-    throw new Error("renameColumnForAlter requires driver implementation");
+    if (this.supportsRenameColumn()) {
+      return `RENAME COLUMN ${this.quoteIdentifier(columnName)} TO ${this.quoteIdentifier(newColumnName)}`;
+    }
+    // Fallback: SHOW COLUMNS + recreate; requires DB access — must be overridden by driver subclass
+    throw new Error(
+      "renameColumnForAlter fallback path requires driver-level DB access; override in subclass",
+    );
   }
 
   /** @internal */
@@ -1110,7 +1114,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     void tableName;
     void columnName;
     void options;
-    throw new Error("addIndexForAlter requires driver implementation");
+    throw new Error("addIndexForAlter: not yet wired (requires SchemaStatements.addIndexOptions)");
   }
 
   /** @internal */
@@ -1122,19 +1126,20 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     void tableName;
     void columnName;
     void options;
-    throw new Error("removeIndexForAlter requires driver implementation");
+    throw new Error(
+      "removeIndexForAlter: not yet wired (requires SchemaStatements.indexNameForRemove)",
+    );
   }
 
   /** @internal */
   async columnDefinitions(tableName: string): Promise<Record<string, unknown>[]> {
-    void tableName;
-    return [];
+    return this.schemaQuery(`SHOW FULL FIELDS FROM ${this.quoteTableName(tableName)}`);
   }
 
   /** @internal */
   async createTableInfo(tableName: string): Promise<string | null> {
-    void tableName;
-    return null;
+    const rows = await this.schemaQuery(`SHOW CREATE TABLE ${this.quoteTableName(tableName)}`);
+    return (rows[0]?.["Create Table"] as string | null | undefined) ?? null;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -20,7 +20,6 @@ import {
   StatementInvalid,
   ValueTooLong,
   sqlTypeToMigrationKeyword,
-  NotImplementedError,
 } from "../errors.js";
 import { sql as arelSql, type Nodes, Visitors } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
@@ -831,29 +830,31 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
+   * @internal
    * Build a MismatchedForeignKey from a MySQL FK constraint error.
    * Parses the FK SQL to identify the mismatched columns, then looks up
    * the referenced column's type to produce a helpful suggestion.
    *
    * Mirrors: AbstractMysqlAdapter#mismatched_foreign_key (abstract_mysql_adapter.rb:1001)
    */
-  protected _mismatchedForeignKey(
+  protected mismatchedForeignKey(
     message: string,
     sql: string,
     binds: unknown[],
     cause: unknown,
   ): MismatchedForeignKey {
-    const details = this._mismatchedForeignKeyDetails(message, sql);
+    const details = this.mismatchedForeignKeyDetails(message, sql);
     return new MismatchedForeignKey({ message, sql, binds, cause, ...details });
   }
 
   /**
+   * @internal
    * Parse a CREATE TABLE / ALTER TABLE SQL statement to extract the FK
    * details needed for a helpful MismatchedForeignKey error message.
    *
    * Mirrors: AbstractMysqlAdapter#mismatched_foreign_key_details (abstract_mysql_adapter.rb:978)
    */
-  private _mismatchedForeignKeyDetails(
+  protected mismatchedForeignKeyDetails(
     message: string,
     sql: string,
   ): Partial<ConstructorParameters<typeof MismatchedForeignKey>[0]> {
@@ -943,10 +944,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         return new InvalidForeignKey(msg, { sql, binds, cause });
       case ER_CANNOT_ADD_FOREIGN:
       case ER_FK_INCOMPATIBLE_COLUMNS:
-        return this._mismatchedForeignKey(msg, sql, binds, cause);
+        return this.mismatchedForeignKey(msg, sql, binds, cause);
       case ER_CANNOT_CREATE_TABLE:
         if (msg.includes("errno: 150") || msg.includes("errno 150")) {
-          return this._mismatchedForeignKey(msg, sql, binds, cause);
+          return this.mismatchedForeignKey(msg, sql, binds, cause);
         }
         return new StatementInvalid(msg, { sql, binds, cause });
       case ER_NOT_NULL_VIOLATION:
@@ -1080,6 +1081,68 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /** @internal */
+  changeColumnForAlter(
+    tableName: string,
+    columnName: string,
+    type: string,
+    options: Record<string, unknown> = {},
+  ): string {
+    const cd = this.buildChangeColumnDefinition(tableName, columnName, type, options);
+    return (
+      this as unknown as { schemaCreation: { accept(o: unknown): string } }
+    ).schemaCreation.accept(cd);
+  }
+
+  /** @internal */
+  renameColumnForAlter(tableName: string, columnName: string, newColumnName: string): string {
+    void tableName;
+    void columnName;
+    void newColumnName;
+    throw new Error("renameColumnForAlter requires driver implementation");
+  }
+
+  /** @internal */
+  addIndexForAlter(
+    tableName: string,
+    columnName: string | string[],
+    options: Record<string, unknown> = {},
+  ): string {
+    void tableName;
+    void columnName;
+    void options;
+    throw new Error("addIndexForAlter requires driver implementation");
+  }
+
+  /** @internal */
+  removeIndexForAlter(
+    tableName: string,
+    columnName?: string | string[],
+    options: Record<string, unknown> = {},
+  ): string {
+    void tableName;
+    void columnName;
+    void options;
+    throw new Error("removeIndexForAlter requires driver implementation");
+  }
+
+  /** @internal */
+  async columnDefinitions(tableName: string): Promise<Record<string, unknown>[]> {
+    void tableName;
+    return [];
+  }
+
+  /** @internal */
+  async createTableInfo(tableName: string): Promise<string | null> {
+    void tableName;
+    return null;
+  }
+
+  /** @internal */
+  buildStatementPool(): StatementPool {
+    return new StatementPool(this.statementLimit);
+  }
+
+  /** @internal */
   protected extractPrecision(sqlType: string): number | null {
     const match = /\((\d+)(?:,\d+)?\)/.exec(sqlType);
     const parsed = match ? parseInt(match[1], 10) : null;
@@ -1125,67 +1188,4 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   nextKey(): string {
     return `a${++this._counter}`;
   }
-}
-
-/** @internal */
-function changeColumnForAlter(tableName: any, columnName: any, type: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#change_column_for_alter is not implemented",
-  );
-}
-
-/** @internal */
-function renameColumnForAlter(tableName: any, columnName: any, newColumnName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#rename_column_for_alter is not implemented",
-  );
-}
-
-/** @internal */
-function addIndexForAlter(tableName: any, columnName: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#add_index_for_alter is not implemented",
-  );
-}
-
-/** @internal */
-function removeIndexForAlter(tableName: any, columnName?: any, options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#remove_index_for_alter is not implemented",
-  );
-}
-
-/** @internal */
-function columnDefinitions(tableName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#column_definitions is not implemented",
-  );
-}
-
-/** @internal */
-function createTableInfo(tableName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#create_table_info is not implemented",
-  );
-}
-
-/** @internal */
-function buildStatementPool(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#build_statement_pool is not implemented",
-  );
-}
-
-/** @internal */
-function mismatchedForeignKeyDetails(message?: any, sql?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#mismatched_foreign_key_details is not implemented",
-  );
-}
-
-/** @internal */
-function mismatchedForeignKey(message: any, sql?: any, binds?: any, connectionPool?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#mismatched_foreign_key is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1127,6 +1127,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       // "default" maps to "ALGORITHM = DEFAULT" in the table but means no algorithm clause
       algorithmSql = algorithmKey === "default" ? undefined : algorithms[algorithmKey];
     }
+    const comment = options.comment as string | undefined;
     const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
       where: options.where as string | undefined,
       using: options.using as string | undefined,
@@ -1134,10 +1135,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       lengths: (options.length ?? {}) as Record<string, number>,
       orders: (options.order ?? {}) as Record<string, string>,
       include: options.include as string[] | undefined,
+      comment,
     });
     // Mirrors visit_IndexDefinition(o, create=false): no ON clause, no CREATE prefix.
     // Lengths applied per MySQL's add_index_length: col(N) for prefix indexes.
-    // Algorithm appended with ", " separator per Rails' add_index_for_alter.
+    // Comment appended via addSqlCommentBang pattern. Algorithm with ", " separator.
     const lengths = idx.lengths as Record<string, number> | number | undefined;
     const indexType = idx.type?.toUpperCase() ?? (idx.unique ? "UNIQUE" : undefined);
     const parts: string[] = [];
@@ -1157,7 +1159,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       })
       .join(", ");
     parts.push(`(${quotedCols})`);
-    const idxSql = parts.join(" ");
+    let idxSql = parts.join(" ");
+    if (comment) idxSql += ` COMMENT ${mysqlQuoteString(comment)}`;
     return algorithmSql ? `ADD ${idxSql}, ${algorithmSql}` : `ADD ${idxSql}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -41,7 +41,12 @@ import {
   unquotedTrue as mysqlUnquotedTrue,
   unquotedFalse as mysqlUnquotedFalse,
 } from "./mysql/quoting.js";
-import { ForeignKeyDefinition, IndexDefinition } from "./abstract/schema-definitions.js";
+import {
+  ChangeColumnDefinition,
+  ColumnDefinition,
+  ForeignKeyDefinition,
+  IndexDefinition,
+} from "./abstract/schema-definitions.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -1088,10 +1093,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     type: string,
     options: Record<string, unknown> = {},
   ): string {
-    const cd = this.buildChangeColumnDefinition(tableName, columnName, type, options);
-    return new MysqlSchemaCreation().accept(
-      cd as unknown as Parameters<MysqlSchemaCreation["accept"]>[0],
-    );
+    const colDef = new ColumnDefinition(columnName, type, options);
+    const cd = new ChangeColumnDefinition(colDef, columnName);
+    return new MysqlSchemaCreation().accept(cd);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1115,9 +1115,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const indexName =
       (options.name as string | undefined) ?? `index_${tableName}_on_${columnNames.join("_and_")}`;
     const algorithmKey = (options.algorithm as string | undefined)?.toLowerCase();
-    const algorithmSql = algorithmKey
-      ? (this.indexAlgorithms() as Record<string, string>)[algorithmKey]
-      : undefined;
+    let algorithmSql: string | undefined;
+    if (algorithmKey) {
+      const algorithms = this.indexAlgorithms() as Record<string, string>;
+      if (!(algorithmKey in algorithms)) {
+        const valid = Object.keys(algorithms);
+        throw new Error(
+          `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
+        );
+      }
+      // "default" maps to "ALGORITHM = DEFAULT" in the table but means no algorithm clause
+      algorithmSql = algorithmKey === "default" ? undefined : algorithms[algorithmKey];
+    }
     const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
       where: options.where as string | undefined,
       using: options.using as string | undefined,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -83,6 +83,19 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
+  override accept(
+    o:
+      | Parameters<AbstractSchemaCreation["accept"]>[0]
+      | ChangeColumnDefinition
+      | ChangeColumnDefaultDefinition,
+  ): string {
+    if (o instanceof ChangeColumnDefinition) return this.visitChangeColumnDefinition(o);
+    if (o instanceof ChangeColumnDefaultDefinition)
+      return this.visitChangeColumnDefaultDefinition(o);
+    return super.accept(o as Parameters<AbstractSchemaCreation["accept"]>[0]);
+  }
+
+  /** @internal */
   protected visitChangeColumnDefinition(o: ChangeColumnDefinition): string {
     const sql = `CHANGE ${this.adapter.quoteIdentifier(o.name)} ${this.accept(o.column)}`;
     return this.addColumnPositionBang(sql, this.columnOptions(o.column) as MysqlColumnOptions);


### PR DESCRIPTION
## Summary

- Lands 9 missing methods on `AbstractMysqlAdapter` to bring `abstract_mysql_adapter.rb` to **100% (92/92)**
- Renames `_mismatchedForeignKey` → `mismatchedForeignKey` and `_mismatchedForeignKeyDetails` → `mismatchedForeignKeyDetails` (Rails-private naming convention, `@internal` JSDoc)
- Adds `changeColumnForAlter`, `renameColumnForAlter`, `addIndexForAlter`, `removeIndexForAlter`, `columnDefinitions`, `createTableInfo`, `buildStatementPool` as proper instance methods
- Removes the free-function `NotImplementedError` stubs at the bottom of the file (were never wired to the class)
- Extends `MysqlSchemaCreation.accept()` to dispatch `ChangeColumnDefinition` and `ChangeColumnDefaultDefinition`

## Before / After

| File | Before | After |
|---|---|---|
| `abstract_mysql_adapter.rb` | 83/92 (90%) | 92/92 (100%) ✓ |

## Parent PR

Depends on Wave 4 PR 21 (#1186, merged).

## Known gap (follow-up)

`renameColumnForAlter` throws on the fallback path for MySQL <8.0.3 / MariaDB <10.5.2 instead of building a `CHANGE` clause. Modern servers (MySQL 8.0+, MariaDB 10.5.2+) always hit the fast-path `RENAME COLUMN`. Tracked in #1254.

## Copilot review notes (for reviewer context)

Copilot filed 4 rounds of review. Several comments reference code that was fixed in later commits on this branch — the as-shipped state addresses them:

- **"changeColumnForAlter will throw Unknown definition type"** (all 4 rounds) — Fixed in commit `5d280c5`: `MysqlSchemaCreation.accept()` now dispatches `ChangeColumnDefinition`, and `changeColumnForAlter` constructs the definition directly rather than going through the stub `buildChangeColumnDefinition`.
- **"void tableName no-op in removeIndexForAlter"** — Fixed: removed.
- **"algorithm validation drops unknown values silently"** — Fixed: throws with allowed-values list matching `SchemaStatements.indexAlgorithm`.
- **"addIndexForAlter ignores lengths"** — Fixed: per-column and scalar lengths both applied as `col(N)`.
- **"addIndexForAlter drops comment"** — Fixed: `comment` forwarded to `IndexDefinition` and appended via `mysqlQuoteString`.
- **"quoteColumnName vs quoteIdentifier for index name"** — Rails parity: `abstract_mysql_adapter.rb:remove_index_for_alter` uses `quote_column_name`; our `quoteColumnName` is the correct mirror.
- **"renameColumnForAlter fallback"** — Acknowledged gap, documented with TODO comment, tracked in #1254.