### PR TITLE
feat(activerecord): Story R — datetime precision propagation + loose-date-parse combined format

### DIFF
--- a/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.test.ts
@@ -15,6 +15,22 @@ describe("looseDateParse", () => {
     expect(looseDateParse("7/4/2020")).toMatchObject({ year: 2020, month: 7, day: 4 });
   });
 
+  it("US slashes with 12-hour time MM/DD/YYYY H:MMam", () => {
+    expect(looseDateParse("8/17/2014 12:30pm")).toMatchObject({
+      year: 2014,
+      month: 8,
+      day: 17,
+      hour: 12,
+      minute: 30,
+    });
+    expect(looseDateParse("8/17/2014 3am")).toMatchObject({
+      year: 2014,
+      month: 8,
+      day: 17,
+      hour: 3,
+    });
+  });
+
   it("year-first slashes YYYY/MM/DD", () => {
     expect(looseDateParse("2020/07/04")).toMatchObject({ year: 2020, month: 7, day: 4 });
   });

--- a/packages/activemodel/src/type/helpers/loose-date-parse.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.ts
@@ -75,8 +75,23 @@ export function looseDateParse(input: string): LooseDateParts | null {
 
   // Layer 4: regex set for common non-ISO formats
 
+  // US slashes with 12-hour time: MM/DD/YYYY H:MMam or MM/DD/YYYY H:MM am
+  let m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(s);
+  if (m) {
+    const rawHour = int(m[4]);
+    const minute = m[5] !== undefined ? int(m[5]) : undefined;
+    if (rawHour >= 1 && rawHour <= 12 && (minute === undefined || minute <= 59)) {
+      const ampm = m[6].toLowerCase();
+      const hour =
+        ampm === "am" ? (rawHour === 12 ? 0 : rawHour) : rawHour === 12 ? 12 : rawHour + 12;
+      const parts: LooseDateParts = { year: int(m[3]), month: int(m[1]), day: int(m[2]), hour };
+      if (minute !== undefined) parts.minute = minute;
+      return parts;
+    }
+  }
+
   // US slashes: MM/DD/YYYY
-  let m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
   if (m) return { year: int(m[3]), month: int(m[1]), day: int(m[2]) };
 
   // Year-first slashes: YYYY/MM/DD

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -981,7 +981,8 @@ export class TableDefinition {
         case "datetime":
         case "timestamp": {
           const base = this._adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
-          const tp = col.options.precision;
+          // precision: undefined → Rails default of 6; precision: null → no precision suffix
+          const tp = col.options.precision === undefined ? 6 : col.options.precision;
           if (tp != null && !(tp >= 0 && tp <= 6))
             throw new ArgumentError(
               `No ${base} type has precision of ${tp}. The allowed range of precision is from 0 to 6`,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -219,7 +219,7 @@ export interface ColumnOptions {
   null?: boolean;
   default?: unknown;
   limit?: number;
-  precision?: number;
+  precision?: number | null;
   scale?: number;
   index?: boolean;
   unique?: boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -828,7 +828,7 @@ export class TableDefinition {
   }
 
   decimal(name: string, options: ColumnOptions = {}): this {
-    if (options.scale !== undefined && options.precision === undefined) {
+    if (options.scale !== undefined && typeof options.precision !== "number") {
       throw new Error("Error adding decimal column: precision is required if scale is specified");
     }
     return this.column(name, "decimal", options);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2635,15 +2635,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       default?: unknown;
       null?: boolean;
       array?: boolean;
-      limit?: number;
-      precision?: number;
-      scale?: number;
+      limit?: number | null;
+      precision?: number | null;
+      scale?: number | null;
       ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteIdentifier(columnName);
-    const pgType = this.typeToSql(type, options);
+    const pgType = this.typeToSql(type, {
+      ...options,
+      precision: options.precision ?? undefined,
+      limit: options.limit ?? undefined,
+      scale: options.scale ?? undefined,
+    });
     let colSql = `${quotedCol} ${pgType}`;
     if (options.default !== undefined) {
       const defaultClause = pgQuoteDefaultExpression(

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -163,7 +163,7 @@ describe("DateTimePrecisionTest", () => {
 
   it("schema dump with without precision has precision as nil", async () => {
     await ctx.createTable("foos", { force: true }, (t) => {
-      (t as any).timestamps({ precision: null });
+      t.timestamps({ precision: null });
     });
     const output = SchemaDumper.dump(ctx) as string;
     expect(output).toMatch(/t\.datetime\("created_at".*precision.*null/);

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -58,10 +58,16 @@ describe("DateTimePrecisionTest", () => {
     expect(nsec((foo as any).updated_at)).toBe(123456000);
   });
 
-  it("no datetime precision isnt truncated on assignment", () => {
-    // BLOCKED: datetime without explicit precision should use native default precision 6
-    // ROOT-CAUSE: MigrationContext._mapType and SQLite3 type-map don't propagate native default
-    //   precision (6). Fix requires ~20 LOC in migration.ts + sqlite3-adapter.ts native types.
+  it("no datetime precision isnt truncated on assignment", async () => {
+    await ctx.createTable("foos", { force: true }, (t) => {
+      t.datetime("happened_at");
+    });
+    const Foo = makeFoo();
+    await Foo.loadSchema();
+    expect((Foo.columnsHash() as any)["happened_at"].precision).toBe(6);
+    const time = Temporal.Instant.from("2000-01-01T12:00:00.123456789Z");
+    const foo = new Foo({ happened_at: time });
+    expect(nsec((foo as any).happened_at)).toBe(123456000);
   });
 
   it("timestamps helper with custom precision", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -400,8 +400,8 @@ describe("Migrations", () => {
       td.timestamps();
 
       const sql = td.toSql();
-      expect(sql).toContain('"created_at" DATETIME NOT NULL');
-      expect(sql).toContain('"updated_at" DATETIME NOT NULL');
+      expect(sql).toContain('"created_at" DATETIME(6) NOT NULL');
+      expect(sql).toContain('"updated_at" DATETIME(6) NOT NULL');
     });
 
     it("supports references", () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1134,9 +1134,9 @@ export class MigrationContext {
         primaryKey?: boolean;
         null?: boolean;
         default?: unknown;
-        limit?: number;
-        precision?: number;
-        scale?: number;
+        limit?: number | null;
+        precision?: number | null;
+        scale?: number | null;
       }
     >
   >();
@@ -1194,9 +1194,9 @@ export class MigrationContext {
         primaryKey?: boolean;
         null?: boolean;
         default?: unknown;
-        limit?: number;
-        precision?: number;
-        scale?: number;
+        limit?: number | null;
+        precision?: number | null;
+        scale?: number | null;
       }
     >();
     if (options?.id !== false) {
@@ -1386,11 +1386,11 @@ export class MigrationContext {
       meta.set(column, {
         ...entry,
         type,
-        null: _options?.null ?? entry.null,
-        default: _options?.default ?? entry.default,
-        limit: _options?.limit ?? entry.limit,
-        precision: _options?.precision ?? entry.precision,
-        scale: _options?.scale ?? entry.scale,
+        null: _options?.null !== undefined ? _options.null : entry.null,
+        default: _options?.default !== undefined ? _options.default : entry.default,
+        limit: _options?.limit !== undefined ? _options.limit : entry.limit,
+        precision: _options?.precision !== undefined ? _options.precision : entry.precision,
+        scale: _options?.scale !== undefined ? _options.scale : entry.scale,
       });
     }
   }
@@ -1521,9 +1521,9 @@ export class MigrationContext {
     primaryKey?: boolean;
     null?: boolean;
     default?: unknown;
-    limit?: number;
-    precision?: number;
-    scale?: number;
+    limit?: number | null;
+    precision?: number | null;
+    scale?: number | null;
   }> {
     const meta = this._columnMeta.get(tableName);
     if (meta) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1389,7 +1389,12 @@ export class MigrationContext {
         null: _options?.null !== undefined ? _options.null : entry.null,
         default: _options?.default !== undefined ? _options.default : entry.default,
         limit: _options?.limit !== undefined ? _options.limit : entry.limit,
-        precision: _options?.precision !== undefined ? _options.precision : entry.precision,
+        precision:
+          _options?.precision !== undefined
+            ? _options.precision
+            : type === "datetime" || type === "timestamp"
+              ? 6
+              : entry.precision,
         scale: _options?.scale !== undefined ? _options.scale : entry.scale,
       });
     }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1275,7 +1275,8 @@ export class MigrationContext {
       case "datetime":
       case "timestamp": {
         const base = an === "postgres" ? "TIMESTAMP" : "DATETIME";
-        const p = options?.precision;
+        // precision: undefined → Rails default of 6; precision: null → no precision suffix
+        const p = options?.precision === undefined ? 6 : options.precision;
         if (p != null && !(p >= 0 && p <= 6))
           throw new ArgumentError(
             `No ${base} type has precision of ${p}. The allowed range of precision is from 0 to 6`,
@@ -1372,11 +1373,11 @@ export class MigrationContext {
   ): Promise<void> {
     if (this._adapterName === "mysql") {
       await this.adapter.executeMutation(
-        `ALTER TABLE "${table}" MODIFY COLUMN "${column}" ${this._mapType(type)}`,
+        `ALTER TABLE "${table}" MODIFY COLUMN "${column}" ${this._mapType(type, _options)}`,
       );
     } else {
       await this.adapter.executeMutation(
-        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE ${this._mapType(type)}`,
+        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE ${this._mapType(type, _options)}`,
       );
     }
     const meta = this._columnMeta.get(table);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -573,6 +573,15 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).toContain("index_comments_on_post_id");
   });
 
+  it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    await ctx.createTable("events", {}, (t) => {
+      (t as any).datetime("happened_at", { precision: null });
+    });
+    const result = await TopLevelDumper.dump(adapter);
+    expect(result).toMatch(/t\.datetime\("happened_at"[^)]*precision.*null/);
+  });
+
   it("skips internal tables when dumping from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
     const { SchemaMigration } = await import("./schema-migration.js");

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -579,7 +579,7 @@ describe("SchemaDumperAdapterTest", () => {
       (t as any).datetime("happened_at", { precision: null });
     });
     const result = await TopLevelDumper.dump(adapter);
-    expect(result).toMatch(/t\.datetime\("happened_at"[^)]*precision.*null/);
+    expect(result).toMatch(/t\.datetime\("happened_at"[^}]*precision\s*:\s*null/);
   });
 
   it("skips internal tables when dumping from adapter", async () => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -576,7 +576,7 @@ describe("SchemaDumperAdapterTest", () => {
   it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
     await ctx.createTable("events", {}, (t) => {
-      (t as any).datetime("happened_at", { precision: null });
+      t.datetime("happened_at", { precision: null });
     });
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toMatch(/t\.datetime\("happened_at"[^}]*precision\s*:\s*null/);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -315,7 +315,7 @@ class AdapterSchemaSource implements SchemaSource {
       null: col.null,
       default: col.default,
       limit: col.limit ?? undefined,
-      precision: col.precision ?? undefined,
+      precision: col.precision === undefined ? undefined : col.precision,
       scale: col.scale ?? undefined,
       collation: col.collation ?? undefined,
       array: (col as any).array === true ? true : undefined,


### PR DESCRIPTION
## Summary

Follow-up to #1332. Three precision-propagation gaps (Group A) and one datetime parser gap (B3).

### Group A — Precision propagation

**A1: Default precision 6** — `MigrationContext._mapType` and `TableDefinition.toSql` now default datetime/timestamp columns to `DATETIME(6)` / `TIMESTAMP(6)` when no precision is specified (mirrors Rails `DEFAULT_DATETIME_PRECISION = 6`). `precision: null` still emits without a precision suffix (explicit "no precision").

**A2: `changeColumn` forwards options** — `changeColumn` was calling `_mapType(type)` without the `_options` argument, so `changeColumn('t', 'col', 'datetime', { precision: 3 })` emitted `DATETIME` instead of `DATETIME(3)`. Fixed to pass `_options` in both MySQL (`MODIFY COLUMN`) and Postgres/SQLite (`ALTER COLUMN … TYPE`) paths.

**A3: `AdapterSchemaSource.columns()` preserves `null` precision** — `col.precision ?? undefined` coerced `null` to `undefined`, making the adapter-backed schema-dump path unable to emit `precision: null`. Changed to `col.precision === undefined ? undefined : col.precision`.

### Group B3 — `looseDateParse` combined MM/DD/YYYY H:MMam

Added a combined US-slash + 12-hour-time branch (`^MM/DD/YYYY H:MMam$`) before the existing date-only slash branch.

### Out of scope (deferred)

- B1 (`time.to_s` Rails format) — still blocked; stub retained.
- B2 (PlainTime WHERE quoting) — already implemented in quoting.ts; no gap.
- B4 (`with_timezone_config`, `timestamptz`) — postgres-only; separate slot.

## Test count delta

- `DateTimePrecisionTest > no datetime precision isnt truncated on assignment` — un-skipped (was empty stub)
- `MigrationTest > TableDefinition > supports timestamps` — assertion updated: `DATETIME NOT NULL` → `DATETIME(6) NOT NULL`
- `looseDateParse > US slashes with 12-hour time MM/DD/YYYY H:MMam` — new test