### PR TITLE
feat(api-compare): className filter for per-test exclusions; load-async thread-pool classes

### DIFF
--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -26,7 +26,9 @@ export type ExcludedFile = { reason: string } & (
   | { pattern?: string; testFile: string; tests?: never }
   // Per-test exclusion: test-only — never affects api:compare.
   // Only the listed Ruby test descriptions are dropped from test:compare counts.
-  | { pattern?: never; testFile: string; tests: string[] }
+  // `className` narrows the match to a specific Ruby *Test class within the file,
+  // enabling exclusion of GVL-only subclasses that share test names with portable ones.
+  | { pattern?: never; testFile: string; className?: string; tests: string[] }
 );
 
 export const EXCLUDED_FILES: ExcludedFile[] = [
@@ -282,16 +284,33 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
     tests: [
       // LoadAsyncTest — uses Concurrent::CountDownLatch + GVL thread interleaving
       "load async instrumentation is thread safe",
-      // LoadAsyncMultiThreadPoolExecutorTest — Concurrent::ThreadPoolExecutor
-      // min_length/max_length/max_queue/fallback_policy config; unique name in file
-      "async query executor and configuration",
     ],
     reason:
-      "Ruby Concurrent::ThreadPoolExecutor / Concurrent::CountDownLatch / GVL semantics. " +
-      "JS is single-threaded — thread-pool configuration and GVL race tests have no equivalent. " +
-      "Note: LoadAsyncMultiThreadPoolExecutorTest and LoadAsyncMixedThreadPoolExecutorTest share " +
-      "test names with the implementable LoadAsyncTest/NullExecutorTest classes; those duplicates " +
-      "cannot be excluded here without dropping the implementable counterparts.",
+      "Ruby Concurrent::CountDownLatch / GVL thread-interleaving semantics. " +
+      "JS is single-threaded — GVL race tests have no equivalent.",
+  },
+  {
+    testFile: "relation/load_async_test.rb",
+    className: "LoadAsyncMultiThreadPoolExecutorTest",
+    tests: [
+      "async query executor and configuration",
+      "scheduled?",
+      "reset",
+      "simple query",
+      "load async from transaction",
+      "eager loading query",
+      "contradiction",
+      "pluck",
+      "size",
+      "empty?",
+    ],
+    reason: "Concurrent::ThreadPoolExecutor — GVL semantics; no Node.js equivalent.",
+  },
+  {
+    testFile: "relation/load_async_test.rb",
+    className: "LoadAsyncMixedThreadPoolExecutorTest",
+    tests: ["scheduled?", "simple query"],
+    reason: "Concurrent::ThreadPoolExecutor — GVL semantics; no Node.js equivalent.",
   },
 ];
 
@@ -303,8 +322,17 @@ export function isTestExcluded(testFile: string): boolean {
   return EXCLUDED_FILES.some((e) => e.testFile && !e.tests && testFile.includes(e.testFile));
 }
 
-export function isTestCaseExcluded(testFile: string, testName: string): boolean {
+export function isTestCaseExcluded(
+  testFile: string,
+  testName: string,
+  className?: string,
+): boolean {
   return EXCLUDED_FILES.some(
-    (e) => e.testFile && e.tests && testFile.includes(e.testFile) && e.tests.includes(testName),
+    (e) =>
+      e.testFile &&
+      e.tests &&
+      testFile.includes(e.testFile) &&
+      e.tests.includes(testName) &&
+      (e.className === undefined || e.className === className),
   );
 }

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -263,7 +263,7 @@ function main() {
       const seenPaths = new Set<string>();
       const seenDescs = new Set<string>();
       for (const tc of file.testCases) {
-        if (isTestCaseExcluded(file.file, tc.description)) continue;
+        if (isTestCaseExcluded(file.file, tc.description, tc.ancestors[0])) continue;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);
         if (!seenPaths.has(np)) {
@@ -302,7 +302,7 @@ function main() {
       const matchedRuby = new Set<number>();
 
       const excludedCount = file.testCases.filter((tc) =>
-        isTestCaseExcluded(file.file, tc.description),
+        isTestCaseExcluded(file.file, tc.description, tc.ancestors[0]),
       ).length;
 
       let matched = 0;
@@ -316,7 +316,7 @@ function main() {
       // Pass 1: Path matches (exact ancestor + description match)
       for (let ri = 0; ri < file.testCases.length; ri++) {
         const tc = file.testCases[ri];
-        if (isTestCaseExcluded(file.file, tc.description)) continue;
+        if (isTestCaseExcluded(file.file, tc.description, tc.ancestors[0])) continue;
         const np = normPath(tc.ancestors, tc.description);
         const tsIdx = consumeIndex(pathIndex.get(np), consumedTs);
         if (tsIdx >= 0) {
@@ -339,7 +339,7 @@ function main() {
       for (let ri = 0; ri < file.testCases.length; ri++) {
         if (matchedRuby.has(ri)) continue;
         const tc = file.testCases[ri];
-        if (isTestCaseExcluded(file.file, tc.description)) continue;
+        if (isTestCaseExcluded(file.file, tc.description, tc.ancestors[0])) continue;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);
 
@@ -377,7 +377,7 @@ function main() {
       for (let ri = 0; ri < file.testCases.length; ri++) {
         if (matchedRuby.has(ri)) continue;
         const tc = file.testCases[ri];
-        if (isTestCaseExcluded(file.file, tc.description)) continue;
+        if (isTestCaseExcluded(file.file, tc.description, tc.ancestors[0])) continue;
         totalRuby++;
         const np = normPath(tc.ancestors, tc.description);
         const nd = normalize(tc.description);


### PR DESCRIPTION
## Summary

- Extends the `ExcludedFile` per-test variant with an optional `className?: string` field. When set, `isTestCaseExcluded()` only drops a test if its containing Ruby class matches — enabling exclusion of GVL-only test subclasses that share method names with portable ones.
- Updates all five `isTestCaseExcluded()` call sites in `test-compare.ts` to pass `tc.ancestors[0]` (the containing class name, already emitted by `extract-ruby-tests.rb`).
- Adds two class-scoped exclusion entries for `relation/load_async_test.rb`:
  - `LoadAsyncMultiThreadPoolExecutorTest` — 10 tests (Concurrent::ThreadPoolExecutor; GVL)
  - `LoadAsyncMixedThreadPoolExecutorTest` — 2 tests (same reason)

**Denominator impact:** `load_async_test.rb` drops from 36 → 25 (−11 GVL-only tests). The story estimated −12; the actual file has 9 not-yet-excluded tests in `MultiThreadPool` plus 2 in `Mixed` = 11.