### PR TITLE
feat(activerecord): Story N0 — Encryptor cipher dispatch (~30 LOC)

### DIFF
--- a/packages/activerecord/src/encryption/cipher.test.ts
+++ b/packages/activerecord/src/encryption/cipher.test.ts
@@ -12,28 +12,30 @@ describe("ActiveRecord::Encryption::CipherTest", () => {
   it("encrypts returns a encrypted test that can be decrypted with the same key", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    const encrypted = cipher.encrypt("clean text", key);
-    expect(cipher.decrypt(encrypted, key)).toBe("clean text");
+    const encrypted = cipher.encrypt("clean text", { key });
+    expect(cipher.decrypt(encrypted, { key }).toString("utf-8")).toBe("clean text");
   });
 
   it("by default, encrypts uses random initialization vectors for each encryption operation", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    expect(cipher.encrypt("clean text", key)).not.toBe(cipher.encrypt("clean text", key));
+    expect(cipher.encrypt("clean text", { key }).payload).not.toBe(
+      cipher.encrypt("clean text", { key }).payload,
+    );
   });
 
   it("deterministic encryption with :deterministic param", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    expect(cipher.encrypt("clean text", key, { deterministic: true })).toBe(
-      cipher.encrypt("clean text", key, { deterministic: true }),
+    expect(cipher.encrypt("clean text", { key, deterministic: true }).payload).toBe(
+      cipher.encrypt("clean text", { key, deterministic: true }).payload,
     );
   });
 
   it("raises an ArgumentError when provided a key with the wrong length", () => {
     const cipher = new Cipher();
     // 4 bytes encoded — well under the 32-byte minimum
-    expect(() => cipher.encrypt("clean text", Buffer.alloc(4).toString("base64"))).toThrow(
+    expect(() => cipher.encrypt("clean text", { key: Buffer.alloc(4).toString("base64") })).toThrow(
       ConfigError,
     );
   });
@@ -46,23 +48,31 @@ describe("ActiveRecord::Encryption::CipherTest", () => {
   it("generates different ciphertexts on different invocations with the same key (not deterministic)", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    expect(cipher.encrypt("clean text", key)).not.toBe(cipher.encrypt("clean text", key));
+    expect(cipher.encrypt("clean text", { key }).payload).not.toBe(
+      cipher.encrypt("clean text", { key }).payload,
+    );
   });
 
   it("decrypt can work with multiple keys", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    const encrypted = cipher.encrypt("clean text", key);
-    expect(cipher.decrypt(encrypted, [generateKey(), key])).toBe("clean text");
-    expect(cipher.decrypt(encrypted, [generateKey(), key, generateKey()])).toBe("clean text");
-    expect(cipher.decrypt(encrypted, [key, generateKey(), generateKey()])).toBe("clean text");
+    const encrypted = cipher.encrypt("clean text", { key });
+    expect(cipher.decrypt(encrypted, { key: [generateKey(), key] }).toString("utf-8")).toBe(
+      "clean text",
+    );
+    expect(
+      cipher.decrypt(encrypted, { key: [generateKey(), key, generateKey()] }).toString("utf-8"),
+    ).toBe("clean text");
+    expect(
+      cipher.decrypt(encrypted, { key: [key, generateKey(), generateKey()] }).toString("utf-8"),
+    ).toBe("clean text");
   });
 
   it("decrypt will raise an ActiveRecord::Encryption::Errors::Decryption error when none of the keys works", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    const encrypted = cipher.encrypt("clean text", key);
-    expect(() => cipher.decrypt(encrypted, [generateKey(), generateKey()])).toThrow(
+    const encrypted = cipher.encrypt("clean text", { key });
+    expect(() => cipher.decrypt(encrypted, { key: [generateKey(), generateKey()] })).toThrow(
       DecryptionError,
     );
   });
@@ -70,14 +80,16 @@ describe("ActiveRecord::Encryption::CipherTest", () => {
   it("keep encoding from the source string", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    const encrypted = cipher.encrypt("café résumé naïve", key);
-    expect(cipher.decrypt(encrypted, key)).toBe("café résumé naïve");
+    const encrypted = cipher.encrypt("café résumé naïve", { key });
+    expect(cipher.decrypt(encrypted, { key }).toString("utf-8")).toBe("café résumé naïve");
   });
 
   it("can encode unicode strings with emojis", () => {
     const cipher = new Cipher();
     const key = generateKey();
-    const encrypted = cipher.encrypt("Getting around with the ⚡️Go Menu", key);
-    expect(cipher.decrypt(encrypted, key)).toBe("Getting around with the ⚡️Go Menu");
+    const encrypted = cipher.encrypt("Getting around with the ⚡️Go Menu", { key });
+    expect(cipher.decrypt(encrypted, { key }).toString("utf-8")).toBe(
+      "Getting around with the ⚡️Go Menu",
+    );
   });
 });

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -6,7 +6,7 @@
  */
 
 import { Aes256Gcm as AesGcmCipher } from "./cipher/aes256-gcm.js";
-import { ConfigError, DecryptionError } from "./errors.js";
+import { DecryptionError } from "./errors.js";
 import { Message } from "./message.js";
 
 export class Cipher {
@@ -38,9 +38,8 @@ export class Cipher {
       try {
         return this.cipherFor(keys[i]).decrypt(encryptedMessage);
       } catch (e) {
-        if (e instanceof ConfigError) throw e;
+        if (!(e instanceof DecryptionError)) throw e; // integrity/config errors propagate immediately
         lastError = e;
-        if (i < keys.length - 1) continue;
       }
     }
     const msg = lastError instanceof Error ? lastError.message : String(lastError);

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -1,7 +1,6 @@
 /**
  * Public-facing cipher API that wraps Aes256Gcm with multi-key rotation
- * and deterministic-mode support. The internal encryption subsystem
- * (Encryptor, EncryptedAttributeType) uses Aes256Gcm directly.
+ * and deterministic-mode support.
  *
  * Mirrors: ActiveRecord::Encryption::Cipher (encryption/cipher.rb)
  */
@@ -11,20 +10,13 @@ import { ConfigError, DecryptionError } from "./errors.js";
 import { Message } from "./message.js";
 
 export class Cipher {
-  encrypt(clearText: string, key: string, options?: { deterministic?: boolean }): string {
-    const message = this.cipherFor(key, options?.deterministic ?? false).encrypt(
-      clearText,
-      options,
-    );
-    return JSON.stringify({
-      p: message.payload,
-      iv: message.headers.get("iv"),
-      at: message.headers.get("at"),
-    });
+  encrypt(clearText: string | Buffer, options: { key: string; deterministic?: boolean }): Message {
+    return this.cipherFor(options.key, options.deterministic ?? false).encrypt(clearText, options);
   }
 
-  decrypt(encryptedText: string, key: string | string[]): string {
-    return this.tryToDecryptWithEach(encryptedText, { keys: Array.isArray(key) ? key : [key] });
+  decrypt(encryptedMessage: Message, options: { key: string | string[] }): Buffer {
+    const keys = Array.isArray(options.key) ? options.key : [options.key];
+    return this.tryToDecryptWithEach(encryptedMessage, { keys });
   }
 
   keyLength(): number {
@@ -36,35 +28,16 @@ export class Cipher {
   }
 
   /** @internal */
-  private tryToDecryptWithEach(encryptedText: string, { keys }: { keys: string[] }): string {
-    let data: { p: string; iv: string; at: string };
-    try {
-      const parsed = JSON.parse(encryptedText) as unknown;
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        typeof (parsed as any).p !== "string" ||
-        typeof (parsed as any).iv !== "string" ||
-        typeof (parsed as any).at !== "string"
-      ) {
-        throw new DecryptionError("Invalid encrypted text format");
-      }
-      data = parsed as { p: string; iv: string; at: string };
-    } catch (e) {
-      if (e instanceof DecryptionError) throw e;
-      throw new DecryptionError("Invalid encrypted text format");
-    }
+  private tryToDecryptWithEach(encryptedMessage: Message, { keys }: { keys: string[] }): Buffer {
     if (keys.length === 0) throw new DecryptionError("No decryption keys provided");
     let lastError: unknown;
-    for (const key of keys) {
+    for (let i = 0; i < keys.length; i++) {
       try {
-        const msg = new Message(data.p);
-        msg.addHeaders({ iv: data.iv, at: data.at });
-        const buf = this.cipherFor(key).decrypt(msg);
-        return buf.toString("utf-8");
+        return this.cipherFor(keys[i]).decrypt(encryptedMessage);
       } catch (e) {
         if (e instanceof ConfigError) throw e;
         lastError = e;
+        if (i < keys.length - 1) continue;
       }
     }
     const msg = lastError instanceof Error ? lastError.message : String(lastError);

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -14,7 +14,10 @@ export class Cipher {
     return this.cipherFor(options.key, options.deterministic ?? false).encrypt(clearText, options);
   }
 
-  decrypt(encryptedMessage: Message, options: { key: string | string[] }): Buffer {
+  decrypt(
+    encryptedMessage: Message,
+    options: { key: string | string[]; [k: string]: unknown },
+  ): Buffer {
     const keys = Array.isArray(options.key) ? options.key : [options.key];
     return this.tryToDecryptWithEach(encryptedMessage, { keys });
   }

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -280,13 +280,23 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
   });
 
   it("buildEncryptedMessage dispatches through cipher() for encrypt and decrypt", () => {
-    Configurable.config.primaryKey = "a".repeat(32);
-    Configurable.config.keyDerivationSalt = "testsalt";
-    const enc = new Encryptor({ compress: false });
-    const cipherSpy = vi.spyOn(enc as any, "cipher");
-    const encrypted = enc.encrypt("secret text");
-    expect(cipherSpy).toHaveBeenCalled();
-    cipherSpy.mockRestore();
-    expect(enc.decrypt(encrypted)).toBe("secret text");
+    const savedKey = Configurable.config.primaryKey;
+    const savedSalt = Configurable.config.keyDerivationSalt;
+    try {
+      Configurable.config.primaryKey = "a".repeat(32);
+      Configurable.config.keyDerivationSalt = "testsalt";
+      clearDefaultKeyProviderCache();
+      const enc = new Encryptor({ compress: false });
+      const cipherSpy = vi.spyOn(enc as any, "cipher");
+      const encrypted = enc.encrypt("secret text");
+      const decrypted = enc.decrypt(encrypted);
+      expect(cipherSpy).toHaveBeenCalledTimes(2); // once for encrypt, once for decrypt
+      expect(decrypted).toBe("secret text");
+      cipherSpy.mockRestore();
+    } finally {
+      Configurable.config.primaryKey = savedKey;
+      Configurable.config.keyDerivationSalt = savedSalt;
+      clearDefaultKeyProviderCache();
+    }
   });
 });

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Cipher } from "./cipher.js";
 import { Encryptor } from "./encryptor.js";
 import { Configurable } from "./configurable.js";
@@ -277,5 +277,16 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     Contexts.withEncryptionContext({ cipher: customCipher }, () => {
       expect((new Encryptor() as any).cipher()).toBe(customCipher);
     });
+  });
+
+  it("buildEncryptedMessage dispatches through cipher() for encrypt and decrypt", () => {
+    Configurable.config.primaryKey = "a".repeat(32);
+    Configurable.config.keyDerivationSalt = "testsalt";
+    const enc = new Encryptor({ compress: false });
+    const cipherSpy = vi.spyOn(enc as any, "cipher");
+    const encrypted = enc.encrypt("secret text");
+    expect(cipherSpy).toHaveBeenCalled();
+    cipherSpy.mockRestore();
+    expect(enc.decrypt(encrypted)).toBe("secret text");
   });
 });

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -115,7 +115,7 @@ export class Encryptor {
 
     let decrypted: Buffer;
     try {
-      decrypted = this.cipher().decrypt(message, { key: keys, ...options?.cipherOptions });
+      decrypted = this.cipher().decrypt(message, { ...options?.cipherOptions, key: keys });
     } catch (e) {
       if (e instanceof Base) throw e;
       throw new DecryptionError(e instanceof Error ? e.message : String(e));

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -98,9 +98,9 @@ export class Encryptor {
     }
 
     const message = this.deserializeMessage(encryptedText);
-    const compressed = message.headers.get("c") === true;
 
-    // Precedence mirrors encrypt(): keyProvider > key > default.
+    // Collect all candidate secrets then delegate key-rotation to Cipher#decrypt,
+    // mirroring Rails: cipher.decrypt(message, key: keys.collect(&:secret), **cipher_options)
     let keys: string[];
     if (options?.keyProvider) {
       keys = options.keyProvider.decryptionKeys(message).map((k) => k.secret);
@@ -111,27 +111,22 @@ export class Encryptor {
       if (!kp) throw new DecryptionError("No decryption key provided");
       keys = kp.decryptionKeys(message).map((k) => k.secret);
     }
+    if (keys.length === 0) throw new DecryptionError("No decryption key provided");
 
-    // Mirrors Rails: try_to_decrypt_with_each rescues only Errors::Decryption (wrong key /
-    // auth-tag mismatch) and re-raises on the last key. Non-Decryption errors (e.g.
-    // EncryptedContentIntegrity, ConfigError) propagate immediately. Inflate errors are
-    // message-level so they are wrapped as DecryptionError and thrown immediately.
-    for (const key of keys) {
-      let decryptedBuf: Buffer;
-      try {
-        decryptedBuf = this.cipher().decrypt(message, { key });
-      } catch (e) {
-        if (e instanceof DecryptionError) continue; // wrong key — try next
-        throw e; // EncryptedContentIntegrity, ConfigError, etc.
-      }
-      try {
-        return this.uncompressIfNeeded(decryptedBuf, compressed);
-      } catch (e) {
-        if (e instanceof Base) throw e;
-        throw new DecryptionError(e instanceof Error ? e.message : String(e));
-      }
+    let decrypted: Buffer;
+    try {
+      decrypted = this.cipher().decrypt(message, { key: keys, ...options?.cipherOptions });
+    } catch (e) {
+      if (e instanceof Base) throw e;
+      throw new DecryptionError(e instanceof Error ? e.message : String(e));
     }
-    throw new DecryptionError("None of the provided keys could decrypt the data");
+
+    try {
+      return this.uncompressIfNeeded(decrypted, message.headers.get("c") === true);
+    } catch (e) {
+      if (e instanceof Base) throw e;
+      throw new DecryptionError(e instanceof Error ? e.message : String(e));
+    }
   }
 
   isEncrypted(text: string): boolean {

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::Encryption::Encryptor
  */
 
-import { Aes256Gcm } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
@@ -120,7 +119,7 @@ export class Encryptor {
     for (const key of keys) {
       let decryptedBuf: Buffer;
       try {
-        decryptedBuf = new Aes256Gcm(key).decrypt(message);
+        decryptedBuf = this.cipher().decrypt(message, { key });
       } catch (e) {
         if (e instanceof DecryptionError) continue; // wrong key — try next
         throw e; // EncryptedContentIntegrity, ConfigError, etc.
@@ -218,7 +217,7 @@ export class Encryptor {
     if (key == null) throw new ConfigError("No encryption key provided");
 
     const [cipherInput, compressed] = this.compressIfWorthIt(clearText);
-    const message = new Aes256Gcm(key, cipherOptions).encrypt(cipherInput);
+    const message = this.cipher().encrypt(cipherInput, { key, ...cipherOptions });
     if (compressed) message.addHeader("c", true);
     if (encKeyObj.publicTags) {
       for (const [k, v] of Object.entries(encKeyObj.publicTags)) {


### PR DESCRIPTION
## Summary

- `Cipher.encrypt` / `decrypt` now carry the correct Rails signature:
  `encrypt(clearText, { key:, deterministic? })` → `Message`;
  `decrypt(message, { key: })` → `Buffer`
  (Rails: `cipher.rb` lines 14–30)
- `Encryptor#buildEncryptedMessage` dispatches through `this.cipher()` instead of `new Aes256Gcm(key, opts).encrypt(...)` — Rails: `encryptor.rb` line 115
- `Encryptor#decrypt` loop dispatches through `this.cipher().decrypt(message, { key })` instead of `new Aes256Gcm(key).decrypt(message)`
- Context-configured ciphers (e.g. `Contexts.withEncryptionContext({ cipher: ... })`) are now honoured end-to-end for both paths
- Closes follow-up gap from PR #1330: "cipher() not used internally"

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/encryption/` — 277 passed, 10 skipped
- [ ] New dispatch test in `encryptor.test.ts` spies on `cipher()` during `encrypt`
- [ ] `cipher.test.ts` updated to Rails-correct kwarg API with Message round-trip