### PR TITLE
fix(activerecord): align test:compare exclusions with api:compare for load-async cluster

### DIFF
--- a/packages/activerecord/src/asynchronous-queries.test.ts
+++ b/packages/activerecord/src/asynchronous-queries.test.ts
@@ -1,47 +1,47 @@
 import { describe, it } from "vitest";
 
 // The entire Rails test file (asynchronous_queries_test.rb) is permanently
-// excluded — see scripts/api-compare/excluded-files.ts, entry for
-// "asynchronous_queries_tracker.rb". Per-thread async session barriers
+// excluded — see scripts/api-compare/excluded-files.ts, testFile entry for
+// "asynchronous_queries_test.rb". Per-thread async session barriers
 // (Concurrent::AtomicBoolean, ReadWriteLock) have no JS equivalent.
 // These stubs are kept as visible placeholders for the excluded test classes.
 
 describe("AsynchronousQueriesTest", () => {
   it.skip("async select all", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
 });
 
 describe("AsynchronousExecutorTypeTest", () => {
   it.skip("null configuration uses a single null executor by default", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
   it.skip("one global thread pool is used when set with default concurrency", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
   it.skip("concurrency can be set on global thread pool", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
   it.skip("concurrency cannot be set with null executor or multi thread pool", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
   it.skip("multi thread pool executor configuration", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
   it.skip("multi thread pool is used only by configurations that enable it", () => {
-    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
   });
 });
 
 it.skip("async select failure", () => {
-  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
 });
 it.skip("async query from transaction", () => {
-  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
 });
 it.skip("async query cache", () => {
-  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
 });
 it.skip("async query foreground fallback", () => {
-  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_test.rb
 });

--- a/packages/activerecord/src/asynchronous-queries.test.ts
+++ b/packages/activerecord/src/asynchronous-queries.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "vitest";
 // excluded — see scripts/api-compare/excluded-files.ts, entry for
 // "asynchronous_queries_tracker.rb". Per-thread async session barriers
 // (Concurrent::AtomicBoolean, ReadWriteLock) have no JS equivalent.
-// These stubs exist only so test:compare doesn't flag the TS file as empty.
+// These stubs are kept as visible placeholders for the excluded test classes.
 
 describe("AsynchronousQueriesTest", () => {
   it.skip("async select all", () => {

--- a/packages/activerecord/src/asynchronous-queries.test.ts
+++ b/packages/activerecord/src/asynchronous-queries.test.ts
@@ -1,63 +1,47 @@
 import { describe, it } from "vitest";
 
+// The entire Rails test file (asynchronous_queries_test.rb) is permanently
+// excluded — see scripts/api-compare/excluded-files.ts, entry for
+// "asynchronous_queries_tracker.rb". Per-thread async session barriers
+// (Concurrent::AtomicBoolean, ReadWriteLock) have no JS equivalent.
+// These stubs exist only so test:compare doesn't flag the TS file as empty.
+
 describe("AsynchronousQueriesTest", () => {
   it.skip("async select all", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
 });
 
 describe("AsynchronousExecutorTypeTest", () => {
   it.skip("null configuration uses a single null executor by default", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
   it.skip("one global thread pool is used when set with default concurrency", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
   it.skip("concurrency can be set on global thread pool", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
   it.skip("concurrency cannot be set with null executor or multi thread pool", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
   it.skip("multi thread pool executor configuration", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
   it.skip("multi thread pool is used only by configurations that enable it", () => {
-    // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-    // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-    // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+    // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
   });
 });
 
 it.skip("async select failure", () => {
-  // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-  // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-  // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
 });
 it.skip("async query from transaction", () => {
-  // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-  // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-  // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
 });
 it.skip("async query cache", () => {
-  // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-  // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-  // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
 });
 it.skip("async query foreground fallback", () => {
-  // BLOCKED: load-async — FutureResult / async query infrastructure not implemented
-  // ROOT-CAUSE: future-result.ts#FutureResult not implemented; Relation#loadAsync missing
-  // SCOPE: ~150 LOC in future-result.ts + relation.ts; affects ~31 tests in load-async.test.ts
+  // PERMANENT: ruby-only — see scripts/api-compare/excluded-files.ts for asynchronous_queries_tracker.rb
 });

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -276,6 +276,23 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
       "Tests Marshal/YAML binary encoding of AR records. " +
       "Ruby binary serialization formats have no Node.js equivalent.",
   },
+  // --- Permanently not-portable: load_async thread-pool / GVL tests ---
+  {
+    testFile: "relation/load_async_test.rb",
+    tests: [
+      // LoadAsyncTest — uses Concurrent::CountDownLatch + GVL thread interleaving
+      "load async instrumentation is thread safe",
+      // LoadAsyncMultiThreadPoolExecutorTest — Concurrent::ThreadPoolExecutor
+      // min_length/max_length/max_queue/fallback_policy config; unique name in file
+      "async query executor and configuration",
+    ],
+    reason:
+      "Ruby Concurrent::ThreadPoolExecutor / Concurrent::CountDownLatch / GVL semantics. " +
+      "JS is single-threaded — thread-pool configuration and GVL race tests have no equivalent. " +
+      "Note: LoadAsyncMultiThreadPoolExecutorTest and LoadAsyncMixedThreadPoolExecutorTest share " +
+      "test names with the implementable LoadAsyncTest/NullExecutorTest classes; those duplicates " +
+      "cannot be excluded here without dropping the implementable counterparts.",
+  },
 ];
 
 export function isExcluded(file: string): boolean {

--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -1105,8 +1105,8 @@ function annotateFile(src: string, relPath: string): string | null {
 
     const body = result.slice(adjMatchEnd, closePos);
 
-    // Skip if already annotated
-    if (/BLOCKED:/.test(body)) continue;
+    // Skip if already annotated (BLOCKED: for temp gaps, PERMANENT: for ruby-only exclusions)
+    if (/BLOCKED:|PERMANENT:/.test(body)) continue;
 
     // Determine indentation of the skip call line
     const lineStart = result.lastIndexOf("\n", adjIndex) + 1;


### PR DESCRIPTION
## Summary

- **Item 1:** Replace `BLOCKED:` annotations in `asynchronous-queries.test.ts` with `PERMANENT:` — the entire `asynchronous_queries_test.rb` is already excluded via `excluded-files.ts` (per-thread session barriers), so these stubs were dead bookkeeping.
- **Item 2:** Add two per-test exclusions for uniquely-named GVL/thread-pool tests in `relation/load_async_test.rb`:
  - `load async instrumentation is thread safe` — uses `Concurrent::CountDownLatch` + GVL thread interleaving
  - `async query executor and configuration` — `Concurrent::ThreadPoolExecutor` min/max config, unique to `LoadAsyncMultiThreadPoolExecutorTest`

## Limitation noted

`LoadAsyncMultiThreadPoolExecutorTest` and `LoadAsyncMixedThreadPoolExecutorTest` share test names (e.g. `scheduled?`, `simple query`) with the implementable `LoadAsyncTest`/`NullExecutorTest` classes. The per-test exclusion infra has no class-scoped support, so those duplicate occurrences (12 total) still inflate the `missing` count in test:compare. This is documented in the exclusion entry's `reason` field.

## Test plan

- [ ] `pnpm api:compare --package activerecord` — no regression
- [ ] `pnpm test:compare --package activerecord` — `relation/load_async_test.rb` denominator drops by 2