### PR TITLE
fix(activerecord): attributeWas auto-timestamp baseline + datetime isChanged (~74 LOC)

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -146,3 +146,70 @@ describe("DateTimeTest", () => {
     expect(zdt.minute).toBe(0);
   });
 });
+
+describe("DateTimeType#isChanged", () => {
+  // 1_000_000n ns = exactly 1ms from epoch — a clean boundary for all precision tests.
+  const MS1 = 1_000_000n;
+
+  it("two identical Temporal.Instant references are unchanged", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    expect(t.isChanged(a, a)).toBe(false);
+  });
+
+  it("two distinct Temporal.Instant objects with same epoch are unchanged (precision=null)", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1);
+    expect(t.isChanged(a, b)).toBe(false);
+  });
+
+  it("instants differing only in sub-microsecond nanoseconds are unchanged (precision=null defaults 6)", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1); // 1_000_000ns = 1000μs exactly
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 999n); // 1000μs + 999ns (same μs bucket)
+    expect(t.isChanged(a, b)).toBe(false);
+  });
+
+  it("instants differing by one full microsecond are changed (precision=null)", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1000n); // next μs bucket
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("instants differing only in sub-millisecond are unchanged (precision=3)", () => {
+    const t = new Types.DateTimeType({ precision: 3 });
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1); // exactly 1ms
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 999_000n); // 1ms + 999μs (same ms bucket)
+    expect(t.isChanged(a, b)).toBe(false);
+  });
+
+  it("instants differing by one full millisecond are changed (precision=3)", () => {
+    const t = new Types.DateTimeType({ precision: 3 });
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n); // next ms bucket
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("instants differing only in sub-second are unchanged (precision=0)", () => {
+    const t = new Types.DateTimeType({ precision: 0 });
+    // Use 1s boundary + 999ms — both in the same second bucket
+    const a = Temporal.Instant.fromEpochNanoseconds(1_000_000_000n);
+    const b = Temporal.Instant.fromEpochNanoseconds(1_000_000_000n + 999_999_999n);
+    expect(t.isChanged(a, b)).toBe(false);
+  });
+
+  it("instants differing by one full nanosecond are changed (precision=9)", () => {
+    const t = new Types.DateTimeType({ precision: 9 });
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1n);
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("non-Instant values fall back to reference equality", () => {
+    const t = new Types.DateTimeType();
+    expect(t.isChanged(null, null)).toBe(false);
+    expect(t.isChanged(null, "2024-01-01")).toBe(true);
+  });
+});

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -87,8 +87,8 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   // sub-precision nanosecond noise from Temporal.Now (when precision=null) doesn't
   // produce spurious dirty marks after serialize → cast round-trips.
   private _nsAtPrecision(ns: bigint): bigint {
-    const p = this.precision ?? 6;
-    if (!Number.isInteger(p) || p < 0 || p > 9) return ns;
+    const raw = this.precision ?? 6;
+    const p = Number.isInteger(raw) && raw >= 0 && raw <= 9 ? raw : 6;
     const mod = 10n ** BigInt(9 - p);
     let subsec = ns % 1_000_000_000n;
     if (subsec < 0n) subsec += 1_000_000_000n;

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -75,7 +75,9 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     if (oldValue instanceof Temporal.Instant && newValue instanceof Temporal.Instant) {
       // Compare at microsecond precision — serialization truncates to 6 decimal places.
-      return oldValue.epochNanoseconds / 1000n !== newValue.epochNanoseconds / 1000n;
+      // Use roundingMode:"trunc" to match Temporal.toString() truncation semantics.
+      const opts = { smallestUnit: "microsecond" as const, roundingMode: "trunc" as const };
+      return oldValue.round(opts).epochNanoseconds !== newValue.round(opts).epochNanoseconds;
     }
     return oldValue !== newValue;
   }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -72,6 +72,14 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     }
   }
 
+  override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
+    if (oldValue instanceof Temporal.Instant && newValue instanceof Temporal.Instant) {
+      // Compare at microsecond precision — serialization truncates to 6 decimal places.
+      return oldValue.epochNanoseconds / 1000n !== newValue.epochNanoseconds / 1000n;
+    }
+    return oldValue !== newValue;
+  }
+
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
     // Sentinels are Postgres-specific; base type returns null. The Postgres

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -74,12 +74,26 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     if (oldValue instanceof Temporal.Instant && newValue instanceof Temporal.Instant) {
-      // Compare at microsecond precision — serialization truncates to 6 decimal places.
-      // Use roundingMode:"trunc" to match Temporal.toString() truncation semantics.
-      const opts = { smallestUnit: "microsecond" as const, roundingMode: "trunc" as const };
-      return oldValue.round(opts).epochNanoseconds !== newValue.round(opts).epochNanoseconds;
+      return (
+        this._nsAtPrecision(oldValue.epochNanoseconds) !==
+        this._nsAtPrecision(newValue.epochNanoseconds)
+      );
     }
     return oldValue !== newValue;
+  }
+
+  // Truncate epoch nanoseconds to column precision, matching _applySecondsPrecision /
+  // Temporal.toString() floor-style sub-second truncation. Used by isChanged so that
+  // sub-precision nanosecond noise from Temporal.Now (when precision=null) doesn't
+  // produce spurious dirty marks after serialize → cast round-trips.
+  private _nsAtPrecision(ns: bigint): bigint {
+    const p = this.precision ?? 6;
+    if (!Number.isInteger(p) || p < 0 || p > 9) return ns;
+    const mod = 10n ** BigInt(9 - p);
+    let subsec = ns % 1_000_000_000n;
+    if (subsec < 0n) subsec += 1_000_000_000n;
+    const roundedOff = subsec % mod;
+    return ns - roundedOff;
   }
 
   serialize(value: unknown): string | null {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -4,7 +4,9 @@
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversionTest
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { typeRegistry } from "@blazetrails/activemodel";
+import { typeRegistry, Types } from "@blazetrails/activemodel";
+import { TimeWithZone, TimeZone } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import { loadSchemaFromAdapter } from "../model-schema.js";
@@ -111,5 +113,53 @@ describe("TimeZoneConversionTest", () => {
     await loadSchemaFromAdapter.call(Post);
     expect(Post._attributeDefinitions.get("published_at")?.type).toBeInstanceOf(TimeZoneConverter);
     expect(Post._attributeDefinitions.get("title")?.type).not.toBeInstanceOf(TimeZoneConverter);
+  });
+});
+
+describe("TimeZoneConverter#isChanged", () => {
+  const zone = new TimeZone("Europe/Paris");
+  const MS1 = 1_000_000n; // exactly 1ms from epoch — clean boundary for all precision tests
+
+  function converter(precision?: number) {
+    return TimeZoneConverter.wrap(
+      new Types.DateTimeType(precision !== undefined ? { precision } : {}),
+    );
+  }
+  function twz(ns: bigint) {
+    return new TimeWithZone(Temporal.Instant.fromEpochNanoseconds(ns), zone);
+  }
+
+  it("two distinct TimeWithZone wrapping the same instant are unchanged (DB round-trip)", () => {
+    expect(converter().isChanged(twz(MS1), twz(MS1))).toBe(false);
+  });
+
+  it("TimeWithZone objects differing only in sub-microsecond are unchanged (precision=null defaults 6)", () => {
+    expect(converter().isChanged(twz(MS1), twz(MS1 + 999n))).toBe(false);
+  });
+
+  it("TimeWithZone objects differing by one microsecond are changed (precision=null)", () => {
+    expect(converter().isChanged(twz(MS1), twz(MS1 + 1000n))).toBe(true);
+  });
+
+  it("TimeWithZone objects differing only in sub-millisecond are unchanged (precision=3)", () => {
+    expect(converter(3).isChanged(twz(MS1), twz(MS1 + 999_000n))).toBe(false);
+  });
+
+  it("TimeWithZone objects differing by one millisecond are changed (precision=3)", () => {
+    expect(converter(3).isChanged(twz(MS1), twz(MS1 + 1_000_000n))).toBe(true);
+  });
+
+  it("Temporal.Instant values with same epoch are unchanged", () => {
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1);
+    expect(converter().isChanged(a, b)).toBe(false);
+  });
+
+  it("null vs null is unchanged", () => {
+    expect(converter().isChanged(null, null)).toBe(false);
+  });
+
+  it("null vs TimeWithZone is changed", () => {
+    expect(converter().isChanged(null, twz(MS1))).toBe(true);
   });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -130,7 +130,9 @@ export class TimeZoneConverter extends ValueType<unknown> {
           : null;
     if (oldInstant !== null && newInstant !== null) {
       // Compare at microsecond precision — serialization truncates to 6 decimal places.
-      return oldInstant.epochNanoseconds / 1000n !== newInstant.epochNanoseconds / 1000n;
+      // Use roundingMode:"trunc" to match Temporal.toString() truncation semantics.
+      const opts = { smallestUnit: "microsecond" as const, roundingMode: "trunc" as const };
+      return oldInstant.round(opts).epochNanoseconds !== newInstant.round(opts).epochNanoseconds;
     }
     return oldValue !== newValue;
   }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -140,8 +140,8 @@ export class TimeZoneConverter extends ValueType<unknown> {
   // Same floor-style truncation as DateTimeType._nsAtPrecision / _applySecondsPrecision.
   // Uses the wrapped subtype's precision so behavior matches the column's serialize output.
   private _nsAtPrecision(ns: bigint): bigint {
-    const p = this._subtype.precision ?? 6;
-    if (!Number.isInteger(p) || p < 0 || p > 9) return ns;
+    const raw = this._subtype.precision ?? 6;
+    const p = Number.isInteger(raw) && raw >= 0 && raw <= 9 ? raw : 6;
     const mod = 10n ** BigInt(9 - p);
     let subsec = ns % 1_000_000_000n;
     if (subsec < 0n) subsec += 1_000_000_000n;

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -19,8 +19,8 @@ export interface TimeZoneConversion {
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
  * Rails uses `DelegateClass(Type::Value)` to auto-delegate all methods; we extend
  * ValueType and explicitly delegate type/cast/deserialize/serialize/serializeCastValue
- * to the wrapped subtype. Other Type methods (isChanged, isSerializable, etc.) fall
- * back to ValueType defaults, matching the base type's behavior for time values.
+ * to the wrapped subtype. `isChanged` is also overridden to compare instants by value
+ * at the subtype's column precision (matching Rails' `TimeWithZone#==` semantics).
  */
 export class TimeZoneConverter extends ValueType<unknown> {
   private readonly _subtype: Type;
@@ -129,12 +129,24 @@ export class TimeZoneConverter extends ValueType<unknown> {
           ? newValue
           : null;
     if (oldInstant !== null && newInstant !== null) {
-      // Compare at microsecond precision — serialization truncates to 6 decimal places.
-      // Use roundingMode:"trunc" to match Temporal.toString() truncation semantics.
-      const opts = { smallestUnit: "microsecond" as const, roundingMode: "trunc" as const };
-      return oldInstant.round(opts).epochNanoseconds !== newInstant.round(opts).epochNanoseconds;
+      return (
+        this._nsAtPrecision(oldInstant.epochNanoseconds) !==
+        this._nsAtPrecision(newInstant.epochNanoseconds)
+      );
     }
     return oldValue !== newValue;
+  }
+
+  // Same floor-style truncation as DateTimeType._nsAtPrecision / _applySecondsPrecision.
+  // Uses the wrapped subtype's precision so behavior matches the column's serialize output.
+  private _nsAtPrecision(ns: bigint): bigint {
+    const p = this._subtype.precision ?? 6;
+    if (!Number.isInteger(p) || p < 0 || p > 9) return ns;
+    const mod = 10n ** BigInt(9 - p);
+    let subsec = ns % 1_000_000_000n;
+    if (subsec < 0n) subsec += 1_000_000_000n;
+    const roundedOff = subsec % mod;
+    return ns - roundedOff;
   }
 
   override equals(other: Type): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -115,6 +115,26 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return this._subtype.serialize(resolved);
   }
 
+  override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
+    const oldInstant =
+      oldValue instanceof TimeWithZone
+        ? oldValue.utc()
+        : oldValue instanceof Temporal.Instant
+          ? oldValue
+          : null;
+    const newInstant =
+      newValue instanceof TimeWithZone
+        ? newValue.utc()
+        : newValue instanceof Temporal.Instant
+          ? newValue
+          : null;
+    if (oldInstant !== null && newInstant !== null) {
+      // Compare at microsecond precision — serialization truncates to 6 decimal places.
+      return oldInstant.epochNanoseconds / 1000n !== newInstant.epochNanoseconds / 1000n;
+    }
+    return oldValue !== newValue;
+  }
+
   override equals(other: Type): boolean {
     if (!(other instanceof TimeZoneConverter)) return false;
     const sub = this._subtype as ValueTypeInstance;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2460,17 +2460,10 @@ export class Base extends Model {
     // Auto-populate timestamps (unless touch: false)
     if (!this._skipTouch) {
       const now = Temporal.Now.instant();
-      if (
-        ctor._attributeDefinitions.has("created_at") &&
-        this._readAttribute("created_at") === null
-      ) {
-        this._attributes.set("created_at", now);
-      }
-      if (
-        ctor._attributeDefinitions.has("updated_at") &&
-        this._readAttribute("updated_at") === null
-      ) {
-        this._attributes.set("updated_at", now);
+      for (const col of Timestamp.allTimestampAttributesInModel.call(ctor)) {
+        if (ctor._attributeDefinitions.has(col) && this._readAttribute(col) == null) {
+          this._writeAttribute(col, now);
+        }
       }
     }
 

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -471,7 +471,12 @@ describe("DirtyTest", () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       posts: { title: "string" },
-      pirates: { catchphrase: "string", created_on: "datetime", parrot_id: "integer" },
+      pirates: {
+        catchphrase: "string",
+        created_at: "datetime",
+        created_on: "datetime",
+        parrot_id: "integer",
+      },
     });
   });
 
@@ -494,7 +499,6 @@ describe("DirtyTest", () => {
       expect(pirate.attributeChanged("created_on")).toBe(false);
       expect(pirate.attributeChange("created_on")).toBeNull();
 
-      pirate.created_on = new TimeWithZone(Temporal.Now.instant().subtract({ hours: 48 }), zone);
       pirate.catchphrase = "arrrr, time zone!!";
       await pirate.saveBang();
       expect(pirate.attributeChanged("created_on")).toBe(false);
@@ -508,6 +512,29 @@ describe("DirtyTest", () => {
       );
       await pirate.reload();
       expect(pirate.attributeChanged("created_on")).toBe(false);
+    });
+  });
+  it("attributeWas reflects auto-timestamp baseline after create", async () => {
+    await withTimezoneConfig({ zone: "Europe/Paris", awareAttributes: true }, async () => {
+      class Pirate extends Base {
+        static {
+          this.tableName = "pirates";
+          this.attribute("created_at", "datetime");
+          this.attribute("catchphrase", "string");
+          this.adapter = adapter;
+        }
+      }
+      const zone = getZone()!;
+      const pirate = await Pirate.create({ catchphrase: "yo ho" });
+      expect(pirate.attributeChanged("created_at")).toBe(false);
+      expect(pirate.created_at).toBeInstanceOf(TimeWithZone);
+      const autoSetCreatedAt = pirate.created_at as TimeWithZone;
+      pirate.created_at = new TimeWithZone(Temporal.Now.instant().subtract({ hours: 1 }), zone);
+      expect(pirate.attributeChanged("created_at")).toBe(true);
+      expect(pirate.attributeWas("created_at")).toBeInstanceOf(TimeWithZone);
+      expect((pirate.attributeWas("created_at") as TimeWithZone).utc().epochMilliseconds).toBe(
+        autoSetCreatedAt.utc().epochMilliseconds,
+      );
     });
   });
   it("setting time attributes with time zone field to itself should not be marked as a change", async () => {


### PR DESCRIPTION
## Summary

- **`_performInsert()` in base.ts**: replaced the hardcoded `created_at`/`updated_at` block using `_attributes.set()` with a loop over `allTimestampAttributesInModel` using `_writeAttribute()`. `_attributes.set()` creates a `WithCastValue` whose `typeCast` is identity, so `changesApplied()` snapshotted a raw `Temporal.Instant` instead of the TZ-converted `TimeWithZone`. Using `_writeAttribute` runs through the type system (cast + dirty tracking), so the snapshot stores the correctly-typed value. Also covers `created_on`/`updated_on` which were silently skipped before.
- **`TimeZoneConverter.isChanged`**: add value comparison at microsecond precision. Two `TimeWithZone` objects representing the same instant are different JS references, so `!==` always returned true after any DB round-trip. Serialization uses 6 decimal places so we compare at microsecond granularity.
- **`DateTimeType.isChanged`**: same microsecond-precision fix for the non-TZ path (`Temporal.Instant` comparisons).

Removes the explicit `pirate.created_on = ...` workaround from #1384; `created_on` is now auto-set and correctly snapshotted. Adds a regression test for `created_at` auto-timestamp → `attributeWas` roundtrip.

## Dead-code confirmation: `callbacks.ts:_createRecord`

`callbacks.ts:_createRecord` is wired to `Base.prototype._createRecord` (base.ts:3320) but is **never called** from the main save path. The path is:

```
save() → createOrUpdate() [callbacks.ts, just delegates]
  → this._createOrUpdate() [base.ts private, line 2384]
    → _callbackChain.runCallbacks("create", this, callback)
      → callback: this._performInsert() [base.ts private, line 2447]
```

`this._createRecord()` is never invoked in this chain. Its callers are associations (which have their own `_createRecord` override) and `encryptable-record.ts`. No double-write risk.

## Pre-existing follow-up (not introduced here)

`_performInsert()` gates on `!_skipTouch`; Rails gates on `record_timestamps`. These are orthogonal. The correct fix (add `recordTimestamps !== false` check) is out of scope for this PR.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/dirty.test.ts` — 89 tests pass (new regression test + removed workaround)
- [x] `pnpm vitest run packages/activemodel/src/dirty.test.ts` — 74 tests pass
- [x] `pnpm vitest run --project activerecord` — 10804 passed, no regressions
- [x] `pnpm api:compare --package activerecord` — 4955/4958 (no regression)
- [x] LOC: 74 (under 300)