### PR TITLE
feat(activerecord): Story TZ-wire — wire TimeZoneConversion + fix .type() predicate bug (~130 LOC)

### DIFF
--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -68,4 +68,16 @@ describe("TimeZoneConversionTest", () => {
     const type = Post._attributeDefinitions.get("starts_at")?.type;
     expect(type).toBeInstanceOf(TimeZoneConverter);
   });
+
+  it("instance attribute type matches _attributeDefinitions after _defaultAttributes replay", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+        this.attribute("published_at", "datetime");
+      }
+    }
+    const defaults = Post._defaultAttributes();
+    const attr = defaults.getAttribute("published_at");
+    expect(attr?.type).toBeInstanceOf(TimeZoneConverter);
+  });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for TimeZoneConversion wiring on Base.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversionTest
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { TimeZoneConverter } from "./time-zone-conversion.js";
+
+describe("TimeZoneConversionTest", () => {
+  beforeEach(() => {
+    createTestAdapter();
+  });
+
+  it("wraps datetime attribute when timeZoneAwareAttributes is true", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+        this.attribute("published_at", "datetime");
+      }
+    }
+    const type = Post._attributeDefinitions.get("published_at")?.type;
+    expect(type).toBeInstanceOf(TimeZoneConverter);
+  });
+
+  it("does not wrap datetime attribute when timeZoneAwareAttributes is false", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = false;
+        this.attribute("published_at", "datetime");
+      }
+    }
+    const type = Post._attributeDefinitions.get("published_at")?.type;
+    expect(type).not.toBeInstanceOf(TimeZoneConverter);
+  });
+
+  it("does not wrap non-datetime attribute even when timeZoneAwareAttributes is true", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+        this.attribute("title", "string");
+      }
+    }
+    const type = Post._attributeDefinitions.get("title")?.type;
+    expect(type).not.toBeInstanceOf(TimeZoneConverter);
+  });
+
+  it("does not wrap attribute listed in skipTimeZoneConversionForAttributes", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+        this.skipTimeZoneConversionForAttributes = ["published_at"];
+        this.attribute("published_at", "datetime");
+      }
+    }
+    const type = Post._attributeDefinitions.get("published_at")?.type;
+    expect(type).not.toBeInstanceOf(TimeZoneConverter);
+  });
+
+  it("wraps time attribute when timeZoneAwareAttributes is true", () => {
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+        this.attribute("starts_at", "time");
+      }
+    }
+    const type = Post._attributeDefinitions.get("starts_at")?.type;
+    expect(type).toBeInstanceOf(TimeZoneConverter);
+  });
+});

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -4,8 +4,10 @@
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversionTest
  */
 import { describe, it, expect, beforeEach } from "vitest";
+import { typeRegistry } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { loadSchemaFromAdapter } from "../model-schema.js";
 import { TimeZoneConverter } from "./time-zone-conversion.js";
 
 describe("TimeZoneConversionTest", () => {
@@ -79,5 +81,35 @@ describe("TimeZoneConversionTest", () => {
     const defaults = Post._defaultAttributes();
     const attr = defaults.getAttribute("published_at");
     expect(attr?.type).toBeInstanceOf(TimeZoneConverter);
+  });
+
+  it("wraps schema-reflected datetime column when timeZoneAwareAttributes is true", async () => {
+    const datetimeType = typeRegistry.lookup("datetime");
+    const stringType = typeRegistry.lookup("string");
+    const cols = {
+      published_at: { sqlType: "datetime" },
+      title: { sqlType: "string" },
+    } as Record<string, unknown>;
+    const adapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => cols,
+        getCachedColumnsHash: () => cols,
+        isCached: () => true,
+      },
+      lookupCastTypeFromColumn(col: { sqlType: string }) {
+        return col.sqlType === "datetime" ? datetimeType : stringType;
+      },
+    };
+    class Post extends Base {
+      static {
+        this.timeZoneAwareAttributes = true;
+      }
+      static override tableName = "posts";
+    }
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await loadSchemaFromAdapter.call(Post);
+    expect(Post._attributeDefinitions.get("published_at")?.type).toBeInstanceOf(TimeZoneConverter);
+    expect(Post._attributeDefinitions.get("title")?.type).not.toBeInstanceOf(TimeZoneConverter);
   });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -56,11 +56,14 @@ interface TimeZoneConversionHost {
   _hookAttributeType?(name: string, castType: unknown): unknown;
 }
 
-/** @internal */
-function hookAttributeType(
+/**
+ * @internal
+ * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods#hook_attribute_type
+ */
+export function hookAttributeType(
   this: TimeZoneConversionHost,
   name: string,
-  castType: { type?: string },
+  castType: { type?(): string },
 ): unknown {
   if (isCreateTimeZoneConversionAttribute.call(this, name, castType)) {
     return new TimeZoneConverter(castType as any);
@@ -72,12 +75,12 @@ function hookAttributeType(
 function isCreateTimeZoneConversionAttribute(
   this: TimeZoneConversionHost,
   name: string,
-  castType: { type?: string },
+  castType: { type?(): string },
 ): boolean {
   const enabledForColumn =
     this.timeZoneAwareAttributes && !this.skipTimeZoneConversionForAttributes.includes(name as any);
   return (
     enabledForColumn &&
-    (this.timeZoneAwareTypes ?? ["datetime", "time"]).includes(castType.type ?? "")
+    (this.timeZoneAwareTypes ?? ["datetime", "time"]).includes(castType.type?.() ?? "")
   );
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -1,56 +1,60 @@
 /**
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
+import { Type, ValueType } from "@blazetrails/activemodel";
+
 export interface TimeZoneConversion {
   timeZoneAwareAttributes: boolean;
   skipTimeZoneConversionForAttributes: string[];
 }
 
-type Subtype = {
-  cast(value: unknown): unknown;
-  deserialize?(value: unknown): unknown;
-  map?(value: unknown): unknown;
-};
-
 /**
  * Time zone converter type — wraps a time type to apply zone conversion.
  *
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+ * Rails uses `DelegateClass(Type::Value)` to auto-delegate; we extend ValueType
+ * and forward all unoverridden methods to the wrapped subtype.
  */
-export class TimeZoneConverter {
-  private readonly subtype: Subtype;
+export class TimeZoneConverter extends ValueType<unknown> {
+  private readonly _subtype: Type;
+  override readonly name: string;
 
-  constructor(subtype: Subtype) {
-    this.subtype = subtype;
+  constructor(subtype: Type) {
+    super();
+    this._subtype = subtype;
+    this.name = subtype.name;
   }
 
   /** Idempotent factory — mirrors Rails' `self.new` guard. */
-  static wrap(subtype: Subtype): TimeZoneConverter {
+  static wrap(subtype: Type): TimeZoneConverter {
     return subtype instanceof TimeZoneConverter ? subtype : new TimeZoneConverter(subtype);
   }
 
-  cast(value: unknown): unknown {
+  override type(): string {
+    return this._subtype.type();
+  }
+
+  override cast(value: unknown): unknown {
     if (value == null) return null;
     if (Array.isArray(value)) {
       // mirrors: map(super) { |v| cast(v) }
-      const casted = this.subtype.cast(value);
+      const casted = this._subtype.cast(value);
       return Array.isArray(casted) ? casted.map((v) => this.cast(v)) : this.cast(casted);
     }
     // TODO: requires TimeWithZone — user_input_in_time_zone(value) for time-like values
-    return this.subtype.cast(value);
+    return this._subtype.cast(value);
   }
 
-  deserialize(value: unknown): unknown {
-    const raw = this.subtype.deserialize
-      ? this.subtype.deserialize(value)
-      : this.subtype.cast(value);
-    return convertTimeToTimeZone(raw);
+  override deserialize(value: unknown): unknown {
+    return convertTimeToTimeZone(this._subtype.deserialize(value));
+  }
+
+  override serialize(value: unknown): unknown {
+    return this._subtype.serialize(value);
   }
 
   equals(other: unknown): boolean {
-    return (
-      other instanceof TimeZoneConverter && this.subtype === (other as TimeZoneConverter).subtype
-    );
+    return other instanceof TimeZoneConverter && this._subtype === other._subtype;
   }
 }
 
@@ -88,10 +92,10 @@ interface TimeZoneConversionHost {
 export function hookAttributeType(
   this: TimeZoneConversionHost,
   name: string,
-  castType: { type?(): string },
-): unknown {
+  castType: Type,
+): Type {
   if (isCreateTimeZoneConversionAttribute.call(this, name, castType)) {
-    return TimeZoneConverter.wrap(castType as Subtype);
+    return TimeZoneConverter.wrap(castType);
   }
   return castType;
 }
@@ -100,12 +104,12 @@ export function hookAttributeType(
 function isCreateTimeZoneConversionAttribute(
   this: TimeZoneConversionHost,
   name: string,
-  castType: { type?(): string },
+  castType: Type,
 ): boolean {
   const enabledForColumn =
     this.timeZoneAwareAttributes && !this.skipTimeZoneConversionForAttributes.includes(name as any);
   return (
     enabledForColumn &&
-    (this.timeZoneAwareTypes ?? ["datetime", "time"]).includes(castType.type?.() ?? "")
+    (this.timeZoneAwareTypes ?? ["datetime", "time"]).includes(castType.type() ?? "")
   );
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -3,6 +3,7 @@
  */
 import type { Type } from "@blazetrails/activemodel";
 import { ValueType } from "@blazetrails/activemodel";
+type ValueTypeInstance = InstanceType<typeof ValueType>;
 
 export interface TimeZoneConversion {
   timeZoneAwareAttributes: boolean;
@@ -57,8 +58,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return this._subtype.serializeCastValue(value as any);
   }
 
-  equals(other: unknown): boolean {
-    return other instanceof TimeZoneConverter && this._subtype === other._subtype;
+  override equals(other: Type): boolean {
+    return (
+      other instanceof TimeZoneConverter &&
+      (this._subtype as ValueTypeInstance).equals(other._subtype)
+    );
   }
 }
 

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -1,11 +1,13 @@
 /**
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
-import { Type, ValueType } from "@blazetrails/activemodel";
+import type { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 export interface TimeZoneConversion {
   timeZoneAwareAttributes: boolean;
   skipTimeZoneConversionForAttributes: string[];
+  timeZoneAwareTypes: string[];
 }
 
 /**
@@ -36,12 +38,8 @@ export class TimeZoneConverter extends ValueType<unknown> {
 
   override cast(value: unknown): unknown {
     if (value == null) return null;
-    if (Array.isArray(value)) {
-      // mirrors: map(super) { |v| cast(v) }
-      const casted = this._subtype.cast(value);
-      return Array.isArray(casted) ? casted.map((v) => this.cast(v)) : this.cast(casted);
-    }
-    // TODO: requires TimeWithZone — user_input_in_time_zone(value) for time-like values
+    // TODO: requires TimeWithZone — in_time_zone branch via user_input_in_time_zone(value)
+    // Fallback mirrors: map(super) { |v| cast(v) } — delegate to subtype
     return this._subtype.cast(value);
   }
 
@@ -51,6 +49,10 @@ export class TimeZoneConverter extends ValueType<unknown> {
 
   override serialize(value: unknown): unknown {
     return this._subtype.serialize(value);
+  }
+
+  override serializeCastValue(value: unknown): unknown {
+    return this._subtype.serializeCastValue(value as never);
   }
 
   equals(other: unknown): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -59,10 +59,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 
   override equals(other: Type): boolean {
-    return (
-      other instanceof TimeZoneConverter &&
-      (this._subtype as ValueTypeInstance).equals(other._subtype)
-    );
+    if (!(other instanceof TimeZoneConverter)) return false;
+    const sub = this._subtype as ValueTypeInstance;
+    return typeof sub.equals === "function"
+      ? sub.equals(other._subtype)
+      : this._subtype === other._subtype;
   }
 }
 

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -54,7 +54,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 
   override serializeCastValue(value: unknown): unknown {
-    return this._subtype.serializeCastValue(value as never);
+    return this._subtype.serializeCastValue(value as any);
   }
 
   equals(other: unknown): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -55,7 +55,13 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 
   override serializeCastValue(value: unknown): unknown {
-    return this._subtype.serializeCastValue(value as any);
+    const sub = this._subtype as ValueTypeInstance;
+    if (typeof sub.itselfIfSerializeCastValueCompatible === "function") {
+      return sub.itselfIfSerializeCastValueCompatible()
+        ? sub.serializeCastValue(value as any)
+        : this._subtype.serialize(value);
+    }
+    return this._subtype.serialize(value);
   }
 
   override equals(other: Type): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -6,48 +6,73 @@ export interface TimeZoneConversion {
   skipTimeZoneConversionForAttributes: string[];
 }
 
+type Subtype = {
+  cast(value: unknown): unknown;
+  deserialize?(value: unknown): unknown;
+  map?(value: unknown): unknown;
+};
+
 /**
  * Time zone converter type — wraps a time type to apply zone conversion.
  *
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
  */
 export class TimeZoneConverter {
-  private readonly subtype: { cast(value: unknown): unknown };
+  private readonly subtype: Subtype;
 
-  constructor(subtype: { cast(value: unknown): unknown }) {
+  constructor(subtype: Subtype) {
     this.subtype = subtype;
   }
 
+  /** Idempotent factory — mirrors Rails' `self.new` guard. */
+  static wrap(subtype: Subtype): TimeZoneConverter {
+    return subtype instanceof TimeZoneConverter ? subtype : new TimeZoneConverter(subtype);
+  }
+
   cast(value: unknown): unknown {
+    if (value == null) return null;
+    if (Array.isArray(value)) {
+      // mirrors: map(super) { |v| cast(v) }
+      const casted = this.subtype.cast(value);
+      return Array.isArray(casted) ? casted.map((v) => this.cast(v)) : this.cast(casted);
+    }
+    // TODO: requires TimeWithZone — user_input_in_time_zone(value) for time-like values
     return this.subtype.cast(value);
   }
 
   deserialize(value: unknown): unknown {
-    return (this.subtype as any).deserialize
-      ? (this.subtype as any).deserialize(value)
+    const raw = this.subtype.deserialize
+      ? this.subtype.deserialize(value)
       : this.subtype.cast(value);
+    return convertTimeToTimeZone(raw);
+  }
+
+  equals(other: unknown): boolean {
+    return (
+      other instanceof TimeZoneConverter && this.subtype === (other as TimeZoneConverter).subtype
+    );
   }
 }
 
 /** @internal */
 function convertTimeToTimeZone(value: unknown): unknown {
   if (value == null) return value;
-  // boundary: legacy callers may still hand in JS Date for time-zone-aware
-  // attributes; pass through unchanged (the typed cast layer handles Temporal).
-  if (value instanceof Date) {
-    return value;
-  }
   if (Array.isArray(value)) {
     return value.map((v) => convertTimeToTimeZone(v));
   }
+  // TODO: requires TimeWithZone — value.in_time_zone for time-like values
   return value;
 }
 
 /** @internal */
 function setTimeZoneWithoutConversion(value: unknown): unknown {
   if (value == null) return value;
+  // TODO: requires TimeWithZone — Time.zone.local_to_utc(value).try(:in_time_zone)
   return value;
 }
+
+// Silence unused-variable warnings until TimeWithZone is implemented.
+void setTimeZoneWithoutConversion;
 
 interface TimeZoneConversionHost {
   timeZoneAwareAttributes: boolean;
@@ -66,7 +91,7 @@ export function hookAttributeType(
   castType: { type?(): string },
 ): unknown {
   if (isCreateTimeZoneConversionAttribute.call(this, name, castType)) {
-    return new TimeZoneConverter(castType as any);
+    return TimeZoneConverter.wrap(castType as Subtype);
   }
   return castType;
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -14,8 +14,10 @@ export interface TimeZoneConversion {
  * Time zone converter type — wraps a time type to apply zone conversion.
  *
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
- * Rails uses `DelegateClass(Type::Value)` to auto-delegate; we extend ValueType
- * and forward all unoverridden methods to the wrapped subtype.
+ * Rails uses `DelegateClass(Type::Value)` to auto-delegate all methods; we extend
+ * ValueType and explicitly delegate type/cast/deserialize/serialize/serializeCastValue
+ * to the wrapped subtype. Other Type methods (isChanged, isSerializable, etc.) fall
+ * back to ValueType defaults, matching the base type's behavior for time values.
  */
 export class TimeZoneConverter extends ValueType<unknown> {
   private readonly _subtype: Type;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -95,6 +95,7 @@ const loadSignedId = async () => {
 };
 import * as LockingOptimistic from "./locking/optimistic.js";
 import * as LockingPessimistic from "./locking/pessimistic.js";
+import { hookAttributeType as tzHookAttributeType } from "./attribute-methods/time-zone-conversion.js";
 import * as Translation from "./translation.js";
 import * as Sanitization from "./sanitization.js";
 import * as Serialization from "./serialization.js";
@@ -580,6 +581,27 @@ export class Base extends Model {
   static _protectedEnvironments: string[] = ["production"];
   static _lockingColumn: string = "lock_version";
 
+  /**
+   * When true, datetime/time attributes are wrapped in a TimeZoneConverter.
+   *
+   * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion.time_zone_aware_attributes
+   */
+  static timeZoneAwareAttributes: boolean = false;
+
+  /**
+   * Attribute names exempt from time-zone conversion.
+   *
+   * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion.skip_time_zone_conversion_for_attributes
+   */
+  static skipTimeZoneConversionForAttributes: string[] = [];
+
+  /**
+   * Column types eligible for time-zone conversion.
+   *
+   * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion.time_zone_aware_types
+   */
+  static timeZoneAwareTypes: string[] = ["datetime", "time"];
+
   static get protectedEnvironments(): string[] {
     return ModelSchema.protectedEnvironments.call(this);
   }
@@ -762,12 +784,32 @@ export class Base extends Model {
       return;
     }
     super.attribute(name, typeName, options);
+    // Apply hookAttributeType decorators (TZ conversion, locking) to the
+    // just-registered type so user-declared datetime attributes are wrapped.
+    const def = this._attributeDefinitions.get(name);
+    if (def) {
+      const hooked = this.hookAttributeType(name, def.type);
+      if (hooked !== def.type) {
+        this._attributeDefinitions.set(name, { ...def, type: hooked });
+      }
+    }
     // If we just defined an "id" accessor on a subclass prototype, remove it
     // so Base.prototype.id (which handles CPK) is used instead.
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
       delete (this.prototype as any).id;
     }
     encryptionHooks.applyPendingEncryptions(this);
+  }
+
+  /**
+   * Chains time-zone-conversion and optimistic-locking type decoration.
+   *
+   * @internal Rails-private helper.
+   * Mirrors: ActiveRecord::Base#hook_attribute_type (composed via module includes)
+   */
+  static override hookAttributeType(name: string, type: Type): Type {
+    const tzType = tzHookAttributeType.call(this as any, name, type) as Type;
+    return LockingOptimistic.hookAttributeType.call(this as any, name, tzType);
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Model, type Type, typeRegistry } from "@blazetrails/activemodel";
+import { Model, type Type, typeRegistry, pushPendingDecorator } from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
 import {
   Table,
@@ -786,11 +786,15 @@ export class Base extends Model {
     super.attribute(name, typeName, options);
     // Apply hookAttributeType decorators (TZ conversion, locking) to the
     // just-registered type so user-declared datetime attributes are wrapped.
+    // Patch _attributeDefinitions immediately (read path) and also push a
+    // PendingDecorator so _defaultAttributes() replay sees the hooked type
+    // after the PendingType for this attribute.
     const def = this._attributeDefinitions.get(name);
     if (def) {
       const hooked = this.hookAttributeType(name, def.type);
       if (hooked !== def.type) {
         this._attributeDefinitions.set(name, { ...def, type: hooked });
+        pushPendingDecorator(this, [name], (_n: string, _t: Type) => hooked);
       }
     }
     // If we just defined an "id" accessor on a subclass prototype, remove it

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -41,8 +41,8 @@ export function lockingEnabled(modelClass: typeof Base): boolean {
 /**
  * Type wrapper for the lock_version column that ensures nil → 0 on
  * serialize/deserialize so passing nil doesn't trigger StaleObjectError.
- * cast() is intentionally not overridden — Rails' LockingType delegates it
- * to the subtype unchanged, preserving null for new records.
+ * cast() delegates unchanged to the subtype (no nil → 0 coercion), preserving
+ * null for new records that explicitly pass nil — matching Rails' LockingType.
  *
  * Mirrors: ActiveRecord::Locking::LockingType
  */

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -39,8 +39,10 @@ export function lockingEnabled(modelClass: typeof Base): boolean {
 }
 
 /**
- * Type wrapper for the lock_version column that ensures values are
- * always coerced to integers on serialize and deserialize.
+ * Type wrapper for the lock_version column that ensures nil → 0 on
+ * serialize/deserialize so passing nil doesn't trigger StaleObjectError.
+ * cast() is intentionally not overridden — Rails' LockingType delegates it
+ * to the subtype unchanged, preserving null for new records.
  *
  * Mirrors: ActiveRecord::Locking::LockingType
  */
@@ -54,15 +56,15 @@ export class LockingType extends ValueType<number> {
     this.name = subtype.name;
   }
 
-  cast(value: unknown): number {
-    return toInt(this._subtype.cast(value));
+  override cast(value: unknown): number | null {
+    return this._subtype.cast(value) as number | null;
   }
 
-  deserialize(value: unknown): number {
+  override deserialize(value: unknown): number {
     return toInt(this._subtype.deserialize(value));
   }
 
-  serialize(value: unknown): number {
+  override serialize(value: unknown): number {
     return toInt(this._subtype.serialize(value));
   }
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -364,6 +364,7 @@ interface SchemaHost {
   adapter: any;
   prototype: any;
   superclass?: SchemaHost;
+  hookAttributeType?(name: string, type: Type): Type;
 }
 
 export function deriveJoinTableName(this: SchemaHost, otherTableName: string): string {
@@ -695,6 +696,8 @@ function applyColumnsHash(
         ? adapter.lookupCastTypeFromColumn(column)
         : null;
     let type = (castType as Type | null) ?? typeRegistry.lookup("value");
+
+    type = host.hookAttributeType?.(name, type) ?? type;
 
     // Preserve encryption wrappers across schema reflection. Both
     // EncryptedAttributeType variants implement `WrappedType`; any

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -217,6 +217,7 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   ["ValueType", "Type"],
   ["LockingType", "ValueType"],
   ["Serialized", "ValueType"],
+  ["TimeZoneConverter", "ValueType"],
   // `ActiveRecord::Base` has no Ruby super; TS `Base` extends `Model`
   // so the ActiveModel mixin surface is type-visible on subclasses.
   ["Base", "Model"],


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: `hookAttributeType` from `time-zone-conversion.ts` was exported but never called. Now wired in two places:
  - `Base.hookAttributeType()` — new override that chains TZ conversion → optimistic locking decoration
  - `Base.attribute()` — applies the hook after registering user-declared attributes
  - `applyColumnsHash()` in `model-schema.ts` — applies the hook during schema reflection
- **Bug 2 fixed**: `castType.type ?? ""` read `type` as a property; `Type` exposes it as a method. Changed to `castType.type?.() ?? ""`.
- **New properties** on `Base`: `timeZoneAwareAttributes` (default `false`), `skipTimeZoneConversionForAttributes` (default `[]`), `timeZoneAwareTypes` (default `["datetime", "time"]`).
- **7 regression tests** in `time-zone-conversion.test.ts` covering: datetime wrapped when enabled, datetime not wrapped when disabled, non-datetime never wrapped, skipped attributes not wrapped, time column wrapped.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts` — 7/7 pass
- [x] `pnpm vitest run packages/activerecord/src/base.test.ts` — 284 pass, 34 skipped (no regressions)
- [x] `pnpm api:compare --package activerecord` — 4969/4969 (100%), no regression

## Out of scope

- `TimeWithZone` class implementation (actual value conversion) — separate slot
- `with_timezone_config` test helper — separate slot
- PG `timestamptz` routing — separate slot
- Range types (`tsrange`/`tstzrange`) — separate slot

## Known gaps (out of scope for this PR)

- **TimeWithZone not implemented** — `TimeZoneConverter.cast()` and `convertTimeToTimeZone()` have `// TODO: requires TimeWithZone` comments. The `in_time_zone` branch in `cast()` and the actual timezone conversion in `deserialize()` are pass-throughs until `TimeWithZone` is ported. Tracked as a separate slot.
- **`setTimeZoneWithoutConversion`** — Hash branch in `cast()` also requires `TimeWithZone`; currently a pass-through.

- **`defineAttribute` intentionally excludes the hook** — Rails' `define_attribute` writes directly to `attribute_types` without calling `hook_attribute_type` (AR `attributes.rb:231–239`). It is a lower-level bypass used for internal registration and is intentionally excluded from the TZ conversion chain, matching Rails.