### PR TITLE
feat(activerecord): Story M — small leftovers bundle (5 items, ~100 LOC)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -172,6 +172,14 @@ export interface DatabaseAdapter {
   readonly adapterName: AdapterName;
 
   /**
+   * Returns true when `error` is a raw driver error indicating the database
+   * does not exist (e.g. SQLSTATE 3D000 for pg, ER_BAD_DB_ERROR for mysql2,
+   * SQLITE_CANTOPEN for sqlite3). Used as a defensive fallback when pool
+   * proxies re-surface untranslated errors before NoDatabaseError is thrown.
+   */
+  isNoDatabaseError(error: unknown): boolean;
+
+  /**
    * Execute a SQL query and return rows.
    */
   execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]>;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -352,6 +352,15 @@ export class AbstractAdapter implements Quoting {
 
   _queryCache: Store | null = null;
 
+  /**
+   * Returns true when `error` is a raw driver error indicating the database
+   * does not exist. Concrete adapters override this with driver-specific checks.
+   * The base implementation always returns false (safe default for custom adapters).
+   */
+  isNoDatabaseError(_error: unknown): boolean {
+    return false;
+  }
+
   pool: unknown = null;
   logger: unknown = null;
   lock: unknown = null;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -281,8 +281,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     try {
       return await this._driverPool.getConnection();
     } catch (error) {
-      const e = error as { code?: unknown; errno?: unknown };
-      if (e.code === "ER_BAD_DB_ERROR" || e.errno === 1049) {
+      if (this.isNoDatabaseError(error)) {
         throw NoDatabaseError.dbError(this._database ?? "unknown");
       }
       throw error;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -261,6 +261,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._driverPool = Mysql2Adapter.newClient(this._poolConfig);
   }
 
+  /** Returns true for raw mysql2 errors that indicate the database doesn't exist (ER_BAD_DB_ERROR). */
+  isNoDatabaseError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+    const e = error as { code?: unknown; errno?: unknown };
+    return e.code === "ER_BAD_DB_ERROR" || e.errno === 1049;
+  }
+
   /** Checkout a fresh connection from the pool, translating ER_BAD_DB_ERROR. */
   private async _checkoutConn(): Promise<mysql.PoolConnection> {
     // Lazy reconnect after disconnectBang() — mirrors Rails' reconnect on next

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1502,6 +1502,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this._useInsertReturning;
   }
 
+  /** Returns true for raw pg errors that indicate the database doesn't exist (SQLSTATE 3D000). */
+  isNoDatabaseError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+    return (error as { code?: unknown }).code === "3D000";
+  }
+
   // Mirrors: PostgreSQLAdapter.new_client (postgresql_adapter.rb:57)
   // Connects a single pg.Client and translates connection errors into
   // the same ActiveRecord error hierarchy as Rails (ConnectionNotEstablished,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -88,8 +88,8 @@ export interface SchemaStatements {
   validateConstraint(tableName: string, constraintName: string): Promise<void>;
   validateCheckConstraint(tableName: string, name: string): Promise<void>;
   validateForeignKey(tableName: string, name: string): Promise<void>;
-  exclusionConstraints(tableName: string): Promise<unknown[]>;
-  uniqueConstraints(tableName: string): Promise<unknown[]>;
+  exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]>;
+  uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]>;
   commentOnColumn(tableName: string, columnName: string, comment: string | null): Promise<void>;
   commentOnTable(tableName: string, comment: string | null): Promise<void>;
   addColumn(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -105,6 +105,16 @@ export class SQLiteDateTimeType extends ARDateTimeType {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter
  */
+
+function _isSqliteMissingDbError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: unknown; message?: unknown };
+  return (
+    e.code === "SQLITE_CANTOPEN" ||
+    (typeof e.message === "string" && /unable to open database file/i.test(e.message))
+  );
+}
+
 export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override get adapterName(): AdapterName {
     return "sqlite";
@@ -112,12 +122,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /** Returns true for raw SQLite driver errors that indicate a missing or unopenable database file (SQLITE_CANTOPEN). */
   isNoDatabaseError(error: unknown): boolean {
-    if (!error || typeof error !== "object") return false;
-    const e = error as { code?: unknown; message?: unknown };
-    return (
-      e.code === "SQLITE_CANTOPEN" ||
-      (typeof e.message === "string" && /unable to open database file/i.test(e.message))
-    );
+    return _isSqliteMissingDbError(error);
   }
 
   static columnNameMatcher(): RegExp {
@@ -2255,7 +2260,7 @@ function translateException(
   if (msg.includes("String or BLOB exceeded size limit")) {
     return new ValueTooLong(message, { sql, binds, cause: exception });
   }
-  if (code === "SQLITE_CANTOPEN" || /unable to open database file/i.test(msg)) {
+  if (_isSqliteMissingDbError(exception)) {
     return new NoDatabaseError(message, { sql, binds, cause: exception });
   }
   if (/called on a closed database/i.test(msg)) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -110,6 +110,16 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return "sqlite";
   }
 
+  /** Returns true for raw better-sqlite3 errors that indicate a missing database file (SQLITE_CANTOPEN). */
+  isNoDatabaseError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+    const e = error as { code?: unknown; message?: unknown };
+    return (
+      e.code === "SQLITE_CANTOPEN" ||
+      (typeof e.message === "string" && /unable to open database file/i.test(e.message))
+    );
+  }
+
   static columnNameMatcher(): RegExp {
     // Mirrors Rails SQLite3 column_name_matcher. Uses "..." quoted identifiers
     // (SQLite double-quote escaping: "" inside quotes). Strict 0-or-1 function

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -110,7 +110,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return "sqlite";
   }
 
-  /** Returns true for raw better-sqlite3 errors that indicate a missing database file (SQLITE_CANTOPEN). */
+  /** Returns true for raw SQLite driver errors that indicate a missing or unopenable database file (SQLITE_CANTOPEN). */
   isNoDatabaseError(error: unknown): boolean {
     if (!error || typeof error !== "object") return false;
     const e = error as { code?: unknown; message?: unknown };

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -44,6 +44,9 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   override get adapterName(): AdapterName {
     return "sqlite";
   }
+  isNoDatabaseError(_error: unknown): boolean {
+    return false;
+  }
   readonly inTransaction = false;
 
   async execute(

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -95,4 +95,29 @@ export class MigrationProxy {
     }
     return new (klass as new (name: string, version: string) => object)(this.name, this.version);
   }
+
+  /** @internal */
+  async loadMigrationAsync(): Promise<object> {
+    try {
+      // require() works for CJS migrations; falls through to import() for ESM.
+      return this.loadMigration();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ERR_REQUIRE_ESM") throw err;
+      // ESM migration file — use dynamic import() via file URL.
+      const { pathToFileURL } = await import("node:url");
+      const mod = (await import(/* @vite-ignore */ pathToFileURL(this.filename).href)) as Record<
+        string,
+        new (name: string, version: string) => object
+      >;
+      const klass = mod[this.name] ?? mod.default;
+      if (typeof klass !== "function") {
+        throw new Error(
+          `Migration ${this.name} could not be loaded from ${this.filename}: ` +
+            `no export named "${this.name}" or "default" found`,
+          { cause: err },
+        );
+      }
+      return new (klass as new (name: string, version: string) => object)(this.name, this.version);
+    }
+  }
 }

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -96,7 +96,15 @@ export class MigrationProxy {
     return new (klass as new (name: string, version: string) => object)(this.name, this.version);
   }
 
-  /** @internal */
+  /**
+   * @internal
+   * ESM-capable loader. The sync `loadMigration()` / `migration()` path is
+   * retained for backward compatibility; wiring this into Migrator would
+   * require making `MigrationProxy.migration()` async, cascading to the
+   * `MigrationProxy` interface in migration.ts. In practice, the trailties
+   * migration-loader already uses `import(pathToFileURL(...))` so ESM
+   * migrations are handled before they reach this class.
+   */
   async loadMigrationAsync(): Promise<object> {
     try {
       // require() works for CJS migrations; falls through to import() for ESM.

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -112,6 +112,10 @@ export class MigrationProxy {
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ERR_REQUIRE_ESM") throw err;
       // ESM migration file — use dynamic import() via file URL.
+      // Note: unlike the require() path above, import() is module-cached by the
+      // Node.js ESM loader and will not reload the file if it changes during the
+      // same process. Cache-busting (e.g. appending ?t=Date.now()) is unstable
+      // across runtimes; in practice, ESM migrations run once per process.
       const { pathToFileURL } = await import("node:url");
       const mod = (await import(/* @vite-ignore */ pathToFileURL(this.filename).href)) as Record<
         string,

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -36,7 +36,7 @@ export class DefaultStrategy extends ExecutionStrategy {
     // own connection field if set.
     return (
       this._adapter ??
-      (this.migration as MigrationLike).connection ??
+      (this.migration as MigrationLike | null)?.connection ??
       (() => {
         throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
       })()

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -27,6 +27,6 @@ export class DefaultStrategy extends ExecutionStrategy {
 
   /** @internal */
   connection(): DatabaseAdapter {
-    return (this.migration as { connection: DatabaseAdapter }).connection;
+    return (this.migration as MigrationLike).connection!;
   }
 }

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -12,12 +12,15 @@ import { ExecutionStrategy } from "./execution-strategy.js";
 import type { MigrationLike } from "./execution-strategy.js";
 
 export class DefaultStrategy extends ExecutionStrategy {
+  private _adapter: DatabaseAdapter | null = null;
+
   async exec(
     direction: "up" | "down",
     migration: MigrationLike,
     adapter: DatabaseAdapter,
   ): Promise<void> {
     this.migration = migration;
+    this._adapter = adapter;
     if (direction === "up") {
       await migration.up(adapter);
     } else {
@@ -27,6 +30,16 @@ export class DefaultStrategy extends ExecutionStrategy {
 
   /** @internal */
   connection(): DatabaseAdapter {
-    return (this.migration as MigrationLike).connection!;
+    // Mirrors Rails: DefaultStrategy#connection delegates to migration.connection,
+    // which returns @connection || DatabaseTasks.migration_connection. Here we
+    // prefer the adapter that exec() received, falling back to the migration's
+    // own connection field if set.
+    return (
+      this._adapter ??
+      (this.migration as MigrationLike).connection ??
+      (() => {
+        throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
+      })()
+    );
   }
 }

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -30,13 +30,13 @@ export class DefaultStrategy extends ExecutionStrategy {
 
   /** @internal */
   connection(): DatabaseAdapter {
-    // Mirrors Rails: DefaultStrategy#connection delegates to migration.connection,
-    // which returns @connection || DatabaseTasks.migration_connection. Here we
-    // prefer the adapter that exec() received, falling back to the migration's
-    // own connection field if set.
+    // Mirrors Rails: DefaultStrategy#connection → migration.connection →
+    //   @connection || DatabaseTasks.migration_connection.
+    // migration.connection is the per-migration override (@connection); _adapter
+    // is the global migration connection passed to exec(). Per-migration wins.
     return (
-      this._adapter ??
       (this.migration as MigrationLike | null)?.connection ??
+      this._adapter ??
       (() => {
         throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
       })()

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -14,6 +14,8 @@ export interface MigrationLike {
   down(adapter: DatabaseAdapter): Promise<void>;
   /** When true, Migrator skips DDL transaction wrapping for this migration. */
   disableDdlTransaction?: boolean;
+  /** Adapter used by this migration instance; set by DefaultStrategy.exec. */
+  connection?: DatabaseAdapter;
 }
 
 export abstract class ExecutionStrategy {

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -14,7 +14,7 @@ export interface MigrationLike {
   down(adapter: DatabaseAdapter): Promise<void>;
   /** When true, Migrator skips DDL transaction wrapping for this migration. */
   disableDdlTransaction?: boolean;
-  /** Adapter used by this migration instance; set by DefaultStrategy.exec. */
+  /** Adapter for this migration; mirrors Rails' Migration#connection (@connection field). */
   connection?: DatabaseAdapter;
 }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -121,6 +121,10 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return this.inner.adapterName;
   }
 
+  isNoDatabaseError(error: unknown): boolean {
+    return this.inner.isNoDatabaseError(error);
+  }
+
   readonly inner: DatabaseAdapter;
   readonly cache: QueryCacheStore;
   private _queryCount = 0;

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1542,6 +1542,28 @@ describe("initializeDatabase", () => {
     expect(result).toBe(true);
   });
 
+  it("calls DatabaseTasks.create when adapter.isNoDatabaseError returns true for a raw driver error", async () => {
+    let created = false;
+    const rawDriverError = Object.assign(new Error("ER_BAD_DB_ERROR"), {
+      code: "ER_BAD_DB_ERROR",
+      errno: 1049,
+    });
+    vi.spyOn(DatabaseTasks as any, "_connectFor").mockResolvedValue({
+      execute: async () => {
+        throw rawDriverError;
+      },
+      close: async () => {},
+      isNoDatabaseError: (e: unknown) => (e as { code?: unknown }).code === "ER_BAD_DB_ERROR",
+    });
+    vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
+      created = true;
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    const result = await initializeDatabase(config);
+    expect(created).toBe(true);
+    expect(result).toBe(true);
+  });
+
   it("loads schema dump when DB is fresh and dump file exists", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-initdb-schema-"));
     const schemaFile = path.join(tmp, "schema.ts");

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1558,7 +1558,9 @@ describe("initializeDatabase", () => {
     vi.spyOn(DatabaseTasks, "create").mockImplementation(async () => {
       created = true;
     });
-    const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" });
+    // adapter is "mysql2" to match the MySQL-flavored raw error; _connectFor is
+    // mocked so no real connection is made — the test validates delegation only.
+    const config = new HashConfig("test", "primary", { adapter: "mysql2", database: "mydb" });
     const result = await initializeDatabase(config);
     expect(created).toBe(true);
     expect(result).toBe(true);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1201,7 +1201,7 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
       const sm = new SchemaMigration(adapter);
       alreadyInitialized = await sm.tableExists();
     } catch (error) {
-      if (error instanceof NoDatabaseError || _isMissingDatabaseError(error)) {
+      if (error instanceof NoDatabaseError || _isMissingDatabaseError(error, adapter)) {
         await DatabaseTasks.create(dbConfig);
       } else {
         throw error;
@@ -1224,10 +1224,13 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
 
 // Defensive fallback for SQL-level errors that slip through pool proxies or
 // adapters that don't yet translate at connection time.
-function _isMissingDatabaseError(error: unknown): boolean {
+function _isMissingDatabaseError(
+  error: unknown,
+  adapter?: import("../adapter.js").DatabaseAdapter,
+): boolean {
+  // Delegate to the adapter's per-driver check when available.
+  if (typeof adapter?.isNoDatabaseError === "function") return adapter.isNoDatabaseError(error);
+  // Legacy fallback: PostgreSQL SQLSTATE 3D000.
   if (!error || typeof error !== "object") return false;
-  const e = error as { code?: unknown };
-  // PostgreSQL SQLSTATE 3D000 — normally translated by PostgreSQLAdapter.newClient,
-  // kept here as a safety net for pool proxies that re-surface the raw error.
-  return e.code === "3D000";
+  return (error as { code?: unknown }).code === "3D000";
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -546,6 +546,10 @@ class SchemaAdapter implements DatabaseAdapter {
     return this.inner?.adapterName ?? "sqlite";
   }
 
+  isNoDatabaseError(error: unknown): boolean {
+    return this.inner?.isNoDatabaseError?.(error) ?? false;
+  }
+
   private inner: any;
 
   constructor(inner: any) {

--- a/packages/website/src/lib/frontiers/sql-js-adapter.ts
+++ b/packages/website/src/lib/frontiers/sql-js-adapter.ts
@@ -4,6 +4,10 @@ import type { Database } from "sql.js";
 export class SqlJsAdapter implements DatabaseAdapter {
   readonly adapterName = "SQLite";
 
+  isNoDatabaseError(_error: unknown): boolean {
+    return false;
+  }
+
   constructor(private db: Database) {}
 
   async execute(sql: string, binds: unknown[] = []): Promise<Record<string, unknown>[]> {

--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -111,11 +111,11 @@ function testNameOverride(testName: string, relPath: string): Annotation | null 
   }
 
   // Ruby module namespace (not STI — Ruby constant lookup semantics)
-  if (/\bmodel.*classes.*matching\b/.test(n)) {
+  if (/\bmodel.*classes.*matching\b|\bnamespace\b/.test(n)) {
     return {
       blocked: "unknown — Ruby module namespace / constant lookup semantics not translatable",
       rootCause: "Node.js has no Ruby Module namespace for matching class names by constant path",
-      scope: "~0 LOC fix; likely permanent skip-list.ts candidate",
+      scope: "~0 LOC fix; permanent skip-list.ts candidate",
     };
   }
 
@@ -125,15 +125,6 @@ function testNameOverride(testName: string, relPath: string): Annotation | null 
       blocked: "schema — schema loading / cache invalidation gap",
       rootCause: "schema-cache.ts#clear or connection-handler.ts#clearCache not fully wired",
       scope: "~20 LOC fix in schema-cache.ts; affects ~1 test",
-    };
-  }
-
-  // Ruby module namespace wrapping (e.g. `module Foo; class Bar; end; end`)
-  if (/\bnamespace\b/.test(n)) {
-    return {
-      blocked: "unknown — Ruby module namespace / constant lookup semantics not translatable",
-      rootCause: "Node.js has no Ruby Module namespace for matching class names by constant path",
-      scope: "~0 LOC fix; permanent skip-list.ts candidate",
     };
   }
 

--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -128,6 +128,24 @@ function testNameOverride(testName: string, relPath: string): Annotation | null 
     };
   }
 
+  // Ruby module namespace wrapping (e.g. `module Foo; class Bar; end; end`)
+  if (/\bnamespace\b/.test(n)) {
+    return {
+      blocked: "unknown — Ruby module namespace / constant lookup semantics not translatable",
+      rootCause: "Node.js has no Ruby Module namespace for matching class names by constant path",
+      scope: "~0 LOC fix; permanent skip-list.ts candidate",
+    };
+  }
+
+  // Default scope interactions
+  if (/\bdefault.?scope\b/.test(n)) {
+    return {
+      blocked: "relation — default scope application gap",
+      rootCause: "Relation#defaultScope or scope chain not fully applied in all query paths",
+      scope: "~20 LOC fix in relation.ts; affects ~1 test",
+    };
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

Five small independent cleanups bundled together. Each commit is self-contained and reversible.

### M1: `exclusionConstraints`/`uniqueConstraints` return type tightening

**Before:** `Promise<unknown[]>` in `postgresql/schema-statements.ts` interface.  
**After:** `Promise<ExclusionConstraintDefinition[]>` / `Promise<UniqueConstraintDefinition[]>`, matching the concrete pg adapter impl and closing a type-safety gap in `schema-dumper.ts`.

### M2: `MigrationLike.connection?` field

**Before:** `DefaultStrategy.connection()` cast `this.migration` to `{ connection: DatabaseAdapter }`, but `MigrationLike` had no such field — plain `{ up, down }` objects would return `undefined`.  
**After:** `connection?: DatabaseAdapter` declared on `MigrationLike`; cast replaced with typed access.

### M3: `MigrationProxy.loadMigrationAsync` ESM support

**Before:** `MigrationProxy.loadMigration()` used `createRequire`, throwing `ERR_REQUIRE_ESM` on ESM migration files.  
**After:** New `loadMigrationAsync()` tries `require()` first; on `ERR_REQUIRE_ESM`, falls back to `import(pathToFileURL(...))`. The sync `loadMigration` is retained for the existing internal cache path.

### M4: `testNameOverride` keyword groups extension

**Before:** `namespace` and `default scope` test names fell through to the file-level categorizer and got wrong annotations.  
**After:** Two new keyword guards handle them (with `blocked`/`rootCause`/`scope` metadata matching the existing pattern).

### M5: `isNoDatabaseError` adapter-layer method

**Before:** `_isMissingDatabaseError` in `database-tasks.ts` hardcoded SQLSTATE 3D000 as a PostgreSQL safety-net check.  
**After:** `isNoDatabaseError(error)` added to the `DatabaseAdapter` interface and implemented in all three adapters (pg: 3D000, mysql2: ER_BAD_DB_ERROR/errno 1049, sqlite3: SQLITE_CANTOPEN). `_isMissingDatabaseError` delegates to the adapter method when available, with the legacy 3D000 check as a final fallback.

## Verification

- `pnpm api:compare --package activerecord` → 4969/4969 (100%), no regression
- `pnpm test:types` → clean
- `pnpm vitest run packages/activerecord/src/tasks/database-tasks.test.ts` → all pass