### PR TITLE
feat(activerecord): store accessor super-chain + HWIA coercion + 4 store.test.ts un-skips (audit Slot A)

### DIFF
--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -4,7 +4,12 @@
  */
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { Base, registerModel, store, storedAttributes, localStoredAttributes } from "./index.js";
-import { IndifferentHashAccessor, getStoreCoder, storeAccessorFor } from "./store.js";
+import {
+  IndifferentHashAccessor,
+  getStoreCoder,
+  storeAccessorFor,
+  storeAccessor,
+} from "./store.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -122,11 +127,28 @@ describe("StoreTest", () => {
     expect((u as any).theme).toBe("new");
   });
 
-  it.skip("overriding a read accessor using super", () => {
-    // BLOCKED: type — store accessor / serialized column type gap
-    // ROOT-CAUSE: store.ts#store or StoreType not fully implementing Rails store accessor semantics
-    // SCOPE: ~30 LOC fix in store.ts; affects ~4 tests in store.test.ts
-    /* needs Ruby-style super in JS property accessor */
+  it("overriding a read accessor using super", () => {
+    const a2 = freshAdapter();
+    class SongUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("settings", "string");
+        this.adapter = a2;
+      }
+    }
+    store(SongUser, "settings", { accessors: ["color"] });
+    // The store accessor lives on the storeModule (intermediate proto below SongUser.prototype).
+    // We can override on SongUser.prototype and delegate to it — the TS analog of Ruby `super`.
+    const storeModule = Object.getPrototypeOf(SongUser.prototype) as object;
+    const baseGet = Object.getOwnPropertyDescriptor(storeModule, "color")!.get!;
+    Object.defineProperty(SongUser.prototype, "color", {
+      get() {
+        return baseGet.call(this) ?? "red";
+      },
+      configurable: true,
+    });
+    const u = new SongUser({ name: "John", settings: JSON.stringify({ color: null }) });
+    expect((u as any).color).toBe("red");
   });
 
   it("updating the store populates the changed array correctly", () => {
@@ -293,11 +315,31 @@ describe("StoreTest", () => {
     expect((u as any).theme).toBe("custom:blue");
   });
 
-  it.skip("overriding a write accessor using super", () => {
-    // BLOCKED: type — store accessor / serialized column type gap
-    // ROOT-CAUSE: store.ts#store or StoreType not fully implementing Rails store accessor semantics
-    // SCOPE: ~30 LOC fix in store.ts; affects ~4 tests in store.test.ts
-    /* needs Ruby-style super */
+  it("overriding a write accessor using super", () => {
+    const a2 = freshAdapter();
+    class SongUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("settings", "string");
+        this.adapter = a2;
+      }
+    }
+    store(SongUser, "settings", { accessors: ["color"] });
+    const storeModule = Object.getPrototypeOf(SongUser.prototype) as object;
+    const baseGet = Object.getOwnPropertyDescriptor(storeModule, "color")!.get!;
+    const baseSet = Object.getOwnPropertyDescriptor(storeModule, "color")!.set!;
+    Object.defineProperty(SongUser.prototype, "color", {
+      get() {
+        return baseGet.call(this);
+      },
+      set(v: unknown) {
+        baseSet.call(this, "blue");
+      },
+      configurable: true,
+    });
+    const u = new SongUser({ name: "John" });
+    (u as any).color = "yellow";
+    expect((u as any).color).toBe("blue");
   });
 
   it("preserve store attributes data in HashWithIndifferentAccess format without any conversion", () => {
@@ -327,11 +369,16 @@ describe("StoreTest", () => {
     expect((u as any).theme).toBe("ocean");
   });
 
-  it.skip("convert store attributes from any format other than Hash or HashWithIndifferentAccess losing the data", () => {
-    // BLOCKED: type — store accessor / serialized column type gap
-    // ROOT-CAUSE: store.ts#store or StoreType not fully implementing Rails store accessor semantics
-    // SCOPE: ~30 LOC fix in store.ts; affects ~4 tests in store.test.ts
-    /* Ruby-specific YAML behavior */
+  it("convert store attributes from any format other than Hash or HashWithIndifferentAccess losing the data", async () => {
+    const { HashWithIndifferentAccess: HWIA } = await import("@blazetrails/activesupport");
+    const { User } = makeModel();
+    const u = new User({ name: "test", settings: "somedata" });
+    (u as any).theme = "low";
+    const settings = u.settings as any;
+    expect(settings).toBeInstanceOf(HWIA);
+    expect((u as any).theme).toBe("low");
+    // Original non-hash data is lost — only the written key remains
+    expect(settings.get("language")).toBeUndefined();
   });
 
   it("accessing attributes not exposed by accessors encoded with JSON", () => {
@@ -570,11 +617,21 @@ describe("StoreTest", () => {
     expect(attrs["settings"]).toEqual(["theme", "language"]);
   });
 
-  it.skip("store_accessor raises an exception if the column is not either serializable or a structured type", () => {
-    // BLOCKED: type — store accessor / serialized column type gap
-    // ROOT-CAUSE: store.ts#store or StoreType not fully implementing Rails store accessor semantics
-    // SCOPE: ~30 LOC fix in store.ts; affects ~4 tests in store.test.ts
-    /* needs type checking */
+  it("store_accessor raises an exception if the column is not either serializable or a structured type", () => {
+    const a2 = freshAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = a2;
+      }
+    }
+    // storeAccessor on a plain string column (no store() called → no coder wired)
+    storeAccessor(Item, "name", { accessors: ["color"] });
+    const item = new Item({ name: "Alice" });
+    expect(() => (item as any).color).toThrow("has not been configured as a store");
+    expect(() => {
+      (item as any).color = "blue";
+    }).toThrow("has not been configured as a store");
   });
 
   it("reading store attributes through accessors with prefix", () => {

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -110,6 +110,30 @@ const _storedAttributes = new WeakMap<typeof Base, Record<string, string[]>>();
 const _storeAccessorsModules = new WeakMap<typeof Base, Set<string>>();
 
 /**
+ * Intermediate prototype objects inserted into the prototype chain so that
+ * store accessors can be overridden on modelClass.prototype with `super`.
+ * Mirrors Rails: Module.new { include … } inserted via _store_accessors_module.
+ */
+const _storeModuleProtos = new WeakMap<typeof Base, object>();
+
+/**
+ * Returns (creating if needed) the intermediate prototype that holds store
+ * accessor descriptors for a model class. On first call the intermediate
+ * object is spliced into the chain between modelClass.prototype and its
+ * current parent so that user overrides on modelClass.prototype can call super.
+ *
+ * @internal
+ */
+function getOrCreateStoreModuleProto(modelClass: typeof Base): object {
+  if (_storeModuleProtos.has(modelClass)) return _storeModuleProtos.get(modelClass)!;
+  const currentParent = Object.getPrototypeOf(modelClass.prototype) as object;
+  const storeModule = Object.create(currentParent);
+  Object.setPrototypeOf(modelClass.prototype, storeModule);
+  _storeModuleProtos.set(modelClass, storeModule);
+  return storeModule;
+}
+
+/**
  * Returns (creating if needed) the store-accessor module for a model class.
  * Mirrors: ActiveRecord::Store::ClassMethods#_store_accessors_module
  */
@@ -312,13 +336,14 @@ export function storeAccessor(
       accessorName = `${accessorName}_${suf}`;
     }
 
-    // Capture `modelClass` at definition time so subclass instances still resolve
-    // the correct accessor even when `record.constructor` differs from the declaring class.
+    // Install on the intermediate storeModule prototype so that user overrides
+    // on modelClass.prototype can reach the store accessor via `super`.
     // Mirrors Rails: _store_accessors_module.module_eval { define_method ... }
     storeAccessorsModule(modelClass).add(accessorName);
 
     const declaringClass = modelClass;
-    Object.defineProperty(modelClass.prototype, accessorName, {
+    const storeModuleProto = getOrCreateStoreModuleProto(modelClass);
+    Object.defineProperty(storeModuleProto, accessorName, {
       get: function (this: Base) {
         return readStoreAttribute(this, attribute, accessor, declaringClass);
       },
@@ -409,27 +434,10 @@ export function storeAccessorFor(
   // Check IndifferentCoder registered by store() (covers both standalone and Base.store()) — returns IndifferentHashAccessor.
   const coder = getStoreCoder(modelClass, storeAttribute);
   if (coder) return coder.accessor();
-  // Last resort: confirm the column was declared via store() and use IndifferentHashAccessor.
-  if (!_hasStoredAttribute(modelClass, storeAttribute)) {
-    throw new ConfigurationError(
-      `the column '${storeAttribute}' has not been configured as a store. ` +
-        `Please make sure the column is declared via store() or use a structured column type.`,
-    );
-  }
-  return IndifferentHashAccessor;
-}
-
-// Direct ancestry walk — short-circuits on first hit without building the full
-// merged map that storedAttributes() produces. Stops at Function.prototype
-// consistent with other prototype-chain walks in this codebase.
-function _hasStoredAttribute(klass: typeof Base, name: string): boolean {
-  let cls: typeof Base | null = klass;
-  while (cls && typeof cls === "function" && cls !== Function.prototype) {
-    const local = _storedAttributes.get(cls);
-    if (local && Object.prototype.hasOwnProperty.call(local, name)) return true;
-    cls = Object.getPrototypeOf(cls) as typeof Base | null;
-  }
-  return false;
+  throw new ConfigurationError(
+    `the column '${storeAttribute}' has not been configured as a store. ` +
+      `Please make sure the column is declared via store() or use a structured column type.`,
+  );
 }
 
 /**

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -275,14 +275,22 @@ export class HashAccessor {
 }
 
 /**
- * In Rails, IndifferentHashAccessor ensures the store value is a
- * HashWithIndifferentAccess. In TypeScript, JS objects already use
- * string keys natively, so no additional behavior is needed beyond
- * HashAccessor. Kept as a distinct class for Rails API parity.
+ * Ensures the store attribute value is a HashWithIndifferentAccess before
+ * reading or writing a key. Non-HWIA values (plain objects, strings, null)
+ * are coerced to an empty HWIA — matching Rails' behavior for structured
+ * column types (json/jsonb/hstore) where the type deserializer may return
+ * a plain hash or nil rather than a HWIA.
  *
  * Mirrors: ActiveRecord::Store::IndifferentHashAccessor
  */
-export class IndifferentHashAccessor extends HashAccessor {}
+export class IndifferentHashAccessor extends HashAccessor {
+  static override prepare(object: Base, attribute: string): void {
+    const val = object.readAttribute(attribute);
+    if (!(val instanceof HashWithIndifferentAccess)) {
+      object.writeAttribute(attribute, asIndifferentHash(val));
+    }
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::Store::StringKeyedHashAccessor.
@@ -436,7 +444,8 @@ export function storeAccessorFor(
   if (coder) return coder.accessor();
   throw new ConfigurationError(
     `the column '${storeAttribute}' has not been configured as a store. ` +
-      `Please make sure the column is declared via store() or use a structured column type.`,
+      `Please make sure the column is declared serializable via 'ActiveRecord.store' or, ` +
+      `if your database supports it, use a structured column type like hstore or json.`,
   );
 }
 

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -276,10 +276,12 @@ export class HashAccessor {
 
 /**
  * Ensures the store attribute value is a HashWithIndifferentAccess before
- * reading or writing a key. Non-HWIA values (plain objects, strings, null)
- * are coerced to an empty HWIA — matching Rails' behavior for structured
- * column types (json/jsonb/hstore) where the type deserializer may return
- * a plain hash or nil rather than a HWIA.
+ * reading or writing a key. The `prepare` override coerces non-HWIA values
+ * via `asIndifferentHash`: hash-like objects (plain `{}`) are promoted to
+ * HWIA preserving their keys; non-object values (strings, numbers, null)
+ * become an empty HWIA. Matches Rails' behavior for structured column types
+ * (json/jsonb/hstore) where the type deserializer may return a plain hash
+ * or nil rather than a HWIA.
  *
  * Mirrors: ActiveRecord::Store::IndifferentHashAccessor
  */


### PR DESCRIPTION
## Summary

- **Super-chain**: `storeAccessor()` now installs property descriptors on a synthesized intermediate prototype (`storeModule`) that is spliced between `modelClass.prototype` and its current parent. User code on `modelClass.prototype` can override store accessors and delegate to the base implementation by reaching through `Object.getPrototypeOf(ModelClass.prototype)` — the TypeScript/esbuild-safe analog of Ruby `super` in `_store_accessors_module.module_eval`.
- **`storeAccessorFor` hardened**: Removed the `_hasStoredAttribute` fallback that incorrectly returned `IndifferentHashAccessor` for non-serializable columns declared with `storeAccessor` but no `store()`. Now raises `ConfigurationError` whenever neither the column type has an `.accessor()` nor an `IndifferentCoder` has been registered.
- **4 blocked tests un-skipped** in `store.test.ts`: "overriding a read accessor using super", "overriding a write accessor using super", "convert store attributes from any format other than Hash or HashWithIndifferentAccess losing the data", "store_accessor raises an exception if the column is not either serializable or a structured type".

## Changes

- `packages/activerecord/src/store.ts`: +~50 LOC — `_storeModuleProtos` WeakMap, `getOrCreateStoreModuleProto()`, storeAccessor install target change, `storeAccessorFor` error path cleanup, `_hasStoredAttribute` deleted
- `packages/activerecord/src/store.test.ts`: +~60 LOC — 4 test bodies implemented

## Verify

- `pnpm vitest run packages/activerecord/src/store.test.ts` — 76/76 pass (previously 72 pass + 4 skip)
- `pnpm api:compare --package activerecord` — 4954/4958 (99.9%), unchanged
- Lint + typecheck — clean