### PR TITLE
feat(activerecord): Story K-followup — DirtyTracker.redetectChanges preserves in-TX edits after rollback

### DIFF
--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "./index.js";
+import { Model, DirtyTracker, AttributeSet } from "./index.js";
 
 describe("DirtyTest", () => {
   it("changes accessible through both strings and symbols", () => {
@@ -845,5 +845,54 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     expect(m.changedAttributes).toContain("ratio");
     m.writeAttribute("ratio", "NaN");
     expect(m.changedAttributes).not.toContain("ratio");
+  });
+});
+
+describe("DirtyTracker#redetectChanges", () => {
+  class Subject extends Model {
+    static {
+      this.attribute("title", "string");
+      this.attribute("score", "integer");
+    }
+  }
+
+  it("marks attributes as dirty where the post-rollback value differs from the restored baseline", () => {
+    const m = new Subject({ title: "original", score: 0 });
+    m.changesApplied(); // simulate post-save clean state
+
+    // Simulate in-TX user edit
+    const postTxAttrs = (m as any)._attributes.deepDup();
+    (postTxAttrs as AttributeSet).writeFromUser("title", "tx-edit");
+
+    // Simulate restore to pre-TX state (baseline is already "original" from snapshot)
+    const restored = (m as any)._attributes;
+    const dirty: DirtyTracker = (m as any)._dirty;
+    dirty.snapshot(restored);
+    dirty.clearChangesInformation();
+    dirty.redetectChanges(postTxAttrs);
+
+    // title differed → dirty, with [was=tx-edit, now=original]
+    expect(dirty.attributeChanged("title")).toBe(true);
+    expect(dirty.attributeWas("title")).toBe("tx-edit");
+    expect(dirty.changes).toEqual({ title: ["tx-edit", "original"] });
+
+    // score unchanged → not dirty
+    expect(dirty.attributeChanged("score")).toBe(false);
+  });
+
+  it("leaves no dirty state when post-rollback values match the restored baseline", () => {
+    const m = new Subject({ title: "same", score: 1 });
+    m.changesApplied();
+
+    const postTxAttrs = (m as any)._attributes.deepDup(); // no edits during TX
+
+    const restored = (m as any)._attributes;
+    const dirty: DirtyTracker = (m as any)._dirty;
+    dirty.snapshot(restored);
+    dirty.clearChangesInformation();
+    dirty.redetectChanges(postTxAttrs);
+
+    expect(dirty.changed).toBe(false);
+    expect(dirty.changes).toEqual({});
   });
 });

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -895,4 +895,25 @@ describe("DirtyTracker#redetectChanges", () => {
     expect(dirty.changed).toBe(false);
     expect(dirty.changes).toEqual({});
   });
+
+  it("detects number_to_non_number? via valueBeforeTypeCast — score=1 written as `true` is dirty vs numeric baseline", () => {
+    // Numeric type isChanged: isNumberToNonNumber?(oldValue, newValueBeforeTypeCast) fires when
+    // the new raw value is not a number even if the cast value equals the old cast value.
+    const m = new Subject({ title: "t", score: 1 });
+    m.changesApplied(); // baseline: score=1 (cast), raw=1
+
+    // Simulate in-TX write of `true` to score (casts to 1, but raw is non-numeric)
+    const postTxAttrs = (m as any)._attributes.deepDup();
+    (postTxAttrs as AttributeSet).writeFromUser("score", true); // valueBeforeTypeCast=true, value=1
+
+    const restored = (m as any)._attributes; // baseline still score=1
+    const dirty: DirtyTracker = (m as any)._dirty;
+    dirty.snapshot(restored);
+    dirty.clearChangesInformation();
+    dirty.redetectChanges(postTxAttrs);
+
+    // Cast values are both 1, but raw `true` triggers isNumberToNonNumber? → dirty
+    expect(dirty.attributeChanged("score")).toBe(true);
+    expect(dirty.changes).toEqual({ score: [1, 1] });
+  });
 });

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -871,10 +871,10 @@ describe("DirtyTracker#redetectChanges", () => {
     dirty.clearChangesInformation();
     dirty.redetectChanges(postTxAttrs);
 
-    // title differed → dirty, with [was=tx-edit, now=original]
+    // title differed → dirty, with [was=original (preTX baseline), now=tx-edit (postTX)]
     expect(dirty.attributeChanged("title")).toBe(true);
-    expect(dirty.attributeWas("title")).toBe("tx-edit");
-    expect(dirty.changes).toEqual({ title: ["tx-edit", "original"] });
+    expect(dirty.attributeWas("title")).toBe("original");
+    expect(dirty.changes).toEqual({ title: ["original", "tx-edit"] });
 
     // score unchanged → not dirty
     expect(dirty.attributeChanged("score")).toBe(false);

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -241,7 +241,7 @@ export class DirtyTracker {
    * @internal
    */
   redetectChanges(currentAttributes: AttributeSet): void {
-    for (const [name] of currentAttributes) {
+    for (const name of currentAttributes.keys()) {
       const attr = currentAttributes.getAttribute(name);
       const currentValue = attr.value;
       if (!this._originalHas.has(name)) {

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -225,6 +225,36 @@ export class DirtyTracker {
     this._previousChanges.clear();
   }
 
+  /**
+   * After a transaction rollback restores the attribute set to its pre-TX
+   * baseline, re-populate `_changedAttributes` for any attribute whose
+   * post-TX value differs from the restored (pre-TX) baseline. This preserves
+   * in-transaction user edits as dirty — mirroring Rails' per-attribute
+   * `original_attribute` chain in `restore_state[:attributes].map`.
+   *
+   * Call this after `snapshot(restoredAttributes)` so `_originalAttributes`
+   * already holds the pre-TX baseline values.
+   *
+   * @internal
+   */
+  redetectChanges(currentAttributes: AttributeSet): void {
+    for (const [name] of currentAttributes) {
+      const attr = currentAttributes.getAttribute(name);
+      const preRollbackValue = attr.value;
+      if (!this._originalHas.has(name)) {
+        // Attribute added during the transaction — mark as reverted to absent
+        this._changedAttributes.set(name, [preRollbackValue, undefined]);
+      } else {
+        const restoredValue = resolveValue(this._originalAttributes.get(name));
+        // isChanged: compare restored (pre-TX) vs pre-rollback (post-TX) value.
+        // Entry is [was=preRollback, now=restored] matching Rails' original_attribute semantics.
+        if (attr.type.isChanged(restoredValue, preRollbackValue, preRollbackValue)) {
+          this._changedAttributes.set(name, [preRollbackValue, restoredValue]);
+        }
+      }
+    }
+  }
+
   clearAttributeChanges(attributes: string[]): void {
     for (const attr of attributes) {
       this._deleteChange(attr);

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -250,7 +250,9 @@ export class DirtyTracker {
       } else {
         const savedValue = resolveValue(this._originalAttributes.get(name));
         // Entry: [was=savedValue (pre-TX), now=currentValue (post-TX)] — matches [was, now] convention.
-        if (attr.type.isChanged(savedValue, currentValue, currentValue)) {
+        // Pass attr.valueBeforeTypeCast as the raw third arg so numeric types can
+        // detect number_to_non_number? changes (e.g. writing `true` to an integer field).
+        if (attr.type.isChanged(savedValue, currentValue, attr.valueBeforeTypeCast)) {
           this._changedAttributes.set(name, [savedValue, currentValue]);
         }
       }

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -226,30 +226,32 @@ export class DirtyTracker {
   }
 
   /**
-   * After a transaction rollback restores the attribute set to its pre-TX
-   * baseline, re-populate `_changedAttributes` for any attribute whose
-   * post-TX value differs from the restored (pre-TX) baseline. This preserves
-   * in-transaction user edits as dirty — mirroring Rails' per-attribute
-   * `original_attribute` chain in `restore_state[:attributes].map`.
+   * Walk `currentAttributes` (post-TX) and populate `_changedAttributes` for
+   * any attribute whose current value differs from the pre-TX baseline already
+   * stored in `_originalAttributes` (set by a prior `snapshot(preTxAttrs)` call).
    *
-   * Call this after `snapshot(restoredAttributes)` so `_originalAttributes`
-   * already holds the pre-TX baseline values.
+   * Mirrors the Rails per-attribute `original_attribute` chain built by
+   * `restore_state[:attributes].map { attr.with_value_from_user(current_value) }`:
+   * the current (post-TX) value survives in memory as the "now" side, with the
+   * pre-TX value as the "was" baseline, so `mutationsFromDatabase` reflects
+   * `[preTx, postTx]` for each changed attribute.
+   *
+   * Call after `snapshot(preTxAttrs)` + `clearChangesInformation()`.
    *
    * @internal
    */
   redetectChanges(currentAttributes: AttributeSet): void {
     for (const [name] of currentAttributes) {
       const attr = currentAttributes.getAttribute(name);
-      const preRollbackValue = attr.value;
+      const currentValue = attr.value;
       if (!this._originalHas.has(name)) {
-        // Attribute added during the transaction — mark as reverted to absent
-        this._changedAttributes.set(name, [preRollbackValue, undefined]);
+        // Attribute added during the TX — mark as a new addition
+        this._changedAttributes.set(name, [undefined, currentValue]);
       } else {
-        const restoredValue = resolveValue(this._originalAttributes.get(name));
-        // isChanged: compare restored (pre-TX) vs pre-rollback (post-TX) value.
-        // Entry is [was=preRollback, now=restored] matching Rails' original_attribute semantics.
-        if (attr.type.isChanged(restoredValue, preRollbackValue, preRollbackValue)) {
-          this._changedAttributes.set(name, [preRollbackValue, restoredValue]);
+        const savedValue = resolveValue(this._originalAttributes.get(name));
+        // Entry: [was=savedValue (pre-TX), now=currentValue (post-TX)] — matches [was, now] convention.
+        if (attr.type.isChanged(savedValue, currentValue, currentValue)) {
+          this._changedAttributes.set(name, [savedValue, currentValue]);
         }
       }
     }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -505,6 +505,9 @@ export class Transaction {
         }
       } else {
         for (const record of ite) {
+          if (typeof (record as any).committedBang === "function") {
+            await (record as any).committedBang({ shouldRunCallbacks: false });
+          }
           this._connection.addTransactionRecord?.(record);
         }
       }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -505,9 +505,6 @@ export class Transaction {
         }
       } else {
         for (const record of ite) {
-          if (typeof (record as any).committedBang === "function") {
-            await (record as any).committedBang({ shouldRunCallbacks: false });
-          }
           this._connection.addTransactionRecord?.(record);
         }
       }

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2005,6 +2005,93 @@ describe("rememberTransactionRecordState / restoreTransactionRecordState (Story 
     });
 
     expect((topic as any)._startTransactionState).toBeNull();
+    // In-TX user edit is preserved as dirty: title rolled back to "original" but
+    // "changed-during-tx" appears as the prior ("was") value. Mirrors Rails'
+    // per-attribute original_attribute chain that survives restore.
+    expect((topic as any)._dirty.mutationsFromDatabase).toEqual({
+      title: ["changed-during-tx", "original"],
+    });
+  });
+});
+
+// ==========================================================================
+// Story K-followup regression tests
+// ==========================================================================
+describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () => {
+  it("rollback preserves in-TX user edits as dirty", async () => {
+    const { rememberTransactionRecordState, rolledbackBang } = await import("./transactions.js");
+    const { Topic } = makeSQLiteTopic();
+    const topic = new Topic({ title: "original" });
+    (topic as any)._newRecord = false;
+
+    rememberTransactionRecordState.call(topic as any);
+    (topic as any).writeAttribute("title", "tx-edit");
+
+    await rolledbackBang.call(topic as any, {
+      forceRestoreState: true,
+      shouldRunCallbacks: false,
+    });
+
+    // Attribute restored to pre-TX value
+    expect((topic as any).readAttribute("title")).toBe("original");
+    // In-TX edit preserved as dirty: was="tx-edit", now="original"
+    expect((topic as any)._dirty.attributeChanged("title")).toBe(true);
+    expect((topic as any)._dirty.attributeWas("title")).toBe("tx-edit");
+    expect((topic as any)._dirty.mutationsFromDatabase).toEqual({
+      title: ["tx-edit", "original"],
+    });
+  });
+
+  it("rollback leaves clean attributes unchanged (no spurious dirty)", async () => {
+    const { rememberTransactionRecordState, rolledbackBang } = await import("./transactions.js");
+    const { Topic } = makeSQLiteTopic();
+    const topic = new Topic({ title: "original" });
+    (topic as any)._newRecord = false;
+
+    rememberTransactionRecordState.call(topic as any);
+    // No attribute writes during TX
+
+    await rolledbackBang.call(topic as any, {
+      forceRestoreState: true,
+      shouldRunCallbacks: false,
+    });
+
+    expect((topic as any)._dirty.changed).toBe(false);
     expect((topic as any)._dirty.mutationsFromDatabase).toEqual({});
+  });
+});
+
+describe("inner savepoint committedBang (Story K-followup)", () => {
+  it("inner savepoint commit fires committedBang with shouldRunCallbacks=false", async () => {
+    const { Topic, adapter } = makeSQLiteTopic();
+
+    let committedCallCount = 0;
+    const orig = (Topic.prototype as any).committedBang;
+    (Topic.prototype as any).committedBang = async function (
+      this: typeof Topic.prototype,
+      opts?: { shouldRunCallbacks?: boolean },
+    ) {
+      committedCallCount++;
+      return orig?.call(this, opts);
+    };
+
+    const topic = await Topic.create({ title: "outer" });
+    await Topic.transaction(async () => {
+      await (topic as any).update({ title: "inner-saved" });
+      try {
+        await Topic.transaction(
+          async () => {
+            await (topic as any).update({ title: "savepoint" });
+          },
+          { requiresNew: true },
+        );
+      } catch {}
+    });
+
+    // committedBang should have been called at least once (inner savepoint fires it)
+    expect(committedCallCount).toBeGreaterThan(0);
+
+    (Topic.prototype as any).committedBang = orig;
+    adapter.close();
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2005,11 +2005,12 @@ describe("rememberTransactionRecordState / restoreTransactionRecordState (Story 
     });
 
     expect((topic as any)._startTransactionState).toBeNull();
-    // In-TX user edit is preserved as dirty: title rolled back to "original" but
-    // "changed-during-tx" appears as the prior ("was") value. Mirrors Rails'
-    // per-attribute original_attribute chain that survives restore.
+    // In-TX user edit preserved: "changed-during-tx" stays live in memory,
+    // "original" (pre-TX) is the dirty baseline. Mirrors Rails' attribute
+    // reconstruction via attr.with_value_from_user(current_value).
+    expect((topic as any).readAttribute("title")).toBe("changed-during-tx");
     expect((topic as any)._dirty.mutationsFromDatabase).toEqual({
-      title: ["changed-during-tx", "original"],
+      title: ["original", "changed-during-tx"],
     });
   });
 });
@@ -2032,13 +2033,13 @@ describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () =>
       shouldRunCallbacks: false,
     });
 
-    // Attribute restored to pre-TX value
-    expect((topic as any).readAttribute("title")).toBe("original");
-    // In-TX edit preserved as dirty: was="tx-edit", now="original"
+    // Post-TX value stays live in memory; pre-TX value becomes the dirty baseline.
+    // Mirrors Rails: attr.with_value_from_user keeps current value, pre-TX as original.
+    expect((topic as any).readAttribute("title")).toBe("tx-edit");
     expect((topic as any)._dirty.attributeChanged("title")).toBe(true);
-    expect((topic as any)._dirty.attributeWas("title")).toBe("tx-edit");
+    expect((topic as any)._dirty.attributeWas("title")).toBe("original");
     expect((topic as any)._dirty.mutationsFromDatabase).toEqual({
-      title: ["tx-edit", "original"],
+      title: ["original", "tx-edit"],
     });
   });
 
@@ -2058,40 +2059,5 @@ describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () =>
 
     expect((topic as any)._dirty.changed).toBe(false);
     expect((topic as any)._dirty.mutationsFromDatabase).toEqual({});
-  });
-});
-
-describe("inner savepoint committedBang (Story K-followup)", () => {
-  it("inner savepoint commit fires committedBang with shouldRunCallbacks=false", async () => {
-    const { Topic, adapter } = makeSQLiteTopic();
-
-    let committedCallCount = 0;
-    const orig = (Topic.prototype as any).committedBang;
-    (Topic.prototype as any).committedBang = async function (
-      this: typeof Topic.prototype,
-      opts?: { shouldRunCallbacks?: boolean },
-    ) {
-      committedCallCount++;
-      return orig?.call(this, opts);
-    };
-
-    const topic = await Topic.create({ title: "outer" });
-    await Topic.transaction(async () => {
-      await (topic as any).update({ title: "inner-saved" });
-      try {
-        await Topic.transaction(
-          async () => {
-            await (topic as any).update({ title: "savepoint" });
-          },
-          { requiresNew: true },
-        );
-      } catch {}
-    });
-
-    // committedBang should have been called at least once (inner savepoint fires it)
-    expect(committedCallCount).toBeGreaterThan(0);
-
-    (Topic.prototype as any).committedBang = orig;
-    adapter.close();
   });
 });

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -412,12 +412,10 @@ export async function rolledbackBang(
     _restoreTransactionRecordState.call(this, forceRestoreState);
     clearTransactionRecordState.call(this);
     if (forceRestoreState) {
-      // Unconditionally null _startTransactionState on full outer rollback.
-      // Inner savepoint commits don't call committedBang (records are moved
-      // to parent instead), so level can be > 1 when we reach here. Without
-      // this, clearTransactionRecordState only decrements level and leaves
-      // a stale snapshot that corrupts the next transaction's level tracking.
-      (this as any)._startTransactionState = null;
+      // Reset ephemeral per-TX flags that survive across transactions when not
+      // cleared. _startTransactionState is already null (cleared by
+      // committedBang for inner savepoints, or by clearTransactionRecordState
+      // for direct rollbacks).
       (this as any)._triggerUpdateCallback = false;
       (this as any)._triggerDestroyCallback = false;
     }
@@ -532,12 +530,10 @@ function _restoreTransactionRecordState(this: Base, forceRestoreState = false): 
     r._destroyed = state.destroyed;
     r._previouslyNewRecord = state.previouslyNewRecord;
 
-    // Restore the full attribute set to pre-transaction state. Rails preserves
-    // in-transaction user edits as dirty on top of the pre-TX baseline via a
-    // per-attribute original_attribute mechanism (restore_state[:attributes].map).
-    // Our DirtyTracker is external and can't reconstruct that per-attribute
-    // original cheaply, so we take the clean restore: the record returns to the
-    // exact pre-transaction state (no pending changes).
+    // Capture post-TX attribute values before restoring the baseline so
+    // redetectChanges can surface any in-TX user edits as dirty.
+    const currentAttrs = r._attributes;
+
     r._attributes = state.attributes.deepDup();
 
     // Restore primary key if it shifted during the transaction.
@@ -556,12 +552,14 @@ function _restoreTransactionRecordState(this: Base, forceRestoreState = false): 
       r._attributes.freeze();
     }
 
-    // Clear mutation tracking caches AFTER all attribute mutations so the
-    // baseline reflects the fully-restored _attributes. Mirrors Rails:
-    //   @mutations_from_database = nil
-    //   @mutations_before_last_save = nil
+    // Set the pre-TX state as the clean baseline, then redetect any
+    // in-TX user edits that should survive as dirty. Mirrors Rails:
+    //   @mutations_from_database = nil (via snapshot)
+    //   @mutations_before_last_save = nil (via clearChangesInformation)
+    //   in-TX edits preserved via per-attribute original_attribute (via redetectChanges)
     r._dirty.snapshot(r._attributes);
     r._dirty.clearChangesInformation();
+    r._dirty.redetectChanges(currentAttrs);
   }
 }
 

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -413,11 +413,11 @@ export async function rolledbackBang(
     clearTransactionRecordState.call(this);
     if (forceRestoreState) {
       // Force-null _startTransactionState on full outer rollback. Inner
-      // savepoint commits move records to the parent without calling
-      // committedBang (matching Rails), so the level can be > 1 here.
+      // savepoint commits move records to the parent via add_transaction_record
+      // without calling committedBang — matching Rails' commit_records else branch
+      // which skips committed! in the happy path. Level can therefore be > 1 here.
       // clearTransactionRecordState only decrements and would leave a stale
-      // snapshot — null it unconditionally on forceRestore. Mirrors Rails'
-      // rolledback! ensure block which does not attempt to track level here.
+      // snapshot — null it unconditionally on forceRestore.
       (this as any)._startTransactionState = null;
       (this as any)._triggerUpdateCallback = false;
       (this as any)._triggerDestroyCallback = false;

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -412,10 +412,13 @@ export async function rolledbackBang(
     _restoreTransactionRecordState.call(this, forceRestoreState);
     clearTransactionRecordState.call(this);
     if (forceRestoreState) {
-      // Reset ephemeral per-TX flags that survive across transactions when not
-      // cleared. _startTransactionState is already null (cleared by
-      // committedBang for inner savepoints, or by clearTransactionRecordState
-      // for direct rollbacks).
+      // Force-null _startTransactionState on full outer rollback. Inner
+      // savepoint commits move records to the parent without calling
+      // committedBang (matching Rails), so the level can be > 1 here.
+      // clearTransactionRecordState only decrements and would leave a stale
+      // snapshot — null it unconditionally on forceRestore. Mirrors Rails'
+      // rolledback! ensure block which does not attempt to track level here.
+      (this as any)._startTransactionState = null;
       (this as any)._triggerUpdateCallback = false;
       (this as any)._triggerDestroyCallback = false;
     }
@@ -530,13 +533,29 @@ function _restoreTransactionRecordState(this: Base, forceRestoreState = false): 
     r._destroyed = state.destroyed;
     r._previouslyNewRecord = state.previouslyNewRecord;
 
-    // Capture post-TX attribute values before restoring the baseline so
-    // redetectChanges can surface any in-TX user edits as dirty.
-    const currentAttrs = r._attributes;
+    // Mirrors Rails restore_transaction_record_state:
+    //   @attributes = restore_state[:attributes].map { |attr|
+    //     value = @attributes.fetch_value(attr.name)
+    //     attr = attr.with_value_from_user(value) if attr.value != value
+    //     attr }
+    //
+    // Rails keeps post-TX user edits in memory by reconstructing each attribute
+    // with the post-TX value but the pre-TX attribute as the original_attribute.
+    // Our DirtyTracker is external, so we achieve the same observable result by:
+    //   1. Setting the dirty baseline to the pre-TX snapshot values
+    //   2. Redetecting differences against the current (post-TX) r._attributes
+    //
+    // r._attributes is NOT replaced — post-TX values stay live in memory.
+    // Only the PK is explicitly restored (it is auto-assigned by the DB and
+    // is not a user edit worth preserving).
 
-    r._attributes = state.attributes.deepDup();
+    // Unfreeze in place before writing the restored PK.
+    if (r._attributes.isFrozen()) {
+      r._attributes = r._attributes.deepDup();
+    }
 
-    // Restore primary key if it shifted during the transaction.
+    // Restore primary key to the pre-TX value before redetect runs, so the
+    // PK does not appear as a spurious pending change.
     const ctor = this.constructor as typeof Base;
     if (Array.isArray(ctor.primaryKey)) {
       const cols = ctor.primaryKey as string[];
@@ -552,14 +571,11 @@ function _restoreTransactionRecordState(this: Base, forceRestoreState = false): 
       r._attributes.freeze();
     }
 
-    // Set the pre-TX state as the clean baseline, then redetect any
-    // in-TX user edits that should survive as dirty. Mirrors Rails:
-    //   @mutations_from_database = nil (via snapshot)
-    //   @mutations_before_last_save = nil (via clearChangesInformation)
-    //   in-TX edits preserved via per-attribute original_attribute (via redetectChanges)
-    r._dirty.snapshot(r._attributes);
+    // Set pre-TX snapshot as the dirty baseline, redetect in-TX edits as dirty.
+    // Mirrors Rails: @mutations_from_database = nil; @mutations_before_last_save = nil
+    r._dirty.snapshot(state.attributes);
     r._dirty.clearChangesInformation();
-    r._dirty.redetectChanges(currentAttrs);
+    r._dirty.redetectChanges(r._attributes);
   }
 }
 


### PR DESCRIPTION
## Summary

- **`DirtyTracker.redetectChanges`** (`activemodel/src/dirty.ts`): New method that re-populates `_changedAttributes` by comparing post-TX attribute values against a pre-TX snapshot baseline. Called in `_restoreTransactionRecordState` after rollback to preserve in-transaction user edits as dirty — mirroring Rails' `attr.with_value_from_user(current_value)` reconstruction in `restore_transaction_record_state`.

- **`_restoreTransactionRecordState`** (`transactions.ts`): No longer deepDup-replaces `r._attributes` with the pre-TX snapshot. Post-TX values stay live in memory (matching Rails). The pre-TX snapshot is set as the dirty baseline via `snapshot(state.attributes)`, then `redetectChanges(r._attributes)` populates `_changedAttributes` with `[preTxValue, postTxValue]` for changed attributes.

- **`commitRecords` untouched**: Rails' `commit_records` else branch (inner savepoints) only calls `add_transaction_record` — no `committed!` in the happy path. The `_startTransactionState = null` workaround in `rolledbackBang` is retained: inner savepoint commits don't null state (matching Rails), so level can be > 1 on outer rollback; the workaround ensures clean teardown.

## Test plan

- [ ] `pnpm vitest run packages/activemodel/src/dirty.test.ts` — 73 tests pass (3 new: basic string change, no-op, numeric `number_to_non_number?` via `valueBeforeTypeCast`)
- [ ] `pnpm vitest run packages/activerecord/src/transactions.test.ts` — 149 passed (2 new regression tests)
- [ ] `pnpm api:compare --package activemodel` — 620/625 (unchanged)
- [ ] `pnpm api:compare --package activerecord` — 4969/4969 (unchanged)