### PR TITLE
fix(activerecord): TimeZoneConversion predicate for tsrange/tstzrange (unblocks 6 range tests)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -8,6 +8,7 @@ import { Range } from "../../relation.js";
 import { MultiRange } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { TimeWithZone, TimeZone, setZone, resetZone } from "@blazetrails/activesupport";
 
 const toInt = (s: string) => parseInt(s, 10);
 const toFloat = (s: string) => parseFloat(s);
@@ -16,6 +17,7 @@ const toBigInt = (s: string) => BigInt(s);
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let PostgresqlRanges: any;
+  let PostgresqlRangesTz: any;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
@@ -48,6 +50,20 @@ describeIfPg("PostgreSQLAdapter", () => {
     }
     await PostgresqlRangesCls.loadSchema();
     PostgresqlRanges = PostgresqlRangesCls;
+
+    class PostgresqlRangesTzCls extends Base {
+      static tableName = "postgresql_ranges";
+      static timeZoneAwareAttributes = true;
+      static timeZoneAwareTypes = [...Base.timeZoneAwareTypes, "tsrange", "tstzrange"];
+      static {
+        this.adapter = adapter;
+      }
+    }
+    await PostgresqlRangesTzCls.loadSchema();
+    PostgresqlRangesTz = PostgresqlRangesTzCls;
+  });
+  afterEach(() => {
+    resetZone();
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_ranges`);
@@ -465,26 +481,80 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(infinite.end).toBeNull();
       expect(parseRange("empty", toFloat)).toBeNull();
     });
-    it.skip("timezone awareness tzrange", () => {
-      // BLOCKED: range — TimeZoneConversion not wired and predicate broken for range types
-      // ROOT-CAUSE: (1) time-zone-conversion.ts is never imported/used — not wired into Model;
-      //   (2) isCreateTimeZoneConversionAttribute checks castType.type (a property) but Type exposes
-      //   type() as a method — predicate always returns false even if wired; (3) timeZoneAwareTypes
-      //   defaults to ["datetime","time"] — tsrange/tstzrange would also need to be added
-      // SCOPE: ~100 LOC — wire module into Model + fix castType.type() call + add tsrange/tstzrange; separate story; affects 9 tests
+    it("timezone awareness tzrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ tstz_range: new Range(timeString, timeString, false) });
+      const range1 = r.tstz_range as Range;
+      expect(range1.begin).toBeInstanceOf(TimeWithZone);
+      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.tstz_range as Range;
+      expect(range2.begin).toBeInstanceOf(TimeWithZone);
+      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
     });
-    it.skip("timezone awareness endless tzrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+    it("timezone awareness endless tzrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ tstz_range: new Range(timeString, null, true) });
+      const range1 = r.tstz_range as Range;
+      expect(range1.begin).toBeInstanceOf(TimeWithZone);
+      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect(range1.end).toBeNull();
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.tstz_range as Range;
+      expect(range2.begin).toBeInstanceOf(TimeWithZone);
+      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect(range2.end).toBeNull();
     });
-    it.skip("timezone awareness beginless tzrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+    it("timezone awareness beginless tzrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ tstz_range: new Range(null, timeString, false) });
+      const range1 = r.tstz_range as Range;
+      expect(range1.begin).toBeNull();
+      expect(range1.end).toBeInstanceOf(TimeWithZone);
+      expect((range1.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range1.end as TimeWithZone).timeZone.name).toBe(zone.name);
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.tstz_range as Range;
+      expect(range2.begin).toBeNull();
+      expect(range2.end).toBeInstanceOf(TimeWithZone);
+      expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
     it.skip("timezone array awareness tzrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // ROOT-CAUSE: same as "timezone awareness tzrange"; also requires ts_ranges/tstz_ranges array columns in setup
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+      // DEFERRED to follow-up PR: requires tstz_ranges tstzrange[] column in setup
     });
     it("create tstzrange", async () => {
       // Rails: Time.parse("2010-01-01 14:30:00 +0100")...Time.parse("2011-02-02 14:30:00 CDT") → UTC-normalised
@@ -603,22 +673,80 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((res2.end as Temporal.Instant).epochMilliseconds).toBe(t.epochMilliseconds);
       expect(res2.excludeEnd).toBe(false);
     });
-    it.skip("timezone awareness tsrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+    it("timezone awareness tsrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, timeString, false) });
+      const range1 = r.ts_range as Range;
+      expect(range1.begin).toBeInstanceOf(TimeWithZone);
+      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.ts_range as Range;
+      expect(range2.begin).toBeInstanceOf(TimeWithZone);
+      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
     });
-    it.skip("timezone awareness endless tsrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+    it("timezone awareness endless tsrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, null, true) });
+      const range1 = r.ts_range as Range;
+      expect(range1.begin).toBeInstanceOf(TimeWithZone);
+      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect(range1.end).toBeNull();
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.ts_range as Range;
+      expect(range2.begin).toBeInstanceOf(TimeWithZone);
+      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+      expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect(range2.end).toBeNull();
     });
-    it.skip("timezone awareness beginless tsrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+    it("timezone awareness beginless tsrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2020-06-15T10:00:00-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ ts_range: new Range(null, timeString, false) });
+      const range1 = r.ts_range as Range;
+      expect(range1.begin).toBeNull();
+      expect(range1.end).toBeInstanceOf(TimeWithZone);
+      expect((range1.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range1.end as TimeWithZone).timeZone.name).toBe(zone.name);
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.ts_range as Range;
+      expect(range2.begin).toBeNull();
+      expect(range2.end).toBeInstanceOf(TimeWithZone);
+      expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
     it.skip("timezone array awareness tsrange", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // ROOT-CAUSE: same as "timezone awareness tzrange"; also requires ts_ranges array column in setup
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+      // DEFERRED to follow-up PR: requires ts_ranges tsrange[] column in setup
     });
     it("create tstzrange preserve usec", async () => {
       // Rails: Time.parse("2010-01-01 14:30:00.670277 +0100")...Time.parse("2011-02-02 14:30:00.745125 CDT")
@@ -668,9 +796,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(r.ts_range).toBeNull();
     });
     it.skip("timezone awareness tsrange preserve usec", () => {
-      // BLOCKED: range — time_zone_aware_types infrastructure not implemented
-      // ROOT-CAUSE: same as "timezone awareness tzrange"; also requires µs-level time-zone conversion
-      // SCOPE: ~200+ LOC shared with "timezone awareness tzrange" fix; affects 9 tests
+      // DEFERRED to follow-up PR (LOC budget): same infrastructure as basic tests; µs precision
     });
     it("create numrange", async () => {
       // Rails: assert_equal_round_trip(@new_range, :num_range, BigDecimal("0.5")...BigDecimal("1"))

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -337,14 +337,8 @@ interface RangeLike {
 
 /** @internal */
 function isRangeLike(v: unknown): v is RangeLike {
-  return (
-    v != null &&
-    typeof v === "object" &&
-    !Array.isArray(v) &&
-    "begin" in v &&
-    "end" in v &&
-    "excludeEnd" in v
-  );
+  if (v == null || typeof v !== "object" || Array.isArray(v) || isPlainObject(v)) return false;
+  return "begin" in v && "end" in v && "excludeEnd" in v;
 }
 
 /** @internal */

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -86,13 +86,29 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // to mirror Rails' `map(super) { |v| cast(v) }`.
     const casted = this._subtype.cast(value);
     if (Array.isArray(casted)) {
-      return casted.map((v) => this.cast(v));
+      // Elements may themselves be Range-like (tsrange[] columns): apply TZ
+      // conversion to each bound. Bounds may be strings (when the user assigns
+      // Range objects with string bounds) or Instants (when cast by the subtype).
+      return casted.map((v) =>
+        isRangeLike(v) ? mapRange(v, (b) => castBoundInZone(b)) : this.cast(v),
+      );
+    }
+    if (isRangeLike(casted)) {
+      // Range-typed columns (tsrange/tstzrange): recurse cast() on each bound so
+      // strings are parsed in the current zone and Instants are zone-wrapped.
+      return mapRange(casted, (bound) => this.cast(bound));
     }
     return convertTimeToTimeZone(casted);
   }
 
   override deserialize(value: unknown): unknown {
-    return convertTimeToTimeZone(this._subtype.deserialize(value));
+    const d = this._subtype.deserialize(value);
+    if (Array.isArray(d))
+      return (d as unknown[]).map((v) =>
+        isRangeLike(v) ? mapRange(v, convertTimeToTimeZone) : convertTimeToTimeZone(v),
+      );
+    if (isRangeLike(d)) return mapRange(d, convertTimeToTimeZone);
+    return convertTimeToTimeZone(d);
   }
 
   override serialize(value: unknown): unknown {
@@ -100,11 +116,43 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // cast_value on it. In Ruby, TimeWithZone acts_like?(:time) so AR's
     // DateTime type can handle it. In TS, DateTime.castValue() can't parse
     // a TimeWithZone — extract the UTC Temporal.Instant first.
+    if (Array.isArray(value)) {
+      return this._subtype.serialize(
+        value.map((v) =>
+          isRangeLike(v)
+            ? mapRange(v, (b) => (b instanceof TimeWithZone ? b.utc() : b))
+            : v instanceof TimeWithZone
+              ? v.utc()
+              : v,
+        ),
+      );
+    }
+    if (isRangeLike(value)) {
+      return this._subtype.serialize(
+        mapRange(value, (v) => (v instanceof TimeWithZone ? v.utc() : v)),
+      );
+    }
     const resolved = value instanceof TimeWithZone ? value.utc() : value;
     return this._subtype.serialize(resolved);
   }
 
   override serializeCastValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return this._subtype.serialize(
+        value.map((v) =>
+          isRangeLike(v)
+            ? mapRange(v, (b) => (b instanceof TimeWithZone ? b.utc() : b))
+            : v instanceof TimeWithZone
+              ? v.utc()
+              : v,
+        ),
+      );
+    }
+    if (isRangeLike(value)) {
+      return this._subtype.serialize(
+        mapRange(value, (v) => (v instanceof TimeWithZone ? v.utc() : v)),
+      );
+    }
     const resolved = value instanceof TimeWithZone ? value.utc() : value;
     const sub = this._subtype as ValueTypeInstance;
     if (typeof sub.itselfIfSerializeCastValueCompatible === "function") {
@@ -256,6 +304,49 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
   const proto = Object.getPrototypeOf(v);
   return proto === Object.prototype || proto === null;
+}
+
+/** @internal */
+function castBoundInZone(value: unknown): unknown {
+  if (value == null) return null;
+  if (value instanceof TimeWithZone) return convertTimeToTimeZone(value);
+  if (value instanceof Temporal.Instant) return convertTimeToTimeZone(value);
+  if (typeof value === "string") {
+    const zone = getZone();
+    if (zone) {
+      const parsed = parseStringInZone(value, zone);
+      if (parsed !== null) return parsed;
+    }
+  }
+  return convertTimeToTimeZone(value);
+}
+
+interface RangeLike {
+  readonly begin: unknown;
+  readonly end: unknown;
+  readonly excludeEnd: boolean;
+  constructor: new (begin: unknown, end: unknown, excludeEnd: boolean) => object;
+}
+
+/** @internal */
+function isRangeLike(v: unknown): v is RangeLike {
+  return (
+    v != null &&
+    typeof v === "object" &&
+    !Array.isArray(v) &&
+    "begin" in v &&
+    "end" in v &&
+    "excludeEnd" in v
+  );
+}
+
+/** @internal */
+function mapRange(range: RangeLike, fn: (v: unknown) => unknown): object {
+  return new (range.constructor as any)(
+    range.begin != null ? fn(range.begin) : null,
+    range.end != null ? fn(range.end) : null,
+    range.excludeEnd,
+  );
 }
 
 interface TimeZoneConversionHost {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -181,7 +181,6 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return extractUtc(value);
   }
 
-
   override equals(other: Type): boolean {
     if (!(other instanceof TimeZoneConverter)) return false;
     const sub = this._subtype as ValueTypeInstance;

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -94,9 +94,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
       );
     }
     if (isRangeLike(casted)) {
-      // Range-typed columns (tsrange/tstzrange): recurse cast() on each bound so
-      // strings are parsed in the current zone and Instants are zone-wrapped.
-      return mapRange(casted, (bound) => this.cast(bound));
+      // Range-typed columns (tsrange/tstzrange): cast each bound through the
+      // dedicated bound helper so string bounds are parsed in the current zone
+      // and Instants are zone-wrapped — without routing through _subtype.cast
+      // (which is RangeType and would misparse a timestamp string as a range literal).
+      return mapRange(casted, castBoundInZone);
     }
     return convertTimeToTimeZone(casted);
   }
@@ -311,6 +313,11 @@ function castBoundInZone(value: unknown): unknown {
   if (value == null) return null;
   if (value instanceof TimeWithZone) return convertTimeToTimeZone(value);
   if (value instanceof Temporal.Instant) return convertTimeToTimeZone(value);
+  if (value instanceof Temporal.ZonedDateTime) return convertTimeToTimeZone(value.toInstant());
+  if (value instanceof Temporal.PlainDateTime) {
+    const instant = value.toZonedDateTime(configuredTimezone()).toInstant();
+    return setTimeZoneWithoutConversion(instant);
+  }
   if (typeof value === "string") {
     const zone = getZone();
     if (zone) {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -89,9 +89,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
       // Elements may themselves be Range-like (tsrange[] columns): apply TZ
       // conversion to each bound. Bounds may be strings (when the user assigns
       // Range objects with string bounds) or Instants (when cast by the subtype).
-      return casted.map((v) =>
-        isRangeLike(v) ? mapRange(v, (b) => castBoundInZone(b)) : this.cast(v),
-      );
+      // Scalar elements (datetime[] columns) arrive here as Temporal.Instants
+      // after ArrayType pre-casts them through the DateTime subtype; this.cast(v)
+      // reaches convertTimeToTimeZone via the fallback path rather than through
+      // ArrayType.cast again (which would be a no-op second pass).
+      return casted.map((v) => (isRangeLike(v) ? mapRange(v, castBoundInZone) : this.cast(v)));
     }
     if (isRangeLike(casted)) {
       // Range-typed columns (tsrange/tstzrange): cast each bound through the
@@ -118,44 +120,11 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // cast_value on it. In Ruby, TimeWithZone acts_like?(:time) so AR's
     // DateTime type can handle it. In TS, DateTime.castValue() can't parse
     // a TimeWithZone — extract the UTC Temporal.Instant first.
-    if (Array.isArray(value)) {
-      return this._subtype.serialize(
-        value.map((v) =>
-          isRangeLike(v)
-            ? mapRange(v, (b) => (b instanceof TimeWithZone ? b.utc() : b))
-            : v instanceof TimeWithZone
-              ? v.utc()
-              : v,
-        ),
-      );
-    }
-    if (isRangeLike(value)) {
-      return this._subtype.serialize(
-        mapRange(value, (v) => (v instanceof TimeWithZone ? v.utc() : v)),
-      );
-    }
-    const resolved = value instanceof TimeWithZone ? value.utc() : value;
-    return this._subtype.serialize(resolved);
+    return this._subtype.serialize(this._resolveForSerialize(value));
   }
 
   override serializeCastValue(value: unknown): unknown {
-    if (Array.isArray(value)) {
-      return this._subtype.serialize(
-        value.map((v) =>
-          isRangeLike(v)
-            ? mapRange(v, (b) => (b instanceof TimeWithZone ? b.utc() : b))
-            : v instanceof TimeWithZone
-              ? v.utc()
-              : v,
-        ),
-      );
-    }
-    if (isRangeLike(value)) {
-      return this._subtype.serialize(
-        mapRange(value, (v) => (v instanceof TimeWithZone ? v.utc() : v)),
-      );
-    }
-    const resolved = value instanceof TimeWithZone ? value.utc() : value;
+    const resolved = this._resolveForSerialize(value);
     const sub = this._subtype as ValueTypeInstance;
     if (typeof sub.itselfIfSerializeCastValueCompatible === "function") {
       return sub.itselfIfSerializeCastValueCompatible()
@@ -198,6 +167,20 @@ export class TimeZoneConverter extends ValueType<unknown> {
     const roundedOff = subsec % mod;
     return ns - roundedOff;
   }
+
+  // Strips TimeWithZone from any value before DB serialization. Extracts UTC
+  // Temporal.Instant from TimeWithZone bounds in Range/Array values so the
+  // subtype's serialize (which doesn't understand TimeWithZone) receives plain
+  // Instants or timestamps.
+  private _resolveForSerialize(value: unknown): unknown {
+    const extractUtc = (v: unknown): unknown => (v instanceof TimeWithZone ? v.utc() : v);
+    if (Array.isArray(value)) {
+      return value.map((v) => (isRangeLike(v) ? mapRange(v, extractUtc) : extractUtc(v)));
+    }
+    if (isRangeLike(value)) return mapRange(value, extractUtc);
+    return extractUtc(value);
+  }
+
 
   override equals(other: Type): boolean {
     if (!(other instanceof TimeZoneConverter)) return false;
@@ -332,7 +315,7 @@ interface RangeLike {
   readonly begin: unknown;
   readonly end: unknown;
   readonly excludeEnd: boolean;
-  constructor: new (begin: unknown, end: unknown, excludeEnd: boolean) => object;
+  constructor: new (begin: unknown, end: unknown, excludeEnd: boolean) => RangeLike;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -123,12 +123,7 @@ export class RangeType extends ValueType<Range> {
   encodeLiteral(value: unknown): string {
     const serialized = this.serialize(value);
     if (!(serialized instanceof Range)) return String(value);
-    const encode = (v: unknown): string => {
-      if (v === null || v === undefined || v === -Infinity || v === Infinity) return "";
-      const s = String(v);
-      return /[",\\\s[\]()]/.test(s) ? `"${s.replace(/\\/g, "\\\\").replace(/"/g, '""')}"` : s;
-    };
-    return `[${encode(serialized.begin)},${encode(serialized.end)}${serialized.excludeEnd ? ")" : "]"}`;
+    return serialized.toString();
   }
 
   private typeCastSingle(value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -30,6 +30,15 @@ export class Range {
     this.end = end;
     this.excludeEnd = excludeEnd;
   }
+
+  toString(): string {
+    const encode = (v: unknown): string => {
+      if (v === null || v === undefined || v === -Infinity || v === Infinity) return "";
+      const s = String(v);
+      return /[",\\\s[\]()]/.test(s) ? `"${s.replace(/\\/g, "\\\\").replace(/"/g, '""')}"` : s;
+    };
+    return `[${encode(this.begin)},${encode(this.end)}${this.excludeEnd ? ")" : "]"}`;
+  }
 }
 
 export interface RangeSubtype {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -397,17 +397,7 @@ function encodeRange(value: Range): string {
 
 /** @internal */
 function encodeMultirange(value: MultiRange): string {
-  return `{${value.ranges.map(encodeRangeLiteral).join(",")}}`;
-}
-
-/** @internal */
-function encodeRangeLiteral(value: Range): string {
-  const encode = (v: unknown): string => {
-    if (v === null || v === undefined || v === -Infinity || v === Infinity) return "";
-    const s = String(v);
-    return /[",\\\s[\]()]/.test(s) ? `"${s.replace(/\\/g, "\\\\").replace(/"/g, '""')}"` : s;
-  };
-  return `[${encode(value.begin)},${encode(value.end)}${value.excludeEnd ? ")" : "]"}`;
+  return `{${value.ranges.map((r) => r.toString()).join(",")}}`;
 }
 
 function isSqlLiteral(value: unknown): value is { value: string } {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -177,7 +177,7 @@ export function quote(value: unknown): string {
     return quoteString(value.toString());
   }
   if (value instanceof Range) {
-    return quoteString(encodeRange(value));
+    return quoteString(value.toString());
   }
   if (value instanceof MultiRange) {
     return quoteString(encodeMultirange(value));
@@ -237,7 +237,7 @@ export function typeCast(value: unknown): unknown {
     return value.toString();
   }
   if (value instanceof Range) {
-    return encodeRange(value);
+    return value.toString();
   }
   if (value instanceof MultiRange) {
     return encodeMultirange(value);
@@ -386,13 +386,6 @@ export function quotedDate(
     return base.replace(/^-?\d+/, bceYear) + " BC";
   }
   return abstractQuotedDate(value);
-}
-
-/** @internal */
-function encodeRange(value: Range): string {
-  const lower = value.begin == null || value.begin === -Infinity ? "" : String(value.begin);
-  const upper = value.end == null || value.end === Infinity ? "" : String(value.end);
-  return `[${lower},${upper}${value.excludeEnd ? ")" : "]"}`;
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

- Adds `isRangeLike` / `mapRange` / `castBoundInZone` helpers to `TimeZoneConverter` so that Range-typed column values (tsrange/tstzrange) get their begin/end bounds mapped through TZ conversion in `cast`, `deserialize`, `serialize`, and `serializeCastValue`
- Adds `Range.toString()` so array encoding (`Array.encode`) works correctly when `tsrange[]`/`tstzrange[]` columns serialize their Range elements via `String(value)`
- Adds a `PostgresqlRangesTz` model fixture to `range.test.ts` with `timeZoneAwareAttributes=true` and `timeZoneAwareTypes = [...defaults, "tsrange", "tstzrange"]`
- Unskips 6 of the 9 previously-BLOCKED timezone-awareness tests; 3 deferred to follow-up PR (2 array × and 1 preserve-usec) for LOC budget

## Follow-up

3 tests remain skipped with a DEFERRED annotation:
- `timezone array awareness tzrange` — needs `tstz_ranges tstzrange[]` column
- `timezone array awareness tsrange` — needs `ts_ranges tsrange[]` column
- `timezone awareness tsrange preserve usec` — same infrastructure as basic tests