### PR TITLE
feat(activerecord): followups bundle — MariaDB-detect helper + withPostgresqlDatetimeType + Json.cast integration tests (~97 LOC)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -4,12 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationEvent } from "@blazetrails/activesupport";
-import {
-  describeIfMysql,
-  describeIfMysqlOnly,
-  Mysql2Adapter,
-  MYSQL_TEST_URL,
-} from "./test-helper.js";
+import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { NoDatabaseError, DatabaseVersionError } from "../../errors.js";
 
 describeIfMysql("Mysql2Adapter", () => {
@@ -35,8 +30,9 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    describeIfMysqlOnly("no automatic reconnection after timeout", () => {
-      it("no automatic reconnection after timeout", async () => {
+    it.skipIf(isMariaDb)(
+      "no automatic reconnection after timeout",
+      async () => {
         const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
         try {
           expect(await singleConn.activeAsync()).toBe(true);
@@ -46,8 +42,9 @@ describeIfMysql("Mysql2Adapter", () => {
         } finally {
           await singleConn.close();
         }
-      }, 10_000);
-    });
+      },
+      10_000,
+    );
     it("successful reconnection after timeout with manual reconnect", async () => {
       // Use connectionLimit: 1 so SET SESSION wait_timeout and the sleep share
       // the same physical connection — otherwise a second pool connection with

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -4,7 +4,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationEvent } from "@blazetrails/activesupport";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysql,
+  describeIfMysqlOnly,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 import { NoDatabaseError, DatabaseVersionError } from "../../errors.js";
 
 describeIfMysql("Mysql2Adapter", () => {
@@ -30,11 +35,18 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    it.skip("no automatic reconnection after timeout", () => {
-      // BLOCKED: MariaDB reconnects transparently at the driver level even with
-      // connectionLimit:1, so activeAsync() returns true after wait_timeout.
-      // MySQL exposes the dead socket correctly but the CI also runs MariaDB,
-      // making this assertion non-deterministic across engines.
+    describeIfMysqlOnly("no automatic reconnection after timeout", () => {
+      it("no automatic reconnection after timeout", async () => {
+        const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
+        try {
+          expect(await singleConn.activeAsync()).toBe(true);
+          await singleConn.execute("SET SESSION wait_timeout=1");
+          await new Promise((r) => setTimeout(r, 2000));
+          expect(await singleConn.activeAsync()).toBe(false);
+        } finally {
+          await singleConn.close();
+        }
+      }, 10_000);
     });
     it("successful reconnection after timeout with manual reconnect", async () => {
       // Use connectionLimit: 1 so SET SESSION wait_timeout and the sleep share

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -18,7 +18,7 @@ async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }>
   } catch {
     return { available: false, isMariaDb: false };
   } finally {
-    await conn?.end();
+    await conn?.end().catch(() => {});
   }
 }
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -25,7 +25,6 @@ async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }>
 ({ available: mysqlAvailable, isMariaDb: mariaDb } = await checkMysql());
 
 export const describeIfMysql = mysqlAvailable ? describe : (describe.skip as typeof describe);
-/** Gates a suite to MySQL only — skips when the server is MariaDB. */
-export const describeIfMysqlOnly =
-  mysqlAvailable && !mariaDb ? describe : (describe.skip as typeof describe);
+/** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
+export const isMariaDb = mariaDb;
 export { Mysql2Adapter };

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -9,14 +9,16 @@ let mysqlAvailable = false;
 let mariaDb = false;
 
 async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }> {
+  let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {
-    const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
+    conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
     const [rows] = await conn.query("SELECT VERSION() AS v");
     const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
-    await conn.end();
     return { available: true, isMariaDb: /mariadb/i.test(ver) };
   } catch {
     return { available: false, isMariaDb: false };
+  } finally {
+    await conn?.end();
   }
 }
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -11,10 +11,10 @@ let mariaDb = false;
 async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }> {
   try {
     const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
-    const [rows] = await conn.query("SELECT @@version_comment AS comment");
-    const comment = (rows as Array<{ comment: string }>)[0]?.comment ?? "";
+    const [rows] = await conn.query("SELECT VERSION() AS v");
+    const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
     await conn.end();
-    return { available: true, isMariaDb: /MariaDB/i.test(comment) };
+    return { available: true, isMariaDb: /mariadb/i.test(ver) };
   } catch {
     return { available: false, isMariaDb: false };
   }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -6,19 +6,24 @@ export const MYSQL_TEST_URL =
   process.env.MYSQL_TEST_URL ?? "mysql://root@localhost:3306/rails_js_test";
 
 let mysqlAvailable = false;
+let mariaDb = false;
 
-async function checkMysql(): Promise<boolean> {
+async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }> {
   try {
     const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
-    await conn.query("SELECT 1");
+    const [rows] = await conn.query("SELECT @@version_comment AS comment");
+    const comment = (rows as Array<{ comment: string }>)[0]?.comment ?? "";
     await conn.end();
-    return true;
+    return { available: true, isMariaDb: /MariaDB/i.test(comment) };
   } catch {
-    return false;
+    return { available: false, isMariaDb: false };
   }
 }
 
-mysqlAvailable = await checkMysql();
+({ available: mysqlAvailable, isMariaDb: mariaDb } = await checkMysql());
 
 export const describeIfMysql = mysqlAvailable ? describe : (describe.skip as typeof describe);
+/** Gates a suite to MySQL only — skips when the server is MariaDB. */
+export const describeIfMysqlOnly =
+  mysqlAvailable && !mariaDb ? describe : (describe.skip as typeof describe);
 export { Mysql2Adapter };

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -19,22 +19,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlJsonTest", () => {
-    it("json string cast round-trip", async () => {
-      const { Base } = await import("../../index.js");
-      class JsonStringCast extends Base {
-        static {
-          this.tableName = "json_test";
-        }
-      }
-      JsonStringCast.adapter = adapter;
-      await JsonStringCast.loadSchema();
-      const record = new JsonStringCast();
-      (record as any).settings = '{"a":1}';
-      await record.save();
-      await record.reload();
-      expect((record as any).settings).toBe('{"a":1}');
-    });
-
     it("json column", async () => {
       const obj = { foo: "bar", baz: 123 };
       await adapter.executeMutation(`INSERT INTO "json_test" ("settings", "name") VALUES (?, ?)`, [

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -19,6 +19,22 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlJsonTest", () => {
+    it("json string cast round-trip", async () => {
+      const { Base } = await import("../../index.js");
+      class JsonStringCast extends Base {
+        static {
+          this.tableName = "json_test";
+        }
+      }
+      JsonStringCast.adapter = adapter;
+      await JsonStringCast.loadSchema();
+      const record = new JsonStringCast();
+      (record as any).settings = '{"a":1}';
+      await record.save();
+      await record.reload();
+      expect((record as any).settings).toBe('{"a":1}');
+    });
+
     it("json column", async () => {
       const obj = { foo: "bar", baz: 123 };
       await adapter.executeMutation(`INSERT INTO "json_test" ("settings", "name") VALUES (?, ?)`, [

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -25,7 +25,7 @@ export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof de
 /** Mirrors Rails' with_postgresql_datetime_type — temporarily changes the adapter's datetimeType. */
 export async function withPostgresqlDatetimeType<T>(
   type: "timestamp" | "timestamptz",
-  fn: () => Promise<T>,
+  fn: () => T | Promise<T>,
 ): Promise<T> {
   const original = PostgreSQLAdapter.datetimeType;
   PostgreSQLAdapter.datetimeType = type;

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -21,4 +21,19 @@ async function checkPg(): Promise<boolean> {
 pgAvailable = await checkPg();
 
 export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);
+
+/** Mirrors Rails' with_postgresql_datetime_type — temporarily changes the adapter's datetimeType. */
+export async function withPostgresqlDatetimeType<T>(
+  type: "timestamp" | "timestamptz",
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = PostgreSQLAdapter.datetimeType;
+  PostgreSQLAdapter.datetimeType = type;
+  try {
+    return await fn();
+  } finally {
+    PostgreSQLAdapter.datetimeType = original;
+  }
+}
+
 export { PostgreSQLAdapter };

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -287,8 +287,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("adds column as timestamptz if datetime type changed", async () => {
       await withPostgresqlDatetimeType("timestamptz", async () => {
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
-        await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
         try {
+          await adapter.exec(
+            `CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`,
+          );
           await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
           const rows = await adapter.execute(
             `SELECT data_type FROM information_schema.columns

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -4,7 +4,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import {
+  describeIfPg,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+  withPostgresqlDatetimeType,
+} from "./test-helper.js";
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 import { DateTime as OidDateTime } from "../../connection-adapters/postgresql/oid/date-time.js";
 
@@ -161,15 +166,15 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLTimestampWithTimeZoneTest", () => {
     it.skip("timestamp with zone values with rails time zone support and timestamptz and no time zone set", () => {
-      // BLOCKED: adapter-pg — with_postgresql_datetime_type(:timestamptz) not wired
-      // ROOT-CAUSE: Rails' with_postgresql_datetime_type helper temporarily changes the
-      // adapter-level datetime_type class attribute; our adapter has datetimeType static
-      // but no mechanism to change it per-connection for the duration of a block.
-      // SCOPE: ~30 LOC test helper + datetimeType scoping in postgresql-adapter.ts.
+      // BLOCKED: adapter-pg — aware_attributes / aware_types routing not implemented.
+      // withPostgresqlDatetimeType is now wired (see test-helper.ts); the remaining
+      // blocker is with_timezone_config(aware_attributes: true, aware_types: [...]),
+      // which routes timestamptz columns through TimeWithZone instead of Temporal.Instant.
+      // SCOPE: ~150 LOC — TimeWithZone class + OID::TimestampWithTimeZone routing.
     });
     it.skip("timestamp with zone values with rails time zone support and timestamptz and time zone set", () => {
-      // BLOCKED: adapter-pg — same as above; additionally requires TimeWithZone wrapping.
-      // ROOT-CAUSE: Same as the two prior timezone tests combined.
+      // BLOCKED: adapter-pg — same as above; additionally requires per-connection timezone
+      // config (zone: "Pacific Time (US & Canada)") and TimeWithZone wrapping.
       // SCOPE: Same as above.
     });
   });
@@ -280,25 +285,17 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("adds column as timestamptz if datetime type changed", async () => {
-      class TimestamptzAdapter extends PostgreSQLAdapter {
-        static override datetimeType: "timestamp" | "timestamptz" = "timestamptz";
-      }
-      const tzAdapter = new TimestamptzAdapter(PG_TEST_URL);
-      try {
-        await tzAdapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
-        await tzAdapter.exec(
-          `CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`,
-        );
-        await tzAdapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
-        const rows = await tzAdapter.execute(
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
+        await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
+        const rows = await adapter.execute(
           `SELECT data_type FROM information_schema.columns
            WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
         );
         expect(rows[0]?.data_type).toBe("timestamp with time zone");
-      } finally {
-        await tzAdapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
-        await tzAdapter.close();
-      }
+        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+      });
     });
 
     it.skip("adds column as custom type", async () => {

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -288,13 +288,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       await withPostgresqlDatetimeType("timestamptz", async () => {
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
         await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
-        await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
-        const rows = await adapter.execute(
-          `SELECT data_type FROM information_schema.columns
-           WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
-        );
-        expect(rows[0]?.data_type).toBe("timestamp with time zone");
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        try {
+          await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
+          const rows = await adapter.execute(
+            `SELECT data_type FROM information_schema.columns
+             WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
+          );
+          expect(rows[0]?.data_type).toBe("timestamp with time zone");
+        } finally {
+          await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        }
       });
     });
 

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 
 describe("SQLite3JSONTest", () => {
   it("json string cast round-trip", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "json_string_cast" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "data" JSON)`,
     );
     class JsonStringCast extends Base {

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -16,6 +16,24 @@ afterEach(() => {
 });
 
 describe("SQLite3JSONTest", () => {
+  it("json string cast round-trip", async () => {
+    adapter.exec(
+      `CREATE TABLE "json_string_cast" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "data" JSON)`,
+    );
+    class JsonStringCast extends Base {
+      static {
+        this.tableName = "json_string_cast";
+      }
+    }
+    JsonStringCast.adapter = adapter;
+    await JsonStringCast.loadSchema();
+    const record = new JsonStringCast();
+    (record as any).data = '{"a":1}';
+    await record.save();
+    await record.reload();
+    expect((record as any).data).toBe('{"a":1}');
+  });
+
   it("test_default", async () => {
     adapter.exec(`CREATE TABLE "json_data_type" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary

Three small followups bundled together, one commit per item for clean revertability.

**Item 1 — MariaDB detection + un-skip \`no automatic reconnection after timeout\`**

Exports \`isMariaDb\` from the MySQL test helper (detected via \`SELECT VERSION()\`, matching Rails' \`AbstractMysqlAdapter#mariadb?\`). Uses \`it.skipIf(isMariaDb)\` on the reconnection test so it runs on MySQL and is skipped on MariaDB, keeping the test path stable for test:compare. MariaDB reconnects transparently at the driver level (even with \`connectionLimit: 1\`), making the dead-socket assertion non-deterministic across CI engines.

**Item 2 — \`withPostgresqlDatetimeType\` helper + timestamptz migration test refactor**

Adds \`withPostgresqlDatetimeType\` to the PG test helper, mirroring Rails' block-arg helper. Refactors "adds column as timestamptz if datetime type changed" to use the helper instead of the subclass workaround. Updates BLOCKED comments on the two timezone tests to clarify the remaining blocker is \`aware_attributes\`/TimeWithZone routing, not the missing helper.

**Item 3 — \`Json.cast\` string round-trip integration test (SQLite3)**

Assigning a JSON-shaped string (\`'{"a":1}'\`) to a \`:json\` column should preserve it as a string (not parsed to an object) after save/reload. Test added for SQLite3. PG json columns always round-trip through \`JSON.parse\` in the pg driver so string values are deserialized on read-back — that is a pre-existing adapter-level semantic gap, not a \`Json.cast\` issue, so no PG test is included.

## Verification

- \`isMariaDb\` uses \`SELECT VERSION()\` (matches Rails \`AbstractMysqlAdapter#mariadb?\`); mysql probe connection always closed in \`try/finally\`
- \`it.skipIf(isMariaDb)\` keeps test path at \`ConnectionTest > no automatic reconnection after timeout\` for test:compare
- \`withPostgresqlDatetimeType\` saves/restores \`PostgreSQLAdapter.datetimeType\` in try/finally
- "adds column as timestamptz if datetime type changed": CREATE TABLE inside try, DROP in finally
- \`json string cast round-trip\` passes on SQLite3
- \`pnpm api:compare --package activerecord\` — no regression (4969/4969)