### PR TITLE
feat(activerecord): core.ts + model-schema.ts to 100% (Wave 7 PR 35)

### DIFF
--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::Core
  */
 
-import { NotImplementedError } from "./errors.js";
 import { RecordNotFound } from "./errors.js";
 import { Notifications, getAsyncContext, ParameterFilter } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
@@ -565,47 +564,73 @@ export function arelTable(this: CoreHost): Table {
 }
 
 /** @internal */
-function initInternals(): never {
-  throw new NotImplementedError("ActiveRecord::Core#init_internals is not implemented");
+function initInternals(
+  this: CoreRecord & {
+    _readonly: boolean;
+    _destroyed: boolean;
+    _markedForDestruction: boolean;
+    _destroyedByAssociation: unknown;
+    _strictLoading: boolean;
+    _strictLoadingMode: StrictLoadingMode;
+  },
+): void {
+  this._readonly = false;
+  this._destroyed = false;
+  this._markedForDestruction = false;
+  this._destroyedByAssociation = null;
+  const klass = this.constructor as any;
+  this._strictLoading = klass.strictLoadingByDefault ?? false;
+  this._strictLoadingMode = klass.strictLoadingMode ?? "all";
 }
 
 /** @internal */
-function initializeInternalsCallback(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Core#initialize_internals_callback is not implemented",
-  );
+function initializeInternalsCallback(this: unknown): void {
+  // hook for subclasses — overridden by inheritance.ts
 }
 
 /** @internal */
-function isCustomInspectMethodDefined(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Core#custom_inspect_method_defined? is not implemented",
-  );
+function isCustomInspectMethodDefined(this: { constructor: { prototype: object } }): boolean {
+  return Object.prototype.hasOwnProperty.call(this.constructor.prototype, "inspect");
 }
 
 /** @internal */
-function inspectWithAttributes(attributesToList: any): never {
-  throw new NotImplementedError("ActiveRecord::Core#inspect_with_attributes is not implemented");
+function inspectWithAttributes(this: CoreRecord, attributesToList: string[]): string {
+  const ctor = this.constructor as { name: string };
+  if (!this._attributes) return `#<${ctor.name} not initialized>`;
+  const attrMap = new Map(Array.from(this._attributes));
+  const attrs = attributesToList
+    .filter((name) => attrMap.has(name))
+    .map((name) => `${name}: ${formatForInspect.call(this, name, this.readAttribute(name))}`)
+    .join(", ");
+  return `#<${ctor.name} ${attrs}>`;
 }
 
 /** @internal */
-function attributesForInspect(): never {
-  throw new NotImplementedError("ActiveRecord::Core#attributes_for_inspect is not implemented");
+function attributesForInspect(this: CoreRecord): string[] {
+  const klass = this.constructor as any;
+  const forInspect = klass.attributesForInspect;
+  if (forInspect === "all" || forInspect == null) return allAttributesForInspect.call(this);
+  return Array.isArray(forInspect) ? forInspect : allAttributesForInspect.call(this);
 }
 
 /** @internal */
-function allAttributesForInspect(): never {
-  throw new NotImplementedError("ActiveRecord::Core#all_attributes_for_inspect is not implemented");
+function allAttributesForInspect(this: CoreRecord): string[] {
+  if (!this._attributes) return [];
+  return Array.from(this._attributes).map(([k]) => k);
 }
 
 /** @internal */
-function relation(): never {
-  throw new NotImplementedError("ActiveRecord::Core#relation is not implemented");
+function relation(this: CoreHost): any {
+  return (this as any).all();
 }
 
 /** @internal */
-function cachedFindBy(): never {
-  throw new NotImplementedError("ActiveRecord::Core#cached_find_by is not implemented");
+function cachedFindBy(this: CoreHost, keys: string[], values: unknown[]): Promise<any> {
+  const conditions: Record<string, unknown> = {};
+  for (let i = 0; i < keys.length; i++) {
+    conditions[keys[i]] = values[i];
+  }
+  return (this as any).findBy(conditions);
 }
 
 export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -567,20 +567,20 @@ export function arelTable(this: CoreHost): Table {
 function initInternals(
   this: CoreRecord & {
     _readonly: boolean;
+    _previouslyNewRecord: boolean;
     _destroyed: boolean;
-    _markedForDestruction: boolean;
     _destroyedByAssociation: unknown;
     _strictLoading: boolean;
-    _strictLoadingMode: StrictLoadingMode;
+    _strictLoadingMode?: StrictLoadingMode;
   },
 ): void {
   this._readonly = false;
+  this._previouslyNewRecord = false;
   this._destroyed = false;
-  this._markedForDestruction = false;
   this._destroyedByAssociation = null;
   const klass = this.constructor as any;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
-  this._strictLoadingMode = klass.strictLoadingMode ?? "all";
+  this._strictLoadingMode = klass.strictLoadingMode;
 }
 
 /** @internal */
@@ -594,15 +594,21 @@ function isCustomInspectMethodDefined(this: { constructor: { prototype: object }
 }
 
 /** @internal */
-function inspectWithAttributes(this: CoreRecord, attributesToList: string[]): string {
+function inspectWithAttributes(
+  this: CoreRecord & { _attributes: any },
+  attributesToList: string[],
+): string {
   const ctor = this.constructor as { name: string };
   if (!this._attributes) return `#<${ctor.name} not initialized>`;
-  const attrMap = new Map(Array.from(this._attributes));
-  const attrs = attributesToList
-    .filter((name) => attrMap.has(name))
-    .map((name) => `${name}: ${formatForInspect.call(this, name, this.readAttribute(name))}`)
-    .join(", ");
-  return `#<${ctor.name} ${attrs}>`;
+  // Rails: attributes_to_list.filter_map { |name| ... if _has_attribute?(name) }
+  // _has_attribute? checks @attributes.key?(name) — same as checking the attribute set
+  const knownKeys = new Set<string>(
+    Array.from(this._attributes as Iterable<[string, unknown]>).map(([k]) => k),
+  );
+  const parts = attributesToList
+    .filter((name) => knownKeys.has(name))
+    .map((name) => `${name}: ${formatForInspect.call(this, name, this.readAttribute(name))}`);
+  return `#<${ctor.name} ${parts.join(", ")}>`;
 }
 
 /** @internal */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
@@ -1021,42 +1020,45 @@ export const ClassMethods = {
 };
 
 /** @internal */
-function initializeLoadSchemaMonitor(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ModelSchema#initialize_load_schema_monitor is not implemented",
-  );
+function yamlEncoder(this: SchemaHost): AttributeSetCoder {
+  return attributeSetCoder.call(this);
 }
 
 /** @internal */
-function reloadSchemaFromCache(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ModelSchema#reload_schema_from_cache is not implemented",
-  );
+function initializeLoadSchemaMonitor(this: SchemaHost): void {
+  // no-op: JS is single-threaded; no Monitor/Mutex needed
 }
 
 /** @internal */
-function isSchemaLoaded(): never {
-  throw new NotImplementedError("ActiveRecord::ModelSchema#schema_loaded? is not implemented");
+function reloadSchemaFromCache(this: SchemaHost): void {
+  resetColumnInformation.call(this);
 }
 
 /** @internal */
-function loadSchemaBang(): never {
-  throw new NotImplementedError("ActiveRecord::ModelSchema#load_schema! is not implemented");
+function isSchemaLoaded(this: SchemaHost): boolean {
+  return this._schemaLoaded ?? false;
 }
 
 /** @internal */
-function undecoratedTableName(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ModelSchema#undecorated_table_name is not implemented",
-  );
+function loadSchemaBang(this: SchemaHost): void {
+  loadSchema.call(this);
 }
 
 /** @internal */
-function computeTableName(): never {
-  throw new NotImplementedError("ActiveRecord::ModelSchema#compute_table_name is not implemented");
+function undecoratedTableName(this: SchemaHost, modelName: string): string {
+  const base = modelName.split("::").pop() ?? modelName;
+  return pluralize(underscore(base));
 }
 
 /** @internal */
-function typeForColumn(): never {
-  throw new NotImplementedError("ActiveRecord::ModelSchema#type_for_column is not implemented");
+function computeTableName(this: SchemaHost): string {
+  return resolveTableName.call(this as any);
+}
+
+/** @internal */
+function typeForColumn(this: SchemaHost, connection: any, column: any): any {
+  if (typeof connection?.lookupCastTypeFromColumn === "function") {
+    return connection.lookupCastTypeFromColumn(column);
+  }
+  return null;
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1030,8 +1030,14 @@ function initializeLoadSchemaMonitor(this: SchemaHost): void {
 }
 
 /** @internal */
-function reloadSchemaFromCache(this: SchemaHost): void {
+function reloadSchemaFromCache(this: SchemaHost, recursive = true): void {
   resetColumnInformation.call(this);
+  if (recursive) {
+    const subclasses: SchemaHost[] = (this as any).subclasses ?? [];
+    for (const sub of subclasses) {
+      reloadSchemaFromCache.call(sub, true);
+    }
+  }
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

- Replaces 8 `NotImplementedError` stubs in `core.ts` with real implementations (`initInternals`, `initializeInternalsCallback`, `isCustomInspectMethodDefined`, `inspectWithAttributes`, `attributesForInspect`, `allAttributesForInspect`, `relation`, `cachedFindBy`)
- Replaces 7 stubs in `model-schema.ts` with real implementations (`initializeLoadSchemaMonitor`, `reloadSchemaFromCache`, `isSchemaLoaded`, `loadSchemaBang`, `undecoratedTableName`, `computeTableName`, `typeForColumn`) and adds `yamlEncoder`
- Both files reach 100%: `core.rb` 54/54 ✓, `model_schema.rb` 39/39 ✓
- Net: 69 additions, 42 deletions (109 LOC total, well within 300 ceiling)

## Why the stubs weren't counted

`extract-ts-api.ts` explicitly skips non-exported functions whose body is `throw new NotImplementedError(...)`. The fix is to give every method a real body — the api:compare tool then picks them up as file-local private helpers (`internal: true`).

## Test plan

- [x] `pnpm api:compare --package activerecord` — core.ts 100% ✓, model-schema.ts 100% ✓
- [x] `pnpm lint` — clean
- [x] Pre-commit hooks pass (build + typecheck)