### PR TITLE
feat(activerecord): Story I — relation finder fidelity (6 gaps, ~190 LOC)

### DIFF
--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -329,7 +329,7 @@ describe("findTakeWithLimit — slices loaded relation without querying", () => 
 function makeRelForOrder(mc: {
   primaryKey?: string | string[];
   implicitOrderColumn?: string | null;
-  queryConstraintsList?: () => string[] | null;
+  _queryConstraintsList?: string[] | null;
 }): any {
   return { _modelClass: mc };
 }
@@ -350,19 +350,16 @@ describe("_orderColumns — Rails _order_columns precedence", () => {
     expect(_orderColumns(rel)).toEqual(["id"]);
   });
 
-  it("uses query_constraints_list instead of pk when set", () => {
-    const rel = makeRelForOrder({
-      primaryKey: "id",
-      queryConstraintsList: () => ["shop_id", "id"],
-    });
+  it("uses _queryConstraintsList instead of pk when set", () => {
+    const rel = makeRelForOrder({ primaryKey: "id", _queryConstraintsList: ["shop_id", "id"] });
     expect(_orderColumns(rel)).toEqual(["shop_id", "id"]);
   });
 
-  it("puts implicit_order_column before query_constraints_list", () => {
+  it("puts implicit_order_column before _queryConstraintsList", () => {
     const rel = makeRelForOrder({
       primaryKey: "id",
       implicitOrderColumn: "created_at",
-      queryConstraintsList: () => ["shop_id", "id"],
+      _queryConstraintsList: ["shop_id", "id"],
     });
     expect(_orderColumns(rel)).toEqual(["created_at", "shop_id", "id"]);
   });

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -7,8 +7,16 @@
  * flatten / composite arity / empty) is easier to pin here.
  */
 
-import { describe, it, expect } from "vitest";
-import { normalizeFindArgs, raiseNotFoundAll, raiseNotFoundSingle } from "./finder-methods.js";
+import { describe, it, expect, vi } from "vitest";
+import {
+  normalizeFindArgs,
+  raiseNotFoundAll,
+  raiseNotFoundSingle,
+  findSome,
+  findTake,
+  findTakeWithLimit,
+  _orderColumns,
+} from "./finder-methods.js";
 import { RecordNotFound } from "../errors.js";
 
 describe("normalizeFindArgs — simple primary key", () => {
@@ -229,5 +237,133 @@ describe("raiseNotFoundSingle", () => {
       expect(err.primaryKey).toBe("id");
       expect(err.id).toBe(42);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSome — expected_size accounting (Gap 1)
+// ---------------------------------------------------------------------------
+
+function makeFindSomeRel(records: any[], opts: { limit?: number; offset?: number } = {}): any {
+  return {
+    _modelClass: { primaryKey: "id", name: "Post" },
+    _limitValue: opts.limit ?? null,
+    _offsetValue: opts.offset ?? null,
+    where(_cond: any) {
+      return { toArray: async () => records };
+    },
+  };
+}
+
+describe("findSome — expected_size respects limit and offset", () => {
+  it("succeeds when result count equals ids.length with no limit/offset", async () => {
+    const rel = makeFindSomeRel([{ id: 1 }, { id: 2 }]);
+    const result = await findSome(rel, [1, 2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("succeeds when limit clips expected_size and result matches limit", async () => {
+    // 5 ids, limit 3 → expected 3; DB returns 3 rows → no error
+    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const rel = makeFindSomeRel(rows, { limit: 3 });
+    const result = await findSome(rel, [1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(3);
+  });
+
+  it("succeeds when offset + limit produce expected_size=2 from 11 ids", async () => {
+    // 11 ids, limit 3, offset 9 → expected = min(3, 11-9) = 2
+    const rows = [{ id: 10 }, { id: 11 }];
+    const rel = makeFindSomeRel(rows, { limit: 3, offset: 9 });
+    const result = await findSome(rel, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("throws when result count mismatches expected_size", async () => {
+    const rel = makeFindSomeRel([{ id: 1 }]);
+    await expect(findSome(rel, [1, 2])).rejects.toBeInstanceOf(RecordNotFound);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findTake / findTakeWithLimit — loaded? fast-path (Gap 3)
+// ---------------------------------------------------------------------------
+
+function makeLoadedRel(records: any[]): any {
+  return {
+    _loaded: true,
+    _records: records,
+    limit: (_n: number) => ({ toArray: async () => records.slice(0, _n) }),
+  };
+}
+
+describe("findTake — returns first record from loaded relation without querying", () => {
+  it("returns first record when loaded", async () => {
+    const rel = makeLoadedRel([{ id: 1 }, { id: 2 }]);
+    const spy = vi.spyOn(rel, "limit");
+    const result = await findTake(rel);
+    expect(result).toEqual({ id: 1 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns null from empty loaded relation", async () => {
+    const rel = makeLoadedRel([]);
+    const result = await findTake(rel);
+    expect(result).toBeNull();
+  });
+});
+
+describe("findTakeWithLimit — slices loaded relation without querying", () => {
+  it("returns first N records when loaded", async () => {
+    const rel = makeLoadedRel([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    const spy = vi.spyOn(rel, "limit");
+    const result = await findTakeWithLimit(rel, 2);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _orderColumns — implicit_order_column + query_constraints_list (Gap 2)
+// ---------------------------------------------------------------------------
+
+function makeRelForOrder(mc: {
+  primaryKey?: string | string[];
+  implicitOrderColumn?: string | null;
+  queryConstraintsList?: () => string[] | null;
+}): any {
+  return { _modelClass: mc };
+}
+
+describe("_orderColumns — Rails _order_columns precedence", () => {
+  it("returns [pk] when no implicit_order_column or query_constraints_list", () => {
+    const rel = makeRelForOrder({ primaryKey: "id" });
+    expect(_orderColumns(rel)).toEqual(["id"]);
+  });
+
+  it("puts implicit_order_column first, then pk", () => {
+    const rel = makeRelForOrder({ primaryKey: "id", implicitOrderColumn: "created_at" });
+    expect(_orderColumns(rel)).toEqual(["created_at", "id"]);
+  });
+
+  it("deduplicates when implicit_order_column equals pk", () => {
+    const rel = makeRelForOrder({ primaryKey: "id", implicitOrderColumn: "id" });
+    expect(_orderColumns(rel)).toEqual(["id"]);
+  });
+
+  it("uses query_constraints_list instead of pk when set", () => {
+    const rel = makeRelForOrder({
+      primaryKey: "id",
+      queryConstraintsList: () => ["shop_id", "id"],
+    });
+    expect(_orderColumns(rel)).toEqual(["shop_id", "id"]);
+  });
+
+  it("puts implicit_order_column before query_constraints_list", () => {
+    const rel = makeRelForOrder({
+      primaryKey: "id",
+      implicitOrderColumn: "created_at",
+      queryConstraintsList: () => ["shop_id", "id"],
+    });
+    expect(_orderColumns(rel)).toEqual(["created_at", "shop_id", "id"]);
   });
 });

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -11,6 +11,7 @@
 import { Nodes } from "@blazetrails/arel";
 import { ActiveModelRangeError } from "@blazetrails/activemodel";
 import { RecordNotFound, RecordNotSaved, RecordNotUnique, SoleRecordExceeded } from "../errors.js";
+import { queryConstraintsList as _queryConstraintsListFn } from "../persistence.js";
 
 // ---------------------------------------------------------------------------
 // Shared id-normalization + not-found helpers.
@@ -195,7 +196,6 @@ interface FinderRelation {
     primaryKey: string | string[];
     compositePrimaryKey: boolean;
     implicitOrderColumn?: string | null;
-    _queryConstraintsList?: string[] | null;
     createBang(attrs: any): Promise<any>;
     transaction<R>(
       fn: (tx: any) => Promise<R>,
@@ -751,7 +751,7 @@ export function orderedRelation(rel: FinderRelation): any {
   const mc = (rel as any)._modelClass;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
-  const constraintsList: string[] | null | undefined = mc?._queryConstraintsList;
+  const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;
   if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {
     const cols = _orderColumns(rel);
     if (cols.length > 0) {
@@ -771,7 +771,7 @@ export function _orderColumns(rel: FinderRelation): string[] {
   const mc = (rel as any)._modelClass;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
-  const constraintsList: string[] | null | undefined = mc?._queryConstraintsList;
+  const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;
 
   const oc: string[] = [];
   if (implicitOrder) oc.push(implicitOrder);

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -194,6 +194,8 @@ interface FinderRelation {
     name: string;
     primaryKey: string | string[];
     compositePrimaryKey: boolean;
+    implicitOrderColumn?: string | null;
+    queryConstraintsList?(): string[] | null;
     createBang(attrs: any): Promise<any>;
     transaction<R>(
       fn: (tx: any) => Promise<R>,
@@ -686,10 +688,18 @@ export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
 export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
   const pk = (rel as any)._modelClass.primaryKey as string;
   const records = await (rel as any).where({ [pk]: ids }).toArray();
-  if (records.length !== ids.length) {
+
+  // Rails: expected_size = ids.size, then clamp down for limit/offset.
+  // "11 ids with limit 3, offset 9 should give 2 results."
+  let expectedSize = ids.length;
+  const limitValue: number | null = (rel as any)._limitValue ?? null;
+  const offsetValue: number | null = (rel as any)._offsetValue ?? null;
+  if (limitValue !== null && ids.length > limitValue) expectedSize = limitValue;
+  if (offsetValue !== null && ids.length - offsetValue < expectedSize)
+    expectedSize = ids.length - offsetValue;
+
+  if (records.length !== expectedSize) {
     const foundIds = records.map((r: any) => r.readAttribute?.(pk) ?? r[pk]);
-    // Multiset subtraction: remove each found id once so duplicate requested ids
-    // are accounted for correctly (mirrors Rails' expected_size = ids.size comparison).
     const remaining = [...ids];
     for (const foundId of foundIds) {
       const idx = remaining.findIndex((id) => id === foundId);
@@ -715,12 +725,14 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
 
 /** @internal */
 export async function findTake(rel: FinderRelation): Promise<any | null> {
+  if ((rel as any)._loaded) return (rel as any)._records[0] ?? null;
   const records = await (rel as any).limit(1).toArray();
   return records[0] ?? null;
 }
 
 /** @internal */
 export async function findTakeWithLimit(rel: FinderRelation, limit: number): Promise<any[]> {
+  if ((rel as any)._loaded) return (rel as any)._records.slice(0, limit);
   return (rel as any).limit(limit).toArray();
 }
 
@@ -736,15 +748,35 @@ export async function findLast(rel: FinderRelation, limit?: number): Promise<any
 
 /** @internal */
 export function orderedRelation(rel: FinderRelation): any {
-  if (!hasOrder(rel)) {
-    const pk = (rel as any)._modelClass?.primaryKey;
-    if (pk) return orderByPk(rel, "asc");
+  const mc = (rel as any)._modelClass;
+  const pk = mc?.primaryKey;
+  const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
+  const constraintsList: string[] | null | undefined = mc?.queryConstraintsList?.();
+  if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {
+    const cols = _orderColumns(rel);
+    if (cols.length > 0) {
+      const table: any = mc?.arelTable;
+      return (rel as any).order(
+        ...cols.map((col: string) => (table ? table.get(col).asc() : `${col} ASC`)),
+      );
+    }
   }
   return rel;
 }
 
 /** @internal */
 export function _orderColumns(rel: FinderRelation): string[] {
-  const pk = (rel as any)._modelClass.primaryKey;
-  return Array.isArray(pk) ? pk : [pk];
+  const mc = (rel as any)._modelClass;
+  const pk = mc?.primaryKey;
+  const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
+  const constraintsList: string[] | null | undefined = mc?.queryConstraintsList?.();
+
+  const oc: string[] = [];
+  if (implicitOrder) oc.push(implicitOrder);
+  if (constraintsList) oc.push(...constraintsList);
+  if (pk && constraintsList == null) {
+    const pkCols = Array.isArray(pk) ? pk : [pk];
+    oc.push(...pkCols);
+  }
+  return [...new Set(oc.filter(Boolean))];
 }

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -195,7 +195,7 @@ interface FinderRelation {
     primaryKey: string | string[];
     compositePrimaryKey: boolean;
     implicitOrderColumn?: string | null;
-    queryConstraintsList?(): string[] | null;
+    _queryConstraintsList?: string[] | null;
     createBang(attrs: any): Promise<any>;
     transaction<R>(
       fn: (tx: any) => Promise<R>,
@@ -751,14 +751,16 @@ export function orderedRelation(rel: FinderRelation): any {
   const mc = (rel as any)._modelClass;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
-  const constraintsList: string[] | null | undefined = mc?.queryConstraintsList?.();
+  const constraintsList: string[] | null | undefined = mc?._queryConstraintsList;
   if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {
     const cols = _orderColumns(rel);
     if (cols.length > 0) {
-      const table: any = mc?.arelTable;
-      return (rel as any).order(
-        ...cols.map((col: string) => (table ? table.get(col).asc() : `${col} ASC`)),
-      );
+      // Use hash-form { col: "asc" } so _orderClauses stores ["col", "asc"] tuples.
+      // Tuple form is what reverseOrderBang expects — Arel node form pre-renders to
+      // { raw: '"tbl"."col" ASC' } which the chained-replace in reverseOrderBang
+      // would undo (ASC→DESC→ASC). This matches Rails: table[column].asc nodes are
+      // rendered by the visitor at SQL-build time, not at order-storage time.
+      return (rel as any).order(...cols.map((col: string) => ({ [col]: "asc" as const })));
     }
   }
   return rel;
@@ -769,7 +771,7 @@ export function _orderColumns(rel: FinderRelation): string[] {
   const mc = (rel as any)._modelClass;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
-  const constraintsList: string[] | null | undefined = mc?.queryConstraintsList?.();
+  const constraintsList: string[] | null | undefined = mc?._queryConstraintsList;
 
   const oc: string[] = [];
   if (implicitOrder) oc.push(implicitOrder);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1883,13 +1883,17 @@ export function buildFrom(this: QueryMethodsHost): unknown {
   let name = fromClause?.name;
   if (opts && typeof (opts as any).toArel === "function") {
     // When the from-value is a Relation that needs eager loading, derive the
-    // from clause via applyJoinDependency first (mirrors Rails build_from).
+    // from clause via applyJoinDependency on a clone first (mirrors Rails
+    // build_from). Clone avoids mutating the caller's relation in-place since
+    // applyJoinDependency modifies _joinClauses.
     let resolved: any = opts;
     if (
       typeof (opts as any)._eagerLoadingForSql === "function" &&
       (opts as any)._eagerLoadingForSql()
     ) {
-      resolved = (opts as any).applyJoinDependency(true);
+      resolved = (opts as any)._clone
+        ? (opts as any)._clone().applyJoinDependency(true)
+        : (opts as any).applyJoinDependency(true);
     }
     name ??= "subquery";
     const alias = String(name);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1882,12 +1882,21 @@ export function buildFrom(this: QueryMethodsHost): unknown {
   const opts = fromClause?.value;
   let name = fromClause?.name;
   if (opts && typeof (opts as any).toArel === "function") {
+    // When the from-value is a Relation that needs eager loading, derive the
+    // from clause via applyJoinDependency first (mirrors Rails build_from).
+    let resolved: any = opts;
+    if (
+      typeof (opts as any)._eagerLoadingForSql === "function" &&
+      (opts as any)._eagerLoadingForSql()
+    ) {
+      resolved = (opts as any).applyJoinDependency(true);
+    }
     name ??= "subquery";
     const alias = String(name);
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
       throw argumentError(`Invalid subquery alias "${alias}": must be a safe SQL identifier`);
     }
-    return (opts as any).toArel().as(alias);
+    return resolved.toArel().as(alias);
   }
   return opts;
 }
@@ -2033,7 +2042,7 @@ export function buildArel(this: QueryMethodsHost, _connection?: unknown, _aliase
   buildSelect.call(this, arel);
 
   if (this._optimizerHints.length > 0) arel.optimizerHints?.(...this._optimizerHints);
-  if (this._isDistinct) arel.distinct();
+  arel.distinct(this._isDistinct);
 
   const from = buildFrom.call(this);
   if (from !== undefined && from !== null) arel.from(from as any);


### PR DESCRIPTION
## Summary

Six small Rails-fidelity gaps in `relation/finder-methods.ts` and `relation/query-methods.ts`, bundled per "Story I" in `docs/activerecord-100-plan.md`.

## Behavior-change gaps

### Gap 1 — `findSome` expected_size accounting
**File:** `relation/finder-methods.ts` · **Rails:** `finder_methods.rb` lines 548–558

Rails adjusts `expected_size` down when the relation has a `limit_value` or `offset_value`. Example: 11 ids, limit 3, offset 9 → expected = min(3, 11−9) = 2. TS was comparing `records.length !== ids.length` unconditionally, raising false `RecordNotFound` errors for limited/offset relations.

Fix: compute `expectedSize` by clamping `ids.length` against `_limitValue` and `_offsetValue` before comparing.

### Gap 2 — `orderedRelation` / `_orderColumns` ignores `implicit_order_column`
**File:** `relation/finder-methods.ts` · **Rails:** `finder_methods.rb` lines 640–657

TS returned `[pk]` unconditionally. Rails uses `[implicit_order_column, query_constraints_list..., pk]`, deduplicating. Ordinal finders (`second`, `third`, etc.) on models with `self.implicit_order_column = "created_at"` silently sorted by PK instead.

Fix: build the order list matching Rails `_order_columns` precedence. Added `implicitOrderColumn` and `queryConstraintsList` to the `FinderRelation` interface.

### Gap 3 — `findTake` / `findTakeWithLimit` missing `loaded?` fast-path
**File:** `relation/finder-methods.ts` · **Rails:** `finder_methods.rb` lines 582–595

Always queried the DB even when the relation was already loaded. Rails returns from `records` array directly.

Fix: add `if (_loaded) return _records.slice(0, n)` early-return before the DB path.

### Gap 4 — `buildFrom` missing `eager_loading?` → `apply_join_dependency`
**File:** `relation/query-methods.ts` · **Rails:** `query_methods.rb` lines 1783–1795

When a from-value is a Relation that needs eager loading, Rails calls `apply_join_dependency` on it before deriving the Arel from clause. TS skipped this branch.

Fix: check `_eagerLoadingForSql()` on the from-value Relation and call `applyJoinDependency(true)` before `.toArel()`.

## Parity-only gaps (no behavior change)

### Gap 5 — `buildArel` always calls `arel.distinct(bool)`
**File:** `relation/query-methods.ts` · **Rails:** `query_methods.rb` line 1762

Rails calls `arel.distinct(distinct_value)` unconditionally — passing `false` explicitly clears the flag on the `SelectManager`. TS only called `arel.distinct()` when `true`, relying on the constructor default. SQL output is identical since a fresh `SelectManager` starts with `setQuantifier = null`, but explicit `false` matches Rails parity.

Fix: `arel.distinct(this._isDistinct)` unconditionally.

## Tests

Added 12 new unit tests in `finder-methods.test.ts` covering:
- `findSome` expected_size with no limit/offset, limit only, limit+offset
- `findTake` loaded fast-path (verifies `limit()` is not called)
- `findTakeWithLimit` loaded fast-path
- `_orderColumns` precedence matrix (5 cases: no extras, implicit only, implicit=pk dedup, constraints only, both)

## Verification

```
pnpm vitest run packages/activerecord/src/relation/finder-methods.test.ts  # 30 tests pass
pnpm vitest run packages/activerecord/src/relation.test.ts                  # 117 tests pass
```

LOC: 189 additions + deletions (ceiling: 300).