### PR TITLE
feat(activerecord): database_configurations.rb + connection_url_resolver.rb to 100% (PR 48)

### DIFF
--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -123,6 +123,20 @@ describe("DatabaseConfigurationsTest", () => {
     expect(cache[0].database).toBe("cache.db");
   });
 
+  it("resolve returns current-env config when same name exists in multiple envs", () => {
+    DatabaseConfigurations.defaultEnv = "development";
+    const configs = new DatabaseConfigurations({
+      development: {
+        primary: { adapter: "sqlite3", database: "dev.db" },
+      },
+      test: {
+        primary: { adapter: "sqlite3", database: "test.db" },
+      },
+    });
+    const resolved = configs.resolve("primary");
+    expect(resolved.database).toBe("dev.db");
+  });
+
   it("configs for with include hidden", () => {
     const configs = new DatabaseConfigurations({
       development: {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -1,4 +1,5 @@
 import { getEnv } from "@blazetrails/activesupport";
+import { AdapterNotSpecified } from "./errors.js";
 import {
   DatabaseConfig,
   type DatabaseConfigOptions,
@@ -375,9 +376,8 @@ export class DatabaseConfigurations {
 
   /** @internal */
   private buildConfigs(configs: RawConfigurations | DatabaseConfig[]): DatabaseConfig[] {
-    return this._buildConfigs(
-      this._mergeDatabaseUrl(configs as RawConfigurations, DatabaseConfigurations.defaultEnv),
-    );
+    if (Array.isArray(configs)) return configs;
+    return this._buildConfigs(this._mergeDatabaseUrl(configs, DatabaseConfigurations.defaultEnv));
   }
 
   /** @internal */
@@ -395,7 +395,7 @@ export class DatabaseConfigurations {
     const dbConfig = this.findDbConfig(name);
     if (dbConfig) return dbConfig;
     const defaultEnv = DatabaseConfigurations.defaultEnv;
-    throw new Error(
+    throw new AdapterNotSpecified(
       `The \`${name}\` database is not configured for the \`${defaultEnv}\` environment.\n\n  Available database configurations are:\n\n  ${this.buildConfigurationSentence()}`,
     );
   }

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -1,5 +1,4 @@
 import { getEnv } from "@blazetrails/activesupport";
-import { NotImplementedError } from "./errors.js";
 import {
   DatabaseConfig,
   type DatabaseConfigOptions,
@@ -365,18 +364,124 @@ export class DatabaseConfigurations {
     name: string,
     config: DatabaseConfigOptions,
   ): DatabaseConfig {
-    // Mirrors Rails: iterate handlers in reverse (most recently registered first),
-    // pull url out of config, and return the first non-null DatabaseConfig.
+    return this.buildDbConfigFromHash(envName, name, config);
+  }
+
+  /** @internal */
+  private envWithConfigs(env?: string): DatabaseConfig[] {
+    if (env) return this._configurations.filter((c) => c.envName === env);
+    return this._configurations;
+  }
+
+  /** @internal */
+  private buildConfigs(configs: RawConfigurations | DatabaseConfig[]): DatabaseConfig[] {
+    return this._buildConfigs(
+      this._mergeDatabaseUrl(configs as RawConfigurations, DatabaseConfigurations.defaultEnv),
+    );
+  }
+
+  /** @internal */
+  private walkConfigs(
+    envName: string,
+    config: Record<string, DatabaseConfigOptions>,
+  ): DatabaseConfig[] {
+    return Object.entries(config).map(([name, subConfig]) =>
+      this.buildDbConfigFromRawConfig(envName, name, subConfig),
+    );
+  }
+
+  /** @internal */
+  private resolveSymbolConnection(name: string): DatabaseConfig {
+    const dbConfig = this.findDbConfig(name);
+    if (dbConfig) return dbConfig;
+    const defaultEnv = DatabaseConfigurations.defaultEnv;
+    throw new Error(
+      `The \`${name}\` database is not configured for the \`${defaultEnv}\` environment.\n\n  Available database configurations are:\n\n  ${this.buildConfigurationSentence()}`,
+    );
+  }
+
+  /** @internal */
+  private buildConfigurationSentence(): string {
+    const configs = this.configsFor({ includeHidden: true });
+    const byEnv = new Map<string, string[]>();
+    for (const cfg of configs) {
+      const names = byEnv.get(cfg.envName) ?? [];
+      names.push(cfg.name);
+      byEnv.set(cfg.envName, names);
+    }
+    return Array.from(byEnv.entries())
+      .map(([env, names]) => (names.length > 1 ? `${env}: ${names.join(", ")}` : env))
+      .join("\n");
+  }
+
+  /** @internal */
+  private buildDbConfigFromRawConfig(
+    envName: string,
+    name: string,
+    config: string | DatabaseConfigOptions,
+  ): DatabaseConfig {
+    if (typeof config === "string") return this.buildDbConfigFromString(envName, name, config);
+    if (typeof config === "object" && config !== null)
+      return this.buildDbConfigFromHash(envName, name, config);
+    throw new InvalidConfigurationError(
+      `'{ ${envName} => ${String(config)} }' is not a valid configuration. Expected a URL string or a Hash.`,
+    );
+  }
+
+  /** @internal */
+  private buildDbConfigFromString(envName: string, name: string, config: string): DatabaseConfig {
+    if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config)) {
+      const safe = config.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
+      throw new InvalidConfigurationError(
+        `'{ ${envName} => ${safe} }' is not a valid configuration. Expected a URL string or a Hash.`,
+      );
+    }
+    return new UrlConfig(envName, name, config);
+  }
+
+  /** @internal */
+  private buildDbConfigFromHash(
+    envName: string,
+    name: string,
+    config: DatabaseConfigOptions,
+  ): DatabaseConfig {
     const url = config.url;
     const configWithoutUrl = { ...config };
     delete configWithoutUrl.url;
-
     for (let i = DatabaseConfigurations.dbConfigHandlers.length - 1; i >= 0; i--) {
       const handler = DatabaseConfigurations.dbConfigHandlers[i];
       const result = handler(envName, name, url, configWithoutUrl);
       if (result) return result;
     }
     throw new InvalidConfigurationError(`No db config handler matched for ${envName}/${name}`);
+  }
+
+  /** @internal */
+  private environmentValueFor(name: string): string | undefined {
+    const nameEnvKey = `${name.toUpperCase()}_DATABASE_URL`;
+    return getEnv(nameEnvKey) ?? (name === "primary" ? getEnv("DATABASE_URL") : undefined);
+  }
+
+  /** @internal */
+  private environmentUrlConfig(
+    env: string,
+    name: string,
+    config: DatabaseConfigOptions,
+  ): DatabaseConfig | null {
+    const url = this.environmentValueFor(name);
+    if (!url) return null;
+    return new UrlConfig(env, name, url, config);
+  }
+
+  /** @internal */
+  private mergeDbEnvironmentVariables(
+    currentEnv: string,
+    configs: DatabaseConfig[],
+  ): DatabaseConfig[] {
+    return configs.map((config) => {
+      if (config instanceof UrlConfig || config.envName !== currentEnv) return config;
+      return this.environmentUrlConfig(currentEnv, config.name, config.configuration) ?? config;
+    });
   }
 }
 
@@ -399,80 +504,3 @@ _setDefaultEnvGetter(() => DatabaseConfigurations.defaultEnv);
 // Register the primary checker so HashConfig.isPrimary can consult the
 // current DatabaseConfigurations instance (matching Rails' global Base.configurations).
 _setPrimaryChecker((name) => _currentConfigurations?.isPrimary(name) ?? false);
-
-/** @internal */
-function envWithConfigs(env?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#env_with_configs is not implemented",
-  );
-}
-
-/** @internal */
-function buildConfigs(configs: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#build_configs is not implemented",
-  );
-}
-
-/** @internal */
-function walkConfigs(envName: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#walk_configs is not implemented",
-  );
-}
-
-/** @internal */
-function resolveSymbolConnection(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#resolve_symbol_connection is not implemented",
-  );
-}
-
-/** @internal */
-function buildConfigurationSentence(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#build_configuration_sentence is not implemented",
-  );
-}
-
-/** @internal */
-function buildDbConfigFromRawConfig(envName: any, name: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#build_db_config_from_raw_config is not implemented",
-  );
-}
-
-/** @internal */
-function buildDbConfigFromString(envName: any, name: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#build_db_config_from_string is not implemented",
-  );
-}
-
-/** @internal */
-function buildDbConfigFromHash(envName: any, name: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#build_db_config_from_hash is not implemented",
-  );
-}
-
-/** @internal */
-function mergeDbEnvironmentVariables(currentEnv: any, configs: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#merge_db_environment_variables is not implemented",
-  );
-}
-
-/** @internal */
-function environmentUrlConfig(env: any, name: any, config: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#environment_url_config is not implemented",
-  );
-}
-
-/** @internal */
-function environmentValueFor(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations#environment_value_for is not implemented",
-  );
-}

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -213,28 +213,23 @@ export class DatabaseConfigurations {
    */
   resolve(config: unknown): DatabaseConfig {
     if (config instanceof DatabaseConfig) return config;
-    const defaultEnv = DatabaseConfigurations.defaultEnv;
     if (typeof config === "string") {
       // Mirrors Rails: resolve(symbol) → resolve_symbol_connection → find_db_config
       // Strings with a URI scheme (e.g. "postgres://", "sqlite3:") are treated as URLs.
       // Strings without a scheme are treated as env names (mirrors Ruby symbol lookup).
       const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config);
       if (!hasScheme) {
-        const found = this.findDbConfig(config);
-        if (found) return found;
-        throw new Error(
-          `The \`${config}\` database is not configured for the \`${defaultEnv}\` environment.`,
-        );
+        return this.resolveSymbolConnection(config);
       }
-      return new UrlConfig(defaultEnv, "primary", config);
+      return new UrlConfig(DatabaseConfigurations.defaultEnv, "primary", config);
     }
     if (typeof config === "object" && config !== null) {
       const opts = config as DatabaseConfigOptions;
       if (opts.url) {
         const { url, ...configWithoutUrl } = opts;
-        return new UrlConfig(defaultEnv, "primary", url, configWithoutUrl);
+        return new UrlConfig(DatabaseConfigurations.defaultEnv, "primary", url, configWithoutUrl);
       }
-      return new HashConfig(defaultEnv, "primary", opts);
+      return new HashConfig(DatabaseConfigurations.defaultEnv, "primary", opts);
     }
     throw new TypeError(
       `Invalid type for configuration. Expected string, hash, or DatabaseConfig. Got ${typeof config}`,

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -421,7 +421,7 @@ export class DatabaseConfigurations {
     config: string | DatabaseConfigOptions,
   ): DatabaseConfig {
     if (typeof config === "string") return this.buildDbConfigFromString(envName, name, config);
-    if (typeof config === "object" && config !== null)
+    if (typeof config === "object" && config !== null && !Array.isArray(config))
       return this.buildDbConfigFromHash(envName, name, config);
     throw new InvalidConfigurationError(
       `'{ ${envName} => ${String(config)} }' is not a valid configuration. Expected a URL string or a Hash.`,

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -431,6 +431,7 @@ export class DatabaseConfigurations {
   /** @internal */
   private buildDbConfigFromString(envName: string, name: string, config: string): DatabaseConfig {
     if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config)) {
+      // Rails leaks the URL verbatim; we redact credentials to avoid logging secrets.
       const safe = config.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
       throw new InvalidConfigurationError(
         `'{ ${envName} => ${safe} }' is not a valid configuration. Expected a URL string or a Hash.`,

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -9,7 +9,6 @@
  *   // => { adapter: "postgresql", host: "localhost", port: 9000,
  *   //      database: "foo_test", username: "foo", password: "bar", pool: "5" }
  */
-import { NotImplementedError } from "../errors.js";
 import type { DatabaseConfigOptions } from "./database-config.js";
 
 // Scheme-to-adapter mapping (Rails' ActiveRecord.protocol_adapters).
@@ -81,7 +80,7 @@ export class ConnectionUrlResolver {
    * Mirrors: ConnectionUrlResolver#to_hash
    */
   toHash(): DatabaseConfigOptions {
-    const config: Record<string, unknown> = { ...this._queryHash(), ...this._rawConfig() };
+    const config: Record<string, unknown> = { ...this.queryHash(), ...this.rawConfig() };
 
     // Remove null/undefined/empty values (Rails: compact_blank)
     for (const key of Object.keys(config)) {
@@ -106,7 +105,23 @@ export class ConnectionUrlResolver {
     return config as DatabaseConfigOptions;
   }
 
-  private _queryHash(): Record<string, string> {
+  /** @internal */
+  private get uri(): URL | null {
+    return this._parsed;
+  }
+
+  /** @internal */
+  private get uriParser(): { unescape(s: string): string } {
+    return { unescape: decodeURIComponent };
+  }
+
+  /** @internal */
+  private get resolvedAdapter(): string | null {
+    return this._adapter;
+  }
+
+  /** @internal */
+  private queryHash(): Record<string, string> {
     if (!this._query) return {};
     const result: Record<string, string> = {};
     for (const pair of this._query.split("&")) {
@@ -122,7 +137,8 @@ export class ConnectionUrlResolver {
     return result;
   }
 
-  private _rawConfig(): Record<string, unknown> {
+  /** @internal */
+  private rawConfig(): Record<string, unknown> {
     if (this._opaque !== null) {
       // Opaque URI: adapter + database (from opaque part)
       return {
@@ -137,13 +153,14 @@ export class ConnectionUrlResolver {
       username: parsed.username || undefined,
       password: parsed.password || undefined,
       port: parsed.port ? Number(parsed.port) : undefined,
-      database: this._databaseFromPath(parsed.pathname),
+      database: this.databaseFromPath(parsed.pathname),
       // URL API wraps IPv6 addresses in brackets; strip them to match Rails behavior
       host: parsed.hostname ? parsed.hostname.replace(/^\[(.+)\]$/, "$1") : undefined,
     };
   }
 
-  private _databaseFromPath(path: string): string | undefined {
+  /** @internal */
+  private databaseFromPath(path: string): string | undefined {
     if (!path) return undefined;
     // SQLite uses the full path as database name; others strip the leading slash
     if (this._adapter === "sqlite3") {
@@ -157,46 +174,4 @@ export class ConnectionUrlResolver {
 // logged without leaking credentials embedded in connection URLs.
 function redactUrl(url: string): string {
   return url.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
-}
-
-/** @internal */
-function uri(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#uri is not implemented",
-  );
-}
-
-/** @internal */
-function uriParser(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#uri_parser is not implemented",
-  );
-}
-
-/** @internal */
-function queryHash(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#query_hash is not implemented",
-  );
-}
-
-/** @internal */
-function rawConfig(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#raw_config is not implemented",
-  );
-}
-
-/** @internal */
-function resolvedAdapter(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#resolved_adapter is not implemented",
-  );
-}
-
-/** @internal */
-function databaseFromPath(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#database_from_path is not implemented",
-  );
 }


### PR DESCRIPTION
## Summary

- Adds 11 \`@internal\` private methods to \`DatabaseConfigurations\` matching Rails' private API: \`envWithConfigs\`, \`buildConfigs\`, \`walkConfigs\`, \`resolveSymbolConnection\`, \`buildConfigurationSentence\`, \`buildDbConfigFromRawConfig\`, \`buildDbConfigFromString\`, \`buildDbConfigFromHash\`, \`mergeDbEnvironmentVariables\`, \`environmentUrlConfig\`, \`environmentValueFor\`
- Adds 6 \`@internal\` private methods to \`ConnectionUrlResolver\` matching Rails: \`uri\`, \`uriParser\`, \`resolvedAdapter\`, \`queryHash\`, \`rawConfig\`, \`databaseFromPath\` (renamed from \`_\`-prefixed versions)
- Removes all \`NotImplementedError\` standalone stubs from both files
- Both files reach 100% (\`database_configurations.rb\` 22/22, \`connection_url_resolver.rb\` 7/7)

## Test plan

- [x] \`pnpm vitest run database-configurations\` — all 26 tests pass, 54 skipped
- [x] \`pnpm run api:compare --package activerecord\` — both files show 100% ✓
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm build && pnpm typecheck\` — clean (verified by pre-commit hook)