### PR TITLE
feat(test-compare): per-test exclusions for mixed GVL/serialization files

### DIFF
--- a/docs/test-compare-100-plan.md
+++ b/docs/test-compare-100-plan.md
@@ -360,7 +360,7 @@ Delta: 7970 → 7930 Ruby tests (−40), 2085 → 2048 skipped (−37).
 - `test/cases/marshal_serialization_test.rb` — Marshal.dump/load (**already excluded** before this PR)
 - `test/cases/coders/yaml_column_test.rb` — Psych YAMLColumn (**already excluded** before this PR)
 - `test/cases/message_pack_test.rb` — MessagePack Ruby bridge (**already excluded** before this PR)
-- `test/cases/serialized_attribute_test.rb` — 17 YAML/class-serializer cases (**per-test excluded**)
+- `test/cases/serialized_attribute_test.rb` — 19 YAML/class-serializer cases excluded (17 unique names; 2 names appear in both the base class and a subclass within the file)
 - `test/cases/base_test.rb` — 7 Marshal cases (**per-test excluded**)
 
 ### Ruby concurrency / thread / GVL ✓ partially excluded

--- a/docs/test-compare-100-plan.md
+++ b/docs/test-compare-100-plan.md
@@ -361,7 +361,7 @@ Delta: 7970 → 7930 Ruby tests (−40), 2085 → 2048 skipped (−37).
 - `test/cases/coders/yaml_column_test.rb` — Psych YAMLColumn (**already excluded** before this PR)
 - `test/cases/message_pack_test.rb` — MessagePack Ruby bridge (**already excluded** before this PR)
 - `test/cases/serialized_attribute_test.rb` — 17 YAML/class-serializer cases (**per-test excluded**)
-- `test/cases/base_test.rb` — 6 Marshal cases (**per-test excluded**)
+- `test/cases/base_test.rb` — 7 Marshal cases (**per-test excluded**)
 
 ### Ruby concurrency / thread / GVL ✓ partially excluded
 

--- a/docs/test-compare-100-plan.md
+++ b/docs/test-compare-100-plan.md
@@ -350,7 +350,7 @@ This drops them from both the Ruby denominator and the skipped backlog.
 **PR that added whole-file exclusions: #1304** (chore(test-compare): exclude permanently-not-portable Rails tests).
 Delta: 8097 → 7970 Ruby tests (−127), 2211 → 2085 skipped (−126).
 
-**PR that added per-test exclusion infra + mixed-file entries: TBD** (feat(test-compare): per-test exclusions for mixed GVL/serialization files).
+**PR that added per-test exclusion infra + mixed-file entries: #1305** (feat(test-compare): per-test exclusions for mixed GVL/serialization files).
 Delta: 7970 → 7930 Ruby tests (−40), 2085 → 2048 skipped (−37).
 
 ### YAML / Marshal / Ruby object serialization ✓ excluded

--- a/docs/test-compare-100-plan.md
+++ b/docs/test-compare-100-plan.md
@@ -350,6 +350,9 @@ This drops them from both the Ruby denominator and the skipped backlog.
 **PR that added whole-file exclusions: #1304** (chore(test-compare): exclude permanently-not-portable Rails tests).
 Delta: 8097 → 7970 Ruby tests (−127), 2211 → 2085 skipped (−126).
 
+**PR that added per-test exclusion infra + mixed-file entries: TBD** (feat(test-compare): per-test exclusions for mixed GVL/serialization files).
+Delta: 7970 → 7930 Ruby tests (−40), 2085 → 2048 skipped (−37).
+
 ### YAML / Marshal / Ruby object serialization ✓ excluded
 
 - `test/cases/yaml_serialization_test.rb` — YAML round-trip of arbitrary Ruby objects (**excluded**)
@@ -357,14 +360,16 @@ Delta: 8097 → 7970 Ruby tests (−127), 2211 → 2085 skipped (−126).
 - `test/cases/marshal_serialization_test.rb` — Marshal.dump/load (**already excluded** before this PR)
 - `test/cases/coders/yaml_column_test.rb` — Psych YAMLColumn (**already excluded** before this PR)
 - `test/cases/message_pack_test.rb` — MessagePack Ruby bridge (**already excluded** before this PR)
-- Any `serialized_attribute_test.rb` case asserting `Marshal.dump` / `Marshal.load` (mixed file — per-test exclusion pending)
+- `test/cases/serialized_attribute_test.rb` — 17 YAML/class-serializer cases (**per-test excluded**)
+- `test/cases/base_test.rb` — 6 Marshal cases (**per-test excluded**)
 
 ### Ruby concurrency / thread / GVL ✓ partially excluded
 
 - `test/cases/transaction_isolation_test.rb` — all 7 cases GVL thread parallelism (**excluded**)
 - `test/cases/schema_loading_test.rb` — all 3 cases Zeitwerk/on_load from background threads (**excluded**)
 - `test/cases/reload_models_test.rb` — ActiveSupport::Dependencies class reloading (**excluded**)
-- `test/cases/connection_pool_test.rb` cases asserting on `Thread#priority`, GVL release timing (mixed file — per-test exclusion pending)
+- `test/cases/connection_pool_test.rb` — 11 GVL thread cases (**per-test excluded**)
+- `test/cases/base_test.rb` — 2 GVL thread-handler cases (**per-test excluded**)
 - `test/cases/relation/load_async_test.rb` cases that assert GVL release while a query runs (mixed file)
 
 ### Ruby autoload / `require` / class reloading ✓ excluded (see GVL above)
@@ -372,7 +377,7 @@ Delta: 8097 → 7970 Ruby tests (−127), 2211 → 2085 skipped (−126).
 ### Process / Signal / fork
 
 - `connection_handler_test.rb` cases asserting `Process.fork` cleanup (mixed file)
-- `reaper_test.rb` cases asserting `Thread.kill` semantics (mixed file)
+- `test/cases/reaper_test.rb` — 1 fork case (**per-test excluded**)
 
 ### Rake / dbconsole shell-out ✓ excluded
 

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -24,9 +24,9 @@
 export type ExcludedFile = { reason: string } & (
   | { pattern: string; testFile?: string; tests?: never }
   | { pattern?: string; testFile: string; tests?: never }
-  // Per-test exclusion: file is not whole-file excluded; only the listed Ruby
-  // test descriptions are dropped. Use isTestCaseExcluded() to check.
-  | { pattern?: string; testFile: string; tests: string[] }
+  // Per-test exclusion: test-only — never affects api:compare.
+  // Only the listed Ruby test descriptions are dropped from test:compare counts.
+  | { pattern?: never; testFile: string; tests: string[] }
 );
 
 export const EXCLUDED_FILES: ExcludedFile[] = [

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -23,6 +23,10 @@
 
 export type ExcludedFile = {
   reason: string;
+  // Per-test exclusion: when set, the file itself is NOT whole-file excluded;
+  // only the listed Ruby test descriptions are dropped from test:compare counts.
+  // Use isTestCaseExcluded() to check. Requires testFile to be set.
+  tests?: string[];
 } & ({ pattern: string; testFile?: string } | { pattern?: string; testFile: string });
 
 export const EXCLUDED_FILES: ExcludedFile[] = [
@@ -193,6 +197,72 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
       "Tests `rails dbconsole` PTY/exec invocation for SQLite. " +
       "Spawning a PTY-backed interactive subprocess has no Node.js equivalent.",
   },
+  // --- Permanently not-portable: per-test GVL / serialization in mixed files ---
+  {
+    testFile: "connection_pool_test.rb",
+    tests: [
+      "lock thread allow fiber reentrency",
+      "released connection moves between threads",
+      "inactive are returned from dead thread",
+      "remove connection for thread",
+      "concurrent connection establishment",
+      "non bang disconnect and clear reloadable connections throw exception if threads dont return their conns",
+      "disconnect and clear reloadable connections attempt to wait for threads to return their conns",
+      "bang versions of disconnect and clear reloadable connections if unable to acquire all connections proceed anyway",
+      "disconnect and clear reloadable connections are able to preempt other waiting threads",
+      "clear reloadable connections creates new connections for waiting threads if necessary",
+      "public connections access threadsafe",
+    ],
+    reason:
+      "GVL / Ruby Thread semantics — concurrent connection tests cannot translate to single-threaded Node.js.",
+  },
+  {
+    testFile: "serialized_attribute_test.rb",
+    tests: [
+      "serialized class attribute",
+      "serialized class does not become frozen",
+      "serialized attribute should raise exception on assignment with wrong type",
+      "serialized attribute with class constraint",
+      "where by serialized attribute with array",
+      "where by serialized attribute with hash",
+      "where by serialized attribute with hash in array",
+      "serialize attribute via select method when time zone available",
+      "serialize attribute can be serialized in an integer column",
+      "classes without no arg constructors are not supported",
+      "is not changed when stored blob",
+      "is not changed when stored in blob frozen payload",
+      "decorated type with type for attribute",
+      "decorated type with decorator block",
+      "serialized attribute works under concurrent initial access",
+      "serialized time attribute",
+      "supports permitted classes for default column serializer",
+    ],
+    reason:
+      "YAML/Psych column serialization and class-constrained serializers — Ruby-only format with no Node.js equivalent.",
+  },
+  {
+    testFile: "base_test.rb",
+    tests: [
+      // GVL
+      "new threads get default the default connection handler",
+      "changing a connection handler in a main thread does not poison the other threads",
+      // Ruby Marshal serialization
+      "marshal round trip",
+      "marshal inspected round trip",
+      "marshal new record round trip",
+      "marshalling with associations 6 1",
+      "marshalling with associations 7 1",
+      "marshal between processes",
+      "marshalling new record round trip with associations",
+    ],
+    reason:
+      "GVL / Ruby Thread semantics and Marshal binary serialization — both are Ruby-only; no Node.js equivalent.",
+  },
+  {
+    testFile: "reaper_test.rb",
+    tests: ["connection pool starts reaper in fork"],
+    reason: "GVL / Ruby fork() semantics — process forking has no Node.js equivalent.",
+  },
   // --- Permanently not-portable: Ruby serialization formats ---
   {
     testFile: "yaml_serialization_test.rb",
@@ -213,5 +283,11 @@ export function isExcluded(file: string): boolean {
 }
 
 export function isTestExcluded(testFile: string): boolean {
-  return EXCLUDED_FILES.some((e) => e.testFile && testFile.includes(e.testFile));
+  return EXCLUDED_FILES.some((e) => e.testFile && !e.tests && testFile.includes(e.testFile));
+}
+
+export function isTestCaseExcluded(testFile: string, testName: string): boolean {
+  return EXCLUDED_FILES.some(
+    (e) => e.testFile && e.tests && testFile.includes(e.testFile) && e.tests.includes(testName),
+  );
 }

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -21,13 +21,13 @@
 // `testFile` because their TS source counterparts either don't exist or
 // are being actively ported.
 
-export type ExcludedFile = {
-  reason: string;
-  // Per-test exclusion: when set, the file itself is NOT whole-file excluded;
-  // only the listed Ruby test descriptions are dropped from test:compare counts.
-  // Use isTestCaseExcluded() to check. Requires testFile to be set.
-  tests?: string[];
-} & ({ pattern: string; testFile?: string } | { pattern?: string; testFile: string });
+export type ExcludedFile = { reason: string } & (
+  | { pattern: string; testFile?: string; tests?: never }
+  | { pattern?: string; testFile: string; tests?: never }
+  // Per-test exclusion: file is not whole-file excluded; only the listed Ruby
+  // test descriptions are dropped. Use isTestCaseExcluded() to check.
+  | { pattern?: string; testFile: string; tests: string[] }
+);
 
 export const EXCLUDED_FILES: ExcludedFile[] = [
   {

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -301,6 +301,10 @@ function main() {
       // Track which Ruby tests (by index) have been matched
       const matchedRuby = new Set<number>();
 
+      const excludedCount = file.testCases.filter((tc) =>
+        isTestCaseExcluded(file.file, tc.description),
+      ).length;
+
       let matched = 0;
       let matchedSkipped = 0;
       let wrongDescribe = 0;
@@ -483,12 +487,12 @@ function main() {
         rubyFile: file.file,
         conventionTsFile: conventionTs,
         tsFileExists: exists,
-        rubyTestCount: file.testCases.length,
+        rubyTestCount: file.testCases.length - excludedCount,
         matched,
         matchedSkipped,
         wrongDescribe,
         misplaced,
-        missing: file.testCases.length - matched - misplaced,
+        missing: file.testCases.length - excludedCount - matched - misplaced,
         ...(showMissing ? { missingTests } : {}),
         ...(misplacedTests.length > 0 ? { misplacedTests } : {}),
         ...(wrongDescribeTests.length > 0 ? { wrongDescribeTests } : {}),

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -27,7 +27,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { TestManifest } from "./types.js";
-import { isTestExcluded } from "../api-compare/excluded-files.js";
+import { isTestCaseExcluded, isTestExcluded } from "../api-compare/excluded-files.js";
 
 const SCRIPT_DIR = __dirname;
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
@@ -263,6 +263,7 @@ function main() {
       const seenPaths = new Set<string>();
       const seenDescs = new Set<string>();
       for (const tc of file.testCases) {
+        if (isTestCaseExcluded(file.file, tc.description)) continue;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);
         if (!seenPaths.has(np)) {
@@ -311,6 +312,7 @@ function main() {
       // Pass 1: Path matches (exact ancestor + description match)
       for (let ri = 0; ri < file.testCases.length; ri++) {
         const tc = file.testCases[ri];
+        if (isTestCaseExcluded(file.file, tc.description)) continue;
         const np = normPath(tc.ancestors, tc.description);
         const tsIdx = consumeIndex(pathIndex.get(np), consumedTs);
         if (tsIdx >= 0) {
@@ -333,6 +335,7 @@ function main() {
       for (let ri = 0; ri < file.testCases.length; ri++) {
         if (matchedRuby.has(ri)) continue;
         const tc = file.testCases[ri];
+        if (isTestCaseExcluded(file.file, tc.description)) continue;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);
 
@@ -370,6 +373,7 @@ function main() {
       for (let ri = 0; ri < file.testCases.length; ri++) {
         if (matchedRuby.has(ri)) continue;
         const tc = file.testCases[ri];
+        if (isTestCaseExcluded(file.file, tc.description)) continue;
         totalRuby++;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);


### PR DESCRIPTION
## Summary

Extends \`excluded-files.ts\` from whole-file exclusions (#1304) to per-test exclusions so mixed-content Rails test files can drop only their permanently-not-portable cases from the test:compare backlog.

- **New \`tests: string[]\` field** on \`ExcludedFile\` (per-test exclusion arm) — when present, the file is not whole-file excluded; only the listed Ruby test descriptions are dropped from counts. The arm uses \`pattern?: never\` so per-test entries can never accidentally affect api:compare.
- **New \`isTestCaseExcluded(testFile, testName)\`** helper, wired into all four Ruby-test loops in \`test-compare.ts\` (duplicate pre-pass + passes 1/1.5/2) and used to compute per-file \`rubyTestCount\` / \`missing\` consistently.
- **Four per-test entries** for the mixed files deferred from #1304:
  - \`connection_pool_test.rb\` — 11 GVL/thread cases
  - \`serialized_attribute_test.rb\` — 17 unique names → 19 cases (2 names appear in both base class and subclass)
  - \`base_test.rb\` — 2 GVL thread-handler + 7 Marshal cases
  - \`reaper_test.rb\` — 1 fork case

## test:compare delta (activerecord)

| | Before | After |
|---|---|---|
| Matched / Total | 5884 / 7970 (73.8%) | 5881 / 7930 (74.2%) |
| Skipped | 2085 | 2048 |
| Ruby tests excluded | — | −40 |

The −3 in numerator reflects excluded tests that were already matched-as-skipped (counted on both sides); the denominator drops by 40 (= 11 + 19 + 9 + 1).

## Constraints satisfied

- 98 LOC (well under 300 ceiling)
- No test renames — Ruby names used verbatim from \`.rails-source\`
- \`isTestExcluded\` unchanged for whole-file entries (guard: \`!e.tests\`)