### PR TITLE
feat(activerecord): middleware resolver cluster — database-selector/resolver + session (PR 50)

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -332,3 +332,5 @@ export { Map as TypeCasterMap } from "./type-caster/map.js";
 export { Trailtie } from "./trailtie.js";
 export { deprecator, gemVersion, version } from "./deprecator.js";
 export { JobRuntime } from "./railties/job-runtime.js";
+export { Resolver as DatabaseSelectorResolver } from "./middleware/database-selector/resolver.js";
+export { Session as DatabaseSelectorSession } from "./middleware/database-selector/resolver/session.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -334,3 +334,5 @@ export { deprecator, gemVersion, version } from "./deprecator.js";
 export { JobRuntime } from "./railties/job-runtime.js";
 export { Resolver as DatabaseSelectorResolver } from "./middleware/database-selector/resolver.js";
 export { Session as DatabaseSelectorSession } from "./middleware/database-selector/resolver/session.js";
+export { DatabaseSelector } from "./middleware/database-selector.js";
+export { ShardSelector } from "./middleware/shard-selector.js";

--- a/packages/activerecord/src/middleware/database-selector.ts
+++ b/packages/activerecord/src/middleware/database-selector.ts
@@ -61,19 +61,6 @@ export class DatabaseSelector {
   }
 
   /** @internal */
-  isReadFromPrimary(request: MiddlewareRequest): boolean {
-    const context = this.contextKlass.call(request);
-    const resolver = this.resolverKlass.call(context, this.options);
-    return !resolver.isReadingRequest(request);
-  }
-
-  /** @internal */
-  updateLastWriteTimestamp(request: MiddlewareRequest): void {
-    const context = this.contextKlass.call(request);
-    context.updateLastWriteTimestamp();
-  }
-
-  /** @internal */
   selectDatabase(request: MiddlewareRequest, blk: () => Promise<unknown>): Promise<unknown> {
     const context = this.contextKlass.call(request);
     const resolver = this.resolverKlass.call(context, this.options);

--- a/packages/activerecord/src/middleware/database-selector.ts
+++ b/packages/activerecord/src/middleware/database-selector.ts
@@ -27,8 +27,6 @@ type ContextClass = {
   call(request: MiddlewareRequest): ResolverContext;
 };
 
-type NextHandler = () => Promise<unknown>;
-
 export class DatabaseSelector {
   /** @internal */
   readonly resolverKlass: ResolverClass;
@@ -37,10 +35,10 @@ export class DatabaseSelector {
   /** @internal */
   readonly options: Record<string, unknown>;
 
-  private readonly app: (next: NextHandler) => Promise<unknown>;
+  private readonly app: (request: MiddlewareRequest) => Promise<unknown>;
 
   constructor(
-    app: (next: NextHandler) => Promise<unknown>,
+    app: (request: MiddlewareRequest) => Promise<unknown>,
     resolverKlass?: ResolverClass,
     contextKlass?: ContextClass,
     options: Record<string, unknown> = {},
@@ -52,7 +50,7 @@ export class DatabaseSelector {
   }
 
   async call(request: MiddlewareRequest): Promise<unknown> {
-    return this.selectDatabase(request, () => this.app(() => Promise.resolve()));
+    return this.selectDatabase(request, () => this.app(request));
   }
 
   /** @internal */

--- a/packages/activerecord/src/middleware/database-selector.ts
+++ b/packages/activerecord/src/middleware/database-selector.ts
@@ -1,0 +1,91 @@
+/**
+ * Mirrors: ActiveRecord::Middleware::DatabaseSelector
+ *
+ * Provides automatic primary/replica switching based on request type and
+ * recency of writes, using pluggable resolver and context classes.
+ */
+
+import { Notifications } from "@blazetrails/activesupport";
+import { Resolver } from "./database-selector/resolver.js";
+import type { ResolverContext } from "./database-selector/resolver.js";
+import { Session } from "./database-selector/resolver/session.js";
+
+export interface MiddlewareRequest {
+  method: string;
+  session: {
+    get(key: string): unknown;
+    set(key: string, value: unknown): void;
+    delete(key: string): void;
+  };
+}
+
+type ResolverClass = {
+  call(context: ResolverContext, options: Record<string, unknown>): Resolver;
+};
+
+type ContextClass = {
+  call(request: MiddlewareRequest): ResolverContext;
+};
+
+type NextHandler = () => Promise<unknown>;
+
+export class DatabaseSelector {
+  /** @internal */
+  readonly resolverKlass: ResolverClass;
+  /** @internal */
+  readonly contextKlass: ContextClass;
+  /** @internal */
+  readonly options: Record<string, unknown>;
+
+  private readonly app: (next: NextHandler) => Promise<unknown>;
+
+  constructor(
+    app: (next: NextHandler) => Promise<unknown>,
+    resolverKlass?: ResolverClass,
+    contextKlass?: ContextClass,
+    options: Record<string, unknown> = {},
+  ) {
+    this.app = app;
+    this.resolverKlass = resolverKlass ?? (Resolver as unknown as ResolverClass);
+    this.contextKlass = contextKlass ?? (Session as unknown as ContextClass);
+    this.options = options;
+  }
+
+  async call(request: MiddlewareRequest): Promise<unknown> {
+    return this.selectDatabase(request, () => this.app(() => Promise.resolve()));
+  }
+
+  /** @internal */
+  instrumenter(): typeof Notifications {
+    return Notifications;
+  }
+
+  /** @internal */
+  isReadFromPrimary(request: MiddlewareRequest): boolean {
+    const context = this.contextKlass.call(request);
+    const resolver = this.resolverKlass.call(context, this.options);
+    return !resolver.isReadingRequest(request);
+  }
+
+  /** @internal */
+  updateLastWriteTimestamp(request: MiddlewareRequest): void {
+    const context = this.contextKlass.call(request);
+    context.updateLastWriteTimestamp();
+  }
+
+  /** @internal */
+  selectDatabase(request: MiddlewareRequest, blk: () => Promise<unknown>): Promise<unknown> {
+    const context = this.contextKlass.call(request);
+    const resolver = this.resolverKlass.call(context, this.options);
+
+    const responseP = resolver.isReadingRequest(request) ? resolver.read(blk) : resolver.write(blk);
+
+    return responseP.then((response) => {
+      resolver.updateContext(response);
+      return response;
+    });
+  }
+}
+
+export { Resolver };
+export type { ResolverContext };

--- a/packages/activerecord/src/middleware/database-selector/resolver.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver.ts
@@ -51,69 +51,10 @@ export class Resolver {
   }
 
   /** @internal */
-  isReadPrimary(): boolean {
-    return this.isReadFromPrimaryQ();
-  }
-
-  /** @internal */
-  isReadReplica(): boolean {
-    return !this.isReadFromPrimaryQ();
-  }
-
-  /** @internal */
-  isPreventWritesToPrimary(): boolean {
-    return false;
-  }
-
-  /** @internal */
-  isRequiresPrimary(): boolean {
-    return this.isReadFromPrimaryQ();
-  }
-
-  /** @internal */
-  isSendRequestToPrimary(): boolean {
-    return this.isReadFromPrimaryQ();
-  }
-
-  updateLastWriteTimestamp(): void {
-    this.context.updateLastWriteTimestamp();
-  }
-
-  /** @internal */
-  isPotentialWriteOperation(request: { method: string }): boolean {
-    return !this.isReadingRequest(request);
-  }
-
-  /** @internal */
-  isSavedRecentWrite(): boolean {
-    return !this.isTimeSinceLastWriteOk();
-  }
-
-  /** @internal */
-  isRecentWrite(time: Temporal.Instant): boolean {
-    return Temporal.Now.instant().epochMilliseconds - time.epochMilliseconds < this.delay;
-  }
-
-  /** @internal */
   sendToReplicaDelay(): number {
     return this.delay;
   }
 
-  /** @internal */
-  secondsSinceLastWriteTimestamp(): number {
-    return (
-      (Temporal.Now.instant().epochMilliseconds -
-        this.context.lastWriteTimestamp().epochMilliseconds) /
-      1000
-    );
-  }
-
-  /** @internal */
-  contextFor(_request: unknown): ResolverContext {
-    return this.context;
-  }
-
-  /** @internal */
   private isReadFromPrimaryQ(): boolean {
     return !this.isTimeSinceLastWriteOk();
   }
@@ -127,24 +68,28 @@ export class Resolver {
   }
 
   private async readFromPrimary<T>(blk: () => T | Promise<T>): Promise<T> {
-    return (Base as any).connectedTo({ role: "writing", preventWrites: true }, () =>
-      Notifications.instrumentAsync("database_selector.active_record.read_from_primary", {}, () =>
-        Promise.resolve(blk()),
+    return Base.connectedTo({ role: "writing", preventWrites: true }, () =>
+      this.instrumenter.instrumentAsync(
+        "database_selector.active_record.read_from_primary",
+        {},
+        () => Promise.resolve(blk()),
       ),
-    );
+    ) as Promise<T>;
   }
 
   private async readFromReplica<T>(blk: () => T | Promise<T>): Promise<T> {
-    return (Base as any).connectedTo({ role: "reading", preventWrites: true }, () =>
-      Notifications.instrumentAsync("database_selector.active_record.read_from_replica", {}, () =>
-        Promise.resolve(blk()),
+    return Base.connectedTo({ role: "reading", preventWrites: true }, () =>
+      this.instrumenter.instrumentAsync(
+        "database_selector.active_record.read_from_replica",
+        {},
+        () => Promise.resolve(blk()),
       ),
-    );
+    ) as Promise<T>;
   }
 
   private async writeToPrimary<T>(blk: () => T | Promise<T>): Promise<T> {
-    return (Base as any).connectedTo({ role: "writing", preventWrites: false }, () =>
-      Notifications.instrumentAsync(
+    return Base.connectedTo({ role: "writing", preventWrites: false }, () =>
+      this.instrumenter.instrumentAsync(
         "database_selector.active_record.wrote_to_primary",
         {},
         async () => {
@@ -155,7 +100,7 @@ export class Resolver {
           }
         },
       ),
-    );
+    ) as Promise<T>;
   }
 }
 

--- a/packages/activerecord/src/middleware/database-selector/resolver.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver.ts
@@ -1,0 +1,162 @@
+/**
+ * Mirrors: ActiveRecord::Middleware::DatabaseSelector::Resolver
+ */
+
+import { Notifications } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Session } from "./resolver/session.js";
+import { Base } from "../../base.js";
+
+export interface ResolverContext {
+  lastWriteTimestamp(): Temporal.Instant;
+  updateLastWriteTimestamp(): void;
+  save(response: unknown): void;
+}
+
+const SEND_TO_REPLICA_DELAY = 2000;
+
+export class Resolver {
+  /** @internal */
+  readonly context: ResolverContext;
+  /** @internal */
+  readonly delay: number;
+  /** @internal */
+  readonly instrumenter: typeof Notifications;
+
+  constructor(context: ResolverContext, options: { delay?: number } = {}) {
+    this.context = context;
+    this.delay = options.delay !== undefined ? options.delay : SEND_TO_REPLICA_DELAY;
+    this.instrumenter = Notifications;
+  }
+
+  static call(context: ResolverContext, options: { delay?: number } = {}): Resolver {
+    return new Resolver(context, options);
+  }
+
+  async read<T>(blk: () => T | Promise<T>): Promise<T> {
+    return this.isReadFromPrimaryQ() ? this.readFromPrimary(blk) : this.readFromReplica(blk);
+  }
+
+  async write<T>(blk: () => T | Promise<T>): Promise<T> {
+    return this.writeToPrimary(blk);
+  }
+
+  updateContext(response: unknown): void {
+    this.context.save(response);
+  }
+
+  isReadingRequest(request: { method: string }): boolean {
+    const m = request.method.toUpperCase();
+    return m === "GET" || m === "HEAD";
+  }
+
+  /** @internal */
+  isReadPrimary(): boolean {
+    return this.isReadFromPrimaryQ();
+  }
+
+  /** @internal */
+  isReadReplica(): boolean {
+    return !this.isReadFromPrimaryQ();
+  }
+
+  /** @internal */
+  isPreventWritesToPrimary(): boolean {
+    return false;
+  }
+
+  /** @internal */
+  isRequiresPrimary(): boolean {
+    return this.isReadFromPrimaryQ();
+  }
+
+  /** @internal */
+  isSendRequestToPrimary(): boolean {
+    return this.isReadFromPrimaryQ();
+  }
+
+  updateLastWriteTimestamp(): void {
+    this.context.updateLastWriteTimestamp();
+  }
+
+  /** @internal */
+  isPotentialWriteOperation(request: { method: string }): boolean {
+    return !this.isReadingRequest(request);
+  }
+
+  /** @internal */
+  isSavedRecentWrite(): boolean {
+    return !this.isTimeSinceLastWriteOk();
+  }
+
+  /** @internal */
+  isRecentWrite(time: Temporal.Instant): boolean {
+    return Temporal.Now.instant().epochMilliseconds - time.epochMilliseconds < this.delay;
+  }
+
+  /** @internal */
+  sendToReplicaDelay(): number {
+    return this.delay;
+  }
+
+  /** @internal */
+  secondsSinceLastWriteTimestamp(): number {
+    return (
+      (Temporal.Now.instant().epochMilliseconds -
+        this.context.lastWriteTimestamp().epochMilliseconds) /
+      1000
+    );
+  }
+
+  /** @internal */
+  contextFor(_request: unknown): ResolverContext {
+    return this.context;
+  }
+
+  /** @internal */
+  private isReadFromPrimaryQ(): boolean {
+    return !this.isTimeSinceLastWriteOk();
+  }
+
+  private isTimeSinceLastWriteOk(): boolean {
+    return (
+      Temporal.Now.instant().epochMilliseconds -
+        this.context.lastWriteTimestamp().epochMilliseconds >=
+      this.delay
+    );
+  }
+
+  private async readFromPrimary<T>(blk: () => T | Promise<T>): Promise<T> {
+    return (Base as any).connectedTo({ role: "writing", preventWrites: true }, () =>
+      Notifications.instrumentAsync("database_selector.active_record.read_from_primary", {}, () =>
+        Promise.resolve(blk()),
+      ),
+    );
+  }
+
+  private async readFromReplica<T>(blk: () => T | Promise<T>): Promise<T> {
+    return (Base as any).connectedTo({ role: "reading", preventWrites: true }, () =>
+      Notifications.instrumentAsync("database_selector.active_record.read_from_replica", {}, () =>
+        Promise.resolve(blk()),
+      ),
+    );
+  }
+
+  private async writeToPrimary<T>(blk: () => T | Promise<T>): Promise<T> {
+    return (Base as any).connectedTo({ role: "writing", preventWrites: false }, () =>
+      Notifications.instrumentAsync(
+        "database_selector.active_record.wrote_to_primary",
+        {},
+        async () => {
+          try {
+            return await blk();
+          } finally {
+            this.context.updateLastWriteTimestamp();
+          }
+        },
+      ),
+    );
+  }
+}
+
+export { Session };

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -32,7 +32,7 @@ export class Session {
 
   lastWriteTimestamp(): Temporal.Instant {
     const raw = this.session.get("lastWrite");
-    // Non-numeric/NaN session value → epoch 0 → treated as "very long ago" → route to primary.
+    // Non-numeric/NaN session value → epoch 0 → "very long ago" → time_since_last_write_ok? is true → route to replica.
     return Session.convertTimestampToTime(Number.isFinite(raw) ? (raw as number) : undefined);
   }
 

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -1,0 +1,64 @@
+/**
+ * Mirrors: ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+ */
+
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
+export interface SessionStore {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+  delete(key: string): void;
+}
+
+export class Session {
+  /** @internal */
+  readonly session: SessionStore;
+
+  constructor(session: SessionStore) {
+    this.session = session;
+  }
+
+  static call(request: { session: SessionStore }): Session {
+    return new Session(request.session);
+  }
+
+  static convertTimeToTimestamp(time: Temporal.Instant): number {
+    return time.epochMilliseconds;
+  }
+
+  static convertTimestampToTime(timestamp: number | undefined): Temporal.Instant {
+    return Temporal.Instant.fromEpochMilliseconds(timestamp ?? 0);
+  }
+
+  lastWriteTimestamp(): Temporal.Instant {
+    return Session.convertTimestampToTime(this.session.get("lastWrite") as number | undefined);
+  }
+
+  updateLastWriteTimestamp(): void {
+    this.session.set("lastWrite", Session.convertTimeToTimestamp(Temporal.Now.instant()));
+  }
+
+  save(_response: unknown): void {}
+
+  /** @internal */
+  restoreSession(request: { session: SessionStore }): void {
+    this.session.set("lastWrite", request.session.get("lastWrite"));
+  }
+
+  /** @internal */
+  contextFor(request: { session: SessionStore }): Session {
+    return new Session(request.session);
+  }
+
+  /** @internal */
+  delete(key: string): void {
+    this.session.delete(key);
+  }
+
+  /** @internal */
+  isStale(delaySeconds: number): boolean {
+    const elapsed =
+      Temporal.Now.instant().epochMilliseconds - this.lastWriteTimestamp().epochMilliseconds;
+    return elapsed >= delaySeconds * 1000;
+  }
+}

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -31,7 +31,8 @@ export class Session {
   }
 
   lastWriteTimestamp(): Temporal.Instant {
-    return Session.convertTimestampToTime(this.session.get("lastWrite") as number | undefined);
+    const raw = this.session.get("lastWrite");
+    return Session.convertTimestampToTime(typeof raw === "number" ? raw : undefined);
   }
 
   updateLastWriteTimestamp(): void {

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -39,26 +39,4 @@ export class Session {
   }
 
   save(_response: unknown): void {}
-
-  /** @internal */
-  restoreSession(request: { session: SessionStore }): void {
-    this.session.set("lastWrite", request.session.get("lastWrite"));
-  }
-
-  /** @internal */
-  contextFor(request: { session: SessionStore }): Session {
-    return new Session(request.session);
-  }
-
-  /** @internal */
-  delete(key: string): void {
-    this.session.delete(key);
-  }
-
-  /** @internal */
-  isStale(delaySeconds: number): boolean {
-    const elapsed =
-      Temporal.Now.instant().epochMilliseconds - this.lastWriteTimestamp().epochMilliseconds;
-    return elapsed >= delaySeconds * 1000;
-  }
 }

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -32,7 +32,7 @@ export class Session {
 
   lastWriteTimestamp(): Temporal.Instant {
     const raw = this.session.get("lastWrite");
-    return Session.convertTimestampToTime(typeof raw === "number" ? raw : undefined);
+    return Session.convertTimestampToTime(Number.isFinite(raw) ? (raw as number) : undefined);
   }
 
   updateLastWriteTimestamp(): void {

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -32,6 +32,7 @@ export class Session {
 
   lastWriteTimestamp(): Temporal.Instant {
     const raw = this.session.get("lastWrite");
+    // Non-numeric/NaN session value → epoch 0 → treated as "very long ago" → route to primary.
     return Session.convertTimestampToTime(Number.isFinite(raw) ? (raw as number) : undefined);
   }
 

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -66,8 +66,8 @@ export class ShardSelector {
   private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
     const shardKey =
       typeof shard === "string" ? shard : (Symbol.keyFor(shard) ?? shard.description ?? "");
-    return (Base as any).connectedTo({ shard: shardKey }, () =>
-      (Base as any).prohibitShardSwapping(() => block(), this.options.lock ?? true),
-    );
+    return Base.connectedTo({ shard: shardKey }, () =>
+      Base.prohibitShardSwapping(() => block(), this.options.lock ?? true),
+    ) as Promise<T>;
   }
 }

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -66,7 +66,7 @@ export class ShardSelector {
   private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
     const shardKey = typeof shard === "string" ? shard : shard.toString();
     return (Base as any).connectedTo({ shard: shardKey }, () =>
-      (Base as any).prohibitShardSwapping(this.options.lock ?? true, () => block()),
+      (Base as any).prohibitShardSwapping(() => block(), this.options.lock ?? true),
     );
   }
 }

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -1,0 +1,72 @@
+/**
+ * Mirrors: ActiveRecord::Middleware::ShardSelector
+ *
+ * Middleware for automatic shard selection based on request context.
+ */
+
+import { Base } from "../base.js";
+import { Notifications } from "@blazetrails/activesupport";
+
+export interface ShardRequest {
+  method: string;
+  [key: string]: unknown;
+}
+
+type ShardResolverFn = (request: ShardRequest) => string | symbol;
+
+type NextHandler = () => Promise<unknown>;
+
+export class ShardSelector {
+  /** @internal */
+  readonly resolver: ShardResolverFn;
+  /** @internal */
+  readonly options: { lock?: boolean };
+
+  private readonly app: (next: NextHandler) => Promise<unknown>;
+
+  constructor(
+    app: (next: NextHandler) => Promise<unknown>,
+    resolver: ShardResolverFn,
+    options: { lock?: boolean } = {},
+  ) {
+    this.app = app;
+    this.resolver = resolver;
+    this.options = options;
+  }
+
+  async call(request: ShardRequest): Promise<unknown> {
+    const shard = this.selectShard(request);
+    return this.setShard(shard, () => this.app(() => Promise.resolve()));
+  }
+
+  /** @internal */
+  instrumenter(): typeof Notifications {
+    return Notifications;
+  }
+
+  /** @internal */
+  shardResolver(): ShardResolverFn {
+    return this.resolver;
+  }
+
+  /** @internal */
+  shardSelectorStrategy(): { lock: boolean } {
+    return { lock: this.options.lock ?? true };
+  }
+
+  /** @internal */
+  selectedShard(request: ShardRequest): string | symbol {
+    return this.resolver(request);
+  }
+
+  private selectShard(request: ShardRequest): string | symbol {
+    return this.selectedShard(request);
+  }
+
+  private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
+    const shardKey = typeof shard === "string" ? shard : shard.toString();
+    return (Base as any).connectedTo({ shard: shardKey }, () =>
+      (Base as any).prohibitShardSwapping(this.options.lock ?? true, () => block()),
+    );
+  }
+}

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -64,7 +64,8 @@ export class ShardSelector {
   }
 
   private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
-    const shardKey = typeof shard === "string" ? shard : shard.toString();
+    const shardKey =
+      typeof shard === "string" ? shard : (Symbol.keyFor(shard) ?? shard.description ?? "");
     return (Base as any).connectedTo({ shard: shardKey }, () =>
       (Base as any).prohibitShardSwapping(() => block(), this.options.lock ?? true),
     );

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -14,18 +14,16 @@ export interface ShardRequest {
 
 type ShardResolverFn = (request: ShardRequest) => string | symbol;
 
-type NextHandler = () => Promise<unknown>;
-
 export class ShardSelector {
   /** @internal */
   readonly resolver: ShardResolverFn;
   /** @internal */
   readonly options: { lock?: boolean };
 
-  private readonly app: (next: NextHandler) => Promise<unknown>;
+  private readonly app: (request: ShardRequest) => Promise<unknown>;
 
   constructor(
-    app: (next: NextHandler) => Promise<unknown>,
+    app: (request: ShardRequest) => Promise<unknown>,
     resolver: ShardResolverFn,
     options: { lock?: boolean } = {},
   ) {
@@ -36,7 +34,7 @@ export class ShardSelector {
 
   async call(request: ShardRequest): Promise<unknown> {
     const shard = this.selectShard(request);
-    return this.setShard(shard, () => this.app(() => Promise.resolve()));
+    return this.setShard(shard, () => this.app(request));
   }
 
   /** @internal */
@@ -64,8 +62,14 @@ export class ShardSelector {
   }
 
   private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
-    const shardKey =
-      typeof shard === "string" ? shard : (Symbol.keyFor(shard) ?? shard.description ?? "");
+    let shardKey: string;
+    if (typeof shard === "string") {
+      shardKey = shard;
+    } else {
+      const name = Symbol.keyFor(shard) ?? shard.description;
+      if (!name) throw new Error(`Cannot convert symbol to shard key: ${String(shard)}`);
+      shardKey = name;
+    }
     return Base.connectedTo({ shard: shardKey }, () =>
       Base.prohibitShardSwapping(() => block(), this.options.lock ?? true),
     ) as Promise<T>;

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -6,6 +6,7 @@
 
 import { Base } from "../base.js";
 import { Notifications } from "@blazetrails/activesupport";
+import { ArgumentError } from "@blazetrails/activemodel";
 
 export interface ShardRequest {
   method: string;
@@ -63,7 +64,7 @@ export class ShardSelector {
       shardKey = shard;
     } else {
       const name = Symbol.keyFor(shard) ?? shard.description;
-      if (!name) throw new Error(`Cannot convert symbol to shard key: ${String(shard)}`);
+      if (!name) throw new ArgumentError(`Cannot convert symbol to shard key: ${String(shard)}`);
       shardKey = name;
     }
     return Base.connectedTo({ shard: shardKey }, () =>

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -33,7 +33,7 @@ export class ShardSelector {
   }
 
   async call(request: ShardRequest): Promise<unknown> {
-    const shard = this.selectShard(request);
+    const shard = this.selectedShard(request);
     return this.setShard(shard, () => this.app(request));
   }
 
@@ -55,10 +55,6 @@ export class ShardSelector {
   /** @internal */
   selectedShard(request: ShardRequest): string | symbol {
     return this.resolver(request);
-  }
-
-  private selectShard(request: ShardRequest): string | symbol {
-    return this.selectedShard(request);
   }
 
   private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary

Implements all four middleware files to 100%:

- `middleware/database-selector/resolver.ts` — 15/15: Resolver with primary/replica routing, write-recency delay, Notifications instrumentation via `this.instrumenter.instrumentAsync`, Temporal-based timestamp comparison
- `middleware/database-selector/resolver/session.ts` — 8/8: Session-backed context storing last-write `Temporal.Instant` as epoch-ms; `convertTimeToTimestamp`/`convertTimestampToTime` class helpers
- `middleware/database-selector.ts` — 6/6: DatabaseSelector middleware orchestrating resolver + context; delegates read/write routing to resolver
- `middleware/shard-selector.ts` — 6/6: ShardSelector middleware with symbol-safe shard-key extraction (`Symbol.keyFor ?? description`), `Base.connectedTo` + `prohibitShardSwapping(lock)` wiring

## Design notes

Rails middleware uses Rack `call(env)`. The TS project has no Rack equivalent. Both middleware classes define a minimal `MiddlewareRequest` interface (`{ method, session }`) that callers adapt to — the behavior (role routing, timestamp tracking, shard locking) is Rails-faithful even though the HTTP surface differs.

Temporal.Instant is used throughout instead of `Date` per the `blazetrails/no-native-date` lint rule.

## Depends on

PR 48 ✅ (#1261) — database_configurations + connection_url_resolver