### PR TITLE
feat(activerecord): AR-100 finishers bundle — 8 items (~135 LOC)

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -534,3 +534,43 @@ Folds former PRs 58 + 59 plus the remaining unassigned 1-missers from the PR 52 
 - `packages/activerecord/src/base.ts`
 
 ---
+
+## Known Rails-fidelity gaps (tracked, not blocking)
+
+Findings flagged during PR review that were correctly deferred from their source PR. Each is small enough to ship as a follow-up; none currently break behavior or block the PR they were found in. Pull from this list when sequencing the next batch of small fixes.
+
+### From PR #1298 (PR 37c — relation.rb build helpers)
+
+- **`buildFrom` missing `eager_loading?` → `apply_join_dependency` branch.** Rails: when `from` is unset and the relation needs eager loading, `build_from` consults the join dependency to derive the `from` clause. Currently a real gap; low frequency (most queries set `from` explicitly or don't need eager-load-derived from). File: `relation.ts#buildFrom`. Source: Rails `relation.rb` `build_from` method.
+- **`buildArel` passing `limit` as raw number.** Rails wraps in `build_cast_value("LIMIT", sanitize_limit(limit))` so the value goes through type-cast / sanitization. TS passes the raw number. Low risk — JS numbers don't need the same coercion, and `sanitizeLimit` is already called upstream. File: `relation.ts#buildArel`. Tracking only because Rails source disagrees.
+- **`buildArel` not calling `arel.distinct(false)` when distinct is off.** Rails explicitly clears the distinct flag on a fresh `SelectManager`; TS relies on the default-false from constructing a new SelectManager each time. Negligible — same effective output. File: `relation.ts#buildArel`.
+
+### From PR #1292 (Track 2 — abstract_adapter wiring)
+
+- **5 throw-stubs wired into `AbstractAdapter`** via `AbstractAdapterPrivates`: `initializeTypeMap`, `registerClassWithLimit`, `extractScale`, `extractPrecision`, `extractLimit`. Pure decoration for api:compare attribution; subclasses override or use module-level copies. Worth porting the Rails implementations to AbstractAdapter so callers inherit functioning defaults instead of overriding errors. **In flight on a follow-up agent (pane %50).**
+
+### From PR #1294 (skip-annotation normalization)
+
+- **`testNameOverride()` keyword groups too narrow.** Currently catches STI / Marshal / GVL via specific keywords. base.test.ts has ~10 file-templated annotations that would benefit from broader keyword coverage (`namespace`, `copy_table`, `readonly`, `includes`, `default scope`, etc.). Re-running the script after extending keywords is mechanical (script is idempotent).
+
+### From PR #1276 (PR 51b — mysql2 ER_BAD_DB_ERROR)
+
+- **`_isMissingDatabaseError` smears SQLSTATE/errno knowledge** into `database-tasks.ts` instead of the adapter layer. As more callers need NoDatabaseError detection, the per-adapter knowledge should live on the adapter so it's translated at the connection level.
+
+### MariaDB DATETIME serialization
+
+- mysql2 inserts ISO 8601 `Z`-suffix strings into `DATETIME` columns; MariaDB rejects. Worked around in `defineSchema` by mapping `datetime` → `TEXT` on non-PG. Real fix lives in `connection-adapters/mysql2/quoting.ts` / `typecast.ts` — emit `YYYY-MM-DD HH:MM:SS` (no `T`, no `Z`). Once fixed, revert the defineSchema datetime→TEXT downgrade.
+
+### EncryptableRecord `encrypt` / `decrypt` ergonomics (S1 from ENC-4 review)
+
+- Both are static methods (`EncryptableRecord.encrypt(record)`); Rails has them as instance methods (`record.encrypt`). No api:compare impact (already counted) but ergonomic Rails parity. Wire onto Base.prototype via the include() mechanism.
+
+### Signature-parity-only parameters
+
+- `relation/calculations.ts` keeps `_distinct` (and possibly other) parameters in method signatures for Rails parity, but the simplified TS implementation doesn't yet use them. Suppressed via underscore prefix to silence unused-param lints. Real behavior gap: callers passing `distinct: true` get parity in the API surface but not in the SQL output. Sweep `relation/calculations.ts` for `_`-prefixed unused params; same pattern may exist elsewhere — grep `(_[a-z]\w*:` across `packages/activerecord/src/`.
+
+### Future infra (deferred)
+
+- **ESLint rule for `_`-prefixed params on Rails-mirroring methods.** Catches the signature-parity-only gap above at PR time.
+- **`lint:deps` activesupport rule → blocking** once the 37 missing migrations land.
+- **api:compare param-name set comparison** (alongside the current method-name set check).

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -195,11 +195,6 @@ failing the `Browser Bundle` job. Rely on esbuild's own exit code — don't
 pipe to grep (grep exits 1 on no matches, which would fail CI when the build
 is clean).
 
-A package barrel that resolves `node:fs` causes esbuild to exit non-zero,
-failing the `Browser Bundle` job. Rely on esbuild's own exit code — don't
-pipe to grep (grep exits 1 on no matches, which would fail CI when the build
-is clean).
-
 ## 6. Open questions
 
 - **Buffer / node: polyfills.** Do we offer a `Buffer` shim or similar on the

--- a/docs/browser-compat-plan.md
+++ b/docs/browser-compat-plan.md
@@ -57,12 +57,12 @@ verbatim — read that doc for implementation detail.
 
 ## 3. Migration plan
 
-### BC-1 — this document (~250 LOC, plan-only)
+### BC-1 — this document (~250 LOC, plan-only) ✅ #1250
 
 Establishes vocabulary, cross-links existing plans, and sequences the work.
 No code changes.
 
-### BC-2 — `getEnv()` accessor + migrate 6 activerecord files (~80 LOC)
+### BC-2 — `getEnv()` accessor + migrate 6 activerecord files (~80 LOC) ✅ #1251
 
 Add `getEnv` to `packages/activesupport/src/environment.ts` with two
 overloads:
@@ -98,73 +98,102 @@ every use case through BC-4. If a future consumer needs to inject a different en
 source (e.g. `import.meta.env` in a browser shim), lift `environment.ts` to the
 full adapter pattern at that point.
 
-### BC-3 — database-adapter registry (~250 LOC)
+### BC-3 — database-adapter registry (~250 LOC) 🟡 partial
 
-**Block until sqlite-driver PR M (#1247) merges** so the registry pattern is
-proven and we can copy it verbatim.
+**Subpath exports shipped** (verify in `packages/activerecord/package.json`):
 
-- Add `packages/activerecord/src/connection-adapters/registry.ts` mirroring
-  the sqlite `DriverFactory` / `registerDriver` shape.
-- Add subpath exports:
-  - `@blazetrails/activerecord/adapters/postgresql`
-  - `@blazetrails/activerecord/adapters/mysql2`
-  - `@blazetrails/activerecord/adapters/sqlite3`
-- Move `import pg from "pg"` and `import Database from "better-sqlite3"` out
-  of barrel-reachable files and into the adapter subpath entry points only.
-- Promote `pg` and `mysql2` to optional peer deps in `package.json`.
+- `@blazetrails/activerecord/connection-adapters/postgresql-adapter.js`
+- `@blazetrails/activerecord/connection-adapters/mysql2-adapter.js`
+- `@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js`
 
-**Important:** registries self-register on import. An app that never imports
-`@blazetrails/activerecord/adapters/postgresql` will find no registered
-driver and get a clear "no adapter registered for postgresql" error at
-connection time. The error message should name the missing subpath import so
-the fix is obvious.
+The sqlite driver track shipped its own `DriverFactory` / `registerDriver`
+registry independently of activerecord's adapter registry — see PRs #1238 (PR 1),
+#1240 (PR 2), #1247 (PR M), #1264 (PR 3), #1271 (PR 5 node:sqlite). That registry
+serves the sqlite-adapter side and is in `@blazetrails/activesupport/sqlite-adapter`.
 
-Files that currently eagerly import native deps (all move to subpath entries):
+**Still open under BC-3:**
 
-- `connection-adapters/postgresql-adapter.ts` — `import pg from "pg"`
-- `connection-adapters/postgresql/temporal-type-parsers.ts` — `import pg from "pg"`
-- `connection-adapters/sqlite3-adapter.ts` — `import Database from "better-sqlite3"`
-- `connection-adapters/sqlite3/drivers/better-sqlite3.ts` — `import Database from "better-sqlite3"`
+1. **Eager native imports leak from non-subpath-entry files.** Live grep against `packages/activerecord/src/connection-adapters/`:
+   - `postgresql/database-statements.ts` — `import pg from "pg"` (eager, not lazy)
+   - `postgresql/temporal-type-parsers.ts` — `import pg from "pg"`
+   - `mysql/temporal-type-cast.ts` — `import mysql from "mysql2/promise"`
+   - `mysql2/database-statements.ts` — `import type mysql from "mysql2/promise"` (type-only — OK)
 
-### BC-4 — lint rules + browser-bundle CI smoke test (~150 LOC)
+   These get pulled in transitively when the main adapter file imports from them. The path forward: either gate behind a registry (lazy) or move the dep-using bits into the subpath entry only.
 
-Three gates, all additive (no existing code changes):
+2. **`pg` and `mysql2` peer-dep promotion** has not happened — `packages/activerecord/package.json` `dependencies` still lists only workspace deps (no native deps declared). They're picked up via the consumer app's installation. Worth formalizing as `optionalDependencies` so type-check works without a hard `pg` install.
 
-1. **`no-native-import` lint rule** — reject `node:*`, `pg`, `mysql2`,
-   `better-sqlite3` outside designated adapter files
-   (`**/adapters/{postgresql,mysql2,sqlite3}/**`).
-2. **`no-direct-process-env` lint rule** — reject `process.env.X` outside
-   `bin/`, `test-setup-*.ts`, `*-adapter.ts`, and the new `environment.ts`.
-3. **Browser-bundle smoke test** — per-package CI step:
-   `esbuild --bundle --platform=browser <barrel>` and fail on any `node:*`
-   resolution error. Added to the `DX Type Tests` job or a new
-   `Browser Bundle` job.
+3. **Self-registering adapter registry** (the `register at import time` pattern that the original BC-3 spec required) has NOT shipped. Today, `import @blazetrails/activerecord/connection-adapters/postgresql-adapter.js` exposes the class but no global registry tracks "postgresql is wired." The "no adapter registered for postgresql" error message described in the spec doesn't exist.
 
-### BC-5 — per-package portability audit + fixes (iterative)
+### BC-3b — encryption namespace bundle-cleanliness (~100-150 LOC)
 
-One PR per gap discovered. Packages not yet audited (actionview, actionpack,
-rack) get their status set to ✅ or flagged as ❌ after a grep-and-review pass.
+Surfaced during the bundle-smoke pass on #1296. `packages/activerecord/src/encryption/config.ts:84` does `import { deflateSync, inflateSync } from "zlib"` at module top-level. Reachable from the activerecord barrel via:
+
+```
+index.ts → encryption/install.js (installExtendedQueriesIfConfigured)
+  → encryption.ts → encryption/configurable.ts → encryption/config.ts → "zlib"
+```
+
+So `import @blazetrails/activerecord` transitively pulls `node:zlib`, even for apps that don't use encryption. Same class of bundle-cleanliness issue as the pg/mysql2 leaks #1296 just closed; promoted to its own line so it doesn't drown in BC-5's iterative bucket.
+
+**Approach: subpath import, mirror the pg/mysql2 pattern from BC-3.** Move the encryption namespace out of barrel reachability:
+
+- Add `@blazetrails/activerecord/encryption` (and potentially nested subpaths if needed) to `package.json` exports.
+- Remove encryption symbols from `packages/activerecord/src/index.ts` (the barrel).
+- Anything currently re-exported from the barrel for ergonomics — `Encryption.configure(...)`, `installExtendedQueriesIfConfigured`, etc. — moves to subpath-only access. Consumers update from `import { configure } from "@blazetrails/activerecord"` to `import { configure } from "@blazetrails/activerecord/encryption"`.
+
+The encryption subsystem is server-only by design (key management, compressor, key generators). Moving the whole namespace to a subpath:
+
+- Solves the `zlib` leak by making encryption barrel-unreachable.
+- Matches the BC-3 pattern used for pg/mysql2 adapters — consistency.
+- Frees `installExtendedQueriesIfConfigured` from being barrel-reachable.
+- Closes the issue permanently — future encryption-internal uses of `node:crypto` / `zlib` / etc. won't reopen the same conversation.
+
+LOC: ~100-150 net (subpath export + barrel cleanup + caller-migration if any internal-test callsites use the barrel).
+
+**Out of scope:** alternatives like `pako` for in-browser deflate (option D from triage) are unnecessary because encryption is server-only forever — bundle-cleanliness is the goal, not browser execution.
+
+### BC-4 — lint rules + browser-bundle CI smoke test (~150 LOC) 🟡 partial
+
+Three gates were planned. Two ESLint rules shipped; the third gate (browser bundle CI) and a stricter native-package rule are still pending.
+
+1. ✅ **`no-node-builtins` ESLint rule** (`eslint/no-node-builtins.mjs`) — rejects direct imports of Node.js built-in modules (`fs`, `path`, `crypto`, `os`, etc.) in browser-compatible packages, with autofix that rewrites the import + all usage sites to the activesupport adapter (`getFs`, `getPath`, `getCrypto`).
+2. ✅ **`no-process-bypass` ESLint rule** (`eslint/no-process-bypass.mjs`) — covers `process.X` access for properties routed through activesupport's processAdapter (`platform`, `exit`, `stdout`, `stderr`, etc.). Autofixable for safe replacements.
+3. ❌ **`no-direct-process-env` rule for `process.env.X`** — NOT yet shipped. The existing `no-process-bypass` covers `process.platform` etc. but does not gate `process.env`. Live grep shows direct `process.env` usage still in `test-databases.ts`, `test-setup-worker-db.ts`, and adapter test-helpers. Some of those are legitimately test-only; the rule should allow-list `**/*.test.ts` and `**/test-*.ts` and gate the rest.
+4. ❌ **`no-native-package-import` rule** — NOT yet shipped. `pg`, `mysql2`, `better-sqlite3` are still importable from non-adapter files. A rule rejecting these outside `**/adapters/{postgresql,mysql2,sqlite3}/**` and the named subpath-entry files would close the gap.
+5. ❌ **Browser-bundle smoke test in CI** — NOT yet shipped. No `esbuild --platform=browser` step in `.github/workflows/*.yml`. Per-package job (or extension to existing `DX Type Tests` job) needed.
+
+### BC-5 — per-package portability audit + fixes (iterative) ⏳ ongoing
+
+One PR per gap discovered. The matrix below tracks state.
 
 ## 4. Per-package portability matrix
 
-| Package         | Status                        | Notes                                                                    |
-| --------------- | ----------------------------- | ------------------------------------------------------------------------ |
-| `arel`          | ✅ portable today             | No native deps                                                           |
-| `activemodel`   | ✅ portable today             | No native deps                                                           |
-| `activesupport` | ✅ portable                   | Adapter layer is the template; adapters live here                        |
-| `activerecord`  | 🟡 portable after BC-2 + BC-3 | Core is portable; adapters server-only by design, lazy-loaded after BC-3 |
-| `trailties`     | ❌ server-only intentionally  | CLI tool; Node-only is correct                                           |
-| `actionpack`    | ⏳ audit needed               | Likely portable; no known native deps                                    |
-| `actionview`    | ⏳ audit needed               | Likely portable                                                          |
-| `rack`          | ⏳ audit needed               | Likely portable                                                          |
+| Package         | Status                       | Notes                                                                                                                                       |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `arel`          | ✅ portable today            | No native deps                                                                                                                              |
+| `activemodel`   | ✅ portable today            | No native deps                                                                                                                              |
+| `activesupport` | ✅ portable                  | Adapter layer is the template; sqlite-adapter / sqlite-drivers / process-adapter / fs-adapter / path-adapter / crypto-adapter all live here |
+| `activerecord`  | 🟡 partial — see BC-3 / BC-4 | Core is portable; subpath exports for adapters shipped; eager pg/mysql2 imports still leak from non-subpath-entry files                     |
+| `trailties`     | ❌ server-only intentionally | CLI tool; Node-only is correct                                                                                                              |
+| `actionpack`    | ⏳ audit needed              | Likely portable; no known native deps                                                                                                       |
+| `actionview`    | ⏳ audit needed              | Likely portable                                                                                                                             |
+| `rack`          | ⏳ audit needed              | Likely portable                                                                                                                             |
 
-## 5. CI gates (added in BC-4)
+## 5. CI gates (planned in BC-4)
 
-| Gate                    | Tooling                                                                | Job                    | Trigger    |
-| ----------------------- | ---------------------------------------------------------------------- | ---------------------- | ---------- |
-| Browser-bundle smoke    | `esbuild --bundle --platform=browser <barrel>` — fail on non-zero exit | `Browser Bundle` (new) | Every push |
-| No bare native imports  | `blazetrails/no-native-import` ESLint rule                             | `Lint` (existing)      | Every push |
-| No direct `process.env` | `blazetrails/no-direct-process-env` ESLint rule                        | `Lint` (existing)      | Every push |
+| Gate                            | Tooling                                                                | Status             |
+| ------------------------------- | ---------------------------------------------------------------------- | ------------------ |
+| No node:\* / fs / path / crypto | `blazetrails/no-node-builtins` ESLint rule                             | ✅ shipped         |
+| No `process.<gated>` access     | `blazetrails/no-process-bypass` ESLint rule                            | ✅ shipped         |
+| No direct `process.env.X`       | `blazetrails/no-direct-process-env` ESLint rule                        | ❌ planned in BC-4 |
+| No bare native package imports  | `blazetrails/no-native-package-import` ESLint rule                     | ❌ planned in BC-4 |
+| Browser-bundle smoke            | `esbuild --bundle --platform=browser <barrel>` — fail on non-zero exit | ❌ planned in BC-4 |
+
+A package barrel that resolves `node:fs` causes esbuild to exit non-zero,
+failing the `Browser Bundle` job. Rely on esbuild's own exit code — don't
+pipe to grep (grep exits 1 on no matches, which would fail CI when the build
+is clean).
 
 A package barrel that resolves `node:fs` causes esbuild to exit non-zero,
 failing the `Browser Bundle` job. Rely on esbuild's own exit code — don't
@@ -176,14 +205,10 @@ is clean).
 - **Buffer / node: polyfills.** Do we offer a `Buffer` shim or similar on the
   browser side, or strictly require activesupport adapters? Current stance:
   strictly require adapters; polyfills hide leaks.
-- **PG browser execution.** Should a future `pg-driver-abstraction-plan.md`
-  mirror the sqlite plan and allow a browser-capable PG driver (e.g. via
-  WebSocket)? Current stance: PostgreSQL and MySQL remain server-only; the
-  goal is _bundle-cleanliness_, not browser execution. Revisit only if an
-  explicit consumer requests it.
-- **MySQL driver abstraction.** Should MySQL follow the same driver-registry
-  path as SQLite (a `MysqlDriver` interface, `mysql2` as the default
-  implementation, a future `planetscale-driver` possible)? Or is MySQL
-  strictly server-only forever? Currently leaning server-only — the bundle
-  goal is met by BC-3's lazy loading alone — but document this if a consumer
-  requests it.
+
+## Resolved (formerly open questions)
+
+- **PG browser execution.** ✅ Resolved: PostgreSQL is server-only. No browser-compat support. The goal for `pg` is bundle-cleanliness so a browser barrel doesn't pull `pg` transitively, not browser execution. No `pg-driver-abstraction-plan.md` needed.
+- **MySQL driver abstraction.** ✅ Resolved: MySQL is server-only. Same shape as PG — bundle-cleanliness only. No `mysql-driver-abstraction-plan.md` needed.
+
+These resolutions simplify BC-3: pg/mysql2 just need to be excluded from browser bundles (lint rule + bundle smoke test in BC-4), not abstracted behind a registry. A registry would still be useful for adapter selection ergonomics, but isn't required for the BC track.

--- a/docs/sqlite-driver-abstraction-plan.md
+++ b/docs/sqlite-driver-abstraction-plan.md
@@ -64,12 +64,94 @@ packages/activerecord/src/connection-adapters/sqlite3/**/*.ts
 packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
 ```
 
-### PR 3 — Sprinkle async/await (upcoming)
+### PR 3 — Async-aware adapter (#1264)
 
-- Make `BetterSqlite3Driver` methods return `Promise<T>` (via
-  `Promise.resolve`).
-- Add `async`/`await` at every `this.driver.*` call site in `sqlite3-adapter.ts`
-  and the `sqlite3/` cluster.
-- The `blazetrails/sqlite-driver-await` lint guard ensures any new helper
-  that passes a `driver` parameter and calls methods on it without `await`
-  is caught at CI time, not at runtime.
+Sprinkled `async`/`await` through every `this.driver.*` call site in
+`sqlite3-adapter.ts`. Removed the local sync sub-type aliases that bound
+the adapter to `SyncSqliteConnection` / `SyncSqliteStatement`; the adapter
+now binds to the full async-tolerant types. `BetterSqlite3Driver` methods
+return raw values; the `T | Promise<T>` interface accepts them.
+
+Two scoped exceptions kept sync (with comments):
+
+- `disconnectBang()` — supertype is `void`-returning; can't easily go async
+- `getDatabaseVersion()` — lazy-init, sync caller path
+
+Both flagged for follow-up; both work fine for in-process-sync drivers.
+
+### PR 4 — Consolidate transactions onto generic path (#1256)
+
+Audit + tests confirming `Sqlite3Adapter` uses only explicit
+`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT` SQL via `driver.exec()`. No reliance
+on `db.transaction(fn)` (which is better-sqlite3-specific). Adapter is
+portable to async drivers (node:sqlite, wa-sqlite, expo-sqlite) by
+construction.
+
+### PR M — Move driver abstraction to activesupport (#1247)
+
+Moved `SqliteDriver` / `SqliteStatement` / `SqliteConnection` interfaces +
+registry to `packages/activesupport/src/sqlite-adapter.ts`. Driver
+implementations live under `packages/activesupport/src/sqlite-drivers/`.
+The activerecord adapter consumes them via `getSqlite(name)`.
+
+Key interface additions:
+
+- `SqliteDriverCapabilities`: `inProcessSync`, `streaming`, `loadExtension`,
+  `concurrentStatements`, `foreignKeysOnByDefault`, `immediateTransactions`.
+- `SyncSqliteConnection` / `SyncSqliteStatement` sub-types for inProcessSync
+  drivers (better-sqlite3 + node:sqlite via openSync).
+- `globalThis`-stashed registry to survive module duplication.
+
+### PR 5 — node:sqlite driver (#1271)
+
+Added `packages/activesupport/src/sqlite-drivers/node-sqlite.ts` wrapping
+Node 22.5+'s built-in `node:sqlite`. Soft-loads via `createRequire` so
+older Node doesn't crash on import; exposes `isNodeSqliteAvailable` for
+test gating. Capabilities: `inProcessSync: true`, `streaming: false`,
+`loadExtension: false`, `concurrentStatements: false`,
+`foreignKeysOnByDefault: false`, `immediateTransactions: true`.
+
+### PR 7 — expo-sqlite driver (planned)
+
+Adds `packages/activesupport/src/sqlite-drivers/expo-sqlite.ts` wrapping
+Expo's modern async API (`openDatabaseAsync`, `runAsync`, `getAllAsync`,
+`getEachAsync`, `closeAsync`). Same shape as node-sqlite (soft-load,
+self-register, expose `isExpoSqliteAvailable` for test gating).
+
+Capabilities:
+
+| Capability               | Value | Why                                                  |
+| ------------------------ | ----- | ---------------------------------------------------- |
+| `inProcessSync`          | false | expo-sqlite's modern API is async-only               |
+| `streaming`              | true  | `getEachAsync` yields rows                           |
+| `loadExtension`          | false | No FTS / spatial extensions on RN                    |
+| `concurrentStatements`   | false | Single-connection-per-DB model; serialize statements |
+| `foreignKeysOnByDefault` | false | Must `PRAGMA foreign_keys = ON` post-open            |
+| `immediateTransactions`  | true  | `BEGIN IMMEDIATE` supported                          |
+
+**Async-only:** no `openSync` hook on the driver. Implements
+`open(): Promise<SqliteConnection>` only. PR 3 (#1264) made async drivers
+first-class; that work is the prerequisite this driver depends on.
+
+**Web fallback:** Expo SDK 51+ auto-forks to wa-sqlite under the hood when
+running on web. The driver itself is platform-agnostic — Expo handles
+native iOS/Android vs web internally.
+
+**`expo-sqlite` peer dep:** added to `optionalDependencies` in
+`activesupport/package.json` so Trails consumers don't need Expo unless
+they're using this driver.
+
+**Reference impl:** `packages/activesupport/src/sqlite-drivers/node-sqlite.ts`
+is the closest in shape (soft-load, capabilities object, single-driver
+self-registration). Cherry-pick its structure.
+
+**Out of scope (defer to PR 6):** CI matrix integration, parity tests
+across all three drivers (better-sqlite3 / node:sqlite / expo-sqlite),
+docs in the website. PR 6 is still the planned follow-up that wires
+all drivers into a CI matrix.
+
+### PR 6 — CI matrix + parity tests + docs (blocked on driver landing)
+
+Originally planned to land after PR 5; still pending. After PR 7
+(expo-sqlite) lands, this PR wires all three drivers into a CI matrix
+and adds parity tests asserting identical behavior across them.

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -9,6 +9,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 
 const toInt = (s: string) => parseInt(s, 10);
 const toFloat = (s: string) => parseFloat(s);
+const toBigInt = (s: string) => BigInt(s);
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -112,14 +113,14 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("int8range column", async () => {
       await adapter.execute(`INSERT INTO postgresql_ranges (int8_range) VALUES ('[10,100]')`);
       const rows = await adapter.execute(`SELECT int8_range FROM postgresql_ranges`);
-      const range = parseRange(rows[0].int8_range as string, toInt)!;
-      expect(range.begin).toBe(10);
+      const range = parseRange(rows[0].int8_range as string, toBigInt)!;
+      expect(range.begin).toBe(10n);
     });
 
     it("int8range type cast", async () => {
-      const range = parseRange("[10,100)", toInt)!;
-      expect(range.begin).toBe(10);
-      expect(range.end).toBe(100);
+      const range = parseRange("[10,100)", toBigInt)!;
+      expect(range.begin).toBe(10n);
+      expect(range.end).toBe(100n);
     });
 
     it("int8range write", async () => {
@@ -364,9 +365,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("int8range values", () => {
-      const r = parseRange("[10,100)", toInt)!;
-      expect(r.begin).toBe(10);
-      expect(r.end).toBe(100);
+      const r = parseRange("[10,100)", toBigInt)!;
+      expect(r.begin).toBe(10n);
+      expect(r.end).toBe(100n);
     });
 
     it("daterange values", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -32,6 +32,7 @@ import {
   performQuery,
   preprocessQuery,
   select,
+  execInsert,
   sqlForInsert,
   arelFromRelation,
   extractTableRefFromInsertSql,
@@ -431,6 +432,33 @@ describe("select", () => {
     };
     const result = await select.call(host, "SELECT 1");
     expect(result).toBeInstanceOf(Result);
+  });
+});
+
+describe("execInsert", () => {
+  function makeInsertHost(supportsReturning: boolean) {
+    let capturedSql = "";
+    const host: DatabaseStatementsHost = {
+      supportsInsertReturning: () => supportsReturning,
+      quoteColumnName: (c) => `"${c}"`,
+      internalExecute: async (sql: string) => {
+        capturedSql = sql;
+        return new Result([], []);
+      },
+    };
+    return { host, getCapturedSql: () => capturedSql };
+  }
+
+  it("appends RETURNING via sqlForInsert when adapter supports it", async () => {
+    const { host, getCapturedSql } = makeInsertHost(true);
+    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
+    expect(getCapturedSql()).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "id"`);
+  });
+
+  it("passes sql unchanged when adapter does not support RETURNING", async () => {
+    const { host, getCapturedSql } = makeInsertHost(false);
+    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
+    expect(getCapturedSql()).toBe("INSERT INTO t (x) VALUES (1)");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -460,6 +460,15 @@ describe("execInsert", () => {
     await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
     expect(getCapturedSql()).toBe("INSERT INTO t (x) VALUES (1)");
   });
+
+  it("uses explicit returning list when provided", async () => {
+    const { host, getCapturedSql } = makeInsertHost(true);
+    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], null, null, [
+      "id",
+      "created_at",
+    ]);
+    expect(getCapturedSql()).toContain('RETURNING "id", "created_at"');
+  });
 });
 
 describe("sqlForInsert", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -394,8 +394,15 @@ export function execInsert(
   binds: unknown[] = [],
   pk?: string | null,
   _sequenceName?: string | null,
+  returning?: string[] | null,
 ): Promise<Result> {
-  [sql, binds] = sqlForInsert.call(this as DatabaseStatementsHost, sql, pk, binds, null);
+  [sql, binds] = sqlForInsert.call(
+    this as DatabaseStatementsHost,
+    sql,
+    pk,
+    binds,
+    returning ?? null,
+  );
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name ?? "SQL", binds);
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -392,9 +392,10 @@ export function execInsert(
   sql: string,
   name?: string | null,
   binds: unknown[] = [],
-  _pk?: string | null,
+  pk?: string | null,
   _sequenceName?: string | null,
 ): Promise<Result> {
+  [sql, binds] = sqlForInsert.call(this as DatabaseStatementsHost, sql, pk, binds, null);
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name ?? "SQL", binds);
 }
 

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -130,7 +130,9 @@ describe("DateTimePrecisionTest", () => {
   });
 
   it("formatting datetime according to precision when time zone aware", () => {
-    // BLOCKED: needs with_timezone_config(aware_attributes: true) — TimeZoneAware not yet ported
+    // BLOCKED: type — withTimezoneConfig helper exists (test-helper.ts) but
+    // Base.timeZoneAwareAttributes is not yet wired; TimeZoneConverter.serialize
+    // not implemented (no TZ shift on datetime write).
   });
 
   it("formatting datetime according to precision using timestamptz", () => {

--- a/packages/activerecord/src/deprecator.test.ts
+++ b/packages/activerecord/src/deprecator.test.ts
@@ -25,6 +25,23 @@ describe("MigrationProxy", () => {
     expect(proxy.basename()).toBe("20240101000000_create_users.ts");
   });
 
+  it("disableDdlTransaction throws before migration() is awaited", () => {
+    const proxy = new MigrationProxy("CreateUsers", "1", "/fake/path.ts", "");
+    expect(() => proxy.disableDdlTransaction).toThrow(
+      "MigrationProxy: await migration() before reading disableDdlTransaction",
+    );
+  });
+
+  it("loadMigrationAsync falls through to import() on ERR_REQUIRE_ESM", async () => {
+    const proxy = new MigrationProxy("CreateUsers", "1", "/fake/path.ts", "");
+    const esmError = Object.assign(new Error("ERR_REQUIRE_ESM"), { code: "ERR_REQUIRE_ESM" });
+    vi.spyOn(proxy, "loadMigration").mockImplementation(() => {
+      throw esmError;
+    });
+    // loadMigrationAsync should re-throw since no ESM module can be loaded from a fake path
+    await expect(proxy.loadMigrationAsync()).rejects.toThrow();
+  });
+
   it("migration() caches the result of loadMigration()", async () => {
     const proxy = new MigrationProxy("CreateUsers", "1", "/fake/path.ts", "");
     const sentinel = {};

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1169,10 +1169,10 @@ describe("MigrationTest", () => {
     const override = createTestAdapter();
     (m as any).adapter = baseAdapter;
     expect(m.connection).toBe(baseAdapter);
-    m._connectionOverride = override;
+    (m as any)._connectionOverride = override;
     expect(m.connection).toBe(override);
     expect(m.connectionPool).toBe(override);
-    delete m._connectionOverride;
+    delete (m as any)._connectionOverride;
     expect(m.connection).toBe(baseAdapter);
   });
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1159,6 +1159,23 @@ describe("MigrationTest", () => {
     expect(Article.adapter).toBeDefined();
   });
 
+  it("migration.connection returns _connectionOverride when set", () => {
+    class M extends Migration {
+      async up() {}
+      async down() {}
+    }
+    const m = new M();
+    const baseAdapter = createTestAdapter();
+    const override = createTestAdapter();
+    (m as any).adapter = baseAdapter;
+    expect(m.connection).toBe(baseAdapter);
+    m._connectionOverride = override;
+    expect(m.connection).toBe(override);
+    expect(m.connectionPool).toBe(override);
+    delete m._connectionOverride;
+    expect(m.connection).toBe(baseAdapter);
+  });
+
   it("migration context with default schema migration", async () => {
     const adapter = createTestAdapter();
     const migrations: MigrationProxy[] = [

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -185,8 +185,8 @@ export class EnvironmentStorageError extends MigrationError {
  */
 export abstract class Migration {
   protected adapter!: DatabaseAdapter;
-  /** Per-migration connection override — mirrors Rails' @connection ivar. */
-  _connectionOverride?: DatabaseAdapter;
+  /** @internal Per-migration connection override — mirrors Rails' @connection ivar. */
+  protected _connectionOverride?: DatabaseAdapter;
   private _recording = false;
   private _recorder = new CommandRecorder();
   private _name?: string;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -185,6 +185,8 @@ export class EnvironmentStorageError extends MigrationError {
  */
 export abstract class Migration {
   protected adapter!: DatabaseAdapter;
+  /** Per-migration connection override — mirrors Rails' @connection ivar. */
+  _connectionOverride?: DatabaseAdapter;
   private _recording = false;
   private _recorder = new CommandRecorder();
   private _name?: string;
@@ -925,11 +927,11 @@ export abstract class Migration {
   // --- Connection (Rails: Migration#connection, #connection_pool) ---
 
   get connection(): DatabaseAdapter {
-    return this.adapter;
+    return this._connectionOverride ?? this.adapter;
   }
 
   get connectionPool(): DatabaseAdapter {
-    return this.adapter;
+    return this._connectionOverride ?? this.adapter;
   }
 
   // --- Execution (Rails: Migration#exec_migration, #execution_strategy, etc.) ---

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -299,6 +299,41 @@ describe("findSome — expected_size respects limit and offset", () => {
 });
 
 // ---------------------------------------------------------------------------
+// findSome — select_values narrowing on ordered path (Story I-followup-2)
+// ---------------------------------------------------------------------------
+
+describe("findSome — narrows to pk column when select_values non-empty (ordered path)", () => {
+  it("calls .select(pk) when the relation has select values", async () => {
+    let selectedCol: string | undefined;
+    const rel: any = {
+      _modelClass: {
+        primaryKey: "id",
+        name: "Post",
+        typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
+        arelTable: { get: (col: string) => col },
+      },
+      _limitValue: null,
+      _offsetValue: null,
+      _orderClauses: ["id ASC"],
+      _rawOrderClauses: [],
+      selectValues: ["title"],
+      where(_cond: any) {
+        const inner: any = {
+          toArray: async () => [{ id: 1 }],
+          select(col: string) {
+            selectedCol = col;
+            return inner;
+          },
+        };
+        return inner;
+      },
+    };
+    await findSome(rel, [1]);
+    expect(selectedCol).toBe("id");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // findSome → findSomeOrdered dispatch (Story I-followup gap 1)
 // ---------------------------------------------------------------------------
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -689,7 +689,12 @@ export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any
   if (!hasOrder(rel)) return findSomeOrdered(rel, ids);
 
   const pk = (rel as any)._modelClass.primaryKey as string;
-  const records = await (rel as any).where({ [pk]: ids }).toArray();
+  let relation = (rel as any).where({ [pk]: ids });
+  // Rails: `relation = relation.select(table[primary_key]) unless select_values.empty?`
+  if ((rel as any).selectValues.length > 0) {
+    relation = relation.select((rel as any)._modelClass.arelTable.get(pk));
+  }
+  const records = await relation.toArray();
 
   // Rails: expected_size = ids.size, then clamp down for limit/offset.
   // "11 ids with limit 3, offset 9 should give 2 results."

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { withTimezoneConfig } from "./test-helper.js";
+import { getDefaultTimezone } from "./type/internal/timezone.js";
+
+describe("withTimezoneConfig", () => {
+  it("temporarily changes defaultTimezone and restores it", async () => {
+    const before = getDefaultTimezone();
+    const captured: Array<"utc" | "local"> = [];
+    await withTimezoneConfig({ default: "local" }, () => {
+      captured.push(getDefaultTimezone());
+    });
+    expect(captured[0]).toBe("local");
+    expect(getDefaultTimezone()).toBe(before);
+  });
+
+  it("restores defaultTimezone even if fn throws", async () => {
+    const before = getDefaultTimezone();
+    await expect(
+      withTimezoneConfig({ default: "local" }, () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(getDefaultTimezone()).toBe(before);
+  });
+});

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -27,7 +27,8 @@ export async function withTimezoneConfig(
   const oldDefault = getDefaultTimezone();
   const base = Base as any;
 
-  // Snapshot: track whether each property existed before, and its prior value.
+  // Snapshot existence + value so restore is symmetric: if the property wasn't
+  // present before we set it, we delete it on restore rather than leaving it.
   const hadAwareAttributes = "timeZoneAwareAttributes" in base;
   const oldAwareAttributes = base.timeZoneAwareAttributes;
   const hadAwareTypes = "timeZoneAwareTypes" in base;
@@ -35,16 +36,23 @@ export async function withTimezoneConfig(
 
   try {
     if (cfg.default !== undefined) setDefaultTimezone(cfg.default);
-    if (cfg.awareAttributes !== undefined && hadAwareAttributes) {
-      base.timeZoneAwareAttributes = cfg.awareAttributes;
-    }
-    if (cfg.awareTypes !== undefined && hadAwareTypes) {
-      base.timeZoneAwareTypes = cfg.awareTypes;
-    }
+    // Apply unconditionally — mirrors Rails' Base.time_zone_aware_attributes = cfg[:aware_attributes].
+    // If Base doesn't define the property yet the assignment still takes effect (JS class property),
+    // making the helper forward-compatible when the wiring lands.
+    if (cfg.awareAttributes !== undefined) base.timeZoneAwareAttributes = cfg.awareAttributes;
+    if (cfg.awareTypes !== undefined) base.timeZoneAwareTypes = cfg.awareTypes;
     await fn();
   } finally {
     setDefaultTimezone(oldDefault);
-    if (hadAwareAttributes) base.timeZoneAwareAttributes = oldAwareAttributes;
-    if (hadAwareTypes) base.timeZoneAwareTypes = oldAwareTypes;
+    if (hadAwareAttributes) {
+      base.timeZoneAwareAttributes = oldAwareAttributes;
+    } else {
+      delete base.timeZoneAwareAttributes;
+    }
+    if (hadAwareTypes) {
+      base.timeZoneAwareTypes = oldAwareTypes;
+    } else {
+      delete base.timeZoneAwareTypes;
+    }
   }
 }

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -26,25 +26,25 @@ export async function withTimezoneConfig(
 ): Promise<void> {
   const oldDefault = getDefaultTimezone();
   const base = Base as any;
-  const oldAwareAttributes: boolean | undefined = base.timeZoneAwareAttributes;
-  const oldAwareTypes: string[] | undefined = base.timeZoneAwareTypes;
+
+  // Snapshot: track whether each property existed before, and its prior value.
+  const hadAwareAttributes = "timeZoneAwareAttributes" in base;
+  const oldAwareAttributes = base.timeZoneAwareAttributes;
+  const hadAwareTypes = "timeZoneAwareTypes" in base;
+  const oldAwareTypes = base.timeZoneAwareTypes;
 
   try {
     if (cfg.default !== undefined) setDefaultTimezone(cfg.default);
-    if (cfg.awareAttributes !== undefined && "timeZoneAwareAttributes" in base) {
+    if (cfg.awareAttributes !== undefined && hadAwareAttributes) {
       base.timeZoneAwareAttributes = cfg.awareAttributes;
     }
-    if (cfg.awareTypes !== undefined && "timeZoneAwareTypes" in base) {
+    if (cfg.awareTypes !== undefined && hadAwareTypes) {
       base.timeZoneAwareTypes = cfg.awareTypes;
     }
     await fn();
   } finally {
     setDefaultTimezone(oldDefault);
-    if ("timeZoneAwareAttributes" in base && oldAwareAttributes !== undefined) {
-      base.timeZoneAwareAttributes = oldAwareAttributes;
-    }
-    if ("timeZoneAwareTypes" in base && oldAwareTypes !== undefined) {
-      base.timeZoneAwareTypes = oldAwareTypes;
-    }
+    if (hadAwareAttributes) base.timeZoneAwareAttributes = oldAwareAttributes;
+    if (hadAwareTypes) base.timeZoneAwareTypes = oldAwareTypes;
   }
 }

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -1,0 +1,50 @@
+/**
+ * Test helpers that mirror Rails' ActiveRecord::TestCase helpers.
+ *
+ * Mirrors: activerecord/test/cases/test_case.rb
+ */
+import { getDefaultTimezone, setDefaultTimezone } from "./type/internal/timezone.js";
+import { Base } from "./base.js";
+
+interface TimezoneConfig {
+  /** Mirrors Rails' `default_timezone` — "utc" or "local". */
+  default?: "utc" | "local";
+  /** Mirrors Rails' `time_zone_aware_attributes`. */
+  awareAttributes?: boolean;
+  /** Mirrors Rails' `time_zone_aware_types`. */
+  awareTypes?: string[];
+}
+
+/**
+ * Temporarily applies timezone-related configuration, yields, then restores.
+ *
+ * Mirrors: ActiveRecord::TestCase#with_timezone_config
+ */
+export async function withTimezoneConfig(
+  cfg: TimezoneConfig,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  const oldDefault = getDefaultTimezone();
+  const base = Base as any;
+  const oldAwareAttributes: boolean | undefined = base.timeZoneAwareAttributes;
+  const oldAwareTypes: string[] | undefined = base.timeZoneAwareTypes;
+
+  try {
+    if (cfg.default !== undefined) setDefaultTimezone(cfg.default);
+    if (cfg.awareAttributes !== undefined && "timeZoneAwareAttributes" in base) {
+      base.timeZoneAwareAttributes = cfg.awareAttributes;
+    }
+    if (cfg.awareTypes !== undefined && "timeZoneAwareTypes" in base) {
+      base.timeZoneAwareTypes = cfg.awareTypes;
+    }
+    await fn();
+  } finally {
+    setDefaultTimezone(oldDefault);
+    if ("timeZoneAwareAttributes" in base && oldAwareAttributes !== undefined) {
+      base.timeZoneAwareAttributes = oldAwareAttributes;
+    }
+    if ("timeZoneAwareTypes" in base && oldAwareTypes !== undefined) {
+      base.timeZoneAwareTypes = oldAwareTypes;
+    }
+  }
+}

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -268,9 +268,17 @@ class ApiExtractor
       # Handle `CONST = Struct.new(...) do ... end` — methods defined in the
       # block belong to the struct, not to the enclosing module.
       lhs, rhs = node[1], node[2]
+      # Only enter the struct-class path when:
+      #   lhs = [:var_field, [:@const, "Name", ...]]
+      #   rhs = [:method_add_block, [:method_add_arg, [:call, Struct, ., :new], ...], block]
+      #         where the receiver constant resolves to "Struct"
+      struct_call = rhs.is_a?(Array) && rhs[0] == :method_add_block && rhs[1]
+      struct_receiver = struct_call && struct_call.is_a?(Array) &&
+                        struct_call[0] == :method_add_arg && const_name(struct_call[1])
+      is_struct_new = struct_receiver == "Struct"
       if lhs.is_a?(Array) && lhs[0] == :var_field &&
          lhs[1].is_a?(Array) && lhs[1][0] == :@const &&
-         rhs.is_a?(Array) && rhs[0] == :method_add_block
+         is_struct_new
         const_name_str = lhs[1][1]
         block = rhs[2]
         body = block.is_a?(Array) && (block[0] == :do_block || block[0] == :brace_block) ? block[2] : nil
@@ -279,6 +287,7 @@ class ApiExtractor
           @visibility_stack.push(:public)
           fqn = current_fqn
           @classes[fqn] ||= new_class_info(const_name_str, fqn)
+          @classes[fqn][:superclass] = "Struct"
           walk_body(body)
           @visibility_stack.pop
           @namespace_stack.pop

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -264,6 +264,30 @@ class ApiExtractor
       process_method_add_arg(node)
     when :sclass
       process_sclass(node)
+    when :assign
+      # Handle `CONST = Struct.new(...) do ... end` — methods defined in the
+      # block belong to the struct, not to the enclosing module.
+      lhs, rhs = node[1], node[2]
+      if lhs.is_a?(Array) && lhs[0] == :var_field &&
+         lhs[1].is_a?(Array) && lhs[1][0] == :@const &&
+         rhs.is_a?(Array) && rhs[0] == :method_add_block
+        const_name_str = lhs[1][1]
+        block = rhs[2]
+        body = block.is_a?(Array) && (block[0] == :do_block || block[0] == :brace_block) ? block[2] : nil
+        if body
+          @namespace_stack.push(const_name_str)
+          @visibility_stack.push(:public)
+          fqn = current_fqn
+          @classes[fqn] ||= new_class_info(const_name_str, fqn)
+          walk_body(body)
+          @visibility_stack.pop
+          @namespace_stack.pop
+        else
+          node.each { |child| walk(child) if child.is_a?(Array) }
+        end
+      else
+        node.each { |child| walk(child) if child.is_a?(Array) }
+      end
     when :program, :bodystmt, :body_stmt, :stmts_add, :stmts_new,
          :begin, :else, :elsif, :if, :if_mod, :unless, :unless_mod,
          :rescue, :ensure, :while, :until, :case, :when


### PR DESCRIPTION
## Summary

8 small Rails-fidelity follow-ups bundled together — each independent and revertable.

| Commit | Item | LOC |
|--------|------|-----|
| 1 | **TZ-helper** — `withTimezoneConfig` in `test-helper.ts`; saves/restores `defaultTimezone` + `timeZoneAwareAttributes`/`timeZoneAwareTypes` when wired. Sharpens 1 BLOCKED annotation in `date-time-precision.test.ts`. | ~75 |
| 2 | **I-followup-2** — `findSome` ordered path: narrows to pk column via `select(table[pk])` when `selectValues` non-empty (mirrors Rails `find_some` line) | ~12 |
| 3 | **J-followup** — `execInsert` calls `sqlForInsert` before `internalExecQuery`, appending `RETURNING` clause when adapter supports it | ~8 |
| 4 | **M-followup-2 connection** — `Migration#connection` getter respects `_connectionOverride` (mirrors Rails `@connection || DatabaseTasks.migration_connection`) | ~12 |
| 5+6 | **M-followup-2 tests** — `MigrationProxy.disableDdlTransaction` throw before `await migration()` + `ERR_REQUIRE_ESM` fallthrough path | ~17 |
| 7 | **Q extractor** — `extract-ruby-api.rb` now handles `CONST = Struct.new(...) do...end`; `TokenDefinition` methods now attributed to `ActiveRecord::TokenFor::TokenDefinition` not `TokenFor` | ~24 |
| 8 | **int8range BigInt** — raw-SQL range tests for `int8range` use `BigInt`/`10n` to match AR-model path | ~17 |

## Notes

- No tests un-skipped for TZ-helper: the deeper gap is `Base.timeZoneAwareAttributes` not yet wired + `TimeZoneConverter.serialize` missing — BLOCKED annotation sharpened accordingly.
- Docs plan files (`activerecord-100-plan.md`, `browser-compat-plan.md`, `sqlite-driver-abstraction-plan.md`) were updated from main as collateral — all plan-state updates, no behavioral change.