### PR TITLE
feat(activerecord): BC-3 — eliminate pg/mysql2 eager-import leaks from barrel

### DIFF
--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -52,6 +52,11 @@
     "@blazetrails/arel": "workspace:*",
     "@blazetrails/activemodel": "workspace:*"
   },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.6.2",
+    "mysql2": "^3.18.2",
+    "pg": "^8.19.0"
+  },
   "peerDependencies": {
     "typescript": ">=5.0.0"
   },

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -52,13 +52,22 @@
     "@blazetrails/arel": "workspace:*",
     "@blazetrails/activemodel": "workspace:*"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "better-sqlite3": "^12.6.2",
     "mysql2": "^3.18.2",
-    "pg": "^8.19.0"
-  },
-  "peerDependencies": {
+    "pg": "^8.19.0",
     "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "better-sqlite3": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -19,7 +19,7 @@
  * a process-wide registry shared with other mysql2 users in the process.
  */
 
-import mysql from "mysql2/promise";
+import type mysql from "mysql2/promise";
 import {
   parseMysqlInstant,
   parseMysqlDatetimeAsInstant,

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
-import pg from "pg";
+import type pg from "pg";
 import { PreparedStatementCacheExpired } from "../../errors.js";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -11,6 +11,7 @@
  * etc. Per-connection tables, not global mutation.
  */
 
+// Reachable only via the postgresql-adapter subpath; safe to import pg at runtime here.
 import pg from "pg";
 import {
   parsePostgresInstant,

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -11,7 +11,7 @@
  * etc. Per-connection tables, not global mutation.
  */
 
-// Reachable only via the postgresql-adapter subpath; safe to import pg at runtime here.
+// Not imported by the top-level activerecord barrel; only pulled in when the PostgreSQL adapter is loaded.
 import pg from "pg";
 import {
   parsePostgresInstant,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,16 @@ importers:
       typescript:
         specifier: '>=5.0.0'
         version: 5.9.3
+    optionalDependencies:
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
+      mysql2:
+        specifier: ^3.18.2
+        version: 3.19.0(@types/node@25.3.5)
+      pg:
+        specifier: ^8.19.0
+        version: 8.20.0
 
   packages/activesupport:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,10 +120,6 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../arel
-      typescript:
-        specifier: '>=5.0.0'
-        version: 5.9.3
-    optionalDependencies:
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -133,6 +129,9 @@ importers:
       pg:
         specifier: ^8.19.0
         version: 8.20.0
+      typescript:
+        specifier: '>=5.0.0'
+        version: 5.9.3
 
   packages/activesupport:
     dependencies:


### PR DESCRIPTION
## Summary

BC-3 finishing work. The subpath exports for postgresql/mysql2/sqlite3 adapters already shipped. This PR closes the remaining three eager-import leaks and declares the native packages as optional peer dependencies.

### Changes

**`import type` conversions (type-only pg/mysql2 uses)**

- `postgresql/database-statements.ts`: All `pg` references were in type position (`pg.PoolClient`, `pg.QueryResult`, `pg.QueryConfig`) — no runtime calls. Converted to `import type pg from "pg"`.
- `mysql/temporal-type-cast.ts`: `mysql.PoolOptions` only appears in type position (type annotation and `as` cast). Converted to `import type mysql from "mysql2/promise"`.

**Annotated runtime import (already barrier-isolated)**

- `postgresql/temporal-type-parsers.ts`: Retains `import pg from "pg"` because `pg.types.getTypeParser(...)` is called at runtime. This file is not imported by the top-level activerecord barrel — only pulled in when the PostgreSQL adapter is loaded. Added comment documenting this invariant.

**`peerDependencies` + `peerDependenciesMeta.optional` in `packages/activerecord/package.json`**

Promotes `pg ^8.19.0`, `mysql2 ^3.18.2`, and `better-sqlite3 ^12.6.2` to optional peer dependencies, matching the pattern activesupport uses for `better-sqlite3`. Consumers who don't use a given adapter won't have it installed; adapters are loaded only via subpath import.

### Bundle smoke test

```
esbuild --bundle --platform=browser \
  --external:@blazetrails/* --external:pg --external:mysql2 --external:better-sqlite3 \
  --log-level=error packages/activerecord/dist/index.js

exit: 0
(zero pg / mysql2 / node:* resolution errors)
```

The only remaining non-external built-in is `zlib` from `encryption/config.ts` — a pre-existing issue (BC-5 scope) that predates this PR. The `zlib` import is behind `installExtendedQueriesIfConfigured` in the barrel; it is not caused by any of the three files changed here.

### Verification

- `pnpm build` ✅
- `pnpm typecheck` ✅  
- `pnpm lint --fix` ✅
- esbuild smoke test: exit 0, zero pg/mysql2 errors ✅

## Out of scope

- BC-4 lint rules (`no-native-import`, `no-direct-process-env`) — separate PR.
- BC-4 browser-bundle CI step.
- `zlib` from encryption barrel — BC-5.
- Self-registering adapter registry — de-prioritized (pg/mysql are server-only forever).