### PR TITLE
feat(activerecord): Story M-followup — Migrator async loader + DefaultStrategy global fallback

### DIFF
--- a/packages/activerecord/src/deprecator.test.ts
+++ b/packages/activerecord/src/deprecator.test.ts
@@ -25,13 +25,13 @@ describe("MigrationProxy", () => {
     expect(proxy.basename()).toBe("20240101000000_create_users.ts");
   });
 
-  it("migration() caches the result of loadMigration()", () => {
+  it("migration() caches the result of loadMigrationAsync()", async () => {
     const proxy = new MigrationProxy("CreateUsers", "1", "/fake/path.ts", "");
     const sentinel = {};
-    const spy = vi.spyOn(proxy, "loadMigration").mockReturnValue(sentinel);
+    const spy = vi.spyOn(proxy, "loadMigrationAsync").mockResolvedValue(sentinel);
 
-    const first = proxy.migration();
-    const second = proxy.migration();
+    const first = await proxy.migration();
+    const second = await proxy.migration();
 
     expect(first).toBe(sentinel);
     expect(second).toBe(sentinel);

--- a/packages/activerecord/src/deprecator.test.ts
+++ b/packages/activerecord/src/deprecator.test.ts
@@ -25,7 +25,7 @@ describe("MigrationProxy", () => {
     expect(proxy.basename()).toBe("20240101000000_create_users.ts");
   });
 
-  it("migration() caches the result of loadMigrationAsync()", async () => {
+  it("migration() caches the result of loadMigration()", async () => {
     const proxy = new MigrationProxy("CreateUsers", "1", "/fake/path.ts", "");
     const sentinel = {};
     const spy = vi.spyOn(proxy, "loadMigrationAsync").mockResolvedValue(sentinel);

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -102,12 +102,8 @@ export class MigrationProxy {
 
   /**
    * @internal
-   * ESM-capable loader. The sync `loadMigration()` / `migration()` path is
-   * retained for backward compatibility; wiring this into Migrator would
-   * require making `MigrationProxy.migration()` async, cascading to the
-   * `MigrationProxy` interface in migration.ts. In practice, the trailties
-   * migration-loader already uses `import(pathToFileURL(...))` so ESM
-   * migrations are handled before they reach this class.
+   * ESM-capable loader. Falls through to `require()` for CJS migrations and
+   * uses `import(pathToFileURL(...))` for ESM files (ERR_REQUIRE_ESM).
    */
   async loadMigrationAsync(): Promise<object> {
     try {

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -74,9 +74,9 @@ export class MigrationProxy {
   }
 
   get disableDdlTransaction(): boolean {
-    // Callers must await migration() before reading this; _migration is
-    // populated by that call and the cached value is accessed synchronously here.
-    return !!(this._migration as { disableDdlTransaction?: boolean } | null)?.disableDdlTransaction;
+    if (!this._migration)
+      throw new Error("MigrationProxy: await migration() before reading disableDdlTransaction");
+    return !!(this._migration as { disableDdlTransaction?: boolean }).disableDdlTransaction;
   }
 
   /** @internal */

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -74,8 +74,8 @@ export class MigrationProxy {
   }
 
   get disableDdlTransaction(): boolean {
-    // _migration is populated by migration() before this is called in
-    // _runMigration; accessing the cached value synchronously is safe.
+    // Callers must await migration() before reading this; _migration is
+    // populated by that call and the cached value is accessed synchronously here.
     return !!(this._migration as { disableDdlTransaction?: boolean } | null)?.disableDdlTransaction;
   }
 

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -59,25 +59,29 @@ export class MigrationProxy {
     return getPath().basename(this.filename);
   }
 
-  migrate(direction: "up" | "down"): Promise<void> {
-    return (this.migration() as { migrate(d: "up" | "down"): Promise<void> }).migrate(direction);
+  async migrate(direction: "up" | "down"): Promise<void> {
+    return ((await this.migration()) as { migrate(d: "up" | "down"): Promise<void> }).migrate(
+      direction,
+    );
   }
 
-  announce(message: string): void {
-    (this.migration() as { announce(msg: string): void }).announce(message);
+  async announce(message: string): Promise<void> {
+    ((await this.migration()) as { announce(msg: string): void }).announce(message);
   }
 
-  write(text = ""): void {
-    (this.migration() as { write(t: string): void }).write(text);
+  async write(text = ""): Promise<void> {
+    ((await this.migration()) as { write(t: string): void }).write(text);
   }
 
   get disableDdlTransaction(): boolean {
-    return !!(this.migration() as { disableDdlTransaction?: boolean }).disableDdlTransaction;
+    // _migration is populated by migration() before this is called in
+    // _runMigration; accessing the cached value synchronously is safe.
+    return !!(this._migration as { disableDdlTransaction?: boolean } | null)?.disableDdlTransaction;
   }
 
   /** @internal */
-  migration(): object {
-    this._migration ??= this.loadMigration();
+  async migration(): Promise<object> {
+    this._migration ??= await this.loadMigrationAsync();
     return this._migration;
   }
 

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -47,6 +47,7 @@ export class MigrationProxy {
   scope: string;
 
   private _migration: object | null = null;
+  private _migrationPromise: Promise<object> | null = null;
 
   constructor(name: string, version: string, filename: string, scope: string) {
     this.name = name;
@@ -80,9 +81,9 @@ export class MigrationProxy {
   }
 
   /** @internal */
-  async migration(): Promise<object> {
-    this._migration ??= await this.loadMigrationAsync();
-    return this._migration;
+  migration(): Promise<object> {
+    this._migrationPromise ??= this.loadMigrationAsync().then((m) => (this._migration = m));
+    return this._migrationPromise;
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1190,6 +1190,20 @@ describe("MigrationTest", () => {
     expect(pendingAfter.length).toBe(3);
   });
 
+  it("migration context with async migration() proxy", async () => {
+    const adapter = createTestAdapter();
+    const migrations: MigrationProxy[] = [
+      {
+        version: "1",
+        name: "AsyncFirst",
+        migration: async () => ({ up: async () => {}, down: async () => {} }),
+      },
+    ];
+    const migrator = new Migrator(adapter, migrations);
+    await migrator.up();
+    expect(await migrator.currentVersion()).toBe(1);
+  });
+
   it("migrator versions", async () => {
     const adapter = createTestAdapter();
     const migrations: MigrationProxy[] = [

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1552,7 +1552,7 @@ export interface MigrationProxy {
   version: string;
   name: string;
   filename?: string;
-  migration: () => MigrationLike;
+  migration: () => MigrationLike | Promise<MigrationLike>;
 }
 
 export class Migrator {
@@ -2103,7 +2103,7 @@ export class Migrator {
       Migration.logger.info(`== ${proxy.version} ${proxy.name}: ${action} ==`);
     }
 
-    const migration = proxy.migration();
+    const migration = await proxy.migration();
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -30,30 +30,12 @@ export class DefaultStrategy extends ExecutionStrategy {
 
   /** @internal */
   connection(): DatabaseAdapter {
-    // Mirrors Rails: DefaultStrategy#connection → migration.connection →
-    //   @connection || DatabaseTasks.migration_connection.
-    // migration.connection is the per-migration override; _adapter is the
-    // global migration connection passed to exec(). Per-migration wins,
-    // then global exec() connection, then DatabaseTasks.migrationConnection().
-    const conn =
-      (this.migration as MigrationLike | null)?.connection ??
-      this._adapter ??
-      this._migrationConnectionFallback();
-    if (!conn) throw new Error("DefaultStrategy: no adapter available");
+    // Mirrors Rails: DefaultStrategy#connection → migration.connection.
+    // Migration#connection in Rails returns @connection || DatabaseTasks.migration_connection,
+    // so the global fallback lives on the migration, not here.
+    const conn = (this.migration as MigrationLike | null)?.connection ?? this._adapter;
+    if (!conn)
+      throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
     return conn;
-  }
-
-  private _migrationConnectionFallback(): DatabaseAdapter | null {
-    // Lazy import to avoid a circular dep: database-tasks.ts → migration.ts →
-    // default-strategy.ts → database-tasks.ts.
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { DatabaseTasks } = require("../tasks/database-tasks.js") as {
-        DatabaseTasks: { migrationConnection(): DatabaseAdapter | null };
-      };
-      return DatabaseTasks.migrationConnection();
-    } catch {
-      return null;
-    }
   }
 }

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -31,8 +31,7 @@ export class DefaultStrategy extends ExecutionStrategy {
   /** @internal */
   connection(): DatabaseAdapter {
     // Mirrors Rails: DefaultStrategy#connection → migration.connection.
-    // Migration#connection in Rails returns @connection || DatabaseTasks.migration_connection,
-    // so the global fallback lives on the migration, not here.
+    // _adapter is our exec()-time fallback; per-migration connection wins.
     const conn = (this.migration as MigrationLike | null)?.connection ?? this._adapter;
     if (!conn)
       throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -32,14 +32,28 @@ export class DefaultStrategy extends ExecutionStrategy {
   connection(): DatabaseAdapter {
     // Mirrors Rails: DefaultStrategy#connection → migration.connection →
     //   @connection || DatabaseTasks.migration_connection.
-    // migration.connection is the per-migration override (@connection); _adapter
-    // is the global migration connection passed to exec(). Per-migration wins.
-    return (
+    // migration.connection is the per-migration override; _adapter is the
+    // global migration connection passed to exec(). Per-migration wins,
+    // then global exec() connection, then DatabaseTasks.migrationConnection().
+    const conn =
       (this.migration as MigrationLike | null)?.connection ??
       this._adapter ??
-      (() => {
-        throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
-      })()
-    );
+      this._migrationConnectionFallback();
+    if (!conn) throw new Error("DefaultStrategy: no adapter available");
+    return conn;
+  }
+
+  private _migrationConnectionFallback(): DatabaseAdapter | null {
+    // Lazy import to avoid a circular dep: database-tasks.ts → migration.ts →
+    // default-strategy.ts → database-tasks.ts.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { DatabaseTasks } = require("../tasks/database-tasks.js") as {
+        DatabaseTasks: { migrationConnection(): DatabaseAdapter | null };
+      };
+      return DatabaseTasks.migrationConnection();
+    } catch {
+      return null;
+    }
   }
 }

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -72,7 +72,7 @@ function discoverMigrations(
                   `Migration ${match![1]} from ${file.path} did not register after execution`,
                 );
               }
-              await reg.migration().up(adapter);
+              await (await reg.migration()).up(adapter);
             },
             async down(adapter) {
               const content = vfs.read(file.path)?.content;
@@ -84,7 +84,7 @@ function discoverMigrations(
                   `Migration ${match![1]} from ${file.path} did not register after execution`,
                 );
               }
-              await reg.migration().down(adapter);
+              await (await reg.migration()).down(adapter);
             },
           }),
         },


### PR DESCRIPTION
## Summary

Three follow-ups from #1350 (Story M small leftovers). Items 1 and 2 are implemented here; item 3 is deferred.

**Item 1 — \`MigrationProxy.migration()\` async + ESM loader**

\`MigrationProxy.migration()\` now returns \`Promise<MigrationLike>\`, enabling \`MigrationLoader.migration()\` to call \`loadMigrationAsync()\`. This routes ESM migration files through \`import()\` (via \`pathToFileURL\`) instead of \`require()\`, which would throw \`ERR_REQUIRE_ESM\`. \`Migrator._runMigration\` now \`await\`s the result. The \`MigrationProxy\` interface in \`migration.ts\` is widened to \`() => MigrationLike | Promise<MigrationLike>\` — existing sync mocks remain valid.

**Item 2 — \`DefaultStrategy.connection()\` aligned with Rails**

Rails \`DefaultStrategy#connection\` simply delegates to \`migration.connection\` (migration/default_strategy.rb). Our implementation now matches: reads \`migration.connection ?? _adapter\` and throws if neither is set. The \`_adapter\` field is populated by \`exec()\` and serves as the exec-time fallback (Rails gets this from the connection pool implicitly). The \`DatabaseTasks.migration_connection\` fallback in Rails lives on \`Migration#connection\`, not on \`DefaultStrategy\`.

**Item 3 — \`SqlJsAdapter\` interface gap (deferred)**

\`packages/website/src/lib/frontiers/sql-js-adapter.ts\` has \`adapterName: "SQLite"\` (not a valid \`AdapterName\` literal) and is missing many required \`DatabaseAdapter\` methods. A full fix requires either a complete adapter implementation or a narrower internal interface — too large for this PR. Tracked for a future slot.