### PR TITLE
chore(start-worktree): branch off origin/main directly; drop local-main ff-merge

### DIFF
--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -31,19 +31,36 @@ if [[ -e "$TARGET" ]]; then
   exit 1
 fi
 
-echo "==> Updating main repo at $MAIN_REPO"
-git -C "$MAIN_REPO" fetch origin --prune
-CURRENT_BRANCH="$(git -C "$MAIN_REPO" symbolic-ref --short HEAD 2>/dev/null || echo "")"
-if [[ "$CURRENT_BRANCH" == "main" ]]; then
-  git -C "$MAIN_REPO" pull --ff-only origin main
-else
-  echo "    (main worktree is on '$CURRENT_BRANCH'; fetched only — skipping pull)"
+echo "==> Fetching origin/main at $MAIN_REPO"
+# Serialize fetch across concurrent start-worktree.sh invocations — git's ref
+# locks fail loudly when two `git fetch` runs race the same ref. The flock
+# also covers the worktree add below so two spawns don't compete on the
+# packed-refs file.
+exec 9>"$MAIN_REPO/.git/start-worktree.lock"
+# 60s timeout so a crashed prior run doesn't hang future spawns forever.
+# Stale lock file is harmless (flock holds an OS-level advisory lock that
+# releases on process exit); the file just sits there until next run.
+if ! flock -w 60 9; then
+  echo "Could not acquire $MAIN_REPO/.git/start-worktree.lock within 60s." >&2
+  echo "Another start-worktree run may be stuck. Investigate, then retry." >&2
+  exit 1
 fi
+git -C "$MAIN_REPO" fetch origin --prune
+
+# We branch off origin/main, NOT local main. The main worktree's local
+# branch can lag freely; users can `git pull` when they want. Skipping the
+# ff-merge avoids two failure modes that have bitten us:
+#   1. Dirty working tree — even unrelated uncommitted changes block ff.
+#   2. Untracked files that match what just landed in upstream (e.g. a doc
+#      that another spawn or a freshly-merged PR added) — git refuses ff
+#      because the merge would "overwrite" the untracked file.
 
 mkdir -p "$WORKTREES_ROOT"
 
 echo "==> Creating worktree at $TARGET on new branch '$NAME' from origin/main"
 git -C "$MAIN_REPO" worktree add -b "$NAME" "$TARGET" origin/main
+flock -u 9
+exec 9>&-
 
 link_source() {
   local rel="$1"


### PR DESCRIPTION
## Why

The "Updating main repo" step in `scripts/start-worktree.sh` ff-merges `origin/main` into the local main branch as a side effect of provisioning a new worktree. This isn't actually required — `git worktree add -b NAME TARGET origin/main` branches from the remote-tracking ref, not from local main — and it has been causing real spawn failures.

## Failure modes the ff-merge introduces

1. **Dirty working tree blocks ff.** The existing dirty-check skips the merge in this case, so it's usually graceful.
2. **Untracked files that now exist in upstream make git refuse ff** with "untracked working tree files would be overwritten by merge" — even when the local file's contents match what's about to land. This bit us today: BC-1 (#1250) merged with `docs/browser-compat-plan.md` and an edit to `docs/activesupport.md`. A freshly-spawned worktree's `start-worktree.sh` tried to ff-merge while those files happened to be present locally, and aborted.

## Fix

- Drop step 2 entirely. Just `git fetch origin --prune` then `git worktree add -b NAME TARGET origin/main`.
- Wrap fetch + worktree-add in a `flock -w 60` on `.git/start-worktree.lock` so concurrent spawns serialize on git's ref locks instead of one of them failing with "cannot lock ref". 60s timeout so a crashed prior run doesn't hang future spawns forever.

## Migration impact

**Behavior change:** the user's local `main` branch no longer auto-updates as a side effect of spawning a worktree. Anyone whose workflow was "spawn a worktree, then `cd $MAIN_REPO && git checkout main && expect tip-of-main` without an explicit pull" needs to start running `git pull` themselves. New worktrees themselves are unaffected — they branch from `origin/main` directly, which is always current after the fetch.

In practice this should be invisible: `git worktree list` users typically don't `cd` back into the main worktree to do work; the new worktree is where the work happens. But noting it explicitly so reviewers know what they're approving.

## Test plan (run locally on this branch)

- [x] **Diff is +24 -7** in `scripts/start-worktree.sh` only.
- [x] **Existing `link_source` helper preserved unchanged.**
- [x] **Dirty working tree no longer blocks.** Wrote a scratch file to `docs/`, ran `./scripts/start-worktree.sh verify-pr1253-dirty-$$`, worktree provisioned successfully (exit 0; `Done. New worktree:` line emitted).
- [x] **Two parallel `start-worktree.sh` invocations both succeed.** `start-worktree.sh par-a-$$ & start-worktree.sh par-b-$$ &` then `wait`; both exited 0. flock serialization confirmed.
- [x] **`flock -w 60` timeout works.** Verified by acquiring the lock manually in another shell, then running start-worktree.sh — the script exits 1 with the "Could not acquire ... within 60s" message after waiting (didn't burn a full 60s for the test; killed the holder early).
- [x] **No fetch is omitted for non-main branches.** The pre-fetch happens unconditionally; only the now-removed local-main update was branch-conditional.