### PR TITLE
feat(activerecord): pg database_statements residual privates to 100% (PR 18b)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -90,8 +90,14 @@ interface CastResultHost {
   getOidType(oid: number, fmod: number, columnName: string, sqlType?: string): Promise<Type>;
 }
 
-/** @internal */
-function cancelAnyRunningQuery(): never {
+/**
+ * node-pg has no equivalent of PG::Connection#cancel; requires a separate
+ * backend connection issuing pg_cancel_backend(pid).
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query
+ * @internal
+ */
+export function cancelAnyRunningQuery(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query is not implemented",
   );
@@ -201,50 +207,100 @@ export function affectedRows(result: pg.QueryResult): number {
 }
 
 /** @internal */
-function executeBatch(statements: any, name?: any, kwargs?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute_batch is not implemented",
-  );
+interface ExecuteBatchHost {
+  execute(sql: string, binds?: unknown[], name?: string | null): Promise<unknown>;
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute_batch
+ * @internal
+ */
+export async function executeBatch(
+  this: ExecuteBatchHost,
+  statements: string[],
+  name: string | null = null,
+): Promise<unknown> {
+  return this.execute(statements.join("; "), [], name);
 }
 
 /** @internal */
-function buildTruncateStatements(tableNames: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_truncate_statements is not implemented",
-  );
+interface BuildTruncateStatementsHost {
+  quoteTableName(name: string): string;
+}
+
+/**
+ * Rails combines all table names into a single TRUNCATE statement.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_truncate_statements
+ * @internal
+ */
+export function buildTruncateStatements(
+  this: BuildTruncateStatementsHost,
+  tableNames: string[],
+): string[] {
+  return [`TRUNCATE TABLE ${tableNames.map((t) => this.quoteTableName(t)).join(", ")}`];
 }
 
 /** @internal */
-function lastInsertIdResult(sequenceName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#last_insert_id_result is not implemented",
-  );
+interface LastInsertIdResultHost {
+  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  quote(value: unknown): string;
 }
 
-/** @internal */
-function returningColumnValues(result: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#returning_column_values is not implemented",
-  );
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#last_insert_id_result
+ * @internal
+ */
+export async function lastInsertIdResult(
+  this: LastInsertIdResultHost,
+  sequenceName: string,
+): Promise<Result> {
+  return this.execQuery(`SELECT currval(${this.quote(sequenceName)})`, "SQL");
 }
 
-/** @internal */
-function suppressCompositePrimaryKey(pk: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#suppress_composite_primary_key is not implemented",
-  );
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#returning_column_values
+ * @internal
+ */
+export function returningColumnValues(result: Result): unknown[] | undefined {
+  return result.rows[0];
 }
 
-/** @internal */
-function handleWarnings(sql: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings is not implemented",
-  );
+/**
+ * Returns pk unless it is composite (array), in which case returns undefined.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#suppress_composite_primary_key
+ * @internal
+ */
+export function suppressCompositePrimaryKey(pk: string | string[] | undefined): string | undefined {
+  return Array.isArray(pk) ? undefined : pk;
 }
 
-/** @internal */
-function isWarningIgnored(warning: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored? is not implemented",
-  );
+/**
+ * Dispatches accumulated notice-receiver warnings to the configured warnings action.
+ * Rails passes the PG::Result to this method (named `sql` in the source) so each
+ * warning can have its `sql` attribute set; we receive the pg.QueryResult here.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
+ * @internal
+ */
+export function handleWarnings(
+  this: { _noticeReceiverSqlWarnings?: Array<{ level?: string; sql?: unknown }> },
+  result: pg.QueryResult,
+): void {
+  if (!this._noticeReceiverSqlWarnings?.length) return;
+  for (const warning of this._noticeReceiverSqlWarnings) {
+    if (isWarningIgnored(warning)) continue;
+    warning.sql = result;
+  }
+}
+
+const IGNORED_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored?
+ * @internal
+ */
+export function isWarningIgnored(warning: { level?: string }): boolean {
+  return !IGNORED_LEVELS.has(warning.level ?? "");
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -279,15 +279,34 @@ export function suppressCompositePrimaryKey(pk: string | string[] | undefined): 
   return Array.isArray(pk) ? undefined : pk;
 }
 
+// Levels that Rails treats as actionable (not ignored). Anything outside
+// this set (e.g. NOTICE, DEBUG) is silently dropped.
+const ACTIONABLE_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
+
 /** @internal */
-interface HandleWarningsHost extends IsWarningIgnoredHost {
-  _noticeReceiverSqlWarnings?: Array<{ level?: string; sql?: unknown; [k: string]: unknown }>;
+type SqlWarning = {
+  level?: string;
+  message?: string;
+  code?: string | number;
+  sql?: unknown;
+  [k: string]: unknown;
+};
+
+/** @internal */
+interface HandleWarningsHost {
+  _noticeReceiverSqlWarnings?: SqlWarning[];
+  // Used to call the abstract adapter's pattern-matcher without risking
+  // recursion if this module's isWarningIgnored is later bound to the class.
+  _abstractIsWarningIgnored?(warning: SqlWarning): boolean;
 }
 
 /**
- * Iterates notice-receiver warnings accumulated during the query, attaches the
- * result object (Rails attaches the PG::Result; node-pg equivalent here), and
- * dispatches each actionable warning. No-ops when no warnings were collected.
+ * Iterates notice-receiver warnings accumulated during the query and attaches
+ * the result object (mirrors Rails attaching the PG::Result).
+ *
+ * Rails also calls `ActiveRecord.db_warnings_action.call(warning)` here.
+ * That global hook is not yet wired in TS; warnings are collected and filtered
+ * but not dispatched to a user-configured action. Tracked as a follow-up.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
  * @internal
@@ -297,34 +316,28 @@ export function handleWarnings(this: HandleWarningsHost, result: pg.QueryResult)
   for (const warning of this._noticeReceiverSqlWarnings) {
     if (isWarningIgnored.call(this, warning)) continue;
     warning.sql = result;
+    // TODO: dispatch to ActiveRecord.db_warnings_action equivalent once wired
   }
 }
 
-// Levels that Rails treats as actionable (not ignored). Anything outside
-// this set (e.g. NOTICE, DEBUG) is silently dropped.
-const ACTIONABLE_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
-
 /** @internal */
 interface IsWarningIgnoredHost {
-  /** @internal */
-  isWarningIgnored(warning: {
-    message?: string;
-    code?: string | number;
-    [k: string]: unknown;
-  }): boolean;
+  _abstractIsWarningIgnored?(warning: SqlWarning): boolean;
 }
 
 /**
- * A warning is ignored if its level is below the actionable threshold OR if
- * the base adapter's pattern matchers (db_warnings_ignore) say to ignore it.
+ * A warning is ignored if its level is below the actionable threshold (not in
+ * WARNING/ERROR/FATAL/PANIC) OR if the base adapter's pattern matchers
+ * (db_warnings_ignore) say to ignore it.
+ *
+ * Uses `_abstractIsWarningIgnored` (set to `AbstractAdapter.prototype.isWarningIgnored`)
+ * for the `|| super` delegation, avoiding self-recursion if this function is ever
+ * assigned to the class as `isWarningIgnored`.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored?
  * @internal
  */
-export function isWarningIgnored(
-  this: IsWarningIgnoredHost | void,
-  warning: { level?: string; message?: string; code?: string | number; [k: string]: unknown },
-): boolean {
+export function isWarningIgnored(this: IsWarningIgnoredHost | void, warning: SqlWarning): boolean {
   const belowThreshold = !ACTIONABLE_LEVELS.has(warning.level ?? "");
-  return belowThreshold || (this != null && this.isWarningIgnored(warning));
+  return belowThreshold || (this?._abstractIsWarningIgnored?.(warning) ?? false);
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -5,7 +5,7 @@
  */
 
 import pg from "pg";
-import { NotImplementedError, PreparedStatementCacheExpired } from "../../errors.js";
+import { PreparedStatementCacheExpired } from "../../errors.js";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
 import type { ExplainOption } from "../../adapter.js";
@@ -90,17 +90,20 @@ interface CastResultHost {
   getOidType(oid: number, fmod: number, columnName: string, sqlType?: string): Promise<Type>;
 }
 
+/** @internal */
+interface CancelAnyRunningQueryHost {
+  _cancelAnyRunningQuery(): void;
+}
+
 /**
- * node-pg has no equivalent of PG::Connection#cancel; requires a separate
- * backend connection issuing pg_cancel_backend(pid).
+ * Delegates to the adapter's `_cancelAnyRunningQuery` which uses node-pg's
+ * internal `client.cancel()` to send a CancelRequest before ROLLBACK.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query
  * @internal
  */
-export function cancelAnyRunningQuery(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query is not implemented",
-  );
+export function cancelAnyRunningQuery(this: CancelAnyRunningQueryHost): void {
+  this._cancelAnyRunningQuery();
 }
 
 /**
@@ -220,7 +223,7 @@ export async function executeBatch(
   statements: string[],
   name: string | null = null,
 ): Promise<unknown> {
-  return this.execute(statements.join("; "), [], name);
+  return this.execute(statements.join("; "), [], name ?? undefined);
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -276,31 +276,52 @@ export function suppressCompositePrimaryKey(pk: string | string[] | undefined): 
   return Array.isArray(pk) ? undefined : pk;
 }
 
+/** @internal */
+interface HandleWarningsHost extends IsWarningIgnoredHost {
+  _noticeReceiverSqlWarnings?: Array<{ level?: string; sql?: unknown; [k: string]: unknown }>;
+}
+
 /**
- * Dispatches accumulated notice-receiver warnings to the configured warnings action.
- * Rails passes the PG::Result to this method (named `sql` in the source) so each
- * warning can have its `sql` attribute set; we receive the pg.QueryResult here.
+ * Iterates notice-receiver warnings accumulated during the query, attaches the
+ * result object (Rails attaches the PG::Result; node-pg equivalent here), and
+ * dispatches each actionable warning. No-ops when no warnings were collected.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
  * @internal
  */
-export function handleWarnings(
-  this: { _noticeReceiverSqlWarnings?: Array<{ level?: string; sql?: unknown }> },
-  result: pg.QueryResult,
-): void {
+export function handleWarnings(this: HandleWarningsHost, result: pg.QueryResult): void {
   if (!this._noticeReceiverSqlWarnings?.length) return;
   for (const warning of this._noticeReceiverSqlWarnings) {
-    if (isWarningIgnored(warning)) continue;
+    if (isWarningIgnored.call(this, warning)) continue;
     warning.sql = result;
   }
 }
 
-const IGNORED_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
+// Levels that Rails treats as actionable (not ignored). Anything outside
+// this set (e.g. NOTICE, DEBUG) is silently dropped.
+const ACTIONABLE_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
+
+/** @internal */
+interface IsWarningIgnoredHost {
+  /** @internal */
+  isWarningIgnored(warning: {
+    message?: string;
+    code?: string | number;
+    [k: string]: unknown;
+  }): boolean;
+}
 
 /**
+ * A warning is ignored if its level is below the actionable threshold OR if
+ * the base adapter's pattern matchers (db_warnings_ignore) say to ignore it.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored?
  * @internal
  */
-export function isWarningIgnored(warning: { level?: string }): boolean {
-  return !IGNORED_LEVELS.has(warning.level ?? "");
+export function isWarningIgnored(
+  this: IsWarningIgnoredHost | void,
+  warning: { level?: string; message?: string; code?: string | number; [k: string]: unknown },
+): boolean {
+  const belowThreshold = !ACTIONABLE_LEVELS.has(warning.level ?? "");
+  return belowThreshold || (this != null && this.isWarningIgnored(warning));
 }


### PR DESCRIPTION
## Summary

- Implements 7 remaining private methods in \`connection-adapters/postgresql/database-statements.ts\`, bringing it from 71% (17/24) to 100% (24/24)
- Implements \`cancelAnyRunningQuery\` by delegating to the adapter's existing \`_cancelAnyRunningQuery()\` (node-pg CancelRequest via \`client.cancel()\`)
- Implements \`executeBatch\`, \`buildTruncateStatements\`, \`lastInsertIdResult\`, \`returningColumnValues\`, \`suppressCompositePrimaryKey\`, \`handleWarnings\`, \`isWarningIgnored\` with real behavior matching Rails source

## Details

- \`cancelAnyRunningQuery\`: delegates to \`this._cancelAnyRunningQuery()\` which sends a CancelRequest before ROLLBACK/ROLLBACK AND CHAIN
- \`buildTruncateStatements\`: single \`TRUNCATE TABLE a, b, c\` statement (PG supports combined form)
- \`lastInsertIdResult\`: \`SELECT currval(\${quote(sequenceName)})\` via \`execQuery\`
- \`returningColumnValues\`: returns \`result.rows[0]\` (mirrors Rails' \`result.rows.first\`)
- \`suppressCompositePrimaryKey\`: \`undefined\` for array PKs, passthrough otherwise
- \`isWarningIgnored\`: level check against ACTIONABLE_LEVELS + delegates to \`_abstractIsWarningIgnored\` for the \`|| super\` pattern-matcher chain; avoids self-recursion if function is later mixed into the class
- \`handleWarnings\`: iterates \`_noticeReceiverSqlWarnings\`, filters via \`isWarningIgnored\`, attaches result; \`db_warnings_action\` dispatch not yet wired in TS (TODO)
- \`executeBatch\`: joins with \`"; "\` and delegates to \`execute\`; \`batch: true\` flag (PG pipeline mode) is a known divergence from Rails

## Verification

\`\`\`
connection_adapters/postgresql/database_statements.rb → 24/24 100% ✓
\`\`\`

~100 net LOC, well within 300 LOC ceiling.

Depends on: #1262 (PR 18, merged)