### PR TITLE
feat(activerecord): enum bundle — subtype detection, scope.build/create, reserved-name validation, method aliases (~165 LOC)

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -604,17 +604,39 @@ describe("EnumTest", () => {
     expect((p as any).isWritten()).toBe(true);
     expect((p as any).isDraft()).toBe(false);
   });
-  it.skip("reserved enum values", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs reserved name validation */
+  it("reserved enum values", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    Post.attribute("id", "integer");
+    Post.attribute("status", "integer");
+    Post.adapter = freshAdapter();
+    defineEnum(Post, "status", { draft: 0, published: 1 });
+
+    // :valid → isValid conflicts with AR instance method
+    // :save  → saveBang conflicts with AR instance method
+    const conflicts = ["valid", "save"];
+    conflicts.forEach((value, i) => {
+      const enumName = `status_${i}`;
+      Post.attribute(enumName, "integer");
+      expect(() => defineEnum(Post, enumName, [value])).toThrow(ArgumentError);
+    });
   });
-  it.skip("reserved enum values for relation", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs reserved name validation */
+  it("reserved enum values for relation", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    Post.attribute("id", "integer");
+    Post.attribute("status", "integer");
+    Post.adapter = freshAdapter();
+
+    // Scope names that conflict with existing static model class methods
+    const conflicts = ["all", "where"];
+    conflicts.forEach((value, i) => {
+      const enumName = `category_${i}`;
+      Post.attribute(enumName, "integer");
+      expect(() => defineEnum(Post, enumName, [value])).toThrow(ArgumentError);
+    });
   });
 
   it("query state by predicate with custom prefix", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -401,11 +401,23 @@ describe("EnumTest", () => {
     expect(readEnumValue(b, "status")).toBe("published");
   });
 
-  it.skip("enum with string column", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs string-based enum mapping support */
+  it("enum with string column", async () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    Post.attribute("id", "integer");
+    Post.attribute("color", "string");
+    Post.adapter = freshAdapter();
+    defineEnum(Post, "color", { red: "red", green: "green", blue: "blue" });
+    const p = new Post({ color: "red" });
+    expect(readEnumValue(p, "color")).toBe("red");
+    expect((p as any).isRed()).toBe(true);
+    expect((p as any).isGreen()).toBe(false);
+    await Post.create({ color: "red" });
+    await Post.create({ color: "green" });
+    const reds = await (Post as any).red().toArray();
+    expect(reds.length).toBe(1);
+    expect(readEnumValue(reds[0], "color")).toBe("red");
   });
 
   it("enum without scope", async () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -576,17 +576,33 @@ describe("EnumTest", () => {
     expect(changes.status[1]).toBe(2); // to: published (2)
   });
 
-  it.skip("building new objects with enum scopes", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs scope.build() support */
+  it("building new objects with enum scopes", () => {
+    const adp = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("status", "integer");
+        this.adapter = adp;
+      }
+    }
+    defineEnum(Post, "status", { draft: 0, written: 1, published: 2 });
+    const p = (Post as any).written().build();
+    expect((p as any).isWritten()).toBe(true);
+    expect((p as any).isDraft()).toBe(false);
   });
-  it.skip("creating new objects with enum scopes", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs scope.create() support */
+  it("creating new objects with enum scopes", async () => {
+    const adp = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("status", "integer");
+        this.adapter = adp;
+      }
+    }
+    defineEnum(Post, "status", { draft: 0, written: 1, published: 2 });
+    const p = await (Post as any).written().create();
+    expect((p as any).isWritten()).toBe(true);
+    expect((p as any).isDraft()).toBe(false);
   });
   it.skip("reserved enum values", () => {
     // BLOCKED: type — enum type feature gap

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -511,10 +511,25 @@ describe("EnumTest", () => {
     expect(readEnumValue(b, "status")).toBe("active");
   });
 
-  it.skip("overriding enum definition on subclass", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
+  it("overriding enum definition on subclass", () => {
+    const adp = freshAdapter();
+    class Book extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("status", "integer");
+        this.adapter = adp;
+      }
+    }
+    defineEnum(Book, "status", { proposed: 0, written: 1, published: 2 });
+
+    class SpecialBook extends Book {}
+    defineEnum(SpecialBook, "status", { available: 0, soldOut: 1 });
+
+    const sb = new SpecialBook({ status: 0 });
+    expect(readEnumValue(sb, "status")).toBe("available");
+
+    const b = new Book({ status: 0 });
+    expect(readEnumValue(b, "status")).toBe("proposed");
   });
 
   it("enum changed?", async () => {
@@ -539,10 +554,19 @@ describe("EnumTest", () => {
     expect(readEnumValue(found[0], "status")).toBe("published");
   });
 
-  it.skip("find via negative scope", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
+  it("find via negative scope", async () => {
+    const Book = makeBook();
+    const pub = await Book.create({
+      status: castEnumValue(Book, "status", "published"),
+      name: "Pub",
+    });
+    await Book.create({ status: castEnumValue(Book, "status", "proposed"), name: "Pro" });
+
+    const notPublished = await (Book as any).notPublished().toArray();
+    expect(notPublished.some((b: any) => (b as any).id === (pub as any).id)).toBe(false);
+
+    const notProposed = await (Book as any).notProposed().toArray();
+    expect(notProposed.some((b: any) => readEnumValue(b, "status") === "published")).toBe(true);
   });
 
   it("find via where with values.to_s", async () => {
@@ -665,17 +689,41 @@ describe("EnumTest", () => {
     expect((p as any).isPublishedStatus()).toBe(true);
   });
 
-  it.skip("enum methods with custom suffix defined", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs bang setters like draft_status! */
+  it("enum methods with custom suffix defined", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    Post.attribute("id", "integer");
+    Post.attribute("difficulty", "integer");
+    Post.adapter = freshAdapter();
+    defineEnum(Post, "difficulty", { easy: 0, medium: 1, hard: 2 }, { suffix: "to_read" });
+    const p = new Post({ difficulty: 0 });
+    expect(typeof (Post as any).easyToRead).toBe("function");
+    expect(typeof (Post as any).mediumToRead).toBe("function");
+    expect(typeof (Post as any).hardToRead).toBe("function");
+    expect(typeof (p as any).isEasyToRead).toBe("function");
+    expect(typeof (p as any).isMediumToRead).toBe("function");
+    expect(typeof (p as any).isHardToRead).toBe("function");
+    expect(typeof (p as any).easyToReadBang).toBe("function");
+    expect(typeof (p as any).mediumToReadBang).toBe("function");
+    expect(typeof (p as any).hardToReadBang).toBe("function");
   });
-  it.skip("update enum attributes with custom suffix", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs bang setters */
+  it("update enum attributes with custom suffix", async () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    Post.attribute("id", "integer");
+    Post.attribute("difficulty", "integer");
+    Post.adapter = freshAdapter();
+    defineEnum(Post, "difficulty", { easy: 0, medium: 1, hard: 2 }, { suffix: "to_read" });
+    const p = new Post({ difficulty: 1 }); // medium
+    expect((p as any).isMediumToRead()).toBe(true);
+    await (p as any).easyToReadBang();
+    expect((p as any).isEasyToRead()).toBe(true);
+    expect((p as any).isMediumToRead()).toBe(false);
+    await (p as any).hardToReadBang();
+    expect((p as any).isHardToRead()).toBe(true);
+    expect((p as any).isEasyToRead()).toBe(false);
   });
 
   it("enum on custom attribute with default", () => {
@@ -690,11 +738,20 @@ describe("EnumTest", () => {
     expect(readEnumValue(p, "status")).toBe("draft");
   });
 
-  it.skip("scopes are named like methods", () => {
-    // BLOCKED: type — enum type feature gap
-    // ROOT-CAUSE: enum.ts#defineEnum or EnumType missing Rails parity for enum scopes / predicates
-    // SCOPE: ~50 LOC fix in enum.ts; affects ~10 tests in enum.test.ts
-    /* needs method introspection */
+  it("scopes are named like methods", () => {
+    class Cat extends Base {
+      static _tableName = "cats";
+    }
+    Cat.attribute("id", "integer");
+    Cat.attribute("breed", "string");
+    Cat.adapter = freshAdapter();
+    defineEnum(Cat, "breed", {
+      "American Bobtail": "american_bobtail",
+      "Balinese-Javanese": "balinese_javanese",
+    });
+    // Method-friendly aliases replace non-word ASCII chars with _ then camelize
+    expect(typeof (Cat as any).americanBobtail).toBe("function");
+    expect(typeof (Cat as any).balineseJavanese).toBe("function");
   });
 });
 

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -637,8 +637,6 @@ describe("EnumTest", () => {
     Post.adapter = freshAdapter();
     defineEnum(Post, "status", { draft: 0, published: 1 });
 
-    // :valid → isValid conflicts with AR instance method
-    // :save  → saveBang conflicts with AR instance method
     const conflicts = ["valid", "save"];
     conflicts.forEach((value, i) => {
       const enumName = `status_${i}`;
@@ -654,7 +652,6 @@ describe("EnumTest", () => {
     Post.attribute("status", "integer");
     Post.adapter = freshAdapter();
 
-    // Scope names that conflict with existing static model class methods
     const conflicts = ["all", "where"];
     conflicts.forEach((value, i) => {
       const enumName = `category_${i}`;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -98,82 +98,48 @@ export function defineEnum(
   // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
-  // Collect method names upfront so all conflicts are validated before any
-  // method is defined — mirrors Rails: detect_enum_conflict! is called for
-  // every value before any method is registered, preventing partial state.
-  const valueEntries = [] as Array<{
-    name: string;
-    value: string | number;
-    fullName: string;
-    predicateName: string;
-    bangName: string;
-    scopeName: string;
-    notScopeName: string;
-    friendlyName: string;
-  }>;
+  // Pass 1: validate all conflicts before defining any method (mirrors Rails:
+  // detect_enum_conflict! is called for all values before registration).
+  for (const [name] of mapping) {
+    const fullName = toCamel(methodName(name));
+    const capitalizedFullName = camelize(methodName(name));
+    const predicateName = `is${capitalizedFullName}`;
+    const bangName = `${fullName}Bang`;
+    const notScopeName = `not${capitalizedFullName}`;
+    const friendlyName = toCamel(methodName(name).replace(/[^\w\x80-\uffff]+/g, "_"));
 
+    if (predicateName in (modelClass.prototype as object))
+      raiseConflictError.call(modelClass, attribute, predicateName);
+    if (bangName in (modelClass.prototype as object))
+      raiseConflictError.call(modelClass, attribute, bangName);
+    if (fullName in (modelClass as object))
+      raiseConflictError.call(modelClass, attribute, fullName, { type: "class" });
+    if (notScopeName in (modelClass as object))
+      raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
+    if (friendlyName !== fullName) {
+      if (friendlyName in (modelClass as object))
+        raiseConflictError.call(modelClass, attribute, friendlyName, { type: "class" });
+      const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
+      if (notFriendlyName in (modelClass as object))
+        raiseConflictError.call(modelClass, attribute, notFriendlyName, { type: "class" });
+    }
+  }
+
+  // Register only after all conflicts are validated.
+  defs.set(attribute, def);
+
+  // Pass 2: define all methods.
   for (const [name, value] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));
     const predicateName = `is${capitalizedFullName}`;
     const bangName = `${fullName}Bang`;
-    const scopeName = fullName;
     const notScopeName = `not${capitalizedFullName}`;
-    // Method-friendly alias: replace non-word ASCII chars with _, then camelize.
-    // Mirrors Rails: label.gsub(/[\W&&[:ascii:]]+/, "_")
-    const friendlyName = toCamel(methodName(name).replace(/[^\w-￿]+/g, "_"));
+    const friendlyName = toCamel(methodName(name).replace(/[^\w\x80-\uffff]+/g, "_"));
 
-    // Conflict detection (mirrors Rails' detect_enum_conflict!)
-    if (predicateName in (modelClass.prototype as object)) {
-      raiseConflictError.call(modelClass, attribute, predicateName);
-    }
-    if (bangName in (modelClass.prototype as object)) {
-      raiseConflictError.call(modelClass, attribute, bangName);
-    }
-    if (scopeName in (modelClass as object)) {
-      raiseConflictError.call(modelClass, attribute, scopeName, { type: "class" });
-    }
-    if (notScopeName in (modelClass as object)) {
-      raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
-    }
-    if (friendlyName !== scopeName) {
-      if (friendlyName in (modelClass as object)) {
-        raiseConflictError.call(modelClass, attribute, friendlyName, { type: "class" });
-      }
-      const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
-      if (notFriendlyName in (modelClass as object)) {
-        raiseConflictError.call(modelClass, attribute, notFriendlyName, { type: "class" });
-      }
-    }
+    modelClass.scope(fullName, (rel: any) => rel.where({ [attribute]: value }));
 
-    valueEntries.push({
-      name,
-      value,
-      fullName,
-      predicateName,
-      bangName,
-      scopeName,
-      notScopeName,
-      friendlyName,
-    });
-  }
-
-  // Register only after conflict validation succeeds — keeps enumRegistry atomic.
-  defs.set(attribute, def);
-
-  // Define all scopes and instance methods only after all conflicts are validated.
-  for (const {
-    value,
-    fullName,
-    predicateName,
-    bangName,
-    scopeName,
-    notScopeName,
-    friendlyName,
-  } of valueEntries) {
-    modelClass.scope(scopeName, (rel: any) => rel.where({ [attribute]: value }));
-
-    if (friendlyName !== scopeName) {
+    if (friendlyName !== fullName) {
       modelClass.scope(friendlyName, (rel: any) => rel.where({ [attribute]: value }));
       const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
       modelClass.scope(notFriendlyName, (rel: any) => rel.whereNot({ [attribute]: value }));

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -97,19 +97,33 @@ export function defineEnum(
   // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
-  // Define scopes for each enum value
-  for (const [name, value] of mapping) {
-    const scopeName = toCamel(methodName(name));
-    modelClass.scope(scopeName, (rel: any) => rel.where({ [attribute]: value }));
-  }
-
-  // Define instance methods on the prototype
+  // Define scopes and instance methods for each enum value
   for (const [name, value] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));
+    const predicateName = `is${capitalizedFullName}`;
+    const bangName = `${fullName}Bang`;
+    const scopeName = fullName;
+    const notScopeName = `not${capitalizedFullName}`;
+
+    // Conflict detection (mirrors Rails' detect_enum_conflict!)
+    if (predicateName in (modelClass.prototype as object)) {
+      raiseConflictError.call(modelClass, attribute, predicateName);
+    }
+    if (bangName in (modelClass.prototype as object)) {
+      raiseConflictError.call(modelClass, attribute, bangName);
+    }
+    if (scopeName in (modelClass as object)) {
+      raiseConflictError.call(modelClass, attribute, scopeName, { type: "class" });
+    }
+    if (notScopeName in (modelClass as object)) {
+      raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
+    }
+
+    modelClass.scope(scopeName, (rel: any) => rel.where({ [attribute]: value }));
 
     // Predicate: record.isDraft() or record.isStatusDraft()
-    Object.defineProperty(modelClass.prototype, `is${capitalizedFullName}`, {
+    Object.defineProperty(modelClass.prototype, predicateName, {
       value: function (this: Base) {
         return this.readAttribute(attribute) === value;
       },
@@ -129,7 +143,6 @@ export function defineEnum(
     }
 
     // Bang setter: record.draftBang() or record.statusDraftBang()
-    const bangName = `${fullName}Bang`;
     Object.defineProperty(modelClass.prototype, bangName, {
       value: async function (this: any) {
         this.writeAttribute(attribute, value);
@@ -142,7 +155,6 @@ export function defineEnum(
     });
 
     // whereNot scope: Model.notDraft() or Model.notStatusDraft()
-    const notScopeName = `not${capitalizedFullName}`;
     modelClass.scope(notScopeName, (rel: any) => rel.whereNot({ [attribute]: value }));
   }
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -10,7 +10,7 @@ import { ArgumentError, ValueType } from "@blazetrails/activemodel";
 
 interface EnumDefinition {
   attribute: string;
-  mapping: Map<string, number>;
+  mapping: Map<string, number | string>;
   type: EnumType;
 }
 
@@ -47,10 +47,10 @@ export function getEnumDefinitions(modelClass: typeof Base): Map<string, EnumDef
 export function defineEnum(
   modelClass: typeof Base,
   attribute: string,
-  valuesInput: string[] | Record<string, number>,
+  valuesInput: string[] | Record<string, string | number>,
   options?: { prefix?: boolean | string; suffix?: boolean | string },
 ): void {
-  const mapping = new Map<string, number>();
+  const mapping = new Map<string, string | number>();
 
   if (Array.isArray(valuesInput)) {
     valuesInput.forEach((name, index) => {
@@ -63,7 +63,13 @@ export function defineEnum(
   }
 
   const defs = getEnumDefinitions(modelClass);
-  const enumType = new EnumType(attribute, mapping, "integer");
+  let subtype = "integer";
+  try {
+    subtype = modelClass.typeForAttribute(attribute).type();
+  } catch {
+    // attribute not registered; default to integer
+  }
+  const enumType = new EnumType(attribute, mapping, subtype);
   const def: EnumDefinition = { attribute, mapping, type: enumType };
   defs.set(attribute, def);
 
@@ -551,12 +557,12 @@ export function castEnumValue(
   modelClass: typeof Base,
   attribute: string,
   value: unknown,
-): number | null {
+): number | string | null {
   const defs = getEnumDefinitions(modelClass);
   const def = defs.get(attribute);
   if (!def) return null;
 
-  return def.type.serialize(value) as number | null;
+  return def.type.serialize(value) as number | string | null;
 }
 
 /**

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -98,8 +98,7 @@ export function defineEnum(
   // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
-  // Pass 1: validate all conflicts before defining any method (mirrors Rails:
-  // detect_enum_conflict! is called for all values before registration).
+  // Pass 1: validate all conflicts before defining any method.
   for (const [name] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));
@@ -117,6 +116,11 @@ export function defineEnum(
     if (notScopeName in (modelClass as object))
       raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
     if (friendlyName !== fullName) {
+      const fp = `is${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
+      if (fp in (modelClass.prototype as object))
+        raiseConflictError.call(modelClass, attribute, fp);
+      if (`${friendlyName}Bang` in (modelClass.prototype as object))
+        raiseConflictError.call(modelClass, attribute, `${friendlyName}Bang`);
       if (friendlyName in (modelClass as object))
         raiseConflictError.call(modelClass, attribute, friendlyName, { type: "class" });
       const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
@@ -143,6 +147,24 @@ export function defineEnum(
       modelClass.scope(friendlyName, (rel: any) => rel.where({ [attribute]: value }));
       const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
       modelClass.scope(notFriendlyName, (rel: any) => rel.whereNot({ [attribute]: value }));
+      const fp = `is${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
+      Object.defineProperty(modelClass.prototype, fp, {
+        value: function (this: Base) {
+          return this.readAttribute(attribute) === value;
+        },
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(modelClass.prototype, `${friendlyName}Bang`, {
+        value: async function (this: any) {
+          this.writeAttribute(attribute, value);
+          if (this.isPersisted()) {
+            await this.updateColumn(attribute, value);
+          }
+        },
+        writable: true,
+        configurable: true,
+      });
     }
 
     // Predicate: record.isDraft() or record.isStatusDraft()

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -95,7 +95,6 @@ export function defineEnum(
     return name;
   };
 
-  // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
   for (const [name] of mapping) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -122,6 +122,15 @@ export function defineEnum(
 
     modelClass.scope(scopeName, (rel: any) => rel.where({ [attribute]: value }));
 
+    // Method-friendly alias: replace non-word ASCII chars with _, then camelize
+    // Mirrors Rails: label.gsub(/[\W&&[:ascii:]]+/, "_")
+    const friendlyName = toCamel(methodName(name).replace(/[^\w-￿]+/g, "_"));
+    if (friendlyName !== scopeName) {
+      modelClass.scope(friendlyName, (rel: any) => rel.where({ [attribute]: value }));
+      const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
+      modelClass.scope(notFriendlyName, (rel: any) => rel.whereNot({ [attribute]: value }));
+    }
+
     // Predicate: record.isDraft() or record.isStatusDraft()
     Object.defineProperty(modelClass.prototype, predicateName, {
       value: function (this: Base) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -102,7 +102,7 @@ export function defineEnum(
   // Collect method names upfront so all conflicts are validated before any
   // method is defined — mirrors Rails: detect_enum_conflict! is called for
   // every value before any method is registered, preventing partial state.
-  type ValueEntry = {
+  const valueEntries = [] as Array<{
     name: string;
     value: string | number;
     fullName: string;
@@ -111,8 +111,7 @@ export function defineEnum(
     scopeName: string;
     notScopeName: string;
     friendlyName: string;
-  };
-  const valueEntries: ValueEntry[] = [];
+  }>;
 
   for (const [name, value] of mapping) {
     const fullName = toCamel(methodName(name));
@@ -137,6 +136,15 @@ export function defineEnum(
     }
     if (notScopeName in (modelClass as object)) {
       raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
+    }
+    if (friendlyName !== scopeName) {
+      if (friendlyName in (modelClass as object)) {
+        raiseConflictError.call(modelClass, attribute, friendlyName, { type: "class" });
+      }
+      const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;
+      if (notFriendlyName in (modelClass as object)) {
+        raiseConflictError.call(modelClass, attribute, notFriendlyName, { type: "class" });
+      }
     }
 
     valueEntries.push({
@@ -179,7 +187,7 @@ export function defineEnum(
     });
 
     // Setter: record.draft() or record.statusDraft() — sets the value in memory
-    if (!Object.hasOwn(modelClass.prototype, fullName)) {
+    if (!(fullName in (modelClass.prototype as object))) {
       Object.defineProperty(modelClass.prototype, fullName, {
         value: function (this: Base) {
           this.writeAttribute(attribute, value);
@@ -609,8 +617,8 @@ export function readEnumValue(record: Base, attribute: string): string | null {
 }
 
 /**
- * Cast an enum value (string name or number) to its integer storage value.
- * Delegates to EnumType.serialize for the mapping lookup.
+ * Cast an enum value (string name or number) to its storage value (integer or string,
+ * depending on the attribute subtype). Delegates to EnumType.serialize for the mapping lookup.
  */
 export function castEnumValue(
   modelClass: typeof Base,

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -98,7 +98,6 @@ export function defineEnum(
   // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
-  // Pass 1: validate all conflicts before defining any method.
   for (const [name] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));
@@ -129,10 +128,8 @@ export function defineEnum(
     }
   }
 
-  // Register only after all conflicts are validated.
   defs.set(attribute, def);
 
-  // Pass 2: define all methods.
   for (const [name, value] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -63,11 +63,13 @@ export function defineEnum(
   }
 
   const defs = getEnumDefinitions(modelClass);
-  let subtype = "integer";
+  let subtype: string;
   try {
-    subtype = modelClass.typeForAttribute(attribute).type();
+    const t = modelClass.typeForAttribute(attribute).type();
+    // "value" is the fallback for unregistered attributes — treat as integer
+    subtype = t === "value" ? "integer" : t;
   } catch {
-    // attribute not registered; default to integer
+    subtype = "integer";
   }
   const enumType = new EnumType(attribute, mapping, subtype);
   const def: EnumDefinition = { attribute, mapping, type: enumType };
@@ -97,7 +99,21 @@ export function defineEnum(
   // Camel-case a method name: "status_draft" -> "statusDraft"
   const toCamel = (s: string) => camelize(s, false);
 
-  // Define scopes and instance methods for each enum value
+  // Collect method names upfront so all conflicts are validated before any
+  // method is defined — mirrors Rails: detect_enum_conflict! is called for
+  // every value before any method is registered, preventing partial state.
+  type ValueEntry = {
+    name: string;
+    value: string | number;
+    fullName: string;
+    predicateName: string;
+    bangName: string;
+    scopeName: string;
+    notScopeName: string;
+    friendlyName: string;
+  };
+  const valueEntries: ValueEntry[] = [];
+
   for (const [name, value] of mapping) {
     const fullName = toCamel(methodName(name));
     const capitalizedFullName = camelize(methodName(name));
@@ -105,6 +121,9 @@ export function defineEnum(
     const bangName = `${fullName}Bang`;
     const scopeName = fullName;
     const notScopeName = `not${capitalizedFullName}`;
+    // Method-friendly alias: replace non-word ASCII chars with _, then camelize.
+    // Mirrors Rails: label.gsub(/[\W&&[:ascii:]]+/, "_")
+    const friendlyName = toCamel(methodName(name).replace(/[^\w-￿]+/g, "_"));
 
     // Conflict detection (mirrors Rails' detect_enum_conflict!)
     if (predicateName in (modelClass.prototype as object)) {
@@ -120,11 +139,30 @@ export function defineEnum(
       raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
     }
 
+    valueEntries.push({
+      name,
+      value,
+      fullName,
+      predicateName,
+      bangName,
+      scopeName,
+      notScopeName,
+      friendlyName,
+    });
+  }
+
+  // Define all scopes and instance methods only after all conflicts are validated.
+  for (const {
+    value,
+    fullName,
+    predicateName,
+    bangName,
+    scopeName,
+    notScopeName,
+    friendlyName,
+  } of valueEntries) {
     modelClass.scope(scopeName, (rel: any) => rel.where({ [attribute]: value }));
 
-    // Method-friendly alias: replace non-word ASCII chars with _, then camelize
-    // Mirrors Rails: label.gsub(/[\W&&[:ascii:]]+/, "_")
-    const friendlyName = toCamel(methodName(name).replace(/[^\w-￿]+/g, "_"));
     if (friendlyName !== scopeName) {
       modelClass.scope(friendlyName, (rel: any) => rel.where({ [attribute]: value }));
       const notFriendlyName = `not${friendlyName.charAt(0).toUpperCase()}${friendlyName.slice(1)}`;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -66,7 +66,7 @@ export function defineEnum(
   let subtype: string;
   try {
     const t = modelClass.typeForAttribute(attribute).type();
-    subtype = t === "value" ? "integer" : t;
+    subtype = t === "value" || t === "big_integer" ? "integer" : t;
   } catch {
     subtype = "integer";
   }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -66,7 +66,6 @@ export function defineEnum(
   let subtype: string;
   try {
     const t = modelClass.typeForAttribute(attribute).type();
-    // "value" is the fallback for unregistered attributes — treat as integer
     subtype = t === "value" ? "integer" : t;
   } catch {
     subtype = "integer";
@@ -163,7 +162,6 @@ export function defineEnum(
       });
     }
 
-    // Predicate: record.isDraft() or record.isStatusDraft()
     Object.defineProperty(modelClass.prototype, predicateName, {
       value: function (this: Base) {
         return this.readAttribute(attribute) === value;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -73,7 +73,6 @@ export function defineEnum(
   }
   const enumType = new EnumType(attribute, mapping, subtype);
   const def: EnumDefinition = { attribute, mapping, type: enumType };
-  defs.set(attribute, def);
 
   // Compute prefix/suffix for method names
   const prefixStr =
@@ -158,6 +157,9 @@ export function defineEnum(
       friendlyName,
     });
   }
+
+  // Register only after conflict validation succeeds — keeps enumRegistry atomic.
+  defs.set(attribute, def);
 
   // Define all scopes and instance methods only after all conflicts are validated.
   for (const {


### PR DESCRIPTION
## Summary

- **Item 1**: `defineEnum` now detects the attribute's registered type (`typeForAttribute`) to determine string vs. integer subtype, instead of hardcoding `"integer"`. Widens `EnumDefinition.mapping` and `castEnumValue` return type accordingly. Un-skips: _enum with string column_.
- **Item 2**: `Relation#build` / `#create` already propagate `scopeForCreate` from WHERE constraints — no implementation change needed; enum scopes pre-set the attribute on new records. Un-skips: _building new objects with enum scopes_, _creating new objects with enum scopes_.
- **Item 3**: `defineEnum` now calls `raiseConflictError` before defining each predicate, bang setter, or scope if the generated name already exists on the prototype / class, mirroring Rails' `detect_enum_conflict!`. Un-skips: _reserved enum values_, _reserved enum values for relation_.
- **Item 4**: Added method-friendly alias generation (replace non-word ASCII chars with `_`, then camelize — matching Rails' `label.gsub(/[\W&&[:ascii:]]+/, "_")`) and filled in 5 empty test stubs. Un-skips: _find via negative scope_, _overriding enum definition on subclass_, _scopes are named like methods_, _enum methods with custom suffix defined_, _update enum attributes with custom suffix_.

## Stats

- 10 previously skipped tests now pass (0 remaining skipped in enum.test.ts)
- LOC: ~264 additions+deletions (ceiling: 300)
- `api:compare`: 4955/4958 (99.9%) — no regression
- `test:compare`: 6039/7930 (76.2%) — no regression

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/enum.test.ts` — 202/202 passing, 0 skipped
- [x] `pnpm test:compare --package activerecord` — no regression
- [x] `pnpm api:compare --package activerecord` — no regression