### PR TITLE
feat(activemodel): FromDatabase#changedInPlace dispatches to type.isChangedInPlace

### DIFF
--- a/packages/activemodel/src/attribute.test.ts
+++ b/packages/activemodel/src/attribute.test.ts
@@ -488,4 +488,33 @@ describe("AttributeTest", () => {
       expect(updated.isChanged()).toBe(false);
     });
   });
+
+  describe("FromDatabase#changedInPlace dispatches to type.isChangedInPlace", () => {
+    it("returns false before value is read", () => {
+      const mutableType = Object.create(typeRegistry.lookup("value"));
+      mutableType.isChangedInPlace = (_raw: unknown, _val: unknown) => true;
+      const attr = Attribute.fromDatabase("data", { a: 1 }, mutableType);
+      expect(attr.changedInPlace()).toBe(false);
+    });
+
+    it("returns true after in-place mutation for a mutable type", () => {
+      const mutableType = Object.create(typeRegistry.lookup("value"));
+      let callCount = 0;
+      mutableType.isChangedInPlace = (_raw: unknown, _val: unknown) => {
+        callCount++;
+        return true;
+      };
+      const attr = Attribute.fromDatabase("data", '{"a":1}', mutableType);
+      void attr.value;
+      expect(attr.changedInPlace()).toBe(true);
+      expect(callCount).toBeGreaterThan(0);
+    });
+
+    it("returns false for an immutable type even after value is read", () => {
+      const immutableType = typeRegistry.lookup("string");
+      const attr = Attribute.fromDatabase("name", "hello", immutableType);
+      void attr.value;
+      expect(attr.changedInPlace()).toBe(false);
+    });
+  });
 });

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -261,6 +261,13 @@ export class FromDatabase extends Attribute {
     return this.type.deserialize(value);
   }
 
+  override changedInPlace(): boolean {
+    // Rails: has_been_read? && type.changed_in_place?(original_value_for_database, value)
+    return (
+      this.hasBeenRead() && this.type.isChangedInPlace(this._originalValueForDatabase(), this.value)
+    );
+  }
+
   /** @internal */
   protected override _originalValueForDatabase(): unknown {
     return this.valueBeforeTypeCast;

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -419,24 +419,28 @@ describeIfPg("PostgreSQLAdapter", () => {
       //   call type.isChangedInPlace() for mutable types.
       // SCOPE: ~50 LOC store_accessor + ~5 LOC attribute.ts changedInPlace delegation.
     });
-    it.skip("changes in place", () => {
-      // BLOCKED: dirty-tracking — Attribute.changedInPlace() does not delegate to type.isChangedInPlace()
-      // ROOT-CAUSE: activemodel/src/attribute.ts FromDatabase.changedInPlace() returns false
-      //   unconditionally; Rails calls type.changed_in_place?(original_value_for_database, value).
-      //   Hstore.isChangedInPlace() is implemented but never called by the Attribute layer.
-      // SCOPE: ~5 LOC in activemodel/src/attribute.ts FromDatabase subclass.
+    it("changes in place", async () => {
+      const hstore = await HstoreModel.createBang({ settings: { one: "two" } });
+      (hstore as any).settings["three"] = "four";
+      await (hstore as any).saveBang();
+      await (hstore as any).reload();
+      expect((hstore as any).settings["three"]).toBe("four");
+      expect((hstore as any).isChanged()).toBe(false);
     });
-    it.skip("dirty from user equal", () => {
-      // BLOCKED: dirty-tracking — same Attribute.changedInPlace() gap as "changes in place"
-      // ROOT-CAUSE: After reassigning an attribute with a deep-equal hash, the dirty tracker
-      //   must call type.isChangedInPlace() to detect equality; currently it compares by identity.
-      // SCOPE: ~5 LOC in activemodel/src/attribute.ts FromDatabase.changedInPlace().
+    it("dirty from user equal", async () => {
+      const settings = { alongkey: "anything", key: "value" };
+      const hstore = await HstoreModel.createBang({ settings });
+      (hstore as any).settings = { key: "value", alongkey: "anything" };
+      expect((hstore as any).settings).toEqual(settings);
+      expect((hstore as any).isChanged()).toBe(false);
     });
-    it.skip("hstore dirty from database equal", () => {
-      // BLOCKED: dirty-tracking — same Attribute.changedInPlace() gap as "changes in place"
-      // ROOT-CAUSE: After reload + reassign with same hash, dirty must be false; requires
-      //   Attribute.changedInPlace() → type.isChangedInPlace() delegation to detect equality.
-      // SCOPE: ~5 LOC in activemodel/src/attribute.ts FromDatabase.changedInPlace().
+    it("hstore dirty from database equal", async () => {
+      const settings = { alongkey: "anything", key: "value" };
+      const hstore = await HstoreModel.createBang({ settings });
+      await (hstore as any).reload();
+      expect((hstore as any).settings).toEqual(settings);
+      (hstore as any).settings = settings;
+      expect((hstore as any).isChanged()).toBe(false);
     });
 
     it("spaces", () => {

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -276,6 +276,19 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
       "Tests Marshal/YAML binary encoding of AR records. " +
       "Ruby binary serialization formats have no Node.js equivalent.",
   },
+  {
+    testFile: "hstore_test.rb",
+    tests: [
+      "hstore dirty tracking",
+      "hstore duplication",
+      "hstore nested",
+      "hstore populate",
+      "hstore schema dump",
+      "hstore gen random uuid",
+      "hstore gen random uuid default",
+    ],
+    reason: "TS-only invention; no Rails counterpart in hstore_test.rb",
+  },
 ];
 
 export function isExcluded(file: string): boolean {


### PR DESCRIPTION
## Summary

**Story E** from `docs/activerecord-100-plan.md` — two paired items in one ~87 LOC PR.

### Item 1 — `FromDatabase#changedInPlace` dispatch (5 LOC core)

Before: `FromDatabase` inherited the base `Attribute#changedInPlace(): boolean { return false; }` unconditionally.

After: overrides to mirror Rails `active_model/attribute.rb FromDatabase#changed_in_place?`:

```ruby
def changed_in_place?
  has_been_read? && type.changed_in_place?(original_value_for_database, value)
end
```

**Cross-type benefit** — every mutable AR type now gets correct dirty detection:
- `HstoreType` (already had `isChangedInPlace`) — 3 tests immediately un-skipped
- `JsonType` (packages/activerecord/src/type/json.ts) — `isChangedInPlace` already implemented; previously never called
- `JsonbType` extends `JsonType` — inherits the fix
- `MacaddrType`, `PointType`, `IntervalType` — ready for `isChangedInPlace` impls as those tests open

Guard: `hasBeenRead()` (mirrors `has_been_read?`) prevents computing the cast value if it was never accessed, consistent with Rails.

### Item 2 — 7 hstore orphans → permanent skip list

Verified each against `.rails-source/activerecord/test/cases/adapters/postgresql/hstore_test.rb`:

| TS test name | Rails counterpart |
|---|---|
| `hstore dirty tracking` | none |
| `hstore duplication` | none (closest: `test_duplication_with_store_accessors`, blocked separately) |
| `hstore nested` | none |
| `hstore populate` | none |
| `hstore schema dump` | none |
| `hstore gen random uuid` | none |
| `hstore gen random uuid default` | none |

Added as per-test exclusions under `hstore_test.rb` in `excluded-files.ts`.

## Before / After

| Metric | Before | After |
|---|---|---|
| `hstore_test.rb` matched | 29 | 32 (+3) |
| `hstore_test.rb` skipped | 16 | 13 (−3) |
| `attribute.test.ts` tests | 50 | 53 (+3 new dispatch tests) |
| activemodel api:compare | 620/625 | 620/625 (no regression) |
| activerecord api:compare | 4969/4969 | 4969/4969 (no regression) |