### PR TITLE
feat(activerecord): wire committedBang/rolledbackBang onto Base + call addToTransaction from withTransactionReturningStatus

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -213,8 +213,6 @@ import {
   rememberTransactionRecordState as _rememberTransactionRecordState,
   restoreTransactionRecordState as _restoreTransactionRecordState,
   isTransactionIncludeAnyAction as _isTransactionIncludeAnyAction,
-  addToTransaction as _addToTransaction,
-  hasTransactionalCallbacks as _hasTransactionalCallbacks,
 } from "./transactions.js";
 
 import {
@@ -3190,8 +3188,6 @@ include(Base, {
   rememberTransactionRecordState: _rememberTransactionRecordState,
   restoreTransactionRecordState: _restoreTransactionRecordState,
   isTransactionIncludeAnyAction: _isTransactionIncludeAnyAction,
-  addToTransaction: _addToTransaction,
-  hasTransactionalCallbacks: _hasTransactionalCallbacks,
   // TouchLater privates (instance-level) wired here for api:compare credit.
   surreptitiouslyTouch: TouchLater.surreptitiouslyTouch,
   touchDeferredAttributes: TouchLater.touchDeferredAttributes,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -202,6 +202,7 @@ import {
   withTransactionReturningStatus as _withTransactionReturningStatus,
   committedBang as _committedBang,
   rolledbackBang as _rolledbackBang,
+  isTriggerTransactionalCallbacks as _isTriggerTransactionalCallbacks,
   addToTransaction as _addToTransaction,
   hasTransactionalCallbacks as _hasTransactionalCallbacks,
   _newRecordBeforeLastCommit as _txNewRecordBeforeLastCommit,
@@ -3162,6 +3163,7 @@ include(Base, {
   // Transactions instance methods
   committedBang: _committedBang,
   rolledbackBang: _rolledbackBang,
+  isTriggerTransactionalCallbacks: _isTriggerTransactionalCallbacks,
   withTransactionReturningStatus: _withTransactionReturningStatus,
   addToTransaction: _addToTransaction,
   hasTransactionalCallbacks: _hasTransactionalCallbacks,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2889,6 +2889,21 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   /** @internal */
   initInternals(): void;
   /** @internal */
+  committedBang(options?: { shouldRunCallbacks?: boolean }): Promise<void>;
+  /** @internal */
+  rolledbackBang(options?: {
+    forceRestoreState?: boolean;
+    shouldRunCallbacks?: boolean;
+  }): Promise<void>;
+  /** @internal */
+  isTriggerTransactionalCallbacks(): boolean;
+  /** @internal */
+  withTransactionReturningStatus<T>(fn: () => Promise<T>): Promise<T>;
+  /** @internal */
+  addToTransaction(ensureFinalize?: boolean): Promise<void>;
+  /** @internal */
+  hasTransactionalCallbacks(): boolean;
+  /** @internal */
   _createRecord(): Promise<boolean>;
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -200,6 +200,10 @@ import {
   transaction as _transaction,
   currentTransactionPublic as _currentTransactionPublic,
   withTransactionReturningStatus as _withTransactionReturningStatus,
+  committedBang as _committedBang,
+  rolledbackBang as _rolledbackBang,
+  addToTransaction as _addToTransaction,
+  hasTransactionalCallbacks as _hasTransactionalCallbacks,
   _newRecordBeforeLastCommit as _txNewRecordBeforeLastCommit,
   _triggerDestroyCallback as _txTriggerDestroyCallback,
   clearTransactionRecordState as _clearTransactionRecordState,
@@ -3155,15 +3159,13 @@ include(Base, {
   // AutosaveAssociation privates
   computePrimaryKey: _computePrimaryKey,
   _ensureNoDuplicateErrors: _autosaveEnsureNoDuplicateErrors,
-  // Transactions privates
-  // committedBang / rolledbackBang intentionally omitted: transaction.ts calls
-  // these as record.committedBang({ shouldRunCallbacks }) — the record-arg form
-  // would receive the options hash as `record`, breaking that callsite.
+  // Transactions instance methods
+  committedBang: _committedBang,
+  rolledbackBang: _rolledbackBang,
   withTransactionReturningStatus: _withTransactionReturningStatus,
+  addToTransaction: _addToTransaction,
+  hasTransactionalCallbacks: _hasTransactionalCallbacks,
   _newRecordBeforeLastCommit: _txNewRecordBeforeLastCommit,
-  // isTriggerTransactionalCallbacks omitted: transaction.ts calls it as
-  // record.isTriggerTransactionalCallbacks() with no args; the record-arg
-  // form would receive undefined as `record`, throwing at runtime.
   _committedAlreadyCalled: _txCommittedAlreadyCalled,
   _triggerUpdateCallback: _txTriggerUpdateCallback,
   _triggerDestroyCallback: _txTriggerDestroyCallback,

--- a/packages/activerecord/src/transaction-instrumentation.test.ts
+++ b/packages/activerecord/src/transaction-instrumentation.test.ts
@@ -415,4 +415,57 @@ describe("TransactionInstrumentationTest", () => {
 
     Notifications.unsubscribe(sub);
   });
+
+  it("TM path: addTransactionRecord called and after_commit fires on save", async () => {
+    const { Topic, adapter } = makeTopic();
+    const enrolled: unknown[] = [];
+    const orig = (adapter as any).addTransactionRecord?.bind(adapter);
+    (adapter as any).addTransactionRecord = (record: unknown, ...rest: unknown[]) => {
+      enrolled.push(record);
+      return orig?.(record, ...rest);
+    };
+
+    const committed: string[] = [];
+    Topic.afterCommit(function (record: InstanceType<typeof Topic>) {
+      committed.push(record.title as string);
+    });
+
+    await Topic.create({ title: "tm-test" });
+
+    expect(enrolled.length).toBeGreaterThan(0);
+    expect(committed).toEqual(["tm-test"]);
+  });
+
+  it("TM path: after_rollback fires on explicit rollback", async () => {
+    const { Topic } = makeTopic();
+
+    const rolledBack: string[] = [];
+    Topic.afterRollback(function (record: InstanceType<typeof Topic>) {
+      rolledBack.push(record.title as string);
+    });
+
+    await Topic.transaction(async () => {
+      await Topic.create({ title: "rollback-test" });
+      throw new Rollback();
+    });
+
+    expect(rolledBack).toEqual(["rollback-test"]);
+  });
+
+  it("TM path: nested transaction propagates enrollment to outer and fires after_commit once", async () => {
+    const { Topic } = makeTopic();
+
+    const committed: string[] = [];
+    Topic.afterCommit(function (record: InstanceType<typeof Topic>) {
+      committed.push(record.title as string);
+    });
+
+    await Topic.transaction(async () => {
+      await Topic.transaction(async () => {
+        await Topic.create({ title: "nested-test" });
+      });
+    });
+
+    expect(committed).toEqual(["nested-test"]);
+  });
 });

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -372,10 +372,23 @@ export async function beforeCommittedBang(record: Base): Promise<void> {
  *
  * Mirrors: ActiveRecord::Transactions#committed!
  */
-export async function committedBang(this: Base): Promise<void> {
-  if (!isTriggerTransactionalCallbacks(this)) return;
-  const ctor = this.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfter?.("commit", this);
+export async function committedBang(
+  this: Base,
+  { shouldRunCallbacks = true }: { shouldRunCallbacks?: boolean } = {},
+): Promise<void> {
+  const r = this as any;
+  r._startTransactionState = null;
+  try {
+    if (shouldRunCallbacks && isTriggerTransactionalCallbacks.call(this)) {
+      r._committedAlreadyCalled = true;
+      const ctor = this.constructor as typeof Base;
+      await (ctor as any)._callbackChain?.runAfter?.("commit", this);
+    }
+  } finally {
+    r._committedAlreadyCalled = false;
+    r._triggerUpdateCallback = false;
+    r._triggerDestroyCallback = false;
+  }
 }
 
 /**
@@ -383,10 +396,26 @@ export async function committedBang(this: Base): Promise<void> {
  *
  * Mirrors: ActiveRecord::Transactions#rolledback!
  */
-export async function rolledbackBang(this: Base): Promise<void> {
-  if (!isTriggerTransactionalCallbacks(this)) return;
-  const ctor = this.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfter?.("rollback", this);
+export async function rolledbackBang(
+  this: Base,
+  {
+    forceRestoreState = false,
+    shouldRunCallbacks = true,
+  }: { forceRestoreState?: boolean; shouldRunCallbacks?: boolean } = {},
+): Promise<void> {
+  try {
+    if (shouldRunCallbacks && isTriggerTransactionalCallbacks.call(this)) {
+      const ctor = this.constructor as typeof Base;
+      await (ctor as any)._callbackChain?.runAfter?.("rollback", this);
+    }
+  } finally {
+    _restoreTransactionRecordState.call(this, forceRestoreState);
+    clearTransactionRecordState.call(this);
+    if (forceRestoreState) {
+      (this as any)._triggerUpdateCallback = false;
+      (this as any)._triggerDestroyCallback = false;
+    }
+  }
 }
 
 /**
@@ -459,6 +488,32 @@ export function restoreTransactionRecordState(
   }
 }
 
+// this-typed form used by rolledbackBang ensure block — reads _startTransactionState
+// (populated by remember_transaction_record_state level-tracking; currently always
+// null since our fallback uses captured snapshots, so this is a no-op until the
+// level-tracking state is implemented).
+/** @internal */
+function _restoreTransactionRecordState(this: Base, _forceRestoreState = false): void {
+  const r = this as any;
+  if (!r._startTransactionState) return;
+  const state = r._startTransactionState;
+  if (_forceRestoreState || state.level <= 1) {
+    r._newRecord = state.newRecord;
+    r._destroyed = state.destroyed;
+    r._previouslyNewRecord = state.previouslyNewRecord;
+    if (r._attributes.isFrozen()) {
+      r._attributes = r._attributes.deepDup();
+    }
+    const ctor = this.constructor as typeof Base;
+    if (state.newRecord && !Array.isArray(this.id)) {
+      r._attributes.set(ctor.primaryKey as string, state.id);
+    }
+    if (state.frozen && !r._attributes.isFrozen()) {
+      r._attributes.freeze();
+    }
+  }
+}
+
 /**
  * Execute a block within a transaction and capture its return value as a
  * status flag. If the status is falsy (false/null/undefined), the transaction
@@ -476,13 +531,12 @@ export async function withTransactionReturningStatus<T>(
   // Mirrors: remember_transaction_record_state — snapshot before transaction
   const snapshot = rememberTransactionRecordState.call(this);
 
-  // Reset transaction tracking flags (the block will set them if the
-  // operation succeeds).
+  // Mirrors: remember_transaction_record_state — set _newRecordBeforeLastCommit.
+  // _triggerUpdateCallback/_triggerDestroyCallback are NOT reset here; Rails resets
+  // those only in committed!/rolledback! ensure blocks.
   const r = this as any;
   r._transactionAction = undefined;
   r._newRecordBeforeLastCommit = r._newRecord ?? this.isNewRecord?.() ?? false;
-  r._triggerUpdateCallback = false;
-  r._triggerDestroyCallback = false;
 
   let status: T;
   let rolledBack = false;
@@ -554,14 +608,15 @@ export function _newRecordBeforeLastCommit(this: Base): boolean {
  *
  * Mirrors: ActiveRecord::Transactions#trigger_transactional_callbacks?
  */
-export function isTriggerTransactionalCallbacks(record: Base): boolean {
-  const r = record as any;
-  const newBeforeLastCommit = r._newRecordBeforeLastCommit ?? false;
-  const triggerUpdate = r._triggerUpdateCallback ?? false;
-  const triggerDestroy = r._triggerDestroyCallback ?? false;
+export function isTriggerTransactionalCallbacks(this: Base): boolean {
+  const r = this as any;
+  // Use === true to avoid prototype method bleeding through as a truthy value.
+  const newBeforeLastCommit = r._newRecordBeforeLastCommit === true;
+  const triggerUpdate = r._triggerUpdateCallback === true;
+  const triggerDestroy = r._triggerDestroyCallback === true;
   return (
-    ((newBeforeLastCommit || triggerUpdate) && record.isPersisted()) ||
-    (triggerDestroy && record.isDestroyed())
+    ((newBeforeLastCommit || triggerUpdate) && this.isPersisted()) ||
+    (triggerDestroy && this.isDestroyed())
   );
 }
 

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -589,7 +589,7 @@ export async function withTransactionReturningStatus<T>(
           // transaction, not the pre-transaction state. Matches Rails where
           // rolledback! fires during rollback, restore runs in ensure.
           await rolledbackBang.call(this);
-          restoreTransactionRecordState(this, snapshot);
+          restoreTransactionRecordState.call(this, snapshot);
         });
       } else {
         await committedBang.call(this);

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -372,10 +372,10 @@ export async function beforeCommittedBang(record: Base): Promise<void> {
  *
  * Mirrors: ActiveRecord::Transactions#committed!
  */
-export async function committedBang(record: Base): Promise<void> {
-  if (!isTriggerTransactionalCallbacks(record)) return;
-  const ctor = record.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfter?.("commit", record);
+export async function committedBang(this: Base): Promise<void> {
+  if (!isTriggerTransactionalCallbacks(this)) return;
+  const ctor = this.constructor as typeof Base;
+  await (ctor as any)._callbackChain?.runAfter?.("commit", this);
 }
 
 /**
@@ -383,10 +383,10 @@ export async function committedBang(record: Base): Promise<void> {
  *
  * Mirrors: ActiveRecord::Transactions#rolledback!
  */
-export async function rolledbackBang(record: Base): Promise<void> {
-  if (!isTriggerTransactionalCallbacks(record)) return;
-  const ctor = record.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfter?.("rollback", record);
+export async function rolledbackBang(this: Base): Promise<void> {
+  if (!isTriggerTransactionalCallbacks(this)) return;
+  const ctor = this.constructor as typeof Base;
+  await (ctor as any)._callbackChain?.runAfter?.("rollback", this);
 }
 
 /**
@@ -487,10 +487,22 @@ export async function withTransactionReturningStatus<T>(
   let status: T;
   let rolledBack = false;
 
+  // Capture whether there is an outer transaction before entering transaction().
+  // Mirrors Rails' `ensure_finalize = !connection.transaction_open?`.
+  const hadOuterTransaction = currentTransaction() !== null;
+  const hasTransactionManager =
+    typeof (modelClass.adapter as any).withinNewTransaction === "function";
+
   await transaction(modelClass, async (tx) => {
-    // Mirrors: add_to_transaction — register for state restoration on rollback.
-    // Actual committedBang/rolledbackBang callbacks are scheduled after
-    // the transaction returns, on the outer transaction or fired immediately.
+    // Enroll record with the TransactionManager so it fires committedBang/
+    // rolledbackBang after the transaction commits or rolls back.
+    if (hasTransactionManager) {
+      await addToTransaction.call(
+        this,
+        !hadOuterTransaction || hasTransactionalCallbacks.call(this),
+      );
+    }
+
     tx.afterRollback(async () => {
       restoreTransactionRecordState.call(this, snapshot);
     });
@@ -504,26 +516,27 @@ export async function withTransactionReturningStatus<T>(
     return status;
   });
 
-  // Schedule commit/rollback callbacks. If inside an outer transaction,
-  // defer to it. If the inner transaction rolled back, fire rolledbackBang
-  // immediately (state was already restored by the afterRollback above).
-  if (!rolledBack) {
-    const outerTx = currentTransaction();
-    if (outerTx) {
-      outerTx.afterCommit(async () => await committedBang(this));
-      outerTx.afterRollback(async () => {
-        // Fire callbacks before restoring state — rolledbackBang needs
-        // isPersisted()/isDestroyed() to reflect what happened during the
-        // transaction, not the pre-transaction state. Matches Rails where
-        // rolledback! fires during rollback, restore runs in ensure.
-        await rolledbackBang(this);
-        restoreTransactionRecordState.call(this, snapshot);
-      });
+  // For adapters without a TransactionManager, addToTransaction is a no-op,
+  // so we must schedule callbacks manually.
+  if (!hasTransactionManager) {
+    if (!rolledBack) {
+      const outerTx = currentTransaction();
+      if (outerTx) {
+        outerTx.afterCommit(async () => await committedBang.call(this));
+        outerTx.afterRollback(async () => {
+          // Fire callbacks before restoring state — rolledbackBang needs
+          // isPersisted()/isDestroyed() to reflect what happened during the
+          // transaction, not the pre-transaction state. Matches Rails where
+          // rolledback! fires during rollback, restore runs in ensure.
+          await rolledbackBang.call(this);
+          restoreTransactionRecordState(this, snapshot);
+        });
+      } else {
+        await committedBang.call(this);
+      }
     } else {
-      await committedBang(this);
+      await rolledbackBang.call(this);
     }
-  } else {
-    await rolledbackBang(this);
   }
 
   return status!;
@@ -615,11 +628,9 @@ export function isTransactionIncludeAnyAction(this: Base, actions: string[]): bo
 /** @internal */
 export async function addToTransaction(this: Base, ensureFinalize = true): Promise<void> {
   const ctor = this.constructor as any;
-  if (typeof ctor.withConnection === "function") {
-    await ctor.withConnection(async (connection: any) => {
-      connection.addTransactionRecord?.(this, ensureFinalize);
-    });
-  }
+  // We're always called from within a transaction, so the adapter IS the
+  // current connection — no need to go through withConnection.
+  ctor.adapter?.addTransactionRecord?.(this, ensureFinalize);
 }
 
 // Mirrors: ActiveRecord::Transactions#has_transactional_callbacks?

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -541,11 +541,17 @@ export async function withTransactionReturningStatus<T>(
   let status: T;
   let rolledBack = false;
 
-  // Capture whether there is an outer transaction before entering transaction().
   // Mirrors Rails' `ensure_finalize = !connection.transaction_open?`.
-  const hadOuterTransaction = currentTransaction() !== null;
+  // inTransaction covers external transactions (e.g. fixtures) that
+  // TransactionManager doesn't track — same condition used in transaction().
+  const adapter = modelClass.adapter;
+  const hadOuterTransaction = currentTransaction() !== null || adapter.inTransaction;
+  // TransactionManager path is only active when withinNewTransaction exists AND
+  // we're not in the external-transaction fallback (adapter.inTransaction &&
+  // currentTransaction() === null causes transaction() to use the fallback).
   const hasTransactionManager =
-    typeof (modelClass.adapter as any).withinNewTransaction === "function";
+    typeof (adapter as any).withinNewTransaction === "function" &&
+    !(currentTransaction() === null && adapter.inTransaction);
 
   await transaction(modelClass, async (tx) => {
     // Enroll record with the TransactionManager so it fires committedBang/


### PR DESCRIPTION
## Summary

- Converts `committedBang`, `rolledbackBang`, `addToTransaction`, and `hasTransactionalCallbacks` from record-arg functions to `this`-typed functions so the TransactionManager can invoke them as instance methods on enrolled records
- Wires all four into `include(Base, {...})` in `base.ts` for api:compare attribution (removes the blocking comment)
- Updates `withTransactionReturningStatus` to enroll the record via `addToTransaction` when the adapter has a TransactionManager (`withinNewTransaction` present), replacing the manual `afterCommit`/`afterRollback` scheduling for that path; the manual fallback is retained for simple adapters
- `addToTransaction` calls `adapter.addTransactionRecord?.()` directly (we're already inside a transaction, no `withConnection` needed)

**api:compare**: `base.rb` 241→247/277 (87%→89%), `transactions.rb` 34/34 (100%)

## Test plan

- [ ] `pnpm test:types` — passes (83 tests)
- [ ] `pnpm vitest run packages/activerecord` — 312 test files pass, no regressions
- [ ] `pnpm lint --fix` — clean
- [ ] `pnpm api:compare --package activerecord` — base.rb 89%, transactions.rb 100%