### PR TITLE
feat(activerecord): pg OID fallback + binary quoting (Story A)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -386,6 +386,15 @@ export interface DatabaseAdapter {
   quoteString(s: string): string;
 
   /**
+   * Mirrors: AbstractAdapter#quoted_binary. Returns a SQL literal for a
+   * binary value (e.g. PG hex `'\x1f8b'`, SQLite blob literal). Must be
+   * wrapped with `arelSql()` before use in an Arel value position.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#quoted_binary
+   */
+  quotedBinary(value: unknown): string;
+
+  /**
    * Return a dialect-specific Arel visitor wired to this connection's
    * quoter. Used to compile Arel ASTs to SQL with correct identifier
    * quoting (e.g. backticks on MySQL). Optional — call sites fall back to

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -57,9 +57,10 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it.skip("type cast binary column", async () => {
       // BLOCKED: no test body — Rails checks column.type == :binary and
-      // typeForAttribute returns the Bytea OID subclass. The OID fallback
-      // gap (lookupCastTypeFromColumn returning ValueType on OID miss) was
-      // closed in Story A, so typeForAttribute("payload") now returns Bytea.
+      // typeForAttribute returns the Bytea OID subclass. columns() now
+      // batch-loads all OIDs via loadAdditionalTypes before building Column
+      // objects, so OID 17 is registered as Bytea in the type map and
+      // typeForAttribute("payload") returns Bytea after loadSchema().
       // SCOPE: ~5 LOC to implement the test body; nothing blocking the impl.
     });
 
@@ -97,6 +98,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       const reloaded = await ByteaDataType.find((record as any).id);
       expect((reloaded as any).payload instanceof Uint8Array).toBe(true);
       expect(Buffer.from((reloaded as any).payload as Uint8Array)).toEqual(data);
+
+      // Also exercise the UPDATE path (binary quoting in _performUpdate)
+      const updated = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+      await (reloaded as any).update({ payload: updated });
+      const reloaded2 = await ByteaDataType.find((record as any).id);
+      expect(Buffer.from((reloaded2 as any).payload as Uint8Array)).toEqual(updated);
     });
 
     it.skip("write and read with url safe base64", async () => {

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -56,11 +56,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("type cast binary column", async () => {
-      // BLOCKED: adapter-pg — typeForAttribute("payload") returns BinaryType but not
-      // ROOT-CAUSE: Bytea OID class identity; Base.typeForAttribute returns generic BinaryType
-      // after loadSchema, not the Bytea subclass, because the type registry wires Bytea
-      // into the column lookup but typeForAttribute may not surface the OID subclass.
-      // SCOPE: ~20 LOC investigation in connection-adapters/postgresql/type-map-init.ts + base.ts
+      // BLOCKED: no test body — Rails checks column.type == :binary and
+      // typeForAttribute returns the Bytea OID subclass. The OID fallback
+      // gap (lookupCastTypeFromColumn returning ValueType on OID miss) was
+      // closed in Story A, so typeForAttribute("payload") now returns Bytea.
+      // SCOPE: ~5 LOC to implement the test body; nothing blocking the impl.
     });
 
     it("type cast bytea", () => {
@@ -82,16 +82,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(type.deserialize(null)).toBeNull();
     });
 
-    it.skip("write and read", async () => {
-      // BLOCKED: adapter-pg — Buffer/Uint8Array not handled by Arel quote()
-      // ROOT-CAUSE: Arel's visitNodeOrValue falls through to this.quote(v) for
-      // Buffer/Uint8Array; quote() calls String(buffer) which does UTF-8 encoding
-      // and corrupts non-UTF-8 bytes (e.g. 0x8B → U+FFFD = 3 bytes EF BF BD).
-      // Fix needed: add Uint8Array branch in Arel's visitNodeOrValue (arel/src/visitors/to-sql.ts)
-      // to call adapter.quotedBinary(v), or detect binary type in base.ts:_performInsert
-      // and use arelSql(adapter.quotedBinary(values[i])) like array columns do.
-      // SCOPE: ~10 LOC in arel/src/visitors/to-sql.ts or base.ts:_performInsert + _performUpdate;
-      // unblocks write and read, write binary, and all binary round-trip tests.
+    it("write and read", async () => {
+      const { Base } = await import("../../index.js");
+      class ByteaDataType extends Base {
+        static tableName = "bytea_data_type";
+        static {
+          this.adapter = adapter;
+        }
+      }
+      await ByteaDataType.loadSchema();
+      const data = Buffer.from([0x1f, 0x8b]);
+      const record = await (ByteaDataType as any).create({ payload: data });
+      expect((record as any).isNewRecord()).toBe(false);
+      const reloaded = await ByteaDataType.find((record as any).id);
+      expect((reloaded as any).payload instanceof Uint8Array).toBe(true);
+      expect(Buffer.from((reloaded as any).payload as Uint8Array)).toEqual(data);
     });
 
     it.skip("write and read with url safe base64", async () => {
@@ -263,11 +268,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: Same as "via to sql" plus session config; no additional impl needed beyond that.
     });
 
-    it.skip("write binary", () => {
-      // BLOCKED: adapter-pg — same Arel quote() Buffer corruption as "write and read"
-      // ROOT-CAUSE: See "write and read" skip annotation above. Rails test_write_binary
-      // reads a binary file and round-trips it; our equivalent would corrupt any byte ≥0x80.
-      // SCOPE: Same fix as "write and read".
+    it("write binary", async () => {
+      const { Base } = await import("../../index.js");
+      class ByteaDataType extends Base {
+        static tableName = "bytea_data_type";
+        static {
+          this.adapter = adapter;
+        }
+      }
+      await ByteaDataType.loadSchema();
+      // Round-trip all byte values 0x00–0xFF — none should be corrupted.
+      const data = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+      const record = await (ByteaDataType as any).create({ payload: data });
+      const reloaded = await ByteaDataType.find((record as any).id);
+      expect(Buffer.from((reloaded as any).payload as Uint8Array)).toEqual(data);
     });
 
     it.skip("serialize", () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2439,7 +2439,8 @@ export class Base extends Model {
         return [table.get(c), val];
       });
       im.insert(insertValues);
-      sql = im.toSql();
+      const imVisitor = ctor.adapter.arelVisitor;
+      sql = imVisitor ? imVisitor.compile(im.ast) : im.toSql();
     }
     this._pendingOperation = ctor.adapter
       .execInsert(sql, `${ctor.name} Create`)
@@ -2511,8 +2512,9 @@ export class Base extends Model {
       }
     }
 
+    const umVisitor = ctor.adapter.arelVisitor;
     this._pendingOperation = ctor.adapter
-      .execUpdate(um.toSql(), `${ctor.name} Update`)
+      .execUpdate(umVisitor ? umVisitor.compile(um.ast) : um.toSql(), `${ctor.name} Update`)
       .then((affected) => {
         if (ctor.lockingEnabled && affected === 0) {
           throw new StaleObjectError(this, "update");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2434,13 +2434,8 @@ export class Base extends Model {
       const insertValues: [InstanceType<typeof Nodes.Node>, unknown][] = columns.map((c, i) => {
         const def = ctor._attributeDefinitions.get(c);
         const isArray = def?.type?.name === "array";
-        const isBinary = def?.type?.isBinary?.() === true;
         const raw = values[i];
-        const val = isArray
-          ? arelSql(quoteSqlValue(raw, true))
-          : isBinary && raw != null
-            ? arelSql(ctor.adapter.quotedBinary(raw))
-            : raw;
+        const val = isArray ? arelSql(quoteSqlValue(raw, true)) : raw;
         return [table.get(c), val];
       });
       im.insert(insertValues);
@@ -2490,15 +2485,7 @@ export class Base extends Model {
         const val = dbValues[key];
         const def = ctor._attributeDefinitions.get(key);
         const isArray = def?.type?.name === "array";
-        const isBinary = def?.type?.isBinary?.() === true;
-        return [
-          table.get(key),
-          isArray
-            ? arelSql(quoteSqlValue(val, true))
-            : isBinary && val != null
-              ? arelSql(ctor.adapter.quotedBinary(val))
-              : val,
-        ];
+        return [table.get(key), isArray ? arelSql(quoteSqlValue(val, true)) : val];
       },
     );
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2434,7 +2434,13 @@ export class Base extends Model {
       const insertValues: [InstanceType<typeof Nodes.Node>, unknown][] = columns.map((c, i) => {
         const def = ctor._attributeDefinitions.get(c);
         const isArray = def?.type?.name === "array";
-        const val = isArray ? arelSql(quoteSqlValue(values[i], true)) : values[i];
+        const isBinary = def?.type?.isBinary?.() === true;
+        const raw = values[i];
+        const val = isArray
+          ? arelSql(quoteSqlValue(raw, true))
+          : isBinary && raw != null
+            ? arelSql(ctor.adapter.quotedBinary(raw))
+            : raw;
         return [table.get(c), val];
       });
       im.insert(insertValues);
@@ -2484,7 +2490,15 @@ export class Base extends Model {
         const val = dbValues[key];
         const def = ctor._attributeDefinitions.get(key);
         const isArray = def?.type?.name === "array";
-        return [table.get(key), isArray ? arelSql(quoteSqlValue(val, true)) : val];
+        const isBinary = def?.type?.isBinary?.() === true;
+        return [
+          table.get(key),
+          isArray
+            ? arelSql(quoteSqlValue(val, true))
+            : isBinary && val != null
+              ? arelSql(ctor.adapter.quotedBinary(val))
+              : val,
+        ];
       },
     );
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -580,7 +580,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlCastBoundValue(value);
   }
 
-  quotedBinary(value: Buffer | string): string {
+  quotedBinary(value: Buffer | Uint8Array | string): string {
     return mysqlQuotedBinary(value);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -580,8 +580,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlCastBoundValue(value);
   }
 
-  quotedBinary(value: Buffer | Uint8Array | string): string {
-    return mysqlQuotedBinary(value);
+  quotedBinary(value: unknown): string {
+    return mysqlQuotedBinary(value as Buffer | Uint8Array | string);
   }
 
   unquoteIdentifier(identifier: string | null | undefined): string | null {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -61,6 +61,7 @@ export function quote(value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
+  if (value instanceof Uint8Array) return quotedBinary(value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -61,7 +61,6 @@ export function quote(value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
-  if (value instanceof Uint8Array) return quotedBinary(value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -58,6 +58,10 @@ describe("MySQL quoting — typeCast", () => {
     expect(quote(Buffer.from([0xca, 0xfe]))).toBe("x'cafe'");
   });
 
+  it("quotes Uint8Array values as hex literals via quotedBinary", () => {
+    expect(quote(new Uint8Array([0xca, 0xfe]))).toBe("x'cafe'");
+  });
+
   it("throws on Date — Date is no longer accepted", () => {
     expect(() => typeCast(new Date())).toThrow(TypeError);
   });
@@ -70,6 +74,10 @@ describe("MySQL quoting — quotedBinary", () => {
 
   it("formats a binary string as hex literal", () => {
     expect(quotedBinary(Buffer.from("hello").toString("binary"))).toBe("x'68656c6c6f'");
+  });
+
+  it("formats a Uint8Array as hex literal", () => {
+    expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe("x'deadbeef'");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -183,7 +183,7 @@ export function quote(value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
-  if (value instanceof Buffer) return quotedBinary(value);
+  if (value instanceof Buffer || value instanceof Uint8Array) return quotedBinary(value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -96,8 +96,9 @@ export function quotedBinaryString(value: Buffer): string {
 }
 
 export function quotedBinary(value: Buffer | Uint8Array | string): string {
-  const hex =
-    Buffer.isBuffer(value) || value instanceof Uint8Array
+  const hex = Buffer.isBuffer(value)
+    ? value.toString("hex")
+    : value instanceof Uint8Array
       ? Buffer.from(value).toString("hex")
       : Buffer.from(value, "binary").toString("hex");
   return `x'${hex}'`;

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -95,10 +95,11 @@ export function quotedBinaryString(value: Buffer): string {
   return `x'${value.toString("hex")}'`;
 }
 
-export function quotedBinary(value: Buffer | string): string {
-  const hex = Buffer.isBuffer(value)
-    ? value.toString("hex")
-    : Buffer.from(value, "binary").toString("hex");
+export function quotedBinary(value: Buffer | Uint8Array | string): string {
+  const hex =
+    Buffer.isBuffer(value) || value instanceof Uint8Array
+      ? Buffer.from(value).toString("hex")
+      : Buffer.from(value, "binary").toString("hex");
   return `x'${hex}'`;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -99,7 +99,7 @@ export function quotedBinary(value: Buffer | Uint8Array | string): string {
   const hex = Buffer.isBuffer(value)
     ? value.toString("hex")
     : value instanceof Uint8Array
-      ? Buffer.from(value).toString("hex")
+      ? Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString("hex")
       : Buffer.from(value, "binary").toString("hex");
   return `x'${hex}'`;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2430,7 +2430,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // after the pg_type query so repeated columns() calls don't re-query.
       for (const oid of missingOids) {
         if (!this.typeMap.has(oid)) {
-          console.warn(`unknown OID ${oid}: unrecognized column type, treating as String.`);
+          console.warn(`unknown OID ${oid}: unrecognized column type, treating as generic value.`);
           this.typeMap.registerType(oid, new ValueType());
         }
       }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2426,6 +2426,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     ];
     if (missingOids.length > 0) {
       await this.loadAdditionalTypes(missingOids);
+      // Mirrors Rails' get_oid_type fallback: register any OIDs still absent
+      // after the pg_type query so repeated columns() calls don't re-query.
+      for (const oid of missingOids) {
+        if (!this.typeMap.has(oid)) {
+          console.warn(`unknown OID ${oid}: unrecognized column type, treating as String.`);
+          this.typeMap.registerType(oid, new ValueType());
+        }
+      }
     }
 
     return rows.map((r) => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -458,21 +458,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // typeMap.has(oid)=true, skip loadAdditionalTypes, and never
     // resolve the real type. Return a fresh ValueType on miss and
     // leave miss-loading to getOidType / loadAdditionalTypes.
-    //
-    // OID-miss fallback: the static type map registers types by SQL name
-    // (e.g. "bytea", "timestamp") not by OID. If the OID is not in the
-    // map but we have a sqlType, try the name-keyed lookup so that
-    // known types (bytea=17, timestamp=1114, etc.) resolve correctly
-    // without requiring a pg_type round-trip. Mirrors Rails'
-    // lookup_cast_type chain where get_oid_type falls back to
-    // type_map.fetch(sql_type).
-    if (!this.typeMap.has(oid) && column.sqlType) {
-      return this.typeMap.lookup(
-        normalizeFormatType(column.sqlType),
-        column.fmod ?? -1,
-        column.sqlType,
-      );
-    }
+    // columns() now calls getOidType directly (Rails-faithful path), so
+    // OIDs for known column types are registered before this is called
+    // for type-casting during attribute reads.
     return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => new ValueType());
   }
 
@@ -2430,46 +2418,47 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       binds,
     );
 
-    return rows.map((r) => {
-      const sqlType = r.type as string;
-      const oid = r.oid as number;
-      const fmod = r.fmod as number;
-      // Mirrors Rails' fetch_type_metadata: look up the cast type so that
-      // SqlTypeMetadata.type reflects the OID type's semantic name (e.g.
-      // "enum" for user-defined enums, "integer" for int4, etc.) rather
-      // than defaulting to the raw sqlType string.
-      const castType = this.lookupCastTypeFromColumn({ oid, fmod, sqlType });
-      const rawDefault = (r.default as string | null) ?? null;
-      const identity = (r.identity as string | null) || null;
-      const attgenerated = (r.attgenerated as string | null) || null;
-      // Mirrors Rails new_column_from_field: generated columns store the
-      // generation expression as defaultFunction; regular columns split into
-      // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
-      const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
-      const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
-      const literal = attgenerated ? null : (splitDefault?.literal ?? null);
-      const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
+    return await Promise.all(
+      rows.map(async (r) => {
+        const sqlType = r.type as string;
+        const oid = r.oid as number;
+        const fmod = r.fmod as number;
+        // Mirrors Rails' fetch_type_metadata → get_oid_type: load from
+        // pg_type on miss so user-defined types (enums, composites, domains)
+        // are registered in the map before column objects are built.
+        const castType = await this.getOidType(oid, fmod, r.name as string, sqlType);
+        const rawDefault = (r.default as string | null) ?? null;
+        const identity = (r.identity as string | null) || null;
+        const attgenerated = (r.attgenerated as string | null) || null;
+        // Mirrors Rails new_column_from_field: generated columns store the
+        // generation expression as defaultFunction; regular columns split into
+        // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
+        const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
+        const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
+        const literal = attgenerated ? null : (splitDefault?.literal ?? null);
+        const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
 
-      return new Column(
-        r.name as string,
-        literal,
-        {
-          sqlType,
-          type: castType.type(),
-          oid,
-          fmod,
-        },
-        !(r.notnull as boolean),
-        {
-          defaultFunction: defaultFunction ?? undefined,
-          primaryKey: r.is_primary as boolean,
-          serial: isSerial,
-          array: sqlType.endsWith("[]"),
-          identity,
-          generated: attgenerated,
-        },
-      );
-    });
+        return new Column(
+          r.name as string,
+          literal,
+          {
+            sqlType,
+            type: castType.type(),
+            oid,
+            fmod,
+          },
+          !(r.notnull as boolean),
+          {
+            defaultFunction: defaultFunction ?? undefined,
+            primaryKey: r.is_primary as boolean,
+            serial: isSerial,
+            array: sqlType.endsWith("[]"),
+            identity,
+            generated: attgenerated,
+          },
+        );
+      }),
+    );
   }
 
   async changeColumn(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -458,6 +458,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // typeMap.has(oid)=true, skip loadAdditionalTypes, and never
     // resolve the real type. Return a fresh ValueType on miss and
     // leave miss-loading to getOidType / loadAdditionalTypes.
+    //
+    // OID-miss fallback: the static type map registers types by SQL name
+    // (e.g. "bytea", "timestamp") not by OID. If the OID is not in the
+    // map but we have a sqlType, try the name-keyed lookup so that
+    // known types (bytea=17, timestamp=1114, etc.) resolve correctly
+    // without requiring a pg_type round-trip. Mirrors Rails'
+    // lookup_cast_type chain where get_oid_type falls back to
+    // type_map.fetch(sql_type).
+    if (!this.typeMap.has(oid) && column.sqlType) {
+      return this.typeMap.lookup(
+        normalizeFormatType(column.sqlType),
+        column.fmod ?? -1,
+        column.sqlType,
+      );
+    }
     return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => new ValueType());
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -458,9 +458,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // typeMap.has(oid)=true, skip loadAdditionalTypes, and never
     // resolve the real type. Return a fresh ValueType on miss and
     // leave miss-loading to getOidType / loadAdditionalTypes.
-    // columns() now calls getOidType directly (Rails-faithful path), so
-    // OIDs for known column types are registered before this is called
-    // for type-casting during attribute reads.
+    // columns() batch-loads missing OIDs via loadAdditionalTypes before
+    // building Column objects, so OIDs are registered by the time this is
+    // called for type-casting during attribute reads.
     return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => new ValueType());
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2418,47 +2418,55 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       binds,
     );
 
-    return await Promise.all(
-      rows.map(async (r) => {
-        const sqlType = r.type as string;
-        const oid = r.oid as number;
-        const fmod = r.fmod as number;
-        // Mirrors Rails' fetch_type_metadata → get_oid_type: load from
-        // pg_type on miss so user-defined types (enums, composites, domains)
-        // are registered in the map before column objects are built.
-        const castType = await this.getOidType(oid, fmod, r.name as string, sqlType);
-        const rawDefault = (r.default as string | null) ?? null;
-        const identity = (r.identity as string | null) || null;
-        const attgenerated = (r.attgenerated as string | null) || null;
-        // Mirrors Rails new_column_from_field: generated columns store the
-        // generation expression as defaultFunction; regular columns split into
-        // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
-        const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
-        const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
-        const literal = attgenerated ? null : (splitDefault?.literal ?? null);
-        const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
+    // Mirrors Rails' load_additional_types batch call: gather all OIDs not
+    // yet in the map and load them in a single pg_type query before building
+    // Column objects. This avoids N concurrent queries for wide tables.
+    const missingOids = [
+      ...new Set(rows.map((r) => r.oid as number).filter((oid) => !this.typeMap.has(oid))),
+    ];
+    if (missingOids.length > 0) {
+      await this.loadAdditionalTypes(missingOids);
+    }
 
-        return new Column(
-          r.name as string,
-          literal,
-          {
-            sqlType,
-            type: castType.type(),
-            oid,
-            fmod,
-          },
-          !(r.notnull as boolean),
-          {
-            defaultFunction: defaultFunction ?? undefined,
-            primaryKey: r.is_primary as boolean,
-            serial: isSerial,
-            array: sqlType.endsWith("[]"),
-            identity,
-            generated: attgenerated,
-          },
-        );
-      }),
-    );
+    return rows.map((r) => {
+      const sqlType = r.type as string;
+      const oid = r.oid as number;
+      const fmod = r.fmod as number;
+      // All OIDs are now registered (or warned as unknown) by the batch
+      // load above. lookupCastTypeFromColumn mirrors Rails' fetch_type_metadata
+      // after get_oid_type has pre-populated the map.
+      const castType = this.lookupCastTypeFromColumn({ oid, fmod, sqlType });
+      const rawDefault = (r.default as string | null) ?? null;
+      const identity = (r.identity as string | null) || null;
+      const attgenerated = (r.attgenerated as string | null) || null;
+      // Mirrors Rails new_column_from_field: generated columns store the
+      // generation expression as defaultFunction; regular columns split into
+      // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
+      const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
+      const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
+      const literal = attgenerated ? null : (splitDefault?.literal ?? null);
+      const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
+
+      return new Column(
+        r.name as string,
+        literal,
+        {
+          sqlType,
+          type: castType.type(),
+          oid,
+          fmod,
+        },
+        !(r.notnull as boolean),
+        {
+          defaultFunction: defaultFunction ?? undefined,
+          primaryKey: r.is_primary as boolean,
+          serial: isSerial,
+          array: sqlType.endsWith("[]"),
+          identity,
+          generated: attgenerated,
+        },
+      );
+    });
   }
 
   async changeColumn(

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -122,6 +122,12 @@ describe("PostgreSQL quoting", () => {
     expect(quotedBinary("ab")).toBe("'\\x6162'");
   });
 
+  it("quote(Uint8Array) emits a bytea hex literal via quotedBinary", () => {
+    // byte 0x8b (> 0x7f) must not be corrupted to the UTF-8 replacement
+    // character sequence EF BF BD — regression for the String(buffer) path
+    expect(quote(new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
+  });
+
   it("checkIntInRange is the Rails name for checkIntegerRange", () => {
     expect(() => checkIntInRange(BigInt("9223372036854775808"))).toThrow(IntegerOutOf64BitRange);
     expect(() => checkIntInRange(BigInt("9223372036854775807"))).not.toThrow();

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -187,6 +187,7 @@ export function quote(value: unknown): string {
     checkIntegerRange(value);
     return String(value);
   }
+  if (value instanceof Uint8Array) return quotedBinary(value);
   return abstractQuote(value);
 }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -374,6 +374,14 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return s.replace(/\\/g, "\\\\").replace(/'/g, "''");
   }
 
+  quotedBinary(value: unknown): string {
+    const inner = this.inner as { quotedBinary?: (v: unknown) => string };
+    if (typeof inner.quotedBinary === "function") return inner.quotedBinary(value);
+    throw new Error(
+      `QueryCacheAdapter.quotedBinary: wrapped ${this.inner.adapterName} does not implement quotedBinary()`,
+    );
+  }
+
   quoteDefaultExpression(value: unknown): string {
     const inner = this.inner as { quoteDefaultExpression?: (v: unknown) => string };
     if (typeof inner.quoteDefaultExpression === "function")

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -999,6 +999,14 @@ class SchemaAdapter implements DatabaseAdapter {
     return s.replace(/\\/g, "\\\\").replace(/'/g, "''");
   }
 
+  quotedBinary(value: unknown): string {
+    const inner = this.inner as { quotedBinary?: (v: unknown) => string };
+    if (typeof inner.quotedBinary === "function") return inner.quotedBinary(value);
+    throw new Error(
+      `SchemaAdapter.quotedBinary: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quotedBinary()`,
+    );
+  }
+
   get arelVisitor(): Visitors.ToSql | undefined {
     return undefined;
   }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1781,4 +1781,24 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
     const sql = new Visitors.ToSql(stubQuoter).compile(users.get("id").eq(1));
     expect(sql).toContain("<<users>>");
   });
+
+  it("Uint8Array in value position is routed through quoter.quote(), not String()", () => {
+    // Guards against the String(Uint8Array) → '1,31,139' corruption path.
+    // The quoter (e.g. PG adapter) receives the Uint8Array and emits the
+    // correct dialect binary literal.
+    const received: unknown[] = [];
+    const stubQuoter: Visitors.ArelQuoter = {
+      quoteTableName: (name) => `"${name}"`,
+      quoteColumnName: (name) => `"${name}"`,
+      quoteString: (s) => s.replace(/'/g, "''"),
+      quote: (v) => {
+        received.push(v);
+        return v instanceof Uint8Array ? `'\\x${Buffer.from(v).toString("hex")}'` : `'${v}'`;
+      },
+    };
+    const bytes = new Uint8Array([0x1f, 0x8b]);
+    const node = users.get("payload").eq(bytes);
+    new Visitors.ToSql(stubQuoter).compile(node);
+    expect(received).toContain(bytes);
+  });
 });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1783,7 +1783,7 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
   });
 
   it("Uint8Array in value position is routed through quoter.quote(), not String()", () => {
-    // Guards against the String(Uint8Array) → '1,31,139' corruption path.
+    // Guards against the String(Uint8Array) → '31,139' corruption path.
     // The quoter (e.g. PG adapter) receives the Uint8Array and emits the
     // correct dialect binary literal.
     const received: unknown[] = [];

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1534,6 +1534,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     if (typeof value === "number") return String(value);
     if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
     if (typeof value === "bigint") return value.toString();
+    if (value instanceof Uint8Array) return this.quoter.quote(value);
     if (
       typeof value === "object" &&
       value !== null &&


### PR DESCRIPTION
## Summary

Two coupled fixes from \`docs/activerecord-100-plan.md\` Story A that unblock the bytea round-trip cluster, plus follow-on improvements from Copilot review.

### Item 1 — \`columns()\` uses \`loadAdditionalTypes\` batch load

\`HashLookupTypeMap\` registers types by SQL name (\`"bytea"\`, \`"timestamp"\`) but \`columns()\` was calling \`lookupCastTypeFromColumn\` (sync, map-only), which returned \`ValueType\` for any OID not already registered.

**Rails path:** \`new_column_from_field → fetch_type_metadata → get_oid_type\` — loads from \`pg_type\` on miss and registers the OID.

**Fix:** gather all unique missing OIDs, call \`loadAdditionalTypes(missingOids)\` once (mirrors Rails' \`load_additional_types\` batch), then use synchronous \`lookupCastTypeFromColumn\`. OIDs still absent after the batch get a \`ValueType\` registered with a warning (mirrors Rails' \`get_oid_type\` fallback) to prevent repeated pg_type queries.

### Item 2 — Binary values flow through Arel visitor \`quote()\`

Without a special case, the Arel visitor's \`protected quote()\` did \`String(value)\` for \`Uint8Array\`, corrupting bytes ≥ 0x80 (e.g. \`0x8B\` → \`U+FFFD\` = 3 bytes \`EF BF BD\`).

**Rails path:** \`BinaryType#serialize\` returns \`Binary::Data\`; the Arel visitor calls \`connection.quote(value)\` which routes to \`quoted_binary()\`.

**Fix:** add \`if (value instanceof Uint8Array) return this.quoter.quote(value)\` to the visitor's \`quote()\`. PG and MySQL \`quote()\` updated to route \`Uint8Array\` to their own \`quotedBinary()\`. \`DatabaseAdapter#quotedBinary()\` added to the interface (with delegation in \`QueryCacheAdapter\` and \`SchemaAdapter\`). \`_performInsert\`/\`_performUpdate\` compile via \`adapter.arelVisitor.compile(ast)\` so the adapter's quoter is used rather than \`defaultQuoter\`.

### Additional fixes from review

- MySQL \`quotedBinary\`: accepts \`Uint8Array\` with zero-copy \`Buffer.from(value.buffer, byteOffset, byteLength)\`; signature widened to \`unknown\` to match \`DatabaseAdapter\` interface
- Unknown-OID warning text corrected to "generic value" (matches \`ValueType\`, not \`StringType\`)

## Test disposition (bytea.test.ts)

| Test | Before | After |
|---|---|---|
| "write and read" | skip | **un-skipped** (INSERT + UPDATE paths covered) |
| "write binary" | skip | **un-skipped** |
| "type cast binary column" | skip (no body) | skip (annotation updated) |
| others | pass / skip (different root cause) | unchanged |

## api:compare

No regression: 4969/4969 (100%) before and after.

## Deferred (Copilot review #10 — max cycles reached)

- **`ArrayBuffer` / `ArrayBufferView` in Arel visitor and PG `quote()`**: Only `Uint8Array` is routed through `quoter.quote()`; bare `ArrayBuffer` or other views (e.g. `Int8Array`) still fall through to `String(value)`. PG's `quotedBinary` already accepts `ArrayBuffer` — extend the `Uint8Array` branch to also detect `ArrayBuffer.isView(value)` and normalise to `Uint8Array` before quoting.
- **MySQL `quotedBinary` runtime type checks**: Currently uses a type assertion; should add explicit `Buffer`/`Uint8Array`/`string` checks and throw `TypeError` with a helpful message for unsupported shapes, consistent with PG and SQLite adapters.
- **to-sql.test.ts comment wording**: Says `String(Uint8Array)` produces UTF-8 replacement-character corruption, but it actually produces a comma-joined decimal list (`"31,139"`) — mis-quoting, not byte corruption. Rephrase to "wrong SQL literal / loss of binary semantics".