### PR TITLE
fix(activerecord): Story P — wire four silently-dropped _-prefixed params (~70 LOC)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { Column } from "./mysql/column.js";
+
+function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
+  return new Column("id", null, { sqlType: "bigint" }, false, {
+    autoIncrement: opts.autoIncrement ?? false,
+    defaultFunction: opts.defaultFunction ?? null,
+  });
+}
+
+describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {
+  it("returns true for auto-increment column when INSERT RETURNING not supported", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+    adapter.supportsInsertReturning = () => false;
+    expect(adapter.returnValueAfterInsert(makeColumn({ autoIncrement: true }))).toBe(true);
+  });
+
+  it("returns false for non-auto-increment column when INSERT RETURNING not supported", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+    adapter.supportsInsertReturning = () => false;
+    expect(adapter.returnValueAfterInsert(makeColumn({ autoIncrement: false }))).toBe(false);
+  });
+
+  it("returns true for auto-populated column (default function) when INSERT RETURNING supported", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+    adapter.supportsInsertReturning = () => true;
+    expect(adapter.returnValueAfterInsert(makeColumn({ defaultFunction: "uuid()" }))).toBe(true);
+  });
+
+  it("returns false for plain column when INSERT RETURNING supported", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+    adapter.supportsInsertReturning = () => true;
+    expect(adapter.returnValueAfterInsert(makeColumn())).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -359,8 +359,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return false;
   }
 
-  returnValueAfterInsert(_column: string): boolean {
-    return false;
+  returnValueAfterInsert(column: Column): boolean {
+    return this.supportsInsertReturning()
+      ? column.isAutoPopulated()
+      : column.isAutoIncrementedByDb();
   }
 
   supportsSavepoints(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -160,3 +160,28 @@ describe("Table#raise_on_if_exist_options", () => {
     await expect(t.string("name", { ifExists: true })).rejects.toThrow("if_exists");
   });
 });
+
+describe("Table#aliasedTypes", () => {
+  const fakeSchema2 = {
+    addColumn: async () => {},
+    removeColumn: async () => {},
+    changeColumn: async () => {},
+    renameColumn: async () => {},
+    addIndex: async () => {},
+    removeIndex: async () => {},
+    addReference: async () => {},
+    addTimestamps: async () => {},
+    renameIndex: async () => {},
+  };
+
+  it('maps "timestamp" to "datetime"', () => {
+    const t = new Table("users", fakeSchema2 as any);
+    expect(t.aliasedTypes("timestamp", "timestamp")).toBe("datetime");
+  });
+
+  it("returns fallback for unrecognised type names", () => {
+    const t = new Table("users", fakeSchema2 as any);
+    expect(t.aliasedTypes("string", "string")).toBe("string");
+    expect(t.aliasedTypes("datetime", "datetime")).toBe("datetime");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1102,8 +1102,8 @@ export class Table {
   ) {}
 
   /** @internal */
-  aliasedTypes(_name: string, fallback: string): string {
-    return fallback;
+  aliasedTypes(name: string, fallback: string): string {
+    return name === "timestamp" ? "datetime" : fallback;
   }
 
   async string(name: string, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -240,3 +240,28 @@ describe("SchemaStatements privates (PR 8)", () => {
     );
   });
 });
+
+describe("SchemaStatements#quotedColumnsForIndex", () => {
+  it("quotes column names without options", () => {
+    const ss = makeStatements();
+    expect(ss.quotedColumnsForIndex(["id", "name"])).toBe('"id", "name"');
+  });
+
+  it("appends sort order when adapter supports it and order option is given", () => {
+    const ss = makeStatements({
+      supportsIndexSortOrder: () => true,
+    });
+    expect(ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc", name: "asc" } })).toBe(
+      '"id" DESC, "name" ASC',
+    );
+  });
+
+  it("ignores sort order when adapter does not support it", () => {
+    const ss = makeStatements({
+      supportsIndexSortOrder: () => false,
+    });
+    expect(ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc" } })).toBe(
+      '"id", "name"',
+    );
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1322,8 +1322,11 @@ export class SchemaStatements {
     );
   }
 
-  quotedColumnsForIndex(columnNames: string[], _options: Record<string, unknown> = {}): string {
-    return columnNames.map((name) => this._qi(name)).join(", ");
+  quotedColumnsForIndex(columnNames: string[], options: Record<string, unknown> = {}): string {
+    const quotedColumns = new Map(columnNames.map((name) => [name, this._qi(name)]));
+    return Array.from(this.addOptionsForIndexColumns(quotedColumns, options as any).values()).join(
+      ", ",
+    );
   }
 
   isOptionsIncludeDefault(options: Record<string, unknown>): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1324,9 +1324,12 @@ export class SchemaStatements {
 
   quotedColumnsForIndex(columnNames: string[], options: Record<string, unknown> = {}): string {
     const quotedColumns = new Map(columnNames.map((name) => [name, this._qi(name)]));
-    return Array.from(this.addOptionsForIndexColumns(quotedColumns, options as any).values()).join(
-      ", ",
-    );
+    return Array.from(
+      this.addOptionsForIndexColumns(
+        quotedColumns,
+        options as { order?: string | Record<string, string> },
+      ).values(),
+    ).join(", ");
   }
 
   isOptionsIncludeDefault(options: Record<string, unknown>): boolean {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -689,12 +689,12 @@ export abstract class Migration {
     if (fn) await fn(table);
   }
 
-  async renameIndex(_tableName: string, oldName: string, newName: string): Promise<void> {
+  async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     if (this._recording) {
-      this._recorder.record("renameIndex", [_tableName, oldName, newName]);
+      this._recorder.record("renameIndex", [tableName, oldName, newName]);
       return;
     }
-    await this.schema.renameIndex(_tableName, oldName, newName);
+    await this.schema.renameIndex(tableName, oldName, newName);
   }
 
   indexName(tableName: string, options: { column?: string | string[] }): string {


### PR DESCRIPTION
## Audit summary

Full sweep of `_`-prefixed function/method parameters in `packages/activerecord/src/` that exist for Rails-signature parity but are silently ignored. Each parameter was cross-checked against the matching Rails source method.

### Findings

| File | Method | Param | Category | Action |
|------|--------|-------|----------|--------|
| `abstract/schema-definitions.ts` | `Table#aliasedTypes` | `_name` | **Bug** — Rails maps `"timestamp"→:datetime` | Implement |
| `abstract/schema-statements.ts` | `SchemaStatements#quotedColumnsForIndex` | `_options` | **Bug** — Rails calls `add_options_for_index_columns` for sort order | Implement |
| `abstract-mysql-adapter.ts` | `AbstractMysqlAdapter#returnValueAfterInsert` | `_column: string` | **Bug** — Rails checks `column.auto_populated?` / `column.auto_increment?` | Implement |
| `migration.ts` | `MigrationProxy#renameIndex` | `_tableName` | **Spurious `_`** — param IS used (passed to recorder + schema) | Rename |
| `query-methods.ts` | `uniqBang` | `_name?` | Rails uses `name` to deduplicate a named clause array | Out of scope — semantic mismatch requires separate PR |
| `query-methods.ts` | `buildArel` | `_connection?`, `_aliases?` | Rails uses connection for `sanitize_limit`, aliases for eager-load joins | Out of scope — deep refactor |
| `calculations.ts` | `isDistinctSelect` | `_rel` | Rails' `distinct_select?` also ignores the relation; correctly a no-op | No action |
| `calculations.ts` | `lookupCastTypeFromJoinDependencies` | `_rel`, `_name` | Function body returns `null`; full implementation gap, not just param | Out of scope |
| `schema-cache.ts` | `clearDataSourceCacheBang` | `_connection` | Rails also ignores `_connection` | No action |
| `abstract-adapter.ts` | `configureConnection` | `..._args` | Rails also doesn't use args | No action |
| `schema-dumper.ts` | `extensions`, `types`, `schemas` | `_lines` | Abstract hooks; override contracts supply them | No action |
| Various stubs/test-helpers | Many | Various | Interface conformance / stub bodies | No action |

### Changes

**`Table#aliasedTypes`** (`abstract/schema-definitions.ts:1105`)
Rails' `ColumnMethods#aliased_types` maps `"timestamp"` → `:datetime`. The sibling `TableDefinition#aliasedTypes` already did this correctly; `Table` (used in `change_table` blocks) did not.

**`quotedColumnsForIndex`** (`abstract/schema-statements.ts:1325`)
Rails calls `add_options_for_index_columns` to attach sort-order suffixes (ASC/DESC) to each quoted column name. We had `addOptionsForIndexColumns` fully implemented but never threaded options through the call.

**`returnValueAfterInsert`** (`abstract-mysql-adapter.ts:362`)
Rails: `supports_insert_returning? ? column.auto_populated? : column.auto_increment?`. We were ignoring the column and returning `false` unconditionally. Parameter type corrected from `string` to `Column`.

**`renameIndex` `_tableName`** (`migration.ts:692`)
The underscore was simply wrong — the parameter is forwarded to both the recorder and `schema.renameIndex`. Removed.

## Test plan

- [x] `pnpm vitest run` on new/affected test files — all 63 tests pass
- [x] `pnpm api:compare --package activerecord` — 4969/4969 (100%), no regression
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/` — 1029 passed, 290 skipped