### PR TITLE
fix(api-compare): scope include resolution to host namespace

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -6,6 +6,7 @@ import {
   methodInMode,
   tsShouldIncludeInIndex,
   flattenIncludedMethodInfos,
+  resolveModuleName,
   dedupeRubyMethodInto,
   selectMisplacedFile,
   MISPLACED_MIN_HITS,
@@ -287,7 +288,7 @@ describe("flattenIncludedMethodInfos", () => {
       ["Predications", ["Arel::Predications"]],
       ["Math", ["Arel::Math"]],
     ]);
-    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    const f = flattenIncludedMethodInfos(host, "Arel::Nodes::NodeExpression", pkg, byShort);
     expect(f.instance.map((m) => m.name).sort()).toEqual(
       ["add", "eq", "gt", "hash", "lt", "subtract"].sort(),
     );
@@ -309,7 +310,7 @@ describe("flattenIncludedMethodInfos", () => {
       modules: { Enum: enums },
     };
     const byShort = new Map([["Enum", ["Enum"]]]);
-    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    const f = flattenIncludedMethodInfos(host, "Base", pkg, byShort);
     expect(f.instance.map((m) => m.name)).toEqual([]);
     expect(f.klass.map((m) => m.name).sort()).toEqual(["inherited", "lookup", "values"]);
   });
@@ -334,7 +335,7 @@ describe("flattenIncludedMethodInfos", () => {
       ["Predications", ["Arel::Predications"]],
       ["Constants", ["Arel::Constants"]],
     ]);
-    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    const f = flattenIncludedMethodInfos(host, "Arel::Attribute", pkg, byShort);
     expect(f.instance.map((m) => m.name).sort()).toEqual(["eq", "null", "true_value"]);
   });
 
@@ -363,7 +364,7 @@ describe("flattenIncludedMethodInfos", () => {
       ["Concern", ["Concern"]],
       ["MyConcern", ["MyConcern"]],
     ]);
-    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    const f = flattenIncludedMethodInfos(host, "Host", pkg, byShort);
     expect(f.instance.map((m) => m.name).sort()).toEqual(["instance_helper"]);
     expect(f.klass).toEqual([]);
   });
@@ -379,7 +380,7 @@ describe("flattenIncludedMethodInfos", () => {
       classMethods: [],
     };
     const pkg: PackageInfo = { classes: {}, modules: {} };
-    const f = flattenIncludedMethodInfos(host, pkg, new Map());
+    const f = flattenIncludedMethodInfos(host, "Range", pkg, new Map());
     expect(f.instance.map((m) => m.name)).toEqual(["first"]);
   });
 
@@ -399,8 +400,132 @@ describe("flattenIncludedMethodInfos", () => {
       ["A", ["A"]],
       ["B", ["B"]],
     ]);
-    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    const f = flattenIncludedMethodInfos(host, "Host", pkg, byShort);
     expect(f.instance.map((m) => m.name).sort()).toEqual(["a1", "b1", "h1"]);
+  });
+
+  it("scopes include resolution to host namespace — base Quoting, not adapter siblings", () => {
+    // AbstractAdapter includes "Quoting". Ruby resolves to the base
+    // ConnectionAdapters::Quoting, NOT to PostgreSQL::Quoting or MySQL::Quoting.
+    const baseQuoting = mod("Quoting", ["quote", "quoteColumnName"]);
+    const pgQuoting = mod("PostgreSQL::Quoting", ["escapeBytea", "quoteSchemaName"]);
+    const mysqlQuoting = mod("MySQL::Quoting", ["unquotedBool"]);
+    const host: ClassInfo = {
+      name: "AbstractAdapter",
+      file: "connection_adapters/abstract_adapter.rb",
+      includes: ["Quoting"],
+      extends: [],
+      instanceMethods: [],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = {
+      classes: {},
+      modules: {
+        "ActiveRecord::ConnectionAdapters::Quoting": baseQuoting,
+        "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting": pgQuoting,
+        "ActiveRecord::ConnectionAdapters::MySQL::Quoting": mysqlQuoting,
+      },
+    };
+    const byShort = new Map([
+      [
+        "Quoting",
+        [
+          "ActiveRecord::ConnectionAdapters::Quoting",
+          "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting",
+          "ActiveRecord::ConnectionAdapters::MySQL::Quoting",
+        ],
+      ],
+    ]);
+    const f = flattenIncludedMethodInfos(
+      host,
+      "ActiveRecord::ConnectionAdapters::AbstractAdapter",
+      pkg,
+      byShort,
+    );
+    // Should only get base Quoting methods, NOT PG or MySQL specifics
+    expect(f.instance.map((m) => m.name).sort()).toEqual(["quote", "quoteColumnName"]);
+  });
+
+  it("scopes include resolution to adapter namespace — adapter-specific Quoting", () => {
+    // PostgreSQLAdapter includes "Quoting". Ruby resolves to PostgreSQL::Quoting.
+    const baseQuoting = mod("Quoting", ["quote", "quoteColumnName"]);
+    const pgQuoting = mod("PostgreSQL::Quoting", ["escapeBytea", "quoteSchemaName"]);
+    const host: ClassInfo = {
+      name: "PostgreSQLAdapter",
+      file: "connection_adapters/postgresql_adapter.rb",
+      includes: ["Quoting"],
+      extends: [],
+      instanceMethods: [],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = {
+      classes: {},
+      modules: {
+        "ActiveRecord::ConnectionAdapters::Quoting": baseQuoting,
+        "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting": pgQuoting,
+      },
+    };
+    const byShort = new Map([
+      [
+        "Quoting",
+        [
+          "ActiveRecord::ConnectionAdapters::Quoting",
+          "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting",
+        ],
+      ],
+    ]);
+    const f = flattenIncludedMethodInfos(
+      host,
+      "ActiveRecord::ConnectionAdapters::PostgreSQL::PostgreSQLAdapter",
+      pkg,
+      byShort,
+    );
+    // Should resolve to PostgreSQL::Quoting, not the base abstract Quoting
+    expect(f.instance.map((m) => m.name).sort()).toEqual(["escapeBytea", "quoteSchemaName"]);
+  });
+});
+
+describe("resolveModuleName", () => {
+  it("returns the single candidate unchanged", () => {
+    const byShort = new Map([["Quoting", ["AR::ConnectionAdapters::Quoting"]]]);
+    expect(
+      resolveModuleName("Quoting", "AR::ConnectionAdapters::AbstractAdapter", byShort),
+    ).toEqual(["AR::ConnectionAdapters::Quoting"]);
+  });
+
+  it("passes through already-qualified names", () => {
+    const byShort = new Map([["Foo::Bar", ["Foo::Bar"]]]);
+    expect(resolveModuleName("Foo::Bar", "Baz::Qux", byShort)).toEqual(["Foo::Bar"]);
+  });
+
+  it("returns all candidates when context has no prefix match", () => {
+    const byShort = new Map([["Foo", ["X::Foo", "Y::Foo"]]]);
+    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual(["X::Foo", "Y::Foo"]);
+  });
+
+  it("prefers nearest namespace prefix — abstract base wins over sibling adapter", () => {
+    const candidates = [
+      "AR::ConnectionAdapters::Quoting",
+      "AR::ConnectionAdapters::PostgreSQL::Quoting",
+      "AR::ConnectionAdapters::MySQL::Quoting",
+    ];
+    const byShort = new Map([["Quoting", candidates]]);
+    const result = resolveModuleName("Quoting", "AR::ConnectionAdapters::AbstractAdapter", byShort);
+    expect(result).toEqual(["AR::ConnectionAdapters::Quoting"]);
+  });
+
+  it("prefers adapter-specific namespace when including class is in that namespace", () => {
+    const candidates = [
+      "AR::ConnectionAdapters::Quoting",
+      "AR::ConnectionAdapters::PostgreSQL::Quoting",
+    ];
+    const byShort = new Map([["Quoting", candidates]]);
+    const result = resolveModuleName(
+      "Quoting",
+      "AR::ConnectionAdapters::PostgreSQL::PostgreSQLAdapter",
+      byShort,
+    );
+    expect(result).toEqual(["AR::ConnectionAdapters::PostgreSQL::Quoting"]);
   });
 });
 

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -493,9 +493,9 @@ describe("resolveModuleName", () => {
     ).toEqual(["AR::ConnectionAdapters::Quoting"]);
   });
 
-  it("passes through already-qualified names", () => {
-    const byShort = new Map([["Foo::Bar", ["Foo::Bar"]]]);
-    expect(resolveModuleName("Foo::Bar", "Baz::Qux", byShort)).toEqual(["Foo::Bar"]);
+  it("passes through already-qualified names without consulting the map", () => {
+    // Early return fires on "::" — byShort is irrelevant for pre-qualified names.
+    expect(resolveModuleName("Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
   });
 
   it("returns all candidates when context has no prefix match", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -315,6 +315,45 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
 }
 
 /**
+ * Resolve a bare include name (e.g. `"Quoting"`) to the best-matching FQN(s)
+ * from the perspective of `contextFqn` (the including class or module).
+ *
+ * Ruby's constant lookup walks enclosing namespaces outward. Given
+ * `ActiveRecord::ConnectionAdapters::AbstractAdapter` including `"Quoting"`,
+ * Ruby resolves to `ActiveRecord::ConnectionAdapters::Quoting` — NOT to
+ * `ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting` even though both
+ * have the same short name. This scoped resolution avoids the false-positive
+ * where PostgreSQL-specific methods inflate AbstractAdapter's missing count.
+ *
+ * If the name already contains `::` it is returned as-is. If only one FQN
+ * matches the short name, that single candidate is returned regardless of
+ * context. When multiple candidates exist, namespace-prefix walking picks the
+ * nearest enclosing match; if none of the candidates share a namespace prefix
+ * with the context the full candidate list is returned (original behavior,
+ * safe fallback).
+ */
+export function resolveModuleName(
+  incName: string,
+  contextFqn: string,
+  moduleFqnByShort: Map<string, string[]>,
+): string[] {
+  if (incName.includes("::")) return [incName];
+  const candidates = moduleFqnByShort.get(incName);
+  if (!candidates || candidates.length === 0) return [incName];
+  if (candidates.length === 1) return candidates;
+
+  // Walk namespace prefixes from longest to shortest, pick first match.
+  const parts = contextFqn.split("::");
+  for (let i = parts.length; i > 0; i--) {
+    const candidate = `${parts.slice(0, i).join("::")}::${incName}`;
+    if (candidates.includes(candidate)) return [candidate];
+  }
+
+  // No prefix match — fall back to all candidates (original behavior).
+  return candidates;
+}
+
+/**
  * Flatten `include`/`extend`-reachable methods onto a host entity.
  *
  * Ruby's `include Mod` flattens Mod's instance methods onto the including
@@ -338,9 +377,14 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
  *
  * Cycles are guarded by `visited`. Modules outside the package are
  * silently skipped — stdlib like `Comparable`/`Enumerable` falls through.
+ *
+ * `entityFqn` drives namespace-scoped include resolution (see
+ * `resolveModuleName`): `AbstractAdapter` including `"Quoting"` resolves
+ * only to `ConnectionAdapters::Quoting`, not to adapter-specific siblings.
  */
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
+  entityFqn: string,
   rubyPkg: PackageInfo,
   moduleFqnByShort: Map<string, string[]>,
 ): { instance: MethodInfo[]; klass: MethodInfo[] } {
@@ -348,8 +392,8 @@ export function flattenIncludedMethodInfos(
   const klass: MethodInfo[] = [...entity.classMethods];
   const visited = new Set<string>();
 
-  const walk = (incName: string, asClassMethods: boolean): void => {
-    const fqns = moduleFqnByShort.get(incName) ?? [incName];
+  const walk = (incName: string, asClassMethods: boolean, contextFqn: string): void => {
+    const fqns = resolveModuleName(incName, contextFqn, moduleFqnByShort);
     for (const fqn of fqns) {
       if (visited.has(fqn)) continue;
       visited.add(fqn);
@@ -357,12 +401,12 @@ export function flattenIncludedMethodInfos(
       if (!mod) continue;
       const sink = asClassMethods ? klass : instance;
       for (const m of mod.instanceMethods) sink.push(m);
-      for (const inc of mod.includes ?? []) walk(inc, asClassMethods);
+      for (const inc of mod.includes ?? []) walk(inc, asClassMethods, fqn);
     }
   };
 
-  for (const inc of entity.includes ?? []) walk(inc, false);
-  for (const ext of entity.extends ?? []) walk(ext, true);
+  for (const inc of entity.includes ?? []) walk(inc, false, entityFqn);
+  for (const ext of entity.extends ?? []) walk(ext, true, entityFqn);
   return { instance, klass };
 }
 
@@ -815,7 +859,7 @@ function main() {
       // `invert`). Count once.
       const seen = new Map<string, { rubyName: string; rubyModule: string }>();
       for (const item of items) {
-        const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
+        const f = flattenIncludedMethodInfos(item.info, item.fqn, rubyPkg, moduleFqnByShort);
         const rubyMethods = [...f.instance, ...f.klass];
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;


### PR DESCRIPTION
## Summary

\`api:compare\` was multi-resolving bare module names (e.g. \`"Quoting"\`) against every FQN sharing that short name. When \`AbstractAdapter\` includes \`"Quoting"\`, the comparator pulled in \`PostgreSQL::Quoting\`, \`MySQL::Quoting\`, and \`SQLite3::Quoting\` in addition to the abstract base \`Quoting\` — so adapter-specific methods like \`escapeBytea\` appeared as missing from \`abstract_adapter.rb\` even though they're correctly implemented in their own adapter files.

**Root cause:** \`flattenIncludedMethodInfos\` called \`moduleFqnByShort.get(incName)\` which returns all FQNs with that short name. No namespace scoping.

**Fix:** Add \`resolveModuleName(incName, contextFqn, byShort)\` which walks namespace prefixes outward from the including entity's FQN, returning the first candidate that shares a prefix. Thread \`entityFqn\` through the recursive walk so nested includes scope correctly too.

## Before / After

| File | Before | After |
|------|--------|-------|
| \`connection_adapters/abstract_adapter.rb\` | 374/465 (80%) | 373/379 (98%) |
| \`connection_adapters/postgresql/quoting.rb\` | 23/23 (100%) | 23/23 (100%) |
| \`connection_adapters/mysql/quoting.rb\` | 10/10 (100%) | 10/10 (100%) |
| **Overall** | 4861/5060 (96.1%) | 4855/4969 (97.7%) |

85 false positives removed. 6 genuine gaps remain on \`abstract_adapter.rb\` (Category B from #1297, separate PR).

## Out of scope

The \`moduleIncluderFqns\` builder (used for "move detection") at ~line 750 also calls \`moduleFqnByShort.get(inc)\` without namespace scoping. That graph answers "which TS files host this module's methods" and does not affect missing/matched counts — intentionally left unfixed here to keep the PR focused.