### PR TITLE
docs: refresh AR/TS plan status + add sqlite-driver + parallelism plans

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -125,221 +125,57 @@ TS paths use `$TS/` = `packages/activerecord/src/`.
 
 ### Wave 0 — Misplaced-method cleanup (pure moves)
 
-**PR M2 — Move base.ts module methods to correct files**
+**PR M2 — Move base.ts module methods to correct files** ✅ #1151 #1152 #1156 #1157
 
-- Rails source: `$AR/base.rb` (338 LOC, mostly `include` directives — the methods live in the included module files)
-- TS source: `$TS/base.ts` (3148 LOC — monolith containing methods that belong in module files)
-- Target files: `$TS/core.ts`, `$TS/model-schema.ts`, `$TS/persistence.ts`, `$TS/attribute-methods.ts`, `$TS/scoping/default.ts`, `$TS/scoping/named.ts`, `$TS/autosave-association.ts`, `$TS/no-touching.ts`
-- Misplaced methods (sample): `id`, `touch`, `delete`, `save`, `save!`, `destroy`, `reload`, `_touchRow`, `_updateRecord`, `_createRecord`, `initInternals`, `attributeMethodsGenerated?`, `defineAttributeMethods`, `undefineAttributeMethods`, `scopeAttributes?`, `ignoreDefaultScope?`, `isScopeAttributes`
-- Split:
-  - M2: core + model-schema + persistence (~30 moves)
-  - M2b: scoping/\* + attribute-methods + small modules (~35 moves)
-- LOC: ~150 LOC each (moves only, no new logic)
-- Dependencies: none
-- Risk: `include()` wiring must be preserved — every moved method must still resolve at the class level. Run the full test suite between M2 and M2b.
-
-**PR M3 — Move adapter-layer misplaced methods (combined)**
-
-- TS sources: `$TS/connection-adapters/abstract-adapter.ts` (1270 LOC), `$TS/connection-adapters/abstract/schema-definitions.ts` (1352 LOC)
-- Abstract-adapter moves: `initialize`, `resetTransaction` → `$TS/connection-adapters/abstract/database-statements.ts`; `isWriteQuery`, `buildExplainClause` → `$TS/connection-adapters/mysql/database-statements.ts`; `selectAll` → `$TS/connection-adapters/mysql2/database-statements.ts`
-- Schema-definitions cross-adapter moves: `newColumnDefinition` (mysql), `aliasedTypes` (pg), `primaryKey` (mysql)
-- Plus: extract `quoteColumnName`, `quoteTableName`, `quoteString` from abstract-adapter.ts → `$TS/connection-adapters/abstract/quoting.ts` (currently inlined; ~6 misplaced)
-- Misplaced: ~24, LOC: ~220 net (moves + re-exports + `include()` wiring + smoke tests)
-- Dependencies: none (do before Wave 2)
-- Risk: every moved method must still resolve at the class level via `include()` or static assignment.
+**PR M3 — Move adapter-layer misplaced methods (combined)** ✅ #1161
 
 ---
 
 ### Wave 1 — Base type infrastructure
 
-**PR 1 — Base types + adapter-specific registry (combined)** _(~260 net LOC)_
-
-Wave 1 is unblocking infrastructure for Waves 2–5. Three small file groups merged into one PR — each is too small to ship alone (60/120/80 LOC) and they share the same TS type-system surface.
-
-_Component A — `type/time.rb` + `type/unsigned_integer.rb`_
-
-- Rails: `$AR/type/time.rb` (35 LOC), `$AR/type/unsigned_integer.rb` (16 LOC)
-- TS: `$TS/type/time.ts` (scaffold, 0 matched), `$TS/type/unsigned-integer.ts` (scaffold, 0 matched)
-- Missing: `time.ts` (3): `serialize`, `serializeCastValue`, `castValue`; `unsigned-integer.ts` (2): `maxValue`, `minValue`
-
-_Component B — `type/adapter_specific_registry.rb`_
-
-- Rails: `$AR/type/adapter_specific_registry.rb` (144 LOC)
-- TS: `$TS/type/adapter-specific-registry.ts` (9 matched, 12 missing, 43%)
-- Missing (12): `registrations`, `findRegistration`, `block`, `override`, `priorityExceptAdapter`, `matchesAdapter?`, `conflictsWith?`, `samePriorityExceptAdapter?`, `hasAdapterConflict?`, `options`, `klass`, `matchesOptions?`
-
-_Component C — Deduplicable cluster (5 files)_
-
-- Rails sources and current TS state:
-
-| Rails file                                            | LOC  | TS file                                               | Matched | Missing |
-| ----------------------------------------------------- | ---- | ----------------------------------------------------- | ------- | ------- |
-| `$AR/connection_adapters/deduplicable.rb`             | ~25  | `$TS/connection-adapters/deduplicable.ts`             | 3       | 1       |
-| `$AR/connection_adapters/column.rb`                   | ~100 | `$TS/connection-adapters/column.ts`                   | 14      | 2       |
-| `$AR/connection_adapters/sql_type_metadata.rb`        | ~40  | `$TS/connection-adapters/sql-type-metadata.ts`        | 6       | 2       |
-| `$AR/connection_adapters/mysql/type_metadata.rb`      | ~35  | `$TS/connection-adapters/mysql/type-metadata.ts`      | 2       | 2       |
-| `$AR/connection_adapters/postgresql/type_metadata.rb` | ~40  | `$TS/connection-adapters/postgresql/type-metadata.ts` | 3       | 2       |
-
-- Missing methods (9 total):
-  - `deduplicable.ts` (1): `deduplicate`
-  - `column.ts` (2): `autoPopulated?`, `virtual?` _(api:compare reports `autoPoppulated?` — confirmed typo in tooling output; Rails source `$AR/connection_adapters/column.rb` defines `auto_populated?`)_
-  - `sql-type-metadata.ts` (2): `deduplicated`, `hash`
-  - `mysql/type-metadata.ts` (2): `deduplicated`, `hash`
-  - `postgresql/type-metadata.ts` (2): `deduplicated`, `hash`
-- Component LOCs: A ~60, B ~120, C ~80 → **~260 combined**
-- Dependencies: verify #1136 (PG OID consolidation) before Component B
-- Risk: `block`/`override` use Ruby proc semantics — map to TS callbacks. `serializeCastValue` is a Rails 7.2 internal cast-pipeline hook.
-
-> **PRs 2 + 3 from prior revision are folded into PR 1.** The original Wave 1 had three sub-200 LOC PRs.
+**PR 1 — Base types + adapter-specific registry (combined)** _(~260 net LOC)_ ✅ #1147
 
 ---
 
 ### Wave 2 — Abstract adapter decomposition
 
-**PR 4 — `abstract/database_statements.rb` impl half**
+**PR 4 — `abstract/database_statements.rb` impl half** ✅ #1154
 
-- Rails: `$AR/connection_adapters/abstract/database_statements.rb` (747 LOC, lines 1–460 public, 460+ private)
-- TS: `$TS/connection-adapters/abstract/database-statements.ts` (1496 LOC, 59 matched, 13 missing, 82%)
-- Missing (13): `performQuery`, `preprocessQuery`, `defaultInsertValue`, `buildFixtureSql`, `buildFixtureStatements`, `buildTruncateStatement`, `buildTruncateStatements`, `combineMultiStatements`, `select`, `sqlForInsert`, `returningColumnValues`, `arelFromRelation`, `extractTableRefFromInsertSql`
-- Also move `initialize` + `resetTransaction` from `abstract-adapter.ts` (PR M3)
-- `performQuery` is the R2 cross-cutting hook (lines 400–430 of `$AR/.../abstract/database_statements.rb`)
-- LOC: Rails 747 LOC, TS 1496 LOC existing → ~240 net (new methods + fixture pipeline)
-- Split:
-  - PR 4: `performQuery`, `preprocessQuery`, `select`, `sqlForInsert`, `arelFromRelation`, `extractTableRefFromInsertSql`, `defaultInsertValue`, `returningColumnValues` (8 methods — query execution core)
-  - PR 4b: `buildFixtureSql`, `buildFixtureStatements`, `buildTruncateStatement`, `buildTruncateStatements`, `combineMultiStatements` (5 methods — fixture/truncate pipeline)
-- Dependencies: none
-- Risk: `performQuery` (Rails 7.2 central chokepoint, lines ~400–430) instruments, caches, and retries — study the full call chain including `withRawConnection` before implementing.
+**PR 5 — `abstract/schema_creation.rb`** ✅ #1139
 
-**PR 5 — `abstract/schema_creation.rb`** _(covered by #1139 — verify merge before starting)_
+**PR 6 — `abstract/schema_definitions.rb`** ✅ #1174
 
-- Rails: `$AR/connection_adapters/abstract/schema_creation.rb` (189 LOC)
-- TS: `$TS/connection-adapters/abstract/schema-creation.ts` (447 LOC, 11 matched, 10 missing, 52%)
-- Missing (10): `visitPrimaryKeyDefinition`, `visitAddForeignKey`, `visitDropConstraint`, `visitAddCheckConstraint`, `quotedColumns`, `addTableOptions!`, `columnOptions`, `addColumnOptions!`, `toSql`, `tableModifierInCreate`
-- LOC: Rails 189 LOC, TS 447 LOC existing → ~100 net (visitor implementations)
-- Dependencies: none (Wave 2 base)
-- Risk: `visitAddForeignKey` has a signature conflict noted in #1139 — legacy `(fromTable, toTable, options)` vs Rails `(o)`; the file-local helper workaround in #1139 must be preserved.
+**PR 7 — `abstract/schema_dumper.rb`** ✅ #1139
 
-**PR 6 — `abstract/schema_definitions.rb`** _(merged #1174)_
+**PR 8 — `abstract/schema_statements.rb` privates (part A)** ✅ #1165
 
-- Rails: `$AR/connection_adapters/abstract/schema_definitions.rb` (970 LOC)
-- TS: `$TS/connection-adapters/abstract/schema-definitions.ts` → 100% (86/86)
-- Dependencies: PR 5 (schema-creation visitors referenced in column definitions)
-
-**PR 7 — `abstract/schema_dumper.rb`** _(covered by #1139 — verify merge)_
-
-- Rails: `$AR/connection_adapters/abstract/schema_dumper.rb` (106 LOC)
-- TS: `$TS/connection-adapters/abstract/schema-dumper.ts` (118 LOC, 1 matched, 13 missing, 7%)
-- Missing (13): `columnSpec`, `columnSpecForPrimaryKey`, `prepareColumnOptions`, `defaultPrimaryKey?`, `explicitPrimaryKeyDefault?`, `schemaTypeWithVirtual`, `schemaType`, `schemaLimit`, `schemaPrecision`, `schemaScale`, `schemaDefault`, `schemaExpression`, `schemaCollation`
-- LOC: Rails 106 LOC, TS 118 LOC existing → ~80 net
-- Dependencies: PR 6
-
-**PR 8 — `abstract/schema_statements.rb` privates (part A)**
-
-- Rails: `$AR/connection_adapters/abstract/schema_statements.rb` (1899 LOC)
-- TS: `$TS/connection-adapters/abstract/schema-statements.ts` (1711 LOC, 76 matched, 42 missing, 64%)
-- Missing A (25): `generateIndexName`, `validateChangeColumnNullArgument!`, `columnOptionsKeys`, `addIndexSortOrder`, `optionsForIndexColumns`, `addOptionsForIndexColumns`, `indexNameForRemove`, `renameTableIndexes`, `renameColumnIndexes`, `createTableDefinition`, `createAlterTable`, `validateCreateTableOptions!`, `fetchTypeMetadata`, `indexColumnNames`, `indexNameOptions`, `expressionColumnName?`, `stripTableNamePrefixAndSuffix`, `foreignKeyName`, `foreignKeyFor`, `foreignKeyFor!`, `extractForeignKeyAction`, `foreignKeysEnabled?`, `checkConstraintName`, `checkConstraintFor`, `checkConstraintFor!`
-- LOC: ~250 net (each method ~5–15 LOC)
-- Dependencies: PR 6
-
-**PR 8b — `abstract/schema_statements.rb` privates (part B)**
-
-- Missing B (17): `validateIndexLength!`, `validateTableLength!`, `extractNewDefaultValue`, `canRemoveIndexByName?`, `referenceNameForTable`, `addColumnForAlter`, `changeColumnDefaultForAlter`, `renameColumnSql`, `removeColumnForAlter`, `removeColumnsForAlter`, `addTimestampsForAlter`, `removeTimestampsForAlter`, `insertVersionsSql`, `dataSourceSql`, `quotedScope`, `findJoinTableName`, `joinTableName`
-- LOC: ~250 net
-- Dependencies: PR 8
+**PR 8b — `abstract/schema_statements.rb` privates (part B)** ✅ #1175
 
 ---
 
 ### Wave 3 — Adapter-specific schema files
 
-**PR 9 — `mysql/schema_creation.rb` + `mysql/explain_pretty_printer.rb` (combined)** _(~260 net LOC)_
+**PR 9 — `mysql/schema_creation.rb` + `mysql/explain_pretty_printer.rb` (combined)** ✅ #1167
 
-- Rails: `mysql/schema_creation.rb` (106 LOC), `mysql/explain_pretty_printer.rb` (71 LOC)
-- TS: `$TS/connection-adapters/mysql/schema-creation.ts` (114 LOC, 0%, 11 missing), `$TS/connection-adapters/mysql/explain-pretty-printer.ts` (20%, 4 missing)
-- schema-creation missing (11): `visitDropForeignKey`, `visitDropCheckConstraint`, `visitAddColumnDefinition`, `visitChangeColumnDefinition`, `visitChangeColumnDefaultDefinition`, `visitCreateIndexDefinition`, `visitIndexDefinition`, `addTableOptions!`, `addColumnOptions!`, `addColumnPosition!`, `indexInCreate`
-- explain-pretty-printer missing (4): `computeColumnWidths`, `buildSeparator`, `buildCells`, `buildFooter`
-- LOC: ~180 + ~80 → **~260 combined**
-- Dependencies: PR 5 (for schema_creation)
-- Rationale: explain_pretty_printer is too small alone (~80 LOC); pairs with schema_creation as the mysql visitor/output cluster.
+**PR 10 — `mysql/schema_dumper.rb` (0%)** ✅ #1179
 
-**PR 10 — `mysql/schema_dumper.rb` (0%)**
+**PR 11 — `mysql/schema_statements.rb`** ✅ #1182
 
-- Rails: `$AR/connection_adapters/mysql/schema_dumper.rb` (97 LOC)
-- TS: `$TS/connection-adapters/mysql/schema-dumper.ts` (77 LOC scaffold, 0 matched, 9 missing)
-- Missing (9): `columnSpec`, `prepareColumnOptions`, `schemaType`, `schemaLimit`, `schemaPrecision`, `schemaScale`, `schemaDefault`, `schemaExpression`, `schemaCollation` (all override abstract base)
-- LOC: ~160 net + ~80 LOC of byte-exact-output snapshot tests → **~240 net**
-- Dependencies: PR 7
-- Note: snapshot tests vs schema.rb output are necessary; bringing the LOC into target range.
+**PR 12 — `postgresql/schema_creation.rb` (14%)** ✅ #1169
 
-**PR 11 — `mysql/schema_statements.rb` (38%)**
+**PR 13 — `postgresql/schema_dumper.rb` (0%)** ✅ #1178
 
-- Rails: `$AR/connection_adapters/mysql/schema_statements.rb` (307 LOC)
-- TS: `$TS/connection-adapters/mysql/schema-statements.ts` (191 LOC, 10 matched, 16 missing, 38%)
-- Missing (16): `createTable`, `dropTable`, `renameTable`, `addColumn`, `renameColumn`, `changeColumn`, `changeColumnDefault`, `changeColumnNull`, `addIndex`, `removeIndex`, `addAutoIncrementColumn`, `primaryKeys`, `caseInsensitiveComparison`, `strictMode?`, `createTableDefinition`, `fetchTypeMetadata`
-- LOC: Rails 307 LOC, TS 191 LOC → ~220 net
-- Dependencies: PR 8/8b, PR 6
+**PR 14 — `postgresql/schema_statements.rb` (83%)** ✅ #1183
 
-**PR 12 — `postgresql/schema_creation.rb` (14%)**
+**PR 15 — `sqlite3/schema_creation.rb` + `schema_definitions.rb` + `schema_dumper.rb`** ✅ #1184
 
-- Rails: `$AR/connection_adapters/postgresql/schema_creation.rb` (160 LOC)
-- TS: `$TS/connection-adapters/postgresql/schema-creation.ts` (150 LOC scaffold, 2 matched, 14 missing, 14%)
-- Missing (14): `visitAlterTable`, `visitAddForeignKey`, `visitForeignKeyDefinition`, `visitCheckConstraintDefinition`, `visitValidateConstraint`, `visitExclusionConstraintDefinition`, `visitUniqueConstraintDefinition`, `visitAddExclusionConstraint`, `visitAddUniqueConstraint`, `visitChangeColumnDefinition`, `visitChangeColumnDefaultDefinition`, `addColumnOptions!`, `quotedIncludeColumns`, `tableModifierInCreate`
-- LOC: Rails 160 LOC, TS 150 LOC → ~220 net
-- Dependencies: PR 5
-
-**PR 13 — `postgresql/schema_dumper.rb` (0%)**
-
-- Rails: `$AR/connection_adapters/postgresql/schema_dumper.rb` (128 LOC)
-- TS: `$TS/connection-adapters/postgresql/schema-dumper.ts` (91 LOC scaffold, 0 matched, 10 missing)
-- Missing (10): `columnSpec`, `prepareColumnOptions`, `schemaType`, `schemaLimit`, `schemaPrecision`, `schemaScale`, `schemaDefault`, `schemaExpression`, `schemaCollation`, `defaultPrimaryKey?` (all PG-specific overrides of abstract base)
-- LOC: Rails 128 LOC → ~200 net
-- Dependencies: PR 7
-
-**PR 14 — `postgresql/schema_statements.rb` (83%)**
-
-- Rails: `$AR/connection_adapters/postgresql/schema_statements.rb` (1163 LOC)
-- TS: `$TS/connection-adapters/postgresql/schema-statements.ts` (450 LOC, 76 matched, 16 missing, 83%)
-- Missing (16): `createDatabase`, `dropDatabase`, `createSchema`, `dropSchema`, `addIndex`, `removeIndex`, `renameTable`, `addForeignKey`, `validateForeignKey`, `addCheckConstraint`, `addExclusionConstraint`, `addUniqueConstraint`, `dropConstraint`, `createTableDefinition`, `fetchTypeMetadata`, `extractSchemaQualifiedTableName`
-- LOC: Rails 1163 LOC (large file, many already done), TS 450 LOC → ~240 net
-- Dependencies: PR 8/8b, PR 12
-
-**PR 15 — `sqlite3/schema_creation.rb` + `schema_definitions.rb` + `schema_dumper.rb`**
-
-- Rails sources:
-  - `$AR/connection_adapters/sqlite3/schema_creation.rb` (37 LOC) — 0%, 3 missing
-  - `$AR/connection_adapters/sqlite3/schema_definitions.rb` (~25 LOC) — 60%, 2 missing
-  - `$AR/connection_adapters/sqlite3/schema_dumper.rb` (47 LOC) — 0%, 5 missing
-- TS files:
-  - `$TS/connection-adapters/sqlite3/schema-creation.ts` (scaffold exists, 0 matched)
-  - `$TS/connection-adapters/sqlite3/schema-definitions.ts` (3 matched, 2 missing)
-  - `$TS/connection-adapters/sqlite3/schema-dumper.ts` (scaffold exists, 0 matched)
-- Missing (10 total):
-  - schema-creation (3): `visitForeignKeyDefinition`, `supportsIndexUsing?`, `addColumnOptions!`
-  - schema-definitions (2): `integerLikePrimaryKeyType`, `validColumnDefinitionOptions`
-  - schema-dumper (5): `columnSpec`, `prepareColumnOptions`, `schemaType`, `schemaLimit`, `schemaDefault`
-- LOC: ~180 net
-- Dependencies: PR 5, PR 7
-
-**PR 16 — `sqlite3/schema_statements.rb` (50%)**
-
-- Rails: `$AR/connection_adapters/sqlite3/schema_statements.rb` (223 LOC)
-- TS: `$TS/connection-adapters/sqlite3/schema-statements.ts` (9 matched, 9 missing, 50%)
-- Missing (9): `createTable`, `addColumn`, `changeColumn`, `changeColumnDefault`, `changeColumnNull`, `removeColumn`, `renameTable`, `renameColumn`, `addPrimaryKeyConstraint`
-- LOC: Rails 223 LOC → ~160 net
-- Dependencies: PR 8/8b, PR 15
+**PR 16 — `sqlite3/schema_statements.rb` (50%)** ✅ #1191
 
 ---
 
 ### Wave 4 — Database statements per adapter
 
-**PR 17 — sqlite3 + mysql `database_statements.rb` (combined)** _(~280 net LOC)_
-
-- Rails: `sqlite3/database_statements.rb` (149 LOC), `mysql/database_statements.rb` (95 LOC)
-- TS: `$TS/connection-adapters/sqlite3/database-statements.ts` (151 LOC, 56%), `$TS/connection-adapters/mysql/database-statements.ts` (61 LOC, 40%)
-- sqlite3 missing (8): `internalBeginTransaction`, `performQuery`, `castResult`, `affectedRows`, `executeBatch`, `buildTruncateStatement`, `returningColumnValues`, `defaultInsertValue`
-- mysql missing (6): `performQuery`, `castResult`, `affectedRows`, `executeAndFreeResult`, `combineMultiStatements`, `withoutPreparedStatement`
-- LOC: ~160 + ~120 → **~280 combined**
-- Dependencies: PR 4
-- Rationale: both implement the same `performQuery`/`castResult`/`affectedRows` triplet from R2; landing together reduces review-cycle on the protocol shape.
+**PR 17 — sqlite3 + mysql `database_statements.rb` (combined)** ✅ #1231
 
 **PR 18 — mysql2 + postgresql `database_statements.rb` (combined)** _(~320 net LOC — over hard limit, see split note)_
 
@@ -358,112 +194,33 @@ _Component C — Deduplicable cluster (5 files)_
 
 ### Wave 5 — Adapter classes
 
-**PR 21 — `abstract_mysql_adapter.rb` (76%)**
+**PR 21 — `abstract_mysql_adapter.rb` (76%)** ✅ #1186 (first split, 12/22)
 
-- Rails: `$AR/connection_adapters/abstract_mysql_adapter.rb` (1027 LOC)
-- TS: `$TS/connection-adapters/abstract-mysql-adapter.ts` (1205 LOC, 70 matched, 22 missing, 76%)
-- Missing (22): `initializeTypeMap`, `registerDateTimeTypes`, `registerIntegerTypes`, `registerStringTypes`, `registerNumericTypes`, `registerFloatTypes`, `registerBlobTypes`, `registerBooleanTypes`, `registerJsonTypes`, `validateType`, `typeToSql`, `newColumnDefinition`, `columnSpec`, `fullVersionString`, `getMysqlVariable`, `setMysqlVariable`, `caseInsensitiveComparison`, `caseSensitiveComparison`, `limitedSupportsIndexSortOrder?`, `limitedSupportsIndexInclude?`, `limitedSupportsDdlTransactions?`, `renameTableIndexes`
-- Split:
-  - PR 21 (12): `initializeTypeMap` + all `register*Types` helpers + `typeToSql`, `newColumnDefinition` (type-map core)
-  - PR 21b (10): `columnSpec`, `fullVersionString`, `getMysqlVariable`, `setMysqlVariable`, `caseInsensitiveComparison`, `caseSensitiveComparison`, `limitedSupports*`, `renameTableIndexes` (query/schema helpers)
-- LOC: ~250 net each
-- Dependencies: PR 1, PR 11, PR 18/18b
+**PR 22 — `mysql2_adapter.rb` (64%) + `mysql2_adapter` test parity** ✅ #1233
 
-**PR 22 — `mysql2_adapter.rb` (64%) + `mysql2_adapter` test parity** _(~250 net LOC)_
+**PR 23 — `postgresql_adapter.rb` (82%)** ✅ #1199 (first split) + #1242 (PR 23b)
 
-- Rails: `$AR/connection_adapters/mysql2_adapter.rb` (203 LOC)
-- TS: `$TS/connection-adapters/mysql2-adapter.ts` (1109 LOC, 14 matched, 8 missing, 64%)
-- Missing (8): `newClientConnection`, `connectWithoutRetry`, `configure`, `defaultPreparedStatements`, `reconnect`, `disconnect!`, `discard!`, `buildStatement`
-- Add Rails-mirrored test cases for the connect/discard/reconnect lifecycle (`test/cases/adapters/mysql2/connection_test.rb`)
-- LOC: ~150 impl + ~100 tests → ~250 net
-- Dependencies: PR 21
-
-**PR 23 — `postgresql_adapter.rb` (82%)**
-
-- Rails: `$AR/connection_adapters/postgresql_adapter.rb` (1189 LOC)
-- TS: `$TS/connection-adapters/postgresql-adapter.ts` (4212 LOC, 76 matched, 17 missing, 82%)
-- Missing (17): `connectAndConfigure`, `configureConnection`, `reconnect!`, `disconnect!`, `discard!`, `truncateTable`, `getAdvisoryLock`, `releaseAdvisoryLock`, `allSchemas`, `schema`, `encoderFor`, `decoderFor`, `pgEncoderForType`, `pgDecoderForType`, `initializeTypeMap`, `registerDateTimeTypes`, `enableExtension`
-- Split:
-  - PR 23 (9): `connectAndConfigure`, `configureConnection`, `reconnect!`, `disconnect!`, `discard!`, `truncateTable`, `getAdvisoryLock`, `releaseAdvisoryLock`, `allSchemas`
-  - PR 23b (8): `encoderFor`, `decoderFor`, `pgEncoderForType`, `pgDecoderForType`, `initializeTypeMap`, `registerDateTimeTypes`, `schema`, `enableExtension`
-- LOC: ~250 net each
-- Dependencies: PR 14, PR 18b
-
-**PR 24 — `sqlite3_adapter.rb` (75% → 86%) — table-rebuild cluster ✓ MERGED**
-
-- Rails: `$AR/connection_adapters/sqlite3_adapter.rb` (849 LOC)
-- TS: `$TS/connection-adapters/sqlite3-adapter.ts` (62 matched, 10 missing, 86%)
-- PR 24 (8, merged): `tableInfo`, `tableStructureSql`, `tableStructureWithCollation`, `tableStructure`, `moveTable`, `copyTable`, `copyTableIndexes`, `copyTableContents`
-- PR 24b (10 remaining): `bindParamsLength`, `extractValueFromDefault`, `extractDefaultFunction`, `hasDefaultFunction`, `isInvalidAlterTableType`, `translateException`, `buildStatementPool`, `connect`, `configureConnection`, `initializeTypeMap`
-- LOC: ~274 net (PR 24)
-- Dependencies: PR 16, PR 17
+**PR 24 — `sqlite3_adapter.rb`** ✅ #1195 (first split) + #1232 (PR 24b lifecycle/type-map)
 
 ---
 
 ### Wave 6 — abstract_adapter.rb residual
 
-**PR 25 — `abstract_adapter.rb` core privates**
-
-- Rails: `$AR/connection_adapters/abstract_adapter.rb` (1234 LOC, lines 946–1234 are privates)
-- TS: `$TS/connection-adapters/abstract-adapter.ts` (1270 LOC, 160 matched, ~40–60 true residual after Wave 2–5 account for sub-file methods)
-- Missing privates (from lines 946–1234 of Rails source): `reconnectCanRestoreState?`, `withRawConnection`, `verified!`, `retryableConnectionError?`, `invalidateTransaction`, `retryableQueryError?`, `backoff`, `reconnect`, `anyRawConnection`, `validRawConnection`, `extendedTypeMapKey`, `typeMap`, `translateExceptionClass`, `log`, `instrumenter`, `translateException`, `columnFor`, `columnForAttribute`, `collector`, `arelVisitor`, `buildStatementPool`, `buildResult`, `configureConnection`, `attemptConfigureConnection`, `defaultPreparedStatements`, `warningIgnored?`, `lookupCastTypeFromColumn`
-- Split:
-  - PR 25 (13): Connection lifecycle — `withRawConnection` (lines 983–1053), `verified!` (line 1054), `retryableConnectionError?`, `invalidateTransaction`, `retryableQueryError?`, `backoff`, `reconnect`, `anyRawConnection`, `validRawConnection`, `reconnectCanRestoreState?`, `extendedTypeMapKey`, `typeMap`, `configureConnection`
-  - PR 25b (14): Query/logging infrastructure — `translateExceptionClass`, `log`, `instrumenter`, `translateException`, `columnFor`, `columnForAttribute`, `collector`, `arelVisitor`, `buildStatementPool`, `buildResult`, `attemptConfigureConnection`, `defaultPreparedStatements`, `warningIgnored?`, `lookupCastTypeFromColumn`
-- LOC: ~250 net each
-- Dependencies: all of Waves 2–5
-
-**Risk:** `withRawConnection` (lines 983–1053 of `$AR/connection_adapters/abstract_adapter.rb`) is a deeply stateful lease — it tracks raw connection validity, handles retry loops, and calls `verified!`. It couples tightly to the connection pool work in #1133/#1134. Study those PRs before PR 25.
-
-**Also:** `lookupCastTypeFromColumn` appears in both `abstract_adapter.rb` (line 1227) and `postgresql/quoting.rb` (line 189) with different implementations — both must land separately.
+**PR 25 — `abstract_adapter.rb` core privates** ✅ #1235 (first split, 13/27)
 
 ---
 
 ### Wave 7 — Core AR model files
 
-**PR 26 — `attribute_assignment.rb` (0%)**
+**PR 26 — `attribute_assignment.rb` (0%)** ✅ #1180
 
-- Rails: `$AR/attribute_assignment.rb` (82 LOC)
-- TS: `$TS/attribute-assignment.ts` — **file does not exist; must be created**
-- Missing (7): `assignAttributes`, `_assignAttributes`, `assignMultiparameterAttributes`, `extractCallableAttribute`, `executeCallables`, `typeCastAttributeFromMultiparameterAssignment`, `findParamNamesAndAllowedRanges`
-- LOC: Rails 82 LOC → ~180 net (multiparameter date parsing is non-trivial in TS)
-- Dependencies: none
-- Risk: `assignMultiparameterAttributes` handles Rails date/time decomposition (`(1i)`, `(2i)`, `(3i)` field suffixes) — no direct TS equivalent. Must implement a field-grouping parser.
+**PR 27 — `attribute_methods.rb`** ✅ #1185
 
-**PR 27 — `attribute_methods.rb` (56% → 100%) ✅ merged #1185**
+**PR 28 — `attributes.rb` + `aggregations.rb` (combined)** ✅ #1237
 
-- Rails: `$AR/attribute_methods.rb` (547 LOC)
-- TS: `$TS/attribute-methods.ts` — 71/71 (100%)
-- Also fixed `attributesInDatabase` bug (was returning new values; should return original DB values per Rails spec)
-- Also broke circular import: primary-key.ts imports dangerousAttributeMethods from attribute-methods.ts, so the 5 id\* methods are inlined instead of imported
-- Dependencies: none
+**PR 29 — `timestamp.rb` (31%)** ✅ #1229
 
-**PR 28 — `attributes.rb` + `aggregations.rb` (combined)** _(~250 net LOC)_
-
-- Rails: `$AR/attributes.rb` (~80 LOC), `$AR/aggregations.rb` (287 LOC)
-- TS: `$TS/attributes.ts` (29%, 5 missing), `$TS/aggregations.ts` (50%, 3 missing)
-- attributes missing (5): `attribute`, `defaultAttributes`, `_default_attributes`, `buildAttributeFromUser`, `buildAttributeFromDatabase`
-- aggregations missing (3): `mapAggregationAttribute`, `reflectionFor`, `newValueFrom`
-- LOC: ~100 + ~80 + ~70 of value-object/composed-of test scaffolding → ~250
-- Dependencies: PR 27
-- Rationale: both define value-object/attribute factories layered on `attribute_methods`; pairs naturally.
-
-**PR 29 — `timestamp.rb` (31%)**
-
-- Rails: `$AR/timestamp.rb` (177 LOC)
-- TS: `$TS/timestamp.ts` (249 LOC, 5 matched, 11 missing, 31%)
-- Missing (11): `recordTimestamps`, `currentTime`, `maxUpdatedColumn`, `maxUpdatedAt`, `allTimestampAttributesInModel`, `timestampAttributesForCreate`, `timestampAttributesForUpdate`, `timestampAttributesForCreateInModel`, `timestampAttributesForUpdateInModel`, `touchedAttributesForCreate`, `touchedAttributesForUpdate`
-- LOC: Rails 177 LOC, TS 249 LOC → ~180 net
-- Dependencies: PR 27
-
-**PR 30 — `autosave_association.rb` (34%)**
-
-- Rails: `$AR/autosave_association.rb` (596 LOC)
-- TS: `$TS/autosave-association.ts` (629 LOC, 10 matched, 19 missing, 34%)
-- Missing (19): `saveCollectionAssociation`, `saveBelongsToAssociation`, `saveHasOneAssociation`, `nested_records_changed_for_autosave?`, `associationValid?`, `markForDestructionUnlessNew`, `destroyMarkedForDestructionAssociations`, `associationForeignKeyChanged?`, `markForDestruction`, `markedForDestruction?`, `raiseNestedAttributesRecordNotFoundError`, `callbacksForSave`, `shouldAutosave?`, `associationIsValid?`, `validatesPresenceOfBelongsTo?`, `defineNonCyclicMethod`, `addAutosaveAssociationCallbacks`, `addAutosaveBelongsToCallbacks`, `addAutosaveThroughCallbacks`
-- LOC: Rails 596 LOC, TS 629 LOC → ~260 net
-- Dependencies: PR 27, PR 29
-- Risk: `defineNonCyclicMethod` uses Ruby `define_method` + a cycle-detection registry. The TS equivalent must prevent infinite autosave loops — verify existing TS approach (`defineNonCyclicMethod` may already be partially implemented in `autosave-association.ts`).
+**PR 30 — `autosave_association.rb` (34%)** ✅ #1239
 
 **PR 31 — `nested_attributes.rb` (14%)**
 
@@ -473,17 +230,7 @@ _Component C — Deduplicable cluster (5 files)_
 - LOC: Rails 633 LOC → ~250 net
 - Dependencies: PR 30
 
-**PR 32 — `locking/optimistic.rb` + `counter_cache.rb` (combined)** _(~240 net LOC)_
-
-- Rails: `$AR/locking/optimistic.rb` (228 LOC), `$AR/counter_cache.rb` (230 LOC)
-- TS: `$TS/locking/optimistic.ts` (53%, 8 missing), `$TS/counter-cache.ts` (67%, 3 missing)
-- optimistic missing (8): `lockOptimistically?`, `lockingColumn`, `lockingEnabled?`, `addLockColumn`, `updateRecord`, `destroyWithVersionCheck`, `updateWithVersionCheck`, `lockedAttributeName`
-- counter_cache missing (3): `counterCacheName?`, `shouldUpdateCounter?`, `updateCounters`
-- LOC: ~160 + ~80 → ~240
-- Dependencies: PR 27
-- Rationale: both override `_updateRecord`/`destroy_row` write-path hooks — testing them together keeps the row-write contract coherent.
-
-> **PR 34 (aggregations) folded into PR 28.**
+**PR 32 — `locking/optimistic.rb` + `counter_cache.rb` (combined)** ✅ #1230
 
 **PR 35 — `core.rb` + `model_schema.rb` (combined)** _(~280 net LOC)_
 
@@ -545,25 +292,11 @@ _Component C — Deduplicable cluster (5 files)_
 
 **PR 39 — `encryptor.rb` (35%)** _(covered by E3)_
 
-- Rails: `$AR/encryption/encryptor.rb` (177 LOC)
-- TS: `$TS/encryption/encryptor.ts` (7 matched, 13 missing)
-- Missing (13): `defaultKeyProvider`, `validatePayloadType`, `cipher`, `buildEncryptedMessage`, `serializeMessage`, `deserializeMessage`, `serializer`, `compressIfWorthIt`, `compress`, `uncompressIfNeeded`, `uncompress`, `forceEncodingIfNeeded`, `forcedEncodingForDeterministicEncryption`
-
 **PR 40 — `message_serializer.rb` + `message_pack_message_serializer.rb`** _(covered by E2)_
-
-- Rails: `$AR/encryption/message_serializer.rb` (96 LOC) — 3 matched, 7 missing
-- Missing (7): `parseMessage`, `validateMessageDataFormat`, `parseProperties`, `messageToJson`, `headersToJson`, `encodeIfNeeded`, `decodeIfNeeded`
-- `message_pack_message_serializer.rb` — 3 matched, 5 missing
 
 **PR 41 — `encrypted_attribute_type.rb` (45%)** _(covered by E4)_
 
-- Rails: `$AR/encryption/encrypted_attribute_type.rb`
-- Missing (16): listed in E4 PR body
-
 **PR 42 — `encryptable_record.rb` (30%)** _(covered by E4)_
-
-- Rails: `$AR/encryption/encryptable_record.rb`
-- Missing (16): public `encrypt`/`decrypt`/`ciphertext_for`/`loadSchema!` (42); privates (42b)
 
 **PR 43 — Remaining encryption small files**
 
@@ -591,21 +324,9 @@ _Component C — Deduplicable cluster (5 files)_
 
 ### Wave 10 — Migration cluster
 
-**PR 44 — `migration/join_table.rb` (0%)**
+**PR 44 — `migration/join_table.rb` (0%)** ✅ #1188
 
-- Rails: `$AR/migration/join_table.rb` (16 LOC)
-- TS: `$TS/migration/join-table.ts` — **file does not exist; must be created**
-- Missing (2): `findJoinTableName`, `joinTableName`
-- LOC: Rails 16 LOC → ~40 net (create file + implement)
-- Dependencies: PR 8b (join table name logic referenced there)
-
-**PR 45 — `migration/command_recorder.rb` (42%)**
-
-- Rails: `$AR/migration/command_recorder.rb` (409 LOC)
-- TS: `$TS/migration/command-recorder.ts` (336 LOC, 16 matched, 22 missing, 42%)
-- Missing (22): `invertAddColumn`, `invertRemoveColumn`, `invertAddIndex`, `invertRemoveIndex`, `invertAddTimestamps`, `invertRemoveTimestamps`, `invertAddReference`, `invertRemoveReference`, `invertAddForeignKey`, `invertRemoveForeignKey`, `invertAddCheckConstraint`, `invertRemoveCheckConstraint`, `invertAddExclusionConstraint`, `invertRemoveExclusionConstraint`, `invertAddUniqueConstraint`, `invertRemoveUniqueConstraint`, `invertCreateTable`, `invertDropTable`, `invertCreateJoinTable`, `invertDropJoinTable`, `invertRenameTable`, `invertRenameColumn`
-- LOC: Rails 409 LOC, TS 336 LOC → ~250 net (likely dispatch table — check existing `invertX` pattern before reimplementing)
-- Dependencies: PR 44
+**PR 45 — `migration/command_recorder.rb` (42%)** ✅ #1236
 
 **PR 46 — `migration.rb` (68%)**
 
@@ -707,16 +428,7 @@ _Component C — Deduplicable cluster (5 files)_
 - Total: ~57 missing methods, ~240 net LOC
 - Dependencies: relevant Wave 2–7 PRs per file
 
-**PR 53 — Railtie + deprecator + job_runtime + query_assertions (combined)** _(~290 net LOC)_
-
-- Rails: `$AR/railtie.rb`, `$AR/deprecator.rb`, `$AR/railties/job_runtime.rb`, `$AR/testing/query_assertions.rb` (121 LOC)
-- TS: `$TS/railtie.ts`, `$TS/deprecator.ts`, `$TS/railties/job-runtime.ts` — **none of these files/dirs exist** — and `$TS/testing/query-assertions.ts` (11%, 8 missing)
-- Railtie/deprecator/job_runtime missing (13): railtie initialization hooks, deprecation wrapper, job runtime instrumentation
-- query_assertions missing (8): `assertQueries`, `assertNoQueries`, `assertQueriesMatch`, `assertNoQueriesMatch`, `countingQueries`, `countingQueriesMatching`, `querySubscriptionBlock`, `querySubscriptionCountingBlock`
-- LOC: ~150 + ~140 → ~290
-- Dependencies: PR 4 (for query_assertions subscription hook)
-- Rationale: all four are framework-instrumentation concerns sitting on the same notification subsystem; pairing keeps the instrumenter contract review single-pass.
-- Risk: `railtie.rb` may need actionpack cross-package wiring; ship stub initializers first if needed.
+**PR 53 — Railtie + deprecator + job_runtime + query_assertions (combined)** ✅ #1197 + #1198 (PR 53b query_assertions)
 
 ---
 
@@ -783,6 +495,8 @@ Folds former PRs 58 + 59 plus the remaining unassigned 1-missers from the PR 52 
 11. **`mysql2/` directory missing entirely**: `$TS/connection-adapters/mysql2/` does not exist. PR 18 must create directory + file. Verify `tsconfig.json` and `package.json` exports map do not need updating.
 
 12. **`railtie.ts` + `middleware/` directory both missing**: These require creating new top-level files and directories. Verify `$TS/index.ts` or barrel exports need updating after PR 50 and PR 53.
+
+13. **MariaDB `DATETIME` serialization**: The mysql2 adapter inserts ISO 8601 `Z`-suffix strings into `DATETIME` columns (e.g. `"2026-05-05T14:32:00Z"`) which MariaDB rejects. Surfaced during the test-schema migration (TS-4d #1211): both `defineSchema` and the legacy auto-schema path work around it by mapping `datetime` → `TEXT` on non-PG, so timestamp columns are never exercised as real `DATETIME` on MariaDB/SQLite. The real fix is in the adapter's datetime quoter/typecaster — emit MariaDB-compatible `YYYY-MM-DD HH:MM:SS` (no `T`, no `Z`) for `DATETIME` columns. Likely lives near `connection-adapters/mysql2/quoting.ts` / `typecast.ts`. Slot in alongside PR 22 (`mysql2_adapter.rb`) or as a standalone fix; tag PR 22's body with this dependency. Once fixed, revert the `defineSchema` datetime→TEXT downgrade so MariaDB tests actually exercise `DATETIME` semantics.
 
 ---
 

--- a/docs/ar-test-parallelism-plan.md
+++ b/docs/ar-test-parallelism-plan.md
@@ -1,0 +1,167 @@
+# activerecord test parallelism plan (postmortem)
+
+Status: ✅ **shipped.** All six PRs (P1..P6) merged 2026-05-05/06 via #1223 #1224 #1225 #1226 #1227 #1228. CI is green on PG/MariaDB with file-level parallelism re-enabled. This document captures the diagnosis and rollout for future readers; it is not an active plan.
+
+## Background
+
+The activerecord package runs ~12k vitest tests against three backends in
+separate CI jobs (`.github/workflows/ci.yml`):
+
+- `sqlite-tests` — `:memory:` per fork, naturally isolated.
+- `postgres-tests` (lines 264–300) — provisions `rails_js_test_2..4`
+  alongside the base `rails_js_test`, sets `AR_DB_FORKS=4`.
+- `mariadb-tests` (lines 302–339) — same shape against MariaDB.
+
+The shared module-level `_sharedAdapter` in `packages/activerecord/src/test-adapter.ts:51`
+holds one adapter per worker process; every test file in the worker shares
+its connection pool and its `dropAllTables` state.
+
+### What PR #1092 added
+
+PR #1092 ("Parallel AR tests merged") attempted real per-worker DB
+isolation. Four pieces survived in the tree:
+
+1. `AR_DB_FORKS: 4` in `.github/workflows/ci.yml` lines 300 and 339.
+2. The "Create parallel test databases" CI step (lines 292–296, 330–335)
+   that pre-creates `rails_js_test_2..4` on PG / MariaDB.
+3. The slot-mapping formula in
+   `packages/activerecord/src/test-setup-worker-db.ts:21`:
+   `slot = ((VITEST_WORKER_ID - 1) % AR_DB_FORKS) + 1`, applied as a URL
+   suffix to `PG_TEST_URL` / `MYSQL_TEST_URL`.
+4. The fork pinning in `vitest.config.ts:106–110`:
+   `pool: "forks"`, `poolOptions.forks.maxForks = minForks = AR_DB_MAX_FORKS`,
+   where `AR_DB_MAX_FORKS = AR_DB_FORKS ?? (realDb ? 1 : undefined)`.
+
+The intent: fix the worker count at 4, pin each worker to a distinct DB
+via a stable `VITEST_WORKER_ID`, run files in parallel.
+
+### Why it doesn't actually parallelize safely
+
+`VITEST_WORKER_ID` is not a stable slot identifier. Vitest 3.2 increments
+it monotonically per spawned worker, recycling forks freely; observed CI
+runs see IDs into the 400s for ~160 files. With `AR_DB_FORKS=4`, IDs 1, 5,
+9, … all map to slot 1. If two live workers hold colliding IDs at the same
+moment, both connect to `rails_js_test_1` and race on
+`dropAllTables` / `defineSchema`.
+
+`maxForks=minForks=N` does not prevent this: it caps _concurrent_ forks
+but vitest still recycles workers (each new fork gets a fresh
+`VITEST_WORKER_ID`). The only knob that reliably serializes file
+execution is the CLI flag `--no-file-parallelism`, which is the
+short-term mitigation tracked in the in-flight PR #1222.
+
+### Symptom
+
+Pre-TS-4: the dynamic test-adapter's regex-based recovery path
+(`test-adapter.ts`, the historical "missing column ALTER" code) masked
+cross-worker drops by re-CREATEing tables mid-query. As TS-4 migrates
+files to explicit `defineSchema` + `dropAllTables`, that masking is gone,
+and `associations/join-model.test.ts` plus any TS-4-migrated file
+intermittently fails on PG/MariaDB with `relation "X" does not exist`
+when worker B's `dropAllTables` lands inside worker A's setup.
+
+### What is in flight
+
+- PR #1222 (branch `fix/ar-pg-worker-db-isolation`): re-add
+  `--no-file-parallelism` to the three test commands. Restores stability,
+  loses the parallel speed-up. Treat as a stop-gap.
+- `docs/explicit-test-schema-plan.md` (TS-1..TS-final): replacing the
+  dynamic test-adapter with explicit `defineSchema`. ~25% migrated.
+
+## Design alternatives
+
+| Option                                                                                                                                                                          | Pros                                                                                                             | Cons                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. PG advisory locks / MariaDB `GET_LOCK`** for slot acquisition. Worker iterates `pg_try_advisory_lock(N)` for `N=1..MAX`, claims first success, holds for process lifetime. | No reliance on `VITEST_WORKER_ID`. Self-healing on crash (PG drops session locks on disconnect). Backend-native. | Two code paths (PG + MariaDB) to maintain. SQLite no-op. Slot count still bounded by pre-provisioned DBs.                                                                   |
+| **B. `flock` lockfiles** (`/tmp/ar-test-slot-N.lock`).                                                                                                                          | Backend-uniform; single code path.                                                                               | Stale locks survive `SIGKILL` on Linux (kernel releases on exit, OK in practice — but containers and `kill -9` edge cases need care). Adds FS dependency to a DB-only flow. |
+| **C. Database-per-file** (`CREATE DATABASE` in adapter setup, drop in teardown).                                                                                                | Total isolation; no shared state.                                                                                | PG `CREATE DATABASE` ≈ 200–500ms × ~165 files ≈ 30–80s overhead per backend. Likely _negates_ parallelism savings; also serialized on the `template1` lock.                 |
+| **D. Schema-per-worker** (single DB, `SET search_path` per slot).                                                                                                               | One DB, fast setup.                                                                                              | MariaDB has no schema namespace (schema == database). PG-only solution; still needs slot acquisition. FK-across-schemas surprises in test fixtures.                         |
+| **E. Status quo + CLI flag (#1222)**.                                                                                                                                           | Zero design risk.                                                                                                | Loses ~3min/job; doesn't scale as the suite grows.                                                                                                                          |
+
+Option C variant — _worker-scoped_ `CREATE DATABASE` once at init, drop
+on exit — collapses the 80s into a one-time cost per worker. Combined
+with advisory locking it removes the need for the pre-provisioned
+`rails_js_test_2..4` step entirely.
+
+## Recommendation
+
+**Option A (advisory locks) over a fixed pool of pre-provisioned DBs**,
+phased in behind a feature flag. Rationale:
+
+- Removes the `VITEST_WORKER_ID` dependency, the actual root cause.
+- Keeps pre-provisioning (cheap, one-shot in CI) so we don't pay
+  per-worker `CREATE DATABASE` cost.
+- PG / MariaDB locks are released automatically on disconnect →
+  crash-safe by construction.
+- Compatible with the TS-4 migration: each slot is exclusively held
+  by one worker for its lifetime, so files in that worker — whether
+  using the dynamic adapter or `defineSchema` — never cross paths
+  with files in another worker.
+
+Migration-period compatibility: dynamic-adapter files and `defineSchema`
+files coexist within a single worker today; the only invariant the new
+mechanism must preserve is _one worker = one DB for the worker's
+lifetime_. Advisory locks give us exactly that without `VITEST_WORKER_ID`.
+
+## Implementation plan
+
+Each PR ≤300 LOC; draft; conventional commits.
+
+1. **PR-P1 — advisory-lock slot acquisition (PG)** ✅ #1223
+   `test-setup-worker-db.ts`: on first DB use, open a bootstrap
+   connection to the base URL and try `pg_try_advisory_lock(slot)` for
+   `slot=1..AR_DB_FORKS`. Rewrite `PG_TEST_URL` to the claimed slot's
+   DB. Hold the bootstrap connection for the lifetime of the process
+   (release-on-exit handler as defence in depth). No CI changes.
+   Gate behind `AR_DB_LOCK_MODE=advisory`; default unchanged.
+2. **PR-P2 — same for MariaDB** via `GET_LOCK('ar_test_slot_N', 0)`. ✅ #1224
+3. **PR-P3 — flip default to `advisory`** and remove the
+   `((id-1) % forks) + 1` formula. Keep `AR_DB_FORKS` as the slot count;
+   keep the "Create parallel test databases" CI step. ✅ #1225
+4. **PR-P4 — unpin worker count.** Remove `maxForks/minForks` from
+   `vitest.config.ts`; allow vitest to spawn freely. Workers that can't
+   acquire a slot busy-wait briefly (bounded retry) — slot count caps
+   real concurrency, not worker count. ✅ #1226
+5. **PR-P5 — revert #1222** (remove `--no-file-parallelism`) once P1–P4
+   showed zero flakes across PG and MariaDB CI. ✅ #1227
+6. **PR-P6 — cleanup.** Deleted the `AR_DB_LOCK_MODE` flag and residual
+   modulo helpers; kept `AR_DB_FORKS` and the "Create parallel test
+   databases" step (they define the pool size). ✅ #1228
+
+Migration ordering vs TS-4 (as it played out): P1–P4 were independent of TS-4 (the lock mechanism cares only about worker–DB binding, not how the schema is defined). P5 landed after TS-4 had reached the files most prone to cross-worker leakage (`associations/join-model.test.ts`, `dirty.test.ts`, `relation.test.ts`), so when CI stayed green on parallelism re-enable, the parallelism change was the clearly attributable cause rather than residual dynamic-adapter races.
+
+Rollback path (preserved here as architectural note, not active): each PR was independently revertable. P5 was the only behaviour-visible flip; if flakes had returned, reverting P5 alone would have left P1–P4 dormant under serialized execution and let us diagnose without CI pressure. Did not need to use it.
+
+## Success criteria
+
+- PG and MariaDB CI wall-clock ≤ current parallel-broken time and
+  strictly less than `--no-file-parallelism` time. Target: ≥2 min
+  saved per backend job vs serial.
+- Across 50 consecutive CI runs post-P5: zero failures in
+  `associations/join-model.test.ts`, `dirty.test.ts`, `relation.test.ts`,
+  `transactions/*.test.ts`, `callbacks.test.ts`,
+  `serialized-attribute.test.ts` attributable to cross-worker DB races.
+- `git grep -n 'VITEST_WORKER_ID\|AR_DB_MAX_FORKS\|((.*-.*1.*).*%.*)+1' packages/activerecord`
+  returns nothing.
+- `AR_DB_FORKS` and the "Create parallel test databases" CI step remain
+  (they define the slot pool); the modulo formula and the
+  `maxForks/minForks` pinning are gone.
+
+## Open questions
+
+- Does vitest's fork lifecycle keep the bootstrap PG connection alive
+  long enough? `pool: "forks"` reuses workers across files, but if a
+  worker is recycled mid-suite the lock is lost — needs an empirical
+  check on a long run.
+- MariaDB `GET_LOCK` semantics under connection pooling: does the
+  underlying mysql2 driver guarantee one physical connection for the
+  bootstrap? May need to bypass the pool and hold a raw connection.
+- Acceptable busy-wait policy in P4 if all `AR_DB_FORKS` slots are
+  held: linear backoff vs blocking acquire (`pg_advisory_lock` without
+  `try`)? Blocking is simpler but masks deadlocks during development.
+- Does the `_sharedAdapter` re-init path (`test-adapter.ts:400–424`)
+  need to release and re-acquire the lock, or is the bootstrap
+  connection sufficient? Likely the latter, but verify before P3.
+- Do we want one slot pool shared across PG and MariaDB CI jobs (they
+  run in separate runners, so no), or per-backend (yes — current shape).
+  Document so future maintainers don't unify accidentally.

--- a/docs/explicit-test-schema-plan.md
+++ b/docs/explicit-test-schema-plan.md
@@ -14,19 +14,33 @@ and the recovery path never needs to fire.
 
 ## Tickets
 
-| ID    | Description                                          | Status          |
-| ----- | ---------------------------------------------------- | --------------- |
-| TS-1  | `defineSchema()` test helper                         | ✅ #1201        |
-| TS-2  | `dropAllTables()` test helper                        | 🟡 #1202 (open) |
-| TS-3  | Env flag to disable the dynamic auto-schema path     | ⏳ not started  |
-| TS-4a | Migrate `join-model.test.ts` (canary)                | ✅ this PR      |
-| TS-4… | Migrate remaining association/STI/polymorphic suites | ⏳ scheduled    |
+| ID       | Description                                         | Status                                                  |
+| -------- | --------------------------------------------------- | ------------------------------------------------------- |
+| TS-1     | `defineSchema()` test helper                        | ✅ #1201                                                |
+| TS-2     | `dropAllTables()` test helper                       | ✅ #1202                                                |
+| TS-3     | `AR_NO_AUTO_SCHEMA` env flag                        | ✅ #1203                                                |
+| TS-3-fix | env flag read per-call so `vi.stubEnv` engages      | ✅ #1216                                                |
+| TS-4a    | Migrate `join-model.test.ts` (canary)               | ✅ #1204                                                |
+| TS-4a-2  | Flip env flag for join-model + drop #1200 hacks     | ✅ #1215                                                |
+| TS-4b    | validations batch (7 files)                         | ✅ #1206                                                |
+| TS-4c    | timestamp + serialization (2 files)                 | ✅ #1210                                                |
+| TS-4d    | callbacks (1 file)                                  | ✅ #1211                                                |
+| TS-4e    | transactions (1 file)                               | ✅ #1212                                                |
+| TS-4f    | small-file batch (12 files)                         | ✅ #1213                                                |
+| TS-4g    | medium-file batch (10 files)                        | ✅ #1214                                                |
+| TS-4h    | small/medium batch (10 files)                       | ✅ #1217                                                |
+| TS-4i    | test-databases/defaults/explain/json-ser. (6 files) | ✅ #1218                                                |
+| TS-4j    | dirty/store/serialized-attribute (3 files)          | ✅ #1219                                                |
+| TS-4l    | `relation.test.ts` (1 file)                         | ✅ #1221                                                |
+| TS-4m    | `base.test.ts` (1 file, biggest)                    | ✅ #1234                                                |
+| TS-4…    | remaining association / large-file batches          | ⏳ in flight (48 / 162 files migrated as of 2026-05-06) |
+| TS-final | Delete dynamic adapter + HABTM shims                | ⏳ blocked on TS-4 completion                           |
 
-## Known flaky tests
+## Known flaky tests (resolved)
 
-| Test                                                                      | Diagnosed root cause                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Fix                                |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `AssociationsJoinModelTest > has many with multiple authors` (PG/MariaDB) | **Partially diagnosed.** Initial hypothesis was cross-file `_declaredColumns` drift in the recovery path, but on the shared CI PG instance, removing PR #1200's id-set filter caused all three assertions to deterministically return empty result sets — not extra rows, not wrong types. defineSchema is necessary but not sufficient; some additional cross-file mechanism (likely modelRegistry STI scoping or shared adapter state) is also at play. Pending TS-3 (env flag to disable the dynamic adapter) for full removal of the workaround. | TS-3 (workaround retained for now) |
+The flaky `AssociationsJoinModelTest` cases that motivated this work were not, in the end, caused by the dynamic test-adapter's recovery path. The real cause was diagnosed in [docs/ar-test-parallelism-plan.md](./ar-test-parallelism-plan.md): vitest's `--no-file-parallelism` flag had been silently dropped (PR #1092), workers monotonic-incrementing `VITEST_WORKER_ID` modulo-collided onto the same `rails_js_test_N` DB, and worker B's `dropAllTables` afterAll landed inside worker A's `defineSchema` sequence. Fixed by the PR-P1..P6 advisory-lock parallelism work (#1222–#1228).
+
+The schema-migration plan still stands on its own merits — explicit schema is clearer, kills the recovery-path-masks-bugs problem, and lets `test-adapter.ts` shrink to ≤200 LOC. But the original "join-model PG flake" is no longer a TS-final blocker.
 
 ## Migration pattern (TS-4a canary)
 
@@ -49,15 +63,6 @@ After this, `_declaredColumns` is irrelevant for the named tables — the
 schema is whatever `defineSchema` wrote, not whatever sibling files happened
 to register first.
 
-### Known limitation (deferred to TS-3)
+### Resolved limitation (TS-3 #1203)
 
-`defineSchema()` writes DDL through `SchemaAdapter`, which only records
-the `id` column in `_createdColumns`. The next `processPendingModels`
-pass therefore emits a redundant `ALTER TABLE ADD COLUMN` per declared
-column; each errors with "column already exists" and is caught silently.
-This is benign (savepoint-wrapped, no transaction poisoning) but adds
-noise. Fixing it cleanly requires either bypassing `SchemaAdapter` to
-the inner driver, or letting `defineSchema` populate the tracking maps —
-both of which need changes inside `test-adapter.ts`. That file is
-reserved for TS-3, so the optimization rides along when TS-3 lands the
-env flag to disable the dynamic adapter path entirely.
+The TS-4a canary documented a redundant-ALTER noise problem: `defineSchema()` wrote DDL through `SchemaAdapter`, which only recorded the `id` column in `_createdColumns`, so the next `processPendingModels` pass re-issued `ALTER TABLE ADD COLUMN` for every declared column (each erroring "column already exists" and being caught silently). TS-3 (`AR_NO_AUTO_SCHEMA=1`) eliminates this entirely — with the flag on, `processPendingModels` short-circuits and the redundant ALTERs never run. Migrated files now set the flag at module load (`vi.stubEnv("AR_NO_AUTO_SCHEMA", "1")`); see TS-3-fix #1216 for the per-call read that makes `vi.stubEnv` engage.

--- a/docs/explicit-test-schema-plan.md
+++ b/docs/explicit-test-schema-plan.md
@@ -38,7 +38,7 @@ and the recovery path never needs to fire.
 
 ## Known flaky tests (resolved)
 
-The flaky `AssociationsJoinModelTest` cases that motivated this work were not, in the end, caused by the dynamic test-adapter's recovery path. The real cause was diagnosed in [docs/ar-test-parallelism-plan.md](./ar-test-parallelism-plan.md): vitest's `--no-file-parallelism` flag had been silently dropped (PR #1092), workers monotonic-incrementing `VITEST_WORKER_ID` modulo-collided onto the same `rails_js_test_N` DB, and worker B's `dropAllTables` afterAll landed inside worker A's `defineSchema` sequence. Fixed by the PR-P1..P6 advisory-lock parallelism work (#1222–#1228).
+The flaky `AssociationsJoinModelTest` cases that motivated this work were not, in the end, caused by the dynamic test-adapter's recovery path. The real cause was diagnosed in [docs/ar-test-parallelism-plan.md](./ar-test-parallelism-plan.md): vitest's `--no-file-parallelism` flag had been silently dropped (PR #1092), workers monotonic-incrementing `VITEST_WORKER_ID` modulo-collided onto the same `rails_js_test_N` DB, and worker B's `dropAllTables` afterAll landed inside worker A's `defineSchema` sequence. Fixed by the PR-P1..P6 advisory-lock parallelism work (#1223–#1228); #1222 was a separate stop-gap that re-added `--no-file-parallelism` while the proper fix was being designed.
 
 The schema-migration plan still stands on its own merits — explicit schema is clearer, kills the recovery-path-masks-bugs problem, and lets `test-adapter.ts` shrink to ≤200 LOC. But the original "join-model PG flake" is no longer a TS-final blocker.
 

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -1,0 +1,509 @@
+# SQLite driver abstraction plan
+
+Goal: decouple `Sqlite3Adapter` from `better-sqlite3` so the same adapter can
+run on top of any SQLite driver — `node:sqlite`, `expo-sqlite`,
+`@sqlite.org/sqlite-wasm`, `wa-sqlite`, `sql.js`, etc. — by having activerecord
+consume a generic `getSqlite()` accessor from `activesupport`, modeled on
+`getFs()` / `fs-adapter.ts`.
+
+## Status (2026-05-06)
+
+- ✅ **Original PR 1 merged** — `packages/activerecord/src/connection-adapters/sqlite3/driver.ts`
+  exists with `SqliteConnection` / `SqliteStatement` / `SqliteDriver` interfaces, plus
+  `drivers/better-sqlite3.ts` wrapping the existing `Database`/`Statement` calls.
+- ✅ **Original PR 2 merged** — `Sqlite3Adapter` routes all driver calls through
+  `this.driver.foo()`. Statement pool typed against `SqliteStatement`.
+  `safeIntegers` unified as `setReadBigInts`.
+- 🟡 **PR #1241 in flight** — adds `blazetrails/sqlite-driver-await` ESLint rule
+  scoped to `sqlite3/**` and `sqlite3-adapter.ts`. Flags any `driver.<method>(...)`
+  not wrapped in `await` / `.then` / `.catch`. With async committed everywhere
+  (open question #1 settled below), this rule is no longer a PR 3 _gate_ — it's
+  a permanent regression guard against future drift. Merge it as-is; PR M
+  extends the rule's glob to `packages/activesupport/src/sqlite-adapter.ts` and
+  `sqlite-drivers/**` when the driver code moves.
+
+The driver interface today **lives in activerecord**. The pivot below moves it
+to activesupport so other packages (FileStore, ActionDispatch session store,
+ActiveJob queue adapters) get SQLite for free, and so `node:fs` / `process.env`
+plumbing can be solved once at the activesupport layer instead of re-derived
+inside activerecord.
+
+## Why activesupport
+
+The abstraction "open a SQLite handle and run statements" is a generic
+capability, like "read/write a filesystem." Query building, type maps, and
+schema dumping stay in activerecord. Bytes-in/rows-out is a primitive.
+
+Concretely, putting the driver in activesupport:
+
+1. **Pattern parity with `getFs()`.** Same `register*Adapter` / `get*` shape,
+   same lazy-load default, same subpath-export model for non-Node drivers.
+   Consumers already know how to swap `getFs`; swapping `getSqlite` is the
+   same muscle memory.
+2. **Dissolves the carve-out.** The old PR 6 ("remove `node:fs` from the base
+   adapter") existed only because activerecord was tangled with both
+   `better-sqlite3` and `node:fs`. Once the driver lives in activesupport
+   behind `getSqlite()`, activerecord stops touching either. The
+   browser-bundle CI gate moves to activesupport, where `getFs` already needs
+   it.
+3. **Reuse beyond AR.** Rails has `SQLite3CacheStore`, SQLite session stores,
+   SQLite-backed ActiveJob queues. Each of these lands in a different
+   trails package. Putting the driver in activesupport means each consumer
+   takes a dep on activesupport (which they already do) instead of on
+   activerecord.
+
+## Design
+
+### Driver interface
+
+`packages/activesupport/src/sqlite-adapter.ts` (moved from
+`packages/activerecord/src/connection-adapters/sqlite3/driver.ts`).
+
+**Design principles**
+
+- All methods async-tolerant: return type `T | Promise<T>`. Sync drivers (better-sqlite3) return values directly; async drivers (sqlite-wasm, sqlite-network, expo-sqlite) return Promises. Callers always `await`. This applies to `prepare()` too — sync drivers return the statement immediately and the adapter pays one microtask at the await boundary; async drivers return a Promise. The adapter never assumes one or the other.
+- Driver code is opaque to AR query construction: bytes-in (SQL string + binds), rows-out (raw row values + column metadata). Type-coercion / casting / Date-encoding stay in the AR adapter so PG/MySQL/SQLite share one code path.
+- Driver-thrown errors are not normalized at this layer; AR's `translateException` maps them. Drivers throw whatever the underlying library throws.
+- Statements are reusable across `run` / `get` / `all` / `iterate` calls. Each call independently rebinds.
+
+**Bind values**
+
+```ts
+/** Anything a sqlite driver must accept as a bound parameter. */
+export type SqliteBindValue =
+  | null
+  | string
+  | number
+  | bigint
+  | boolean // drivers MAY coerce to 0/1; AR adapter pre-coerces for parity with PG/MySQL
+  | Uint8Array // BLOB; Buffer (Node) is also valid because Buffer extends Uint8Array
+  | Date; // drivers MAY coerce to ISO string; AR pre-formats for parity
+
+/** Positional or named binds; statement methods accept either form. */
+export type SqliteBinds = readonly SqliteBindValue[] | { readonly [name: string]: SqliteBindValue };
+```
+
+**Driver and statement**
+
+```ts
+export interface SqliteConnection {
+  prepare(sql: string): SqliteStatement | Promise<SqliteStatement>;
+
+  /** Multi-statement DDL/DML. No binds, no return value. */
+  exec(sql: string): void | Promise<void>;
+
+  /**
+   * `PRAGMA <source>;` — returns rows from `prepare("PRAGMA …").all()`.
+   * `simple: true` returns the scalar value of the first column when there's
+   * exactly one row + one column (mirrors better-sqlite3's helper).
+   */
+  pragma(source: string, opts?: { simple?: boolean }): unknown | Promise<unknown>;
+
+  /** Idempotent. After close(), all calls reject / throw. */
+  close(): void | Promise<void>;
+
+  /** True between successful open() and close(). */
+  isOpen(): boolean;
+
+  /** Driver-specific escape hatch (e.g. better-sqlite3 `Database` instance). */
+  readonly raw: unknown;
+}
+
+export interface SqliteStatement {
+  /** INSERT/UPDATE/DELETE/DDL. */
+  run(binds?: SqliteBinds): RunResult | Promise<RunResult>;
+
+  /** First row, or null if none. */
+  get(binds?: SqliteBinds): unknown | Promise<unknown>;
+
+  /** All rows. Drivers MAY stream internally but MUST return a fully-realized array. */
+  all(binds?: SqliteBinds): unknown[] | Promise<unknown[]>;
+
+  /**
+   * Row-at-a-time iteration. Sync drivers return Iterable; async drivers return
+   * AsyncIterable. AR's batch path uses this for large result sets.
+   */
+  iterate(binds?: SqliteBinds): Iterable<unknown> | AsyncIterable<unknown>;
+
+  /** Column metadata for the prepared statement. Stable across calls. */
+  columns(): ColumnInfo[];
+
+  /**
+   * When true, integer columns return as bigint; when false, as number (with
+   * silent loss of precision for values outside Number.MAX_SAFE_INTEGER).
+   * Default: false. Drivers without a per-statement toggle (some WASM ports)
+   * MAY no-op and document the gap.
+   */
+  setReadBigInts(on: boolean): void;
+
+  /**
+   * Release driver resources. Optional — drivers without explicit finalization
+   * (better-sqlite3) leave it undefined; the statement pool calls it when set.
+   */
+  finalize?(): void | Promise<void>;
+}
+
+export interface ColumnInfo {
+  name: string; // result-set column name (alias if any)
+  column: string | null; // source column from the underlying table; null for expressions
+  table: string | null; // source table name; null for expressions
+  database: string | null; // attached-db name; null for expressions or main db
+  type: string | null; // declared sqlite type per sqlite_master, may be null
+}
+
+export interface RunResult {
+  /** Rows affected. SQLite reports this from `sqlite3_changes()`. */
+  changes: number;
+  /**
+   * INSERT rowid. `bigint` when setReadBigInts is on, else `number`.
+   * Caller must check the type if it accepts both modes.
+   */
+  lastInsertRowid: number | bigint;
+}
+```
+
+**Open / driver registration**
+
+```ts
+export interface SqliteOpenConfig {
+  /** File path or special URI (`:memory:`, `file::memory:?cache=shared`). */
+  database: string;
+
+  /** Open in read-only mode. Default false. */
+  readOnly?: boolean;
+
+  /** SQLITE_OPEN_NOMUTEX equivalent — opt-in for single-threaded use. */
+  noMutex?: boolean;
+
+  /** busy_timeout ms for SQLITE_BUSY contention. Default 5000. */
+  timeout?: number;
+
+  /**
+   * Driver-specific options pass-through. Drivers document their own keys;
+   * AR core never inspects this object.
+   */
+  driverOptions?: Record<string, unknown>;
+}
+
+export interface SqliteDriver {
+  readonly name: string;
+
+  /**
+   * Driver self-declared capabilities. Consumers introspect this to decide
+   * whether a given feature path is available without splitting the adapter
+   * into sync/async code paths. The adapter itself always awaits at driver
+   * boundaries (see "Settled decisions" below); capabilities are for
+   * feature-detection, not call-shape branching.
+   */
+  readonly capabilities: SqliteDriverCapabilities;
+
+  open(config: SqliteOpenConfig): Promise<SqliteConnection>;
+
+  /**
+   * Pre-flight check used by `tasks/sqlite_database_tasks.ts` to decide
+   * whether `db:create` should run before connecting. Optional — drivers
+   * that can't statelessly answer (network-backed, ephemeral) leave it
+   * undefined and the task layer falls back to attempt-and-catch.
+   */
+  databaseExists?(config: SqliteOpenConfig): boolean | Promise<boolean>;
+}
+
+export interface SqliteDriverCapabilities {
+  /**
+   * True when prepare/run/get/all return values without yielding to the event
+   * loop (the adapter still awaits at the boundary; this only signals
+   * microtask-only overhead vs. real I/O latency). better-sqlite3 + node:sqlite:
+   * true. WASM, network, expo-sqlite: false.
+   */
+  readonly inProcessSync: boolean;
+
+  /**
+   * True when iterate() yields rows incrementally (vs. collecting then
+   * yielding). Drivers that materialize all rows internally MUST set false
+   * so AR's batch path can pick a different strategy.
+   */
+  readonly streaming: boolean;
+
+  /**
+   * True when SQLite extensions (loadable .so / .dll / .dylib via
+   * `sqlite3_load_extension`) work. node:sqlite: false. better-sqlite3:
+   * true on Node, false on bundled-WASM builds. Adapter paths that need
+   * extensions throw NotImplementedError when this is false.
+   */
+  readonly loadExtension: boolean;
+
+  /**
+   * True when multiple statements can be live on one connection at once
+   * without interfering. better-sqlite3 + node:sqlite: true. Some
+   * older WASM ports: false (must finalize before preparing the next).
+   * AR's statement-cache eviction policy reads this.
+   */
+  readonly concurrentStatements: boolean;
+
+  /**
+   * True when the driver enforces foreign-key constraints by default.
+   * SQLite is opt-in via `PRAGMA foreign_keys = ON`; most drivers default
+   * to ON for AR, but turso/libsql defaults differ. AR's connection setup
+   * uses this to decide whether to issue the PRAGMA.
+   */
+  readonly foreignKeysOnByDefault: boolean;
+
+  /**
+   * True when `BEGIN IMMEDIATE` / `BEGIN EXCLUSIVE` are honored. WAL mode
+   * + standard SQLite: true. Some network-backed drivers serialize
+   * differently and don't accept these. AR's transaction setup falls back
+   * to plain `BEGIN` when false.
+   */
+  readonly immediateTransactions: boolean;
+}
+```
+
+**Capability matrix per driver** (sanity-check that the flag set is right; also drives PR 6's parity allow-list):
+
+| Capability               | better-sqlite3 (Node) | node:sqlite (≥22.5) | sqlite-wasm (browser)      | expo-sqlite (RN) | turso/libsql (network) |
+| ------------------------ | --------------------- | ------------------- | -------------------------- | ---------------- | ---------------------- |
+| `inProcessSync`          | true                  | true                | false (init() async)       | false            | false                  |
+| `streaming`              | true                  | true                | false (collect-then-yield) | false            | false                  |
+| `loadExtension`          | true                  | false               | false                      | false            | false                  |
+| `concurrentStatements`   | true                  | true                | varies                     | true             | true                   |
+| `foreignKeysOnByDefault` | false (PRAGMA needed) | false               | false                      | false            | varies                 |
+| `immediateTransactions`  | true                  | true                | true                       | true             | false (network)        |
+
+**Out of scope for v1** (tracked as future open questions, not blocking):
+custom function/aggregate registration, virtual tables, authorizer hooks, `db.backup()`, online schema-change hooks, encryption (SQLCipher) plumbing. Drivers expose these via `driver.raw` until usage patterns are clear enough to lift into the interface. Capabilities flags can be added incrementally — the interface is open for extension as long as new flags default to `false` (driver presumed not to support).
+
+### Accessor surface (mirrors `fs-adapter.ts`)
+
+```ts
+export function registerSqliteDriver(driver: SqliteDriver): void;
+export function clearSqliteDrivers(): void;
+export function getSqlite(name?: string): SqliteDriver;
+export async function getSqliteAsync(name?: string): Promise<SqliteDriver>;
+```
+
+**Resolution rules** (deterministic; no implicit "first wins"):
+
+- `getSqlite(name)` with an explicit `name` returns the registered driver or throws if missing.
+- `getSqlite()` with no arg:
+  1. If `AR_SQLITE_DRIVER` env var is set (Node only), use it. Throws if the named driver isn't registered.
+  2. Else, if **exactly one** driver is registered, return it.
+  3. Else (zero registered, or two-or-more without an explicit selection), throw with a helpful message naming the registered drivers and the env var to set.
+- `getSqliteAsync()` exists for drivers whose modules are themselves async (WASM bindings that await `init()` before exporting). Same resolution rules as `getSqlite()`. Mirrors the `getFsAsync` precedent.
+- Driver-name collisions overwrite the prior registration with a one-time `console.warn`. Tests use `clearSqliteDrivers()` to swap deterministically.
+
+### Package layout
+
+```
+packages/activesupport/src/
+  sqlite-adapter.ts           # interface + registry + getSqlite/getSqliteAsync
+  sqlite-drivers/
+    better-sqlite3.ts         # imports better-sqlite3 (optional peer dep)
+    node-sqlite.ts            # imports node:sqlite
+```
+
+`@blazetrails/activesupport` `package.json` exports map:
+
+```json
+"./sqlite/better-sqlite3": "./dist/.../sqlite-drivers/better-sqlite3.js",
+"./sqlite/node-sqlite":    "./dist/.../sqlite-drivers/node-sqlite.js"
+```
+
+activerecord's `Sqlite3Adapter` imports the _type_ `SqliteConnection` from
+activesupport and resolves the _instance_ via `getSqlite()`. No driver code
+remains in activerecord.
+
+`better-sqlite3` becomes an `optionalPeerDependency` of activesupport.
+`node:sqlite` is a Node built-in — no install footprint. Consumers using
+neither (browser/RN) register their own driver and never import the
+defaults.
+
+### Config
+
+```ts
+{
+  adapter: "sqlite3",
+  driver: "better-sqlite3", // or "node-sqlite", or a SqliteDriver
+  database: "./dev.sqlite3",
+}
+```
+
+`pool-config` accepts `driver: string | SqliteDriver` and passes it
+through to the sqlite3 adapter, which calls `getSqlite(config.driver)` at
+connect time.
+
+## PR breakdown (revised)
+
+Sized for the project's 300-LOC ceiling. Old PRs 1 and 2 are already merged;
+the remaining work re-homes the abstraction in activesupport, then proceeds
+with async + node:sqlite.
+
+### PR M — Move driver interface from activerecord to activesupport
+
+- Copy `packages/activerecord/src/connection-adapters/sqlite3/driver.ts` →
+  `packages/activesupport/src/sqlite-adapter.ts`. Type-only move; no runtime
+  behavior change.
+- Add `registerSqliteDriver` / `clearSqliteDrivers` / `getSqlite` /
+  `getSqliteAsync` accessors mirroring `fs-adapter.ts`.
+- Move `packages/activerecord/src/connection-adapters/sqlite3/drivers/better-sqlite3.ts`
+  → `packages/activesupport/src/sqlite-drivers/better-sqlite3.ts`. Self-registers
+  on import.
+- Add subpath exports in activesupport `package.json`. Move
+  `better-sqlite3` peer-dep declaration from activerecord to activesupport.
+- **No deprecation shims.** Pre-1.0; every consumer of the activerecord-side
+  interfaces is in this monorepo. PR M is the rename — in-flight branches
+  rebase onto main like any other PR.
+- activerecord's `Sqlite3Adapter` constructor now calls
+  `getSqlite(config.driver).open(config)` instead of newing up a
+  `BetterSqlite3Driver` directly.
+- **Back-compat import lives in `packages/activerecord/src/test-setup-ar.ts` only**, NOT `activerecord/index.ts`. Putting it in `index.ts` would pull `better-sqlite3` transitively for every consumer that imports any AR module — defeating the optionalPeerDependency promise. Apps using sqlite explicitly opt in via either (a) `import "@blazetrails/activesupport/sqlite/better-sqlite3"` in their bootstrap, or (b) `driver: betterSqlite3Driver` in their pool config.
+- `pool-config` accepts the `driver` field.
+
+LOC: realistic ~350 (median). The diff covers: type-only move, 4 accessors,
+driver-module move, 2 package.json exports entries, peer-dep migration, adapter
+constructor rewrite, pool-config plumbing, test-setup back-compat import.
+Plan to split as PR Mb (test-setup + back-compat imports) if the main diff
+crosses 300; don't fight to fit in one PR.
+
+**This PR replaces old PRs 1 (already done), 5 (registry), and 6 (carve-out)
+in one move.** The carve-out is implicit: `getFs` calls move with the driver
+into activesupport, and activerecord's adapter stops importing them.
+
+### PR 3 — Async-aware adapter
+
+`blazetrails/sqlite-driver-await` (PR #1241) provides the regression guard:
+missed `await driver.foo()` becomes a CI lint failure. After PR M, extend the
+rule's scope to the activesupport driver paths.
+
+Scope:
+
+- Sprinkle `async`/`await` through `sqlite3-adapter.ts` at every driver
+  call boundary. Public methods that already return promises (`execQuery`,
+  `selectAll`, transaction control) need no signature change. Sync-typed
+  internal helpers (`pragma()`, `_cachedStatement`, introspection helpers,
+  `copyTable`) become async.
+- Audit: `grep` for adapter callers that don't `await`. Most are tests and
+  internal sqlite paths; PG/MySQL parallels are already async.
+- Statement pool gains async finalize on eviction.
+
+**No performance gate.** Async everywhere is the explicit design choice — the
+flexibility to drop in WASM / network / async drivers (sqlite-wasm, expo-sqlite,
+turso) is the whole point of the abstraction. better-sqlite3's microtask-per-call
+overhead is acceptable; if a benchmark elsewhere regresses noticeably, address
+it in that benchmark, not by reverting the async lift.
+
+LOC: ~250–300, plus a focused test pass.
+
+### PR 4 — Consolidate transactions onto the generic path
+
+- Audit any remaining reliance on better-sqlite3's `db.transaction(fn)`.
+  Currently we call `BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT` directly via
+  `db.exec`, so this PR is likely a no-op audit + tests proving
+  nested-transaction parity with PG/MySQL across drivers.
+
+LOC: ~100, mostly tests.
+
+### PR 5 — `node:sqlite` driver
+
+`packages/activesupport/src/sqlite-drivers/node-sqlite.ts` implementing
+`SqliteConnection`. Self-registers as `"node-sqlite"`. Differences from
+better-sqlite3 normalized inside the driver:
+
+- No `.pragma()` helper → implement via `prepare("PRAGMA …").all()`. Mirror
+  better-sqlite3's `[{ pragma_name: value }]` row shape so the adapter sees
+  identical results.
+- `setReadBigInts` exists as a per-statement setter — direct mapping.
+- No `loadExtension` — throw `NotImplementedError` from any adapter path that
+  needs it; document the gap in `docs/sqlite-driver-parity.md` (created in PR 6).
+- Bind handling: node:sqlite uses positional `?` and named `:foo` differently
+  from better-sqlite3 — driver normalizes both forms of `SqliteBinds` into
+  whatever node:sqlite expects.
+- `transaction(fn)` helper absent — already unused; we do explicit
+  `BEGIN`/`COMMIT`.
+- `iterate()` uses node:sqlite's iterator return; sync today, but the
+  interface allows AsyncIterable for future drivers without recompilation.
+- Engine guard: throw at registration time on Node < 22.5 (or whatever
+  version stabilizes `node:sqlite`); link to the version compatibility note
+  in the engine-guard error message.
+
+**Async path validation.** Even though node:sqlite is sync internally, ensure
+the adapter→driver call sites all `await` (relying on the lint guard from
+#1241). Order discipline: PR M → PR 3 (async lift) → PR 5 (node:sqlite). PR 5
+landing before PR 3 means the adapter still wraps everything sync and we'd
+never validate the async path against a real driver. If for any reason PR 5
+ships first, PR 6's CI matrix MUST run node:sqlite under
+`AR_FORCE_ASYNC_DRIVER=1` (a test-only knob the driver wrapper honors by
+returning everything wrapped in `Promise.resolve(...)`) so missed awaits
+surface deterministically.
+
+LOC: ~250.
+
+### PR 6 — CI matrix + parity tests + docs
+
+- Run the existing sqlite test suite under both drivers via
+  `AR_SQLITE_DRIVER=better-sqlite3` and `AR_SQLITE_DRIVER=node-sqlite`.
+- Two CI jobs (or one matrixed job). Expect a small allow-list of
+  known-different behaviors documented in `docs/sqlite-driver-parity.md`
+  (created in this PR).
+- Smoke test exercising both drivers in the same process to catch
+  global-state leaks.
+- Browser-bundle CI test on activesupport: build a minimal entry that
+  imports `getSqlite` (no concrete driver) and runs through `esbuild
+--platform=browser --bundle`. Failing on `node:fs` resolution is the
+  regression signal. Catches anyone re-adding `node:*` imports to the base
+  accessor module.
+- Public README section on choosing a driver.
+- Driver authoring guide pointing at the activesupport interface.
+
+LOC: ~250.
+
+## Order and dependencies
+
+- PR M is independent; can land as soon as TS infrastructure is stable.
+- PR 3 depends on PR M (so async lift happens against the activesupport
+  interface, not the soon-to-move activerecord one). Also blocks on
+  TS-final or the lint guard.
+- PR 4 can land any time after PR 3.
+- PR 5 depends on PR M (the registry lives in activesupport). It does
+  _not_ depend on PR 3 — node:sqlite is sync, same as better-sqlite3, and
+  the existing sync wrapping in the adapter still works pre-PR 3. But
+  shipping node:sqlite _before_ PR 3 means we never validate the async
+  path against a real driver, so order PR M → 3 → 5 in practice.
+- PR 6 depends on PR 5.
+
+## Settled decisions
+
+1. **Async everywhere.** Adapter awaits at every driver boundary. Sync drivers
+   (better-sqlite3) cost one microtask per call; the flexibility to swap in
+   async drivers (sqlite-wasm, expo-sqlite, turso, etc.) is worth it. No
+   dual-class fallback.
+2. **better-sqlite3 stays the Node default.** Apps that want `node:sqlite` opt
+   in via `driver: "node-sqlite"` or `AR_SQLITE_DRIVER=node-sqlite`. No silent
+   default switch when `node:sqlite` exits experimental.
+3. **Adapter name is `sqlite3`** regardless of driver (Rails parity); `driver`
+   is a sub-selector.
+4. **Driver-name collisions overwrite with one-time `console.warn`.** Tests
+   use `clearSqliteDrivers()` for deterministic state. Per-connection
+   statement pools already isolate prepared statements across drivers.
+5. **Resolution requires explicit selection when multiple drivers are
+   registered** (see Resolution rules above). No "first registered" wins.
+
+## Open questions
+
+1. **Should FileStore / cache pick up the SQLite driver too?** Out of scope
+   for this plan, but the activesupport home makes it trivial: a
+   `SqliteCacheStore` lives next to `FileStore` and consumes `getSqlite()`
+   the same way `FileStore` consumes `getFs()`. Defer until a concrete
+   consumer needs it.
+
+2. **Custom function / aggregate registration.** The base interface omits
+   `function()` / `aggregate()` because better-sqlite3 and node:sqlite
+   diverge in shape and not every driver supports them (WASM ports often
+   don't). AR's collation needs (e.g. `BINARY` vs `NOCASE`) are SQL-side,
+   not function-side. If we hit a real consumer that needs custom Ruby-style
+   `define_method` callbacks, lift through the `driver.raw` escape hatch
+   first; lift to interface only if multiple drivers benefit.
+
+3. **`databaseExists?` call site.** Today only `tasks/sqlite_database_tasks.ts`
+   needs it (to decide whether `db:create` runs before connecting). The
+   interface marks it optional; drivers that can't statelessly answer
+   leave it undefined. If task layer drift makes it unused, drop it.

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -9,8 +9,12 @@ consume a generic `getSqlite()` accessor from `activesupport`, modeled on
 ## Status (2026-05-06)
 
 - ✅ **Original PR 1 merged** — `packages/activerecord/src/connection-adapters/sqlite3/driver.ts`
-  exists with `SqliteConnection` / `SqliteStatement` / `SqliteDriver` interfaces, plus
-  `drivers/better-sqlite3.ts` wrapping the existing `Database`/`Statement` calls.
+  exists with `SqliteDriver` (the open handle), `SqliteStatement`, `DriverFactory`,
+  and `SqliteConfig` interfaces, plus `drivers/better-sqlite3.ts` wrapping the
+  existing `Database`/`Statement` calls. Note: the rename to `SqliteConnection`
+  (handle) / `SqliteDriver` (registered thing) — described in the "Driver
+  interface" section below — has NOT yet shipped. It lands as part of PR M when
+  the abstraction moves to activesupport; today's code uses the as-merged names.
 - ✅ **Original PR 2 merged** — `Sqlite3Adapter` routes all driver calls through
   `this.driver.foo()`. Statement pool typed against `SqliteStatement`.
   `safeIntegers` unified as `setReadBigInts`.


### PR DESCRIPTION
## Why

We've shipped a lot of plan-driven work in the last week — the activerecord 100% parity drive, the explicit-test-schema migration, the test-parallelism saga, and the sqlite-driver abstraction kickoff. The status of each was scattered across PR descriptions and chat. This refresh brings the four planning docs into a single coherent state of the world so future contributors (and future-us) can see what's done, what's in flight, and what's next without piecing it together from git history.

## What

- **`docs/activerecord-100-plan.md`** — mark 30 merged PRs (M2, M3, PR 1, 4, 5, 6, 7, 8, 8b, 9, 11, 12, 13, 14, 15, 16, 17, 22, 23, 23b, 24, 24b, 25, 27, 28, 29, 30, 32, 44, 45, 53, 53b) with PR refs; collapse bodies of completed sections (saves ~290 LOC of stale spec). Doc shrinks from 797 → 511 lines while adding completion data.

- **`docs/explicit-test-schema-plan.md`** — refresh status table with TS-1..TS-4m merges (17 TS PRs landed; **48 / 162 test files** now on explicit `defineSchema`, ≈30%). Replace the stale "Known flaky tests" speculation with the actual root cause (it was the parallelism issue, not the dynamic adapter — see the parallelism doc). Replace the deferred `defineSchema` redundant-ALTER limitation with its resolution via TS-3 #1203 + TS-3-fix #1216.

- **`docs/sqlite-driver-abstraction-plan.md`** (new) — driver-abstraction plan with fully-fleshed `SqliteConnection` / `SqliteStatement` / `SqliteDriver` interfaces (positional + named binds, streaming `iterate()`, lifecycle introspection via `isOpen()`, structured `SqliteOpenConfig`, explicit `RunResult` shape), capabilities flags (`inProcessSync`, `streaming`, `loadExtension`, `concurrentStatements`, `foreignKeysOnByDefault`, `immediateTransactions`), deterministic resolution rules (no implicit "first wins"), and a per-driver capability matrix covering better-sqlite3, node:sqlite, sqlite-wasm, expo-sqlite, turso/libsql. PR 1 (#1238) + PR 2 (#1240) already merged. PR 3 (async sweep) and PR 5 (node:sqlite driver) remaining.

- **`docs/ar-test-parallelism-plan.md`** (new) — postmortem of the file-parallelism saga. PR-P1..P6 all merged via #1223–#1228. Doc captures: how PR #1092 silently dropped `--no-file-parallelism`, why `VITEST_WORKER_ID` modulo-collisions surfaced as `relation X does not exist` errors on shared CI DBs, and the advisory-lock slot-acquisition design that fixed it. Each PR-P section marks its merge ref inline; the prose body is past-tense throughout so readers don't mistake it for an active plan. Rollback architecture preserved as a note in case a future regression brings the same shape back.

## Reviewer notes

- This PR is purely planning-doc cleanup. No source / test / config / CI changes.
- The activemodel alignment plan is intentionally out of scope — it's healthy as-is and a refresh is its own PR.
- An unrelated set of working-tree changes (`docs/activemodel-alignment.md`, `scripts/start-worktree.sh`, `scripts/sync-stats/sync.ts`) is what triggers `gh`'s "uncommitted changes" warning at PR-create time. Those will land separately.

## Test plan

- [x] Doc-only PR — no source / config / test changes
- [x] Prettier auto-formatting on commit
- [x] PR refs cross-checked against `git log --oneline origin/main` (last 7 days)
- [x] Both new plans cross-link the other doc where relevant
- [x] Capability matrix in the sqlite plan covers the five driver shapes the interface is designed against
- [x] Each PR-P heading in the parallelism doc carries its merge ref inline; prose body is past-tense
- [x] All non-Skipped CI checks green (Prettier; everything else correctly SKIPPED for docs-only)