### PR TITLE
feat(activerecord): port 5 abstract_adapter throw-stubs to real Rails implementations

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { TypeMap } from "../type/type-map.js";
 import {
   BooleanType,
@@ -13,80 +13,78 @@ import { Time as TimeType } from "../type/time.js";
 import { DateTime as DateTimeType } from "../type/date-time.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
-
-// Access the private wired methods via a minimal AbstractAdapter-like host.
-// Since the functions are mixed in via include(), we instantiate a real subclass.
 import { AbstractAdapter } from "./abstract-adapter.js";
 
+// All 5 methods are class-level in Rails (class << self private), so test via a subclass.
 class TestAdapter extends AbstractAdapter {
   static get adapterName() {
     return "TestAdapter";
   }
-  // Minimal overrides to satisfy abstract surface; not called in these tests.
   override get adapterName() {
     return "TestAdapter" as const;
   }
 }
 
-const adapter = new TestAdapter();
-
-describe("AbstractAdapter#extractLimit", () => {
+describe("AbstractAdapter.extractLimit", () => {
   it("parses limit from sql type with parens", () => {
-    expect((adapter as any).extractLimit("varchar(255)")).toBe(255);
+    expect(TestAdapter.extractLimit("varchar(255)")).toBe(255);
   });
 
   it("returns undefined when no parens", () => {
-    expect((adapter as any).extractLimit("text")).toBeUndefined();
+    expect(TestAdapter.extractLimit("text")).toBeUndefined();
   });
 
-  it("parses limit from decimal(10,2) as leading number", () => {
-    expect((adapter as any).extractLimit("decimal(10,2)")).toBe(10);
+  it("parses leading digits from decimal(10,2)", () => {
+    expect(TestAdapter.extractLimit("decimal(10,2)")).toBe(10);
   });
 });
 
-describe("AbstractAdapter#extractPrecision", () => {
+describe("AbstractAdapter.extractPrecision", () => {
   it("returns first number for p,s form", () => {
-    expect((adapter as any).extractPrecision("decimal(10,2)")).toBe(10);
+    expect(TestAdapter.extractPrecision("decimal(10,2)")).toBe(10);
   });
 
   it("returns number for p-only form", () => {
-    expect((adapter as any).extractPrecision("decimal(10)")).toBe(10);
+    expect(TestAdapter.extractPrecision("decimal(10)")).toBe(10);
   });
 
   it("returns undefined when no parens", () => {
-    expect((adapter as any).extractPrecision("decimal")).toBeUndefined();
+    expect(TestAdapter.extractPrecision("decimal")).toBeUndefined();
   });
 });
 
-describe("AbstractAdapter#extractScale", () => {
+describe("AbstractAdapter.extractScale", () => {
   it("returns second number for p,s form", () => {
-    expect((adapter as any).extractScale("decimal(10,2)")).toBe(2);
+    expect(TestAdapter.extractScale("decimal(10,2)")).toBe(2);
   });
 
   it("returns 0 for single-number form", () => {
-    expect((adapter as any).extractScale("decimal(10)")).toBe(0);
+    expect(TestAdapter.extractScale("decimal(10)")).toBe(0);
   });
 
   it("returns undefined when no parens", () => {
-    expect((adapter as any).extractScale("decimal")).toBeUndefined();
+    expect(TestAdapter.extractScale("decimal")).toBeUndefined();
   });
 });
 
-describe("AbstractAdapter#registerClassWithLimit", () => {
-  it("registers a type that uses extractLimit", () => {
+describe("AbstractAdapter.registerClassWithLimit", () => {
+  it("registers a type factory that extracts limit", () => {
     const m = new TypeMap();
-    (adapter as any).registerClassWithLimit(m, /varchar/i, IntegerType);
+    TestAdapter.registerClassWithLimit(m, /varchar/i, IntegerType);
     const type = m.lookup("varchar(64)");
     expect(type).toBeInstanceOf(IntegerType);
   });
 });
 
-describe("AbstractAdapter#initializeTypeMap", () => {
+describe("AbstractAdapter.initializeTypeMap", () => {
   let m: TypeMap;
 
-  it("registers boolean", () => {
+  beforeAll(() => {
     m = new TypeMap();
-    (adapter as any).initializeTypeMap(m);
+    TestAdapter.initializeTypeMap(m);
+  });
+
+  it("registers boolean", () => {
     expect(m.lookup("boolean")).toBeInstanceOf(BooleanType);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { TypeMap } from "../type/type-map.js";
+import {
+  BooleanType,
+  BinaryType,
+  IntegerType,
+  FloatType,
+  DecimalType,
+} from "@blazetrails/activemodel";
+import { Text as TextType } from "../type/text.js";
+import { Date as DateType } from "../type/date.js";
+import { Time as TimeType } from "../type/time.js";
+import { DateTime as DateTimeType } from "../type/date-time.js";
+import { Json as JsonType } from "../type/json.js";
+import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
+
+// Access the private wired methods via a minimal AbstractAdapter-like host.
+// Since the functions are mixed in via include(), we instantiate a real subclass.
+import { AbstractAdapter } from "./abstract-adapter.js";
+
+class TestAdapter extends AbstractAdapter {
+  static get adapterName() {
+    return "TestAdapter";
+  }
+  // Minimal overrides to satisfy abstract surface; not called in these tests.
+  override get adapterName() {
+    return "TestAdapter" as const;
+  }
+}
+
+const adapter = new TestAdapter();
+
+describe("AbstractAdapter#extractLimit", () => {
+  it("parses limit from sql type with parens", () => {
+    expect((adapter as any).extractLimit("varchar(255)")).toBe(255);
+  });
+
+  it("returns undefined when no parens", () => {
+    expect((adapter as any).extractLimit("text")).toBeUndefined();
+  });
+
+  it("parses limit from decimal(10,2) as leading number", () => {
+    expect((adapter as any).extractLimit("decimal(10,2)")).toBe(10);
+  });
+});
+
+describe("AbstractAdapter#extractPrecision", () => {
+  it("returns first number for p,s form", () => {
+    expect((adapter as any).extractPrecision("decimal(10,2)")).toBe(10);
+  });
+
+  it("returns number for p-only form", () => {
+    expect((adapter as any).extractPrecision("decimal(10)")).toBe(10);
+  });
+
+  it("returns undefined when no parens", () => {
+    expect((adapter as any).extractPrecision("decimal")).toBeUndefined();
+  });
+});
+
+describe("AbstractAdapter#extractScale", () => {
+  it("returns second number for p,s form", () => {
+    expect((adapter as any).extractScale("decimal(10,2)")).toBe(2);
+  });
+
+  it("returns 0 for single-number form", () => {
+    expect((adapter as any).extractScale("decimal(10)")).toBe(0);
+  });
+
+  it("returns undefined when no parens", () => {
+    expect((adapter as any).extractScale("decimal")).toBeUndefined();
+  });
+});
+
+describe("AbstractAdapter#registerClassWithLimit", () => {
+  it("registers a type that uses extractLimit", () => {
+    const m = new TypeMap();
+    (adapter as any).registerClassWithLimit(m, /varchar/i, IntegerType);
+    const type = m.lookup("varchar(64)");
+    expect(type).toBeInstanceOf(IntegerType);
+  });
+});
+
+describe("AbstractAdapter#initializeTypeMap", () => {
+  let m: TypeMap;
+
+  it("registers boolean", () => {
+    m = new TypeMap();
+    (adapter as any).initializeTypeMap(m);
+    expect(m.lookup("boolean")).toBeInstanceOf(BooleanType);
+  });
+
+  it("registers text", () => {
+    expect(m.lookup("text")).toBeInstanceOf(TextType);
+  });
+
+  it("registers binary", () => {
+    expect(m.lookup("binary")).toBeInstanceOf(BinaryType);
+  });
+
+  it("registers float", () => {
+    expect(m.lookup("float")).toBeInstanceOf(FloatType);
+  });
+
+  it("registers integer", () => {
+    expect(m.lookup("integer")).toBeInstanceOf(IntegerType);
+  });
+
+  it("registers date", () => {
+    expect(m.lookup("date")).toBeInstanceOf(DateType);
+  });
+
+  it("registers time", () => {
+    expect(m.lookup("time")).toBeInstanceOf(TimeType);
+  });
+
+  it("registers datetime", () => {
+    expect(m.lookup("datetime")).toBeInstanceOf(DateTimeType);
+  });
+
+  it("registers json", () => {
+    expect(m.lookup("json")).toBeInstanceOf(JsonType);
+  });
+
+  it("registers decimal with scale as DecimalType", () => {
+    expect(m.lookup("decimal(10,2)")).toBeInstanceOf(DecimalType);
+  });
+
+  it("registers decimal without scale as DecimalWithoutScale", () => {
+    expect(m.lookup("decimal(10)")).toBeInstanceOf(DecimalWithoutScale);
+  });
+
+  it("aliases blob to binary", () => {
+    expect(m.lookup("blob")).toBeInstanceOf(BinaryType);
+  });
+
+  it("aliases clob to text", () => {
+    expect(m.lookup("clob")).toBeInstanceOf(TextType);
+  });
+
+  it("aliases timestamp to datetime", () => {
+    expect(m.lookup("timestamp")).toBeInstanceOf(DateTimeType);
+  });
+
+  it("aliases double to float", () => {
+    expect(m.lookup("double")).toBeInstanceOf(FloatType);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1228,19 +1228,88 @@ export class AbstractAdapter implements Quoting {
 
   static dbconsole(_config?: unknown): void {}
 
-  // --- Type registration ---
+  // --- Type registration (Rails: class << self private) ---
 
+  /** @internal */
+  static initializeTypeMap(this: typeof AbstractAdapter, m: TypeMap): void {
+    this.registerClassWithLimit(m, /boolean/i, BooleanType);
+    this.registerClassWithLimit(m, /char/i, StringType);
+    this.registerClassWithLimit(m, /binary/i, BinaryType);
+    this.registerClassWithLimit(m, /text/i, TextType);
+    this.registerClassWithPrecision(m, /date/i, DateType);
+    this.registerClassWithPrecision(m, /time/i, TimeType);
+    this.registerClassWithPrecision(m, /datetime/i, DateTimeType);
+    this.registerClassWithLimit(m, /float/i, FloatType);
+    this.registerClassWithLimit(m, /int/i, IntegerType);
+
+    const aliasTo = (targetKey: string) => (sqlType: string) => {
+      const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
+      return m.lookup(`${targetKey}${meta}`);
+    };
+    m.registerType(/blob/i, undefined, aliasTo("binary"));
+    m.registerType(/clob/i, undefined, aliasTo("text"));
+    m.registerType(/timestamp/i, undefined, aliasTo("datetime"));
+    m.registerType(/numeric/i, undefined, aliasTo("decimal"));
+    m.registerType(/number/i, undefined, aliasTo("decimal"));
+    m.registerType(/double/i, undefined, aliasTo("float"));
+
+    m.registerType(/^json/i, new JsonType());
+
+    m.registerType(/decimal/i, undefined, (sqlType: string) => {
+      const scale = this.extractScale(sqlType);
+      const precision = this.extractPrecision(sqlType);
+      if (scale === 0) return new DecimalWithoutScale({ precision });
+      return new DecimalType({ precision, scale });
+    });
+  }
+
+  /** @internal */
+  static registerClassWithLimit(
+    this: typeof AbstractAdapter,
+    mapping: TypeMap,
+    key: string | RegExp,
+    klass: new (options?: { limit?: number }) => object,
+  ): void {
+    mapping.registerType(key, undefined, (sqlType: string) => {
+      return new klass({ limit: this.extractLimit(sqlType) }) as ReturnType<typeof mapping.lookup>;
+    });
+  }
+
+  /** @internal */
   static registerClassWithPrecision(
-    typeMap: TypeMap,
+    this: typeof AbstractAdapter,
+    mapping: TypeMap,
     key: string | RegExp,
     klass: new (options?: { precision?: number }) => object,
     extraOptions: Record<string, unknown> = {},
   ): void {
-    typeMap.registerType(key, undefined, (sqlType: string) => {
-      const match = /\((\d+)(,\d+)?\)/.exec(sqlType);
-      const precision = match ? Number.parseInt(match[1], 10) : undefined;
-      return new klass({ precision, ...extraOptions }) as ReturnType<typeof typeMap.lookup>;
+    mapping.registerType(key, undefined, (sqlType: string) => {
+      return new klass({
+        precision: this.extractPrecision(sqlType),
+        ...extraOptions,
+      }) as ReturnType<typeof mapping.lookup>;
     });
+  }
+
+  /** @internal */
+  static extractScale(sqlType: string): number | undefined {
+    if (/\(\d+\)/.test(sqlType)) return 0;
+    const match = /\(\d+,(\d+)\)/.exec(sqlType);
+    return match ? Number.parseInt(match[1], 10) : undefined;
+  }
+
+  /** @internal */
+  static extractPrecision(sqlType: string): number | undefined {
+    const match = /\((\d+)(,\d+)?\)/.exec(sqlType);
+    return match ? Number.parseInt(match[1], 10) : undefined;
+  }
+
+  /** @internal */
+  static extractLimit(sqlType: string): number | undefined {
+    const match = /\((.*)\)/.exec(sqlType);
+    if (!match) return undefined;
+    const n = Number.parseInt(match[1], 10);
+    return Number.isNaN(n) ? 0 : n;
   }
 
   private _extendedTypeMap?: Map<string, unknown>;
@@ -1570,97 +1639,3 @@ include(AbstractAdapter, {
   indexNameLength,
   bindParamsLength,
 });
-
-// Wire abstract private stubs so api:compare credits them to AbstractAdapter.
-const AbstractAdapterPrivates = {
-  initializeTypeMap,
-  registerClassWithLimit,
-  extractScale,
-  extractPrecision,
-  extractLimit,
-};
-include(AbstractAdapter, AbstractAdapterPrivates);
-
-/** @internal */
-function initializeTypeMap(this: AbstractAdapter, m: TypeMap): void {
-  registerClassWithLimit.call(this, m, /boolean/i, BooleanType);
-  registerClassWithLimit.call(this, m, /char/i, StringType);
-  registerClassWithLimit.call(this, m, /binary/i, BinaryType);
-  registerClassWithLimit.call(this, m, /text/i, TextType);
-  registerClassWithPrecision(m, /date/i, DateType);
-  registerClassWithPrecision(m, /time/i, TimeType);
-  registerClassWithPrecision(m, /datetime/i, DateTimeType);
-  registerClassWithLimit.call(this, m, /float/i, FloatType);
-  registerClassWithLimit.call(this, m, /int/i, IntegerType);
-
-  const aliasTo = (targetKey: string) => (sqlType: string) => {
-    const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
-    return m.lookup(`${targetKey}${meta}`);
-  };
-  m.registerType(/blob/i, undefined, aliasTo("binary"));
-  m.registerType(/clob/i, undefined, aliasTo("text"));
-  m.registerType(/timestamp/i, undefined, aliasTo("datetime"));
-  m.registerType(/numeric/i, undefined, aliasTo("decimal"));
-  m.registerType(/number/i, undefined, aliasTo("decimal"));
-  m.registerType(/double/i, undefined, aliasTo("float"));
-
-  m.registerType(/^json/i, new JsonType());
-
-  m.registerType(/decimal/i, undefined, (sqlType: string) => {
-    const scale = extractScale.call(this, sqlType);
-    const precision = extractPrecision.call(this, sqlType);
-    if (scale === 0) return new DecimalWithoutScale({ precision });
-    return new DecimalType({ precision, scale });
-  });
-}
-
-/** @internal */
-function registerClassWithLimit(
-  this: AbstractAdapter,
-  mapping: TypeMap,
-  key: string | RegExp,
-  klass: new (options?: { limit?: number }) => object,
-): void {
-  mapping.registerType(key, undefined, (sqlType: string) => {
-    const limit = extractLimit.call(this, sqlType);
-    return new klass({ limit }) as ReturnType<typeof mapping.lookup>;
-  });
-}
-
-/** @internal */
-function registerClassWithPrecision(
-  mapping: TypeMap,
-  key: string | RegExp,
-  klass: new (options?: { precision?: number }) => object,
-  extraOptions: Record<string, unknown> = {},
-): void {
-  mapping.registerType(key, undefined, (sqlType: string) => {
-    const precision = extractPrecisionStandalone(sqlType);
-    return new klass({ precision, ...extraOptions }) as ReturnType<typeof mapping.lookup>;
-  });
-}
-
-/** @internal */
-function extractScale(this: AbstractAdapter, sqlType: string): number | undefined {
-  if (/\((\d+)\)/.test(sqlType) && !/\((\d+),/.test(sqlType)) return 0;
-  const match = /\((\d+),(\d+)\)/.exec(sqlType);
-  return match ? Number.parseInt(match[2], 10) : undefined;
-}
-
-/** @internal */
-function extractPrecision(this: AbstractAdapter, sqlType: string): number | undefined {
-  return extractPrecisionStandalone(sqlType);
-}
-
-function extractPrecisionStandalone(sqlType: string): number | undefined {
-  const match = /\((\d+)(,\d+)?\)/.exec(sqlType);
-  return match ? Number.parseInt(match[1], 10) : undefined;
-}
-
-/** @internal */
-function extractLimit(this: AbstractAdapter, sqlType: string): number | undefined {
-  const match = /\((.*)\)/.exec(sqlType);
-  if (!match) return undefined;
-  const n = Number.parseInt(match[1], 10);
-  return Number.isNaN(n) ? 0 : n;
-}

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -9,7 +9,6 @@ import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { type Nodes, Visitors, Collectors } from "@blazetrails/arel";
 import {
   ReadOnlyError,
-  NotImplementedError,
   ActiveRecordError,
   StatementInvalid,
   ConnectionNotEstablished,
@@ -83,6 +82,21 @@ import type {
   ColumnOptions,
 } from "./abstract/schema-definitions.js";
 import type { Column } from "./column.js";
+import { TypeMap } from "../type/type-map.js";
+import {
+  StringType,
+  IntegerType,
+  FloatType,
+  BooleanType,
+  BinaryType,
+  DecimalType,
+} from "@blazetrails/activemodel";
+import { Text as TextType } from "../type/text.js";
+import { Date as DateType } from "../type/date.js";
+import { Time as TimeType } from "../type/time.js";
+import { DateTime as DateTimeType } from "../type/date-time.js";
+import { Json as JsonType } from "../type/json.js";
+import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -1216,7 +1230,18 @@ export class AbstractAdapter implements Quoting {
 
   // --- Type registration ---
 
-  static registerClassWithPrecision(_typeMap: unknown, _name: string, _klass: unknown): void {}
+  static registerClassWithPrecision(
+    typeMap: TypeMap,
+    key: string | RegExp,
+    klass: new (options?: { precision?: number }) => object,
+    extraOptions: Record<string, unknown> = {},
+  ): void {
+    typeMap.registerType(key, undefined, (sqlType: string) => {
+      const match = /\((\d+)(,\d+)?\)/.exec(sqlType);
+      const precision = match ? Number.parseInt(match[1], 10) : undefined;
+      return new klass({ precision, ...extraOptions }) as ReturnType<typeof typeMap.lookup>;
+    });
+  }
 
   private _extendedTypeMap?: Map<string, unknown>;
   get extendedTypeMap(): Map<string, unknown> {
@@ -1557,36 +1582,85 @@ const AbstractAdapterPrivates = {
 include(AbstractAdapter, AbstractAdapterPrivates);
 
 /** @internal */
-function initializeTypeMap(m: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#initialize_type_map is not implemented",
-  );
+function initializeTypeMap(this: AbstractAdapter, m: TypeMap): void {
+  registerClassWithLimit.call(this, m, /boolean/i, BooleanType);
+  registerClassWithLimit.call(this, m, /char/i, StringType);
+  registerClassWithLimit.call(this, m, /binary/i, BinaryType);
+  registerClassWithLimit.call(this, m, /text/i, TextType);
+  registerClassWithPrecision(m, /date/i, DateType);
+  registerClassWithPrecision(m, /time/i, TimeType);
+  registerClassWithPrecision(m, /datetime/i, DateTimeType);
+  registerClassWithLimit.call(this, m, /float/i, FloatType);
+  registerClassWithLimit.call(this, m, /int/i, IntegerType);
+
+  const aliasTo = (targetKey: string) => (sqlType: string) => {
+    const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
+    return m.lookup(`${targetKey}${meta}`);
+  };
+  m.registerType(/blob/i, undefined, aliasTo("binary"));
+  m.registerType(/clob/i, undefined, aliasTo("text"));
+  m.registerType(/timestamp/i, undefined, aliasTo("datetime"));
+  m.registerType(/numeric/i, undefined, aliasTo("decimal"));
+  m.registerType(/number/i, undefined, aliasTo("decimal"));
+  m.registerType(/double/i, undefined, aliasTo("float"));
+
+  m.registerType(/^json/i, new JsonType());
+
+  m.registerType(/decimal/i, undefined, (sqlType: string) => {
+    const scale = extractScale.call(this, sqlType);
+    const precision = extractPrecision.call(this, sqlType);
+    if (scale === 0) return new DecimalWithoutScale({ precision });
+    return new DecimalType({ precision, scale });
+  });
 }
 
 /** @internal */
-function registerClassWithLimit(mapping: any, key: any, klass: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#register_class_with_limit is not implemented",
-  );
+function registerClassWithLimit(
+  this: AbstractAdapter,
+  mapping: TypeMap,
+  key: string | RegExp,
+  klass: new (options?: { limit?: number }) => object,
+): void {
+  mapping.registerType(key, undefined, (sqlType: string) => {
+    const limit = extractLimit.call(this, sqlType);
+    return new klass({ limit }) as ReturnType<typeof mapping.lookup>;
+  });
 }
 
 /** @internal */
-function extractScale(sqlType: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_scale is not implemented",
-  );
+function registerClassWithPrecision(
+  mapping: TypeMap,
+  key: string | RegExp,
+  klass: new (options?: { precision?: number }) => object,
+  extraOptions: Record<string, unknown> = {},
+): void {
+  mapping.registerType(key, undefined, (sqlType: string) => {
+    const precision = extractPrecisionStandalone(sqlType);
+    return new klass({ precision, ...extraOptions }) as ReturnType<typeof mapping.lookup>;
+  });
 }
 
 /** @internal */
-function extractPrecision(sqlType: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_precision is not implemented",
-  );
+function extractScale(this: AbstractAdapter, sqlType: string): number | undefined {
+  if (/\((\d+)\)/.test(sqlType) && !/\((\d+),/.test(sqlType)) return 0;
+  const match = /\((\d+),(\d+)\)/.exec(sqlType);
+  return match ? Number.parseInt(match[2], 10) : undefined;
 }
 
 /** @internal */
-function extractLimit(sqlType: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_limit is not implemented",
-  );
+function extractPrecision(this: AbstractAdapter, sqlType: string): number | undefined {
+  return extractPrecisionStandalone(sqlType);
+}
+
+function extractPrecisionStandalone(sqlType: string): number | undefined {
+  const match = /\((\d+)(,\d+)?\)/.exec(sqlType);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** @internal */
+function extractLimit(this: AbstractAdapter, sqlType: string): number | undefined {
+  const match = /\((.*)\)/.exec(sqlType);
+  if (!match) return undefined;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isNaN(n) ? 0 : n;
 }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1035,7 +1035,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /** @internal */
-  protected static initializeTypeMap(this: typeof AbstractMysqlAdapter, m: TypeMap): void {
+  static override initializeTypeMap(this: typeof AbstractMysqlAdapter, m: TypeMap): void {
     // Base types (mirrors AbstractAdapter#initialize_type_map via super)
     m.registerType(/^boolean/i, undefined, () => new BooleanType());
     m.registerType(/^char/i, undefined, () => new StringType());

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2098,7 +2098,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   /** @internal */
-  private static initializeTypeMap(m: TypeMap): void {
+  static override initializeTypeMap(m: TypeMap): void {
     const sqlite3Int = (limit?: number) => new IntegerType({ limit: limit ?? 8 });
     m.registerType("string", new StringType());
     m.registerType("text", new TextType());


### PR DESCRIPTION
## Summary

- Replaces `NotImplementedError` throw-stubs for `extractLimit`, `extractPrecision`, `extractScale`, `registerClassWithLimit`, and `initializeTypeMap` with Rails-faithful implementations on `AbstractAdapter`
- Promotes the empty `registerClassWithPrecision` static stub to a real implementation (mirrors `abstract_adapter.rb:870`)
- Adds `abstract-adapter.test.ts` (25 tests) covering all 5 methods + `initializeTypeMap` type registrations

## Follow-up to

#1292 — which wired the stubs via `include(AbstractAdapter, AbstractAdapterPrivates)` for api:compare credit; this PR replaces the stubs with behavior.

## Verification

- `pnpm api:compare --package activerecord --files connection_adapters/abstract_adapter.rb` — 80% (unchanged; methods were already counted)
- `pnpm vitest run packages/activerecord/src/connection-adapters/abstract-adapter.test.ts` — 25/25 pass
- `pnpm vitest run packages/activerecord/src/connection-adapters/` — 989 pass, no regressions
- `pnpm lint` — clean