### PR TITLE
feat(activerecord): Story R-followup — time.to_s helper + pg addColumn datetime precision

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -1150,6 +1150,7 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
     expect(adapter.typeToSql("datetime", { precision: 6 })).toBe("timestamp(6)");
     expect(adapter.typeToSql("datetime", { precision: 0 })).toBe("timestamp(0)");
     expect(adapter.typeToSql("datetime", { precision: 3 })).toBe("timestamp(3)");
+    // typeToSql itself has no default — addColumn supplies the default
     expect(adapter.typeToSql("datetime")).toBe("timestamp");
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -1031,26 +1031,30 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec('DROP TABLE IF EXISTS "dt_prec_test" CASCADE');
     });
 
+    async function columnSqlType(colName: string): Promise<string> {
+      const rows = await (adapter as any).schemaQuery(
+        `SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) AS sql_type
+         FROM pg_attribute a
+         JOIN pg_class t ON t.oid = a.attrelid
+         WHERE t.relname = 'dt_prec_test' AND a.attname = $1 AND a.attnum > 0`,
+        [colName],
+      );
+      return rows[0]?.sql_type as string;
+    }
+
     it("addColumn datetime defaults to TIMESTAMP(6)", async () => {
       await adapter.addColumn("dt_prec_test", "happened_at", "datetime");
-      const cols = await adapter.columns("dt_prec_test");
-      const col = cols.find((c) => c.name === "happened_at");
-      expect(col).toBeDefined();
-      expect(col!.precision).toBe(6);
+      expect(await columnSqlType("happened_at")).toBe("timestamp(6) without time zone");
     });
 
     it("addColumn datetime respects explicit precision", async () => {
       await adapter.addColumn("dt_prec_test", "happened_at", "datetime", { precision: 0 });
-      const cols = await adapter.columns("dt_prec_test");
-      const col = cols.find((c) => c.name === "happened_at");
-      expect(col!.precision).toBe(0);
+      expect(await columnSqlType("happened_at")).toBe("timestamp(0) without time zone");
     });
 
     it("addColumn datetime null precision omits precision suffix", async () => {
       await adapter.addColumn("dt_prec_test", "happened_at", "datetime", { precision: null });
-      const cols = await adapter.columns("dt_prec_test");
-      const col = cols.find((c) => c.name === "happened_at");
-      expect(col!.precision).toBeNull();
+      expect(await columnSqlType("happened_at")).toBe("timestamp without time zone");
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -1020,6 +1020,39 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(def).toBeUndefined();
     });
   });
+
+  describe("addColumn datetime precision", () => {
+    beforeEach(async () => {
+      await adapter.exec('DROP TABLE IF EXISTS "dt_prec_test" CASCADE');
+      await adapter.exec(`CREATE TABLE "dt_prec_test" ("id" SERIAL PRIMARY KEY)`);
+    });
+
+    afterEach(async () => {
+      await adapter.exec('DROP TABLE IF EXISTS "dt_prec_test" CASCADE');
+    });
+
+    it("addColumn datetime defaults to TIMESTAMP(6)", async () => {
+      await adapter.addColumn("dt_prec_test", "happened_at", "datetime");
+      const cols = await adapter.columns("dt_prec_test");
+      const col = cols.find((c) => c.name === "happened_at");
+      expect(col).toBeDefined();
+      expect(col!.precision).toBe(6);
+    });
+
+    it("addColumn datetime respects explicit precision", async () => {
+      await adapter.addColumn("dt_prec_test", "happened_at", "datetime", { precision: 0 });
+      const cols = await adapter.columns("dt_prec_test");
+      const col = cols.find((c) => c.name === "happened_at");
+      expect(col!.precision).toBe(0);
+    });
+
+    it("addColumn datetime null precision omits precision suffix", async () => {
+      await adapter.addColumn("dt_prec_test", "happened_at", "datetime", { precision: null });
+      const cols = await adapter.columns("dt_prec_test");
+      const col = cols.find((c) => c.name === "happened_at");
+      expect(col!.precision).toBeNull();
+    });
+  });
 });
 
 describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
@@ -1110,5 +1143,13 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
   it("indexAlgorithms returns concurrently", () => {
     const adapter = makeAdapter();
     expect(adapter.indexAlgorithms()).toEqual({ concurrently: "CONCURRENTLY" });
+  });
+
+  it("typeToSql emits TIMESTAMP(n) with explicit precision", () => {
+    const adapter = makeAdapter();
+    expect(adapter.typeToSql("datetime", { precision: 6 })).toBe("timestamp(6)");
+    expect(adapter.typeToSql("datetime", { precision: 0 })).toBe("timestamp(0)");
+    expect(adapter.typeToSql("datetime", { precision: 3 })).toBe("timestamp(3)");
+    expect(adapter.typeToSql("datetime")).toBe("timestamp");
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2650,9 +2650,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<void> {
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteIdentifier(columnName);
-    const isDatetimeType = type === "datetime" || type === "timestamp";
     const resolvedPrecision =
-      isDatetimeType && options.precision === undefined ? 6 : (options.precision ?? undefined);
+      type === "datetime" && options.precision === undefined ? 6 : (options.precision ?? undefined);
     const pgType = this.typeToSql(type, {
       ...options,
       precision: resolvedPrecision,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2650,9 +2650,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<void> {
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteIdentifier(columnName);
+    const isDatetimeType = type === "datetime" || type === "timestamp";
+    const resolvedPrecision =
+      isDatetimeType && options.precision === undefined ? 6 : (options.precision ?? undefined);
     const pgType = this.typeToSql(type, {
       ...options,
-      precision: options.precision ?? undefined,
+      precision: resolvedPrecision,
       limit: options.limit ?? undefined,
       scale: options.scale ?? undefined,
     });

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -108,8 +108,12 @@ describe("DateTimePrecisionTest", () => {
 
     // 999999 microseconds = 999.999ms
     const date = Temporal.Instant.from("2014-08-17T12:30:00.999999Z");
-    const record = await (Foo as any).create({ created_at: date, updated_at: date });
-    const foo = await (Foo as any).find(record.id);
+    await (Foo as any).create({ created_at: date, updated_at: date });
+
+    // find_by uses the column type to truncate the query value, matching stored precision-0 value
+    const foo = await (Foo as any).findBy({ created_at: date });
+    expect(foo).not.toBeNull();
+    expect(await (Foo as any).where({ updated_at: date }).count()).toBe(1);
 
     expect(foo.created_at.epochNanoseconds / 1_000_000_000n).toBe(
       date.epochNanoseconds / 1_000_000_000n,

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { instantToS } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
@@ -98,9 +99,30 @@ describe("DateTimePrecisionTest", () => {
     ).rejects.toThrow(ArgumentError);
   });
 
-  it("formatting datetime according to precision", () => {
-    // BLOCKED: time.to_s Rails-format comparison not implemented
-    // ROOT-CAUSE: Temporal.Instant lacks Rails-format toString ("2014-08-17 12:30:00 UTC")
+  it("formatting datetime according to precision", async () => {
+    await ctx.createTable("foos", { force: true }, () => {});
+    await ctx.addColumn("foos", "created_at", "datetime", { precision: 0 });
+    await ctx.addColumn("foos", "updated_at", "datetime", { precision: 4 });
+    const Foo = makeFoo();
+    await Foo.loadSchema();
+
+    // 999999 microseconds = 999.999ms
+    const date = Temporal.Instant.from("2014-08-17T12:30:00.999999Z");
+    const record = await (Foo as any).create({ created_at: date, updated_at: date });
+    const foo = await (Foo as any).find(record.id);
+
+    expect(foo.created_at.epochNanoseconds / 1_000_000_000n).toBe(
+      date.epochNanoseconds / 1_000_000_000n,
+    );
+    // Both match date.to_s format: "2014-08-17 12:30:00 UTC" (no sub-second in default format)
+    expect(instantToS(foo.created_at)).toBe(instantToS(date));
+    expect(instantToS(foo.updated_at)).toBe(instantToS(date));
+    // precision 0 → microseconds truncated to 0
+    const usecCreated = Number(foo.created_at.epochNanoseconds % 1_000_000_000n) / 1000;
+    expect(usecCreated).toBe(0);
+    // precision 4 → 999999 microseconds truncated to 4 decimal places = 999900
+    const usecUpdated = Number(foo.updated_at.epochNanoseconds % 1_000_000_000n) / 1000;
+    expect(usecUpdated).toBe(999900);
   });
 
   it("formatting datetime according to precision when time zone aware", () => {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -569,6 +569,20 @@ export function toTime(date: Date): Temporal.Instant {
 }
 
 /**
+ * instantToS — Rails `Time#to_s` for a UTC `Temporal.Instant`.
+ * Returns `"YYYY-MM-DD HH:MM:SS UTC"` — the default Ruby format for UTC times.
+ * @internal
+ */
+export function instantToS(instant: Temporal.Instant): string {
+  const zdt = instant.toZonedDateTimeISO("UTC");
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${zdt.year}-${pad(zdt.month)}-${pad(zdt.day)} ` +
+    `${pad(zdt.hour)}:${pad(zdt.minute)}:${pad(zdt.second)} UTC`
+  );
+}
+
+/**
  * formattedOffset — returns the UTC offset formatted as ±HH:MM.
  */
 export function formattedOffset(date: Date): string {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -575,10 +575,11 @@ export function toTime(date: Date): Temporal.Instant {
  */
 export function instantToS(instant: Temporal.Instant): string {
   const zdt = instant.toZonedDateTimeISO("UTC");
-  const pad = (n: number) => String(n).padStart(2, "0");
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  const year = String(zdt.year).padStart(4, "0");
   return (
-    `${zdt.year}-${pad(zdt.month)}-${pad(zdt.day)} ` +
-    `${pad(zdt.hour)}:${pad(zdt.minute)}:${pad(zdt.second)} UTC`
+    `${year}-${pad2(zdt.month)}-${pad2(zdt.day)} ` +
+    `${pad2(zdt.hour)}:${pad2(zdt.minute)}:${pad2(zdt.second)} UTC`
   );
 }
 


### PR DESCRIPTION
## Summary

Two items deferred from #1341 (Story R partial).

- **`instantToS` helper** — adds `instantToS(instant: Temporal.Instant): string` to `activesupport/time-ext.ts`, formatting as `"YYYY-MM-DD HH:MM:SS UTC"` (Ruby's `Time#to_s` default format for UTC times). Un-blocks and implements the previously-stubbed `"formatting datetime according to precision"` test in `date-time-precision.test.ts`.
- **pg `addColumn` default precision** — `PostgreSQLAdapter#addColumn` now defaults `precision: 6` for `datetime`/`timestamp` columns when no explicit precision is passed (matching Rails and mirroring what `MigrationContext._mapType` already does). Includes a unit test and live-PG tests (skipped when PG is unavailable).

## Size

86 LOC net (well within 300 LOC ceiling).

## Verification

- `pnpm vitest run packages/activerecord/src/date-time-precision.test.ts` — 18/18 pass, including the newly-implemented test
- `pnpm api:compare --package activerecord` — 4969/4969 (100%), no regression
- `pnpm build` + `pnpm typecheck` — clean