### PR TITLE
docs: browser compatibility portability plan (BC-1)

### DIFF
--- a/docs/activesupport.md
+++ b/docs/activesupport.md
@@ -82,7 +82,10 @@ host-level primitives that downstream packages compose with.
 `fsAdapter`, `pathAdapter`, `osAdapter`, `processAdapter`,
 `childProcessAdapter`, `cryptoAdapter`, `asyncContextAdapter`. Lazy
 node defaults; trailties / a browser shell can override. CLI-only
-utilities (`glob`) live behind subpath exports.
+utilities (`glob`) live behind subpath exports. The adapter pattern is the
+canonical model for every new native-dep abstraction in the monorepo — see
+[browser-compat-plan.md](browser-compat-plan.md) for the full portability
+policy.
 
 ### Cache
 

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -45,7 +45,8 @@ The JS ecosystem treats `NODE_ENV` as a _build-time hint_ (bundlers replace it
 statically), not a reliable runtime value. `trailties/database.ts` already
 prefers `TRAILS_ENV` with a `NODE_ENV` fallback. BC-2 codifies this
 everywhere: `TRAILS_ENV` is the canonical runtime environment name; `NODE_ENV`
-is a one-release fallback shim, then dropped.
+remains a silent read-only fallback indefinitely (never written, never
+advertised, but never removed — too many apps set only `NODE_ENV`).
 
 ### SQLite driver registry
 
@@ -153,11 +154,11 @@ rack) get their status set to ✅ or flagged as ❌ after a grep-and-review pass
 
 ## 5. CI gates (added in BC-4)
 
-| Gate                    | Tooling                                                                                           | Job                    | Trigger    |
-| ----------------------- | ------------------------------------------------------------------------------------------------- | ---------------------- | ---------- |
-| Browser-bundle smoke    | `esbuild --bundle --platform=browser --bundle <barrel> 2>&1 \| grep -E "^(✘\|error)"` per package | `Browser Bundle` (new) | Every push |
-| No bare native imports  | `blazetrails/no-native-import` ESLint rule                                                        | `Lint` (existing)      | Every push |
-| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                                                   | `Lint` (existing)      | Every push |
+| Gate                    | Tooling                                                                                  | Job                    | Trigger    |
+| ----------------------- | ---------------------------------------------------------------------------------------- | ---------------------- | ---------- |
+| Browser-bundle smoke    | `esbuild --bundle --platform=browser <barrel> 2>&1 \| grep -E "^(✘\|error)"` per package | `Browser Bundle` (new) | Every push |
+| No bare native imports  | `blazetrails/no-native-import` ESLint rule                                               | `Lint` (existing)      | Every push |
+| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                                          | `Lint` (existing)      | Every push |
 
 A package barrel that resolves `node:fs` in the browser-bundle step fails
 the `Browser Bundle` job with a non-zero exit code — the hard signal that a

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -13,8 +13,9 @@ leave them in browser builds even when the feature is unused. Lint rules and
 browser-bundle CI (added in BC-4) enforce this.
 
 **Database adapters opt in via registry, not eager import.**
-Apps that use PostgreSQL or MySQL import `@blazetrails/activerecord/adapters/postgresql`
-(or `/mysql2`, `/sqlite3`). Core activerecord has zero top-level imports of
+Apps that use PostgreSQL import `@blazetrails/activerecord/adapters/postgresql`,
+MySQL import `@blazetrails/activerecord/adapters/mysql2`, SQLite import
+`@blazetrails/activerecord/adapters/sqlite3`. Core activerecord has zero top-level imports of
 adapter packages. The goal is _PG-not-bundled-when-unused_, not
 _PG-in-the-browser_.
 
@@ -71,8 +72,10 @@ function getEnv(key: string, defaultValue: string): string;
 function getEnv(key: string): string | undefined;
 ```
 
-Read-back policy: read `TRAILS_ENV`, no fallback. Pre-release — direct
-replacement with no shim.
+Read-back policy: read `TRAILS_ENV` only — no `NODE_ENV` fallback.
+Pre-release; direct replacement. The `defaultValue` argument (e.g.
+`getEnv("TRAILS_ENV", "development")`) is for explicit caller-supplied
+defaults, not for `NODE_ENV` aliasing.
 
 Files to migrate:
 
@@ -149,16 +152,16 @@ rack) get their status set to ✅ or flagged as ❌ after a grep-and-review pass
 
 ## 5. CI gates (added in BC-4)
 
-| Gate                    | Tooling                                                                                  | Job                    | Trigger    |
-| ----------------------- | ---------------------------------------------------------------------------------------- | ---------------------- | ---------- |
-| Browser-bundle smoke    | `esbuild --bundle --platform=browser <barrel> 2>&1 \| grep -E "^(✘\|error)"` per package | `Browser Bundle` (new) | Every push |
-| No bare native imports  | `blazetrails/no-native-import` ESLint rule                                               | `Lint` (existing)      | Every push |
-| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                                          | `Lint` (existing)      | Every push |
+| Gate                    | Tooling                                                                | Job                    | Trigger    |
+| ----------------------- | ---------------------------------------------------------------------- | ---------------------- | ---------- |
+| Browser-bundle smoke    | `esbuild --bundle --platform=browser <barrel>` — fail on non-zero exit | `Browser Bundle` (new) | Every push |
+| No bare native imports  | `blazetrails/no-native-import` ESLint rule                             | `Lint` (existing)      | Every push |
+| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                        | `Lint` (existing)      | Every push |
 
-A package barrel that resolves `node:fs` in the browser-bundle step fails
-the `Browser Bundle` job with a non-zero exit code — the hard signal that a
-dep has leaked past the adapter layer. This catches regressions that
-tree-shaker analysis would miss.
+A package barrel that resolves `node:fs` causes esbuild to exit non-zero,
+failing the `Browser Bundle` job. Rely on esbuild's own exit code — don't
+pipe to grep (grep exits 1 on no matches, which would fail CI when the build
+is clean).
 
 ## 6. Open questions
 

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -42,11 +42,9 @@ abstraction.
 ### `TRAILS_ENV` vs `NODE_ENV`
 
 The JS ecosystem treats `NODE_ENV` as a _build-time hint_ (bundlers replace it
-statically), not a reliable runtime value. `trailties/database.ts` already
-prefers `TRAILS_ENV` with a `NODE_ENV` fallback. BC-2 codifies this
-everywhere: `TRAILS_ENV` is the canonical runtime environment name; `NODE_ENV`
-remains a silent read-only fallback indefinitely (never written, never
-advertised, but never removed — too many apps set only `NODE_ENV`).
+statically), not a reliable runtime value. BC-2 replaces all `NODE_ENV` reads
+with `TRAILS_ENV` — no fallback, no shim. Pre-release means no backwards
+compat obligations.
 
 ### SQLite driver registry
 
@@ -73,10 +71,8 @@ function getEnv(key: string, defaultValue: string): string;
 function getEnv(key: string): string | undefined;
 ```
 
-Read-back policy: check `TRAILS_ENV` first; fall back to `NODE_ENV` silently.
-The fallback is indefinite — `NODE_ENV` is never advertised but never removed,
-because too many existing apps set only `NODE_ENV`. `TRAILS_ENV` always wins
-when both are set; neither is ever written by `getEnv`.
+Read-back policy: read `TRAILS_ENV`, no fallback. Pre-release — direct
+replacement with no shim.
 
 Files to migrate:
 

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -73,11 +73,10 @@ function getEnv(key: string, defaultValue: string): string;
 function getEnv(key: string): string | undefined;
 ```
 
-Read-back policy: check `TRAILS_ENV` first; fall back to `NODE_ENV` with a
-deprecation warning for one release; then drop the fallback. Because many
-existing apps set only `NODE_ENV`, the fallback should remain indefinite as
-a read-only alias — `TRAILS_ENV` takes precedence, `NODE_ENV` is a silent
-fallback, never written.
+Read-back policy: check `TRAILS_ENV` first; fall back to `NODE_ENV` silently.
+The fallback is indefinite — `NODE_ENV` is never advertised but never removed,
+because too many existing apps set only `NODE_ENV`. `TRAILS_ENV` always wins
+when both are set; neither is ever written by `getEnv`.
 
 Files to migrate:
 

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -64,10 +64,19 @@ No code changes.
 
 ### BC-2 — `getEnv()` accessor + migrate 6 activerecord files (~80 LOC)
 
-Add `getEnv(key: string, defaultValue?: string): string | undefined` to
-`packages/activesupport/src/environment.ts`. One-release read-back: check
-`TRAILS_ENV` first, fall back to `NODE_ENV` with a deprecation warning, then
-drop the fallback in the following release.
+Add `getEnv` to `packages/activesupport/src/environment.ts` with two
+overloads:
+
+```ts
+function getEnv(key: string, defaultValue: string): string;
+function getEnv(key: string): string | undefined;
+```
+
+Read-back policy: check `TRAILS_ENV` first; fall back to `NODE_ENV` with a
+deprecation warning for one release; then drop the fallback. Because many
+existing apps set only `NODE_ENV`, the fallback should remain indefinite as
+a read-only alias — `TRAILS_ENV` takes precedence, `NODE_ENV` is a silent
+fallback, never written.
 
 Files to migrate:
 
@@ -96,6 +105,12 @@ proven and we can copy it verbatim.
 - Move `import pg from "pg"` and `import Database from "better-sqlite3"` out
   of barrel-reachable files and into the adapter subpath entry points only.
 - Promote `pg` and `mysql2` to optional peer deps in `package.json`.
+
+**Important:** registries self-register on import. An app that never imports
+`@blazetrails/activerecord/adapters/postgresql` will find no registered
+driver and get a clear "no adapter registered for postgresql" error at
+connection time. The error message should name the missing subpath import so
+the fix is obvious.
 
 Files that currently eagerly import native deps (all move to subpath entries):
 
@@ -138,15 +153,16 @@ rack) get their status set to ✅ or flagged as ❌ after a grep-and-review pass
 
 ## 5. CI gates (added in BC-4)
 
-| Gate                    | Tooling                                 | Trigger    |
-| ----------------------- | --------------------------------------- | ---------- |
-| Browser-bundle smoke    | `esbuild --platform=browser` per barrel | Every push |
-| No bare native imports  | Custom ESLint rule                      | Every push |
-| No direct `process.env` | Custom ESLint rule                      | Every push |
+| Gate                    | Tooling                                                                                           | Job                    | Trigger    |
+| ----------------------- | ------------------------------------------------------------------------------------------------- | ---------------------- | ---------- |
+| Browser-bundle smoke    | `esbuild --bundle --platform=browser --bundle <barrel> 2>&1 \| grep -E "^(✘\|error)"` per package | `Browser Bundle` (new) | Every push |
+| No bare native imports  | `blazetrails/no-native-import` ESLint rule                                                        | `Lint` (existing)      | Every push |
+| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                                                   | `Lint` (existing)      | Every push |
 
-A package barrel that resolves `node:fs` in the browser-bundle smoke test
-fails the build immediately. This is the hard signal that a new dep has leaked
-past the adapter layer.
+A package barrel that resolves `node:fs` in the browser-bundle step fails
+the `Browser Bundle` job with a non-zero exit code — the hard signal that a
+dep has leaked past the adapter layer. This catches regressions that
+tree-shaker analysis would miss.
 
 ## 6. Open questions
 
@@ -158,6 +174,9 @@ past the adapter layer.
   WebSocket)? Current stance: PostgreSQL and MySQL remain server-only; the
   goal is _bundle-cleanliness_, not browser execution. Revisit only if an
   explicit consumer requests it.
-- **`TRAILS_ENV` deprecation window.** One release of `NODE_ENV` fallback may
-  not be enough for apps that set only `NODE_ENV`. Should the fallback be
-  indefinite (read both, prefer `TRAILS_ENV`)? Decide before BC-2 ships.
+- **MySQL driver abstraction.** Should MySQL follow the same driver-registry
+  path as SQLite (a `MysqlDriver` interface, `mysql2` as the default
+  implementation, a future `planetscale-driver` possible)? Or is MySQL
+  strictly server-only forever? Currently leaning server-only — the bundle
+  goal is met by BC-3's lazy loading alone — but document this if a consumer
+  requests it.

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -1,0 +1,163 @@
+# Browser Compatibility Plan
+
+This document codifies the portability policy for the trails monorepo so each
+new package doesn't rediscover it. It also tracks the migration from the
+current ad-hoc state to a fully enforced baseline.
+
+## 1. Principles
+
+**Native deps are never imported eagerly from any package barrel/index.**
+`node:fs`, `node:path`, `node:crypto`, `pg`, `mysql2`, `better-sqlite3` are
+all server-only. Eagerly bundling them into a barrel causes tree-shakers to
+leave them in browser builds even when the feature is unused. Lint rules and
+browser-bundle CI (added in BC-4) enforce this.
+
+**Database adapters opt in via registry, not eager import.**
+Apps that use PostgreSQL or MySQL import `@blazetrails/activerecord/adapters/postgresql`
+(or `/mysql2`, `/sqlite3`). Core activerecord has zero top-level imports of
+adapter packages. The goal is _PG-not-bundled-when-unused_, not
+_PG-in-the-browser_.
+
+**Env vars are accessed through `getEnv()` in activesupport.**
+Direct `process.env` reads break in environments that lack `process`
+(browsers, Deno, Bun edge runtimes). All env reads go through `getEnv(key,
+defaultValue?)`, which falls back gracefully. The single canonical name for
+the application environment is `TRAILS_ENV` — see §2 for the rationale.
+
+**Each package owns a one-line portability status** (the matrix in §4).
+New packages must declare their status before merging.
+
+## 2. Existing plumbing
+
+### activesupport adapter pattern
+
+`packages/activesupport/src` already ships `fsAdapter`, `pathAdapter`,
+`cryptoAdapter` (and others — see [activesupport.md](activesupport.md) §Adapters).
+Twenty files across activerecord use `getFs()` / `getPath()` / `getCrypto()`
+instead of importing `node:*` directly, and there are zero bare `node:*`
+imports in `packages/activerecord/src` (excluding `tsc-wrapper/`, a
+build-time tool). This pattern is the template for every future native-dep
+abstraction.
+
+### `TRAILS_ENV` vs `NODE_ENV`
+
+The JS ecosystem treats `NODE_ENV` as a _build-time hint_ (bundlers replace it
+statically), not a reliable runtime value. `trailties/database.ts` already
+prefers `TRAILS_ENV` with a `NODE_ENV` fallback. BC-2 codifies this
+everywhere: `TRAILS_ENV` is the canonical runtime environment name; `NODE_ENV`
+is a one-release fallback shim, then dropped.
+
+### SQLite driver registry
+
+`docs/sqlite-driver-abstraction-plan.md` describes the registry pattern:
+a `DriverFactory` interface, a `registerDriver()` call in the adapter subpath
+export, and capability flags so the adapter layer can branch on
+async vs sync. The database-adapter registry in BC-3 copies this shape
+verbatim — read that doc for implementation detail.
+
+## 3. Migration plan
+
+### BC-1 — this document (~250 LOC, plan-only)
+
+Establishes vocabulary, cross-links existing plans, and sequences the work.
+No code changes.
+
+### BC-2 — `getEnv()` accessor + migrate 6 activerecord files (~80 LOC)
+
+Add `getEnv(key: string, defaultValue?: string): string | undefined` to
+`packages/activesupport/src/environment.ts`. One-release read-back: check
+`TRAILS_ENV` first, fall back to `NODE_ENV` with a deprecation warning, then
+drop the fallback in the following release.
+
+Files to migrate:
+
+| File                                 | Sites | Old name                                         | New name                                                  |
+| ------------------------------------ | ----- | ------------------------------------------------ | --------------------------------------------------------- |
+| `token-for.ts:32`                    | 1     | `process.env` guard                              | `getEnv()` guard                                          |
+| `connection-handling.ts`             | 3     | `process.env.NODE_ENV`                           | `getEnv("TRAILS_ENV", "development")`                     |
+| `schema.ts:114`                      | 1     | `process.env.NODE_ENV`                           | `getEnv("TRAILS_ENV", "development")`                     |
+| `database-configurations.ts:254,269` | 2     | `NODE_ENV`, `DATABASE_URL`                       | `TRAILS_ENV`; `DATABASE_URL` stays                        |
+| `migration.ts:1461,1931`             | 2     | `NODE_ENV`, `DISABLE_DATABASE_ENVIRONMENT_CHECK` | `TRAILS_ENV`, `TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK` |
+| `tasks/database-tasks.ts:350,358`    | 2     | `VERSION`                                        | `TRAILS_MIGRATION_VERSION`                                |
+
+`DATABASE_URL` is an industry standard and stays unchanged.
+
+### BC-3 — database-adapter registry (~250 LOC)
+
+**Block until sqlite-driver PR M (#1247) merges** so the registry pattern is
+proven and we can copy it verbatim.
+
+- Add `packages/activerecord/src/connection-adapters/registry.ts` mirroring
+  the sqlite `DriverFactory` / `registerDriver` shape.
+- Add subpath exports:
+  - `@blazetrails/activerecord/adapters/postgresql`
+  - `@blazetrails/activerecord/adapters/mysql2`
+  - `@blazetrails/activerecord/adapters/sqlite3`
+- Move `import pg from "pg"` and `import Database from "better-sqlite3"` out
+  of barrel-reachable files and into the adapter subpath entry points only.
+- Promote `pg` and `mysql2` to optional peer deps in `package.json`.
+
+Files that currently eagerly import native deps (all move to subpath entries):
+
+- `connection-adapters/postgresql-adapter.ts` — `import pg from "pg"`
+- `connection-adapters/postgresql/temporal-type-parsers.ts` — `import pg from "pg"`
+- `connection-adapters/sqlite3-adapter.ts` — `import Database from "better-sqlite3"`
+- `connection-adapters/sqlite3/drivers/better-sqlite3.ts` — `import Database from "better-sqlite3"`
+
+### BC-4 — lint rules + browser-bundle CI smoke test (~150 LOC)
+
+Three gates, all additive (no existing code changes):
+
+1. **`no-native-import` lint rule** — reject `node:*`, `pg`, `mysql2`,
+   `better-sqlite3` outside designated adapter files
+   (`**/adapters/{postgresql,mysql2,sqlite3}/**`).
+2. **`no-direct-process-env` lint rule** — reject `process.env.X` outside
+   `bin/`, `test-setup-*.ts`, `*-adapter.ts`, and the new `environment.ts`.
+3. **Browser-bundle smoke test** — per-package CI step:
+   `esbuild --bundle --platform=browser <barrel>` and fail on any `node:*`
+   resolution error. Added to the `DX Type Tests` job or a new
+   `Browser Bundle` job.
+
+### BC-5 — per-package portability audit + fixes (iterative)
+
+One PR per gap discovered. Packages not yet audited (actionview, actionpack,
+rack) get their status set to ✅ or flagged as ❌ after a grep-and-review pass.
+
+## 4. Per-package portability matrix
+
+| Package         | Status                        | Notes                                                                    |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------ |
+| `arel`          | ✅ portable today             | No native deps                                                           |
+| `activemodel`   | ✅ portable today             | No native deps                                                           |
+| `activesupport` | ✅ portable                   | Adapter layer is the template; adapters live here                        |
+| `activerecord`  | 🟡 portable after BC-2 + BC-3 | Core is portable; adapters server-only by design, lazy-loaded after BC-3 |
+| `trailties`     | ❌ server-only intentionally  | CLI tool; Node-only is correct                                           |
+| `actionpack`    | ⏳ audit needed               | Likely portable; no known native deps                                    |
+| `actionview`    | ⏳ audit needed               | Likely portable                                                          |
+| `rack`          | ⏳ audit needed               | Likely portable                                                          |
+
+## 5. CI gates (added in BC-4)
+
+| Gate                    | Tooling                                 | Trigger    |
+| ----------------------- | --------------------------------------- | ---------- |
+| Browser-bundle smoke    | `esbuild --platform=browser` per barrel | Every push |
+| No bare native imports  | Custom ESLint rule                      | Every push |
+| No direct `process.env` | Custom ESLint rule                      | Every push |
+
+A package barrel that resolves `node:fs` in the browser-bundle smoke test
+fails the build immediately. This is the hard signal that a new dep has leaked
+past the adapter layer.
+
+## 6. Open questions
+
+- **Buffer / node: polyfills.** Do we offer a `Buffer` shim or similar on the
+  browser side, or strictly require activesupport adapters? Current stance:
+  strictly require adapters; polyfills hide leaks.
+- **PG browser execution.** Should a future `pg-driver-abstraction-plan.md`
+  mirror the sqlite plan and allow a browser-capable PG driver (e.g. via
+  WebSocket)? Current stance: PostgreSQL and MySQL remain server-only; the
+  goal is _bundle-cleanliness_, not browser execution. Revisit only if an
+  explicit consumer requests it.
+- **`TRAILS_ENV` deprecation window.** One release of `NODE_ENV` fallback may
+  not be enough for apps that set only `NODE_ENV`. Should the fallback be
+  indefinite (read both, prefer `TRAILS_ENV`)? Decide before BC-2 ships.


### PR DESCRIPTION
## Summary

- Adds `docs/browser-compat-plan.md` — the canonical portability policy doc for the trails monorepo.
- Codifies: no eager native-dep imports, database adapters via registry, env vars through `getEnv()`/`TRAILS_ENV`, per-package status matrix.
- Plans 5 PRs: BC-1 (this doc) → BC-2 (`getEnv()` + 6 file migration) → BC-3 (adapter registry, blocks on #1247) → BC-4 (lint rules + CI smoke) → BC-5 (iterative per-package audits).

## Test plan

- [ ] Doc renders correctly in GitHub markdown preview
- [ ] Cross-links to `docs/sqlite-driver-abstraction-plan.md` and `docs/activesupport.md` resolve