### PR TITLE
feat(activerecord): DML facade on AbstractAdapter (6 methods, 98.9%→99%)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -295,6 +295,45 @@ export interface AbstractAdapter {
     },
     arel: unknown,
   ): [unknown, unknown[]];
+  insert(
+    arel: unknown,
+    name?: string | null,
+    pk?: string | null,
+    idValue?: unknown,
+    sequenceName?: string | null,
+    binds?: unknown[],
+    opts?: { returning?: string[] | null },
+  ): Promise<unknown>;
+  update(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
+  delete(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
+  /** @internal */ /** @internal */
+  rawExecute(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    prepare?: boolean,
+    async?: boolean,
+    allowRetry?: boolean,
+    materializeTransactions?: boolean,
+    batch?: boolean,
+  ): Promise<unknown>;
+  /** @internal */ /** @internal */
+  internalExecute(
+    sql: string,
+    name?: string,
+    binds?: unknown[],
+    prepare?: boolean,
+    async?: boolean,
+    allowRetry?: boolean,
+    materializeTransactions?: boolean,
+    block?: unknown,
+  ): Promise<unknown>;
+  /** @internal */ /** @internal */
+  executeBatch(
+    statements: string[],
+    name?: string | null,
+    kwargs?: Record<string, unknown>,
+  ): Promise<void>;
 }
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractAdapter implements Quoting {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -306,7 +306,7 @@ export interface AbstractAdapter {
   ): Promise<unknown>;
   update(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
   delete(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
-  /** @internal */ /** @internal */
+  /** @internal */
   rawExecute(
     sql: string,
     name?: string | null,
@@ -317,7 +317,7 @@ export interface AbstractAdapter {
     materializeTransactions?: boolean,
     batch?: boolean,
   ): Promise<unknown>;
-  /** @internal */ /** @internal */
+  /** @internal */
   internalExecute(
     sql: string,
     name?: string,
@@ -326,14 +326,9 @@ export interface AbstractAdapter {
     async?: boolean,
     allowRetry?: boolean,
     materializeTransactions?: boolean,
-    block?: unknown,
   ): Promise<unknown>;
-  /** @internal */ /** @internal */
-  executeBatch(
-    statements: string[],
-    name?: string | null,
-    kwargs?: Record<string, unknown>,
-  ): Promise<void>;
+  /** @internal */
+  executeBatch(statements: string[], name?: string | null): Promise<void>;
 }
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractAdapter implements Quoting {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1399,6 +1399,46 @@ export const DatabaseStatements = {
     return cacheableQuery.call(this as never, klass, arel);
   },
 
+  async insert(
+    this: any,
+    arel: unknown,
+    name?: string | null,
+    pk?: string | null,
+    idValue?: unknown,
+    _sequenceName?: string | null,
+    binds: unknown[] = [],
+    opts?: { returning?: string[] | null },
+  ): Promise<unknown> {
+    const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
+    const result = await this.execInsert(sql, name, resolvedBinds, pk);
+    if (opts?.returning != null) return returningColumnValues.call(this, result);
+    return idValue ?? lastInsertedId(result as Result);
+  },
+
+  async update(
+    this: any,
+    arel: unknown,
+    name?: string | null,
+    binds: unknown[] = [],
+  ): Promise<number> {
+    const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
+    return this.execUpdate(sql, name, resolvedBinds);
+  },
+
+  async delete(
+    this: any,
+    arel: unknown,
+    name?: string | null,
+    binds: unknown[] = [],
+  ): Promise<number> {
+    const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
+    return this.execDelete(sql, name, resolvedBinds);
+  },
+
+  rawExecute,
+  internalExecute,
+  executeBatch,
+
   // Standalone helpers wired into the host so include(AbstractAdapter, DatabaseStatements)
   // credits them to the host class (mirrors Rails' `include DatabaseStatements`).
   toSql,
@@ -1455,7 +1495,7 @@ export const DatabaseStatements = {
 };
 
 /** @internal */
-function rawExecute(
+export function rawExecute(
   sql: any,
   name?: any,
   binds?: any,
@@ -1516,7 +1556,7 @@ export function preprocessQuery(this: DatabaseStatementsHost, sql: string): stri
 }
 
 /** @internal */
-function internalExecute(
+export function internalExecute(
   sql: any,
   name?: any,
   binds?: any,
@@ -1532,7 +1572,7 @@ function internalExecute(
 }
 
 /** @internal */
-function executeBatch(statements: any, name?: any, kwargs?: any): never {
+export function executeBatch(statements: any, name?: any, kwargs?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1555,27 +1555,48 @@ export function preprocessQuery(this: DatabaseStatementsHost, sql: string): stri
   return sql;
 }
 
-/** @internal */
+/**
+ * Preprocesses then delegates to rawExecute with the native connection.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute
+ * @internal
+ */
 export function internalExecute(
-  sql: any,
-  name?: any,
-  binds?: any,
-  prepare?: any,
-  async?: any,
-  allowRetry?: any,
-  materializeTransactions?: any,
-  block?: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute is not implemented",
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string = "SQL",
+  binds: unknown[] = [],
+  prepare = false,
+  _async = false,
+  allowRetry = false,
+  materializeTransactions = true,
+): Promise<unknown> {
+  const processed = preprocessQuery.call(this, sql);
+  return (this as any).rawExecute(
+    processed,
+    name,
+    binds,
+    prepare,
+    false,
+    allowRetry,
+    materializeTransactions,
   );
 }
 
-/** @internal */
-export function executeBatch(statements: any, name?: any, kwargs?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch is not implemented",
-  );
+/**
+ * Executes each statement by calling rawExecute.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch
+ * @internal
+ */
+export async function executeBatch(
+  this: DatabaseStatementsHost,
+  statements: string[],
+  name?: string | null,
+): Promise<void> {
+  for (const statement of statements) {
+    await (this as any).rawExecute(statement, name);
+  }
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -7,6 +7,7 @@
 import type mysql from "mysql2/promise";
 import { NotImplementedError } from "../../errors.js";
 import { Result } from "../../result.js";
+import { combineMultiStatements } from "../abstract/database-statements.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -52,11 +53,21 @@ export async function selectAll(
   return this.execQuery(sql, name, binds);
 }
 
-/** @internal */
-function executeBatch(statements: any, name?: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#execute_batch is not implemented",
-  );
+/**
+ * Combines statements via `combineMultiStatements` then executes each block.
+ * Mirrors Rails' use of `multi_statement: true` for batched execution.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#execute_batch
+ * @internal
+ */
+export async function executeBatch(
+  this: { execute(sql: string, name?: string | null): Promise<unknown> },
+  statements: string[],
+  name?: string | null,
+): Promise<void> {
+  for (const statement of combineMultiStatements(statements)) {
+    await this.execute(statement, name);
+  }
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

- Wire \`insert\`, \`update\`, \`delete\`, \`rawExecute\`, \`internalExecute\`, \`executeBatch\` into \`AbstractAdapter\` via the \`DatabaseStatements\` include() module object
- Implement mysql2 \`executeBatch\` override using the MySQL module's \`combineMultiStatements\` (packet-aware chunking + \`execute\` per chunk)
- Export and implement \`internalExecute\` and \`executeBatch\` with real Rails-mirroring logic

## api:compare delta

| File | Before | After |
|------|--------|-------|
| \`abstract_adapter.rb\` | 373/379 (98%) | 379/379 (100% ✓) |
| \`mysql2/database_statements.rb\` | 7/8 (88%) | 8/8 (100% ✓) |
| **Overall** | 4913/4969 (98.9%) | 4921/4969 (99.0%) |

## Methods wired

**abstract_adapter.rb** (via \`DatabaseStatements\` module object):
- \`insert\` — Arel → \`execInsert\`, returns PK or \`returningColumnValues\`; handles both \`Result\` and numeric insertId from \`execInsert\`
- \`update\` — Arel → \`execUpdate\`
- \`delete\` — Arel → \`execDelete\`
- \`rawExecute\` \`@internal\` — throws \`NotImplementedError\` (equivalent to Rails' abstract \`perform_query raise NotImplementedError\`)
- \`internalExecute\` \`@internal\` — \`preprocessQuery\` then delegates to \`rawExecute\` (mirrors Rails exactly)
- \`executeBatch\` \`@internal\` — loops \`rawExecute\` per statement (mirrors Rails exactly)

**mysql2/database_statements.rb**:
- \`executeBatch\` — uses MySQL module's \`combineMultiStatements\` (packet-aware array) then \`execute\` per chunk

## Notes

- The module object's \`insert\`/\`update\`/\`delete\` call \`this.execInsert\`/\`execUpdate\`/\`execDelete\` (instance methods) rather than the standalone functions — avoids the \`internalExecute\`-always-truthy dispatch trap.
- \`rawExecute\` throwing is equivalent to Rails' \`perform_query raise NotImplementedError\`; concrete adapters implement \`performQuery\` directly.
- Follow-up: other adapters' \`executeBatch\` overrides (postgresql, sqlite3, trilogy) are out of scope.