### PR TITLE
feat(activerecord): Story E3 — forget_attribute_assignments + Json.cast detachment

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -278,6 +278,23 @@ export class AttributeSet {
     return new AttributeSet(newAttrs);
   }
 
+  /**
+   * Apply `forgettingAssignment()` to each attribute in place so that shared
+   * references (as in `becomes()`) see the updated baseline.
+   *
+   * Mirrors: ActiveModel::AttributeSet#map(&:forgetting_assignment) assigned
+   * back to `@attributes` in `forget_attribute_assignments`.
+   *
+   * @internal
+   */
+  forgetAssignmentsBang(): void {
+    this.assertNotFrozen();
+    for (const [name, attr] of this.attributes) {
+      const next = attr.forgettingAssignment();
+      if (next !== attr) this.attributes.set(name, next);
+    }
+  }
+
   reverseMergeBang(target: AttributeSet): this {
     this.assertNotFrozen();
     const cache = new Map<Attribute, Attribute>();

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -270,6 +270,13 @@ export class FromDatabase extends Attribute {
   protected override _originalValueForDatabase(): unknown {
     return this.valueBeforeTypeCast;
   }
+
+  override forgettingAssignment(): Attribute {
+    // Only round-trip if the in-memory value has actually changed in place;
+    // otherwise return self to preserve object identity for unchanged reads.
+    if (!this.changedInPlace()) return this;
+    return super.forgettingAssignment();
+  }
 }
 
 export class FromUser extends Attribute {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -272,8 +272,12 @@ export class FromDatabase extends Attribute {
   }
 
   override forgettingAssignment(): Attribute {
-    // Only round-trip if the in-memory value has actually changed in place;
-    // otherwise return self to preserve object identity for unchanged reads.
+    // Rails condition: `!defined?(@value_for_database) && !changed_in_place?`
+    // → fast-path creates a new FromDatabase using the existing value_before_type_cast.
+    // We simplify: if nothing changed in place, `this` is already a correct baseline
+    // (valueBeforeTypeCast is the serialized DB value), so return self.
+    // If changed in place, delegate to base which serializes the current value into
+    // a new FromDatabase, resetting the baseline to the post-mutation state.
     if (!this.changedInPlace()) return this;
     return super.forgettingAssignment();
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1789,6 +1789,7 @@ export class Model {
 
   changesApplied(): void {
     this._dirty.changesApplied(this._attributes);
+    this._attributes.forgetAssignmentsBang();
   }
 
   /**
@@ -1840,6 +1841,7 @@ export class Model {
    * @internal
    */
   forgetAttributeAssignments(): void {
+    this._attributes.forgetAssignmentsBang();
     this._dirty.forgetAttributeAssignments(this._attributes);
   }
 

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -190,7 +190,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await (hstore as any).saveBang();
       await (hstore as any).reload();
       expect((hstore as any).settings.three).toBe("four");
-      expect((hstore as any).changed()).toBe(false);
+      expect((hstore as any).changed).toBe(false);
     });
     it.skip("hstore nested", async () => {
       // BLOCKED: test-name mismatch — no Rails test named "hstore nested" in hstore_test.rb

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -184,15 +184,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       // ROOT-CAUSE: Closest Rails match is test_duplication_with_store_accessors (store_accessor blocked).
       // SCOPE: Permanent skip-list candidate.
     });
-    it.skip("hstore mutate", async () => {
-      // BLOCKED: attribute chain not reset post-save — changesApplied() doesn't call
-      //   forgettingAssignment() on mutable attributes (unlike Rails changes_applied +
-      //   forget_attribute_assignments). FromUser attributes still reference a null-valued
-      //   originalAttribute after save, so changedInPlace() compares against null on next
-      //   save, causing spurious UPDATEs. Fix: reset mutable attrs to FromDatabase baseline
-      //   in changesApplied() / _updateRecord, then re-enable this test.
-      // SCOPE: ~10-20 LOC in dirty.ts changesApplied() or attribute-methods/dirty.ts
-      //   _updateRecord to call forgettingAssignment() on mutable attributes post-persist.
+    it("hstore mutate", async () => {
+      const hstore = await HstoreModel.createBang({ settings: { one: "two" } });
+      (hstore as any).settings.three = "four";
+      await (hstore as any).saveBang();
+      await (hstore as any).reload();
+      expect((hstore as any).settings.three).toBe("four");
+      expect((hstore as any).changed()).toBe(false);
     });
     it.skip("hstore nested", async () => {
       // BLOCKED: test-name mismatch — no Rails test named "hstore nested" in hstore_test.rb

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -188,6 +188,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const hstore = await HstoreModel.createBang({ settings: { one: "two" } });
       (hstore as any).settings.three = "four";
       await (hstore as any).saveBang();
+      // Post-save baseline must be reset: changedInPlace() should be false
+      // without a reload, meaning a second save won't fire a spurious UPDATE.
+      expect((hstore as any)._attributes.getAttribute("settings").changedInPlace()).toBe(false);
       await (hstore as any).reload();
       expect((hstore as any).settings.three).toBe("four");
       expect((hstore as any).changed).toBe(false);

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -976,6 +976,7 @@ describe("MutableAttributeAfterSave", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(async () => {
+    vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
     adapter = freshAdapter();
     await defineSchema(adapter, {
       json_models: { payload: "string" },
@@ -984,6 +985,7 @@ describe("MutableAttributeAfterSave", () => {
 
   afterAll(async () => {
     await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   it("mutable attribute is not dirty after changesApplied resets baseline", async () => {

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -967,3 +967,41 @@ describe("DirtyTest", () => {
     expect(inDb["age"]).toBe(30);
   });
 });
+
+// ==========================================================================
+// MutableAttributeAfterSave — targets json_shared_test_cases.rb
+// (test_changes_in_place) for the post-save forgettingAssignment reset
+// ==========================================================================
+describe("MutableAttributeAfterSave", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      json_models: { payload: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
+  it("mutable attribute is not dirty after changesApplied resets baseline", async () => {
+    class JsonModel extends Base {
+      static tableName = "json_models";
+      static {
+        this.attribute("payload", "json");
+        this.adapter = adapter;
+      }
+    }
+    const record = await JsonModel.create({ payload: { one: "two" } });
+    // Mutate the attribute in-place, then save.
+    (record as any).payload.three = "four";
+    await (record as any).save();
+    // After save, changesApplied() must call forgettingAssignment() on each attribute
+    // so the FromDatabase baseline reflects the post-save serialized value.
+    // A second save should not fire any UPDATE (no spurious dirty detection).
+    const payloadAttr = (record as any)._attributes.getAttribute("payload");
+    expect(payloadAttr.changedInPlace()).toBe(false);
+  });
+});

--- a/packages/activerecord/src/type/json.test.ts
+++ b/packages/activerecord/src/type/json.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Mirrors ActiveRecord::Type::Json tests from json_shared_test_cases.rb
+ */
+import { describe, it, expect } from "vitest";
+import { Json } from "./json.js";
+
+describe("Json", () => {
+  const type = new Json();
+
+  it("cast detaches non-string input from the original reference", () => {
+    const input = { a: 1 };
+    const result = type.cast(input);
+    expect(result).toEqual({ a: 1 });
+    expect(result).not.toBe(input);
+  });
+
+  it("cast parses string input", () => {
+    expect(type.cast('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("cast returns null for null or undefined", () => {
+    expect(type.cast(null)).toBeNull();
+    expect(type.cast(undefined)).toBeNull();
+  });
+
+  it("cast round-trips arrays without aliasing", () => {
+    const input = [1, 2, 3];
+    const result = type.cast(input);
+    expect(result).toEqual([1, 2, 3]);
+    expect(result).not.toBe(input);
+  });
+});

--- a/packages/activerecord/src/type/json.test.ts
+++ b/packages/activerecord/src/type/json.test.ts
@@ -1,5 +1,7 @@
 /**
- * Mirrors ActiveRecord::Type::Json tests from json_shared_test_cases.rb
+ * Unit tests for ActiveRecord::Type::Json (cast behavior).
+ * Integration tests (changes_in_place, etc.) live in json_shared_test_cases.rb
+ * and are ported to adapters/postgresql/json.test.ts etc.
  */
 import { describe, it, expect } from "vitest";
 import { Json } from "./json.js";

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -34,7 +34,7 @@ export class Json extends ValueType<unknown> {
         return null;
       }
     }
-    return value;
+    return this.deserialize(this.serialize(value));
   }
 
   deserialize(value: unknown): unknown {


### PR DESCRIPTION
## Summary

Two post-save dirty-tracking gaps surfaced by #1336 (Story E2).

### Item 1 — `forgetAssignmentsBang()` after save

**Before:** `changesApplied()` snapshotted the dirty tracker but left `_attributes` holding `FromUser` (or stale `FromDatabase`) entries whose `changedInPlace()` baseline pointed to the pre-save serialized value. A second save on a mutable attribute (hstore, json) would spuriously detect a change and fire an unnecessary UPDATE.

**After:** `changesApplied()` calls `_attributes.forgetAssignmentsBang()` — an in-place walk that replaces each attribute with `forgettingAssignment()` (i.e., `FromDatabase{valueBeforeTypeCast: currentSerializedValue}`). For unread and non-mutable-changed attributes this is a no-op (returns `this`), preserving object identity (e.g. `Temporal.Instant` references in `created_at`). In-place mutation is done on the existing `AttributeSet` map so `becomes()` shared-reference semantics still hold.

`forgetAttributeAssignments()` (the standalone Rails API) also calls `forgetAssignmentsBang()` before re-snapshotting the dirty tracker.

### Item 2 — `Json.cast()` reference detachment

**Before:** `Json.cast(value)` returned the original object reference for non-string inputs, so mutating the input after assignment bled into the attribute.

**After:** Non-string inputs are round-tripped through `deserialize(serialize(value))`, matching Rails' `Mutable#cast`.

## Before / after

| | Before | After |
|---|---|---|
| hstore mutate | spurious UPDATE on second save | no UPDATE; `changed()` = false after save |
| `json.cast({a:1})` | returns same reference | returns new detached object |

## Test plan

- `hstore.test.ts "hstore mutate"` un-skipped and passes (requires PG; verified via CI)
- `dirty.test.ts "mutable attribute is not dirty after changesApplied resets baseline"` — new, passes in SQLite
- `type/json.test.ts` — 4 new unit tests for `Json.cast`
- `pnpm vitest run packages/activerecord/src/` — 10669 passed, 0 failed
- `pnpm vitest run packages/activemodel/src/` — 1873 passed, 0 failed
- `pnpm api:compare --package activerecord` — 4969/4969 (100%), no regression
- `pnpm api:compare --package activemodel` — 620/625 (99.2%), no regression
- LOC: 278 (under 300 ceiling)