### PR TITLE
feat(activerecord/encryption): ENC-0 — invalidation hook + ignoreCase accessor

### DIFF
--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -156,6 +156,34 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     }
   });
 
+  it("_invalidateCaches fires registered onConfigure hooks", () => {
+    let callCount = 0;
+    const dispose = Configurable.onConfigure(() => {
+      callCount++;
+    });
+    try {
+      Configurable._invalidateCaches();
+      expect(callCount).toBe(1);
+      Configurable._invalidateCaches();
+      expect(callCount).toBe(2);
+    } finally {
+      dispose();
+    }
+  });
+
+  it(".configure calls _invalidateCaches so onConfigure hooks fire", () => {
+    let fired = false;
+    const dispose = Configurable.onConfigure(() => {
+      fired = true;
+    });
+    try {
+      Configurable.configure({ primaryKey: "test-key" });
+      expect(fired).toBe(true);
+    } finally {
+      dispose();
+    }
+  });
+
   it("excludeFromFilterParameters excludes specific attributes while others are still filtered", () => {
     Configurable.config.excludeFromFilterParameters = ["secret_token"];
 

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -156,7 +156,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     }
   });
 
-  it(".configure calls _invalidateCaches so onConfigure hooks fire", () => {
+  it("configure fires onConfigure hooks so cache-clearing callbacks take effect", () => {
     let fired = false;
     const dispose = Configurable.onConfigure(() => {
       fired = true;

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -156,21 +156,6 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     }
   });
 
-  it("_invalidateCaches fires registered onConfigure hooks", () => {
-    let callCount = 0;
-    const dispose = Configurable.onConfigure(() => {
-      callCount++;
-    });
-    try {
-      Configurable._invalidateCaches();
-      expect(callCount).toBe(1);
-      Configurable._invalidateCaches();
-      expect(callCount).toBe(2);
-    } finally {
-      dispose();
-    }
-  });
-
   it(".configure calls _invalidateCaches so onConfigure hooks fire", () => {
     let fired = false;
     const dispose = Configurable.onConfigure(() => {

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -50,8 +50,7 @@ export class Configurable {
     this._invalidateCaches();
   }
 
-  /** @internal */
-  static _invalidateCaches(): void {
+  private static _invalidateCaches(): void {
     // Mirror Rails: reset_default_context after setting config so context
     // properties derived from config (e.g. key_provider) are re-evaluated.
     Contexts.resetDefaultContext();

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -47,6 +47,11 @@ export class Configurable {
       }
     }
 
+    this._invalidateCaches();
+  }
+
+  /** @internal */
+  static _invalidateCaches(): void {
     // Mirror Rails: reset_default_context after setting config so context
     // properties derived from config (e.g. key_provider) are re-evaluated.
     Contexts.resetDefaultContext();

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -54,7 +54,7 @@ export class Configurable {
     // Mirror Rails: reset_default_context after setting config so context
     // properties derived from config (e.g. key_provider) are re-evaluated.
     Contexts.resetDefaultContext();
-    for (const hook of _configureHooks) hook();
+    for (const hook of [..._configureHooks]) hook();
   }
 
   static onConfigure(hook: () => void): () => void {

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -8,7 +8,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 // Memoized SHA1 key provider: PBKDF2 is expensive (65536 iterations), so
 // reuse the same provider as long as primaryKey and keyDerivationSalt haven't
-// changed. Keyed on the tuple so config rotation invalidates the cache.
+// changed. Cleared by the onConfigure hook below so config rotation invalidates it.
 let _sha1ProviderCache:
   | {
       primaryKey: string | string[];
@@ -16,6 +16,12 @@ let _sha1ProviderCache:
       provider: DerivedSecretKeyProvider;
     }
   | undefined;
+
+// Clear the SHA1 provider cache whenever configure() is called so the new
+// primary key / key derivation salt is picked up on the next encrypt call.
+Configurable.onConfigure(() => {
+  _sha1ProviderCache = undefined;
+});
 
 function getSha1KeyProvider(
   primaryKey: string | string[],

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -135,6 +135,10 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.scheme.deterministic ?? false;
   }
 
+  get ignoreCase(): boolean {
+    return this.scheme.ignoreCase;
+  }
+
   override type(): string {
     return this.castType.type();
   }


### PR DESCRIPTION
## Summary

Prerequisites for reopening E3 (#1143) and E4 (#1144), which closed with: *"will reopen once the Configurable invalidation hook and ignoreCase accessor infrastructure are in place."*

- **Piece 1 — `Configurable._invalidateCaches()`**: Extracts the post-`configure()` cleanup (`resetDefaultContext` + firing `onConfigure` hooks) into a named private method, consistent with the snapshot iteration pattern already used in `encryptedAttributeWasDeclared`. Also registers an `onConfigure` hook in `encryptable-record.ts` to clear `_sha1ProviderCache` on config rotation.
- **Piece 2 — `EncryptedAttributeType.ignoreCase` getter**: Delegates to `scheme.ignoreCase`, giving ENC-3/4 a stable public accessor without casting through `scheme`.

## What this is NOT

This PR does **not** implement `encryption.ts`, `encryptor.ts`, `encryptable-record.ts`, or `encrypted-attribute-type.ts` beyond the two pieces above. All of that belongs in ENC-1..4.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/encryption/configurable.test.ts` — 8 tests pass (1 new: `configure fires onConfigure hooks so cache-clearing callbacks take effect`)
- [ ] `pnpm vitest run packages/activerecord/src/encryption/encryptable-record.test.ts` — 52 tests pass
- [ ] Build + typecheck pass (verified via pre-commit hook)