### PR TITLE
feat(activerecord): wire transactions/touch-later/connection-handling privates onto base.rb (87%→90%)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -212,6 +212,11 @@ import {
   clearTransactionRecordState as _clearTransactionRecordState,
   _committedAlreadyCalled as _txCommittedAlreadyCalled,
   _triggerUpdateCallback as _txTriggerUpdateCallback,
+  rememberTransactionRecordState as _rememberTransactionRecordState,
+  restoreTransactionRecordState as _restoreTransactionRecordState,
+  isTransactionIncludeAnyAction as _isTransactionIncludeAnyAction,
+  addToTransaction as _addToTransaction,
+  hasTransactionalCallbacks as _hasTransactionalCallbacks,
 } from "./transactions.js";
 
 import {
@@ -959,6 +964,10 @@ export class Base extends Model {
   declare static clearCacheBang: typeof ConnectionHandling.clearCacheBang;
   declare static shardKeys: typeof ConnectionHandling.shardKeys;
   declare static isSharded: typeof ConnectionHandling.isSharded;
+  /** @internal */
+  declare static withRoleAndShard: typeof ConnectionHandling.withRoleAndShard;
+  /** @internal */
+  declare static appendToConnectedToStack: typeof ConnectionHandling.appendToConnectedToStack;
   /** @internal */
   declare static resolveConfigForConnection: typeof ConnectionHandling.resolveConfigForConnection;
 
@@ -3170,6 +3179,14 @@ include(Base, {
   _triggerUpdateCallback: _txTriggerUpdateCallback,
   _triggerDestroyCallback: _txTriggerDestroyCallback,
   clearTransactionRecordState: _clearTransactionRecordState,
+  rememberTransactionRecordState: _rememberTransactionRecordState,
+  restoreTransactionRecordState: _restoreTransactionRecordState,
+  isTransactionIncludeAnyAction: _isTransactionIncludeAnyAction,
+  addToTransaction: _addToTransaction,
+  hasTransactionalCallbacks: _hasTransactionalCallbacks,
+  // TouchLater privates (instance-level) wired here for api:compare credit.
+  surreptitiouslyTouch: TouchLater.surreptitiouslyTouch,
+  touchDeferredAttributes: TouchLater.touchDeferredAttributes,
 });
 
 for (const [name, fn] of [

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -408,7 +408,7 @@ function removeStackEntry(entry: object): void {
 }
 
 /** @internal */
-function withRoleAndShard<T>(
+export function withRoleAndShard<T>(
   this: typeof Base,
   role: string | undefined,
   shard: string | undefined,
@@ -437,7 +437,7 @@ function withRoleAndShard<T>(
 }
 
 /** @internal */
-function appendToConnectedToStack(entry: {
+export function appendToConnectedToStack(entry: {
   role?: string;
   shard?: string;
   preventWrites?: boolean;
@@ -770,6 +770,8 @@ export const ClassMethods = {
   clearCacheBang,
   shardKeys,
   isSharded,
+  withRoleAndShard,
+  appendToConnectedToStack,
 };
 
 // Register adapter class resolver so DatabaseConfig#adapterClass and

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -56,7 +56,7 @@ export async function touchLater(this: Base, ...names: string[]): Promise<void> 
   }
 
   self._touchTime = currentTimeFromProperTimezone();
-  surreptitiouslyTouch(this, self._deferTouchAttrs as string[], self._touchTime as Date);
+  surreptitiouslyTouch.call(this, self._deferTouchAttrs as string[], self._touchTime as Date);
 
   // Register with the current transaction so beforeCommitted! fires before
   // commit — mirrors Rails' add_to_transaction call in touch_later.
@@ -75,7 +75,7 @@ export async function touchLater(this: Base, ...names: string[]): Promise<void> 
   if (hasOpenRealTransaction) {
     adapter.addTransactionRecord(this);
   } else {
-    await touchDeferredAttributes(this);
+    await touchDeferredAttributes.call(this);
     return;
   }
 
@@ -132,7 +132,7 @@ export async function touch(this: Base, ...names: string[]): Promise<boolean> {
 export async function beforeCommittedBang(this: Base): Promise<void> {
   const self = this as any;
   if (self._deferTouchAttrs?.length && this.isPersisted()) {
-    await touchDeferredAttributes(this);
+    await touchDeferredAttributes.call(this);
   }
   await transactionsBeforeCommittedBang(this);
 }
@@ -142,22 +142,22 @@ export async function beforeCommittedBang(this: Base): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-function surreptitiouslyTouch(record: Base, attrNames: string[], time: Date): void {
+export function surreptitiouslyTouch(this: Base, attrNames: string[], time: Date): void {
   for (const attr of attrNames) {
-    (record as any).writeAttribute(attr, time);
+    (this as any).writeAttribute(attr, time);
     // Per-attribute clear so the baseline rebinds to the touched value;
     // otherwise a later write would diff against the pre-touch original.
-    if (typeof (record as any).clearAttributeChange === "function") {
-      (record as any).clearAttributeChange(attr);
-    } else if (typeof (record as any).clearAttributeChanges === "function") {
-      (record as any).clearAttributeChanges([attr]);
+    if (typeof (this as any).clearAttributeChange === "function") {
+      (this as any).clearAttributeChange(attr);
+    } else if (typeof (this as any).clearAttributeChanges === "function") {
+      (this as any).clearAttributeChanges([attr]);
     }
   }
 }
 
 /** @internal */
-async function touchDeferredAttributes(record: Base): Promise<void> {
-  const self = record as any;
+export async function touchDeferredAttributes(this: Base): Promise<void> {
+  const self = this as any;
   const deferredAttrs = self._deferTouchAttrs as string[];
   const time: Date = self._touchTime ?? currentTimeFromProperTimezone();
 
@@ -166,7 +166,7 @@ async function touchDeferredAttributes(record: Base): Promise<void> {
   const attrs: Record<string, unknown> = {};
   for (const attr of deferredAttrs) attrs[attr] = time;
 
-  await record.updateColumns(attrs);
+  await this.updateColumns(attrs);
 
   // Clear state only after successful update — mirrors touch_deferred_attributes
   // calling touch() which clears @_defer_touch_attrs / @_touch_time on return.
@@ -175,8 +175,8 @@ async function touchDeferredAttributes(record: Base): Promise<void> {
 
   // Run after_touch callbacks — mirrors touch() going through Timestamp#touch
   // which fires the after_touch chain.
-  const ctor = record.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfter?.("touch", record);
+  const ctor = this.constructor as typeof Base;
+  await (ctor as any)._callbackChain?.runAfter?.("touch", this);
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -410,13 +410,13 @@ interface TransactionRecordSnapshot {
 }
 
 /** @internal */
-function rememberTransactionRecordState(record: Base): TransactionRecordSnapshot {
-  const r = record as any;
+export function rememberTransactionRecordState(this: Base): TransactionRecordSnapshot {
+  const r = this as any;
   return {
     newRecord: r._newRecord,
     destroyed: r._destroyed,
     frozen: r._attributes.isFrozen(),
-    id: record.id,
+    id: this.id,
     previouslyNewRecord: r._previouslyNewRecord,
   };
 }
@@ -430,8 +430,11 @@ function rememberTransactionRecordState(record: Base): TransactionRecordSnapshot
  *
  * @internal
  */
-function restoreTransactionRecordState(record: Base, snapshot: TransactionRecordSnapshot): void {
-  const r = record as any;
+export function restoreTransactionRecordState(
+  this: Base,
+  snapshot: TransactionRecordSnapshot,
+): void {
+  const r = this as any;
   r._newRecord = snapshot.newRecord;
   r._destroyed = snapshot.destroyed;
   r._previouslyNewRecord = snapshot.previouslyNewRecord;
@@ -445,8 +448,8 @@ function restoreTransactionRecordState(record: Base, snapshot: TransactionRecord
   }
 
   // Restore the primary key if it was auto-assigned during insert
-  if (snapshot.newRecord && !Array.isArray(record.id)) {
-    const ctor = record.constructor as typeof Base;
+  if (snapshot.newRecord && !Array.isArray(this.id)) {
+    const ctor = this.constructor as typeof Base;
     r._attributes.set(ctor.primaryKey as string, snapshot.id);
   }
 
@@ -471,7 +474,7 @@ export async function withTransactionReturningStatus<T>(
   const modelClass = this.constructor as typeof Base;
 
   // Mirrors: remember_transaction_record_state — snapshot before transaction
-  const snapshot = rememberTransactionRecordState(this);
+  const snapshot = rememberTransactionRecordState.call(this);
 
   // Reset transaction tracking flags (the block will set them if the
   // operation succeeds).
@@ -489,7 +492,7 @@ export async function withTransactionReturningStatus<T>(
     // Actual committedBang/rolledbackBang callbacks are scheduled after
     // the transaction returns, on the outer transaction or fired immediately.
     tx.afterRollback(async () => {
-      restoreTransactionRecordState(this, snapshot);
+      restoreTransactionRecordState.call(this, snapshot);
     });
 
     status = await fn();
@@ -514,7 +517,7 @@ export async function withTransactionReturningStatus<T>(
         // transaction, not the pre-transaction state. Matches Rails where
         // rolledback! fires during rollback, restore runs in ensure.
         await rolledbackBang(this);
-        restoreTransactionRecordState(this, snapshot);
+        restoreTransactionRecordState.call(this, snapshot);
       });
     } else {
       await committedBang(this);
@@ -592,16 +595,14 @@ export function clearTransactionRecordState(this: Base): void {
 
 // Mirrors: ActiveRecord::Transactions#transaction_include_any_action?
 /** @internal */
-function isTransactionIncludeAnyAction(record: Base, actions: string[]): boolean {
-  const r = record as any;
+export function isTransactionIncludeAnyAction(this: Base, actions: string[]): boolean {
+  const r = this as any;
   return actions.some((action) => {
     switch (action) {
       case "create":
-        return record.isPersisted() && !!r._newRecordBeforeLastCommit;
+        return this.isPersisted() && !!r._newRecordBeforeLastCommit;
       case "update":
-        return (
-          !(r._newRecordBeforeLastCommit || record.isDestroyed()) && !!r._triggerUpdateCallback
-        );
+        return !(r._newRecordBeforeLastCommit || this.isDestroyed()) && !!r._triggerUpdateCallback;
       case "destroy":
         return !!r._triggerDestroyCallback;
       default:
@@ -612,19 +613,19 @@ function isTransactionIncludeAnyAction(record: Base, actions: string[]): boolean
 
 // Mirrors: ActiveRecord::Transactions#add_to_transaction
 /** @internal */
-async function addToTransaction(record: Base, ensureFinalize = true): Promise<void> {
-  const ctor = record.constructor as any;
+export async function addToTransaction(this: Base, ensureFinalize = true): Promise<void> {
+  const ctor = this.constructor as any;
   if (typeof ctor.withConnection === "function") {
     await ctor.withConnection(async (connection: any) => {
-      connection.addTransactionRecord?.(record, ensureFinalize);
+      connection.addTransactionRecord?.(this, ensureFinalize);
     });
   }
 }
 
 // Mirrors: ActiveRecord::Transactions#has_transactional_callbacks?
 /** @internal */
-function hasTransactionalCallbacks(record: Base): boolean {
-  const ctor = record.constructor as any;
+export function hasTransactionalCallbacks(this: Base): boolean {
+  const ctor = this.constructor as any;
   const chain = ctor._callbackChain;
   if (!chain) return false;
   const entries: Array<{ event: string }> = (chain as any).callbacks ?? [];
@@ -664,7 +665,7 @@ function setOptionsForCallbacksBang(
     assertValidTransactionAction(fireOn);
     const existingIf = options.if as CallbackFn | CallbackFn[] | undefined;
     options.if = (record: Base) => {
-      if (!isTransactionIncludeAnyAction(record, fireOn)) return false;
+      if (!isTransactionIncludeAnyAction.call(record, fireOn)) return false;
       if (!existingIf) return true;
       if (Array.isArray(existingIf)) return existingIf.every((fn) => fn(record));
       return (existingIf as CallbackFn)(record) as boolean;


### PR DESCRIPTION
## Summary

Export 9 private helpers as `this`-typed functions and wire into `include(Base, {...})` / `extend(Base, {...})` so `api:compare` credits them to `base.rb`. No behavior changes — pure attribution wiring following the pattern from PR #1303.

**Before:** base.rb 240/277 (87%)  
**After:** base.rb 249/277 (90%)

## Methods wired

### transactions.ts — 5 methods

| Method | Checklist |
|---|---|
| `rememberTransactionRecordState` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `restoreTransactionRecordState` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `isTransactionIncludeAnyAction` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `addToTransaction` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `hasTransactionalCallbacks` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |

All 5 converted from `record`-arg form to `this: Base` form. Internal callers updated to `.call()` form (`rememberTransactionRecordState.call(this)`, `restoreTransactionRecordState.call(this, snapshot)`, `isTransactionIncludeAnyAction.call(record, actions)`).

### touch-later.ts — 2 methods

| Method | Checklist |
|---|---|
| `surreptitiouslyTouch` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `touchDeferredAttributes` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |

Both converted from `record`-arg form to `this: Base` form. Internal callers in `touchLater` and `beforeCommittedBang` updated to `.call()`.

### connection-handling.ts — 2 methods (class-level)

| Method | Checklist |
|---|---|
| `withRoleAndShard` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |
| `appendToConnectedToStack` | ✅ Not a getter · ✅ No cycle · ✅ Type-safe |

Both added to `ClassMethods` (picked up by existing `extend(Base, ConnectionHandling.ClassMethods)`) and declared as `declare static` in the Base class body so the api:compare extractor attributes them to `base.ts`. These are class-level helpers, so `declare static` is the correct attribution mechanism (the extractor's `include()` path is for instance methods only).

## Notes

- `isTriggerTransactionalCallbacks`, `committedBang`, `rolledbackBang` remain excluded per existing inline comments (category A — called with incompatible signatures in the record-arg form).
- `store.ts` registry unification remains out of scope.