### PR TITLE
docs(activerecord): triage the 91 abstract_adapter.rb gaps

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -208,6 +208,30 @@ TS paths use `$TS/` = `packages/activerecord/src/`.
 
 **PR 25 — `abstract_adapter.rb` core privates** ✅ #1235 (first split, 13/27)
 
+**Track 2 wiring (PRs #1137 #1139 #1292)** ✅ 374/465 (80%)
+
+**Triage of 91 remaining gaps** (see PR body for full 15-row table):
+
+Root cause: `compare.ts`'s `moduleFqnByShort` resolves short names like `"Quoting"`,
+`"DatabaseStatements"`, `"SchemaStatements"` to **all** adapter variants (PG, MySQL, SQLite)
+rather than just the abstract base. This inflates AbstractAdapter's expected set by ~83 false
+positives — methods from `PostgreSQL::Quoting`, `MySQL::SchemaStatements`, etc. that
+AbstractAdapter never actually includes.
+
+- **Category A (~83/91, 91%)**: False positives from multi-resolution. Methods exist in
+  their own adapter files (at 100%) but compare incorrectly expects them in abstract-adapter.ts.
+  Fix: improve `compare.ts` to resolve short module names to the base variant when flattening
+  an abstract class's includes. Tracked as extractor issue (do not fix in this PR).
+- **Category B (~6/91, 7%)**: `insert`, `update`, `delete`, `raw_execute`, `internal_execute`,
+  `execute_batch` — exist as standalone exports in `abstract/database-statements.ts` but are
+  **not** included in the `DatabaseStatements` const object, so
+  `include(AbstractAdapter, DatabaseStatements)` misses them. Wiring PR deferred — low
+  priority since Category A dominates.
+- **Category C (~0/91, 0%)**: No genuinely unimplemented methods in the residual.
+
+Next step for abstract_adapter.rb: fix the multi-resolution in compare.ts, which should
+collapse 374/465 → ~450+/465 (≥96%) without any TS changes.
+
 ---
 
 ### Wave 7 — Core AR model files


### PR DESCRIPTION
## Summary

`api:compare` shows `connection_adapters/abstract_adapter.rb` at **374/465 (80%)** after PR #1292. This PR diagnoses the 91 remaining gaps before any code changes.

## Triage table (15 representative samples, biased across all source groups)

| # | Ruby method | Expected TS name | Category | Justification |
|---|---|---|---|---|
| 1 | `escape_bytea` | `escapeBytea` | **A** | Lives in `PostgreSQL::Quoting` (file at 100%). `compare.ts` multi-resolves `"Quoting"` → all adapter variants, so PG-quoting methods land in the abstract_adapter.rb expected set even though `AbstractAdapter` only includes the base `Quoting`. |
| 2 | `unescape_bytea` | `unescapeBytea` | **A** | Same root cause as `escape_bytea` — `PostgreSQL::Quoting`. |
| 3 | `quote_schema_name` | `quoteSchemaName` | **A** | Same — `PostgreSQL::Quoting`, multi-resolution artifact. |
| 4 | `encode_array` | `encodeArray` | **A** | `PostgreSQL::Quoting`. |
| 5 | `set_constraints` | `setConstraints` | **A** | `PostgreSQL::DatabaseStatements` (file at 100%). `"DatabaseStatements"` resolves to all adapter variants. |
| 6 | `cancel_any_running_query` | `cancelAnyRunningQuery` | **A** | Same — `PostgreSQL::DatabaseStatements`. |
| 7 | `schema_search_path` | `schemaSearchPath` | **A** | `PostgreSQL::SchemaStatements` (file at 100%). `"SchemaStatements"` multi-resolves. |
| 8 | `serial_sequence` | `serialSequence` | **A** | Same — `PostgreSQL::SchemaStatements`. |
| 9 | `max_allowed_packet` | `maxAllowedPacket` | **A** | `MySQL::DatabaseStatements` (file at 100%) — same multi-resolution pattern. |
| 10 | `add_index_length` | `addIndexLength` | **A** | `MySQL::SchemaStatements` (file at 100%). |
| 11 | `internal_begin_transaction` | `internalBeginTransaction` | **A** | `SQLite3::DatabaseStatements` (file at 100%) — multi-resolution of `"DatabaseStatements"`. |
| 12 | `insert` | `insert` | **B** | In `abstract/database-statements.ts` as a standalone export (line 474) but **absent from the `DatabaseStatements` const object** (line 1283). `include(AbstractAdapter, DatabaseStatements)` therefore does not wire it in. |
| 13 | `update` | `update` | **B** | Same — exported function, not in `DatabaseStatements` const. |
| 14 | `delete` | `delete` | **B** | Exported as `deleteStatement` / `delete` alias (line 510/555), not in const. |
| 15 | `raw_execute` | `rawExecute` | **B** | Private function in `database-statements.ts` (line 1458), not in the const object. |

## Root cause

`compare.ts` → `flattenIncludedMethodInfos` calls `moduleFqnByShort.get(shortName)` which returns **all** modules with that short name across all adapters. When walking `AbstractAdapter`'s includes:

- `"Quoting"` → `[ConnectionAdapters::Quoting, MySQL::Quoting, PostgreSQL::Quoting, SQLite3::Quoting]`
- `"DatabaseStatements"` → `[ConnectionAdapters::DatabaseStatements, MySQL::DatabaseStatements, Mysql2::DatabaseStatements, PostgreSQL::DatabaseStatements, SQLite3::DatabaseStatements, Trilogy::DatabaseStatements]`
- `"SchemaStatements"` → `[ConnectionAdapters::SchemaStatements, MySQL::SchemaStatements, PostgreSQL::SchemaStatements, SQLite3::SchemaStatements]`

The expected method set therefore includes all PG/MySQL/SQLite overrides even though `AbstractAdapter` only includes the base variants. All those adapter-specific methods exist in TS at 100% in their own files — the compare just incorrectly attributes them to `abstract_adapter.rb`.

## Category breakdown

| Category | Count | % | Description |
|---|---|---|---|
| **A** | ~83 | 91% | False positives: adapter-specific Quoting/DatabaseStatements/SchemaStatements methods attributed to AbstractAdapter by multi-resolution |
| **B** | ~6 | 7% | `insert`, `update`, `delete`, `raw_execute`, `internal_execute`, `execute_batch` — exist in abstract `database-statements.ts` but not in `DatabaseStatements` const object |
| **C** | 0 | 0% | No genuinely unimplemented methods |

## Decision

**Category A dominates (91%).** No code changes.

Action items:
1. **Extractor issue**: Fix `moduleFqnByShort` resolution in `compare.ts` — when flattening an abstract base class's includes, prefer the module in the same namespace (e.g. `ConnectionAdapters::Quoting`) over adapter-specific variants (`PostgreSQL::Quoting`). Fixing this should lift abstract_adapter.rb from 374/465 → ~450+/465 without any TS changes.
2. **Follow-up wiring PR** (low priority, ~6 methods): Wire `insert`, `update`, `delete`, `raw_execute`, `internal_execute`, `execute_batch` into the `DatabaseStatements` const object.

## What changed

`docs/activerecord-100-plan.md` — added triage summary under Wave 6.