### PR TITLE
feat(activerecord): fix inheritance attribution for GeneratedAttributeMethods + Aes256Gcm

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -101,8 +101,7 @@ export function accessedFields(this: AttributeRecord): string[] {
  *
  * Mirrors: ActiveRecord::AttributeMethods::GeneratedAttributeMethods
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface GeneratedAttributeMethods {}
+export class GeneratedAttributeMethods {}
 
 // ---------------------------------------------------------------------------
 // Class methods — mirrors ActiveRecord::AttributeMethods::ClassMethods

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -23,7 +23,7 @@ import { type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
-import { Cipher as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
+import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
 import { globalPreviousSchemesFor, EncryptableRecord } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -6,7 +6,7 @@
  * Mirrors: ActiveRecord::Encryption::Cipher (encryption/cipher.rb)
  */
 
-import { Cipher as AesGcmCipher } from "./cipher/aes256-gcm.js";
+import { Aes256Gcm as AesGcmCipher } from "./cipher/aes256-gcm.js";
 import { ConfigError, DecryptionError } from "./errors.js";
 
 export class Cipher {

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Cipher } from "./aes256-gcm.js";
+import { Aes256Gcm as Cipher } from "./aes256-gcm.js";
 import * as crypto from "crypto";
 import { inspect } from "util";
 

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -11,7 +11,7 @@ const KEY_LENGTH = 32;
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
-export class Cipher {
+export class Aes256Gcm {
   static keyLength = KEY_LENGTH;
   static ivLength = IV_LENGTH;
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Encryptor
  */
 
-import { Cipher } from "./cipher/aes256-gcm.js";
+import { Aes256Gcm as Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -4,7 +4,7 @@ export { Properties } from "./properties.js";
 export { Key } from "./key.js";
 export { KeyGenerator } from "./key-generator.js";
 export { Cipher } from "./cipher.js";
-export { Cipher as Aes256Gcm } from "./cipher/aes256-gcm.js";
+export { Aes256Gcm } from "./cipher/aes256-gcm.js";
 export { MessageSerializer } from "./message-serializer.js";
 export { Encryptor } from "./encryptor.js";
 export type { EncryptorOptions, EncryptorLike, KeyProviderLike } from "./encryptor.js";


### PR DESCRIPTION
## Summary

Two attribution-only fixes that close 2 of the 6 inheritance mismatches reported by `pnpm api:compare --package activerecord --inheritance`.

**Before:** `inheritance: 203/209`
**After:** `inheritance: 205/209`

### Fix 1 — `GeneratedAttributeMethods`: interface → class

`active_record/attribute_methods.rb` defines `module GeneratedAttributeMethods`. The comparator expects a class (or class-like construct); an `interface` doesn't register as one. Converted to an empty `class` — no consumers use it for declaration-merging or structural typing.

### Fix 2 — `aes256-gcm.ts`: `Cipher` → `Aes256Gcm`

Rails nests `Aes256Gcm` inside `Cipher` (`active_record/encryption/cipher/aes256_gcm.rb`). The TS file was named after the Rails file but exported the generic name `Cipher`, causing the comparator to report `Aes256Gcm` as missing. Renamed the exported class to `Aes256Gcm` and updated all 5 import sites (using local aliases where needed).

## Deferred mismatches (4 remaining)

- `DeterministicKeyProvider extends KeyProvider` (should be `DerivedSecretKeyProvider`) — real semantic gap
- `EncryptingOnlyEncryptor` no parent (should extend `Encryptor`) — real semantic gap
- `trailtie.ts:Railtie` filename mismatch — requires rename + comparator consideration
- `DecimalWithoutScale extends IntegerType` (should be `BigIntegerType`) — latent correctness bug, needs test coverage