### PR TITLE
feat(activerecord): PR 38b — base.rb wiring part 2 + inheritance.rb to 100%

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -29,6 +29,7 @@ import {
   baseClass as _inheritanceBaseClass,
   getAbstractClass as _getAbstractClass,
   setAbstractClass as _setAbstractClass,
+  isBaseClass as _isBaseClass,
 } from "./inheritance.js";
 import {
   NotImplementedError,
@@ -155,6 +156,16 @@ import * as _Core from "./core.js";
 import * as _Persistence from "./persistence.js";
 import * as _Aggregations from "./aggregations.js";
 import * as _EnumModule from "./enum.js";
+import {
+  collectingQueriesForExplain as _collectingQueriesForExplain,
+  execExplain as _execExplain,
+  renderBind as _renderBind,
+  buildExplainClause as _buildExplainClause,
+} from "./explain.js";
+import {
+  delegatedType as _delegatedType,
+  defineDelegatedTypeMethods as _defineDelegatedTypeMethods,
+} from "./delegated-type.js";
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
@@ -955,6 +966,15 @@ export class Base extends Model {
     return isFinderNeedsTypeCondition(this);
   }
 
+  /**
+   * Returns true if this class is its own STI base class.
+   *
+   * Mirrors: ActiveRecord::Inheritance::ClassMethods#base_class?
+   */
+  static isBaseClass(): boolean {
+    return _isBaseClass(this);
+  }
+
   static primaryAbstractClass(): void {
     primaryAbstractClass(this);
   }
@@ -1199,16 +1219,69 @@ export class Base extends Model {
   declare static validates: typeof _Validations.validates;
   declare static validatesAssociated: typeof _Validations.validatesAssociated;
 
-  // -- Enums --
+  // -- Enums (wired via extend() after class body) --
   static _enums: Map<string, Record<string, number>> = new Map();
 
   /**
    * Declare an enum attribute. Maps symbolic names to integer values.
-   * Implementation lives in enum.ts; wired via extend() after the class body.
    *
    * Mirrors: ActiveRecord::Enum.enum
    */
   declare static enum: typeof _EnumModule.enumMethod;
+
+  /** @internal */
+  declare static _enum: typeof _EnumModule._enum;
+  /** @internal */
+  declare static _enumMethodsModule: typeof _EnumModule._enumMethodsModule;
+  /** @internal */
+  declare static detectEnumConflictBang: typeof _EnumModule.detectEnumConflictBang;
+  /** @internal */
+  declare static raiseConflictError: typeof _EnumModule.raiseConflictError;
+  /** @internal */
+  declare static assertValidEnumDefinitionValues: typeof _EnumModule.assertValidEnumDefinitionValues;
+  /** @internal */
+  declare static assertValidEnumOptions: typeof _EnumModule.assertValidEnumOptions;
+  /** @internal */
+  declare static detectNegativeEnumConditionsBang: typeof _EnumModule.detectNegativeEnumConditionsBang;
+
+  // -- Explain --
+
+  /** @internal */
+  declare static collectingQueriesForExplain: typeof _collectingQueriesForExplain;
+
+  /** @internal */
+  static execExplain(queries: [string, unknown[]][], options?: any[]): Promise<string> {
+    return _execExplain(this, queries, options);
+  }
+
+  /** @internal */
+  declare static renderBind: typeof _renderBind;
+
+  /** @internal */
+  declare static buildExplainClause: typeof _buildExplainClause;
+
+  // -- DelegatedType --
+
+  /**
+   * Declare a delegated type on this model.
+   *
+   * Mirrors: ActiveRecord::DelegatedType.delegated_type
+   */
+  static delegatedType(
+    role: string,
+    options: import("./delegated-type.js").DelegatedTypeOptions,
+  ): void {
+    _delegatedType(this, role, options);
+  }
+
+  /** @internal */
+  static defineDelegatedTypeMethods(
+    role: string,
+    types: string[],
+    options: import("./delegated-type.js").DelegatedTypeOptions,
+  ): void {
+    _defineDelegatedTypeMethods(this, role, types, options);
+  }
 
   // -- Store --
   static _storedAttributes: Map<string, { accessors?: string[] }> = new Map();
@@ -2776,7 +2849,22 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, _Validations.ClassMethods);
-extend(Base, { enum: _EnumModule.enumMethod });
+extend(Base, {
+  enum: _EnumModule.enumMethod,
+  _enum: _EnumModule._enum,
+  _enumMethodsModule: _EnumModule._enumMethodsModule,
+  detectEnumConflictBang: _EnumModule.detectEnumConflictBang,
+  raiseConflictError: _EnumModule.raiseConflictError,
+  assertValidEnumDefinitionValues: _EnumModule.assertValidEnumDefinitionValues,
+  assertValidEnumOptions: _EnumModule.assertValidEnumOptions,
+  detectNegativeEnumConditionsBang: _EnumModule.detectNegativeEnumConditionsBang,
+});
+extend(Base, {
+  collectingQueriesForExplain: _collectingQueriesForExplain,
+  execExplain: _execExplain,
+  renderBind: _renderBind,
+  buildExplainClause: _buildExplainClause,
+});
 extend(Base, _Reflection.ClassMethods);
 extend(Base, {
   defaultScope: _defaultScope,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -11,7 +11,7 @@ import {
   sql as arelSql,
   setToSqlVisitor,
 } from "@blazetrails/arel";
-import type { DatabaseAdapter } from "./adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import type { Relation } from "./relation.js";
 import {
   getInheritanceColumn,
@@ -452,9 +452,6 @@ function _applyScopeAttributes(
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
-  /** @internal Sentinel used by setBaseClass to identify the AR root class. */
-  static readonly _isARBase = true;
-
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
 
@@ -1253,7 +1250,10 @@ export class Base extends Model {
   declare static collectingQueriesForExplain: typeof _collectingQueriesForExplain;
 
   /** @internal */
-  static execExplain(queries: [string, unknown[]][], options?: any[]): Promise<string> {
+  static execExplain(
+    queries: [string, unknown[]][],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     return _execExplain(this, queries, options);
   }
 
@@ -1281,9 +1281,14 @@ export class Base extends Model {
   static defineDelegatedTypeMethods(
     role: string,
     types: string[],
-    options: import("./delegated-type.js").DelegatedTypeOptions,
+    options: Omit<import("./delegated-type.js").DelegatedTypeOptions, "types">,
   ): void {
-    _defineDelegatedTypeMethods(this, role, types, options);
+    _defineDelegatedTypeMethods(
+      this,
+      role,
+      types,
+      options as import("./delegated-type.js").DelegatedTypeOptions,
+    );
   }
 
   // -- Store --

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -452,6 +452,9 @@ function _applyScopeAttributes(
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
+  /** @internal Sentinel used by setBaseClass to identify the AR root class. */
+  static readonly _isARBase = true;
+
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
 
@@ -2861,7 +2864,7 @@ extend(Base, {
 });
 extend(Base, {
   collectingQueriesForExplain: _collectingQueriesForExplain,
-  execExplain: _execExplain,
+  // execExplain is a static wrapper (passes `this`) — not in extend()
   renderBind: _renderBind,
   buildExplainClause: _buildExplainClause,
 });

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -168,4 +168,13 @@ describe("DelegatedTypeTest", () => {
     expect(e.entryable_type).toBe("Message");
     expect(e.entryable_id).toBe(5);
   });
+
+  it("registers a polymorphic belongs_to for the delegated role", () => {
+    const { Entry } = makeModels();
+    const reflection = Entry._reflectOnAssociation("entryable");
+    expect(reflection).not.toBeNull();
+    expect((reflection as any).options?.polymorphic).toBe(true);
+    expect((reflection as any).options?.foreignKey).toBe("entryable_id");
+    expect((reflection as any).options?.foreignType).toBe("entryable_type");
+  });
 });

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -48,18 +48,13 @@ export function delegatedType(
   const config = { ...options, foreignKey, foreignType };
 
   // Rails: belongs_to role, scope, **options.merge(polymorphic: true)
-  // Wire the polymorphic belongs_to so entry.entryable / entry.entryable= work.
-  if (typeof (modelClass as any).belongsTo === "function") {
-    const { types: _types, ...assocOptions } = options as DelegatedTypeOptions & {
-      types?: unknown;
-    };
-    (modelClass as any).belongsTo(role, {
-      ...assocOptions,
-      polymorphic: true,
-      foreignKey,
-      foreignType,
-    });
-  }
+  const { types: _types, ...assocOptions } = options as DelegatedTypeOptions & { types?: unknown };
+  (modelClass as any).belongsTo(role, {
+    ...assocOptions,
+    polymorphic: true,
+    foreignKey,
+    foreignType,
+  });
 
   if (!delegatedTypeRegistry.has(modelClass)) {
     delegatedTypeRegistry.set(modelClass, new Map());

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -47,7 +47,8 @@ export function delegatedType(
   const foreignType = options.foreignType ?? `${role}_type`;
   const config = { ...options, foreignKey, foreignType };
 
-  // Rails: belongs_to role, scope, **options.merge(polymorphic: true)
+  // Rails: belongs_to role, **options.merge(polymorphic: true)
+  // (Rails also accepts an optional scope proc; we omit it as there's no proc equivalent)
   const { types: _types, ...assocOptions } = options as DelegatedTypeOptions & { types?: unknown };
   (modelClass as any).belongsTo(role, {
     ...assocOptions,

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -47,6 +47,20 @@ export function delegatedType(
   const foreignType = options.foreignType ?? `${role}_type`;
   const config = { ...options, foreignKey, foreignType };
 
+  // Rails: belongs_to role, scope, **options.merge(polymorphic: true)
+  // Wire the polymorphic belongs_to so entry.entryable / entry.entryable= work.
+  if (typeof (modelClass as any).belongsTo === "function") {
+    const { types: _types, ...assocOptions } = options as DelegatedTypeOptions & {
+      types?: unknown;
+    };
+    (modelClass as any).belongsTo(role, {
+      ...assocOptions,
+      polymorphic: true,
+      foreignKey,
+      foreignType,
+    });
+  }
+
   if (!delegatedTypeRegistry.has(modelClass)) {
     delegatedTypeRegistry.set(modelClass, new Map());
   }

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2109,11 +2109,9 @@ describe("Base constructor wires initializeInternalsCallback", () => {
     const record = Vehicle._instantiate({ id: 1, type: "Vehicle" }) as any;
     expect(record.readAttribute("type")).toBe("Vehicle");
   });
+});
 
-  // -------------------------------------------------------------------------
-  // base_class? / set_base_class (setBaseClass)
-  // -------------------------------------------------------------------------
-
+describe("base_class? / isBaseClass", () => {
   it("base_class? returns true for the STI root and false for subclasses", () => {
     const adapter2 = createTestAdapter();
     class User2 extends Base {
@@ -2135,11 +2133,9 @@ describe("Base constructor wires initializeInternalsCallback", () => {
     expect(User2.isBaseClass()).toBe(true);
     expect(Manager2.isBaseClass()).toBe(false);
   });
+});
 
-  // -------------------------------------------------------------------------
-  // STI subclass routing: User.find(manager_id) returns Manager instance
-  // -------------------------------------------------------------------------
-
+describe("STI subclass routing via find", () => {
   it("subclass from find returns the subclass instance", async () => {
     const adapter3 = createTestAdapter();
     class User3 extends Base {
@@ -2165,8 +2161,10 @@ describe("Base constructor wires initializeInternalsCallback", () => {
     expect(found).toBeInstanceOf(Manager3);
     expect((found as any).name).toBe("Alice");
   });
+});
 
-  it("setBaseClass caches the STI base on the model class", () => {
+describe("set_base_class / setBaseClass", () => {
+  it("setBaseClass caches the base class using the Rails hierarchy logic", () => {
     const adapter4 = createTestAdapter();
     class Animal2 extends Base {
       static {
@@ -2184,9 +2182,9 @@ describe("Base constructor wires initializeInternalsCallback", () => {
 
     setBaseClass(Animal2);
     setBaseClass(Dog2);
-    // Animal2's superclass is Base (no _computedBaseClass) → Animal2 is its own root
+    // Animal2's superclass is Base (_isActiveRecordBase) → Animal2 is its own root
     expect((Animal2 as any)._computedBaseClass).toBe(Animal2);
-    // Dog2's superclass is Animal2, which has _computedBaseClass set → Dog2 inherits it
+    // Dog2's superclass is Animal2 (concrete, not abstract) → Dog2 inherits Animal2
     expect((Dog2 as any)._computedBaseClass).toBe(Animal2);
   });
 });

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2162,7 +2162,7 @@ describe("Base constructor wires initializeInternalsCallback", () => {
 
     const mgr = await Manager3.create({ name: "Alice" });
     const found = await User3.find(mgr.id);
-    expect(found.constructor.name).toBe("Manager3");
+    expect(found).toBeInstanceOf(Manager3);
     expect((found as any).name).toBe("Alice");
   });
 

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass, SubclassNotFound } from "./index.js";
-import { getStiBase, isStiSubclass } from "./inheritance.js";
+import { getStiBase, isStiSubclass, setBaseClass } from "./inheritance.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -2108,5 +2108,83 @@ describe("Base constructor wires initializeInternalsCallback", () => {
     // as-is from the DB row, not overwritten by initializeInternalsCallback.
     const record = Vehicle._instantiate({ id: 1, type: "Vehicle" }) as any;
     expect(record.readAttribute("type")).toBe("Vehicle");
+  });
+
+  // -------------------------------------------------------------------------
+  // base_class? / set_base_class (setBaseClass)
+  // -------------------------------------------------------------------------
+
+  it("base_class? returns true for the STI root and false for subclasses", () => {
+    const adapter2 = createTestAdapter();
+    class User2 extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("type", "string");
+        this._tableName = "user2s";
+        this.adapter = adapter2;
+        enableSti(User2);
+      }
+    }
+    class Manager2 extends User2 {
+      static {
+        registerModel(Manager2);
+        registerSubclass(Manager2);
+      }
+    }
+
+    expect(User2.isBaseClass()).toBe(true);
+    expect(Manager2.isBaseClass()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // STI subclass routing: User.find(manager_id) returns Manager instance
+  // -------------------------------------------------------------------------
+
+  it("subclass from find returns the subclass instance", async () => {
+    const adapter3 = createTestAdapter();
+    class User3 extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("type", "string");
+        this._tableName = "user3s";
+        this.adapter = adapter3;
+        enableSti(User3);
+      }
+    }
+    class Manager3 extends User3 {
+      static {
+        this.adapter = adapter3;
+        registerModel(Manager3);
+        registerSubclass(Manager3);
+      }
+    }
+
+    const mgr = await Manager3.create({ name: "Alice" });
+    const found = await User3.find(mgr.id);
+    expect(found.constructor.name).toBe("Manager3");
+    expect((found as any).name).toBe("Alice");
+  });
+
+  it("setBaseClass caches the STI base on the model class", () => {
+    const adapter4 = createTestAdapter();
+    class Animal2 extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("type", "string");
+        this.adapter = adapter4;
+        enableSti(Animal2);
+      }
+    }
+    class Dog2 extends Animal2 {
+      static {
+        registerSubclass(Dog2);
+      }
+    }
+
+    setBaseClass(Dog2);
+    expect((Dog2 as any)._cachedBaseClass).toBe(Animal2);
+    setBaseClass(Animal2);
+    expect((Animal2 as any)._cachedBaseClass).toBe(Animal2);
   });
 });

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2182,9 +2182,11 @@ describe("Base constructor wires initializeInternalsCallback", () => {
       }
     }
 
-    setBaseClass(Dog2);
-    expect((Dog2 as any)._cachedBaseClass).toBe(Animal2);
     setBaseClass(Animal2);
-    expect((Animal2 as any)._cachedBaseClass).toBe(Animal2);
+    setBaseClass(Dog2);
+    // Animal2's superclass is Base (no _computedBaseClass) → Animal2 is its own root
+    expect((Animal2 as any)._computedBaseClass).toBe(Animal2);
+    // Dog2's superclass is Animal2, which has _computedBaseClass set → Dog2 inherits it
+    expect((Dog2 as any)._computedBaseClass).toBe(Animal2);
   });
 });

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -98,7 +98,8 @@ export function isDescendsFromActiveRecord(modelClass: typeof Base): boolean {
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#base_class?
  */
 export function isBaseClass(modelClass: typeof Base): boolean {
-  if (!(modelClass as any)._computedBaseClass) setBaseClass(modelClass);
+  if (!Object.prototype.hasOwnProperty.call(modelClass, "_computedBaseClass"))
+    setBaseClass(modelClass);
   return (modelClass as any)._computedBaseClass === modelClass;
 }
 
@@ -129,8 +130,8 @@ export function setBaseClass(modelClass: typeof Base): void {
   if (parentIsARBase || parentIsAbstract) {
     (modelClass as any)._computedBaseClass = modelClass;
   } else {
-    // Ensure parent is computed first (lazy on first call).
-    if (!(parent as any)._computedBaseClass) setBaseClass(parent);
+    // Ensure parent has its own computed entry before inheriting it.
+    if (!Object.prototype.hasOwnProperty.call(parent, "_computedBaseClass")) setBaseClass(parent);
     (modelClass as any)._computedBaseClass = (parent as any)._computedBaseClass;
   }
 }
@@ -213,7 +214,7 @@ export function isStiSubclass(modelClass: typeof Base): boolean {
  * @internal
  */
 export function baseClass(this: typeof Base): typeof Base {
-  if (!(this as any)._computedBaseClass) setBaseClass(this);
+  if (!Object.prototype.hasOwnProperty.call(this, "_computedBaseClass")) setBaseClass(this);
   return (this as any)._computedBaseClass as typeof Base;
 }
 

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -213,7 +213,8 @@ export function isStiSubclass(modelClass: typeof Base): boolean {
  * @internal
  */
 export function baseClass(this: typeof Base): typeof Base {
-  return getStiBase(this);
+  if (!(this as any)._computedBaseClass) setBaseClass(this);
+  return (this as any)._computedBaseClass as typeof Base;
 }
 
 /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -91,6 +91,26 @@ export function isDescendsFromActiveRecord(modelClass: typeof Base): boolean {
 }
 
 /**
+ * Check if this class is its own STI base class (i.e. `base_class == self`).
+ *
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#base_class?
+ */
+export function isBaseClass(modelClass: typeof Base): boolean {
+  return getStiBase(modelClass) === modelClass;
+}
+
+/**
+ * Compute and cache the STI base class for this model.
+ * Called during class setup to initialise the `base_class` reference.
+ *
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods#set_base_class
+ * @internal
+ */
+export function setBaseClass(modelClass: typeof Base): void {
+  (modelClass as any)._cachedBaseClass = getStiBase(modelClass);
+}
+
+/**
  * Return the STI name for this class (used as the type column value).
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#sti_name

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -92,11 +92,14 @@ export function isDescendsFromActiveRecord(modelClass: typeof Base): boolean {
 
 /**
  * Check if this class is its own STI base class (i.e. `base_class == self`).
+ * Uses the cached `_computedBaseClass` from `setBaseClass`, computing it on
+ * demand if not already set.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#base_class?
  */
 export function isBaseClass(modelClass: typeof Base): boolean {
-  return getStiBase(modelClass) === modelClass;
+  if (!(modelClass as any)._computedBaseClass) setBaseClass(modelClass);
+  return (modelClass as any)._computedBaseClass === modelClass;
 }
 
 /**
@@ -108,15 +111,20 @@ export function isBaseClass(modelClass: typeof Base): boolean {
  * @internal
  */
 export function setBaseClass(modelClass: typeof Base): void {
+  // Rails: if self == Base → base_class = self.
+  // Detected via the _isActiveRecordBase own-property sentinel on Base.
+  if (Object.prototype.hasOwnProperty.call(modelClass, "_isActiveRecordBase")) {
+    (modelClass as any)._computedBaseClass = modelClass;
+    return;
+  }
   const parent = Object.getPrototypeOf(modelClass) as typeof Base | null;
   if (!parent || parent === Function.prototype || typeof parent.name !== "string") {
-    // modelClass IS Base (or detached) — it is its own base.
     (modelClass as any)._computedBaseClass = modelClass;
     return;
   }
   // Rails: if superclass == Base || superclass.abstract_class? → self is root.
-  // We detect the AR root via the _isARBase sentinel set on Base.
-  const parentIsARBase = Object.prototype.hasOwnProperty.call(parent, "_isARBase");
+  // Use _isActiveRecordBase (existing sentinel) to identify the AR root class.
+  const parentIsARBase = Object.prototype.hasOwnProperty.call(parent, "_isActiveRecordBase");
   const parentIsAbstract = getAbstractClass.call(parent);
   if (parentIsARBase || parentIsAbstract) {
     (modelClass as any)._computedBaseClass = modelClass;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -100,14 +100,28 @@ export function isBaseClass(modelClass: typeof Base): boolean {
 }
 
 /**
- * Compute and cache the STI base class for this model.
- * Called during class setup to initialise the `base_class` reference.
+ * Compute and cache the base class for this model using the Rails hierarchy
+ * logic: a class is its own base if its immediate superclass is Base or is
+ * abstract; otherwise it inherits the superclass's base class.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#set_base_class
  * @internal
  */
 export function setBaseClass(modelClass: typeof Base): void {
-  (modelClass as any)._cachedBaseClass = getStiBase(modelClass);
+  const parent = Object.getPrototypeOf(modelClass) as typeof Base | null;
+  if (!parent || parent === Function.prototype || typeof parent.name !== "string") {
+    // modelClass IS Base (or detached) — it is its own base.
+    (modelClass as any)._computedBaseClass = modelClass;
+    return;
+  }
+  // Rails: if superclass == Base || superclass.abstract_class? → self is root
+  const parentIsAbstract = getAbstractClass.call(parent);
+  const parentIsBase = !(parent as any)._computedBaseClass; // parent hasn't been through setBaseClass → it's Base itself
+  if (parentIsAbstract || parentIsBase) {
+    (modelClass as any)._computedBaseClass = modelClass;
+  } else {
+    (modelClass as any)._computedBaseClass = (parent as any)._computedBaseClass ?? parent;
+  }
 }
 
 /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -114,13 +114,16 @@ export function setBaseClass(modelClass: typeof Base): void {
     (modelClass as any)._computedBaseClass = modelClass;
     return;
   }
-  // Rails: if superclass == Base || superclass.abstract_class? → self is root
+  // Rails: if superclass == Base || superclass.abstract_class? → self is root.
+  // We detect the AR root via the _isARBase sentinel set on Base.
+  const parentIsARBase = Object.prototype.hasOwnProperty.call(parent, "_isARBase");
   const parentIsAbstract = getAbstractClass.call(parent);
-  const parentIsBase = !(parent as any)._computedBaseClass; // parent hasn't been through setBaseClass → it's Base itself
-  if (parentIsAbstract || parentIsBase) {
+  if (parentIsARBase || parentIsAbstract) {
     (modelClass as any)._computedBaseClass = modelClass;
   } else {
-    (modelClass as any)._computedBaseClass = (parent as any)._computedBaseClass ?? parent;
+    // Ensure parent is computed first (lazy on first call).
+    if (!(parent as any)._computedBaseClass) setBaseClass(parent);
+    (modelClass as any)._computedBaseClass = (parent as any)._computedBaseClass;
   }
 }
 


### PR DESCRIPTION
## Summary

- **inheritance.rb 95% → 100%**: Added `isBaseClass` (mirrors `base_class?`) and `setBaseClass` (mirrors `set_base_class`) to `inheritance.ts`
- **Explain wiring on Base**: `collectingQueriesForExplain`, `execExplain`, `renderBind`, `buildExplainClause` now accessible as class methods on Base (mirrors `extend Explain` in `base.rb`)
- **DelegatedType wiring on Base**: `delegatedType` and `defineDelegatedTypeMethods` now static methods on Base (mirrors `extend DelegatedType` in `base.rb`); wires polymorphic `belongsTo` for the delegated role
- **Enum privates on Base**: `_enum`, `_enumMethodsModule`, `detectEnumConflictBang`, `raiseConflictError`, `assertValidEnumDefinitionValues`, `assertValidEnumOptions`, `detectNegativeEnumConditionsBang` wired via `extend()` (mirrors full `extend Enum` in `base.rb`)
- **base.rb**: 158/277 (57%) → 169/277 (61%)
- **Out of scope**: EncryptableRecord wiring — depends on ENC-4 (#1281); planned for PR 38c

## Key implementation details

- `setBaseClass` uses `_isActiveRecordBase` own-property sentinel (existing, used by `connection-handling.ts`) to identify the AR root, then mirrors Rails' `superclass == Base || superclass.abstract_class?` logic to determine the hierarchy root. Result cached on `_computedBaseClass`.
- `baseClass()` and `isBaseClass()` both derive from `_computedBaseClass` (computed lazily via `setBaseClass`), keeping them consistent — mirrors Rails where both stem from `set_base_class`.

## STI tests added

- `base_class?` predicate: `User.isBaseClass() === true`, `Manager.isBaseClass() === false`
- Subclass-from-find routing: `User.find(manager_id)` returns a `Manager` instance
- `setBaseClass` cache: `Dog._computedBaseClass === Animal`
- `delegatedType` registers polymorphic `belongsTo` with correct `foreignKey`/`foreignType`

## Test plan

- [x] `pnpm api:compare --package activerecord` → `inheritance.rb 22/22 100% ✓`, `base.rb 169/277 (61%)`
- [x] `pnpm vitest run packages/activerecord/src/inheritance.test.ts` → 113 passed, 2 skipped
- [x] `pnpm vitest run packages/activerecord/src/delegated-type.test.ts` → 12 passed, 2 skipped
- [x] `pnpm lint --fix` — clean
- [x] ~220 net LOC (under 300 ceiling)