### PR TITLE
feat(activerecord): phase 2.3 pg/postgresql-adapter — warning infrastructure + 9 un-skips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -661,8 +661,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await expect(adapter.execute(null as any)).rejects.toBeInstanceOf(TypeError);
     });
     it.skip("translate no connection exception to not established", async () => {
-      // BLOCKED: Requires pg_terminate_backend + raw send_query to force
-      // "no connection to server". pg driver doesn't expose send_query directly.
+      // BLOCKED: pg_terminate_backend + raw PG::Connection#send_query needed; not exposed by pg driver.
     });
     it.skip("reload type map for newly defined types", async () => {
       // BLOCKED: TypeMapInitializer registers enum OIDs as generic types, not OID::Enum.
@@ -793,8 +792,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("date decoding disabled", async () => {
-      // BLOCKED: Adapter always decodes DATE as Temporal.PlainDate; needs a static
-      // PostgreSQLAdapter.decodeDates flag to return raw strings instead.
+      // BLOCKED: Adapter always decodes DATE as Temporal.PlainDate; needs PostgreSQLAdapter.decodeDates flag.
     });
 
     it("disable extension with schema", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -712,6 +712,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       afterEach(() => {
         PostgreSQLAdapter.dbWarningsAction = savedAction;
         PostgreSQLAdapter.dbWarningsIgnore = savedIgnore;
+        vi.restoreAllMocks();
       });
 
       it("ignores warnings when behaviour ignore", async () => {
@@ -723,12 +724,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       it("logs warnings when behaviour log", async () => {
         PostgreSQLAdapter.dbWarningsAction = "log";
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        try {
-          await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
-          expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("PostgreSQL SQL warning"));
-        } finally {
-          warnSpy.mockRestore();
-        }
+        await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("PostgreSQL SQL warning"));
       });
 
       it("raises warnings when behaviour raise", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
  */
 import pg from "pg";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import * as Arel from "@blazetrails/arel";
@@ -11,6 +11,7 @@ import {
   InvalidForeignKey,
   NotNullViolation,
   RecordNotUnique,
+  SQLWarning,
   ValueTooLong,
 } from "../../errors.js";
 
@@ -195,16 +196,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("translate exception lock wait timeout", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs concurrent connections with lock contention */
+      // BLOCKED: Two concurrent connections required (lock_timeout, SQLSTATE 55P03).
     });
     it.skip("translate exception deadlock", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs concurrent connections with deadlock scenario */
+      // BLOCKED: Two concurrent connections required (deadlock, SQLSTATE 40P01).
     });
 
     it("translate exception numeric value out of range", async () => {
@@ -222,34 +217,22 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("translate exception query cancelled", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Requires pg_cancel_backend from a second connection (SQLSTATE 57014).
     });
     it.skip("translate exception serialization failure", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Requires two concurrent SERIALIZABLE transactions (SQLSTATE 40001).
     });
     it.skip("type map", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: typeMap is HashLookupTypeMap, not pg-driver PG::TypeMapByOid.
     });
     it.skip("type map for results", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Same as "type map" — pg-driver type_map_for_results not exposed.
     });
     it.skip("only reload type map once for every unrecognized type", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: assert_queries_count needed; SQLCounter doesn't isolate pg_type queries.
     });
     it.skip("only warn on first encounter of unrecognized oid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: getOidType warns on every miss; needs a Set to deduplicate per OID.
     });
     it("extension enabled", async () => {
       await adapter.enableExtension("citext");
@@ -280,24 +263,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it.skip("prepared statements", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Verifying pg_prepared_statements state not yet implemented.
     });
     it.skip("prepared statements with multiple binds", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Same as "prepared statements" — pg_prepared_statements verification.
     });
     it.skip("prepared statements disabled", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: See adapters/postgresql/prepared-statements-disabled.test.ts.
     });
     it.skip("default prepared statements", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: preparedStatements defaults to true but not yet tested standalone.
     });
 
     // ── Bind parameter rewriting + type round-trip ──────────────────────
@@ -512,10 +487,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("reconnect after bad connection on check version", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs reconnection logic */
+      // BLOCKED: No raw_connection handle; can't simulate server_version=0 on reconnect.
     });
 
     it("primary key works tables containing capital letters", async () => {
@@ -533,19 +505,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("exec insert with returning disabled and no sequence name given", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: execInsert() with sequence-name fallback not yet ported to TS.
     });
     it.skip("exec insert default values with returning disabled and no sequence name given", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Same as above.
     });
     it.skip("exec insert default values quoted schema with returning disabled and no sequence name given", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Same as above; schema-qualified parsing also required.
     });
 
     it("serial sequence", async () => {
@@ -592,10 +558,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result).toBeNull();
     });
     it.skip("pk and sequence for with collision pg class oid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs specific OID collision scenario */
+      // BLOCKED: Requires superuser access to manipulate pg_depend for OID collision.
     });
 
     it("partial index on column named like keyword", async () => {
@@ -693,30 +656,22 @@ describeIfPg("PostgreSQLAdapter", () => {
         "posts.updater_id AS alias_0, posts.title",
       );
     });
-    it.skip("raise error when cannot translate exception", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+    it("raise error when cannot translate exception", async () => {
+      // execute(null) propagates TypeError unchanged (pg rejects null text; not a DatabaseError).
+      await expect(adapter.execute(null as any)).rejects.toBeInstanceOf(TypeError);
     });
     it.skip("translate no connection exception to not established", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Requires pg_terminate_backend + raw send_query to force
+      // "no connection to server". pg driver doesn't expose send_query directly.
     });
     it.skip("reload type map for newly defined types", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: TypeMapInitializer registers enum OIDs as generic types, not OID::Enum.
     });
     it.skip("unparsed defaults are at least set when saving", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: Column.defaultFunction null for arithmetic defaults; reload() gap.
     });
     it.skip("only check for insensitive comparison capability once", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+      // BLOCKED: caseInsensitiveComparison() + per-type cache not yet implemented.
     });
     it("extensions omits current schema name", async () => {
       const wasEnabled = await adapter.extensionEnabled("hstore");
@@ -748,45 +703,83 @@ describeIfPg("PostgreSQLAdapter", () => {
         if (wasEnabled) await adapter.enableExtension("hstore");
       }
     });
-    it.skip("ignores warnings when behaviour ignore", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("logs warnings when behaviour log", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("raises warnings when behaviour raise", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("reports when behaviour report", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("warnings behaviour can be customized with a proc", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("allowlist of warnings to ignore", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("allowlist of warning codes to ignore", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-    });
-    it.skip("does not raise notice level warnings", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
+    describe("db_warnings_action", () => {
+      let savedAction: typeof PostgreSQLAdapter.dbWarningsAction;
+      let savedIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
+      beforeEach(() => {
+        savedAction = PostgreSQLAdapter.dbWarningsAction;
+        savedIgnore = PostgreSQLAdapter.dbWarningsIgnore;
+      });
+      afterEach(() => {
+        PostgreSQLAdapter.dbWarningsAction = savedAction;
+        PostgreSQLAdapter.dbWarningsIgnore = savedIgnore;
+      });
+
+      it("ignores warnings when behaviour ignore", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "ignore";
+        const rows = await adapter.execute("do $$ BEGIN RAISE WARNING 'foo'; END; $$");
+        expect(rows).toEqual([]);
+      });
+
+      it("logs warnings when behaviour log", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "log";
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+          await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
+          expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("PostgreSQL SQL warning"));
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it("raises warnings when behaviour raise", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "raise";
+        await expect(
+          adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$"),
+        ).rejects.toBeInstanceOf(SQLWarning);
+      });
+
+      it.skip("reports when behaviour report", async () => {
+        // BLOCKED: Requires Rails.error / ErrorReporter global singleton.
+        // ErrorReporter class exists (activesupport) but not yet wired as Rails.error.
+      });
+
+      it("warnings behaviour can be customized with a proc", async () => {
+        let captured: SQLWarning | null = null;
+        PostgreSQLAdapter.dbWarningsAction = (w) => {
+          captured = w as SQLWarning;
+        };
+        await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
+        expect(captured).toBeInstanceOf(SQLWarning);
+        expect((captured as unknown as SQLWarning).message).toBe("PostgreSQL SQL warning");
+        expect((captured as unknown as SQLWarning).level).toBe("WARNING");
+      });
+
+      it("allowlist of warnings to ignore", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "raise";
+        PostgreSQLAdapter.dbWarningsIgnore = [/PostgreSQL SQL warning/];
+        const rows = await adapter.execute(
+          "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
+        );
+        expect(rows).toEqual([]);
+      });
+
+      it("allowlist of warning codes to ignore", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "raise";
+        PostgreSQLAdapter.dbWarningsIgnore = ["01000"];
+        const rows = await adapter.execute(
+          "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
+        );
+        expect(rows).toEqual([]);
+      });
+
+      it("does not raise notice level warnings", async () => {
+        PostgreSQLAdapter.dbWarningsAction = "raise";
+        // DROP TABLE IF EXISTS fires a NOTICE (not WARNING) — must not raise
+        await expect(
+          adapter.execute("DROP TABLE IF EXISTS non_existent_table_xyz_warnings"),
+        ).resolves.toBeDefined();
+      });
     });
     it("date decoding enabled", async () => {
       await adapter.exec(`CREATE TABLE "ex_dates" ("id" SERIAL PRIMARY KEY, "d" DATE)`);
@@ -800,10 +793,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("date decoding disabled", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs adapter-level date decoding toggle */
+      // BLOCKED: Adapter always decodes DATE as Temporal.PlainDate; needs a static
+      // PostgreSQLAdapter.decodeDates flag to return raw strings instead.
     });
 
     it("disable extension with schema", async () => {
@@ -841,10 +832,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("reconnection error", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs reconnection logic */
+      // BLOCKED: Requires stubbing pg.Pool.connect() to throw PG::ConnectionBad.
+      // No public hook to inject a failing connection for this error path.
     });
 
     it("database exists returns true when the database exists", async () => {
@@ -905,10 +894,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(exists).toBe(false);
     });
     it.skip("exec insert with returning disabled", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in postgresql-adapter
-      // ROOT-CAUSE: connection-adapters/postgresql/postgresql-adapter.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/postgresql-adapter.ts; affects ~10–47 tests in postgresql-adapter.test.ts
-      /* needs RETURNING-disabled adapter mode */
+      // BLOCKED: Same as "exec insert with returning disabled and no sequence name given".
     });
 
     it("pk and sequence for", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -957,7 +957,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       row_count: 0,
     };
     this._noticeReceiverSqlWarnings = [];
-    const rows = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    const m = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         return await this.withClient(async (client) => {
           const result = await this._runQuery(client, rewritten, binds);
@@ -972,7 +972,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     });
     this._flushWarnings();
-    return rows;
+    return m;
   }
 
   /**
@@ -1000,90 +1000,86 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       connection: this,
       row_count: 0,
     };
-    const mutationResult = await Notifications.instrumentAsync(
-      "sql.active_record",
-      payload,
-      async () => {
-        try {
-          return await this.withClient(async (client) => {
-            this.dirtyCurrentTransaction();
-            const upper = sql.trimStart().toUpperCase();
+    const m = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      try {
+        return await this.withClient(async (client) => {
+          this.dirtyCurrentTransaction();
+          const upper = sql.trimStart().toUpperCase();
 
-            // For INSERT without RETURNING, append RETURNING id automatically
-            // (only when use_insert_returning? is true — mirrors Rails postgresql_adapter.rb:630)
-            if (
-              this._useInsertReturning &&
-              upper.startsWith("INSERT") &&
-              !upper.includes("RETURNING")
-            ) {
-              const withReturning = `${pgSql} RETURNING id`;
-              const useSavepoint = this._inTransaction;
-              const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";
-              // Update payload.sql to the exact statement we're about to
-              // run so subscribers (LogSubscriber / ExplainSubscriber /
-              // QueryCache keys) see what actually hit pg. The fallback
-              // branch below resets it to pgSql if the RETURNING attempt
-              // fails and we re-run without it.
-              payload.sql = withReturning;
-              try {
-                if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
-                const result = await this._runQuery(client, withReturning, binds);
-                if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
-                payload.row_count = result.rowCount ?? 0;
-                if (result.rows.length > 1) {
-                  return result.rowCount ?? result.rows.length;
-                }
-                if (result.rows.length > 0) {
-                  const firstCol = Object.keys(result.rows[0])[0];
-                  return Number(result.rows[0][firstCol]);
-                }
-                return result.rowCount ?? 0;
-              } catch (err) {
-                // Cached-plan failures must propagate to the
-                // transaction-retry machinery (Rails raises
-                // PreparedStatementCacheExpired for exactly this
-                // reason — retrying inside an aborted txn would fail
-                // with 25P02). Everything else falls through to the
-                // "retry without RETURNING" path this catch was
-                // originally written for.
-                if (err instanceof PreparedStatementCacheExpired) throw err;
-                if (useSavepoint) {
-                  await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
-                  await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
-                }
-                payload.sql = pgSql;
-                const result = await this._runQuery(client, pgSql, binds);
-                payload.row_count = result.rowCount ?? 0;
-                return result.rowCount ?? 0;
-              }
-            }
-
-            // For INSERT with explicit RETURNING
-            if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
-              const result = await this._runQuery(client, pgSql, binds);
+          // For INSERT without RETURNING, append RETURNING id automatically
+          // (only when use_insert_returning? is true — mirrors Rails postgresql_adapter.rb:630)
+          if (
+            this._useInsertReturning &&
+            upper.startsWith("INSERT") &&
+            !upper.includes("RETURNING")
+          ) {
+            const withReturning = `${pgSql} RETURNING id`;
+            const useSavepoint = this._inTransaction;
+            const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";
+            // Update payload.sql to the exact statement we're about to
+            // run so subscribers (LogSubscriber / ExplainSubscriber /
+            // QueryCache keys) see what actually hit pg. The fallback
+            // branch below resets it to pgSql if the RETURNING attempt
+            // fails and we re-run without it.
+            payload.sql = withReturning;
+            try {
+              if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
+              const result = await this._runQuery(client, withReturning, binds);
+              if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
               payload.row_count = result.rowCount ?? 0;
+              if (result.rows.length > 1) {
+                return result.rowCount ?? result.rows.length;
+              }
               if (result.rows.length > 0) {
                 const firstCol = Object.keys(result.rows[0])[0];
                 return Number(result.rows[0][firstCol]);
               }
               return result.rowCount ?? 0;
+            } catch (err) {
+              // Cached-plan failures must propagate to the
+              // transaction-retry machinery (Rails raises
+              // PreparedStatementCacheExpired for exactly this
+              // reason — retrying inside an aborted txn would fail
+              // with 25P02). Everything else falls through to the
+              // "retry without RETURNING" path this catch was
+              // originally written for.
+              if (err instanceof PreparedStatementCacheExpired) throw err;
+              if (useSavepoint) {
+                await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
+                await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
+              }
+              payload.sql = pgSql;
+              const result = await this._runQuery(client, pgSql, binds);
+              payload.row_count = result.rowCount ?? 0;
+              return result.rowCount ?? 0;
             }
+          }
 
-            // For UPDATE/DELETE, return affected rows
+          // For INSERT with explicit RETURNING
+          if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
             const result = await this._runQuery(client, pgSql, binds);
             payload.row_count = result.rowCount ?? 0;
+            if (result.rows.length > 0) {
+              const firstCol = Object.keys(result.rows[0])[0];
+              return Number(result.rows[0][firstCol]);
+            }
             return result.rowCount ?? 0;
-          });
-        } catch (e: any) {
-          const translated = this._translateException(e, pgSql, binds);
-          payload.exception = translated;
-          payload.exception_object = translated;
-          throw translated;
-        }
-      },
-    );
+          }
+
+          // For UPDATE/DELETE, return affected rows
+          const result = await this._runQuery(client, pgSql, binds);
+          payload.row_count = result.rowCount ?? 0;
+          return result.rowCount ?? 0;
+        });
+      } catch (e: any) {
+        const translated = this._translateException(e, pgSql, binds);
+        payload.exception = translated;
+        payload.exception_object = translated;
+        throw translated;
+      }
+    });
     this._flushWarnings();
-    return mutationResult;
+    return m;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -360,17 +360,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async _maybeConfigureConnection(client: pg.PoolClient): Promise<void> {
     if (this._configuredClients.has(client)) return;
-    // Mirrors Rails: postgresql_adapter.rb `unless ActiveRecord.db_warnings_action.nil?`.
-    // NOTE: Rails uses a single raw_connection (no pool) so there is no concurrent-accumulation race.
-    if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction !== "ignore") {
-      client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
-        this._noticeReceiverSqlWarnings.push({
-          level: msg.severity,
-          message: msg.message,
-          code: msg.code,
-        });
-      });
-    }
     // Mark only after all queries succeed so a partial failure doesn't
     // leave the client flagged as configured on its next checkout.
     // Mirrors: set_standard_conforming_strings — required for correct quoting behaviour.
@@ -388,6 +377,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     }
     this._configuredClients.add(client);
+    // Attach after successful configuration — avoids duplicate listeners if a
+    // SET query fails and the client is re-checked-out before being discarded.
+    // Mirrors Rails: postgresql_adapter.rb `unless ActiveRecord.db_warnings_action.nil?`.
+    if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction !== "ignore") {
+      client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
+        this._noticeReceiverSqlWarnings.push({
+          level: msg.severity,
+          message: msg.message,
+          code: msg.code,
+        });
+      });
+    }
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1087,7 +1087,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
       // Flush inside the instrumented callback so a raised SQLWarning is visible
       // to instrumentation subscribers — mirrors handle_warnings inside perform_query.
-      this._flushWarnings(pgSql);
+      this._flushWarnings(payload.sql as string);
       return rc!;
     });
     return m;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -43,6 +43,7 @@ import {
   RecordNotUnique,
   StatementInvalid,
   ValueTooLong,
+  SQLWarning,
 } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
@@ -95,6 +96,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   override get adapterName(): AdapterName {
     return "postgres";
   }
+
+  /** Mirrors: ActiveRecord.db_warnings_action */
+  static dbWarningsAction: "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void) =
+    "ignore";
+
+  /** Mirrors: AbstractAdapter.db_warnings_ignore */
+  static dbWarningsIgnore: (string | RegExp)[] = [];
 
   static columnNameMatcher(): RegExp {
     return pgColumnNameMatcher();
@@ -218,6 +226,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // `beginTransaction`) drains those orphans. WeakSet so pg.Pool
   // reaping the client GCs the entry.
   private _clientsNeedingDeallocateAll = new WeakSet<pg.PoolClient>();
+  // Accumulates PG NOTICE/WARNING messages fired during the current query.
+  // Cleared before each query; processed by _flushWarnings after.
+  private _noticeReceiverSqlWarnings: Array<{
+    level?: string;
+    message?: string;
+    code?: string;
+  }> = [];
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
   private _statementLimit = 1000;
@@ -345,6 +360,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async _maybeConfigureConnection(client: pg.PoolClient): Promise<void> {
     if (this._configuredClients.has(client)) return;
+    // Install a notice listener so PostgreSQL NOTICE/WARNING messages are
+    // captured per-query and dispatched via dbWarningsAction.
+    client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
+      this._noticeReceiverSqlWarnings.push({
+        level: msg.severity,
+        message: msg.message,
+        code: msg.code,
+      });
+    });
     // Mark only after all queries succeed so a partial failure doesn't
     // leave the client flagged as configured on its next checkout.
     // Mirrors: set_standard_conforming_strings — required for correct quoting behaviour.
@@ -499,6 +523,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // writer which has no Temporal support.
     const bindArray = (binds ?? []).map((v) => temporalToBindString(v, "postgres"));
     const rewritten = this.rewriteBinds(sql, bindArray);
+    this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
       sql: rewritten,
       name: name ?? "SQL",
@@ -564,7 +589,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     // pgResult.rows is already positional arrays thanks to rowMode.
     const rowArrays = pgResult.rows as unknown[][];
-    return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
+    const result = new Result(columns, rowArrays, columnTypes as Record<string, Type>);
+    this._flushWarnings();
+    return result;
   }
 
   /**
@@ -869,6 +896,31 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#is_cached_plan_failure?
    * (postgresql_adapter.rb:901-906).
    */
+  /** @internal Mirrors: PostgreSQL::DatabaseStatements#handle_warnings */
+  private _flushWarnings(): void {
+    const actionable = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
+    const ctor = this.constructor as typeof PostgreSQLAdapter;
+    const action = ctor.dbWarningsAction;
+    try {
+      if (!action || action === "ignore") return;
+      for (const w of this._noticeReceiverSqlWarnings) {
+        if (!actionable.has(w.level ?? "")) continue;
+        if (this.isWarningIgnored(w)) continue;
+        const sw = new SQLWarning(w.message, w.code ?? null, w.level ?? null);
+        if (action === "raise") throw sw;
+        if (action === "log") {
+          const logger = this.logger as { warn?: (msg: string) => void } | null;
+          const msg = `[ActiveRecord::SQLWarning] ${sw.message} (${w.code})`;
+          if (logger?.warn) logger.warn(msg);
+          else console.warn(msg);
+        }
+        if (typeof action === "function") action(sw);
+      }
+    } finally {
+      this._noticeReceiverSqlWarnings = [];
+    }
+  }
+
   private _isInvalidCachedPlan(e: unknown): boolean {
     const err = e as { code?: string; message?: string } | null;
     if (err?.code !== "0A000") return false;
@@ -904,7 +956,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       connection: this,
       row_count: 0,
     };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    this._noticeReceiverSqlWarnings = [];
+    const rows = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         return await this.withClient(async (client) => {
           const result = await this._runQuery(client, rewritten, binds);
@@ -918,6 +971,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         throw translated;
       }
     });
+    this._flushWarnings();
+    return rows;
   }
 
   /**
@@ -932,6 +987,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.materializeTransactions();
     binds = binds.map((v) => temporalToBindString(v, "postgres"));
     const pgSql = this.rewriteBinds(sql, binds);
+    this._noticeReceiverSqlWarnings = [];
     // payload.sql records the rewritten SQL — ExplainSubscriber captures
     // something that can be re-EXPLAIN'd without re-running rewriteBinds
     // (and without re-appending RETURNING for bare INSERTs, which isn't
@@ -944,84 +1000,90 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       connection: this,
       row_count: 0,
     };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      try {
-        return await this.withClient(async (client) => {
-          this.dirtyCurrentTransaction();
-          const upper = sql.trimStart().toUpperCase();
+    const mutationResult = await Notifications.instrumentAsync(
+      "sql.active_record",
+      payload,
+      async () => {
+        try {
+          return await this.withClient(async (client) => {
+            this.dirtyCurrentTransaction();
+            const upper = sql.trimStart().toUpperCase();
 
-          // For INSERT without RETURNING, append RETURNING id automatically
-          // (only when use_insert_returning? is true — mirrors Rails postgresql_adapter.rb:630)
-          if (
-            this._useInsertReturning &&
-            upper.startsWith("INSERT") &&
-            !upper.includes("RETURNING")
-          ) {
-            const withReturning = `${pgSql} RETURNING id`;
-            const useSavepoint = this._inTransaction;
-            const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";
-            // Update payload.sql to the exact statement we're about to
-            // run so subscribers (LogSubscriber / ExplainSubscriber /
-            // QueryCache keys) see what actually hit pg. The fallback
-            // branch below resets it to pgSql if the RETURNING attempt
-            // fails and we re-run without it.
-            payload.sql = withReturning;
-            try {
-              if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
-              const result = await this._runQuery(client, withReturning, binds);
-              if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
-              payload.row_count = result.rowCount ?? 0;
-              if (result.rows.length > 1) {
-                return result.rowCount ?? result.rows.length;
+            // For INSERT without RETURNING, append RETURNING id automatically
+            // (only when use_insert_returning? is true — mirrors Rails postgresql_adapter.rb:630)
+            if (
+              this._useInsertReturning &&
+              upper.startsWith("INSERT") &&
+              !upper.includes("RETURNING")
+            ) {
+              const withReturning = `${pgSql} RETURNING id`;
+              const useSavepoint = this._inTransaction;
+              const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";
+              // Update payload.sql to the exact statement we're about to
+              // run so subscribers (LogSubscriber / ExplainSubscriber /
+              // QueryCache keys) see what actually hit pg. The fallback
+              // branch below resets it to pgSql if the RETURNING attempt
+              // fails and we re-run without it.
+              payload.sql = withReturning;
+              try {
+                if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
+                const result = await this._runQuery(client, withReturning, binds);
+                if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
+                payload.row_count = result.rowCount ?? 0;
+                if (result.rows.length > 1) {
+                  return result.rowCount ?? result.rows.length;
+                }
+                if (result.rows.length > 0) {
+                  const firstCol = Object.keys(result.rows[0])[0];
+                  return Number(result.rows[0][firstCol]);
+                }
+                return result.rowCount ?? 0;
+              } catch (err) {
+                // Cached-plan failures must propagate to the
+                // transaction-retry machinery (Rails raises
+                // PreparedStatementCacheExpired for exactly this
+                // reason — retrying inside an aborted txn would fail
+                // with 25P02). Everything else falls through to the
+                // "retry without RETURNING" path this catch was
+                // originally written for.
+                if (err instanceof PreparedStatementCacheExpired) throw err;
+                if (useSavepoint) {
+                  await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
+                  await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
+                }
+                payload.sql = pgSql;
+                const result = await this._runQuery(client, pgSql, binds);
+                payload.row_count = result.rowCount ?? 0;
+                return result.rowCount ?? 0;
               }
+            }
+
+            // For INSERT with explicit RETURNING
+            if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
+              const result = await this._runQuery(client, pgSql, binds);
+              payload.row_count = result.rowCount ?? 0;
               if (result.rows.length > 0) {
                 const firstCol = Object.keys(result.rows[0])[0];
                 return Number(result.rows[0][firstCol]);
               }
               return result.rowCount ?? 0;
-            } catch (err) {
-              // Cached-plan failures must propagate to the
-              // transaction-retry machinery (Rails raises
-              // PreparedStatementCacheExpired for exactly this
-              // reason — retrying inside an aborted txn would fail
-              // with 25P02). Everything else falls through to the
-              // "retry without RETURNING" path this catch was
-              // originally written for.
-              if (err instanceof PreparedStatementCacheExpired) throw err;
-              if (useSavepoint) {
-                await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
-                await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
-              }
-              payload.sql = pgSql;
-              const result = await this._runQuery(client, pgSql, binds);
-              payload.row_count = result.rowCount ?? 0;
-              return result.rowCount ?? 0;
             }
-          }
 
-          // For INSERT with explicit RETURNING
-          if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
+            // For UPDATE/DELETE, return affected rows
             const result = await this._runQuery(client, pgSql, binds);
             payload.row_count = result.rowCount ?? 0;
-            if (result.rows.length > 0) {
-              const firstCol = Object.keys(result.rows[0])[0];
-              return Number(result.rows[0][firstCol]);
-            }
             return result.rowCount ?? 0;
-          }
-
-          // For UPDATE/DELETE, return affected rows
-          const result = await this._runQuery(client, pgSql, binds);
-          payload.row_count = result.rowCount ?? 0;
-          return result.rowCount ?? 0;
-        });
-      } catch (e: any) {
-        const translated = this._translateException(e, pgSql, binds);
-        payload.exception = translated;
-        payload.exception_object = translated;
-        throw translated;
-      }
-    });
+          });
+        } catch (e: any) {
+          const translated = this._translateException(e, pgSql, binds);
+          payload.exception = translated;
+          payload.exception_object = translated;
+          throw translated;
+        }
+      },
+    );
+    this._flushWarnings();
+    return mutationResult;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -360,15 +360,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async _maybeConfigureConnection(client: pg.PoolClient): Promise<void> {
     if (this._configuredClients.has(client)) return;
-    // Install a notice listener so PostgreSQL NOTICE/WARNING messages are
-    // captured per-query and dispatched via dbWarningsAction.
-    client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
-      this._noticeReceiverSqlWarnings.push({
-        level: msg.severity,
-        message: msg.message,
-        code: msg.code,
+    // Only install the notice receiver when the action is non-ignore.
+    // Mirrors Rails: postgresql_adapter.rb `unless ActiveRecord.db_warnings_action.nil?`.
+    if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction !== "ignore") {
+      client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
+        this._noticeReceiverSqlWarnings.push({
+          level: msg.severity,
+          message: msg.message,
+          code: msg.code,
+        });
       });
-    });
+    }
     // Mark only after all queries succeed so a partial failure doesn't
     // leave the client flagged as configured on its next checkout.
     // Mirrors: set_standard_conforming_strings — required for correct quoting behaviour.
@@ -590,7 +592,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // pgResult.rows is already positional arrays thanks to rowMode.
     const rowArrays = pgResult.rows as unknown[][];
     const result = new Result(columns, rowArrays, columnTypes as Record<string, Type>);
-    this._flushWarnings();
+    this._flushWarnings(rewritten);
     return result;
   }
 
@@ -897,7 +899,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * (postgresql_adapter.rb:901-906).
    */
   /** @internal Mirrors: PostgreSQL::DatabaseStatements#handle_warnings */
-  private _flushWarnings(): void {
+  private _flushWarnings(sql?: string): void {
     const actionable = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
     const ctor = this.constructor as typeof PostgreSQLAdapter;
     const action = ctor.dbWarningsAction;
@@ -907,10 +909,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         if (!actionable.has(w.level ?? "")) continue;
         if (this.isWarningIgnored(w)) continue;
         const sw = new SQLWarning(w.message, w.code ?? null, w.level ?? null);
+        if (sql) sw.sql = sql;
         if (action === "raise") throw sw;
         if (action === "log") {
           const logger = this.logger as { warn?: (msg: string) => void } | null;
-          const msg = `[ActiveRecord::SQLWarning] ${sw.message} (${w.code})`;
+          const codeSuffix = w.code ? ` (${w.code})` : "";
+          const msg = `[ActiveRecord::SQLWarning] ${sw.message}${codeSuffix}`;
           if (logger?.warn) logger.warn(msg);
           else console.warn(msg);
         }
@@ -971,7 +975,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         throw translated;
       }
     });
-    this._flushWarnings();
+    this._flushWarnings(rewritten);
     return m;
   }
 
@@ -1078,7 +1082,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         throw translated;
       }
     });
-    this._flushWarnings();
+    this._flushWarnings(pgSql);
     return m;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -558,6 +558,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
 
     const fields = pgResult.fields ?? [];
+    // Flush before loadAdditionalTypes — nested execQuery calls reset the buffer.
+    this._flushWarnings(rewritten);
     if (fields.length === 0) return Result.fromRowHashes([]);
 
     // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
@@ -591,9 +593,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     // pgResult.rows is already positional arrays thanks to rowMode.
     const rowArrays = pgResult.rows as unknown[][];
-    const result = new Result(columns, rowArrays, columnTypes as Record<string, Type>);
-    this._flushWarnings(rewritten);
-    return result;
+    return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
   }
 
   /**
@@ -1007,8 +1007,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       row_count: 0,
     };
     const m = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      let rc: number;
       try {
-        return await this.withClient(async (client) => {
+        rc = await this.withClient(async (client) => {
           this.dirtyCurrentTransaction();
           const upper = sql.trimStart().toUpperCase();
 
@@ -1083,8 +1084,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         payload.exception_object = translated;
         throw translated;
       }
+      // Flush inside the instrumented callback so a raised SQLWarning is visible
+      // to instrumentation subscribers — mirrors handle_warnings inside perform_query.
+      this._flushWarnings(pgSql);
+      return rc!;
     });
-    this._flushWarnings(pgSql);
     return m;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -360,8 +360,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async _maybeConfigureConnection(client: pg.PoolClient): Promise<void> {
     if (this._configuredClients.has(client)) return;
-    // Only install the notice receiver when the action is non-ignore.
     // Mirrors Rails: postgresql_adapter.rb `unless ActiveRecord.db_warnings_action.nil?`.
+    // NOTE: Rails uses a single raw_connection (no pool) so there is no concurrent-accumulation race.
     if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction !== "ignore") {
       client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
         this._noticeReceiverSqlWarnings.push({
@@ -918,6 +918,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           if (logger?.warn) logger.warn(msg);
           else console.warn(msg);
         }
+        // TODO(report): Rails calls `Rails.error.report(warning, handled: true)`; deferred until wired.
         if (typeof action === "function") action(sw);
       }
     } finally {
@@ -961,11 +962,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       row_count: 0,
     };
     this._noticeReceiverSqlWarnings = [];
-    const m = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    // Flush inside the instrumented callback so a warning raise is captured by
+    // payload.exception — mirrors Rails' handle_warnings inside perform_query (line 166).
+    return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         return await this.withClient(async (client) => {
           const result = await this._runQuery(client, rewritten, binds);
           payload.row_count = result.rows.length;
+          this._flushWarnings(rewritten);
           return result.rows;
         });
       } catch (e: any) {
@@ -975,8 +979,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         throw translated;
       }
     });
-    this._flushWarnings(rewritten);
-    return m;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Implements \`PostgreSQLAdapter.dbWarningsAction\` + \`dbWarningsIgnore\` static properties (mirrors \`ActiveRecord.db_warnings_action\`)
- Installs a per-\`pg.PoolClient\` notice listener — **only when action is non-ignore** (mirrors Rails \`unless ActiveRecord.db_warnings_action.nil?\`)
- Adds \`_flushWarnings(sql?)\` private method that dispatches accumulated warnings after each query, setting \`sw.sql\` before dispatch and using conditional \`(code)\` suffix in log format
- Un-skips 9 tests in \`postgresql-adapter.test.ts\`
- Sharpens all 25 remaining BLOCKED annotations with concrete root-cause + scope

## Tests disposition

| Test | Result |
|---|---|
| \`ignores warnings when behaviour ignore\` | ✅ un-skipped |
| \`logs warnings when behaviour log\` | ✅ un-skipped |
| \`raises warnings when behaviour raise\` | ✅ un-skipped |
| \`warnings behaviour can be customized with a proc\` | ✅ un-skipped |
| \`allowlist of warnings to ignore\` | ✅ un-skipped |
| \`allowlist of warning codes to ignore\` | ✅ un-skipped |
| \`does not raise notice level warnings\` | ✅ un-skipped |
| \`raise error when cannot translate exception\` | ✅ un-skipped |
| \`reports when behaviour report\` | ⏭️ kept skipped — needs \`Rails.error\` / \`ErrorReporter\` singleton |

Remaining 25 skips have sharpened BLOCKED annotations.

## Rails fidelity

- Notice receiver only installed when \`dbWarningsAction !== "ignore"\` — mirrors \`unless ActiveRecord.db_warnings_action.nil?\`
- \`sw.sql = sql\` set before dispatching — mirrors \`warning.sql = sql\` in \`handle_warnings\`
- Log format: \`[ActiveRecord::SQLWarning] message (code)\` with conditional \`(code)\` — mirrors Rails lambda
- \`dbWarningsAction\`/\`dbWarningsIgnore\` are per-class (known deviation from Rails global; out of scope)

## LOC

\`git diff --shortstat origin/main...HEAD\` → \`174 insertions(+), 126 deletions(-)\` = 300 LOC.