### PR TITLE
feat(activerecord): TransactionManager wiring + small fidelity bundle

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -16,7 +16,7 @@ export class Store {
   enabled = false;
   dirties = true;
 
-  constructor(maxSize: number = DEFAULT_MAX_SIZE, version: { value: number } | null = null) {
+  constructor(version: { value: number } | null = null, maxSize: number = DEFAULT_MAX_SIZE) {
     this._maxSize = maxSize;
     this._version = version;
     this._currentVersion = version?.value ?? 0;
@@ -218,7 +218,7 @@ export class ConnectionPoolConfiguration {
 
   get queryCache(): Store {
     return this._threadQueryCaches.computeIfAbsent("default", () => {
-      return new Store(this._queryCacheMaxSize ?? 0, this._queryCacheVersion);
+      return new Store(this._queryCacheVersion, this._queryCacheMaxSize ?? 0);
     });
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
 import {
+  AddColumnDefinition,
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   CreateIndexDefinition,
@@ -103,5 +104,11 @@ describe("MySQL::SchemaCreation", () => {
     const col = new ColumnDefinition("id", "integer", {});
     const result = (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
     expect(result).not.toContain("AUTO_INCREMENT");
+  });
+
+  it("addColumn with autoIncrement: true emits AUTO_INCREMENT in DDL", () => {
+    const col = new ColumnDefinition("id", "integer", { autoIncrement: true, null: false });
+    const sql = sc.accept(new AddColumnDefinition(col));
+    expect(sql).toMatch(/ADD .+ AUTO_INCREMENT/);
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -527,7 +527,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   async beginDeferredTransaction(): Promise<void> {
-    return this.beginTransaction();
+    return this.beginDbTransaction();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -559,7 +559,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   async rollbackDbTransaction(): Promise<void> {
-    if (!this._conn) return; // no materialized transaction — nothing to roll back
+    if (!this._conn) throw new Error("No active transaction");
     await this._conn.query("ROLLBACK");
     this._conn.release();
     this._conn = null;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -514,13 +514,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Begin a transaction. Acquires a dedicated connection from the pool.
    */
   async beginTransaction(): Promise<void> {
-    this._conn = await this._checkoutConn();
-    await this._conn.query("BEGIN");
-    this._inTransaction = true;
+    // Force materialization (_lazy: false) so _inTransaction is set immediately.
+    // The _transactionFallback path in transactions.ts checks adapter.inTransaction
+    // to decide savepoint-vs-begin; lazy BEGIN causes it to double-BEGIN.
+    await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
   async beginDbTransaction(): Promise<void> {
-    return this.beginTransaction();
+    this._conn = await this._checkoutConn();
+    await this._conn.query("BEGIN");
+    this._inTransaction = true;
   }
 
   async beginDeferredTransaction(): Promise<void> {
@@ -531,6 +534,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Commit the current transaction and release the connection.
    */
   async commit(): Promise<void> {
+    return this._transactionManager.commitTransaction();
+  }
+
+  async commitDbTransaction(): Promise<void> {
     if (!this._conn) throw new Error("No active transaction");
     await this._conn.query("COMMIT");
     this._conn.release();
@@ -538,23 +545,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._inTransaction = false;
   }
 
-  async commitDbTransaction(): Promise<void> {
-    return this.commit();
-  }
-
   /**
    * Rollback the current transaction and release the connection.
    */
   async rollback(): Promise<void> {
+    return this._transactionManager.rollbackTransaction();
+  }
+
+  async rollbackDbTransaction(): Promise<void> {
     if (!this._conn) throw new Error("No active transaction");
     await this._conn.query("ROLLBACK");
     this._conn.release();
     this._conn = null;
     this._inTransaction = false;
-  }
-
-  async rollbackDbTransaction(): Promise<void> {
-    return this.rollback();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -534,10 +534,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Commit the current transaction and release the connection.
    */
   async commit(): Promise<void> {
-    return this._transactionManager.commitTransaction();
-  }
-
-  async commitDbTransaction(): Promise<void> {
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.commitTransaction();
+    }
     if (!this._conn) throw new Error("No active transaction");
     await this._conn.query("COMMIT");
     this._conn.release();
@@ -545,15 +544,22 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._inTransaction = false;
   }
 
+  async commitDbTransaction(): Promise<void> {
+    return this.commit();
+  }
+
   /**
    * Rollback the current transaction and release the connection.
    */
   async rollback(): Promise<void> {
-    return this._transactionManager.rollbackTransaction();
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.rollbackTransaction();
+    }
+    return this.rollbackDbTransaction();
   }
 
   async rollbackDbTransaction(): Promise<void> {
-    if (!this._conn) throw new Error("No active transaction");
+    if (!this._conn) return; // no materialized transaction — nothing to roll back
     await this._conn.query("ROLLBACK");
     this._conn.release();
     this._conn = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1125,7 +1125,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async beginDeferredTransaction(): Promise<void> {
-    return this.beginTransaction();
+    return this.beginDbTransaction();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1107,39 +1107,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
-    // Routes through `_acquireFreshClient` so the drain runs on every
-    // checkout (a tagged client returned here gets `DEALLOCATE ALL`'d
-    // before BEGIN). Drain failures are released-with-error inside
-    // the helper, so a thrown drain doesn't leak `_client`.
+    await this._transactionManager.beginTransaction();
+  }
+
+  async beginDbTransaction(): Promise<void> {
     this._client = await this._acquireFreshClient();
     try {
       await this._client.query("BEGIN");
       this._inTransaction = true;
-      // Note: do NOT null `_lastReleasedTxnClient` here. After-rollback
-      // callbacks (rollback_records) run BEFORE TransactionManager's
-      // `after_failure_actions` hook fires; if such a callback opens a
-      // new transaction (this beginTransaction call), nulling the ref
-      // would lose the pointer to the just-failed client and the hook
-      // would clear the wrong pool. The ref is dropped instead inside
-      // `clearCacheBang` after `reset()` — bounded to the failure-hook
-      // window, while still WeakRef-held so pg.Pool can reap idles.
     } catch (error) {
-      // If BEGIN fails (e.g. network blip after connect), release the
-      // acquired client so it returns to the pool. Leaving `_client`
-      // set would leak a pool slot and eventually deadlock acquires.
-      // Pass the error to release() so node-postgres discards the
-      // (potentially damaged) client instead of returning a bad
-      // socket to the idle set.
       const client = this._client;
       this._client = null;
       this._inTransaction = false;
       client?.release(error instanceof Error ? error : undefined);
       throw error;
     }
-  }
-
-  async beginDbTransaction(): Promise<void> {
-    return this.beginTransaction();
   }
 
   async beginDeferredTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1186,7 +1186,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
   async execRollbackDbTransaction(): Promise<void> {
     this._cancelAnyRunningQuery();
-    if (!this._client) return; // no materialized transaction — nothing to roll back on the DB
+    if (!this._client) throw new Error("No active transaction");
     const releasedClient = this._client;
     let rollbackError: unknown;
     try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1132,6 +1132,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Commit the current transaction and release the client.
    */
   async commit(): Promise<void> {
+    return this._transactionManager.commitTransaction();
+  }
+
+  async commitDbTransaction(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
     // Keep the per-client StatementPool attached through the pg.Pool
@@ -1146,15 +1150,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._inTransaction = false;
   }
 
-  async commitDbTransaction(): Promise<void> {
-    return this.commit();
-  }
-
   /**
    * Rollback the current transaction and release the client.
    */
   async rollback(): Promise<void> {
-    if (!this._client) throw new Error("No active transaction");
+    return this._transactionManager.rollbackTransaction();
+  }
+
+  async rollbackDbTransaction(): Promise<void> {
+    return this.execRollbackDbTransaction();
+  }
+
+  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
+  async execRollbackDbTransaction(): Promise<void> {
+    this._cancelAnyRunningQuery();
+    if (!this._client) return; // lazy transaction never materialized — nothing to roll back on the DB
     const releasedClient = this._client;
     let rollbackError: unknown;
     try {
@@ -1163,10 +1173,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // If ROLLBACK itself throws (e.g. network drop mid-txn), we still
       // have to release the client or the pool leaks. Rethrow after
       // cleanup. Pass the error to release() so pg.Pool discards the
-      // client rather than returning it to the idle set.
+      // (potentially damaged) client instead of returning it to the idle set.
       rollbackError = e;
     } finally {
-      // See commit() — ROLLBACK doesn't drop server-side prepared
+      // See commitDbTransaction() — ROLLBACK doesn't drop server-side prepared
       // statements, so we keep the pool attached to the pg.PoolClient
       // for the duration of the connection's life.
       this._client = null;
@@ -1174,7 +1184,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Normalize to Error before passing to release() — node-postgres
       // expects an Error to discard the client, and downstream code
       // (and our own rethrow path) may read `.message`. Matches the
-      // pattern in beginTransaction's catch.
+      // pattern in beginDbTransaction's catch.
       releasedClient.release(
         rollbackError === undefined
           ? undefined
@@ -1192,16 +1202,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._lastReleasedTxnClient = releasedClient;
     }
     if (rollbackError !== undefined) throw rollbackError;
-  }
-
-  async rollbackDbTransaction(): Promise<void> {
-    return this.execRollbackDbTransaction();
-  }
-
-  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
-  async execRollbackDbTransaction(): Promise<void> {
-    this._cancelAnyRunningQuery();
-    return this.rollback();
   }
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1167,16 +1167,37 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Rollback the current transaction and release the client.
    *
    * Routes through TransactionManager when the TM has an open transaction.
-   * Falls through to execRollbackDbTransaction() when openTransactions == 0,
-   * covering: (a) the TM calling rollbackDbTransaction() (which calls
-   * execRollbackDbTransaction() directly — no recursion), and (b) direct
-   * beginDbTransaction() + rollback() pairs in tests.
+   * Falls through to the direct DB path when openTransactions == 0 (e.g.
+   * beginDbTransaction() + rollback() direct pairs). Does NOT call
+   * _cancelAnyRunningQuery() in the direct path — that cancel step is only
+   * safe in the TM path (via execRollbackDbTransaction()) where no
+   * fire-and-forget adapter work is in flight. Calling cancel when statement
+   * pool deallocs are in-flight causes "unexpected commandComplete" errors.
    */
   async rollback(): Promise<void> {
     if (this._transactionManager.openTransactions > 0) {
       return this._transactionManager.rollbackTransaction();
     }
-    return this.execRollbackDbTransaction();
+    if (!this._client) throw new Error("No active transaction");
+    const releasedClient = this._client;
+    let rollbackError: unknown;
+    try {
+      await this._client.query("ROLLBACK");
+    } catch (e) {
+      rollbackError = e;
+    } finally {
+      this._client = null;
+      this._inTransaction = false;
+      releasedClient.release(
+        rollbackError === undefined
+          ? undefined
+          : rollbackError instanceof Error
+            ? rollbackError
+            : new Error(String(rollbackError)),
+      );
+      this._lastReleasedTxnClient = releasedClient;
+    }
+    if (rollbackError !== undefined) throw rollbackError;
   }
 
   async rollbackDbTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1134,8 +1134,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   /**
    * Commit the current transaction and release the client.
+   *
+   * Routes through TransactionManager when the TM has an open transaction
+   * (e.g. started by beginTransaction()) so the stack stays in sync.
+   * Falls through to the direct DB path when openTransactions == 0, which
+   * covers: (a) TM calling commitDbTransaction() after already popping the
+   * stack, and (b) beginDbTransaction() + commit() direct pairs in tests.
    */
   async commit(): Promise<void> {
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.commitTransaction();
+    }
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
     // Keep the per-client StatementPool attached through the pg.Pool
@@ -1156,9 +1165,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   /**
    * Rollback the current transaction and release the client.
+   *
+   * Routes through TransactionManager when the TM has an open transaction.
+   * Falls through to execRollbackDbTransaction() when openTransactions == 0,
+   * covering: (a) the TM calling rollbackDbTransaction() (which calls
+   * execRollbackDbTransaction() directly — no recursion), and (b) direct
+   * beginDbTransaction() + rollback() pairs in tests.
    */
   async rollback(): Promise<void> {
-    if (!this._client) throw new Error("No active transaction");
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.rollbackTransaction();
+    }
+    return this.execRollbackDbTransaction();
+  }
+
+  async rollbackDbTransaction(): Promise<void> {
+    return this.execRollbackDbTransaction();
+  }
+
+  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
+  async execRollbackDbTransaction(): Promise<void> {
+    this._cancelAnyRunningQuery();
+    if (!this._client) return; // no materialized transaction — nothing to roll back on the DB
     const releasedClient = this._client;
     let rollbackError: unknown;
     try {
@@ -1197,16 +1225,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._lastReleasedTxnClient = releasedClient;
     }
     if (rollbackError !== undefined) throw rollbackError;
-  }
-
-  async rollbackDbTransaction(): Promise<void> {
-    return this.execRollbackDbTransaction();
-  }
-
-  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
-  async execRollbackDbTransaction(): Promise<void> {
-    this._cancelAnyRunningQuery();
-    return this.rollback();
   }
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1136,10 +1136,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Commit the current transaction and release the client.
    */
   async commit(): Promise<void> {
-    return this._transactionManager.commitTransaction();
-  }
-
-  async commitDbTransaction(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
     // Keep the per-client StatementPool attached through the pg.Pool
@@ -1154,21 +1150,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._inTransaction = false;
   }
 
+  async commitDbTransaction(): Promise<void> {
+    return this.commit();
+  }
+
   /**
    * Rollback the current transaction and release the client.
    */
   async rollback(): Promise<void> {
-    return this._transactionManager.rollbackTransaction();
-  }
-
-  async rollbackDbTransaction(): Promise<void> {
-    return this.execRollbackDbTransaction();
-  }
-
-  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
-  async execRollbackDbTransaction(): Promise<void> {
-    this._cancelAnyRunningQuery();
-    if (!this._client) return; // lazy transaction never materialized — nothing to roll back on the DB
+    if (!this._client) throw new Error("No active transaction");
     const releasedClient = this._client;
     let rollbackError: unknown;
     try {
@@ -1177,10 +1167,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // If ROLLBACK itself throws (e.g. network drop mid-txn), we still
       // have to release the client or the pool leaks. Rethrow after
       // cleanup. Pass the error to release() so pg.Pool discards the
-      // (potentially damaged) client instead of returning it to the idle set.
+      // (potentially damaged) client instead of returning a bad
+      // socket to the idle set.
       rollbackError = e;
     } finally {
-      // See commitDbTransaction() — ROLLBACK doesn't drop server-side prepared
+      // See commit() — ROLLBACK doesn't drop server-side prepared
       // statements, so we keep the pool attached to the pg.PoolClient
       // for the duration of the connection's life.
       this._client = null;
@@ -1206,6 +1197,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._lastReleasedTxnClient = releasedClient;
     }
     if (rollbackError !== undefined) throw rollbackError;
+  }
+
+  async rollbackDbTransaction(): Promise<void> {
+    return this.execRollbackDbTransaction();
+  }
+
+  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
+  async execRollbackDbTransaction(): Promise<void> {
+    this._cancelAnyRunningQuery();
+    return this.rollback();
   }
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1107,7 +1107,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
-    await this._transactionManager.beginTransaction();
+    // Force materialization (_lazy: false) so _client is acquired and
+    // _inTransaction is set immediately. createSavepoint() uses withClient()
+    // which falls back to a fresh pool connection when _client is null,
+    // causing "SAVEPOINT can only be used in transaction blocks".
+    await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
   async beginDbTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -430,7 +430,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async commit(): Promise<void> {
-    return this._transactionManager.commitTransaction();
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.commitTransaction();
+    }
+    return this.commitDbTransaction();
   }
 
   async rollbackDbTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -449,7 +449,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async rollback(): Promise<void> {
-    return this._transactionManager.rollbackTransaction();
+    if (this._transactionManager.openTransactions > 0) {
+      return this._transactionManager.rollbackTransaction();
+    }
+    return this.rollbackDbTransaction();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -415,8 +415,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async beginTransaction(): Promise<void> {
-    await this.driver.exec("BEGIN IMMEDIATE TRANSACTION");
-    this._inTransaction = true;
+    // Force materialization (_lazy: false) so _inTransaction is set immediately.
+    // The _transactionFallback path in transactions.ts checks adapter.inTransaction
+    // to decide savepoint-vs-begin; lazy BEGIN causes it to double-BEGIN.
+    await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
   /**
@@ -428,7 +430,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async commit(): Promise<void> {
-    return this.commitDbTransaction();
+    return this._transactionManager.commitTransaction();
   }
 
   async rollbackDbTransaction(): Promise<void> {
@@ -444,7 +446,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async rollback(): Promise<void> {
-    return this.rollbackDbTransaction();
+    return this._transactionManager.rollbackTransaction();
   }
 
   /**

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -573,7 +573,7 @@ describe("QueryCacheExpiryTest", () => {
 
   it("store checkVersion clears cache on version increment", async () => {
     const version = { value: 0 };
-    const store = new Store(10, version);
+    const store = new Store(version, 10);
     store.enabled = true;
     await store.computeIfAbsent("key1", async () => [{ val: 1 }]);
     expect(store.size).toBe(1);
@@ -586,7 +586,7 @@ describe("QueryCacheExpiryTest", () => {
   });
 
   it("query cache lru eviction", async () => {
-    const store = new Store(3);
+    const store = new Store(null, 3);
     store.enabled = true;
     for (let i = 0; i < 5; i++) {
       await store.computeIfAbsent(`query_${i}`, async () => [{ val: i }]);
@@ -624,10 +624,27 @@ describe("TransactionInCachedSqlActiveRecordPayloadTest", () => {
     expect(hit.payload.transaction).toBeNull();
   });
 
-  it.skip("payload with open transaction", () => {
-    // BLOCKED: query-cache — concrete adapters (SQLite3, PostgreSQL) bypass TransactionManager
-    // in beginTransaction(); currentTransaction().userTransaction is never open through the
-    // QueryCacheAdapter wrapper path. Re-enable when beginTransaction() wires TransactionManager.
+  it("payload with open transaction", async () => {
+    const { cached } = setup();
+    cached.enableQueryCache();
+    const sql = "SELECT 1 AS val";
+    const events: unknown[] = [];
+    const { Notifications } = await import("@blazetrails/activesupport");
+    const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e));
+    try {
+      await cached.beginTransaction();
+      await cached.execute(sql);
+      await cached.execute(sql); // cache hit
+      await cached.commit();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    const hit = (events as any[]).find(
+      (e) =>
+        e?.payload?.cached === true && e?.payload?.sql === sql && e?.payload?.connection === cached,
+    );
+    expect(hit).toBeDefined();
+    expect(hit.payload.transaction).not.toBeNull();
   });
 });
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -162,7 +162,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
 
   constructor(inner: DatabaseAdapter, maxSize?: number) {
     this.inner = inner;
-    this.cache = new QueryCacheStore(maxSize);
+    this.cache = new QueryCacheStore(null, maxSize);
   }
 
   get queryCount(): number {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -844,7 +844,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#offset
    */
-  offset(value: number): Relation<T> {
+  offset(value: number | null): Relation<T> {
     return this._clone().offsetBang(value);
   }
 


### PR DESCRIPTION
## Summary

- **Wire TransactionManager into `beginTransaction()`** on SQLite3, PostgreSQL, and MySQL2 so `currentTransaction().userTransaction` returns a live `UserTransaction` through the `QueryCacheAdapter` wrapper. Un-skips `payload with open transaction` in `query-cache.test.ts`. All three adapters use `_lazy: false` to force immediate BEGIN so `adapter.inTransaction` is set immediately — required because `_transactionFallback` in `transactions.ts` reads `inTransaction` to decide savepoint-vs-BEGIN.
- `commit()` and `rollback()` on all three adapters check `openTransactions > 0` and route through TransactionManager when the TM has an open transaction (keeping TM stack in sync); fall through to direct DB work otherwise (preserving `beginDbTransaction() + rollback()` direct pairing used in statement-pool tests).
- PG `rollback()` direct path skips `_cancelAnyRunningQuery()` — calling it when statement pool DEALLOCATEs are in-flight fire-and-forget caused "unexpected commandComplete" pg errors.
- **Align `Store` constructor arg order** to Rails `Store.new(version, max_size)`. Updates all call sites.
- **Widen `Relation#offset` to `number | null`** — matches `limit()` and Rails `offset(value = nil)`.
- **Smoke-test `addColumn` AUTO_INCREMENT DDL** on MySQL SchemaCreation.

## Known remaining concerns

- **`_lazy: false` is a workaround**: Rails returns `supports_lazy_transactions? = true` for all three adapters. We force eager BEGIN because `_transactionFallback` in `transactions.ts` reads `adapter.inTransaction` to decide savepoint-vs-BEGIN, and lazy deferral leaves `_inTransaction = false` right after `beginTransaction()`. The correct upstream fix is to update `_transactionFallback` to consult the TM stack (via `currentTransaction()`) instead of `adapter.inTransaction` — this would restore lazy transactions and eliminate the `_lazy: false` workarounds (~30 LOC, separate PR).
- **`SchemaAdapter` missing `withinNewTransaction()` forwarding**: If `SchemaAdapter` forwarded `withinNewTransaction()` to `inner`, PG/MySQL2-via-SchemaAdapter would use the full TM path instead of `_transactionFallback`, eliminating all `openTransactions > 0` guards in one shot (~10 LOC, separate PR).
- **`beginDbTransaction()` error path** (suppressed Copilot comment): non-`Error` throwables passed as `undefined` to `client.release()`. Pre-existing pattern; not introduced by this PR.