### PR TITLE
refactor(activerecord): review-followup sweep — PG row coercion, MigrationLike, FROM regex, visitor dedupe, TZ helper

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -19,6 +19,7 @@ import {
 import { Associations, loadBelongsTo } from "./associations.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
+import type { JoinDependency } from "./associations/join-dependency.js";
 import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -7549,13 +7550,17 @@ describe("lookupCastTypeFromJoinDependencies", () => {
     const intType = { cast: (v: unknown) => Number(v) };
     const fakeNode = { modelClass: { attributeTypes: () => ({ credit_limit: intType }) } };
     const fakeJd = [fakeNode];
-    const result = lookupCastTypeFromJoinDependencies({} as any, "credit_limit", [fakeJd]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "credit_limit", [
+      fakeJd,
+    ] as unknown as JoinDependency[]);
     expect(result).toBe(intType);
   });
 
   it("returns null when name is not in any joined table", () => {
     const fakeNode = { modelClass: { attributeTypes: () => ({ other: {} }) } };
-    const result = lookupCastTypeFromJoinDependencies({} as any, "missing", [[fakeNode]]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "missing", [
+      [fakeNode],
+    ] as unknown as JoinDependency[]);
     expect(result).toBeNull();
   });
 
@@ -7564,21 +7569,28 @@ describe("lookupCastTypeFromJoinDependencies", () => {
     const type2 = { cast: (v: unknown) => Number(v) };
     const node1 = { modelClass: { attributeTypes: () => ({ name: type1 }) } };
     const node2 = { modelClass: { attributeTypes: () => ({ name: type2 }) } };
-    const result = lookupCastTypeFromJoinDependencies({} as any, "name", [[node1], [node2]]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "name", [
+      [node1],
+      [node2],
+    ] as unknown as JoinDependency[]);
     expect(result).toBe(type1);
   });
 
   it("supports attributeTypes as a plain object", () => {
     const strType = { cast: (v: unknown) => String(v) };
     const fakeNode = { modelClass: { attributeTypes: { title: strType } } };
-    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [[fakeNode]]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [
+      [fakeNode],
+    ] as unknown as JoinDependency[]);
     expect(result).toBe(strType);
   });
 
   it("supports attributeTypes as a Map", () => {
     const strType = { cast: (v: unknown) => String(v) };
     const fakeNode = { modelClass: { attributeTypes: new Map([["title", strType]]) } };
-    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [[fakeNode]]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "title", [
+      [fakeNode],
+    ] as unknown as JoinDependency[]);
     expect(result).toBe(strType);
   });
 
@@ -7586,7 +7598,9 @@ describe("lookupCastTypeFromJoinDependencies", () => {
     const type = { cast: (v: unknown) => v };
     const nodeMissing = { modelClass: undefined };
     const nodeGood = { modelClass: { attributeTypes: () => ({ val: type }) } };
-    const result = lookupCastTypeFromJoinDependencies({} as any, "val", [[nodeMissing, nodeGood]]);
+    const result = lookupCastTypeFromJoinDependencies({} as any, "val", [
+      [nodeMissing, nodeGood],
+    ] as unknown as JoinDependency[]);
     expect(result).toBe(type);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3004,8 +3004,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         let column: string;
         let primaryKey: string;
         if (conkey.length > 1) {
-          const cols = await this.columnNamesFromColumnNumbers(row.conrelid as number, conkey);
-          const pks = await this.columnNamesFromColumnNumbers(row.confrelid as number, confkey);
+          const cols = await this.columnNamesFromColumnNumbers(Number(row.conrelid), conkey);
+          const pks = await this.columnNamesFromColumnNumbers(Number(row.confrelid), confkey);
           column = cols.join(",");
           primaryKey = pks.join(",");
         } else {
@@ -4631,8 +4631,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       format_type: r.format_type as string,
       pg_get_expr: (r.pg_get_expr as string | null) ?? null,
       attnotnull: r.attnotnull as boolean,
-      atttypid: r.atttypid as number,
-      atttypmod: r.atttypmod as number,
+      atttypid: Number(r.atttypid),
+      atttypmod: Number(r.atttypmod),
       collname: (r.collname as string | null) ?? null,
       comment: (r.comment as string | null) ?? null,
       identity: (r.identity as string | null) || null,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -936,6 +936,10 @@ export abstract class Migration {
     return this._connectionOverride ?? this.adapter;
   }
 
+  set connection(conn: DatabaseAdapter | undefined) {
+    this._connectionOverride = conn;
+  }
+
   get connectionPool(): ConnectionPool {
     // Mirrors Rails: @pool || DatabaseTasks.migration_connection_pool.
     // _poolOverride is a real ConnectionPool when set by the migration runner.

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -21,10 +21,11 @@ export class DefaultStrategy extends ExecutionStrategy {
   ): Promise<void> {
     this.migration = migration;
     this._adapter = adapter;
+    migration.connection = adapter;
     if (direction === "up") {
-      await migration.up(adapter);
+      await migration.up();
     } else {
-      await migration.down(adapter);
+      await migration.down();
     }
   }
 

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -10,8 +10,8 @@
 import type { DatabaseAdapter } from "../adapter.js";
 
 export interface MigrationLike {
-  up(adapter?: DatabaseAdapter): Promise<void>;
-  down(adapter?: DatabaseAdapter): Promise<void>;
+  up(): Promise<void>;
+  down(): Promise<void>;
   /** When true, Migrator skips DDL transaction wrapping for this migration. */
   disableDdlTransaction?: boolean;
   /** Adapter for this migration; mirrors Rails' Migration#connection (@connection field). */

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./migration.js";
 import { resetVersionRegistry } from "./migration/compatibility.js";
 import type { MigrationProxy } from "./migration.js";
-import { ExecutionStrategy } from "./migration/execution-strategy.js";
+import { ExecutionStrategy, type MigrationLike } from "./migration/execution-strategy.js";
 import { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -577,17 +577,15 @@ describe("MigratorTest", () => {
     class LoggingStrategy extends ExecutionStrategy {
       async exec(
         direction: "up" | "down",
-        migration: {
-          up(a?: DatabaseAdapter): Promise<void>;
-          down(a?: DatabaseAdapter): Promise<void>;
-        },
+        migration: MigrationLike,
         a: DatabaseAdapter,
       ): Promise<void> {
         log.push(`before:${direction}`);
+        migration.connection = a;
         if (direction === "up") {
-          await migration.up(a);
+          await migration.up();
         } else {
-          await migration.down(a);
+          await migration.down();
         }
         log.push(`after:${direction}`);
       }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -11,6 +11,7 @@
 import { Nodes, Table } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import type { AdapterName } from "../adapter.js";
+import type { JoinDependency } from "../associations/join-dependency.js";
 import { buildJoinDependencies } from "./query-methods.js";
 
 /**
@@ -562,8 +563,7 @@ export function typeFor(rel: CalculationRelation, field: string): unknown {
 export function lookupCastTypeFromJoinDependencies(
   rel: CalculationRelation,
   name: string,
-  // @todo tighten to JoinDependency[] once test stubs migrate to real instances
-  joinDependencies?: Iterable<Iterable<{ modelClass?: { attributeTypes?: unknown } }>>,
+  joinDependencies?: JoinDependency[],
 ): unknown {
   const deps = joinDependencies ?? buildJoinDependencies.call(rel as any);
   for (const jd of deps) {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1325,16 +1325,22 @@ export class CreatePosts extends Migration {
         {
           version: "20260101000000",
           name: "CreateWidgets",
-          migration: () => ({
-            up: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
-              if (!a) throw new Error("adapter required");
-              await a.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
-            },
-            down: async (a?: import("@blazetrails/activerecord").DatabaseAdapter) => {
-              if (!a) throw new Error("adapter required");
-              await a.executeMutation(`DROP TABLE widgets`);
-            },
-          }),
+          migration: () => {
+            const m: import("@blazetrails/activerecord").MigrationLike = {
+              connection: undefined,
+              async up() {
+                if (!m.connection) throw new Error("adapter required");
+                await m.connection.executeMutation(
+                  `CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`,
+                );
+              },
+              async down() {
+                if (!m.connection) throw new Error("adapter required");
+                await m.connection.executeMutation(`DROP TABLE widgets`);
+              },
+            };
+            return m;
+          },
         },
       ];
       const migrator = new Migrator(adapter, migrations, {

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -55,14 +55,17 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       name,
       filename: filePath,
       migration: () => {
-        const loader = {
-          async up(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+        const loader: import("@blazetrails/activerecord").MigrationLike = {
+          connection: undefined,
+          async up(): Promise<void> {
+            const adapter = loader.connection;
             if (!adapter) throw new Error("migration-loader: adapter is required for up()");
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "up");
           },
-          async down(adapter?: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
+          async down(): Promise<void> {
+            const adapter = loader.connection;
             if (!adapter) throw new Error("migration-loader: adapter is required for down()");
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -59,14 +59,20 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
           connection: undefined,
           async up(): Promise<void> {
             const adapter = loader.connection;
-            if (!adapter) throw new Error("migration-loader: adapter is required for up()");
+            if (!adapter)
+              throw new Error(
+                "migration-loader: migration.connection must be set before calling up()",
+              );
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "up");
           },
           async down(): Promise<void> {
             const adapter = loader.connection;
-            if (!adapter) throw new Error("migration-loader: adapter is required for down()");
+            if (!adapter)
+              throw new Error(
+                "migration-loader: migration.connection must be set before calling down()",
+              );
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "down");

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -61,32 +61,42 @@ function discoverMigrations(
           version: match[1],
           name: camelize(match[2].replace(/-/g, "_")),
           filename: file.path,
-          migration: (): MigrationLike => ({
-            async up(adapter) {
-              const content = vfs.read(file.path)?.content;
-              if (!content) throw new Error(`File not found: ${file.path}`);
-              await executeCode(content);
-              const reg = getMigrations().find((m) => m.version === match![1]);
-              if (!reg) {
-                throw new Error(
-                  `Migration ${match![1]} from ${file.path} did not register after execution`,
-                );
-              }
-              await (await reg.migration()).up(adapter);
-            },
-            async down(adapter) {
-              const content = vfs.read(file.path)?.content;
-              if (!content) throw new Error(`File not found: ${file.path}`);
-              await executeCode(content);
-              const reg = getMigrations().find((m) => m.version === match![1]);
-              if (!reg) {
-                throw new Error(
-                  `Migration ${match![1]} from ${file.path} did not register after execution`,
-                );
-              }
-              await (await reg.migration()).down(adapter);
-            },
-          }),
+          migration: (): MigrationLike => {
+            const m: MigrationLike = {
+              connection: undefined,
+              async up() {
+                const adapter = m.connection;
+                const content = vfs.read(file.path)?.content;
+                if (!content) throw new Error(`File not found: ${file.path}`);
+                await executeCode(content);
+                const reg = getMigrations().find((r) => r.version === match![1]);
+                if (!reg) {
+                  throw new Error(
+                    `Migration ${match![1]} from ${file.path} did not register after execution`,
+                  );
+                }
+                const inner = await reg.migration();
+                inner.connection = adapter;
+                await inner.up();
+              },
+              async down() {
+                const adapter = m.connection;
+                const content = vfs.read(file.path)?.content;
+                if (!content) throw new Error(`File not found: ${file.path}`);
+                await executeCode(content);
+                const reg = getMigrations().find((r) => r.version === match![1]);
+                if (!reg) {
+                  throw new Error(
+                    `Migration ${match![1]} from ${file.path} did not register after execution`,
+                  );
+                }
+                const inner = await reg.migration();
+                inner.connection = adapter;
+                await inner.down();
+              },
+            };
+            return m;
+          },
         },
       ];
     });

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -66,6 +66,10 @@ function discoverMigrations(
               connection: undefined,
               async up() {
                 const adapter = m.connection;
+                if (!adapter)
+                  throw new Error(
+                    "trail-cli: migration.connection must be set before calling up()",
+                  );
                 const content = vfs.read(file.path)?.content;
                 if (!content) throw new Error(`File not found: ${file.path}`);
                 await executeCode(content);
@@ -81,6 +85,10 @@ function discoverMigrations(
               },
               async down() {
                 const adapter = m.connection;
+                if (!adapter)
+                  throw new Error(
+                    "trail-cli: migration.connection must be set before calling down()",
+                  );
                 const content = vfs.read(file.path)?.content;
                 if (!content) throw new Error(`File not found: ${file.path}`);
                 await executeCode(content);


### PR DESCRIPTION
Small fidelity cleanups surfaced during reviews of #1385, #1386, #1390, #1395.

## Changes

**Item 1 — PG query-row `Number(...)` coercion** (`postgresql-adapter.ts`): Replace `as number` TypeScript-only casts on PG row fields (`conrelid`, `confrelid`, `atttypid`, `atttypmod`) with `Number(...)` to match the `toInt()` pattern already used elsewhere.

**Item 2 — `MigrationLike#up/down` drop `adapter` arg** (`execution-strategy.ts`, `default-strategy.ts`, `migration-loader.ts`, `trail-cli.ts`): Rails' `DefaultStrategy` wires the adapter via `migration.connection` rather than passing it as a parameter. `DefaultStrategy.exec()` now sets `migration.connection = adapter` before calling `migration.up()`/`migration.down()` without args.

**Item 3 — `lookupCastTypeFromJoinDependencies` param tighten** (`calculations.ts`): Removes the `@todo` comment and tightens the `joinDependencies` param from a loose `Iterable<Iterable<...>>` stub type to `JoinDependency[]`. Test call sites use `as unknown as JoinDependency[]` casts.

**Items 4 & 5** (schema-qualified FROM regex, `_selectVisitor` dedupe) — already done in prior PRs.

**Item 6** (`_mapTimeWithZoneToUtc` extract) — already done as `_resolveForSerialize` in `time-zone-conversion.ts`.

## Verification

- `pnpm test:types` — ✅ 83/83
- migrator + calculations unit tests — ✅ 610 tests, 8 skipped
- `pnpm lint` — ✅ clean
- `pnpm build` + `pnpm typecheck` — ✅ (pre-commit hook)