### PR TITLE
feat(activerecord): TZ test fill-in batch 2 + small fixes (~183 LOC)

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -130,6 +130,18 @@ describe("DateTimeTest", () => {
     );
   });
 
+  it("cast accepts numeric-keyed multiparameter hash and returns Temporal.Instant", () => {
+    const type = new Types.DateTimeType();
+    const result = type.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 30 });
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(2024);
+    expect(zdt.month).toBe(6);
+    expect(zdt.day).toBe(15);
+    expect(zdt.hour).toBe(10);
+    expect(zdt.minute).toBe(30);
+  });
+
   it("valueFromMultiparameterAssignment defaults hour/minute to 0 when only date parts given (P21)", () => {
     class Probe extends Types.DateTimeType {
       call(values: Record<number, unknown>) {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -6,7 +6,10 @@ import {
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
-import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
+import {
+  AcceptsMultiparameterTime,
+  isNumericKeyHash,
+} from "./helpers/accepts-multiparameter-time.js";
 import { configuredTimezone } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
 
@@ -20,6 +23,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     if (value === DateInfinity) return DateInfinity;
     if (value === DateNegativeInfinity) return DateNegativeInfinity;
     if (value instanceof Temporal.Instant) return this._applySecondsPrecision(value);
+    if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
     return this.parseString(str);

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -171,7 +171,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
-    values: Record<string, unknown>,
+    values: Record<string | number, unknown>,
   ): DateTimeCastResult | null {
     const missing = [1, 2, 3].filter((k) => !Object.hasOwn(values, k));
     if (missing.length > 0) {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -171,7 +171,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
-    values: Record<number, unknown>,
+    values: Record<string, unknown>,
   ): DateTimeCastResult | null {
     const missing = [1, 2, 3].filter((k) => !Object.hasOwn(values, k));
     if (missing.length > 0) {

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -37,6 +37,20 @@ describe("TimeZoneConverterTest", () => {
     expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
   });
 
+  it("cast wraps Temporal.ZonedDateTime in current zone", () => {
+    setZone("Eastern Time (US & Canada)");
+    const converter = new TimeZoneConverter(new DateTime());
+    // ZonedDateTime in UTC at 14:00
+    const zdt = Temporal.Instant.from("2024-06-15T14:00:00Z").toZonedDateTimeISO("UTC");
+    const result = converter.cast(zdt);
+    expect(result).toBeInstanceOf(TimeWithZone);
+    const twz = result as TimeWithZone;
+    // 14:00 UTC = 10:00 EDT (UTC-4 in summer)
+    expect(twz.hour).toBe(10);
+    expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
+    expect(twz.toI()).toBe(zdt.toInstant().epochMilliseconds / 1000);
+  });
+
   it("cast moves existing TimeWithZone to current zone", () => {
     const pacific = TimeZone.find("Pacific Time (US & Canada)");
     const eastern = TimeZone.find("Eastern Time (US & Canada)");

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -20,9 +20,12 @@ import { registerModel } from "./associations.js";
 import { connectedToStack } from "./core.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Range as ArRange } from "./connection-adapters/postgresql/oid/range.js";
-import { Notifications, Logger } from "@blazetrails/activesupport";
+import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTimezoneConfig } from "./test-helper.js";
+import { adapterType } from "./test-adapter.js";
+import { IntegerType } from "@blazetrails/activemodel";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
@@ -1849,34 +1852,40 @@ describe("BasicsTest", () => {
     expect(() => User.limit("1, 7 ; DROP TABLE users" as any)).toThrow(/invalid limit/i);
   });
   it.skip("preserving time objects", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures — reads Topic.find(1).written_on / bonus_time with known usec values (223300, 9900, 129346) from topics.yml fixture data; no equivalent in our in-memory test adapter
   });
   it.skip("preserving time objects with local time conversion to default timezone utc", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures + with_env_tz — sets process-level TZ env var (eastern_time_zone) then creates Topic from fixture; Node.js has no equivalent of Ruby's with_env_tz (ENV["TZ"])
   });
   it.skip("preserving time objects with time with zone conversion to default timezone utc", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures + with_env_tz — same as above; uses Time.zone.local(2000) in CST then reloads and checks UTC offset
   });
   it.skip("preserving time objects with utc time conversion to default timezone local", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures + with_env_tz — reads back Time in "local" (EST) timezone via process-level TZ; no JS equivalent
   });
   it.skip("preserving time objects with time with zone conversion to default timezone local", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures + with_env_tz — same as above; Time.zone.local(2000) in CST then reload in EST local
   });
-  it.skip("time zone aware attribute with default timezone utc on utc can be created", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+  it("time zone aware attribute with default timezone utc on utc can be created", async () => {
+    await withTimezoneConfig({ awareAttributes: true, default: "utc", zone: "UTC" }, async () => {
+      class Pet extends Base {
+        static {
+          this.tableName = "tz_pets";
+          this.attribute("name", "string");
+          this.attribute("created_at", "datetime");
+          this.attribute("updated_at", "datetime");
+          this.adapter = adapter;
+        }
+      }
+      await defineSchema(adapter, {
+        tz_pets: { name: "string", created_at: "datetime", updated_at: "datetime" },
+      });
+      const pet = await Pet.create({ name: "Bidu" });
+      expect(pet.isPersisted()).toBe(true);
+      const savedPet = await Pet.find(pet.id);
+      expect(savedPet.readAttribute("created_at")).toBeInstanceOf(TimeWithZone);
+      expect(savedPet.readAttribute("updated_at")).toBeInstanceOf(TimeWithZone);
+    });
   });
   it("singular table name guesses with prefixes and suffixes", () => {
     class PrefixedModel extends Base {
@@ -1892,14 +1901,35 @@ describe("BasicsTest", () => {
     expect(Account.tableName).toBe("accounts");
   });
   it.skip("utc as time zone", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: fixtures + with_env_tz — reads Topic.find(1).bonus_time after assigning "5:42:00AM" string; requires process-level TZ env var and Topic fixture data
   });
-  it.skip("utc as time zone and new", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+  it("utc as time zone and new", async () => {
+    await withTimezoneConfig({ default: "utc" }, () => {
+      class Topic extends Base {
+        static {
+          this.tableName = "topics_tz";
+          this.attribute("bonus_time", "time");
+          this.adapter = adapter;
+        }
+      }
+      const attributes = {
+        "bonus_time(1i)": "2000",
+        "bonus_time(2i)": "1",
+        "bonus_time(3i)": "1",
+        "bonus_time(4i)": "10",
+        "bonus_time(5i)": "35",
+        "bonus_time(6i)": "50",
+      };
+      const topic = new Topic(attributes);
+      const bonusTime = topic.readAttribute("bonus_time") as {
+        hour: number;
+        minute: number;
+        second: number;
+      };
+      expect(bonusTime.hour).toBe(10);
+      expect(bonusTime.minute).toBe(35);
+      expect(bonusTime.second).toBe(50);
+    });
   });
   it("out of range slugs", async () => {
     class Topic extends Base {
@@ -2143,10 +2173,7 @@ describe("BasicsTest", () => {
     await expect(post2.update({ author_id: author2.id })).rejects.toThrow(ReadonlyAttributeError);
   });
   it.skip("respect internal encoding", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
-    /* Ruby-specific: tests Encoding.default_internal (EUC-JP) on column names — no JS equivalent */
+    // BLOCKED: Ruby-only — tests Encoding.default_internal (EUC-JP) on column names; JS has no string encoding model
   });
   it("non valid identifier column name", async () => {
     class Weird extends Base {
@@ -2160,16 +2187,10 @@ describe("BasicsTest", () => {
     expect(reloaded.readAttribute("a$b")).toBe("value");
   });
   it.skip("attributes on dummy time", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
-    /* needs time-string parsing ("5:42:00AM" -> dummy date 2000-01-01) with timezone config */
+    // BLOCKED: fixtures + with_env_tz — assigns "5:42:00AM" string to Topic.find(1).bonus_time; needs Topic fixture and process-level TZ change; then assert_equal using find_by, requiring DB
   });
   it.skip("attributes on dummy time with invalid time", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
-    /* needs time-string parsing — invalid time should return null */
+    // BLOCKED: fixtures — reads Topic.find(1) and assigns invalid time string; relies on Topic fixture data
   });
   it("previously persisted returns boolean", async () => {
     class User extends Base {
@@ -2246,39 +2267,25 @@ describe("BasicsTest", () => {
     expect(u.name).toBe("");
   });
   it.skip("default in local time", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: DB column defaults + with_env_tz — reads Default.new.fixed_time which is a DB-level default ('2004-01-01 00:00:00'); no column-default propagation in our test adapter
   });
   it.skip("default in utc", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: DB column defaults — reads Default.new.fixed_time from a DB-level column default; our test adapter creates columns without defaults
   });
   it.skip("default in utc with time zone", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: DB column defaults — same as "default in utc"; also uses Time.use_zone which doesn't affect DB-default reads
   });
   it.skip("switching default time zone", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: DB column defaults + with_env_tz — toggles default_timezone between :local and :utc while reading Default.new.fixed_time from DB default
   });
   it.skip("mutating time objects", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: DB column defaults + with_env_tz — reads Default.new.fixed_time, calls .utc, confirms original unchanged; requires DB-level column default
   });
   it.skip("connection in local time", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: establish_connection — requires Base.establish_connection with per-connection default_timezone; SchemaAdapter does not support reconnecting with new config
   });
   it.skip("connection in utc time", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: establish_connection — same as "connection in local time"
   });
   it("column name properly quoted", () => {
     class User extends Base {
@@ -2494,15 +2501,13 @@ describe("BasicsTest", () => {
     class Concrete extends AbstractMiddle {}
     expect(Concrete.tableName).toBe("concretes");
   });
-  it.skip("column types on queries on postgresql", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+  it("column types on queries on postgresql", async () => {
+    if (adapterType !== "postgres") return;
+    const result = await (adapter as any).execQuery("SELECT 1 AS test");
+    expect(result.columnTypes["test"]).toBeInstanceOf(IntegerType);
   });
   it.skip("connection_handler can be overridden", () => {
-    // BLOCKED: type — time-zone aware attribute / timezone conversion gap (dominant theme in base.test.ts)
-    // ROOT-CAUSE: type/date-time.ts#castForDatabase or TimeZoneAwareAttribute not applying timezone on read/write; marshal round-trips are serialization gaps
-    // SCOPE: ~50–100 LOC in type/date-time.ts + connection-adapters/abstract/connection-handler.ts; affects ~36 tests in base.test.ts across time-zone, marshal, STI, and connection-handler clusters
+    // BLOCKED: GVL — uses Ruby Thread.new to override connection_handler in a child thread and verify isolation; Node.js has no threads with shared object model
   });
   it.skip("new threads get default the default connection handler", () => {
     // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2502,7 +2502,7 @@ describe("BasicsTest", () => {
   });
   it("column types on queries on postgresql", async () => {
     if (adapterType !== "postgres") return;
-    const result = await adapter.execQuery("SELECT 1 AS test");
+    const result = await (adapter as any).innerAdapter.execQuery("SELECT 1 AS test");
     expect(result.columnTypes["test"]).toBeInstanceOf(IntegerType);
   });
   it.skip("connection_handler can be overridden", () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2502,7 +2502,7 @@ describe("BasicsTest", () => {
   });
   it("column types on queries on postgresql", async () => {
     if (adapterType !== "postgres") return;
-    const result = await (adapter as any).execQuery("SELECT 1 AS test");
+    const result = await adapter.execQuery("SELECT 1 AS test");
     expect(result.columnTypes["test"]).toBeInstanceOf(IntegerType);
   });
   it.skip("connection_handler can be overridden", () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -15,7 +15,7 @@ import {
 import { SubclassNotFound, NameError } from "./errors.js";
 import { quoteSqlValue } from "./base.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, adapterType } from "./test-adapter.js";
 import { registerModel } from "./associations.js";
 import { connectedToStack } from "./core.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -24,7 +24,6 @@ import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport"
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { withTimezoneConfig } from "./test-helper.js";
-import { adapterType } from "./test-adapter.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -24,7 +24,7 @@ import { Visitors } from "@blazetrails/arel";
 import { DatabaseStatements } from "./connection-adapters/abstract/database-statements.js";
 import { include } from "@blazetrails/activesupport";
 import { isWriteQuerySql } from "./connection-adapters/sql-classification.js";
-import { Result } from "./result.js";
+import type { Result } from "./result.js";
 import { _setOnAdapterSetHook } from "./base.js";
 
 // process.env.PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
@@ -566,6 +566,11 @@ class SchemaAdapter implements DatabaseAdapter {
     return this.inner?.pool ?? this.inner;
   }
 
+  /** Expose the underlying adapter for tests that need adapter-specific behavior (e.g. columnTypes). */
+  get innerAdapter(): any {
+    return this.inner;
+  }
+
   /** Expose created tables for test introspection. */
   get tables(): Set<string> {
     return _createdTables;
@@ -651,39 +656,6 @@ class SchemaAdapter implements DatabaseAdapter {
     // Unwrap only top-level parens by tracking nesting depth
     sql = this.unwrapCompoundSelect(sql);
     return sql;
-  }
-
-  // Override execQuery so PG/MySQL's adapter-specific castResult (which populates
-  // columnTypes) is preserved, while keeping the same setup/retry/savepoint recovery
-  // that execute() provides. SQLite falls through to execute() + fromRowHashes.
-  async execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
-    if (!isPg() && !isMysql()) {
-      const rows = await this.execute(sql, binds ?? [], name ?? undefined);
-      return Result.fromRowHashes(rows);
-    }
-    await this.setup();
-    let lastError: unknown;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
-      const sp = useSp ? `_sr_${attempt}` : "";
-      try {
-        if (useSp) await this.inner.createSavepoint(sp);
-        const result = await this.inner.execQuery(sql, name, binds);
-        if (useSp) await this.inner.releaseSavepoint(sp);
-        return result;
-      } catch (e: any) {
-        lastError = e;
-        if (useSp) {
-          try {
-            await this.inner.rollbackToSavepoint(sp);
-            await this.inner.releaseSavepoint(sp);
-          } catch {}
-        }
-        if (await this.handleMissingSchemaError(e, sql)) continue;
-        throw e;
-      }
-    }
-    throw lastError;
   }
 
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -653,6 +653,13 @@ class SchemaAdapter implements DatabaseAdapter {
     return sql;
   }
 
+  // Override execQuery to delegate to the inner adapter so adapter-specific
+  // behavior (e.g. PG's castResult populating columnTypes) is preserved.
+  async execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
+    await this.setup();
+    return this.inner.execQuery(sql, name, binds);
+  }
+
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {
     await this.setup();
     sql = this.fixSqliteCompat(sql);

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -24,7 +24,7 @@ import { Visitors } from "@blazetrails/arel";
 import { DatabaseStatements } from "./connection-adapters/abstract/database-statements.js";
 import { include } from "@blazetrails/activesupport";
 import { isWriteQuerySql } from "./connection-adapters/sql-classification.js";
-import type { Result } from "./result.js";
+import { Result } from "./result.js";
 import { _setOnAdapterSetHook } from "./base.js";
 
 // process.env.PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
@@ -653,11 +653,17 @@ class SchemaAdapter implements DatabaseAdapter {
     return sql;
   }
 
-  // Override execQuery to delegate to the inner adapter so adapter-specific
-  // behavior (e.g. PG's castResult populating columnTypes) is preserved.
+  // Override execQuery so PG/MySQL's adapter-specific castResult (which populates
+  // columnTypes) is preserved. SQLite falls through to the default DatabaseStatements
+  // execQuery path (via execute()) to keep fixSqliteCompat + retry logic intact.
   async execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
-    await this.setup();
-    return this.inner.execQuery(sql, name, binds);
+    if (isPg() || isMysql()) {
+      await this.setup();
+      return this.inner.execQuery(sql, name, binds);
+    }
+    // SQLite: use execute() so fixSqliteCompat + missing-schema retry apply.
+    const rows = await this.execute(sql, binds ?? [], name ?? undefined);
+    return Result.fromRowHashes(rows);
   }
 
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -497,6 +497,7 @@ export async function resetTestAdapterState(): Promise<void> {
   try {
     if (_sharedAdapter) {
       await dropAllTables(_sharedAdapter);
+      _sharedAdapter.schemaCache?.clear();
     }
     _createdTables.clear();
     _createdColumns.clear();

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -654,16 +654,36 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   // Override execQuery so PG/MySQL's adapter-specific castResult (which populates
-  // columnTypes) is preserved. SQLite falls through to the default DatabaseStatements
-  // execQuery path (via execute()) to keep fixSqliteCompat + retry logic intact.
+  // columnTypes) is preserved, while keeping the same setup/retry/savepoint recovery
+  // that execute() provides. SQLite falls through to execute() + fromRowHashes.
   async execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
-    if (isPg() || isMysql()) {
-      await this.setup();
-      return this.inner.execQuery(sql, name, binds);
+    if (!isPg() && !isMysql()) {
+      const rows = await this.execute(sql, binds ?? [], name ?? undefined);
+      return Result.fromRowHashes(rows);
     }
-    // SQLite: use execute() so fixSqliteCompat + missing-schema retry apply.
-    const rows = await this.execute(sql, binds ?? [], name ?? undefined);
-    return Result.fromRowHashes(rows);
+    await this.setup();
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
+      const sp = useSp ? `_sr_${attempt}` : "";
+      try {
+        if (useSp) await this.inner.createSavepoint(sp);
+        const result = await this.inner.execQuery(sql, name, binds);
+        if (useSp) await this.inner.releaseSavepoint(sp);
+        return result;
+      } catch (e: any) {
+        lastError = e;
+        if (useSp) {
+          try {
+            await this.inner.rollbackToSavepoint(sp);
+            await this.inner.releaseSavepoint(sp);
+          } catch {}
+        }
+        if (await this.handleMissingSchemaError(e, sql)) continue;
+        throw e;
+      }
+    }
+    throw lastError;
   }
 
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -1,8 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { withTimezoneConfig } from "./test-helper.js";
 import { getDefaultTimezone } from "./type/internal/timezone.js";
+import {
+  getZone,
+  setZone,
+  setZoneDefault,
+  isZoneExplicit,
+  resetZone,
+  TimeZone,
+} from "@blazetrails/activesupport";
 
 describe("withTimezoneConfig", () => {
+  afterEach(() => {
+    resetZone();
+    setZoneDefault(null);
+  });
+
   it("temporarily changes defaultTimezone and restores it", async () => {
     const before = getDefaultTimezone();
     const captured: Array<"utc" | "local"> = [];
@@ -11,6 +24,36 @@ describe("withTimezoneConfig", () => {
     });
     expect(captured[0]).toBe("local");
     expect(getDefaultTimezone()).toBe(before);
+  });
+
+  it("restores zone to unset state when zone was not explicitly set before", async () => {
+    // zone_default is set but _zone is not explicitly set (falls through to default)
+    const paris = TimeZone.find("Europe/Paris");
+    setZoneDefault(paris);
+    resetZone(); // ensure _zone is unset (not explicit)
+    expect(isZoneExplicit()).toBe(false);
+    expect(getZone()).toBe(paris); // reads zone_default
+
+    await withTimezoneConfig({ zone: "UTC" }, () => {
+      expect(getZone()?.name).toBe("UTC");
+    });
+
+    // After the block: zone must be unset (not explicit), still falls through to zone_default
+    expect(isZoneExplicit()).toBe(false);
+    expect(getZone()).toBe(paris);
+  });
+
+  it("restores zone to explicit value when zone was explicitly set before", async () => {
+    const paris = TimeZone.find("Europe/Paris");
+    setZone(paris);
+    expect(isZoneExplicit()).toBe(true);
+
+    await withTimezoneConfig({ zone: "UTC" }, () => {
+      expect(getZone()?.name).toBe("UTC");
+    });
+
+    expect(isZoneExplicit()).toBe(true);
+    expect(getZone()).toBe(paris);
   });
 
   it("restores defaultTimezone even if fn throws", async () => {

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -5,7 +5,7 @@
  */
 import { getDefaultTimezone, setDefaultTimezone } from "./type/internal/timezone.js";
 import { Base } from "./base.js";
-import { getZone, setZone, resetZone } from "@blazetrails/activesupport";
+import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
 
 interface TimezoneConfig {
   /** Mirrors Rails' `default_timezone` — "utc" or "local". */
@@ -36,6 +36,7 @@ export async function withTimezoneConfig(
   const oldAwareAttributes = base.timeZoneAwareAttributes;
   const hadAwareTypes = "timeZoneAwareTypes" in base;
   const oldAwareTypes = base.timeZoneAwareTypes;
+  const wasZoneExplicit = isZoneExplicit();
   const oldZone = getZone();
 
   try {
@@ -59,12 +60,12 @@ export async function withTimezoneConfig(
     } else {
       delete base.timeZoneAwareTypes;
     }
-    if (oldZone !== getZone()) {
-      if (oldZone) {
-        setZone(oldZone);
-      } else {
-        resetZone();
-      }
+    if (!wasZoneExplicit) {
+      resetZone();
+    } else if (oldZone) {
+      setZone(oldZone);
+    } else {
+      resetZone();
     }
   }
 }

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -314,6 +314,7 @@ export {
   getZone,
   setZone,
   resetZone,
+  isZoneExplicit,
   getZoneDefault,
   setZoneDefault,
   useZone,

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -55,6 +55,13 @@ export function resetZone(): void {
 }
 
 /**
+ * Returns true if Time.zone was explicitly set (not falling through to zone_default).
+ */
+export function isZoneExplicit(): boolean {
+  return _zone !== undefined;
+}
+
+/**
  * Get/set the zone_default (used when Time.zone is not explicitly set).
  */
 export function getZoneDefault(): TimeZone | null {


### PR DESCRIPTION
## Summary

- **3 base.test.ts TZ tests unskipped** (`time zone aware attribute with default timezone utc on utc can be created`, `utc as time zone and new`, `column types on queries on postgresql`) — 17 remaining stubs get sharpened BLOCKED messages with actual root causes (fixtures, with_env_tz, DB column defaults, establish_connection, GVL)
- **`isZoneExplicit()` added to activesupport** + `withTimezoneConfig` zone-restore fix — when zone was unset before the block, restoring via `setZone(zone_default)` wrongly left it explicitly set; now uses `resetZone()` via the new `isZoneExplicit()` flag
- **`ZonedDateTime cast()` unit test** added to `TimeZoneConverter` test suite
- **`DateTimeType` numeric-keyed hash support** — mirrors `TimeType`; `{ 4 => 10, 5 => 30 }` form-helper path now works for datetime columns
- **`resetTestAdapterState()` clears schema cache** — cross-test schema cache isolation: inner adapter's `schemaCache.clear()` called alongside table drops

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/base.test.ts` — 287 passing, 31 skipped (was 284/34)
- [ ] `pnpm vitest run packages/activerecord/src/attribute-methods/time-zone-converter.test.ts` — 12 passing
- [ ] `pnpm vitest run packages/activerecord/src/test-helper.test.ts` — passes