### PR TITLE
feat(activerecord): nested-attributes.ts to 100% (Wave 7 PR 31)

### DIFF
--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -4,6 +4,7 @@ import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./erro
 import { singularize, camelize, underscore } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
 import { isMarkedForDestruction, markForDestruction } from "./autosave-association.js";
+import { BooleanType } from "@blazetrails/activemodel";
 
 /**
  * Raised when more nested-attribute records are provided than the
@@ -32,7 +33,7 @@ export function _destroy(this: Base): boolean {
 interface NestedAttributeOptions {
   allowDestroy?: boolean;
   rejectIf?: (attrs: Record<string, unknown>) => boolean;
-  limit?: number;
+  limit?: number | ((...args: unknown[]) => number);
   updateOnly?: boolean;
 }
 
@@ -135,10 +136,11 @@ export function assignNestedAttributes(
   const ctor = record.constructor as typeof Base;
   const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
   const config = configs.find((c) => c.associationName === associationName);
-  if (config?.options.limit !== undefined && attrs.length > config.options.limit) {
+  const rawLimit = config?.options.limit;
+  const resolvedLimit = typeof rawLimit === "function" ? rawLimit() : rawLimit;
+  if (resolvedLimit !== undefined && attrs.length > resolvedLimit) {
     throw new TooManyRecords(
-      `Maximum ${config.options.limit} records are allowed. ` +
-        `Got ${attrs.length} records instead.`,
+      `Maximum ${resolvedLimit} records are allowed. ` + `Got ${attrs.length} records instead.`,
     );
   }
 
@@ -260,11 +262,11 @@ async function processNestedAttributes(record: Base): Promise<void> {
 
 const UNASSIGNABLE_KEYS = new Set(["id", "_destroy"]);
 
+const _booleanType = new BooleanType();
+
 /** @internal */
 function hasDestroyFlag(hash: Record<string, unknown>): boolean {
-  const v = hash["_destroy"];
-  if (v == null || v === false || v === "" || v === "0" || v === "false") return false;
-  return Boolean(v);
+  return _booleanType.cast(hash["_destroy"]) === true;
 }
 
 /** @internal */
@@ -348,10 +350,15 @@ function raiseNestedAttributesRecordNotFoundBang(
 }
 
 /** @internal */
-function checkRecordLimitBang(limit: number | undefined, attributesCollection: unknown[]): void {
-  if (limit !== undefined && attributesCollection.length > limit) {
+function checkRecordLimitBang(
+  limit: number | ((...args: unknown[]) => number) | undefined,
+  attributesCollection: unknown[],
+): void {
+  if (limit === undefined) return;
+  const resolved = typeof limit === "function" ? limit() : limit;
+  if (resolved !== undefined && attributesCollection.length > resolved) {
     throw new TooManyRecords(
-      `Maximum ${limit} records are allowed. Got ${attributesCollection.length} records instead.`,
+      `Maximum ${resolved} records are allowed. Got ${attributesCollection.length} records instead.`,
     );
   }
 }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -1,9 +1,9 @@
 import type { Base } from "./base.js";
 import { modelRegistry } from "./associations.js";
-import { ActiveRecordError, UnknownAttributeError, NotImplementedError } from "./errors.js";
+import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./errors.js";
 import { singularize, camelize, underscore } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
-import { isMarkedForDestruction } from "./autosave-association.js";
+import { isMarkedForDestruction, markForDestruction } from "./autosave-association.js";
 
 /**
  * Raised when more nested-attribute records are provided than the
@@ -82,10 +82,13 @@ export function acceptsNestedAttributesFor(
     options,
   } as NestedAttributeConfig);
 
-  // Define the setter for `{associationName}Attributes`
-  const attrName = `${associationName}Attributes`;
+  const type =
+    assocExists.type === "hasMany" || assocExists.type === "hasAndBelongsToMany"
+      ? "collection"
+      : "one_to_one";
+  generateAssociationWriter(modelClass, associationName, type);
 
-  // Store pending nested attrs on instance for processing during save
+  // Wrap save to flush pending nested attributes after the parent is persisted
   const originalSave = modelClass.prototype.save;
   if (!(modelClass as any)._nestedSaveWrapped) {
     (modelClass as any)._nestedSaveWrapped = true;
@@ -94,7 +97,6 @@ export function acceptsNestedAttributesFor(
       const result = await originalSave.call(this);
       if (!result) return false;
 
-      // Process pending nested attributes
       await processNestedAttributes(this);
       return true;
     };
@@ -256,88 +258,178 @@ async function processNestedAttributes(record: Base): Promise<void> {
   (record as any)._pendingNestedAttributes = null;
 }
 
+const UNASSIGNABLE_KEYS = new Set(["id", "_destroy"]);
+
+/** @internal */
+function hasDestroyFlag(hash: Record<string, unknown>): boolean {
+  const v = hash["_destroy"];
+  if (v == null || v === false || v === "" || v === "0" || v === "false") return false;
+  return Boolean(v);
+}
+
+/** @internal */
+function isAllowDestroy(record: Base, associationName: string): boolean {
+  const configs: NestedAttributeConfig[] =
+    (record.constructor as any)._nestedAttributeConfigs ?? [];
+  return configs.find((c) => c.associationName === associationName)?.options.allowDestroy ?? false;
+}
+
+/** @internal */
+function isWillBeDestroyed(
+  record: Base,
+  associationName: string,
+  attributes: Record<string, unknown>,
+): boolean {
+  return isAllowDestroy(record, associationName) && hasDestroyFlag(attributes);
+}
+
+/** @internal */
+function callRejectIf(
+  record: Base,
+  associationName: string,
+  attributes: Record<string, unknown>,
+): boolean {
+  if (isWillBeDestroyed(record, associationName, attributes)) return false;
+  const configs: NestedAttributeConfig[] =
+    (record.constructor as any)._nestedAttributeConfigs ?? [];
+  const rejectIf = configs.find((c) => c.associationName === associationName)?.options.rejectIf;
+  return rejectIf ? rejectIf(attributes) : false;
+}
+
+/** @internal */
+function isRejectNewRecord(
+  record: Base,
+  associationName: string,
+  attributes: Record<string, unknown>,
+): boolean {
+  return (
+    isWillBeDestroyed(record, associationName, attributes) ||
+    callRejectIf(record, associationName, attributes)
+  );
+}
+
+/** @internal */
+function assignToOrMarkForDestruction(
+  childRecord: Base,
+  attributes: Record<string, unknown>,
+  allowDestroy: boolean,
+): void {
+  const assignable: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(attributes)) {
+    if (!UNASSIGNABLE_KEYS.has(k)) assignable[k] = v;
+  }
+  childRecord.assignAttributes(assignable);
+  if (hasDestroyFlag(attributes) && allowDestroy) {
+    markForDestruction(childRecord);
+  }
+}
+
+/** @internal */
+function findRecordById(_klass: typeof Base, records: Base[], id: unknown): Base | undefined {
+  return records.find((r) => String(r.id) === String(id));
+}
+
+/** @internal */
+function raiseNestedAttributesRecordNotFoundBang(
+  record: Base,
+  associationName: string,
+  recordId: unknown,
+): never {
+  const ctor = record.constructor as typeof Base;
+  const associations: any[] = (ctor as any)._associations ?? [];
+  const assocDef = associations.find((a: any) => a.name === associationName);
+  const modelName = assocDef?.options?.className ?? camelize(singularize(associationName));
+  throw new RecordNotFound(
+    `Couldn't find ${modelName} with ID=${recordId} for ${ctor.name} with ID=${record.id}`,
+    modelName,
+    "id",
+    recordId,
+  );
+}
+
+/** @internal */
+function checkRecordLimitBang(limit: number | undefined, attributesCollection: unknown[]): void {
+  if (limit !== undefined && attributesCollection.length > limit) {
+    throw new TooManyRecords(
+      `Maximum ${limit} records are allowed. Got ${attributesCollection.length} records instead.`,
+    );
+  }
+}
+
+/** @internal */
+function generateAssociationWriter(
+  modelClass: typeof Base,
+  associationName: string,
+  type: "collection" | "one_to_one",
+): void {
+  const attrName = `${associationName}Attributes`;
+  if (type === "collection") {
+    Object.defineProperty(modelClass.prototype, attrName, {
+      set(this: Base, value: any) {
+        assignNestedAttributesForCollectionAssociation(this, associationName, value);
+      },
+      configurable: true,
+    });
+  } else {
+    Object.defineProperty(modelClass.prototype, attrName, {
+      set(this: Base, value: any) {
+        assignNestedAttributesForOneToOneAssociation(this, associationName, value);
+      },
+      configurable: true,
+    });
+  }
+}
+
 /** @internal */
 function assignNestedAttributesForOneToOneAssociation(
-  associationName: any,
-  attributes: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#assign_nested_attributes_for_one_to_one_association is not implemented",
-  );
+  record: Base,
+  associationName: string,
+  attributes: Record<string, unknown>,
+): void {
+  if (typeof attributes !== "object" || attributes === null || Array.isArray(attributes)) {
+    throw new Error(
+      `Hash expected for \`${associationName}\` attributes, got ${typeof attributes}`,
+    );
+  }
+  if (!isRejectNewRecord(record, associationName, attributes)) {
+    if (!(record as any)._pendingNestedAttributes) {
+      (record as any)._pendingNestedAttributes = new Map();
+    }
+    (record as any)._pendingNestedAttributes.set(associationName, [attributes]);
+  }
 }
 
 /** @internal */
 function assignNestedAttributesForCollectionAssociation(
-  associationName: any,
-  attributesCollection: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#assign_nested_attributes_for_collection_association is not implemented",
-  );
-}
+  record: Base,
+  associationName: string,
+  attributesCollection: Record<string, unknown>[] | Record<string, Record<string, unknown>>,
+): void {
+  if (typeof attributesCollection !== "object" || attributesCollection === null) {
+    throw new Error(
+      `Hash or Array expected for \`${associationName}\` attributes, got ${typeof attributesCollection}`,
+    );
+  }
+  const ctor = record.constructor as typeof Base;
+  const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
+  const config = configs.find((c) => c.associationName === associationName);
 
-/** @internal */
-function checkRecordLimitBang(limit: any, attributesCollection: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#check_record_limit! is not implemented",
-  );
-}
+  let attrs: Record<string, unknown>[];
+  if (Array.isArray(attributesCollection)) {
+    attrs = attributesCollection;
+  } else {
+    const keys = Object.keys(attributesCollection);
+    if (keys.includes("id")) {
+      attrs = [attributesCollection as unknown as Record<string, unknown>];
+    } else {
+      attrs = keys.sort().map((k) => (attributesCollection as any)[k]);
+    }
+  }
 
-/** @internal */
-function assignToOrMarkForDestruction(record: any, attributes: any, allowDestroy: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#assign_to_or_mark_for_destruction is not implemented",
-  );
-}
+  checkRecordLimitBang(config?.options.limit, attrs);
 
-/** @internal */
-function hasDestroyFlag(hash: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#has_destroy_flag? is not implemented",
-  );
-}
-
-/** @internal */
-function isRejectNewRecord(associationName: any, attributes: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#reject_new_record? is not implemented",
-  );
-}
-
-/** @internal */
-function callRejectIf(associationName: any, attributes: any): never {
-  throw new NotImplementedError("ActiveRecord::NestedAttributes#call_reject_if is not implemented");
-}
-
-/** @internal */
-function isWillBeDestroyed(associationName: any, attributes: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#will_be_destroyed? is not implemented",
-  );
-}
-
-/** @internal */
-function isAllowDestroy(associationName: any): never {
-  throw new NotImplementedError("ActiveRecord::NestedAttributes#allow_destroy? is not implemented");
-}
-
-/** @internal */
-function raiseNestedAttributesRecordNotFoundBang(associationName: any, recordId: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#raise_nested_attributes_record_not_found! is not implemented",
-  );
-}
-
-/** @internal */
-function findRecordById(klass: any, records: any, id: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#find_record_by_id is not implemented",
-  );
-}
-
-/** @internal */
-function generateAssociationWriter(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::NestedAttributes#generate_association_writer is not implemented",
-  );
+  if (!(record as any)._pendingNestedAttributes) {
+    (record as any)._pendingNestedAttributes = new Map();
+  }
+  (record as any)._pendingNestedAttributes.set(associationName, attrs);
 }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -262,6 +262,7 @@ async function processNestedAttributes(record: Base): Promise<void> {
 
 const UNASSIGNABLE_KEYS = new Set(["id", "_destroy"]);
 
+/** @internal Stateless; one instance shared across all calls. */
 const _booleanType = new BooleanType();
 
 /** @internal */
@@ -327,7 +328,14 @@ function assignToOrMarkForDestruction(
 }
 
 /** @internal */
-function findRecordById(_klass: typeof Base, records: Base[], id: unknown): Base | undefined {
+function findRecordById(klass: typeof Base, records: Base[], id: unknown): Base | undefined {
+  if (Array.isArray((klass as any).primaryKey)) {
+    const needle = (Array.isArray(id) ? id : [id]).map(String);
+    return records.find((r) => {
+      const rid = Array.isArray(r.id) ? r.id : [r.id];
+      return rid.map(String).join(",") === needle.join(",");
+    });
+  }
   return records.find((r) => String(r.id) === String(id));
 }
 


### PR DESCRIPTION
## Summary

- Implements 12 missing private helpers in \`nested-attributes.ts\`, bringing \`nested_attributes.rb\` from 14% (2/14) to **100% (14/14)**
- Replaces \`NotImplementedError\` stubs with real behavior for all 12 Rails private methods

**Method names follow Rails source directly** (not the task prompt's list, which contained non-existent Rails names like \`existingRecord?\`, \`shouldDeleteRecord?\`, \`missingDestroyFlag?\`). The actual Rails surface is:
\`hasDestroyFlag\`, \`isAllowDestroy\`, \`isWillBeDestroyed\`, \`callRejectIf\`, \`isRejectNewRecord\`, \`assignToOrMarkForDestruction\`, \`findRecordById\`, \`raiseNestedAttributesRecordNotFoundBang\`, \`checkRecordLimitBang\`, \`generateAssociationWriter\`, \`assignNestedAttributesForOneToOneAssociation\`, \`assignNestedAttributesForCollectionAssociation\`

**Key implementation notes:**
- \`hasDestroyFlag\` delegates to \`BooleanType.cast()\` matching Rails' \`Type::Boolean.new.cast(hash["_destroy"])\`
- \`checkRecordLimitBang\` supports number and callable limit (Rails: Proc/Symbol dispatch)
- \`findRecordById\` handles composite primary keys via \`klass.primaryKey\` array detection
- \`generateAssociationWriter\` uses \`Object.defineProperty\` to install the \`${associationName}Attributes\` setter
- \`acceptsNestedAttributesFor\` now calls \`generateAssociationWriter\` so the setter is wired immediately on declaration

**Architectural note:** \`assignNestedAttributesFor*\` store pending attrs and defer DB work to \`processNestedAttributes\` at save time. Rails does this synchronously via loaded association proxy + autosave; our async architecture requires the deferral. The \`reject_if\`, \`_destroy\`, and limit checks that can run synchronously still do.

## Depends on

PR #1239 (autosave_association, merged)

## Test plan

- [x] \`pnpm api:compare --package activerecord\` → \`nested_attributes.rb\` 14/14 ✓
- [x] Build + typecheck passes (enforced by pre-commit hook)
- [x] Existing \`nested-attributes.test.ts\` (135 tests passing, 18 skipped)