### PR TITLE
feat(activerecord): newly-surfaced bundle May 8 — 5 items (~117 LOC)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -37,3 +37,38 @@ describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {
     expect(adapter.returnValueAfterInsert(makeColumn())).toBe(false);
   });
 });
+
+describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
+  async function makeAdapter(columnName: string, extra: string, supportsRename = false) {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+    adapter.supportsRenameColumn = () => supportsRename;
+    adapter.getDatabaseVersion = async () => {};
+    adapter.quoteIdentifier = (s: string) => `\`${s}\``;
+    adapter.columnDefinitions = async (_: string) => [
+      {
+        Field: columnName,
+        Type: "int(11)",
+        Null: "NO",
+        Default: null,
+        Extra: extra,
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    return adapter;
+  }
+
+  it("allows auto_increment Extra without throwing", async () => {
+    const adapter = await makeAdapter("id", "auto_increment");
+    const sql: string = await adapter.renameColumnForAlter("users", "id", "user_id");
+    expect(sql).toContain("AUTO_INCREMENT");
+  });
+
+  it("throws for unrecognised Extra values", async () => {
+    const adapter = await makeAdapter("updated_at", "on update current_timestamp()");
+    await expect(adapter.renameColumnForAlter("users", "updated_at", "ts")).rejects.toThrow(
+      "renameColumnForAlter fallback",
+    );
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1191,7 +1191,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // auto_increment?/comment; our ColumnDefinition lacks that field. Throw explicitly so
     // callers know to upgrade MySQL rather than receive a lossy CHANGE clause.
     const extra = ((col["Extra"] as string | undefined) ?? "").trim().toLowerCase();
-    if (extra) {
+    if (extra && extra !== "auto_increment") {
       throw new Error(
         `renameColumnForAlter fallback: cannot safely CHANGE column "${columnName}" in table "${tableName}" ` +
           `— Extra="${col["Extra"]}" is not preserved by this path. ` +
@@ -1206,6 +1206,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       null: (col["Null"] as string) === "YES",
       collation: (col["Collation"] as string | undefined) || undefined,
       comment: (col["Comment"] as string | undefined) || undefined,
+      autoIncrement: extra === "auto_increment" || undefined,
     });
     const cd = new ChangeColumnDefinition(colDef, columnName);
     return new MysqlSchemaCreation().accept(cd);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -226,6 +226,9 @@ export class SchemaCreation {
     if (options.null === false) {
       sql += " NOT NULL";
     }
+    if (options.autoIncrement) {
+      sql += " AUTO_INCREMENT";
+    }
     if (options.primaryKey) {
       sql += " PRIMARY KEY";
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -229,6 +229,7 @@ export interface ColumnOptions {
   comment?: string;
   ifExists?: boolean;
   ifNotExists?: boolean;
+  autoIncrement?: boolean;
 }
 
 export interface AddIndexOptions {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -92,4 +92,16 @@ describe("MySQL::SchemaCreation", () => {
     expect(sql).toContain("`my_idx`");
     expect(sql).toContain("`email`");
   });
+
+  it("addColumnOptionsBang emits AUTO_INCREMENT when autoIncrement: true", () => {
+    const col = new ColumnDefinition("id", "integer", { autoIncrement: true });
+    const result = (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
+    expect(result).toContain("AUTO_INCREMENT");
+  });
+
+  it("addColumnOptionsBang does not emit AUTO_INCREMENT when not set", () => {
+    const col = new ColumnDefinition("id", "integer", {});
+    const result = (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
+    expect(result).not.toContain("AUTO_INCREMENT");
+  });
 });

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -56,6 +56,10 @@ export class LockingType extends ValueType<number> {
     this.name = subtype.name;
   }
 
+  // cast() intentionally does NOT coerce null → 0. Rails' LockingType also leaves cast()
+  // unchanged so that new records receiving an explicit nil get null, not 0. The nil → 0
+  // coercion was removed when hookAttributeType() was wired in #1366; serialize/deserialize
+  // still apply the coercion via toInt() to guard against StaleObjectError on persisted rows.
   override cast(value: unknown): number | null {
     return this._subtype.cast(value) as number | null;
   }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1184,6 +1184,20 @@ describe("MigrationTest", () => {
     expect(m.connectionPool).toBe(baseAdapter);
   });
 
+  it("migration.schema uses connection (respects _connectionOverride)", () => {
+    class M extends Migration {
+      async up() {}
+      async down() {}
+    }
+    const m = new M();
+    const baseAdapter = createTestAdapter();
+    const override = createTestAdapter();
+    (m as any).adapter = baseAdapter;
+    expect((m.schema as any).adapter).toBe(baseAdapter);
+    (m as any)._connectionOverride = override;
+    expect((m.schema as any).adapter).toBe(override);
+  });
+
   it("migration context with default schema migration", async () => {
     const adapter = createTestAdapter();
     const migrations: MigrationProxy[] = [

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -208,14 +208,10 @@ export abstract class Migration {
     return this.adapter.adapterName;
   }
 
-  private _schema?: SchemaStatements;
-
   get schema(): SchemaStatements {
-    if (!this._schema) {
-      assertSchemaAdapter(this.adapter);
-      this._schema = new SchemaStatements(this.adapter);
-    }
-    return this._schema;
+    const conn = this.connection;
+    assertSchemaAdapter(conn);
+    return new SchemaStatements(conn);
   }
 
   /**
@@ -947,7 +943,7 @@ export abstract class Migration {
         await this.down();
       }
     } finally {
-      this._schema = undefined;
+      this._connectionOverride = undefined;
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -208,10 +208,17 @@ export abstract class Migration {
     return this.adapter.adapterName;
   }
 
+  private _schema?: SchemaStatements;
+  private _schemaConn?: DatabaseAdapter;
+
   get schema(): SchemaStatements {
     const conn = this.connection;
-    assertSchemaAdapter(conn);
-    return new SchemaStatements(conn);
+    if (!this._schema || this._schemaConn !== conn) {
+      assertSchemaAdapter(conn);
+      this._schema = new SchemaStatements(conn);
+      this._schemaConn = conn;
+    }
+    return this._schema;
   }
 
   /**

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -10,8 +10,8 @@
 import type { DatabaseAdapter } from "../adapter.js";
 
 export interface MigrationLike {
-  up(adapter: DatabaseAdapter): Promise<void>;
-  down(adapter: DatabaseAdapter): Promise<void>;
+  up(adapter?: DatabaseAdapter): Promise<void>;
+  down(adapter?: DatabaseAdapter): Promise<void>;
   /** When true, Migrator skips DDL transaction wrapping for this migration. */
   disableDdlTransaction?: boolean;
   /** Adapter for this migration; mirrors Rails' Migration#connection (@connection field). */

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -23,8 +23,8 @@ import type { DatabaseAdapter } from "./adapter.js";
 function makeMigration(
   version: string,
   name: string,
-  upFn?: (adapter: DatabaseAdapter) => Promise<void>,
-  downFn?: (adapter: DatabaseAdapter) => Promise<void>,
+  upFn?: (adapter?: DatabaseAdapter) => Promise<void>,
+  downFn?: (adapter?: DatabaseAdapter) => Promise<void>,
 ): MigrationProxy {
   return {
     version,
@@ -578,8 +578,8 @@ describe("MigratorTest", () => {
       async exec(
         direction: "up" | "down",
         migration: {
-          up(a: DatabaseAdapter): Promise<void>;
-          down(a: DatabaseAdapter): Promise<void>;
+          up(a?: DatabaseAdapter): Promise<void>;
+          down(a?: DatabaseAdapter): Promise<void>;
         },
         a: DatabaseAdapter,
       ): Promise<void> {

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -182,3 +182,10 @@ describe("Relation private build-arel helpers", () => {
     });
   });
 });
+
+describe("Relation#offset float truncation", () => {
+  it("truncates float offset to integer via Math.trunc", () => {
+    const r = relation().offset(1.7);
+    expect((r as any)._offsetValue).toBe(1);
+  });
+});

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -975,7 +975,7 @@ function limitBang(this: QueryMethodsHost, value: number | null): any {
 }
 
 function offsetBang(this: QueryMethodsHost, value: number): any {
-  this._offsetValue = value;
+  this._offsetValue = Math.trunc(value);
   return this;
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -974,8 +974,8 @@ function limitBang(this: QueryMethodsHost, value: number | null): any {
   return this;
 }
 
-function offsetBang(this: QueryMethodsHost, value: number): any {
-  this._offsetValue = Math.trunc(value);
+function offsetBang(this: QueryMethodsHost, value: number | null): any {
+  this._offsetValue = value === null ? null : Math.trunc(value);
   return this;
 }
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1326,11 +1326,11 @@ export class CreatePosts extends Migration {
           version: "20260101000000",
           name: "CreateWidgets",
           migration: () => ({
-            up: async (a: typeof adapter) => {
-              await a.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
+            up: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
+              await a!.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
             },
-            down: async (a: typeof adapter) => {
-              await a.executeMutation(`DROP TABLE widgets`);
+            down: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
+              await a!.executeMutation(`DROP TABLE widgets`);
             },
           }),
         },

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1327,10 +1327,12 @@ export class CreatePosts extends Migration {
           name: "CreateWidgets",
           migration: () => ({
             up: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
-              await a!.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
+              if (!a) throw new Error("adapter required");
+              await a.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
             },
             down: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
-              await a!.executeMutation(`DROP TABLE widgets`);
+              if (!a) throw new Error("adapter required");
+              await a.executeMutation(`DROP TABLE widgets`);
             },
           }),
         },

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -57,11 +57,13 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       migration: () => {
         const loader = {
           async up(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+            if (!adapter) throw new Error("migration-loader: adapter is required for up()");
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "up");
           },
           async down(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+            if (!adapter) throw new Error("migration-loader: adapter is required for down()");
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "down");

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -56,12 +56,12 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       filename: filePath,
       migration: () => {
         const loader = {
-          async up(adapter: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+          async up(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "up");
           },
-          async down(adapter: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+          async down(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "down");


### PR DESCRIPTION
## Summary

Five small items surfaced by recent post-prs.

- **MySQL `autoIncrement` column option**: Added `autoIncrement?: boolean` to `ColumnOptions`, wired `AUTO_INCREMENT` emission in `MysqlSchemaCreation`, and relaxed the `extra === ""` guard in `renameColumnForAlter` to also allow `"auto_increment"` (fixes the throw left by #1362).
- **`offsetBang` float truncation**: `Math.trunc` applied so `offset(1.7)` produces `OFFSET 1` (Rails `to_i` parity, gap left by #1369).
- **`Migration#schema` uses `this.connection`**: Schema operations inside user migrations now honor `_connectionOverride` instead of binding to `this.adapter` directly.
- **`DefaultStrategy#exec` adapter arg**: Made `MigrationLike#up/down` take `adapter?` (optional) — Rails' `up` takes no args; the adapter pass-through is a TS-only compat shim, now opt-in.
- **`LockingType.cast` null→0 regression note**: Comment in `optimistic.ts` explaining the intentional removal of `null → 0` coercion in #1366.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/` — 10,745 passed, 0 failures
- [ ] `pnpm api:compare --package activerecord` — 4,955/4,958 (99.9%), no regression
- [ ] 117 LOC (well under 300 ceiling)
- [ ] New unit tests for Items 1–3