### PR TITLE
feat(activerecord): insert_all.rb to 100% (Wave 7 PR 56)

### DIFF
--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, defineEnum } from "./index.js";
-
+import { InsertAll } from "./insert-all.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
@@ -817,5 +817,74 @@ describe("insertAll / upsertAll (Rails-guided)", () => {
 
     const books = await Book.all().toArray();
     expect(books.length).toBe(2);
+  });
+
+  // Rails: disallow_raw_sql! is called on on_duplicate and returning in the InsertAll constructor
+  // (lines 24-25 of insert_all.rb). Tested via InsertAll directly since the relation wrappers
+  // insertAll/upsertAll have their own restricted option types.
+  it("rejects raw SQL string for onDuplicate", () => {
+    class Book extends Base {
+      static {
+        this._tableName = "books";
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    expect(
+      () =>
+        new InsertAll(Book.all() as any, adapter, [{ title: "x" }], {
+          onDuplicate: "title = 'injected'" as any,
+        }),
+    ).toThrow("Dangerous query method");
+  });
+
+  it("allows Arel.sql for onDuplicate", async () => {
+    const { sql } = await import("@blazetrails/arel");
+    class Book extends Base {
+      static {
+        this._tableName = "books";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    expect(
+      () =>
+        new InsertAll(Book.all() as any, adapter, [{ id: 1, title: "x" }], {
+          onDuplicate: sql("title = excluded.title"),
+        }),
+    ).not.toThrow();
+  });
+
+  it("rejects raw SQL string for returning", () => {
+    class Book extends Base {
+      static {
+        this._tableName = "books";
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    expect(
+      () =>
+        new InsertAll(Book.all() as any, adapter, [{ title: "x" }], {
+          returning: "DROP TABLE books" as any,
+        }),
+    ).toThrow("Dangerous query method");
+  });
+
+  it("allows safe column name string for returning", () => {
+    class Book extends Base {
+      static {
+        this._tableName = "books";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    // plain column-name string (Ruby symbol equivalent) must not throw
+    expect(
+      () =>
+        new InsertAll(Book.all() as any, adapter, [{ id: 1, title: "x" }], { returning: "title" }),
+    ).not.toThrow();
   });
 });

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -13,6 +13,12 @@ type AdapterDialect = AdapterName;
 const TIMESTAMP_COLUMNS = ["created_at", "updated_at"] as const;
 const UPDATE_TIMESTAMP_COLUMNS = ["updated_at"] as const;
 
+// Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#column_name_with_order_matcher
+// Allows safe column names (optionally table-qualified, with optional ASC/DESC/NULLS).
+// Used by disallowRawSqlBang to distinguish Ruby-symbol-equivalent strings from raw SQL.
+const COLUMN_NAME_WITH_ORDER =
+  /^\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?[\w,\s]*)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?[\w,\s]*)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*\s*$/i;
+
 export interface InsertAllOptions {
   onDuplicate?: "skip" | "update" | Nodes.SqlLiteral;
   updateOnly?: string | string[];
@@ -62,6 +68,10 @@ export class InsertAll {
     this._recordTimestamps = options.recordTimestamps ?? this.model.recordTimestamps;
     this.updateSql = undefined;
     this.onDuplicate = undefined;
+
+    if (options.onDuplicate !== undefined) this.disallowRawSqlBang(options.onDuplicate);
+    if (options.returning !== undefined && options.returning !== false)
+      this.disallowRawSqlBang(options.returning);
 
     if (options.returning !== undefined) {
       this.returning =
@@ -296,9 +306,10 @@ export class InsertAll {
   }
 
   /** @internal */
-  private disallowRawSqlBang(value: unknown): void {
+  private disallowRawSqlBang(value: unknown, permit: RegExp = COLUMN_NAME_WITH_ORDER): void {
     if (value instanceof Nodes.SqlLiteral) return;
     if (typeof value !== "string") return;
+    if (permit.test(value)) return;
     throw new Error(
       `Dangerous query method called with raw SQL string: ${value}. ` +
         "Known-safe values can be passed by wrapping them in Arel.sql().",

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -3,6 +3,7 @@ import { Nodes, Visitors } from "@blazetrails/arel";
 import { SerializeCastValue } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { quoteSqlValue } from "./base.js";
+import { stiName } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import type { AdapterName } from "./adapter.js";
 
@@ -210,8 +211,7 @@ export class InsertAll {
 
   /** @internal */
   private uniqueByColumns(): string[] {
-    if (!this.uniqueBy) return [];
-    return Array.isArray(this.uniqueBy) ? this.uniqueBy : [this.uniqueBy];
+    return this.findUniqueIndexFor(this.uniqueBy);
   }
 
   /** @internal */
@@ -229,26 +229,20 @@ export class InsertAll {
 
   /** @internal */
   private hasAttributeAliases(attributes: Record<string, unknown>): boolean {
-    return Object.keys(attributes).some(
-      (attr) =>
-        typeof (this.model as any).attributeAlias === "function" &&
-        (this.model as any).attributeAlias(attr) != null,
-    );
+    const aliases = (this.model as any)._attributeAliases as Record<string, string> | undefined;
+    if (!aliases) return false;
+    return Object.keys(attributes).some((attr) => attr in aliases);
   }
 
   /** @internal */
   private resolveSti(): void {
-    if (
-      typeof (this.model as any).descendsFromActiveRecord === "function" &&
-      (this.model as any).descendsFromActiveRecord()
-    )
-      return;
-    const inheritanceCol = (this.model as any).inheritanceColumn as string | undefined;
+    // descendsFromActiveRecord? is not yet implemented; use inheritanceColumn as proxy
+    const inheritanceCol = this.model.inheritanceColumn;
     if (!inheritanceCol) return;
-    const stiType = (this.model as any).stiName ?? this.model.name;
+    const type = stiName(this.model);
     for (const insert of this.inserts) {
       if (insert[inheritanceCol] == null) {
-        insert[inheritanceCol] = stiType;
+        insert[inheritanceCol] = type;
       }
     }
   }
@@ -267,22 +261,29 @@ export class InsertAll {
 
   /** @internal */
   private resolveAttributeAlias(attribute: string): string {
-    if (typeof (this.model as any).attributeAlias === "function") {
-      return (this.model as any).attributeAlias(attribute) ?? attribute;
-    }
-    return attribute;
+    const aliases = (this.model as any)._attributeAliases as Record<string, string> | undefined;
+    return aliases?.[attribute] ?? attribute;
   }
 
   /** @internal */
   private findUniqueIndexFor(uniqueBy: string | string[] | undefined): string[] {
-    const cols =
+    const nameOrCols =
       uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
-    return cols;
+    const sortedMatch = [...nameOrCols].sort().join(",");
+    const idx = this.uniqueIndexes().find(
+      (i: any) =>
+        nameOrCols.includes(i.name) ||
+        (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
+    ) as any;
+    if (idx) return Array.isArray(idx.columns) ? idx.columns : nameOrCols;
+    if (uniqueBy == null || sortedMatch === [...this.primaryKeys()].sort().join(","))
+      return uniqueBy == null ? [] : this.primaryKeys();
+    throw new Error(`No unique index found for ${JSON.stringify(uniqueBy)}`);
   }
 
   /** @internal */
   private uniqueIndexes(): unknown[] {
-    const schemaCache = (this.model as any).schemaCache ?? (this.model as any).schema_cache;
+    const schemaCache = (this.model as any).schemaCache;
     if (!schemaCache) return [];
     const indexes = schemaCache.indexes?.(this.model.arelTable.name) ?? [];
     return (indexes as any[]).filter((i: any) => i.unique);
@@ -296,8 +297,8 @@ export class InsertAll {
 
   /** @internal */
   private disallowRawSqlBang(value: unknown): void {
+    if (value instanceof Nodes.SqlLiteral) return;
     if (typeof value !== "string") return;
-    if ((value as any) instanceof Nodes.SqlLiteral) return;
     throw new Error(
       `Dangerous query method called with raw SQL string: ${value}. ` +
         "Known-safe values can be passed by wrapping them in Arel.sql().",

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -14,8 +14,9 @@ const TIMESTAMP_COLUMNS = ["created_at", "updated_at"] as const;
 const UPDATE_TIMESTAMP_COLUMNS = ["updated_at"] as const;
 
 // Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#column_name_with_order_matcher
-// Allows safe column names (optionally table-qualified, with optional ASC/DESC/NULLS).
-// Used by disallowRawSqlBang to distinguish Ruby-symbol-equivalent strings from raw SQL.
+// Intentionally more restrictive than Rails: quoted identifiers ("col", `col`) and COLLATE
+// clauses are not matched. Callers with those forms must use Arel.sql(). This is the safe
+// direction — false-negatives force Arel.sql(), false-positives would allow SQL injection.
 const COLUMN_NAME_WITH_ORDER =
   /^\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?[\w,\s]*)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?[\w,\s]*)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*\s*$/i;
 
@@ -239,6 +240,7 @@ export class InsertAll {
 
   /** @internal */
   private hasAttributeAliases(attributes: Record<string, unknown>): boolean {
+    // _attributeAliases is on the AttributeMethods mixin host, not yet declared on typeof Base
     const aliases = (this.model as any)._attributeAliases as Record<string, string> | undefined;
     if (!aliases) return false;
     return Object.keys(attributes).some((attr) => attr in aliases);
@@ -286,6 +288,9 @@ export class InsertAll {
         (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
     ) as any;
     if (idx) return Array.isArray(idx.columns) ? idx.columns : nameOrCols;
+    // uniqueBy == null → caller wants PK uniqueness; PKs are already in readonlyColumns()
+    // so returning [] here is equivalent (they're excluded from updatableColumns either way).
+    // uniqueBy matching primary keys explicitly → return the PK columns directly.
     if (uniqueBy == null || sortedMatch === [...this.primaryKeys()].sort().join(","))
       return uniqueBy == null ? [] : this.primaryKeys();
     throw new Error(`No unique index found for ${JSON.stringify(uniqueBy)}`);
@@ -293,16 +298,15 @@ export class InsertAll {
 
   /** @internal */
   private uniqueIndexes(): unknown[] {
-    const schemaCache = (this.model as any).schemaCache;
-    if (!schemaCache) return [];
-    const indexes = schemaCache.indexes?.(this.model.arelTable.name) ?? [];
+    const cache = this.model.schemaCache;
+    if (!cache) return [];
+    const indexes = (cache as any).indexes?.(this.model.arelTable.name) ?? [];
     return (indexes as any[]).filter((i: any) => i.unique);
   }
 
   /** @internal */
   private readonlyColumns(): string[] {
-    const readonlyAttrs: string[] = (this.model as any).readonlyAttributes ?? [];
-    return [...this.primaryKeys(), ...readonlyAttrs];
+    return [...this.primaryKeys(), ...this.model.readonlyAttributes];
   }
 
   /** @internal */

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -79,6 +79,8 @@ export class InsertAll {
     if (this.inserts.length === 0) {
       this.keys = new Set();
     } else {
+      this.resolveSti();
+      this.resolveAttributeAliases();
       this.keys = new Set(Object.keys(this.inserts[0]));
     }
 
@@ -104,7 +106,7 @@ export class InsertAll {
 
   updatableColumns(): string[] {
     if (this._updatableColumns) return this._updatableColumns;
-    const exclude = new Set([...this.primaryKeys(), ...this.uniqueByColumns()]);
+    const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {
         exclude.add(col);
@@ -128,15 +130,13 @@ export class InsertAll {
   }
 
   mapKeyWithValue<T>(fn: (key: string, value: unknown) => T): T[][] {
-    const now = this.recordTimestamps() ? Temporal.Now.instant() : undefined;
+    const timestamps = this.recordTimestamps() ? this.timestampsForCreate() : undefined;
     const keysList = [...this.keysIncludingTimestamps()];
     return this.inserts.map((row) => {
       const merged = { ...this._scopeAttributes, ...row };
-      if (now) {
-        for (const col of TIMESTAMP_COLUMNS) {
-          if (this.model._attributeDefinitions.has(col) && merged[col] == null) {
-            merged[col] = now;
-          }
+      if (timestamps) {
+        for (const [col, val] of Object.entries(timestamps)) {
+          if (merged[col] == null) merged[col] = val;
         }
       }
       return keysList.map((key) => fn(key, merged[key]));
@@ -181,6 +181,14 @@ export class InsertAll {
         "You can't set :update_only and provide custom update SQL via :on_duplicate at the same time",
       );
     }
+    if (
+      onDuplicate !== undefined &&
+      onDuplicate !== "update" &&
+      !this.isCustomUpdateSqlProvided(onDuplicate) &&
+      this.updateOnly !== undefined
+    ) {
+      throw new Error("Cannot use both onDuplicate and updateOnly");
+    }
 
     if (this.updateOnly !== undefined) {
       this._updatableColumns = Array.isArray(this.updateOnly) ? this.updateOnly : [this.updateOnly];
@@ -196,9 +204,7 @@ export class InsertAll {
   }
 
   /** @internal */
-  private isCustomUpdateSqlProvided(
-    onDuplicate: InsertAllOptions["onDuplicate"] = this.updateSql,
-  ): boolean {
+  private isCustomUpdateSqlProvided(onDuplicate: InsertAllOptions["onDuplicate"]): boolean {
     return onDuplicate instanceof Nodes.SqlLiteral;
   }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,5 +1,4 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { NotImplementedError } from "./errors.js";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { SerializeCastValue } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
@@ -91,9 +90,9 @@ export class InsertAll {
       this.keys.add(key);
     }
 
-    this._verifyAttributes();
-    this._configureDuplicateLogic(options.onDuplicate);
-    this._ensureValidOptionsForConnection();
+    this.verifyAttributes();
+    this.configureOnDuplicateUpdateLogic(options.onDuplicate);
+    this.ensureValidOptionsForConnectionBang();
   }
 
   async execute(): Promise<number> {
@@ -105,7 +104,7 @@ export class InsertAll {
 
   updatableColumns(): string[] {
     if (this._updatableColumns) return this._updatableColumns;
-    const exclude = new Set([...this.primaryKeys(), ...this._uniqueByColumns()]);
+    const exclude = new Set([...this.primaryKeys(), ...this.uniqueByColumns()]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {
         exclude.add(col);
@@ -164,7 +163,8 @@ export class InsertAll {
     return this._keysIncludingTimestamps;
   }
 
-  private _verifyAttributes(): void {
+  /** @internal */
+  private verifyAttributes(): void {
     if (this.inserts.length <= 1) return;
     for (const row of this.inserts.slice(1)) {
       const rowKeys = new Set([...Object.keys(row), ...Object.keys(this._scopeAttributes)]);
@@ -174,26 +174,19 @@ export class InsertAll {
     }
   }
 
-  private _configureDuplicateLogic(onDuplicate: InsertAllOptions["onDuplicate"]): void {
-    if (onDuplicate instanceof Nodes.SqlLiteral && this.updateOnly !== undefined) {
+  /** @internal */
+  private configureOnDuplicateUpdateLogic(onDuplicate: InsertAllOptions["onDuplicate"]): void {
+    if (this.isCustomUpdateSqlProvided(onDuplicate) && this.updateOnly !== undefined) {
       throw new Error(
         "You can't set :update_only and provide custom update SQL via :on_duplicate at the same time",
       );
-    }
-    if (
-      onDuplicate !== undefined &&
-      onDuplicate !== "update" &&
-      !(onDuplicate instanceof Nodes.SqlLiteral) &&
-      this.updateOnly !== undefined
-    ) {
-      throw new Error("Cannot use both onDuplicate and updateOnly");
     }
 
     if (this.updateOnly !== undefined) {
       this._updatableColumns = Array.isArray(this.updateOnly) ? this.updateOnly : [this.updateOnly];
       this.onDuplicate = this._updatableColumns.length === 0 ? "skip" : "update";
-    } else if (onDuplicate instanceof Nodes.SqlLiteral) {
-      this.updateSql = onDuplicate;
+    } else if (this.isCustomUpdateSqlProvided(onDuplicate)) {
+      this.updateSql = onDuplicate as Nodes.SqlLiteral;
       this.onDuplicate = "update";
     } else if (onDuplicate === "skip") {
       this.onDuplicate = "skip";
@@ -202,12 +195,21 @@ export class InsertAll {
     }
   }
 
-  private _uniqueByColumns(): string[] {
+  /** @internal */
+  private isCustomUpdateSqlProvided(
+    onDuplicate: InsertAllOptions["onDuplicate"] = this.updateSql,
+  ): boolean {
+    return onDuplicate instanceof Nodes.SqlLiteral;
+  }
+
+  /** @internal */
+  private uniqueByColumns(): string[] {
     if (!this.uniqueBy) return [];
     return Array.isArray(this.uniqueBy) ? this.uniqueBy : [this.uniqueBy];
   }
 
-  private _ensureValidOptionsForConnection(): void {
+  /** @internal */
+  private ensureValidOptionsForConnectionBang(): void {
     if (
       this.returning &&
       typeof (this.connection as any).supportsInsertReturning === "function" &&
@@ -217,6 +219,95 @@ export class InsertAll {
         `${(this.connection as any).constructor?.name ?? "Adapter"} does not support INSERT...RETURNING`,
       );
     }
+  }
+
+  /** @internal */
+  private hasAttributeAliases(attributes: Record<string, unknown>): boolean {
+    return Object.keys(attributes).some(
+      (attr) =>
+        typeof (this.model as any).attributeAlias === "function" &&
+        (this.model as any).attributeAlias(attr) != null,
+    );
+  }
+
+  /** @internal */
+  private resolveSti(): void {
+    if (
+      typeof (this.model as any).descendsFromActiveRecord === "function" &&
+      (this.model as any).descendsFromActiveRecord()
+    )
+      return;
+    const inheritanceCol = (this.model as any).inheritanceColumn as string | undefined;
+    if (!inheritanceCol) return;
+    const stiType = (this.model as any).stiName ?? this.model.name;
+    for (const insert of this.inserts) {
+      if (insert[inheritanceCol] == null) {
+        insert[inheritanceCol] = stiType;
+      }
+    }
+  }
+
+  /** @internal */
+  private resolveAttributeAliases(): void {
+    if (!this.inserts[0] || !this.hasAttributeAliases(this.inserts[0])) return;
+    for (let i = 0; i < this.inserts.length; i++) {
+      const resolved: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(this.inserts[i])) {
+        resolved[this.resolveAttributeAlias(key)] = val;
+      }
+      this.inserts[i] = resolved;
+    }
+  }
+
+  /** @internal */
+  private resolveAttributeAlias(attribute: string): string {
+    if (typeof (this.model as any).attributeAlias === "function") {
+      return (this.model as any).attributeAlias(attribute) ?? attribute;
+    }
+    return attribute;
+  }
+
+  /** @internal */
+  private findUniqueIndexFor(uniqueBy: string | string[] | undefined): string[] {
+    const cols =
+      uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
+    return cols;
+  }
+
+  /** @internal */
+  private uniqueIndexes(): unknown[] {
+    const schemaCache = (this.model as any).schemaCache ?? (this.model as any).schema_cache;
+    if (!schemaCache) return [];
+    const indexes = schemaCache.indexes?.(this.model.arelTable.name) ?? [];
+    return (indexes as any[]).filter((i: any) => i.unique);
+  }
+
+  /** @internal */
+  private readonlyColumns(): string[] {
+    const readonlyAttrs: string[] = (this.model as any).readonlyAttributes ?? [];
+    return [...this.primaryKeys(), ...readonlyAttrs];
+  }
+
+  /** @internal */
+  private disallowRawSqlBang(value: unknown): void {
+    if (typeof value !== "string") return;
+    if ((value as any) instanceof Nodes.SqlLiteral) return;
+    throw new Error(
+      `Dangerous query method called with raw SQL string: ${value}. ` +
+        "Known-safe values can be passed by wrapping them in Arel.sql().",
+    );
+  }
+
+  /** @internal */
+  private timestampsForCreate(): Record<string, unknown> {
+    const now = Temporal.Now.instant();
+    const result: Record<string, unknown> = {};
+    for (const col of TIMESTAMP_COLUMNS) {
+      if (this.model._attributeDefinitions.has(col)) {
+        result[col] = now;
+      }
+    }
+    return result;
   }
 }
 
@@ -439,91 +530,4 @@ export class Builder {
       }),
     );
   }
-}
-
-/** @internal */
-function hasAttributeAliases(attributes: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#has_attribute_aliases? is not implemented",
-  );
-}
-
-/** @internal */
-function resolveSti(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#resolve_sti is not implemented");
-}
-
-/** @internal */
-function resolveAttributeAliases(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#resolve_attribute_aliases is not implemented",
-  );
-}
-
-/** @internal */
-function resolveAttributeAlias(attribute: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#resolve_attribute_alias is not implemented",
-  );
-}
-
-/** @internal */
-function configureOnDuplicateUpdateLogic(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#configure_on_duplicate_update_logic is not implemented",
-  );
-}
-
-/** @internal */
-function isCustomUpdateSqlProvided(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#custom_update_sql_provided? is not implemented",
-  );
-}
-
-/** @internal */
-function findUniqueIndexFor(uniqueBy: any): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#find_unique_index_for is not implemented");
-}
-
-/** @internal */
-function uniqueIndexes(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#unique_indexes is not implemented");
-}
-
-/** @internal */
-function ensureValidOptionsForConnectionBang(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::InsertAll#ensure_valid_options_for_connection! is not implemented",
-  );
-}
-
-/** @internal */
-function toSql(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#to_sql is not implemented");
-}
-
-/** @internal */
-function readonlyColumns(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#readonly_columns is not implemented");
-}
-
-/** @internal */
-function uniqueByColumns(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#unique_by_columns is not implemented");
-}
-
-/** @internal */
-function verifyAttributes(attributes: any): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#verify_attributes is not implemented");
-}
-
-/** @internal */
-function disallowRawSqlBang(value: any): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#disallow_raw_sql! is not implemented");
-}
-
-/** @internal */
-function timestampsForCreate(): never {
-  throw new NotImplementedError("ActiveRecord::InsertAll#timestamps_for_create is not implemented");
 }


### PR DESCRIPTION
## Summary

- Moves 14 Rails-private methods from module-level stubs into real \`@internal\` private methods on the \`InsertAll\` class
- Renames \`_verifyAttributes\`, \`_configureDuplicateLogic\`, \`_uniqueByColumns\`, \`_ensureValidOptionsForConnection\` to their Rails-named equivalents
- Wires the full Rails call graph: \`resolveSti\` + \`resolveAttributeAliases\` called in constructor, \`readonlyColumns()\` used in \`updatableColumns()\`, \`timestampsForCreate()\` used in \`mapKeyWithValue()\`
- \`insert_all.rb\` goes from 19/33 (58%) → 33/33 (100%)

## Methods added

\`verifyAttributes\`, \`configureOnDuplicateUpdateLogic\`, \`isCustomUpdateSqlProvided\`, \`uniqueByColumns\`, \`ensureValidOptionsForConnectionBang\`, \`hasAttributeAliases\`, \`resolveSti\`, \`resolveAttributeAliases\`, \`resolveAttributeAlias\`, \`findUniqueIndexFor\`, \`uniqueIndexes\`, \`readonlyColumns\`, \`disallowRawSqlBang\`, \`timestampsForCreate\`

## Test plan

- [x] \`pnpm api:compare --package activerecord\` → \`insert_all.rb 33/33 100% ✓\`
- [x] \`pnpm vitest run packages/activerecord/src/insert-all.test.ts\` → 53 passed, 64 skipped
- [x] \`pnpm lint --fix\` — clean