### PR TITLE
fix(activerecord): mysql2 ER_BAD_DB_ERROR → NoDatabaseError + integration tests (PR 51b)

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -378,7 +378,7 @@ TS paths use `$TS/` = `packages/activerecord/src/`.
 - Dependencies: PR 48
 - Risk: These depend on Rack-style middleware infrastructure. Verify how `connection-handling.ts` implements the middleware interface before implementing.
 
-**PR 51 — Tasks cluster**
+**PR 51 — Tasks cluster** (#1270)
 
 - Rails sources:
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -841,7 +841,7 @@ describeIfMysql("Mysql2Adapter", () => {
       try {
         await expect(adapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
       } finally {
-        await (adapter as any).close?.();
+        await adapter.close();
       }
     });
   });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -3,6 +3,7 @@ import mysql from "mysql2/promise";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { Base, transaction, registerModel, loadBelongsTo, loadHasMany } from "../index.js";
+import { NoDatabaseError } from "../errors.js";
 
 /**
  * These tests require a running MySQL instance. They will be skipped if
@@ -829,6 +830,19 @@ describeIfMysql("Mysql2Adapter", () => {
 
     it("defaultPreparedStatements returns false", () => {
       expect((adapter as any).defaultPreparedStatements()).toBe(false);
+    });
+  });
+
+  describe("NoDatabaseError translation", () => {
+    it("throws NoDatabaseError when connecting to a nonexistent database", async () => {
+      const url = new URL(MYSQL_TEST_URL);
+      url.pathname = "/trails_nonexistent_db_" + Math.random().toString(36).slice(2);
+      const adapter = new Mysql2Adapter(url.toString());
+      try {
+        await expect(adapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
+      } finally {
+        await (adapter as any).close?.();
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -208,23 +208,27 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._driverPool = Mysql2Adapter.newClient(mysqlConfig);
   }
 
-  /**
-   * Get the active connection — either the transaction connection or a fresh
-   * one from the pool.
-   */
-  private async getConn(): Promise<mysql.PoolConnection> {
-    if (this._conn) return this._conn;
+  /** Checkout a fresh connection from the pool, translating ER_BAD_DB_ERROR. */
+  private async _checkoutConn(): Promise<mysql.PoolConnection> {
     if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     try {
       return await this._driverPool.getConnection();
     } catch (error) {
       const e = error as { code?: unknown; errno?: unknown };
       if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) {
-        const db = this._database ?? "unknown";
-        throw NoDatabaseError.dbError(db);
+        throw NoDatabaseError.dbError(this._database ?? "unknown");
       }
       throw error;
     }
+  }
+
+  /**
+   * Get the active connection — either the transaction connection or a fresh
+   * one from the pool.
+   */
+  private async getConn(): Promise<mysql.PoolConnection> {
+    if (this._conn) return this._conn;
+    return this._checkoutConn();
   }
 
   /**
@@ -427,8 +431,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Begin a transaction. Acquires a dedicated connection from the pool.
    */
   async beginTransaction(): Promise<void> {
-    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
-    this._conn = await this._driverPool.getConnection();
+    this._conn = await this._checkoutConn();
     await this._conn.query("BEGIN");
     this._inTransaction = true;
   }
@@ -907,8 +910,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _advisoryLockConn: mysql.PoolConnection | null = null;
 
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
-    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
-    const conn = await this._driverPool.getConnection();
+    const conn = await this._checkoutConn();
     try {
       const [rows] = await conn.query("SELECT GET_LOCK(?, 0) AS locked", [String(lockId)]);
       const locked = (rows as Record<string, unknown>[])[0]?.locked === 1;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -8,7 +8,7 @@ import {
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
 import { Version } from "./abstract-adapter.js";
-import { MismatchedForeignKey, NotImplementedError } from "../errors.js";
+import { MismatchedForeignKey, NoDatabaseError, NotImplementedError } from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
@@ -168,6 +168,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // not yet probed, `true`/`false` = result.
   private _statisticsHasExpression: boolean | undefined;
   private _fullVersionString: string | null = null;
+  private _database: string | undefined;
 
   constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
     super();
@@ -184,6 +185,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const { statementLimit, preparedStatements, ...mysqlConfig } = config;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
+    this._database = mysqlConfig.database as string | undefined;
     this._driverPool = Mysql2Adapter.newClient(mysqlConfig);
   }
 
@@ -194,7 +196,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private async getConn(): Promise<mysql.PoolConnection> {
     if (this._conn) return this._conn;
     if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
-    return this._driverPool.getConnection();
+    try {
+      return await this._driverPool.getConnection();
+    } catch (error) {
+      const e = error as { code?: unknown; errno?: unknown };
+      if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) {
+        const db = this._database ?? "unknown";
+        throw NoDatabaseError.dbError(db);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -174,7 +174,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     super();
     if (typeof config === "string") {
       try {
-        this._database = new URL(config).pathname.replace(/^\/+/, "") || undefined;
+        this._database =
+          decodeURIComponent(new URL(config).pathname.replace(/^\/+/, "").replace(/\/+$/, "")) ||
+          undefined;
       } catch {
         // malformed URI — leave _database undefined
       }
@@ -195,7 +197,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       (() => {
         try {
           const uri = (mysqlConfig as { uri?: string }).uri;
-          return uri ? new URL(uri).pathname.replace(/^\/+/, "") || undefined : undefined;
+          return uri
+            ? decodeURIComponent(new URL(uri).pathname.replace(/^\/+/, "").replace(/\/+$/, "")) ||
+                undefined
+            : undefined;
         } catch {
           return undefined;
         }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -190,7 +190,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const { statementLimit, preparedStatements, ...mysqlConfig } = config;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
-    this._database = mysqlConfig.database as string | undefined;
+    this._database =
+      (mysqlConfig.database as string | undefined) ??
+      (() => {
+        try {
+          const uri = (mysqlConfig as { uri?: string }).uri;
+          return uri ? new URL(uri).pathname.replace(/^\/+/, "") || undefined : undefined;
+        } catch {
+          return undefined;
+        }
+      })();
     this._driverPool = Mysql2Adapter.newClient(mysqlConfig);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -173,6 +173,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
     super();
     if (typeof config === "string") {
+      try {
+        this._database = new URL(config).pathname.replace(/^\/+/, "") || undefined;
+      } catch {
+        // malformed URI — leave _database undefined
+      }
       this._driverPool = Mysql2Adapter.newClient({ uri: config });
       return;
     }

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1420,41 +1420,20 @@ describe("initializeDatabase", () => {
     await expect(initializeDatabase(config)).rejects.toThrow("unexpected connection error");
   });
 
-  it("creates the DB and returns true when probe throws NoDatabaseError", async () => {
-    let created = false;
-    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
-      execute: async () => {
-        throw new NoDatabaseError("no database");
-      },
-      close: async () => {},
-    });
-    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
-      created = true;
-    });
-    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
-    const result = await initializeDatabase(config);
-    expect(created).toBe(true);
-    expect(result).toBe(true);
-  });
-
-  it("creates the DB and returns true when probe throws MySQL ER_BAD_DB_ERROR", async () => {
-    let created = false;
-    const mysqlErr = Object.assign(new Error("Unknown database 'mydb'"), {
-      code: "ER_BAD_DB_ERROR",
-    });
-    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
-      execute: async () => {
-        throw mysqlErr;
-      },
-      close: async () => {},
-    });
-    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
-      created = true;
-    });
-    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
-    const result = await initializeDatabase(config);
-    expect(created).toBe(true);
-    expect(result).toBe(true);
+  it("creates the DB and returns true when the database file does not exist", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-initdb-new-"));
+    const dbFile = path.join(tmp, "newdb.sqlite3");
+    try {
+      const config = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: dbFile,
+      });
+      const result = await initializeDatabase(config);
+      expect(result).toBe(true);
+      expect(fs.existsSync(dbFile)).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("loads schema dump when DB is fresh and dump file exists", async () => {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1436,6 +1436,23 @@ describe("initializeDatabase", () => {
     }
   });
 
+  it("calls DatabaseTasks.create when probe throws NoDatabaseError", async () => {
+    let created = false;
+    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+      execute: async () => {
+        throw new NoDatabaseError("no database");
+      },
+      close: async () => {},
+    });
+    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
+      created = true;
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    const result = await initializeDatabase(config);
+    expect(created).toBe(true);
+    expect(result).toBe(true);
+  });
+
   it("loads schema dump when DB is fresh and dump file exists", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-initdb-schema-"));
     const schemaFile = path.join(tmp, "schema.ts");

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1222,17 +1222,12 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
   });
 }
 
-// TODO: remove _isMissingDatabaseError once mysql2-adapter translates ER_BAD_DB_ERROR to
-// NoDatabaseError at the connection level (matching how postgresql-adapter already does in
-// newClient). The 3D000 branch is dead code for PG today because connection failures are
-// already translated by PostgreSQLAdapter.newClient before SELECT 1 runs.
+// Defensive fallback for SQL-level errors that slip through pool proxies or
+// adapters that don't yet translate at connection time.
 function _isMissingDatabaseError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const e = error as { code?: unknown; errno?: unknown };
-  // MySQL: ER_BAD_DB_ERROR (errno 1049) — adapter doesn't translate this to NoDatabaseError yet
-  if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) return true;
-  // PostgreSQL: SQLSTATE 3D000 — dead code today since PG translates at connection time,
-  // kept as a defensive fallback in case the SQL-level error surfaces through a pool proxy.
-  if (e.code === "3D000") return true;
-  return false;
+  const e = error as { code?: unknown };
+  // PostgreSQL SQLSTATE 3D000 — normally translated by PostgreSQLAdapter.newClient,
+  // kept here as a safety net for pool proxies that re-surface the raw error.
+  return e.code === "3D000";
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1270 (tasks cluster). Addresses three known gaps documented in that PR body.

- **mysql2-adapter**: translate `ER_BAD_DB_ERROR` (errno 1049) to `NoDatabaseError` in `getConn()`, matching how `PostgreSQLAdapter.newClient` already does it at the connection level. Stores `_database` from constructor config for the error message.
- **database-tasks**: remove the MySQL `ER_BAD_DB_ERROR` branch from `_isMissingDatabaseError` (now handled by the adapter); the function is now a defensive PG SQLSTATE 3D000 fallback only.
- **tests**: replace the two fragile `_connectFor` mock tests for `initializeDatabase` with a single real file-based SQLite integration test (non-existent path → creates file → returns true). The redundant MySQL ER_BAD_DB_ERROR test is dropped since it now goes through the same NoDatabaseError path.
- **docs**: mark PR 51 as merged with `(#1270)`.