### PR TITLE
feat(activerecord): Range cluster L-3c + L-3d bundle (~140 LOC)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -19,8 +19,8 @@ describeIfPg("PostgreSQLAdapter", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_ranges`);
-    await adapter.exec(`DROP TYPE IF EXISTS floatrange`);
-    await adapter.exec(`DROP TYPE IF EXISTS stringrange`);
+    await adapter.dropRange("floatrange", { ifExists: true });
+    await adapter.dropRange("stringrange", { ifExists: true });
     await adapter.createRange("floatrange", { subtype: "float8", subtypeDiff: "float8mi" });
     await adapter.createRange("stringrange", { subtype: "varchar" });
     await adapter.exec(`
@@ -49,8 +49,8 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_ranges`);
-    await adapter.exec(`DROP TYPE IF EXISTS floatrange`);
-    await adapter.exec(`DROP TYPE IF EXISTS stringrange`);
+    await adapter.dropRange("floatrange", { ifExists: true });
+    await adapter.dropRange("stringrange", { ifExists: true });
     await adapter.close();
   });
 

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { parseRange } from "./pg-range.js";
 import { Range } from "../../relation.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 const toInt = (s: string) => parseInt(s, 10);
@@ -18,6 +19,10 @@ describeIfPg("PostgreSQLAdapter", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_ranges`);
+    await adapter.exec(`DROP TYPE IF EXISTS floatrange`);
+    await adapter.exec(`DROP TYPE IF EXISTS stringrange`);
+    await adapter.createRange("floatrange", { subtype: "float8", subtypeDiff: "float8mi" });
+    await adapter.createRange("stringrange", { subtype: "varchar" });
     await adapter.exec(`
       CREATE TABLE postgresql_ranges (
         id serial primary key,
@@ -26,7 +31,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         ts_range tsrange,
         tstz_range tstzrange,
         int4_range int4range,
-        int8_range int8range
+        int8_range int8range,
+        float_range floatrange,
+        string_range stringrange
       )
     `);
     await adapter.loadAdditionalTypes();
@@ -42,6 +49,8 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_ranges`);
+    await adapter.exec(`DROP TYPE IF EXISTS floatrange`);
+    await adapter.exec(`DROP TYPE IF EXISTS stringrange`);
     await adapter.close();
   });
 
@@ -220,32 +229,56 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].date_range).toBeDefined();
     });
 
-    it.skip("custom range column", async () => {
-      // BLOCKED: range — custom range type setup missing from beforeEach
-      // ROOT-CAUSE: beforeEach doesn't CREATE TYPE floatrange/stringrange AS RANGE or add float_range/string_range columns;
-      //   TypeMapInitializer already handles typtype='r' rows so no core OID gap exists
-      // SCOPE: ~25 LOC — extend beforeEach + write assertion body; affects 4 custom-range tests
+    it("custom range column", async () => {
+      await adapter.execute(`INSERT INTO postgresql_ranges (float_range) VALUES ('[0.5,0.7]')`);
+      const rows = await adapter.execute(`SELECT float_range FROM postgresql_ranges`);
+      const range = parseRange(rows[0].float_range as string, toFloat)!;
+      expect(range).toBeInstanceOf(Range);
+      expect(range.begin).toBeCloseTo(0.5);
+      expect(range.end).toBeCloseTo(0.7);
+      expect(range.excludeEnd).toBe(false);
     });
-    it.skip("custom range type cast", async () => {
-      // BLOCKED: range — custom range type setup missing from beforeEach
-      // SCOPE: ~25 LOC shared with "custom range column" fix; affects 4 custom-range tests
+    it("custom range type cast", () => {
+      const range = parseRange("[0.5,0.7)", toFloat)!;
+      expect(range.begin).toBeCloseTo(0.5);
+      expect(range.end).toBeCloseTo(0.7);
+      expect(range.excludeEnd).toBe(true);
     });
-    it.skip("custom range write", async () => {
-      // BLOCKED: range — custom range type setup missing from beforeEach
-      // SCOPE: ~25 LOC shared with "custom range column" fix; affects 4 custom-range tests
+    it("custom range write", async () => {
+      await adapter.execute(`INSERT INTO postgresql_ranges (float_range) VALUES ('[0.5,0.7)')`);
+      const rows = await adapter.execute(`SELECT float_range FROM postgresql_ranges`);
+      const range = parseRange(rows[0].float_range as string, toFloat)!;
+      expect(range.begin).toBeCloseTo(0.5);
+      expect(range.end).toBeCloseTo(0.7);
+      expect(range.excludeEnd).toBe(true);
     });
-    it.skip("range schema dump", async () => {
-      // BLOCKED: range — range SQL types absent from SQL_TYPE_MAP / DSL_HELPER_METHODS
-      // ROOT-CAUSE: schema-dumper.ts SQL_TYPE_MAP has no entries for int4range, int8range, numrange,
-      //   daterange, tsrange, tstzrange; sqlTypeToDsl() hits the enum fallback → t.column(name,"int4range")
-      //   instead of the dedicated DSL helper; DSL_HELPER_METHODS also needs them to emit t.int4range(...)
-      // SCOPE: ~15 LOC in schema-dumper.ts (SQL_TYPE_MAP + DSL_HELPER_METHODS) + ~10 LOC test body; affects 1 test
+    it("range schema dump", async () => {
+      const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_ranges");
+      expect(output).toContain('t.int4range("int4_range"');
+      expect(output).toContain('t.int8range("int8_range"');
+      expect(output).toContain('t.numrange("num_range"');
+      expect(output).toContain('t.daterange("date_range"');
+      expect(output).toContain('t.tsrange("ts_range"');
+      expect(output).toContain('t.tstzrange("tstz_range"');
+      expect(output).not.toContain('t.column("int4_range"');
     });
-    it.skip("range migration", async () => {
-      // BLOCKED: range — test body not yet written; no core infra gap expected
-      // ROOT-CAUSE: per-column helpers (int4range(), tstzrange(), daterange(), etc.) exist in schema-definitions.ts;
-      //   test should exercise create_table with range columns; createRange() is only needed for custom range types
-      // SCOPE: ~15 LOC test body; createRange()/dropRange() (~30 LOC) is a separate gap (see custom-range tests)
+    it("range migration", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);
+      await adapter.createTable("range_migration_test", (t: any) => {
+        t.column("i4", "int4range");
+        t.column("i8", "int8range");
+        t.column("num", "numrange");
+        t.column("dr", "daterange");
+        t.column("tsr", "tsrange");
+        t.column("tstzr", "tstzrange");
+        t.column("fr", "floatrange");
+      });
+      const cols = await adapter.columns("range_migration_test");
+      const names = cols.map((c: any) => c.name);
+      expect(names).toContain("i4");
+      expect(names).toContain("i8");
+      expect(names).toContain("fr");
+      await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);
     });
     it.skip("multirange int4", async () => {
       // BLOCKED: range — multirange types not registered (PG 14+ / Rails 7+)
@@ -381,9 +414,17 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(r.begin as string).toContain("2010-01-01");
     });
 
-    it.skip("custom range values", () => {
-      // BLOCKED: range — custom range type setup missing from beforeEach
-      // SCOPE: ~25 LOC shared with "custom range column" fix; affects 4 custom-range tests
+    it("custom range values", () => {
+      // Rails: 0.5..0.7, 0.5...0.7, 0.5...Infinity, -Infinity...Infinity, nil
+      expect(parseRange("[0.5,0.7]", toFloat)!.excludeEnd).toBe(false);
+      expect(parseRange("[0.5,0.7)", toFloat)!.excludeEnd).toBe(true);
+      const endless = parseRange("[0.5,)", toFloat)!;
+      expect(endless.begin).toBeCloseTo(0.5);
+      expect(endless.end).toBeNull();
+      const infinite = parseRange("[,]", toFloat)!;
+      expect(infinite.begin).toBeNull();
+      expect(infinite.end).toBeNull();
+      expect(parseRange("empty", toFloat)).toBeNull();
     });
     it.skip("timezone awareness tzrange", () => {
       // BLOCKED: range — TimeZoneConversion not wired and predicate broken for range types

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -264,21 +264,24 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("range migration", async () => {
       await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);
-      await adapter.createTable("range_migration_test", (t: any) => {
-        t.column("i4", "int4range");
-        t.column("i8", "int8range");
-        t.column("num", "numrange");
-        t.column("dr", "daterange");
-        t.column("tsr", "tsrange");
-        t.column("tstzr", "tstzrange");
-        t.column("fr", "floatrange");
-      });
-      const cols = await adapter.columns("range_migration_test");
-      const names = cols.map((c: any) => c.name);
-      expect(names).toContain("i4");
-      expect(names).toContain("i8");
-      expect(names).toContain("fr");
-      await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);
+      try {
+        await adapter.createTable("range_migration_test", (t: any) => {
+          t.column("i4", "int4range");
+          t.column("i8", "int8range");
+          t.column("num", "numrange");
+          t.column("dr", "daterange");
+          t.column("tsr", "tsrange");
+          t.column("tstzr", "tstzrange");
+          t.column("fr", "floatrange");
+        });
+        const cols = await adapter.columns("range_migration_test");
+        const names = cols.map((c: any) => c.name);
+        expect(names).toContain("i4");
+        expect(names).toContain("i8");
+        expect(names).toContain("fr");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);
+      }
     });
     it.skip("multirange int4", async () => {
       // BLOCKED: range — multirange types not registered (PG 14+ / Rails 7+)

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1132,6 +1132,13 @@ export class AbstractAdapter implements Quoting {
 
   async dropEnum(_name: string): Promise<void> {}
 
+  async createRange(
+    _name: string,
+    _options: { subtype: string; subtypeDiff?: string },
+  ): Promise<void> {}
+
+  async dropRange(_name: string, _options?: { ifExists?: boolean }): Promise<void> {}
+
   async renameEnum(_oldName: string, _newName: string): Promise<void> {}
 
   async addEnumValue(_enumName: string, _value: string): Promise<void> {}

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3461,19 +3461,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qualifiedName = schema
       ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(rangeName)}`
       : this.quoteIdentifier(rangeName);
-    const quoteTypeName = (typeName: string, param: string) => {
-      if (/[\s()]/.test(typeName)) {
+    const quoteQualifiedIdentifier = (identifier: string, param: string) => {
+      if (/[\s()]/.test(identifier)) {
         throw new Error(
           `PostgreSQLAdapter#createRange: ${param} must be a simple or schema-qualified identifier ` +
-            `(e.g. "float8", "myschema.mytype"). Use the single-word alias instead of "${typeName}".`,
+            `(e.g. "float8", "myschema.mytype"). Use the single-word alias instead of "${identifier}".`,
         );
       }
-      const { schema: s, table: t } = this.parseSchemaQualifiedName(typeName);
+      const { schema: s, table: t } = this.parseSchemaQualifiedName(identifier);
       return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
     };
-    const parts = [`SUBTYPE = ${quoteTypeName(options.subtype, "subtype")}`];
-    if (options.subtypeDiff)
-      parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff, "subtypeDiff")}`);
+    const parts = [`SUBTYPE = ${quoteQualifiedIdentifier(options.subtype, "subtype")}`];
+    if (options.subtypeDiff) {
+      parts.push(`SUBTYPE_DIFF = ${quoteQualifiedIdentifier(options.subtypeDiff, "subtypeDiff")}`);
+    }
     await this.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3449,6 +3449,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
   }
 
+  // ---------------------------------------------------------------------------
+  // Range types
+  // ---------------------------------------------------------------------------
+
+  async createRange(
+    name: string,
+    options: { subtype: string; subtypeDiff?: string },
+  ): Promise<void> {
+    const { schema, table: rangeName } = this.parseSchemaQualifiedName(name);
+    const qualifiedName = schema
+      ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(rangeName)}`
+      : this.quoteIdentifier(rangeName);
+    const parts = [`SUBTYPE = ${this.quoteIdentifier(options.subtype)}`];
+    if (options.subtypeDiff)
+      parts.push(`SUBTYPE_DIFF = ${this.quoteIdentifier(options.subtypeDiff)}`);
+    await this.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
+  }
+
+  async dropRange(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
+    const { schema, table: rangeName } = this.parseSchemaQualifiedName(name);
+    const qualifiedName = schema
+      ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(rangeName)}`
+      : this.quoteIdentifier(rangeName);
+    const ifExists = options.ifExists ? " IF EXISTS" : "";
+    await this.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
+  }
+
   async renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void> {
     const newName = typeof newNameOrOptions === "string" ? newNameOrOptions : newNameOrOptions.to;
     const { schema: newSchema } = this.parseSchemaQualifiedName(newName);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3461,12 +3461,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qualifiedName = schema
       ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(rangeName)}`
       : this.quoteIdentifier(rangeName);
-    const quoteTypeName = (typeName: string) => {
+    const quoteTypeName = (typeName: string, param: string) => {
+      if (/[\s()]/.test(typeName)) {
+        throw new Error(
+          `PostgreSQLAdapter#createRange: ${param} must be a simple or schema-qualified identifier ` +
+            `(e.g. "float8", "myschema.mytype"). Use the single-word alias instead of "${typeName}".`,
+        );
+      }
       const { schema: s, table: t } = this.parseSchemaQualifiedName(typeName);
       return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
     };
-    const parts = [`SUBTYPE = ${quoteTypeName(options.subtype)}`];
-    if (options.subtypeDiff) parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff)}`);
+    const parts = [`SUBTYPE = ${quoteTypeName(options.subtype, "subtype")}`];
+    if (options.subtypeDiff)
+      parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff, "subtypeDiff")}`);
     await this.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3468,6 +3468,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             `(e.g. "float8", "myschema.mytype"). Use the single-word alias instead of "${identifier}".`,
         );
       }
+      const parts = splitQuotedIdentifier(identifier);
+      if (parts.length === 0 || parts.length > 2) {
+        throw new Error(
+          `PostgreSQLAdapter#createRange: ${param} must have 1 or 2 dot-separated parts, got ${parts.length}: "${identifier}".`,
+        );
+      }
       const { schema: s, table: t } = this.parseSchemaQualifiedName(identifier);
       return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
     };

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3463,7 +3463,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       : this.quoteIdentifier(rangeName);
     const quoteTypeName = (typeName: string) => {
       const { schema: s, table: t } = this.parseSchemaQualifiedName(typeName);
-      return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : t;
+      return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
     };
     const parts = [`SUBTYPE = ${quoteTypeName(options.subtype)}`];
     if (options.subtypeDiff) parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff)}`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3463,7 +3463,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       : this.quoteIdentifier(rangeName);
     const quoteTypeName = (typeName: string) => {
       const { schema: s, table: t } = this.parseSchemaQualifiedName(typeName);
-      return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
+      return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : t;
     };
     const parts = [`SUBTYPE = ${quoteTypeName(options.subtype)}`];
     if (options.subtypeDiff) parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff)}`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3461,9 +3461,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qualifiedName = schema
       ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(rangeName)}`
       : this.quoteIdentifier(rangeName);
-    const parts = [`SUBTYPE = ${this.quoteIdentifier(options.subtype)}`];
-    if (options.subtypeDiff)
-      parts.push(`SUBTYPE_DIFF = ${this.quoteIdentifier(options.subtypeDiff)}`);
+    const quoteTypeName = (typeName: string) => {
+      const { schema: s, table: t } = this.parseSchemaQualifiedName(typeName);
+      return s ? `${this.quoteIdentifier(s)}.${this.quoteIdentifier(t)}` : this.quoteIdentifier(t);
+    };
+    const parts = [`SUBTYPE = ${quoteTypeName(options.subtype)}`];
+    if (options.subtypeDiff) parts.push(`SUBTYPE_DIFF = ${quoteTypeName(options.subtypeDiff)}`);
     await this.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -59,6 +59,8 @@ export interface SchemaStatements {
   inheritedTableNames(tableName: string): Promise<string[]>;
   createEnum(name: string, values: string[]): Promise<void>;
   dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  createRange(name: string, options: { subtype: string; subtypeDiff?: string }): Promise<void>;
+  dropRange(name: string, options?: { ifExists?: boolean }): Promise<void>;
   renameEnum(name: string, newName: string): Promise<void>;
   addEnumValue(
     name: string,

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -140,6 +140,12 @@ const SQL_TYPE_MAP: Record<string, DslMapping> = {
   citext: { dslType: "citext" },
   ltree: { dslType: "ltree" },
   oid: { dslType: "oid" },
+  int4range: { dslType: "int4range" },
+  int8range: { dslType: "int8range" },
+  numrange: { dslType: "numrange" },
+  daterange: { dslType: "daterange" },
+  tsrange: { dslType: "tsrange" },
+  tstzrange: { dslType: "tstzrange" },
   serial: { dslType: "serial" },
   bigserial: { dslType: "bigserial" },
   character: { dslType: "char" },
@@ -186,6 +192,12 @@ const DSL_HELPER_METHODS = new Set([
   "binary",
   "json",
   "jsonb",
+  "int4range",
+  "int8range",
+  "numrange",
+  "daterange",
+  "tsrange",
+  "tstzrange",
 ]);
 
 function sqlTypeToDsl(sqlType: string): DslMapping {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -171,8 +171,10 @@ const KNOWN_DSL_TYPES = new Set([
 ]);
 
 /**
- * DSL methods that actually exist as helpers on TableDefinition
- * (connection-adapters/abstract/schema-definitions.ts). Types mapped
+ * DSL methods that actually exist as helpers on TableDefinition —
+ * either the abstract base (connection-adapters/abstract/schema-definitions.ts)
+ * or adapter-specific subclasses (e.g. PG range helpers in
+ * connection-adapters/postgresql/schema-definitions.ts). Types mapped
  * to names outside this set are emitted as `t.column(name, sqlType,
  * options)` so the dumped schema loads through MigrationContext
  * without a ReferenceError.


### PR DESCRIPTION
## Summary

- **L-3c**: Register 6 built-in range types (`int4range`, `int8range`, `numrange`, `daterange`, `tsrange`, `tstzrange`) in `schema-dumper.ts` `SQL_TYPE_MAP` + `DSL_HELPER_METHODS` so schema dumps emit `t.int4range(name)` instead of `t.column(name, "int4range")`
- **L-3d-helpers**: Add `createRange()` / `dropRange()` to PostgreSQL adapter (+ no-op stubs on abstract adapter + interface)
- **L-3d-tests**: Extend `range.test.ts` `beforeEach` to create `floatrange`/`stringrange` custom types; implement 6 previously-BLOCKED test bodies: custom range column/type cast/write/values, range schema dump, range migration

## Commits

1. `feat(activerecord): Story L-3c` — schema-dumper SQL_TYPE_MAP + DSL_HELPER_METHODS
2. `feat(activerecord): Story L-3d-helpers` — createRange/dropRange
3. `test(activerecord): Story L-3d-tests` — custom range + schema dump + migration

## Verification

- `pnpm vitest run packages/activerecord/src/adapters/postgresql/range.test.ts` — 76 passed, 15 skipped (timezone-awareness tests still blocked)
- `pnpm vitest run packages/activerecord/src/schema-dumper.test.ts` — clean