### PR TITLE
fix(activerecord): mix SchemaStatements into AbstractAdapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -68,6 +68,7 @@ import type {
   Table,
   ForeignKeyDefinition,
   AddForeignKeyOptions,
+  AddIndexOptions,
   ColumnType,
   ColumnOptions,
 } from "./abstract/schema-definitions.js";
@@ -173,7 +174,13 @@ export interface AbstractAdapter {
     tableName: string,
     ...columns: Array<{ name: string; type: ColumnType; options?: ColumnOptions }>
   ): Promise<void>;
+  removeColumn(
+    tableName: string,
+    columnName: string,
+    options?: { ifExists?: boolean },
+  ): Promise<void>;
   removeColumns(tableName: string, ...columns: string[]): Promise<void>;
+  addIndex(tableName: string, columns: string | string[], options?: AddIndexOptions): Promise<void>;
   removeIndex(
     tableName: string,
     options?: { column?: string | string[]; name?: string },

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -529,7 +529,8 @@ export class AbstractAdapter implements Quoting {
    * resolve to the same object.
    * @internal
    */
-  get adapter(): import("./abstract/assert-schema-adapter.js").SchemaQuoter & DatabaseAdapter {
+  protected get adapter(): import("./abstract/assert-schema-adapter.js").SchemaQuoter &
+    DatabaseAdapter {
     return this as unknown as import("./abstract/assert-schema-adapter.js").SchemaQuoter &
       DatabaseAdapter;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -135,7 +135,7 @@ export interface AbstractAdapter {
   // --- SchemaStatements (DDL) ---
   // The abstract base signatures are declared here. Concrete adapter subclasses
   // that override with dialect-specific variants (PG's createTable/dropTable)
-  // carry // @ts-ignore on those overrides; the runtime behaviour is correct.
+  // carry // @ts-expect-error on those overrides; the runtime behaviour is correct.
   createTable(
     name: string,
     optionsOrFn?:

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -220,7 +220,7 @@ export interface AbstractAdapter {
   createJoinTable(
     table1: string,
     table2: string,
-    options?: Record<string, unknown>,
+    options?: { tableName?: string } | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
   dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -202,6 +202,12 @@ export interface AbstractAdapter {
   indexes(tableName: string): Promise<unknown[]>;
   foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
   addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
+  removeForeignKey(
+    fromTable: string,
+    toTableOrOptions?:
+      | string
+      | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
+  ): Promise<void>;
   addReference(
     tableName: string,
     refName: string,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -146,7 +146,9 @@ export interface AbstractAdapter {
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
   dropTable(
-    ...args: string[] | [...string[], { ifExists?: boolean; force?: string }]
+    ...args:
+      | [string, ...string[]]
+      | [string, ...string[], { ifExists?: boolean; force?: "cascade" }]
   ): Promise<void>;
   renameTable(oldName: string, newName: string): Promise<void>;
   addColumn(

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -62,6 +62,16 @@ import {
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting-interface.js";
 import { include } from "@blazetrails/activesupport";
+import { SchemaStatements } from "./abstract/schema-statements.js";
+import type {
+  TableDefinition,
+  Table,
+  ForeignKeyDefinition,
+  AddForeignKeyOptions,
+  ColumnType,
+  ColumnOptions,
+} from "./abstract/schema-definitions.js";
+import type { Column } from "./column.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -118,8 +128,107 @@ export class Version {
 // include() below). Using method signatures (not property-typed
 // functions from `Included<>`) lets concrete adapter subclasses
 // override with method syntax without tripping TS2425.
+// SchemaStatements methods mixed in via include() at the bottom of this file.
+// Rails: `AbstractAdapter` includes `SchemaStatements` so `connection.create_table(...)` works.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AbstractAdapter {
+  // --- SchemaStatements (DDL) ---
+  // The abstract base signatures are declared here. Concrete adapter subclasses
+  // that override with dialect-specific variants (PG's createTable/dropTable)
+  // carry // @ts-ignore on those overrides; the runtime behaviour is correct.
+  createTable(
+    name: string,
+    optionsOrFn?:
+      | { id?: boolean | "uuid"; force?: boolean; ifNotExists?: boolean }
+      | ((t: TableDefinition) => void),
+    fn?: (t: TableDefinition) => void,
+  ): Promise<void>;
+  dropTable(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  renameTable(oldName: string, newName: string): Promise<void>;
+  addColumn(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions & { ifNotExists?: boolean },
+  ): Promise<void>;
+  renameColumn(tableName: string, oldName: string, newName: string): Promise<void>;
+  changeColumn(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions,
+  ): Promise<void>;
+  changeColumnDefault(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): Promise<void>;
+  changeColumnNull(
+    tableName: string,
+    columnName: string,
+    nullable: boolean,
+    defaultValue?: unknown,
+  ): Promise<void>;
+  addColumns(
+    tableName: string,
+    ...columns: Array<{ name: string; type: ColumnType; options?: ColumnOptions }>
+  ): Promise<void>;
+  removeColumns(tableName: string, ...columns: string[]): Promise<void>;
+  removeIndex(
+    tableName: string,
+    options?: { column?: string | string[]; name?: string },
+  ): Promise<void>;
+  renameIndex(tableName: string, oldName: string, newName: string): Promise<void>;
+  indexName(tableName: string, options: { column?: string | string[] }): string;
+  indexExists(
+    tableName: string,
+    columns: string | string[],
+    options?: { name?: string; unique?: boolean },
+  ): Promise<boolean>;
+  tableExists(tableName: string): Promise<boolean>;
+  columnExists(tableName: string, columnName: string): Promise<boolean>;
+  tables(): Promise<string[]>;
+  views(): Promise<string[]>;
+  viewExists(viewName: string): Promise<boolean>;
+  columns(tableName: string): Promise<Column[]>;
+  primaryKey(tableName: string): Promise<string | string[] | null>;
+  indexes(tableName: string): Promise<unknown[]>;
+  foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
+  addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
+  addReference(
+    tableName: string,
+    refName: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  removeReference(
+    tableName: string,
+    refName: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  addTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
+  removeTimestamps(tableName: string): Promise<void>;
+  addCheckConstraint(
+    tableName: string,
+    expression: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  isCheckConstraintExists(
+    tableName: string,
+    options: { name?: string; expression?: string },
+  ): Promise<boolean>;
+  removeConstraint(tableName: string, constraintName: string): Promise<void>;
+  createJoinTable(
+    table1: string,
+    table2: string,
+    options?: Record<string, unknown>,
+    fn?: (t: TableDefinition) => void,
+  ): Promise<void>;
+  dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;
+  changeTable(tableName: string, fn?: (t: Table) => void | Promise<void>): Promise<void>;
+  tableAliasFor(tableName: string): string;
+  dataSources(): Promise<string[]>;
+  isDataSourceExists(name: string): Promise<boolean>;
+  // --- DatabaseStatements ---
   selectAll(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   selectOne(
     sql: string,
@@ -410,6 +519,29 @@ export class AbstractAdapter implements Quoting {
 
   get adapterName(): string {
     return "Abstract";
+  }
+
+  /**
+   * Returns `this` typed as `DatabaseAdapter & SchemaQuoter`. SchemaStatements
+   * methods (mixed in via `include()` below) reference `this.adapter` to
+   * call quoting and execution helpers on the adapter — when those methods
+   * run with `this` bound to an adapter instance, `this.adapter` must
+   * resolve to the same object.
+   * @internal
+   */
+  get adapter(): import("./abstract/assert-schema-adapter.js").SchemaQuoter & DatabaseAdapter {
+    return this as unknown as import("./abstract/assert-schema-adapter.js").SchemaQuoter &
+      DatabaseAdapter;
+  }
+
+  /** @internal */
+  protected _qi(name: string): string {
+    return this.quoteIdentifier(name);
+  }
+
+  /** @internal */
+  protected _qt(name: string): string {
+    return this.quoteTableName(name);
   }
 
   // --- Identity & lifecycle ---
@@ -1367,6 +1499,8 @@ export class AbstractAdapter implements Quoting {
 
 // Rails: `include DatabaseStatements` inside the class body.
 include(AbstractAdapter, DatabaseStatements);
+// Rails: `include SchemaStatements` inside the class body.
+include(AbstractAdapter, SchemaStatements);
 
 /** @internal */
 function initializeTypeMap(m: any): never {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -135,8 +135,9 @@ export class Version {
 export interface AbstractAdapter {
   // --- SchemaStatements (DDL) ---
   // The abstract base signatures are declared here. Concrete adapter subclasses
-  // that override with dialect-specific variants (PG's createTable/dropTable)
-  // carry // @ts-expect-error on those overrides; the runtime behaviour is correct.
+  // that override with dialect-specific variants (PG's createTable callback-first)
+  // carry // @ts-expect-error on those overrides. Callers typed as AbstractAdapter
+  // should use the base call forms; PG-specific forms require a concrete type.
   createTable(
     name: string,
     optionsOrFn?:
@@ -144,7 +145,9 @@ export interface AbstractAdapter {
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
-  dropTable(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  dropTable(
+    ...args: string[] | [...string[], { ifExists?: boolean; force?: string }]
+  ): Promise<void>;
   renameTable(oldName: string, newName: string): Promise<void>;
   addColumn(
     tableName: string,
@@ -177,6 +180,7 @@ export interface AbstractAdapter {
   removeColumn(
     tableName: string,
     columnName: string,
+    type?: string,
     options?: { ifExists?: boolean },
   ): Promise<void>;
   removeColumns(tableName: string, ...columns: string[]): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -451,8 +451,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     void newName;
   }
 
-  async dropTable(..._args: unknown[]): Promise<void> {}
-
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     void tableName;
     void oldName;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1308,6 +1308,7 @@ export interface SchemaStatementsLike {
   removeColumn(
     tableName: string,
     columnName: string,
+    type?: string,
     options?: { ifExists?: boolean },
   ): Promise<void>;
   renameColumn(tableName: string, oldName: string, newName: string): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -5,12 +5,32 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { SQLite3Adapter } from "../sqlite3-adapter.js";
+import { AbstractAdapter } from "../abstract-adapter.js";
 
 let adapter: SQLite3Adapter | undefined;
 
 afterEach(async () => {
   await adapter?.close();
 });
+
+/**
+ * Minimal stub adapter that extends AbstractAdapter but overrides nothing from
+ * SchemaStatements. Used to exercise the self-delegation guard: methods like
+ * foreignKeys/removeForeignKey check whether this.adapter.<method> is the
+ * mixed-in SchemaStatements version and, if so, skip delegation and execute
+ * the base SQL directly (or return the base fallback).
+ */
+class StubAdapter extends AbstractAdapter {
+  get adapterName() {
+    return "sqlite" as const;
+  }
+  execute(_sql: string) {
+    return Promise.resolve([] as Record<string, unknown>[]);
+  }
+  executeMutation(_sql: string) {
+    return Promise.resolve(0);
+  }
+}
 
 describe("SchemaStatements mixed into AbstractAdapter", () => {
   it("createTable is callable directly on the adapter", async () => {
@@ -44,18 +64,20 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(await adapter.columnExists("widgets", "color")).toBe(true);
   });
 
-  it("delegating methods (removeForeignKey, foreignKeys) do not infinitely recurse", async () => {
-    // Regression: before the self-delegation guard, mixed-in SchemaStatements
-    // methods like removeForeignKey/foreignKeys checked `this.adapter.<method>`
-    // which returned `this`, causing infinite recursion on adapters without overrides.
-    adapter = new SQLite3Adapter(":memory:");
-    await adapter.createTable("products", (t) => t.string("name"));
-    // foreignKeys falls back to [] on SQLite (no override, no recursion)
-    const fks = await (adapter as any).foreignKeys("products");
-    expect(Array.isArray(fks)).toBe(true);
-    // removeForeignKey on a non-existent key should throw without stack overflow
+  it("delegating methods (foreignKeys, removeForeignKey) do not infinitely recurse on base adapter", async () => {
+    // Regression guard: before the self-delegation fix, mixed-in SchemaStatements
+    // methods checked `this.adapter.<method>` — which returned `this` — and called
+    // themselves again, causing a stack overflow. This test uses StubAdapter, which
+    // does NOT override foreignKeys or removeForeignKey, so it hits the base
+    // SchemaStatements code paths (not a concrete adapter shortcut).
+    const stub = new StubAdapter();
+    // foreignKeys base path returns [] when adapter has no override
+    const fks = await stub.foreignKeys("any_table");
+    expect(fks).toEqual([]);
+    // removeForeignKey base path reaches SQL execution (which our stub no-ops) —
+    // it resolves without a stack overflow
     await expect(
-      (adapter as any).removeForeignKey("products", { name: "nonexistent_fk" }),
-    ).rejects.toThrow();
+      (stub as any).removeForeignKey("products", { name: "fk_products_user_id" }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { SQLite3Adapter } from "../sqlite3-adapter.js";
 
-let adapter: SQLite3Adapter;
+let adapter: SQLite3Adapter | undefined;
 
 afterEach(async () => {
   await adapter?.close();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -43,4 +43,19 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     await adapter.addColumn("widgets", "color", "string");
     expect(await adapter.columnExists("widgets", "color")).toBe(true);
   });
+
+  it("delegating methods (removeForeignKey, foreignKeys) do not infinitely recurse", async () => {
+    // Regression: before the self-delegation guard, mixed-in SchemaStatements
+    // methods like removeForeignKey/foreignKeys checked `this.adapter.<method>`
+    // which returned `this`, causing infinite recursion on adapters without overrides.
+    adapter = new SQLite3Adapter(":memory:");
+    await adapter.createTable("products", (t) => t.string("name"));
+    // foreignKeys falls back to [] on SQLite (no override, no recursion)
+    const fks = await (adapter as any).foreignKeys("products");
+    expect(Array.isArray(fks)).toBe(true);
+    // removeForeignKey on a non-existent key should throw without stack overflow
+    await expect(
+      (adapter as any).removeForeignKey("products", { name: "nonexistent_fk" }),
+    ).rejects.toThrow();
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -11,6 +11,7 @@ let adapter: SQLite3Adapter | undefined;
 
 afterEach(async () => {
   await adapter?.close();
+  adapter = undefined;
 });
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Smoke test: SchemaStatements methods are accessible directly on the adapter.
+ * Rails: `AbstractAdapter` includes `SchemaStatements`, so
+ * `connection.create_table(...)` works without going through MigrationContext.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { SQLite3Adapter } from "../sqlite3-adapter.js";
+
+let adapter: SQLite3Adapter;
+
+afterEach(async () => {
+  await adapter?.close();
+});
+
+describe("SchemaStatements mixed into AbstractAdapter", () => {
+  it("createTable is callable directly on the adapter", async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await adapter.createTable("things", (t) => {
+      t.string("name");
+      t.integer("quantity");
+    });
+    expect(await adapter.tableExists("things")).toBe(true);
+    const cols = await adapter.columns("things");
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("name");
+    expect(names).toContain("quantity");
+  });
+
+  it("dropTable removes the table", async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await adapter.createTable("temp_table", (t) => t.string("value"));
+    expect(await adapter.tableExists("temp_table")).toBe(true);
+    await adapter.dropTable("temp_table");
+    expect(await adapter.tableExists("temp_table")).toBe(false);
+  });
+
+  it("addColumn and columnExists work on adapter", async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await adapter.createTable("widgets", { id: false }, (t) => {
+      t.string("title");
+    });
+    expect(await adapter.columnExists("widgets", "title")).toBe(true);
+    await adapter.addColumn("widgets", "color", "string");
+    expect(await adapter.columnExists("widgets", "color")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -77,7 +77,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // removeForeignKey base path reaches SQL execution (which our stub no-ops) —
     // it resolves without a stack overflow
     await expect(
-      (stub as any).removeForeignKey("products", { name: "fk_products_user_id" }),
+      stub.removeForeignKey("products", { name: "fk_products_user_id" }),
     ).resolves.toBeUndefined();
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -388,7 +388,9 @@ export class SchemaStatements {
     const adapter = this.adapter as any;
     if (
       typeof adapter.addForeignKey === "function" &&
-      typeof adapter.checkConstraints === "function"
+      adapter.addForeignKey !== SchemaStatements.prototype.addForeignKey &&
+      typeof adapter.checkConstraints === "function" &&
+      adapter.checkConstraints !== SchemaStatements.prototype.checkConstraints
     ) {
       return adapter.addForeignKey(fromTable, toTable, options);
     }
@@ -418,7 +420,10 @@ export class SchemaStatements {
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
   ): Promise<void> {
     const adapter = this.adapter as any;
-    if (typeof adapter.removeForeignKey === "function") {
+    if (
+      typeof adapter.removeForeignKey === "function" &&
+      adapter.removeForeignKey !== SchemaStatements.prototype.removeForeignKey
+    ) {
       return adapter.removeForeignKey(fromTable, toTableOrOptions);
     }
     const ifExists = typeof toTableOrOptions === "object" && toTableOrOptions?.ifExists === true;
@@ -448,7 +453,10 @@ export class SchemaStatements {
     options: { name?: string; validate?: boolean } = {},
   ): Promise<void> {
     const adapter = this.adapter as any;
-    if (typeof adapter.addCheckConstraint === "function") {
+    if (
+      typeof adapter.addCheckConstraint === "function" &&
+      adapter.addCheckConstraint !== SchemaStatements.prototype.addCheckConstraint
+    ) {
       return adapter.addCheckConstraint(tableName, expression, options);
     }
     const name = options.name ?? this._checkConstraintName(tableName, expression);
@@ -464,7 +472,10 @@ export class SchemaStatements {
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
   ): Promise<void> {
     const adapter = this.adapter as any;
-    if (typeof adapter.removeCheckConstraint === "function") {
+    if (
+      typeof adapter.removeCheckConstraint === "function" &&
+      adapter.removeCheckConstraint !== SchemaStatements.prototype.removeCheckConstraint
+    ) {
       return adapter.removeCheckConstraint(tableName, expressionOrOptions);
     }
     const ifExists =
@@ -747,7 +758,10 @@ export class SchemaStatements {
     const adapter = this.adapter as {
       foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]>;
     };
-    if (typeof adapter.foreignKeys === "function") {
+    if (
+      typeof adapter.foreignKeys === "function" &&
+      (adapter.foreignKeys as unknown) !== SchemaStatements.prototype.foreignKeys
+    ) {
       return adapter.foreignKeys(tableName);
     }
     return [];
@@ -1052,7 +1066,10 @@ export class SchemaStatements {
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     const adapter = this.adapter as any;
-    if (typeof adapter.checkConstraints === "function") {
+    if (
+      typeof adapter.checkConstraints === "function" &&
+      adapter.checkConstraints !== SchemaStatements.prototype.checkConstraints
+    ) {
       return adapter.checkConstraints(tableName);
     }
     throw new Error("NotImplementedError: checkConstraints is not implemented");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -150,6 +150,9 @@ export class SchemaStatements {
     } else {
       tableNames = args as string[];
     }
+    if (tableNames.length === 0) {
+      throw new ArgumentError("dropTable requires at least one table name");
+    }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     for (const name of tableNames) {
       await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qt(name)}`);
@@ -398,9 +401,9 @@ export class SchemaStatements {
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
     // SQLite can't ALTER TABLE ADD CONSTRAINT — delegate to its rebuild-
-    // based implementation. Gate on checkConstraints (which only rebuild-
-    // adapters implement) to avoid routing to adapters like PostgreSQL whose
-    // addForeignKey is a partial override that drops onDelete/onUpdate.
+    // based implementation. Gate on both addForeignKey and checkConstraints
+    // being adapter-specific overrides (not the SchemaStatements base) to
+    // ensure delegation only reaches adapters that fully implement FK support.
     const adapter = this.adapter as any;
     if (
       typeof adapter.addForeignKey === "function" &&

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -154,8 +154,9 @@ export class SchemaStatements {
       throw new ArgumentError("dropTable requires at least one table name");
     }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
+    const cascade = options.force === "cascade" ? " CASCADE" : "";
     for (const name of tableNames) {
-      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qt(name)}`);
+      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qt(name)}${cascade}`);
     }
   }
 
@@ -400,10 +401,10 @@ export class SchemaStatements {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    // SQLite can't ALTER TABLE ADD CONSTRAINT — delegate to its rebuild-
-    // based implementation. Gate on both addForeignKey and checkConstraints
-    // being adapter-specific overrides (not the SchemaStatements base) to
-    // ensure delegation only reaches adapters that fully implement FK support.
+    // Delegate to adapter-specific FK implementation when the adapter
+    // overrides both addForeignKey and checkConstraints (signals full FK
+    // support, e.g. SQLite's table-rebuild path). The double-gate prevents
+    // self-delegation now that SchemaStatements is mixed into AbstractAdapter.
     const adapter = this.adapter as any;
     if (
       typeof adapter.addForeignKey === "function" &&

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -137,20 +137,22 @@ export class SchemaStatements {
   }
 
   async dropTable(
-    ...args: string[] | [...string[], { ifExists?: boolean; force?: string }]
+    ...args:
+      | [string, ...string[]]
+      | [string, ...string[], { ifExists?: boolean; force?: "cascade" }]
   ): Promise<void> {
     let tableNames: string[];
-    let options: { ifExists?: boolean; force?: string } = {};
+    let options: { ifExists?: boolean; force?: "cascade" } = {};
     const last = args[args.length - 1];
     if (last !== null && last !== undefined && typeof last === "object") {
       tableNames = args.slice(0, -1) as string[];
-      options = last as { ifExists?: boolean; force?: string };
+      options = last as { ifExists?: boolean; force?: "cascade" };
     } else {
       tableNames = args as string[];
     }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     for (const name of tableNames) {
-      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qi(name)}`);
+      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qt(name)}`);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -136,9 +136,22 @@ export class SchemaStatements {
     }
   }
 
-  async dropTable(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
+  async dropTable(
+    ...args: string[] | [...string[], { ifExists?: boolean; force?: string }]
+  ): Promise<void> {
+    let tableNames: string[];
+    let options: { ifExists?: boolean; force?: string } = {};
+    const last = args[args.length - 1];
+    if (last !== null && last !== undefined && typeof last === "object") {
+      tableNames = args.slice(0, -1) as string[];
+      options = last as { ifExists?: boolean; force?: string };
+    } else {
+      tableNames = args as string[];
+    }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qi(name)}`);
+    for (const name of tableNames) {
+      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qi(name)}`);
+    }
   }
 
   async addColumn(
@@ -160,6 +173,7 @@ export class SchemaStatements {
   async removeColumn(
     tableName: string,
     columnName: string,
+    _type?: string,
     options: { ifExists?: boolean } = {},
   ): Promise<void> {
     if (options.ifExists && !(await this.columnExists(tableName, columnName))) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3078,6 +3078,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return rows.length > 0;
   }
 
+  // PG addIndex returns the index name as a string; base returns void. Harmonize in a follow-up.
+  // @ts-expect-error TS2416 — return type is Promise<string> not Promise<void>
   async addIndex(
     tableName: string,
     columns: string | string[],

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2509,8 +2509,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  // @ts-expect-error PG's callback-first signature diverges from the abstract base;
-  // runtime behaviour is correct for all callers. Harmonize in a follow-up.
+  // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.
+  // @ts-expect-error TS2416
   async createTable(
     tableName: string,
     callback: (t: SimpleTableBuilder) => void,
@@ -3518,8 +3518,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.createDatabase(name, options);
   }
 
-  // @ts-expect-error PG's rest-arg overload diverges from the abstract base's (name, options?) form;
-  // runtime behaviour is correct. Harmonize in a follow-up.
+  // PG rest-arg overload diverges from the abstract base (name, options?) form; harmonize in a follow-up.
+  // @ts-expect-error TS2416
   async dropTable(
     ...args:
       | [...tableNames: string[], options: { ifExists?: boolean; force?: "cascade" }]

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2509,6 +2509,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
+  // @ts-expect-error PG's callback-first signature diverges from the abstract base;
+  // runtime behaviour is correct for all callers. Harmonize in a follow-up.
   async createTable(
     tableName: string,
     callback: (t: SimpleTableBuilder) => void,
@@ -3516,6 +3518,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.createDatabase(name, options);
   }
 
+  // @ts-expect-error PG's rest-arg overload diverges from the abstract base's (name, options?) form;
+  // runtime behaviour is correct. Harmonize in a follow-up.
   async dropTable(
     ...args:
       | [...tableNames: string[], options: { ifExists?: boolean; force?: "cascade" }]

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3078,8 +3078,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return rows.length > 0;
   }
 
-  // PG addIndex returns the index name as a string; base returns void. Harmonize in a follow-up.
-  // @ts-expect-error TS2416 — return type is Promise<string> not Promise<void>
   async addIndex(
     tableName: string,
     columns: string | string[],
@@ -3095,7 +3093,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       nullsNotDistinct?: boolean;
       include?: string[];
     } = {},
-  ): Promise<string> {
+  ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
     const quotedTable = this.quoteTableName(tableName);
 
@@ -3145,7 +3143,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
 
     await this.exec(sql);
-    return sql;
   }
 
   async removeIndex(
@@ -3520,8 +3517,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.createDatabase(name, options);
   }
 
-  // PG rest-arg overload diverges from the abstract base (name, options?) form; harmonize in a follow-up.
-  // @ts-expect-error TS2416
   async dropTable(
     ...args:
       | [...tableNames: string[], options: { ifExists?: boolean; force?: "cascade" }]

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3078,7 +3078,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return rows.length > 0;
   }
 
-  // PG addIndex returns the generated SQL string for inspection; Rails returns an index object.
+  // PG addIndex returns the generated SQL string for test/inspection purposes;
+  // Rails add_index returns void. Harmonize in a follow-up.
   // @ts-expect-error TS2416 — return type is Promise<string> not Promise<void>
   async addIndex(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3194,7 +3194,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qi = (s: string) => this.quoteIdentifier(s);
     const qualifiedFrom = fromSchema ? `${qi(fromSchema)}.${qi(fromTbl)}` : qi(fromTbl);
     const qualifiedTo = toSchema ? `${qi(toSchema)}.${qi(toTbl)}` : qi(toTbl);
-    const sc = this.schemaCreation();
+    const sc = this.schemaCreation;
 
     let sql = `ALTER TABLE ${qualifiedFrom} ADD CONSTRAINT ${qi(name)} FOREIGN KEY (${qi(column)}) REFERENCES ${qualifiedTo} (${qi(pk)})`;
     if (options.onDelete) sql += ` ${sc.actionSql("DELETE", options.onDelete)}`;
@@ -3891,7 +3891,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return { ...options };
   }
 
-  schemaCreation(): PgSchemaCreation {
+  get schemaCreation(): PgSchemaCreation {
     return new PgSchemaCreation(this);
   }
 
@@ -3980,7 +3980,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       type,
       options,
     );
-    const sql = `ADD COLUMN ${this.schemaCreation().accept(col)}`;
+    const sql = `ADD COLUMN ${this.schemaCreation.accept(col)}`;
     return "comment" in options
       ? [
           sql,
@@ -4002,7 +4002,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       type,
       options as Parameters<typeof this.buildChangeColumnDefinition>[3],
     );
-    const sqls: unknown[] = [this.schemaCreation().accept(changeDef)];
+    const sqls: unknown[] = [this.schemaCreation.accept(changeDef)];
     if ("comment" in options)
       sqls.push(() =>
         this.changeColumnComment(tableName, columnName, options.comment as string | null),

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3078,6 +3078,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return rows.length > 0;
   }
 
+  // PG addIndex returns the generated SQL string for inspection; Rails returns an index object.
+  // @ts-expect-error TS2416 — return type is Promise<string> not Promise<void>
   async addIndex(
     tableName: string,
     columns: string | string[],
@@ -3093,7 +3095,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       nullsNotDistinct?: boolean;
       include?: string[];
     } = {},
-  ): Promise<void> {
+  ): Promise<string> {
     const cols = Array.isArray(columns) ? columns : [columns];
     const quotedTable = this.quoteTableName(tableName);
 
@@ -3143,6 +3145,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
 
     await this.exec(sql);
+    return sql;
   }
 
   async removeIndex(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -961,6 +961,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.executeMutation(sql);
   }
 
+  // SQLite removes columns via table-rebuild; _type is unused (legacy param).
+  // @ts-expect-error TS2416 — third param is string instead of {ifExists?}; harmonize in a follow-up
   async removeColumn(tableName: string, columnName: string, _type?: string): Promise<void> {
     await this.alterTable(tableName, (columns) => {
       delete columns[columnName];

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -961,8 +961,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.executeMutation(sql);
   }
 
-  // SQLite removes columns via table-rebuild; _type is unused (legacy param).
-  // @ts-expect-error TS2416 — third param is string instead of {ifExists?}; harmonize in a follow-up
   async removeColumn(tableName: string, columnName: string, _type?: string): Promise<void> {
     await this.alterTable(tableName, (columns) => {
       delete columns[columnName];

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -438,7 +438,11 @@ export abstract class Migration {
       this._recorder.record("dropTable", [name]);
       return;
     }
-    await this.schema.dropTable(name, options);
+    if (options) {
+      await this.schema.dropTable(name, options);
+    } else {
+      await this.schema.dropTable(name);
+    }
   }
 
   async addColumn(
@@ -466,7 +470,7 @@ export abstract class Migration {
       this._recorder.record("removeColumn", [tableName, columnName, type, opts]);
       return;
     }
-    await this.schema.removeColumn(tableName, columnName, opts);
+    await this.schema.removeColumn(tableName, columnName, type, opts);
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Rails \`abstract_adapter.rb:35\` does \`include Quoting, DatabaseStatements, SchemaStatements\` — we were missing the SchemaStatements mix-in
- Added \`protected get adapter()\` / \`protected _qi()\` / \`protected _qt()\` bridge properties on \`AbstractAdapter\` so mixed-in \`SchemaStatements\` methods resolve \`this.adapter\` to \`this\`
- Added \`include(AbstractAdapter, SchemaStatements)\` alongside the existing \`DatabaseStatements\` mix-in
- Fixed 6 self-delegation guards in \`SchemaStatements\` (addForeignKey, removeForeignKey, addCheckConstraint, removeCheckConstraint, foreignKeys, checkConstraints) — without these, mixed-in methods looped via \`this.adapter.<method>\` returning \`this\`
- Aligned base \`dropTable\` with Rails \`drop_table(*table_names, **options)\` (rest-args, at least one name required, \`_qt\` for quoting)
- Aligned base \`removeColumn\` with Rails \`remove_column(t, col, type=nil, **opts)\` (type is third param)
- Removed MySQL \`dropTable\` no-op stub that was blocking the mixin
- Declared the stable public DDL surface in the \`AbstractAdapter\` interface
- Smoke tests + regression test for the self-delegation guard

## Gates

- api:compare delta: 0 (non-negative) ✅
- test:compare delta: 0 (non-negative) ✅
- No stubs ✅
- Rails fidelity ✅

## Remaining follow-ups (tracked here, not blocking merge)

These are pre-existing concrete-adapter divergences; the \`@ts-expect-error\` comments name each one:

- **PG \`createTable\` callback-first** — \`(name, callback, opts?)\` vs Rails \`(name, optionsOrFn?, fn?)\`. Callers typed as \`AbstractAdapter\` must use the base form; PG-typed callers use PG's form. Harmonize in a follow-up.
- **PG \`addIndex\` returns SQL string** — Rails \`add_index\` returns void; PG returns the SQL for test inspection. Align return type and update \`active-schema.test.ts\` to assert via side effects.
- **\`typeToSql\` private in SQLite3** — SchemaStatements public method hidden; make public.
- **\`foreignKeyExists\` incompatible PG params** — PG uses positional \`(from, toTable)\` vs options bag.
- **\`nativeDatabaseTypes\` getter in SQLite3** — SchemaStatements declares it a method; SQLite uses a getter.
- **Other concrete-adapter overrides** that further narrow the base interface (checkConstraints return type, etc.) — each will get its own harmonization PR.