### PR TITLE
fix: untrack accidentally-committed .claude/skills self-referential symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-/home/dean/github/blazetrailsdev/trails/.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ scripts/api-compare/.rails-source
 
 # Generated from rails-api.json by scripts/build-rails-privates-manifest.ts
 eslint/rails-private-methods.json
+.claude/skills


### PR DESCRIPTION
## What's broken

PR #1247 (sqlite driver move to activesupport) committed `.claude/skills` as a symlink whose target is itself:

```
$ git show HEAD:.claude/skills
/home/dean/github/blazetrailsdev/trails/.claude/skills
```

That's the file's own absolute path. Every subsequent spawn attempt that resolves through the symlink dies with:

```
/bin/bash: line 1: .../.claude/skills/prompt-agent/run.sh:
  Too many levels of symbolic links
```

I caught this when a routine `prompt-agent` invocation failed with the loop error during a docs-audit pass.

## How it happened

`scripts/start-worktree.sh` creates `.claude/skills` as a symlink in newly-spawned child worktrees pointing at the main worktree's real `.claude/skills` directory. The symlink only works in a child worktree (where the main repo is a *different* path); creating it in the main repo itself produces a self-loop.

PR M's worktree had this symlink. The PR M author noticed and shipped a partial fix in commit `37aeb29524` ("chore: don't track .claude/skills symlink") which `git rm`'d the tracked symlink — but did NOT add `.claude/skills` to `.gitignore`. So when PR M's branch was rebased / re-pushed and the symlink got re-created in the worktree by start-worktree.sh, the symlink ended up retracked at merge time.

Confirmed via git history: `git log --all --diff-filter=A --oneline -- .claude/skills` shows the symlink first appeared on PR M's branch and has only ever been tracked there. The skills/ directory has NEVER been tracked as real files in git — it lives in each worktree as either a real directory (the main worktree, after manual setup) or a symlink (child worktrees, created by start-worktree.sh).

This PR completes that earlier partial fix.

## Fix

- `git rm --cached .claude/skills` — untrack the symlink.
- Add `.claude/skills` to `.gitignore` so it can't be re-committed accidentally (the gap that defeated #37aeb29524).

Future child worktrees still get the symlink via `start-worktree.sh`. Those work correctly because they point INTO the main worktree from a *different* path, not at themselves.

## Coordination needed (post-merge)

Anyone whose local main worktree's `.claude/skills` is currently a broken symlink will need to repopulate it after pulling. Skills have never been tracked in git, so you can't `git checkout` them — they live only in worktree-local copies and symlinks.

Recovery: copy from any active child worktree:

```
cp -r ~/github/blazetrailsdev/worktrees/<some-active>/.claude/skills \
      ~/github/blazetrailsdev/trails/.claude/skills
```

The 5 affected skills: `copilot-review`, `link`, `prompt-agent`, `screenshot`, `workon`.

## Test plan

- [x] `ls -la .claude/skills` shows a real directory after restore (not a symlink, not broken)
- [x] `head -3 .claude/skills/prompt-agent/run.sh` reads the file successfully (proves the loop is gone)
- [x] `find .claude -type l ! -exec test -e {} \; -print` reports zero broken symlinks under `.claude/`
- [x] CI green on diff-only checks (Build & Type Check, Prettier, DX Type Tests, Virtualized DX, Guides) at time of edit; long-running test jobs still in progress

## Recommended follow-up (not this PR)

`start-worktree.sh` currently accepts any name and trusts the caller. If `TARGET == MAIN_REPO` (or the resolved target path equals `MAIN_REPO`), the script should refuse with a clear error — that would make the self-symlink physically impossible. Worth adding a guard. Filed as a mental-note follow-up.