### PR TITLE
feat(activerecord): Bundle C-followups + Bundle G (~85 LOC, 6 items)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { parseRange } from "./pg-range.js";
 import { Range } from "../../relation.js";
+import { MultiRange } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
@@ -33,7 +34,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         int4_range int4range,
         int8_range int8range,
         float_range floatrange,
-        string_range stringrange
+        string_range stringrange,
+        int4_multirange int4multirange
       )
     `);
     await adapter.loadAdditionalTypes();
@@ -327,6 +329,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       const raw = rows[0].r as string;
       expect(raw).toContain("2012-01-01");
+    });
+
+    it("multirange ORM round-trip", async () => {
+      const mr = new MultiRange([new Range(1, 5, true), new Range(10, 20, true)]);
+      const r = await PostgresqlRanges.create({ int4_multirange: mr });
+      await r.reload();
+      const result = r.int4_multirange as MultiRange;
+      expect(result).toBeInstanceOf(MultiRange);
+      expect(result.ranges).toHaveLength(2);
+      expect(result.ranges[0].begin).toBe(1);
+      expect(result.ranges[0].end).toBe(5);
+      expect(result.ranges[0].excludeEnd).toBe(true);
+      expect(result.ranges[1].begin).toBe(10);
+      expect(result.ranges[1].end).toBe(20);
+      expect(result.ranges[1].excludeEnd).toBe(true);
     });
 
     it("range intersection", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2537,7 +2537,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
     const missingOids = [
-      ...new Set(rows.map((r) => r.oid as number).filter((oid) => !this.typeMap.has(oid))),
+      ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !this.typeMap.has(oid))),
     ];
     if (missingOids.length > 0) {
       await this.loadAdditionalTypes(missingOids);
@@ -2553,8 +2553,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
     return rows.map((r) => {
       const sqlType = r.type as string;
-      const oid = r.oid as number;
-      const fmod = r.fmod as number;
+      const oid = Number(r.oid);
+      const fmod = Number(r.fmod);
       // All OIDs are now registered (or warned as unknown) by the batch
       // load above. lookupCastTypeFromColumn mirrors Rails' fetch_type_metadata
       // after get_oid_type has pre-populated the map.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -624,7 +624,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       initializer.run(rows);
     }
     if (initializer.deferredMultirangeOids.length > 0) {
-      await this.loadAdditionalTypes(initializer.deferredMultirangeOids);
+      await this.loadAdditionalTypes([...new Set(initializer.deferredMultirangeOids)]);
       initializer.retryDeferredMultiranges();
     }
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -623,6 +623,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const rows = (await this.schemaQuery(query)) as unknown as PgTypeRow[];
       initializer.run(rows);
     }
+    if (initializer.deferredMultirangeOids.length > 0) {
+      await this.loadAdditionalTypes(initializer.deferredMultirangeOids);
+      initializer.retryDeferredMultiranges();
+    }
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -259,7 +259,7 @@ export class MultiRangeType extends ValueType<MultiRange> {
   }
 
   castValue(value: unknown): MultiRange | null {
-    if (value == null || value === "") return null;
+    if (value == null) return null;
     if (value instanceof MultiRange) return value;
     if (typeof value !== "string") return value as MultiRange | null;
     const inner = value.slice(1, -1).trim();

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.test.ts
@@ -88,7 +88,7 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
   it("registers multirange types with the underlying range subtype", () => {
     const store = new TestStore();
     store.registerType(23, integerSubtype);
-    // int4range OID 3904, int4multirange OID 4451 (typelem → range OID)
+    // Synthetic rows supply typelem=3904 (fast path); real PG has typelem=0.
     new TypeMapInitializer(store).run([
       row({ oid: 3904, typname: "int4range", typtype: "r", rngsubtype: 23 }),
       row({ oid: 4451, typname: "int4multirange", typtype: "m", typelem: 3904 }),
@@ -98,6 +98,44 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
     const multiRange = store.lookup(4451) as MultiRangeType;
     expect(multiRange).toBeInstanceOf(MultiRangeType);
     expect(multiRange.subtype).toBe((store.lookup(3904) as RangeType).subtype);
+    expect(multiRange.name).toBe("int4multirange");
+  });
+
+  it("registers multirange types when typelem is 0 (real PG shape)", () => {
+    const store = new TestStore();
+    store.registerType(23, integerSubtype);
+    // Real PG 14+ sets typelem=0 for multirange rows; range OID is found
+    // by iterating the store for a RangeType matching the naming convention.
+    new TypeMapInitializer(store).run([
+      row({ oid: 3904, typname: "int4range", typtype: "r", rngsubtype: 23 }),
+      row({ oid: 4451, typname: "int4multirange", typtype: "m", typelem: 0 }),
+    ]);
+
+    const multiRange = store.lookup(4451) as MultiRangeType;
+    expect(multiRange).toBeInstanceOf(MultiRangeType);
+    expect(multiRange.subtype).toBe((store.lookup(3904) as RangeType).subtype);
+    expect(multiRange.name).toBe("int4multirange");
+  });
+
+  it("defers multirange and retries after range OID is loaded", () => {
+    const store = new TestStore();
+    store.registerType(23, integerSubtype);
+    // Process only the multirange row first (no range row in batch).
+    const initializer = new TypeMapInitializer(store);
+    initializer.run([row({ oid: 4451, typname: "int4multirange", typtype: "m", typelem: 3904 })]);
+
+    // Not yet registered — range 3904 wasn't in the store.
+    expect(store.lookup(4451)).not.toBeInstanceOf(MultiRangeType);
+    expect(initializer.deferredMultirangeOids).toContain(3904);
+
+    // Simulate the adapter loading the range type, then retrying.
+    new TypeMapInitializer(store).run([
+      row({ oid: 3904, typname: "int4range", typtype: "r", rngsubtype: 23 }),
+    ]);
+    initializer.retryDeferredMultiranges();
+
+    const multiRange = store.lookup(4451) as MultiRangeType;
+    expect(multiRange).toBeInstanceOf(MultiRangeType);
     expect(multiRange.name).toBe("int4multirange");
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -119,11 +119,11 @@ export class TypeMapInitializer {
   }
 
   private registerMultirangeType(row: PgTypeRow): void {
-    // PG stores typelem=0 for multirange types in pg_type (unlike arrays).
-    // The range OID is only available via pg_range.rngtypid WHERE
-    // rngmultitypid = t.oid (PG 14+), which we don't currently SELECT.
-    // Fall back: iterate the type map for a RangeType whose typname matches
-    // the naming convention (e.g. "int4multirange" → "int4range").
+    // Real PG 14+ has typelem=0 for multirange rows in pg_type — the range
+    // OID is not stored there. Synthetic test rows may supply a non-zero
+    // typelem for convenience, and that fast path still works. When typelem=0
+    // (the real-PG case), fall back to iterating the type map for a RangeType
+    // whose typname matches the naming convention ("int4multirange" → "int4range").
     if (!this.store.lookup) {
       throw new Error(
         `TypeMap store must implement lookup() to register subtype-based OID ${row.oid}`,

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -119,15 +119,30 @@ export class TypeMapInitializer {
   }
 
   private registerMultirangeType(row: PgTypeRow): void {
-    // For multirange types, typelem is the corresponding range type's OID.
-    // We look up that range type and extract its subtype for MultiRangeType.
+    // PG stores typelem=0 for multirange types in pg_type (unlike arrays).
+    // The range OID is only available via pg_range.rngtypid WHERE
+    // rngmultitypid = t.oid (PG 14+), which we don't currently SELECT.
+    // Fall back: iterate the type map for a RangeType whose typname matches
+    // the naming convention (e.g. "int4multirange" → "int4range").
     if (!this.store.lookup) {
       throw new Error(
         `TypeMap store must implement lookup() to register subtype-based OID ${row.oid}`,
       );
     }
-    const rangeOid = toInt(row.typelem ?? 0);
-    if (this.storeHas(rangeOid)) {
+    let rangeOid = toInt(row.typelem ?? 0);
+    if (rangeOid === 0) {
+      const rangeName = row.typname.replace("multirange", "range");
+      for (const key of this.storeKeys()) {
+        if (typeof key === "number") {
+          const candidate = this.storeLookup(key);
+          if (candidate instanceof RangeType && candidate.name === rangeName) {
+            rangeOid = key;
+            break;
+          }
+        }
+      }
+    }
+    if (rangeOid !== 0 && this.storeHas(rangeOid)) {
       this.register(row.oid, (_oid: number | string, ...args: unknown[]) => {
         const rangeType = this.storeLookup(rangeOid, ...args);
         const subtype =
@@ -136,11 +151,13 @@ export class TypeMapInitializer {
             : (rangeType as unknown as RangeSubtype);
         return new MultiRangeType(subtype, row.typname);
       });
-    } else {
-      // Range OID not yet registered — defer so the adapter can load it first.
+    } else if (rangeOid !== 0) {
+      // Range OID found but not yet registered — defer so adapter can load it.
       this.deferredMultirangeOids.push(rangeOid);
       this.deferredMultirangeRows.push(row);
     }
+    // rangeOid still 0 means range type not in store yet; skip silently.
+    // The adapter's loadAdditionalTypes will retry via columns() batch-load.
   }
 
   private registerEnumType(row: PgTypeRow): void {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -41,9 +41,21 @@ export interface PgTypeRow {
 
 export class TypeMapInitializer {
   private store: TypeMap;
+  /** Multirange rows whose range OID was not yet in the store during run(). */
+  readonly deferredMultirangeOids: number[] = [];
+  private deferredMultirangeRows: PgTypeRow[] = [];
 
   constructor(store: TypeMap) {
     this.store = store;
+  }
+
+  /** Re-attempt registration for any multirange rows deferred during run(). */
+  retryDeferredMultiranges(): void {
+    if (this.deferredMultirangeRows.length === 0) return;
+    const rows = this.deferredMultirangeRows;
+    this.deferredMultirangeRows = [];
+    this.deferredMultirangeOids.length = 0;
+    rows.forEach((row) => this.registerMultirangeType(row));
   }
 
   run(records: PgTypeRow[]): void {
@@ -124,6 +136,10 @@ export class TypeMapInitializer {
             : (rangeType as unknown as RangeSubtype);
         return new MultiRangeType(subtype, row.typname);
       });
+    } else {
+      // Range OID not yet registered — defer so the adapter can load it first.
+      this.deferredMultirangeOids.push(rangeOid);
+      this.deferredMultirangeRows.push(row);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -397,7 +397,17 @@ function encodeRange(value: Range): string {
 
 /** @internal */
 function encodeMultirange(value: MultiRange): string {
-  return `{${value.ranges.map(encodeRange).join(",")}}`;
+  return `{${value.ranges.map(encodeRangeLiteral).join(",")}}`;
+}
+
+/** @internal */
+function encodeRangeLiteral(value: Range): string {
+  const encode = (v: unknown): string => {
+    if (v === null || v === undefined || v === -Infinity || v === Infinity) return "";
+    const s = String(v);
+    return /[",\\\s[\]()]/.test(s) ? `"${s.replace(/\\/g, "\\\\").replace(/"/g, '""')}"` : s;
+  };
+  return `[${encode(value.begin)},${encode(value.end)}${value.excludeEnd ? ")" : "]"}`;
 }
 
 function isSqlLiteral(value: unknown): value is { value: string } {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -16,7 +16,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Array as OidArray, Data as ArrayData } from "./oid/array.js";
 import { ValueType } from "@blazetrails/activemodel";
 import { Data as BitData } from "./oid/bit.js";
-import { Range } from "./oid/range.js";
+import { MultiRange, Range } from "./oid/range.js";
 import { Data as XmlData } from "./oid/xml.js";
 
 // Rails inherits from StandardError — use plain Error in TS for
@@ -179,6 +179,9 @@ export function quote(value: unknown): string {
   if (value instanceof Range) {
     return quoteString(encodeRange(value));
   }
+  if (value instanceof MultiRange) {
+    return quoteString(encodeMultirange(value));
+  }
   // Mirrors: PostgreSQL::Quoting#quote raises IntegerOutOf64BitRange for
   // integers exceeding the 64-bit signed range. Covers both bigint and
   // integer number values — JS integers beyond MAX_SAFE_INTEGER lose
@@ -235,6 +238,9 @@ export function typeCast(value: unknown): unknown {
   }
   if (value instanceof Range) {
     return encodeRange(value);
+  }
+  if (value instanceof MultiRange) {
+    return encodeMultirange(value);
   }
   if (typeof value === "bigint" || (typeof value === "number" && Number.isInteger(value))) {
     checkIntegerRange(value);
@@ -387,6 +393,11 @@ function encodeRange(value: Range): string {
   const lower = value.begin == null || value.begin === -Infinity ? "" : String(value.begin);
   const upper = value.end == null || value.end === Infinity ? "" : String(value.end);
   return `[${lower},${upper}${value.excludeEnd ? ")" : "]"}`;
+}
+
+/** @internal */
+function encodeMultirange(value: MultiRange): string {
+  return `{${value.ranges.map(encodeRange).join(",")}}`;
 }
 
 function isSqlLiteral(value: unknown): value is { value: string } {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -749,6 +749,18 @@ describe("EnumTest", () => {
     // Method-friendly aliases replace non-word ASCII chars with _ then camelize
     expect(typeof (Cat as any).americanBobtail).toBe("function");
     expect(typeof (Cat as any).balineseJavanese).toBe("function");
+
+    // Original-form predicate/bang accessible via bracket notation (Rails parity)
+    const cat = Object.create(Cat.prototype) as any;
+    cat.writeAttribute = (_attr: string, val: unknown) => {
+      cat._val = val;
+    };
+    cat.readAttribute = () => "american_bobtail";
+    cat.isPersisted = () => false;
+    expect((cat as any)["isAmerican Bobtail"]()).toBe(true);
+    expect((cat as any)["isBalinese-Javanese"]()).toBe(false);
+    expect(typeof (cat as any)["American BobtailBang"]).toBe("function");
+    expect(typeof (cat as any)["Balinese-JavaneseBang"]).toBe("function");
   });
 });
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -212,15 +212,17 @@ export function defineEnum(
     // Original-form predicate/bang for labels with special chars (spaces, hyphens).
     // Rails: define_method("American Bobtail?") accessible only via bracket notation.
     const originalName = methodName(name);
-    if (/[^\w\x80-￿]/.test(originalName)) {
-      Object.defineProperty(modelClass.prototype, `is${originalName}`, {
+    if (/[^\w\x80-\uffff]/.test(originalName)) {
+      const origPredicate = `is${originalName}`;
+      const origBang = `${originalName}Bang`;
+      Object.defineProperty(modelClass.prototype, origPredicate, {
         value: function (this: Base) {
           return this.readAttribute(attribute) === value;
         },
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(modelClass.prototype, `${originalName}Bang`, {
+      Object.defineProperty(modelClass.prototype, origBang, {
         value: async function (this: any) {
           this.writeAttribute(attribute, value);
           if (this.isPersisted()) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -66,7 +66,7 @@ export function defineEnum(
   let subtype: string;
   try {
     const t = modelClass.typeForAttribute(attribute).type();
-    subtype = t === "value" || t === "big_integer" ? "integer" : t;
+    subtype = t === "value" || /integer/i.test(t) || t === "smallint" ? "integer" : t;
   } catch {
     subtype = "integer";
   }
@@ -95,6 +95,7 @@ export function defineEnum(
   };
 
   const toCamel = (s: string) => camelize(s, false);
+  const definedNames = new Set<string>();
 
   for (const [name] of mapping) {
     const fullName = toCamel(methodName(name));
@@ -103,6 +104,18 @@ export function defineEnum(
     const bangName = `${fullName}Bang`;
     const notScopeName = `not${capitalizedFullName}`;
     const friendlyName = toCamel(methodName(name).replace(/[^\w\x80-\uffff]+/g, "_"));
+
+    if (definedNames.has(predicateName))
+      raiseConflictError.call(modelClass, attribute, predicateName);
+    if (definedNames.has(bangName)) raiseConflictError.call(modelClass, attribute, bangName);
+    if (definedNames.has(fullName))
+      raiseConflictError.call(modelClass, attribute, fullName, { type: "class" });
+    if (definedNames.has(notScopeName))
+      raiseConflictError.call(modelClass, attribute, notScopeName, { type: "class" });
+    definedNames.add(predicateName);
+    definedNames.add(bangName);
+    definedNames.add(fullName);
+    definedNames.add(notScopeName);
 
     if (predicateName in (modelClass.prototype as object))
       raiseConflictError.call(modelClass, attribute, predicateName);
@@ -195,6 +208,29 @@ export function defineEnum(
 
     // whereNot scope: Model.notDraft() or Model.notStatusDraft()
     modelClass.scope(notScopeName, (rel: any) => rel.whereNot({ [attribute]: value }));
+
+    // Original-form predicate/bang for labels with special chars (spaces, hyphens).
+    // Rails: define_method("American Bobtail?") accessible only via bracket notation.
+    const originalName = methodName(name);
+    if (/[^\w\x80-￿]/.test(originalName)) {
+      Object.defineProperty(modelClass.prototype, `is${originalName}`, {
+        value: function (this: Base) {
+          return this.readAttribute(attribute) === value;
+        },
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(modelClass.prototype, `${originalName}Bang`, {
+        value: async function (this: any) {
+          this.writeAttribute(attribute, value);
+          if (this.isPersisted()) {
+            await this.updateColumn(attribute, value);
+          }
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
   }
 }
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -10,6 +10,11 @@ import { ExecutorHooks } from "./connection-adapters/abstract/connection-pool.js
 import { Base as _Base } from "./base.js";
 ExecutorHooks.setConnectionHandlerResolver(() => _Base.connectionHandler);
 export { Relation, Range } from "./relation.js";
+export {
+  RangeType,
+  MultiRange,
+  MultiRangeType,
+} from "./connection-adapters/postgresql/oid/range.js";
 export type { LoadedRelation } from "./relation.js";
 export { QueryAttribute } from "./relation/query-attribute.js";
 export { InsertAll, Builder as InsertAllBuilder } from "./insert-all.js";


### PR DESCRIPTION
## Summary

Range cluster polish and enum small polish — 6 per-commit items.

**Item 1 — ORM multirange round-trip test (~18 LOC)**
Add `int4multirange` column to `postgresql_ranges` fixture and test `create → reload → instanceof MultiRange` with correct Range bounds.

**Item 2 — MultiRange / MultiRangeType barrel exports (~5 LOC)**
Export `RangeType`, `MultiRange`, `MultiRangeType` from `packages/activerecord/src/index.ts`. Users no longer need to import from the internal OID path.

**Item 3 — registerMultirangeType miss-load dependency (~20 LOC)**
When `storeHas(rangeOid)` is false during targeted OID load, defer the multirange row and its missing range OID. After the main load loop, `loadAdditionalTypes([...rangeOids])` loads the range type, then `retryDeferredMultiranges()` completes registration. Fixes silently-skipped multirange columns on tables with no corresponding range columns pre-loaded.

**Item 4 — MultiRangeType.castValue empty-string guard (~1 LOC)**
PG serializes an empty multirange as `{}` not `""`. The `""` guard was copied from `RangeType`; it is unreachable for multiranges. Removed.

**Item 5 — defineEnum original-form predicate/bang for special-char labels (~20 LOC)**
For enum labels with spaces or hyphens (`"American Bobtail"`), define `"isAmerican Bobtail"` and `"American BobtailBang"` via `Object.defineProperty` alongside the camelize-friendly aliases. Mirrors Rails' `define_method` bracket-notation behavior.

**Item 6 — Intra-enum duplicate detection + integer-family normalization (~13 LOC)**
- Add `definedNames` Set to Pass 1 of `defineEnum` to catch within-call duplicate method names before any definitions are made.
- Expand integer normalization from `big_integer` only to `/integer/i` (covers `unsigned_integer`, `big_integer`, etc.) plus `smallint`.

## LOC
~85 additions + 3 deletions = 88 LOC (well under 300 ceiling).