### PR TITLE
feat(activerecord): i18n — RecordInvalid localization + I18n.withLocale + 11 validation test un-skips

### DIFF
--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -150,6 +150,20 @@ class I18nService {
   }
 
   /**
+   * Mirrors: I18n.with_locale
+   * Sets locale for the duration of fn and restores it in finally.
+   */
+  withLocale<T>(locale: string, fn: () => T): T {
+    const prev = this._locale;
+    this._locale = locale;
+    try {
+      return fn();
+    } finally {
+      this._locale = prev;
+    }
+  }
+
+  /**
    * Configure the fallback chain. Pass an object mapping locale → chain,
    * or an array treated as a shared chain for every locale. Each chain
    * should include the originating locale as its first element, matching
@@ -186,6 +200,18 @@ class I18nService {
     this._fallbacks = {};
     this._sharedFallbacks = undefined;
     this._storeTranslations("en", defaultEnTranslations);
+  }
+
+  /**
+   * @internal Mirrors Rails' reset_i18n_load_path pattern in tests: clears all
+   * translations including built-in defaults, leaving a truly empty backend.
+   */
+  resetEmpty(): void {
+    this._translations = {};
+    this._locale = "en";
+    this._defaultLocale = "en";
+    this._fallbacks = {};
+    this._sharedFallbacks = undefined;
   }
 
   private _fallbackChain(locale: string): string[] {
@@ -293,6 +319,7 @@ const messages: TranslationTree = {
   passwordTooLong: "is too long",
   in: "must be in %{count}",
   model_invalid: "Validation failed: %{errors}",
+  record_invalid: "Validation failed: %{errors}",
 };
 
 const defaultEnTranslations: TranslationTree = {

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -46,13 +46,17 @@ export class RecordInvalid extends ActiveRecordError {
   readonly record: any;
 
   constructor(record: any) {
-    const fullMessages = record.errors?.fullMessages;
-    const errors = Array.isArray(fullMessages) ? fullMessages.join(", ") : "";
-    const message = I18n.t("activerecord.errors.messages.record_invalid", {
-      errors,
-      defaults: [{ key: "errors.messages.record_invalid" }],
-      defaultValue: "Validation failed: %{errors}",
-    });
+    let message: string;
+    if (record) {
+      const errors = (record.errors?.fullMessages as string[] | undefined)?.join(", ") ?? "";
+      message = I18n.t("activerecord.errors.messages.record_invalid", {
+        errors,
+        defaults: [{ key: "errors.messages.record_invalid" }],
+        defaultValue: "Validation failed: %{errors}",
+      });
+    } else {
+      message = "Record invalid";
+    }
     super(message);
     this.name = "RecordInvalid";
     this.record = record;

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -6,6 +6,7 @@
  * and overrides save/valid? to run validations with context awareness.
  */
 import type { ValidationContext } from "@blazetrails/activemodel";
+import { I18n } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
 
 /**
@@ -46,10 +47,12 @@ export class RecordInvalid extends ActiveRecordError {
 
   constructor(record: any) {
     const fullMessages = record.errors?.fullMessages;
-    const message =
-      Array.isArray(fullMessages) && fullMessages.length > 0
-        ? `Validation failed: ${fullMessages.join(", ")}`
-        : "Validation failed";
+    const errors = Array.isArray(fullMessages) ? fullMessages.join(", ") : "";
+    const message = I18n.t("activerecord.errors.messages.record_invalid", {
+      errors,
+      defaults: [{ key: "errors.messages.record_invalid" }],
+      defaultValue: "Validation failed: %{errors}",
+    });
     super(message);
     this.name = "RecordInvalid";
     this.record = record;

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -1,59 +1,157 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from "vitest";
+import { Base } from "../index.js";
+import { I18n } from "@blazetrails/activemodel";
+import { RecordInvalid } from "../validations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("I18nGenerateMessageValidationTest", () => {
-  it.skip("generate message invalid with default message", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+  let adapter: DatabaseAdapter;
+
+  beforeAll(() => {
+    adapter = createTestAdapter();
   });
-  it.skip("generate message invalid with custom message", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+  beforeEach(async () => {
+    await defineSchema(adapter, { topics: { title: "string" } });
   });
-  it.skip("generate message taken with default message", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+  afterEach(() => {
+    I18n.reset();
   });
-  it.skip("generate message taken with custom message", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
-  it.skip("RecordInvalid exception can be localized", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  function makeTopic() {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    return new Topic();
+  }
+
+  it("generate message invalid with default message", () => {
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "invalid", { value: "title" })).toBe("is invalid");
   });
-  it.skip("RecordInvalid exception translation falls back to the :errors namespace", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("generate message invalid with custom message", () => {
+    const topic = makeTopic();
+    expect(
+      topic.errors.generateMessage("title", "invalid", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toBe("custom message title");
   });
-  it.skip("translation for 'taken' can be overridden", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("generate message taken with default message", () => {
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      "has already been taken",
+    );
   });
-  it.skip("translation for 'taken' can be overridden in activerecord scope", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("generate message taken with custom message", () => {
+    const topic = makeTopic();
+    expect(
+      topic.errors.generateMessage("title", "taken", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toBe("custom message title");
   });
-  it.skip("translation for 'taken' can be overridden in activerecord model scope", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("RecordInvalid exception can be localized", () => {
+    const topic = makeTopic();
+    topic.errors.add("title", "invalid");
+    topic.errors.add("title", "blank");
+    expect(new RecordInvalid(topic).message).toBe(
+      "Validation failed: Title is invalid, Title can't be blank",
+    );
   });
-  it.skip("translation for 'taken' can be overridden in activerecord attributes scope", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("RecordInvalid exception translation falls back to the :errors namespace", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", { errors: { messages: { record_invalid: "fallback message" } } });
+    const topic = makeTopic();
+    topic.errors.add("title", "blank");
+    expect(new RecordInvalid(topic).message).toBe("fallback message");
   });
-  it.skip("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
-    // BLOCKED: i18n — translation / message generation gap in i18n-generate-message-validation
-    // ROOT-CAUSE: translation.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in translation.ts; affects ~4–11 tests in i18n-generate-message-validation.test.ts
+
+  it("translation for 'taken' can be overridden", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", {
+      errors: { attributes: { title: { taken: "Custom taken message" } } },
+    });
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      "Custom taken message",
+    );
+  });
+
+  it("translation for 'taken' can be overridden in activerecord scope", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", {
+      activerecord: { errors: { messages: { taken: "Custom taken message" } } },
+    });
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      "Custom taken message",
+    );
+  });
+
+  it("translation for 'taken' can be overridden in activerecord model scope", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", {
+      activerecord: { errors: { models: { topic: { taken: "Custom taken message" } } } },
+    });
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      "Custom taken message",
+    );
+  });
+
+  it("translation for 'taken' can be overridden in activerecord attributes scope", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", {
+      activerecord: {
+        errors: { models: { topic: { attributes: { title: { taken: "Custom taken message" } } } } },
+      },
+    });
+    const topic = makeTopic();
+    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      "Custom taken message",
+    );
+  });
+
+  it("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
+    I18n.resetEmpty();
+    I18n.storeTranslations("en", {
+      activerecord: {
+        errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } },
+      },
+    });
+    I18n.storeTranslations("en-US", {
+      errors: { messages: { taken: "generic en-US fallback" } },
+    });
+    I18n.setFallbacks({ "en-US": ["en-US", "en"] });
+
+    const topic = makeTopic();
+    I18n.withLocale("en-US", () => {
+      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        "custom en message",
+      );
+      expect(topic.errors.generateMessage("heading", "taken", { value: "heading" })).toBe(
+        "generic en-US fallback",
+      );
+    });
   });
 });

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -23,6 +23,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
   afterAll(async () => {
     await dropAllTables(adapter);
+    vi.unstubAllEnvs();
   });
 
   function makeTopic() {


### PR DESCRIPTION
## Summary

- `RecordInvalid` now builds its message via `I18n.t("activerecord.errors.messages.record_invalid", { errors, defaults: [{ key: "errors.messages.record_invalid" }], defaultValue: "Validation failed: %{errors}" })` — mirrors Rails `validations.rb`
- `I18n.withLocale(locale, fn)` added to `activemodel/src/i18n.ts` — sets locale for duration of `fn`, restores in finally; mirrors `I18n.with_locale`
- `I18n.resetEmpty()` added (test helper) — clears all translations including built-in defaults, mirrors Rails `reset_i18n_load_path` which swaps in a fresh empty backend
- `record_invalid` key added to default en translations (`errors.messages`)
- `i18n-generate-message-validation.test.ts` rewritten: all 11 tests active, inline `Topic` model, uses `defineSchema` + `dropAllTables`, `afterEach(() => I18n.reset())`

## Verify

- `pnpm vitest run packages/activerecord/src/validations/i18n-generate-message-validation.test.ts` — 11/11 pass
- `pnpm api:compare --package activerecord` — 4954/4958 (unchanged)
- typecheck + lint — pass (pre-commit hook confirmed)