### PR TITLE
chore(api-compare): add testFile to source-only exclusions; normalize orphan BLOCKED

### DIFF
--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -2,23 +2,15 @@ import { describe, it } from "vitest";
 
 describe("HotCompatibilityTest", () => {
   it.skip("insert after remove_column", () => {
-    // BLOCKED: migration — migration runner gap in hot-compatibility
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in hot-compatibility.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
   });
   it.skip("update after remove_column", () => {
-    // BLOCKED: migration — migration runner gap in hot-compatibility
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in hot-compatibility.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
   });
   it.skip("cleans up after prepared statement failure in a transaction", () => {
-    // BLOCKED: migration — migration runner gap in hot-compatibility
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in hot-compatibility.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
   });
   it.skip("cleans up after prepared statement failure in nested transactions", () => {
-    // BLOCKED: migration — migration runner gap in hot-compatibility
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in hot-compatibility.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
   });
 });

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -2,15 +2,15 @@ import { describe, it } from "vitest";
 
 describe("HotCompatibilityTest", () => {
   it.skip("insert after remove_column", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
+    // PERMANENT-SKIP: pre-1.0 scope (see scripts/api-compare/excluded-files.ts) — migration/compatibility shims not yet ported
   });
   it.skip("update after remove_column", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
+    // PERMANENT-SKIP: pre-1.0 scope (see scripts/api-compare/excluded-files.ts) — migration/compatibility shims not yet ported
   });
   it.skip("cleans up after prepared statement failure in a transaction", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
+    // PERMANENT-SKIP: pre-1.0 scope (see scripts/api-compare/excluded-files.ts) — migration/compatibility shims not yet ported
   });
   it.skip("cleans up after prepared statement failure in nested transactions", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — migration/compatibility
+    // PERMANENT-SKIP: pre-1.0 scope (see scripts/api-compare/excluded-files.ts) — migration/compatibility shims not yet ported
   });
 });

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -34,6 +34,7 @@ export type ExcludedFile = { reason: string } & (
 export const EXCLUDED_FILES: ExcludedFile[] = [
   {
     pattern: "migration/compatibility",
+    testFile: "migration/compatibility_test.rb",
     reason: "Pre-1.0: legacy Rails version migration compatibility shims.",
   },
   {
@@ -71,7 +72,7 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
       "MessagePack-the-format exists in JS but this file is the Marshal bridge, not a reusable impl.",
   },
   {
-    pattern: "legacy_yaml_adapter.rb",
+    pattern: "legacy_yaml_adapter.rb", // no test counterpart
     reason:
       "Migrates Psych::Coder YAML format versions (:nodoc:). Psych is Ruby-only; " +
       "JS doesn't use YAML for AR column serialization.",
@@ -112,13 +113,13 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
     reason: "Encrypts YAML fixture rows on load. Excluded transitively with fixtures.rb.",
   },
   {
-    pattern: "destroy_association_async_job.rb",
+    pattern: "destroy_association_async_job.rb", // no test counterpart
     reason:
       "ActiveJob subclass that backs `dependent: :destroy_async`. Trails has not " +
       "ported ActiveJob; async destroy is out of scope until a job framework lands.",
   },
   {
-    pattern: "dynamic_matchers.rb",
+    pattern: "dynamic_matchers.rb", // no test counterpart
     reason:
       "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` " +
       "at call time. No TS analog — Proxy-based dispatch can't infer attribute lists at " +
@@ -126,6 +127,7 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
   },
   {
     pattern: "railties/controller_runtime.rb",
+    testFile: "controller_runtime_test.rb",
     reason:
       "Railties ActionController integration that logs DB runtime per request. " +
       "Trails has not ported Railties / ActionController; reintroduce when a web " +

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -33,8 +33,7 @@ export type ExcludedFile = { reason: string } & (
 
 export const EXCLUDED_FILES: ExcludedFile[] = [
   {
-    pattern: "migration/compatibility",
-    testFile: "migration/compatibility_test.rb",
+    pattern: "migration/compatibility", // test excluded by extract-ruby-tests.rb SKIP_PATTERNS (/\/migration\//)
     reason: "Pre-1.0: legacy Rails version migration compatibility shims.",
   },
   {


### PR DESCRIPTION
## Summary

Extends 5 source-only entries in \`excluded-files.ts\` with \`testFile\` (or a comment) so intent is explicit for \`test:compare\`.

### Patterns updated

| Pattern | Result |
|---|---|
| \`migration/compatibility\` | Comment: test already dropped by \`extract-ruby-tests.rb\` \`SKIP_PATTERNS\` (\`/\/migration\//\`) |
| \`railties/controller_runtime.rb\` | \`testFile: "controller_runtime_test.rb"\` (lives in actionview test dir) |
| \`legacy_yaml_adapter.rb\` | \`// no test counterpart\` (no Rails test file exists) |
| \`destroy_association_async_job.rb\` | \`// no test counterpart\` (no Rails test file exists) |
| \`dynamic_matchers.rb\` | \`// no test counterpart\` (no Rails test file exists) |

### TS annotation cleanup

- \`packages/activerecord/src/hot-compatibility.test.ts\`: normalized 4 \`BLOCKED\` → \`PERMANENT-SKIP: pre-1.0 scope\` (migration/compatibility shims not yet ported — not Ruby-only; could be revisited)

## Verification

- \`pnpm api:compare --package activerecord\` — unchanged
- \`pnpm test:compare --package activerecord\` — 6057/7917 tests (76.5%), 320/320 files, 0 misplaced
- \`pnpm lint\` + typecheck — pass