### PR TITLE
feat(activerecord): pg array round-trip polish — defaults + uniqueness (Story C)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -57,9 +57,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("default", async () => {
       await adapter.addColumn("pg_arrays", "score", "integer", { array: true, default: [4, 4, 2] });
-      const columns = await adapter.columns("pg_arrays");
-      const col = columns.find((c) => c.name === "score")!;
-      expect((col as any).default).toEqual(["4", "4", "2"]);
       const { Base } = await import("../../index.js");
       class PgArrays extends Base {
         static tableName = "pg_arrays";
@@ -68,6 +65,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       await PgArrays.loadSchema();
+      // Rails: assert_equal([4, 4, 2], PgArray.column_defaults["score"])
+      expect((PgArrays as any).columnDefaults["score"]).toEqual([4, 4, 2]);
+      // Rails: assert_equal([4, 4, 2], PgArray.new.score)
       expect((new PgArrays() as any).score).toEqual([4, 4, 2]);
     });
     it("default strings", async () => {
@@ -75,9 +75,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         array: true,
         default: ["foo", "bar"],
       });
-      const columns = await adapter.columns("pg_arrays");
-      const col = columns.find((c) => c.name === "names")!;
-      expect((col as any).default).toEqual(["foo", "bar"]);
       const { Base } = await import("../../index.js");
       class PgArrays extends Base {
         static tableName = "pg_arrays";
@@ -86,6 +83,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       await PgArrays.loadSchema();
+      // Rails: assert_equal(["foo", "bar"], PgArray.column_defaults["names"])
+      expect((PgArrays as any).columnDefaults["names"]).toEqual(["foo", "bar"]);
+      // Rails: assert_equal(["foo", "bar"], PgArray.new.names)
       expect((new PgArrays() as any).names).toEqual(["foo", "bar"]);
     });
     it("schema dump with shorthand", async () => {
@@ -463,17 +463,17 @@ describeIfPg("PostgreSQLAdapter", () => {
       await PgArrays.loadSchema();
 
       const tags = ["black", "blue"];
-      const first = await (PgArrays as any).create({ tags });
-      expect((first as any).isPersisted()).toBe(true);
+      // Rails: e1 = klass.create("tags" => ["black", "blue"]); assert_predicate e1, :persisted?
+      const e1 = await (PgArrays as any).create({ tags });
+      expect((e1 as any).isPersisted()).toBe(true);
 
-      const duplicate = new PgArrays({ tags } as any);
-      const saved = await duplicate.save();
-      expect(saved).toBe(false);
-      expect((duplicate as any).errors.fullMessages).toContain("Tags has already been taken");
-
-      const unique = new PgArrays({ tags: ["red", "green"] } as any);
-      const savedUnique = await unique.save();
-      expect(savedUnique).toBe(true);
+      // Rails: e2 = klass.create("tags" => ["black", "blue"]); assert_not e2.persisted?
+      const e2 = await (PgArrays as any).create({ tags });
+      expect((e2 as any).isPersisted()).toBe(false);
+      // Rails: assert_equal ["has already been taken"], e2.errors[:tags]
+      expect((e2 as any).errors.where("tags").map((e: any) => e.message)).toEqual([
+        "has already been taken",
+      ]);
     });
 
     it("encoding arrays of utf8 strings", async () => {

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -55,14 +55,38 @@ describeIfPg("PostgreSQLAdapter", () => {
       //   lifecycle around the OID::Array serialize/deserialize chain is not implemented.
       // SCOPE: ~50 LOC in base.ts serialize decorator + integration with attribute-set lifecycle
     });
-    it.skip("default", async () => {
-      /* BLOCKED: addColumn integer-array default DDL; same root as "default strings" (~20 LOC) */
+    it("default", async () => {
+      await adapter.addColumn("pg_arrays", "score", "integer", { array: true, default: [4, 4, 2] });
+      const columns = await adapter.columns("pg_arrays");
+      const col = columns.find((c) => c.name === "score")!;
+      expect((col as any).default).toEqual(["4", "4", "2"]);
+      const { Base } = await import("../../index.js");
+      class PgArrays extends Base {
+        static tableName = "pg_arrays";
+        static {
+          this.adapter = adapter;
+        }
+      }
+      await PgArrays.loadSchema();
+      expect((new PgArrays() as any).score).toEqual([4, 4, 2]);
     });
-    it.skip("default strings", async () => {
-      // BLOCKED: adapter-pg — addColumn array default DDL gap
-      // ROOT-CAUSE: postgresql/schema-statements.ts addColumn does not serialize array defaults
-      //   (e.g. ["foo","bar"]) into PG literal form (e.g. ARRAY['foo','bar']) for the DEFAULT clause.
-      // SCOPE: ~20 LOC in connection-adapters/postgresql/schema-statements.ts
+    it("default strings", async () => {
+      await adapter.addColumn("pg_arrays", "names", "string", {
+        array: true,
+        default: ["foo", "bar"],
+      });
+      const columns = await adapter.columns("pg_arrays");
+      const col = columns.find((c) => c.name === "names")!;
+      expect((col as any).default).toEqual(["foo", "bar"]);
+      const { Base } = await import("../../index.js");
+      class PgArrays extends Base {
+        static tableName = "pg_arrays";
+        static {
+          this.adapter = adapter;
+        }
+      }
+      await PgArrays.loadSchema();
+      expect((new PgArrays() as any).names).toEqual(["foo", "bar"]);
     });
     it("schema dump with shorthand", async () => {
       const output = await SchemaDumper.dumpTableSchema(adapter, "pg_arrays");
@@ -427,13 +451,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].tags).toEqual(tags);
     });
 
-    it.skip("uniqueness validation", async () => {
-      // BLOCKED: adapter-pg — validates_uniqueness_of array serialization gap
-      // ROOT-CAUSE: uniqueness validator builds a WHERE clause by serializing the attribute value;
-      //   OID::Array#serialize returns a Data object whose toString() is the PG literal, but the
-      //   WHERE-clause quoting path in quoting.ts does not handle ArrayData in the bind-param
-      //   position for uniqueness checks (separate from the INSERT path).
-      // SCOPE: ~10 LOC — verify quoting.ts bindToSql handles ArrayData for WHERE params
+    it("uniqueness validation", async () => {
+      const { Base } = await import("../../index.js");
+      class PgArrays extends Base {
+        static tableName = "pg_arrays";
+        static {
+          this.adapter = adapter;
+          this.validatesUniqueness("tags");
+        }
+      }
+      await PgArrays.loadSchema();
+
+      const tags = ["black", "blue"];
+      const first = await (PgArrays as any).create({ tags });
+      expect((first as any).isPersisted()).toBe(true);
+
+      const duplicate = new PgArrays({ tags } as any);
+      const saved = await duplicate.save();
+      expect(saved).toBe(false);
+      expect((duplicate as any).errors.fullMessages).toContain("Tags has already been taken");
+
+      const unique = new PgArrays({ tags: ["red", "green"] } as any);
+      const savedUnique = await unique.save();
+      expect(savedUnique).toBe(true);
     });
 
     it("encoding arrays of utf8 strings", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1179,8 +1179,8 @@ export class AbstractAdapter implements Quoting {
 
   // --- Comparison helpers ---
 
-  defaultUniquenessComparison(_attribute: unknown, _value: unknown): unknown {
-    return null;
+  defaultUniquenessComparison(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
+    return attribute.eq(value);
   }
 
   caseSensitiveComparison(attribute: Nodes.Attribute, value: unknown): Nodes.Node {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -79,6 +79,7 @@ import {
 } from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
+import { Array as OidArray } from "./postgresql/oid/array.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -4732,7 +4733,8 @@ function splitPgDefault(raw: string | null): { literal: unknown; fn: string | nu
   const arrayLiteral = /^'((?:[^']|'')*)'::[\w"\s.(,)]+\[\]$/.exec(raw);
   if (arrayLiteral) {
     const content = arrayLiteral[1].replace(/''/g, "'");
-    return { literal: content === "{}" ? [] : content, fn: null };
+    if (content === "{}") return { literal: [], fn: null };
+    return { literal: new OidArray(new ValueType()).deserialize(content), fn: null };
   }
   // 'value'::type — quoted literal with an optional cast.
   const quoted = /^'((?:[^']|'')*)'::[\w"\s.]+$/.exec(raw);


### PR DESCRIPTION
## Summary

Three remaining pg/array gaps (Story C):

**Item 1 — `splitPgDefault`: non-empty array defaults**
`splitPgDefault` returned the raw PG literal string `{1,2,3}` for non-empty array defaults. Fixed by routing through `OidArray(ValueType).deserialize(content)` to get a JS array of string elements. The per-element type cast happens downstream in `Attribute.fromDatabase`.

**Item 2 — `defaultUniquenessComparison`: array WHERE equality**
`defaultUniquenessComparison` returned `null`, causing the uniqueness validator to fall through to `base.where({ attr: value })`. For array values, `ArrayHandler` produced `WHERE tags IN ('black', 'blue')` instead of `WHERE tags = '{"black","blue"}'`. Fixed by implementing `attribute.eq(value)` — the correct Rails behavior — so the bind goes through `OidArray.serialize` → `ArrayData.toPostgres()` and PG sees an array equality check.

**Item 3 — Tests**
Wrote bodies for `"default"`, `"default strings"`, and `"uniqueness validation"` tests and removed `.skip`.

## Test count delta

Before: 30 passed / 11 skipped  
After: 33 passed / 8 skipped (3 tests un-skipped, all passing)

## Before / after

```
pnpm vitest run packages/activerecord/src/adapters/postgresql/array.test.ts

Before: 30 passed | 11 skipped
After:  33 passed | 8 skipped
```

`pnpm api:compare --package activerecord`: 4969/4969 (100%) — no regression.