### PR TITLE
feat(activerecord): tiny followups bundle — 4 items (~54 LOC)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -30,15 +30,16 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    it.skip("no automatic reconnection after timeout", () => {
-      // BLOCKED: pool model limitation — with connectionLimit > 1, mysql2 Pool
-      // can transparently create a new connection when getConnection() is called
-      // after a server-side wait_timeout, so activeAsync() may ping a fresh
-      // socket and return true. Rails pings a single raw connection (mysql_ping)
-      // and can directly observe the dead socket. The timeout-without-reconnect
-      // path is only testable with connectionLimit:1 (see the reconnect tests
-      // below) and is covered there via the positive reconnect assertions.
-    });
+    it("no automatic reconnection after timeout", async () => {
+      const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
+      try {
+        await singleConn.execute("SET SESSION wait_timeout = 1");
+        await new Promise((r) => setTimeout(r, 2000));
+        expect(await singleConn.activeAsync()).toBe(false);
+      } finally {
+        await singleConn.close();
+      }
+    }, 10_000);
     it("successful reconnection after timeout with manual reconnect", async () => {
       // Use connectionLimit: 1 so SET SESSION wait_timeout and the sleep share
       // the same physical connection — otherwise a second pool connection with

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -30,16 +30,12 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    it("no automatic reconnection after timeout", async () => {
-      const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
-      try {
-        await singleConn.execute("SET SESSION wait_timeout = 1");
-        await new Promise((r) => setTimeout(r, 2000));
-        expect(await singleConn.activeAsync()).toBe(false);
-      } finally {
-        await singleConn.close();
-      }
-    }, 10_000);
+    it.skip("no automatic reconnection after timeout", () => {
+      // BLOCKED: MariaDB reconnects transparently at the driver level even with
+      // connectionLimit:1, so activeAsync() returns true after wait_timeout.
+      // MySQL exposes the dead socket correctly but the CI also runs MariaDB,
+      // making this assertion non-deterministic across engines.
+    });
     it("successful reconnection after timeout with manual reconnect", async () => {
       // Use connectionLimit: 1 so SET SESSION wait_timeout and the sleep share
       // the same physical connection — otherwise a second pool connection with

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts
@@ -10,7 +10,7 @@ describe("PostgreSQL::OID::Jsonb", () => {
 
   it("cast parses JSON strings", () => {
     const t = new Jsonb();
-    expect(t.cast('{"a":1}')).toEqual({ a: 1 });
+    expect(t.cast('{"a":1}')).toEqual('{"a":1}');
     expect(t.cast({ a: 1 })).toEqual({ a: 1 });
     expect(t.cast(null)).toBeNull();
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
@@ -1,12 +1,5 @@
 /**
- * PostgreSQL jsonb type — binary JSON storage.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb.
- * Rails: `class Jsonb < Type::Json; include Helpers::Mutable`. Overrides
- * `type` to return :jsonb; `name` is also set to "jsonb" (Trails-specific
- * property). `cast` parses JSON strings directly and round-trips non-string
- * values through serialize for reference detachment; `isMutable` and
- * `isChangedInPlace` come from MutableModule.
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb
  */
 
 import { MutableModule } from "@blazetrails/activemodel";
@@ -18,12 +11,6 @@ export class Jsonb extends Json {
 
   override type(): string {
     return "jsonb";
-  }
-
-  override cast(value: unknown): unknown {
-    if (value === null || value === undefined) return null;
-    if (typeof value === "string") return super.cast(value);
-    return super.cast(this.serialize(value));
   }
 }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2731,15 +2731,7 @@ export class Relation<T extends Base> {
         const def = this._modelClass._attributeDefinitions.get(key);
         const isArray = def?.type?.name === "array";
         if (isArray) return [table.get(key), def!.type!.serialize(val)];
-        const dbVal =
-          val instanceof Temporal.Instant ||
-          val instanceof Temporal.PlainDateTime ||
-          val instanceof Temporal.PlainDate ||
-          val instanceof Temporal.PlainTime ||
-          val instanceof Temporal.ZonedDateTime
-            ? (def?.type?.serialize?.(val) ?? val)
-            : val;
-        return [table.get(key), dbVal];
+        return [table.get(key), val];
       },
     );
     const um = new UpdateManager().table(table).set(updateValues);

--- a/packages/activerecord/src/type/json.test.ts
+++ b/packages/activerecord/src/type/json.test.ts
@@ -17,7 +17,11 @@ describe("Json", () => {
   });
 
   it("cast parses string input", () => {
-    expect(type.cast('{"a":1}')).toEqual({ a: 1 });
+    expect(type.cast('{"a":1}')).toEqual('{"a":1}');
+  });
+
+  it("cast round-trips non-JSON string without returning null", () => {
+    expect(type.cast("foo")).toBe("foo");
   });
 
   it("cast returns null for null or undefined", () => {

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -27,13 +27,6 @@ export class Json extends ValueType<unknown> {
 
   cast(value: unknown): unknown {
     if (value === null || value === undefined) return null;
-    if (typeof value === "string") {
-      try {
-        return JSON.parse(value);
-      } catch {
-        return null;
-      }
-    }
     return this.deserialize(this.serialize(value));
   }
 

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -48,4 +48,8 @@ describe("quoteArrayLiteral", () => {
     const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
     expect(quoteArrayLiteral([obj])).toBe('{"2026-01-01T00:00:00Z"}');
   });
+
+  it("handles bigint values inside objects", () => {
+    expect(quoteArrayLiteral([{ id: 42n }])).toBe('{"{\\"id\\":\\"42\\"}"}');
+  });
 });

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -24,11 +24,9 @@ export function quoteArrayLiteral(arr: unknown[]): string {
     }
     let str: string;
     if (typeof v === "object" && v !== null) {
-      try {
-        str = JSON.stringify(v);
-      } catch {
-        str = String(v);
-      }
+      const replacer = (_k: string, val: unknown) =>
+        typeof val === "bigint" ? val.toString() : val;
+      str = JSON.stringify(v, replacer) ?? String(v);
     } else {
       str = String(v);
     }

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -26,7 +26,11 @@ export function quoteArrayLiteral(arr: unknown[]): string {
     if (typeof v === "object" && v !== null) {
       const replacer = (_k: string, val: unknown) =>
         typeof val === "bigint" ? val.toString() : val;
-      str = JSON.stringify(v, replacer) ?? String(v);
+      try {
+        str = JSON.stringify(v, replacer) ?? String(v);
+      } catch {
+        str = String(v);
+      }
     } else {
       str = String(v);
     }


### PR DESCRIPTION
## Summary

- **Arel-Q-cleanup-2**: Drop redundant Temporal pre-serialize in \`updateAll\` — \`connection.quote()\` handles Temporal via \`abstractQuote\` since #1340; 9 LOC deleted from the mapping loop.
- **E3-followup**: \`Json.cast\` string-path uniformity — drop the special string branch so all inputs flow through \`deserialize(serialize(value))\`, matching Rails' \`Mutable#cast\`. Non-JSON strings now round-trip to themselves instead of returning \`null\`. Also removes the compensating \`Jsonb.cast\` override (Rails \`Jsonb\` only overrides \`type\`).
- **O-followup**: \`quoteArrayLiteral\` bigint-in-object — use a \`bigint\`-replacer inside the existing try/catch (same pattern as #1352), so \`{ id: 42n }\` serializes correctly instead of emitting \`[object Object]\`.
- **G-followup (re-skipped)**: \`no automatic reconnection after timeout\` remains skipped. \`connectionLimit: 1\` works on MySQL but MariaDB reconnects transparently at the driver level so \`activeAsync()\` returns \`true\` after wait_timeout — non-deterministic across CI engines. Skip comment updated with the accurate blocker.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/relation.test.ts\` — \`updateAll\` tests pass
- [x] \`pnpm vitest run packages/activerecord/src/type/json.test.ts\` — new round-trip assertion passes
- [x] \`pnpm vitest run packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.test.ts\` — all 7 pass
- [x] \`pnpm vitest run packages/arel/src/quote-array.test.ts\` — new bigint-in-object assertion passes
- [x] \`pnpm api:compare --package activerecord\` — 4969/4969 (no regression)
- [x] \`pnpm api:compare --package arel\` — 884/884 (no regression)