### PR TITLE
feat(activerecord): migration.rb helper cluster to 84% (Wave 8 PR 46a)

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1032,15 +1032,17 @@ export abstract class Migration {
 
   /** @internal */
   formatArguments(args: unknown[]): string {
-    const argList = args.slice(0, -1).map((a) => JSON.stringify(a));
+    const safeJson = (v: unknown) =>
+      JSON.stringify(v, (_k, val) => (typeof val === "bigint" ? `${val}n` : val));
+    const argList = args.slice(0, -1).map((a) => safeJson(a));
     const last = args[args.length - 1];
     if (last !== null && typeof last === "object" && !Array.isArray(last)) {
       const filtered = Object.fromEntries(
         Object.entries(last as Record<string, unknown>).filter(([k]) => !this.isInternalOption(k)),
       );
-      if (Object.keys(filtered).length > 0) argList.push(JSON.stringify(filtered));
+      if (Object.keys(filtered).length > 0) argList.push(safeJson(filtered));
     } else if (last !== undefined) {
-      argList.push(JSON.stringify(last));
+      argList.push(safeJson(last));
     }
     return argList.join(", ");
   }
@@ -2157,6 +2159,8 @@ export class Migrator {
   // Rails: MigrationContext#validate_timestamp?
   /** @internal */
   isValidateTimestamp(): boolean {
+    // Rails: ActiveRecord.timestamped_migrations (default true) && ActiveRecord.validate_migration_timestamps (default false)
+    // true && false = false, so false is the correct default until these config flags are wired.
     return false;
   }
 
@@ -2174,16 +2178,20 @@ export class Migrator {
   /** @internal */
   async move(direction: "up" | "down", steps: number): Promise<void> {
     const current = await this.currentVersion();
-    const sorted = [...this._migrations].sort((a, b) => {
-      const va = BigInt(a.version);
-      const vb = BigInt(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
-    const startIndex = current === 0 ? 0 : sorted.findIndex((m) => m.version === String(current));
+    // Mirror Migrator#migrations: ascending for :up, descending for :down.
+    // MigrationContext#move uses migrator.migrations[start_index + steps], so the
+    // direction of the list determines which version "steps" positions forward lands on.
+    const asc = (a: MigrationProxy, b: MigrationProxy) =>
+      BigInt(a.version) < BigInt(b.version) ? -1 : 1;
+    const ordered =
+      direction === "up"
+        ? [...this._migrations].sort(asc)
+        : [...this._migrations].sort(asc).reverse();
+    const startIndex = current === 0 ? 0 : ordered.findIndex((m) => m.version === String(current));
     if (current !== 0 && startIndex === -1) {
       throw new UnknownMigrationVersionError(String(current));
     }
-    const finish = sorted[startIndex + steps];
+    const finish = ordered[startIndex + steps];
     const targetVersion = finish ? Number(finish.version) : 0;
     if (direction === "up") {
       await this.up(targetVersion);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1056,24 +1056,8 @@ export abstract class Migration {
   }
 
   /** @internal */
-  static isAnySchemaNeedsUpdate(): boolean {
-    return false;
-  }
-
-  /** @internal */
-  static dbConfigsInCurrentEnv(): unknown[] {
-    return [];
-  }
-
-  /** @internal */
   static env(): string {
     return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? "development";
-  }
-
-  /** @internal */
-  static loadSchemaBang(): void {
-    // No-op: in Rails this runs `bin/rails db:test:prepare` as a subprocess.
-    // In TS there is no Rake subprocess; callers invoke Migrator directly.
   }
 }
 
@@ -2179,10 +2163,9 @@ export class Migrator {
   // Rails: MigrationContext#valid_migration_timestamp?
   /** @internal */
   isValidMigrationTimestamp(version: string | number): boolean {
-    const tomorrowMs = Temporal.Now.instant().epochMilliseconds + 86400000;
-    const zdt = Temporal.Instant.fromEpochMilliseconds(tomorrowMs).toZonedDateTimeISO("UTC");
+    const tomorrow = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
     const limit = Number(
-      `${zdt.year}${String(zdt.month).padStart(2, "0")}${String(zdt.day).padStart(2, "0")}${String(zdt.hour).padStart(2, "0")}${String(zdt.minute).padStart(2, "0")}${String(zdt.second).padStart(2, "0")}`,
+      `${tomorrow.year}${String(tomorrow.month).padStart(2, "0")}${String(tomorrow.day).padStart(2, "0")}${String(tomorrow.hour).padStart(2, "0")}${String(tomorrow.minute).padStart(2, "0")}${String(tomorrow.second).padStart(2, "0")}`,
     );
     return Number(version) < limit;
   }
@@ -2403,6 +2386,25 @@ function generateMigratorAdvisoryLockId(): never {
   throw new NotImplementedError(
     "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
   );
+}
+
+/** @internal */
+function isAnySchemaNeedsUpdate(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration#any_schema_needs_update? is not implemented",
+  );
+}
+
+/** @internal */
+function dbConfigsInCurrentEnv(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration#db_configs_in_current_env is not implemented",
+  );
+}
+
+/** @internal */
+function loadSchemaBang(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#load_schema! is not implemented");
 }
 
 /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,4 +1,5 @@
 import { getFs, getPath, Logger, getEnv } from "@blazetrails/activesupport";
+import type { FsDirent } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
@@ -101,8 +102,11 @@ export class PendingMigrationError extends MigrationError {
 
   /** @internal */
   detailedMigrationMessage(pendingMigrations: Array<{ filename?: string }>): string {
+    const env = Migration.env();
     let message =
-      "Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate\n\n";
+      "Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate";
+    if (env !== "development" && env !== "test") message += ` RAILS_ENV=${env}`;
+    message += "\n\n";
     message += `You have ${pendingMigrations.length} pending ${pendingMigrations.length > 1 ? "migrations:" : "migration:"}\n\n`;
     for (const m of pendingMigrations) {
       if (m.filename) message += `${m.filename}\n`;
@@ -2142,12 +2146,18 @@ export class Migrator {
     const { readdirSync, existsSync } = getFs();
     const { join } = getPath();
     const files: string[] = [];
-    for (const p of paths) {
-      if (!existsSync(p)) continue;
-      for (const f of readdirSync(p)) {
-        if (/^\d+_.*\.(ts|js)$/.test(String(f))) files.push(join(p, String(f)));
+    const collect = (dir: string) => {
+      if (!existsSync(dir)) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true }) as FsDirent[]) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          collect(full);
+        } else if (/^\d+_.*\.(ts|js)$/.test(entry.name)) {
+          files.push(full);
+        }
       }
-    }
+    };
+    for (const p of paths) collect(p);
     return files.sort();
   }
 
@@ -2186,11 +2196,12 @@ export class Migrator {
       const vb = BigInt(b.version);
       return va < vb ? -1 : va > vb ? 1 : 0;
     });
-    const currentIndex =
-      current === 0 ? -1 : sorted.findIndex((m) => m.version === String(current));
-    const targetIndex = direction === "up" ? currentIndex + steps : currentIndex - steps;
-    const target = sorted[targetIndex];
-    const targetVersion = target ? Number(target.version) : 0;
+    const startIndex = current === 0 ? 0 : sorted.findIndex((m) => m.version === String(current));
+    if (current !== 0 && startIndex === -1) {
+      throw new UnknownMigrationVersionError(String(current));
+    }
+    const finish = sorted[startIndex + steps];
+    const targetVersion = finish ? Number(finish.version) : 0;
     if (direction === "up") {
       await this.up(targetVersion);
     } else {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -98,6 +98,17 @@ export class PendingMigrationError extends MigrationError {
     super(message);
     this.name = "PendingMigrationError";
   }
+
+  /** @internal */
+  detailedMigrationMessage(pendingMigrations: Array<{ filename?: string }>): string {
+    let message =
+      "Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate\n\n";
+    message += `You have ${pendingMigrations.length} pending ${pendingMigrations.length > 1 ? "migrations:" : "migration:"}\n\n`;
+    for (const m of pendingMigrations) {
+      if (m.filename) message += `${m.filename}\n`;
+    }
+    return message;
+  }
 }
 
 export class ConcurrentMigrationError extends MigrationError {
@@ -1008,6 +1019,57 @@ export abstract class Migration {
 
   get nearestDelegate(): DatabaseAdapter {
     return this.adapter;
+  }
+
+  /** @internal */
+  executeBlock(fn: () => Promise<void>): Promise<void> {
+    return fn();
+  }
+
+  /** @internal */
+  formatArguments(args: unknown[]): string {
+    const argList = args.slice(0, -1).map((a) => JSON.stringify(a));
+    const last = args[args.length - 1];
+    if (last !== null && typeof last === "object" && !Array.isArray(last)) {
+      const filtered = Object.fromEntries(
+        Object.entries(last as Record<string, unknown>).filter(([k]) => !this.isInternalOption(k)),
+      );
+      if (Object.keys(filtered).length > 0) argList.push(JSON.stringify(filtered));
+    } else if (last !== undefined) {
+      argList.push(JSON.stringify(last));
+    }
+    return argList.join(", ");
+  }
+
+  /** @internal */
+  isInternalOption(optionName: string): boolean {
+    return optionName.startsWith("_");
+  }
+
+  /** @internal */
+  commandRecorder(): CommandRecorder {
+    return new CommandRecorder(this.adapter);
+  }
+
+  /** @internal */
+  static isAnySchemaNeedsUpdate(): boolean {
+    return false;
+  }
+
+  /** @internal */
+  static dbConfigsInCurrentEnv(): unknown[] {
+    return [];
+  }
+
+  /** @internal */
+  static env(): string {
+    return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? "development";
+  }
+
+  /** @internal */
+  static loadSchemaBang(): void {
+    // No-op: in Rails this runs `bin/rails db:test:prepare` as a subprocess.
+    // In TS there is no Rake subprocess; callers invoke Migrator directly.
   }
 }
 
@@ -2073,6 +2135,68 @@ export class Migrator {
   }
 
   static migrationsPaths: string[] = [];
+
+  // Rails: MigrationContext#migration_files
+  /** @internal */
+  migrationFiles(paths: string[] = Migrator.migrationsPaths): string[] {
+    const { readdirSync, existsSync } = getFs();
+    const { join } = getPath();
+    const files: string[] = [];
+    for (const p of paths) {
+      if (!existsSync(p)) continue;
+      for (const f of readdirSync(p)) {
+        if (/^\d+_.*\.(ts|js)$/.test(String(f))) files.push(join(p, String(f)));
+      }
+    }
+    return files.sort();
+  }
+
+  // Rails: MigrationContext#parse_migration_filename
+  /** @internal */
+  parseMigrationFilename(filename: string): [string, string, string] | null {
+    const base = filename.replace(/.*[/\\]/, "").replace(/\.(ts|js)$/, "");
+    const m = base.match(/^(\d+)_([a-z0-9_]*)(?:\.([a-z0-9_]*))?$/);
+    if (!m) return null;
+    return [m[1]!, m[2]!, m[3] ?? ""];
+  }
+
+  // Rails: MigrationContext#validate_timestamp?
+  /** @internal */
+  isValidateTimestamp(): boolean {
+    return false;
+  }
+
+  // Rails: MigrationContext#valid_migration_timestamp?
+  /** @internal */
+  isValidMigrationTimestamp(version: string | number): boolean {
+    const tomorrowMs = Temporal.Now.instant().epochMilliseconds + 86400000;
+    const zdt = Temporal.Instant.fromEpochMilliseconds(tomorrowMs).toZonedDateTimeISO("UTC");
+    const limit = Number(
+      `${zdt.year}${String(zdt.month).padStart(2, "0")}${String(zdt.day).padStart(2, "0")}${String(zdt.hour).padStart(2, "0")}${String(zdt.minute).padStart(2, "0")}${String(zdt.second).padStart(2, "0")}`,
+    );
+    return Number(version) < limit;
+  }
+
+  // Rails: MigrationContext#move
+  /** @internal */
+  async move(direction: "up" | "down", steps: number): Promise<void> {
+    const current = await this.currentVersion();
+    const sorted = [...this._migrations].sort((a, b) => {
+      const va = BigInt(a.version);
+      const vb = BigInt(b.version);
+      return va < vb ? -1 : va > vb ? 1 : 0;
+    });
+    const currentIndex =
+      current === 0 ? -1 : sorted.findIndex((m) => m.version === String(current));
+    const targetIndex = direction === "up" ? currentIndex + steps : currentIndex - steps;
+    const target = sorted[targetIndex];
+    const targetVersion = target ? Number(target.version) : 0;
+    if (direction === "up") {
+      await this.up(targetVersion);
+    } else {
+      await this.down(targetVersion);
+    }
+  }
 }
 
 /**
@@ -2175,111 +2299,13 @@ export class CheckPending {
       );
     }
   }
-}
 
-/** @internal */
-function detailedMigrationMessage(pendingMigrations: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::PendingMigrationError#detailed_migration_message is not implemented",
-  );
-}
-
-function connectionPool(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::PendingMigrationError#connection_pool is not implemented",
-  );
-}
-
-/** @internal */
-function executeBlock(): never {
-  throw new NotImplementedError("ActiveRecord::Migration#execute_block is not implemented");
-}
-
-/** @internal */
-function formatArguments(arguments_: any): never {
-  throw new NotImplementedError("ActiveRecord::Migration#format_arguments is not implemented");
-}
-
-/** @internal */
-function isInternalOption(optionName: any): never {
-  throw new NotImplementedError("ActiveRecord::Migration#internal_option? is not implemented");
-}
-
-/** @internal */
-function commandRecorder(): never {
-  throw new NotImplementedError("ActiveRecord::Migration#command_recorder is not implemented");
-}
-
-/** @internal */
-function isAnySchemaNeedsUpdate(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migration#any_schema_needs_update? is not implemented",
-  );
-}
-
-/** @internal */
-function dbConfigsInCurrentEnv(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migration#db_configs_in_current_env is not implemented",
-  );
-}
-
-function pendingMigrations(): never {
-  throw new NotImplementedError("ActiveRecord::Migration#pending_migrations is not implemented");
-}
-
-/** @internal */
-function env(): never {
-  throw new NotImplementedError("ActiveRecord::Migration#env is not implemented");
-}
-
-/** @internal */
-function loadSchemaBang(): never {
-  throw new NotImplementedError("ActiveRecord::Migration#load_schema! is not implemented");
-}
-
-/** @internal */
-function buildWatcher(block?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migration::CheckPending#build_watcher is not implemented",
-  );
-}
-
-function connection(): never {
-  throw new NotImplementedError("ActiveRecord::MigrationContext#connection is not implemented");
-}
-
-/** @internal */
-function migrationFiles(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::MigrationContext#migration_files is not implemented",
-  );
-}
-
-/** @internal */
-function parseMigrationFilename(filename: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::MigrationContext#parse_migration_filename is not implemented",
-  );
-}
-
-/** @internal */
-function isValidateTimestamp(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::MigrationContext#validate_timestamp? is not implemented",
-  );
-}
-
-/** @internal */
-function isValidMigrationTimestamp(version: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::MigrationContext#valid_migration_timestamp? is not implemented",
-  );
-}
-
-/** @internal */
-function move(direction: any, steps: any): never {
-  throw new NotImplementedError("ActiveRecord::MigrationContext#move is not implemented");
+  /** @internal */
+  buildWatcher(_paths?: string[]): null {
+    // In Rails this creates a filesystem watcher for migration files.
+    // In TS migrations are registered programmatically, not watched.
+    return null;
+  }
 }
 
 /** @internal */
@@ -2366,4 +2392,14 @@ function generateMigratorAdvisoryLockId(): never {
   throw new NotImplementedError(
     "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
   );
+}
+
+/** @internal */
+function target(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#target is not implemented");
+}
+
+/** @internal */
+function start(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#start is not implemented");
 }


### PR DESCRIPTION
## Summary

- Implements 12 methods in `migration.ts` with real behavior, closing the gap from 68% → 80% (66/97 → 78/97)
- **Split from PR 46**: LOC exceeded 300. PR 46a covers helper/context methods; PR 46b will cover the Migrator lifecycle cluster (16 methods: `runWithoutLock`..`generateMigratorAdvisoryLockId`)

### Methods implemented

**PendingMigrationError** (1): `detailedMigrationMessage`

**Migration instance helpers** (4): `executeBlock`, `formatArguments`, `isInternalOption`, `commandRecorder`

**Migration static helpers** (1): `env`

**CheckPending** (1): `buildWatcher`

**Migrator/MigrationContext** (5): `migrationFiles`, `parseMigrationFilename`, `isValidateTimestamp`, `isValidMigrationTimestamp`, `move`

### Not implemented (kept as NotImplementedError stubs)

`isAnySchemaNeedsUpdate`, `dbConfigsInCurrentEnv`, `loadSchemaBang` — these require DatabaseTasks/DatabaseConfigurations infrastructure not yet wired in TS. Per CLAUDE.md, returning `false`/`[]`/no-op gives callers wrong signals; leaving as stubs is the honest choice.

### Newly-tracked Migrator privates (stubs added)

`Migrator#target`, `Migrator#start` — discovered during drift audit; added as NotImplementedError stubs per codebase convention to keep the stub inventory current.

### Rails alignment fixes (post-review)

- `detailedMigrationMessage`: adds `RAILS_ENV=<env>` suffix when env is not `development`/`test` (mirrors `!Rails.env.local?`)
- `migrationFiles`: recursive traversal matching Rails `Dir[*paths.flat_map { |path| "#{path}/**/[0-9]*_*.rb" }]`
- `move`: corrected `startIndex` semantics and added `UnknownMigrationVersionError` guard
- `isValidMigrationTimestamp`: simplified to `Temporal.plainDateTimeISO` (cleaner, same result)

### Copilot concern responses

| Concern | Resolution |
|---|---|
| `executeBlock` is a stub | **Disagree** — Rails source: `yield` when connection can't record. `fn()` is correct. |
| `isValidateTimestamp` misleading | **Disagree** — Rails default is `false` (`self.validate_migration_timestamps = false`). |
| `isInternalOption` should check `_internal_` | **Disagree** — Rails source: `option_name.start_with?("_")`. Single underscore is correct. |
| `parseMigrationFilename` needs uppercase | **Disagree** — Rails `MigrationFilenameRegexp` uses `[_a-z0-9]` (lowercase only). |
| `move` uses `runnable.find_index` | **Wrong** — Rails source shows `migrator.migrations.index(migrator.current_migration)`. Our impl matches. |
| `isAnySchemaNeedsUpdate`/`dbConfigsInCurrentEnv`/`loadSchemaBang` misleading | **Accepted** — reverted to NotImplementedError stubs. |
| `isValidMigrationTimestamp` epoch arithmetic fragile | **Accepted** — switched to `Temporal.plainDateTimeISO`. |
| `target()`/`start()` unexplained | **Clarified** — newly-discovered Migrator privates, added per codebase stub convention. |

### LOC
`git diff --shortstat origin/main...HEAD` → 173 additions + 120 deletions = 293 total (limit: 300 ✓)

## Test plan
- [x] `pnpm -w run api:compare --files migration.rb` → 78/97 (80%)
- [x] All 153 migration tests pass (28 pre-existing skips unchanged)
- [x] ESLint clean
- [x] Pre-commit hooks (build + typecheck) pass