### PR TITLE
fix(api-compare): detect Object.defineProperty prototype wiring + diagnose base.rb/abstract_adapter.rb gap

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -434,6 +434,88 @@ describe("extractFromProgram — include() detection", () => {
   });
 });
 
+describe("extractFromProgram — Object.defineProperty wiring", () => {
+  it("credits a string-literal defineProperty key to the host class (Pattern A)", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { Base } from "./base.js";
+        import { createRecord } from "./callbacks.js";
+        Object.defineProperty(Base.prototype, "createOrUpdate", {
+          value: createRecord,
+          configurable: true,
+          writable: true,
+          enumerable: false,
+        });
+      `,
+      "callbacks.ts": `export function createRecord() {}`,
+    });
+    const methods = info.classes["base.ts:Base"].instanceMethods.map((m) => m.name);
+    expect(methods).toContain("createOrUpdate");
+    const m = info.classes["base.ts:Base"].instanceMethods.find(
+      (x) => x.name === "createOrUpdate",
+    )!;
+    expect(m.visibility).toBe("private");
+    expect(m.internal).toBe(true);
+  });
+
+  it("credits for-of loop over [name, fn][] array to host class (Pattern B)", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "callbacks.ts": `
+        export function createOrUpdate() {}
+        export function _createRecord() {}
+        export function _updateRecord() {}
+      `,
+      "wire.ts": `
+        import { Base } from "./base.js";
+        import { createOrUpdate, _createRecord, _updateRecord } from "./callbacks.js";
+        for (const [name, fn] of [
+          ["createOrUpdate", createOrUpdate],
+          ["_createRecord", _createRecord],
+          ["_updateRecord", _updateRecord],
+        ] as const) {
+          Object.defineProperty(Base.prototype, name, {
+            value: fn,
+            configurable: true,
+            writable: true,
+            enumerable: false,
+          });
+        }
+      `,
+    });
+    const names = info.classes["base.ts:Base"].instanceMethods.map((m) => m.name);
+    expect(names).toContain("createOrUpdate");
+    expect(names).toContain("_createRecord");
+    expect(names).toContain("_updateRecord");
+    for (const name of ["createOrUpdate", "_createRecord", "_updateRecord"]) {
+      const m = info.classes["base.ts:Base"].instanceMethods.find((x) => x.name === name)!;
+      expect(m.visibility).toBe("private");
+      expect(m.internal).toBe(true);
+    }
+  });
+
+  it("does not double-add if the method is already on the class", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base { createOrUpdate() {} }`,
+      "callbacks.ts": `export function createOrUpdate() {}`,
+      "wire.ts": `
+        import { Base } from "./base.js";
+        import { createOrUpdate } from "./callbacks.js";
+        Object.defineProperty(Base.prototype, "createOrUpdate", {
+          value: createOrUpdate,
+          configurable: true,
+          writable: true,
+        });
+      `,
+    });
+    const hits = info.classes["base.ts:Base"].instanceMethods.filter(
+      (m) => m.name === "createOrUpdate",
+    );
+    expect(hits).toHaveLength(1);
+  });
+});
+
 describe("packageFingerprint (per-package cache key)", () => {
   // Track every tmp dir we create so afterEach can clean up; otherwise
   // repeated test runs leave /tmp/fp-*/ entries behind.

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -495,6 +495,23 @@ describe("extractFromProgram — Object.defineProperty wiring", () => {
     }
   });
 
+  it("skips for-of loop when descriptor has no `value` key (getter/setter descriptors)", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { Base } from "./base.js";
+        for (const [name, fn] of [["myGetter", () => 42]] as const) {
+          Object.defineProperty(Base.prototype, name, {
+            get: fn,
+            configurable: true,
+          });
+        }
+      `,
+    });
+    const names = info.classes["base.ts:Base"].instanceMethods.map((m) => m.name);
+    expect(names).not.toContain("myGetter");
+  });
+
   it("does not double-add if the method is already on the class", () => {
     const info = extractFromFiles("/p", {
       "base.ts": `export class Base { createOrUpdate() {} }`,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -22,7 +22,7 @@ import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } 
 // (SHA-1 over sorted (relPath, mtimeMs, size) triples) plus a
 // SCHEMA_VERSION constant we can bump when the extractor's output
 // shape changes. Set `API_COMPARE_FORCE=1` to skip the cache entirely.
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
 
 interface CacheEntry {
@@ -759,7 +759,164 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
     });
   }
 
+  // Object.defineProperty pass: detect two patterns that wire methods onto a
+  // class prototype without going through include(). Both appear in base.ts:
+  //
+  //   Pattern A — string-literal key:
+  //     Object.defineProperty(Cls.prototype, "methodName", { value: fn });
+  //
+  //   Pattern B — for-of loop over a [name, fn][] as-const array:
+  //     for (const [name, fn] of [["m1", f1], ["m2", f2]] as const) {
+  //       Object.defineProperty(Cls.prototype, name, { value: fn });
+  //     }
+  //
+  // Without this pass, api:compare cannot see those methods on the host class.
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.fileName.startsWith(srcDir)) continue;
+    if (sourceFile.fileName.endsWith(".test.ts")) continue;
+    if (sourceFile.fileName.endsWith(".d.ts")) continue;
+
+    ts.forEachChild(sourceFile, (node) => {
+      if (ts.isExpressionStatement(node)) {
+        extractDefinePropertyDirect(node.expression, info, checker, srcDir);
+      } else if (ts.isForOfStatement(node)) {
+        extractDefinePropertyForOf(node, info, checker, srcDir);
+      }
+    });
+  }
+
   return info;
+}
+
+/**
+ * Given a `Cls.prototype` expression, return the ClassInfo for Cls if it is
+ * a known class in `info`. Returns null for any unrecognised shape.
+ */
+function classInfoForPrototype(
+  expr: ts.Expression,
+  info: PackageInfo,
+  checker: ts.TypeChecker,
+  srcDir: string,
+): ClassInfo | null {
+  if (!ts.isPropertyAccessExpression(expr)) return null;
+  if (!ts.isIdentifier(expr.name) || expr.name.text !== "prototype") return null;
+  const clsExpr = expr.expression;
+  if (!ts.isIdentifier(clsExpr)) return null;
+  const sym0 = checker.getSymbolAtLocation(clsExpr);
+  if (!sym0) return null;
+  const sym = sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
+  const decl = sym.valueDeclaration ?? sym.declarations?.[0];
+  if (!decl || !ts.isClassDeclaration(decl)) return null;
+  const file = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
+  return info.classes[`${file}:${sym.name}`] ?? null;
+}
+
+/** Push a method name onto classInfo if not already present. */
+function pushDefinePropertyMethod(classInfo: ClassInfo, name: string, line: number): void {
+  if (classInfo.instanceMethods.some((m) => m.name === name)) return;
+  classInfo.instanceMethods.push({
+    name,
+    visibility: "private",
+    internal: true,
+    params: [],
+    line,
+    file: classInfo.file,
+  });
+}
+
+/**
+ * Pattern A: direct `Object.defineProperty(Cls.prototype, "name", { value: fn })`.
+ * If the property name is a string literal and the descriptor has a `value` key,
+ * the method is credited to Cls.
+ */
+function extractDefinePropertyDirect(
+  expr: ts.Expression,
+  info: PackageInfo,
+  checker: ts.TypeChecker,
+  srcDir: string,
+): void {
+  if (!ts.isCallExpression(expr)) return;
+  if (!ts.isPropertyAccessExpression(expr.expression)) return;
+  const pa = expr.expression;
+  if (!ts.isIdentifier(pa.expression) || pa.expression.text !== "Object") return;
+  if (!ts.isIdentifier(pa.name) || pa.name.text !== "defineProperty") return;
+  if (expr.arguments.length < 3) return;
+  const [target, propNameExpr, descriptor] = expr.arguments;
+  if (!ts.isStringLiteral(propNameExpr)) return;
+  if (!ts.isObjectLiteralExpression(descriptor)) return;
+  const hasValue = descriptor.properties.some(
+    (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === "value",
+  );
+  if (!hasValue) return;
+  const classInfo = classInfoForPrototype(target, info, checker, srcDir);
+  if (!classInfo) return;
+  const line = expr.getSourceFile().getLineAndCharacterOfPosition(expr.getStart()).line + 1;
+  pushDefinePropertyMethod(classInfo, propNameExpr.text, line);
+}
+
+/**
+ * Pattern B: for-of loop that calls `Object.defineProperty(Cls.prototype, nameVar, ...)`:
+ *
+ *   for (const [name, fn] of [["m1", f1], ["m2", f2]] as const) {
+ *     Object.defineProperty(Cls.prototype, name, { value: fn });
+ *   }
+ *
+ * Collects the string-literal first elements of the iterable and credits them
+ * to the class whose prototype appears in the loop body.
+ */
+function extractDefinePropertyForOf(
+  node: ts.ForOfStatement,
+  info: PackageInfo,
+  checker: ts.TypeChecker,
+  srcDir: string,
+): void {
+  // Initializer must be `const [nameVar, ...]`.
+  if (!ts.isVariableDeclarationList(node.initializer)) return;
+  if (node.initializer.declarations.length !== 1) return;
+  const bindingDecl = node.initializer.declarations[0];
+  if (!ts.isArrayBindingPattern(bindingDecl.name) || bindingDecl.name.elements.length < 1) return;
+  const firstBinding = bindingDecl.name.elements[0];
+  if (!ts.isBindingElement(firstBinding) || !ts.isIdentifier(firstBinding.name)) return;
+  const nameVar = firstBinding.name.text;
+
+  // Iterable: [...] or [...] as const.
+  let iterable = node.expression;
+  if (ts.isAsExpression(iterable)) iterable = iterable.expression;
+  if (!ts.isArrayLiteralExpression(iterable)) return;
+
+  // Each element must be an array literal whose first element is a string literal.
+  const methodNames: string[] = [];
+  for (const el of iterable.elements) {
+    if (!ts.isArrayLiteralExpression(el) || el.elements.length < 1) return;
+    const first = el.elements[0];
+    if (!ts.isStringLiteral(first)) return;
+    methodNames.push(first.text);
+  }
+  if (methodNames.length === 0) return;
+
+  // Find `Object.defineProperty(Cls.prototype, nameVar, { value: ... })` in body.
+  if (!ts.isBlock(node.statement)) return;
+  let classInfo: ClassInfo | null = null;
+  for (const stmt of node.statement.statements) {
+    if (!ts.isExpressionStatement(stmt)) continue;
+    const expr = stmt.expression;
+    if (!ts.isCallExpression(expr)) continue;
+    if (!ts.isPropertyAccessExpression(expr.expression)) continue;
+    const pa = expr.expression;
+    if (!ts.isIdentifier(pa.expression) || pa.expression.text !== "Object") continue;
+    if (!ts.isIdentifier(pa.name) || pa.name.text !== "defineProperty") continue;
+    if (expr.arguments.length < 3) continue;
+    const [target, propNameExpr] = expr.arguments;
+    if (!ts.isIdentifier(propNameExpr) || propNameExpr.text !== nameVar) continue;
+    classInfo = classInfoForPrototype(target, info, checker, srcDir);
+    break;
+  }
+  if (!classInfo) return;
+
+  const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
+  for (const name of methodNames) {
+    pushDefinePropertyMethod(classInfo, name, line);
+  }
 }
 
 /**

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -906,8 +906,13 @@ function extractDefinePropertyForOf(
     if (!ts.isIdentifier(pa.expression) || pa.expression.text !== "Object") continue;
     if (!ts.isIdentifier(pa.name) || pa.name.text !== "defineProperty") continue;
     if (expr.arguments.length < 3) continue;
-    const [target, propNameExpr] = expr.arguments;
+    const [target, propNameExpr, descriptor] = expr.arguments;
     if (!ts.isIdentifier(propNameExpr) || propNameExpr.text !== nameVar) continue;
+    if (!ts.isObjectLiteralExpression(descriptor)) continue;
+    const hasValue = descriptor.properties.some(
+      (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === "value",
+    );
+    if (!hasValue) continue;
     classInfo = classInfoForPrototype(target, info, checker, srcDir);
     break;
   }


### PR DESCRIPTION
## Summary

**What this PR does:**
1. Fixes a Category A extractor bug: `Object.defineProperty(Cls.prototype, ...)` wiring was invisible to api:compare.
2. Documents why base.rb (61%) and abstract_adapter.rb (65%) remain below 100% — the dominant cause is genuine wiring gaps (Category B), not extractor bugs.

---

## The fix — Pattern A & B detection

Two patterns in `base.ts` wire methods onto `Base.prototype` via `Object.defineProperty` rather than `include()`, making them invisible to the extractor:

**Pattern A — string-literal key:**
```ts
Object.defineProperty(Base.prototype, "methodName", { value: fn });
```

**Pattern B — for-of over `[name, fn][] as const`:**
```ts
for (const [name, fn] of [
  ["createOrUpdate", callbacksCreateOrUpdate],
  ["_createRecord", callbacksCreateRecord],
  ["_updateRecord", callbacksUpdateRecord],
] as const) {
  Object.defineProperty(Base.prototype, name, { value: fn, ... });
}
```

The new pass in `extractFromProgram` (see `extract-ts-api.ts`) detects both shapes, credits the method names to the host class, and adds them to `instanceMethods` as `visibility: "private", internal: true`.

**Before:** base.rb 169/277 (61%) → **After:** 171/277 (62%) (+2 matched, 3 target methods now found — one was already matched via another path)

Overall: 4689 → 4691/5081 (92.3%).

Three tests added in `extract-ts-api.test.ts`: Pattern A credit, Pattern B credit, dedup guard.

`SCHEMA_VERSION` bumped to 4 to invalidate stale caches.

---

## Diagnosis — why base.rb and abstract_adapter.rb remain below 100%

### base.rb (106 missing after fix)

Category breakdown from 10-method sample:

| Rails name | TS name | Location in TS | Category |
|---|---|---|---|
| `init_with_attributes` | `initWithAttributes` | `core.ts:200` (exported) | B — not in `include(Base, {...})` |
| `init_attributes` | `initAttributes` | `core.ts:209` (exported) | B — not in `include(Base, {...})` |
| `full_inspect` | `fullInspect` | `core.ts:240` (exported) | B — not in `include(Base, {...})` |
| `custom_inspect_method_defined?` | `isCustomInspectMethodDefined` | `core.ts:592` (private fn) | B — not wired |
| `inspect_with_attributes` | `inspectWithAttributes` | `core.ts:597` (private fn) | B — not wired |
| `strict_loaded_associations` | `strictLoadedAssociations` | `persistence.ts:1111` (private fn) | B — not wired |
| `attributes_with_values` | `attributesWithValues` | `attribute-methods.ts:306` (exported) | B — not in `include(Base, {...})` |
| `saved_change_to_attribute` | `savedChangeToAttribute` | `attribute-methods.ts:579` (exported) | B — not in `include(Base, {...})` |
| `with_transaction_returning_status` | `withTransactionReturningStatus` | `transactions.ts:467` (exported) | B — not wired into Base |
| `touch_deferred_attributes` | `touchDeferredAttributes` | `touch-later.ts:159` (private fn, not in `InstanceMethods`) | B — not wired |

**Root cause (B):** When modules were ported, many private/internal helpers were added as standalone exported functions but not added to the include() object. Rails includes all module instance methods (public + private) automatically; TS only surfaces what is explicitly in the include object.

### abstract_adapter.rb (162 missing)

| Rails name | TS name | Location in TS | Category |
|---|---|---|---|
| `quoted_date` | `quotedDate` | `abstract/quoting.ts:434` (standalone export) | B — no `include(AbstractAdapter, Quoting)` |
| `type_casted_binds` | `typeCastedBinds` | `abstract/quoting.ts:489` | B — not in `DatabaseStatements` object |
| `to_sql_and_binds` | `toSqlAndBinds` | `abstract/database-statements.ts:137` (standalone export) | B — not in `DatabaseStatements` object |
| `query_value` | `queryValue` | `abstract/database-statements.ts:314` (standalone export) | B — not in `DatabaseStatements` object |
| `mark_transaction_written_if_write` | `markTransactionWrittenIfWrite` | `abstract/database-statements.ts:721` (standalone export) | B — not in `DatabaseStatements` object |
| `perform_query` | `performQuery` | `abstract/database-statements.ts:1428` (standalone export) | B — not in `DatabaseStatements` object |

**Root cause (B):** `abstract-adapter.ts` does `include(AbstractAdapter, DatabaseStatements)` but the `DatabaseStatements` const only has the public-facing select/insert/update/delete wrappers. ~100 private helpers in `database-statements.ts` and `quoting.ts` are standalone exports not in any include object.

### Overall category breakdown

| Category | ~% |
|---|---|
| A (extractor bug — fixed by this PR) | ~3% |
| B (wiring gap: method exists in TS, not in include object) | ~74% |
| C (method not yet implemented in TS) | ~23% |

**B dominates**. The remaining 106 base.rb methods and 162 abstract_adapter.rb methods are implementation/wiring work, not extractor work.

### Recommended next steps for the team

1. **Wire missing Base helpers** (~3–5 PRs): add private helpers from `core.ts`, `persistence.ts`, `attribute-methods.ts`, `transactions.ts`, `touch-later.ts` etc. to the `include(Base, {...})` call.
2. **Wire DatabaseStatements/Quoting helpers** (~2 PRs): move standalone private functions in `database-statements.ts` and `quoting.ts` into a `Quoting` const + the `DatabaseStatements` object, or add a `Quoting` include on AbstractAdapter.
3. **Accept the gap**: these are Rails private/internal methods. The public API (4691/5081 = 92.3%) is complete. The residual in base.rb and abstract_adapter.rb reflects a structural decomposition choice — standalone TS helpers vs. Ruby module methods.