### PR TITLE
feat(activerecord): abstract_adapter.rb query/logging infrastructure (Wave 6 PR 25b)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from "vitest";
+import { AbstractAdapter } from "./abstract-adapter.js";
+import { ActiveRecordError, StatementInvalid } from "../errors.js";
+import { Notifications } from "@blazetrails/activesupport";
+import { Collectors } from "@blazetrails/arel";
+
+describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
+  describe("translateExceptionClass", () => {
+    it("passes through ActiveRecordError subclasses unchanged", () => {
+      const a = new AbstractAdapter();
+      const err = new ActiveRecordError("boom");
+      expect(a.translateExceptionClass(err, "SELECT 1", [])).toBe(err);
+    });
+
+    it("wraps native errors via translateException", () => {
+      const a = new AbstractAdapter();
+      const native = new Error("disk I/O error");
+      const result = a.translateExceptionClass(native, "INSERT INTO t VALUES (1)", []);
+      expect(result).toBeInstanceOf(StatementInvalid);
+    });
+
+    it("copies stack from native error onto wrapped error", () => {
+      const a = new AbstractAdapter();
+      const native = new Error("native");
+      native.stack = "some stack";
+      const result = a.translateExceptionClass(native, "SELECT 1", []) as Error;
+      expect(result.stack).toBe("some stack");
+    });
+  });
+
+  describe("translateException", () => {
+    it("passes ActiveRecordError through", () => {
+      const a = new AbstractAdapter();
+      const err = new ActiveRecordError("nope");
+      expect(a.translateException(err, { message: "msg", sql: "SELECT 1", binds: [] })).toBe(err);
+    });
+
+    it("wraps unknown errors as StatementInvalid", () => {
+      const a = new AbstractAdapter();
+      const err = new Error("native db error");
+      const result = a.translateException(err, {
+        message: "Error: native db error",
+        sql: "DELETE FROM t",
+        binds: [],
+      });
+      expect(result).toBeInstanceOf(StatementInvalid);
+      expect((result as StatementInvalid).sql).toBe("DELETE FROM t");
+    });
+  });
+
+  describe("instrumenter", () => {
+    it("returns the Notifications class", () => {
+      const a = new AbstractAdapter();
+      expect(a.instrumenter).toBe(Notifications);
+    });
+  });
+
+  describe("log", () => {
+    it("wraps block in sql.active_record notification", async () => {
+      const a = new AbstractAdapter();
+      const events: string[] = [];
+      const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e.name));
+      try {
+        await a.log("SELECT 1", "SQL", [], [], false, async () => "result");
+        expect(events).toContain("sql.active_record");
+      } finally {
+        Notifications.unsubscribe(sub);
+      }
+    });
+
+    it("re-throws StatementInvalid with query attached", async () => {
+      const a = new AbstractAdapter();
+      const inner = new StatementInvalid("oops");
+      await expect(
+        a.log("SELECT 1", "SQL", [1, 2], [], false, async () => {
+          throw inner;
+        }),
+      ).rejects.toBeInstanceOf(StatementInvalid);
+    });
+  });
+
+  describe("collector", () => {
+    it("returns Composite when preparedStatements=true", () => {
+      const a = new AbstractAdapter();
+      (a as any)._preparedStatements = true;
+      expect(a.collector()).toBeInstanceOf(Collectors.Composite);
+    });
+
+    it("returns SubstituteBinds when preparedStatements=false", () => {
+      const a = new AbstractAdapter();
+      (a as any)._preparedStatements = false;
+      expect(a.collector()).toBeInstanceOf(Collectors.SubstituteBinds);
+    });
+  });
+
+  describe("buildResult", () => {
+    it("constructs a Result with the given columns, rows, and types", () => {
+      const a = new AbstractAdapter();
+      const result = a.buildResult(["id", "name"], [[1, "Alice"]]);
+      expect(result.columns).toEqual(["id", "name"]);
+      expect(result.rows).toEqual([[1, "Alice"]]);
+    });
+  });
+
+  describe("buildStatementPool", () => {
+    it("returns undefined in the base implementation", () => {
+      const a = new AbstractAdapter();
+      expect(a.buildStatementPool()).toBeUndefined();
+    });
+  });
+
+  describe("defaultPreparedStatements", () => {
+    it("returns true in the base implementation", () => {
+      const a = new AbstractAdapter();
+      expect(a.defaultPreparedStatements()).toBe(true);
+    });
+  });
+
+  describe("attemptConfigureConnection", () => {
+    it("calls configureConnection and resolves", async () => {
+      const a = new AbstractAdapter();
+      let called = 0;
+      a.configureConnection = async () => void called++;
+      await a.attemptConfigureConnection();
+      expect(called).toBe(1);
+    });
+
+    it("disconnects and re-throws if configureConnection fails", async () => {
+      const a = new AbstractAdapter();
+      a.configureConnection = async () => {
+        throw new Error("connect failed");
+      };
+      const spy = vi.spyOn(a, "disconnectBang");
+      await expect(a.attemptConfigureConnection()).rejects.toThrow("connect failed");
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("isWarningIgnored", () => {
+    it("returns false when no matchers are configured", () => {
+      const a = new AbstractAdapter();
+      expect(a.isWarningIgnored({ message: "some warning", code: "W123" })).toBe(false);
+    });
+
+    it("matches by string substring on message", () => {
+      const a = new AbstractAdapter();
+      (a.constructor as any).dbWarningsIgnore = ["deprecated"];
+      expect(a.isWarningIgnored({ message: "this feature is deprecated" })).toBe(true);
+      delete (a.constructor as any).dbWarningsIgnore;
+    });
+
+    it("matches by RegExp on message", () => {
+      const a = new AbstractAdapter();
+      (a.constructor as any).dbWarningsIgnore = [/W\d+/];
+      expect(a.isWarningIgnored({ message: "ok", code: "W001" })).toBe(true);
+      delete (a.constructor as any).dbWarningsIgnore;
+    });
+  });
+
+  describe("lookupCastTypeFromColumn", () => {
+    it("returns null for a column with null sqlType", () => {
+      const a = new AbstractAdapter();
+      expect(a.lookupCastTypeFromColumn({ sqlType: null })).toBeNull();
+    });
+
+    it("delegates to lookupCastType when available", () => {
+      const a = new AbstractAdapter();
+      (a as any).lookupCastType = (t: string) => `cast:${t}`;
+      expect(a.lookupCastTypeFromColumn({ sqlType: "varchar" })).toBe("cast:varchar");
+    });
+
+    it("returns the sqlType string when lookupCastType is absent", () => {
+      const a = new AbstractAdapter();
+      expect(a.lookupCastTypeFromColumn({ sqlType: "integer" })).toBe("integer");
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -6,10 +6,12 @@
 
 import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
-import { type Nodes, Visitors } from "@blazetrails/arel";
+import { type Nodes, Visitors, Collectors } from "@blazetrails/arel";
 import {
   ReadOnlyError,
   NotImplementedError,
+  ActiveRecordError,
+  StatementInvalid,
   ConnectionNotEstablished,
   ConnectionNotDefined,
   ConnectionFailed,
@@ -17,6 +19,8 @@ import {
   Deadlocked,
   LockWaitTimeout,
 } from "../errors.js";
+import { Notifications } from "@blazetrails/activesupport";
+import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache } from "./schema-cache.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
@@ -58,7 +62,6 @@ import {
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting-interface.js";
 import { include } from "@blazetrails/activesupport";
-import type { Result } from "../result.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -1209,107 +1212,158 @@ export class AbstractAdapter implements Quoting {
   configureConnection(..._args: unknown[]): void | Promise<void> {
     this.checkVersion();
   }
+
+  /** @internal Mirrors: AbstractAdapter#translate_exception_class */
+  translateExceptionClass(nativeError: unknown, sql: unknown, binds: unknown): unknown {
+    if (nativeError instanceof ActiveRecordError) return nativeError;
+    const name = (nativeError as any)?.constructor?.name ?? "Error";
+    const msg = (nativeError as any)?.message ?? "";
+    const message = `${name}: ${msg}`;
+    const arError = this.translateException(nativeError, {
+      message,
+      sql: sql as string,
+      binds: binds as unknown[],
+    });
+    if (arError !== nativeError && arError instanceof Error && nativeError instanceof Error) {
+      arError.stack = nativeError.stack;
+    }
+    return arError;
+  }
+
+  /** Mirrors: AbstractAdapter#log */
+  async log<T>(
+    sql: string,
+    name: string | null | undefined = "SQL",
+    binds: unknown[] = [],
+    typeCastedBinds: unknown[] = [],
+    isAsync = false,
+    block?: () => Promise<T>,
+  ): Promise<T | void> {
+    try {
+      return await Notifications.instrumentAsync(
+        "sql.active_record",
+        {
+          sql,
+          name: name ?? "SQL",
+          binds,
+          type_casted_binds: typeCastedBinds,
+          async: isAsync,
+          connection: this,
+          row_count: 0,
+        },
+        block,
+      );
+    } catch (ex) {
+      if (ex instanceof StatementInvalid) {
+        throw ex.setQuery(sql, binds);
+      }
+      throw ex;
+    }
+  }
+
+  /** @internal Mirrors: AbstractAdapter#instrumenter */
+  get instrumenter(): typeof Notifications {
+    return Notifications;
+  }
+
+  /** @internal Mirrors: AbstractAdapter#translate_exception */
+  translateException(
+    exception: unknown,
+    opts: { message: string; sql: string; binds: unknown[] },
+  ): unknown {
+    if (exception instanceof ActiveRecordError) return exception;
+    return new StatementInvalid(opts.message, {
+      sql: opts.sql,
+      binds: opts.binds,
+      connectionPool: this.pool,
+    });
+  }
+
+  /** @internal Mirrors: AbstractAdapter#column_for */
+  async columnFor(tableName: string, columnName: string): Promise<import("./column.js").Column> {
+    const cols = await (this as any).columns(tableName);
+    const col = (cols as import("./column.js").Column[]).find((c) => c.name === columnName);
+    if (!col) throw new ActiveRecordError(`No such column: ${tableName}.${columnName}`);
+    return col;
+  }
+
+  /** @internal Mirrors: AbstractAdapter#column_for_attribute */
+  async columnForAttribute(attribute: {
+    relation: { name: string };
+    name: string;
+  }): Promise<import("./column.js").Column | undefined> {
+    const hash = await (this.schemaCache as any).columnsHash(this.pool, attribute.relation.name);
+    return hash?.[attribute.name];
+  }
+
+  /** @internal Mirrors: AbstractAdapter#collector */
+  collector(): Collectors.Composite | Collectors.SubstituteBinds {
+    if (this.preparedStatements) {
+      return new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+    }
+    return new Collectors.SubstituteBinds(this as any, new Collectors.SQLString());
+  }
+
+  /** @internal Mirrors: AbstractAdapter#build_statement_pool */
+  buildStatementPool(..._args: unknown[]): unknown {
+    return undefined;
+  }
+
+  /** @internal Mirrors: AbstractAdapter#build_result */
+  buildResult(
+    columns: string[],
+    rows: unknown[][],
+    columnTypes: ColumnTypes | null = null,
+  ): Result {
+    return new Result(columns, rows, columnTypes);
+  }
+
+  /** @internal Mirrors: AbstractAdapter#attempt_configure_connection */
+  async attemptConfigureConnection(): Promise<void> {
+    try {
+      await this.configureConnection();
+    } catch (e) {
+      this.disconnectBang();
+      throw e;
+    }
+  }
+
+  /** @internal Mirrors: AbstractAdapter#default_prepared_statements */
+  defaultPreparedStatements(): boolean {
+    return true;
+  }
+
+  /** @internal Mirrors: AbstractAdapter#warning_ignored? */
+  isWarningIgnored(warning: {
+    message?: string;
+    code?: string | number;
+    [k: string]: unknown;
+  }): boolean {
+    const matchers: (string | RegExp)[] = (this.constructor as any).dbWarningsIgnore ?? [];
+    const msg = warning.message ?? "";
+    return matchers.some(
+      (m) =>
+        (typeof m === "string" ? msg.includes(m) : m.test(msg)) ||
+        (warning.code !== undefined &&
+          (typeof m === "string"
+            ? String(warning.code).includes(m)
+            : m.test(String(warning.code)))),
+    );
+  }
+
+  /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */
+  lookupCastTypeFromColumn(column: { sqlType: string | null }): unknown {
+    const sqlType = column.sqlType;
+    if (!sqlType) return null;
+    if (typeof (this as any).lookupCastType === "function") {
+      return (this as any).lookupCastType(sqlType);
+    }
+    return sqlType;
+  }
 }
 
 // Rails: `include DatabaseStatements` inside the class body.
 include(AbstractAdapter, DatabaseStatements);
-
-/** @internal */
-function translateExceptionClass(nativeError: any, sql: any, binds: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class is not implemented",
-  );
-}
-
-function log(
-  sql: any,
-  name?: any,
-  binds?: any,
-  typeCastedBinds?: any,
-  async?: any,
-  block?: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#log is not implemented",
-  );
-}
-
-/** @internal */
-function instrumenter(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#instrumenter is not implemented",
-  );
-}
-
-/** @internal */
-function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception is not implemented",
-  );
-}
-
-/** @internal */
-function columnFor(tableName: any, columnName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#column_for is not implemented",
-  );
-}
-
-/** @internal */
-function columnForAttribute(attribute: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#column_for_attribute is not implemented",
-  );
-}
-
-/** @internal */
-function collector(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#collector is not implemented",
-  );
-}
-
-/** @internal */
-function arelVisitor(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#arel_visitor is not implemented",
-  );
-}
-
-/** @internal */
-function buildStatementPool(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#build_statement_pool is not implemented",
-  );
-}
-
-/** @internal */
-function buildResult(columns?: any, rows?: any, columnTypes?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#build_result is not implemented",
-  );
-}
-
-/** @internal */
-function attemptConfigureConnection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#attempt_configure_connection is not implemented",
-  );
-}
-
-/** @internal */
-function defaultPreparedStatements(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#default_prepared_statements is not implemented",
-  );
-}
-
-/** @internal */
-function isWarningIgnored(warning: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#warning_ignored? is not implemented",
-  );
-}
 
 /** @internal */
 function initializeTypeMap(m: any): never {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1240,6 +1240,8 @@ export class AbstractAdapter implements Quoting {
     block?: () => Promise<T>,
   ): Promise<T | void> {
     try {
+      const tx = this.currentTransaction();
+      const userTx = (tx as any).userTransaction ?? null;
       return await Notifications.instrumentAsync(
         "sql.active_record",
         {
@@ -1249,6 +1251,7 @@ export class AbstractAdapter implements Quoting {
           type_casted_binds: typeCastedBinds,
           async: isAsync,
           connection: this,
+          transaction: userTx,
           row_count: 0,
         },
         block,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1000,7 +1000,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /** @internal */
-  protected isWarningIgnored(warning: { level?: string }): boolean {
+  override isWarningIgnored(warning: { level?: string; [k: string]: unknown }): boolean {
     return warning.level === "Note";
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1064,7 +1064,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /** @internal */
-  private defaultPreparedStatements(): boolean {
+  /** @internal */
+  override defaultPreparedStatements(): boolean {
     return false;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1064,7 +1064,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /** @internal */
-  /** @internal */
   override defaultPreparedStatements(): boolean {
     return false;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1972,7 +1972,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   /** @internal */
-  private buildStatementPool(): GenericStatementPool<SqliteStatement> {
+  override buildStatementPool(): GenericStatementPool<SqliteStatement> {
     return new GenericStatementPool<SqliteStatement>(this._statementLimit);
   }
 


### PR DESCRIPTION
## Summary

- Implements 13 Rails-private methods in `AbstractAdapter` covering query execution, logging, and cast/visitor/collector primitives
- Methods: `translateExceptionClass`, `log`, `instrumenter`, `translateException`, `columnFor`, `columnForAttribute`, `collector`, `buildStatementPool`, `buildResult`, `attemptConfigureConnection`, `defaultPreparedStatements`, `isWarningIgnored`, `lookupCastTypeFromColumn`
- abstract_adapter.rb coverage: 172 → 185 matched (40%)
- Fixes override signatures in `AbstractMysqlAdapter.isWarningIgnored`, `Mysql2Adapter.defaultPreparedStatements`, `SQLite3Adapter.buildStatementPool` to properly extend base
- 21 new unit tests in `abstract-adapter.query-logging.test.ts`

## Dependencies

- Unblocks: Wave 6 follow-up PRs

## Test plan

- [x] `pnpm test abstract-adapter.query-logging` — 21/21 passing
- [x] `pnpm build` — clean
- [x] `bash scripts/api-compare/run.sh --package activerecord` — 172→185 matched on abstract_adapter.rb
- [x] LOC: 236 additions + deletions (< 300 ceiling)