### PR TITLE
feat(activerecord): pg BC datetime serialize + MySQL DATETIME format fix

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -6,6 +6,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
+import { DateTime as OidDateTime } from "../../connection-adapters/postgresql/oid/date-time.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -221,28 +222,41 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: ~5 LOC in postgresql-adapter.ts:lookupCastTypeFromColumn; unblocks save
       // infinity, BC timestamp tests, and bytea round-trip tests.
     });
-    it.skip("bc timestamp", () => {
-      // BLOCKED: adapter-pg — BC date serialize path not wired for PG BC format
-      // ROOT-CAUSE: base DateTimeType.serialize calls Temporal.Instant.toString() which
-      // outputs ISO 8601 with negative year (e.g. "-0043-01-01T00:00:00Z"). PostgreSQL's
-      // timestamp parser does NOT accept ISO 8601 negative years natively; it expects the
-      // "YYYY-MM-DD BC" proleptic Gregorian format. A custom serialize override in
-      // OID::DateTime is needed to convert negative Temporal years to the PG BC suffix format.
-      // SCOPE: ~20 LOC in connection-adapters/postgresql/oid/date-time.ts serialize override;
-      // unblocks all 3 bc timestamp tests.
+    it("bc timestamp", async () => {
+      // Rails: Time.new(0) - 1.week = Dec 25, ISO year -1 (2 BC)
+      const oidType = new OidDateTime();
+      const instant = oidType.castValue("0002-12-25 00:00:00 BC") as Temporal.Instant;
+      expect(instant.toZonedDateTimeISO("UTC").year).toBe(-1);
+      const serialized = oidType.serialize(instant) as string;
+      expect(serialized).toBe("0002-12-25 00:00:00.000000 BC");
+      const rows = await adapter.execute(`SELECT '${serialized}'::timestamp AS val`);
+      const roundTripped = rows[0].val as Temporal.Instant;
+      expect(roundTripped).toBeInstanceOf(Temporal.Instant);
+      expect(roundTripped.epochMilliseconds).toBe(instant.epochMilliseconds);
     });
-    it.skip("bc timestamp leap year", () => {
-      // BLOCKED: adapter-pg — same BC date serialize gap as "bc timestamp".
-      // ROOT-CAUSE: Temporal.Instant.toString() → ISO negative year not accepted by PG;
-      // needs serialize override in OID::DateTime to emit "YYYY-MM-DD BC" format.
-      // SCOPE: Same fix as "bc timestamp".
+    it("bc timestamp leap year", async () => {
+      // Rails: Time.utc(-4, 2, 29) = Feb 29, ISO year -4 (5 BC)
+      const oidType = new OidDateTime();
+      const instant = oidType.castValue("0005-02-29 00:00:00 BC") as Temporal.Instant;
+      expect(instant.toZonedDateTimeISO("UTC").year).toBe(-4);
+      const serialized = oidType.serialize(instant) as string;
+      expect(serialized).toBe("0005-02-29 00:00:00.000000 BC");
+      const rows = await adapter.execute(`SELECT '${serialized}'::timestamp AS val`);
+      const roundTripped = rows[0].val as Temporal.Instant;
+      expect(roundTripped).toBeInstanceOf(Temporal.Instant);
+      expect(roundTripped.epochMilliseconds).toBe(instant.epochMilliseconds);
     });
-    it.skip("bc timestamp year zero", () => {
-      // BLOCKED: adapter-pg — same BC date serialize gap as "bc timestamp".
-      // ROOT-CAUSE: Year 0 in ISO 8601 = 1 BCE in PG proleptic Gregorian; same serialize
-      // mismatch applies. After the serialize fix, also verify that PG "0001 BC" round-trips
-      // correctly through parseBcTimestampAsInstant (bcYearToIso converts 1 → 0).
-      // SCOPE: Same fix as "bc timestamp"; add year-zero edge case to the serialize helper.
+    it("bc timestamp year zero", async () => {
+      // Rails: Time.utc(0, 4, 7) = Apr 7, ISO year 0 (1 BC)
+      const oidType = new OidDateTime();
+      const instant = oidType.castValue("0001-04-07 00:00:00 BC") as Temporal.Instant;
+      expect(instant.toZonedDateTimeISO("UTC").year).toBe(0);
+      const serialized = oidType.serialize(instant) as string;
+      expect(serialized).toBe("0001-04-07 00:00:00.000000 BC");
+      const rows = await adapter.execute(`SELECT '${serialized}'::timestamp AS val`);
+      const roundTripped = rows[0].val as Temporal.Instant;
+      expect(roundTripped).toBeInstanceOf(Temporal.Instant);
+      expect(roundTripped.epochMilliseconds).toBe(instant.epochMilliseconds);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -59,7 +59,7 @@ import {
 } from "@blazetrails/activemodel";
 import { UnsignedInteger } from "../type/unsigned-integer.js";
 import { Date as DateType } from "../type/date.js";
-import { DateTime as DateTimeType } from "../type/date-time.js";
+import { DateTime as MysqlDateTimeType } from "./mysql/date-time.js";
 import { Time as TimeType } from "../type/time.js";
 import { Text as TextType } from "../type/text.js";
 import { Json as JsonType } from "../type/json.js";
@@ -1114,7 +1114,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     m.registerType(/^varbinary/i, undefined, () => new BinaryType());
     m.registerType(/^date$/i, new DateType());
     m.registerType(/^time\b/i, undefined, () => new TimeType());
-    m.registerType(/^datetime/i, undefined, () => new DateTimeType());
+    m.registerType(/^datetime/i, undefined, () => new MysqlDateTimeType());
     m.registerType(/decimal/i, undefined, () => new DecimalType());
     m.registerType(/numeric/i, undefined, () => new DecimalType());
     m.registerType("json", new JsonType());
@@ -1137,7 +1137,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     this.registerIntegerType(m, /^tinyint/i, { limit: 1 });
     m.registerType(/^year/i, undefined, () => new IntegerType());
     m.registerType(/^bit/i, undefined, () => new BinaryType());
-    m.registerType(/^timestamp/i, undefined, () => new DateTimeType());
+    m.registerType(/^timestamp/i, undefined, () => new MysqlDateTimeType());
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -304,6 +304,7 @@ function formatDatePrefix(v: { year: number; month: number; day: number }): stri
 }
 
 function padYear(year: number): string {
+  if (year < 0) return String(year);
   return String(year).padStart(4, "0");
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -304,7 +304,7 @@ function formatDatePrefix(v: { year: number; month: number; day: number }): stri
 }
 
 function padYear(year: number): string {
-  return String(year);
+  return String(year).padStart(4, "0");
 }
 
 function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {

--- a/packages/activerecord/src/connection-adapters/mysql/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/date-time.test.ts
@@ -1,0 +1,38 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
+import { describe, expect, it } from "vitest";
+import { DateTime } from "./date-time.js";
+
+describe("MySQL::DateTime", () => {
+  const type = new DateTime();
+
+  it("serialize emits YYYY-MM-DD HH:MM:SS.ffffff without T or Z", () => {
+    const instant = Temporal.Instant.from("2026-05-08T14:32:00.123456Z");
+    expect(type.serialize(instant)).toBe("2026-05-08 14:32:00.123456");
+  });
+
+  it("serialize zero-pads years below 1000", () => {
+    // Realistic case: year 44 CE — ensure 4-digit year, not 2-digit (MySQL
+    // 2-digit-year rules would misinterpret "44-01-01 00:00:00")
+    const instant = Temporal.Instant.from("0044-01-01T00:00:00Z");
+    const result = type.serialize(instant) as string;
+    expect(result).toMatch(/^0044-/);
+  });
+
+  it("serialize returns null for null input", () => {
+    expect(type.serialize(null)).toBeNull();
+  });
+
+  it("serialize returns null for infinity sentinels (MySQL has no infinity timestamps)", () => {
+    expect(type.serialize(DateInfinity)).toBeNull();
+    expect(type.serialize(DateNegativeInfinity)).toBeNull();
+  });
+
+  it("serialize strips fractional seconds when microseconds are zero", () => {
+    const instant = Temporal.Instant.from("2026-05-08T14:32:00Z");
+    const result = type.serialize(instant) as string;
+    expect(result).not.toContain("T");
+    expect(result).not.toContain("Z");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/date-time.ts
@@ -16,7 +16,7 @@ export class DateTime extends ARDateTime {
     if (cast === null) return null;
     if (cast instanceof Temporal.Instant) return formatInstantForSqlMysql(cast);
     // Sentinels (DateInfinity/DateNegativeInfinity): MySQL has no infinity
-    // timestamp values, so return null (skipped on INSERT/UPDATE).
+    // timestamp values, so serialize to SQL NULL.
     return null;
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/date-time.ts
@@ -15,6 +15,8 @@ export class DateTime extends ARDateTime {
     const cast = this.cast(value);
     if (cast === null) return null;
     if (cast instanceof Temporal.Instant) return formatInstantForSqlMysql(cast);
-    return super.serialize(value);
+    // Sentinels (DateInfinity/DateNegativeInfinity): MySQL has no infinity
+    // timestamp values, so return null (skipped on INSERT/UPDATE).
+    return null;
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/date-time.ts
@@ -1,0 +1,20 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { formatInstantForSqlMysql } from "../abstract/quoting.js";
+import { DateTime as ARDateTime } from "../../type/date-time.js";
+
+/**
+ * MySQL/MariaDB datetime type. Overrides serialize to emit
+ * "YYYY-MM-DD HH:MM:SS[.ffffff]" (no T, no Z) so MariaDB DATETIME
+ * columns accept the value. The base DateTimeType emits ISO 8601 with
+ * T and Z which MariaDB rejects in strict SQL mode.
+ *
+ * @internal
+ */
+export class DateTime extends ARDateTime {
+  override serialize(value: unknown): string | null {
+    const cast = this.cast(value);
+    if (cast === null) return null;
+    if (cast instanceof Temporal.Instant) return formatInstantForSqlMysql(cast);
+    return super.serialize(value);
+  }
+}

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -33,6 +33,34 @@ describe("PostgreSQL::OID::DateTime", () => {
     expect(zdt.day).toBe(15);
   });
 
+  it("serialize converts BC Temporal.Instant to PG BC format", () => {
+    // 44 BC = ISO year -43; round-trip via castValue to create the Instant
+    const instant = type.castValue("0044-01-01 00:00:00 BC") as Temporal.Instant;
+    expect(instant.toZonedDateTimeISO("UTC").year).toBe(-43);
+    expect(type.serialize(instant)).toBe("0044-01-01 00:00:00.000000 BC");
+  });
+
+  it("serialize converts ISO year 0 to 1 BC", () => {
+    const instant = type.castValue("0001-04-07 00:00:00 BC") as Temporal.Instant;
+    expect(instant.toZonedDateTimeISO("UTC").year).toBe(0);
+    expect(type.serialize(instant)).toBe("0001-04-07 00:00:00.000000 BC");
+  });
+
+  it("serialize preserves microseconds in BC format", () => {
+    const instant = type.castValue("0005-02-29 12:34:56.123456 BC") as Temporal.Instant;
+    expect(type.serialize(instant)).toBe("0005-02-29 12:34:56.123456 BC");
+  });
+
+  it("serialize leaves AD dates unchanged", () => {
+    const instant = Temporal.Instant.from("2023-06-15T12:00:00Z");
+    expect(type.serialize(instant)).toBe("2023-06-15T12:00:00.000000Z");
+  });
+
+  it("serialize returns 'infinity' / '-infinity' for sentinels", () => {
+    expect(type.serialize(DateInfinity)).toBe("infinity");
+    expect(type.serialize(DateNegativeInfinity)).toBe("-infinity");
+  });
+
   it("type_cast_for_schema renders infinity sentinels", () => {
     expect(type.typeCastForSchema(DateInfinity)).toBe("::Float::INFINITY");
     expect(type.typeCastForSchema(DateNegativeInfinity)).toBe("-::Float::INFINITY");

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -62,7 +62,20 @@ export class DateTime extends DateTimeType {
   override serialize(value: unknown): string | null {
     if (value === DateInfinity) return "infinity";
     if (value === DateNegativeInfinity) return "-infinity";
-    return super.serialize(value);
+    const result = super.serialize(value);
+    if (result === null) return null;
+    // PostgreSQL does not accept ISO 8601 negative-year timestamps. Convert
+    // astronomical year Y ≤ 0 to "YYYY-MM-DD HH:MM:SS[.ffffff] BC" format.
+    // ISO year -43 → 44 BC; ISO year 0 → 1 BC.
+    const m = /^(-?\d+)-(\d{2})-(\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?)Z?$/.exec(result);
+    if (m) {
+      const isoYear = parseInt(m[1], 10);
+      if (isoYear <= 0) {
+        const bcYear = String(-isoYear + 1).padStart(4, "0");
+        return `${bcYear}-${m[2]}-${m[3]} ${m[4]} BC`;
+      }
+    }
+    return result;
   }
 
   override typeCastForSchema(value: unknown): string {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -85,22 +85,15 @@ const COLUMN_TYPE_MAP_PG: Record<PrimitiveColumnSpec, string> = {
   json: "json",
 };
 
-// SQLite stores temporal and binary types as TEXT; using typed column names
-// causes better-sqlite3 to return them as strings without conversion.
+// Non-PG adapters (SQLite, MySQL/MariaDB) store temporal and binary types as
+// TEXT, matching test-adapter.ts's sqlType() mapping. Using the typed column
+// names causes MariaDB to reject ISO 8601 Z-suffix strings when the base
+// DateTimeType.serialize is used (e.g. via attribute() declarations).
 /** @internal */
-const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
+const COLUMN_TYPE_MAP_OTHER: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_PG,
   datetime: "string",
   date: "string",
-  binary: "string",
-  json: "string",
-};
-
-// MySQL/MariaDB supports native DATETIME; serialize now emits "YYYY-MM-DD HH:MM:SS"
-// (no T, no Z) so MariaDB accepts the value in strict SQL mode.
-/** @internal */
-const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
-  ...COLUMN_TYPE_MAP_PG,
   binary: "string",
   json: "string",
 };
@@ -112,12 +105,7 @@ export async function defineSchema(
 ): Promise<void> {
   const ss = new SchemaStatements(adapter);
   const order = resolveReferences(schema);
-  const typeMap =
-    adapter.adapterName === "postgres"
-      ? COLUMN_TYPE_MAP_PG
-      : adapter.adapterName === "mysql"
-        ? COLUMN_TYPE_MAP_MYSQL
-        : COLUMN_TYPE_MAP_SQLITE;
+  const typeMap = adapter.adapterName === "postgres" ? COLUMN_TYPE_MAP_PG : COLUMN_TYPE_MAP_OTHER;
 
   if (opts?.dropExisting) {
     for (const table of [...order].reverse()) {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -85,14 +85,22 @@ const COLUMN_TYPE_MAP_PG: Record<PrimitiveColumnSpec, string> = {
   json: "json",
 };
 
-// Non-PG adapters (SQLite, MySQL/MariaDB) store temporal and binary types as
-// TEXT, matching test-adapter.ts's sqlType() mapping. Using the typed column
-// names causes MariaDB to reject ISO 8601 Z-suffix strings.
+// SQLite stores temporal and binary types as TEXT; using typed column names
+// causes better-sqlite3 to return them as strings without conversion.
 /** @internal */
-const COLUMN_TYPE_MAP_OTHER: Record<PrimitiveColumnSpec, string> = {
+const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_PG,
   datetime: "string",
   date: "string",
+  binary: "string",
+  json: "string",
+};
+
+// MySQL/MariaDB supports native DATETIME; serialize now emits "YYYY-MM-DD HH:MM:SS"
+// (no T, no Z) so MariaDB accepts the value in strict SQL mode.
+/** @internal */
+const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
+  ...COLUMN_TYPE_MAP_PG,
   binary: "string",
   json: "string",
 };
@@ -104,7 +112,12 @@ export async function defineSchema(
 ): Promise<void> {
   const ss = new SchemaStatements(adapter);
   const order = resolveReferences(schema);
-  const typeMap = adapter.adapterName === "postgres" ? COLUMN_TYPE_MAP_PG : COLUMN_TYPE_MAP_OTHER;
+  const typeMap =
+    adapter.adapterName === "postgres"
+      ? COLUMN_TYPE_MAP_PG
+      : adapter.adapterName === "mysql"
+        ? COLUMN_TYPE_MAP_MYSQL
+        : COLUMN_TYPE_MAP_SQLITE;
 
   if (opts?.dropExisting) {
     for (const table of [...order].reverse()) {


### PR DESCRIPTION
## Summary

- **Item 1 — PG BC timestamp serialize**: `OID::DateTime#serialize` now converts ISO astronomical year ≤ 0 to PostgreSQL `YYYY-MM-DD HH:MM:SS[.ffffff] BC` format. PostgreSQL rejects ISO 8601 negative-year timestamps; year -43 → `0044-... BC`, year 0 → `0001-... BC`.
- **Item 2 — MySQL DATETIME format**: New `mysql/date-time.ts` overrides `serialize` to emit `YYYY-MM-DD HH:MM:SS[.ffffff]` (no T, no Z) via `formatInstantForSqlMysql`. Registered in `AbstractMysqlAdapter` for `/^datetime/i` and `/^timestamp/i`.
- **defineSchema revert**: `COLUMN_TYPE_MAP_MYSQL` now uses native `datetime`/`date` columns. SQLite retains the TEXT workaround (better-sqlite3 returns datetime as TEXT anyway).

## Before / after

| Test | Before | After |
|------|--------|-------|
| `oid/date-time.test.ts` | 11 tests | 16 tests (+5 serialize) |
| `timestamp.test.ts` bc timestamp | skipped | passes (PG round-trip) |
| `timestamp.test.ts` bc timestamp leap year | skipped | passes |
| `timestamp.test.ts` bc timestamp year zero | skipped | passes |
| MySQL DATETIME insert | rejects ISO Z string | accepts `YYYY-MM-DD HH:MM:SS` |

## LOC

145 additions + deletions (well under 300 ceiling).

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts` — 16/16 pass
- [ ] `PG_TEST_URL=... pnpm vitest run packages/activerecord/src/adapters/postgresql/timestamp.test.ts` — 3 BC tests now active
- [ ] `DATABASE_URL=mysql://... pnpm vitest run packages/activerecord/src/adapters/mysql2/` — datetime round-trip without TEXT workaround
- [ ] `pnpm test:types` — no errors