### PR TITLE
fix(activerecord): TM currentTransaction migration + adapter unification (~40 LOC, 3 items)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -237,6 +237,15 @@ export interface DatabaseAdapter {
   readonly inTransaction: boolean;
 
   /**
+   * Number of open transactions on this adapter's TransactionManager stack.
+   * Zero for adapters without a TransactionManager.
+   * Includes lazy (unmaterialized) transactions.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::TransactionManager#open_transactions
+   */
+  readonly openTransactions?: number;
+
+  /**
    * Schema cache for this adapter's connection pool. Holds table/column
    * metadata so repeated introspection queries are avoided.
    *

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -673,6 +673,12 @@ export class RestartParentTransaction extends Transaction {
     this.state.commitBang();
   }
 
+  /** @internal */
+  override incompleteBang(): void {
+    // RestartParentTransaction has no own instrumentation lifecycle —
+    // materializeBang() delegates to parent, so _instrumenter is never started.
+  }
+
   override isFullRollback(): boolean {
     return false;
   }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -894,7 +894,7 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   get openTransactions(): number {
-    return (this.inner as any).openTransactions ?? 0;
+    return this.inner.openTransactions ?? 0;
   }
 
   emptyInsertStatementValue(pk?: string | null): string {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -343,7 +343,7 @@ let _ddlSpCounter = 0;
  * so we need savepoints to isolate DDL failures and allow rollback+retry.
  */
 async function execDdlWithSavepoint(inner: any, sql: string): Promise<void> {
-  const useSp = isPg() && inner.inTransaction;
+  const useSp = isPg() && ((inner.openTransactions ?? 0) > 0 || inner.inTransaction);
   const sp = useSp ? `_ddl_sp_${++_ddlSpCounter}` : "";
   try {
     if (useSp) await inner.createSavepoint(sp);
@@ -651,7 +651,7 @@ class SchemaAdapter implements DatabaseAdapter {
       // In PG, errors inside a transaction abort it. Use a savepoint so we
       // can rollback the failed statement and retry after auto-creating the
       // missing table/column.
-      const useSp = isPg() && this.inTransaction;
+      const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
       const sp = useSp ? `_sr_${attempt}` : "";
       try {
         if (useSp) await this.inner.createSavepoint(sp);
@@ -696,7 +696,7 @@ class SchemaAdapter implements DatabaseAdapter {
 
     let lastError: unknown;
     for (let attempt = 0; attempt < 5; attempt++) {
-      const useSp = isPg() && this.inTransaction;
+      const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
       const sp = useSp ? `_sr_m_${attempt}` : "";
       try {
         if (useSp) await this.inner.createSavepoint(sp);
@@ -891,6 +891,10 @@ class SchemaAdapter implements DatabaseAdapter {
   }
   get inTransaction(): boolean {
     return this.inner.inTransaction;
+  }
+
+  get openTransactions(): number {
+    return (this.inner as any).openTransactions ?? 0;
   }
 
   emptyInsertStatementValue(pk?: string | null): string {

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -179,9 +179,7 @@ async function _transactionFallback<T>(
   // Also check TM's openTransactions so lazy (unmaterialized) transactions are
   // detected even when adapter.inTransaction is still false.
   const nested =
-    currentTransaction() !== null ||
-    ((adapter as any).openTransactions ?? 0) > 0 ||
-    adapter.inTransaction;
+    currentTransaction() !== null || (adapter.openTransactions ?? 0) > 0 || adapter.inTransaction;
   let releaseLock = nested ? null : await acquireAdapterLock(adapter);
 
   let result: T;

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -176,7 +176,12 @@ async function _transactionFallback<T>(
   }
 
   const tx = new Transaction(adapter);
-  const nested = currentTransaction() !== null || adapter.inTransaction;
+  // Also check TM's openTransactions so lazy (unmaterialized) transactions are
+  // detected even when adapter.inTransaction is still false.
+  const nested =
+    currentTransaction() !== null ||
+    ((adapter as any).openTransactions ?? 0) > 0 ||
+    adapter.inTransaction;
   let releaseLock = nested ? null : await acquireAdapterLock(adapter);
 
   let result: T;


### PR DESCRIPTION
## Summary

- **\`_transactionFallback\` nesting detection** (\`transactions.ts\`): \`adapter.inTransaction\` returns \`false\` for lazy (unmaterialized) TM transactions. Add \`(adapter.openTransactions ?? 0) > 0\` as an additional check so savepoint-vs-BEGIN is decided correctly even before BEGIN has been sent to the DB. \`openTransactions\` is now an optional field on the \`DatabaseAdapter\` interface (no more \`as any\` cast).

- **SchemaAdapter \`openTransactions\`** (\`test-adapter.ts\`): Expose \`openTransactions\` (forwarding to inner adapter's TM stack depth) on \`SchemaAdapter\`. This makes the fix above visible to \`_transactionFallback\` for test-adapter-wrapped adapters. Also fixes the bare \`inTransaction\` guards in \`execute\`, \`executeMutation\`, and \`execDdlWithSavepoint\` — all three now use \`openTransactions > 0 || inTransaction\` so PostgreSQL DDL is wrapped in savepoints even during lazy transactions.

- **\`RestartParentTransaction.incompleteBang()\` override** (\`transaction.ts\`): \`RestartParentTransaction\` delegates \`materializeBang\`/\`isMaterialized\` to parent and therefore never starts its own \`_instrumenter\`. When \`incompleteBang()\` fires in the double-failure path (commit fails then rollback also fails), the inherited implementation would call \`_instrumenter.finish()\` on an instrumenter that was never started — crashing with \`InstrumentationNotStartedError\`. Override \`incompleteBang()\` to a no-op on \`RestartParentTransaction\` since it owns no instrumentation lifecycle. \`TransactionInstrumenter.finish()\` retains its throw-on-unstarted guard, matching Rails.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/\` — 327 passed / 0 failed
- [x] \`pnpm api:compare --package activerecord\` — 4955/4958 (99.9%), no regression