### PR TITLE
fix(activerecord): correct combineMultiStatements import and insert() id extraction

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { TypeMap } from "../type/type-map.js";
 import {
   BooleanType,
@@ -14,6 +14,7 @@ import { DateTime as DateTimeType } from "../type/date-time.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
+import { Result } from "../result.js";
 
 // All 5 methods are class-level in Rails (class << self private), so test via a subclass.
 class TestAdapter extends AbstractAdapter {
@@ -142,5 +143,45 @@ describe("AbstractAdapter.initializeTypeMap", () => {
 
   it("aliases double to float", () => {
     expect(m.lookup("double")).toBeInstanceOf(FloatType);
+  });
+});
+
+describe("DatabaseStatements#insert id extraction", () => {
+  // execInsert/execute are include()-mixed methods, not class declarations,
+  // so we assign them via any rather than using class override syntax.
+  class InsertTestAdapter extends AbstractAdapter {
+    static get adapterName() {
+      return "InsertTestAdapter";
+    }
+    override get adapterName() {
+      return "InsertTestAdapter" as const;
+    }
+  }
+
+  it("returns numeric insertId when execInsert returns a number", async () => {
+    const adapter = new InsertTestAdapter() as any;
+    adapter.execInsert = async () => 42;
+    expect(await adapter.insert("INSERT INTO t VALUES (1)")).toBe(42);
+  });
+
+  it("respects idValue override when provided, regardless of execInsert return type", async () => {
+    const adapter = new InsertTestAdapter() as any;
+    adapter.execInsert = async () => 42;
+    expect(await adapter.insert("INSERT INTO t VALUES (1)", null, null, 99)).toBe(99);
+  });
+
+  it("extracts id from Result via lastInsertedId when execInsert returns a Result", async () => {
+    const adapter = new InsertTestAdapter() as any;
+    adapter.execInsert = async () => new Result(["id"], [[99]]);
+    expect(await adapter.insert("INSERT INTO t VALUES (1)")).toBe(99);
+  });
+
+  it("calls adapter lastInsertedId when present and execInsert returns a Result", async () => {
+    const adapter = new InsertTestAdapter() as any;
+    adapter.execInsert = async () => new Result(["id"], [[99]]);
+    const customLastInserted = vi.fn().mockReturnValue(77);
+    adapter.lastInsertedId = customLastInserted;
+    expect(await adapter.insert("INSERT INTO t VALUES (1)")).toBe(77);
+    expect(customLastInserted).toHaveBeenCalled();
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1412,7 +1412,14 @@ export const DatabaseStatements = {
     const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
     const result = await this.execInsert(sql, name, resolvedBinds, pk);
     if (opts?.returning != null) return returningColumnValues.call(this, result);
-    return idValue ?? lastInsertedId(result as Result);
+    if (idValue != null) return idValue;
+    // execInsert may return a Result (PG/adapter with RETURNING support) or a
+    // number/insertId (MySQL/SQLite via executeMutation). Delegate to the
+    // adapter's lastInsertedId when available; fall back to treating the
+    // result directly as the id (matches executeMutation returning insertId).
+    if (this.lastInsertedId && result instanceof Result) return this.lastInsertedId(result);
+    if (result instanceof Result) return lastInsertedId(result);
+    return result; // numeric insertId from executeMutation
   },
 
   async update(

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -7,7 +7,7 @@
 import type mysql from "mysql2/promise";
 import { NotImplementedError } from "../../errors.js";
 import { Result } from "../../result.js";
-import { combineMultiStatements } from "../abstract/database-statements.js";
+import { combineMultiStatements } from "../mysql/database-statements.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;


### PR DESCRIPTION
Fixes two bugs introduced in #1310 that were caught by Copilot review but committed after the merge window closed.

## Bugs fixed

### 1. mysql2/executeBatch — wrong `combineMultiStatements` import

`mysql2/database-statements.ts` was importing `combineMultiStatements` from `abstract/database-statements` (returns a single joined **string**), so `for...of` was iterating one character per loop. Should import from `mysql/database-statements` which returns a `string[]` of packet-aware chunks.

### 2. insert() — numeric insertId treated as Result

The module-object `execInsert` returns a `number` from `executeMutation` (the insertId), but `insert()` passed it to `lastInsertedId(result as Result)` which reads `result.rows` — crashing for any adapter that doesn't override `execInsert`. Fixed to fall through: use `lastInsertedId` when result is a `Result`, otherwise return the numeric insertId directly.