### PR TITLE
feat(api-compare): track extend() calls alongside include()

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -235,7 +235,8 @@ function extractFromFiles(srcDir: string, files: Record<string, string>): Packag
   // detection's bare-specifier check succeeds in the virtual program.
   const ASC_PATH = "/_node_modules/@blazetrails/activesupport.ts";
   const all: Record<string, string> = {
-    [ASC_PATH]: `export function include(klass: any, mod: any): void {}`,
+    [ASC_PATH]: `export function include(klass: any, mod: any): void {}
+export function extend(klass: any, mod: any): void {}`,
   };
   for (const [rel, text] of Object.entries(files)) all[`${srcDir}/${rel}`] = text;
 
@@ -431,6 +432,85 @@ describe("extractFromProgram — include() detection", () => {
       `,
     });
     expect(info.classes["node-expression.ts:NodeExpression"].extends).toContain("Predications");
+  });
+});
+
+describe("extractFromProgram — extend() detection", () => {
+  it("pushes a bare-identifier class mod onto host.extends", () => {
+    const info = extractFromFiles("/p", {
+      "querying.ts": `export class Querying { all(): void {} }`,
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { extend } from "@blazetrails/activesupport";
+        import { Base } from "./base.js";
+        import { Querying } from "./querying.js";
+        extend(Base, Querying);
+      `,
+    });
+    expect(info.classes["base.ts:Base"].extends).toContain("Querying");
+  });
+
+  it("follows import aliases (`Querying as QueryingMixin`) to the canonical class name", () => {
+    const info = extractFromFiles("/p", {
+      "querying.ts": `export class Querying { all(): void {} }`,
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { extend } from "@blazetrails/activesupport";
+        import { Base } from "./base.js";
+        import { Querying as QueryingMixin } from "./querying.js";
+        extend(Base, QueryingMixin);
+      `,
+    });
+    expect(info.classes["base.ts:Base"].extends).toContain("Querying");
+  });
+
+  it("resolves property-access mod arg by harvesting the declaration's methods directly", () => {
+    const info = extractFromFiles("/p", {
+      "translation.ts": `
+        export function humanAttributeName(): string { return ""; }
+        export const ClassMethods = { humanAttributeName };
+      `,
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { extend } from "@blazetrails/activesupport";
+        import * as Translation from "./translation.js";
+        import { Base } from "./base.js";
+        extend(Base, Translation.ClassMethods);
+      `,
+    });
+    const base = info.classes["base.ts:Base"];
+    expect(base.instanceMethods.map((m) => m.name)).toContain("humanAttributeName");
+    expect(base.extends).not.toContain("ClassMethods");
+  });
+
+  it("pushes inline object-literal mod methods directly onto the host", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { extend } from "@blazetrails/activesupport";
+        import { Base } from "./base.js";
+        extend(Base, { find() {}, findBy: () => {}, where: function () {} });
+      `,
+    });
+    expect(info.classes["base.ts:Base"].instanceMethods.map((m) => m.name).sort()).toEqual([
+      "find",
+      "findBy",
+      "where",
+    ]);
+  });
+
+  it("ignores `extend()` calls when the file doesn't import from @blazetrails/activesupport", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "querying.ts": `export const Querying = { all() {} };`,
+      "wire.ts": `
+        import { Base } from "./base.js";
+        import { Querying } from "./querying.js";
+        function extend(a: any, b: any) {}
+        extend(Base, Querying);
+      `,
+    });
+    expect(info.classes["base.ts:Base"].extends).not.toContain("Querying");
   });
 });
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -759,6 +759,126 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
     });
   }
 
+  // Extend-detection pass: mirrors the include-detection pass above, but for
+  // `extend(Host, Mod)` calls. `extend()` wires class-level (static) methods
+  // whereas `include()` wires instance-level methods; both are tracked on the
+  // same `extends` field because api:compare's expected set conflates them.
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.fileName.startsWith(srcDir)) continue;
+    if (sourceFile.fileName.endsWith(".test.ts")) continue;
+    if (sourceFile.fileName.endsWith(".d.ts")) continue;
+
+    let importsExtend = false;
+    ts.forEachChild(sourceFile, (n) => {
+      if (
+        !ts.isImportDeclaration(n) ||
+        !ts.isStringLiteral(n.moduleSpecifier) ||
+        n.moduleSpecifier.text !== "@blazetrails/activesupport" ||
+        !n.importClause?.namedBindings ||
+        !ts.isNamedImports(n.importClause.namedBindings)
+      ) {
+        return;
+      }
+      for (const el of n.importClause.namedBindings.elements) {
+        if ((el.propertyName ?? el.name).text === "extend") importsExtend = true;
+      }
+    });
+    if (!importsExtend) continue;
+
+    ts.forEachChild(sourceFile, (n) => {
+      if (!ts.isExpressionStatement(n)) return;
+      const call = n.expression;
+      if (!ts.isCallExpression(call)) return;
+      if (!ts.isIdentifier(call.expression) || call.expression.text !== "extend") return;
+      if (call.arguments.length < 2) return;
+      const [hostArg, modArg] = call.arguments;
+      if (!ts.isIdentifier(hostArg)) return;
+
+      const hostSym0 = checker.getSymbolAtLocation(hostArg);
+      if (!hostSym0) return;
+      const hostSym =
+        hostSym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(hostSym0) : hostSym0;
+      let hostDecl: ts.Declaration | undefined =
+        hostSym.valueDeclaration ?? hostSym.declarations?.[0];
+      let hostName: string = hostSym.name;
+      if (!hostDecl || !ts.isClassDeclaration(hostDecl)) {
+        const t = checker.getTypeAtLocation(hostArg);
+        const ctorSigs = t.getConstructSignatures();
+        const inst = ctorSigs[0]?.getReturnType();
+        const sym = inst?.getSymbol();
+        const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+        if (decl && ts.isClassDeclaration(decl) && sym) {
+          hostDecl = decl;
+          hostName = sym.name;
+        } else {
+          return;
+        }
+      }
+      const hostFile = path.relative(srcDir, hostDecl.getSourceFile().fileName).replace(/\\/g, "/");
+      const hostKey = `${hostFile}:${hostName}`;
+      const hostInfo = info.classes[hostKey];
+      if (!hostInfo) return;
+
+      const pushMethods = (methods: MethodInfo[]): void => {
+        for (const m of methods) {
+          if (hostInfo.instanceMethods.some((existing) => existing.name === m.name)) continue;
+          hostInfo.instanceMethods.push({ ...m, file: hostInfo.file });
+        }
+      };
+
+      // Inline object literal: `extend(Host, { foo() {...}, bar: ... })`.
+      if (ts.isObjectLiteralExpression(modArg)) {
+        pushMethods(harvestObjectLiteralMethods(modArg, checker, hostInfo.file ?? ""));
+        return;
+      }
+
+      // Property access: `extend(Host, NS.ClassMethods)`. "ClassMethods"
+      // collides across files, so resolve to the declaration and push
+      // methods directly rather than relying on name-based lookup.
+      if (ts.isPropertyAccessExpression(modArg) && ts.isIdentifier(modArg.name)) {
+        const sym0 = checker.getSymbolAtLocation(modArg);
+        const resolved =
+          sym0 && sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
+        const propDecl = resolved?.valueDeclaration ?? resolved?.declarations?.[0];
+        if (
+          propDecl &&
+          ts.isVariableDeclaration(propDecl) &&
+          propDecl.initializer &&
+          ts.isObjectLiteralExpression(propDecl.initializer)
+        ) {
+          pushMethods(
+            harvestObjectLiteralMethods(propDecl.initializer, checker, hostInfo.file ?? ""),
+          );
+        }
+        return;
+      }
+
+      // Bare identifier: `extend(Host, Mod)`.
+      // (a) Class/interface — push name onto host.extends for compare.ts resolution.
+      // (b) Const object literal — harvest methods directly (same as include pass).
+      if (ts.isIdentifier(modArg)) {
+        const sym0 = checker.getSymbolAtLocation(modArg);
+        const sym =
+          sym0 && sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
+
+        const valDecl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+        if (valDecl && ts.isVariableDeclaration(valDecl) && valDecl.initializer) {
+          let init = valDecl.initializer;
+          while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init)) {
+            init = (init as ts.AsExpression | ts.SatisfiesExpression).expression;
+          }
+          if (ts.isObjectLiteralExpression(init)) {
+            pushMethods(harvestObjectLiteralMethods(init, checker, hostInfo.file ?? ""));
+            return;
+          }
+        }
+
+        const modName = sym?.name ?? modArg.text;
+        if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
+      }
+    });
+  }
+
   // Object.defineProperty pass: detect two patterns that wire methods onto a
   // class prototype without going through include(). Both appear in base.ts:
   //


### PR DESCRIPTION
## Summary

Adds an extend-detection pass to `scripts/api-compare/extract-ts-api.ts` that mirrors the existing include-detection pass. Both passes now walk top-level `extend(Host, Mod)` / `include(Host, Mod)` calls imported from `@blazetrails/activesupport` and push mixed-in methods onto the host class's `extends` surface for api:compare credit.

`extend()` wires class-level (static) methods; `include()` wires instance-level methods. Both are tracked on the same internal `extends` field because api:compare's expected set already conflates instance and class surfaces on the host.

## Scoreboard delta

**activerecord**: 4897/4969 (98.6%) before → 4897/4969 (98.6%) after — no numeric change.

All current `extend()` call-sites in `base.ts` (19 calls, lines 2918–2961) are already credited via `declare static` stubs in the class body, so there is no immediate delta. The pass is correct and ensures that any future wiring via `extend()` (e.g. if a `declare static` stub is removed in favor of pure delegation) is automatically visible without additional extractor work.

No other Rails-mirroring packages (`actionpack`, `actionview`, `activemodel`, `activesupport`, `arel`) use `extend()` from `@blazetrails/activesupport` in their current source.

## Implementation

Duplicates the existing include-detection pass (lines 621–760) as a parallel extend-detection pass. Handles all three argument shapes:

- **Inline object literal** — `extend(Host, { foo() {}, bar: () => {} })` — methods pushed directly onto host.
- **Property access** — `extend(Host, NS.ClassMethods)` — resolves to the declaration's object literal; harvests methods directly to avoid the collision-prone "InstanceMethods" short-name path.
- **Bare identifier** — `extend(Host, Mod)` — object-literal vars harvested directly (branch b); class/interface names pushed onto `host.extends` for compare.ts resolution (branch a).

## Tests

Five new test cases in `extract-ts-api.test.ts` cover all three argument shapes plus the import-guard (local `extend` function not confused for the activesupport one) and import-alias resolution (`Querying as QueryingMixin` → "Querying"). Parallel structure to existing include() tests.

Note: 4 pre-existing test failures in the include() suite (bare-identifier const-object cases) are unchanged — not introduced by this PR.