### PR TITLE
feat(activesupport): getEnv() accessor + migrate 6 AR files (BC-2)

### DIFF
--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -90,6 +90,14 @@ Files to migrate:
 
 `DATABASE_URL` is an industry standard and stays unchanged.
 
+**Implementation note (shipped in #1251):** The original spec called for the full
+`EnvAdapter` / `registerEnvAdapter` / `getEnvAdapter` pattern mirroring `getFs`.
+BC-2 shipped the simpler shape — a thin `getEnv()` wrapper over
+`globalThis.process.env` with no registry. The simpler shape is sufficient for
+every use case through BC-4. If a future consumer needs to inject a different env
+source (e.g. `import.meta.env` in a browser shim), lift `environment.ts` to the
+full adapter pattern at that point.
+
 ### BC-3 — database-adapter registry (~250 LOC)
 
 **Block until sqlite-driver PR M (#1247) merges** so the registry pattern is

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
-import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync, getEnv } from "@blazetrails/activesupport";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
@@ -82,7 +82,7 @@ export function connectsTo(
 
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+      const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
       const found = configs.configsFor({ envName: env, name: dbKey });
       const dbConfig = found[0] ?? new HashConfig(env, dbKey, {});
       const pool = this.connectionHandler.establishConnection(dbConfig, {
@@ -530,7 +530,7 @@ async function establishWithConfig(
   }
 
   const dbConfig = new HashConfig(
-    process.env.NODE_ENV || DatabaseConfigurations.defaultEnv,
+    getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv,
     "primary",
     {
       adapter: adapterName,
@@ -564,7 +564,7 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
     const raw = await loadConfigFile(modelClass);
     configs = DatabaseConfigurations.fromEnv(raw);
   }
-  const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+  const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
   const primaryConfigs = configs.configsFor({ envName: env, name: "primary" });
   const dbConfig = primaryConfigs[0] ?? configs.findDbConfig(env);
 

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -1,3 +1,4 @@
+import { getEnv } from "@blazetrails/activesupport";
 import { NotImplementedError } from "./errors.js";
 import {
   DatabaseConfig,
@@ -251,7 +252,7 @@ export class DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
     // NODE_ENV is the TS equivalent of Rails.env — use it when available so
     // that DATABASE_URL merges into the active runtime environment.
-    const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+    const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
     instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw, env));
     return instance;
   }
@@ -266,7 +267,7 @@ export class DatabaseConfigurations {
    * Mirrors: ActiveRecord::DatabaseConfigurations#build_url_hash
    */
   private _mergeDatabaseUrl(raw: RawConfigurations, envOverride?: string): RawConfigurations {
-    const databaseUrl = process.env.DATABASE_URL;
+    const databaseUrl = getEnv("DATABASE_URL");
     if (!databaseUrl) return raw;
 
     const hasConfigs = Object.keys(raw).length > 0;

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -250,8 +250,8 @@ export class DatabaseConfigurations {
    */
   static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
-    // NODE_ENV is the TS equivalent of Rails.env — use it when available so
-    // that DATABASE_URL merges into the active runtime environment.
+    // TRAILS_ENV is the canonical runtime env (BC-2); NODE_ENV is the one-release fallback.
+    // DATABASE_URL merges into whichever environment is active.
     const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
     instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw, env));
     return instance;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath, Logger } from "@blazetrails/activesupport";
+import { getFs, getPath, Logger, getEnv } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
@@ -1458,7 +1458,10 @@ export class Migrator {
       enabled: options.internalMetadataEnabled ?? true,
     });
     this._environment =
-      options.environment ?? (process.env.NODE_ENV || DatabaseConfigurations.defaultEnv);
+      options.environment ??
+      getEnv("TRAILS_ENV") ??
+      getEnv("NODE_ENV") ??
+      DatabaseConfigurations.defaultEnv;
     this._strategy = options.strategy ?? new DefaultStrategy();
     this._validateMigrations(migrations);
     const normalized = migrations.map((m) => ({
@@ -1928,7 +1931,13 @@ export class Migrator {
     // In Ruby, "" is truthy, so any *present* value (including empty
     // string) bypasses the check. JS treats "" as falsy, so we use a
     // presence check instead to preserve Rails semantics.
-    if (process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK !== undefined) return;
+    // TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK is the canonical name; DISABLE_DATABASE_ENVIRONMENT_CHECK
+    // is the legacy fallback (one-release window — remove when BC-4 lint rule ships).
+    if (
+      (getEnv("TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK") ??
+        getEnv("DISABLE_DATABASE_ENVIRONMENT_CHECK")) !== undefined
+    )
+      return;
     await this._ensureSchemaTable();
     const stored = await this._internalMetadata.get("environment");
     if (stored === null) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1933,6 +1933,9 @@ export class Migrator {
     // presence check instead to preserve Rails semantics.
     // TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK is the canonical name; DISABLE_DATABASE_ENVIRONMENT_CHECK
     // is the legacy fallback (one-release window — remove when BC-4 lint rule ships).
+    // The !== undefined check (not a truthiness check) is intentional: an empty string is "present"
+    // in Ruby (truthy), so any set value — including "" — must bypass the check. Do not simplify
+    // this to a falsy/truthiness test; that would silently break Rails parity.
     if (
       (getEnv("TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK") ??
         getEnv("DISABLE_DATABASE_ENVIRONMENT_CHECK")) !== undefined

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -1,3 +1,4 @@
+import { getEnv } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Current } from "./migration.js";
 import { SchemaMigration } from "./schema-migration.js";
@@ -111,7 +112,10 @@ export class Schema extends Current {
     // keeps Schema.define consistent with how Migrator and other
     // migration-stack pieces resolve the current environment.
     const environment =
-      info.environment ?? process.env.NODE_ENV ?? DatabaseConfigurations.defaultEnv;
+      info.environment ??
+      getEnv("TRAILS_ENV") ??
+      getEnv("NODE_ENV") ??
+      DatabaseConfigurations.defaultEnv;
     const internalMetadata = new InternalMetadata(adapter, { enabled });
     await internalMetadata.createTableAndSetFlags(environment);
   }

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -25,7 +25,7 @@ function adapterPool(adapter: DatabaseAdapter):
 export interface SchemaDefineInfo {
   /** Schema version to mark as migrated (calls assume_migrated_upto_version). */
   version?: string | number;
-  /** Environment label stored in ar_internal_metadata. Defaults to NODE_ENV. */
+  /** Environment label stored in ar_internal_metadata. Defaults to TRAILS_ENV (or NODE_ENV fallback). */
   environment?: string;
 }
 
@@ -105,9 +105,9 @@ export class Schema extends Current {
     // (the rest of the migration stack uses the same shape — see
     // migration.ts:1440).
     const enabled = adapterPool(adapter)?.dbConfig?.useMetadataTable !== false;
-    // Environment fallback chain: explicit info.environment → NODE_ENV
-    // → DatabaseConfigurations.defaultEnv (which itself defaults to
-    // "development" but can be overridden by the app, e.g. via
+    // Environment fallback chain: explicit info.environment → TRAILS_ENV
+    // → NODE_ENV (one-release fallback) → DatabaseConfigurations.defaultEnv
+    // (defaults to "development" but can be overridden by the app, e.g. via
     // trailties boot). Using defaultEnv over a hard-coded literal
     // keeps Schema.define consistent with how Migrator and other
     // migration-stack pieces resolve the current environment.

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -8,7 +8,7 @@ import { NotImplementedError } from "../errors.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs, getPath, getCryptoAsync, getOs } from "@blazetrails/activesupport";
+import { getFs, getPath, getCryptoAsync, getOs, getEnv } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
 /**
@@ -347,7 +347,8 @@ export class DatabaseTasks {
   }
 
   static targetVersion(): number | null {
-    const version = process.env.VERSION;
+    // TRAILS_MIGRATION_VERSION is canonical; VERSION is the legacy fallback (one-release window).
+    const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
     if (!version) return null;
     const str = version.trim();
     if (str === "" || !/^\d+$/.test(str)) return null;
@@ -355,7 +356,7 @@ export class DatabaseTasks {
   }
 
   static checkTargetVersion(version?: number | string): void {
-    const v = version ?? process.env.VERSION;
+    const v = version ?? getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
     if (v === undefined || v === null || String(v).trim() === "") return;
     const str = String(v).trim();
     if (!/^\d+$/.test(str)) {
@@ -364,7 +365,7 @@ export class DatabaseTasks {
   }
 
   static dumpSchemaFilename(config?: DatabaseConfig): string {
-    const envSchema = process.env.SCHEMA?.trim();
+    const envSchema = getEnv("SCHEMA")?.trim();
     if (envSchema) return envSchema;
     const format = this.schemaFormat;
     const ext = format === "sql" ? "sql" : format;

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -5,6 +5,7 @@
  */
 
 import { InvalidSignature, MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { getEnv } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
 
 export { InvalidSignature };
@@ -29,8 +30,7 @@ function resolveSecret(): string {
   if (_tokenForSecret) {
     return typeof _tokenForSecret === "function" ? _tokenForSecret() : _tokenForSecret;
   }
-  const env = typeof process !== "undefined" ? process.env : undefined;
-  const envSecret = env?.BLAZETRAILS_SECRET_KEY_BASE ?? env?.BLAZETRAILS_SIGNED_ID_SECRET;
+  const envSecret = getEnv("BLAZETRAILS_SECRET_KEY_BASE") ?? getEnv("BLAZETRAILS_SIGNED_ID_SECRET");
   if (typeof envSecret === "string" && envSecret.length > 0) return envSecret;
   throw new Error(
     "TokenFor requires a configured secret. Call setTokenForSecret() " +

--- a/packages/activesupport/src/environment.test.ts
+++ b/packages/activesupport/src/environment.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getEnv } from "./environment.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getEnv", () => {
+  it("returns the env var value when set", () => {
+    vi.stubEnv("TEST_KEY", "hello");
+    expect(getEnv("TEST_KEY")).toBe("hello");
+  });
+
+  it("returns undefined when the var is unset", () => {
+    expect(getEnv("SURELY_NOT_SET_XYZ_12345")).toBeUndefined();
+  });
+
+  it("returns defaultValue when the var is unset", () => {
+    expect(getEnv("SURELY_NOT_SET_XYZ_12345", "fallback")).toBe("fallback");
+  });
+
+  it("returns the var value over defaultValue when the var is set", () => {
+    vi.stubEnv("TEST_KEY", "real");
+    expect(getEnv("TEST_KEY", "fallback")).toBe("real");
+  });
+});

--- a/packages/activesupport/src/environment.ts
+++ b/packages/activesupport/src/environment.ts
@@ -1,0 +1,22 @@
+/**
+ * Environment variable accessor — browser-safe wrapper around process.env.
+ *
+ * Direct `process.env` reads throw in environments that lack `process`
+ * (browsers, Deno edge runtimes). All env reads in the framework go through
+ * `getEnv()` instead, which falls back gracefully to `undefined`.
+ */
+
+function readRaw(key: string): string | undefined {
+  if (typeof globalThis.process === "undefined") return undefined;
+  return globalThis.process.env[key];
+}
+
+/**
+ * Read an environment variable. Returns `defaultValue` when the variable is
+ * unset or the environment has no `process.env`.
+ */
+export function getEnv(key: string, defaultValue: string): string;
+export function getEnv(key: string): string | undefined;
+export function getEnv(key: string, defaultValue?: string): string | undefined {
+  return readRaw(key) ?? defaultValue;
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -386,6 +386,7 @@ export {
 export { CurrentAttributes } from "./current-attributes.js";
 export { StringInquirer, inquiry } from "./string-inquirer.js";
 export { EnvironmentInquirer } from "./environment-inquirer.js";
+export { getEnv } from "./environment.js";
 export { ExecutionContext } from "./execution-context.js";
 export { objectWith } from "./core-ext/object/with.js";
 export { ArrayInquirer, arrayInquiry } from "./array-inquirer.js";


### PR DESCRIPTION
## Summary

- Adds `getEnv(key, defaultValue?)` to `packages/activesupport/src/environment.ts` — a browser-safe wrapper around `process.env` that falls back gracefully when `globalThis.process` is absent. Exported from the activesupport barrel.
- Migrates all 9 direct `process.env` reads across the 6 activerecord files listed in the BC-2 plan (`token-for`, `connection-handling`, `schema`, `database-configurations`, `migration`, `tasks/database-tasks`).
- One-release fallback policy: `TRAILS_ENV` → `NODE_ENV` for environment reads; canonical `TRAILS_*` names for the other renamed vars, with legacy names as secondary fallbacks.

## Test plan

- [ ] `pnpm exec vitest run packages/activesupport/src/environment.test.ts` — 4 new unit tests pass
- [ ] `grep -rn "process\.env" packages/activerecord/src/{token-for,connection-handling,schema,database-configurations,migration}.ts packages/activerecord/src/tasks/database-tasks.ts` → zero matches
- [ ] CI (build + typecheck already green via pre-commit hook)