### PR TITLE
chore(start-worktree): link .claude/skills + settings.local.json into new worktrees

### DIFF
--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -49,10 +49,11 @@ link_source() {
   local rel="$1"
   local src="$MAIN_REPO/$rel"
   local dst="$TARGET/$rel"
-  if [[ ! -d "$src" ]]; then
-    echo "    skip $rel (not fetched in main worktree — run pnpm api:compare there first)"
+  if [[ ! -e "$src" ]]; then
+    echo "    skip $rel (not present in main worktree)"
     return
   fi
+  mkdir -p "$(dirname "$dst")"
   rm -rf "$dst"
   ln -s "$src" "$dst"
   echo "    linked $rel -> $src"
@@ -61,6 +62,10 @@ link_source() {
 echo "==> Linking Rails and Rack source from main worktree"
 link_source "scripts/api-compare/.rails-source"
 link_source "scripts/api-compare/.rack-source"
+
+echo "==> Linking .claude config from main worktree (skills + per-machine permissions)"
+link_source ".claude/skills"
+link_source ".claude/settings.local.json"
 
 echo "==> Running pnpm install"
 ( cd "$TARGET" && pnpm install )


### PR DESCRIPTION
## Summary

Spawned agents in fresh worktrees couldn't run trails-specific skills (`/link`, `/workon`, etc.) because the worktree's `.claude/` directory only contained the committed `settings.json`. The skills live in the main worktree at `.claude/skills/`, which isn't checked in.

This PR has \`scripts/start-worktree.sh\` symlink \`.claude/skills\` and \`.claude/settings.local.json\` from the main worktree, mirroring the existing pattern for the \`api-compare/.rails-source\` / \`.rack-source\` paths.

Also generalizes the \`link_source\` helper to handle files (not just dirs) so \`settings.local.json\` — a single JSON file with the per-machine permission allowlist — works.

## Repro of the bug

1. Spawn an agent via prompt-agent skill (which calls \`scripts/start-worktree.sh\`)
2. Agent opens a PR
3. Agent runs \`/link <pr-num>\` to register the worktree for webhook delivery
4. Result: \`Couldn't run /link — skill not registered in this session, so webhook notifications for PR #N won't pipe back here automatically.\`

After this PR, the new worktree has \`.claude/skills\` symlinked and \`/link\` resolves on first use.

## Test plan

- [x] \`scripts/start-worktree.sh test-link-fix\` produces a worktree with \`.claude/skills\` symlinked
- [x] \`.claude/settings.local.json\` symlinked too
- [x] Existing \`api-compare/.rails-source\` / \`.rack-source\` still link correctly