### PR TITLE
feat(activerecord): testing/query-assertions.ts to 100%

### DIFF
--- a/packages/activerecord/src/assertions/query-assertions.test.ts
+++ b/packages/activerecord/src/assertions/query-assertions.test.ts
@@ -1,72 +1,201 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { SQLCounter, assertQueries, assertNoQueries } from "../testing/query-assertions.js";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import {
+  SQLCounter,
+  assertQueriesCount,
+  assertNoQueries,
+  assertQueriesMatch,
+  assertNoQueriesMatch,
+} from "../testing/query-assertions.js";
+import { Notifications } from "@blazetrails/activesupport";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
+/** Instrument an sql.active_record event the way the adapter does. */
+function instrumentSql(sql: string, name?: string, cached = false): void {
+  Notifications.instrument("sql.active_record", { sql, name: name ?? "SQL", cached });
+}
+
 describe("QueryAssertionsTest", () => {
   let adapter: DatabaseAdapter;
-  let counter: SQLCounter;
-  let wrapped: DatabaseAdapter;
+
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
 
   beforeEach(() => {
     adapter = createTestAdapter();
-    counter = new SQLCounter();
-    wrapped = counter.wrap(adapter);
+  });
+
+  it("assert queries count", async () => {
+    await assertQueriesCount(1, false, async () => {
+      instrumentSql("SELECT 1");
+    });
+
+    await expect(
+      assertQueriesCount(2, false, async () => {
+        instrumentSql("SELECT 1");
+      }),
+    ).rejects.toThrow(/1 instead of 2 queries/);
+
+    await expect(
+      assertQueriesCount(0, false, async () => {
+        instrumentSql("SELECT 1");
+      }),
+    ).rejects.toThrow(/1 instead of 0 queries/);
   });
 
   it("assert queries count any", async () => {
-    await assertQueries(counter, 1, async () => {
-      await wrapped.execute("SELECT 1");
+    await assertQueriesCount(undefined, false, async () => {
+      instrumentSql("SELECT 1");
     });
+
+    await expect(assertQueriesCount(undefined, false, async () => {})).rejects.toThrow(
+      "1 or more queries expected",
+    );
   });
 
   it("assert no queries", async () => {
-    await assertNoQueries(counter, async () => {
-      // no queries
+    await assertNoQueries(false, async () => {});
+
+    await expect(
+      assertNoQueries(false, async () => {
+        instrumentSql("SELECT 1");
+      }),
+    ).rejects.toThrow(/1 instead of 0/);
+  });
+
+  it("assert queries match", async () => {
+    await assertQueriesMatch(/LIMIT/i, 1, false, async () => {
+      instrumentSql("SELECT * FROM posts LIMIT 1");
+    });
+
+    await assertQueriesMatch(/LIMIT/i, undefined, false, async () => {
+      instrumentSql("SELECT * FROM posts LIMIT 1");
+    });
+
+    await expect(
+      assertQueriesMatch(/LIMIT/i, 2, false, async () => {
+        instrumentSql("SELECT * FROM posts LIMIT 1");
+      }),
+    ).rejects.toThrow(/1 instead of 2 queries/);
+
+    await expect(
+      assertQueriesMatch(/LIMIT/i, 0, false, async () => {
+        instrumentSql("SELECT * FROM posts LIMIT 1");
+      }),
+    ).rejects.toThrow(/1 instead of 0 queries/);
+  });
+
+  it("assert queries match with matcher", async () => {
+    await expect(
+      assertQueriesMatch(/WHERE "posts"\."id" = \? LIMIT \?/, 1, false, async () => {
+        instrumentSql('SELECT * FROM posts WHERE "posts"."id" = $1 LIMIT 1');
+      }),
+    ).rejects.toThrow(/0 instead of 1 queries/);
+  });
+
+  it("assert queries match when there are no queries", async () => {
+    await expect(assertQueriesMatch(/something/, undefined, false, async () => {})).rejects.toThrow(
+      "1 or more queries expected, but none were executed",
+    );
+  });
+
+  it("assert no queries match", async () => {
+    await assertNoQueriesMatch(/something/, false, async () => {
+      instrumentSql("SELECT 1");
+    });
+
+    await expect(
+      assertNoQueriesMatch(/ORDER BY/i, false, async () => {
+        instrumentSql("SELECT * FROM posts ORDER BY id");
+      }),
+    ).rejects.toThrow(/1 instead of 0/);
+  });
+
+  it("assert no queries match matcher", async () => {
+    await expect(
+      assertNoQueriesMatch(/ORDER BY/i, false, async () => {
+        instrumentSql("SELECT * FROM posts ORDER BY id");
+      }),
+    ).rejects.toThrow(/1 instead of 0/);
+  });
+
+  it("assert queries count include schema", async () => {
+    await assertQueriesCount(undefined, true, async () => {
+      instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
+    });
+
+    await expect(
+      assertQueriesCount(undefined, false, async () => {
+        instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
+      }),
+    ).rejects.toThrow("1 or more queries expected");
+  });
+
+  it("assert no queries include schema", async () => {
+    await assertNoQueries(false, async () => {});
+
+    await expect(
+      assertNoQueries(false, async () => {
+        instrumentSql("SELECT 1");
+      }),
+    ).rejects.toThrow(/\d+ instead of 0/);
+
+    await expect(
+      assertNoQueries(true, async () => {
+        instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
+      }),
+    ).rejects.toThrow(/\d+ instead of 0/);
+  });
+
+  it("assert queries match include schema", async () => {
+    await expect(
+      assertQueriesMatch(/SELECT/i, undefined, false, async () => {
+        instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
+      }),
+    ).rejects.toThrow("1 or more queries expected");
+
+    await assertQueriesMatch(/SELECT/i, undefined, true, async () => {
+      instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
     });
   });
 
-  it("assert queries count fails on mismatch", async () => {
-    await expect(
-      assertQueries(counter, 2, async () => {
-        await wrapped.execute("SELECT 1");
-      }),
-    ).rejects.toThrow("Expected 2 queries, but got 1");
-  });
-
-  it("assert no queries fails when queries are made", async () => {
-    await expect(
-      assertNoQueries(counter, async () => {
-        await wrapped.execute("SELECT 1");
-      }),
-    ).rejects.toThrow("Expected 0 queries, but got 1");
-  });
-
-  it("counter records multiple queries", async () => {
-    await assertQueries(counter, 3, async () => {
-      await wrapped.execute("SELECT 1");
-      await wrapped.execute("SELECT 2");
-      await wrapped.executeMutation('CREATE TABLE IF NOT EXISTS "t" ("id" INTEGER PRIMARY KEY)');
+  it("assert no queries match include schema", async () => {
+    await assertNoQueriesMatch(/SELECT/i, false, async () => {
+      instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
     });
-    expect(counter.queries).toEqual([
-      "SELECT 1",
-      "SELECT 2",
-      'CREATE TABLE IF NOT EXISTS "t" ("id" INTEGER PRIMARY KEY)',
-    ]);
+
+    await expect(
+      assertNoQueriesMatch(/SELECT/i, true, async () => {
+        instrumentSql("SELECT attname FROM pg_attribute", "SCHEMA");
+      }),
+    ).rejects.toThrow(/\d+ instead of 0/);
   });
 
-  it("counter does not record when not listening", async () => {
-    await wrapped.execute("SELECT 1");
-    expect(counter.count).toBe(0);
+  it("SQLCounter skips cached queries", () => {
+    const counter = new SQLCounter();
+    counter.call("sql.active_record", "id1", { sql: "SELECT 1", cached: true });
+    expect(counter.logAll).toHaveLength(0);
+    expect(counter.log).toHaveLength(0);
   });
 
-  it.skip("assert queries match", () => {});
-  it.skip("assert queries match with matcher", () => {});
-  it.skip("assert queries match when there are no queries", () => {});
-  it.skip("assert no queries match", () => {});
-  it.skip("assert no queries match matcher", () => {});
-  it.skip("assert queries count include schema", () => {});
-  it.skip("assert no queries include schema", () => {});
-  it.skip("assert queries match include schema", () => {});
-  it.skip("assert no queries match include schema", () => {});
+  it("SQLCounter separates schema from non-schema", () => {
+    const counter = new SQLCounter();
+    counter.call("sql.active_record", "id1", {
+      sql: "SELECT attname FROM pg_attribute",
+      name: "SCHEMA",
+    });
+    counter.call("sql.active_record", "id2", { sql: "SELECT 1", name: "SQL" });
+    expect(counter.logAll).toHaveLength(2);
+    expect(counter.log).toHaveLength(1);
+    expect(counter.log[0]).toBe("SELECT 1");
+  });
+
+  // Kept to ensure adapter instrumentation flows through Notifications
+  it("adapter queries are captured via notifications", async () => {
+    void adapter; // adapter available if needed for integration tests
+    await assertQueriesCount(1, false, async () => {
+      instrumentSql("SELECT 1");
+    });
+  });
 });

--- a/packages/activerecord/src/assertions/query-assertions.test.ts
+++ b/packages/activerecord/src/assertions/query-assertions.test.ts
@@ -164,6 +164,16 @@ describe("QueryAssertionsTest", () => {
     ).rejects.toThrow(/\d+ instead of 0/);
   });
 
+  it("assert queries match global regex does not alternate due to lastIndex statefulness", async () => {
+    // Ruby Regexp#=== is always stateless; JS RegExp.test with /g advances lastIndex.
+    // assertQueriesMatch must reset lastIndex before each test call.
+    await assertQueriesMatch(/SELECT/gi, 3, false, async () => {
+      instrumentSql("SELECT 1");
+      instrumentSql("SELECT 2");
+      instrumentSql("SELECT 3");
+    });
+  });
+
   it("SQLCounter skips cached queries", () => {
     const counter = new SQLCounter();
     counter.call("sql.active_record", "id1", { sql: "SELECT 1", cached: true });

--- a/packages/activerecord/src/assertions/query-assertions.test.ts
+++ b/packages/activerecord/src/assertions/query-assertions.test.ts
@@ -192,10 +192,4 @@ describe("QueryAssertionsTest", () => {
     expect(counter.log).toHaveLength(1);
     expect(counter.log[0]).toBe("SELECT 1");
   });
-
-  it("adapter queries are captured via notifications", async () => {
-    await assertQueriesCount(1, false, async () => {
-      instrumentSql("SELECT 1");
-    });
-  });
 });

--- a/packages/activerecord/src/assertions/query-assertions.test.ts
+++ b/packages/activerecord/src/assertions/query-assertions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   SQLCounter,
   assertQueriesCount,
@@ -7,8 +7,6 @@ import {
   assertNoQueriesMatch,
 } from "../testing/query-assertions.js";
 import { Notifications } from "@blazetrails/activesupport";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
 
 /** Instrument an sql.active_record event the way the adapter does. */
 function instrumentSql(sql: string, name?: string, cached = false): void {
@@ -16,14 +14,8 @@ function instrumentSql(sql: string, name?: string, cached = false): void {
 }
 
 describe("QueryAssertionsTest", () => {
-  let adapter: DatabaseAdapter;
-
   afterEach(() => {
     Notifications.unsubscribeAll();
-  });
-
-  beforeEach(() => {
-    adapter = createTestAdapter();
   });
 
   it("assert queries count", async () => {
@@ -191,9 +183,7 @@ describe("QueryAssertionsTest", () => {
     expect(counter.log[0]).toBe("SELECT 1");
   });
 
-  // Kept to ensure adapter instrumentation flows through Notifications
   it("adapter queries are captured via notifications", async () => {
-    void adapter; // adapter available if needed for integration tests
     await assertQueriesCount(1, false, async () => {
       instrumentSql("SELECT 1");
     });

--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -4,112 +4,146 @@
  * Mirrors: ActiveRecord::Assertions::QueryAssertions
  */
 
-import type { DatabaseAdapter } from "../adapter.js";
+import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
+
+/** @internal */
+export interface SqlPayload {
+  sql?: string;
+  name?: string;
+  binds?: unknown[];
+  cached?: boolean;
+  [key: string]: unknown;
+}
 
 /**
  * Mirrors: ActiveRecord::Assertions::QueryAssertions::SQLCounter
  *
- * Counts SQL queries executed during a block. Wraps a DatabaseAdapter
- * to intercept execute/executeMutation calls.
+ * Collects SQL queries by subscribing to `sql.active_record` notifications.
+ * `logFull` contains non-schema [sql, binds] pairs; `logAll` contains all sql strings.
  */
 export class SQLCounter {
-  private _queries: string[] = [];
-  private _listening = false;
+  /** @internal */
+  readonly logFull: [string, unknown[]][];
 
-  get queries(): readonly string[] {
-    return this._queries;
+  readonly logAll: string[];
+
+  constructor() {
+    this.logFull = [];
+    this.logAll = [];
   }
 
-  get count(): number {
-    return this._queries.length;
+  get log(): string[] {
+    return this.logFull.map(([sql]) => sql);
   }
 
-  record(sql: string): void {
-    if (this._listening) {
-      this._queries.push(sql);
+  /** Notification handler — mirrors Rails' `call(*, payload)`. */
+  call(_name: unknown, _id: unknown, payload: SqlPayload): void {
+    if (payload.cached) return;
+
+    const sql = payload.sql ?? "";
+    this.logAll.push(sql);
+
+    if (payload.name !== "SCHEMA") {
+      const binds = (payload.binds as unknown[] | undefined) ?? [];
+      this.logFull.push([sql, binds]);
     }
   }
-
-  start(): void {
-    this._queries = [];
-    this._listening = true;
-  }
-
-  stop(): void {
-    this._listening = false;
-  }
-
-  reset(): void {
-    this._queries = [];
-  }
-
-  /**
-   * Wrap a DatabaseAdapter so all queries are recorded by this counter.
-   */
-  wrap(adapter: DatabaseAdapter): DatabaseAdapter {
-    const counter = this;
-    return new Proxy(adapter as object, {
-      get(target, prop, receiver) {
-        if (prop === "execute") {
-          return async (sql: string, binds?: unknown[]) => {
-            counter.record(sql);
-            return (target as DatabaseAdapter).execute(sql, binds);
-          };
-        }
-        if (prop === "executeMutation") {
-          return async (sql: string, binds?: unknown[]) => {
-            counter.record(sql);
-            return (target as DatabaseAdapter).executeMutation(sql, binds);
-          };
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-    }) as DatabaseAdapter;
-  }
 }
 
 /**
- * Mirrors: ActiveRecord::Assertions::QueryAssertions
+ * Asserts that the number of SQL queries executed in the given block matches
+ * the expected count. If `count` is omitted, asserts at least one query ran.
+ *
+ * Mirrors: ActiveRecord::Assertions::QueryAssertions#assert_queries_count
  */
-export interface QueryAssertions {
-  assertQueries(expected: number, fn: () => void | Promise<void>): Promise<void>;
-  assertNoQueries(fn: () => void | Promise<void>): Promise<void>;
-}
-
-/**
- * Mirrors: ActiveRecord::Assertions
- */
-export interface Assertions {
-  queryAssertions: QueryAssertions;
-}
-
-/**
- * Assert that exactly `expected` queries are executed during `fn`.
- */
-export async function assertQueries(
-  counter: SQLCounter,
-  expected: number,
+export async function assertQueriesCount(
+  count: number | undefined,
+  includeSchema: boolean,
   fn: () => void | Promise<void>,
 ): Promise<void> {
-  counter.start();
+  const counter = new SQLCounter();
+  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+    counter.call(event.name, event.transactionId, event.payload as SqlPayload);
+  });
   try {
     await fn();
   } finally {
-    counter.stop();
+    Notifications.unsubscribe(sub);
   }
-  if (counter.count !== expected) {
-    throw new Error(
-      `Expected ${expected} queries, but got ${counter.count}:\n${counter.queries.join("\n")}`,
-    );
+  const queries = includeSchema ? counter.logAll : counter.log;
+  if (count !== undefined) {
+    if (queries.length !== count) {
+      throw new Error(
+        `${queries.length} instead of ${count} queries were executed. Queries: ${queries.join("\n\n")}`,
+      );
+    }
+  } else {
+    if (queries.length < 1) {
+      throw new Error("1 or more queries expected, but none were executed.");
+    }
   }
 }
 
 /**
- * Assert that no queries are executed during `fn`.
+ * Asserts that no SQL queries are executed in the given block.
+ *
+ * Mirrors: ActiveRecord::Assertions::QueryAssertions#assert_no_queries
  */
 export async function assertNoQueries(
-  counter: SQLCounter,
+  includeSchema: boolean,
   fn: () => void | Promise<void>,
 ): Promise<void> {
-  await assertQueries(counter, 0, fn);
+  await assertQueriesCount(0, includeSchema, fn);
+}
+
+/**
+ * Asserts that SQL queries matching `match` executed in the given block meet
+ * the expected count. If `count` is omitted, asserts at least one match.
+ *
+ * Mirrors: ActiveRecord::Assertions::QueryAssertions#assert_queries_match
+ */
+export async function assertQueriesMatch(
+  match: RegExp,
+  count: number | undefined,
+  includeSchema: boolean,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const counter = new SQLCounter();
+  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+    counter.call(event.name, event.transactionId, event.payload as SqlPayload);
+  });
+  try {
+    await fn();
+  } finally {
+    Notifications.unsubscribe(sub);
+  }
+  const queries = includeSchema ? counter.logAll : counter.log;
+  const matched = queries.filter((q) => match.test(q));
+
+  if (count !== undefined) {
+    if (matched.length !== count) {
+      throw new Error(
+        `${matched.length} instead of ${count} queries were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
+      );
+    }
+  } else {
+    if (matched.length < 1) {
+      throw new Error(
+        `1 or more queries expected, but none were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
+      );
+    }
+  }
+}
+
+/**
+ * Asserts that no SQL queries matching `match` are executed in the given block.
+ *
+ * Mirrors: ActiveRecord::Assertions::QueryAssertions#assert_no_queries_match
+ */
+export async function assertNoQueriesMatch(
+  match: RegExp,
+  includeSchema: boolean,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  await assertQueriesMatch(match, 0, includeSchema, fn);
 }

--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -25,6 +25,7 @@ export class SQLCounter {
   /** @internal */
   readonly logFull: [string, unknown[]][];
 
+  /** @internal */
   readonly logAll: string[];
 
   constructor() {
@@ -32,11 +33,12 @@ export class SQLCounter {
     this.logAll = [];
   }
 
+  /** @internal */
   get log(): string[] {
     return this.logFull.map(([sql]) => sql);
   }
 
-  /** Notification handler — mirrors Rails' `call(*, payload)`. */
+  /** @internal */
   call(_name: unknown, _id: unknown, payload: SqlPayload): void {
     if (payload.cached) return;
 

--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -120,7 +120,11 @@ export async function assertQueriesMatch(
     Notifications.unsubscribe(sub);
   }
   const queries = includeSchema ? counter.logAll : counter.log;
-  const matched = queries.filter((q) => match.test(q));
+  // Reset lastIndex before each test to mirror Ruby Regexp#=== (always stateless).
+  const matched = queries.filter((q) => {
+    match.lastIndex = 0;
+    return match.test(q);
+  });
 
   if (count !== undefined) {
     if (matched.length !== count) {

--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -60,7 +60,7 @@ export class SQLCounter {
  */
 export async function assertQueriesCount(
   count: number | undefined,
-  includeSchema: boolean,
+  includeSchema = false,
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
@@ -92,7 +92,7 @@ export async function assertQueriesCount(
  * Mirrors: ActiveRecord::Assertions::QueryAssertions#assert_no_queries
  */
 export async function assertNoQueries(
-  includeSchema: boolean,
+  includeSchema = false,
   fn: () => void | Promise<void>,
 ): Promise<void> {
   await assertQueriesCount(0, includeSchema, fn);
@@ -107,7 +107,7 @@ export async function assertNoQueries(
 export async function assertQueriesMatch(
   match: RegExp,
   count: number | undefined,
-  includeSchema: boolean,
+  includeSchema = false,
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
@@ -120,11 +120,12 @@ export async function assertQueriesMatch(
     Notifications.unsubscribe(sub);
   }
   const queries = includeSchema ? counter.logAll : counter.log;
-  // Reset lastIndex before each test to mirror Ruby Regexp#=== (always stateless).
+  // Reset lastIndex before each test (and after) to mirror Ruby Regexp#=== (always stateless).
   const matched = queries.filter((q) => {
     match.lastIndex = 0;
     return match.test(q);
   });
+  match.lastIndex = 0;
 
   if (count !== undefined) {
     if (matched.length !== count) {
@@ -148,7 +149,7 @@ export async function assertQueriesMatch(
  */
 export async function assertNoQueriesMatch(
   match: RegExp,
-  includeSchema: boolean,
+  includeSchema = false,
   fn: () => void | Promise<void>,
 ): Promise<void> {
   await assertQueriesMatch(match, 0, includeSchema, fn);


### PR DESCRIPTION
## Summary

- Rewrites `SQLCounter` to mirror Rails: `logFull`/`logAll`/`log`/`call` using Notifications subscription rather than adapter wrapping
- Adds `assertQueriesCount`, `assertNoQueries`, `assertQueriesMatch`, `assertNoQueriesMatch` as top-level exports
- Unskips all 9 skipped tests; adds schema-include and matcher coverage

`testing/query_assertions.rb`: 1/9 → 9/9 (100%)

## Test plan
- [x] `npx vitest run packages/activerecord/src/assertions/query-assertions.test.ts` — 15 tests pass
- [x] `pnpm api:compare --package activerecord --files testing/query_assertions.rb` — 9/9 100%
- [x] Build + typecheck pass