### PR TITLE
feat(activerecord): PR 37d — finder privates, relation.rb 95%→100%

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4993,8 +4993,8 @@ export class Relation<T extends Base> {
   }
 
   /** @internal */
-  private findNthWithLimit(index: number): Promise<any | null> {
-    return _fm.findNthWithLimit.call(this as any, index);
+  private findNthWithLimit(index: number, limit: number): Promise<any[]> {
+    return _fm.findNthWithLimit.call(this as any, index, limit);
   }
 
   /** @internal */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -85,7 +85,9 @@ import {
   isBuildCountSubquery as _isBuildCountSubquery,
   buildCountSubquery as _buildCountSubquery,
 } from "./relation/calculations.js";
+import * as _fm from "./relation/finder-methods.js";
 import { FinderMethods } from "./relation/finder-methods.js";
+import * as _sm from "./relation/spawn-methods.js";
 import { SpawnMethods } from "./relation/spawn-methods.js";
 import { FromClause } from "./relation/from-clause.js";
 import { TableMetadata } from "./table-metadata.js";
@@ -4934,6 +4936,90 @@ export class Relation<T extends Base> {
   /** @internal */
   private async(): Relation<T> {
     return (this.spawn() as any).asyncBang();
+  }
+
+  // ---------------------------------------------------------------------------
+  // PR 37d — finder privates (delegates to relation/finder-methods.ts + spawn-methods.ts)
+  // ---------------------------------------------------------------------------
+
+  /** @internal */
+  private constructRelationForExists(conditions: unknown): any {
+    return _fm.constructRelationForExists(this as any, conditions);
+  }
+
+  /** @internal */
+  private applyJoinDependency(eagerLoading: boolean): any {
+    return _fm.applyJoinDependency(this as any, eagerLoading);
+  }
+
+  /** @internal */
+  private isUsingLimitableReflections(reflections: unknown[]): boolean {
+    return _fm.isUsingLimitableReflections(reflections);
+  }
+
+  /** @internal */
+  private async findWithIds(ids: unknown[]): Promise<any> {
+    return _fm.findWithIds(this as any, ids);
+  }
+
+  /** @internal */
+  private async findOne(id: unknown): Promise<any> {
+    return _fm.findOne(this as any, id);
+  }
+
+  /** @internal */
+  private async findSome(ids: unknown[]): Promise<any[]> {
+    return _fm.findSome(this as any, ids);
+  }
+
+  /** @internal */
+  private async findSomeOrdered(ids: unknown[]): Promise<any[]> {
+    return _fm.findSomeOrdered(this as any, ids);
+  }
+
+  /** @internal */
+  private async findTake(): Promise<any | null> {
+    return _fm.findTake(this as any);
+  }
+
+  /** @internal */
+  private async findTakeWithLimit(limit: number): Promise<any[]> {
+    return _fm.findTakeWithLimit(this as any, limit);
+  }
+
+  /** @internal */
+  private findNth(index: number): Promise<any | null> {
+    return _fm.findNth(this as any, index);
+  }
+
+  /** @internal */
+  private findNthWithLimit(index: number): Promise<any | null> {
+    return _fm.findNthWithLimit.call(this as any, index);
+  }
+
+  /** @internal */
+  private findNthFromLast(index: number): Promise<any | null> {
+    return _fm.findNthFromLast.call(this as any, index);
+  }
+
+  /** @internal */
+  private async findLast(limit?: number): Promise<any> {
+    return _fm.findLast(this as any, limit);
+  }
+
+  /** @internal */
+  private orderedRelation(): any {
+    return _fm.orderedRelation(this as any);
+  }
+
+  /** @internal */
+  private _orderColumns(): string[] {
+    return _fm._orderColumns(this as any);
+  }
+
+  /** @internal */
+  private relationWith(values: Partial<Relation<T>>): Relation<T> {
+    return _sm.relationWith(this as any, values as any);
   }
 }
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -612,10 +612,15 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
     // Rails Array form: [sql, bind1, bind2, ...] — spread to avoid triggering
     // the composite-key overload of where() which requires all-string arrays.
     const [sql, ...binds] = conditions as unknown[];
-    if (sql !== undefined) relation = relation.where(sql as string, ...binds);
+    if (sql !== undefined) relation = relation.where(sql, ...binds);
+  } else if (conditions instanceof Nodes.Node) {
+    // Arel node — pass directly rather than wrapping as a PK value.
+    relation = relation.where(conditions);
   } else if (typeof conditions === "object") {
+    // Hash-like: Rails' `when Hash` branch — skip if empty.
     if (Object.keys(conditions as object).length > 0) relation = relation.where(conditions);
   } else {
+    // Scalar → PK lookup (Rails' else branch: `where!(primary_key => conditions)`).
     const pk = (rel as any)._modelClass.primaryKey;
     relation = relation.where({ [pk as string]: conditions });
   }

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -431,6 +431,9 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
     return records[records.length - 1 - index] ?? null;
   }
   const relation: any = orderedRelation(this);
+  // Rails: `if relation.order_values.empty? || relation.has_limit_or_offset?`
+  // After fixing orderedRelation to preserve existing order, checking the result
+  // is equivalent to Rails' post-ordered_relation check.
   if (
     (relation as any)._orderClauses.length === 0 ||
     (relation as any)._limitValue != null ||
@@ -592,13 +595,16 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
   if (conditions === false) return rel;
   // Rails: except(:select, :distinct, :order)._select!("1 AS one").limit!(1)
   // (or except(:order).limit!(1) when distinct+offset are both set)
-  let relation: any =
-    (rel as any)._isDistinct && (rel as any)._offsetValue != null
-      ? (rel as any).unscope("order").limit(1)
-      : (rel as any)
-          .unscope("select", "distinct", "order")
-          .select(new Nodes.SqlLiteral("1 AS one"))
-          .limit(1);
+  let relation: any;
+  if ((rel as any)._isDistinct && (rel as any)._offsetValue != null) {
+    relation = (rel as any).unscope("order").limit(1);
+  } else {
+    // Rails: except(:select, :distinct, :order) — "distinct" is not a valid
+    // unscope() key so clear _isDistinct directly on the cloned relation.
+    relation = (rel as any).unscope("select", "order");
+    relation._isDistinct = false;
+    relation = relation.select(new Nodes.SqlLiteral("1 AS one")).limit(1);
+  }
   if (conditions === null || conditions === undefined || conditions === true) {
     return relation;
   }
@@ -717,7 +723,11 @@ export async function findLast(rel: FinderRelation, limit?: number): Promise<any
 
 /** @internal */
 export function orderedRelation(rel: FinderRelation): any {
-  return orderByPk(rel, "asc");
+  if (!hasOrder(rel)) {
+    const pk = (rel as any)._modelClass?.primaryKey;
+    if (pk) return orderByPk(rel, "asc");
+  }
+  return rel;
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -432,10 +432,10 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
   }
   const relation: any = orderedRelation(this);
   // Rails: `if relation.order_values.empty? || relation.has_limit_or_offset?`
-  // After fixing orderedRelation to preserve existing order, checking the result
-  // is equivalent to Rails' post-ordered_relation check.
+  // Use hasOrder() on the result so _rawOrderClauses (e.g. inOrderOf) are also
+  // treated as "has an order" — avoids loading all records for those relations.
   if (
-    (relation as any)._orderClauses.length === 0 ||
+    !hasOrder(relation) ||
     (relation as any)._limitValue != null ||
     (relation as any)._offsetValue != null
   ) {
@@ -609,7 +609,10 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
     return relation;
   }
   if (Array.isArray(conditions)) {
-    if ((conditions as unknown[]).length > 0) relation = relation.where(conditions);
+    // Rails Array form: [sql, bind1, bind2, ...] — spread to avoid triggering
+    // the composite-key overload of where() which requires all-string arrays.
+    const [sql, ...binds] = conditions as unknown[];
+    if (sql !== undefined) relation = relation.where(sql as string, ...binds);
   } else if (typeof conditions === "object") {
     if (Object.keys(conditions as object).length > 0) relation = relation.where(conditions);
   } else {

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -622,7 +622,11 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
   } else {
     // Scalar → PK lookup (Rails' else branch: `where!(primary_key => conditions)`).
     const pk = (rel as any)._modelClass.primaryKey;
-    relation = relation.where({ [pk as string]: conditions });
+    if (Array.isArray(pk)) {
+      relation = relation.where(buildPkWhere(pk, conditions as unknown[]));
+    } else {
+      relation = relation.where({ [pk as string]: conditions });
+    }
   }
   return relation;
 }
@@ -668,11 +672,12 @@ export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<
 
 /** @internal */
 export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
-  const pk = (rel as any)._modelClass.primaryKey as string;
-  const record = await (rel as any).findBy({ [pk]: id });
+  const pk = (rel as any)._modelClass.primaryKey;
+  const conditions = Array.isArray(pk) ? buildPkWhere(pk, id as unknown[]) : { [pk as string]: id };
+  const record = await (rel as any).findBy(conditions);
   if (!record) {
     const modelName = (rel as any)._modelClass.name as string;
-    throw new RecordNotFound(`Couldn't find ${modelName}`, modelName, pk, id);
+    throw new RecordNotFound(`Couldn't find ${modelName}`, modelName, String(pk), id);
   }
   return record;
 }

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -405,46 +405,58 @@ export async function performTakeBang(this: FinderRelation): Promise<any> {
 }
 
 /** @internal */
-export async function findNthWithLimit(this: FinderRelation, index: number): Promise<any | null> {
-  let rel = this._clone();
-  rel._limitValue = 1;
-  rel._offsetValue = (this._offsetValue ?? 0) + index;
-  if (!hasOrder(rel)) {
-    rel = orderByPk(rel, "asc");
+export async function findNthWithLimit(
+  this: FinderRelation,
+  index: number,
+  limit: number,
+): Promise<any[]> {
+  if ((this as any)._loaded) {
+    return (this as any)._records.slice(index, index + limit) ?? [];
   }
-  const records = await rel.toArray();
-  return records[0] ?? null;
+  let relation: any = orderedRelation(this);
+  if ((this as any)._limitValue != null) {
+    limit = Math.min((this as any)._limitValue - index, limit);
+  }
+  if (limit <= 0) return [];
+  if (index > 0) {
+    relation = relation.offset(((this as any)._offsetValue ?? 0) + index);
+  }
+  return relation.limit(limit).toArray();
 }
 
 /** @internal */
 export async function findNthFromLast(this: FinderRelation, index: number): Promise<any | null> {
-  let rel: any;
-  if (!hasReversibleOrder(this)) {
-    rel = orderByPk(this, "desc");
-  } else {
-    rel = this.reverseOrder();
+  if ((this as any)._loaded) return (this as any)._records[-(index + 1)] ?? null;
+  const relation: any = orderedRelation(this);
+  if (
+    (relation as any)._orderValues?.length === 0 ||
+    (relation as any)._limitValue != null ||
+    (relation as any)._offsetValue != null
+  ) {
+    const records = await relation.toArray();
+    return records[records.length - 1 - index] ?? null;
   }
-  return findNthWithLimit.call(rel, index);
+  return relation.reverseOrder().offset(index).first();
 }
 
 export async function performSecond(this: FinderRelation): Promise<any | null> {
-  return findNthWithLimit.call(this, 1);
+  return (await findNthWithLimit.call(this, 1, 1))[0] ?? null;
 }
 
 export async function performThird(this: FinderRelation): Promise<any | null> {
-  return findNthWithLimit.call(this, 2);
+  return (await findNthWithLimit.call(this, 2, 1))[0] ?? null;
 }
 
 export async function performFourth(this: FinderRelation): Promise<any | null> {
-  return findNthWithLimit.call(this, 3);
+  return (await findNthWithLimit.call(this, 3, 1))[0] ?? null;
 }
 
 export async function performFifth(this: FinderRelation): Promise<any | null> {
-  return findNthWithLimit.call(this, 4);
+  return (await findNthWithLimit.call(this, 4, 1))[0] ?? null;
 }
 
 export async function performFortyTwo(this: FinderRelation): Promise<any | null> {
-  return findNthWithLimit.call(this, 41);
+  return (await findNthWithLimit.call(this, 41, 1))[0] ?? null;
 }
 
 export async function performSecondToLast(this: FinderRelation): Promise<any | null> {
@@ -574,15 +586,25 @@ export const FinderMethods = {
 
 /** @internal */
 export function constructRelationForExists(rel: FinderRelation, conditions: unknown): any {
-  if (conditions === false || conditions === null) return rel;
-  if (typeof conditions === "object" && conditions !== null) {
-    return (rel as any).where(conditions);
+  if (conditions === false) return rel;
+  // Rails: except(:select, :distinct, :order)._select!("1 AS one").limit!(1)
+  // (or except(:order).limit!(1) when distinct+offset are both set)
+  let relation: any =
+    (rel as any)._distinctValue && (rel as any)._offsetValue != null
+      ? (rel as any).unscope("order").limit(1)
+      : (rel as any).unscope("select", "order").select("1 AS one").limit(1);
+  if (conditions === null || conditions === undefined || conditions === true) {
+    return relation;
   }
-  if (conditions !== undefined && conditions !== true) {
+  if (Array.isArray(conditions)) {
+    if ((conditions as unknown[]).length > 0) relation = relation.where(conditions);
+  } else if (typeof conditions === "object") {
+    if (Object.keys(conditions as object).length > 0) relation = relation.where(conditions);
+  } else {
     const pk = (rel as any)._modelClass.primaryKey;
-    return (rel as any).where({ [pk as string]: conditions });
+    relation = relation.where({ [pk as string]: conditions });
   }
-  return rel;
+  return relation;
 }
 
 /** @internal */
@@ -678,8 +700,8 @@ export async function findTakeWithLimit(rel: FinderRelation, limit: number): Pro
 }
 
 /** @internal */
-export function findNth(rel: FinderRelation, index: number): Promise<any | null> {
-  return findNthWithLimit.call(rel, index);
+export async function findNth(rel: FinderRelation, index: number): Promise<any | null> {
+  return (await findNthWithLimit.call(rel, index, 1))[0] ?? null;
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -426,10 +426,13 @@ export async function findNthWithLimit(
 
 /** @internal */
 export async function findNthFromLast(this: FinderRelation, index: number): Promise<any | null> {
-  if ((this as any)._loaded) return (this as any)._records[-(index + 1)] ?? null;
+  if ((this as any)._loaded) {
+    const records: any[] = (this as any)._records;
+    return records[records.length - 1 - index] ?? null;
+  }
   const relation: any = orderedRelation(this);
   if (
-    (relation as any)._orderValues?.length === 0 ||
+    (relation as any)._orderClauses.length === 0 ||
     (relation as any)._limitValue != null ||
     (relation as any)._offsetValue != null
   ) {
@@ -590,7 +593,7 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
   // Rails: except(:select, :distinct, :order)._select!("1 AS one").limit!(1)
   // (or except(:order).limit!(1) when distinct+offset are both set)
   let relation: any =
-    (rel as any)._distinctValue && (rel as any)._offsetValue != null
+    (rel as any)._isDistinct && (rel as any)._offsetValue != null
       ? (rel as any).unscope("order").limit(1)
       : (rel as any).unscope("select", "order").select("1 AS one").limit(1);
   if (conditions === null || conditions === undefined || conditions === true) {

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -595,7 +595,10 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
   let relation: any =
     (rel as any)._isDistinct && (rel as any)._offsetValue != null
       ? (rel as any).unscope("order").limit(1)
-      : (rel as any).unscope("select", "order").select("1 AS one").limit(1);
+      : (rel as any)
+          .unscope("select", "distinct", "order")
+          .select(new Nodes.SqlLiteral("1 AS one"))
+          .limit(1);
   if (conditions === null || conditions === undefined || conditions === true) {
     return relation;
   }

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -405,7 +405,7 @@ export async function performTakeBang(this: FinderRelation): Promise<any> {
 }
 
 /** @internal */
-async function findNthWithLimit(this: FinderRelation, index: number): Promise<any | null> {
+export async function findNthWithLimit(this: FinderRelation, index: number): Promise<any | null> {
   let rel = this._clone();
   rel._limitValue = 1;
   rel._offsetValue = (this._offsetValue ?? 0) + index;
@@ -417,7 +417,7 @@ async function findNthWithLimit(this: FinderRelation, index: number): Promise<an
 }
 
 /** @internal */
-async function findNthFromLast(this: FinderRelation, index: number): Promise<any | null> {
+export async function findNthFromLast(this: FinderRelation, index: number): Promise<any | null> {
   let rel: any;
   if (!hasReversibleOrder(this)) {
     rel = orderByPk(this, "desc");
@@ -573,7 +573,7 @@ export const FinderMethods = {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-function constructRelationForExists(rel: FinderRelation, conditions: unknown): any {
+export function constructRelationForExists(rel: FinderRelation, conditions: unknown): any {
   if (conditions === false || conditions === null) return rel;
   if (typeof conditions === "object" && conditions !== null) {
     return (rel as any).where(conditions);
@@ -586,7 +586,7 @@ function constructRelationForExists(rel: FinderRelation, conditions: unknown): a
 }
 
 /** @internal */
-function applyJoinDependency(rel: FinderRelation, eagerLoading: boolean): any {
+export function applyJoinDependency(rel: FinderRelation, eagerLoading: boolean): any {
   if (!eagerLoading) return rel;
   // Rails: when eager loading, apply a LEFT OUTER JOIN via the join dependency.
   // Our preloader handles this via separate queries, but we record the join type.
@@ -605,14 +605,14 @@ function applyJoinDependency(rel: FinderRelation, eagerLoading: boolean): any {
 }
 
 /** @internal */
-function isUsingLimitableReflections(reflections: unknown[]): boolean {
+export function isUsingLimitableReflections(reflections: unknown[]): boolean {
   return (reflections as any[]).every(
     (r) => r.macro !== "hasMany" && r.macro !== "hasAndBelongsToMany",
   );
 }
 
 /** @internal */
-async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
+export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
   const normalized = normalizeFindArgs(
     (rel as any)._modelClass.name,
     (rel as any)._modelClass.primaryKey,
@@ -625,7 +625,7 @@ async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
 }
 
 /** @internal */
-async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
+export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
   const pk = (rel as any)._modelClass.primaryKey as string;
   const record = await (rel as any).findBy({ [pk]: id });
   if (!record) {
@@ -636,7 +636,7 @@ async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
 }
 
 /** @internal */
-async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
+export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
   const pk = (rel as any)._modelClass.primaryKey as string;
   const records = await (rel as any).where({ [pk]: ids }).toArray();
   if (records.length !== ids.length) {
@@ -655,7 +655,7 @@ async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
 }
 
 /** @internal */
-async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
+export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
   const pk = (rel as any)._modelClass.primaryKey;
   const records = await findSome(rel, ids);
   const idIndex = new Map(ids.map((id, i) => [String(id), i]));
@@ -667,33 +667,33 @@ async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Promise<any
 }
 
 /** @internal */
-async function findTake(rel: FinderRelation): Promise<any | null> {
+export async function findTake(rel: FinderRelation): Promise<any | null> {
   const records = await (rel as any).limit(1).toArray();
   return records[0] ?? null;
 }
 
 /** @internal */
-async function findTakeWithLimit(rel: FinderRelation, limit: number): Promise<any[]> {
+export async function findTakeWithLimit(rel: FinderRelation, limit: number): Promise<any[]> {
   return (rel as any).limit(limit).toArray();
 }
 
 /** @internal */
-function findNth(rel: FinderRelation, index: number): Promise<any | null> {
+export function findNth(rel: FinderRelation, index: number): Promise<any | null> {
   return findNthWithLimit.call(rel, index);
 }
 
 /** @internal */
-async function findLast(rel: FinderRelation, limit?: number): Promise<any> {
+export async function findLast(rel: FinderRelation, limit?: number): Promise<any> {
   return performLast.call(rel, limit);
 }
 
 /** @internal */
-function orderedRelation(rel: FinderRelation): any {
+export function orderedRelation(rel: FinderRelation): any {
   return orderByPk(rel, "asc");
 }
 
 /** @internal */
-function _orderColumns(rel: FinderRelation): string[] {
+export function _orderColumns(rel: FinderRelation): string[] {
   const pk = (rel as any)._modelClass.primaryKey;
   return Array.isArray(pk) ? pk : [pk];
 }

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -110,7 +110,7 @@ export const SpawnMethods = {
 } as const;
 
 /** @internal */
-function relationWith<T extends SpawnRelation<T>>(self: T, values: Partial<T>): T {
+export function relationWith<T extends SpawnRelation<T>>(self: T, values: Partial<T>): T {
   const result = self._clone();
   for (const [key, val] of Object.entries(values as Record<string, unknown>)) {
     (result as any)[key] = val;


### PR DESCRIPTION
## Summary

Final split of the relation.rb series. All 16 missing finder-cluster privates were already implemented in \`relation/finder-methods.ts\` and \`relation/spawn-methods.ts\` — exported and wired into \`Relation\` via delegation wrappers. Two fixes landed in a follow-up commit after Rails-source review.

### Changes

- Export 15 private helpers from \`relation/finder-methods.ts\`: \`constructRelationForExists\`, \`applyJoinDependency\`, \`isUsingLimitableReflections\`, \`findWithIds\`, \`findOne\`, \`findSome\`, \`findSomeOrdered\`, \`findTake\`, \`findTakeWithLimit\`, \`findNth\`, \`findNthWithLimit\`, \`findNthFromLast\`, \`findLast\`, \`orderedRelation\`, \`_orderColumns\`
- Export \`relationWith\` from \`relation/spawn-methods.ts\`
- Add \`@internal\` delegation wrappers in \`Relation\` for all 16 methods
- Fix \`constructRelationForExists\`: call \`unscope("select","order").select("1 AS one").limit(1)\` before applying conditions, matching Rails' \`except(:select,:distinct,:order)._select!(ONE_AS_ONE).limit!(1)\`; handle empty Array/Hash conditions
- Fix \`findNthWithLimit\`: add \`limit\` param, \`loaded?\` fast-path, \`limit_value\` clamping, return \`any[]\` (matches Rails array return); update all callers (\`performSecond\`/\`Third\`/…, \`findNth\`, \`findNthFromLast\`)
- Fix \`findNthFromLast\`: add \`loaded?\` fast-path; match Rails branch logic (load-all when order empty or limit/offset set; otherwise \`reverseOrder().offset()\`)

### Deferred (noted in review, not blocking)

- \`findSome\`/\`findSomeOrdered\`: limit/offset expected-size accounting — affects scoped \`find(ids)\` with an existing limit; tracked for follow-up
- \`orderedRelation\`/\`_orderColumns\`: \`implicit_order_column\` + \`query_constraints_list\` — wire when those features land
- \`findTake\`/\`findTakeWithLimit\`: \`loaded?\` fast-path — low impact, tracked for follow-up

### Metrics

- \`relation.rb\`: 292/308 (95%) → 308/308 (100%) ✓
- \`activerecord\` overall: 4890/4969 (98.4%) → 4906/4969 (98.7%)

## Test plan

- [x] \`pnpm api:compare --package activerecord --files relation.rb\` → 308/308 (100%)
- [x] \`pnpm vitest run packages/activerecord/src/relation.test.ts\` → 117/117 passing
- [x] \`pnpm vitest run packages/activerecord/src/relation/finder-methods.test.ts\` → 18/18 passing
- [x] \`pnpm lint\` clean
- [x] 118 + 80 = ~200 LOC (under 300 ceiling)