### PR TITLE
feat(activerecord): Story F — mysql2 session variable wiring (wait_timeout, strict, variables)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -52,6 +52,21 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
 }
 
 /**
+ * MySQL2-specific adapter options that extend the shared base.
+ * Kept separate so PG/SQLite3 destructuring of `TrailsAdapterOptions`
+ * never receives — and leaks — these keys into their driver configs.
+ */
+export interface MysqlAdapterOptions extends TrailsAdapterOptions {
+  // Mirrors: database.yml `strict:` — controls sql_mode STRICT_ALL_TABLES wiring.
+  // true/undefined → add STRICT_ALL_TABLES; false → remove strict flags; "default" → leave global value.
+  strict?: boolean | "default";
+  // Mirrors: database.yml `wait_timeout:` — SET SESSION wait_timeout = N on each connection.
+  waitTimeout?: number | string;
+  // Mirrors: database.yml `variables:` — SET SESSION key = value on each new connection.
+  variables?: Record<string, string | number | boolean | null | ":default" | "default">;
+}
+
+/**
  * PostgreSQL-specific adapter options that extend the shared base.
  * Kept separate so MySQL2/SQLite3 destructuring of `TrailsAdapterOptions`
  * never receives — and leaks — these keys into their driver configs.

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -57,12 +57,25 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(adapter.active).toBe(false);
     });
 
-    it.skip("wait timeout as string", () => {
-      // BLOCKED: wait_timeout not wired into pool.on('connection') setup in mysql2-adapter.ts.
-      // SCOPE: parse wait_timeout from config; emit `SET SESSION wait_timeout = N` alongside SET time_zone.
+    it("wait timeout as string", async () => {
+      const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, waitTimeout: "60" });
+      try {
+        const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
+        expect(parseInt(rows[0].v as string, 10)).toBe(60);
+      } finally {
+        await testAdapter.close();
+      }
     });
-    it.skip("wait timeout as url", () => {
-      // BLOCKED: same as "wait timeout as string" — URL query param not parsed.
+    it("wait timeout as url", async () => {
+      const url = new URL(MYSQL_TEST_URL);
+      url.searchParams.set("wait_timeout", "60");
+      const testAdapter = new Mysql2Adapter(url.toString());
+      try {
+        const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
+        expect(parseInt(rows[0].v as string, 10)).toBe(60);
+      } finally {
+        await testAdapter.close();
+      }
     });
 
     it("character set connection is configured", async () => {
@@ -76,19 +89,40 @@ describeIfMysql("Mysql2Adapter", () => {
       // showVariable() now implemented; only the second-adapter assertion is missing.
       // SCOPE: add MYSQL_TEST_URL2 + second adapter to test-helper.ts.
     });
-    it.skip("mysql default in strict mode", () => {
-      // BLOCKED: configureConnection() doesn't set sql_mode/STRICT_ALL_TABLES in mysql2-adapter.ts.
-      // SCOPE: implement configureConnection() to emit SET SESSION sql_mode = '...,STRICT_ALL_TABLES'.
+    it("mysql default in strict mode", async () => {
+      const rows = await adapter.execute("SELECT @@SESSION.sql_mode AS v");
+      expect(String(rows[0].v)).toMatch(/STRICT_ALL_TABLES/);
     });
-    it.skip("mysql strict mode disabled", () => {
-      // BLOCKED: strict: false config not wired — same gap as "mysql default in strict mode".
+    it("mysql strict mode disabled", async () => {
+      const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: false });
+      try {
+        const rows = await testAdapter.execute("SELECT @@SESSION.sql_mode AS v");
+        expect(String(rows[0].v)).not.toMatch(/STRICT_ALL_TABLES/);
+      } finally {
+        await testAdapter.close();
+      }
     });
-    it.skip("mysql strict mode specified default", () => {
-      // BLOCKED: strict: :default config not wired — same gap as "mysql default in strict mode".
+    it("mysql strict mode specified default", async () => {
+      const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: "default" });
+      try {
+        const globalRows = await testAdapter.execute("SELECT @@GLOBAL.sql_mode AS v");
+        const sessionRows = await testAdapter.execute("SELECT @@SESSION.sql_mode AS v");
+        expect(sessionRows[0].v).toBe(globalRows[0].v);
+      } finally {
+        await testAdapter.close();
+      }
     });
-    it.skip("mysql sql mode variable overrides strict mode", () => {
-      // BLOCKED: variables config hash not wired into pool.on('connection') in mysql2-adapter.ts.
-      // SCOPE: parse variables; emit SET SESSION for each key alongside SET time_zone.
+    it("mysql sql mode variable overrides strict mode", async () => {
+      const testAdapter = new Mysql2Adapter({
+        uri: MYSQL_TEST_URL,
+        variables: { sql_mode: "ansi" },
+      });
+      try {
+        const rows = await testAdapter.execute("SELECT @@SESSION.sql_mode AS v");
+        expect(String(rows[0].v)).not.toMatch(/STRICT_ALL_TABLES/);
+      } finally {
+        await testAdapter.close();
+      }
     });
     it.skip("passing arbitrary flags to adapter", () => {
       // BLOCKED: pool model has no single raw_connection; flags on query_options not accessible.
@@ -97,11 +131,30 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skip("passing flags by array to adapter", () => {
       // BLOCKED: same as "passing arbitrary flags to adapter".
     });
-    it.skip("mysql set session variable", () => {
-      // BLOCKED: variables config not wired — same gap as "mysql sql mode variable overrides".
+    it("mysql set session variable", async () => {
+      const testAdapter = new Mysql2Adapter({
+        uri: MYSQL_TEST_URL,
+        variables: { default_week_format: 3 },
+      });
+      try {
+        const rows = await testAdapter.execute("SELECT @@SESSION.DEFAULT_WEEK_FORMAT AS v");
+        expect(parseInt(rows[0].v as string, 10)).toBe(3);
+      } finally {
+        await testAdapter.close();
+      }
     });
-    it.skip("mysql set session variable to default", () => {
-      // BLOCKED: same as "mysql set session variable".
+    it("mysql set session variable to default", async () => {
+      const testAdapter = new Mysql2Adapter({
+        uri: MYSQL_TEST_URL,
+        variables: { default_week_format: "default" },
+      });
+      try {
+        const globalRows = await testAdapter.execute("SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT AS v");
+        const sessionRows = await testAdapter.execute("SELECT @@SESSION.DEFAULT_WEEK_FORMAT AS v");
+        expect(sessionRows[0].v).toBe(globalRows[0].v);
+      } finally {
+        await testAdapter.close();
+      }
     });
 
     it("logs name show variable", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -175,6 +175,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     super();
     if (typeof config === "string") {
       let waitTimeout: number | undefined;
+      let uri = config;
       try {
         const url = new URL(config);
         this._database =
@@ -183,11 +184,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         if (wt !== null) {
           const n = parseInt(wt, 10);
           if (Number.isInteger(n)) waitTimeout = n;
+          // Strip from URI so mysql2 doesn't warn about an unknown connection option.
+          url.searchParams.delete("wait_timeout");
+          uri = url.toString();
         }
       } catch {
         // malformed URI — leave _database undefined
       }
-      this._driverPool = Mysql2Adapter.newClient({ uri: config, waitTimeout });
+      this._driverPool = Mysql2Adapter.newClient({ uri, waitTimeout });
       return;
     }
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
@@ -1247,6 +1251,8 @@ function buildConfigureConnectionClauses(
     .map(([k, v]) => {
       if (DEFAULTS.has(String(v))) return `@@SESSION.${k} = DEFAULT`;
       if (typeof v === "number") return `@@SESSION.${k} = ${v}`;
+      // Mirrors Rails quote(true) → '1', quote(false) → '0'
+      if (typeof v === "boolean") return `@@SESSION.${k} = '${v ? 1 : 0}'`;
       return `@@SESSION.${k} = '${String(v).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
     });
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1163,6 +1163,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       typeCast: userTypeCast,
       ...poolOptions
     } = config;
+    // Build configure_connection SET clauses before createPool — mirrors AbstractMysqlAdapter#configure_connection.
+    // time_zone is included here so all session setup is sent as ONE query, queued
+    // synchronously in the 'connection' handler before mysql2 adds the connection to its
+    // free-connection list. A second chained rawConn.query() inside the callback of the
+    // first would race against the caller's query (mysql2 makes the connection available
+    // after emitting 'connection', before our callbacks fire).
+    // Computed before createPool so a validation throw (e.g. bad variable name) doesn't leak a live pool.
+    const sessionClauses = buildConfigureConnectionClauses(strict, waitTimeout, configVars);
+    const initSql = `SET time_zone = '+00:00', ${sessionClauses}`;
+
     const composedTypeCast =
       typeof userTypeCast === "function"
         ? (field: unknown, next: () => unknown) =>
@@ -1175,15 +1185,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       ...poolOptions,
       typeCast: composedTypeCast,
     });
-
-    // Build configure_connection SET clauses — mirrors AbstractMysqlAdapter#configure_connection.
-    // time_zone is included here so all session setup is sent as ONE query, queued
-    // synchronously in the 'connection' handler before mysql2 adds the connection to its
-    // free-connection list. A second chained rawConn.query() inside the callback of the
-    // first would race against the caller's query (mysql2 makes the connection available
-    // after emitting 'connection', before our callbacks fire).
-    const sessionClauses = buildConfigureConnectionClauses(strict, waitTimeout, configVars);
-    const initSql = `SET time_zone = '+00:00', ${sessionClauses}`;
 
     // mysql.Pool (promise wrapper) re-emits 'connection' from the underlying pool
     // via inheritEvents — this is the public typed API on mysql.Pool, no internal

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1,7 +1,7 @@
 import mysql from "mysql2/promise";
 import { Notifications } from "@blazetrails/activesupport";
 import { StringType } from "@blazetrails/activemodel";
-import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption, MysqlAdapterOptions } from "../adapter.js";
 import {
   AbstractMysqlAdapter,
   StatementPool as MysqlStatementPool,
@@ -171,17 +171,23 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _fullVersionString: string | null = null;
   private _database: string | undefined;
 
-  constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
+  constructor(config: string | (mysql.PoolOptions & MysqlAdapterOptions)) {
     super();
     if (typeof config === "string") {
+      let waitTimeout: number | undefined;
       try {
+        const url = new URL(config);
         this._database =
-          decodeURIComponent(new URL(config).pathname.replace(/^\/+/, "").replace(/\/+$/, "")) ||
-          undefined;
+          decodeURIComponent(url.pathname.replace(/^\/+/, "").replace(/\/+$/, "")) || undefined;
+        const wt = url.searchParams.get("wait_timeout");
+        if (wt !== null) {
+          const n = parseInt(wt, 10);
+          if (Number.isInteger(n)) waitTimeout = n;
+        }
       } catch {
         // malformed URI — leave _database undefined
       }
-      this._driverPool = Mysql2Adapter.newClient({ uri: config });
+      this._driverPool = Mysql2Adapter.newClient({ uri: config, waitTimeout });
       return;
     }
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
@@ -190,7 +196,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // hash. Validate & apply the adapter-level keys FIRST so an
     // invalid value fails before `mysql.createPool` runs — otherwise
     // a throw would leave a live pool with no cleanup path.
-    const { statementLimit, preparedStatements, ...mysqlConfig } = config;
+    const { statementLimit, preparedStatements, strict, waitTimeout, variables, ...mysqlConfig } =
+      config;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     this._database =
@@ -206,7 +213,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           return undefined;
         }
       })();
-    this._driverPool = Mysql2Adapter.newClient(mysqlConfig);
+    this._driverPool = Mysql2Adapter.newClient({ ...mysqlConfig, strict, waitTimeout, variables });
   }
 
   /** Checkout a fresh connection from the pool, translating ER_BAD_DB_ERROR. */
@@ -1135,7 +1142,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return false;
   }
 
-  static newClient(config: mysql.PoolOptions): mysql.Pool {
+  static newClient(config: mysql.PoolOptions & MysqlAdapterOptions): mysql.Pool {
     // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
     // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
     // and a JS number for smaller values. Both are handled by BigIntegerType.cast().
@@ -1145,7 +1152,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Compose our Temporal typeCast with any user-supplied typeCast so callers
     // can still intercept non-temporal fields (e.g. custom ENUM handling) without
     // losing Temporal parsing on temporal columns.
-    const userTypeCast = config.typeCast;
+    const {
+      strict,
+      waitTimeout,
+      variables: configVars,
+      typeCast: userTypeCast,
+      ...poolOptions
+    } = config;
     const composedTypeCast =
       typeof userTypeCast === "function"
         ? (field: unknown, next: () => unknown) =>
@@ -1155,11 +1168,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         : TEMPORAL_POOL_OPTIONS.typeCast;
     const pool = mysql.createPool({
       supportBigNumbers: true,
-      ...config,
+      ...poolOptions,
       typeCast: composedTypeCast,
     });
-    // Pin session timezone to UTC so TIMESTAMP wire strings are always in UTC,
-    // allowing parseMysqlInstant to treat them as Temporal.Instant correctly.
+
+    // Build configure_connection SET clauses — mirrors AbstractMysqlAdapter#configure_connection.
+    // time_zone is included here so all session setup is sent as ONE query, queued
+    // synchronously in the 'connection' handler before mysql2 adds the connection to its
+    // free-connection list. A second chained rawConn.query() inside the callback of the
+    // first would race against the caller's query (mysql2 makes the connection available
+    // after emitting 'connection', before our callbacks fire).
+    const sessionClauses = buildConfigureConnectionClauses(strict, waitTimeout, configVars);
+    const initSql = `SET time_zone = '+00:00', ${sessionClauses}`;
+
     // mysql.Pool (promise wrapper) re-emits 'connection' from the underlying pool
     // via inheritEvents — this is the public typed API on mysql.Pool, no internal
     // property access needed. The callback receives the raw PoolConnection (non-
@@ -1169,7 +1190,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         query: (sql: string, cb: (err: Error | null) => void) => void;
         destroy: () => void;
       };
-      rawConn.query("SET time_zone = '+00:00'", (err) => {
+      rawConn.query(initSql, (err) => {
         if (err) {
           rawConn.destroy();
           pool.emit("error", err);
@@ -1178,6 +1199,58 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     });
     return pool;
   }
+}
+
+// Mirrors AbstractMysqlAdapter#configure_connection.
+// Returns the comma-separated SET clause list (without the SET keyword) for
+// wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
+// The caller prepends additional clauses (e.g. time_zone) so everything is
+// sent as one atomic SET statement.
+function buildConfigureConnectionClauses(
+  strict: boolean | "default" | undefined,
+  waitTimeout: number | string | undefined,
+  configVars: Record<string, string | number | boolean | null | ":default" | "default"> | undefined,
+): string {
+  const vars: Record<string, string | number | boolean | null | ":default" | "default"> = {
+    ...(configVars ?? {}),
+  };
+
+  const wt = typeof waitTimeout === "string" ? parseInt(waitTimeout, 10) : waitTimeout;
+  vars["wait_timeout"] = Number.isInteger(wt) ? (wt as number) : 2147483;
+
+  const DEFAULTS = new Set([":default", "default"]);
+
+  let sqlMode: string | undefined;
+  const varSqlMode = vars["sql_mode"];
+  if (varSqlMode !== undefined) {
+    delete vars["sql_mode"];
+    sqlMode = `'${String(varSqlMode).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+  } else if (!DEFAULTS.has(strict as string)) {
+    if (strict !== false) {
+      sqlMode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')";
+    } else {
+      sqlMode = "REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')";
+      sqlMode = `REPLACE(${sqlMode}, 'STRICT_ALL_TABLES', '')`;
+      sqlMode = `REPLACE(${sqlMode}, 'TRADITIONAL', '')`;
+    }
+    sqlMode = `CONCAT(${sqlMode}, ',NO_AUTO_VALUE_ON_ZERO')`;
+  } else {
+    // strict: "default" — sync session to global, counteracting mysql2 Node.js
+    // CLIENT_IGNORE_SPACE flag which otherwise adds IGNORE_SPACE to session sql_mode.
+    sqlMode = "@@GLOBAL.sql_mode";
+  }
+
+  const sqlModeClause = sqlMode ? `@@SESSION.sql_mode = ${sqlMode}` : "";
+
+  const varClauses = Object.entries(vars)
+    .filter(([, v]) => v !== null && v !== undefined)
+    .map(([k, v]) => {
+      if (DEFAULTS.has(String(v))) return `@@SESSION.${k} = DEFAULT`;
+      if (typeof v === "number") return `@@SESSION.${k} = ${v}`;
+      return `@@SESSION.${k} = '${String(v).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+    });
+
+  return [sqlModeClause, ...varClauses].filter(Boolean).join(", ");
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1219,6 +1219,15 @@ function buildConfigureConnectionClauses(
     ...(configVars ?? {}),
   };
 
+  // Validate variable names before interpolating into SQL — matches the pattern used
+  // by PostgreSQLAdapter and SQLite3Adapter to catch misconfigured keys early.
+  const SAFE_VAR_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+  for (const k of Object.keys(vars)) {
+    if (!SAFE_VAR_NAME.test(k)) {
+      throw new Error(`Invalid MySQL session variable name: ${JSON.stringify(k)}`);
+    }
+  }
+
   const wt = typeof waitTimeout === "string" ? parseInt(waitTimeout, 10) : waitTimeout;
   vars["wait_timeout"] = Number.isInteger(wt) ? (wt as number) : 2147483;
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1226,9 +1226,11 @@ function buildConfigureConnectionClauses(
 
   let sqlMode: string | undefined;
   const varSqlMode = vars["sql_mode"];
-  if (varSqlMode !== undefined) {
+  if (varSqlMode !== undefined && varSqlMode !== null) {
+    // Mirrors Rails: `if sql_mode = variables.delete("sql_mode")` — nil is falsy in Ruby,
+    // so null falls through to the strict-mode branch below.
     delete vars["sql_mode"];
-    sqlMode = `'${String(varSqlMode).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+    sqlMode = mysqlQuoteString(String(varSqlMode));
   } else if (!DEFAULTS.has(strict as string)) {
     if (strict !== false) {
       sqlMode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')";
@@ -1251,9 +1253,8 @@ function buildConfigureConnectionClauses(
     .map(([k, v]) => {
       if (DEFAULTS.has(String(v))) return `@@SESSION.${k} = DEFAULT`;
       if (typeof v === "number") return `@@SESSION.${k} = ${v}`;
-      // Mirrors Rails quote(true) → '1', quote(false) → '0'
       if (typeof v === "boolean") return `@@SESSION.${k} = '${v ? 1 : 0}'`;
-      return `@@SESSION.${k} = '${String(v).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+      return `@@SESSION.${k} = ${mysqlQuoteString(String(v))}`;
     });
 
   return [sqlModeClause, ...varClauses].filter(Boolean).join(", ");


### PR DESCRIPTION
## Summary

Wires MySQL session variables from connection config to the live MySQL session, mirroring `AbstractMysqlAdapter#configure_connection`.

- **`wait_timeout`** — integer or string; defaults to 2147483 if not provided
- **`sql_mode`** via `strict` flag — `true`/`undefined` adds `STRICT_ALL_TABLES`; `false` removes strict flags; `"default"` syncs `@@SESSION.sql_mode = @@GLOBAL.sql_mode`
- **`variables` hash** — `SET @@SESSION.key = value` per entry; `:default`/`"default"` values emit `DEFAULT`

All session setup (including the existing `time_zone = '+00:00'`) is sent as **one atomic `SET` statement**, queued synchronously in the `pool.on('connection')` handler. A chained second `rawConn.query()` inside the first callback races against the caller's query (mysql2 makes the connection available after emitting `connection`, before our callbacks fire).

Adds `MysqlAdapterOptions` to `adapter.ts` (`strict`, `waitTimeout`, `variables`).

`wait_timeout` from a URL query string (`?wait_timeout=60`) is parsed out of the URI before passing to mysql2.

## Test disposition (connection.test.ts)

| Test | Before | After |
|------|--------|-------|
| wait timeout as string | BLOCKED | ✓ pass |
| wait timeout as url | BLOCKED | ✓ pass |
| mysql default in strict mode | BLOCKED | ✓ pass |
| mysql strict mode disabled | BLOCKED | ✓ pass |
| mysql strict mode specified default | BLOCKED | ✓ pass |
| mysql sql mode variable overrides strict mode | BLOCKED | ✓ pass |
| mysql set session variable | BLOCKED | ✓ pass |
| mysql set session variable to default | BLOCKED | ✓ pass |
| collation connection is configured | BLOCKED | still BLOCKED (needs MYSQL_TEST_URL2) |
| passing arbitrary/array flags | BLOCKED | still BLOCKED (no raw_connection accessor) |
| reconnect cluster | BLOCKED | still BLOCKED (Story G) |

## Verification

```
MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test \
  pnpm vitest run packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
# 18 passed | 8 skipped

pnpm api:compare --package activerecord
# 4969/4969 (100%) — no regression
```