### PR TITLE
feat(activerecord): wire TimeWithZone into TimeZoneConverter cast/deserialize (~138 LOC)

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -84,6 +84,7 @@ export {
   isUtc as isUtcTimezone,
   defaultTimezone as getDefaultTimezone,
   setDefaultTimezone,
+  configuredTimezone,
 } from "./type/helpers/timezone.js";
 
 import { StringType } from "./type/string.js";

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -3,6 +3,8 @@
  */
 import type { Type } from "@blazetrails/activemodel";
 import { ValueType } from "@blazetrails/activemodel";
+import { TimeWithZone, getZone } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
 
 export interface TimeZoneConversion {
@@ -41,9 +43,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
 
   override cast(value: unknown): unknown {
     if (value == null) return null;
-    // TODO: requires TimeWithZone — in_time_zone branch via user_input_in_time_zone(value)
-    // Fallback mirrors: map(super) { |v| cast(v) } — delegate to subtype
-    return this._subtype.cast(value);
+    // Hash (multiparameter attributes): cast via subtype, then treat wall-clock
+    // components as local time in the current zone (set_time_zone_without_conversion).
+    if (isPlainObject(value)) {
+      return setTimeZoneWithoutConversion(this._subtype.cast(value));
+    }
+    // TimeWithZone or any value with in_time_zone: move to current zone.
+    if (value instanceof TimeWithZone) {
+      return convertTimeToTimeZone(value);
+    }
+    // String, Temporal.Instant, Date, etc.: cast via subtype then wrap in zone.
+    return convertTimeToTimeZone(this._subtype.cast(value));
   }
 
   override deserialize(value: unknown): unknown {
@@ -79,19 +89,38 @@ function convertTimeToTimeZone(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((v) => convertTimeToTimeZone(v));
   }
-  // TODO: requires TimeWithZone — value.in_time_zone for time-like values
+  const zone = getZone();
+  if (!zone) return value;
+  if (value instanceof TimeWithZone) {
+    return value.inTimeZone(zone);
+  }
+  if (value instanceof Temporal.Instant) {
+    return new TimeWithZone(value, zone);
+  }
   return value;
 }
 
 /** @internal */
 function setTimeZoneWithoutConversion(value: unknown): unknown {
-  if (value == null) return value;
-  // TODO: requires TimeWithZone — Time.zone.local_to_utc(value).try(:in_time_zone)
+  if (value == null) return null;
+  const zone = getZone();
+  if (!zone) return value;
+  if (value instanceof Temporal.Instant) {
+    // The subtype cast treats multiparameter hash components as UTC wall-clock
+    // values. Re-interpret those wall-clock components as local time in the
+    // current zone (mirrors Time.zone.local_to_utc(localTime).in_time_zone).
+    const dt = value.toZonedDateTimeISO("UTC").toPlainDateTime();
+    return zone.local(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.millisecond);
+  }
+  if (value instanceof TimeWithZone) {
+    return value.inTimeZone(zone);
+  }
   return value;
 }
 
-// Silence unused-variable warnings until TimeWithZone is implemented.
-void setTimeZoneWithoutConversion;
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && Object.getPrototypeOf(v) === Object.prototype;
+}
 
 interface TimeZoneConversionHost {
   timeZoneAwareAttributes: boolean;

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -2,7 +2,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
 import type { Type } from "@blazetrails/activemodel";
-import { ValueType } from "@blazetrails/activemodel";
+import { ValueType, configuredTimezone } from "@blazetrails/activemodel";
 import { TimeWithZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
@@ -52,7 +52,22 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (value instanceof TimeWithZone) {
       return convertTimeToTimeZone(value);
     }
-    // String, Temporal.Instant, etc.: cast via subtype then wrap in zone.
+    // Strings: Rails gives String an in_time_zone method via CoreExt, so strings
+    // take the respond_to?(:in_time_zone) branch and are parsed as local to
+    // Time.zone (user_input_in_time_zone = value.in_time_zone = zone.parse(value)).
+    // Without this, subtype would interpret the string in default_timezone and
+    // convertTimeToTimeZone would only shift display — wrong underlying instant.
+    if (typeof value === "string") {
+      const zone = getZone();
+      if (zone) {
+        try {
+          return zone.parse(value);
+        } catch {
+          return null;
+        }
+      }
+    }
+    // Temporal.Instant, etc.: cast via subtype then wrap in zone.
     // For array-like results (e.g. Range types), recurse cast() on each element
     // to mirror Rails' `map(super) { |v| cast(v) }`.
     const casted = this._subtype.cast(value);
@@ -118,10 +133,12 @@ function setTimeZoneWithoutConversion(value: unknown): unknown {
   const zone = getZone();
   if (!zone) return value;
   if (value instanceof Temporal.Instant) {
-    // The subtype cast treats multiparameter hash components as UTC wall-clock
-    // values. Re-interpret those wall-clock components as local time in the
-    // current zone (mirrors Time.zone.local_to_utc(localTime).in_time_zone).
-    const dt = value.toZonedDateTimeISO("UTC").toPlainDateTime();
+    // AcceptsMultiparameterTime builds the instant by interpreting components
+    // in configuredTimezone() (UTC when default_timezone is :utc, host-local
+    // when :local). Extract wall-clock components using the SAME timezone so
+    // we get the original component values, then re-interpret them as local
+    // time in the current zone (mirrors Time.zone.local_to_utc(t).in_time_zone).
+    const dt = value.toZonedDateTimeISO(configuredTimezone()).toPlainDateTime();
     return zone.local(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.millisecond);
   }
   if (value instanceof TimeWithZone) {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -52,8 +52,14 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (value instanceof TimeWithZone) {
       return convertTimeToTimeZone(value);
     }
-    // String, Temporal.Instant, Date, etc.: cast via subtype then wrap in zone.
-    return convertTimeToTimeZone(this._subtype.cast(value));
+    // String, Temporal.Instant, etc.: cast via subtype then wrap in zone.
+    // For array-like results (e.g. Range types), recurse cast() on each element
+    // to mirror Rails' `map(super) { |v| cast(v) }`.
+    const casted = this._subtype.cast(value);
+    if (Array.isArray(casted)) {
+      return casted.map((v) => this.cast(v));
+    }
+    return convertTimeToTimeZone(casted);
   }
 
   override deserialize(value: unknown): unknown {
@@ -61,17 +67,23 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 
   override serialize(value: unknown): unknown {
-    return this._subtype.serialize(value);
+    // Rails' DelegateClass forwards serialize to the subtype, which calls
+    // cast_value on it. In Ruby, TimeWithZone acts_like?(:time) so AR's
+    // DateTime type can handle it. In TS, DateTime.castValue() can't parse
+    // a TimeWithZone — extract the UTC Temporal.Instant first.
+    const resolved = value instanceof TimeWithZone ? value.utc() : value;
+    return this._subtype.serialize(resolved);
   }
 
   override serializeCastValue(value: unknown): unknown {
+    const resolved = value instanceof TimeWithZone ? value.utc() : value;
     const sub = this._subtype as ValueTypeInstance;
     if (typeof sub.itselfIfSerializeCastValueCompatible === "function") {
       return sub.itselfIfSerializeCastValueCompatible()
-        ? sub.serializeCastValue(value as any)
-        : this._subtype.serialize(value);
+        ? sub.serializeCastValue(resolved as any)
+        : this._subtype.serialize(resolved);
     }
-    return this._subtype.serialize(value);
+    return this._subtype.serialize(resolved);
   }
 
   override equals(other: Type): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -131,7 +131,9 @@ function setTimeZoneWithoutConversion(value: unknown): unknown {
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === "object" && Object.getPrototypeOf(v) === Object.prototype;
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
 }
 
 interface TimeZoneConversionHost {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -3,7 +3,7 @@
  */
 import type { Type } from "@blazetrails/activemodel";
 import { ValueType, configuredTimezone } from "@blazetrails/activemodel";
-import { TimeWithZone, getZone } from "@blazetrails/activesupport";
+import { TimeWithZone, TimeZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
 
@@ -48,7 +48,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (isPlainObject(value)) {
       return setTimeZoneWithoutConversion(this._subtype.cast(value));
     }
-    // TimeWithZone or any value with in_time_zone: move to current zone.
+    // TimeWithZone: move to current zone.
     if (value instanceof TimeWithZone) {
       return convertTimeToTimeZone(value);
     }
@@ -57,14 +57,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // Time.zone (user_input_in_time_zone = value.in_time_zone = zone.parse(value)).
     // Without this, subtype would interpret the string in default_timezone and
     // convertTimeToTimeZone would only shift display — wrong underlying instant.
+    // Parse inline (not via zone.parse()) to preserve full nanosecond precision.
     if (typeof value === "string") {
       const zone = getZone();
       if (zone) {
-        try {
-          return zone.parse(value);
-        } catch {
-          return null;
-        }
+        return parseStringInZone(value, zone);
       }
     }
     // Temporal.Instant, etc.: cast via subtype then wrap in zone.
@@ -138,13 +135,66 @@ function setTimeZoneWithoutConversion(value: unknown): unknown {
     // when :local). Extract wall-clock components using the SAME timezone so
     // we get the original component values, then re-interpret them as local
     // time in the current zone (mirrors Time.zone.local_to_utc(t).in_time_zone).
-    const dt = value.toZonedDateTimeISO(configuredTimezone()).toPlainDateTime();
-    return zone.local(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.millisecond);
+    const zoned = value.toZonedDateTimeISO(configuredTimezone());
+    const pdt = zoned.toPlainDateTime();
+    // zone.local() takes milliseconds; get the ms-level result with correct DST
+    // disambiguation, then add back sub-millisecond precision from the original.
+    const base = zone.local(
+      pdt.year,
+      pdt.month,
+      pdt.day,
+      pdt.hour,
+      pdt.minute,
+      pdt.second,
+      pdt.millisecond,
+    );
+    const subMs = zoned.microsecond * 1000 + zoned.nanosecond;
+    if (subMs === 0) return base;
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochNanoseconds(base.utc().epochNanoseconds + BigInt(subMs)),
+      zone,
+    );
   }
   if (value instanceof TimeWithZone) {
     return value.inTimeZone(zone);
   }
   return value;
+}
+
+/** @internal */
+function parseStringInZone(value: string, zone: TimeZone): TimeWithZone | null {
+  try {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    // Strings with explicit offset/Z → absolute instant → wrap in zone.
+    if (/[Zz]|[+-]\d{2}:?\d{2}$/.test(trimmed)) {
+      // Normalize short offsets (±HH → ±HH:MM) for Temporal.Instant.from
+      const normalized = trimmed.replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+      return new TimeWithZone(Temporal.Instant.from(normalized), zone);
+    }
+    // No offset → wall-clock components local to the current zone.
+    // Use Temporal.PlainDateTime for full nanosecond precision; zone.local()
+    // for correct DST disambiguation; add back sub-ms nanoseconds.
+    const normalized = trimmed.replace(" ", "T");
+    const pdt = Temporal.PlainDateTime.from(normalized, { overflow: "reject" });
+    const base = zone.local(
+      pdt.year,
+      pdt.month,
+      pdt.day,
+      pdt.hour,
+      pdt.minute,
+      pdt.second,
+      pdt.millisecond,
+    );
+    const subMs = pdt.microsecond * 1000 + pdt.nanosecond;
+    if (subMs === 0) return base;
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochNanoseconds(base.utc().epochNanoseconds + BigInt(subMs)),
+      zone,
+    );
+  } catch {
+    return null;
+  }
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -61,7 +61,13 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (typeof value === "string") {
       const zone = getZone();
       if (zone) {
-        return parseStringInZone(value, zone);
+        // Mirrors Rails' `super(user_input_in_time_zone(value)) || super`:
+        // parse in the current zone; fall back to subtype cast if the format
+        // isn't recognized (preserves support for formats parseStringInZone
+        // doesn't handle, e.g. non-standard strings the subtype accepts).
+        const parsed = parseStringInZone(value, zone);
+        if (parsed !== null) return parsed;
+        return convertTimeToTimeZone(this._subtype.cast(value));
       }
     }
     // Temporal.Instant, etc.: cast via subtype then wrap in zone.
@@ -166,17 +172,21 @@ function parseStringInZone(value: string, zone: TimeZone): TimeWithZone | null {
   try {
     const trimmed = value.trim();
     if (trimmed === "") return null;
-    // Strings with explicit offset/Z → absolute instant → wrap in zone.
-    if (/[Zz]|[+-]\d{2}:?\d{2}$/.test(trimmed)) {
-      // Normalize short offsets (±HH → ±HH:MM) for Temporal.Instant.from
-      const normalized = trimmed.replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+    // Normalize space separator → T first (e.g. "2024-06-15 10:30:00-04:00").
+    const withT = trimmed.replace(" ", "T");
+    // Detect offset: Z/z, ±HH:MM, ±HHMM, or short ±HH (without minutes).
+    if (/[Zz]$|[+-]\d{2}(?::?\d{2})?$/.test(withT)) {
+      // Normalize short offsets ±HH → ±HH:00 so Temporal.Instant.from() accepts them.
+      const normalized = withT.replace(/([-+]\d{2})$/, "$1:00");
       return new TimeWithZone(Temporal.Instant.from(normalized), zone);
     }
     // No offset → wall-clock components local to the current zone.
-    // Use Temporal.PlainDateTime for full nanosecond precision; zone.local()
-    // for correct DST disambiguation; add back sub-ms nanoseconds.
-    const normalized = trimmed.replace(" ", "T");
-    const pdt = Temporal.PlainDateTime.from(normalized, { overflow: "reject" });
+    // Date-only strings ("YYYY-MM-DD") → midnight, matching Rails' in_time_zone behavior.
+    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(withT);
+    const datetimeStr = isDateOnly ? `${withT}T00:00:00` : withT;
+    const pdt = Temporal.PlainDateTime.from(datetimeStr, { overflow: "reject" });
+    // zone.local() gives correct DST disambiguation at millisecond precision;
+    // add back sub-millisecond precision (microseconds + nanoseconds) separately.
     const base = zone.local(
       pdt.year,
       pdt.month,

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { TimeZoneConverter } from "./time-zone-conversion.js";
 import { DateTime } from "../type/date-time.js";
+import { TimeWithZone, TimeZone, setZone, resetZone } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 describe("TimeZoneConverterTest", () => {
+  afterEach(() => {
+    resetZone();
+  });
+
   it("comparison with date time type", () => {
     // Two distinct DateTime instances (mirrors Rails' Marshal round-trip producing
     // a new object) — verifies ValueType.equals compares by shape, not reference.
@@ -11,5 +17,78 @@ describe("TimeZoneConverterTest", () => {
 
     expect(value.equals(valueFromCache)).toBe(true);
     expect(value.equals("foo" as any)).toBe(false);
+  });
+
+  it("cast returns null for null/undefined", () => {
+    const converter = new TimeZoneConverter(new DateTime());
+    expect(converter.cast(null)).toBeNull();
+    expect(converter.cast(undefined)).toBeNull();
+  });
+
+  it("cast wraps Temporal.Instant in TimeWithZone for current zone", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
+    const result = converter.cast(instant);
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    // 14:00 UTC = 10:00 EDT (UTC-4 in summer)
+    expect(twz.hour).toBe(10);
+    expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
+  });
+
+  it("cast moves existing TimeWithZone to current zone", () => {
+    const pacific = TimeZone.find("Pacific Time (US & Canada)");
+    const eastern = TimeZone.find("Eastern Time (US & Canada)");
+    const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
+    const pacificTime = new TimeWithZone(instant, pacific);
+
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    const result = converter.cast(pacificTime);
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    expect(twz.timeZone.name).toBe(eastern.name);
+    expect(twz.toI()).toBe(pacificTime.toI()); // same instant
+  });
+
+  it("cast parses string via subtype then wraps in TimeWithZone", () => {
+    setZone("UTC");
+    const converter = new TimeZoneConverter(new DateTime());
+    const result = converter.cast("2024-06-15 10:30:00");
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    expect(twz.year).toBe(2024);
+    expect(twz.month).toBe(6);
+    expect(twz.day).toBe(15);
+    expect(twz.hour).toBe(10);
+  });
+
+  it("cast returns raw subtype result when no zone is configured", () => {
+    resetZone();
+    const converter = new TimeZoneConverter(new DateTime());
+    const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
+    const result = converter.cast(instant);
+    // No zone set — value passes through unchanged
+    expect(result).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("cast returns null for plain object with non-multiparameter keys", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    // A plain object that isn't a valid multiparameter hash → subtype returns null → null
+    const result = converter.cast({ date: "2024-06-15" });
+    expect(result).toBeNull();
+  });
+
+  it("deserialize wraps Temporal.Instant from subtype in TimeWithZone", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    // DB value: "2024-06-15 14:00:00" (UTC stored value)
+    const result = converter.deserialize("2024-06-15 14:00:00");
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    // 14:00 UTC = 10:00 EDT
+    expect(twz.hour).toBe(10);
   });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -52,16 +52,32 @@ describe("TimeZoneConverterTest", () => {
     expect(twz.toI()).toBe(pacificTime.toI()); // same instant
   });
 
-  it("cast parses string via subtype then wraps in TimeWithZone", () => {
-    setZone("UTC");
+  it("cast parses offset-less string as local to current zone (not default_timezone)", () => {
+    setZone("Eastern Time (US & Canada)");
     const converter = new TimeZoneConverter(new DateTime());
+    // "10:30:00" with no offset → should be 10:30 local Eastern, not 10:30 UTC
     const result = converter.cast("2024-06-15 10:30:00");
     expect(result).toBeInstanceOf(TimeWithZone);
     const twz = result as TimeWithZone;
-    expect(twz.year).toBe(2024);
-    expect(twz.month).toBe(6);
-    expect(twz.day).toBe(15);
+    // Wall-clock in the zone must be 10:30 (not 06:30 as wrong UTC-then-display would give)
     expect(twz.hour).toBe(10);
+    expect(twz.min).toBe(30);
+    expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
+    // UTC instant should be 14:30 (10:30 EDT = UTC+4 in summer)
+    expect(twz.utc().epochMilliseconds).toBe(
+      Temporal.Instant.from("2024-06-15T14:30:00Z").epochMilliseconds,
+    );
+  });
+
+  it("cast parses string with offset as absolute instant then wraps in zone", () => {
+    setZone("UTC");
+    const converter = new TimeZoneConverter(new DateTime());
+    const result = converter.cast("2024-06-15T10:30:00-04:00");
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    // 10:30 EDT = 14:30 UTC, displayed in UTC zone
+    expect(twz.hour).toBe(14);
+    expect(twz.min).toBe(30);
   });
 
   it("cast returns raw subtype result when no zone is configured", () => {

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -91,4 +91,27 @@ describe("TimeZoneConverterTest", () => {
     // 14:00 UTC = 10:00 EDT
     expect(twz.hour).toBe(10);
   });
+
+  it("serialize extracts UTC from TimeWithZone before delegating to subtype", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
+    const eastern = TimeZone.find("Eastern Time (US & Canada)");
+    const twz = new TimeWithZone(instant, eastern);
+    // 14:00 UTC displayed as 10:00 EDT; serialize must produce the UTC SQL string
+    const result = converter.serialize(twz);
+    expect(typeof result).toBe("string");
+    expect(result).toContain("2024-06-15");
+    expect(result).toContain("14:00:00");
+  });
+
+  it("serialize round-trips: deserialize then serialize returns UTC SQL string", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    const deserialized = converter.deserialize("2024-06-15 14:00:00");
+    expect(deserialized).toBeInstanceOf(TimeWithZone);
+    const serialized = converter.serialize(deserialized);
+    // UTC, space-separated SQL format (default precision 6 adds .000000)
+    expect(serialized).toMatch(/^2024-06-15 14:00:00/);
+  });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -63,7 +63,7 @@ describe("TimeZoneConverterTest", () => {
     expect(twz.hour).toBe(10);
     expect(twz.min).toBe(30);
     expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
-    // UTC instant should be 14:30 (10:30 EDT = UTC+4 in summer)
+    // UTC instant should be 14:30 (10:30 EDT = UTC-4, so UTC = 10:30 + 4h)
     expect(twz.utc().epochMilliseconds).toBe(
       Temporal.Instant.from("2024-06-15T14:30:00Z").epochMilliseconds,
     );

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -310,6 +310,18 @@ export type { DurationParts } from "./duration.js";
 export { TimeZone, ZONES_MAP } from "./values/time-zone.js";
 export { TimeWithZone } from "./time-with-zone.js";
 export type { ChangeOptions, AdvanceOptions } from "./time-with-zone.js";
+export {
+  getZone,
+  setZone,
+  resetZone,
+  getZoneDefault,
+  setZoneDefault,
+  useZone,
+  findZone,
+  findZoneBang,
+  current,
+  dateInTimeZone,
+} from "./time-zone-config.js";
 
 export { Notifications } from "./notifications.js";
 export {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -321,6 +321,7 @@ export {
   findZoneBang,
   current,
   dateInTimeZone,
+  ArgumentError,
 } from "./time-zone-config.js";
 
 export { Notifications } from "./notifications.js";


### PR DESCRIPTION
## Summary

- Export `getZone`/`setZone`/`useZone`/`findZone`/`current`/`dateInTimeZone`/`resetZone`/`getZoneDefault`/`setZoneDefault` from `@blazetrails/activesupport` index (previously only accessible via internal import)
- `TimeZoneConverter.cast()`: wraps `Temporal.Instant` → `TimeWithZone` in current zone; moves existing `TimeWithZone` to current zone; routes plain-object (multiparameter) inputs through `setTimeZoneWithoutConversion`
- `convertTimeToTimeZone()`: implements the `BLOCKED: requires TimeWithZone` TODO — wraps `Temporal.Instant` from `deserialize` in a `TimeWithZone` for the current zone
- `setTimeZoneWithoutConversion()`: implements the other TODO — re-interprets UTC wall-clock components as local time in the current zone (mirrors Rails' `Time.zone.local_to_utc(value).try(:in_time_zone)`)
- 7 new tests in `time-zone-converter.test.ts` covering cast with Instant, TimeWithZone, string, null, and deserialize paths

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/attribute-methods/time-zone-converter.test.ts` — 8 tests pass
- [x] `pnpm vitest run packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts` — 7 tests pass
- [x] `pnpm vitest run packages/activesupport/src/time-with-zone.test.ts` — 120 tests pass
- [x] `pnpm run api:compare --package activerecord` — 4955/4958 (99.9%), no regression
- [x] `pnpm build && pnpm typecheck` — clean

## Blocked test disposition

The 36 BLOCKED tests in `base.test.ts` tagged `type — time-zone aware attribute / timezone conversion gap` have empty stubs (no test bodies) — they require full integration DB setup. This PR delivers the infrastructure; filling in the test bodies is tracked separately.

Tracked in `docs/activerecord-100-plan.md` — TimeZone cluster item 1.