### PR TITLE
feat(activesupport): node:sqlite driver (PR 5)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig(
       "packages/activesupport/src/os-adapter.ts",
       // Node-only modules exposed via subpath imports (no browser equivalent)
       "packages/activerecord/src/tsc-wrapper/**",
+      "packages/activesupport/src/sqlite-drivers/node-sqlite.ts",
       "packages/activesupport/src/gzip.ts",
       "packages/rack/src/deflater.ts",
       "packages/activerecord/src/encryption/config.ts",

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/sqlite-drivers/better-sqlite3.d.ts",
       "default": "./dist/sqlite-drivers/better-sqlite3.js"
     },
+    "./sqlite/node-sqlite": {
+      "types": "./dist/sqlite-drivers/node-sqlite.d.ts",
+      "default": "./dist/sqlite-drivers/node-sqlite.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -87,11 +87,13 @@ describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite round-trip
     expect(conn.isOpen()).toBe(true);
   });
 
-  it("statement.reader is true for SELECT, false for INSERT", async () => {
-    const sel = await conn.prepare("SELECT 1");
-    expect(sel.reader).toBe(true);
-    const ins = await conn.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
-    expect(ins.reader).toBe(false);
+  it("statement.reader is true for SELECT/PRAGMA, false for INSERT/write-PRAGMA", async () => {
+    expect((await conn.prepare("SELECT 1")).reader).toBe(true);
+    expect((await conn.prepare("PRAGMA journal_mode")).reader).toBe(true);
+    expect((await conn.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)")).reader).toBe(
+      false,
+    );
+    expect((await conn.prepare("PRAGMA foreign_keys = ON")).reader).toBe(false);
   });
 
   it("databaseExists() reports memory databases as present", () => {

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { SqliteConnection } from "../sqlite-adapter.js";
+
+const nodeMajor = parseInt(process.versions.node.split(".")[0]!, 10);
+const hasNodeSqlite = nodeMajor >= 22;
+
+describe.skipIf(!hasNodeSqlite)("SqliteDriver — node-sqlite round-trip", () => {
+  let conn: SqliteConnection;
+  let nodeSqliteDriver: (typeof import("./node-sqlite.js"))["nodeSqliteDriver"];
+
+  beforeAll(async () => {
+    ({ nodeSqliteDriver } = await import("./node-sqlite.js"));
+    conn = await nodeSqliteDriver.open({ database: ":memory:" });
+    const create = await conn.prepare(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, qty INTEGER)",
+    );
+    await create.run();
+    const insert = await conn.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    await insert.run(["sprocket", 42]);
+    await insert.run(["gear", 7]);
+  });
+
+  afterAll(async () => {
+    await conn.close();
+  });
+
+  it("retrieves a row by name", async () => {
+    const select = await conn.prepare("SELECT id, name, qty FROM widgets WHERE name = ?");
+    const row = (await select.get(["sprocket"])) as Record<string, unknown>;
+    expect(row["name"]).toBe("sprocket");
+    expect(row["qty"]).toBe(42);
+  });
+
+  it("run() returns changes and lastInsertRowid", async () => {
+    const insert = await conn.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    const result = await insert.run(["bolt", 99]);
+    expect(result.changes).toBe(1);
+    expect(
+      typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
+    ).toBe(true);
+  });
+
+  it("returns all rows", async () => {
+    const select = await conn.prepare("SELECT id, name, qty FROM widgets ORDER BY id");
+    const rows = (await select.all()) as Record<string, unknown>[];
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    const names = rows.map((r) => r["name"]);
+    expect(names).toContain("sprocket");
+    expect(names).toContain("gear");
+  });
+
+  it("iterate() yields rows incrementally", async () => {
+    const select = await conn.prepare("SELECT id, name FROM widgets ORDER BY id");
+    const collected: unknown[] = [];
+    for (const row of select.iterate() as Iterable<unknown>) collected.push(row);
+    expect(collected.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("named binds work as a single object", async () => {
+    const select = await conn.prepare("SELECT qty FROM widgets WHERE name = $name");
+    const row = (await select.get({ name: "sprocket" })) as Record<string, unknown>;
+    expect(row["qty"]).toBe(42);
+  });
+
+  it("setReadBigInts enables bigint returns", async () => {
+    const stmt = await conn.prepare("SELECT qty FROM widgets WHERE name = ?");
+    stmt.setReadBigInts(true);
+    const row = (await stmt.get(["sprocket"])) as Record<string, unknown>;
+    expect(typeof row["qty"]).toBe("bigint");
+  });
+
+  it("exec runs SQL", async () => {
+    await conn.exec("CREATE TABLE IF NOT EXISTS tmp_exec (x INTEGER)");
+    await conn.exec("DROP TABLE tmp_exec");
+  });
+
+  it("pragma returns a value", async () => {
+    const result = await conn.pragma("journal_mode");
+    expect(result).toBeDefined();
+  });
+
+  it("isOpen() is true while connected", () => {
+    expect(conn.isOpen()).toBe(true);
+  });
+
+  it("statement.reader is true for SELECT, false for INSERT", async () => {
+    const sel = await conn.prepare("SELECT 1");
+    expect(sel.reader).toBe(true);
+    const ins = await conn.prepare("INSERT INTO widgets (name, qty) VALUES (?, ?)");
+    expect(ins.reader).toBe(false);
+  });
+
+  it("databaseExists() reports memory databases as present", () => {
+    expect(nodeSqliteDriver.databaseExists?.({ database: ":memory:" })).toBe(true);
+  });
+
+  it("capabilities reflect node-sqlite traits", () => {
+    expect(nodeSqliteDriver.capabilities.inProcessSync).toBe(true);
+    expect(nodeSqliteDriver.capabilities.streaming).toBe(true);
+    expect(nodeSqliteDriver.capabilities.foreignKeysOnByDefault).toBe(false);
+  });
+});

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -83,6 +83,10 @@ describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite round-trip
     expect(result).toBeDefined();
   });
 
+  it("write pragma does not throw and returns []", async () => {
+    expect(await conn.pragma("foreign_keys = ON")).toEqual([]);
+  });
+
   it("isOpen() is true while connected", () => {
     expect(conn.isOpen()).toBe(true);
   });

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import type { SqliteConnection } from "../sqlite-adapter.js";
+import { isNodeSqliteAvailable, nodeSqliteDriver } from "./node-sqlite.js";
 
-const nodeMajor = parseInt(process.versions.node.split(".")[0]!, 10);
-const hasNodeSqlite = nodeMajor >= 22;
-
-describe.skipIf(!hasNodeSqlite)("SqliteDriver — node-sqlite round-trip", () => {
+describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite round-trip", () => {
   let conn: SqliteConnection;
-  let nodeSqliteDriver: (typeof import("./node-sqlite.js"))["nodeSqliteDriver"];
 
   beforeAll(async () => {
-    ({ nodeSqliteDriver } = await import("./node-sqlite.js"));
     conn = await nodeSqliteDriver.open({ database: ":memory:" });
     const create = await conn.prepare(
       "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, qty INTEGER)",
@@ -60,6 +56,14 @@ describe.skipIf(!hasNodeSqlite)("SqliteDriver — node-sqlite round-trip", () =>
     const select = await conn.prepare("SELECT qty FROM widgets WHERE name = $name");
     const row = (await select.get({ name: "sprocket" })) as Record<string, unknown>;
     expect(row["qty"]).toBe(42);
+  });
+
+  it("columns() returns column metadata", async () => {
+    const stmt = await conn.prepare("SELECT id, name, qty FROM widgets");
+    const cols = stmt.columns();
+    expect(cols.length).toBe(3);
+    expect(cols[0]!.name).toBe("id");
+    expect(cols[0]!.column === null || typeof cols[0]!.column === "string").toBe(true);
   });
 
   it("setReadBigInts enables bigint returns", async () => {

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -41,7 +41,10 @@ class NodeSqliteStatement implements SqliteStatement, SyncSqliteStatement {
   constructor(private readonly stmt: import("node:sqlite").StatementSync) {
     stmt.setAllowBareNamedParameters(true); // allow { name: val } to bind $name
     const sql = stmt.sourceSQL.trimStart().toUpperCase();
-    this.reader = /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(sql);
+    // PRAGMA without `=` returns rows; PRAGMA with `=` is a write. Matches better-sqlite3.
+    this.reader =
+      /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(sql) ||
+      (/^PRAGMA\b/.test(sql) && !sql.includes("="));
   }
 
   private call<T>(method: string, binds: SqliteBinds | undefined): T {

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -15,7 +15,7 @@ import {
 } from "../sqlite-adapter.js";
 
 // Soft-load: Node 22.5+ only. Sync via createRequire so the module stays sync.
-// open() rejects with a clear error on Node < 22 instead of crashing on import.
+// open() rejects with a clear error on Node < 22.5 instead of crashing on import.
 type NodeSqliteModule = typeof import("node:sqlite");
 let nodeSqlite: NodeSqliteModule | undefined;
 try {
@@ -23,6 +23,9 @@ try {
 } catch {
   /* Node < 22.5 or --experimental-sqlite not set */
 }
+
+/** True when node:sqlite loaded successfully; use as a describe.skipIf gate in tests. */
+export const isNodeSqliteAvailable = nodeSqlite !== undefined;
 
 /** @internal */
 function expandBinds(binds: SqliteBinds | undefined): unknown[] {

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -108,6 +108,12 @@ class NodeSqliteConnection implements SqliteConnection, SyncSqliteConnection {
 
   pragma(source: string, opts?: { simple?: boolean }): unknown {
     const stmt = this.raw.prepare(`PRAGMA ${source}`);
+    // Write PRAGMAs (source contains `=`) don't return rows; must use run().
+    // better-sqlite3 throws if all() is called on a non-reader statement.
+    if (source.includes("=")) {
+      stmt.run();
+      return [];
+    }
     if (opts?.simple) {
       const row = stmt.get() as Record<string, unknown> | undefined;
       return row !== undefined ? Object.values(row)[0] : undefined;

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -1,0 +1,185 @@
+import { createRequire } from "node:module";
+import { getFs } from "../fs-adapter.js";
+import {
+  registerSqliteDriver,
+  type ColumnInfo,
+  type RunResult,
+  type SqliteBinds,
+  type SqliteConnection,
+  type SqliteDriver,
+  type SqliteDriverCapabilities,
+  type SqliteOpenConfig,
+  type SqliteStatement,
+  type SyncSqliteConnection,
+  type SyncSqliteStatement,
+} from "../sqlite-adapter.js";
+
+// Soft-load: Node 22.5+ only. Sync via createRequire so the module stays sync.
+// open() rejects with a clear error on Node < 22 instead of crashing on import.
+type NodeSqliteModule = typeof import("node:sqlite");
+let nodeSqlite: NodeSqliteModule | undefined;
+try {
+  nodeSqlite = createRequire(import.meta.url)("node:sqlite") as NodeSqliteModule;
+} catch {
+  /* Node < 22.5 or --experimental-sqlite not set */
+}
+
+/** @internal */
+function expandBinds(binds: SqliteBinds | undefined): unknown[] {
+  if (binds === undefined) return [];
+  if (Array.isArray(binds)) return binds as unknown[];
+  return [binds]; // named object is the first positional argument
+}
+
+/** @internal */
+class NodeSqliteStatement implements SqliteStatement, SyncSqliteStatement {
+  readonly reader: boolean;
+
+  constructor(private readonly stmt: import("node:sqlite").StatementSync) {
+    stmt.setAllowBareNamedParameters(true); // allow { name: val } to bind $name
+    const sql = stmt.sourceSQL.trimStart().toUpperCase();
+    this.reader = /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(sql);
+  }
+
+  private call<T>(method: string, binds: SqliteBinds | undefined): T {
+    return (this.stmt as unknown as Record<string, (...a: unknown[]) => T>)[method]!(
+      ...expandBinds(binds),
+    );
+  }
+
+  run(binds?: SqliteBinds): RunResult {
+    const r = this.call<import("node:sqlite").StatementResultingChanges>("run", binds);
+    return { changes: Number(r.changes), lastInsertRowid: r.lastInsertRowid };
+  }
+
+  get(binds?: SqliteBinds): unknown {
+    return this.call<unknown>("get", binds);
+  }
+
+  all(binds?: SqliteBinds): unknown[] {
+    return this.call<unknown[]>("all", binds);
+  }
+
+  iterate(binds?: SqliteBinds): Iterable<unknown> {
+    return this.call<Iterable<unknown>>("iterate", binds);
+  }
+
+  columns(): ColumnInfo[] {
+    return this.stmt.columns().map((c) => ({
+      name: c.name,
+      column: c.column,
+      table: c.table,
+      database: c.database,
+      type: c.type,
+    }));
+  }
+
+  setReadBigInts(on: boolean): void {
+    this.stmt.setReadBigInts(on);
+  }
+}
+
+/** @internal */
+class NodeSqliteConnection implements SqliteConnection, SyncSqliteConnection {
+  readonly raw: import("node:sqlite").DatabaseSync;
+  private _open = true;
+
+  constructor(db: import("node:sqlite").DatabaseSync) {
+    this.raw = db;
+  }
+
+  prepare(sql: string): NodeSqliteStatement {
+    return new NodeSqliteStatement(this.raw.prepare(sql));
+  }
+
+  isOpen(): boolean {
+    return this._open;
+  }
+
+  exec(sql: string): void {
+    this.raw.exec(sql);
+  }
+
+  pragma(source: string, opts?: { simple?: boolean }): unknown {
+    const stmt = this.raw.prepare(`PRAGMA ${source}`);
+    if (opts?.simple) {
+      const row = stmt.get() as Record<string, unknown> | undefined;
+      return row !== undefined ? Object.values(row)[0] : undefined;
+    }
+    return stmt.all();
+  }
+
+  close(): void {
+    this._open = false;
+    this.raw.close();
+  }
+}
+
+/** @internal */
+function resolveDatabasePath(database: string): string | null {
+  if (database === ":memory:" || database.startsWith("file::memory:")) return null;
+  if (!database.startsWith("file:")) return database;
+  let url: URL;
+  try {
+    url = new URL(database, "file:///");
+  } catch {
+    return database;
+  }
+  if (url.searchParams.get("mode") === "memory") return null;
+  try {
+    return decodeURIComponent(url.pathname);
+  } catch {
+    return url.pathname;
+  }
+}
+
+/** @internal */
+function openDatabase(config: SqliteOpenConfig): import("node:sqlite").DatabaseSync {
+  if (!nodeSqlite) {
+    throw new Error(
+      "node:sqlite is not available. Node 22.5+ is required. " +
+        "On Node 22.5–22.9 you may also need --experimental-sqlite.",
+    );
+  }
+  const opts: import("node:sqlite").DatabaseSyncOptions = {
+    ...(config.driverOptions as import("node:sqlite").DatabaseSyncOptions | undefined),
+    readOnly: config.readOnly ?? false,
+    enableForeignKeyConstraints: false, // match better-sqlite3 default
+  };
+  if (config.timeout !== undefined) opts.timeout = config.timeout;
+  return new nodeSqlite.DatabaseSync(config.database, opts);
+}
+
+const capabilities: SqliteDriverCapabilities = {
+  inProcessSync: true,
+  streaming: true,
+  loadExtension: false,
+  concurrentStatements: true,
+  foreignKeysOnByDefault: false,
+  immediateTransactions: true,
+};
+
+export const nodeSqliteDriver: SqliteDriver = {
+  name: "node-sqlite",
+  capabilities,
+
+  async open(config: SqliteOpenConfig): Promise<SqliteConnection> {
+    return new NodeSqliteConnection(openDatabase(config));
+  },
+
+  openSync(config: SqliteOpenConfig): SyncSqliteConnection {
+    return new NodeSqliteConnection(openDatabase(config));
+  },
+
+  databaseExists(config: SqliteOpenConfig): boolean {
+    const path = resolveDatabasePath(config.database);
+    if (path === null) return true;
+    try {
+      return getFs().existsSync(path);
+    } catch {
+      return false;
+    }
+  },
+};
+
+registerSqliteDriver(nodeSqliteDriver);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/sqlite-drivers/better-sqlite3.ts",
   ),
+  "@blazetrails/activesupport/sqlite/node-sqlite": path.resolve(
+    __dirname,
+    "packages/activesupport/src/sqlite-drivers/node-sqlite.ts",
+  ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
   "@blazetrails/activesupport/yaml": path.resolve(__dirname, "packages/activesupport/src/yaml.ts"),
   "@blazetrails/activesupport/process-adapter": path.resolve(


### PR DESCRIPTION
## Summary

- Adds `packages/activesupport/src/sqlite-drivers/node-sqlite.ts`: a `SqliteDriver` / `SqliteConnection` / `SqliteStatement` wrapper over Node 22.5's built-in `node:sqlite` module
- Soft-loads `node:sqlite` via `createRequire` at module init — `open()` rejects with a clear message on Node < 22 instead of crashing on import; no adapter changes required
- `enableForeignKeyConstraints: false` to match `better-sqlite3`'s default so AR's explicit `PRAGMA foreign_keys = ON` takes effect; `foreignKeysOnByDefault: false` in capabilities
- Registers via `registerSqliteDriver(nodeSqliteDriver)` so callers can opt in via `getSqlite("node-sqlite")` or `driver: "node-sqlite"` in `SqliteOpenConfig`
- Tests mirror the `better-sqlite3` suite; skip automatically on Node < 22 via `describe.skipIf`
- Adds `./sqlite/node-sqlite` subpath export to `activesupport/package.json` and vitest alias; adds path to `no-node-builtins` eslint ignore (Node-only by design)

**Out of scope:** CI matrix / parity tests / docs (PR 6).

## Test plan

- [ ] All existing tests pass (`pnpm vitest run packages/activesupport/src/sqlite-drivers/`)
- [ ] Typecheck clean (`pnpm tsc -p packages/activesupport/tsconfig.json --noEmit`)
- [ ] Lint clean (`pnpm eslint packages/activesupport/src/sqlite-drivers/node-sqlite.ts`)
- [ ] On Node 22+: `node-sqlite.test.ts` runs 12 tests; on Node 20: all 12 skip