### PR TITLE
fix(start-worktree): fail loudly when required source links are missing

### DIFF
--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -68,10 +68,21 @@ exec 9>&-
 # successful exit at the bottom of the file.
 WORKTREE_CREATED=1
 cleanup_partial_worktree() {
-  if [[ "${WORKTREE_CREATED:-0}" == 1 ]]; then
-    echo "==> Removing partial worktree $TARGET" >&2
-    git -C "$MAIN_REPO" worktree remove --force "$TARGET" 2>/dev/null || true
-    git -C "$MAIN_REPO" branch -D "$NAME" 2>/dev/null || true
+  if [[ "${WORKTREE_CREATED:-0}" != 1 ]]; then return; fi
+  echo "==> Removing partial worktree $TARGET" >&2
+  if ! git -C "$MAIN_REPO" worktree remove --force "$TARGET" 2>/dev/null; then
+    # `git worktree remove` can fail if the worktree got into an inconsistent
+    # state (eg. worktree dir was deleted out of band, lock files left over).
+    # Fall back to manually removing the directory and pruning so the next
+    # invocation of this script doesn't hit "Target already exists".
+    echo "    git worktree remove failed; falling back to rm -rf + git worktree prune" >&2
+    rm -rf "$TARGET"
+    git -C "$MAIN_REPO" worktree prune 2>/dev/null || true
+  fi
+  if ! git -C "$MAIN_REPO" branch -D "$NAME" 2>/dev/null; then
+    # Branch may not exist (worktree add failed before branch creation) or be
+    # already gone — log and continue rather than masking the EXIT status.
+    echo "    note: branch $NAME was not deletable (already gone or never created)" >&2
   fi
 }
 trap cleanup_partial_worktree EXIT
@@ -108,7 +119,11 @@ link_source() {
     done
     echo "    Recovery:" >&2
     if [[ -n "$donor" ]]; then
-      echo "      cp -r $(printf %q "$donor") $(printf %q "$src")" >&2
+      # Prepend `rm -rf` so the recovery works whether $src is missing OR a
+      # broken self-referential symlink. `[[ ! -e ]]` is true for broken
+      # symlinks (the link exists but the target doesn't), and `cp` would
+      # otherwise fail to overwrite the dangling link with a directory.
+      echo "      rm -rf $(printf %q "$src") && cp -r $(printf %q "$donor") $(printf %q "$src")" >&2
     else
       echo "      No sibling worktree has $rel either. Re-run the appropriate fetch" >&2
       echo "      script (e.g. scripts/api-compare/fetch-rails.sh for .rails-source)" >&2

--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -62,13 +62,59 @@ git -C "$MAIN_REPO" worktree add -b "$NAME" "$TARGET" origin/main
 flock -u 9
 exec 9>&-
 
+# If anything below this point fails (e.g. a required link_source missing,
+# pnpm install dying), tear down the half-created worktree so the operator
+# can re-run the script after fixing the underlying issue. Cleared on the
+# successful exit at the bottom of the file.
+WORKTREE_CREATED=1
+cleanup_partial_worktree() {
+  if [[ "${WORKTREE_CREATED:-0}" == 1 ]]; then
+    echo "==> Removing partial worktree $TARGET" >&2
+    git -C "$MAIN_REPO" worktree remove --force "$TARGET" 2>/dev/null || true
+    git -C "$MAIN_REPO" branch -D "$NAME" 2>/dev/null || true
+  fi
+}
+trap cleanup_partial_worktree EXIT
+
 link_source() {
+  # Symlink a path from the main worktree into the new worktree.
+  # `required` (default) — exit 1 with a recovery hint if the source is missing.
+  # `optional`            — log a skip and continue.
+  #
+  # Required because PR #1260 demonstrated this class of silent failure:
+  # `.claude/skills` was untracked from git but no longer present in main,
+  # so new worktrees got a "skip" log line and agents launched without
+  # prompt-agent / link / copilot-review skills. Failing fast forces the
+  # operator to restore the source before spawning agents that depend on it.
   local rel="$1"
+  local mode="${2:-required}"
   local src="$MAIN_REPO/$rel"
   local dst="$TARGET/$rel"
   if [[ ! -e "$src" ]]; then
-    echo "    skip $rel (not present in main worktree)"
-    return
+    if [[ "$mode" == "optional" ]]; then
+      echo "    skip $rel (not present in main worktree, optional)"
+      return
+    fi
+    echo "    ERROR: required source $rel is missing from main worktree at $src" >&2
+    echo "    The new worktree cannot be set up without it." >&2
+    # Look for a sibling worktree that still has this path so we can suggest
+    # a precise recovery command rather than a placeholder.
+    local donor=""
+    for candidate in "$WORKTREES_ROOT"/*/"$rel"; do
+      if [[ -e "$candidate" ]]; then
+        donor="$candidate"
+        break
+      fi
+    done
+    echo "    Recovery:" >&2
+    if [[ -n "$donor" ]]; then
+      echo "      cp -r $(printf %q "$donor") $(printf %q "$src")" >&2
+    else
+      echo "      No sibling worktree has $rel either. Re-run the appropriate fetch" >&2
+      echo "      script (e.g. scripts/api-compare/fetch-rails.sh for .rails-source)" >&2
+      echo "      or copy from a backup." >&2
+    fi
+    exit 1
   fi
   mkdir -p "$(dirname "$dst")"
   rm -rf "$dst"
@@ -78,14 +124,16 @@ link_source() {
 
 echo "==> Linking Rails and Rack source from main worktree"
 link_source "scripts/api-compare/.rails-source"
-link_source "scripts/api-compare/.rack-source"
+link_source "scripts/api-compare/.rack-source" optional
 
 echo "==> Linking .claude config from main worktree (skills + per-machine permissions)"
 link_source ".claude/skills"
-link_source ".claude/settings.local.json"
+link_source ".claude/settings.local.json" optional
 
 echo "==> Running pnpm install"
 ( cd "$TARGET" && pnpm install )
+
+WORKTREE_CREATED=0  # success — disable EXIT-trap cleanup
 
 echo
 echo "Done. New worktree:"


### PR DESCRIPTION
## What's broken

PR #1260's `git rm` of the self-referential `.claude/skills` symlink left main worktrees missing the actual skills directory. New worktrees spawned afterwards silently skipped the `.claude/skills` link with a quiet log line:

```
==> Linking .claude config from main worktree (skills + per-machine permissions)
    skip .claude/skills (not present in main worktree)
```

Agents in those worktrees launched without `prompt-agent` / `link` / `copilot-review` / `screenshot` / `workon`, and the failure was invisible until they tried to invoke one. Hit this on **four** worktrees today (PR 18, PR 3, PR 48, PR 37) — each required manually copying skills into main and symlinking into the affected worktree.

## Fix

Three changes to `scripts/start-worktree.sh`:

**1. `link_source` defaults to `required` and fails loudly.**
A required source missing prints a precise recovery command — it scans `~/github/blazetrailsdev/worktrees/*` for a donor that still has the file and prints the exact `cp` invocation, not a `<some-active>` placeholder. `.rack-source` and `settings.local.json` are explicitly marked `optional`.

**2. EXIT trap removes the half-created worktree on failure.**
Previously, a failed `link_source` (or `pnpm install`) left an orphan worktree dir + branch behind that the operator had to clean up by hand. Trap clears the flag on success.

**3. Comment block on `link_source` cites #1260.**
So the next maintainer reading "why required?" doesn't have to dig through git history.

## Before / after (real output, captured by moving `.claude/skills` aside and re-running)

**Before:**
```
==> Linking .claude config from main worktree (skills + per-machine permissions)
    skip .claude/skills (not present in main worktree)
==> Running pnpm install
... (succeeds, agents launch broken)
```

**After:**
```
==> Linking .claude config from main worktree (skills + per-machine permissions)
    ERROR: required source .claude/skills is missing from main worktree at /home/dean/github/blazetrailsdev/trails/.claude/skills
    The new worktree cannot be set up without it.
    Recovery:
      cp -r /home/dean/github/blazetrailsdev/worktrees/implement-pr-p3-of-the-activerecord-test/.claude/skills /home/dean/github/blazetrailsdev/trails/.claude/skills
==> Removing partial worktree /home/dean/github/blazetrailsdev/worktrees/test-cleanup-1778094307
Deleted branch test-cleanup-1778094307 (was afd94eaaa).
$ echo $?
1
```

## Test plan

- [x] `bash -n scripts/start-worktree.sh` parses
- [x] **Fail path:** moved `.claude/skills` aside, ran the script — exits 1, prints the precise recovery hint pointing at an actual sibling worktree, removes the half-created worktree dir and branch automatically.
- [x] **Happy path:** with `.claude/skills` present, new worktree gets the symlink, exits 0, agent skills work (`.claude/skills/prompt-agent/run.sh` resolves).
- [x] **No-donor case:** if no sibling worktree has the missing file, the recovery hint falls back to "re-run the appropriate fetch script or copy from a backup" (verified by reading the branch; not exercised because all current worktrees have skills).

## Related

- #1260 — untracked the broken self-referential symlink that originally created this class of failure.