### PR TITLE
feat(activerecord): Story J — querying privates fidelity (3 gaps)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -353,7 +353,13 @@ export interface DatabaseAdapter {
   selectValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   selectRows(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
-  execInsert(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
+  execInsert(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    pk?: string | null,
+    sequenceName?: string | null,
+  ): Promise<number>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   isWriteQuery(sql: string): boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1359,6 +1359,8 @@ export const DatabaseStatements = {
     sql: string,
     name?: string | null,
     binds?: unknown[],
+    _pk?: string | null,
+    _sequenceName?: string | null,
   ): Promise<number> {
     return this.executeMutation(sql, binds, name ?? "SQL");
   },
@@ -1407,12 +1409,12 @@ export const DatabaseStatements = {
     name?: string | null,
     pk?: string | null,
     idValue?: unknown,
-    _sequenceName?: string | null,
+    sequenceName?: string | null,
     binds: unknown[] = [],
     opts?: { returning?: string[] | null },
   ): Promise<unknown> {
     const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
-    const result = await this.execInsert(sql, name, resolvedBinds, pk);
+    const result = await this.execInsert(sql, name, resolvedBinds, pk, sequenceName);
     if (opts?.returning != null) return returningColumnValues.call(this, result);
     if (idValue != null) return idValue;
     // execInsert may return a Result (PG/adapter with RETURNING support) or a

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -392,6 +392,8 @@ export function execInsert(
   sql: string,
   name?: string | null,
   binds: unknown[] = [],
+  _pk?: string | null,
+  _sequenceName?: string | null,
 ): Promise<Result> {
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name ?? "SQL", binds);
 }
@@ -475,14 +477,14 @@ export async function insert(
   this: DatabaseStatementsHost | void,
   arel: unknown,
   name?: string | null,
-  _pk?: string | null,
+  pk?: string | null,
   idValue?: unknown,
-  _sequenceName?: string | null,
+  sequenceName?: string | null,
   binds: unknown[] = [],
 ): Promise<unknown> {
   const host = this as DatabaseStatementsHost;
   const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
-  const result = await execInsert.call(this, sql, name, resolvedBinds);
+  const result = await execInsert.call(this, sql, name, resolvedBinds, pk, sequenceName);
   if (idValue !== undefined && idValue !== null) return idValue;
   return host.lastInsertedId!(result);
 }

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base, Relation } from "./index.js";
+import { registerModel } from "./associations.js";
+import { _queryBySql, _loadFromSql } from "./querying.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
@@ -144,5 +146,72 @@ describe("QueryingTest — static forwarders on Base", () => {
 
   it("merge() returns a Relation", () => {
     expect(Post.merge(Post.where({ status: "draft" }))).toBeInstanceOf(Relation);
+  });
+});
+
+describe("_queryBySql — kwargs pass-through (Story J gap 1)", () => {
+  let Model: typeof Base;
+
+  beforeAll(() => {
+    const a = createTestAdapter();
+    class M extends Base {
+      static {
+        this.adapter = a;
+        this.attribute("id", "integer");
+      }
+    }
+    Model = M;
+  });
+
+  it("accepts preparable/async/allowRetry opts without error", async () => {
+    vi.spyOn(Model.adapter, "execute").mockResolvedValueOnce([]);
+    await expect(
+      _queryBySql.call(Model, "SELECT 1", [], { preparable: true, async: false, allowRetry: true }),
+    ).resolves.toEqual([]);
+  });
+
+  it("opts default to empty object — omitting opts still works", async () => {
+    vi.spyOn(Model.adapter, "execute").mockResolvedValueOnce([{ id: 1 }]);
+    const rows = await _queryBySql.call(Model, "SELECT 1");
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+});
+
+describe("_loadFromSql — STI detection (Story J gap 2)", () => {
+  let Animal: typeof Base;
+  let Dog: typeof Base;
+
+  beforeAll(() => {
+    const a = createTestAdapter();
+    class AnimalClass extends Base {
+      static {
+        this.adapter = a;
+        this.inheritanceColumn = "type";
+        this.attribute("id", "integer");
+        this.attribute("type", "string");
+        this.attribute("name", "string");
+      }
+    }
+    class DogClass extends AnimalClass {}
+    Animal = AnimalClass;
+    Dog = DogClass;
+    registerModel(Animal);
+    registerModel(Dog);
+  });
+
+  it("dispatches to the correct STI subclass when inheritance column is present", () => {
+    const rows = [{ id: 1, type: Dog.name, name: "Rex" }];
+    const records = _loadFromSql.call(Animal, rows);
+    expect(records[0]).toBeInstanceOf(Dog);
+  });
+
+  it("instantiates as the base class when inheritance column is absent from result set", () => {
+    const rows = [{ id: 1, name: "Rex" }];
+    const records = _loadFromSql.call(Animal, rows);
+    expect(records[0]).toBeInstanceOf(Animal);
+  });
+
+  it("returns empty array for empty result set", () => {
+    expect(_loadFromSql.call(Animal, [])).toEqual([]);
   });
 });

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { Base, Relation } from "./index.js";
 import { registerModel } from "./associations.js";
 import { _queryBySql, _loadFromSql } from "./querying.js";
@@ -151,6 +151,8 @@ describe("QueryingTest — static forwarders on Base", () => {
 
 describe("_queryBySql — kwargs pass-through (Story J gap 1)", () => {
   let Model: typeof Base;
+
+  afterEach(() => vi.restoreAllMocks());
 
   beforeAll(() => {
     const a = createTestAdapter();

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -7,7 +7,6 @@
 
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
-import { getInheritanceColumn } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import { argumentError } from "./relation/query-methods.js";
 import type { AssociationSpec } from "./relation/query-methods.js";
@@ -109,23 +108,13 @@ export function _loadFromSql<T extends typeof Base>(
   if (rows.length === 0) return [];
 
   const payload = { record_count: rows.length, class_name: this.name };
-  // Rails checks whether the result set includes the inheritance column.
-  // When present, instantiate() dispatches to the correct STI subclass.
-  // When absent, instantiate_instance_of() skips STI lookup for speed.
-  const inheritanceCol = getInheritanceColumn(this);
-  const includesInheritanceColumn =
-    inheritanceCol != null && Object.prototype.hasOwnProperty.call(rows[0], inheritanceCol);
-  const records = Notifications.instrument("instantiation.active_record", payload, () => {
-    if (includesInheritanceColumn) {
-      // Rails: instantiate() dispatches to the correct STI subclass via
-      // discriminate_class_for_record when the inheritance column is present.
-      return rows.map((row) => this._instantiate(row));
-    }
-    // Homogeneous set — Rails uses instantiate_instance_of(self, record) to skip
-    // STI lookup. Our _instantiate already skips dispatch when the column is
-    // absent (undefined is falsy), so the behavior is equivalent.
-    return rows.map((row) => this._instantiate(row));
-  });
+  const records = Notifications.instrument("instantiation.active_record", payload, () =>
+    // Rails uses instantiate() when the result set includes the inheritance
+    // column (full STI dispatch) and instantiate_instance_of(self, …) otherwise
+    // (skip dispatch). _instantiate short-circuits the STI lookup when the
+    // column value is absent (undefined is falsy), covering both paths.
+    rows.map((row) => this._instantiate(row)),
+  );
   if (block) records.forEach(block);
   return records;
 }

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -7,6 +7,7 @@
 
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
+import { getInheritanceColumn } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import { argumentError } from "./relation/query-methods.js";
 import type { AssociationSpec } from "./relation/query-methods.js";
@@ -78,11 +79,13 @@ export function asyncCountBySql(
 /**
  * Internal: execute a raw SQL query through the adapter.
  * Mirrors: ActiveRecord::Querying._query_by_sql
+ * @internal
  */
 export async function _queryBySql(
   this: typeof Base,
   sql: string | [string, ...unknown[]],
   binds: unknown[] = [],
+  _opts: { preparable?: boolean | null; async?: boolean; allowRetry?: boolean } = {},
 ): Promise<Record<string, unknown>[]> {
   if (Array.isArray(sql)) {
     // Array form [sql, ...values] — interpolate into the string
@@ -96,6 +99,7 @@ export async function _queryBySql(
 /**
  * Internal: instantiate model objects from a result set.
  * Mirrors: ActiveRecord::Querying._load_from_sql
+ * @internal
  */
 export function _loadFromSql<T extends typeof Base>(
   this: T,
@@ -105,9 +109,23 @@ export function _loadFromSql<T extends typeof Base>(
   if (rows.length === 0) return [];
 
   const payload = { record_count: rows.length, class_name: this.name };
-  const records = Notifications.instrument("instantiation.active_record", payload, () =>
-    rows.map((row) => this._instantiate(row)),
-  );
+  // Rails checks whether the result set includes the inheritance column.
+  // When present, instantiate() dispatches to the correct STI subclass.
+  // When absent, instantiate_instance_of() skips STI lookup for speed.
+  const inheritanceCol = getInheritanceColumn(this);
+  const includesInheritanceColumn =
+    inheritanceCol != null && Object.prototype.hasOwnProperty.call(rows[0], inheritanceCol);
+  const records = Notifications.instrument("instantiation.active_record", payload, () => {
+    if (includesInheritanceColumn) {
+      // Rails: instantiate() dispatches to the correct STI subclass via
+      // discriminate_class_for_record when the inheritance column is present.
+      return rows.map((row) => this._instantiate(row));
+    }
+    // Homogeneous set — Rails uses instantiate_instance_of(self, record) to skip
+    // STI lookup. Our _instantiate already skips dispatch when the column is
+    // absent (undefined is falsy), so the behavior is equivalent.
+    return rows.map((row) => this._instantiate(row));
+  });
   if (block) records.forEach(block);
   return records;
 }


### PR DESCRIPTION
## Summary

Three fidelity gaps in querying privates, per `docs/activerecord-100-plan.md` Story J.

- **`_queryBySql`**: add `preparable`, `async`, `allowRetry` opts — matches Rails kwargs `_query_by_sql(connection, sql, binds=[], preparable:, async:, allow_retry:)`; opts are threaded but currently no-op since our adapter doesn't distinguish prepared-statement paths.
- **`_loadFromSql`**: add inheritance-column presence check — when the result set includes the inheritance column, Rails calls `instantiate()` (full STI dispatch); when absent, `instantiate_instance_of(self, ...)` skips dispatch. Our `_instantiate` already skips dispatch when the column value is absent (falsy short-circuit), so both branches call it, but the structural check now matches Rails.
- **`execInsert` / `insert`**: add `pk` and `sequenceName` params to `execInsert`; thread `sequenceName` from `insert` through to `execInsert` — matches Rails `exec_insert(sql, name, binds, pk, sequence_name, returning:)`.

## Test plan

- `pnpm vitest run packages/activerecord/src/querying.test.ts` — 35 tests pass (+5 new)
- `pnpm api:compare --package activerecord` — all files 100%, no regression
- New tests cover: `_queryBySql` opts pass-through, `_loadFromSql` STI dispatch when column present, direct instantiation when column absent, empty result set