### PR TITLE
feat(activerecord): migration.rb Migrator lifecycle + advisory lock to 93% (Wave 8 PR 46b)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -361,13 +361,13 @@ export interface DatabaseAdapter {
    * Acquire an advisory lock. Returns true if the lock was obtained.
    * Optional — only implemented by adapters that support advisory locks.
    */
-  getAdvisoryLock?(lockId: number | string): Promise<boolean>;
+  getAdvisoryLock?(lockId: number | bigint | string): Promise<boolean>;
 
   /**
    * Release an advisory lock. Returns true if the lock was released.
    * Optional — only implemented by adapters that support advisory locks.
    */
-  releaseAdvisoryLock?(lockId: number | string): Promise<boolean>;
+  releaseAdvisoryLock?(lockId: number | bigint | string): Promise<boolean>;
 
   /**
    * Quote a raw string for safe inclusion in a SQL literal (escape ' and \).

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -370,6 +370,15 @@ export interface DatabaseAdapter {
   releaseAdvisoryLock?(lockId: number | bigint | string): Promise<boolean>;
 
   /**
+   * Return the name of the currently connected database.
+   * Required by adapters that support advisory locks (used to derive a
+   * per-database lock ID via MIGRATOR_SALT * crc32(dbName)).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#current_database
+   */
+  currentDatabase?(): Promise<string>;
+
+  /**
    * Quote a raw string for safe inclusion in a SQL literal (escape ' and \).
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_string

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -927,11 +927,11 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  async getAdvisoryLock(_lockId: number | string): Promise<boolean> {
+  async getAdvisoryLock(_lockId: number | bigint | string): Promise<boolean> {
     return false;
   }
 
-  async releaseAdvisoryLock(_lockId: number | string): Promise<boolean> {
+  async releaseAdvisoryLock(_lockId: number | bigint | string): Promise<boolean> {
     return false;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -876,7 +876,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // so acquire and release use the same session.
   private _advisoryLockConn: mysql.PoolConnection | null = null;
 
-  async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+  async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     const conn = await this._driverPool.getConnection();
     try {
@@ -894,7 +894,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }
   }
 
-  async releaseAdvisoryLock(lockId: number | string): Promise<boolean> {
+  async releaseAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const conn = this._advisoryLockConn;
     if (!conn) return false;
     try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1898,12 +1898,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // duration of the lock.
   private _advisoryLockClient: pg.PoolClient | null = null;
 
-  async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+  async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const client = await this._acquireFreshClient();
     try {
-      const isNumeric = typeof lockId === "number";
-      const sql = `SELECT pg_try_advisory_lock(${isNumeric ? "$1" : "hashtext($1)"}) AS locked`;
-      const result = await client.query(sql, [isNumeric ? lockId : String(lockId)]);
+      const [sql, param] = _pgAdvisoryLockSql("pg_try_advisory_lock", "locked", lockId);
+      const result = await client.query(sql, [param]);
       const locked = result.rows[0]?.locked === true;
       if (locked) {
         this._advisoryLockClient = client;
@@ -1917,13 +1916,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  async releaseAdvisoryLock(lockId: number | string): Promise<boolean> {
+  async releaseAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const client = this._advisoryLockClient;
     if (!client) return false;
     try {
-      const isNumeric = typeof lockId === "number";
-      const sql = `SELECT pg_advisory_unlock(${isNumeric ? "$1" : "hashtext($1)"}) AS unlocked`;
-      const result = await client.query(sql, [isNumeric ? lockId : String(lockId)]);
+      const [sql, param] = _pgAdvisoryLockSql("pg_advisory_unlock", "unlocked", lockId);
+      const result = await client.query(sql, [param]);
       return result.rows[0]?.unlocked === true;
     } finally {
       this._advisoryLockClient = null;
@@ -4532,6 +4530,16 @@ export class MoneyDecoder {
  * expression defaults as `defaultFunction` rather than applying them as
  * literal bind values.
  */
+function _pgAdvisoryLockSql(
+  fn: string,
+  col: string,
+  lockId: number | bigint | string,
+): [string, unknown] {
+  if (typeof lockId === "bigint") return [`SELECT ${fn}($1::bigint) AS ${col}`, lockId.toString()];
+  if (typeof lockId === "number") return [`SELECT ${fn}($1) AS ${col}`, lockId];
+  return [`SELECT ${fn}(hashtext($1)) AS ${col}`, lockId];
+}
+
 function splitPgDefault(raw: string | null): { literal: unknown; fn: string | null } {
   if (raw == null) return { literal: null, fn: null };
   // 'value'::type — quoted literal with an optional cast.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4523,13 +4523,6 @@ export class MoneyDecoder {
   }
 }
 
-/**
- * Parse a raw `pg_attrdef` default expression into a literal value or a
- * SQL function expression. Mirrors Rails' PG `extract_value_from_default`
- * / `extract_default_function` split — so schema reflection can carry
- * expression defaults as `defaultFunction` rather than applying them as
- * literal bind values.
- */
 function _pgAdvisoryLockSql(
   fn: string,
   col: string,
@@ -4540,6 +4533,13 @@ function _pgAdvisoryLockSql(
   return [`SELECT ${fn}(hashtext($1)) AS ${col}`, lockId];
 }
 
+/**
+ * Parse a raw `pg_attrdef` default expression into a literal value or a
+ * SQL function expression. Mirrors Rails' PG `extract_value_from_default`
+ * / `extract_default_function` split — so schema reflection can carry
+ * expression defaults as `defaultFunction` rather than applying them as
+ * literal bind values.
+ */
 function splitPgDefault(raw: string | null): { literal: unknown; fn: string | null } {
   if (raw == null) return { literal: null, fn: null };
   // 'value'::type — quoted literal with an optional cast.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1589,6 +1589,7 @@ export class Migrator {
       throw new ConcurrentMigrationError();
     }
     // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).
+    // Release errors are swallowed when fn itself failed so the migration error wins.
     const _sentinel = Symbol();
     let fnResult: T | typeof _sentinel = _sentinel;
     let fnError: unknown = _sentinel;
@@ -1597,7 +1598,13 @@ export class Migrator {
     } catch (e) {
       fnError = e;
     }
-    const released = await adapter.releaseAdvisoryLock?.(lockId);
+    let released: boolean | undefined;
+    try {
+      released = await adapter.releaseAdvisoryLock?.(lockId);
+    } catch (releaseErr) {
+      if (fnError !== _sentinel) throw fnError;
+      throw releaseErr;
+    }
     if (fnError !== _sentinel) throw fnError;
     if (released === false) {
       throw new ConcurrentMigrationError(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1588,9 +1588,7 @@ export class Migrator {
     if (!locked) {
       throw new ConcurrentMigrationError();
     }
-    // Mirrors Rails ensure clause: release the lock, raise if release fails.
-    // The fn error (if any) takes priority; release-failed error is raised only
-    // when fn succeeded. Structured this way to satisfy no-unsafe-finally.
+    // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).
     const _sentinel = Symbol();
     let fnResult: T | typeof _sentinel = _sentinel;
     let fnError: unknown = _sentinel;
@@ -1700,12 +1698,7 @@ export class Migrator {
     });
   }
 
-  /**
-   * Run a specific migration (by targetVersion) without acquiring the advisory lock.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#run_without_lock
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#run_without_lock */
   async runWithoutLock(direction: "up" | "down", targetVersion: string | number): Promise<void> {
     await this._ensureSchemaTable();
     const key = String(BigInt(targetVersion));
@@ -1717,58 +1710,33 @@ export class Migrator {
     await this._runMigration(proxy, direction);
   }
 
-  /**
-   * Run all pending migrations without acquiring the advisory lock.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#migrate_without_lock
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#migrate_without_lock */
   async migrateWithoutLock(targetVersion?: number | string | null): Promise<void> {
     await this._ensureSchemaTable();
     await this._migrateUp(targetVersion ?? null);
   }
 
-  /**
-   * Stamp the current environment name into ar_internal_metadata.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#record_environment
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#record_environment */
   async recordEnvironment(): Promise<void> {
     if (this._internalMetadata.enabled) {
       await this._internalMetadata.set("environment", this._environment);
     }
   }
 
-  /**
-   * Return true if the migration at the given version has already been applied.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#ran?
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#ran? */
   async isRan(proxy: MigrationProxy): Promise<boolean> {
     const applied = await this._appliedVersions();
     return applied.has(proxy.version);
   }
 
-  /**
-   * Return true if targetVersion is set but no matching migration exists.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#invalid_target?
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#invalid_target? */
   isInvalidTarget(targetVersion?: string | number | null): boolean {
     if (targetVersion === null || targetVersion === undefined) return false;
     const key = String(BigInt(targetVersion));
     return !this._migrations.some((m) => m.version === key);
   }
 
-  /**
-   * Execute a single migration inside a DDL transaction.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction */
   async executeMigrationInTransaction(
     proxy: MigrationProxy,
     direction: "up" | "down" = "up",
@@ -1776,12 +1744,7 @@ export class Migrator {
     await this._runMigration(proxy, direction);
   }
 
-  /**
-   * Record that a version was applied or rolled back in schema_migrations.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#record_version_state_after_migrating
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#record_version_state_after_migrating */
   async recordVersionStateAfterMigrating(
     version: string,
     direction: "up" | "down" = "up",
@@ -1793,56 +1756,27 @@ export class Migrator {
     }
   }
 
-  /**
-   * Wrap fn in a DDL transaction if the adapter and migration support it.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#ddl_transaction
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#ddl_transaction */
   async ddlTransaction(migration: MigrationLike, fn: () => Promise<void>): Promise<void> {
     return this._ddlTransaction(migration, fn);
   }
 
-  /**
-   * Return true if this migration should be wrapped in a DDL transaction.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#use_transaction?
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#use_transaction? */
   isUseTransaction(migration: MigrationLike): boolean {
     return this._useTransaction(migration);
   }
 
-  /**
-   * Return true if the adapter supports advisory locks and they are enabled.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#use_advisory_lock?
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#use_advisory_lock? */
   isUseAdvisoryLock(): boolean {
     return !!(this._adapter.supportsAdvisoryLocks?.() && this._adapter.getAdvisoryLock);
   }
 
-  /**
-   * Acquire the migrator advisory lock, run fn, then release it.
-   * Raises ConcurrentMigrationError if the lock cannot be acquired or released.
-   * No-op (runs fn directly) when the adapter does not support advisory locks.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#with_advisory_lock
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock */
   async withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
     return this._withAdvisoryLock(fn);
   }
 
-  /**
-   * Return the integer lock ID used for the migrator advisory lock.
-   * Mirrors Rails: `MIGRATOR_SALT * Zlib.crc32(connection.current_database)`.
-   * Falls back to the salt alone when the adapter doesn't expose currentDatabase.
-   *
-   * @internal
-   * Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
   async generateMigratorAdvisoryLockId(): Promise<number> {
     const adapter = this._adapter as unknown as { currentDatabase?(): Promise<string> };
     if (typeof adapter.currentDatabase === "function") {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1608,15 +1608,18 @@ export class Migrator {
     } catch (e) {
       fnError = e;
     }
+    // releaseAdvisoryLock is guaranteed present (checked in the guard above).
+    // Any non-true return — false or undefined — is treated as failure, matching
+    // Rails: `release_advisory_lock(...) or raise` (migration.rb:1608-1612).
     let released: boolean | undefined;
     try {
-      released = await adapter.releaseAdvisoryLock?.(lockId);
+      released = await adapter.releaseAdvisoryLock!(lockId);
     } catch (releaseErr) {
       if (fnError !== _sentinel) throw fnError;
       throw releaseErr;
     }
     if (fnError !== _sentinel) throw fnError;
-    if (released === false) {
+    if (released !== true) {
       throw new ConcurrentMigrationError(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);
     }
     return fnResult as T;
@@ -2038,19 +2041,7 @@ export class Migrator {
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<void> {
     this._validateTargetVersion(targetVersion);
-    await this._withAdvisoryLock(async () => {
-      await this._ensureSchemaTable();
-      const key = String(BigInt(targetVersion));
-      const proxy = this._migrations.find((m) => m.version === key);
-      if (!proxy) {
-        throw new UnknownMigrationVersionError(key);
-      }
-      const applied = await this._appliedVersions();
-      const isApplied = applied.has(key);
-      if (direction === "up" && isApplied) return;
-      if (direction === "down" && !isApplied) return;
-      await this._runMigration(proxy, direction);
-    });
+    await this._withAdvisoryLock(() => this.runWithoutLock(direction, targetVersion));
   }
 
   private async _migrateUp(targetVersion: number | string | null): Promise<void> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -40,6 +40,18 @@ export {
 
 import { ActiveRecordError, NotImplementedError } from "./errors.js";
 
+// Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial).
+function _crc32(str: string): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < str.length; i++) {
+    crc ^= str.charCodeAt(i);
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
 // Migration error classes. Rails defines these in migration.rb, so
 // they live here. internal-metadata.ts imports EnvironmentStorageError
 // back from this module; the ESM cycle is safe because each callsite
@@ -116,6 +128,9 @@ export class PendingMigrationError extends MigrationError {
 }
 
 export class ConcurrentMigrationError extends MigrationError {
+  static readonly RELEASE_LOCK_FAILED_MESSAGE =
+    "Failed to release advisory lock, which means the lock file could not be deleted.";
+
   constructor(message = "Cannot run migrations because another migration is currently running.") {
     super(message);
     this.name = "ConcurrentMigrationError";
@@ -172,6 +187,8 @@ export abstract class Migration {
   private _recording = false;
   private _recorder = new CommandRecorder();
   private _name?: string;
+  /** @internal */
+  static delegate: DatabaseAdapter | null = null;
   private _version?: string;
   verbose = true;
   static logger: Logger = new Logger();
@@ -1016,14 +1033,17 @@ export abstract class Migration {
   }
 
   /** @internal */
+  static get nearestDelegate(): DatabaseAdapter | null {
+    return (
+      this.delegate ?? (Object.getPrototypeOf(this) as typeof Migration).nearestDelegate ?? null
+    );
+  }
+
+  /** @internal */
   static methodMissing(name: string, ...args: unknown[]): unknown {
-    const delegate = (this as unknown as Record<string, unknown>).nearestDelegate;
-    if (
-      delegate !== null &&
-      delegate !== undefined &&
-      typeof (delegate as Record<string, unknown>)[name] === "function"
-    ) {
-      return ((delegate as Record<string, unknown>)[name] as (...a: unknown[]) => unknown)(...args);
+    const delegate = this.nearestDelegate as Record<string, unknown> | null;
+    if (delegate !== null && typeof delegate[name] === "function") {
+      return (delegate[name] as (...a: unknown[]) => unknown)(...args);
     }
     throw new TypeError(`undefined method '${name}' for ${this.name}`);
   }
@@ -1549,8 +1569,8 @@ export class Migrator {
     return [...this._migrations];
   }
 
-  // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32 of googol)
-  private static readonly _LOCK_ID = 2053462845;
+  // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32("googol"))
+  private static readonly _MIGRATOR_SALT = 2053462845;
 
   /**
    * Wrap a block with an advisory lock to prevent concurrent migrations.
@@ -1563,15 +1583,28 @@ export class Migrator {
     if (!adapter.supportsAdvisoryLocks?.() || !adapter.getAdvisoryLock) {
       return fn();
     }
-    const locked = await adapter.getAdvisoryLock(Migrator._LOCK_ID);
+    const lockId = await this.generateMigratorAdvisoryLockId();
+    const locked = await adapter.getAdvisoryLock(lockId);
     if (!locked) {
       throw new ConcurrentMigrationError();
     }
+    // Mirrors Rails ensure clause: release the lock, raise if release fails.
+    // The fn error (if any) takes priority; release-failed error is raised only
+    // when fn succeeded. Structured this way to satisfy no-unsafe-finally.
+    const _sentinel = Symbol();
+    let fnResult: T | typeof _sentinel = _sentinel;
+    let fnError: unknown = _sentinel;
     try {
-      return await fn();
-    } finally {
-      await adapter.releaseAdvisoryLock?.(Migrator._LOCK_ID);
+      fnResult = await fn();
+    } catch (e) {
+      fnError = e;
     }
+    const released = await adapter.releaseAdvisoryLock?.(lockId);
+    if (fnError !== _sentinel) throw fnError;
+    if (released === false) {
+      throw new ConcurrentMigrationError(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);
+    }
+    return fnResult as T;
   }
 
   /**
@@ -1792,7 +1825,8 @@ export class Migrator {
 
   /**
    * Acquire the migrator advisory lock, run fn, then release it.
-   * Raises ConcurrentMigrationError if the lock cannot be acquired.
+   * Raises ConcurrentMigrationError if the lock cannot be acquired or released.
+   * No-op (runs fn directly) when the adapter does not support advisory locks.
    *
    * @internal
    * Mirrors: ActiveRecord::Migrator#with_advisory_lock
@@ -1803,14 +1837,19 @@ export class Migrator {
 
   /**
    * Return the integer lock ID used for the migrator advisory lock.
-   * Derived from a fixed salt (Rails uses Zlib.crc32 of "googol") so
-   * every process targeting the same database uses the same ID.
+   * Mirrors Rails: `MIGRATOR_SALT * Zlib.crc32(connection.current_database)`.
+   * Falls back to the salt alone when the adapter doesn't expose currentDatabase.
    *
    * @internal
    * Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id
    */
-  generateMigratorAdvisoryLockId(): number {
-    return Migrator._LOCK_ID;
+  async generateMigratorAdvisoryLockId(): Promise<number> {
+    const adapter = this._adapter as unknown as { currentDatabase?(): Promise<string> };
+    if (typeof adapter.currentDatabase === "function") {
+      const dbName = await adapter.currentDatabase();
+      return Migrator._MIGRATOR_SALT * _crc32(dbName);
+    }
+    return Migrator._MIGRATOR_SALT;
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -187,7 +187,11 @@ export abstract class Migration {
   private _recording = false;
   private _recorder = new CommandRecorder();
   private _name?: string;
-  /** @internal */
+  /**
+   * Class-level delegation target set from outside (mirrors Rails `class << self; attr_accessor :delegate`).
+   * Distinct from the instance `delegate` getter, which returns the current adapter.
+   * @internal
+   */
   static delegate: DatabaseAdapter | null = null;
   private _version?: string;
   verbose = true;
@@ -1050,6 +1054,7 @@ export abstract class Migration {
 
   // --- Delegation (Rails: Migration#nearest_delegate, #delegate) ---
 
+  /** Instance delegation target — returns the current adapter. Distinct from the class-level `Migration.delegate`. */
   get delegate(): DatabaseAdapter {
     return this.adapter;
   }
@@ -1062,6 +1067,7 @@ export abstract class Migration {
   methodMissing(name: string, ...args: unknown[]): unknown {
     const conn = this.adapter as unknown as Record<string, unknown>;
     if (typeof conn[name] !== "function") {
+      // JS has no NoMethodError; TypeError is the closest stdlib equivalent.
       throw new TypeError(`undefined method '${name}' for ${this.adapter.constructor.name}`);
     }
     return (conn[name] as (...a: unknown[]) => unknown).apply(conn, args);
@@ -1705,7 +1711,17 @@ export class Migrator {
     });
   }
 
-  /** @internal Mirrors: ActiveRecord::Migrator#run_without_lock */
+  /**
+   * @internal Mirrors: ActiveRecord::Migrator#run_without_lock
+   *
+   * Signature differs from Rails: Rails reads `@direction`/`@target_version` from
+   * per-invocation instance state; TS takes them as explicit params.
+   *
+   * The already-applied guards replicate the skip logic in Rails'
+   * `execute_migration_in_transaction` (migration.rb:1528-1530), which checks
+   * `migrated.include?(migration.version)` before running. Our `_runMigration`
+   * doesn't carry that check, so the guard lives here instead.
+   */
   async runWithoutLock(direction: "up" | "down", targetVersion: string | number): Promise<void> {
     this._validateTargetVersion(targetVersion);
     await this._ensureSchemaTable();
@@ -1791,13 +1807,21 @@ export class Migrator {
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
   async generateMigratorAdvisoryLockId(): Promise<bigint> {
     const adapter = this._adapter as unknown as { currentDatabase?(): Promise<string> };
-    if (typeof adapter.currentDatabase === "function") {
-      const dbName = await adapter.currentDatabase();
-      if (dbName) {
-        return BigInt(Migrator._MIGRATOR_SALT) * BigInt(_crc32(dbName));
-      }
+    if (typeof adapter.currentDatabase !== "function") {
+      // Rails always calls connection.current_database; a missing implementation is a
+      // bug in the adapter. Throw here so it surfaces rather than silently sharing a
+      // global lock ID across databases (which defeats multi-DB advisory-lock isolation).
+      throw new Error(
+        `${this._adapter.constructor.name} must implement currentDatabase() to support advisory-locked migrations`,
+      );
     }
-    return BigInt(Migrator._MIGRATOR_SALT);
+    const dbName = await adapter.currentDatabase();
+    if (!dbName) {
+      // currentDatabase() returned empty — adapter bug (MySQL stub returns "").
+      // Fall back to the salt so migrations don't hard-fail; file a fix for the adapter.
+      return BigInt(Migrator._MIGRATOR_SALT);
+    }
+    return BigInt(Migrator._MIGRATOR_SALT) * BigInt(_crc32(dbName));
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1586,7 +1586,11 @@ export class Migrator {
    */
   private async _withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
     const adapter = this._adapter;
-    if (!adapter.supportsAdvisoryLocks?.() || !adapter.getAdvisoryLock) {
+    if (
+      !adapter.supportsAdvisoryLocks?.() ||
+      !adapter.getAdvisoryLock ||
+      !adapter.releaseAdvisoryLock
+    ) {
       return fn();
     }
     const lockId = await this.generateMigratorAdvisoryLockId();
@@ -1806,7 +1810,7 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
   async generateMigratorAdvisoryLockId(): Promise<bigint> {
-    const adapter = this._adapter as unknown as { currentDatabase?(): Promise<string> };
+    const adapter = this._adapter;
     if (typeof adapter.currentDatabase !== "function") {
       // Rails always calls connection.current_database; a missing implementation is a
       // bug in the adapter. Throw here so it surfaces rather than silently sharing a

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1800,7 +1800,12 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#use_advisory_lock? */
   isUseAdvisoryLock(): boolean {
-    return !!(this._adapter.supportsAdvisoryLocks?.() && this._adapter.getAdvisoryLock);
+    return !!(
+      this._adapter.supportsAdvisoryLocks?.() &&
+      this._adapter.getAdvisoryLock &&
+      this._adapter.releaseAdvisoryLock &&
+      typeof this._adapter.currentDatabase === "function"
+    );
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1015,6 +1015,19 @@ export abstract class Migration {
     await this.checkPendingMigrations();
   }
 
+  /** @internal */
+  static methodMissing(name: string, ...args: unknown[]): unknown {
+    const delegate = (this as unknown as Record<string, unknown>).nearestDelegate;
+    if (
+      delegate !== null &&
+      delegate !== undefined &&
+      typeof (delegate as Record<string, unknown>)[name] === "function"
+    ) {
+      return ((delegate as Record<string, unknown>)[name] as (...a: unknown[]) => unknown)(...args);
+    }
+    throw new TypeError(`undefined method '${name}' for ${this.name}`);
+  }
+
   // --- Delegation (Rails: Migration#nearest_delegate, #delegate) ---
 
   get delegate(): DatabaseAdapter {
@@ -1023,6 +1036,15 @@ export abstract class Migration {
 
   get nearestDelegate(): DatabaseAdapter {
     return this.adapter;
+  }
+
+  /** @internal */
+  methodMissing(name: string, ...args: unknown[]): unknown {
+    const conn = this.adapter as unknown as Record<string, unknown>;
+    if (typeof conn[name] !== "function") {
+      throw new TypeError(`undefined method '${name}' for ${this.adapter.constructor.name}`);
+    }
+    return (conn[name] as (...a: unknown[]) => unknown)(...args);
   }
 
   /** @internal */
@@ -1643,6 +1665,152 @@ export class Migrator {
         await this._runMigration(proxy, "up");
       }
     });
+  }
+
+  /**
+   * Run a specific migration (by targetVersion) without acquiring the advisory lock.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#run_without_lock
+   */
+  async runWithoutLock(direction: "up" | "down", targetVersion: string | number): Promise<void> {
+    await this._ensureSchemaTable();
+    const key = String(BigInt(targetVersion));
+    const proxy = this._migrations.find((m) => m.version === key);
+    if (!proxy) throw new UnknownMigrationVersionError(key);
+    const applied = await this._appliedVersions();
+    if (direction === "up" && applied.has(key)) return;
+    if (direction === "down" && !applied.has(key)) return;
+    await this._runMigration(proxy, direction);
+  }
+
+  /**
+   * Run all pending migrations without acquiring the advisory lock.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#migrate_without_lock
+   */
+  async migrateWithoutLock(targetVersion?: number | string | null): Promise<void> {
+    await this._ensureSchemaTable();
+    await this._migrateUp(targetVersion ?? null);
+  }
+
+  /**
+   * Stamp the current environment name into ar_internal_metadata.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#record_environment
+   */
+  async recordEnvironment(): Promise<void> {
+    if (this._internalMetadata.enabled) {
+      await this._internalMetadata.set("environment", this._environment);
+    }
+  }
+
+  /**
+   * Return true if the migration at the given version has already been applied.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#ran?
+   */
+  async isRan(proxy: MigrationProxy): Promise<boolean> {
+    const applied = await this._appliedVersions();
+    return applied.has(proxy.version);
+  }
+
+  /**
+   * Return true if targetVersion is set but no matching migration exists.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#invalid_target?
+   */
+  isInvalidTarget(targetVersion?: string | number | null): boolean {
+    if (targetVersion === null || targetVersion === undefined) return false;
+    const key = String(BigInt(targetVersion));
+    return !this._migrations.some((m) => m.version === key);
+  }
+
+  /**
+   * Execute a single migration inside a DDL transaction.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction
+   */
+  async executeMigrationInTransaction(
+    proxy: MigrationProxy,
+    direction: "up" | "down" = "up",
+  ): Promise<void> {
+    await this._runMigration(proxy, direction);
+  }
+
+  /**
+   * Record that a version was applied or rolled back in schema_migrations.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#record_version_state_after_migrating
+   */
+  async recordVersionStateAfterMigrating(
+    version: string,
+    direction: "up" | "down" = "up",
+  ): Promise<void> {
+    if (direction === "up") {
+      await this._schemaMigration.recordVersion(version);
+    } else {
+      await this._schemaMigration.deleteVersion(version);
+    }
+  }
+
+  /**
+   * Wrap fn in a DDL transaction if the adapter and migration support it.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#ddl_transaction
+   */
+  async ddlTransaction(migration: MigrationLike, fn: () => Promise<void>): Promise<void> {
+    return this._ddlTransaction(migration, fn);
+  }
+
+  /**
+   * Return true if this migration should be wrapped in a DDL transaction.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#use_transaction?
+   */
+  isUseTransaction(migration: MigrationLike): boolean {
+    return this._useTransaction(migration);
+  }
+
+  /**
+   * Return true if the adapter supports advisory locks and they are enabled.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#use_advisory_lock?
+   */
+  isUseAdvisoryLock(): boolean {
+    return !!(this._adapter.supportsAdvisoryLocks?.() && this._adapter.getAdvisoryLock);
+  }
+
+  /**
+   * Acquire the migrator advisory lock, run fn, then release it.
+   * Raises ConcurrentMigrationError if the lock cannot be acquired.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#with_advisory_lock
+   */
+  async withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
+    return this._withAdvisoryLock(fn);
+  }
+
+  /**
+   * Return the integer lock ID used for the migrator advisory lock.
+   * Derived from a fixed salt (Rails uses Zlib.crc32 of "googol") so
+   * every process targeting the same database uses the same ID.
+   *
+   * @internal
+   * Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id
+   */
+  generateMigratorAdvisoryLockId(): number {
+    return Migrator._LOCK_ID;
   }
 
   /**
@@ -2308,92 +2476,6 @@ export class CheckPending {
     // In TS migrations are registered programmatically, not watched.
     return null;
   }
-}
-
-/** @internal */
-function runWithoutLock(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#run_without_lock is not implemented");
-}
-
-/** @internal */
-function migrateWithoutLock(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#migrate_without_lock is not implemented");
-}
-
-/** @internal */
-function recordEnvironment(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#record_environment is not implemented");
-}
-
-/** @internal */
-function isRan(migration: any): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#ran? is not implemented");
-}
-
-/** @internal */
-function isInvalidTarget(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#invalid_target? is not implemented");
-}
-
-/** @internal */
-function executeMigrationInTransaction(migration: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migrator#execute_migration_in_transaction is not implemented",
-  );
-}
-
-/** @internal */
-function finish(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#finish is not implemented");
-}
-
-/** @internal */
-function validate(migrations: any): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#validate is not implemented");
-}
-
-/** @internal */
-function recordVersionStateAfterMigrating(version: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migrator#record_version_state_after_migrating is not implemented",
-  );
-}
-
-/** @internal */
-function isUp(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#up? is not implemented");
-}
-
-/** @internal */
-function isDown(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#down? is not implemented");
-}
-
-/** @internal */
-function ddlTransaction(migration: any, block?: any): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#ddl_transaction is not implemented");
-}
-
-/** @internal */
-function isUseTransaction(migration: any): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#use_transaction? is not implemented");
-}
-
-/** @internal */
-function isUseAdvisoryLock(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#use_advisory_lock? is not implemented");
-}
-
-/** @internal */
-function withAdvisoryLock(): never {
-  throw new NotImplementedError("ActiveRecord::Migrator#with_advisory_lock is not implemented");
-}
-
-/** @internal */
-function generateMigratorAdvisoryLockId(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
-  );
 }
 
 /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1755,6 +1755,7 @@ export class Migrator {
   /** @internal Mirrors: ActiveRecord::Migrator#record_environment */
   async recordEnvironment(): Promise<void> {
     if (this._internalMetadata.enabled) {
+      await this._ensureSchemaTable();
       await this._internalMetadata.set("environment", this._environment);
     }
   }
@@ -1823,8 +1824,12 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
   async generateMigratorAdvisoryLockId(): Promise<bigint> {
-    // currentDatabase presence is already verified by _withAdvisoryLock before this is called.
-    const dbName = await this._adapter.currentDatabase!();
+    if (typeof this._adapter.currentDatabase !== "function") {
+      throw new Error(
+        `${this._adapter.constructor.name} must implement currentDatabase() to support advisory-locked migrations`,
+      );
+    }
+    const dbName = await this._adapter.currentDatabase();
     if (!dbName) {
       // currentDatabase() returned empty — adapter bug (MySQL stub returns "").
       // Fall back to the salt; file a fix for the adapter.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1593,6 +1593,11 @@ export class Migrator {
     ) {
       return fn();
     }
+    if (typeof adapter.currentDatabase !== "function") {
+      throw new Error(
+        `${adapter.constructor.name} must implement currentDatabase() to support advisory-locked migrations`,
+      );
+    }
     const lockId = await this.generateMigratorAdvisoryLockId();
     const locked = await adapter.getAdvisoryLock(lockId);
     if (!locked) {
@@ -1818,19 +1823,11 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
   async generateMigratorAdvisoryLockId(): Promise<bigint> {
-    const adapter = this._adapter;
-    if (typeof adapter.currentDatabase !== "function") {
-      // Rails always calls connection.current_database; a missing implementation is a
-      // bug in the adapter. Throw here so it surfaces rather than silently sharing a
-      // global lock ID across databases (which defeats multi-DB advisory-lock isolation).
-      throw new Error(
-        `${this._adapter.constructor.name} must implement currentDatabase() to support advisory-locked migrations`,
-      );
-    }
-    const dbName = await adapter.currentDatabase();
+    // currentDatabase presence is already verified by _withAdvisoryLock before this is called.
+    const dbName = await this._adapter.currentDatabase!();
     if (!dbName) {
       // currentDatabase() returned empty — adapter bug (MySQL stub returns "").
-      // Fall back to the salt so migrations don't hard-fail; file a fix for the adapter.
+      // Fall back to the salt; file a fix for the adapter.
       return BigInt(Migrator._MIGRATOR_SALT);
     }
     return BigInt(Migrator._MIGRATOR_SALT) * BigInt(_crc32(dbName));
@@ -2040,7 +2037,6 @@ export class Migrator {
    * scoped to `target_version` and calls `#run`).
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<void> {
-    this._validateTargetVersion(targetVersion);
     await this._withAdvisoryLock(() => this.runWithoutLock(direction, targetVersion));
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -40,11 +40,12 @@ export {
 
 import { ActiveRecordError, NotImplementedError } from "./errors.js";
 
-// Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial).
+// Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial) operating on UTF-8 bytes.
 function _crc32(str: string): number {
+  const bytes = new TextEncoder().encode(str);
   let crc = 0xffffffff;
-  for (let i = 0; i < str.length; i++) {
-    crc ^= str.charCodeAt(i);
+  for (const byte of bytes) {
+    crc ^= byte;
     for (let j = 0; j < 8; j++) {
       crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
     }
@@ -128,8 +129,7 @@ export class PendingMigrationError extends MigrationError {
 }
 
 export class ConcurrentMigrationError extends MigrationError {
-  static readonly RELEASE_LOCK_FAILED_MESSAGE =
-    "Failed to release advisory lock, which means the lock file could not be deleted.";
+  static readonly RELEASE_LOCK_FAILED_MESSAGE = "Failed to release advisory lock";
 
   constructor(message = "Cannot run migrations because another migration is currently running.") {
     super(message);
@@ -1043,7 +1043,7 @@ export abstract class Migration {
   static methodMissing(name: string, ...args: unknown[]): unknown {
     const delegate = this.nearestDelegate as Record<string, unknown> | null;
     if (delegate !== null && typeof delegate[name] === "function") {
-      return (delegate[name] as (...a: unknown[]) => unknown)(...args);
+      return (delegate[name] as (...a: unknown[]) => unknown).apply(delegate, args);
     }
     throw new TypeError(`undefined method '${name}' for ${this.name}`);
   }
@@ -1064,7 +1064,7 @@ export abstract class Migration {
     if (typeof conn[name] !== "function") {
       throw new TypeError(`undefined method '${name}' for ${this.adapter.constructor.name}`);
     }
-    return (conn[name] as (...a: unknown[]) => unknown)(...args);
+    return (conn[name] as (...a: unknown[]) => unknown).apply(conn, args);
   }
 
   /** @internal */
@@ -1700,6 +1700,7 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#run_without_lock */
   async runWithoutLock(direction: "up" | "down", targetVersion: string | number): Promise<void> {
+    this._validateTargetVersion(targetVersion);
     await this._ensureSchemaTable();
     const key = String(BigInt(targetVersion));
     const proxy = this._migrations.find((m) => m.version === key);
@@ -1732,8 +1733,12 @@ export class Migrator {
   /** @internal Mirrors: ActiveRecord::Migrator#invalid_target? */
   isInvalidTarget(targetVersion?: string | number | null): boolean {
     if (targetVersion === null || targetVersion === undefined) return false;
-    const key = String(BigInt(targetVersion));
-    return !this._migrations.some((m) => m.version === key);
+    try {
+      const key = String(BigInt(targetVersion));
+      return !this._migrations.some((m) => m.version === key);
+    } catch {
+      return true;
+    }
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction */
@@ -1777,13 +1782,15 @@ export class Migrator {
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */
-  async generateMigratorAdvisoryLockId(): Promise<number> {
+  async generateMigratorAdvisoryLockId(): Promise<bigint> {
     const adapter = this._adapter as unknown as { currentDatabase?(): Promise<string> };
     if (typeof adapter.currentDatabase === "function") {
       const dbName = await adapter.currentDatabase();
-      return Migrator._MIGRATOR_SALT * _crc32(dbName);
+      if (dbName) {
+        return BigInt(Migrator._MIGRATOR_SALT) * BigInt(_crc32(dbName));
+      }
     }
-    return Migrator._MIGRATOR_SALT;
+    return BigInt(Migrator._MIGRATOR_SALT);
   }
 
   /**

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -795,7 +795,7 @@ describe("Migrator advisory lock wrapping", () => {
     );
   });
 
-  it("uses db-scoped lock ID when adapter exposes currentDatabase", async () => {
+  it("uses db-scoped lock ID matching Rails MIGRATOR_SALT * Zlib.crc32(dbName)", async () => {
     const adapter = createTestAdapter();
     const lockIds: unknown[] = [];
     adapter.supportsAdvisoryLocks = () => true;
@@ -807,7 +807,8 @@ describe("Migrator advisory lock wrapping", () => {
     (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "myapp_test";
     const migrator = new Migrator(adapter, []);
     await migrator.migrate();
-    expect(typeof lockIds[0]).toBe("bigint");
-    expect(lockIds[0]).not.toBe(BigInt(2053462845));
+    // Ruby: Zlib.crc32("myapp_test") == 601888509
+    // Rails: MIGRATOR_SALT (2053462845) * 601888509 == 1235955690063948105
+    expect(lockIds[0]).toBe(1235955690063948105n);
   });
 });

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -670,10 +670,10 @@ describe("Migrator advisory lock wrapping", () => {
   });
 
   it("throws ConcurrentMigrationError when lock cannot be acquired", async () => {
-    const { ConcurrentMigrationError } = await import("./migration.js");
     const adapter = createTestAdapter();
     addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => false;
+    adapter.releaseAdvisoryLock = async () => true;
 
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
     await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -654,7 +654,7 @@ describe("Migrator advisory lock wrapping", () => {
   it("acquires and releases advisory lock when adapter supports it", async () => {
     const adapter = createTestAdapter();
     const lockLog: string[] = [];
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => {
       lockLog.push("lock");
       return true;
@@ -672,7 +672,7 @@ describe("Migrator advisory lock wrapping", () => {
   it("throws ConcurrentMigrationError when lock cannot be acquired", async () => {
     const { ConcurrentMigrationError } = await import("./migration.js");
     const adapter = createTestAdapter();
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => false;
 
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
@@ -682,7 +682,7 @@ describe("Migrator advisory lock wrapping", () => {
   it("releases lock even when migration throws", async () => {
     const adapter = createTestAdapter();
     const lockLog: string[] = [];
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => {
       lockLog.push("lock");
       return true;
@@ -711,7 +711,7 @@ describe("Migrator advisory lock wrapping", () => {
   it("wraps rollback in advisory lock", async () => {
     const adapter = createTestAdapter();
     const lockLog: string[] = [];
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => {
       lockLog.push("lock");
       return true;
@@ -731,7 +731,7 @@ describe("Migrator advisory lock wrapping", () => {
   it("wraps run in advisory lock", async () => {
     const adapter = createTestAdapter();
     const lockLog: string[] = [];
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => {
       lockLog.push("lock");
       return true;
@@ -746,10 +746,15 @@ describe("Migrator advisory lock wrapping", () => {
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
 
+  function addAdvisoryLockSupport(adapter: DatabaseAdapter) {
+    adapter.supportsAdvisoryLocks = () => true;
+    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "test_db";
+  }
+
   function lockableAdapter() {
     const adapter = createTestAdapter();
     const lockLog: string[] = [];
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => {
       lockLog.push("lock");
       return true;
@@ -786,7 +791,7 @@ describe("Migrator advisory lock wrapping", () => {
 
   it("raises ConcurrentMigrationError with RELEASE_LOCK_FAILED_MESSAGE when releaseAdvisoryLock returns false", async () => {
     const adapter = createTestAdapter();
-    adapter.supportsAdvisoryLocks = () => true;
+    addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => true;
     adapter.releaseAdvisoryLock = async () => false;
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
@@ -810,5 +815,30 @@ describe("Migrator advisory lock wrapping", () => {
     // Ruby: Zlib.crc32("myapp_test") == 601888509
     // Rails: MIGRATOR_SALT (2053462845) * 601888509 == 1235955690063948105
     expect(lockIds[0]).toBe(1235955690063948105n);
+  });
+
+  it("lock ID is deterministic for the same db name", async () => {
+    const adapter = createTestAdapter();
+    const lockIds: bigint[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async (id) => {
+      lockIds.push(id as bigint);
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => true;
+    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "myapp_test";
+    const migrator = new Migrator(adapter, []);
+    await migrator.migrate();
+    await migrator.migrate();
+    expect(lockIds[0]).toBe(lockIds[1]);
+  });
+
+  it("throws when adapter supports advisory locks but lacks currentDatabase()", async () => {
+    const adapter = createTestAdapter();
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => true;
+    adapter.releaseAdvisoryLock = async () => true;
+    const migrator = new Migrator(adapter, []);
+    await expect(migrator.migrate()).rejects.toThrow("must implement currentDatabase()");
   });
 });

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -4,6 +4,7 @@ import {
   Migrator,
   CheckPending,
   PendingMigrationError,
+  ConcurrentMigrationError,
   EnvironmentMismatchError,
   NoEnvironmentInSchemaError,
   ProtectedEnvironmentError,
@@ -781,5 +782,32 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
     await migrator.forward(1);
     expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("raises ConcurrentMigrationError with RELEASE_LOCK_FAILED_MESSAGE when releaseAdvisoryLock returns false", async () => {
+    const adapter = createTestAdapter();
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => true;
+    adapter.releaseAdvisoryLock = async () => false;
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await expect(migrator.migrate()).rejects.toThrow(
+      ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE,
+    );
+  });
+
+  it("uses db-scoped lock ID when adapter exposes currentDatabase", async () => {
+    const adapter = createTestAdapter();
+    const lockIds: unknown[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async (id) => {
+      lockIds.push(id);
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => true;
+    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "myapp_test";
+    const migrator = new Migrator(adapter, []);
+    await migrator.migrate();
+    expect(typeof lockIds[0]).toBe("bigint");
+    expect(lockIds[0]).not.toBe(BigInt(2053462845));
   });
 });

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -748,7 +748,7 @@ describe("Migrator advisory lock wrapping", () => {
 
   function addAdvisoryLockSupport(adapter: DatabaseAdapter) {
     adapter.supportsAdvisoryLocks = () => true;
-    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "test_db";
+    adapter.currentDatabase = async () => "test_db";
   }
 
   function lockableAdapter() {
@@ -809,7 +809,7 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
     adapter.releaseAdvisoryLock = async () => true;
-    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "myapp_test";
+    adapter.currentDatabase = async () => "myapp_test";
     const migrator = new Migrator(adapter, []);
     await migrator.migrate();
     // Ruby: Zlib.crc32("myapp_test") == 601888509
@@ -826,7 +826,7 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
     adapter.releaseAdvisoryLock = async () => true;
-    (adapter as unknown as Record<string, unknown>).currentDatabase = async () => "myapp_test";
+    adapter.currentDatabase = async () => "myapp_test";
     const migrator = new Migrator(adapter, []);
     await migrator.migrate();
     await migrator.migrate();


### PR DESCRIPTION
## Summary

Moves \`migration.rb\` from **80% → 93%** (90/97) by implementing 14 Rails-named methods across \`Migrator\` and \`Migration\`.

**\`Migrator\` (12 instance methods)**
- \`runWithoutLock\` — lock-free entry point; \`run\` delegates to it inside the advisory lock
- \`migrateWithoutLock\` — lock-free up-migration entry point (Rails API surface; our \`migrate\` handles bi-directional logic directly due to the auto-detect-direction feature that Rails handles via \`@direction\` instance state)
- \`recordEnvironment\`, \`isRan\`, \`isInvalidTarget\` — state helpers
- \`executeMigrationInTransaction\`, \`recordVersionStateAfterMigrating\` — transaction/version bookkeeping
- \`ddlTransaction\`, \`isUseTransaction\` — DDL transaction wrappers
- \`isUseAdvisoryLock\`, \`withAdvisoryLock\`, \`generateMigratorAdvisoryLockId\` — advisory lock surface

**\`Migration\` (2 methods)**
- \`static methodMissing\` — delegates unknown class-level calls to \`nearestDelegate\`
- \`instance methodMissing\` — delegates unknown instance calls to the adapter connection

**Advisory lock improvements (behavioral changes)**
- \`generateMigratorAdvisoryLockId\` computes \`MIGRATOR_SALT * Zlib.crc32(dbName)\` using \`bigint\` arithmetic. Throws with a clear message when \`currentDatabase()\` is absent. Returns the salt alone if \`currentDatabase()\` returns empty (MySQL stub gap — tracked as follow-up).
- \`_withAdvisoryLock\` guard requires all four: \`supportsAdvisoryLocks\`, \`getAdvisoryLock\`, \`releaseAdvisoryLock\`, \`currentDatabase\` — matching \`isUseAdvisoryLock()\`. Raises \`ConcurrentMigrationError(RELEASE_LOCK_FAILED_MESSAGE)\` on any non-\`true\` release result (matches Rails \`release_advisory_lock(...) or raise\`).
- \`run\` delegates to \`runWithoutLock\` inside the lock, matching Rails' \`def run; with_advisory_lock { run_without_lock }; end\`.
- Adapter interface widened: \`currentDatabase?()\` added; lock ID params accept \`bigint\`; PG uses \`\$1::bigint\` cast.

**Removes** 13 module-level \`throw NotImplementedError\` stubs that were invisible to \`api:compare\`.

## Known follow-up items (deferred)

- **MySQL \`currentDatabase()\` returns \`""\`** — \`AbstractMysqlAdapter.currentDatabase()\` is a stub returning empty string, so MySQL advisory migrations fall back to the bare salt as the lock name. Real implementation should query \`SELECT DATABASE()\`. Tracked separately.
- **PG \`releaseAdvisoryLock\` connection leak on unlock error** — If \`pg_advisory_unlock\` query throws, the pinned client is returned to the pool via \`finally\` and may still hold the lock. Should \`client.release(new Error(...))\` on the failure path so the pool destroys the connection. Pre-existing in the adapter; out of scope for this PR.
- **MySQL \`releaseAdvisoryLock\` same pattern** — Same issue: \`RELEASE_LOCK\` failure leaves the connection in the pool potentially holding the lock.

## Remaining (7 missing → PR 46c)
- \`inherited\`, \`[]\` (lifecycle/operator hooks)
- \`isAnySchemaNeedsUpdate\`, \`dbConfigsInCurrentEnv\`, \`loadSchemaBang\` (schema/env helpers)
- \`detailedMigrationMessage\`, \`connectionPool\` (PendingMigrationError helpers)

## Test plan
- [ ] \`pnpm api:compare --package activerecord\` shows migration.rb at 93%
- [ ] \`pnpm vitest run packages/activerecord/src/migrator.test.ts\` passes (58 tests including exact lock-ID assertion against \`Zlib.crc32("myapp_test") == 601888509\` verified in Ruby, failed-release raise, determinism, missing-\`currentDatabase\` throw)
- [ ] \`pnpm build\` / \`pnpm typecheck\` passes