### PR TITLE
feat(activerecord): tasks cluster to 100% (PR 51)

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1300,8 +1300,18 @@ describe("eachCurrentEnvironment", () => {
     expect(eachCurrentEnvironment("development")).toEqual(["development"]);
   });
 
+  it("skips test expansion when SKIP_TEST_DATABASE is set to empty string", () => {
+    process.env.SKIP_TEST_DATABASE = "";
+    expect(eachCurrentEnvironment("development")).toEqual(["development"]);
+  });
+
   it("skips test expansion when DATABASE_URL is set", () => {
     process.env.DATABASE_URL = "sqlite3::memory:";
+    expect(eachCurrentEnvironment("development")).toEqual(["development"]);
+  });
+
+  it("skips test expansion when DATABASE_URL is set to empty string", () => {
+    process.env.DATABASE_URL = "";
     expect(eachCurrentEnvironment("development")).toEqual(["development"]);
   });
 });
@@ -1395,8 +1405,7 @@ describe("initializeDatabase", () => {
   });
 
   it("re-throws unexpected errors from the probe query", async () => {
-    const origConnect = (DatabaseTasks as any)._connectFor.bind(DatabaseTasks);
-    (DatabaseTasks as any)._connectFor = async () => ({
+    const spy = vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
       execute: async () => {
         throw new Error("unexpected connection error");
       },
@@ -1409,7 +1418,7 @@ describe("initializeDatabase", () => {
       });
       await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
     } finally {
-      (DatabaseTasks as any)._connectFor = origConnect;
+      spy.mockRestore();
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1470,7 +1470,6 @@ describe("initializeDatabase", () => {
       });
       vi.spyOn(DatabaseTasks, "create").mockResolvedValue(undefined);
       const loadSchemaSpy = vi.spyOn(DatabaseTasks, "loadSchema").mockResolvedValue(undefined);
-      const origPath = DatabaseTasks.schemaDumpPath;
       vi.spyOn(DatabaseTasks, "schemaDumpPath").mockReturnValue(schemaFile);
       const config = new HashConfig("test", "primary", {
         adapter: "sqlite3",

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1244,3 +1244,172 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
     }
   });
 });
+
+import {
+  isVerbose,
+  eachCurrentEnvironment,
+  schemaSha1,
+  structureDumpFlagsFor,
+  structureLoadFlagsFor,
+  initializeDatabase,
+} from "./database-tasks.js";
+
+describe("isVerbose", () => {
+  afterEach(() => {
+    delete (process.env as Record<string, string | undefined>).VERBOSE;
+  });
+
+  it("returns true by default", () => {
+    delete (process.env as Record<string, string | undefined>).VERBOSE;
+    expect(isVerbose()).toBe(true);
+  });
+
+  it("returns false when VERBOSE=false", () => {
+    process.env.VERBOSE = "false";
+    expect(isVerbose()).toBe(false);
+  });
+
+  it("returns true when VERBOSE=true", () => {
+    process.env.VERBOSE = "true";
+    expect(isVerbose()).toBe(true);
+  });
+
+  it("returns true for any non-false value", () => {
+    process.env.VERBOSE = "1";
+    expect(isVerbose()).toBe(true);
+  });
+});
+
+describe("eachCurrentEnvironment", () => {
+  afterEach(() => {
+    delete (process.env as Record<string, string | undefined>).SKIP_TEST_DATABASE;
+    delete (process.env as Record<string, string | undefined>).DATABASE_URL;
+  });
+
+  it("returns single env for non-development", () => {
+    expect(eachCurrentEnvironment("test")).toEqual(["test"]);
+    expect(eachCurrentEnvironment("production")).toEqual(["production"]);
+  });
+
+  it("expands development to include test", () => {
+    expect(eachCurrentEnvironment("development")).toEqual(["development", "test"]);
+  });
+
+  it("skips test expansion when SKIP_TEST_DATABASE is set", () => {
+    process.env.SKIP_TEST_DATABASE = "1";
+    expect(eachCurrentEnvironment("development")).toEqual(["development"]);
+  });
+
+  it("skips test expansion when DATABASE_URL is set", () => {
+    process.env.DATABASE_URL = "sqlite3::memory:";
+    expect(eachCurrentEnvironment("development")).toEqual(["development"]);
+  });
+});
+
+describe("schemaSha1", () => {
+  it("returns a 40-char hex SHA1 of the file contents", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
+    const file = path.join(tmp, "schema.ts");
+    try {
+      fs.writeFileSync(file, "export default () => {};");
+      const result = schemaSha1(file);
+      expect(result).toMatch(/^[0-9a-f]{40}$/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns different hashes for different content", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
+    const a = path.join(tmp, "a.ts");
+    const b = path.join(tmp, "b.ts");
+    try {
+      fs.writeFileSync(a, "content A");
+      fs.writeFileSync(b, "content B");
+      expect(schemaSha1(a)).not.toBe(schemaSha1(b));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("structureDumpFlagsFor / structureLoadFlagsFor", () => {
+  afterEach(() => {
+    DatabaseTasks.structureDumpFlags = null;
+    DatabaseTasks.structureLoadFlags = null;
+  });
+
+  it("returns null when flags are not set", () => {
+    expect(structureDumpFlagsFor("sqlite3")).toBeNull();
+    expect(structureLoadFlagsFor("sqlite3")).toBeNull();
+  });
+
+  it("returns the flat string/array value regardless of adapter", () => {
+    DatabaseTasks.structureDumpFlags = "--no-create-db";
+    expect(structureDumpFlagsFor("sqlite3")).toBe("--no-create-db");
+    DatabaseTasks.structureLoadFlags = ["--verbose"];
+    expect(structureLoadFlagsFor("mysql2")).toEqual(["--verbose"]);
+  });
+
+  it("returns adapter-specific flags from a hash", () => {
+    DatabaseTasks.structureDumpFlags = { sqlite3: "--compact", mysql2: "--no-data" };
+    expect(structureDumpFlagsFor("sqlite3")).toBe("--compact");
+    expect(structureDumpFlagsFor("mysql2")).toBe("--no-data");
+    expect(structureDumpFlagsFor("postgresql")).toBeNull();
+  });
+});
+
+describe("initializeDatabase", () => {
+  afterEach(() => {
+    DatabaseTasks.setAdapter(null);
+  });
+
+  it("returns true (fresh DB) when schema_migrations table does not exist", async () => {
+    // In-memory SQLite: SELECT 1 succeeds (DB exists), but schema_migrations is absent.
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    const result = await initializeDatabase(config);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when schema_migrations table already exists", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-initdb-"));
+    const dbFile = path.join(tmp, "test.sqlite3");
+    try {
+      // Pre-create the DB file with schema_migrations so initializeDatabase sees it.
+      const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+      const setup = new SQLite3Adapter(dbFile);
+      await setup.executeMutation(
+        "CREATE TABLE schema_migrations (version VARCHAR(255) NOT NULL PRIMARY KEY)",
+      );
+      await (setup as unknown as { close(): Promise<void> }).close();
+
+      const config = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: dbFile,
+      });
+      const result = await initializeDatabase(config);
+      expect(result).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("re-throws unexpected errors from the probe query", async () => {
+    const origConnect = (DatabaseTasks as any)._connectFor.bind(DatabaseTasks);
+    (DatabaseTasks as any)._connectFor = async () => ({
+      execute: async () => {
+        throw new Error("unexpected connection error");
+      },
+      close: async () => {},
+    });
+    try {
+      const config = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: ":memory:",
+      });
+      await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
+    } finally {
+      (DatabaseTasks as any)._connectFor = origConnect;
+    }
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1372,6 +1372,7 @@ describe("structureDumpFlagsFor / structureLoadFlagsFor", () => {
 describe("initializeDatabase", () => {
   afterEach(() => {
     DatabaseTasks.setAdapter(null);
+    vi.restoreAllMocks();
   });
 
   it("returns true (fresh DB) when schema_migrations table does not exist", async () => {
@@ -1405,20 +1406,16 @@ describe("initializeDatabase", () => {
   });
 
   it("re-throws unexpected errors from the probe query", async () => {
-    const spy = vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
       execute: async () => {
         throw new Error("unexpected connection error");
       },
       close: async () => {},
     });
-    try {
-      const config = new HashConfig("test", "primary", {
-        adapter: "sqlite3",
-        database: ":memory:",
-      });
-      await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
-    } finally {
-      spy.mockRestore();
-    }
+    const config = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: ":memory:",
+    });
+    await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -3,7 +3,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
-import { DatabaseTasks, DatabaseNotSupported } from "./database-tasks.js";
+import {
+  DatabaseTasks,
+  DatabaseNotSupported,
+  isVerbose,
+  eachCurrentEnvironment,
+  schemaSha1,
+  structureDumpFlagsFor,
+  structureLoadFlagsFor,
+  initializeDatabase,
+} from "./database-tasks.js";
 import { quoteTableName as mysqlQuoteTableName } from "../connection-adapters/mysql/quoting.js";
 import { quoteTableName as abstractQuoteTableName } from "../connection-adapters/abstract/quoting.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
@@ -1244,15 +1253,6 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
     }
   });
 });
-
-import {
-  isVerbose,
-  eachCurrentEnvironment,
-  schemaSha1,
-  structureDumpFlagsFor,
-  structureLoadFlagsFor,
-  initializeDatabase,
-} from "./database-tasks.js";
 
 describe("isVerbose", () => {
   afterEach(() => {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1307,26 +1307,26 @@ describe("eachCurrentEnvironment", () => {
 });
 
 describe("schemaSha1", () => {
-  it("returns a 40-char hex SHA1 of the file contents", () => {
+  it("returns a 40-char hex SHA1 of the file contents", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
     const file = path.join(tmp, "schema.ts");
     try {
       fs.writeFileSync(file, "export default () => {};");
-      const result = schemaSha1(file);
+      const result = await schemaSha1(file);
       expect(result).toMatch(/^[0-9a-f]{40}$/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 
-  it("returns different hashes for different content", () => {
+  it("returns different hashes for different content", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
     const a = path.join(tmp, "a.ts");
     const b = path.join(tmp, "b.ts");
     try {
       fs.writeFileSync(a, "content A");
       fs.writeFileSync(b, "content B");
-      expect(schemaSha1(a)).not.toBe(schemaSha1(b));
+      expect(await schemaSha1(a)).not.toBe(await schemaSha1(b));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -18,6 +18,7 @@ import { quoteTableName as abstractQuoteTableName } from "../connection-adapters
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { NoDatabaseError } from "../errors.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
   it("raises an error when called with protected environment", async () => {
@@ -1417,5 +1418,68 @@ describe("initializeDatabase", () => {
       database: ":memory:",
     });
     await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
+  });
+
+  it("creates the DB and returns true when probe throws NoDatabaseError", async () => {
+    let created = false;
+    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+      execute: async () => {
+        throw new NoDatabaseError("no database");
+      },
+      close: async () => {},
+    });
+    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
+      created = true;
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    const result = await initializeDatabase(config);
+    expect(created).toBe(true);
+    expect(result).toBe(true);
+  });
+
+  it("creates the DB and returns true when probe throws MySQL ER_BAD_DB_ERROR", async () => {
+    let created = false;
+    const mysqlErr = Object.assign(new Error("Unknown database 'mydb'"), {
+      code: "ER_BAD_DB_ERROR",
+    });
+    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+      execute: async () => {
+        throw mysqlErr;
+      },
+      close: async () => {},
+    });
+    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
+      created = true;
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    const result = await initializeDatabase(config);
+    expect(created).toBe(true);
+    expect(result).toBe(true);
+  });
+
+  it("loads schema dump when DB is fresh and dump file exists", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-initdb-schema-"));
+    const schemaFile = path.join(tmp, "schema.ts");
+    fs.writeFileSync(schemaFile, "export default async () => {};");
+    try {
+      vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+        execute: async () => {
+          throw new NoDatabaseError("no database");
+        },
+        close: async () => {},
+      });
+      vi.spyOn(DatabaseTasks, "create").mockResolvedValue(undefined);
+      const loadSchemaSpy = vi.spyOn(DatabaseTasks, "loadSchema").mockResolvedValue(undefined);
+      const origPath = DatabaseTasks.schemaDumpPath;
+      vi.spyOn(DatabaseTasks, "schemaDumpPath").mockReturnValue(schemaFile);
+      const config = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: ":memory:",
+      });
+      await initializeDatabase(config);
+      expect(loadSchemaSpy).toHaveBeenCalled();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1102,7 +1102,7 @@ export function isVerbose(): boolean {
 
 /** @internal */
 export function databaseAdapterFor(
-  dbConfig: DatabaseConfig,
+  _dbConfig: DatabaseConfig,
   ...arguments_: unknown[]
 ): import("../adapter.js").DatabaseAdapter | null {
   void arguments_;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1089,10 +1089,8 @@ export async function withTemporaryPool(
 
 /** @internal */
 export function resolveConfiguration(configuration: unknown): DatabaseConfig {
-  if (!DatabaseTasks.databaseConfiguration) {
-    throw new Error("DatabaseTasks.databaseConfiguration is not set");
-  }
-  return DatabaseTasks.databaseConfiguration.resolve(configuration);
+  const configs = DatabaseTasks.databaseConfiguration ?? new DatabaseConfigurations([]);
+  return configs.resolve(configuration);
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -911,11 +911,7 @@ export class DatabaseTasks {
   }
 
   private static async _schemaSha1(filename: string): Promise<string> {
-    const contents = getFs().readFileSync(filename, "utf-8");
-    const crypto = await getCryptoAsync();
-    const hash = crypto.createHash("sha1");
-    hash.update(contents);
-    return hash.digest("hex");
+    return _sha1File(filename);
   }
 
   /**
@@ -1138,7 +1134,11 @@ export function eachCurrentConfiguration(environment: string, name?: string): Da
 /** @internal */
 export function eachCurrentEnvironment(environment: string): string[] {
   const envs = [environment];
-  if (environment === "development" && !getEnv("SKIP_TEST_DATABASE") && !getEnv("DATABASE_URL")) {
+  if (
+    environment === "development" &&
+    getEnv("SKIP_TEST_DATABASE") === undefined &&
+    getEnv("DATABASE_URL") === undefined
+  ) {
     envs.push("test");
   }
   return envs;
@@ -1151,11 +1151,15 @@ export function isLocalDatabase(dbConfig: DatabaseConfig): boolean {
 }
 
 /** @internal */
-export async function schemaSha1(file: string): Promise<string> {
-  const contents = getFs().readFileSync(file, "utf-8");
+export function schemaSha1(file: string): Promise<string> {
+  return _sha1File(file);
+}
+
+async function _sha1File(filename: string): Promise<string> {
+  const bytes = getFs().readFileSync(filename);
   const crypto = await getCryptoAsync();
   const hash = crypto.createHash("sha1");
-  hash.update(contents);
+  hash.update(bytes);
   return hash.digest("hex");
 }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1208,9 +1208,14 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
       }
     }
     if (!alreadyInitialized) {
-      const schemaDumpPath = DatabaseTasks.schemaDumpPath(dbConfig);
-      if (schemaDumpPath && getFs().existsSync(schemaDumpPath)) {
-        await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat);
+      const rawPath = DatabaseTasks.schemaDumpPath(dbConfig);
+      if (rawPath) {
+        const p = getPath();
+        const resolved =
+          p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
+        if (getFs().existsSync(resolved)) {
+          await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
+        }
       }
     }
     return !alreadyInitialized;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -599,10 +599,7 @@ export class DatabaseTasks {
 
   private static _environmentsFor(environment?: string): string[] {
     const env = this._normalizeEnv(environment);
-    if (!environment?.trim() && env === "development") {
-      return ["development", "test"];
-    }
-    return [env];
+    return eachCurrentEnvironment(env);
   }
 
   static async structureDump(

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,14 +7,7 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import {
-  getFs,
-  getPath,
-  getCrypto,
-  getCryptoAsync,
-  getOs,
-  getEnv,
-} from "@blazetrails/activesupport";
+import { getFs, getPath, getCryptoAsync, getOs, getEnv } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
 /**
@@ -1158,9 +1151,10 @@ export function isLocalDatabase(dbConfig: DatabaseConfig): boolean {
 }
 
 /** @internal */
-export function schemaSha1(file: string): string {
+export async function schemaSha1(file: string): Promise<string> {
   const contents = getFs().readFileSync(file, "utf-8");
-  const hash = getCrypto().createHash("sha1");
+  const crypto = await getCryptoAsync();
+  const hash = crypto.createHash("sha1");
   hash.update(contents);
   return hash.digest("hex");
 }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1193,22 +1193,26 @@ export async function checkCurrentProtectedEnvironmentBang(
 /** @internal */
 export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<boolean> {
   return DatabaseTasks.withTemporaryConnection(dbConfig, async () => {
+    const adapter = DatabaseTasks.migrationConnection()!;
+    const { NoDatabaseError } = await import("../errors.js");
     const { SchemaMigration } = await import("../schema-migration.js");
-    const adapter = DatabaseTasks.migrationConnection();
-    if (!adapter) return false;
-    let alreadyInitialized: boolean;
+    let alreadyInitialized = false;
     try {
+      // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
+      // tableExists() swallows all errors internally so can't detect a missing DB.
+      await adapter.execute("SELECT 1");
       const sm = new SchemaMigration(adapter);
       alreadyInitialized = await sm.tableExists();
-    } catch {
-      await DatabaseTasks.create(dbConfig);
-      const sm = new SchemaMigration(adapter);
-      alreadyInitialized = await sm.tableExists();
+    } catch (error) {
+      if (error instanceof NoDatabaseError) {
+        await DatabaseTasks.create(dbConfig);
+      } else {
+        throw error;
+      }
     }
     if (!alreadyInitialized) {
       const schemaDumpPath = DatabaseTasks.schemaDumpPath(dbConfig);
-      const { getFs: fs } = await import("@blazetrails/activesupport");
-      if (schemaDumpPath && fs().existsSync(schemaDumpPath)) {
+      if (schemaDumpPath && getFs().existsSync(schemaDumpPath)) {
         await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat);
       }
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,7 +7,14 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs, getPath, getCryptoAsync, getOs, getEnv } from "@blazetrails/activesupport";
+import {
+  getFs,
+  getPath,
+  getCrypto,
+  getCryptoAsync,
+  getOs,
+  getEnv,
+} from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
 /**
@@ -1153,15 +1160,9 @@ export function isLocalDatabase(dbConfig: DatabaseConfig): boolean {
 /** @internal */
 export function schemaSha1(file: string): string {
   const contents = getFs().readFileSync(file, "utf-8");
-  const nodeCrypto = (
-    globalThis as {
-      require?: (mod: string) => {
-        createHash(a: string): { update(d: string): { digest(e: string): string } };
-      };
-    }
-  ).require?.("node:crypto");
-  if (!nodeCrypto) throw new Error("schemaSha1 requires a Node.js crypto module");
-  return nodeCrypto.createHash("sha1").update(contents).digest("hex");
+  const hash = getCrypto().createHash("sha1");
+  hash.update(contents);
+  return hash.digest("hex");
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1092,7 +1092,7 @@ function truncateTables(dbConfig: any): never {
 }
 
 /** @internal */
-function withTemporaryPool(dbConfig: any, clobber?: any): never {
+export function withTemporaryPool(dbConfig: any, clobber?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#with_temporary_pool is not implemented",
   );
@@ -1106,40 +1106,40 @@ function configsFor(options?: any): never {
 }
 
 /** @internal */
-function resolveConfiguration(configuration: any): never {
+export function resolveConfiguration(configuration: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#resolve_configuration is not implemented",
   );
 }
 
 /** @internal */
-function isVerbose(): never {
+export function isVerbose(): never {
   throw new NotImplementedError("ActiveRecord::Tasks::DatabaseTasks#verbose? is not implemented");
 }
 
 /** @internal */
-function databaseAdapterFor(dbConfig: any, ...arguments_: any[]): never {
+export function databaseAdapterFor(dbConfig: any, ...arguments_: any[]): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#database_adapter_for is not implemented",
   );
 }
 
 /** @internal */
-function classForAdapter(adapter: any): never {
+export function classForAdapter(adapter: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#class_for_adapter is not implemented",
   );
 }
 
 /** @internal */
-function eachCurrentConfiguration(environment: any, name?: any): never {
+export function eachCurrentConfiguration(environment: any, name?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#each_current_configuration is not implemented",
   );
 }
 
 /** @internal */
-function eachCurrentEnvironment(environment: any, block?: any): never {
+export function eachCurrentEnvironment(environment: any, block?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#each_current_environment is not implemented",
   );
@@ -1153,42 +1153,42 @@ function eachLocalConfiguration(): never {
 }
 
 /** @internal */
-function isLocalDatabase(dbConfig: any): never {
+export function isLocalDatabase(dbConfig: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#local_database? is not implemented",
   );
 }
 
 /** @internal */
-function schemaSha1(file: any): never {
+export function schemaSha1(file: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#schema_sha1 is not implemented",
   );
 }
 
 /** @internal */
-function structureDumpFlagsFor(adapter: any): never {
+export function structureDumpFlagsFor(adapter: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#structure_dump_flags_for is not implemented",
   );
 }
 
 /** @internal */
-function structureLoadFlagsFor(adapter: any): never {
+export function structureLoadFlagsFor(adapter: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#structure_load_flags_for is not implemented",
   );
 }
 
 /** @internal */
-function checkCurrentProtectedEnvironmentBang(dbConfig: any): never {
+export function checkCurrentProtectedEnvironmentBang(dbConfig: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#check_current_protected_environment! is not implemented",
   );
 }
 
 /** @internal */
-function initializeDatabase(dbConfig: any): never {
+export function initializeDatabase(dbConfig: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#initialize_database is not implemented",
   );

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::DatabaseTasks
  */
 
-import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
 import { getFs, getPath, getCryptoAsync, getOs, getEnv } from "@blazetrails/activesupport";
@@ -1089,7 +1089,11 @@ export async function withTemporaryPool(
 
 /** @internal */
 export function resolveConfiguration(configuration: unknown): DatabaseConfig {
-  const configs = DatabaseTasks.databaseConfiguration ?? new DatabaseConfigurations([]);
+  // DatabaseConfig instances don't need a configurations registry — return as-is.
+  // Avoids constructing a new DatabaseConfigurations (which mutates the global singleton).
+  if (configuration instanceof DatabaseConfig) return configuration;
+  const configs = DatabaseTasks.databaseConfiguration;
+  if (!configs) throw new Error("DatabaseTasks.databaseConfiguration is not set");
   return configs.resolve(configuration);
 }
 
@@ -1200,7 +1204,7 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
       const sm = new SchemaMigration(adapter);
       alreadyInitialized = await sm.tableExists();
     } catch (error) {
-      if (error instanceof NoDatabaseError) {
+      if (error instanceof NoDatabaseError || _isMissingDatabaseError(error)) {
         await DatabaseTasks.create(dbConfig);
       } else {
         throw error;
@@ -1214,4 +1218,14 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
     }
     return !alreadyInitialized;
   });
+}
+
+function _isMissingDatabaseError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: unknown; errno?: unknown; message?: unknown };
+  // MySQL: ER_BAD_DB_ERROR (errno 1049) — adapter doesn't translate this to NoDatabaseError yet
+  if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) return true;
+  // PostgreSQL: SQLSTATE 3D000 "invalid_catalog_name" — database does not exist
+  if (e.code === "3D000") return true;
+  return false;
 }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1217,12 +1217,17 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
   });
 }
 
+// TODO: remove _isMissingDatabaseError once mysql2-adapter translates ER_BAD_DB_ERROR to
+// NoDatabaseError at the connection level (matching how postgresql-adapter already does in
+// newClient). The 3D000 branch is dead code for PG today because connection failures are
+// already translated by PostgreSQLAdapter.newClient before SELECT 1 runs.
 function _isMissingDatabaseError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const e = error as { code?: unknown; errno?: unknown; message?: unknown };
+  const e = error as { code?: unknown; errno?: unknown };
   // MySQL: ER_BAD_DB_ERROR (errno 1049) — adapter doesn't translate this to NoDatabaseError yet
   if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) return true;
-  // PostgreSQL: SQLSTATE 3D000 "invalid_catalog_name" — database does not exist
+  // PostgreSQL: SQLSTATE 3D000 — dead code today since PG translates at connection time,
+  // kept as a defensive fallback in case the SQL-level error surfaces through a pool proxy.
   if (e.code === "3D000") return true;
   return false;
 }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1080,11 +1080,11 @@ export interface DatabaseTaskHandler {
 }
 
 /** @internal */
-export async function withTemporaryPool(
+export async function withTemporaryPool<T = void>(
   dbConfig: DatabaseConfig,
-  fn: (adapter: import("../adapter.js").DatabaseAdapter) => Promise<void>,
-): Promise<void> {
-  await DatabaseTasks.withTemporaryConnection(dbConfig, fn);
+  fn: (adapter: import("../adapter.js").DatabaseAdapter) => Promise<T>,
+): Promise<T> {
+  return DatabaseTasks.withTemporaryConnection(dbConfig, fn);
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::Tasks::DatabaseTasks
  */
 
-import { NotImplementedError } from "../errors.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
@@ -1085,111 +1084,133 @@ export interface DatabaseTaskHandler {
 }
 
 /** @internal */
-function truncateTables(dbConfig: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#truncate_tables is not implemented",
-  );
+export async function withTemporaryPool(
+  dbConfig: DatabaseConfig,
+  fn: (adapter: import("../adapter.js").DatabaseAdapter) => Promise<void>,
+): Promise<void> {
+  await DatabaseTasks.withTemporaryConnection(dbConfig, fn);
 }
 
 /** @internal */
-export function withTemporaryPool(dbConfig: any, clobber?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#with_temporary_pool is not implemented",
-  );
+export function resolveConfiguration(configuration: unknown): DatabaseConfig {
+  if (!DatabaseTasks.databaseConfiguration) {
+    throw new Error("DatabaseTasks.databaseConfiguration is not set");
+  }
+  return DatabaseTasks.databaseConfiguration.resolve(configuration);
 }
 
 /** @internal */
-function configsFor(options?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#configs_for is not implemented",
-  );
+export function isVerbose(): boolean {
+  const v = getEnv("VERBOSE");
+  return v !== undefined ? v !== "false" : true;
 }
 
 /** @internal */
-export function resolveConfiguration(configuration: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#resolve_configuration is not implemented",
-  );
+export function databaseAdapterFor(
+  dbConfig: DatabaseConfig,
+  ...arguments_: unknown[]
+): import("../adapter.js").DatabaseAdapter | null {
+  void arguments_;
+  return DatabaseTasks.migrationConnection();
 }
 
 /** @internal */
-export function isVerbose(): never {
-  throw new NotImplementedError("ActiveRecord::Tasks::DatabaseTasks#verbose? is not implemented");
+export function classForAdapter(adapter: string): DatabaseTaskHandler {
+  const handler = DatabaseTasks.resolveTask(adapter);
+  if (!handler) {
+    throw new DatabaseNotSupported(`Rake tasks not supported by '${adapter}' adapter`);
+  }
+  return handler;
 }
 
 /** @internal */
-export function databaseAdapterFor(dbConfig: any, ...arguments_: any[]): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#database_adapter_for is not implemented",
-  );
+export function eachCurrentConfiguration(environment: string, name?: string): DatabaseConfig[] {
+  const results: DatabaseConfig[] = [];
+  for (const env of eachCurrentEnvironment(environment)) {
+    for (const cfg of DatabaseTasks.configsFor(env)) {
+      if (name && name !== cfg.name) continue;
+      results.push(cfg);
+    }
+  }
+  return results;
 }
 
 /** @internal */
-export function classForAdapter(adapter: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#class_for_adapter is not implemented",
-  );
+export function eachCurrentEnvironment(environment: string): string[] {
+  const envs = [environment];
+  if (environment === "development" && !getEnv("SKIP_TEST_DATABASE") && !getEnv("DATABASE_URL")) {
+    envs.push("test");
+  }
+  return envs;
 }
 
 /** @internal */
-export function eachCurrentConfiguration(environment: any, name?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#each_current_configuration is not implemented",
-  );
+export function isLocalDatabase(dbConfig: DatabaseConfig): boolean {
+  const host = dbConfig.host;
+  return !host || host === "localhost" || host === "127.0.0.1" || host === "::1";
 }
 
 /** @internal */
-export function eachCurrentEnvironment(environment: any, block?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#each_current_environment is not implemented",
-  );
+export function schemaSha1(file: string): string {
+  const contents = getFs().readFileSync(file, "utf-8");
+  const nodeCrypto = (
+    globalThis as {
+      require?: (mod: string) => {
+        createHash(a: string): { update(d: string): { digest(e: string): string } };
+      };
+    }
+  ).require?.("node:crypto");
+  if (!nodeCrypto) throw new Error("schemaSha1 requires a Node.js crypto module");
+  return nodeCrypto.createHash("sha1").update(contents).digest("hex");
 }
 
 /** @internal */
-function eachLocalConfiguration(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#each_local_configuration is not implemented",
-  );
+export function structureDumpFlagsFor(adapter: string): string | string[] | null {
+  const flags = DatabaseTasks.structureDumpFlags;
+  if (!flags) return null;
+  if (typeof flags === "string" || Array.isArray(flags)) return flags;
+  return (flags as Record<string, string | string[]>)[adapter] ?? null;
 }
 
 /** @internal */
-export function isLocalDatabase(dbConfig: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#local_database? is not implemented",
-  );
+export function structureLoadFlagsFor(adapter: string): string | string[] | null {
+  const flags = DatabaseTasks.structureLoadFlags;
+  if (!flags) return null;
+  if (typeof flags === "string" || Array.isArray(flags)) return flags;
+  return (flags as Record<string, string | string[]>)[adapter] ?? null;
 }
 
 /** @internal */
-export function schemaSha1(file: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#schema_sha1 is not implemented",
-  );
+export async function checkCurrentProtectedEnvironmentBang(
+  dbConfig: DatabaseConfig,
+): Promise<void> {
+  await DatabaseTasks.withTemporaryConnection(dbConfig, async () => {
+    await DatabaseTasks.checkProtectedEnvironmentsBang(dbConfig.envName);
+  });
 }
 
 /** @internal */
-export function structureDumpFlagsFor(adapter: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#structure_dump_flags_for is not implemented",
-  );
-}
-
-/** @internal */
-export function structureLoadFlagsFor(adapter: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#structure_load_flags_for is not implemented",
-  );
-}
-
-/** @internal */
-export function checkCurrentProtectedEnvironmentBang(dbConfig: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#check_current_protected_environment! is not implemented",
-  );
-}
-
-/** @internal */
-export function initializeDatabase(dbConfig: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::DatabaseTasks#initialize_database is not implemented",
-  );
+export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<boolean> {
+  return DatabaseTasks.withTemporaryConnection(dbConfig, async () => {
+    const { SchemaMigration } = await import("../schema-migration.js");
+    const adapter = DatabaseTasks.migrationConnection();
+    if (!adapter) return false;
+    let alreadyInitialized: boolean;
+    try {
+      const sm = new SchemaMigration(adapter);
+      alreadyInitialized = await sm.tableExists();
+    } catch {
+      await DatabaseTasks.create(dbConfig);
+      const sm = new SchemaMigration(adapter);
+      alreadyInitialized = await sm.tableExists();
+    }
+    if (!alreadyInitialized) {
+      const schemaDumpPath = DatabaseTasks.schemaDumpPath(dbConfig);
+      const { getFs: fs } = await import("@blazetrails/activesupport");
+      if (schemaDumpPath && fs().existsSync(schemaDumpPath)) {
+        await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat);
+      }
+    }
+    return !alreadyInitialized;
+  });
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -377,6 +377,6 @@ export class MySQLDatabaseTasks {
 export function runCmdError(cmd: string, _args: string[], _action: string): string {
   return (
     `failed to execute: \`${cmd}\`\n` +
-    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
+    `Please check the output for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -369,7 +369,8 @@ export class MySQLDatabaseTasks {
 
   /** @internal */
   private configurationHashWithoutDatabase(): ConfigHash {
-    return { ...this.configurationHash, database: undefined };
+    const { database: _db, ...rest } = this.configurationHash;
+    return rest;
   }
 }
 

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -336,28 +336,28 @@ export class MySQLDatabaseTasks {
 }
 
 /** @internal */
-function connection(): never {
+export function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::MySQLDatabaseTasks#connection is not implemented",
   );
 }
 
 /** @internal */
-function establishConnection(config?: any): never {
+export function establishConnection(config?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::MySQLDatabaseTasks#establish_connection is not implemented",
   );
 }
 
 /** @internal */
-function configurationHashWithoutDatabase(): never {
+export function configurationHashWithoutDatabase(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::MySQLDatabaseTasks#configuration_hash_without_database is not implemented",
   );
 }
 
 /** @internal */
-function runCmdError(cmd: any, args: any, action: any): never {
+export function runCmdError(cmd: any, args: any, action: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::MySQLDatabaseTasks#run_cmd_error is not implemented",
   );

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -7,7 +7,7 @@
 import { getFs, getChildProcessAsync, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
-import { DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
+import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { coercePort } from "./task-utils.js";
 
@@ -333,32 +333,45 @@ export class MySQLDatabaseTasks {
   private escapeIdent(value: string): string {
     return value.replace(/`/g, "``");
   }
+
+  /** @internal */
+  private connection(): import("../adapter.js").DatabaseAdapter | null {
+    return DatabaseTasks.migrationConnection();
+  }
+
+  /** @internal */
+  private async establishConnection(config?: DatabaseConfig): Promise<void> {
+    const cfg = config ?? this.dbConfig;
+    const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
+    const c = cfg.configuration;
+    const socket = this.resolvedField("socket");
+    const adapter = socket
+      ? new Mysql2Adapter({
+          database: cfg.database,
+          user: c.username as string | undefined,
+          password: c.password as string | undefined,
+          socketPath: socket,
+        })
+      : new Mysql2Adapter({
+          host: (c.host as string) ?? "localhost",
+          port: coercePort(c.port, 3306),
+          database: cfg.database,
+          user: c.username as string | undefined,
+          password: c.password as string | undefined,
+        });
+    DatabaseTasks.setAdapter(adapter);
+  }
+
+  /** @internal */
+  private configurationHashWithoutDatabase(): ConfigHash {
+    return { ...this.configurationHash, database: undefined };
+  }
 }
 
 /** @internal */
-export function connection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::MySQLDatabaseTasks#connection is not implemented",
-  );
-}
-
-/** @internal */
-export function establishConnection(config?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::MySQLDatabaseTasks#establish_connection is not implemented",
-  );
-}
-
-/** @internal */
-export function configurationHashWithoutDatabase(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::MySQLDatabaseTasks#configuration_hash_without_database is not implemented",
-  );
-}
-
-/** @internal */
-export function runCmdError(cmd: any, args: any, action: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::MySQLDatabaseTasks#run_cmd_error is not implemented",
+export function runCmdError(cmd: string, _args: string[], _action: string): string {
+  return (
+    `failed to execute: \`${cmd}\`\n` +
+    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -335,7 +335,7 @@ export class MySQLDatabaseTasks {
   }
 
   /** @internal */
-  private connection(): import("../adapter.js").DatabaseAdapter | null {
+  private connection(): DatabaseAdapter | null {
     return DatabaseTasks.migrationConnection();
   }
 
@@ -344,21 +344,26 @@ export class MySQLDatabaseTasks {
     const cfg = config ?? this.dbConfig;
     const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
     const c = cfg.configuration;
-    const socket = this.resolvedField("socket");
-    const adapter = socket
-      ? new Mysql2Adapter({
-          database: cfg.database,
-          user: c.username as string | undefined,
-          password: c.password as string | undefined,
-          socketPath: socket,
-        })
-      : new Mysql2Adapter({
-          host: (c.host as string) ?? "localhost",
-          port: coercePort(c.port, 3306),
-          database: cfg.database,
-          user: c.username as string | undefined,
-          password: c.password as string | undefined,
-        });
+    let adapter: DatabaseAdapter;
+    if (c.url) {
+      adapter = new Mysql2Adapter(String(c.url));
+    } else {
+      const socket = c.socket as string | undefined;
+      adapter = socket
+        ? new Mysql2Adapter({
+            database: cfg.database,
+            user: c.username as string | undefined,
+            password: c.password as string | undefined,
+            socketPath: socket,
+          })
+        : new Mysql2Adapter({
+            host: (c.host as string) ?? "localhost",
+            port: coercePort(c.port, 3306),
+            database: cfg.database,
+            user: c.username as string | undefined,
+            password: c.password as string | undefined,
+          });
+    }
     DatabaseTasks.setAdapter(adapter);
   }
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
-import { DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
+import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { coercePort } from "./task-utils.js";
 
@@ -363,6 +363,33 @@ export class PostgreSQLDatabaseTasks {
   private escapeSingle(value: string): string {
     return value.replace(/'/g, "''");
   }
+
+  /** @internal */
+  private connection(): DatabaseAdapter | null {
+    return DatabaseTasks.migrationConnection();
+  }
+
+  /** @internal */
+  private async establishConnection(config?: DatabaseConfig): Promise<void> {
+    const cfg = config ?? this.dbConfig;
+    const { PostgreSQLAdapter } = await import("../connection-adapters/postgresql-adapter.js");
+    const c = cfg.configuration;
+    const adapter = c.url
+      ? new PostgreSQLAdapter(String(c.url))
+      : new PostgreSQLAdapter({
+          host: (c.host as string) ?? "localhost",
+          port: coercePort(c.port, 5432),
+          database: cfg.database,
+          user: c.username as string | undefined,
+          password: c.password as string | undefined,
+        });
+    DatabaseTasks.setAdapter(adapter);
+  }
+
+  /** @internal */
+  private publicSchemaConfig(): ConfigHash {
+    return { ...this.configurationHash, database: "postgres", schema_search_path: "public" };
+  }
 }
 
 function formatCmdError(
@@ -415,29 +442,9 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
 }
 
 /** @internal */
-export function connection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#connection is not implemented",
-  );
-}
-
-/** @internal */
-export function establishConnection(config?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#establish_connection is not implemented",
-  );
-}
-
-/** @internal */
-export function publicSchemaConfig(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#public_schema_config is not implemented",
-  );
-}
-
-/** @internal */
-export function runCmdError(cmd: any, args: any, action: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd_error is not implemented",
+export function runCmdError(cmd: string, args: string[], _action: string): string {
+  return (
+    `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -415,28 +415,28 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
 }
 
 /** @internal */
-function connection(): never {
+export function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#connection is not implemented",
   );
 }
 
 /** @internal */
-function establishConnection(config?: any): never {
+export function establishConnection(config?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#establish_connection is not implemented",
   );
 }
 
 /** @internal */
-function publicSchemaConfig(): never {
+export function publicSchemaConfig(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#public_schema_config is not implemented",
   );
 }
 
 /** @internal */
-function runCmdError(cmd: any, args: any, action: any): never {
+export function runCmdError(cmd: any, args: any, action: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd_error is not implemented",
   );

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -388,7 +388,7 @@ export class PostgreSQLDatabaseTasks {
 
   /** @internal */
   private publicSchemaConfig(): ConfigHash {
-    return { ...this.configurationHash, database: "postgres", schema_search_path: "public" };
+    return { ...this.configurationHash, database: "postgres", schemaSearchPath: "public" };
   }
 }
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -445,6 +445,6 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
 export function runCmdError(cmd: string, args: string[], _action: string): string {
   return (
     `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
+    `Please check the output for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -405,8 +405,8 @@ export async function runCmd(cmd: string, args: string[], out: string): Promise<
     if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
     throw new Error(runCmdError(cmd, args) + (details.length ? details.join("\n") + "\n" : ""));
   }
-  if (out && result.stdout) {
-    getFs().writeFileSync(out, String(result.stdout));
+  if (out) {
+    getFs().writeFileSync(out, result.stdout ?? "");
   }
 }
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -414,6 +414,6 @@ export async function runCmd(cmd: string, args: string[], out: string): Promise<
 export function runCmdError(cmd: string, args: string[]): string {
   return (
     `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
+    `Please check the output for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -9,11 +9,16 @@
  * subprocess required.
  */
 
-import { getFs, getPath } from "@blazetrails/activesupport";
+import {
+  getFs,
+  getPath,
+  getChildProcessAsync,
+  type SpawnSyncResult,
+} from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
-import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
+import { NoDatabaseError, DatabaseAlreadyExists } from "../errors.js";
 
 /**
  * True for SQLite in-memory database names per the SQLite URI spec
@@ -300,6 +305,18 @@ export class SQLiteDatabaseTasks {
     if (typeof close === "function") await close.call(adapter);
   }
 
+  /** @internal */
+  private connection(): DatabaseAdapter | null {
+    return DatabaseTasks.migrationConnection();
+  }
+
+  /** @internal */
+  private async establishConnection(config?: DatabaseConfig): Promise<void> {
+    const cfg = config ?? this.dbConfig;
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    DatabaseTasks.setAdapter(new SQLite3Adapter(cfg.database ?? this.resolveDbPath()));
+  }
+
   static register(): void {
     DatabaseTasks.registerTask(/sqlite/, {
       create: async (config) => new SQLiteDatabaseTasks(config).create(),
@@ -375,29 +392,21 @@ function splitSqlStatements(sql: string): string[] {
 }
 
 /** @internal */
-export function connection(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::SQLiteDatabaseTasks#connection is not implemented",
-  );
+export async function runCmd(cmd: string, args: string[], out: string): Promise<void> {
+  const childProcess = await getChildProcessAsync();
+  const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, { encoding: "utf8" });
+  if (result.error || result.status !== 0 || result.signal) {
+    throw new Error(runCmdError(cmd, args));
+  }
+  if (out && result.stdout) {
+    getFs().writeFileSync(out, String(result.stdout));
+  }
 }
 
 /** @internal */
-export function establishConnection(config?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::SQLiteDatabaseTasks#establish_connection is not implemented",
-  );
-}
-
-/** @internal */
-export function runCmd(cmd: any, args: any, out: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd is not implemented",
-  );
-}
-
-/** @internal */
-export function runCmdError(cmd: any, args: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd_error is not implemented",
+export function runCmdError(cmd: string, args: string[]): string {
+  return (
+    `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+    `Please check the output above for any errors and make sure that \`${cmd}\` is installed in your PATH and has proper permissions.\n\n`
   );
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -312,9 +312,9 @@ export class SQLiteDatabaseTasks {
 
   /** @internal */
   private async establishConnection(config?: DatabaseConfig): Promise<void> {
-    const cfg = config ?? this.dbConfig;
+    const tasks = config ? new SQLiteDatabaseTasks(config, this.root) : this;
     const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
-    DatabaseTasks.setAdapter(new SQLite3Adapter(cfg.database ?? this.resolveDbPath()));
+    DatabaseTasks.setAdapter(new SQLite3Adapter(tasks.resolveDbPath()));
   }
 
   static register(): void {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -375,28 +375,28 @@ function splitSqlStatements(sql: string): string[] {
 }
 
 /** @internal */
-function connection(): never {
+export function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#connection is not implemented",
   );
 }
 
 /** @internal */
-function establishConnection(config?: any): never {
+export function establishConnection(config?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#establish_connection is not implemented",
   );
 }
 
 /** @internal */
-function runCmd(cmd: any, args: any, out: any): never {
+export function runCmd(cmd: any, args: any, out: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd is not implemented",
   );
 }
 
 /** @internal */
-function runCmdError(cmd: any, args: any): never {
+export function runCmdError(cmd: any, args: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd_error is not implemented",
   );

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -4,9 +4,11 @@
  * Mirrors: ActiveRecord::Tasks::SQLiteDatabaseTasks.
  *
  * Unlike Rails (which shells out to the `sqlite3` CLI for structureDump /
- * structureLoad), trails runs these operations through the SQLite3Adapter so
- * the same code works under sqlite-wasm + the activesupport vfs adapter — no
- * subprocess required.
+ * structureLoad), trails runs structureDump/structureLoad through the
+ * SQLite3Adapter so the same code works under sqlite-wasm + the
+ * activesupport vfs adapter. The exported `runCmd` helper shells out via
+ * `sqlite3` only for Rails API parity and is not invoked by the public
+ * task methods above.
  */
 
 import {
@@ -405,9 +407,7 @@ export async function runCmd(cmd: string, args: string[], out: string): Promise<
     if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
     throw new Error(runCmdError(cmd, args) + (details.length ? details.join("\n") + "\n" : ""));
   }
-  if (out) {
-    getFs().writeFileSync(out, result.stdout ?? "");
-  }
+  getFs().writeFileSync(out, result.stdout ?? "");
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -396,7 +396,14 @@ export async function runCmd(cmd: string, args: string[], out: string): Promise<
   const childProcess = await getChildProcessAsync();
   const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, { encoding: "utf8" });
   if (result.error || result.status !== 0 || result.signal) {
-    throw new Error(runCmdError(cmd, args));
+    const details: string[] = [];
+    if (result.error) details.push(`Error: ${result.error.message}`);
+    if (result.status !== null && result.status !== 0)
+      details.push(`Exit status: ${result.status}`);
+    if (result.signal) details.push(`Signal: ${result.signal}`);
+    if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
+    if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
+    throw new Error(runCmdError(cmd, args) + (details.length ? details.join("\n") + "\n" : ""));
   }
   if (out && result.stdout) {
     getFs().writeFileSync(out, String(result.stdout));


### PR DESCRIPTION
## Summary

Brings 4 tasks files from 71–83% → 100% (25 methods). The private Rails methods were already present as unexported stubs; this PR implements them and exports them.

## LOC ceiling note (620 total churn, 467+153)

The original PR was ~50 LOC (adding `export` to stubs). 12 Copilot review cycles demanded real implementations, integration tests for `initializeDatabase`, and `eachCurrentEnvironment`/`schemaSha1` test suites — the bulk of the addition. The test file alone is +243 LOC added in direct response to review comments. Splitting now would produce a PR 51b that is purely tests. Requesting explicit acceptance of the overage.

## Key implementation decisions

- **`withTemporaryPool`** — generic `<T>`, delegates to `withTemporaryConnection`; return value propagates
- **`initializeDatabase`** — probes with `SELECT 1`; creates DB if missing; resolves schema dump path relative to `DatabaseTasks.root` before `existsSync`; passes the resolved absolute path to `loadSchema`
- **`_environmentsFor` delegates to `eachCurrentEnvironment`** — "development" always expands to include "test" (matching Rails' `each_current_environment` exactly); the old TS behavior only expanded when the argument was blank, which was a divergence from Rails
- **`schemaSha1`** — async, raw-byte `Buffer` hash via `getCryptoAsync()`; shared `_sha1File` helper with `_schemaSha1`
- **`resolveConfiguration`** — short-circuits on `instanceof DatabaseConfig`; avoids mutating the global `DatabaseConfigurations.current` singleton
- **`configurationHashWithoutDatabase`** — destructures to omit the key entirely
- **`runCmdError` helpers** — return formatted string, consistent with Rails

## Known gaps (out of scope)

### `_isMissingDatabaseError` adapter layering

MySQL adapter does not translate `ER_BAD_DB_ERROR` to `NoDatabaseError` at the connection level. PostgreSQL adapter already does (`newClient` translates), so the `3D000` branch is dead code today — kept as a defensive fallback. A TODO comment in the code points at the mysql2-adapter follow-up.

### `establishConnection` subclass methods

Delegates to `DatabaseTasks.setAdapter` (single adapter, not a pool). For task operations this is intentional — tasks don't share a connection pool with `Base.connection` callers.

### `initializeDatabase` mock-test fragility

Two tests spy on private `_connectFor` via `as any`. The `schema_migrations absent`/`present` tests using real SQLite file connections are the more robust pattern.

## Test plan

- [x] `pnpm api:compare --package activerecord --files tasks/database_tasks.rb,...` → all 4 at 100%
- [x] `pnpm build` + `pnpm typecheck` pass
- [x] 96 tests pass
- [x] CI: PostgreSQL/MariaDB jobs cancelled (infrastructure timeout), unrelated to this diff