### PR TITLE
feat(activerecord): encryption — binary-column fixtures + 3 test un-skips (audit Slot A)

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -38,8 +38,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const post = await withoutEncryption(() => Post.create({ title, body }));
     await post.encrypt();
 
-    assertEncryptedAttribute(post, "title", title);
-    assertEncryptedAttribute(post, "body", body);
+    await assertEncryptedAttribute(post, "title", title);
+    await assertEncryptedAttribute(post, "body", body);
 
     // Verify the DB was actually updated with ciphertext.
     const reloaded = await Post.find(post.id);
@@ -67,7 +67,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const title = "the Starfleet is here!";
     const body = "<p>the Starfleet is here, we are safe now!</p>";
     const post = await Post.create({ title, body });
-    assertEncryptedAttribute(post, "title", title);
+    await assertEncryptedAttribute(post, "title", title);
 
     await post.decrypt();
 
@@ -99,7 +99,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     for (let i = 0; i < 3; i++) await post.encrypt();
 
     const reloaded = await Post.find(post.id);
-    assertEncryptedAttribute(reloaded, "title", "the Starfleet is here");
+    await assertEncryptedAttribute(reloaded, "title", "the Starfleet is here");
     expect(reloaded.encryptedAttribute("title")).toBe(true);
   });
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -46,14 +46,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it("encrypts the attribute seamlessly when creating and updating records", async () => {
     const Post = makeEncryptedPost(freshAdapter());
     const post = await Post.create({ title: "The Starfleet is here!", body: "take cover!" });
-    assertEncryptedAttribute(post, "title", "The Starfleet is here!");
+    await assertEncryptedAttribute(post, "title", "The Starfleet is here!");
 
     await post.update({ title: "The Klingons are coming!" });
-    assertEncryptedAttribute(post, "title", "The Klingons are coming!");
+    await assertEncryptedAttribute(post, "title", "The Klingons are coming!");
 
     post.title = "You sure?";
     await post.save();
-    assertEncryptedAttribute(post, "title", "You sure?");
+    await assertEncryptedAttribute(post, "title", "You sure?");
   });
 
   it("attribute is not accessible with the wrong key", async () => {
@@ -133,7 +133,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     Post.encrypts("body", { keyProvider });
 
     const post = await Post.create({ title: "The Starfleet is here!", body: "take cover!" });
-    assertEncryptedAttribute(post, "body", "take cover!");
+    await assertEncryptedAttribute(post, "body", "take cover!");
 
     // Verify round-trip: reload and decrypt using the scheme's own key provider.
     const reloaded = await Post.find(post.id);
@@ -146,7 +146,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     Author.encrypts("name", { key: customKey });
 
     const author = await Author.create({ name: "Stephen King" });
-    assertEncryptedAttribute(author, "name", "Stephen King");
+    await assertEncryptedAttribute(author, "name", "Stephen King");
 
     // Verify round-trip: reload and decrypt using the scheme's own key.
     const reloaded = await Author.find(author.id);
@@ -158,8 +158,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const title = "The Starfleet is here!";
     const body = "<p>the Starfleet is here, we are safe now!</p>";
     const post = await Post.create({ title, body });
-    assertEncryptedAttribute(post, "title", title);
-    assertEncryptedAttribute(post, "body", body);
+    await assertEncryptedAttribute(post, "title", title);
+    await assertEncryptedAttribute(post, "body", body);
   });
 
   it("encrypted_attributes returns the list of encrypted attributes in a model (each record class holds their own list)", () => {
@@ -466,7 +466,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Book = makeEncryptedBook(freshAdapter());
     new Book();
     const book = await Book.create({});
-    assertEncryptedAttribute(book, "name", "<untitled>");
+    await assertEncryptedAttribute(book, "name", "<untitled>");
   });
 
   it.skip("loading records with encrypted attributes defined on columns with default values", () => {
@@ -529,8 +529,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Book = makeEncryptedBookIgnoreCase(freshAdapter());
     new Book();
     const book = await Book.create({ name: "Dune" });
-    assertEncryptedAttribute(book, "name", "Dune");
-    assertEncryptedAttribute(book, "original_name", "Dune");
+    await assertEncryptedAttribute(book, "name", "Dune");
+    await assertEncryptedAttribute(book, "original_name", "Dune");
     // In-memory read before save reflects the assigned value immediately.
     const unsaved = new Book({ name: "Arrakis" });
     expect(unsaved.name).toBe("Arrakis");
@@ -572,15 +572,15 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Book = makeEncryptedBookWithBinary(freshAdapter());
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
-    assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
-    assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
+    await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+    await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
   });
   it("serialized binary data can be encrypted", async () => {
     const jsonBytes = Array.from({ length: 96 }, (_, i) => String.fromCharCode(i + 32));
     const Book1 = makeEncryptedBookWithSerializedFirstBinary(freshAdapter());
-    assertEncryptedAttribute(await Book1.create({ logo: jsonBytes }), "logo", jsonBytes);
+    await assertEncryptedAttribute(await Book1.create({ logo: jsonBytes }), "logo", jsonBytes);
     const Book2 = makeEncryptedBookWithSerializedSecondBinary(freshAdapter());
-    assertEncryptedAttribute(await Book2.create({ logo: jsonBytes }), "logo", jsonBytes);
+    await assertEncryptedAttribute(await Book2.create({ logo: jsonBytes }), "logo", jsonBytes);
   });
   it.skip("deterministic ciphertexts remain constant", () => {
     // BLOCKED: encryption — encryption subsystem gap in encryptable-record
@@ -619,9 +619,9 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     BookNormalized.encrypts("logo", { deterministic: true, downcase: true });
     new BookNormalized();
     const b1 = await BookNormalized.create({ name: "Book" });
-    assertEncryptedAttribute(await BookNormalized.find(b1.id), "name", "book");
+    await assertEncryptedAttribute(await BookNormalized.find(b1.id), "name", "book");
     const b2 = await BookNormalized.create({ logo: "Book" });
-    assertEncryptedAttribute(await BookNormalized.find(b2.id), "logo", "book");
+    await assertEncryptedAttribute(await BookNormalized.find(b2.id), "logo", "book");
   });
 
   it("EncryptableRecord.validateEncryptionAllowed throws when encryption is frozen", () => {
@@ -666,11 +666,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Post = makeEncryptedPost(adp);
     new Post();
     const post = await Post.create({ title: "Hello", body: "World" });
-    assertEncryptedAttribute(post, "title", "Hello");
+    await assertEncryptedAttribute(post, "title", "Hello");
     // Re-encrypt: DB gets fresh ciphertext, in-memory stays plaintext.
     await EncryptableRecord.encryptAttributes(post);
     expect(post.title).toBe("Hello");
-    assertEncryptedAttribute(await Post.find(post.id), "title", "Hello");
+    await assertEncryptedAttribute(await Post.find(post.id), "title", "Hello");
   });
 
   it("EncryptableRecord.decryptAttributes stores plaintext in DB", async () => {
@@ -679,7 +679,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Post = makeEncryptedPost(adp);
     new Post();
     const post = await Post.create({ title: "Hello", body: "World" });
-    assertEncryptedAttribute(post, "title", "Hello");
+    await assertEncryptedAttribute(post, "title", "Hello");
     await EncryptableRecord.decryptAttributes(post);
     // supportUnencryptedData=true lets the EncryptedAttributeType pass through plaintext.
     const reloaded = await Post.find(post.id);
@@ -695,6 +695,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     BookDate.attribute("name", "date"); // override cast type to date (DB stays text)
     BookDate.encrypts("name");
     const book = await BookDate.create({ name: "2024-01-01" });
-    assertEncryptedAttribute(book, "name", Temporal.PlainDate.from("2024-01-01"));
+    await assertEncryptedAttribute(book, "name", Temporal.PlainDate.from("2024-01-01"));
   });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -11,6 +11,9 @@ import {
   makeEncryptedBookIgnoreCase,
   makeEncryptedAuthor,
   makeBookThatWillFailToEncryptName,
+  makeEncryptedBookWithBinary,
+  makeEncryptedBookWithSerializedFirstBinary,
+  makeEncryptedBookWithSerializedSecondBinary,
   makeEncryptedBookWithCustomCompressor,
   makeFreshModel,
   makeKeyProvider,
@@ -558,20 +561,26 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const overridingInstance = found!.becomes(OverridingBook);
     expect(overridingInstance.name).toBe("Dune-overridden");
   });
-  it.skip("binary data can be encrypted", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
+  it("binary data can be encrypted", async () => {
+    const Book = makeEncryptedBookWithBinary(freshAdapter());
+    const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
+    expect((await Book.create({ logo: allBytes })).logo).toEqual(allBytes);
+    expect((await Book.create({ logo: null })).logo).toBeNull();
+    expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
-  it.skip("binary data can be encrypted uncompressed", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
+  it("binary data can be encrypted uncompressed", async () => {
+    const Book = makeEncryptedBookWithBinary(freshAdapter());
+    const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
+    const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
+    assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+    assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
   });
-  it.skip("serialized binary data can be encrypted", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
+  it("serialized binary data can be encrypted", async () => {
+    const jsonBytes = Array.from({ length: 96 }, (_, i) => String.fromCharCode(i + 32));
+    const Book1 = makeEncryptedBookWithSerializedFirstBinary(freshAdapter());
+    assertEncryptedAttribute(await Book1.create({ logo: jsonBytes }), "logo", jsonBytes);
+    const Book2 = makeEncryptedBookWithSerializedSecondBinary(freshAdapter());
+    assertEncryptedAttribute(await Book2.create({ logo: jsonBytes }), "logo", jsonBytes);
   });
   it.skip("deterministic ciphertexts remain constant", () => {
     // BLOCKED: encryption — encryption subsystem gap in encryptable-record

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -245,7 +245,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     // the encryptor receives a valid string rather than "0,1,2,..." (Array#toString).
     const str =
       casted instanceof Uint8Array
-        ? Array.from(casted, (b) => String.fromCharCode(b)).join("")
+        ? Buffer.from(casted).toString("latin1")
         : typeof casted === "string"
           ? casted
           : String(casted);
@@ -307,10 +307,9 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private textToDatabaseType(value: unknown): unknown {
     if (value != null && this.castType.isBinary()) {
       if (typeof value === "string") {
-        // Use Latin-1 mapping (charCodeAt) so binary payload bytes > 127 round-trip
-        // correctly. UTF-8 encoding (TextEncoder) would expand bytes 128–255 to
-        // two-byte sequences and corrupt the data on decrypt.
-        return new BinaryData(Uint8Array.from(value, (c) => c.charCodeAt(0)));
+        // Use Latin-1 so binary payload bytes > 127 round-trip correctly.
+        // UTF-8 (TextEncoder) would expand bytes 128–255 to two-byte sequences.
+        return new BinaryData(new Uint8Array(Buffer.from(value, "latin1")));
       }
       return new BinaryData(value as string);
     }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -323,9 +323,11 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private databaseTypeToText(value: unknown): unknown {
     if (value != null && this.castType.isBinary()) {
       const raw = this.castType.deserialize?.(value) ?? value;
-      // BinaryType.deserialize returns Uint8Array; decode back to the ciphertext string
-      // so decryptAsText always receives a plain string.
-      return raw instanceof Uint8Array ? new TextDecoder().decode(raw) : raw;
+      // Use Latin-1 (not UTF-8) so bytes 128–255 survive the round-trip. The
+      // ciphertext is always ASCII so Latin-1 == UTF-8 for that path; for
+      // supportUnencryptedData rows the plaintext bytes must also be Latin-1
+      // decoded or they'll be corrupted before textToDatabaseType re-wraps them.
+      return raw instanceof Uint8Array ? Buffer.from(raw).toString("latin1") : raw;
     }
     return value;
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -311,7 +311,10 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
         // UTF-8 (TextEncoder) would expand bytes 128–255 to two-byte sequences.
         return new BinaryData(new Uint8Array(Buffer.from(value, "latin1")));
       }
-      return new BinaryData(value as string);
+      if (value instanceof Uint8Array) return new BinaryData(value);
+      // Already a BinaryData wrapper (e.g. supportUnencryptedData pass-through).
+      if (value instanceof BinaryData) return value;
+      return new BinaryData(String(value));
     }
     return value;
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -241,7 +241,14 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private serializeWithCurrent(value: unknown): unknown {
     const casted = this.castType.serialize?.(value) ?? value;
     if (casted === null || casted === undefined) return null;
-    const str = typeof casted === "string" ? casted : String(casted);
+    // Binary columns: convert each byte to the matching Latin-1 code point so
+    // the encryptor receives a valid string rather than "0,1,2,..." (Array#toString).
+    const str =
+      casted instanceof Uint8Array
+        ? Array.from(casted, (b) => String.fromCharCode(b)).join("")
+        : typeof casted === "string"
+          ? casted
+          : String(casted);
     const normalized = this.deterministic ? this._applyForcedEncoding(str) : str;
     const toEncrypt =
       this.scheme.downcase || this.scheme.ignoreCase ? normalized.toLowerCase() : normalized;
@@ -298,7 +305,15 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private textToDatabaseType(value: unknown): unknown {
-    if (value != null && this.castType.isBinary()) return new BinaryData(value as string);
+    if (value != null && this.castType.isBinary()) {
+      if (typeof value === "string") {
+        // Use Latin-1 mapping (charCodeAt) so binary payload bytes > 127 round-trip
+        // correctly. UTF-8 encoding (TextEncoder) would expand bytes 128–255 to
+        // two-byte sequences and corrupt the data on decrypt.
+        return new BinaryData(Uint8Array.from(value, (c) => c.charCodeAt(0)));
+      }
+      return new BinaryData(value as string);
+    }
     return value;
   }
 

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -333,40 +333,66 @@ export function makeEncryptedBookWithSerializedSecondBinary(adapter: DatabaseAda
 /**
  * Mirrors Rails' assert_encrypted_attribute.
  * Checks that the actual DB-bound value is ciphertext (≠ plaintext) and
- * that reading the attribute returns the expected plaintext.
- *
- * Uses _attributes.valuesForDatabase() to get the exact value that would
- * be written to the DB, matching what Rails' assert_encrypted_attribute
- * checks via read_attribute_before_type_cast on a persisted record.
+ * that reading the attribute returns the expected plaintext. For persisted
+ * records, reloads and re-checks — matching Rails' assert_encrypted_attribute
+ * which calls model.reload before the second assertion.
  */
-export function assertEncryptedAttribute(
+export async function assertEncryptedAttribute(
+  model: any,
+  attrName: string,
+  expectedValue: unknown,
+): Promise<void> {
+  _assertEncryptedAttributeOnModel(model, attrName, expectedValue);
+
+  if (typeof model.isPersisted === "function" && model.isPersisted()) {
+    await model.reload();
+    _assertEncryptedAttributeOnModel(model, attrName, expectedValue);
+  }
+}
+
+function _valuesEqual(readValue: unknown, expectedValue: unknown): boolean {
+  if (readValue === expectedValue) return true;
+  if (
+    readValue instanceof Temporal.Instant &&
+    expectedValue instanceof Temporal.Instant &&
+    Temporal.Instant.compare(readValue, expectedValue) === 0
+  )
+    return true;
+  if (
+    readValue instanceof Temporal.PlainDate &&
+    expectedValue instanceof Temporal.PlainDate &&
+    Temporal.PlainDate.compare(readValue, expectedValue) === 0
+  )
+    return true;
+  if (
+    readValue instanceof Temporal.PlainDateTime &&
+    expectedValue instanceof Temporal.PlainDateTime &&
+    Temporal.PlainDateTime.compare(readValue, expectedValue) === 0
+  )
+    return true;
+  if (
+    readValue instanceof Uint8Array &&
+    expectedValue instanceof Uint8Array &&
+    readValue.length === expectedValue.length &&
+    readValue.every((b, i) => b === (expectedValue as Uint8Array)[i])
+  )
+    return true;
+  if (
+    Array.isArray(readValue) &&
+    Array.isArray(expectedValue) &&
+    JSON.stringify(readValue) === JSON.stringify(expectedValue)
+  )
+    return true;
+  return false;
+}
+
+function _assertEncryptedAttributeOnModel(
   model: any,
   attrName: string,
   expectedValue: unknown,
 ): void {
-  // Verify the attribute reads back as the expected plaintext.
   const readValue = model[attrName];
-  const temporalEqual =
-    (readValue instanceof Temporal.Instant &&
-      expectedValue instanceof Temporal.Instant &&
-      Temporal.Instant.compare(readValue, expectedValue) === 0) ||
-    (readValue instanceof Temporal.PlainDate &&
-      expectedValue instanceof Temporal.PlainDate &&
-      Temporal.PlainDate.compare(readValue, expectedValue) === 0) ||
-    (readValue instanceof Temporal.PlainDateTime &&
-      expectedValue instanceof Temporal.PlainDateTime &&
-      Temporal.PlainDateTime.compare(readValue, expectedValue) === 0);
-  const uint8Equal =
-    readValue instanceof Uint8Array &&
-    expectedValue instanceof Uint8Array &&
-    readValue.length === expectedValue.length &&
-    readValue.every((b, i) => b === (expectedValue as Uint8Array)[i]);
-  const arrayEqual =
-    Array.isArray(readValue) &&
-    Array.isArray(expectedValue) &&
-    JSON.stringify(readValue) === JSON.stringify(expectedValue);
-  const valuesEqual = readValue === expectedValue || temporalEqual || uint8Equal || arrayEqual;
-  if (!valuesEqual) {
+  if (!_valuesEqual(readValue, expectedValue)) {
     throw new Error(
       `assertEncryptedAttribute: expected ${attrName} to equal ` +
         `${JSON.stringify(expectedValue)}, got ${JSON.stringify(readValue)}`,
@@ -374,8 +400,6 @@ export function assertEncryptedAttribute(
   }
 
   // Verify the DB-bound value differs from the plaintext — confirms real encryption.
-  // For non-string types (e.g. Date), also compare against the serialized string
-  // form since dbValue is always a string while expectedValue may be an object.
   if (expectedValue !== null && expectedValue !== undefined) {
     const dbValues = model._attributes.valuesForDatabase();
     const dbValue = dbValues[attrName];
@@ -384,7 +408,6 @@ export function assertEncryptedAttribute(
       type && typeof (type as any).castType?.serialize === "function"
         ? (type as any).castType.serialize(expectedValue)
         : null;
-    // Normalize to string for comparison (EncryptedAttributeType calls String() before encrypting).
     const serializedPlaintext = rawSerialized != null ? String(rawSerialized) : null;
     if (
       dbValue === expectedValue ||

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -18,7 +18,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError, EncryptionError } from "./errors.js";
-import { ValueType } from "@blazetrails/activemodel";
+import { ValueType, BinaryData } from "@blazetrails/activemodel";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import type { Encryptor } from "../encryption.js";
@@ -409,7 +409,29 @@ function _assertEncryptedAttributeOnModel(
         ? (type as any).castType.serialize(expectedValue)
         : null;
     const serializedPlaintext = rawSerialized != null ? String(rawSerialized) : null;
+
+    // For binary attributes the DB value is BinaryData (bytes); compare underlying
+    // bytes against the serialized plaintext bytes so we catch unencrypted storage.
+    const dbBytes =
+      dbValue instanceof BinaryData
+        ? dbValue.bytes
+        : dbValue instanceof Uint8Array
+          ? dbValue
+          : null;
+    const plaintextBytes =
+      rawSerialized instanceof BinaryData
+        ? rawSerialized.bytes
+        : rawSerialized instanceof Uint8Array
+          ? rawSerialized
+          : null;
+    const binaryPlaintextMatch =
+      dbBytes !== null &&
+      plaintextBytes !== null &&
+      dbBytes.length === plaintextBytes.length &&
+      dbBytes.every((b, i) => b === (plaintextBytes as Uint8Array)[i]);
+
     if (
+      binaryPlaintextMatch ||
       dbValue === expectedValue ||
       (serializedPlaintext != null && dbValue === serializedPlaintext)
     ) {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -18,9 +18,46 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError, EncryptionError } from "./errors.js";
+import { ValueType } from "@blazetrails/activemodel";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import type { Encryptor } from "../encryption.js";
+
+// JSON array type: cast/serialize produce a JSON string; deserialize parses it back.
+// Used as the castType for EncryptedBookWithSerialized*Binary factories.
+class _JsonArrayType extends ValueType<unknown> {
+  readonly name = "string";
+  cast(value: unknown): unknown {
+    if (value === null || value === undefined) return null;
+    if (Array.isArray(value)) return value;
+    if (typeof value === "string") {
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+  serialize(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+    return JSON.stringify(value);
+  }
+  deserialize(value: unknown): unknown {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") {
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+  type(): string {
+    return "string";
+  }
+}
 
 export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionError };
 
@@ -238,6 +275,59 @@ export function makeBookThatWillFailToEncryptName(adapter: DatabaseAdapter) {
   } as any;
 }
 
+/**
+ * EncryptedBookWithBinary: logo is a binary attribute, encrypted.
+ * Mirrors Rails' EncryptedBookWithBinary fixture (book_encrypted.rb).
+ */
+export function makeEncryptedBookWithBinary(adapter: DatabaseAdapter) {
+  return class EncryptedBookWithBinary extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("logo", "binary");
+      this.adapter = adapter;
+      this.encrypts("logo");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookWithSerializedFirstBinary: logo stores an Array via JSON serialization,
+ * then encrypted. Mirrors Rails' EncryptedBookWithSerializedFirstBinary fixture.
+ */
+export function makeEncryptedBookWithSerializedFirstBinary(adapter: DatabaseAdapter) {
+  const jsonArrayType = new _JsonArrayType();
+  return class EncryptedBookWithSerializedFirstBinary extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("logo", "string");
+      // Replace string type with JSON-array type via the pending queue so
+      // _defaultAttributes() uses _JsonArrayType as the castType when encrypts wraps it.
+      this.decorateAttributes(["logo"], () => jsonArrayType);
+      this.adapter = adapter;
+      this.encrypts("logo");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookWithSerializedSecondBinary: logo stores an Array, encrypted.
+ * Mirrors Rails' EncryptedBookWithSerializedSecondBinary fixture.
+ * Uses JSON array serialization (YAML is not available in TS; both produce
+ * equivalent results for the ASCII-only test data).
+ */
+export function makeEncryptedBookWithSerializedSecondBinary(adapter: DatabaseAdapter) {
+  const jsonArrayType = new _JsonArrayType();
+  return class EncryptedBookWithSerializedSecondBinary extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("logo", "string");
+      this.decorateAttributes(["logo"], () => jsonArrayType);
+      this.adapter = adapter;
+      this.encrypts("logo");
+    }
+  } as any;
+}
+
 // ─── Assertion helpers ────────────────────────────────────────────────────────
 
 /**
@@ -266,7 +356,16 @@ export function assertEncryptedAttribute(
     (readValue instanceof Temporal.PlainDateTime &&
       expectedValue instanceof Temporal.PlainDateTime &&
       Temporal.PlainDateTime.compare(readValue, expectedValue) === 0);
-  const valuesEqual = readValue === expectedValue || temporalEqual;
+  const uint8Equal =
+    readValue instanceof Uint8Array &&
+    expectedValue instanceof Uint8Array &&
+    readValue.length === expectedValue.length &&
+    readValue.every((b, i) => b === (expectedValue as Uint8Array)[i]);
+  const arrayEqual =
+    Array.isArray(readValue) &&
+    Array.isArray(expectedValue) &&
+    JSON.stringify(readValue) === JSON.stringify(expectedValue);
+  const valuesEqual = readValue === expectedValue || temporalEqual || uint8Equal || arrayEqual;
   if (!valuesEqual) {
     throw new Error(
       `assertEncryptedAttribute: expected ${attrName} to equal ` +

--- a/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
+++ b/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
@@ -40,7 +40,7 @@ describe("ActiveRecord::Encryption::UnencryptedAttributesTest", () => {
     expect(reloaded.title).toBe("The Starfleet is here!");
     // On next save, encryption is applied.
     await post.update({ title: "Other title" });
-    assertEncryptedAttribute(await Post.find(post.id), "title", "Other title");
+    await assertEncryptedAttribute(await Post.find(post.id), "title", "Other title");
   });
 
   it("when :support_unencrypted_data is on, it won't work with unencrypted attributes", async () => {


### PR DESCRIPTION
## Summary

- Fix `EncryptedAttributeType` binary round-trip: `Uint8Array` → Latin-1 string (charCodeAt) before encrypt, and charCodeAt in `textToDatabaseType` after decrypt so bytes 128–255 survive without UTF-8 corruption
- Add 3 test-helper factories: `makeEncryptedBookWithBinary`, `makeEncryptedBookWithSerializedFirstBinary`, `makeEncryptedBookWithSerializedSecondBinary`
- Extend `assertEncryptedAttribute` with Uint8Array and Array deep-equality branches
- Un-skip 3 BLOCKED tests: "binary data can be encrypted", "binary data can be encrypted uncompressed", "serialized binary data can be encrypted"

## Details

**Binary encoding fix** (`encrypted-attribute-type.ts`): Rails binary columns store byte sequences. Converting `Uint8Array` via `String()` produced comma-joined decimal strings (`"0,1,2,..."`); the fix uses `String.fromCharCode` per byte. On the decrypt side, `textToDatabaseType` was using `TextEncoder` (UTF-8) which corrupts bytes > 127; switched to `Uint8Array.from(str, c => c.charCodeAt(0))`.

**Serialized binary factories**: Rails' `EncryptedBookWithSerializedFirst/SecondBinary` serialize arrays before encrypting. Our `serialize()` helper only wraps the read path, so the factories use `decorateAttributes` to inject a `_JsonArrayType` (JSON.stringify/parse) into the pending-decorator queue before `encrypts` wraps it — ensuring `_defaultAttributes()` replay produces the correct `EncryptedAttributeType(castType=_JsonArrayType)`.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/encryption/encryptable-record.test.ts` — 54 pass, 4 skip (3 newly un-skipped)
- [ ] `pnpm api:compare --package activerecord` — 4954/4958, unchanged from baseline
- [ ] Build + typecheck pass (confirmed by pre-commit hook)

## Follow-ups (Slot B / Slot C)

- Slot B: `messageSerializer` option tests
- Slot C: lazy `previousSchemes` + `store_accessor` + insert/defaults + deterministic-ciphertext-byte-parity test