### PR TITLE
feat(activerecord): phase 3.3 connection.test.ts — un-skip 9 tests, sharpen 14 BLOCKEDs

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -18,8 +18,9 @@ describeIfMysql("Mysql2Adapter", () => {
 
   describe("ConnectionTest", () => {
     it("bad connection", async () => {
-      const badUrl = MYSQL_TEST_URL.replace(/\/[^/]*$/, "/inexistent_activerecord_unittest");
-      const badAdapter = new Mysql2Adapter(badUrl);
+      const u = new URL(MYSQL_TEST_URL);
+      u.pathname = "/inexistent_activerecord_unittest";
+      const badAdapter = new Mysql2Adapter(u.toString());
       await expect(badAdapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
       await badAdapter.close();
     });
@@ -119,10 +120,11 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("version string", async () => {
-      vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
+      const spy = vi.spyOn(adapter, "getFullVersion");
+      spy.mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("8.0.35");
 
-      vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce("5.7.0");
+      spy.mockResolvedValueOnce("5.7.0");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("5.7.0");
     });
 
@@ -134,8 +136,9 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("version string invalid", async () => {
+      const spy = vi.spyOn(adapter, "getFullVersion");
       const assertVersionError = async (version: string | null, expectedMsg: string) => {
-        vi.spyOn(adapter, "getFullVersion").mockResolvedValue(version as string);
+        spy.mockResolvedValueOnce(version as string);
         let caughtErr: unknown;
         try {
           await adapter.getDatabaseVersion();

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -13,6 +13,7 @@ describeIfMysql("Mysql2Adapter", () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
   });
   afterEach(async () => {
+    vi.restoreAllMocks();
     await adapter.close();
   });
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -1,8 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import type { NotificationEvent } from "@blazetrails/activesupport";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { NoDatabaseError, DatabaseVersionError } from "../../errors.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -14,45 +17,46 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("ConnectionTest", () => {
+    it("bad connection", async () => {
+      const badUrl = MYSQL_TEST_URL.replace(/\/[^/]*$/, "/inexistent_activerecord_unittest");
+      const badAdapter = new Mysql2Adapter(badUrl);
+      await expect(badAdapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
+      await badAdapter.close();
+    });
+
     it.skip("no automatic reconnection after timeout", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: Mysql2Adapter#active checks `_driverPool != null`, not socket liveness.
+      // SCOPE: wire socket ping into Mysql2Adapter#active (connection-adapters/mysql2-adapter.ts).
     });
     it.skip("successful reconnection after timeout with manual reconnect", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: reconnectBang() not implemented on Mysql2Adapter (no pool teardown + recreate).
+      // SCOPE: store config in constructor; override reconnectBang() in mysql2-adapter.ts.
     });
     it.skip("successful reconnection after timeout with verify", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: verifyBang() doesn't reconnect on Mysql2Adapter — same gap as reconnectBang().
     });
     it.skip("execute after disconnect reconnects", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: _checkoutConn() throws when _driverPool is null; no lazy reconnect.
+      // SCOPE: store config in constructor; recreate _driverPool in _checkoutConn() after disconnect.
     });
-    it.skip("quote after disconnect reconnects", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("quote after disconnect reconnects", () => {
+      adapter.disconnectBang();
+      expect(adapter.quote("string")).toBe("'string'");
     });
-    it.skip("active after disconnect", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("active after disconnect", () => {
+      expect(adapter.active).toBe(true);
+      adapter.disconnectBang();
+      expect(adapter.active).toBe(false);
     });
+
     it.skip("wait timeout as string", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: wait_timeout not wired into pool.on('connection') setup in mysql2-adapter.ts.
+      // SCOPE: parse wait_timeout from config; emit `SET SESSION wait_timeout = N` alongside SET time_zone.
     });
     it.skip("wait timeout as url", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: same as "wait timeout as string" — URL query param not parsed.
     });
 
     it("character set connection is configured", async () => {
@@ -62,79 +66,116 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it.skip("collation connection is configured", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: requires second adapter (ARUnit2Model pattern) — not in TS test infra.
+      // showVariable() now implemented; only the second-adapter assertion is missing.
+      // SCOPE: add MYSQL_TEST_URL2 + second adapter to test-helper.ts.
     });
     it.skip("mysql default in strict mode", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: configureConnection() doesn't set sql_mode/STRICT_ALL_TABLES in mysql2-adapter.ts.
+      // SCOPE: implement configureConnection() to emit SET SESSION sql_mode = '...,STRICT_ALL_TABLES'.
     });
     it.skip("mysql strict mode disabled", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: strict: false config not wired — same gap as "mysql default in strict mode".
     });
     it.skip("mysql strict mode specified default", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: strict: :default config not wired — same gap as "mysql default in strict mode".
     });
     it.skip("mysql sql mode variable overrides strict mode", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: variables config hash not wired into pool.on('connection') in mysql2-adapter.ts.
+      // SCOPE: parse variables; emit SET SESSION for each key alongside SET time_zone.
     });
     it.skip("passing arbitrary flags to adapter", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: pool model has no single raw_connection; flags on query_options not accessible.
+      // SCOPE: expose query_options via a test accessor or pool config read-back.
     });
     it.skip("passing flags by array to adapter", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: same as "passing arbitrary flags to adapter".
     });
     it.skip("mysql set session variable", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: variables config not wired — same gap as "mysql sql mode variable overrides".
     });
     it.skip("mysql set session variable to default", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: same as "mysql set session variable".
     });
-    it.skip("logs name show variable", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("logs name show variable", async () => {
+      await adapter.materializeTransactions();
+      const logged: Array<[string, string]> = [];
+      const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+        logged.push([event.payload.sql as string, event.payload.name as string]);
+      });
+      try {
+        await adapter.showVariable("foo");
+        expect(logged[0]?.[1]).toBe("SCHEMA");
+      } finally {
+        Notifications.unsubscribe(sub);
+      }
     });
+
     it.skip("logs name rename column for alter", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+      // BLOCKED: renameColumnForAlter() returns a SQL fragment (for bulk ALTER) and doesn't
+      //   fire sql.active_record notifications; the SHOW CREATE TABLE path (old MySQL/MariaDB)
+      //   needs to call execute() with name "SCHEMA" — not yet implemented.
     });
-    it.skip("version string", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("version string", async () => {
+      vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
+      expect((await adapter.getDatabaseVersion()).toString()).toBe("8.0.35");
+
+      vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce("5.7.0");
+      expect((await adapter.getDatabaseVersion()).toString()).toBe("5.7.0");
     });
-    it.skip("version string with mariadb", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("version string with mariadb", async () => {
+      vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce(
+        "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal",
+      );
+      expect((await adapter.getDatabaseVersion()).toString()).toBe("10.6.5");
     });
-    it.skip("version string invalid", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("version string invalid", async () => {
+      const assertVersionError = async (version: string | null, expectedMsg: string) => {
+        vi.spyOn(adapter, "getFullVersion").mockResolvedValue(version as string);
+        let caughtErr: unknown;
+        try {
+          await adapter.getDatabaseVersion();
+        } catch (e) {
+          caughtErr = e;
+        }
+        expect(caughtErr).toBeInstanceOf(DatabaseVersionError);
+        expect((caughtErr as DatabaseVersionError).message).toBe(expectedMsg);
+      };
+
+      await assertVersionError(
+        "some-database-proxy",
+        'Unable to parse MySQL version from "some-database-proxy"',
+      );
+      await assertVersionError("", 'Unable to parse MySQL version from ""');
+      await assertVersionError(null, "Unable to parse MySQL version from nil");
     });
-    it.skip("lock free", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in connection
-      // ROOT-CAUSE: adapters/mysql2/connection.ts or abstract-mysql-adapter/connection.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/connection.ts; affects ~10–26 tests in connection.test.ts
+
+    it("get and release advisory lock", async () => {
+      const lockName = "test lock'n'name";
+
+      const gotLock = await adapter.getAdvisoryLock(lockName);
+      expect(gotLock).toBe(true);
+
+      const isFree = await adapter.selectValue(`SELECT IS_FREE_LOCK(${adapter.quote(lockName)})`);
+      expect(isFree).toBe(0);
+
+      const released = await adapter.releaseAdvisoryLock(lockName);
+      expect(released).toBe(true);
+
+      const isFreeAfter = await adapter.selectValue(
+        `SELECT IS_FREE_LOCK(${adapter.quote(lockName)})`,
+      );
+      expect(isFreeAfter).toBe(1);
+    });
+
+    it("release non existent advisory lock", async () => {
+      const lockName = "fake lock'n'name";
+      const released = await adapter.releaseAdvisoryLock(lockName);
+      expect(released).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -125,6 +125,8 @@ describeIfMysql("Mysql2Adapter", () => {
       spy.mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("8.0.35");
 
+      // Clear the cache so the second stub is not masked by the first result.
+      (adapter as any)._databaseVersion = null;
       spy.mockResolvedValueOnce("5.7.0");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("5.7.0");
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -22,8 +22,11 @@ describeIfMysql("Mysql2Adapter", () => {
       const u = new URL(MYSQL_TEST_URL);
       u.pathname = "/inexistent_activerecord_unittest";
       const badAdapter = new Mysql2Adapter(u.toString());
-      await expect(badAdapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
-      await badAdapter.close();
+      try {
+        await expect(badAdapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
+      } finally {
+        await badAdapter.close();
+      }
     });
 
     it.skip("no automatic reconnection after timeout", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -14,6 +14,7 @@ describeIfMysql("Mysql2Adapter", () => {
   });
   afterEach(async () => {
     vi.restoreAllMocks();
+    Notifications.unsubscribeAll();
     await adapter.close();
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -613,10 +613,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Query a MySQL session variable by name.
-   * Mirrors: AbstractMysqlAdapter#show_variable — uses `SELECT @@name` with logging
-   * name "SCHEMA". Returns null for unknown variables (Rails rescues StatementInvalid).
+   * Mirrors: AbstractMysqlAdapter#show_variable — `SELECT @@name` with logging name
+   * "SCHEMA". Returns null for unknown variables (Rails rescues StatementInvalid).
+   * The identifier is validated against MySQL variable-name characters before interpolation.
    */
   async showVariable(name: string): Promise<string | null> {
+    if (!/^\w+$/.test(name)) return null;
     try {
       const rows = await (
         this as unknown as {
@@ -1055,6 +1057,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Mirrors: AbstractMysqlAdapter#get_database_version — calls get_full_version,
    * strips MariaDB prefix via version_string, returns Version.
+   * Note: `getFullVersion()` on Mysql2Adapter caches its result and sets
+   * `_databaseVersion` as a side effect, so the sync `databaseVersion` getter
+   * works after this method has been awaited once.
    */
   override async getDatabaseVersion(): Promise<Version> {
     const fullVersion = await this.getFullVersion();

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -613,18 +613,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Query a MySQL session variable by name.
-   * Mirrors: AbstractMysqlAdapter#show_variable — executes `SHOW VARIABLES LIKE ?`
-   * with logging name "SCHEMA" so LogSubscriber records it under schema queries.
+   * Mirrors: AbstractMysqlAdapter#show_variable — uses `SELECT @@name` with logging
+   * name "SCHEMA". Returns null for unknown variables (Rails rescues StatementInvalid).
    */
   async showVariable(name: string): Promise<string | null> {
-    const rows = await (
-      this as unknown as {
-        execute(sql: string, binds: unknown[], name: string): Promise<Record<string, unknown>[]>;
-      }
-    ).execute("SHOW VARIABLES LIKE ?", [name], "SCHEMA");
-    if (rows.length === 0) return null;
-    const row = rows[0];
-    return (row.Value ?? row.value ?? row.VALUE ?? null) as string | null;
+    try {
+      const rows = await (
+        this as unknown as {
+          execute(sql: string, binds: unknown[], name: string): Promise<Record<string, unknown>[]>;
+        }
+      ).execute(`SELECT @@${name}`, [], "SCHEMA");
+      if (rows.length === 0) return null;
+      const row = rows[0];
+      const val = row[Object.keys(row)[0]];
+      return val == null ? null : String(val);
+    } catch {
+      return null;
+    }
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1080,6 +1080,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * strips MariaDB prefix via version_string, returns Version.
    */
   override async getDatabaseVersion(): Promise<Version> {
+    if (this._databaseVersion) return this._databaseVersion;
     const fullVersion = await this.getFullVersion();
     const version = new Version(this.versionString(fullVersion));
     this._databaseVersion = version;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1078,6 +1078,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   override async getDatabaseVersion(): Promise<Version> {
     if (this._databaseVersion) return this._databaseVersion;
     const fullVersion = await this.getFullVersion();
+    // getFullVersion() may have set _databaseVersion as a side effect
+    // (e.g. Mysql2Adapter#getFullVersion populates it while fetching); re-check
+    // to avoid double-parsing the version string in those subclasses.
+    if (this._databaseVersion) return this._databaseVersion;
     const version = new Version(this.versionString(fullVersion));
     this._databaseVersion = version;
     return version;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -266,6 +266,21 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this._mariadb;
   }
 
+  /**
+   * Sync accessor for the cached database version. Mirrors the PostgreSQLAdapter
+   * pattern: throws a clear error when called before `getDatabaseVersion()` has
+   * been awaited. Overrides AbstractAdapter#databaseVersion which throws whenever
+   * it sees a Promise return from getDatabaseVersion().
+   */
+  override get databaseVersion(): Version {
+    if (!this._databaseVersion) {
+      throw new Error(
+        "databaseVersion is not available yet — call await getDatabaseVersion() after connecting",
+      );
+    }
+    return this._databaseVersion;
+  }
+
   supportsBulkAlter(): boolean {
     return true;
   }
@@ -629,8 +644,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       const row = rows[0];
       const val = row[Object.keys(row)[0]];
       return val == null ? null : String(val);
-    } catch {
-      return null;
+    } catch (e) {
+      // Mirrors Rails: rescue ActiveRecord::StatementInvalid — unknown variables
+      // throw a SQL error which we translate to StatementInvalid. Re-raise
+      // anything else (connection failures, protocol errors) so callers see outages.
+      if (e instanceof StatementInvalid) return null;
+      throw e;
     }
   }
 
@@ -1054,16 +1073,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Parse the server version from the full version string and return it.
+   * Caches the result in `_databaseVersion` so the sync `databaseVersion` getter
+   * works after this method has been awaited once.
    *
    * Mirrors: AbstractMysqlAdapter#get_database_version — calls get_full_version,
    * strips MariaDB prefix via version_string, returns Version.
-   * Note: `getFullVersion()` on Mysql2Adapter caches its result and sets
-   * `_databaseVersion` as a side effect, so the sync `databaseVersion` getter
-   * works after this method has been awaited once.
    */
   override async getDatabaseVersion(): Promise<Version> {
     const fullVersion = await this.getFullVersion();
-    return new Version(this.versionString(fullVersion));
+    const version = new Version(this.versionString(fullVersion));
+    this._databaseVersion = version;
+    return version;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -275,7 +275,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   override get databaseVersion(): Version {
     if (!this._databaseVersion) {
       throw new Error(
-        "databaseVersion is not available yet — call await getDatabaseVersion() after connecting",
+        "databaseVersion is not available yet — await getDatabaseVersion() after connecting",
       );
     }
     return this._databaseVersion;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -635,11 +635,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async showVariable(name: string): Promise<string | null> {
     if (!/^\w+$/.test(name)) return null;
     try {
-      const rows = await (
-        this as unknown as {
-          execute(sql: string, binds: unknown[], name: string): Promise<Record<string, unknown>[]>;
-        }
-      ).execute(`SELECT @@${name}`, [], "SCHEMA");
+      const rows = await this.schemaQuery(`SELECT @@${name}`);
       if (rows.length === 0) return null;
       const row = rows[0];
       const val = row[Object.keys(row)[0]];

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -13,6 +13,7 @@ import type { AdapterName, ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Column } from "./column.js";
 import {
+  DatabaseVersionError,
   InvalidForeignKey,
   MismatchedForeignKey,
   NotNullViolation,
@@ -263,11 +264,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   isMariadb(): boolean {
     return this._mariadb;
-  }
-
-  getDatabaseVersion(): Version {
-    if (this._databaseVersion) return this._databaseVersion;
-    return new Version("0.0.0");
   }
 
   supportsBulkAlter(): boolean {
@@ -615,9 +611,20 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return {};
   }
 
+  /**
+   * Query a MySQL session variable by name.
+   * Mirrors: AbstractMysqlAdapter#show_variable — executes `SHOW VARIABLES LIKE ?`
+   * with logging name "SCHEMA" so LogSubscriber records it under schema queries.
+   */
   async showVariable(name: string): Promise<string | null> {
-    void name;
-    return null;
+    const rows = await (
+      this as unknown as {
+        execute(sql: string, binds: unknown[], name: string): Promise<Record<string, unknown>[]>;
+      }
+    ).execute("SHOW VARIABLES LIKE ?", [name], "SCHEMA");
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    return (row.Value ?? row.value ?? row.VALUE ?? null) as string | null;
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {
@@ -1027,11 +1034,41 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this._databaseVersion?.gte("8.0.3") === true;
   }
 
+  /**
+   * Fetch the raw version string from the MySQL server (e.g. "8.0.28-ubuntu").
+   * Concrete adapters (Mysql2Adapter, TrilogyAdapter) override this to query
+   * the live connection. Base implementation throws — callers must call
+   * `getDatabaseVersion()` only after a subclass has wired this.
+   * @internal
+   */
+  async getFullVersion(): Promise<string> {
+    throw new Error(`${this.constructor.name} must implement getFullVersion()`);
+  }
+
+  /**
+   * Parse the server version from the full version string and return it.
+   *
+   * Mirrors: AbstractMysqlAdapter#get_database_version — calls get_full_version,
+   * strips MariaDB prefix via version_string, returns Version.
+   */
+  override async getDatabaseVersion(): Promise<Version> {
+    const fullVersion = await this.getFullVersion();
+    return new Version(this.versionString(fullVersion));
+  }
+
   /** @internal */
-  protected versionString(fullVersionString: string): string {
+  protected versionString(fullVersionString: string | null | undefined): string {
+    if (fullVersionString == null) {
+      throw new DatabaseVersionError("Unable to parse MySQL version from nil");
+    }
+    if (fullVersionString.length === 0) {
+      throw new DatabaseVersionError(`Unable to parse MySQL version from ""`);
+    }
     const matches = fullVersionString.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/);
     if (matches) return matches[1];
-    throw new Error(`Unable to parse MySQL version from ${JSON.stringify(fullVersionString)}`);
+    throw new DatabaseVersionError(
+      `Unable to parse MySQL version from ${JSON.stringify(fullVersionString)}`,
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -940,12 +940,22 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /**
    * Sever the connection immediately (synchronous contract from AbstractAdapter).
-   * Nulls `_driverPool` so `active` returns false right away; the underlying
-   * pool's END is scheduled asynchronously. Mirrors Rails'
-   * AbstractAdapter#disconnect! which closes `@raw_connection` and sets it to nil.
+   * Releases advisory-lock and transaction connections, nulls `_driverPool` so
+   * `active` returns false right away, then schedules pool.end() asynchronously.
+   * Mirrors Rails' Mysql2Adapter#disconnect! (super + raw_connection.close + nil).
    */
   override disconnectBang(): void {
     super.disconnectBang();
+    if (this._advisoryLockConn) {
+      this._advisoryLockConn.release();
+      this._advisoryLockConn = null;
+    }
+    if (this._conn) {
+      this._statementPools.get(this._conn)?.detach();
+      this._conn.release();
+      this._conn = null;
+    }
+    this._inTransaction = false;
     const pool = this._driverPool;
     this._driverPool = null;
     if (pool) {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -957,6 +957,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       this._conn = null;
     }
     this._inTransaction = false;
+    this._statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
     const pool = this._driverPool;
     this._driverPool = null;
     if (pool) {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -939,6 +939,23 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * Sever the connection immediately (synchronous contract from AbstractAdapter).
+   * Nulls `_driverPool` so `active` returns false right away; the underlying
+   * pool's END is scheduled asynchronously. Mirrors Rails'
+   * AbstractAdapter#disconnect! which closes `@raw_connection` and sets it to nil.
+   */
+  override disconnectBang(): void {
+    super.disconnectBang();
+    const pool = this._driverPool;
+    this._driverPool = null;
+    if (pool) {
+      pool.end().catch(() => {
+        // swallow — pool already torn down or connection already gone
+      });
+    }
+  }
+
+  /**
    * Close the connection pool.
    */
   async close(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -79,6 +79,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   private _driverPool: mysql.Pool | null;
+  private _endingPool: Promise<void> | null = null;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;
   // Per-mysql.PoolConnection StatementPool. Mirrors the PG adapter's
@@ -959,7 +960,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const pool = this._driverPool;
     this._driverPool = null;
     if (pool) {
-      pool.end().catch(() => {
+      this._endingPool = pool.end().catch(() => {
         // swallow — pool already torn down or connection already gone
       });
     }
@@ -986,6 +987,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (this._driverPool) {
       await this._driverPool.end();
       this._driverPool = null;
+    }
+    // If disconnectBang() was called before close(), await the in-flight
+    // pool.end() so callers (e.g. afterEach) can be sure sockets are drained.
+    if (this._endingPool) {
+      await this._endingPool;
+      this._endingPool = null;
     }
   }
 

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -487,6 +487,13 @@ export class NoDatabaseError extends StatementInvalid {
   }
 }
 
+export class DatabaseVersionError extends ActiveRecordError {
+  constructor(message?: string) {
+    super(message ?? "Unknown database version");
+    this.name = "DatabaseVersionError";
+  }
+}
+
 export class DatabaseAlreadyExists extends StatementInvalid {
   constructor(
     message?: string,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -210,6 +210,7 @@ export {
   PreparedStatementInvalid,
   PreparedStatementCacheExpired,
   NoDatabaseError,
+  DatabaseVersionError,
   DatabaseAlreadyExists,
   AttributeAssignmentError,
   TransactionIsolationError,


### PR DESCRIPTION
## Summary

Drives \`connection.test.ts\` from 23 BLOCKED → 14 BLOCKED by implementing missing infrastructure and porting 9 previously-skipped tests.

### Implementation (3 files)

- **\`errors.ts\`** — add \`DatabaseVersionError\` (mirrors \`ActiveRecord::DatabaseVersionError\`)
- **\`abstract-mysql-adapter.ts\`**:
  - \`getFullVersion()\` base method (throws; concrete adapters override)
  - \`getDatabaseVersion()\` async override — cache-first, calls \`getFullVersion()\` + \`versionString()\`, re-checks cache after \`getFullVersion()\` returns (avoids double-parse when subclass populates \`_databaseVersion\` as a side effect); mirrors Rails' \`get_database_version\`
  - \`databaseVersion\` getter override — returns cached \`_databaseVersion\` or throws clear error; mirrors PostgreSQLAdapter pattern
  - \`versionString()\` — throws \`DatabaseVersionError\` for nil/empty/unparseable inputs
  - \`showVariable()\` — \`SELECT @@name\` via \`schemaQuery()\` (logging name \`"SCHEMA"\`), identifier validated against \`/^\w+$/\`, catches only \`StatementInvalid\` (mirrors Rails' \`rescue ActiveRecord::StatementInvalid\`)
- **\`mysql2-adapter.ts\`** — \`disconnectBang()\` override: releases \`_advisoryLockConn\` + \`_conn\`, resets \`_statementPools\`, nulls \`_driverPool\`, stores \`pool.end()\` promise in \`_endingPool\`; \`close()\` awaits \`_endingPool\` for clean drain

### Test changes (\`connection.test.ts\`)

**Un-skipped (9 tests):**
| Test | What it exercises |
|---|---|
| \`bad connection\` | \`NoDatabaseError\` on ER_BAD_DB_ERROR |
| \`quote after disconnect reconnects\` | \`quote()\` works without a connection |
| \`active after disconnect\` | \`disconnectBang()\` + \`active\` property |
| \`logs name show variable\` | \`showVariable()\` fires notification with name \`"SCHEMA"\` |
| \`version string\` | \`getDatabaseVersion()\` + \`versionString()\` |
| \`version string with mariadb\` | MariaDB \`5.5.5-\` prefix stripping |
| \`version string invalid\` | \`DatabaseVersionError\` for nil/empty/garbage |
| \`get and release advisory lock\` | advisory lock acquire + IS_FREE_LOCK + release |
| \`release non existent advisory lock\` | \`releaseAdvisoryLock\` returns false when not held |

**Removed (1 test):** \`lock free\` — \`test_lock_free\` is a \`private\` helper in Rails, not a test.

**Still blocked (14 tests) — per-test disposition:**

| Test | Blocker |
|---|---|
| no automatic reconnection after timeout | \`active\` is pool-null check, not socket liveness |
| successful reconnection after timeout with manual reconnect | \`reconnectBang()\` not implemented (no stored config) |
| successful reconnection after timeout with verify | same gap as reconnectBang |
| execute after disconnect reconnects | \`_checkoutConn()\` throws when pool is null; no lazy reconnect |
| wait timeout as string/url | \`wait_timeout\` not wired into \`pool.on('connection')\` |
| collation connection is configured | requires second adapter (ARUnit2Model pattern) |
| mysql default/disabled/default strict mode | \`configureConnection()\` doesn't set \`sql_mode\` |
| mysql sql mode variable overrides strict mode | \`variables\` config hash not wired into session setup |
| passing arbitrary/array flags | pool model has no single \`raw_connection\` |
| mysql set session variable (×2) | \`variables\` config not wired |
| logs name rename column for alter | \`renameColumnForAlter()\` returns SQL fragment, no notification |

## Remaining known concern (not actioned — no Rails evidence)

**Copilot review #9:** \`showVariable()\` identifier guard \`/^\w+$/\` rejects hypothetical \`global.foo\` / \`session.foo\` prefix syntax. Every Rails call site uses simple unqualified names (\`character_set_client\`, \`collation_connection\`, \`max_allowed_packet\`, etc.) — no \`global.\`/\`session.\` prefix appears anywhere in the Rails source. Expanding the regex would diverge from the Rails contract for no current benefit.

## Test plan

- [ ] \`pnpm test --run\` in \`packages/activerecord\` with \`MYSQL_TEST_URL\` set — 9 un-skipped tests pass
- [ ] \`pnpm test --run\` without MySQL — suite skips cleanly via \`describeIfMysql\`
- [ ] \`pnpm api:compare --package activerecord\` — no regression