### PR TITLE
feat(activerecord/encryption): ENC-4 — EncryptableRecord to 100%

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -285,18 +285,8 @@ export function applyPendingEncryptions(klass: any): void {
     klass._frozenEncryptionValidatorInstalled = true;
     klass.validate((record: any) => {
       if (!getEncryptionContext().frozenEncryption) return;
-      // Use record.constructor so STI subclasses consult their own
-      // encrypted_attributes list — mirrors Rails' self.class.encrypted_attributes.
-      const encryptedAttrs: Set<string> =
-        (record.constructor as any)._encryptedAttributes ?? new Set();
-      const changed: string[] = Array.isArray(record.changedAttributes)
-        ? record.changedAttributes
-        : [];
-      for (const attr of changed) {
-        if (encryptedAttrs.has(attr)) {
-          record.errors.add(attr, "can't be modified because it is encrypted");
-        }
-      }
+      // Delegate to the Rails-mirrored static so both code paths share one impl.
+      EncryptableRecord.cantModifyEncryptedAttributesWhenFrozen(record);
     });
   }
 }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -230,51 +230,7 @@ function _preserveOriginalEncrypted(klass: any, name: string, options: EncryptsO
   const { ignoreCase: _ic, downcase: _dc, ...originalOptions } = options;
   encrypts(klass, originalAttrName, originalOptions);
 
-  // Before each save, copy the in-memory value of `name` into `original_name`
-  // when `name` has been written (is dirty). Using `readAttribute` bypasses
-  // the prototype getter so we read directly from the attribute store, not from
-  // `original_name`. Only syncing when dirty prevents a freshly-loaded record
-  // whose `readAttribute(name)` would return the decrypted downcased value from
-  // overwriting the original-cased `original_name` on an unrelated save.
-  // Mirrors Rails' `name= { self.original_name = value; super(value) }`.
-  if (typeof klass.beforeSave === "function") {
-    klass.beforeSave((record: any) => {
-      // For new records, always sync — changedAttributes is empty because attrs
-      // were assigned before the dirty snapshot in the constructor.
-      // For persisted records, only sync when `name` was actually written to
-      // avoid overwriting original_name with the downcased decrypted value on
-      // unrelated saves.
-      const isNew =
-        typeof record.isNewRecord === "function" ? record.isNewRecord() : !record.isPersisted?.();
-      const changed: string[] = Array.isArray(record.changedAttributes)
-        ? record.changedAttributes
-        : [];
-      if (!isNew && !changed.includes(name)) return;
-      const plaintext = record.readAttribute(name);
-      record.writeAttribute(originalAttrName, plaintext);
-    });
-  }
-
-  // Override the accessor on the prototype. Mirrors Rails'
-  // override_accessors_to_preserve_original:
-  //   - getter returns original_name when present, falls back to name for
-  //     legacy rows that predate the original_name column
-  //   - setter writes both name (for downcased query) and original_name
-  //     (for case-preserving reads) immediately, so in-memory reads see
-  //     the new value before the record is saved
-  Object.defineProperty(klass.prototype, name, {
-    configurable: true,
-    get(this: any) {
-      const originalValue = this.readAttribute(originalAttrName);
-      if (originalValue != null) return originalValue;
-      // Fallback for legacy rows where original_name is absent.
-      return this.readAttribute(name);
-    },
-    set(this: any, value: unknown) {
-      this.writeAttribute(name, value);
-      this.writeAttribute(originalAttrName, value);
-    },
-  });
+  EncryptableRecord.overrideAccessorsToPreserveOriginal(klass, name, originalAttrName);
 }
 
 /**

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -590,6 +590,68 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     assertEncryptedAttribute(await BookNormalized.find(b2.id), "logo", "book");
   });
 
+  it("EncryptableRecord.validateEncryptionAllowed throws when encryption is frozen", () => {
+    withEncryptionContext({ frozenEncryption: true }, () => {
+      expect(() => EncryptableRecord.validateEncryptionAllowed({})).toThrow(
+        "can't be modified because it is encrypted",
+      );
+    });
+  });
+
+  it("EncryptableRecord.validateEncryptionAllowed does not throw when encryption is not frozen", () => {
+    expect(() => EncryptableRecord.validateEncryptionAllowed({})).not.toThrow();
+  });
+
+  it("EncryptableRecord.cantModifyEncryptedAttributesWhenFrozen adds errors for changed encrypted attrs", () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    new Post();
+    const post = new Post({ title: "hello" });
+    post.title = "changed";
+    const errored: Array<[string, string]> = [];
+    const proxy = Object.assign(Object.create(Object.getPrototypeOf(post)), post, {
+      errors: { add: (attr: string, msg: string) => errored.push([attr, msg]) },
+    });
+    EncryptableRecord.cantModifyEncryptedAttributesWhenFrozen(proxy);
+    expect(errored).toEqual([["title", "can't be modified because it is encrypted"]]);
+  });
+
+  it("EncryptableRecord.cantModifyEncryptedAttributesWhenFrozen adds no errors for unchanged attrs", () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    new Post();
+    const post = new Post({ title: "hello" });
+    const errored: Array<[string, string]> = [];
+    const proxy = Object.assign(Object.create(Object.getPrototypeOf(post)), post, {
+      errors: { add: (attr: string, msg: string) => errored.push([attr, msg]) },
+    });
+    EncryptableRecord.cantModifyEncryptedAttributesWhenFrozen(proxy);
+    expect(errored).toEqual([]);
+  });
+
+  it("EncryptableRecord.encryptAttributes writes ciphertext to DB and keeps plaintext in memory", async () => {
+    const adp = freshAdapter();
+    const Post = makeEncryptedPost(adp);
+    new Post();
+    const post = await Post.create({ title: "Hello", body: "World" });
+    assertEncryptedAttribute(post, "title", "Hello");
+    // Re-encrypt: DB gets fresh ciphertext, in-memory stays plaintext.
+    await EncryptableRecord.encryptAttributes(post);
+    expect(post.title).toBe("Hello");
+    assertEncryptedAttribute(await Post.find(post.id), "title", "Hello");
+  });
+
+  it("EncryptableRecord.decryptAttributes stores plaintext in DB", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const adp = freshAdapter();
+    const Post = makeEncryptedPost(adp);
+    new Post();
+    const post = await Post.create({ title: "Hello", body: "World" });
+    assertEncryptedAttribute(post, "title", "Hello");
+    await EncryptableRecord.decryptAttributes(post);
+    // supportUnencryptedData=true lets the EncryptedAttributeType pass through plaintext.
+    const reloaded = await Post.find(post.id);
+    expect(reloaded.title).toBe("Hello");
+  });
+
   it("encrypts attribute data", async () => {
     // The DB column stores ciphertext (text), while the cast type is date.
     // In Rails, encrypted attribute columns are always text in the schema.

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -214,6 +214,17 @@ export class EncryptableRecord {
   /** @internal */
   static preserveOriginalEncrypted(modelClass: any, name: string): void {
     const originalName = `${ORIGINAL_ATTRIBUTE_PREFIX}${name}`;
+    // Mirrors Rails encryptable_record.rb:101–103: raise at declaration time
+    // when the original_<name> column is absent and supportUnencryptedData is
+    // false (which means there's no fallback for reading un-preserved rows).
+    if (!Configurable.config.supportUnencryptedData) {
+      const colNames: string[] = modelClass.columnNames?.() ?? [];
+      if (!colNames.includes(originalName)) {
+        throw new ConfigurationError(
+          `To use :ignore_case for '${name}' you must create an additional column named '${originalName}'`,
+        );
+      }
+    }
     this.encrypts(modelClass, originalName);
     this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
   }
@@ -265,13 +276,19 @@ export class EncryptableRecord {
 
   /** @internal */
   static addLengthValidationForEncryptedColumns(modelClass: any): void {
-    const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set();
+    const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set<string>();
     for (const name of attrs) {
       this.validateColumnSize(modelClass, name);
     }
   }
 
-  /** @internal */
+  /**
+   * Instance-level encrypted-attribute check: resolves aliases and verifies
+   * the stored value is actually encrypted (calls `type.isEncrypted`).
+   * Distinct from `encryption.ts#isEncryptedAttribute(klass, attr)` which is
+   * a class-level check (is the attribute declared encrypted on this class?).
+   * @internal
+   */
   static isEncryptedAttribute(record: any, attributeName: string): boolean {
     const klass = record.constructor as any;
     // Resolve attribute aliases before checking encrypted set.
@@ -310,27 +327,26 @@ export class EncryptableRecord {
 
   /** @internal */
   static _createRecord(record: any, attributeNames?: string[]): unknown {
-    // Rails prepends this to force encrypted attrs into the INSERT column list.
-    // In our codebase _createRecord is the ORM callback chain entry point and
-    // ignores attributeNames; encrypted columns are included unconditionally via
-    // _performInsert. This helper exists for api:compare parity only.
-    return record._createRecord?.(attributeNames);
+    // Mirrors Rails: force encrypted attrs into the INSERT column list so a
+    // column with an encrypted default is always written on first save.
+    const names = attributeNames ?? record.attributeNames ?? [];
+    const encryptedAttrs: Set<string> =
+      record.constructor._encryptedAttributes ?? new Set<string>();
+    const merged = [...new Set<string>([...names, ...encryptedAttrs])];
+    return record._createRecord?.(merged);
   }
 
   /** @internal */
   static async encryptAttributes(record: any): Promise<void> {
     this.validateEncryptionAllowed(record);
     const klass = record.constructor as any;
-    const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
-
-    // Pre-serialize so updateColumns writes ciphertext — updateColumns uses
-    // cast() not serialize(), so plaintext would be written back unchanged.
-    // Mirrors encryption.ts#encryptRecord.
-    const plaintextValues: Record<string, unknown> = {};
+    // Rails: update_columns build_encrypt_attribute_assignments.
+    // buildEncryptAttributeAssignments returns plaintext values (Rails parity).
+    // updateColumns uses cast() not serialize(), so pre-serialize here so the
+    // DB write stores ciphertext. Mirrors encryption.ts#encryptRecord.
+    const plaintextValues = this.buildEncryptAttributeAssignments(record);
     const assignments: Record<string, unknown> = {};
-    for (const name of encryptedAttrs) {
-      const plaintext = record.readAttribute(name);
-      plaintextValues[name] = plaintext;
+    for (const [name, plaintext] of Object.entries(plaintextValues)) {
       const type = getAttributeType(klass, name);
       assignments[name] =
         type instanceof EncryptedAttributeType ? type.serialize(plaintext) : plaintext;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -213,7 +213,7 @@ export class EncryptableRecord {
 
   /** @internal */
   static preserveOriginalEncrypted(modelClass: any, name: string): void {
-    const originalName = `original_${name}`;
+    const originalName = `${ORIGINAL_ATTRIBUTE_PREFIX}${name}`;
     this.encrypts(modelClass, originalName);
     this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
   }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -224,9 +224,11 @@ export class EncryptableRecord {
     _name: string,
     _originalName: string,
   ): void {
-    // Rails uses Ruby's `include(Module.new { define_method ... })` to dynamically
-    // override attribute accessors. TS has no equivalent; the ignoreCase
-    // read-original behaviour is handled at the EncryptedAttributeType level.
+    // The public entry point (Base.encrypts / encryption.ts#encrypts) handles
+    // the ignoreCase accessor override via _preserveOriginalEncrypted, which
+    // uses Object.defineProperty to wire the before-save sync and getter/setter.
+    // This @internal stub exists for api:compare parity only and is not called
+    // on the live path.
   }
 
   /** @internal */
@@ -260,7 +262,11 @@ export class EncryptableRecord {
   static ciphertextFor(record: any, attributeName: string): unknown {
     const klass = record.constructor as any;
     const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
-    return record.readAttributeBeforeTypeCast?.(resolvedName);
+    if (this.isEncryptedAttribute(record, attributeName)) {
+      return record.readAttributeBeforeTypeCast?.(resolvedName);
+    }
+    // Unencrypted — return the DB-serialized value (mirrors read_attribute_for_database).
+    return record._attributes?.valuesForDatabase?.()?.[resolvedName];
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -9,7 +9,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 // Memoized SHA1 key provider: PBKDF2 is expensive (65536 iterations), so
 // reuse the same provider as long as primaryKey and keyDerivationSalt haven't
-// changed. Keyed on the tuple so config rotation invalidates the cache.
+// changed. Cleared by the onConfigure hook below so config rotation invalidates it.
 let _sha1ProviderCache:
   | {
       primaryKey: string | string[];
@@ -17,6 +17,12 @@ let _sha1ProviderCache:
       provider: DerivedSecretKeyProvider;
     }
   | undefined;
+
+// Clear the SHA1 provider cache whenever configure() is called so the new
+// primary key / key derivation salt is picked up on the next encrypt call.
+Configurable.onConfigure(() => {
+  _sha1ProviderCache = undefined;
+});
 
 function getSha1KeyProvider(
   primaryKey: string | string[],
@@ -307,10 +313,7 @@ export class EncryptableRecord {
     const klass = record.constructor as any;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
-      const type = getAttributeType(klass, name);
-      const value = record.readAttribute?.(name) ?? record[name];
-      // Pre-serialize so updateColumns stores ciphertext, not plaintext.
-      result[name] = type instanceof EncryptedAttributeType ? type.serialize(value) : value;
+      result[name] = record.readAttribute?.(name) ?? record[name];
     }
     return result;
   }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -382,7 +382,8 @@ export class EncryptableRecord {
     const klass = record.constructor as any;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
-      result[name] = record.readAttribute?.(name) ?? record[name];
+      result[name] =
+        typeof record.readAttribute === "function" ? record.readAttribute(name) : record[name];
     }
     return result;
   }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -295,8 +295,30 @@ export class EncryptableRecord {
   /** @internal */
   static async encryptAttributes(record: any): Promise<void> {
     this.validateEncryptionAllowed(record);
-    const assignments = this.buildEncryptAttributeAssignments(record);
+    const klass = record.constructor as any;
+    const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+
+    // Pre-serialize so updateColumns writes ciphertext — updateColumns uses
+    // cast() not serialize(), so plaintext would be written back unchanged.
+    // Mirrors encryption.ts#encryptRecord.
+    const plaintextValues: Record<string, unknown> = {};
+    const assignments: Record<string, unknown> = {};
+    for (const name of encryptedAttrs) {
+      const plaintext = record.readAttribute?.(name) ?? record[name];
+      plaintextValues[name] = plaintext;
+      const type = getAttributeType(klass, name);
+      assignments[name] =
+        type instanceof EncryptedAttributeType ? type.serialize(plaintext) : plaintext;
+    }
+
     await record.updateColumns?.(assignments);
+
+    // Restore plaintext as the in-memory cast value — updateColumns set the
+    // ciphertext as the live value via cast(), but callers expect to read plaintext.
+    for (const [name, plaintext] of Object.entries(plaintextValues)) {
+      record._attributes?.writeCastValue?.(name, plaintext);
+    }
+    record.changesApplied?.();
   }
 
   /** @internal */
@@ -347,12 +369,14 @@ export class EncryptableRecord {
   /** @internal */
   static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
     const klass = record.constructor as any;
+    const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
     // changedAttributes is a string[] in this codebase (from DirtyTracker).
+    // Iterate changed once and check Set membership — O(n+m) vs O(n×m).
     const changed: string[] = Array.isArray(record.changedAttributes)
       ? record.changedAttributes
       : [];
-    for (const attr of klass._encryptedAttributes ?? new Set<string>()) {
-      if (changed.includes(attr)) {
+    for (const attr of changed) {
+      if (encryptedAttrs.has(attr)) {
         record.errors?.add?.(attr, "can't be modified because it is encrypted");
       }
     }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -329,7 +329,9 @@ export class EncryptableRecord {
   static _createRecord(record: any, attributeNames?: string[]): unknown {
     // Mirrors Rails: force encrypted attrs into the INSERT column list so a
     // column with an encrypted default is always written on first save.
-    const names = attributeNames ?? record.attributeNames ?? [];
+    const names =
+      attributeNames ??
+      (typeof record.attributeNames === "function" ? record.attributeNames() : []);
     const encryptedAttrs: Set<string> =
       record.constructor._encryptedAttributes ?? new Set<string>();
     const merged = [...new Set<string>([...names, ...encryptedAttrs])];

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -220,15 +220,40 @@ export class EncryptableRecord {
 
   /** @internal */
   static overrideAccessorsToPreserveOriginal(
-    _modelClass: any,
-    _name: string,
-    _originalName: string,
+    modelClass: any,
+    name: string,
+    originalName: string,
   ): void {
-    // The public entry point (Base.encrypts / encryption.ts#encrypts) handles
-    // the ignoreCase accessor override via _preserveOriginalEncrypted, which
-    // uses Object.defineProperty to wire the before-save sync and getter/setter.
-    // This @internal stub exists for api:compare parity only and is not called
-    // on the live path.
+    // Before each save, sync the in-memory value of `name` into `originalName`
+    // when `name` has been written. For new records always sync (changedAttributes
+    // is empty before the first save snapshot). Mirrors Rails'
+    // `name= { self.original_name = value; super(value) }`.
+    if (typeof modelClass.beforeSave === "function") {
+      modelClass.beforeSave((record: any) => {
+        const isNew =
+          typeof record.isNewRecord === "function" ? record.isNewRecord() : !record.isPersisted?.();
+        const changed: string[] = Array.isArray(record.changedAttributes)
+          ? record.changedAttributes
+          : [];
+        if (!isNew && !changed.includes(name)) return;
+        record.writeAttribute(originalName, record.readAttribute(name));
+      });
+    }
+    // Override prototype accessor. Getter returns originalName when present
+    // (case-preserving read), falling back to name for legacy rows. Setter
+    // writes both so in-memory reads see the new value before save.
+    Object.defineProperty(modelClass.prototype, name, {
+      configurable: true,
+      get(this: any) {
+        const originalValue = this.readAttribute(originalName);
+        if (originalValue != null) return originalValue;
+        return this.readAttribute(name);
+      },
+      set(this: any, value: unknown) {
+        this.writeAttribute(name, value);
+        this.writeAttribute(originalName, value);
+      },
+    });
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,5 +1,6 @@
-import { NotImplementedError } from "../errors.js";
 import { Scheme, type SchemeOptions } from "./scheme.js";
+import { getEncryptionContext, withoutEncryption as _withoutEncryption } from "./context.js";
+import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
@@ -8,7 +9,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 // Memoized SHA1 key provider: PBKDF2 is expensive (65536 iterations), so
 // reuse the same provider as long as primaryKey and keyDerivationSalt haven't
-// changed. Cleared by the onConfigure hook below so config rotation invalidates it.
+// changed. Keyed on the tuple so config rotation invalidates the cache.
 let _sha1ProviderCache:
   | {
       primaryKey: string | string[];
@@ -16,12 +17,6 @@ let _sha1ProviderCache:
       provider: DerivedSecretKeyProvider;
     }
   | undefined;
-
-// Clear the SHA1 provider cache whenever configure() is called so the new
-// primary key / key derivation salt is picked up on the next encrypt call.
-Configurable.onConfigure(() => {
-  _sha1ProviderCache = undefined;
-});
 
 function getSha1KeyProvider(
   primaryKey: string | string[],
@@ -204,6 +199,155 @@ export class EncryptableRecord {
     }
     return result;
   }
+
+  /** @internal */
+  static encryptAttribute(modelClass: any, name: string, options: SchemeOptions = {}): void {
+    this.encrypts(modelClass, name, options);
+  }
+
+  /** @internal */
+  static preserveOriginalEncrypted(modelClass: any, name: string): void {
+    const originalName = `original_${name}`;
+    this.encrypts(modelClass, originalName);
+    this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
+  }
+
+  /** @internal */
+  static overrideAccessorsToPreserveOriginal(
+    _modelClass: any,
+    _name: string,
+    _originalName: string,
+  ): void {
+    // Rails uses Ruby's `include(Module.new { define_method ... })` to dynamically
+    // override attribute accessors. TS has no equivalent; the ignoreCase
+    // read-original behaviour is handled at the EncryptedAttributeType level.
+  }
+
+  /** @internal */
+  static loadSchemaBang(modelClass: any): void {
+    if (Configurable.config.validateColumnSize) {
+      this.addLengthValidationForEncryptedColumns(modelClass);
+    }
+  }
+
+  /** @internal */
+  static addLengthValidationForEncryptedColumns(modelClass: any): void {
+    const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set();
+    for (const name of attrs) {
+      this.validateColumnSize(modelClass, name);
+    }
+  }
+
+  /** @internal */
+  static isEncryptedAttribute(record: any, attributeName: string): boolean {
+    const klass = record.constructor as any;
+    // Resolve attribute aliases before checking encrypted set.
+    const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
+    if (!klass._encryptedAttributes?.has(resolvedName)) return false;
+    const type = getAttributeType(klass, resolvedName);
+    if (!(type instanceof EncryptedAttributeType)) return false;
+    const raw = record.readAttributeBeforeTypeCast?.(resolvedName);
+    return type.isEncrypted(raw);
+  }
+
+  /** @internal */
+  static ciphertextFor(record: any, attributeName: string): unknown {
+    const klass = record.constructor as any;
+    const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
+    return record.readAttributeBeforeTypeCast?.(resolvedName);
+  }
+
+  /** @internal */
+  static async encrypt(record: any): Promise<void> {
+    if (this.hasEncryptedAttributes(record.constructor)) {
+      await this.encryptAttributes(record);
+    }
+  }
+
+  /** @internal */
+  static async decrypt(record: any): Promise<void> {
+    if (this.hasEncryptedAttributes(record.constructor)) {
+      await this.decryptAttributes(record);
+    }
+  }
+
+  /** @internal */
+  static _createRecord(record: any, attributeNames?: string[]): unknown {
+    // Rails prepends this to force encrypted attrs into the INSERT column list.
+    // In our codebase _createRecord is the ORM callback chain entry point and
+    // ignores attributeNames; encrypted columns are included unconditionally via
+    // _performInsert. This helper exists for api:compare parity only.
+    return record._createRecord?.(attributeNames);
+  }
+
+  /** @internal */
+  static async encryptAttributes(record: any): Promise<void> {
+    this.validateEncryptionAllowed(record);
+    const assignments = this.buildEncryptAttributeAssignments(record);
+    await record.updateColumns?.(assignments);
+  }
+
+  /** @internal */
+  static async decryptAttributes(record: any): Promise<void> {
+    this.validateEncryptionAllowed(record);
+    const assignments = this.buildDecryptAttributeAssignments(record);
+    await _withoutEncryption(() => record.updateColumns?.(assignments));
+  }
+
+  /** @internal */
+  static validateEncryptionAllowed(_record: any): void {
+    const ctx = getEncryptionContext();
+    if (ctx.frozenEncryption) {
+      throw new ConfigurationError("can't be modified because it is encrypted");
+    }
+  }
+
+  /** @internal */
+  static buildEncryptAttributeAssignments(record: any): Record<string, unknown> {
+    const klass = record.constructor as any;
+    const result: Record<string, unknown> = {};
+    for (const name of klass._encryptedAttributes ?? new Set<string>()) {
+      const type = getAttributeType(klass, name);
+      const value = record.readAttribute?.(name) ?? record[name];
+      // Pre-serialize so updateColumns stores ciphertext, not plaintext.
+      result[name] = type instanceof EncryptedAttributeType ? type.serialize(value) : value;
+    }
+    return result;
+  }
+
+  /** @internal */
+  static buildDecryptAttributeAssignments(record: any): Record<string, unknown> {
+    const klass = record.constructor as any;
+    const result: Record<string, unknown> = {};
+    for (const name of klass._encryptedAttributes ?? new Set<string>()) {
+      const type = getAttributeType(klass, name);
+      const raw = record.readAttributeBeforeTypeCast?.(name);
+      // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
+      // which returns the raw value when support_unencrypted_data is true.
+      if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
+        result[name] = type.deserialize(raw);
+      } else {
+        // Plaintext — return the cast value so typed columns (date, JSON, etc.)
+        // keep their in-memory representation rather than the raw DB string.
+        result[name] = record.readAttribute?.(name) ?? raw;
+      }
+    }
+    return result;
+  }
+
+  /** @internal */
+  static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
+    const klass = record.constructor as any;
+    // changedAttributes is a string[] in this codebase (from DirtyTracker).
+    const changed: string[] = Array.isArray(record.changedAttributes)
+      ? record.changedAttributes
+      : [];
+    for (const attr of klass._encryptedAttributes ?? new Set<string>()) {
+      if (changed.includes(attr)) {
+        record.errors?.add?.(attr, "can't be modified because it is encrypted");
+      }
+    }
+  }
 }
 
 /**
@@ -212,142 +356,4 @@ export class EncryptableRecord {
 export function getAttributeType(klass: any, name: string): unknown {
   const def = klass._attributeDefinitions?.get?.(name);
   return def?.type;
-}
-
-/** @internal */
-function encryptAttribute(
-  name: any,
-  keyProvider?: any,
-  key?: any,
-  deterministic?: any,
-  supportUnencryptedData?: any,
-  downcase?: any,
-  ignoreCase?: any,
-  previous?: any,
-  compress?: any,
-  compressor?: any,
-  contextProperties?: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attribute is not implemented",
-  );
-}
-
-/** @internal */
-function preserveOriginalEncrypted(name: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#preserve_original_encrypted is not implemented",
-  );
-}
-
-/** @internal */
-function overrideAccessorsToPreserveOriginal(name: any, originalAttributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#override_accessors_to_preserve_original is not implemented",
-  );
-}
-
-/** @internal */
-function loadSchemaBang(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#load_schema! is not implemented",
-  );
-}
-
-/** @internal */
-function addLengthValidationForEncryptedColumns(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#add_length_validation_for_encrypted_columns is not implemented",
-  );
-}
-
-/** @internal */
-function validateColumnSize(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#validate_column_size is not implemented",
-  );
-}
-
-/** @internal */
-function isEncryptedAttribute(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute? is not implemented",
-  );
-}
-
-/** @internal */
-function ciphertextFor(attributeName: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#ciphertext_for is not implemented",
-  );
-}
-
-/** @internal */
-function encrypt(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt is not implemented",
-  );
-}
-
-/** @internal */
-function decrypt(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#decrypt is not implemented",
-  );
-}
-
-/** @internal */
-function _createRecord(attributeNames?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#_create_record is not implemented",
-  );
-}
-
-/** @internal */
-function encryptAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attributes is not implemented",
-  );
-}
-
-/** @internal */
-function decryptAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#decrypt_attributes is not implemented",
-  );
-}
-
-/** @internal */
-function validateEncryptionAllowed(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#validate_encryption_allowed is not implemented",
-  );
-}
-
-/** @internal */
-function hasEncryptedAttributes(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#has_encrypted_attributes? is not implemented",
-  );
-}
-
-/** @internal */
-function buildEncryptAttributeAssignments(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#build_encrypt_attribute_assignments is not implemented",
-  );
-}
-
-/** @internal */
-function buildDecryptAttributeAssignments(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#build_decrypt_attribute_assignments is not implemented",
-  );
-}
-
-/** @internal */
-function cantModifyEncryptedAttributesWhenFrozen(): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Encryption::EncryptableRecord#cant_modify_encrypted_attributes_when_frozen is not implemented",
-  );
 }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -304,28 +304,28 @@ export class EncryptableRecord {
     const plaintextValues: Record<string, unknown> = {};
     const assignments: Record<string, unknown> = {};
     for (const name of encryptedAttrs) {
-      const plaintext = record.readAttribute?.(name) ?? record[name];
+      const plaintext = record.readAttribute(name);
       plaintextValues[name] = plaintext;
       const type = getAttributeType(klass, name);
       assignments[name] =
         type instanceof EncryptedAttributeType ? type.serialize(plaintext) : plaintext;
     }
 
-    await record.updateColumns?.(assignments);
+    await record.updateColumns(assignments);
 
     // Restore plaintext as the in-memory cast value — updateColumns set the
     // ciphertext as the live value via cast(), but callers expect to read plaintext.
     for (const [name, plaintext] of Object.entries(plaintextValues)) {
-      record._attributes?.writeCastValue?.(name, plaintext);
+      record._attributes.writeCastValue(name, plaintext);
     }
-    record.changesApplied?.();
+    record.changesApplied();
   }
 
   /** @internal */
   static async decryptAttributes(record: any): Promise<void> {
     this.validateEncryptionAllowed(record);
     const assignments = this.buildDecryptAttributeAssignments(record);
-    await _withoutEncryption(() => record.updateColumns?.(assignments));
+    await _withoutEncryption(() => record.updateColumns(assignments));
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

- Implements 16 missing methods on \`EncryptableRecord\`, bringing \`encryption/encryptable_record.rb\` from 30% (7/23) to 100% (23/23) on \`api:compare\`
- Cherry-picked and refined from \`origin/enc-privates-4\` (encryptable-record.ts hunks only)

## Methods added

\`encryptAttribute\`, \`preserveOriginalEncrypted\`, \`overrideAccessorsToPreserveOriginal\`, \`loadSchemaBang\`, \`addLengthValidationForEncryptedColumns\`, \`isEncryptedAttribute\`, \`ciphertextFor\`, \`encrypt\`, \`decrypt\`, \`_createRecord\`, \`encryptAttributes\`, \`decryptAttributes\`, \`validateEncryptionAllowed\`, \`buildEncryptAttributeAssignments\`, \`buildDecryptAttributeAssignments\`, \`cantModifyEncryptedAttributesWhenFrozen\`

## Key design notes

- \`validateEncryptionAllowed\` checks \`getEncryptionContext().frozenEncryption\` (ENC-0 wired)
- \`decryptAttributes\` wraps \`updateColumns\` in \`withoutEncryption\` (idempotency)
- \`isEncryptedAttribute\` and \`ciphertextFor\` resolve attribute aliases before lookup
- \`buildDecryptAttributeAssignments\` is idempotent — skips plaintext values when \`support_unencrypted_data\` is true
- \`overrideAccessorsToPreserveOriginal\` is fully implemented (beforeSave hook + Object.defineProperty); \`encryption.ts#_preserveOriginalEncrypted\` now delegates to it
- \`cantModifyEncryptedAttributesWhenFrozen\` is live — \`encryption.ts\`'s frozen-encryption validator delegates to it
- \`encryptAttributes\` routes through \`buildEncryptAttributeAssignments\` (Rails parity), then pre-serializes before \`updateColumns\`

## Dependencies

- ENC-0 (#1277, merged): \`ignoreCase\` accessor + \`_invalidateCaches\`
- ENC-3 (#1279, merged): \`EncryptedAttributeType\` at 100%

## Known gaps / follow-up

**\`preserveOriginalEncrypted\` uses default scheme options** (Copilot raised 9 times): Rails' \`preserve_original_encrypted\` calls \`encrypts original_attribute_name\` with no options — our implementation matches. The \`encryption.ts#_preserveOriginalEncrypted\` function propagates options (minus \`ignoreCase\`/\`downcase\`) as an enhancement beyond Rails, but the \`@internal\` static mirrors the Rails method literally. Not a bug.

**\`encryptAttributes\` cast pipeline for non-string cast types** (Copilot comment #9.1/#9.3): \`updateColumns\` runs \`def.type.cast(ciphertext)\` on the pre-serialized value before writing. For \`EncryptedAttributeType\` wrapping a non-string inner cast type (e.g., \`DateType\`), \`cast(ciphertext_string)\` goes through \`EncryptedAttributeType.cast\` → \`deserialize\` → decrypt → inner cast. This should be safe (decrypt then cast works), but the concern is worth a regression test for encrypted date/JSON columns after re-encryption. Follow-up in ENC-5 or as a standalone test PR.