### PR TITLE
feat(activerecord): relation fidelity sweep — 4 items (~89 LOC)

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -19,6 +19,7 @@ import {
 import { Associations, loadBelongsTo } from "./associations.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
+import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
@@ -7539,3 +7540,53 @@ describe("bigint aggregates (big_integer columns)", () => {
 // ==========================================================================
 // CalculationsTest — targets calculations_test.rb (continued)
 // ==========================================================================
+
+// ==========================================================================
+// lookupCastTypeFromJoinDependencies unit tests
+// ==========================================================================
+describe("lookupCastTypeFromJoinDependencies", () => {
+  it("returns cast type from a joined table's attributeTypes", () => {
+    const intType = { cast: (v: unknown) => Number(v) };
+    const fakeNode = { modelClass: { attributeTypes: () => ({ credit_limit: intType }) } };
+    const fakeJd = [fakeNode];
+    const result = lookupCastTypeFromJoinDependencies({} as any, "credit_limit", [fakeJd]);
+    expect(result).toBe(intType);
+  });
+
+  it("returns null when name is not in any joined table", () => {
+    const fakeNode = { modelClass: { attributeTypes: () => ({ other: {} }) } };
+    const result = lookupCastTypeFromJoinDependencies({} as any, "missing", [[fakeNode]]);
+    expect(result).toBeNull();
+  });
+
+  it("returns first match when multiple join deps are present", () => {
+    const type1 = { cast: (v: unknown) => String(v) };
+    const type2 = { cast: (v: unknown) => Number(v) };
+    const node1 = { modelClass: { attributeTypes: () => ({ name: type1 }) } };
+    const node2 = { modelClass: { attributeTypes: () => ({ name: type2 }) } };
+    const result = lookupCastTypeFromJoinDependencies({} as any, "name", [[node1], [node2]]);
+    expect(result).toBe(type1);
+  });
+
+  it("supports attributeTypes as a plain object", () => {
+    const strType = { cast: (v: unknown) => String(v) };
+    const fakeNode = { modelClass: { attributeTypes: { title: strType } } };
+    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [[fakeNode]]);
+    expect(result).toBe(strType);
+  });
+
+  it("supports attributeTypes as a Map", () => {
+    const strType = { cast: (v: unknown) => String(v) };
+    const fakeNode = { modelClass: { attributeTypes: new Map([["title", strType]]) } };
+    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [[fakeNode]]);
+    expect(result).toBe(strType);
+  });
+
+  it("skips nodes without modelClass", () => {
+    const type = { cast: (v: unknown) => v };
+    const nodeMissing = { modelClass: undefined };
+    const nodeGood = { modelClass: { attributeTypes: () => ({ val: type }) } };
+    const result = lookupCastTypeFromJoinDependencies({} as any, "val", [[nodeMissing, nodeGood]]);
+    expect(result).toBe(type);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -26,6 +26,18 @@ class TestAdapter extends AbstractAdapter {
   }
 }
 
+describe("AbstractAdapter#returnValueAfterInsert", () => {
+  it("returns true when column isAutoPopulated", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.returnValueAfterInsert({ isAutoPopulated: () => true })).toBe(true);
+  });
+
+  it("returns false when column is not auto-populated", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.returnValueAfterInsert({ isAutoPopulated: () => false })).toBe(false);
+  });
+});
+
 describe("AbstractAdapter.extractLimit", () => {
   it("parses limit from sql type with parens", () => {
     expect(TestAdapter.extractLimit("varchar(255)")).toBe(255);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -14,6 +14,8 @@ import { DateTime as DateTimeType } from "../type/date-time.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
+import { Column } from "./column.js";
+import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { Result } from "../result.js";
 
 // All 5 methods are class-level in Rails (class << self private), so test via a subclass.
@@ -27,14 +29,18 @@ class TestAdapter extends AbstractAdapter {
 }
 
 describe("AbstractAdapter#returnValueAfterInsert", () => {
-  it("returns true when column isAutoPopulated", () => {
+  it("returns true when column isAutoPopulated (has default function)", () => {
     const adapter = new TestAdapter();
-    expect(adapter.returnValueAfterInsert({ isAutoPopulated: () => true })).toBe(true);
+    const col = new Column("id", null, new SqlTypeMetadata({ sqlType: "uuid" }), false, {
+      defaultFunction: "gen_random_uuid()",
+    });
+    expect(adapter.returnValueAfterInsert(col)).toBe(true);
   });
 
   it("returns false when column is not auto-populated", () => {
     const adapter = new TestAdapter();
-    expect(adapter.returnValueAfterInsert({ isAutoPopulated: () => false })).toBe(false);
+    const col = new Column("name", null, new SqlTypeMetadata({ sqlType: "varchar" }));
+    expect(adapter.returnValueAfterInsert(col)).toBe(false);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -746,6 +746,11 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
+  /** @internal */
+  returnValueAfterInsert(column: { isAutoPopulated(): boolean }): boolean {
+    return column.isAutoPopulated();
+  }
+
   supportsInsertOnDuplicateSkip(): boolean {
     return false;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -747,7 +747,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   /** @internal */
-  returnValueAfterInsert(column: { isAutoPopulated(): boolean }): boolean {
+  returnValueAfterInsert(column: Column): boolean {
     return column.isAutoPopulated();
   }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -562,17 +562,19 @@ export function typeFor(rel: CalculationRelation, field: string): unknown {
 export function lookupCastTypeFromJoinDependencies(
   rel: CalculationRelation,
   name: string,
-  joinDependencies?: Iterable<{ each(cb: (node: any) => void): void }>,
+  joinDependencies?: Iterable<Iterable<{ modelClass?: { attributeTypes?: unknown } }>>,
 ): unknown {
   const deps = joinDependencies ?? buildJoinDependencies.call(rel as any);
   for (const jd of deps) {
-    for (const node of jd as any) {
-      const klass = (node as any).modelClass;
+    for (const node of jd) {
+      const klass = node.modelClass;
       if (!klass) continue;
-      const rawTypes =
-        typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
+      const attrTypes = klass.attributeTypes;
+      const rawTypes: unknown =
+        typeof attrTypes === "function" ? (attrTypes as () => unknown)() : attrTypes;
       if (!rawTypes) continue;
-      const type = rawTypes instanceof Map ? rawTypes.get(name) : rawTypes[name];
+      const type =
+        rawTypes instanceof Map ? rawTypes.get(name) : (rawTypes as Record<string, unknown>)[name];
       if (type) return type;
     }
   }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -11,7 +11,7 @@
 import { Nodes, Table } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import type { AdapterName } from "../adapter.js";
-import { eachJoinDependencies } from "./query-methods.js";
+import { buildJoinDependencies } from "./query-methods.js";
 
 /**
  * Qualify a GROUP BY column string as an Arel attribute node when it is a
@@ -562,20 +562,21 @@ export function typeFor(rel: CalculationRelation, field: string): unknown {
 export function lookupCastTypeFromJoinDependencies(
   rel: CalculationRelation,
   name: string,
-  joinDependencies?: unknown[],
+  joinDependencies?: Iterable<{ each(cb: (node: any) => void): void }>,
 ): unknown {
-  let found: unknown = null;
-  eachJoinDependencies.call(rel as any, joinDependencies as any, (join: any) => {
-    if (found) return;
-    const klass = join.modelClass;
-    if (!klass) return;
-    const rawTypes =
-      typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
-    if (!rawTypes) return;
-    const type = rawTypes instanceof Map ? rawTypes.get(name) : rawTypes[name];
-    if (type) found = type;
-  });
-  return found;
+  const deps = joinDependencies ?? buildJoinDependencies.call(rel as any);
+  for (const jd of deps) {
+    for (const node of jd as any) {
+      const klass = (node as any).modelClass;
+      if (!klass) continue;
+      const rawTypes =
+        typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
+      if (!rawTypes) continue;
+      const type = rawTypes instanceof Map ? rawTypes.get(name) : rawTypes[name];
+      if (type) return type;
+    }
+  }
+  return null;
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -11,6 +11,7 @@
 import { Nodes, Table } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import type { AdapterName } from "../adapter.js";
+import { eachJoinDependencies } from "./query-methods.js";
 
 /**
  * Qualify a GROUP BY column string as an Arel attribute node when it is a
@@ -559,10 +560,22 @@ export function typeFor(rel: CalculationRelation, field: string): unknown {
 
 /** @internal */
 export function lookupCastTypeFromJoinDependencies(
-  _rel: CalculationRelation,
-  _name: string,
+  rel: CalculationRelation,
+  name: string,
+  joinDependencies?: unknown[],
 ): unknown {
-  return null;
+  let found: unknown = null;
+  eachJoinDependencies.call(rel as any, joinDependencies as any, (join: any) => {
+    if (found) return;
+    const klass = join.baseKlass;
+    if (!klass) return;
+    const rawTypes =
+      typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
+    if (!rawTypes) return;
+    const type = rawTypes instanceof Map ? rawTypes.get(name) : rawTypes[name];
+    if (type) found = type;
+  });
+  return found;
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -567,7 +567,7 @@ export function lookupCastTypeFromJoinDependencies(
   let found: unknown = null;
   eachJoinDependencies.call(rel as any, joinDependencies as any, (join: any) => {
     if (found) return;
-    const klass = join.baseKlass;
+    const klass = join.modelClass;
     if (!klass) return;
     const rawTypes =
       typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -569,9 +569,8 @@ export function lookupCastTypeFromJoinDependencies(
     for (const node of jd) {
       const klass = node.modelClass;
       if (!klass) continue;
-      const attrTypes = klass.attributeTypes;
       const rawTypes: unknown =
-        typeof attrTypes === "function" ? (attrTypes as () => unknown)() : attrTypes;
+        typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
       if (!rawTypes) continue;
       const type =
         rawTypes instanceof Map ? rawTypes.get(name) : (rawTypes as Record<string, unknown>)[name];

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -164,6 +164,26 @@ describe("RelationMutationTest", () => {
     expect(sql).toContain("DISTINCT");
   });
 
+  it("uniq! deduplicates the named clause array", () => {
+    const { Post } = makeModel();
+    const rel = Post.group("title").group("title").group("author");
+    expect((rel as any)._groupColumns).toEqual(["title", "title", "author"]);
+    (rel as any).uniqBang("group");
+    expect((rel as any)._groupColumns).toEqual(["title", "author"]);
+  });
+
+  it("uniq! is a no-op for unknown clause names", () => {
+    const { Post } = makeModel();
+    const rel = Post.group("title");
+    expect(() => (rel as any).uniqBang("unknown_clause")).not.toThrow();
+  });
+
+  it("uniq! with no argument is a no-op", () => {
+    const { Post } = makeModel();
+    const rel = Post.group("title");
+    expect(() => (rel as any).uniqBang()).not.toThrow();
+  });
+
   it("order! with empty string does not emit ORDER BY", () => {
     const { Post } = makeModel();
     // Test the bang method directly — order() delegates to orderBang() on a clone.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -16,6 +16,7 @@ import {
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
+import { sanitizeLimit } from "../connection-adapters/abstract/database-statements.js";
 import { columnNameWithOrderMatcher as abstractOrderMatcher } from "../connection-adapters/abstract/sql-formatting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 import { foreignKey } from "@blazetrails/activesupport";
@@ -1101,8 +1102,24 @@ function annotateBang(this: QueryMethodsHost, ...comments: string[]): any {
   return this;
 }
 
-function uniqBang(this: QueryMethodsHost, _name?: string): any {
-  this._isDistinct = true;
+const UNIQ_BANG_FIELDS: Partial<Record<string, keyof QueryMethodsHost>> = {
+  group: "_groupColumns",
+  select: "_selectColumns",
+  order: "_orderClauses",
+  joins: "_joinValues",
+  annotate: "_annotations",
+  optimizer_hints: "_optimizerHints",
+  references: "_referencesValues",
+};
+
+function uniqBang(this: QueryMethodsHost, name?: string): any {
+  if (name === undefined) return this;
+  const field = UNIQ_BANG_FIELDS[name];
+  if (!field) return this;
+  const arr = this[field] as unknown[];
+  if (Array.isArray(arr) && arr.length > 0) {
+    (this as any)[field] = [...new Set(arr)];
+  }
   return this;
 }
 
@@ -2025,17 +2042,17 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
 }
 
 /** @internal */
-export function buildArel(this: QueryMethodsHost, _connection?: unknown, _aliases?: unknown): any {
+export function buildArel(this: QueryMethodsHost, _connection?: unknown, aliases?: unknown): any {
   const mc = (this as any)._modelClass;
   const table: any = mc?.arelTable;
   const arel = new SelectManager(table);
 
-  buildJoins.call(this, arel);
+  buildJoins.call(this, arel, aliases);
 
   if (!this._whereClause.isEmpty()) arel.where(this._whereClause.ast);
   if (!this._havingClause.isEmpty()) arel.having(this._havingClause.ast);
 
-  if (this._limitValue !== null) arel.take(this._limitValue);
+  if (this._limitValue !== null) arel.take(sanitizeLimit(this._limitValue));
   if (this._offsetValue !== null) arel.skip(this._offsetValue);
 
   if (this._groupColumns.length > 0)
@@ -2191,7 +2208,7 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
 }
 
 /** @internal */
-export function buildJoins(this: QueryMethodsHost, arel: any): void {
+export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: unknown): void {
   const hasEagerAssocs =
     this._eagerLoadAssociations.length > 0 || this._leftOuterJoinsValues.length > 0;
   if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasEagerAssocs) return;
@@ -2221,13 +2238,13 @@ export function buildJoins(this: QueryMethodsHost, arel: any): void {
   // no explicit joins). Rails processes these as named_join → OuterJoin type.
   if (namedJoins.length > 0) {
     const jd = constructJoinDependency.call(this, namedJoins, Nodes.OuterJoin);
-    const constraintNodes = jd.joinConstraints(stashedJoins);
+    const constraintNodes = jd.joinConstraints(stashedJoins, aliases);
     for (const node of constraintNodes) arel.source.right.push(node);
   } else if (stashedJoins.length > 0) {
     // Stashed join dependencies (eager_load or left_outer combined with explicit
     // joins) — generate join SQL via joinConstraints (mirrors build_joins:1896).
     const [primary, ...rest] = stashedJoins;
-    const constraintNodes = primary.joinConstraints(rest);
+    const constraintNodes = primary.joinConstraints(rest, aliases);
     for (const node of constraintNodes) arel.source.right.push(node);
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1103,13 +1103,19 @@ function annotateBang(this: QueryMethodsHost, ...comments: string[]): any {
 }
 
 const UNIQ_BANG_FIELDS: Partial<Record<string, keyof QueryMethodsHost>> = {
-  group: "_groupColumns",
+  includes: "_includesAssociations",
+  eager_load: "_eagerLoadAssociations",
+  preload: "_preloadAssociations",
   select: "_selectColumns",
+  group: "_groupColumns",
   order: "_orderClauses",
   joins: "_joinValues",
-  annotate: "_annotations",
-  optimizer_hints: "_optimizerHints",
+  left_outer_joins: "_leftOuterJoinsValues",
   references: "_referencesValues",
+  extending: "_extending",
+  optimizer_hints: "_optimizerHints",
+  annotate: "_annotations",
+  with: "_ctes",
 };
 
 function uniqBang(this: QueryMethodsHost, name?: string): any {


### PR DESCRIPTION
## Summary

Closes 4 small relation/adapter fidelity gaps tracked in Story P followups:

- **P-uniqBang**: `uniq!(name)` now deduplicates the named clause array (`:group`, `:select`, `:order`, `:joins`, `:annotate`, `:optimizer_hints`, `:references`) instead of incorrectly setting `_isDistinct = true`. Matches Rails `query_methods.rb:1541`.
- **P-buildArel**: Wires `sanitizeLimit` around `_limitValue` and threads `aliases` down through `buildJoins` → `joinConstraints`. Matches Rails `build_arel` signature.
- **P-lookupCastTypeFromJoinDependencies**: Implements the join-dependency walk to find cast types for pluck columns from joined tables (was returning `null`). Matches Rails `calculations.rb:602`.
- **P-returnValueAfterInsert**: Adds the base method to `AbstractAdapter` delegating to `column.isAutoPopulated()`. Matches Rails `abstract_adapter.rb:558`.

Item 5 (I-followup-2 `findSome` select narrowing) was already landed in a prior finishers bundle.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/relation/` — all pass
- [ ] `pnpm vitest run packages/activerecord/src/calculations.test.ts` — all pass
- [ ] `pnpm vitest run packages/activerecord/src/connection-adapters/abstract-adapter.test.ts` — all pass
- [ ] `pnpm api:compare --package activerecord` — 4955/4958, no regression
- [ ] LOC: 89 (well under 300 ceiling)