### PR TITLE
feat(api-compare): recognize Railtie → Trailtie as a global class rename

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -199,7 +199,7 @@ describe("resolveTsClassForRuby", () => {
     expect(resolveTsClassForRuby("Registry", "type/registry.ts", map)).toBe(renamed);
   });
 
-  it("resolves Railtie → Trailtie via TS_CLASS_RENAMES (trailtie convention applies to all packages)", () => {
+  it("resolves Railtie → Trailtie (global trailtie convention)", () => {
     const trailtie = cls("trailtie.ts", "Trailtie");
     const map = new Map([["trailtie.ts::Trailtie", trailtie]]);
     expect(resolveTsClassForRuby("Railtie", "trailtie.ts", map)).toBe(trailtie);

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -199,6 +199,12 @@ describe("resolveTsClassForRuby", () => {
     expect(resolveTsClassForRuby("Registry", "type/registry.ts", map)).toBe(renamed);
   });
 
+  it("resolves Railtie → Trailtie via TS_CLASS_RENAMES (trailtie convention applies to all packages)", () => {
+    const trailtie = cls("trailtie.ts", "Trailtie");
+    const map = new Map([["trailtie.ts::Trailtie", trailtie]]);
+    expect(resolveTsClassForRuby("Railtie", "trailtie.ts", map)).toBe(trailtie);
+  });
+
   it("returns undefined when nothing resolves", () => {
     expect(resolveTsClassForRuby("Nothing", "nowhere.ts", new Map())).toBeUndefined();
   });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -227,6 +227,8 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
 // short name → the literal TS class name in the expected file.
 // - `Name` → `ModelName`: Rails `ActiveModel::Name`. `Name` alone is
 //   too generic in TS, so the flattened class keeps the `Model` prefix.
+// - `Railtie` → `Trailtie`: Trails railties are not Rails::Railtie subclasses;
+//   the pun name signals that distinction across all packages.
 // - `Registry` → `TypeRegistry`: same rationale for `ActiveModel::Type::Registry`.
 const TS_CLASS_RENAMES: Record<string, string> = {
   Name: "ModelName",

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -230,6 +230,7 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
 // - `Registry` → `TypeRegistry`: same rationale for `ActiveModel::Type::Registry`.
 const TS_CLASS_RENAMES: Record<string, string> = {
   Name: "ModelName",
+  Railtie: "Trailtie",
   Registry: "TypeRegistry",
 };
 


### PR DESCRIPTION
## Summary

- Adds `Railtie: "Trailtie"` to `TS_CLASS_RENAMES` in `compare.ts` so the inheritance comparator resolves `Railtie` → `Trailtie` across all packages (not just activerecord)
- Adds one unit test pinning the rename in `compare.test.ts`

## Before / After

| Package | Inheritance before | Inheritance after |
|---|---|---|
| activerecord | 206/209 (98%) | 207/209 (99%) |
| all others | unchanged | unchanged |

The two remaining mismatches (`DeterministicKeyProvider`, `EncryptingOnlyEncryptor`) are in flight on a separate branch.

## Pure tooling change — no `packages/*/src/` edits