### PR TITLE
feat(activerecord): encryption — messageSerializer option pass-through + msgpack fixture (audit Slot B)

### DIFF
--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -4,6 +4,8 @@
  * Mirrors: ActiveRecord::Encryption::Contexts
  */
 
+import type { MessageSerializerLike } from "./message-serializer.js";
+
 /**
  * Holds the encryption configuration for a single context frame:
  * key provider, key generator, cipher, message serializer, encryptor,
@@ -15,7 +17,7 @@ export class Context {
   private _keyProvider?: unknown;
   keyGenerator?: unknown;
   cipher?: unknown;
-  messageSerializer?: unknown;
+  messageSerializer?: MessageSerializerLike;
   encryptor?: unknown;
   frozenEncryption: boolean = false;
 
@@ -50,6 +52,7 @@ export interface EncryptionContext {
   protectedMode?: boolean;
   frozenEncryption?: boolean;
   keyProvider?: unknown;
+  messageSerializer?: MessageSerializerLike;
   [key: string]: unknown;
 }
 

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -32,7 +32,9 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
 
   it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
     const Book = makeEncryptedBookWithBinaryMessagePackSerialized(freshAdapter());
-    // Strings below 140 bytes are not compressed
+    // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
+    // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
+    // it may be compressed; the round-trip is correct either way.
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
     await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -1,19 +1,54 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+  makeEncryptedBookWithBinaryMessagePackSerialized,
+  assertEncryptedAttribute,
+  Base,
+} from "./test-helpers.js";
+import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
+import { Encoding as EncodingError } from "./errors.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest", () => {
-  it.skip("binary data can be serialized with message pack", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record-message-pack-serialized
-    // ROOT-CAUSE: encryption/encryptable-record-message-pack-serialized.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record-message-pack-serialized.ts; affects ~6–28 tests in encryptable-record-message-pack-serialized.test.ts
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    configSnapshot = snapshotEncryptionConfig();
+    configureEncryption();
   });
-  it.skip("binary data can be encrypted uncompressed and serialized with message pack", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record-message-pack-serialized
-    // ROOT-CAUSE: encryption/encryptable-record-message-pack-serialized.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record-message-pack-serialized.ts; affects ~6–28 tests in encryptable-record-message-pack-serialized.test.ts
+
+  afterEach(() => {
+    restoreEncryptionConfig(configSnapshot);
   });
-  it.skip("text columns cannot be serialized with message pack", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record-message-pack-serialized
-    // ROOT-CAUSE: encryption/encryptable-record-message-pack-serialized.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record-message-pack-serialized.ts; affects ~6–28 tests in encryptable-record-message-pack-serialized.test.ts
+
+  it("binary data can be serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(freshAdapter());
+    const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
+    const book = await Book.create({ logo: allBytes });
+    await assertEncryptedAttribute(book, "logo", allBytes);
+  });
+
+  it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(freshAdapter());
+    // Strings below 140 bytes are not compressed
+    const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
+    const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
+    await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+    await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
+  });
+
+  it("text columns cannot be serialized with message pack", async () => {
+    const adapter = freshAdapter();
+    const MsgPackTextBook = class extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.encrypts("name", { messageSerializer: new MessagePackMessageSerializer() });
+      }
+    } as any;
+    await expect(MsgPackTextBook.create({ name: "Dune" })).rejects.toThrow(EncodingError);
   });
 });

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -171,31 +171,33 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private decryptAsText(value: unknown): unknown {
-    if (value === null || value === undefined) return value;
-    if (this._default !== undefined && this._default === value) return value;
+    return this.scheme.withContext(() => {
+      if (value === null || value === undefined) return value;
+      if (this._default !== undefined && this._default === value) return value;
 
-    // Adapters that use JSON/JSONB columns (e.g. PostgreSQL) return the stored value
-    // as a parsed JS object rather than a raw string. Re-stringify so the encryptor
-    // always receives the JSON string that was originally stored.
-    let ciphertext: string;
-    if (typeof value === "string") {
-      ciphertext = value;
-    } else {
-      try {
-        ciphertext = JSON.stringify(value) ?? String(value);
-      } catch {
-        ciphertext = String(value);
+      // Adapters that use JSON/JSONB columns (e.g. PostgreSQL) return the stored value
+      // as a parsed JS object rather than a raw string. Re-stringify so the encryptor
+      // always receives the JSON string that was originally stored.
+      let ciphertext: string;
+      if (typeof value === "string") {
+        ciphertext = value;
+      } else {
+        try {
+          ciphertext = JSON.stringify(value) ?? String(value);
+        } catch {
+          ciphertext = String(value);
+        }
       }
-    }
 
-    try {
-      return this._encryptor.decrypt(ciphertext, this.decryptionOptions());
-    } catch (error) {
-      if (!(error instanceof BaseEncryptionError)) throw error;
-      if (this.scheme.previousSchemes.length === 0)
-        return this.handleDeserializeError(error, value);
-      return this.tryToDeserializeWithPreviousEncryptedTypes(value);
-    }
+      try {
+        return this._encryptor.decrypt(ciphertext, this.decryptionOptions());
+      } catch (error) {
+        if (!(error instanceof BaseEncryptionError)) throw error;
+        if (this.scheme.previousSchemes.length === 0)
+          return this.handleDeserializeError(error, value);
+        return this.tryToDeserializeWithPreviousEncryptedTypes(value);
+      }
+    });
   }
 
   private decrypt(value: unknown): unknown {
@@ -257,10 +259,12 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private encryptAsText(value: string): string {
-    if (this._encryptor.isBinary() && !this.castType.isBinary()) {
-      throw new EncodingError("Binary encoded data can only be stored in binary columns");
-    }
-    return this._encryptor.encrypt(value, this.encryptionOptions());
+    return this.scheme.withContext(() => {
+      if (this._encryptor.isBinary() && !this.castType.isBinary()) {
+        throw new EncodingError("Binary encoded data can only be stored in binary columns");
+      }
+      return this._encryptor.encrypt(value, this.encryptionOptions());
+    });
   }
 
   private encrypt(value: string): unknown {

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -102,7 +102,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   isEncrypted(value: unknown): boolean {
     if (typeof value !== "string") return false;
-    return this._encryptor.isEncrypted(value);
+    return this.scheme.withContext(() => this._encryptor.isEncrypted(value));
   }
 
   get deterministic(): boolean {
@@ -171,33 +171,33 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private decryptAsText(value: unknown): unknown {
-    return this.scheme.withContext(() => {
-      if (value === null || value === undefined) return value;
-      if (this._default !== undefined && this._default === value) return value;
+    try {
+      return this.scheme.withContext(() => {
+        if (value === null || value === undefined) return value;
+        if (this._default !== undefined && this._default === value) return value;
 
-      // Adapters that use JSON/JSONB columns (e.g. PostgreSQL) return the stored value
-      // as a parsed JS object rather than a raw string. Re-stringify so the encryptor
-      // always receives the JSON string that was originally stored.
-      let ciphertext: string;
-      if (typeof value === "string") {
-        ciphertext = value;
-      } else {
-        try {
-          ciphertext = JSON.stringify(value) ?? String(value);
-        } catch {
-          ciphertext = String(value);
+        // Adapters that use JSON/JSONB columns (e.g. PostgreSQL) return the stored value
+        // as a parsed JS object rather than a raw string. Re-stringify so the encryptor
+        // always receives the JSON string that was originally stored.
+        let ciphertext: string;
+        if (typeof value === "string") {
+          ciphertext = value;
+        } else {
+          try {
+            ciphertext = JSON.stringify(value) ?? String(value);
+          } catch {
+            ciphertext = String(value);
+          }
         }
-      }
 
-      try {
         return this._encryptor.decrypt(ciphertext, this.decryptionOptions());
-      } catch (error) {
-        if (!(error instanceof BaseEncryptionError)) throw error;
-        if (this.scheme.previousSchemes.length === 0)
-          return this.handleDeserializeError(error, value);
-        return this.tryToDeserializeWithPreviousEncryptedTypes(value);
-      }
-    });
+      });
+    } catch (error) {
+      if (!(error instanceof BaseEncryptionError)) throw error;
+      if (this.scheme.previousSchemes.length === 0)
+        return this.handleDeserializeError(error, value);
+      return this.tryToDeserializeWithPreviousEncryptedTypes(value);
+    }
   }
 
   private decrypt(value: unknown): unknown {

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -6,6 +6,7 @@
 
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
+import { getEncryptionContext } from "./context.js";
 import { Configurable } from "./configurable.js";
 import {
   getOrCreateDefaultKeyProvider,
@@ -198,6 +199,8 @@ export class Encryptor {
 
   /** @internal */
   private serializer(): MessageSerializer {
+    const ctxSerializer = getEncryptionContext().messageSerializer;
+    if (ctxSerializer != null) return ctxSerializer as MessageSerializer;
     return this._serializer;
   }
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -5,7 +5,7 @@
  */
 
 import { Message } from "./message.js";
-import { MessageSerializer } from "./message-serializer.js";
+import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { getEncryptionContext } from "./context.js";
 import { Configurable } from "./configurable.js";
 import {
@@ -198,10 +198,8 @@ export class Encryptor {
   }
 
   /** @internal */
-  private serializer(): MessageSerializer {
-    const ctxSerializer = getEncryptionContext().messageSerializer;
-    if (ctxSerializer != null) return ctxSerializer as MessageSerializer;
-    return this._serializer;
+  private serializer(): MessageSerializerLike {
+    return getEncryptionContext().messageSerializer ?? this._serializer;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
@@ -11,7 +11,11 @@ describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
   });
 
   it("binary? returns false because this implementation uses JSON, not MessagePack binary", () => {
-    expect(new MessagePackMessageSerializer().isBinary()).toBe(false);
+    // isBinary() returns true: mirrors Rails' MessagePackMessageSerializer#binary?,
+    // which signals that the serialized form must be stored in a binary column.
+    // The wire format is JSON-based (not real MessagePack), but the binary-column
+    // constraint is the key behavioral contract.
+    expect(new MessagePackMessageSerializer().isBinary()).toBe(true);
   });
 
   it("serializes messages", () => {

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -7,8 +7,9 @@
 import { Message } from "./message.js";
 import { Properties } from "./properties.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
+import type { MessageSerializerLike } from "./message-serializer.js";
 
-export class MessagePackMessageSerializer {
+export class MessagePackMessageSerializer implements MessageSerializerLike {
   dump(message: Message): string {
     if (!(message instanceof Message)) {
       throw new ForbiddenClass(`Can only serialize Message instances, got ${typeof message}`);

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -30,7 +30,7 @@ export class MessagePackMessageSerializer {
   }
 
   isBinary(): boolean {
-    return false;
+    return true;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -8,7 +8,13 @@ import { Message } from "./message.js";
 import { Properties } from "./properties.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
 
-export class MessageSerializer {
+export interface MessageSerializerLike {
+  dump(message: Message): string;
+  load(serialized: string): Message;
+  isBinary(): boolean;
+}
+
+export class MessageSerializer implements MessageSerializerLike {
   dump(message: Message): string {
     if (!(message instanceof Message)) {
       throw new ForbiddenClass(`Can only serialize Message instances, got ${typeof message}`);

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -29,6 +29,7 @@ export interface SchemeOptions {
   compress?: boolean;
   compressor?: Compressor;
   encryptor?: EncryptorLike;
+  messageSerializer?: unknown;
 }
 
 export class Scheme {
@@ -99,9 +100,14 @@ export class Scheme {
   }
 
   withContext<T>(fn: () => T): T {
-    const { encryptor, compress, compressor } = this._opts;
-    if (encryptor !== undefined || compress === false || compressor !== undefined) {
-      return withEncryptionContext({ encryptor: this._encryptor }, fn);
+    const { encryptor, compress, compressor, messageSerializer } = this._opts;
+    const hasEncryptorOverride =
+      encryptor !== undefined || compress === false || compressor !== undefined;
+    if (hasEncryptorOverride || messageSerializer !== undefined) {
+      const ctx: Record<string, unknown> = {};
+      if (hasEncryptorOverride) ctx["encryptor"] = this._encryptor;
+      if (messageSerializer !== undefined) ctx["messageSerializer"] = messageSerializer;
+      return withEncryptionContext(ctx, fn);
     }
     return fn();
   }
@@ -125,6 +131,7 @@ export class Scheme {
     if (o.compress !== undefined) opts.compress = o.compress;
     if (o.compressor !== undefined) opts.compressor = o.compressor;
     if (o.encryptor !== undefined) opts.encryptor = o.encryptor;
+    if (o.messageSerializer !== undefined) opts.messageSerializer = o.messageSerializer;
     return opts;
   }
 

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -7,6 +7,7 @@
 import { Encryptor, type EncryptorLike } from "./encryptor.js";
 import { ConfigError } from "./errors.js";
 import type { Compressor } from "./config.js";
+import type { MessageSerializerLike } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
 import { withEncryptionContext } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -29,7 +30,7 @@ export interface SchemeOptions {
   compress?: boolean;
   compressor?: Compressor;
   encryptor?: EncryptorLike;
-  messageSerializer?: unknown;
+  messageSerializer?: MessageSerializerLike;
 }
 
 export class Scheme {

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -9,7 +9,7 @@ import { ConfigError } from "./errors.js";
 import type { Compressor } from "./config.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
 import { Configurable } from "./configurable.js";
-import { withEncryptionContext } from "./context.js";
+import { withEncryptionContext, type EncryptionContext } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 import {
@@ -105,9 +105,9 @@ export class Scheme {
     const hasEncryptorOverride =
       encryptor !== undefined || compress === false || compressor !== undefined;
     if (hasEncryptorOverride || messageSerializer !== undefined) {
-      const ctx: Record<string, unknown> = {};
-      if (hasEncryptorOverride) ctx["encryptor"] = this._encryptor;
-      if (messageSerializer !== undefined) ctx["messageSerializer"] = messageSerializer;
+      const ctx: EncryptionContext = {};
+      if (hasEncryptorOverride) ctx.encryptor = this._encryptor;
+      if (messageSerializer !== undefined) ctx.messageSerializer = messageSerializer;
       return withEncryptionContext(ctx, fn);
     }
     return fn();

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -22,6 +22,7 @@ import { ValueType, BinaryData } from "@blazetrails/activemodel";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import type { Encryptor } from "../encryption.js";
+import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
 
 // JSON array type: cast/serialize produce a JSON string; deserialize parses it back.
 // Used as the castType for EncryptedBookWithSerialized*Binary factories.
@@ -324,6 +325,22 @@ export function makeEncryptedBookWithSerializedSecondBinary(adapter: DatabaseAda
       this.decorateAttributes(["logo"], () => jsonArrayType);
       this.adapter = adapter;
       this.encrypts("logo");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookWithBinaryMessagePackSerialized: logo is a binary attribute
+ * encrypted with a MessagePack message serializer. Mirrors the fixture class
+ * defined inline in encryptable_record_message_pack_serialized_test.rb.
+ */
+export function makeEncryptedBookWithBinaryMessagePackSerialized(adapter: DatabaseAdapter) {
+  return class EncryptedBookWithBinaryMessagePackSerialized extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("logo", "binary");
+      this.adapter = adapter;
+      this.encrypts("logo", { messageSerializer: new MessagePackMessageSerializer() });
     }
   } as any;
 }


### PR DESCRIPTION
## Summary

- **`messageSerializer` option pass-through**: Added to `SchemeOptions`/`_toOptions`/`Scheme.withContext` so per-`encrypts()` serializer overrides flow into the encryption context (mirrors Rails `**context_properties` pattern in `Scheme#with_context`)
- **`Encryptor.serializer()` reads from context**: When `messageSerializer` is set in the encryption context, `isBinary()` and message serialization use it instead of the instance default
- **`withContext` on encrypt/decrypt paths**: `encryptAsText` and `decryptAsText` in `EncryptedAttributeType` now wrap with `scheme.withContext()` (mirrors Rails `with_context` block in `EncryptedAttributeType#encrypt_as_text`)
- **`MessagePackMessageSerializer.isBinary()` fixed**: Now returns `true` — the binary-column constraint is the key behavioral contract Rails tests exercise
- **Test helper + 3 un-skips**: `makeEncryptedBookWithBinaryMessagePackSerialized` factory + 3 tests in `encryptable-record-message-pack-serialized.test.ts` pass

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts` — 3 tests pass
- [x] Full encryption suite (29 test files) — all pass
- [x] `pnpm api:compare --package activerecord` — unchanged
- [x] Build + lint — pass

## Out of scope (Slot C)

- Lazy `previousSchemes` + `store_accessor` + insert/defaults + ciphertext constancy
- `databaseTypeToText` `serialized?` branch (~15 LOC followup from audit)