### PR TITLE
feat(activerecord): type cluster slot 3 — TimeZoneConverter.equals + aliasAttribute dirty + hollow type stubs

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -7,6 +7,7 @@
  * In TS, the exported functions use `this: AttributeMethodHost` so they can
  * be assigned directly to Model's static side — no delegation wrappers needed.
  */
+import { defineDirtyAttributeMethods } from "./attributes.js";
 export interface AttributeMethods {
   hasAttribute(name: string): boolean;
   attributePresent(name: string): boolean;
@@ -209,6 +210,11 @@ export function aliasAttribute(this: AttributeMethodHost, newName: string, oldNa
 
   // Generate pattern-based alias methods (e.g., clear_fullName if clear_ prefix exists)
   eagerlyGenerateAliasAttributeMethods(this, newName, oldName);
+  // Generate dirty predicates (nameChanged, nameWas, etc.) for the alias name.
+  // Rails generates these via attribute_method_suffix/affix declarations; we do
+  // it explicitly so titleChanged? delegates to attributeChanged("title") which
+  // resolves the alias at runtime.
+  defineDirtyAttributeMethods(this.prototype, newName);
 }
 
 export function undefineAttributeMethods(this: AttributeMethodHost): void {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -7,7 +7,6 @@
  * In TS, the exported functions use `this: AttributeMethodHost` so they can
  * be assigned directly to Model's static side — no delegation wrappers needed.
  */
-import { defineDirtyAttributeMethods } from "./attributes.js";
 export interface AttributeMethods {
   hasAttribute(name: string): boolean;
   attributePresent(name: string): boolean;
@@ -323,6 +322,65 @@ export function aliasAttributeMethodDefinition(
     configurable: true,
   });
   host._generatedMethods.add(methodName);
+}
+
+/**
+ * Generate per-attribute dirty methods on the prototype, mirroring the
+ * method cascade Rails produces via `attribute_method_suffix` /
+ * `attribute_method_affix` declarations in
+ * activemodel/lib/active_model/dirty.rb.
+ *
+ * For an attribute `name` the generated methods are:
+ *   nameChanged, nameChange, nameWas,
+ *   nameInDatabase, nameBeforeLastSave,
+ *   namePreviouslyChanged, namePreviousChange, namePreviouslyWas,
+ *   savedChangeToName, willSaveChangeToName,
+ *   restoreName
+ *
+ * Each forwards to the corresponding generic `attributeX(name, ...)` on
+ * Model, so subclasses can override the generic and have the
+ * per-attribute form pick up the change automatically. Skips any method
+ * that already exists on the prototype (e.g. user-defined).
+ */
+export function defineDirtyAttributeMethods(prototype: object, attrName: string): void {
+  const cap = attrName.charAt(0).toUpperCase() + attrName.slice(1);
+  const binding: Array<[string, string]> = [
+    [`${attrName}Changed`, "attributeChanged"],
+    [`${attrName}Change`, "attributeChange"],
+    [`${attrName}Was`, "attributeWas"],
+    [`${attrName}InDatabase`, "attributeInDatabase"],
+    [`${attrName}BeforeLastSave`, "attributeBeforeLastSave"],
+    [`${attrName}PreviouslyChanged`, "attributePreviouslyChanged"],
+    [`${attrName}PreviousChange`, "attributePreviousChange"],
+    [`${attrName}PreviouslyWas`, "attributePreviouslyWas"],
+    [`savedChangeTo${cap}`, "savedChangeToAttribute"],
+    [`willSaveChangeTo${cap}`, "willSaveChangeToAttribute"],
+    [`restore${cap}`, "restoreAttribute"],
+  ];
+  for (const [methodName, target] of binding) {
+    if (Object.prototype.hasOwnProperty.call(prototype, methodName)) continue;
+    if (methodName in prototype) continue; // inherited; user/framework took it
+    Object.defineProperty(prototype, methodName, {
+      // Route through attribute_missing(match, ...) so subclasses can
+      // intercept the entire generated cascade by overriding a single
+      // method (Rails attribute_methods.rb:520-522). The match shape
+      // mirrors Rails' AttributeMethodMatch — proxyTarget names the
+      // generic handler; attrName is the bound attribute.
+      value: function (
+        this: {
+          attributeMissing(
+            match: { proxyTarget: string; attrName: string },
+            ...a: unknown[]
+          ): unknown;
+        },
+        ...args: unknown[]
+      ) {
+        return this.attributeMissing({ proxyTarget: target, attrName: attrName }, ...args);
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
 }
 
 export function isAttributeAlias(host: AttributeMethodHost, name: string): boolean {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -5,6 +5,7 @@ import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
   attributeMissing,
+  defineDirtyAttributeMethods,
   isAttributeMethod as _isAttributeMethod,
   matchedAttributeMethod as _matchedAttributeMethod,
   missingAttribute as _missingAttribute,
@@ -133,65 +134,6 @@ export function attribute(
   }
 
   defineDirtyAttributeMethods(this.prototype, name);
-}
-
-/**
- * Generate per-attribute dirty methods on the prototype, mirroring the
- * method cascade Rails produces via `attribute_method_suffix` /
- * `attribute_method_affix` declarations in
- * activemodel/lib/active_model/dirty.rb.
- *
- * For an attribute `name` the generated methods are:
- *   nameChanged, nameChange, nameWas,
- *   nameInDatabase, nameBeforeLastSave,
- *   namePreviouslyChanged, namePreviousChange, namePreviouslyWas,
- *   savedChangeToName, willSaveChangeToName,
- *   restoreName
- *
- * Each forwards to the corresponding generic `attributeX(name, ...)` on
- * Model, so subclasses can override the generic and have the
- * per-attribute form pick up the change automatically. Skips any method
- * that already exists on the prototype (e.g. user-defined).
- */
-export function defineDirtyAttributeMethods(prototype: object, attrName: string): void {
-  const cap = attrName.charAt(0).toUpperCase() + attrName.slice(1);
-  const binding: Array<[string, string]> = [
-    [`${attrName}Changed`, "attributeChanged"],
-    [`${attrName}Change`, "attributeChange"],
-    [`${attrName}Was`, "attributeWas"],
-    [`${attrName}InDatabase`, "attributeInDatabase"],
-    [`${attrName}BeforeLastSave`, "attributeBeforeLastSave"],
-    [`${attrName}PreviouslyChanged`, "attributePreviouslyChanged"],
-    [`${attrName}PreviousChange`, "attributePreviousChange"],
-    [`${attrName}PreviouslyWas`, "attributePreviouslyWas"],
-    [`savedChangeTo${cap}`, "savedChangeToAttribute"],
-    [`willSaveChangeTo${cap}`, "willSaveChangeToAttribute"],
-    [`restore${cap}`, "restoreAttribute"],
-  ];
-  for (const [methodName, target] of binding) {
-    if (Object.prototype.hasOwnProperty.call(prototype, methodName)) continue;
-    if (methodName in prototype) continue; // inherited; user/framework took it
-    Object.defineProperty(prototype, methodName, {
-      // Route through attribute_missing(match, ...) so subclasses can
-      // intercept the entire generated cascade by overriding a single
-      // method (Rails attribute_methods.rb:520-522). The match shape
-      // mirrors Rails' AttributeMethodMatch — proxyTarget names the
-      // generic handler; attrName is the bound attribute.
-      value: function (
-        this: {
-          attributeMissing(
-            match: { proxyTarget: string; attrName: string },
-            ...a: unknown[]
-          ): unknown;
-        },
-        ...args: unknown[]
-      ) {
-        return this.attributeMissing({ proxyTarget: target, attrName: attrName }, ...args);
-      },
-      writable: true,
-      configurable: true,
-    });
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -153,7 +153,7 @@ export function attribute(
  * per-attribute form pick up the change automatically. Skips any method
  * that already exists on the prototype (e.g. user-defined).
  */
-function defineDirtyAttributeMethods(prototype: object, attrName: string): void {
+export function defineDirtyAttributeMethods(prototype: object, attrName: string): void {
   const cap = attrName.charAt(0).toUpperCase() + attrName.slice(1);
   const binding: Array<[string, string]> = [
     [`${attrName}Changed`, "attributeChanged"],

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1613,6 +1613,7 @@ export class Model {
   }
 
   attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
+    name = resolveAliasName(this.constructor as typeof Model, name);
     if (!this._dirty.attributeChanged(name)) return false;
     if (!options) return true;
     const change = this._dirty.attributeChange(name);
@@ -1633,12 +1634,12 @@ export class Model {
   }
 
   attributeWas(name: string): unknown {
-    return this._dirty.attributeWas(name);
+    return this._dirty.attributeWas(resolveAliasName(this.constructor as typeof Model, name));
   }
 
   /** @internal */
   attributeChange(name: string): [unknown, unknown] | undefined {
-    return this._dirty.attributeChange(name);
+    return this._dirty.attributeChange(resolveAliasName(this.constructor as typeof Model, name));
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1648,7 +1648,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#will_save_change_to_attribute
    */
   willSaveChangeToAttributeValues(name: string): [unknown, unknown] | undefined {
-    return this._dirty.attributeChange(name);
+    return this.attributeChange(name);
   }
 
   get previousChanges(): Record<string, [unknown, unknown]> {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1630,7 +1630,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#will_save_change_to_attribute?
    */
   willSaveChangeToAttribute(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    return this.attributeChanged(resolveAliasName(this.constructor as typeof Model, name), options);
+    return this.attributeChanged(name, options);
   }
 
   attributeWas(name: string): unknown {
@@ -1752,10 +1752,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_previously_changed?
    */
   attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    return this.savedChangeToAttribute(
-      resolveAliasName(this.constructor as typeof Model, name),
-      options,
-    );
+    return this.savedChangeToAttribute(name, options);
   }
 
   /**
@@ -1765,7 +1762,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_previously_was
    */
   attributePreviouslyWas(name: string): unknown {
-    return this.attributeBeforeLastSave(resolveAliasName(this.constructor as typeof Model, name));
+    return this.attributeBeforeLastSave(name);
   }
 
   restoreAttributes(): void {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1630,7 +1630,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#will_save_change_to_attribute?
    */
   willSaveChangeToAttribute(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    return this.attributeChanged(name, options);
+    return this.attributeChanged(resolveAliasName(this.constructor as typeof Model, name), options);
   }
 
   attributeWas(name: string): unknown {
@@ -1670,6 +1670,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#saved_change_to_attribute?
    */
   savedChangeToAttribute(name: string, options?: { from?: unknown; to?: unknown }): boolean {
+    name = resolveAliasName(this.constructor as typeof Model, name);
     const changes = this._dirty.previousChanges;
     if (!(name in changes)) return false;
     if (!options) return true;
@@ -1690,6 +1691,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_before_last_save
    */
   attributeBeforeLastSave(name: string): unknown {
+    name = resolveAliasName(this.constructor as typeof Model, name);
     const change = this._dirty.previousChanges[name];
     return change ? change[0] : this.readAttribute(name);
   }
@@ -1701,6 +1703,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_in_database
    */
   attributeInDatabase(name: string): unknown {
+    name = resolveAliasName(this.constructor as typeof Model, name);
     return this._dirty.attributeWas(name) ?? this.readAttribute(name);
   }
 
@@ -1739,7 +1742,7 @@ export class Model {
 
   savedChangeToAttributeValues(name: string): [unknown, unknown] | undefined {
     const changes = this._dirty.previousChanges;
-    return changes[name];
+    return changes[resolveAliasName(this.constructor as typeof Model, name)];
   }
 
   /**
@@ -1749,7 +1752,10 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_previously_changed?
    */
   attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    return this.savedChangeToAttribute(name, options);
+    return this.savedChangeToAttribute(
+      resolveAliasName(this.constructor as typeof Model, name),
+      options,
+    );
   }
 
   /**
@@ -1759,7 +1765,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_previously_was
    */
   attributePreviouslyWas(name: string): unknown {
-    return this.attributeBeforeLastSave(name);
+    return this.attributeBeforeLastSave(resolveAliasName(this.constructor as typeof Model, name));
   }
 
   restoreAttributes(): void {
@@ -1772,7 +1778,10 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#restore_attribute!
    */
   restoreAttribute(name: string): void {
-    this._dirty.restoreAttribute(this._attributes, name);
+    this._dirty.restoreAttribute(
+      this._attributes,
+      resolveAliasName(this.constructor as typeof Model, name),
+    );
   }
 
   /**
@@ -1785,7 +1794,7 @@ export class Model {
    * @internal
    */
   attributePreviousChange(name: string): [unknown, unknown] | undefined {
-    return this._dirty.previousChanges[name];
+    return this._dirty.previousChanges[resolveAliasName(this.constructor as typeof Model, name)];
   }
 
   changesApplied(): void {

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -1,9 +1,14 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { TimeZoneConverter } from "./time-zone-conversion.js";
+import { DateTime } from "../type/date-time.js";
 
 describe("TimeZoneConverterTest", () => {
-  it.skip("comparison with date time type", () => {
-    // BLOCKED: type — time-zone-converter type/attribute gap
-    // ROOT-CAUSE: time-zone-converter.ts or attribute-methods/time-zone-converter.ts missing Rails parity
-    // SCOPE: ~20 LOC fix; affects ~1 test in time-zone-converter.test.ts
+  it("comparison with date time type", () => {
+    const subtype = new DateTime();
+    const value = new TimeZoneConverter(subtype);
+    const valueCopy = new TimeZoneConverter(subtype);
+
+    expect(value.equals(valueCopy)).toBe(true);
+    expect(value.equals("foo" as any)).toBe(false);
   });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -4,11 +4,12 @@ import { DateTime } from "../type/date-time.js";
 
 describe("TimeZoneConverterTest", () => {
   it("comparison with date time type", () => {
-    const subtype = new DateTime();
-    const value = new TimeZoneConverter(subtype);
-    const valueCopy = new TimeZoneConverter(subtype);
+    // Two distinct DateTime instances (mirrors Rails' Marshal round-trip producing
+    // a new object) — verifies ValueType.equals compares by shape, not reference.
+    const value = new TimeZoneConverter(new DateTime());
+    const valueFromCache = new TimeZoneConverter(new DateTime());
 
-    expect(value.equals(valueCopy)).toBe(true);
+    expect(value.equals(valueFromCache)).toBe(true);
     expect(value.equals("foo" as any)).toBe(false);
   });
 });

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -128,11 +128,22 @@ describe("DirtyTest", () => {
     expect(typeof t.changed).toBe("boolean");
   });
 
-  it.skip("aliased attribute changes", () => {
-    // BLOCKED: type — dirty type/attribute gap
-    // ROOT-CAUSE: dirty.ts or attribute-methods/dirty.ts missing Rails parity
-    // SCOPE: ~20 LOC fix; affects ~1 test in dirty.test.ts
-    /* needs aliasAttribute to propagate dirty tracking */
+  it("aliased attribute changes", () => {
+    class Parrot extends Base {
+      static {
+        this.attribute("name", "string");
+        this.aliasAttribute("title", "name");
+        this.adapter = adapter;
+      }
+    }
+    const parrot = new Parrot();
+    expect((parrot as any).titleChanged()).toBe(false);
+    expect((parrot as any).titleChange()).toBeUndefined();
+
+    parrot.name = "Sam";
+    expect((parrot as any).titleChanged()).toBe(true);
+    expect((parrot as any).titleWas()).toBeNull();
+    expect((parrot as any).titleChange()).toEqual((parrot as any).nameChange());
   });
 
   it("saved_change_to_attribute? returns whether a change occurred in the last save", async () => {

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -138,6 +138,7 @@ describe("DirtyTest", () => {
     }
     const parrot = new Parrot();
     expect((parrot as any).titleChanged()).toBe(false);
+    // Rails returns nil; we return undefined (Map lookup miss — pre-existing gap in attributeChange)
     expect((parrot as any).titleChange()).toBeUndefined();
 
     parrot.name = "Sam";

--- a/packages/activerecord/src/type/date-time.test.ts
+++ b/packages/activerecord/src/type/date-time.test.ts
@@ -17,6 +17,7 @@ describe("DateTimeTest", () => {
 
   afterAll(async () => {
     await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   it.skip("datetime seconds precision applied to timestamp", async () => {

--- a/packages/activerecord/src/type/date-time.test.ts
+++ b/packages/activerecord/src/type/date-time.test.ts
@@ -1,14 +1,32 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { DateTime } from "./date-time.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("DateTimeTest", () => {
-  it.skip("datetime seconds precision applied to timestamp", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in date-time
-    // ROOT-CAUSE: type/date-time.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in date-time.test.ts
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { tasks: { starting: "datetime" } });
   });
-  it.skip("serialize_cast_value is equivalent to serialize after cast", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in date-time
-    // ROOT-CAUSE: type/date-time.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in date-time.test.ts
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
+  it.skip("datetime seconds precision applied to timestamp", async () => {
+    // BLOCKED: datetime deserialization — reload() returns null for datetime column
+    // ROOT-CAUSE: test-adapter doesn't deserialize datetime strings back to Date/Temporal
+  });
+
+  it("serialize_cast_value is equivalent to serialize after cast", () => {
+    const type = new DateTime({ precision: 1 });
+    const value = type.cast("1999-12-31 12:34:56.789 -1000");
+    expect(type.serialize(value)).toEqual(type.serializeCastValue(value));
   });
 });

--- a/packages/activerecord/src/type/integer.test.ts
+++ b/packages/activerecord/src/type/integer.test.ts
@@ -1,14 +1,27 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { IntegerType } from "@blazetrails/activemodel";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
 
 describe("IntegerTest", () => {
-  it.skip("casting ActiveRecord models", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in integer
-    // ROOT-CAUSE: type/integer.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in integer.test.ts
+  it("casting ActiveRecord models", () => {
+    const type = new IntegerType();
+    const model = new Base();
+    expect(type.cast(model)).toBeNull();
   });
-  it.skip("values which are out of range can be re-assigned", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in integer
-    // ROOT-CAUSE: type/integer.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in integer.test.ts
+
+  it("values which are out of range can be re-assigned", () => {
+    const adapter = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("foo", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const model = new Post();
+    model.foo = 2147483648;
+    model.foo = 1;
+    expect(model.foo).toBe(1);
   });
 });

--- a/packages/activerecord/src/type/integer.test.ts
+++ b/packages/activerecord/src/type/integer.test.ts
@@ -6,6 +6,7 @@ import { createTestAdapter } from "../test-adapter.js";
 describe("IntegerTest", () => {
   it("casting ActiveRecord models", () => {
     const type = new IntegerType();
+    // AR model stringifies to "[object Object]" → parseInt → NaN → null
     const model = new Base();
     expect(type.cast(model)).toBeNull();
   });

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -1,9 +1,41 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("StringTypeTest", () => {
-  it.skip("string mutations are detected", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in string
-    // ROOT-CAUSE: type/string.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in string.test.ts
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { authors: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
+
+  it("string mutations are detected", async () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const author = await Author.create({ name: "Sean" });
+    expect(author.changed).toBe(false);
+
+    (author.name as string) += " Griffin";
+    expect((author as any).nameChanged()).toBe(true);
+
+    await author.save();
+    await author.reload();
+
+    expect(author.name).toBe("Sean Griffin");
+    expect(author.changed).toBe(false);
   });
 });

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -17,6 +17,7 @@ describe("StringTypeTest", () => {
 
   afterAll(async () => {
     await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   it("string mutations are detected", async () => {
@@ -29,9 +30,9 @@ describe("StringTypeTest", () => {
     const author = await Author.create({ name: "Sean" });
     expect(author.changed).toBe(false);
 
-    // JS strings are immutable; "+=" assigns through the setter rather than mutating in place.
+    // JS strings are immutable; assignment goes through the setter rather than mutating in place.
     // nameChanged() fires via dirty-tracker change detection, not isChangedInPlace.
-    (author.name as string) += " Griffin";
+    author.name = String(author.name) + " Griffin";
     expect((author as any).nameChanged()).toBe(true);
 
     await author.save();

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -29,6 +29,8 @@ describe("StringTypeTest", () => {
     const author = await Author.create({ name: "Sean" });
     expect(author.changed).toBe(false);
 
+    // JS strings are immutable; "+=" assigns through the setter rather than mutating in place.
+    // nameChanged() fires via dirty-tracker change detection, not isChangedInPlace.
     (author.name as string) += " Griffin";
     expect((author as any).nameChanged()).toBe(true);
 

--- a/packages/activerecord/src/type/time.test.ts
+++ b/packages/activerecord/src/type/time.test.ts
@@ -3,9 +3,9 @@ import { Time } from "./time.js";
 
 describe("TimeTest", () => {
   it.skip("default year is correct", () => {
-    // BLOCKED: type — type cast/serialize/deserialize gap in time
-    // ROOT-CAUSE: type/time.ts or attribute-types.ts missing Rails parity
-    // SCOPE: ~20–100 LOC fix in type/; affects ~2–18 tests in time.test.ts
+    // BLOCKED: multiparameter hash-key assignment not implemented
+    // Rails: Topic.new(bonus_time: { 4 => 10, 5 => 30 }) uses numeric-keyed
+    // hash form from form helpers; our multiparameter assignment doesn't handle it.
   });
 
   it("serialize_cast_value is equivalent to serialize after cast", () => {


### PR DESCRIPTION
## Summary

- **TimeZoneConverter.equals**: un-skip `comparison with date time type` test — `equals` was already implemented, just needed the test body ported from Rails
- **aliasAttribute dirty propagation**: export `defineDirtyAttributeMethods` from activemodel `attributes.ts`, call it in `aliasAttribute` so alias names get dirty predicates (`titleChanged`, `titleChange`, `titleWas`, etc.); add alias resolution via `resolveAliasName` in `model.ts`'s `attributeChanged` / `attributeWas` / `attributeChange`
- **Hollow type stubs**: port test bodies from Rails for `integer_test.rb` (2 tests pass), `string_test.rb` (1 test passes), `time_test.rb` (1 skip remains: multiparameter hash-key form not implemented), `date_time_test.rb` (1 skip remains: datetime deserialization gap; `serialize_cast_value` test passes)

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/attribute-methods/time-zone-converter.test.ts` — 1 test passes
- [ ] `pnpm vitest run packages/activerecord/src/dirty.test.ts` — 88 tests pass (0 skipped)
- [ ] `pnpm vitest run packages/activerecord/src/type/` — all pass, 2 remaining skips annotated BLOCKED
- [ ] `pnpm api:compare --package activerecord` — 4955/4958 (99.9%), no regression