### PR TITLE
chore(activerecord): normalize dead BLOCKED annotations on excluded test files

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/dbconsole.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/dbconsole.test.ts
@@ -2,23 +2,15 @@ import { describe, it } from "vitest";
 
 describe("Mysql2DbConsoleTest", () => {
   it.skip("mysql", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("mysql full", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("mysql include password", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("mysql can use alternative cli", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
 });

--- a/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
@@ -2,154 +2,102 @@ import { describe, it } from "vitest";
 
 describe("MysqlDBCreateTest", () => {
   it.skip("establishes connection without database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with no default options", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with given encoding", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with given collation", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when database created successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("create when database exists outputs info to stderr", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MysqlDBCreateWithInvalidPermissionsTest", () => {
   it.skip("raises error", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MySQLDBDropTest", () => {
   it.skip("establishes connection to mysql database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("drops database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when database dropped successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MySQLPurgeTest", () => {
   it.skip("establishes connection without database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("recreates database with no default options", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("recreates database with the given options", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MysqlDBCharsetTest", () => {
   it.skip("db retrieves charset", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MysqlDBCollationTest", () => {
   it.skip("db retrieves collation", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MySQLStructureDumpTest", () => {
   it.skip("structure dump", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with extra flags", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with hash extra flags for a different driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with hash extra flags for the correct driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with ignore tables", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("warn when external structure dump command execution fails", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with port number", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with ssl", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("MySQLStructureLoadTest", () => {
   it.skip("structure load", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with hash extra flags for a different driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with hash extra flags for the correct driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: mysql2-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/dbconsole.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/dbconsole.test.ts
@@ -2,33 +2,21 @@ import { describe, it } from "vitest";
 
 describe("PostgresqlDbConsoleTest", () => {
   it.skip("postgresql", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("postgresql full", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("postgresql with ssl", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("postgresql include password", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("postgresql include variables", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("postgresql can use alternative cli", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
@@ -2,206 +2,132 @@ import { describe, it } from "vitest";
 
 describe("PostgreSQLDBCreateTest", () => {
   it.skip("establishes connection to postgresql database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with default encoding", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with given encoding", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database with given collation and ctype", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("establishes connection to new database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("db create with error prints message", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when database created successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("create when database exists outputs info to stderr", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLDBDropTest", () => {
   it.skip("establishes connection to postgresql database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("drops database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when database dropped successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLPurgeTest", () => {
   it.skip("clears active connections", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("establishes connection to postgresql database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("drops database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("creates database", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("establishes connection", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLDBCharsetTest", () => {
   it.skip("db retrieves charset", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLDBCollationTest", () => {
   it.skip("db retrieves collation", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLStructureDumpTest", () => {
   it.skip("structure dump", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump header comments removed", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with env", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with ssl env", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with extra flags", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with hash extra flags for a different driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with hash extra flags for the correct driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with ignore tables", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with schema search path", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with schema search path and dump schemas all", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with dump schemas string", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump execution fails", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("PostgreSQLStructureLoadTest", () => {
   it.skip("structure load", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with extra flags", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with env", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with ssl env", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with hash extra flags for a different driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load with hash extra flags for the correct driver", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure load accepts path with spaces", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: postgresql-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/dbconsole.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/dbconsole.test.ts
@@ -2,33 +2,21 @@ import { describe, it } from "vitest";
 
 describe("SQLite3DbConsoleTest", () => {
   it.skip("sqlite3", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("sqlite3 mode", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("sqlite3 header", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("sqlite3 db absolute path", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("sqlite3 db with defined rails root", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
   it.skip("sqlite3 can use alternative cli", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#dbconsole not translatable to Node.js (shell-out)
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — dbconsole
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
@@ -2,103 +2,69 @@ import { describe, it } from "vitest";
 
 describe("SqliteDBCreateTest", () => {
   it.skip("db checks database exists", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when db created successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("db create when file exists", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("db create with file does nothing", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("db create establishes a connection", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("db create with error prints message", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("SqliteDBDropTest", () => {
   it.skip("checks db dir is absolute", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("removes file with absolute path", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("generates absolute path with given root", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("removes file with relative path", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("when db dropped successfully outputs info to stdout", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("SqliteDBCharsetTest", () => {
   it.skip("db retrieves charset", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("SqliteDBCollationTest", () => {
   it.skip("db retrieves collation", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("SqliteStructureDumpTest", () => {
   it.skip("structure dump", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump with ignore tables", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
   it.skip("structure dump execution fails", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });
 
 describe("SqliteStructureLoadTest", () => {
   it.skip("structure load", () => {
-    // BLOCKED: rake — Rake/dbconsole shell-out cannot run in Node.js
-    // ROOT-CAUSE: sqlite-rake.ts#exec not translatable to Node.js
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — rake
   });
 });

--- a/packages/activerecord/src/binary.test.ts
+++ b/packages/activerecord/src/binary.test.ts
@@ -2,18 +2,12 @@ import { describe, it } from "vitest";
 
 describe("BinaryTest", () => {
   it.skip("mixed encoding", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("load save", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("unicode input casting", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
 });

--- a/packages/activerecord/src/coders/yaml-column.test.ts
+++ b/packages/activerecord/src/coders/yaml-column.test.ts
@@ -2,81 +2,51 @@ import { describe, it } from "vitest";
 
 describe("YAMLColumnTest", () => {
   it.skip("initialize takes class", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("type mismatch on different classes on dump", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("type mismatch on different classes", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("nil is ok", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("returns new with different class", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("returns string unless starts with dash", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("load raises on other classes", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("load doesnt swallow yaml exceptions", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("load doesnt handle undefined class or module", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
 });
 
 describe("YAMLColumnTestWithSafeLoad", () => {
   it.skip("yaml column permitted classes are consumed by safe load", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml column permitted classes are consumed by safe dump", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml column permitted classes option", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml column unsafe load option", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml column override unsafe load option", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("load doesnt handle undefined class or module", () => {
-    // BLOCKED: serialization — YAML column coder gap
-    // ROOT-CAUSE: coders/yaml-column.ts#YamlColumn missing or incomplete Rails parity
-    // SCOPE: ~30 LOC fix in coders/yaml-column.ts; affects ~15 tests in yaml-column.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
 });

--- a/packages/activerecord/src/marshal-serialization.test.ts
+++ b/packages/activerecord/src/marshal-serialization.test.ts
@@ -2,33 +2,21 @@ import { describe, it } from "vitest";
 
 describe("MarshalSerializationTest", () => {
   it.skip("deserializing rails 6 1 marshal basic", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("deserializing rails 6 1 marshal with loaded association cache", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("deserializing rails 7 1 marshal basic", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("deserializing rails 7 1 marshal with loaded association cache", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("rails 6 1 rountrip", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("rails 7 1 rountrip", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
 });

--- a/packages/activerecord/src/message-pack.test.ts
+++ b/packages/activerecord/src/message-pack.test.ts
@@ -2,28 +2,18 @@ import { describe, it } from "vitest";
 
 describe("ActiveRecordMessagePackTest", () => {
   it.skip("enshrines type IDs", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — message-pack
   });
   it.skip("roundtrips record and cached associations", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — message-pack
   });
   it.skip("roundtrips new_record? status", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — message-pack
   });
   it.skip("roundtrips binary attribute", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — message-pack
   });
   it.skip("raises ActiveSupport::MessagePack::MissingClassError if record class no longer exists", () => {
-    // BLOCKED: serialization — Ruby Marshal / MessagePack round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load or msgpack Ruby object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — message-pack
   });
 });

--- a/packages/activerecord/src/reload-models.test.ts
+++ b/packages/activerecord/src/reload-models.test.ts
@@ -2,8 +2,6 @@ import { describe, it } from "vitest";
 
 describe("ReloadModelsTest", () => {
   it.skip("has one with reload", () => {
-    // BLOCKED: GVL — class reloading via ActiveSupport::Dependencies / Zeitwerk, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Zeitwerk autoload or ActiveSupport::Dependencies class reload
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — fork
   });
 });

--- a/packages/activerecord/src/schema-loading.test.ts
+++ b/packages/activerecord/src/schema-loading.test.ts
@@ -2,18 +2,12 @@ import { describe, it } from "vitest";
 
 describe("SchemaLoadingTest", () => {
   it.skip("basic model is loaded once", () => {
-    // BLOCKED: GVL — schema loading via ActiveSupport.on_load / Zeitwerk, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Zeitwerk autoload or ActiveSupport::Dependencies; class reloading tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("model with custom lock is loaded once", () => {
-    // BLOCKED: GVL — schema loading via ActiveSupport.on_load / Zeitwerk, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Zeitwerk autoload or ActiveSupport::Dependencies; class reloading tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("model with changed custom lock is loaded twice", () => {
-    // BLOCKED: GVL — schema loading via ActiveSupport.on_load / Zeitwerk, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Zeitwerk autoload or ActiveSupport::Dependencies; class reloading tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
 });

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -2,41 +2,27 @@ import { describe, it } from "vitest";
 
 describe("TransactionIsolationUnsupportedTest", () => {
   it.skip("setting the isolation level raises an error", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
 });
 
 describe("TransactionIsolationTest", () => {
   it.skip("read uncommitted", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("read committed", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("repeatable read", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("serializable", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("setting isolation when joining a transaction raises an error", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("setting isolation when starting a nested transaction raises error", () => {
-    // BLOCKED: GVL — Ruby thread isolation semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
 });

--- a/packages/activerecord/src/yaml-serialization.test.ts
+++ b/packages/activerecord/src/yaml-serialization.test.ts
@@ -2,83 +2,51 @@ import { describe, it } from "vitest";
 
 describe("YamlSerializationTest", () => {
   it.skip("to yaml with time with zone should not raise exception", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("roundtrip serialized column", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("psych roundtrip", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("psych roundtrip new object", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("active record relation serialization", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("raw types are not changed on round trip", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("cast types are not changed on round trip", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("new records remain new after round trip", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("types of virtual columns are not changed on round trip", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("a yaml version is provided for future backwards compat", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("deserializing rails v2 yaml", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("deserializing rails v1 mysql yaml", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("deserializing rails 41 yaml", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("deserializing rails 4 2 0 yaml", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml encoding keeps mutations", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
   it.skip("yaml encoding keeps false values", () => {
-    // BLOCKED: serialization — Ruby encoding / YAML round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Encoding::ASCII_8BIT or Ruby Marshal/YAML object round-trip
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
   });
 });


### PR DESCRIPTION
## Summary

14 test files mirror Rails test files that are permanently excluded in `scripts/api-compare/excluded-files.ts` (marshal, yaml, gvl, fork, rake, dbconsole categories — Ruby-only with no JS equivalent). Their `BLOCKED:` annotations carried false "fixable in N LOC" promises, causing open-work greps and audit scripts to count them as real gaps.

This PR replaces every `BLOCKED:` / `ROOT-CAUSE:` / `SCOPE:` annotation block in those files with a single `PERMANENT-SKIP:` comment:

```
// PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — <category>
```

152 blocks replaced across 14 files. No test bodies, names, or `it.skip` calls changed — annotations only.