### PR TITLE
feat(mysql): onUpdate column option + renameColumnForAlter ON UPDATE support (~40 LOC)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -88,22 +88,22 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
       "renameColumnForAlter fallback",
     );
   });
-});
 
-describe("MysqlSchemaCreation addColumn autoIncrement DDL", () => {
-  it("emits AUTO_INCREMENT in column DDL when autoIncrement: true", async () => {
-    const { SchemaCreation } = await import("./mysql/schema-creation.js");
-    const { ColumnDefinition, AddColumnDefinition } =
-      await import("./abstract/schema-definitions.js");
-    const creation = new SchemaCreation();
-    (creation as any).adapter = {
-      quoteIdentifier: (s: string) => `\`${s}\``,
-      quoteTableName: (s: string) => `\`${s}\``,
-      quoteDefaultExpression: (_v: unknown) => "",
-    };
-    const col = new ColumnDefinition("id", "integer", { autoIncrement: true, null: false });
-    const addCol = new AddColumnDefinition(col);
-    const sql = creation.accept(addCol);
-    expect(sql).toMatch(/AUTO_INCREMENT/);
+  it("emits DEFAULT CURRENT_TIMESTAMP unquoted when default is a timestamp function", async () => {
+    const adapter = await makeAdapter("updated_at", "on update CURRENT_TIMESTAMP");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "updated_at",
+        Type: "datetime",
+        Null: "YES",
+        Default: "CURRENT_TIMESTAMP",
+        Extra: "on update CURRENT_TIMESTAMP",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    const sql: string = await adapter.renameColumnForAlter("users", "updated_at", "ts");
+    expect(sql).toContain("DEFAULT CURRENT_TIMESTAMP");
+    expect(sql).not.toContain("DEFAULT 'CURRENT_TIMESTAMP'");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -65,9 +65,16 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     expect(sql).toContain("AUTO_INCREMENT");
   });
 
+  it("preserves on update CURRENT_TIMESTAMP Extra without throwing", async () => {
+    const adapter = await makeAdapter("updated_at", "on update CURRENT_TIMESTAMP");
+    const sql: string = await adapter.renameColumnForAlter("users", "updated_at", "ts");
+    expect(sql).toContain("ON UPDATE");
+    expect(sql).toContain("CURRENT_TIMESTAMP");
+  });
+
   it("throws for unrecognised Extra values", async () => {
-    const adapter = await makeAdapter("updated_at", "on update current_timestamp()");
-    await expect(adapter.renameColumnForAlter("users", "updated_at", "ts")).rejects.toThrow(
+    const adapter = await makeAdapter("gen_col", "VIRTUAL GENERATED");
+    await expect(adapter.renameColumnForAlter("users", "gen_col", "gen_col2")).rejects.toThrow(
       "renameColumnForAlter fallback",
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -72,6 +72,16 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     expect(sql).toContain("CURRENT_TIMESTAMP");
   });
 
+  it("preserves MySQL 8 compound DEFAULT_GENERATED on update Extra", async () => {
+    const adapter = await makeAdapter(
+      "updated_at",
+      "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)",
+    );
+    const sql: string = await adapter.renameColumnForAlter("users", "updated_at", "ts");
+    expect(sql).toContain("ON UPDATE");
+    expect(sql).toContain("CURRENT_TIMESTAMP(6)");
+  });
+
   it("throws for unrecognised Extra values", async () => {
     const adapter = await makeAdapter("gen_col", "VIRTUAL GENERATED");
     await expect(adapter.renameColumnForAlter("users", "gen_col", "gen_col2")).rejects.toThrow(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -79,3 +79,21 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     );
   });
 });
+
+describe("MysqlSchemaCreation addColumn autoIncrement DDL", () => {
+  it("emits AUTO_INCREMENT in column DDL when autoIncrement: true", async () => {
+    const { SchemaCreation } = await import("./mysql/schema-creation.js");
+    const { ColumnDefinition, AddColumnDefinition } =
+      await import("./abstract/schema-definitions.js");
+    const creation = new SchemaCreation();
+    (creation as any).adapter = {
+      quoteIdentifier: (s: string) => `\`${s}\``,
+      quoteTableName: (s: string) => `\`${s}\``,
+      quoteDefaultExpression: (_v: unknown) => "",
+    };
+    const col = new ColumnDefinition("id", "integer", { autoIncrement: true, null: false });
+    const addCol = new AddColumnDefinition(col);
+    const sql = creation.accept(addCol);
+    expect(sql).toMatch(/AUTO_INCREMENT/);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1190,8 +1190,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // columns) that ColumnOptions cannot express. Rails preserves these via column_for's
     // auto_increment?/comment; our ColumnDefinition lacks that field. Throw explicitly so
     // callers know to upgrade MySQL rather than receive a lossy CHANGE clause.
-    const extra = ((col["Extra"] as string | undefined) ?? "").trim().toLowerCase();
-    if (extra && extra !== "auto_increment") {
+    const extraRaw = ((col["Extra"] as string | undefined) ?? "").trim();
+    const extra = extraRaw.toLowerCase();
+    const onUpdateMatch = extraRaw.match(/^on update (.+)$/i);
+    if (extra && extra !== "auto_increment" && !onUpdateMatch) {
       throw new Error(
         `renameColumnForAlter fallback: cannot safely CHANGE column "${columnName}" in table "${tableName}" ` +
           `— Extra="${col["Extra"]}" is not preserved by this path. ` +
@@ -1207,6 +1209,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       collation: (col["Collation"] as string | undefined) || undefined,
       comment: (col["Comment"] as string | undefined) || undefined,
       autoIncrement: extra === "auto_increment" || undefined,
+      onUpdate: onUpdateMatch ? onUpdateMatch[1] : undefined,
     });
     const cd = new ChangeColumnDefinition(colDef, columnName);
     return new MysqlSchemaCreation().accept(cd);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1201,11 +1201,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
           `Upgrade to MySQL ≥8.0.3 or MariaDB ≥10.5.2 to use RENAME COLUMN instead.`,
       );
     }
+    const rawDefault = col["Default"] !== null ? (col["Default"] as string) : undefined;
+    // SHOW FULL FIELDS returns function defaults as plain strings (e.g. "CURRENT_TIMESTAMP").
+    // Rails' column.default is nil for function defaults; pass as a lambda so
+    // quoteDefaultExpression emits it unquoted: DEFAULT CURRENT_TIMESTAMP, not DEFAULT 'CURRENT_TIMESTAMP'.
+    const colDefault =
+      typeof rawDefault === "string" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(rawDefault)
+        ? () => rawDefault
+        : rawDefault;
     const colDef = new ColumnDefinition(newColumnName, col["Type"] as string, {
       // SHOW FULL FIELDS returns NULL for Default both when there is no default and when
       // DEFAULT NULL. Treat null as "no explicit default" (undefined) to avoid emitting
       // DEFAULT NULL on NOT NULL columns — mirrors Rails column_for + new_column_definition.
-      default: col["Default"] !== null ? col["Default"] : undefined,
+      default: colDefault,
       null: (col["Null"] as string) === "YES",
       collation: (col["Collation"] as string | undefined) || undefined,
       comment: (col["Comment"] as string | undefined) || undefined,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1186,13 +1186,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const cols = await this.columnDefinitions(tableName);
     const col = cols.find((c) => (c["Field"] as string) === columnName);
     if (!col) throw new Error(`Column not found: ${columnName} in ${tableName}`);
-    // Guard against silently dropping Extra attributes (AUTO_INCREMENT, ON UPDATE, generated
-    // columns) that ColumnOptions cannot express. Rails preserves these via column_for's
-    // auto_increment?/comment; our ColumnDefinition lacks that field. Throw explicitly so
-    // callers know to upgrade MySQL rather than receive a lossy CHANGE clause.
+    // Guard against silently dropping Extra attributes we cannot reconstruct (e.g. generated
+    // columns). AUTO_INCREMENT is preserved via ColumnOptions.autoIncrement; ON UPDATE <expr>
+    // (including MySQL 8 compound form "DEFAULT_GENERATED on update CURRENT_TIMESTAMP") is
+    // preserved via ColumnOptions.onUpdate. Anything else triggers an explicit throw so callers
+    // know to upgrade MySQL rather than receive a lossy CHANGE clause.
     const extraRaw = ((col["Extra"] as string | undefined) ?? "").trim();
     const extra = extraRaw.toLowerCase();
-    const onUpdateMatch = extraRaw.match(/^on update (.+)$/i);
+    const onUpdateMatch = extraRaw.match(/on update (.+)$/i);
     if (extra && extra !== "auto_increment" && !onUpdateMatch) {
       throw new Error(
         `renameColumnForAlter fallback: cannot safely CHANGE column "${columnName}" in table "${tableName}" ` +

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -229,6 +229,9 @@ export class SchemaCreation {
     if (options.autoIncrement) {
       sql += " AUTO_INCREMENT";
     }
+    if (options.onUpdate) {
+      sql += ` ON UPDATE ${options.onUpdate}`;
+    }
     if (options.primaryKey) {
       sql += " PRIMARY KEY";
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -230,6 +230,7 @@ export interface ColumnOptions {
   ifExists?: boolean;
   ifNotExists?: boolean;
   autoIncrement?: boolean;
+  onUpdate?: string;
 }
 
 export interface AddIndexOptions {


### PR DESCRIPTION
## Summary

- **Item 3 — `ON UPDATE CURRENT_TIMESTAMP`**: Added `onUpdate?: string` to `ColumnOptions`; emit `ON UPDATE <expr>` in `addColumnOptions` (abstract); relaxed `renameColumnForAlter` Extra guard to allow `on update ...` patterns (unanchored regex handles MySQL 8 compound form `DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)`), preserving case from SHOW FULL FIELDS and wiring into the CHANGE COLUMN DDL. Also detects `CURRENT_TIMESTAMP(n)?` function defaults and wraps them as lambdas so `quoteDefaultExpression` emits `DEFAULT CURRENT_TIMESTAMP` unquoted — mirrors how Rails' `column.default` is nil for function defaults.

- **Item 2 — `autoIncrement` guard tests**: `schema-creation.test.ts` already covers the `AUTO_INCREMENT` DDL emission smoke test, so no new test was added here. The `renameColumnForAlter` test suite was updated to verify the `on update CURRENT_TIMESTAMP` and `DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)` Extra forms are preserved, and that `DEFAULT CURRENT_TIMESTAMP` round-trips unquoted.

Items 1 (`autoIncrement` in ColumnOptions + schema-creation emission) and 4 (`Migration#schema` using `this.connection`) were already implemented before this PR.

## Notes

- 69 LOC total (within 300 LOC ceiling)
- `onUpdate` is placed in the abstract `addColumnOptions` (not the MySQL `addColumnOptionsBang` override) because `visitColumnDefinition` calls `addColumnOptions` directly; the MySQL override path is only reached for `AddColumnDefinition`/`ChangeColumnDefinition` visitors that go through `addColumnOptionsBang`.