### PR TITLE
fix(activerecord): timestamp gating fidelity — recordTimestamps guard + updated_on + dead _createRecord cleanup

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2511,11 +2511,11 @@ export class Base extends Model {
 
     const table = ctor.arelTable;
 
-    // Auto-populate update timestamps (unless touch: false)
-    if (!this._skipTouch) {
+    // Auto-populate update timestamps (unless touch: false or recordTimestamps disabled)
+    if (!this._skipTouch && ctor.recordTimestamps !== false) {
       const now = Temporal.Now.instant();
       for (const col of Timestamp.timestampAttributesForUpdateInModel.call(ctor)) {
-        if (!this.willSaveChangeToAttribute(col)) {
+        if (ctor._attributeDefinitions.has(col) && !this.willSaveChangeToAttribute(col)) {
           this._writeAttribute(col, now);
         }
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2459,7 +2459,7 @@ export class Base extends Model {
 
     // Auto-populate timestamps (unless touch: false or recordTimestamps disabled)
     if (!this._skipTouch && ctor.recordTimestamps !== false) {
-      const now = Temporal.Now.instant();
+      const now = Timestamp.currentTimeFromProperTimezone();
       for (const col of Timestamp.allTimestampAttributesInModel.call(ctor)) {
         if (ctor._attributeDefinitions.has(col) && this._readAttribute(col) == null) {
           this._writeAttribute(col, now);
@@ -2513,7 +2513,7 @@ export class Base extends Model {
 
     // Auto-populate update timestamps (unless touch: false or recordTimestamps disabled)
     if (!this._skipTouch && ctor.recordTimestamps !== false) {
-      const now = Temporal.Now.instant();
+      const now = Timestamp.currentTimeFromProperTimezone();
       for (const col of Timestamp.timestampAttributesForUpdateInModel.call(ctor)) {
         if (ctor._attributeDefinitions.has(col) && !this.willSaveChangeToAttribute(col)) {
           this._writeAttribute(col, now);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2457,8 +2457,8 @@ export class Base extends Model {
 
     const table = ctor.arelTable;
 
-    // Auto-populate timestamps (unless touch: false)
-    if (!this._skipTouch) {
+    // Auto-populate timestamps (unless touch: false or recordTimestamps disabled)
+    if (!this._skipTouch && ctor.recordTimestamps !== false) {
       const now = Temporal.Now.instant();
       for (const col of Timestamp.allTimestampAttributesInModel.call(ctor)) {
         if (ctor._attributeDefinitions.has(col) && this._readAttribute(col) == null) {
@@ -2511,9 +2511,14 @@ export class Base extends Model {
 
     const table = ctor.arelTable;
 
-    // Auto-populate updated_at timestamp (unless touch: false)
-    if (!this._skipTouch && ctor._attributeDefinitions.has("updated_at")) {
-      this._writeAttribute("updated_at", Temporal.Now.instant());
+    // Auto-populate update timestamps (unless touch: false)
+    if (!this._skipTouch) {
+      const now = Temporal.Now.instant();
+      for (const col of Timestamp.timestampAttributesForUpdateInModel.call(ctor)) {
+        if (!this.willSaveChangeToAttribute(col)) {
+          this._writeAttribute(col, now);
+        }
+      }
     }
 
     const changedAttrs = { ...this.changes };

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -450,13 +450,14 @@ describe("TimestampTest", () => {
     }
 
     const post = await Post.create({ title: "Hello" });
-    const afterCreate = (post.updated_on as Temporal.Instant).epochMilliseconds;
 
     post.title = "Updated";
+    const beforeSave = Temporal.Now.instant();
     await post.save();
 
-    const afterSave = (post.updated_on as Temporal.Instant).epochMilliseconds;
-    expect(afterSave).toBeGreaterThanOrEqual(afterCreate);
+    const afterSave = post.updated_on as Temporal.Instant;
+    expect(afterSave).toBeInstanceOf(Temporal.Instant);
+    expect(afterSave.epochMilliseconds).toBeGreaterThanOrEqual(beforeSave.epochMilliseconds);
   });
 
   it("does not set updated_on when recordTimestamps is false", async () => {
@@ -476,9 +477,11 @@ describe("TimestampTest", () => {
 
     const post = await Post.create({ title: "Hello" });
     expect(post.updated_on).toBeNull();
+    expect(post.updated_at).toBeNull();
     post.title = "Updated";
     await post.save();
     expect(post.updated_on).toBeNull();
+    expect(post.updated_at).toBeNull();
   });
 
   it("does not touch timestamps when model has no timestamp attributes", async () => {

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -450,10 +450,13 @@ describe("TimestampTest", () => {
     }
 
     const post = await Post.create({ title: "Hello" });
+    const afterCreate = (post.updated_on as Temporal.Instant).epochMilliseconds;
+
     post.title = "Updated";
     await post.save();
 
-    expect(post.updated_on).toBeInstanceOf(Temporal.Instant);
+    const afterSave = (post.updated_on as Temporal.Instant).epochMilliseconds;
+    expect(afterSave).toBeGreaterThanOrEqual(afterCreate);
   });
 
   it("does not set updated_on when recordTimestamps is false", async () => {

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -436,6 +436,48 @@ describe("TimestampTest", () => {
     expect((post.created_at as Temporal.Instant).epochMilliseconds).toBe(originalCreatedAt);
   });
 
+  it("sets updated_on on update when column exists", async () => {
+    const adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", updated_on: "string" },
+    });
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("updated_on", "datetime");
+        this.adapter = adapter;
+      }
+    }
+
+    const post = await Post.create({ title: "Hello" });
+    post.title = "Updated";
+    await post.save();
+
+    expect(post.updated_on).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("does not set updated_on when recordTimestamps is false", async () => {
+    const adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", updated_on: "string", updated_at: "string" },
+    });
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("updated_on", "datetime");
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+        this.recordTimestamps = false;
+      }
+    }
+
+    const post = await Post.create({ title: "Hello" });
+    expect(post.updated_on).toBeNull();
+    post.title = "Updated";
+    await post.save();
+    expect(post.updated_on).toBeNull();
+  });
+
   it("does not touch timestamps when model has no timestamp attributes", async () => {
     const adapter = freshAdapter();
     await defineSchema(adapter, { simples: { name: "string" } });

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -219,7 +219,7 @@ export function initInternals(this: any): void {
 
 /** @internal */
 export async function _createRecord(this: any): Promise<unknown> {
-  if ((this.constructor as any).recordTimestamps) {
+  if ((this.constructor as any).recordTimestamps !== false) {
     const time = currentTimeFromProperTimezone();
     for (const col of allTimestampAttributesInModel.call(this.constructor as TimestampHost)) {
       if (this._readAttribute?.(col) == null) {

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -219,7 +219,7 @@ export function initInternals(this: any): void {
 
 /** @internal */
 export async function _createRecord(this: any): Promise<unknown> {
-  if ((this.constructor as any).recordTimestamps !== false) {
+  if ((this.constructor as any).recordTimestamps) {
     const time = currentTimeFromProperTimezone();
     for (const col of allTimestampAttributesInModel.call(this.constructor as TimestampHost)) {
       if (this._readAttribute?.(col) == null) {


### PR DESCRIPTION
## Summary

Three surgical fidelity fixes from the #1388 post-merge audit:

- **`_performInsert` recordTimestamps gate**: added \`&& ctor.recordTimestamps !== false\` guard — models with \`recordTimestamps = false\` no longer get auto-timestamps on insert.
- **`_performUpdate` updated_on support**: replaced hardcoded \`"updated_at"\` write with \`timestampAttributesForUpdateInModel.call(ctor)\` loop (covers \`updated_on\` too), mirroring Rails' \`timestamp_attributes_for_update_in_model\`. Also added \`ctor._attributeDefinitions.has(col)\` guard and \`willSaveChangeToAttribute\` guard, consistent with the outer callback path.
- **`_performInsert` / `_performUpdate`**: both now call \`Timestamp.currentTimeFromProperTimezone()\` instead of \`Temporal.Now.instant()\` directly, for consistency with the rest of the timestamp stack.

## Note on `timestamp.ts _createRecord`

The truthy \`if (recordTimestamps)\` check in \`timestamp.ts _createRecord\` is intentionally kept — it mirrors Rails exactly (\`if record_timestamps\` in Ruby is a truthy check). Since \`recordTimestamps\` is typed \`boolean\` with default \`true\`, this is equivalent in practice.

## Test plan

- [x] \`pnpm test packages/activerecord/src/base.test.ts packages/activerecord/src/callbacks.test.ts packages/activerecord/src/timestamp.test.ts\` — 450 passed, 32 skipped
- [x] \`pnpm api:compare --package activerecord\` — 4955/4958 (unchanged)
- [x] \`pnpm lint\` — clean