### PR TITLE
refactor(activerecord): drop arelSql pre-serialize workarounds (Story Arel-Q cleanup)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -7,16 +7,14 @@ import {
   Visitors,
   UpdateManager,
   DeleteManager,
-  sql as arelSql,
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
-import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
+import { _setRelationCtor, _setScopeProxyWrapper } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
 import {
   columnNameMatcher as abstractColumnNameMatcher,
   defaultSqlTimezone,
-  formatInstantForSql,
 } from "./connection-adapters/abstract/sql-formatting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
@@ -2732,7 +2730,7 @@ export class Relation<T extends Base> {
       ([key, val]) => {
         const def = this._modelClass._attributeDefinitions.get(key);
         const isArray = def?.type?.name === "array";
-        if (isArray) return [table.get(key), arelSql(quoteSqlValue(val, true))];
+        if (isArray) return [table.get(key), def!.type!.serialize(val)];
         // Pre-serialize Temporal values so the Arel visitor receives a string
         // instead of a raw object — the generic quote() fallback would emit
         // ISO Z format which MySQL/MariaDB DATETIME rejects in strict mode.
@@ -2748,8 +2746,8 @@ export class Relation<T extends Base> {
       },
     );
     const um = new UpdateManager().table(table).set(updateValues);
-    for (const cond of this._buildWhereStrings(table)) {
-      um.where(arelSql(cond));
+    for (const node of predicatesWithWrappedSqlLiterals(this._whereClause.predicates)) {
+      um.where(node);
     }
 
     const count = await this._modelClass.adapter.execUpdate(
@@ -2784,8 +2782,8 @@ export class Relation<T extends Base> {
 
     const table = this._modelClass.arelTable;
     const dm = new DeleteManager().from(table);
-    for (const cond of this._buildWhereStrings(table)) {
-      dm.where(arelSql(cond));
+    for (const node of predicatesWithWrappedSqlLiterals(this._whereClause.predicates)) {
+      dm.where(node);
     }
 
     const count = await this._modelClass.adapter.execDelete(
@@ -2805,26 +2803,25 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    const nowSql = `'${formatInstantForSql(now)}'`;
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model
     if (this._modelClass._attributeDefinitions.has("updated_at")) {
-      updates.updated_at = nowSql;
+      updates.updated_at = now;
     }
     for (const name of names) {
-      updates[name] = nowSql;
+      updates[name] = now;
     }
 
     if (Object.keys(updates).length === 0) return 0;
 
     const table = this._modelClass.arelTable;
     const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = Object.entries(updates).map(
-      ([key, val]) => [table.get(key), arelSql(val as string)],
+      ([key, val]) => [table.get(key), val],
     );
     const um = new UpdateManager().table(table).set(updateValues);
-    for (const cond of this._buildWhereStrings(table)) {
-      um.where(arelSql(cond));
+    for (const node of predicatesWithWrappedSqlLiterals(this._whereClause.predicates)) {
+      um.where(node);
     }
 
     return this._modelClass.adapter.executeMutation(um.toSql());
@@ -3711,11 +3708,6 @@ export class Relation<T extends Base> {
     if (firstDot === -1) return { tbl: table.name, col: key };
     if (key.indexOf(".", firstDot + 1) !== -1) return { tbl: table.name, col: key };
     return { tbl: key.slice(0, firstDot), col: key.slice(firstDot + 1) };
-  }
-
-  private _buildWhereStrings(_table: Table): string[] {
-    const normalized = predicatesWithWrappedSqlLiterals(this._whereClause.predicates);
-    return normalized.map((node) => `(${this._compileArelNode(node)})`);
   }
 
   private async _preloadAssociationsForRecords(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2748,7 +2748,7 @@ export class Relation<T extends Base> {
     }
 
     const count = await this._modelClass.adapter.execUpdate(
-      um.toSql(),
+      this._arelVisitor().compile(um.ast),
       `${this._modelClass.name} Update All`,
     );
     this.reset();
@@ -2784,7 +2784,7 @@ export class Relation<T extends Base> {
     }
 
     const count = await this._modelClass.adapter.execDelete(
-      dm.toSql(),
+      this._arelVisitor().compile(dm.ast),
       `${this._modelClass.name} Delete All`,
     );
     this.reset();
@@ -2821,7 +2821,7 @@ export class Relation<T extends Base> {
       um.where(node);
     }
 
-    return this._modelClass.adapter.executeMutation(um.toSql());
+    return this._modelClass.adapter.executeMutation(this._arelVisitor().compile(um.ast));
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2731,9 +2731,6 @@ export class Relation<T extends Base> {
         const def = this._modelClass._attributeDefinitions.get(key);
         const isArray = def?.type?.name === "array";
         if (isArray) return [table.get(key), def!.type!.serialize(val)];
-        // Pre-serialize Temporal values so the Arel visitor receives a string
-        // instead of a raw object — the generic quote() fallback would emit
-        // ISO Z format which MySQL/MariaDB DATETIME rejects in strict mode.
         const dbVal =
           val instanceof Temporal.Instant ||
           val instanceof Temporal.PlainDateTime ||


### PR DESCRIPTION
## Summary

- `updateAll`: array values now flow through `ArrayType.serialize()` → `ArrayData` → `connection.quote()` instead of being pre-serialized to a SQL string and wrapped in `arelSql()`
- `updateAll` / `deleteAll` / `touchAll`: WHERE predicates now pass Arel nodes directly to `um/dm.where()` instead of compiling to strings and re-wrapping as `SqlLiteral`s
- `touchAll`: `Temporal.Instant` flows directly as a typed value; `nowSql` pre-format string removed
- Removes `_buildWhereStrings`, the `arelSql` (`sql`) import, `quoteSqlValue`, and the now-unused `formatInstantForSql` import from `relation.ts`

Tracked follow-up from #1340 (Story Arel-Q — ArelConnection widening).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation/update-all.test.ts` — 27 passed, 1 skipped
- [x] `pnpm vitest run packages/activerecord/src/relation/` — 599 passed, 111 skipped
- [x] `pnpm vitest run packages/activerecord/src/adapters/postgresql/` — 13 passed, 1151 skipped
- [x] Build + typecheck pass (pre-commit hook)