### PR TITLE
feat(activerecord): Story D-followup — realTypeUnlessAliased datetime_type aliasing

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -33,7 +33,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const cols = await adapter.columns("postgresql_timestamps");
       const col = cols.find((c) => c.name === "created_at");
       expect(col).toBeDefined();
-      expect(col!.type).toBe("timestamp");
+      expect(col!.type).toBe("datetime");
       expect(col!.sqlType).toBe("timestamp without time zone");
     });
 
@@ -67,7 +67,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const cols = await adapter.columns("postgresql_timestamps");
       const col = cols.find((c) => c.name === "precise_at");
       expect(col).toBeDefined();
-      expect(col!.type).toContain("timestamp");
+      expect(col!.type).toBe("datetime");
     });
 
     it("timestamp infinity", async () => {
@@ -102,7 +102,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const cols = await adapter.columns("postgresql_timestamps");
       const col = cols.find((c) => c.name === "created_at");
       expect(col).toBeDefined();
-      expect(col!.type).toContain("timestamp");
+      expect(col!.type).toBe("datetime");
     });
 
     it("datetime default", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -996,7 +996,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       expect(def).toBeDefined();
       expect(def!.column.name).toBe("created_at");
-      expect(def!.column.type).toMatch(/timestamp/i);
+      expect(def!.column.type).toBe("datetime");
       expect(def!.column.sqlType).toMatch(/timestamp/i);
     });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -177,7 +177,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Proxied through pgDatetimeConfig so OID::DateTime.realTypeUnlessAliased can read
   // the current value without creating a circular import.
   static get datetimeType(): "timestamp" | "timestamptz" {
-    return pgDatetimeConfig.datetimeType as "timestamp" | "timestamptz";
+    return pgDatetimeConfig.datetimeType;
   }
   static set datetimeType(v: "timestamp" | "timestamptz") {
     pgDatetimeConfig.datetimeType = v;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -79,6 +79,7 @@ import {
 } from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
+import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -172,9 +173,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     enum: {},
   };
 
-  // Mirrors: PostgreSQLAdapter.datetime_type class_attribute (postgresql_adapter.rb:123)
-  // Default :timestamp; can be changed to :timestamptz to store timezone info.
-  static datetimeType: "timestamp" | "timestamptz" = "timestamp";
+  // Mirrors: PostgreSQLAdapter.datetime_type class_attribute (postgresql_adapter.rb:123).
+  // Proxied through pgDatetimeConfig so OID::DateTime.realTypeUnlessAliased can read
+  // the current value without creating a circular import.
+  static get datetimeType(): "timestamp" | "timestamptz" {
+    return pgDatetimeConfig.datetimeType as "timestamp" | "timestamptz";
+  }
+  static set datetimeType(v: "timestamp" | "timestamptz") {
+    pgDatetimeConfig.datetimeType = v;
+  }
 
   // Mirrors: PostgreSQLAdapter.create_unlogged_tables class_attribute (postgresql_adapter.rb:105).
   // Pass this value as `unlogged` when constructing a PostgreSQL TableDefinition.

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -86,7 +86,7 @@ describe("PostgreSQL::OID::Timestamp", () => {
   it("extends OID::DateTime and reports :timestamp", () => {
     const type = new Timestamp();
     expect(type).toBeInstanceOf(DateTime);
-    expect(type.type()).toBe("timestamp");
+    expect(type.type()).toBe("datetime");
   });
 
   it("inherits infinity + BC handling from OID::DateTime", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -15,6 +15,7 @@
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateTimeType } from "@blazetrails/activemodel";
+import { pgDatetimeConfig } from "../pg-datetime-config.js";
 import {
   DateInfinity,
   DateNegativeInfinity,
@@ -89,13 +90,12 @@ export class DateTime extends DateTimeType {
   }
 
   /**
-   * Rails' `real_type_unless_aliased` — Timestamp / TimestampWithTimeZone
-   * call this to return `:datetime` when the adapter's datetime_type
-   * matches `real_type`, else `real_type` itself. We don't yet have a
-   * per-adapter datetime_type setting so always return the real type,
-   * matching Rails' default when nothing is aliased.
+   * Mirrors: PostgreSQL::OID::DateTime#real_type_unless_aliased.
+   * Returns "datetime" when the adapter's datetime_type is aliased to
+   * real_type (i.e. real_type IS the storage type for datetime), else
+   * returns real_type unchanged.
    */
   protected realTypeUnlessAliased(realType: string): string {
-    return realType;
+    return pgDatetimeConfig.datetimeType === realType ? "datetime" : realType;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/pg-datetime-config.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/pg-datetime-config.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared mutable reference to PostgreSQLAdapter.datetimeType.
+ * Mirrors: PostgreSQLAdapter.datetime_type class_attribute (default: :timestamp).
+ * Stored here to break the circular import that would arise if OID::DateTime
+ * imported PostgreSQLAdapter directly.
+ *
+ * @internal
+ */
+export const pgDatetimeConfig = {
+  datetimeType: "timestamp" as string,
+};

--- a/packages/activerecord/src/connection-adapters/postgresql/pg-datetime-config.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/pg-datetime-config.ts
@@ -7,5 +7,5 @@
  * @internal
  */
 export const pgDatetimeConfig = {
-  datetimeType: "timestamp" as string,
+  datetimeType: "timestamp" as "timestamp" | "timestamptz",
 };


### PR DESCRIPTION
## Summary

- Implements `real_type_unless_aliased` in `PostgreSQL::OID::DateTime` so `Timestamp#type()` returns `"datetime"` (Rails-correct) instead of `"timestamp"`
- `PostgreSQLAdapter.datetimeType` (default `"timestamp"`) now proxies through a shared `pgDatetimeConfig` object, breaking the circular import that would arise if `OID::DateTime` imported `PostgreSQLAdapter` directly
- Updates 5 test assertions that were checking `"timestamp"` (the pre-feature value) to `"datetime"` (Rails-correct); test names unchanged

## Rails reference

`PostgreSQL::OID::DateTime#real_type_unless_aliased(real_type)` in `postgresql/oid/date_time.rb`:
```ruby
def real_type_unless_aliased(real_type)
  PostgreSQLAdapter.datetime_type == real_type ? :datetime : real_type
end
```

With default `datetime_type = :timestamp`, `Timestamp#type` → `realTypeUnlessAliased("timestamp")` → `"datetime"`.

## Verification

- `pnpm vitest run packages/activerecord/` — 10694 passed, 0 failed
- `pnpm api:compare --package activerecord` — 4969/4969 (100%), no regression
- Diff: 32 additions, 14 deletions (well under 300-LOC ceiling)