### PR TITLE
feat(activerecord/encryption): ENC-2 — encryptor private methods to 100%

### DIFF
--- a/packages/activerecord/src/encryption/default-key-provider-cache.ts
+++ b/packages/activerecord/src/encryption/default-key-provider-cache.ts
@@ -1,0 +1,47 @@
+/**
+ * Module-level single-entry cache for the default key provider. Shared across
+ * all Scheme and Encryptor instances so PBKDF2 runs once per
+ * (primaryKey, salt, digest) tuple.
+ */
+
+import { Configurable } from "./configurable.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+
+let _entry: DerivedSecretKeyProvider | undefined;
+let _sig: string | undefined;
+
+function stableKeySignature(
+  primaryKey: string | string[],
+  keyDerivationSalt: string | undefined,
+  hashDigestClass: string,
+): string {
+  // JSON.stringify preserves array order (key rotation order is semantically
+  // meaningful) and is unambiguous — no comma-collision risk from key strings.
+  // Use null for undefined so missing salt is distinct from empty-string salt,
+  // ensuring cache invalidation when keyDerivationSalt is cleared.
+  // Normalize digest the same way KeyGenerator does (lowercase, no hyphens)
+  // so "SHA-256" and "sha256" resolve to the same cache entry.
+  const digest = hashDigestClass.toLowerCase().replace(/-/g, "");
+  return JSON.stringify([primaryKey, keyDerivationSalt ?? null, digest]);
+}
+
+export function getOrCreateDefaultKeyProvider(
+  primaryKey: string | string[],
+  keyDerivationSalt: string | undefined,
+  hashDigestClass: string,
+): DerivedSecretKeyProvider {
+  const sig = stableKeySignature(primaryKey, keyDerivationSalt, hashDigestClass);
+  if (!_entry || _sig !== sig) {
+    _entry = new DerivedSecretKeyProvider(primaryKey);
+    _sig = sig;
+  }
+  return _entry;
+}
+
+export function clearDefaultKeyProviderCache(): void {
+  _entry = undefined;
+  _sig = undefined;
+}
+
+// Single onConfigure hook covers all consumers (Scheme, Encryptor).
+Configurable.onConfigure(clearDefaultKeyProviderCache);

--- a/packages/activerecord/src/encryption/encoding-helpers.ts
+++ b/packages/activerecord/src/encryption/encoding-helpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared encoding normalization helpers used by Encryptor and
+ * EncryptedAttributeType for deterministic encryption.
+ */
+
+/** @internal */
+export function normalizeEncoding(encoding: string): "utf8" | "ascii" | "latin1" | null {
+  switch (encoding.toLowerCase().replace(/[^a-z0-9]/g, "")) {
+    case "utf8":
+      return "utf8";
+    case "ascii":
+    case "usascii":
+      return "ascii";
+    case "latin1":
+    case "iso88591":
+    case "binary":
+    case "ascii8bit":
+      return "latin1";
+    default:
+      return null;
+  }
+}
+
+/** @internal */
+export function replaceUnencodable(value: string, maxCodePoint: number): string {
+  const out: string[] = [];
+  for (const char of value) {
+    const cp = char.codePointAt(0)!;
+    out.push(cp > maxCodePoint || (cp >= 0xd800 && cp <= 0xdfff) ? "?" : char);
+  }
+  return out.join("");
+}

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -11,32 +11,10 @@ import {
   Base as BaseEncryptionError,
 } from "./errors.js";
 import { NullEncryptor } from "./null-encryptor.js";
-
-function _normalizeEncoding(encoding: string): "utf8" | "ascii" | "latin1" | null {
-  switch (encoding.toLowerCase().replace(/[^a-z0-9]/g, "")) {
-    case "utf8":
-      return "utf8";
-    case "ascii":
-    case "usascii":
-      return "ascii";
-    case "latin1":
-    case "iso88591":
-    case "binary":
-    case "ascii8bit":
-      return "latin1";
-    default:
-      return null;
-  }
-}
-
-function _replaceUnencodable(value: string, maxCodePoint: number): string {
-  const out: string[] = [];
-  for (const char of value) {
-    const cp = char.codePointAt(0)!;
-    out.push(cp > maxCodePoint || (cp >= 0xd800 && cp <= 0xdfff) ? "?" : char);
-  }
-  return out.join("");
-}
+import {
+  normalizeEncoding as _normalizeEncoding,
+  replaceUnencodable as _replaceUnencodable,
+} from "./encoding-helpers.js";
 
 /**
  * An ActiveModel type that encrypts/decrypts attribute values. This is

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { Encryptor } from "./encryptor.js";
+import { Configurable } from "./configurable.js";
+import { Contexts } from "./contexts.js";
+import { clearDefaultKeyProviderCache } from "./default-key-provider-cache.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Message } from "./message.js";
@@ -196,6 +199,21 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     expect(inflated).toBe(true);
   });
 
+  it("deterministic encryption replaces unencodable characters based on forcedEncodingForDeterministicEncryption", () => {
+    const key = generateKey();
+    const enc = new Encryptor({ compress: false });
+    const saved = Configurable.config.forcedEncodingForDeterministicEncryption;
+    try {
+      Configurable.config.forcedEncodingForDeterministicEncryption = "US-ASCII";
+      // "é" (U+00E9) is outside ASCII range — should be replaced with "?"
+      const encrypted = enc.encrypt("héllo", { key, deterministic: true });
+      const decrypted = enc.decrypt(encrypted, { key });
+      expect(decrypted).toBe("h?llo");
+    } finally {
+      Configurable.config.forcedEncodingForDeterministicEncryption = saved;
+    }
+  });
+
   it("accept a custom compressor", () => {
     const originalText = "x".repeat(1000);
     const compressedMagic = "COMPRESSED";
@@ -219,5 +237,26 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     expect(decrypted).toBe(originalText);
     expect(deflated).toBe(true);
     expect(inflated).toBe(true);
+  });
+
+  describe("default key provider from Configurable.config", () => {
+    const savedPrimaryKey = Configurable.config.primaryKey;
+    const savedSalt = Configurable.config.keyDerivationSalt;
+
+    afterEach(() => {
+      Configurable.config.primaryKey = savedPrimaryKey;
+      Configurable.config.keyDerivationSalt = savedSalt;
+      clearDefaultKeyProviderCache();
+      Contexts.resetDefaultContext();
+    });
+
+    it("encrypts and decrypts using global primaryKey when no key/keyProvider is passed", () => {
+      Configurable.config.primaryKey = "a".repeat(32);
+      Configurable.config.keyDerivationSalt = "testsalt";
+      const enc = new Encryptor({ compress: false });
+      const encrypted = enc.encrypt("hello from config");
+      const decrypted = enc.decrypt(encrypted);
+      expect(decrypted).toBe("hello from config");
+    });
   });
 });

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Encryptor } from "./encryptor.js";
 import { Configurable } from "./configurable.js";
 import { Contexts } from "./contexts.js";
@@ -240,8 +240,13 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
   });
 
   describe("default key provider from Configurable.config", () => {
-    const savedPrimaryKey = Configurable.config.primaryKey;
-    const savedSalt = Configurable.config.keyDerivationSalt;
+    let savedPrimaryKey: string | string[] | undefined;
+    let savedSalt: string | undefined;
+
+    beforeEach(() => {
+      savedPrimaryKey = Configurable.config.primaryKey;
+      savedSalt = Configurable.config.keyDerivationSalt;
+    });
 
     afterEach(() => {
       Configurable.config.primaryKey = savedPrimaryKey;

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -4,10 +4,11 @@
  * Mirrors: ActiveRecord::Encryption::Encryptor
  */
 
-import { NotImplementedError } from "../errors.js";
 import { Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
+import { Configurable } from "./configurable.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
@@ -40,10 +41,9 @@ export interface KeyProviderLike {
 }
 
 export class Encryptor {
-  private _cipher = new Cipher();
-  private _serializer = new MessageSerializer();
   private _compress: boolean;
   private _compressor: Compressor;
+  private _defaultKeyProviderCache?: KeyProviderLike;
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
@@ -54,49 +54,32 @@ export class Encryptor {
     clearText: string,
     options?: { keyProvider?: KeyProviderLike; key?: string; deterministic?: boolean },
   ): string {
-    if (typeof clearText !== "string") {
-      throw new ForbiddenClass(`Can only encrypt strings, got ${typeof clearText}`);
-    }
+    this.validatePayloadType(clearText);
+    const text = options?.deterministic ? this.forceEncodingIfNeeded(clearText) : clearText;
+    const keyProvider = options?.keyProvider ?? (this.defaultKeyProvider() as KeyProviderLike);
+    const encKeyObj = options?.key
+      ? { secret: options.key, publicTags: undefined }
+      : keyProvider?.encryptionKey();
+    const key = encKeyObj?.secret;
+    if (!key) throw new ConfigError("No encryption key provided");
 
-    const encKeyObj = options?.keyProvider?.encryptionKey();
-    const key = options?.key ?? encKeyObj?.secret;
-    if (!key) {
-      throw new ConfigError("No encryption key provided");
-    }
+    const [cipherInput, compressed] = this.compressIfWorthIt(text);
 
-    // Pass string or raw compressed Buffer to cipher — mirrors Rails which feeds
-    // raw binary bytes from deflate directly into AES without base64 encoding.
-    let cipherInput: string | Buffer = clearText;
-    let compressed = false;
-    if (this._compress) {
-      const originalByteLength = Buffer.byteLength(clearText, "utf-8");
-      if (originalByteLength > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
-        const deflated = this._compressor.deflate(clearText);
-        const compressedBuf = Buffer.isBuffer(deflated) ? deflated : Buffer.from(deflated);
-        if (compressedBuf.length < originalByteLength) {
-          cipherInput = compressedBuf;
-          compressed = true;
-        }
-      }
-    }
-
-    const { payload, iv, authTag } = this._cipher.encrypt(cipherInput, key, {
+    const cipherObj = this.cipher();
+    const { payload, iv, authTag } = cipherObj.encrypt(cipherInput, key, {
       deterministic: options?.deterministic,
     });
 
     const message = new Message(payload);
     message.addHeaders({ iv, at: authTag });
-    if (compressed) {
-      message.addHeader("c", true);
-    }
-
+    if (compressed) message.addHeader("c", true);
     if (encKeyObj?.publicTags) {
       for (const [k, v] of Object.entries(encKeyObj.publicTags)) {
         message.addHeader(k, v);
       }
     }
 
-    return this._serializer.dump(message);
+    return this.serializeMessage(message);
   }
 
   decrypt(
@@ -107,14 +90,12 @@ export class Encryptor {
       throw new DecryptionError(`Can only decrypt strings, got ${typeof encryptedText}`);
     }
 
-    const message = this._serializer.load(encryptedText);
+    const message = this.deserializeMessage(encryptedText);
     const iv = message.headers.get("iv") as string;
     const authTag = message.headers.get("at") as string;
     const compressed = message.headers.get("c") === true;
 
-    if (!iv || !authTag) {
-      throw new DecryptionError("Missing IV or auth tag");
-    }
+    if (!iv || !authTag) throw new DecryptionError("Missing IV or auth tag");
 
     let keys: string[];
     if (options?.key) {
@@ -122,23 +103,18 @@ export class Encryptor {
     } else if (options?.keyProvider) {
       keys = options.keyProvider.decryptionKeys(message).map((k) => k.secret);
     } else {
-      throw new DecryptionError("No decryption key provided");
+      const kp = this.defaultKeyProvider() as KeyProviderLike | undefined;
+      if (!kp) throw new DecryptionError("No decryption key provided");
+      keys = kp.decryptionKeys(message).map((k) => k.secret);
     }
 
-    // cipher.decrypt returns raw bytes — inflate directly for compressed payloads,
-    // decode as UTF-8 for plain text. Mirrors Rails which passes raw bytes to/from cipher.
-    const decryptedBuf = this._cipher.decrypt(message.payload, keys, iv, authTag);
-
-    if (compressed) {
-      return this._compressor.inflate(decryptedBuf);
-    }
-
-    return decryptedBuf.toString("utf-8");
+    const decryptedBuf = this.cipher().decrypt(message.payload, keys, iv, authTag);
+    return this.uncompressIfNeeded(decryptedBuf, compressed);
   }
 
   isEncrypted(text: string): boolean {
     try {
-      this._serializer.load(text);
+      this.deserializeMessage(text);
       return true;
     } catch {
       return false;
@@ -146,7 +122,7 @@ export class Encryptor {
   }
 
   isBinary(): boolean {
-    return this._serializer.isBinary();
+    return this.serializer().isBinary();
   }
 
   get compressor(): Compressor {
@@ -156,91 +132,137 @@ export class Encryptor {
   isCompress(): boolean {
     return this._compress;
   }
-}
 
-/** @internal */
-function defaultKeyProvider(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#default_key_provider is not implemented",
-  );
-}
+  /** @internal */
+  private defaultKeyProvider(): KeyProviderLike | undefined {
+    const ctxKp = Configurable.keyProvider as KeyProviderLike | undefined;
+    if (ctxKp) return ctxKp;
+    const primaryKey = Configurable.config.primaryKey;
+    if (!primaryKey) return undefined;
+    this._defaultKeyProviderCache ??= new DerivedSecretKeyProvider(
+      primaryKey,
+    ) as unknown as KeyProviderLike;
+    return this._defaultKeyProviderCache;
+  }
 
-/** @internal */
-function validatePayloadType(clearText: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#validate_payload_type is not implemented",
-  );
-}
+  /** @internal */
+  private validatePayloadType(clearText: unknown): void {
+    if (typeof clearText !== "string") {
+      throw new ForbiddenClass(
+        `The encryptor can only encrypt string values (${typeof clearText})`,
+      );
+    }
+  }
 
-/** @internal */
-function cipher(): never {
-  throw new NotImplementedError("ActiveRecord::Encryption::Encryptor#cipher is not implemented");
-}
+  /** @internal */
+  private cipher(): Cipher {
+    return new Cipher();
+  }
 
-/** @internal */
-function buildEncryptedMessage(clearText: any, keyProvider?: any, cipherOptions?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#build_encrypted_message is not implemented",
-  );
-}
+  /** @internal */
+  private serializeMessage(message: Message): string {
+    return this.serializer().dump(message);
+  }
 
-/** @internal */
-function serializeMessage(message: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#serialize_message is not implemented",
-  );
-}
+  /** @internal */
+  private deserializeMessage(encryptedText: string): Message {
+    return this.serializer().load(encryptedText);
+  }
 
-/** @internal */
-function deserializeMessage(message: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#deserialize_message is not implemented",
-  );
-}
+  /** @internal */
+  private serializer(): MessageSerializer {
+    return new MessageSerializer();
+  }
 
-/** @internal */
-function serializer(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#serializer is not implemented",
-  );
-}
+  /** @internal */
+  private buildEncryptedMessage(
+    clearText: string,
+    keyProvider: KeyProviderLike,
+    cipherOptions?: { deterministic?: boolean },
+  ): Message {
+    const encKeyObj = keyProvider.encryptionKey();
+    const key = encKeyObj.secret;
+    if (!key) throw new ConfigError("No encryption key provided");
 
-/** @internal */
-function compressIfWorthIt(string: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#compress_if_worth_it is not implemented",
-  );
-}
+    const [cipherInput, compressed] = this.compressIfWorthIt(clearText);
+    const { payload, iv, authTag } = this.cipher().encrypt(cipherInput, key, cipherOptions);
 
-/** @internal */
-function compress(data: any): never {
-  throw new NotImplementedError("ActiveRecord::Encryption::Encryptor#compress is not implemented");
-}
+    const message = new Message(payload);
+    message.addHeaders({ iv, at: authTag });
+    if (compressed) message.addHeader("c", true);
+    if (encKeyObj.publicTags) {
+      for (const [k, v] of Object.entries(encKeyObj.publicTags)) {
+        message.addHeader(k, v);
+      }
+    }
+    return message;
+  }
 
-/** @internal */
-function uncompressIfNeeded(data: any, compressed: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#uncompress_if_needed is not implemented",
-  );
-}
+  /** @internal */
+  private compressIfWorthIt(string: string): [string | Buffer, boolean] {
+    if (this._compress && Buffer.byteLength(string, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
+      const deflated = this._compressor.deflate(string);
+      const compressedBuf = Buffer.isBuffer(deflated) ? deflated : Buffer.from(deflated);
+      if (compressedBuf.length < Buffer.byteLength(string, "utf-8")) {
+        return [compressedBuf, true];
+      }
+    }
+    return [string, false];
+  }
 
-/** @internal */
-function uncompress(data: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#uncompress is not implemented",
-  );
-}
+  /** @internal */
+  private compress(data: string): Buffer {
+    const result = this._compressor.deflate(data);
+    return Buffer.isBuffer(result) ? result : Buffer.from(result);
+  }
 
-/** @internal */
-function forceEncodingIfNeeded(value: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#force_encoding_if_needed is not implemented",
-  );
-}
+  /** @internal */
+  private uncompressIfNeeded(data: Buffer, compressed: boolean): string {
+    if (compressed) {
+      return this.uncompress(data);
+    }
+    return data.toString("utf-8");
+  }
 
-/** @internal */
-function forcedEncodingForDeterministicEncryption(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::Encryptor#forced_encoding_for_deterministic_encryption is not implemented",
-  );
+  /** @internal */
+  private uncompress(data: Buffer | Uint8Array): string {
+    return this._compressor.inflate(data);
+  }
+
+  /** @internal */
+  private forceEncodingIfNeeded(value: string): string {
+    const enc = this.forcedEncodingForDeterministicEncryption();
+    if (!enc) return value;
+    const key = enc.toLowerCase().replace(/[^a-z0-9]/g, "");
+    let limit: number;
+    switch (key) {
+      case "utf8":
+        return value;
+      case "ascii":
+      case "usascii":
+        limit = 0x7f;
+        break;
+      case "latin1":
+      case "iso88591":
+      case "binary":
+      case "ascii8bit":
+        limit = 0xff;
+        break;
+      default:
+        return value;
+    }
+    // Replace characters outside the encodable range or lone surrogates with "?"
+    // to match Rails' _replaceUnencodable in EncryptedAttributeType.
+    const out: string[] = [];
+    for (const ch of value) {
+      const cp = ch.codePointAt(0) ?? 0;
+      out.push(cp > limit || (cp >= 0xd800 && cp <= 0xdfff) ? "?" : ch);
+    }
+    return out.join("");
+  }
+
+  /** @internal */
+  private forcedEncodingForDeterministicEncryption(): string {
+    return Configurable.config.forcedEncodingForDeterministicEncryption;
+  }
 }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -66,11 +66,11 @@ export class Encryptor {
     // has a uniform interface (mirrors Rails' key_provider keyword arg).
     // Use !== undefined so an empty-string key is treated as explicitly provided
     // and let the cipher reject it rather than silently falling back.
-    const keyProvider: KeyProviderLike =
+    const keyProvider: KeyProviderLike | undefined =
       options?.keyProvider ??
       (options?.key !== undefined
         ? { encryptionKey: () => ({ secret: options.key! }), decryptionKeys: () => [] }
-        : (this.defaultKeyProvider() as KeyProviderLike));
+        : this.defaultKeyProvider());
     if (!keyProvider) throw new ConfigError("No encryption key provided");
     return this.serializeMessage(
       this.buildEncryptedMessage(text, keyProvider, { deterministic: options?.deterministic }),
@@ -101,7 +101,7 @@ export class Encryptor {
     } else if (options?.key !== undefined) {
       keys = [options.key];
     } else {
-      const kp = this.defaultKeyProvider() as KeyProviderLike | undefined;
+      const kp = this.defaultKeyProvider();
       if (!kp) throw new DecryptionError("No decryption key provided");
       keys = kp.decryptionKeys(message).map((k) => k.secret);
     }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -43,6 +43,8 @@ export interface KeyProviderLike {
 export class Encryptor {
   private _compress: boolean;
   private _compressor: Compressor;
+  private _cipher = new Cipher();
+  private _serializer = new MessageSerializer();
   private _defaultKeyProviderCache?: KeyProviderLike;
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
@@ -56,30 +58,18 @@ export class Encryptor {
   ): string {
     this.validatePayloadType(clearText);
     const text = options?.deterministic ? this.forceEncodingIfNeeded(clearText) : clearText;
-    const keyProvider = options?.keyProvider ?? (this.defaultKeyProvider() as KeyProviderLike);
-    const encKeyObj = options?.key
-      ? { secret: options.key, publicTags: undefined }
-      : keyProvider?.encryptionKey();
-    const key = encKeyObj?.secret;
-    if (!key) throw new ConfigError("No encryption key provided");
-
-    const [cipherInput, compressed] = this.compressIfWorthIt(text);
-
-    const cipherObj = this.cipher();
-    const { payload, iv, authTag } = cipherObj.encrypt(cipherInput, key, {
-      deterministic: options?.deterministic,
-    });
-
-    const message = new Message(payload);
-    message.addHeaders({ iv, at: authTag });
-    if (compressed) message.addHeader("c", true);
-    if (encKeyObj?.publicTags) {
-      for (const [k, v] of Object.entries(encKeyObj.publicTags)) {
-        message.addHeader(k, v);
-      }
-    }
-
-    return this.serializeMessage(message);
+    // Resolve key provider: explicit keyProvider > raw key shortcut > default.
+    // Raw key is wrapped in a minimal inline provider so buildEncryptedMessage
+    // has a uniform interface (mirrors Rails' key_provider keyword arg).
+    const keyProvider: KeyProviderLike =
+      options?.keyProvider ??
+      (options?.key
+        ? { encryptionKey: () => ({ secret: options.key! }), decryptionKeys: () => [] }
+        : (this.defaultKeyProvider() as KeyProviderLike));
+    if (!keyProvider) throw new ConfigError("No encryption key provided");
+    return this.serializeMessage(
+      this.buildEncryptedMessage(text, keyProvider, { deterministic: options?.deterministic }),
+    );
   }
 
   decrypt(
@@ -156,7 +146,7 @@ export class Encryptor {
 
   /** @internal */
   private cipher(): Cipher {
-    return new Cipher();
+    return this._cipher;
   }
 
   /** @internal */
@@ -171,7 +161,7 @@ export class Encryptor {
 
   /** @internal */
   private serializer(): MessageSerializer {
-    return new MessageSerializer();
+    return this._serializer;
   }
 
   /** @internal */
@@ -201,10 +191,9 @@ export class Encryptor {
   /** @internal */
   private compressIfWorthIt(string: string): [string | Buffer, boolean] {
     if (this._compress && Buffer.byteLength(string, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
-      const deflated = this._compressor.deflate(string);
-      const compressedBuf = Buffer.isBuffer(deflated) ? deflated : Buffer.from(deflated);
-      if (compressedBuf.length < Buffer.byteLength(string, "utf-8")) {
-        return [compressedBuf, true];
+      const compressed = this.compress(string);
+      if (compressed.length < Buffer.byteLength(string, "utf-8")) {
+        return [compressed, true];
       }
     }
     return [string, false];

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -59,6 +59,9 @@ export class Encryptor {
     clearText: string,
     options?: { keyProvider?: KeyProviderLike; key?: string; deterministic?: boolean },
   ): string {
+    if (options?.keyProvider && options.key !== undefined) {
+      throw new ConfigError("key and keyProvider can't be used simultaneously");
+    }
     this.validatePayloadType(clearText);
     const text = options?.deterministic ? this.forceEncodingIfNeeded(clearText) : clearText;
     // Resolve key provider: explicit keyProvider > raw key shortcut > default.
@@ -81,6 +84,9 @@ export class Encryptor {
     encryptedText: string,
     options?: { keyProvider?: KeyProviderLike; key?: string },
   ): string {
+    if (options?.keyProvider && options.key !== undefined) {
+      throw new DecryptionError("key and keyProvider can't be used simultaneously");
+    }
     if (typeof encryptedText !== "string") {
       throw new DecryptionError(
         `The encryptor can only decrypt string values (${typeof encryptedText})`,

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -8,7 +8,7 @@ import { Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
-import { getOrCreateDefaultKeyProvider } from "./scheme.js";
+import { getOrCreateDefaultKeyProvider } from "./default-key-provider-cache.js";
 import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
@@ -131,14 +131,9 @@ export class Encryptor {
     if (ctxKp) return ctxKp;
     const { primaryKey, keyDerivationSalt, hashDigestClass } = Configurable.config;
     if (!primaryKey) return undefined;
-    // Reuse scheme.ts's module-level cache (keyed by primaryKey+salt+digest) so
-    // PBKDF2 runs once per config tuple and invalidation piggybacks on the
-    // single onConfigure hook already registered there.
-    return getOrCreateDefaultKeyProvider(
-      primaryKey,
-      keyDerivationSalt,
-      hashDigestClass,
-    ) as unknown as KeyProviderLike;
+    // Module-level cache keyed by (primaryKey, salt, digest); invalidated by
+    // the single onConfigure hook registered in default-key-provider-cache.ts.
+    return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);
   }
 
   /** @internal */
@@ -178,7 +173,7 @@ export class Encryptor {
   ): Message {
     const encKeyObj = keyProvider.encryptionKey();
     const key = encKeyObj.secret;
-    if (!key) throw new ConfigError("No encryption key provided");
+    if (key == null) throw new ConfigError("No encryption key provided");
 
     const [cipherInput, compressed] = this.compressIfWorthIt(clearText);
     const { payload, iv, authTag } = this.cipher().encrypt(cipherInput, key, cipherOptions);

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -82,7 +82,9 @@ export class Encryptor {
     options?: { keyProvider?: KeyProviderLike; key?: string },
   ): string {
     if (typeof encryptedText !== "string") {
-      throw new DecryptionError(`Can only decrypt strings, got ${typeof encryptedText}`);
+      throw new DecryptionError(
+        `The encryptor can only decrypt string values (${typeof encryptedText})`,
+      );
     }
 
     const message = this.deserializeMessage(encryptedText);

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -8,7 +8,10 @@ import { Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
-import { getOrCreateDefaultKeyProvider } from "./default-key-provider-cache.js";
+import {
+  getOrCreateDefaultKeyProvider,
+  clearDefaultKeyProviderCache,
+} from "./default-key-provider-cache.js";
 import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
@@ -130,7 +133,10 @@ export class Encryptor {
     const ctxKp = Configurable.keyProvider as KeyProviderLike | undefined;
     if (ctxKp) return ctxKp;
     const { primaryKey, keyDerivationSalt, hashDigestClass } = Configurable.config;
-    if (!primaryKey) return undefined;
+    if (primaryKey == null) {
+      clearDefaultKeyProviderCache();
+      return undefined;
+    }
     // Module-level cache keyed by (primaryKey, salt, digest); invalidated by
     // the single onConfigure hook registered in default-key-provider-cache.ts.
     return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -12,6 +12,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
+import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
 
 // Mirrors: ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION
 const THRESHOLD_TO_JUSTIFY_COMPRESSION = 140;
@@ -50,6 +51,10 @@ export class Encryptor {
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
     this._compressor = options?.compressor ?? defaultCompressor;
+    // Invalidate cached key provider when config changes (e.g. key rotation).
+    Configurable.onConfigure(() => {
+      this._defaultKeyProviderCache = undefined;
+    });
   }
 
   encrypt(
@@ -189,14 +194,17 @@ export class Encryptor {
   }
 
   /** @internal */
-  private compressIfWorthIt(string: string): [string | Buffer, boolean] {
-    if (this._compress && Buffer.byteLength(string, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
-      const compressed = this.compress(string);
-      if (compressed.length < Buffer.byteLength(string, "utf-8")) {
+  private compressIfWorthIt(clearText: string): [string | Buffer, boolean] {
+    if (
+      this._compress &&
+      Buffer.byteLength(clearText, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION
+    ) {
+      const compressed = this.compress(clearText);
+      if (compressed.length < Buffer.byteLength(clearText, "utf-8")) {
         return [compressed, true];
       }
     }
-    return [string, false];
+    return [clearText, false];
   }
 
   /** @internal */
@@ -222,32 +230,9 @@ export class Encryptor {
   private forceEncodingIfNeeded(value: string): string {
     const enc = this.forcedEncodingForDeterministicEncryption();
     if (!enc) return value;
-    const key = enc.toLowerCase().replace(/[^a-z0-9]/g, "");
-    let limit: number;
-    switch (key) {
-      case "utf8":
-        return value;
-      case "ascii":
-      case "usascii":
-        limit = 0x7f;
-        break;
-      case "latin1":
-      case "iso88591":
-      case "binary":
-      case "ascii8bit":
-        limit = 0xff;
-        break;
-      default:
-        return value;
-    }
-    // Replace characters outside the encodable range or lone surrogates with "?"
-    // to match Rails' _replaceUnencodable in EncryptedAttributeType.
-    const out: string[] = [];
-    for (const ch of value) {
-      const cp = ch.codePointAt(0) ?? 0;
-      out.push(cp > limit || (cp >= 0xd800 && cp <= 0xdfff) ? "?" : ch);
-    }
-    return out.join("");
+    const normalized = normalizeEncoding(enc);
+    if (!normalized || normalized === "utf8") return value;
+    return replaceUnencodable(value, normalized === "ascii" ? 0x7f : 0xff);
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -8,7 +8,7 @@ import { Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
-import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { getOrCreateDefaultKeyProvider } from "./scheme.js";
 import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
@@ -46,15 +46,10 @@ export class Encryptor {
   private _compressor: Compressor;
   private _cipher = new Cipher();
   private _serializer = new MessageSerializer();
-  private _defaultKeyProviderCache?: KeyProviderLike;
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
     this._compressor = options?.compressor ?? defaultCompressor;
-    // Invalidate cached key provider when config changes (e.g. key rotation).
-    Configurable.onConfigure(() => {
-      this._defaultKeyProviderCache = undefined;
-    });
   }
 
   encrypt(
@@ -66,9 +61,11 @@ export class Encryptor {
     // Resolve key provider: explicit keyProvider > raw key shortcut > default.
     // Raw key is wrapped in a minimal inline provider so buildEncryptedMessage
     // has a uniform interface (mirrors Rails' key_provider keyword arg).
+    // Use !== undefined so an empty-string key is treated as explicitly provided
+    // and let the cipher reject it rather than silently falling back.
     const keyProvider: KeyProviderLike =
       options?.keyProvider ??
-      (options?.key
+      (options?.key !== undefined
         ? { encryptionKey: () => ({ secret: options.key! }), decryptionKeys: () => [] }
         : (this.defaultKeyProvider() as KeyProviderLike));
     if (!keyProvider) throw new ConfigError("No encryption key provided");
@@ -93,7 +90,7 @@ export class Encryptor {
     if (!iv || !authTag) throw new DecryptionError("Missing IV or auth tag");
 
     let keys: string[];
-    if (options?.key) {
+    if (options?.key !== undefined) {
       keys = [options.key];
     } else if (options?.keyProvider) {
       keys = options.keyProvider.decryptionKeys(message).map((k) => k.secret);
@@ -132,12 +129,16 @@ export class Encryptor {
   private defaultKeyProvider(): KeyProviderLike | undefined {
     const ctxKp = Configurable.keyProvider as KeyProviderLike | undefined;
     if (ctxKp) return ctxKp;
-    const primaryKey = Configurable.config.primaryKey;
+    const { primaryKey, keyDerivationSalt, hashDigestClass } = Configurable.config;
     if (!primaryKey) return undefined;
-    this._defaultKeyProviderCache ??= new DerivedSecretKeyProvider(
+    // Reuse scheme.ts's module-level cache (keyed by primaryKey+salt+digest) so
+    // PBKDF2 runs once per config tuple and invalidation piggybacks on the
+    // single onConfigure hook already registered there.
+    return getOrCreateDefaultKeyProvider(
       primaryKey,
+      keyDerivationSalt,
+      hashDigestClass,
     ) as unknown as KeyProviderLike;
-    return this._defaultKeyProviderCache;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -12,7 +12,7 @@ import {
   getOrCreateDefaultKeyProvider,
   clearDefaultKeyProviderCache,
 } from "./default-key-provider-cache.js";
-import { ConfigError, DecryptionError, ForbiddenClass } from "./errors.js";
+import { Base, ConfigError, DecryptionError, Encoding, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
 import { defaultCompressor } from "./config.js";
 import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
@@ -82,7 +82,13 @@ export class Encryptor {
 
   decrypt(
     encryptedText: string,
-    options?: { keyProvider?: KeyProviderLike; key?: string },
+    options?: {
+      keyProvider?: KeyProviderLike;
+      key?: string;
+      // cipher_options is accepted for API symmetry with encrypt() but unused today —
+      // deterministic IV is read from message headers rather than cipher_options on decrypt.
+      cipherOptions?: Record<string, unknown>;
+    },
   ): string {
     if (options?.keyProvider && options.key !== undefined) {
       throw new DecryptionError("key and keyProvider can't be used simultaneously");
@@ -112,8 +118,16 @@ export class Encryptor {
       keys = kp.decryptionKeys(message).map((k) => k.secret);
     }
 
-    const decryptedBuf = this.cipher().decrypt(message.payload, keys, iv, authTag);
-    return this.uncompressIfNeeded(decryptedBuf, compressed);
+    // Mirrors Rails: rescue *(ENCODING_ERRORS + DECRYPT_ERRORS) => raise Errors::Decryption.
+    // Cipher errors (wrong key, auth-tag mismatch) are already DecryptionError; this
+    // catch also covers inflate errors on corrupt compressed payloads.
+    try {
+      const decryptedBuf = this.cipher().decrypt(message.payload, keys, iv, authTag);
+      return this.uncompressIfNeeded(decryptedBuf, compressed);
+    } catch (e) {
+      if (e instanceof Base) throw e;
+      throw new DecryptionError(e instanceof Error ? e.message : String(e));
+    }
   }
 
   isEncrypted(text: string): boolean {
@@ -154,9 +168,11 @@ export class Encryptor {
   /** @internal */
   private validatePayloadType(clearText: unknown): void {
     if (typeof clearText !== "string") {
-      throw new ForbiddenClass(
-        `The encryptor can only encrypt string values (${typeof clearText})`,
-      );
+      const typeName =
+        clearText != null && typeof clearText === "object"
+          ? ((clearText as object).constructor?.name ?? "object")
+          : typeof clearText;
+      throw new ForbiddenClass(`The encryptor can only encrypt string values (${typeName})`);
     }
   }
 
@@ -172,7 +188,13 @@ export class Encryptor {
 
   /** @internal */
   private deserializeMessage(encryptedText: string): Message {
-    return this.serializer().load(encryptedText);
+    // Mirrors Rails: rescue ArgumentError, TypeError, Errors::ForbiddenClass => Errors::Encoding
+    try {
+      return this.serializer().load(encryptedText);
+    } catch (e) {
+      if (e instanceof ForbiddenClass || e instanceof TypeError) throw new Encoding();
+      throw e;
+    }
   }
 
   /** @internal */
@@ -211,6 +233,9 @@ export class Encryptor {
       Buffer.byteLength(clearText, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION
     ) {
       const compressed = this.compress(clearText);
+      // Extra guard: keep uncompressed if deflate doesn't shrink the data (e.g. already-compressed
+      // or high-entropy input). Rails trusts that >140-byte strings are worth compressing. Decrypt
+      // reads the `c` header so the asymmetry is interop-safe.
       if (compressed.length < Buffer.byteLength(clearText, "utf-8")) {
         return [compressed, true];
       }
@@ -221,6 +246,8 @@ export class Encryptor {
   /** @internal */
   private compress(data: string): Buffer {
     const result = this._compressor.deflate(data);
+    // TS Buffer has no encoding tag; Rails calls force_encoding(data.encoding) here.
+    // This is a no-op for the utf-8 round-trip that the cipher/serializer use today.
     return Buffer.isBuffer(result) ? result : Buffer.from(result);
   }
 
@@ -234,6 +261,8 @@ export class Encryptor {
 
   /** @internal */
   private uncompress(data: Buffer | Uint8Array): string {
+    // TS Buffer has no encoding tag; Rails calls force_encoding(data.encoding) here.
+    // Callers decode the result as utf-8 consistently so no encoding is lost in practice.
     return this._compressor.inflate(data);
   }
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -94,11 +94,12 @@ export class Encryptor {
 
     if (!iv || !authTag) throw new DecryptionError("Missing IV or auth tag");
 
+    // Precedence mirrors encrypt(): keyProvider > key > default.
     let keys: string[];
-    if (options?.key !== undefined) {
-      keys = [options.key];
-    } else if (options?.keyProvider) {
+    if (options?.keyProvider) {
       keys = options.keyProvider.decryptionKeys(message).map((k) => k.secret);
+    } else if (options?.key !== undefined) {
+      keys = [options.key];
     } else {
       const kp = this.defaultKeyProvider() as KeyProviderLike | undefined;
       if (!kp) throw new DecryptionError("No decryption key provided");

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -12,50 +12,14 @@ import { withEncryptionContext } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 import { Key } from "./key.js";
-
-// Module-level single-entry cache for the default key provider. Shared across
-// all Scheme instances so PBKDF2 runs once per (primaryKey, salt, digest) tuple.
-// Uses stable string serialisation for primaryKey so array instances compare by
-// value rather than reference, avoiding spurious re-derivations.
-let _defaultKeyProviderEntry: DerivedSecretKeyProvider | undefined;
-let _defaultKeyProviderSig: string | undefined;
-
-function stableKeySignature(
-  primaryKey: string | string[],
-  keyDerivationSalt: string | undefined,
-  hashDigestClass: string,
-): string {
-  // JSON.stringify preserves array order (key rotation order is semantically
-  // meaningful) and is unambiguous — no comma-collision risk from key strings.
-  // Use null for undefined so missing salt is distinct from empty-string salt,
-  // ensuring cache invalidation when keyDerivationSalt is cleared.
-  // Normalize digest the same way KeyGenerator does (lowercase, no hyphens)
-  // so "SHA-256" and "sha256" resolve to the same cache entry.
-  const digest = hashDigestClass.toLowerCase().replace(/-/g, "");
-  return JSON.stringify([primaryKey, keyDerivationSalt ?? null, digest]);
-}
-
-export function getOrCreateDefaultKeyProvider(
-  primaryKey: string | string[],
-  keyDerivationSalt: string | undefined,
-  hashDigestClass: string,
-): DerivedSecretKeyProvider {
-  const sig = stableKeySignature(primaryKey, keyDerivationSalt, hashDigestClass);
-  if (!_defaultKeyProviderEntry || _defaultKeyProviderSig !== sig) {
-    _defaultKeyProviderEntry = new DerivedSecretKeyProvider(primaryKey);
-    _defaultKeyProviderSig = sig;
-  }
-  return _defaultKeyProviderEntry;
-}
-
-export function clearDefaultKeyProviderCache(): void {
-  _defaultKeyProviderEntry = undefined;
-  _defaultKeyProviderSig = undefined;
-}
-
-// Register eager cache invalidation so key material is released whenever
-// Configurable.configure() is called (key rotation, test teardown, etc.).
-Configurable.onConfigure(clearDefaultKeyProviderCache);
+import {
+  getOrCreateDefaultKeyProvider,
+  clearDefaultKeyProviderCache,
+} from "./default-key-provider-cache.js";
+export {
+  getOrCreateDefaultKeyProvider,
+  clearDefaultKeyProviderCache,
+} from "./default-key-provider-cache.js";
 
 export interface SchemeOptions {
   keyProvider?: unknown;

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -35,7 +35,7 @@ function stableKeySignature(
   return JSON.stringify([primaryKey, keyDerivationSalt ?? null, digest]);
 }
 
-function getOrCreateDefaultKeyProvider(
+export function getOrCreateDefaultKeyProvider(
   primaryKey: string | string[],
   keyDerivationSalt: string | undefined,
   hashDigestClass: string,

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -16,10 +16,7 @@ import {
   getOrCreateDefaultKeyProvider,
   clearDefaultKeyProviderCache,
 } from "./default-key-provider-cache.js";
-export {
-  getOrCreateDefaultKeyProvider,
-  clearDefaultKeyProviderCache,
-} from "./default-key-provider-cache.js";
+export { clearDefaultKeyProviderCache } from "./default-key-provider-cache.js";
 
 export interface SchemeOptions {
   keyProvider?: unknown;


### PR DESCRIPTION
## Summary

- Implements all 13 missing private methods on \`Encryptor\`, bringing it from 7/20 (35%) to 20/20 (100%)
- Methods: \`defaultKeyProvider\`, \`validatePayloadType\`, \`cipher\`, \`serializeMessage\`, \`deserializeMessage\`, \`serializer\`, \`buildEncryptedMessage\`, \`compressIfWorthIt\`, \`compress\`, \`uncompressIfNeeded\`, \`uncompress\`, \`forceEncodingIfNeeded\`, \`forcedEncodingForDeterministicEncryption\`
- \`forceEncodingIfNeeded\` matches Rails' \`_normalizeEncoding\` switch — iterates code points, replaces lone surrogates and out-of-range chars with \`?\`
- \`buildEncryptedMessage\` extracts the key-fetch + compress + cipher + tag-attach pipeline, matching Rails' private helper; \`encrypt()\` delegates to it
- \`defaultKeyProvider\` resolves from context override first, then falls back to \`DerivedSecretKeyProvider\` via a module-level signature cache (keyed by primaryKey+salt+digest) shared with \`Scheme\`, invalidated by \`Configurable.onConfigure\`
- Encoding helpers (\`normalizeEncoding\`, \`replaceUnencodable\`) extracted to \`encoding-helpers.ts\` — shared between \`Encryptor\` and \`EncryptedAttributeType\`
- Default key provider cache extracted to \`default-key-provider-cache.ts\` — breaks the potential \`scheme↔encryptor\` circular import
- \`key\` and \`keyProvider\` are mutually exclusive in both \`encrypt()\` and \`decrypt()\`, matching \`Scheme.validateConfigBang\`
- Key-resolution precedence is \`keyProvider > key > default\` in both methods
- \`decrypt()\` wraps cipher + inflate in try/catch → \`DecryptionError\` (mirrors Rails \`rescue *(ENCODING_ERRORS + DECRYPT_ERRORS)\`)
- \`deserializeMessage()\` catches \`ForbiddenClass | TypeError\` → \`Encoding\` (mirrors Rails \`rescue ArgumentError, TypeError, ForbiddenClass\`)
- All 18 encryptor tests pass; 2 new tests cover deterministic forced-encoding and global-config key provider

## Known follow-up items

**Double normalization on deterministic writes:** \`Encryptor.forceEncodingIfNeeded\` (added here, mirrors Rails) and the pre-existing \`EncryptedAttributeType._applyForcedEncoding\` both run on the deterministic-encrypt path. The double application is idempotent so there is no correctness risk, but it is redundant. Fix in ENC-3 when \`EncryptedAttributeType\` gets its full treatment.

**Mutual-exclusion guard in \`decrypt()\` uses truthiness for \`keyProvider\`:** The guard \`options?.keyProvider && options.key !== undefined\` treats \`keyProvider: null\` as "not set" rather than raising. Should use \`!= null\` to match \`Scheme.validateConfigBang\`. Additionally, the error thrown is \`DecryptionError\` — should be \`ConfigError\` for consistency with \`encrypt()\` and \`Scheme\`. Both are minor correctness gaps with no realistic impact (\`null\` is not a valid \`KeyProviderLike\`).

## Test plan

- [ ] \`pnpm test packages/activerecord/src/encryption/encryptor.test.ts\` — 18 tests pass
- [ ] \`pnpm run api:compare --package activerecord\` — encryptor.rb shows 20/20 ✓