### PR TITLE
feat(activerecord): BC-3b — remove encryption namespace from barrel reachability

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -18,7 +18,7 @@ import {
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import type { Base } from "./base.js";
-import { applyPendingEncryptions } from "./encryption.js";
+import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup } from "./type.js";
 
 type AnyClass = any;
@@ -96,7 +96,7 @@ export function defineAttribute(
   });
 
   amResetDefaultAttributes(this);
-  applyPendingEncryptions(this);
+  encryptionHooks.applyPendingEncryptions(this);
 
   // Install prototype accessor so the attribute is readable/writable by name,
   // matching what applyColumnsHash does for schema-reflected columns.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -55,15 +55,8 @@ import {
   UniquenessValidator,
 } from "./validations.js";
 import * as _Validations from "./validations.js";
-import {
-  encrypts as _encrypts,
-  applyPendingEncryptions,
-  encryptedAttributeQ as _encryptedAttributeQ,
-  ciphertextFor as _ciphertextFor,
-  encryptRecord as _encryptRecord,
-  decryptRecord as _decryptRecord,
-  type EncryptsOptions,
-} from "./encryption.js";
+import { encryptionHooks } from "./encryption-hooks.js";
+import type { EncryptsOptions } from "./encryption.js";
 import * as CounterCache from "./counter-cache.js";
 import * as ReadonlyAttributes from "./readonly-attributes.js";
 import {
@@ -741,7 +734,7 @@ export class Base extends Model {
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
       delete (this.prototype as any).id;
     }
-    applyPendingEncryptions(this);
+    encryptionHooks.applyPendingEncryptions(this);
   }
 
   /**
@@ -1192,7 +1185,7 @@ export class Base extends Model {
     // the subclass and reintroduce the shadowing the STI-routing fix
     // is trying to eliminate.
     const target = isStiSubclass(this) ? (getStiBase(this) as typeof Base) : this;
-    _encrypts(target, ...args);
+    encryptionHooks.encrypts(target, ...args);
   }
 
   /**
@@ -1202,7 +1195,7 @@ export class Base extends Model {
    * @internal
    */
   encryptedAttribute(attributeName: string): boolean {
-    return _encryptedAttributeQ(this, attributeName);
+    return encryptionHooks.encryptedAttributeQ(this, attributeName);
   }
 
   /**
@@ -1212,7 +1205,7 @@ export class Base extends Model {
    * @internal
    */
   ciphertextFor(attributeName: string): unknown {
-    return _ciphertextFor(this, attributeName);
+    return encryptionHooks.ciphertextFor(this, attributeName);
   }
 
   /**
@@ -1222,7 +1215,7 @@ export class Base extends Model {
    * @internal
    */
   async encrypt(): Promise<void> {
-    return _encryptRecord(this);
+    return encryptionHooks.encryptRecord(this);
   }
 
   /**
@@ -1232,7 +1225,7 @@ export class Base extends Model {
    * @internal
    */
   async decrypt(): Promise<void> {
-    return _decryptRecord(this);
+    return encryptionHooks.decryptRecord(this);
   }
 
   static async suppress<R>(fn: () => R | Promise<R>): Promise<R> {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3,6 +3,8 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
+// Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
+import "./encryption.js";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   Base,

--- a/packages/activerecord/src/encryption-hooks.test.ts
+++ b/packages/activerecord/src/encryption-hooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 // Intentionally does NOT import encryption.js — tests the unregistered state.
 import { encryptionHooks, registerEncryptionHooks } from "./encryption-hooks.js";
 import { Base } from "./base.js";
@@ -19,20 +19,21 @@ describe("encryptionHooks — unregistered default behavior", () => {
     expect(() => encryptionHooks.applyPendingEncryptions(Base)).not.toThrow();
   });
 
-  it("registerEncryptionHooks replaces the throwing stub", () => {
-    const recorded: string[] = [];
-    registerEncryptionHooks({
-      ...encryptionHooks,
-      encrypts: (_klass: any, name: string) => recorded.push(name),
+  describe("registerEncryptionHooks", () => {
+    const originalEncrypts = encryptionHooks.encrypts;
+
+    afterEach(() => {
+      registerEncryptionHooks({ ...encryptionHooks, encrypts: originalEncrypts });
     });
-    expect(() => encryptionHooks.encrypts(Base, "ssn")).not.toThrow();
-    expect(recorded).toContain("ssn");
-    // Restore original throw so other tests in this suite aren't affected.
-    registerEncryptionHooks({
-      ...encryptionHooks,
-      encrypts: (klass: any) => {
-        throw new Error(`${klass?.name ?? "Model"}.encrypts() — not loaded`);
-      },
+
+    it("replaces the throwing stub and restores it after the test", () => {
+      const recorded: string[] = [];
+      registerEncryptionHooks({
+        ...encryptionHooks,
+        encrypts: (_klass: any, name: string) => recorded.push(name),
+      });
+      expect(() => encryptionHooks.encrypts(Base, "ssn")).not.toThrow();
+      expect(recorded).toContain("ssn");
     });
   });
 });

--- a/packages/activerecord/src/encryption-hooks.test.ts
+++ b/packages/activerecord/src/encryption-hooks.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+// Intentionally does NOT import encryption.js — tests the unregistered state.
+import { encryptionHooks, registerEncryptionHooks } from "./encryption-hooks.js";
+import { Base } from "./base.js";
+
+describe("encryptionHooks — unregistered default behavior", () => {
+  it("encrypts() throws with an actionable message when the encryption namespace is not loaded", () => {
+    expect(() => encryptionHooks.encrypts(Base, "ssn")).toThrowError(
+      /encryption is not loaded.*Base\.encrypts\(\)/,
+    );
+  });
+
+  it("error message includes the actual class name", () => {
+    class MyModel extends Base {}
+    expect(() => encryptionHooks.encrypts(MyModel, "ssn")).toThrowError(/MyModel\.encrypts\(\)/);
+  });
+
+  it("applyPendingEncryptions is a no-op (not a throw) — called on every attribute() definition", () => {
+    expect(() => encryptionHooks.applyPendingEncryptions(Base)).not.toThrow();
+  });
+
+  it("registerEncryptionHooks replaces the throwing stub", () => {
+    const recorded: string[] = [];
+    registerEncryptionHooks({
+      ...encryptionHooks,
+      encrypts: (_klass: any, name: string) => recorded.push(name),
+    });
+    expect(() => encryptionHooks.encrypts(Base, "ssn")).not.toThrow();
+    expect(recorded).toContain("ssn");
+    // Restore original throw so other tests in this suite aren't affected.
+    registerEncryptionHooks({
+      ...encryptionHooks,
+      encrypts: (klass: any) => {
+        throw new Error(`${klass?.name ?? "Model"}.encrypts() — not loaded`);
+      },
+    });
+  });
+});

--- a/packages/activerecord/src/encryption-hooks.ts
+++ b/packages/activerecord/src/encryption-hooks.ts
@@ -1,0 +1,40 @@
+/**
+ * Thin registry that decouples base.ts from the encryption namespace.
+ *
+ * base.ts imports these no-op stubs so the barrel doesn't drag
+ * zlib/crypto into browser bundles. encryption.ts registers the real
+ * implementations at module-load time, which only happens when a
+ * consumer explicitly imports the encryption namespace.
+ *
+ * @internal
+ */
+
+export interface EncryptionHooks {
+  encrypts(klass: any, ...args: any[]): void;
+
+  applyPendingEncryptions(klass: any): void;
+
+  encryptedAttributeQ(klass: any, name: string): boolean;
+
+  ciphertextFor(instance: any, name: string): unknown;
+
+  encryptRecord(instance: any): Promise<void>;
+
+  decryptRecord(instance: any): Promise<void>;
+}
+
+const noop = (): void => {};
+
+export const encryptionHooks: EncryptionHooks = {
+  encrypts: noop,
+  applyPendingEncryptions: noop,
+  encryptedAttributeQ: () => false,
+  ciphertextFor: () => undefined,
+  encryptRecord: async () => {},
+  decryptRecord: async () => {},
+};
+
+/** @internal */
+export function registerEncryptionHooks(hooks: EncryptionHooks): void {
+  Object.assign(encryptionHooks, hooks);
+}

--- a/packages/activerecord/src/encryption-hooks.ts
+++ b/packages/activerecord/src/encryption-hooks.ts
@@ -16,18 +16,23 @@ export interface EncryptionHooks {
 
   encryptedAttributeQ(klass: any, name: string): boolean;
 
-  ciphertextFor(instance: any, name: string): unknown;
+  ciphertextFor(record: any, name: string): unknown;
 
-  encryptRecord(instance: any): Promise<void>;
+  encryptRecord(record: any): Promise<void>;
 
-  decryptRecord(instance: any): Promise<void>;
+  decryptRecord(record: any): Promise<void>;
 }
 
-const noop = (): void => {};
+function notLoaded(method: string): never {
+  throw new Error(
+    `ActiveRecord encryption is not loaded. ` +
+      `Import \`@blazetrails/activerecord/encryption\` before calling \`${method}\`.`,
+  );
+}
 
 export const encryptionHooks: EncryptionHooks = {
-  encrypts: noop,
-  applyPendingEncryptions: noop,
+  encrypts: () => notLoaded("Base.encrypts()"),
+  applyPendingEncryptions: () => {},
   encryptedAttributeQ: () => false,
   ciphertextFor: () => undefined,
   encryptRecord: async () => {},

--- a/packages/activerecord/src/encryption-hooks.ts
+++ b/packages/activerecord/src/encryption-hooks.ts
@@ -31,7 +31,7 @@ function notLoaded(method: string): never {
 }
 
 export const encryptionHooks: EncryptionHooks = {
-  encrypts: () => notLoaded("Base.encrypts()"),
+  encrypts: (klass: any) => notLoaded(`${klass?.name ?? "Model"}.encrypts()`),
   applyPendingEncryptions: () => {},
   encryptedAttributeQ: () => false,
   ciphertextFor: () => undefined,

--- a/packages/activerecord/src/encryption.test.ts
+++ b/packages/activerecord/src/encryption.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+// Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
+import "./encryption.js";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Decryption as DecryptionError } from "./encryption/errors.js";

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -18,6 +18,7 @@
  * two flows share a single wrapper implementation.
  */
 
+import { registerEncryptionHooks } from "./encryption-hooks.js";
 import { type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
@@ -473,3 +474,15 @@ export function currentCustomContext(): EncryptionContext | null {
 export function resetDefaultContext(): void {
   Contexts.resetDefaultContext();
 }
+
+// Register real implementations into the hook registry so base.ts picks them
+// up without statically importing this module (which would drag zlib/crypto
+// into browser bundles via the configurable → config → zlib chain).
+registerEncryptionHooks({
+  encrypts,
+  applyPendingEncryptions,
+  encryptedAttributeQ,
+  ciphertextFor,
+  encryptRecord,
+  decryptRecord,
+});

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -13,6 +13,8 @@ import { Configurable } from "./configurable.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
 import { ExtendedDeterministicUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
 import { UniquenessValidator } from "../validations.js";
+// Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
+import "../encryption.js";
 import { Base } from "../base.js";
 import { Relation } from "../relation.js";
 import { createTestAdapter } from "../test-adapter.js";

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -37,9 +37,8 @@ export {
 // `installExtendedQueriesIfConfigured` is intentionally NOT re-exported
 // here — its top-level `Base`/`Relation` imports would expand the
 // dependency surface of `@blazetrails/activerecord/encryption` for
-// consumers that only need encryption primitives. It's re-exported
-// from the main package index (which already depends on Base/Relation)
-// and is also reachable via `@blazetrails/activerecord/encryption/install.js`.
+// consumers that only need encryption primitives. Use the dedicated
+// subpath: `@blazetrails/activerecord/encryption/install.js`.
 export {
   ExtendedDeterministicUniquenessValidator,
   EncryptedUniquenessValidator,

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -18,6 +18,8 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError, EncryptionError } from "./errors.js";
+// Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
+import "../encryption.js";
 import type { Encryptor } from "../encryption.js";
 
 export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionError };

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -281,14 +281,8 @@ export {
 // hasSecureToken requires node:crypto — use subpath: @blazetrails/activerecord/secure-token
 export { composedOf } from "./aggregations.js";
 export { serialize } from "./serialize.js";
-// Encryption is exposed via the subpath export. Use:
-// `import { ... } from "@blazetrails/activerecord/encryption"`.
-// `Base.encrypts(name, ...)` is still the idiomatic declaration site.
-// The boot-time installer lives here (not in the encryption subpath)
-// because it depends on Base/Relation — exposing it from the encryption
-// subpath would drag those imports into consumers that only want
-// encryption primitives.
-export { installExtendedQueriesIfConfigured } from "./encryption/install.js";
+// Encryption is server-only; import from `@blazetrails/activerecord/encryption`.
+// The boot-time installer is at `@blazetrails/activerecord/encryption/install.js`.
 // generatesTokenFor requires node:crypto — use subpath: @blazetrails/activerecord/generates-token-for
 export { delegatedType, getDelegatedTypeConfig } from "./delegated-type.js";
 export { DatabaseConfig } from "./database-configurations/database-config.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -281,8 +281,9 @@ export {
 // hasSecureToken requires node:crypto — use subpath: @blazetrails/activerecord/secure-token
 export { composedOf } from "./aggregations.js";
 export { serialize } from "./serialize.js";
-// Encryption is server-only; import from `@blazetrails/activerecord/encryption`.
-// The boot-time installer is at `@blazetrails/activerecord/encryption/install.js`.
+// Encryption is server-only. Import `@blazetrails/activerecord/encryption` BEFORE
+// calling Base.encrypts() — omitting it leaves attributes silently unencrypted.
+// Boot-time installer: `@blazetrails/activerecord/encryption/install.js`.
 // generatesTokenFor requires node:crypto — use subpath: @blazetrails/activerecord/generates-token-for
 export { delegatedType, getDelegatedTypeConfig } from "./delegated-type.js";
 export { DatabaseConfig } from "./database-configurations/database-config.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -282,7 +282,7 @@ export {
 export { composedOf } from "./aggregations.js";
 export { serialize } from "./serialize.js";
 // Encryption is server-only. Import `@blazetrails/activerecord/encryption` BEFORE
-// calling Base.encrypts() — omitting it leaves attributes silently unencrypted.
+// calling Base.encrypts() — omitting it throws at declaration time.
 // Boot-time installer: `@blazetrails/activerecord/encryption/install.js`.
 // generatesTokenFor requires node:crypto — use subpath: @blazetrails/activerecord/generates-token-for
 export { delegatedType, getDelegatedTypeConfig } from "./delegated-type.js";

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -9,7 +9,7 @@ import {
   type Type,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
-import { applyPendingEncryptions } from "./encryption.js";
+import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 
 /**
@@ -773,7 +773,7 @@ function applyColumnsHash(
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
 
-  applyPendingEncryptions(host);
+  encryptionHooks.applyPendingEncryptions(host);
 
   // STI: if the subclass previously forked _attributeDefinitions (via
   // attribute()/decorateAttributes()/encrypts()), carry its entries
@@ -801,7 +801,7 @@ function applyColumnsHash(
       }
     }
     originatingHost._attributeDefinitions = baseDefs;
-    applyPendingEncryptions(originatingHost);
+    encryptionHooks.applyPendingEncryptions(originatingHost);
   }
 }
 


### PR DESCRIPTION
## Summary

- Introduces `encryption-hooks.ts` — a thin injection registry that replaces the direct `encryption.ts` import in `base.ts`, `attributes.ts`, and `model-schema.ts`
- Default hooks are no-ops; real implementations self-register when `encryption.ts` first loads (which only happens when a consumer explicitly imports the encryption namespace)
- Removes `installExtendedQueriesIfConfigured` from the barrel; consumers use `@blazetrails/activerecord/encryption/install.js` (already supported via the `./encryption/*` wildcard subpath)
- Three test files that use `Base.encrypts()` but don't import `encryption.ts` get an explicit side-effect import to trigger hook registration

## Bundle smoke (after)

```
$ esbuild --bundle --platform=browser \
    --external:@blazetrails/* --external:pg --external:mysql2 --external:better-sqlite3 \
    --log-level=error packages/activerecord/dist/index.js > /tmp/ar-bundle.js
exit: 0
zlib in bundle: 0
```

## Verification

- `pnpm build` — clean
- `pnpm lint` — clean
- `pnpm vitest run packages/activerecord/src/encryption` — 279/279 passed
- Bundle smoke: exit 0, zero `zlib`/`deflateSync`/`crypto` matches