### PR TITLE
fix(activerecord): DeterministicKeyProvider + EncryptingOnlyEncryptor inheritance (206→208/209)

### DIFF
--- a/packages/activerecord/src/encryption/deterministic-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/deterministic-key-provider.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
-import { Key } from "./key.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { ConfigError } from "./errors.js";
 
 describe("ActiveRecord::Encryption::DeterministicKeyProviderTest", () => {
   it("will raise a configuration error when trying to configure multiple keys", () => {
-    const k1 = new Key("secret1");
-    const k2 = new Key("secret2");
-    expect(() => new DeterministicKeyProvider([k1, k2])).toThrow(ConfigError);
+    expect(() => new DeterministicKeyProvider(["secret1", "secret2"])).toThrow(ConfigError);
+  });
+
+  it("extends DerivedSecretKeyProvider", () => {
+    expect(DeterministicKeyProvider.prototype instanceof DerivedSecretKeyProvider).toBe(true);
   });
 });

--- a/packages/activerecord/src/encryption/deterministic-key-provider.ts
+++ b/packages/activerecord/src/encryption/deterministic-key-provider.ts
@@ -1,19 +1,18 @@
 /**
- * Deterministic key provider — uses a single key for deterministic encryption.
+ * Deterministic key provider — derives a single key from a password.
  *
  * Mirrors: ActiveRecord::Encryption::DeterministicKeyProvider
  */
 
-import { Key } from "./key.js";
 import { ConfigError } from "./errors.js";
-import { KeyProvider } from "./key-provider.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
-export class DeterministicKeyProvider extends KeyProvider {
-  constructor(keys: Key | Key[]) {
-    const keyList = Array.isArray(keys) ? keys : [keys];
-    if (keyList.length > 1) {
-      throw new ConfigError("A DeterministicKeyProvider only supports a single key");
+export class DeterministicKeyProvider extends DerivedSecretKeyProvider {
+  constructor(passwords: string | string[]) {
+    const passwordList = Array.isArray(passwords) ? passwords : [passwords];
+    if (passwordList.length > 1) {
+      throw new ConfigError("Deterministic encryption keys can't be rotated");
     }
-    super(keyList);
+    super(passwordList);
   }
 }

--- a/packages/activerecord/src/encryption/encrypting-only-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encrypting-only-encryptor.test.ts
@@ -22,4 +22,8 @@ describe("ActiveRecord::Encryption::EncryptingOnlyEncryptorTest", () => {
     const decrypted = realEnc.decrypt(encrypted, { key });
     expect(decrypted).toBe("hello");
   });
+
+  it("extends Encryptor", () => {
+    expect(EncryptingOnlyEncryptor.prototype instanceof Encryptor).toBe(true);
+  });
 });

--- a/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
+++ b/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
@@ -5,9 +5,17 @@
  */
 
 import { Encryptor } from "./encryptor.js";
+import type { KeyProviderLike } from "./encryptor.js";
 
 export class EncryptingOnlyEncryptor extends Encryptor {
-  override decrypt(encryptedText: string): string {
+  override decrypt(
+    encryptedText: string,
+    _options?: {
+      keyProvider?: KeyProviderLike;
+      key?: string;
+      cipherOptions?: Record<string, unknown>;
+    },
+  ): string {
     return encryptedText;
   }
 }

--- a/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
+++ b/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
@@ -5,17 +5,9 @@
  */
 
 import { Encryptor } from "./encryptor.js";
-import type { KeyProviderLike } from "./encryptor.js";
 
 export class EncryptingOnlyEncryptor extends Encryptor {
-  override decrypt(
-    encryptedText: string,
-    _options?: {
-      keyProvider?: KeyProviderLike;
-      key?: string;
-      cipherOptions?: Record<string, unknown>;
-    },
-  ): string {
+  override decrypt(encryptedText: string, _options?: Parameters<Encryptor["decrypt"]>[1]): string {
     return encryptedText;
   }
 }

--- a/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
+++ b/packages/activerecord/src/encryption/encrypting-only-encryptor.ts
@@ -5,23 +5,9 @@
  */
 
 import { Encryptor } from "./encryptor.js";
-import type { KeyProviderLike } from "./encryptor.js";
 
-export class EncryptingOnlyEncryptor {
-  private _encryptor: Encryptor;
-
-  constructor() {
-    this._encryptor = new Encryptor();
-  }
-
-  encrypt(
-    clearText: string,
-    options?: { keyProvider?: KeyProviderLike; key?: string; deterministic?: boolean },
-  ): string {
-    return this._encryptor.encrypt(clearText, options);
-  }
-
-  decrypt(encryptedText: string): string {
+export class EncryptingOnlyEncryptor extends Encryptor {
+  override decrypt(encryptedText: string): string {
     return encryptedText;
   }
 }

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -54,12 +54,15 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
 
   it("keyProvider resolves from deterministic: true via DeterministicKeyProvider when config.deterministicKey is set", () => {
     const originalKey = Configurable.config.deterministicKey;
+    const originalSalt = Configurable.config.keyDerivationSalt;
     Configurable.config.deterministicKey = "det-key";
+    Configurable.config.keyDerivationSalt = "test-salt";
     try {
       const scheme = new Scheme({ deterministic: true });
       expect(scheme.keyProvider).toBeInstanceOf(DeterministicKeyProvider);
     } finally {
       Configurable.config.deterministicKey = originalKey;
+      Configurable.config.keyDerivationSalt = originalSalt;
     }
   });
 

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -11,7 +11,6 @@ import { Configurable } from "./configurable.js";
 import { withEncryptionContext } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
-import { Key } from "./key.js";
 import {
   getOrCreateDefaultKeyProvider,
   clearDefaultKeyProviderCache,
@@ -155,9 +154,7 @@ export class Scheme {
   private deterministicKeyProvider(): DeterministicKeyProvider | undefined {
     if (this.deterministic) {
       const deterministicKey = Configurable.config.get("deterministicKey") as string;
-      this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(
-        new Key(deterministicKey),
-      );
+      this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(deterministicKey);
       return this._cachedDeterministicKeyProvider;
     }
     return undefined;


### PR DESCRIPTION
## Summary

- `DeterministicKeyProvider` now extends `DerivedSecretKeyProvider` instead of `KeyProvider` directly, matching Rails' `DeterministicKeyProvider < DerivedSecretKeyProvider`. Constructor signature updated from `Key | Key[]` to `string | string[]` to match the parent; call site in `scheme.ts` updated accordingly.
- `EncryptingOnlyEncryptor` now extends `Encryptor` instead of wrapping one via composition, matching Rails' `EncryptingOnlyEncryptor < Encryptor`. The private `_encryptor` field and delegating `encrypt` override are dropped — `encrypt` is now inherited. `decrypt` is overridden to return the raw text (matching Rails' semantics exactly).

Inheritance: **206/209 → 208/209**. Only `trailtie.ts` rename remains.

## Behavior change

`EncryptingOnlyEncryptor#decrypt` semantics are unchanged (still returns raw text). `DeterministicKeyProvider` now derives keys from password strings via `DerivedSecretKeyProvider` rather than accepting pre-constructed `Key` objects.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/encryption/deterministic-key-provider.test.ts packages/activerecord/src/encryption/encrypting-only-encryptor.test.ts` — 5 tests pass
- [ ] `pnpm api:compare --package activerecord --inheritance` → 208/209
- [ ] `pnpm build && pnpm typecheck` — clean