### PR TITLE
feat(api-compare): cross-package inheritance resolution

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -10,6 +10,7 @@ import {
   dedupeRubyMethodInto,
   selectMisplacedFile,
   MISPLACED_MIN_HITS,
+  buildEntitiesByName,
 } from "./compare.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
@@ -612,5 +613,81 @@ describe("selectMisplacedFile", () => {
       10,
     );
     expect(result).toBe("winner.ts");
+  });
+});
+
+import type { ApiManifest } from "./types.js";
+
+function method(name: string): import("./types.js").MethodInfo {
+  return { name, visibility: "public", params: [] };
+}
+
+function makeManifest(
+  packages: Record<
+    string,
+    { classes?: Record<string, ClassInfo>; modules?: Record<string, ClassInfo> }
+  >,
+): ApiManifest {
+  const result: ApiManifest = { source: "typescript", generatedAt: "", packages: {} };
+  for (const [pkg, p] of Object.entries(packages)) {
+    result.packages[pkg] = { classes: p.classes ?? {}, modules: p.modules ?? {} };
+  }
+  return result;
+}
+
+describe("buildEntitiesByName", () => {
+  it("includes entities from the current package", () => {
+    const base = cls("packages/activerecord/src/base.ts", "Base");
+    const ts = makeManifest({ activerecord: { classes: { Base: base } } });
+    const map = buildEntitiesByName("activerecord", ts);
+    expect(map.get("Base")).toContain(base);
+  });
+
+  it("includes entities from @blazetrails/* dep packages when package.json lists them", () => {
+    // activerecord depends on activemodel; Model lives in activemodel.
+    const model = cls("packages/activemodel/src/model.ts", "Model");
+    model.instanceMethods = [method("attributes")];
+
+    const base = cls("packages/activerecord/src/base.ts", "Base");
+    base.superclass = "Model";
+
+    const ts = makeManifest({
+      activerecord: { classes: { Base: base } },
+      activemodel: { classes: { Model: model } },
+    });
+
+    // activerecord's real package.json includes @blazetrails/activemodel,
+    // so buildEntitiesByName should pull in Model from activemodel.
+    const map = buildEntitiesByName("activerecord", ts);
+    const modelCandidates = map.get("Model") ?? [];
+    expect(modelCandidates).toContain(model);
+  });
+
+  it("does not add dep-package entities for a package with no blazetrails deps (e.g. activesupport)", () => {
+    const concern = cls("packages/activesupport/src/concern.ts", "Concern");
+    const ts = makeManifest({
+      activesupport: { classes: { Concern: concern } },
+      activemodel: { classes: { Model: cls("packages/activemodel/src/model.ts", "Model") } },
+    });
+
+    const map = buildEntitiesByName("activesupport", ts);
+    // activesupport's package.json has no @blazetrails/* deps, so Model must not appear.
+    expect(map.has("Model")).toBe(false);
+  });
+
+  it("current-package entities appear before dep-package entities (same name)", () => {
+    const localModel = cls("packages/activerecord/src/model.ts", "Model");
+    const depModel = cls("packages/activemodel/src/model.ts", "Model");
+    const ts = makeManifest({
+      activerecord: { classes: { LocalModel: localModel } },
+      activemodel: { classes: { Model: depModel } },
+    });
+    // Override localModel name so both share the key "Model"
+    localModel.name = "Model";
+
+    const map = buildEntitiesByName("activerecord", ts);
+    const candidates = map.get("Model") ?? [];
+    // Local should be first (added first due to current-package priority)
+    expect(candidates[0]).toBe(localModel);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -12,7 +12,7 @@ import {
   MISPLACED_MIN_HITS,
   buildEntitiesByName,
 } from "./compare.js";
-import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
+import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 function cls(file: string, name: string, superclass?: string): ClassInfo {
   return {
@@ -24,6 +24,23 @@ function cls(file: string, name: string, superclass?: string): ClassInfo {
     instanceMethods: [],
     classMethods: [],
   };
+}
+
+function method(name: string): MethodInfo {
+  return { name, visibility: "public", params: [] };
+}
+
+function makeManifest(
+  packages: Record<
+    string,
+    { classes?: Record<string, ClassInfo>; modules?: Record<string, ClassInfo> }
+  >,
+): ApiManifest {
+  const result: ApiManifest = { source: "typescript", generatedAt: "", packages: {} };
+  for (const [pkg, p] of Object.entries(packages)) {
+    result.packages[pkg] = { classes: p.classes ?? {}, modules: p.modules ?? {} };
+  }
+  return result;
 }
 
 describe("nameMatches", () => {
@@ -616,25 +633,6 @@ describe("selectMisplacedFile", () => {
   });
 });
 
-import type { ApiManifest } from "./types.js";
-
-function method(name: string): import("./types.js").MethodInfo {
-  return { name, visibility: "public", params: [] };
-}
-
-function makeManifest(
-  packages: Record<
-    string,
-    { classes?: Record<string, ClassInfo>; modules?: Record<string, ClassInfo> }
-  >,
-): ApiManifest {
-  const result: ApiManifest = { source: "typescript", generatedAt: "", packages: {} };
-  for (const [pkg, p] of Object.entries(packages)) {
-    result.packages[pkg] = { classes: p.classes ?? {}, modules: p.modules ?? {} };
-  }
-  return result;
-}
-
 describe("buildEntitiesByName", () => {
   it("includes entities from the current package", () => {
     const base = cls("packages/activerecord/src/base.ts", "Base");
@@ -673,6 +671,25 @@ describe("buildEntitiesByName", () => {
     const map = buildEntitiesByName("activesupport", ts);
     // activesupport's package.json has no @blazetrails/* deps, so Model must not appear.
     expect(map.has("Model")).toBe(false);
+  });
+
+  it("excludes __fixtures__ and tsc-wrapper stubs so they don't shadow real dep-package entities", () => {
+    // activerecord tsc-wrapper fixtures contain a stub Model with 1 method;
+    // the real Model in activemodel has many methods. Fixtures must be skipped.
+    const stubModel = cls("tsc-wrapper/__fixtures__/base.ts", "Model");
+    stubModel.instanceMethods = [method("stub")];
+    const realModel = cls("model.ts", "Model");
+    realModel.instanceMethods = [method("attributes"), method("readAttribute")];
+
+    const ts = makeManifest({
+      activerecord: { classes: { StubModel: stubModel } },
+      activemodel: { classes: { Model: realModel } },
+    });
+
+    const map = buildEntitiesByName("activerecord", ts);
+    const candidates = map.get("Model") ?? [];
+    expect(candidates).toContain(realModel);
+    expect(candidates).not.toContain(stubModel);
   });
 
   it("current-package entities appear before dep-package entities (same name)", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -32,7 +32,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
-import { OUTPUT_DIR, packageSrcDir } from "./config.js";
+import { OUTPUT_DIR, ROOT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import { isExcluded } from "./excluded-files.js";
 
@@ -481,6 +481,57 @@ export function selectMisplacedFile(
   return bestFile;
 }
 
+/**
+ * Build a name → ClassInfo[] map for `pkg`, unioning in entities from every
+ * @blazetrails/* dependency so the inheritance walker can cross package
+ * boundaries (e.g. AR Base extends AM Model).
+ */
+export function buildEntitiesByName(pkg: string, ts: ApiManifest): Map<string, ClassInfo[]> {
+  const map = new Map<string, ClassInfo[]>();
+
+  const isFixture = (e: ClassInfo) =>
+    (e.file ?? "").includes("__fixtures__") || (e.file ?? "").startsWith("tsc-wrapper/");
+
+  const addPkg = (pkgKey: string) => {
+    const p = ts.packages[pkgKey];
+    if (!p) return;
+    for (const entity of [...Object.values(p.classes), ...Object.values(p.modules)]) {
+      if (isFixture(entity)) continue;
+      const list = map.get(entity.name) ?? [];
+      list.push(entity);
+      map.set(entity.name, list);
+    }
+  };
+
+  // Always include the current package first so same-package candidates beat
+  // cross-package ones in the proximity tie-breaker.
+  addPkg(pkg);
+
+  // Read @blazetrails/* deps from package.json to discover sibling packages.
+  const pkgJsonPath = path.join(ROOT_DIR, "packages", pkg, "package.json");
+  if (fs.existsSync(pkgJsonPath)) {
+    try {
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as Record<
+        string,
+        Record<string, string>
+      >;
+      const allDeps = {
+        ...((pkgJson["dependencies"] as Record<string, string>) ?? {}),
+        ...((pkgJson["peerDependencies"] as Record<string, string>) ?? {}),
+      };
+      for (const dep of Object.keys(allDeps)) {
+        if (!dep.startsWith("@blazetrails/")) continue;
+        const depKey = dep.replace("@blazetrails/", "");
+        if (depKey !== pkg) addPkg(depKey);
+      }
+    } catch {
+      // Non-fatal: if we can't read deps, fall back to same-package only.
+    }
+  }
+
+  return map;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const pkgIndex = args.indexOf("--package");
@@ -579,13 +630,9 @@ function main() {
     // and interface/module `extends` chains.
     if (tsPkg) {
       // Key by short name → entity for superclass/extends resolution.
-      // Multiple entities can share a name; store all and resolve by context.
-      const entitiesByName = new Map<string, ClassInfo[]>();
-      for (const entity of [...Object.values(tsPkg.classes), ...Object.values(tsPkg.modules)]) {
-        const list = entitiesByName.get(entity.name) || [];
-        list.push(entity);
-        entitiesByName.set(entity.name, list);
-      }
+      // Includes dep-package entities so walks can cross package boundaries
+      // (e.g. AR Base extends AM Model).
+      const entitiesByName = buildEntitiesByName(pkg, ts);
 
       const entityKey = (e: ClassInfo) => `${e.file}:${e.name}`;
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -32,7 +32,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
-import { OUTPUT_DIR, PACKAGE_DIR_OVERRIDES, ROOT_DIR, packageSrcDir } from "./config.js";
+import {
+  DIR_TO_PACKAGES,
+  OUTPUT_DIR,
+  PACKAGE_DIR_OVERRIDES,
+  ROOT_DIR,
+  packageSrcDir,
+} from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import { isExcluded } from "./excluded-files.js";
 
@@ -522,8 +528,13 @@ export function buildEntitiesByName(pkg: string, ts: ApiManifest): Map<string, C
       };
       for (const dep of Object.keys(allDeps)) {
         if (!dep.startsWith("@blazetrails/")) continue;
-        const depKey = dep.replace("@blazetrails/", "");
-        if (depKey !== pkg) addPkg(depKey);
+        const depDir = dep.replace("@blazetrails/", "");
+        // A single npm package may map to multiple api-compare keys
+        // (e.g. actionpack → actiondispatch + actioncontroller).
+        const depKeys = DIR_TO_PACKAGES[depDir] ?? [depDir];
+        for (const depKey of depKeys) {
+          if (depKey !== pkg) addPkg(depKey);
+        }
       }
     } catch {
       // Non-fatal: if we can't read deps, fall back to same-package only.

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -32,7 +32,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
-import { OUTPUT_DIR, ROOT_DIR, packageSrcDir } from "./config.js";
+import { OUTPUT_DIR, PACKAGE_DIR_OVERRIDES, ROOT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import { isExcluded } from "./excluded-files.js";
 
@@ -508,7 +508,8 @@ export function buildEntitiesByName(pkg: string, ts: ApiManifest): Map<string, C
   addPkg(pkg);
 
   // Read @blazetrails/* deps from package.json to discover sibling packages.
-  const pkgJsonPath = path.join(ROOT_DIR, "packages", pkg, "package.json");
+  const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
+  const pkgJsonPath = path.join(ROOT_DIR, "packages", dirName, "package.json");
   if (fs.existsSync(pkgJsonPath)) {
     try {
       const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as Record<

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -21,6 +21,15 @@ export const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
   actioncontroller: "actionpack",
 };
 
+/**
+ * Inverse of PACKAGE_DIR_OVERRIDES: directory name → api-compare package keys.
+ * Used when resolving an npm dep name (e.g. `@blazetrails/actionpack`) to the
+ * logical package keys used in the TS manifest.
+ */
+export const DIR_TO_PACKAGES: Record<string, string[]> = {
+  actionpack: ["actiondispatch", "actioncontroller"],
+};
+
 /** Override package → src subdirectory when package shares a dir */
 export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
   actiondispatch: "actiondispatch",

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -23,12 +23,16 @@ export const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
 
 /**
  * Inverse of PACKAGE_DIR_OVERRIDES: directory name → api-compare package keys.
+ * Derived automatically so the two maps can't drift.
  * Used when resolving an npm dep name (e.g. `@blazetrails/actionpack`) to the
  * logical package keys used in the TS manifest.
  */
-export const DIR_TO_PACKAGES: Record<string, string[]> = {
-  actionpack: ["actiondispatch", "actioncontroller"],
-};
+export const DIR_TO_PACKAGES: Record<string, string[]> = Object.entries(
+  PACKAGE_DIR_OVERRIDES,
+).reduce<Record<string, string[]>>((acc, [pkg, dir]) => {
+  (acc[dir] ??= []).push(pkg);
+  return acc;
+}, {});
 
 /** Override package → src subdirectory when package shares a dir */
 export const PACKAGE_SRC_SUBDIR: Record<string, string> = {


### PR DESCRIPTION
## Summary

- `buildEntitiesByName` now unions entities from `@blazetrails/*` dep packages (read from `package.json`) into the resolution map used by the inheritance walker
- Excludes `__fixtures__`/`tsc-wrapper` stubs that were shadowing real classes in the proximity tie-breaker
- AR `base.rb` missing count: 18 → 8 (the 8 remaining are genuine source gaps, not attribution issues)

## Per-package before/after

| Package | Before | After |
|---|---|---|
| arel | 884/884 (100%) | 884/884 (100%) |
| activemodel | 620/625 (99.2%) | 620/625 (99.2%) |
| activerecord | 4937/4969 (99.4%) | 4947/4969 (99.6%) |
| activesupport | 501/2145 (23.4%) | 501/2145 (23.4%) |
| actiondispatch | 66/1352 (4.9%) | 66/1352 (4.9%) |
| actioncontroller | 252/581 (43.4%) | 252/581 (43.4%) |
| actionview | 31/2530 (1.2%) | 31/2530 (1.2%) |
| trailties | 2/1524 (0.1%) | 2/1524 (0.1%) |

No false positives: only activerecord gains (it's the only package whose classes extend across a package boundary).

## Methods now credited on base.rb

`attributes`, `readAttributeBeforeTypeCast`, `attributesBeforeTypeCast`, `savedChangeToAttribute`, `savedChanges`, `hasChangesToSave`, `changesToSave`, `changedAttributeNamesToSave`, `attributesInDatabase`, `normalizeAttribute` — all inherited from `Model` in `@blazetrails/activemodel`.

## Remaining 8 missing (genuine source gaps)

`fullPurpose`, `messageVerifier`, `payloadFor`, `generateToken`, `resolveToken`, `generateTokenFor`, `_queryBySql`, `_loadFromSql` — not in any TS class; need separate implementation PRs.