### PR TITLE
chore(activerecord): normalize per-test dead BLOCKED in mixed-status test files (Class 2)

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2488,29 +2488,19 @@ describe("BasicsTest", () => {
     expect(after).not.toBe(before);
   });
   it.skip("marshal inspected round trip", () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("marshalling with associations 6 1", () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("marshalling with associations 7 1", () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("marshal between processes", () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it.skip("marshalling new record round trip with associations", () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
   it("attribute names on abstract class", () => {
     class AbstractModel extends Base {
@@ -2546,14 +2536,10 @@ describe("BasicsTest", () => {
     // BLOCKED: GVL — uses Ruby Thread.new to override connection_handler in a child thread and verify isolation; Node.js has no threads with shared object model
   });
   it.skip("new threads get default the default connection handler", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it.skip("changing a connection handler in a main thread does not poison the other threads", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   });
   it("ignored columns are not present in columns_hash", () => {
     class User extends Base {
@@ -2957,10 +2943,7 @@ describe("BasicsTest", () => {
   });
 
   it.skip("marshal round trip", async () => {
-    // BLOCKED: serialization — Ruby Marshal round-trip, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Marshal.dump/load; Ruby object serialization tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
-    // Ruby-only serialization feature
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — marshal
   });
 
   it("benchmark with log level", async () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -115,9 +115,7 @@ function makeTransactionAwarePool(size: number = 5): ConnectionPool {
 
 describe("ConnectionPoolThreadTest", () => {
   it.skip("lock thread allow fiber reentrency", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
     /* needs fiber/thread emulation */
   });
 });
@@ -138,9 +136,7 @@ it("checkout after close", () => {
 });
 
 it.skip("released connection moves between threads", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread emulation */
 });
 
@@ -271,9 +267,7 @@ it.skip("reap inactive", () => {
 });
 
 it.skip("inactive are returned from dead thread", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
@@ -384,9 +378,7 @@ it("remove connection", () => {
 });
 
 it.skip("remove connection for thread", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
@@ -557,44 +549,32 @@ it.skip("pool sets connection schema cache", () => {
 });
 
 it.skip("concurrent connection establishment", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs concurrency */
 });
 
 it.skip("non bang disconnect and clear reloadable connections throw exception if threads dont return their conns", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
 it.skip("disconnect and clear reloadable connections attempt to wait for threads to return their conns", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
 it.skip("bang versions of disconnect and clear reloadable connections if unable to acquire all connections proceed anyway", () => {
-  // BLOCKED: connection-pool — connection pool / handler gap in connection-pool
-  // ROOT-CAUSE: connection-adapters/abstract/connection-pool.ts or abstract/connection-handler.ts missing Rails parity for pool lifecycle
-  // SCOPE: ~50–100 LOC fix in connection-adapters/abstract/connection-pool.ts; affects ~10–24 tests in connection-pool.test.ts
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
 it.skip("disconnect and clear reloadable connections are able to preempt other waiting threads", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
 it.skip("clear reloadable connections creates new connections for waiting threads if necessary", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread tracking */
 });
 
@@ -610,9 +590,7 @@ it("connection pool stat", () => {
 });
 
 it.skip("public connections access threadsafe", () => {
-  // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-  // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
-  // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
+  // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — gvl
   /* needs thread safety */
 });
 

--- a/packages/activerecord/src/reaper.test.ts
+++ b/packages/activerecord/src/reaper.test.ts
@@ -111,10 +111,7 @@ describe("ReaperTest", () => {
   });
 
   it.skip("connection pool starts reaper in fork", () => {
-    // BLOCKED: GVL — Thread.kill / reaper semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.kill; connection reaper depends on Ruby thread lifecycle
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
-    // N/A: Node.js does not fork processes the way Ruby does
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — fork
   });
 
   it("reaper does not reap discarded connection pools", () => {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -217,15 +217,11 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("serialized class attribute", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs class-based serialization */
   });
   it.skip("serialized class does not become frozen", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* Ruby-specific frozen concept */
   });
 
@@ -249,9 +245,7 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("serialized attribute should raise exception on assignment with wrong type", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs write-time type validation in serialize (assert_valid_value on dump) */
   });
   it("should raise exception on serialized attribute with type mismatch", async () => {
@@ -274,27 +268,19 @@ describe("SerializedAttributeTest", () => {
     expect(() => found.content).toThrow(SerializationTypeMismatch);
   });
   it.skip("serialized attribute with class constraint", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs class-based serialization */
   });
   it.skip("where by serialized attribute with array", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs serialized where support */
   });
   it.skip("where by serialized attribute with hash", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs serialized where support */
   });
   it.skip("where by serialized attribute with hash in array", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs serialized where support */
   });
 
@@ -346,15 +332,11 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("serialize attribute via select method when time zone available", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs timezone support */
   });
   it.skip("serialize attribute can be serialized in an integer column", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs integer column serialize */
   });
 
@@ -415,9 +397,7 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("classes without no arg constructors are not supported", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* Ruby-specific */
   });
 
@@ -430,15 +410,11 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("is not changed when stored blob", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs blob support */
   });
   it.skip("is not changed when stored in blob frozen payload", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs blob support */
   });
 
@@ -501,15 +477,11 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("decorated type with type for attribute", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs custom type decoration */
   });
   it.skip("decorated type with decorator block", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs custom type decoration */
   });
 
@@ -529,9 +501,7 @@ describe("SerializedAttributeTest", () => {
   });
 
   it.skip("serialized attribute works under concurrent initial access", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     /* needs concurrency testing */
   });
 
@@ -647,9 +617,7 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
   // Rails test_serialized_time_attribute is SKIPPED in the safe_load variant:
   // "Time is a DisallowedClass in Psych safe_load()"
   it.skip("serialized time attribute", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     // Skipped in Rails WithYamlSafeLoad: Time is a DisallowedClass for Psych safe_load.
   });
 
@@ -727,9 +695,7 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
   });
 
   it.skip("supports permitted classes for default column serializer", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialized-attribute
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialized-attribute.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — yaml
     // Rails-specific: YAML permitted classes have no equivalent in trails (JSON serialization).
   });
 });


### PR DESCRIPTION
## Summary

Class 1 (#1391) cleaned up BLOCKED annotations in **fully-excluded** test files. Class 2 covers the **mixed-status** files — where the Rails counterpart has a `tests: [...]` per-test exclusion array in `scripts/api-compare/excluded-files.ts`, meaning some tests are Ruby-only but others are real implementable gaps.

For each BLOCKED annotation, the test name was cross-referenced against the matching `tests: [...]` array. Matches → `PERMANENT-SKIP: Ruby-only (see scripts/api-compare/excluded-files.ts) — <category>`. Non-matches are left untouched (real gaps).

**Normalized per file:**

| File | Normalized | Category | BLOCKED remaining |
|---|---|---|---|
| `base.test.ts` | 8 | 6 marshal, 2 gvl | 21 |
| `connection-pool.test.ts` | 11 | all gvl | 13 |
| `serialized-attribute.test.ts` | 17 | all yaml | 0 |
| `reaper.test.ts` | 1 | fork | 0 |

No test bodies, test names, or `it.skip` calls were changed.