### PR TITLE
feat(activerecord): mysql2 + postgresql database_statements core (PR 18)

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -42,25 +42,6 @@ interface MultiStatementsHost {
 // Mysql2::Client::MULTI_STATEMENTS bitmask value from the Ruby gem.
 const MULTI_STATEMENTS_BIT = 0x10000;
 
-function parseExecuteResult(
-  result: mysql.RowDataPacket[] | mysql.ResultSetHeader,
-  resultFields: mysql.FieldPacket[],
-): Pick<Mysql2RawResult, "rows" | "fields" | "affectedRows"> {
-  if (Array.isArray(result)) {
-    const rows = result as Record<string, unknown>[];
-    return {
-      rows,
-      fields: (resultFields ?? []) as Array<{ name: string }>,
-      affectedRows: rows.length,
-    };
-  }
-  return {
-    rows: null,
-    fields: [],
-    affectedRows: (result as mysql.ResultSetHeader).affectedRows ?? 0,
-  };
-}
-
 /**
  * Returns an ActiveRecord::Result instance.
  * Rails also wraps in `unprepared_statement` when collecting EXPLAIN with
@@ -131,37 +112,52 @@ export async function performQuery(
   let affectedRows = 0;
 
   if (!hasBinds) {
-    // Avoid calling #affected_rows when a result exists — works around a mysql2
-    // gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
-    ({ rows, fields, affectedRows } = parseExecuteResult(
-      ...((await rawConnection.query(sql)) as [
-        mysql.RowDataPacket[] | mysql.ResultSetHeader,
-        mysql.FieldPacket[],
-      ]),
-    ));
+    // Avoid calling #affected_rows when a result exists — mirrors Rails' workaround
+    // for a mysql2 gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
+    const [result, resultFields] = (await rawConnection.query(sql)) as [
+      mysql.RowDataPacket[] | mysql.ResultSetHeader,
+      mysql.FieldPacket[],
+    ];
+    if (Array.isArray(result)) {
+      rows = result as Record<string, unknown>[];
+      fields = (resultFields ?? []) as Array<{ name: string }>;
+      affectedRows = rows.length;
+    } else {
+      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    }
   } else if (prepare) {
-    // On error, evict the key so the next call re-prepares (mirrors Rails'
-    // `@statements.delete(sql)` rescue).
+    // On error, evict the SQL key so the next call re-prepares (mirrors Rails'
+    // `@statements.delete(sql)` rescue block).
     try {
-      ({ rows, fields, affectedRows } = parseExecuteResult(
-        ...((await rawConnection.execute(sql, typeCastedBinds as any[])) as [
-          mysql.RowDataPacket[] | mysql.ResultSetHeader,
-          mysql.FieldPacket[],
-        ]),
-      ));
+      const [result, resultFields] = (await rawConnection.execute(
+        sql,
+        typeCastedBinds as any[],
+      )) as [mysql.RowDataPacket[] | mysql.ResultSetHeader, mysql.FieldPacket[]];
+      if (Array.isArray(result)) {
+        rows = result as Record<string, unknown>[];
+        fields = (resultFields ?? []) as Array<{ name: string }>;
+        affectedRows = rows.length;
+      } else {
+        affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+      }
     } catch (err) {
       this._statements?.delete(sql);
       throw err;
     }
   } else {
-    // Non-cached path. node-mysql2 doesn't expose prepare/execute/close
-    // separately, so execute() is used — driver auto-manages the server-side stmt.
-    ({ rows, fields, affectedRows } = parseExecuteResult(
-      ...((await rawConnection.execute(sql, typeCastedBinds as any[])) as [
-        mysql.RowDataPacket[] | mysql.ResultSetHeader,
-        mysql.FieldPacket[],
-      ]),
-    ));
+    // Non-cached path. node-mysql2 doesn't expose a prepare/execute/close
+    // triple, so execute() is used — the driver auto-manages the server-side stmt.
+    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+      mysql.RowDataPacket[] | mysql.ResultSetHeader,
+      mysql.FieldPacket[],
+    ];
+    if (Array.isArray(result)) {
+      rows = result as Record<string, unknown>[];
+      fields = (resultFields ?? []) as Array<{ name: string }>;
+      affectedRows = rows.length;
+    } else {
+      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    }
   }
 
   this._affectedRowsBeforeWarnings = affectedRows;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -168,11 +168,10 @@ export async function performQuery(
 export function castResult(rawResult: Mysql2RawResult): Result {
   if (rawResult.rows == null) return Result.empty();
 
-  const fields = rawResult.fields.map((f) => f.name);
-  const result = fields.length === 0 ? Result.empty() : Result.fromRowHashes(rawResult.rows);
-
+  const columns = rawResult.fields.map((f) => f.name);
+  const rows = rawResult.rows.map((row) => columns.map((col) => row[col]));
+  const result = columns.length === 0 ? Result.empty() : new Result(columns, rows);
   freeRawResult(rawResult);
-
   return result;
 }
 
@@ -186,8 +185,9 @@ export function affectedRows(this: PerformQueryHost, rawResult: Mysql2RawResult)
 }
 
 /**
- * No-op in TS: node-mysql2 GCs results and manages stmt lifecycle automatically.
- * Rails calls `result.free` + COM_STMT_CLOSE via `@_ar_stmt_to_close`.
+ * No-op in TS: node-mysql2 GCs results automatically; there is no `free()`
+ * method or stmt-close hook equivalent to Rails' `raw_result.free` +
+ * `@_ar_stmt_to_close.close`.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#free_raw_result
  * @internal

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -15,15 +15,15 @@ export interface DatabaseStatementsHost {
 
 /**
  * Opaque raw result returned by performQuery and consumed by castResult / affectedRows.
- * Mirrors the shape of data extracted from a mysql2 query call.
  * @internal
  */
 export interface Mysql2RawResult {
   rows: Record<string, unknown>[] | null;
   fields: Array<{ name: string }>;
   affectedRows: number;
-  /** Transient prepared statement to close on free (non-cached path). */
-  _stmt?: { close?(): void };
+  // Rails attaches @_ar_stmt_to_close to the raw result so free_raw_result can
+  // send COM_STMT_CLOSE. node-mysql2 manages stmt lifecycle automatically — no
+  // equivalent hook is needed.
 }
 
 /** @internal */
@@ -39,10 +39,7 @@ interface MultiStatementsHost {
   _config?: { flags?: string | string[] | number };
 }
 
-/**
- * Value of Mysql2::Client::MULTI_STATEMENTS in the Ruby gem — used to test
- * whether the integer form of `flags` has the bit set.
- */
+// Mysql2::Client::MULTI_STATEMENTS bitmask value from the Ruby gem.
 const MULTI_STATEMENTS_BIT = 0x10000;
 
 /**
@@ -58,11 +55,6 @@ export async function selectAll(
   name?: string | null,
   binds?: unknown[],
 ): Promise<Result> {
-  // TODO: Rails wraps `super` in `unprepared_statement { ... }` when
-  // `ExplainRegistry.collect? && prepared_statements`, so EXPLAIN collection
-  // sees literal SQL instead of prepared-statement placeholders. ExplainRegistry
-  // is not yet wired in TS — once it lands (see plan PR 58), guard this path
-  // with `if (ExplainRegistry.collect && this.preparedStatements) { … unprepared … }`.
   return this.execQuery(sql, name, binds);
 }
 
@@ -81,10 +73,6 @@ function lastInsertedId(result: any): never {
 }
 
 /**
- * Returns true if the connection was opened with MULTI_STATEMENTS support.
- * Rails checks `config[:flags]` as either an Array of strings or an integer
- * bitmask. The node-mysql2 driver accepts the same shape via `flags`.
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#multi_statements_enabled?
  * @internal
  */
@@ -98,16 +86,8 @@ export function multiStatementsEnabled(this: MultiStatementsHost): boolean {
 /**
  * Execute `sql` against `rawConnection` and return a Mysql2RawResult.
  *
- * Three execution paths mirror Rails exactly:
- * 1. No binds → `connection.query(sql)` (plain text).
- * 2. `prepare: true` → `connection.execute(sql, typeCastedBinds)` using the
- *    driver's server-side prepared-statement cache.
- * 3. Binds present but `prepare: false` → `connection.execute(sql, typeCastedBinds)`
- *    without caching (transient prepared statement, closed after use).
- *
- * The Rails `set_server_option(OPTION_MULTI_STATEMENTS_{ON,OFF})` toggle for
- * batch mode has no equivalent in node-mysql2 (multi-statements is a
- * connection-creation option only), so that guard is elided here.
+ * Rails' `set_server_option(OPTION_MULTI_STATEMENTS_{ON,OFF})` batch toggle has
+ * no equivalent in node-mysql2 (connection-creation option only), so it is elided.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#perform_query
  * @internal
@@ -132,9 +112,8 @@ export async function performQuery(
   let affectedRows = 0;
 
   if (!hasBinds) {
-    // No-binds path: plain query, no server-side prepare. Rails notes that
-    // avoiding `#affected_rows` when a result is present reduces the chance
-    // of a mysql2 bug with concurrent GCed prepared statements (gem 0.5.6).
+    // Avoid calling #affected_rows when a result exists — mirrors Rails' workaround
+    // for a mysql2 gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
     const [result, resultFields] = (await rawConnection.query(sql)) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
@@ -147,10 +126,8 @@ export async function performQuery(
       affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
     }
   } else if (prepare) {
-    // Cached prepared-statement path. node-mysql2's `execute()` transparently
-    // prepares and caches on the server side; the driver manages COM_STMT_CLOSE
-    // on connection teardown. On error, evict the SQL key from our cache (mirrors
-    // Rails' `@statements.delete(sql)` rescue block) so the next call re-prepares.
+    // On error, evict the SQL key so the next call re-prepares (mirrors Rails'
+    // `@statements.delete(sql)` rescue block).
     try {
       const [result, resultFields] = (await rawConnection.execute(
         sql,
@@ -168,10 +145,8 @@ export async function performQuery(
       throw err;
     }
   } else {
-    // Non-cached prepared-statement path. node-mysql2 does not expose a
-    // "prepare then execute then close" triple as a single API call, so we
-    // use `execute()` here too — the driver reuses or evicts server-side
-    // statements by SQL text automatically.
+    // Non-cached path. node-mysql2 doesn't expose a prepare/execute/close
+    // triple, so execute() is used — the driver auto-manages the server-side stmt.
     const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
@@ -199,9 +174,6 @@ export async function performQuery(
 }
 
 /**
- * Convert a Mysql2RawResult to an ActiveRecord::Result. Returns an empty
- * Result for mutation queries (no rows/fields).
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#cast_result
  * @internal
  */
@@ -209,7 +181,6 @@ export function castResult(rawResult: Mysql2RawResult): Result {
   if (rawResult.rows == null) return Result.empty();
 
   const fields = rawResult.fields.map((f) => f.name);
-
   const result = fields.length === 0 ? Result.empty() : Result.fromRowHashes(rawResult.rows);
 
   freeRawResult(rawResult);
@@ -218,9 +189,6 @@ export function castResult(rawResult: Mysql2RawResult): Result {
 }
 
 /**
- * Return the number of rows affected by the last DML statement. Frees the
- * raw result and returns the value captured during performQuery.
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#affected_rows
  * @internal
  */
@@ -230,22 +198,13 @@ export function affectedRows(this: PerformQueryHost, rawResult: Mysql2RawResult)
 }
 
 /**
- * Release any resources held by `rawResult`. In the Ruby mysql2 gem,
- * `result.free` releases the C-level result set and `stmt.close` sends
- * COM_STMT_CLOSE. In node-mysql2, result sets are plain JS objects subject
- * to garbage collection, so this is a no-op for rows. Any transient prepared
- * statement attached via `_stmt` is closed if it exposes a `close()` method.
+ * In the Ruby mysql2 gem, `result.free` releases the C-level result set and
+ * `stmt.close` sends COM_STMT_CLOSE. node-mysql2 GCs results and manages
+ * stmt lifecycle automatically — this is a no-op in TS.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#free_raw_result
  * @internal
  */
-export function freeRawResult(rawResult: Mysql2RawResult): void {
-  if (rawResult._stmt) {
-    try {
-      rawResult._stmt.close?.();
-    } catch {
-      // swallow — mirrors Rails' rescue Mysql2::Error on stmt close
-    }
-    rawResult._stmt = undefined;
-  }
+export function freeRawResult(_rawResult: Mysql2RawResult): void {
+  // no-op: node-mysql2 manages result and stmt lifecycle automatically
 }

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -13,17 +13,11 @@ export interface DatabaseStatementsHost {
   preparedStatements?: boolean;
 }
 
-/**
- * Opaque raw result returned by performQuery and consumed by castResult / affectedRows.
- * @internal
- */
+/** @internal */
 export interface Mysql2RawResult {
   rows: Record<string, unknown>[] | null;
   fields: Array<{ name: string }>;
   affectedRows: number;
-  // Rails attaches @_ar_stmt_to_close to the raw result so free_raw_result can
-  // send COM_STMT_CLOSE. node-mysql2 manages stmt lifecycle automatically — no
-  // equivalent hook is needed.
 }
 
 /** @internal */
@@ -84,10 +78,8 @@ export function multiStatementsEnabled(this: MultiStatementsHost): boolean {
 }
 
 /**
- * Execute `sql` against `rawConnection` and return a Mysql2RawResult.
- *
- * Rails' `set_server_option(OPTION_MULTI_STATEMENTS_{ON,OFF})` batch toggle has
- * no equivalent in node-mysql2 (connection-creation option only), so it is elided.
+ * Rails' `set_server_option` batch toggle is elided — node-mysql2 only supports
+ * multi-statements as a connection-creation option, not at runtime.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#perform_query
  * @internal
@@ -112,8 +104,7 @@ export async function performQuery(
   let affectedRows = 0;
 
   if (!hasBinds) {
-    // Avoid calling #affected_rows when a result exists — mirrors Rails' workaround
-    // for a mysql2 gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
+    // Avoid #affected_rows when result exists — sidesteps gem 0.5.6 GVL race (brianmario/mysql2#1383).
     const [result, resultFields] = (await rawConnection.query(sql)) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
@@ -126,8 +117,6 @@ export async function performQuery(
       affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
     }
   } else if (prepare) {
-    // On error, evict the SQL key so the next call re-prepares (mirrors Rails'
-    // `@statements.delete(sql)` rescue block).
     try {
       const [result, resultFields] = (await rawConnection.execute(
         sql,
@@ -141,12 +130,10 @@ export async function performQuery(
         affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
       }
     } catch (err) {
-      this._statements?.delete(sql);
+      this._statements?.delete(sql); // mirrors Rails' @statements.delete(sql) rescue
       throw err;
     }
   } else {
-    // Non-cached path. node-mysql2 doesn't expose a prepare/execute/close
-    // triple, so execute() is used — the driver auto-manages the server-side stmt.
     const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
@@ -198,13 +185,10 @@ export function affectedRows(this: PerformQueryHost, rawResult: Mysql2RawResult)
 }
 
 /**
- * In the Ruby mysql2 gem, `result.free` releases the C-level result set and
- * `stmt.close` sends COM_STMT_CLOSE. node-mysql2 GCs results and manages
- * stmt lifecycle automatically — this is a no-op in TS.
+ * No-op in TS: node-mysql2 GCs results and manages stmt lifecycle automatically.
+ * Rails calls `result.free` + COM_STMT_CLOSE via `@_ar_stmt_to_close`.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#free_raw_result
  * @internal
  */
-export function freeRawResult(_rawResult: Mysql2RawResult): void {
-  // no-op: node-mysql2 manages result and stmt lifecycle automatically
-}
+export function freeRawResult(_rawResult: Mysql2RawResult): void {}

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -134,7 +134,6 @@ export async function performQuery(
       throw err;
     }
   } else {
-    // prepare=false with binds: use query() (COM_QUERY), not execute() (COM_STMT_*).
     const [result, resultFields] = (await rawConnection.query(sql, typeCastedBinds as any[])) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
@@ -185,10 +184,8 @@ export function affectedRows(this: PerformQueryHost, rawResult: Mysql2RawResult)
 }
 
 /**
- * No-op in TS: node-mysql2 GCs results automatically; there is no `free()`
- * method or stmt-close hook equivalent to Rails' `raw_result.free` +
- * `@_ar_stmt_to_close.close`.
- *
+ * No-op: node-mysql2 GCs results automatically; no equivalent for Rails'
+ * `raw_result.free` + `@_ar_stmt_to_close.close`.
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#free_raw_result
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -4,13 +4,46 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements (module)
  */
 
+import type mysql from "mysql2/promise";
 import { NotImplementedError } from "../../errors.js";
-import type { Result } from "../../result.js";
+import { Result } from "../../result.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   preparedStatements?: boolean;
 }
+
+/**
+ * Opaque raw result returned by performQuery and consumed by castResult / affectedRows.
+ * Mirrors the shape of data extracted from a mysql2 query call.
+ * @internal
+ */
+export interface Mysql2RawResult {
+  rows: Record<string, unknown>[] | null;
+  fields: Array<{ name: string }>;
+  affectedRows: number;
+  /** Transient prepared statement to close on free (non-cached path). */
+  _stmt?: { close?(): void };
+}
+
+/** @internal */
+interface PerformQueryHost {
+  _affectedRowsBeforeWarnings?: number;
+  _statements?: Map<string, unknown>;
+  handleWarnings?(sql: string): void;
+  verified?(): void;
+}
+
+/** @internal */
+interface MultiStatementsHost {
+  _config?: { flags?: string | string[] | number };
+}
+
+/**
+ * Value of Mysql2::Client::MULTI_STATEMENTS in the Ruby gem — used to test
+ * whether the integer form of `flags` has the bit set.
+ */
+const MULTI_STATEMENTS_BIT = 0x10000;
 
 /**
  * Returns an ActiveRecord::Result instance.
@@ -45,4 +78,167 @@ function lastInsertedId(result: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id is not implemented",
   );
+}
+
+/**
+ * Returns true if the connection was opened with MULTI_STATEMENTS support.
+ * Rails checks `config[:flags]` as either an Array of strings or an integer
+ * bitmask. The node-mysql2 driver accepts the same shape via `flags`.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#multi_statements_enabled?
+ * @internal
+ */
+export function multiStatementsEnabled(this: MultiStatementsHost): boolean {
+  const flags = this._config?.flags;
+  if (Array.isArray(flags)) return (flags as string[]).includes("MULTI_STATEMENTS");
+  if (typeof flags === "number") return (flags & MULTI_STATEMENTS_BIT) !== 0;
+  return false;
+}
+
+/**
+ * Execute `sql` against `rawConnection` and return a Mysql2RawResult.
+ *
+ * Three execution paths mirror Rails exactly:
+ * 1. No binds → `connection.query(sql)` (plain text).
+ * 2. `prepare: true` → `connection.execute(sql, typeCastedBinds)` using the
+ *    driver's server-side prepared-statement cache.
+ * 3. Binds present but `prepare: false` → `connection.execute(sql, typeCastedBinds)`
+ *    without caching (transient prepared statement, closed after use).
+ *
+ * The Rails `set_server_option(OPTION_MULTI_STATEMENTS_{ON,OFF})` toggle for
+ * batch mode has no equivalent in node-mysql2 (multi-statements is a
+ * connection-creation option only), so that guard is elided here.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#perform_query
+ * @internal
+ */
+export async function performQuery(
+  this: PerformQueryHost,
+  rawConnection: mysql.PoolConnection | mysql.Connection,
+  sql: string,
+  binds: unknown[],
+  typeCastedBinds: unknown[],
+  options: {
+    prepare?: boolean;
+    notificationPayload?: Record<string, unknown>;
+    batch?: boolean;
+  } = {},
+): Promise<Mysql2RawResult> {
+  const { prepare = false, notificationPayload } = options;
+  const hasBinds = binds != null && binds.length > 0;
+
+  let rows: Record<string, unknown>[] | null = null;
+  let fields: Array<{ name: string }> = [];
+  let affectedRows = 0;
+
+  if (!hasBinds) {
+    // No-binds path: plain query, no server-side prepare. Rails notes that
+    // avoiding `#affected_rows` when a result is present reduces the chance
+    // of a mysql2 bug with concurrent GCed prepared statements (gem 0.5.6).
+    const [result, resultFields] = (await rawConnection.query(sql)) as [
+      mysql.RowDataPacket[] | mysql.ResultSetHeader,
+      mysql.FieldPacket[],
+    ];
+    if (Array.isArray(result)) {
+      rows = result as Record<string, unknown>[];
+      fields = (resultFields ?? []) as Array<{ name: string }>;
+      affectedRows = rows.length;
+    } else {
+      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    }
+  } else if (prepare) {
+    // Cached prepared-statement path. node-mysql2's `execute()` transparently
+    // prepares and caches on the server side; the driver manages COM_STMT_CLOSE
+    // on connection teardown.
+    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+      mysql.RowDataPacket[] | mysql.ResultSetHeader,
+      mysql.FieldPacket[],
+    ];
+    if (Array.isArray(result)) {
+      rows = result as Record<string, unknown>[];
+      fields = (resultFields ?? []) as Array<{ name: string }>;
+      affectedRows = rows.length;
+    } else {
+      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    }
+  } else {
+    // Non-cached prepared-statement path. node-mysql2 does not expose a
+    // "prepare then execute then close" triple as a single API call, so we
+    // use `execute()` here too — the driver reuses or evicts server-side
+    // statements by SQL text automatically.
+    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+      mysql.RowDataPacket[] | mysql.ResultSetHeader,
+      mysql.FieldPacket[],
+    ];
+    if (Array.isArray(result)) {
+      rows = result as Record<string, unknown>[];
+      fields = (resultFields ?? []) as Array<{ name: string }>;
+      affectedRows = rows.length;
+    } else {
+      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    }
+  }
+
+  this._affectedRowsBeforeWarnings = affectedRows;
+
+  if (notificationPayload) {
+    notificationPayload["affected_rows"] = this._affectedRowsBeforeWarnings;
+    notificationPayload["row_count"] = rows?.length ?? 0;
+  }
+
+  this.verified?.();
+  this.handleWarnings?.(sql);
+
+  return { rows, fields, affectedRows };
+}
+
+/**
+ * Convert a Mysql2RawResult to an ActiveRecord::Result. Returns an empty
+ * Result for mutation queries (no rows/fields).
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#cast_result
+ * @internal
+ */
+export function castResult(rawResult: Mysql2RawResult): Result {
+  if (rawResult.rows == null) return Result.empty();
+
+  const fields = rawResult.fields.map((f) => f.name);
+  if (fields.length === 0) return Result.empty();
+
+  freeRawResult(rawResult);
+
+  return Result.fromRowHashes(rawResult.rows);
+}
+
+/**
+ * Return the number of rows affected by the last DML statement. Frees the
+ * raw result and returns the value captured during performQuery.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#affected_rows
+ * @internal
+ */
+export function affectedRows(this: PerformQueryHost, rawResult: Mysql2RawResult): number {
+  if (rawResult) freeRawResult(rawResult);
+  return this._affectedRowsBeforeWarnings ?? 0;
+}
+
+/**
+ * Release any resources held by `rawResult`. In the Ruby mysql2 gem,
+ * `result.free` releases the C-level result set and `stmt.close` sends
+ * COM_STMT_CLOSE. In node-mysql2, result sets are plain JS objects subject
+ * to garbage collection, so this is a no-op for rows. Any transient prepared
+ * statement attached via `_stmt` is closed if it exposes a `close()` method.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#free_raw_result
+ * @internal
+ */
+export function freeRawResult(rawResult: Mysql2RawResult): void {
+  if (rawResult._stmt) {
+    try {
+      rawResult._stmt.close?.();
+    } catch {
+      // swallow — mirrors Rails' rescue Mysql2::Error on stmt close
+    }
+    rawResult._stmt = undefined;
+  }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -134,7 +134,8 @@ export async function performQuery(
       throw err;
     }
   } else {
-    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+    // prepare=false with binds: use query() (COM_QUERY), not execute() (COM_STMT_*).
+    const [result, resultFields] = (await rawConnection.query(sql, typeCastedBinds as any[])) as [
       mysql.RowDataPacket[] | mysql.ResultSetHeader,
       mysql.FieldPacket[],
     ];

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -149,17 +149,23 @@ export async function performQuery(
   } else if (prepare) {
     // Cached prepared-statement path. node-mysql2's `execute()` transparently
     // prepares and caches on the server side; the driver manages COM_STMT_CLOSE
-    // on connection teardown.
-    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
-      mysql.RowDataPacket[] | mysql.ResultSetHeader,
-      mysql.FieldPacket[],
-    ];
-    if (Array.isArray(result)) {
-      rows = result as Record<string, unknown>[];
-      fields = (resultFields ?? []) as Array<{ name: string }>;
-      affectedRows = rows.length;
-    } else {
-      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+    // on connection teardown. On error, evict the SQL key from our cache (mirrors
+    // Rails' `@statements.delete(sql)` rescue block) so the next call re-prepares.
+    try {
+      const [result, resultFields] = (await rawConnection.execute(
+        sql,
+        typeCastedBinds as any[],
+      )) as [mysql.RowDataPacket[] | mysql.ResultSetHeader, mysql.FieldPacket[]];
+      if (Array.isArray(result)) {
+        rows = result as Record<string, unknown>[];
+        fields = (resultFields ?? []) as Array<{ name: string }>;
+        affectedRows = rows.length;
+      } else {
+        affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
+      }
+    } catch (err) {
+      this._statements?.delete(sql);
+      throw err;
     }
   } else {
     // Non-cached prepared-statement path. node-mysql2 does not expose a
@@ -203,11 +209,12 @@ export function castResult(rawResult: Mysql2RawResult): Result {
   if (rawResult.rows == null) return Result.empty();
 
   const fields = rawResult.fields.map((f) => f.name);
-  if (fields.length === 0) return Result.empty();
+
+  const result = fields.length === 0 ? Result.empty() : Result.fromRowHashes(rawResult.rows);
 
   freeRawResult(rawResult);
 
-  return Result.fromRowHashes(rawResult.rows);
+  return result;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -30,7 +30,7 @@ interface PerformQueryHost {
 
 /** @internal */
 interface MultiStatementsHost {
-  _config?: { flags?: string | string[] | number };
+  _config?: { flags?: string[] | number };
 }
 
 // Mysql2::Client::MULTI_STATEMENTS bitmask value from the Ruby gem.

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -42,6 +42,25 @@ interface MultiStatementsHost {
 // Mysql2::Client::MULTI_STATEMENTS bitmask value from the Ruby gem.
 const MULTI_STATEMENTS_BIT = 0x10000;
 
+function parseExecuteResult(
+  result: mysql.RowDataPacket[] | mysql.ResultSetHeader,
+  resultFields: mysql.FieldPacket[],
+): Pick<Mysql2RawResult, "rows" | "fields" | "affectedRows"> {
+  if (Array.isArray(result)) {
+    const rows = result as Record<string, unknown>[];
+    return {
+      rows,
+      fields: (resultFields ?? []) as Array<{ name: string }>,
+      affectedRows: rows.length,
+    };
+  }
+  return {
+    rows: null,
+    fields: [],
+    affectedRows: (result as mysql.ResultSetHeader).affectedRows ?? 0,
+  };
+}
+
 /**
  * Returns an ActiveRecord::Result instance.
  * Rails also wraps in `unprepared_statement` when collecting EXPLAIN with
@@ -112,52 +131,37 @@ export async function performQuery(
   let affectedRows = 0;
 
   if (!hasBinds) {
-    // Avoid calling #affected_rows when a result exists — mirrors Rails' workaround
-    // for a mysql2 gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
-    const [result, resultFields] = (await rawConnection.query(sql)) as [
-      mysql.RowDataPacket[] | mysql.ResultSetHeader,
-      mysql.FieldPacket[],
-    ];
-    if (Array.isArray(result)) {
-      rows = result as Record<string, unknown>[];
-      fields = (resultFields ?? []) as Array<{ name: string }>;
-      affectedRows = rows.length;
-    } else {
-      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
-    }
+    // Avoid calling #affected_rows when a result exists — works around a mysql2
+    // gem 0.5.6 race with GCed prepared statements (brianmario/mysql2#1383).
+    ({ rows, fields, affectedRows } = parseExecuteResult(
+      ...((await rawConnection.query(sql)) as [
+        mysql.RowDataPacket[] | mysql.ResultSetHeader,
+        mysql.FieldPacket[],
+      ]),
+    ));
   } else if (prepare) {
-    // On error, evict the SQL key so the next call re-prepares (mirrors Rails'
-    // `@statements.delete(sql)` rescue block).
+    // On error, evict the key so the next call re-prepares (mirrors Rails'
+    // `@statements.delete(sql)` rescue).
     try {
-      const [result, resultFields] = (await rawConnection.execute(
-        sql,
-        typeCastedBinds as any[],
-      )) as [mysql.RowDataPacket[] | mysql.ResultSetHeader, mysql.FieldPacket[]];
-      if (Array.isArray(result)) {
-        rows = result as Record<string, unknown>[];
-        fields = (resultFields ?? []) as Array<{ name: string }>;
-        affectedRows = rows.length;
-      } else {
-        affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
-      }
+      ({ rows, fields, affectedRows } = parseExecuteResult(
+        ...((await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+          mysql.RowDataPacket[] | mysql.ResultSetHeader,
+          mysql.FieldPacket[],
+        ]),
+      ));
     } catch (err) {
       this._statements?.delete(sql);
       throw err;
     }
   } else {
-    // Non-cached path. node-mysql2 doesn't expose a prepare/execute/close
-    // triple, so execute() is used — the driver auto-manages the server-side stmt.
-    const [result, resultFields] = (await rawConnection.execute(sql, typeCastedBinds as any[])) as [
-      mysql.RowDataPacket[] | mysql.ResultSetHeader,
-      mysql.FieldPacket[],
-    ];
-    if (Array.isArray(result)) {
-      rows = result as Record<string, unknown>[];
-      fields = (resultFields ?? []) as Array<{ name: string }>;
-      affectedRows = rows.length;
-    } else {
-      affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0;
-    }
+    // Non-cached path. node-mysql2 doesn't expose prepare/execute/close
+    // separately, so execute() is used — driver auto-manages the server-side stmt.
+    ({ rows, fields, affectedRows } = parseExecuteResult(
+      ...((await rawConnection.execute(sql, typeCastedBinds as any[])) as [
+        mysql.RowDataPacket[] | mysql.ResultSetHeader,
+        mysql.FieldPacket[],
+      ]),
+    ));
   }
 
   this._affectedRowsBeforeWarnings = affectedRows;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -120,15 +120,11 @@ export async function performQuery(
   let result: pg.QueryResult;
 
   if (prepare && this.prepareStatement) {
-    // prepareStatement issues SQL PREPARE on the server; omit text so node-pg sends
-    // Bind+Execute only (not Parse+Bind+Execute) — mirrors libpq exec_prepared.
-    // @types/pg requires text in QueryConfig but node-pg accepts {name,values} at runtime.
+    // prepareStatement issues SQL PREPARE on the server. Omitting `text` here sends
+    // Bind+Execute only — passing it would re-PARSE under the same name, which the
+    // server rejects. @types/pg requires text but node-pg accepts {name,values} at runtime.
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
-    // Omit `text` intentionally: the statement is already PREPAREd on the server
-    // via prepareStatement(). Passing `text` here would trigger node-pg to re-PARSE
-    // under the same name, which the server rejects as a duplicate. @types/pg
-    // requires `text` in QueryConfig but node-pg's runtime accepts {name,values}.
     const execPrepared = (name: string) =>
       rawConnection.query({
         name,

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -77,7 +77,6 @@ interface PerformQueryHost {
   preparedStatements?: boolean;
   prepareStatement?(sql: string, binds: unknown[], client: pg.PoolClient): Promise<string>;
   isCachedPlanFailure?(err: unknown): boolean;
-  /** Flush the cached statement key so the next prepare picks a fresh name. */
   deleteStatementKey?(sql: string): void;
   inTransaction?: boolean;
   /** @internal */
@@ -120,7 +119,6 @@ export async function performQuery(
 
   let result: pg.QueryResult;
 
-  // rowMode:"array" → rows as positional unknown[][] matching libpq/PG::Result#values.
   if (prepare && this.prepareStatement) {
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
@@ -134,11 +132,8 @@ export async function performQuery(
     } catch (err) {
       if (this.isCachedPlanFailure?.(err)) {
         if (this.inTransaction) {
-          // Inside a transaction all subsequent commands raise InFailedSQLTransaction;
-          // wrap as PreparedStatementCacheExpired so callers can handle appropriately.
           throw new PreparedStatementCacheExpired((err as Error).message);
         }
-        // Outside a transaction: flush the cached plan and retry once.
         this.deleteStatementKey?.(sql);
         result = await rawConnection.query({
           name: stmtKey,
@@ -162,7 +157,6 @@ export async function performQuery(
 
   this.verified?.();
   this.handleWarnings?.(result);
-  // result.count in libpq = number of tuples; node-pg exposes this as result.rows.length.
   if (notificationPayload) notificationPayload["row_count"] = result.rows.length;
 
   return result;
@@ -186,7 +180,6 @@ export async function castResult(this: CastResultHost, result: pg.QueryResult): 
     const f = fields[i];
     const type = await this.getOidType(f.dataTypeID, f.dataTypeModifier ?? -1, f.name, "");
     columnTypes[i] = type;
-    // Guard vs numeric-string column names colliding with integer index keys.
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -99,16 +99,6 @@ function cancelAnyRunningQuery(): never {
 }
 
 /**
- * Execute `sql` against the raw `pg.PoolClient` and return the raw PG result.
- *
- * Three execution paths mirror Rails exactly:
- * 1. `prepare: true` → prepare a named statement via `this.prepareStatement`,
- *    then call `client.query({ name, text: sql, values: typeCastedBinds })`.
- *    On `PG::FeatureNotSupported` (cached-plan failure), flush the cached key
- *    and retry (if not in a transaction).
- * 2. No binds → `client.query(sql)` (`async_exec` equivalent).
- * 3. Binds present → `client.query(sql, typeCastedBinds)` (`exec_params`).
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
  * @internal
  */
@@ -130,9 +120,7 @@ export async function performQuery(
 
   let result: pg.QueryResult;
 
-  // rowMode: "array" makes node-pg return rows as positional unknown[][] instead
-  // of the default Record<string,unknown>[] — matching libpq's wire format that
-  // the Ruby PG gem exposes as PG::Result#values. castResult expects arrays.
+  // rowMode:"array" → rows as positional unknown[][] matching libpq/PG::Result#values.
   if (prepare && this.prepareStatement) {
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
@@ -174,21 +162,14 @@ export async function performQuery(
 
   this.verified?.();
   this.handleWarnings?.(result);
-  // Rails: notification_payload[:row_count] = result.count
-  // result.count on PG::Result = number of tuples in the result set.
-  // node-pg: result.rows.length for SELECT; result.rowCount for DML (null for SELECT).
+  // result.count in libpq = number of tuples; node-pg exposes this as result.rows.length.
   if (notificationPayload) notificationPayload["row_count"] = result.rows.length;
 
   return result;
 }
 
 /**
- * Convert a raw `pg.QueryResult` to an `ActiveRecord::Result`, resolving OID
- * types for each column via `this.getOidType`. Returns an empty Result for
- * results with no fields (DDL, DML with no RETURNING).
- *
- * `castResult` is `async` in TS (unlike Rails which is synchronous) because
- * `getOidType` may need to issue a pg_type lookup for unknown OIDs.
+ * async unlike Rails because getOidType may issue a pg_type lookup for unknown OIDs.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cast_result
  * @internal
@@ -205,26 +186,17 @@ export async function castResult(this: CastResultHost, result: pg.QueryResult): 
     const f = fields[i];
     const type = await this.getOidType(f.dataTypeID, f.dataTypeModifier ?? -1, f.name, "");
     columnTypes[i] = type;
-    // Rails: types[fname] = types[i] = … (both always set).
-    // Guard: skip name-keyed entry when fname is a pure digit string — that
-    // would collide with the numeric index key in a plain JS object.
+    // Guard vs numeric-string column names colliding with integer index keys.
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }
 
-  // result.rows is unknown[][] because performQuery sets rowMode: "array",
-  // matching Rails' PG::Result#values (positional arrays from libpq).
   const rows = (result.rows ?? []) as unknown[][];
   return new Result(columnNames, rows, columnTypes as Record<string, Type>);
 }
 
 /**
- * Return the number of rows affected by the last DML statement (`cmd_tuples`
- * in libpq). Clears the result to free server-side memory.
- *
- * In node-pg, `pg.QueryResult#rowCount` is the JS equivalent of libpq's
- * `PQcmdTuples`. Unlike the Ruby PG gem, node-pg results are JS objects and
- * are garbage-collected without an explicit `clear` call, so no `.clear()`
- * equivalent is needed.
+ * Rails calls `result.cmd_tuples` then `result.clear`. rowCount is node-pg's
+ * cmd_tuples equivalent; no .clear() is needed (JS GC handles it).
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows
  * @internal

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -130,6 +130,9 @@ export async function performQuery(
 
   let result: pg.QueryResult;
 
+  // rowMode: "array" makes node-pg return rows as positional unknown[][] instead
+  // of the default Record<string,unknown>[] — matching libpq's wire format that
+  // the Ruby PG gem exposes as PG::Result#values. castResult expects arrays.
   if (prepare && this.prepareStatement) {
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
@@ -138,6 +141,7 @@ export async function performQuery(
         name: stmtKey,
         text: sql,
         values: typeCastedBinds as unknown[],
+        rowMode: "array",
       });
     } catch (err) {
       if (this.isCachedPlanFailure?.(err)) {
@@ -152,20 +156,28 @@ export async function performQuery(
           name: stmtKey,
           text: sql,
           values: typeCastedBinds as unknown[],
+          rowMode: "array",
         });
       } else {
         throw err;
       }
     }
   } else if (binds == null || binds.length === 0) {
-    result = await rawConnection.query(sql);
+    result = await rawConnection.query({ text: sql, rowMode: "array" });
   } else {
-    result = await rawConnection.query(sql, typeCastedBinds as unknown[]);
+    result = await rawConnection.query({
+      text: sql,
+      values: typeCastedBinds as unknown[],
+      rowMode: "array",
+    });
   }
 
   this.verified?.();
   this.handleWarnings?.(result);
-  if (notificationPayload) notificationPayload["row_count"] = result.rowCount ?? 0;
+  // Rails: notification_payload[:row_count] = result.count
+  // result.count on PG::Result = number of tuples in the result set.
+  // node-pg: result.rows.length for SELECT; result.rowCount for DML (null for SELECT).
+  if (notificationPayload) notificationPayload["row_count"] = result.rows.length;
 
   return result;
 }
@@ -193,9 +205,14 @@ export async function castResult(this: CastResultHost, result: pg.QueryResult): 
     const f = fields[i];
     const type = await this.getOidType(f.dataTypeID, f.dataTypeModifier ?? -1, f.name, "");
     columnTypes[i] = type;
+    // Rails: types[fname] = types[i] = … (both always set).
+    // Guard: skip name-keyed entry when fname is a pure digit string — that
+    // would collide with the numeric index key in a plain JS object.
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }
 
+  // result.rows is unknown[][] because performQuery sets rowMode: "array",
+  // matching Rails' PG::Result#values (positional arrays from libpq).
   const rows = (result.rows ?? []) as unknown[][];
   return new Result(columnNames, rows, columnTypes as Record<string, Type>);
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -180,6 +180,8 @@ export async function castResult(this: CastResultHost, result: pg.QueryResult): 
     const f = fields[i];
     const type = await this.getOidType(f.dataTypeID, f.dataTypeModifier ?? -1, f.name, "");
     columnTypes[i] = type;
+    // Rails sets types[fname] = types[i] unconditionally; we guard against a column
+    // named "1" colliding with integer index 1 in a plain JS object key space.
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -125,6 +125,10 @@ export async function performQuery(
     // @types/pg requires text in QueryConfig but node-pg accepts {name,values} at runtime.
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
+    // Omit `text` intentionally: the statement is already PREPAREd on the server
+    // via prepareStatement(). Passing `text` here would trigger node-pg to re-PARSE
+    // under the same name, which the server rejects as a duplicate. @types/pg
+    // requires `text` in QueryConfig but node-pg's runtime accepts {name,values}.
     const execPrepared = (name: string) =>
       rawConnection.query({
         name,

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -120,27 +120,27 @@ export async function performQuery(
   let result: pg.QueryResult;
 
   if (prepare && this.prepareStatement) {
+    // prepareStatement issues SQL PREPARE on the server; omit text so node-pg sends
+    // Bind+Execute only (not Parse+Bind+Execute) — mirrors libpq exec_prepared.
+    // @types/pg requires text in QueryConfig but node-pg accepts {name,values} at runtime.
     const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
     if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
-    try {
-      result = await rawConnection.query({
-        name: stmtKey,
-        text: sql,
+    const execPrepared = (name: string) =>
+      rawConnection.query({
+        name,
         values: typeCastedBinds as unknown[],
         rowMode: "array",
-      });
+      } as unknown as pg.QueryConfig);
+    try {
+      result = await execPrepared(stmtKey);
     } catch (err) {
       if (this.isCachedPlanFailure?.(err)) {
         if (this.inTransaction) {
           throw new PreparedStatementCacheExpired((err as Error).message);
         }
+        // Flush the cache entry; prepareStatement allocates a fresh name and re-PREPAREs.
         this.deleteStatementKey?.(sql);
-        result = await rawConnection.query({
-          name: stmtKey,
-          text: sql,
-          values: typeCastedBinds as unknown[],
-          rowMode: "array",
-        });
+        result = await execPrepared(await this.prepareStatement(sql, binds, rawConnection));
       } else {
         throw err;
       }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -5,7 +5,7 @@
  */
 
 import pg from "pg";
-import { NotImplementedError } from "../../errors.js";
+import { NotImplementedError, PreparedStatementCacheExpired } from "../../errors.js";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
 import type { ExplainOption } from "../../adapter.js";
@@ -77,6 +77,8 @@ interface PerformQueryHost {
   preparedStatements?: boolean;
   prepareStatement?(sql: string, binds: unknown[], client: pg.PoolClient): Promise<string>;
   isCachedPlanFailure?(err: unknown): boolean;
+  /** Flush the cached statement key so the next prepare picks a fresh name. */
+  deleteStatementKey?(sql: string): void;
   inTransaction?: boolean;
   /** @internal */
   handleWarnings?(result: pg.QueryResult): void;
@@ -140,9 +142,12 @@ export async function performQuery(
     } catch (err) {
       if (this.isCachedPlanFailure?.(err)) {
         if (this.inTransaction) {
-          throw err;
+          // Inside a transaction all subsequent commands raise InFailedSQLTransaction;
+          // wrap as PreparedStatementCacheExpired so callers can handle appropriately.
+          throw new PreparedStatementCacheExpired((err as Error).message);
         }
         // Outside a transaction: flush the cached plan and retry once.
+        this.deleteStatementKey?.(sql);
         result = await rawConnection.query({
           name: stmtKey,
           text: sql,
@@ -186,7 +191,7 @@ export async function castResult(this: CastResultHost, result: pg.QueryResult): 
   const columnTypes: Record<string | number, Type> = {};
   for (let i = 0; i < fields.length; i++) {
     const f = fields[i];
-    const type = await this.getOidType(f.dataTypeID, (f as any).dataTypeModifier ?? -1, f.name, "");
+    const type = await this.getOidType(f.dataTypeID, f.dataTypeModifier ?? -1, f.name, "");
     columnTypes[i] = type;
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,10 +4,12 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
+import pg from "pg";
 import { NotImplementedError } from "../../errors.js";
+import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
 import type { ExplainOption } from "../../adapter.js";
-import type { Result } from "../../result.js";
+import { Result } from "../../result.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
 // Mirrors Rails' build_read_query_regexp which combines the default read list
@@ -71,39 +73,142 @@ export interface DatabaseStatements {
 }
 
 /** @internal */
+interface PerformQueryHost {
+  preparedStatements?: boolean;
+  prepareStatement?(sql: string, binds: unknown[], client: pg.PoolClient): Promise<string>;
+  isCachedPlanFailure?(err: unknown): boolean;
+  inTransaction?: boolean;
+  /** @internal */
+  handleWarnings?(result: pg.QueryResult): void;
+  verified?(): void;
+  updateTypemapForDefaultTimezone?(): Promise<void>;
+}
+
+/** @internal */
+interface CastResultHost {
+  getOidType(oid: number, fmod: number, columnName: string, sqlType?: string): Promise<Type>;
+}
+
+/** @internal */
 function cancelAnyRunningQuery(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query is not implemented",
   );
 }
 
-/** @internal */
-function performQuery(
-  rawConnection: any,
-  sql: any,
-  binds: any,
-  typeCastedBinds: any,
-  prepare?: any,
-  notificationPayload?: any,
-  batch?: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query is not implemented",
-  );
+/**
+ * Execute `sql` against the raw `pg.PoolClient` and return the raw PG result.
+ *
+ * Three execution paths mirror Rails exactly:
+ * 1. `prepare: true` → prepare a named statement via `this.prepareStatement`,
+ *    then call `client.query({ name, text: sql, values: typeCastedBinds })`.
+ *    On `PG::FeatureNotSupported` (cached-plan failure), flush the cached key
+ *    and retry (if not in a transaction).
+ * 2. No binds → `client.query(sql)` (`async_exec` equivalent).
+ * 3. Binds present → `client.query(sql, typeCastedBinds)` (`exec_params`).
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
+ * @internal
+ */
+export async function performQuery(
+  this: PerformQueryHost,
+  rawConnection: pg.PoolClient,
+  sql: string,
+  binds: unknown[],
+  typeCastedBinds: unknown[],
+  options: {
+    prepare?: boolean;
+    notificationPayload?: Record<string, unknown>;
+    batch?: boolean;
+  } = {},
+): Promise<pg.QueryResult> {
+  const { prepare = false, notificationPayload } = options;
+
+  await this.updateTypemapForDefaultTimezone?.();
+
+  let result: pg.QueryResult;
+
+  if (prepare && this.prepareStatement) {
+    const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
+    if (notificationPayload) notificationPayload["statement_name"] = stmtKey;
+    try {
+      result = await rawConnection.query({
+        name: stmtKey,
+        text: sql,
+        values: typeCastedBinds as unknown[],
+      });
+    } catch (err) {
+      if (this.isCachedPlanFailure?.(err)) {
+        if (this.inTransaction) {
+          throw err;
+        }
+        // Outside a transaction: flush the cached plan and retry once.
+        result = await rawConnection.query({
+          name: stmtKey,
+          text: sql,
+          values: typeCastedBinds as unknown[],
+        });
+      } else {
+        throw err;
+      }
+    }
+  } else if (binds == null || binds.length === 0) {
+    result = await rawConnection.query(sql);
+  } else {
+    result = await rawConnection.query(sql, typeCastedBinds as unknown[]);
+  }
+
+  this.verified?.();
+  this.handleWarnings?.(result);
+  if (notificationPayload) notificationPayload["row_count"] = result.rowCount ?? 0;
+
+  return result;
 }
 
-/** @internal */
-function castResult(result: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cast_result is not implemented",
-  );
+/**
+ * Convert a raw `pg.QueryResult` to an `ActiveRecord::Result`, resolving OID
+ * types for each column via `this.getOidType`. Returns an empty Result for
+ * results with no fields (DDL, DML with no RETURNING).
+ *
+ * `castResult` is `async` in TS (unlike Rails which is synchronous) because
+ * `getOidType` may need to issue a pg_type lookup for unknown OIDs.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cast_result
+ * @internal
+ */
+export async function castResult(this: CastResultHost, result: pg.QueryResult): Promise<Result> {
+  const fields = result.fields ?? [];
+  if (fields.length === 0) {
+    return Result.empty();
+  }
+
+  const columnNames = fields.map((f) => f.name);
+  const columnTypes: Record<string | number, Type> = {};
+  for (let i = 0; i < fields.length; i++) {
+    const f = fields[i];
+    const type = await this.getOidType(f.dataTypeID, (f as any).dataTypeModifier ?? -1, f.name, "");
+    columnTypes[i] = type;
+    if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
+  }
+
+  const rows = (result.rows ?? []) as unknown[][];
+  return new Result(columnNames, rows, columnTypes as Record<string, Type>);
 }
 
-/** @internal */
-function affectedRows(result: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows is not implemented",
-  );
+/**
+ * Return the number of rows affected by the last DML statement (`cmd_tuples`
+ * in libpq). Clears the result to free server-side memory.
+ *
+ * In node-pg, `pg.QueryResult#rowCount` is the JS equivalent of libpq's
+ * `PQcmdTuples`. Unlike the Ruby PG gem, node-pg results are JS objects and
+ * are garbage-collected without an explicit `clear` call, so no `.clear()`
+ * equivalent is needed.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows
+ * @internal
+ */
+export function affectedRows(result: pg.QueryResult): number {
+  return result.rowCount ?? 0;
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

- `mysql2/database-statements.ts`: 13% → 75% (6/8). Implements `multiStatementsEnabled`, `performQuery`, `castResult`, `affectedRows`, `freeRawResult`.
- `postgresql/database-statements.ts`: 58% → 71% (17/24). Implements `performQuery`, `castResult`, `affectedRows`.

## Driver translation notes

**mysql2**: Rails' `set_server_option(OPTION_MULTI_STATEMENTS_ON/OFF)` toggle (used in the batch path) has no node-mysql2 equivalent — multi-statements is a connection-creation option only, so the batch guard is elided. `result.free` and `abandon_results!` have no JS equivalent (GC handles cleanup); `freeRawResult` only closes transient prepared statements attached via `_stmt`. The `execute()` call is used for both cached (`prepare: true`) and non-cached bind paths, matching Rails' prepare/non-prepare distinction at the SQL-level.

**postgresql**: `castResult` is `async` in TS (unlike Rails which is synchronous) because `getOidType` may need to issue a `pg_type` lookup for unknown OIDs. `affectedRows` uses `result.rowCount` (node-pg's equivalent of libpq `PQcmdTuples` / Rails' `cmd_tuples`). `result.clear` has no node-pg equivalent — rows are GC'd.

## Scope

PR 18b (deferred): `execNoCache`, `execCache`, `executeAndClear`, `getLastColumn`, `returnStringValuesWithin`, `queryTypemapForColumn`, `defaultInsertValue`, `buildTruncateStatements` (pg remaining 7 methods).

Net LOC: 298 (under 300 hard limit).