### PR TITLE
feat(lint-deps): DEP-0 — skip type-position identifiers + lint-deps-ignore annotation

### DIFF
--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import * as ts from "typescript";
+import { methodUsesDepImport } from "./lint-deps.js";
+
+function makeSourceFile(source: string): ts.SourceFile {
+  return ts.createSourceFile("virtual.ts", source, ts.ScriptTarget.Latest, true);
+}
+
+function firstMethod(sf: ts.SourceFile): ts.Node {
+  let found: ts.Node | undefined;
+  const visit = (n: ts.Node) => {
+    if (found) return;
+    if (ts.isMethodDeclaration(n) || ts.isFunctionDeclaration(n) || ts.isArrowFunction(n)) {
+      found = n;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(sf, visit);
+  if (!found) throw new Error("no method found");
+  return found;
+}
+
+const DEP = "arel";
+
+describe("methodUsesDepImport — type-position filtering", () => {
+  it("cast-only (as Imported) does NOT count as usage", () => {
+    const sf = makeSourceFile(`
+      function foo(x: unknown) { return (x as Nodes); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("return type annotation does NOT count as usage", () => {
+    const sf = makeSourceFile(`
+      function foo(): Nodes { throw new Error(); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("parameter type annotation does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo(x: ArelTable): void {}
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["ArelTable"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("generic type arg does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo(): Promise<Nodes> { return Promise.resolve(null as any); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("real property access call DOES count", () => {
+    const sf = makeSourceFile(`
+      function foo(x: unknown) { return Nodes.create(x); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(true);
+  });
+
+  it("new expression DOES count", () => {
+    const sf = makeSourceFile(`
+      function foo() { return new ArelTable("x"); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["ArelTable"]), new Set(), DEP, sf)).toBe(true);
+  });
+
+  it("bare call expression DOES count", () => {
+    const sf = makeSourceFile(`
+      function foo() { return arelTable("x"); }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(), new Set(["arelTable"]), DEP, sf)).toBe(true);
+  });
+});
+
+describe("methodUsesDepImport — lint-deps-ignore annotation", () => {
+  it("opt-out comment above method marks as covered", () => {
+    const sf = makeSourceFile(`
+      // lint-deps-ignore: arel — uses raw SQL; no Arel needed
+      function foo() {}
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf)).toBe(true);
+  });
+
+  it("opt-out for wrong dep does NOT mark as covered", () => {
+    const sf = makeSourceFile(`
+      // lint-deps-ignore: activesupport
+      function foo() {}
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf)).toBe(false);
+  });
+});

--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -56,6 +56,38 @@ describe("methodUsesDepImport — type-position filtering", () => {
     expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
   });
 
+  it("old-style type assertion <Imported>x does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo(x: unknown) { return <Nodes>x; }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("satisfies expression does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo(x: unknown) { return x satisfies Nodes; }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("type predicate (x is T) does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo(x: unknown): x is Nodes { return true; }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), DEP, sf)).toBe(false);
+  });
+
+  it("variable type annotation does NOT count", () => {
+    const sf = makeSourceFile(`
+      function foo() { let x: ArelTable; }
+    `);
+    const node = firstMethod(sf);
+    expect(methodUsesDepImport(node, new Set(["ArelTable"]), new Set(), DEP, sf)).toBe(false);
+  });
+
   it("real property access call DOES count", () => {
     const sf = makeSourceFile(`
       function foo(x: unknown) { return Nodes.create(x); }

--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -21,6 +21,15 @@ function firstMethod(sf: ts.SourceFile): ts.Node {
   return found;
 }
 
+function firstVariableStatement(sf: ts.SourceFile): ts.VariableStatement {
+  let found: ts.VariableStatement | undefined;
+  ts.forEachChild(sf, (n) => {
+    if (!found && ts.isVariableStatement(n)) found = n;
+  });
+  if (!found) throw new Error("no variable statement found");
+  return found;
+}
+
 const DEP = "arel";
 
 describe("methodUsesDepImport — type-position filtering", () => {
@@ -130,5 +139,27 @@ describe("methodUsesDepImport — lint-deps-ignore annotation", () => {
     `);
     const node = firstMethod(sf);
     expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf)).toBe(false);
+  });
+
+  it("opt-out above const arrow function works (anchor = VariableStatement)", () => {
+    const sf = makeSourceFile(`
+      // lint-deps-ignore: arel — uses raw SQL
+      const foo = () => {};
+    `);
+    const node = firstMethod(sf);
+    const anchor = firstVariableStatement(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf, anchor)).toBe(true);
+  });
+
+  it("opt-out for wrong dep on arrow function does NOT cover", () => {
+    const sf = makeSourceFile(`
+      // lint-deps-ignore: activesupport
+      const foo = () => {};
+    `);
+    const node = firstMethod(sf);
+    const anchor = firstVariableStatement(sf);
+    expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf, anchor)).toBe(
+      false,
+    );
   });
 });

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -127,7 +127,12 @@ function collectRubyDepMethods(ruby: ApiManifest, pkg: string, dep: string): Rub
 
 type TsDepMap = Map<string, Map<string, boolean>>; // file -> method -> usesDep
 
-function analyzeTsDepUsage(pkgSrcDir: string, tsImport: string, tsIdentifiers: string[]): TsDepMap {
+function analyzeTsDepUsage(
+  pkgSrcDir: string,
+  tsImport: string,
+  tsIdentifiers: string[],
+  dep: string,
+): TsDepMap {
   const result: TsDepMap = new Map();
   const allFiles = getAllTsFiles(pkgSrcDir);
   if (allFiles.length === 0) return result;
@@ -178,7 +183,7 @@ function analyzeTsDepUsage(pkgSrcDir: string, tsImport: string, tsIdentifiers: s
     // Check each method's signature and body for dependency references.
     const methodMap = new Map<string, boolean>();
     visitMethodDeclarations(sourceFile, (name, methodNode) => {
-      const uses = methodUsesDepImport(methodNode, importedNames, knownIds);
+      const uses = methodUsesDepImport(methodNode, importedNames, knownIds, dep, sourceFile);
       const existing = methodMap.get(name);
       if (existing === undefined || uses) methodMap.set(name, uses);
     });
@@ -240,19 +245,42 @@ function visitMethodDeclarations(
   ts.forEachChild(sourceFile, visit);
 }
 
-function methodUsesDepImport(
+export function isWithinTypeNode(node: ts.Node): boolean {
+  let current = node.parent;
+  while (current) {
+    if (ts.isTypeNode(current)) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+export function hasLintDepsIgnore(node: ts.Node, dep: string, sourceFile: ts.SourceFile): boolean {
+  const fullText = sourceFile.getFullText();
+  const nodeStart = node.getFullStart();
+  // Collect leading trivia (comments) before the node
+  const trivia = fullText.slice(nodeStart, node.getStart(sourceFile));
+  const re = /\/\/\s*lint-deps-ignore:\s*(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(trivia)) !== null) {
+    if (m[1] === dep) return true;
+  }
+  return false;
+}
+
+export function methodUsesDepImport(
   node: ts.Node,
   importedNames: Set<string>,
   knownIdentifiers: Set<string>,
+  dep: string,
+  sourceFile: ts.SourceFile,
 ): boolean {
-  // Check the entire method declaration: parameter types, return type, and body.
-  // Skip identifiers in declaration name positions (param names, method names)
-  // to avoid false positives from names that happen to match import names.
+  if (hasLintDepsIgnore(node, dep, sourceFile)) return true;
   let found = false;
   const check = (n: ts.Node) => {
     if (found) return;
     if (ts.isIdentifier(n)) {
       if (isDeclarationName(n)) return;
+      if (isWithinTypeNode(n)) return;
       if (importedNames.has(n.text) || knownIdentifiers.has(n.text)) {
         found = true;
         return;
@@ -495,7 +523,12 @@ function main() {
     const rubyMethods = collectRubyDepMethods(ruby, rule.package, rule.dependency);
 
     const pkgSrcDir = packageSrcDir(rule.package);
-    const tsDepMap = analyzeTsDepUsage(pkgSrcDir, rule.tsImport, rule.tsIdentifiers);
+    const tsDepMap = analyzeTsDepUsage(
+      pkgSrcDir,
+      rule.tsImport,
+      rule.tsIdentifiers,
+      rule.dependency,
+    );
 
     const { violations, compliant, unmatched } = crossReference(rubyMethods, tsDepMap);
     allResults.push({ rule, violations, compliant, unmatched });
@@ -538,4 +571,7 @@ function main() {
   }
 }
 
-main();
+// Only run when invoked directly, not when imported by tests
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  main();
+}

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -12,6 +12,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { pathToFileURL } from "url";
 import * as ts from "typescript";
 import type { ApiManifest, ClassInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
@@ -257,7 +258,6 @@ export function isWithinTypeNode(node: ts.Node): boolean {
 export function hasLintDepsIgnore(node: ts.Node, dep: string, sourceFile: ts.SourceFile): boolean {
   const fullText = sourceFile.getFullText();
   const nodeStart = node.getFullStart();
-  // Collect leading trivia (comments) before the node
   const trivia = fullText.slice(nodeStart, node.getStart(sourceFile));
   const re = /\/\/\s*lint-deps-ignore:\s*(\S+)/g;
   let m: RegExpExecArray | null;
@@ -571,7 +571,6 @@ function main() {
   }
 }
 
-// Only run when invoked directly, not when imported by tests
-if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -12,7 +12,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { pathToFileURL } from "url";
+import { fileURLToPath } from "url";
 import * as ts from "typescript";
 import type { ApiManifest, ClassInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
@@ -183,8 +183,15 @@ function analyzeTsDepUsage(
 
     // Check each method's signature and body for dependency references.
     const methodMap = new Map<string, boolean>();
-    visitMethodDeclarations(sourceFile, (name, methodNode) => {
-      const uses = methodUsesDepImport(methodNode, importedNames, knownIds, dep, sourceFile);
+    visitMethodDeclarations(sourceFile, (name, methodNode, anchor) => {
+      const uses = methodUsesDepImport(
+        methodNode,
+        importedNames,
+        knownIds,
+        dep,
+        sourceFile,
+        anchor,
+      );
       const existing = methodMap.get(name);
       if (existing === undefined || uses) methodMap.set(name, uses);
     });
@@ -196,27 +203,28 @@ function analyzeTsDepUsage(
 
 function visitMethodDeclarations(
   sourceFile: ts.SourceFile,
-  callback: (name: string, node: ts.Node) => void,
+  // anchor: the node whose leading trivia holds doc comments (e.g. VariableStatement, not its initializer)
+  callback: (name: string, node: ts.Node, anchor: ts.Node) => void,
 ) {
   const visit = (node: ts.Node) => {
     if (ts.isMethodDeclaration(node) && node.name && ts.isIdentifier(node.name)) {
-      callback(node.name.text, node);
+      callback(node.name.text, node, node);
       return;
     }
     if (ts.isGetAccessorDeclaration(node) && node.name && ts.isIdentifier(node.name)) {
-      callback(node.name.text, node);
+      callback(node.name.text, node, node);
       return;
     }
     if (ts.isSetAccessorDeclaration(node) && node.name && ts.isIdentifier(node.name)) {
-      callback(node.name.text, node);
+      callback(node.name.text, node, node);
       return;
     }
     if (ts.isConstructorDeclaration(node)) {
-      callback("constructor", node);
+      callback("constructor", node, node);
       return;
     }
     if (ts.isFunctionDeclaration(node) && node.name) {
-      if (!isNotImplementedStub(node.body)) callback(node.name.text, node);
+      if (!isNotImplementedStub(node.body)) callback(node.name.text, node, node);
       return;
     }
     if (ts.isVariableStatement(node)) {
@@ -224,7 +232,8 @@ function visitMethodDeclarations(
         if (ts.isIdentifier(decl.name) && decl.initializer) {
           if (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer)) {
             if (!isNotImplementedStub(decl.initializer.body)) {
-              callback(decl.name.text, decl.initializer);
+              // anchor = VariableStatement so lint-deps-ignore above `const foo = ...` is found
+              callback(decl.name.text, decl.initializer, node);
             }
           }
         }
@@ -236,7 +245,7 @@ function visitMethodDeclarations(
         node.initializer &&
         (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
       ) {
-        callback(node.name.text, node.initializer);
+        callback(node.name.text, node.initializer, node);
         return;
       }
     }
@@ -273,8 +282,9 @@ export function methodUsesDepImport(
   knownIdentifiers: Set<string>,
   dep: string,
   sourceFile: ts.SourceFile,
+  anchor: ts.Node = node,
 ): boolean {
-  if (hasLintDepsIgnore(node, dep, sourceFile)) return true;
+  if (hasLintDepsIgnore(anchor, dep, sourceFile)) return true;
   let found = false;
   const check = (n: ts.Node) => {
     if (found) return;
@@ -571,6 +581,16 @@ function main() {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+const resolveReal = (p: string): string => {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+};
+if (
+  process.argv[1] &&
+  resolveReal(fileURLToPath(import.meta.url)) === resolveReal(process.argv[1])
+) {
   main();
 }


### PR DESCRIPTION
## Summary

- Adds `isWithinTypeNode()` helper that walks a node's parent chain; returns `true` if any ancestor is a `TypeNode`. Identifiers in type position (parameter types, return types, generic args, `as` casts, `satisfies`, type predicates) now correctly do **not** count as dep usage.
- Adds `hasLintDepsIgnore()` that reads `// lint-deps-ignore: <dep>` from leading trivia; methods with a matching annotation are treated as covered without requiring a real import.
- Guards `main()` behind an `import.meta.url` check so `lint-deps.ts` is importable by tests without side-effects.

## Score impact

`pnpm lint:deps --package activerecord` before and after: **no change** (arel 93/93, activemodel 19/19, activesupport 22/59). The existing methods that are "covered" happen to use real calls, not casts, so no regression is visible here. The rule is now honest — future cast-only additions will correctly fail.

## Out of scope

Per Track 5 plan: no methods are migrated here. DEP-1..6 handle the actual migration cluster by cluster.

## Test plan

- [x] `pnpm vitest run scripts/api-compare/lint-deps.test.ts` — 9 new tests pass
- [x] `pnpm lint:deps --package activerecord` — scores unchanged
- [x] Build and typecheck pass (pre-commit hook)