### PR TITLE
feat(activerecord): migration — instance-method proxies for PG-only DDL (audit Slot A, 21 un-skips)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -14,52 +14,52 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlExtensionMigrationTest", () => {
-    it.skip("enable extension", async () => {
+    it("enable extension", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("disable extension", async () => {
+    it("disable extension", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("enable extension idempotent", async () => {
+    it("enable extension idempotent", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("disable extension idempotent", async () => {
+    it("disable extension idempotent", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("extension schema dump", async () => {
+    it("extension schema dump", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("enable extension migration ignores prefix and suffix", async () => {
+    it("enable extension migration ignores prefix and suffix", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("enable extension migration with schema", async () => {
+    it("enable extension migration with schema", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("disable extension migration ignores prefix and suffix", async () => {
+    it("disable extension migration ignores prefix and suffix", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("disable extension raises when dependent objects exist", async () => {
+    it("disable extension raises when dependent objects exist", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
     });
-    it.skip("disable extension drops extension when cascading", async () => {
+    it("disable extension drops extension when cascading", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
       // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -67,6 +67,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       await new EnableCitext().run(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
+      const dump = await adapter.createSchemaDumper({}).dump();
+      expect(dump).toContain(`enable_extension "citext"`);
     });
     it("enable extension migration ignores prefix and suffix", async () => {
       // Rails: table_name_prefix/suffix don't affect extension names

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -1,68 +1,107 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Migration } from "../../index.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.disableExtension("citext", { force: "cascade" }).catch(() => {});
   });
   afterEach(async () => {
+    await adapter.execute("DROP TABLE IF EXISTS test_citext_tbl").catch(() => {});
+    await adapter.disableExtension("citext", { force: "cascade" }).catch(() => {});
     await adapter.close();
   });
 
   describe("PostgresqlExtensionMigrationTest", () => {
     it("enable extension", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      class EnableCitext extends Migration {
+        async change() {
+          await this.enableExtension("citext");
+        }
+      }
+      await new EnableCitext().run(adapter, "up");
+      expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("disable extension", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      await adapter.enableExtension("citext");
+      class DisableCitext extends Migration {
+        async change() {
+          await this.disableExtension("citext", { force: "cascade" });
+        }
+      }
+      await new DisableCitext().run(adapter, "up");
+      expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("enable extension idempotent", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      class EnableCitext extends Migration {
+        async change() {
+          await this.enableExtension("citext");
+        }
+      }
+      const m = new EnableCitext();
+      await m.run(adapter, "up");
+      await expect(m.run(adapter, "up")).resolves.toBeUndefined();
+      expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("disable extension idempotent", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      class DisableCitext extends Migration {
+        async change() {
+          await this.disableExtension("citext", { force: "cascade" });
+        }
+      }
+      const m = new DisableCitext();
+      await m.run(adapter, "up");
+      await expect(m.run(adapter, "up")).resolves.toBeUndefined();
+      expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("extension schema dump", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      await adapter.enableExtension("citext");
+      expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration ignores prefix and suffix", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      class EnableCitext extends Migration {
+        async change() {
+          await this.enableExtension("citext");
+        }
+      }
+      await new EnableCitext().run(adapter, "up");
+      expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration with schema", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      class EnableCitext extends Migration {
+        async change() {
+          await this.enableExtension("citext");
+        }
+      }
+      await new EnableCitext().run(adapter, "up");
+      expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("disable extension migration ignores prefix and suffix", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      await adapter.enableExtension("citext");
+      class DisableCitext extends Migration {
+        async change() {
+          await this.disableExtension("citext", { force: "cascade" });
+        }
+      }
+      await new DisableCitext().run(adapter, "up");
+      expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("disable extension raises when dependent objects exist", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      await adapter.enableExtension("citext");
+      await adapter.execute(`CREATE TABLE test_citext_tbl (id SERIAL PRIMARY KEY, data CITEXT)`);
+      await expect(adapter.disableExtension("citext")).rejects.toThrow();
+      await adapter.execute("DROP TABLE test_citext_tbl");
     });
     it("disable extension drops extension when cascading", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in extension-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/extension-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/extension-migration.ts; affects ~10–47 tests in extension-migration.test.ts
+      await adapter.enableExtension("citext");
+      await adapter.execute(`CREATE TABLE test_citext_tbl (id SERIAL PRIMARY KEY, data CITEXT)`);
+      await adapter.disableExtension("citext", { force: "cascade" });
+      expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -66,10 +66,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       await new EnableCitext().run(adapter, "up");
-      const schemaDumper = adapter.createSchemaDumper({});
-      const dump = (await (schemaDumper as any).extensionStatements?.()) ?? "";
-      // Schema dump should reference citext; if schemaDumper doesn't have
-      // extensionStatements the extension is still enabled (proxy works)
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration ignores prefix and suffix", async () => {

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -60,10 +60,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("extension schema dump", async () => {
-      await adapter.enableExtension("citext");
+      class EnableCitext extends Migration {
+        async change() {
+          await this.enableExtension("citext");
+        }
+      }
+      await new EnableCitext().run(adapter, "up");
+      const schemaDumper = adapter.createSchemaDumper({});
+      const dump = (await (schemaDumper as any).extensionStatements?.()) ?? "";
+      // Schema dump should reference citext; if schemaDumper doesn't have
+      // extensionStatements the extension is still enabled (proxy works)
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration ignores prefix and suffix", async () => {
+      // Rails: table_name_prefix/suffix don't affect extension names
+      // TS: same — extension names pass through unmodified
       class EnableCitext extends Migration {
         async change() {
           await this.enableExtension("citext");
@@ -73,9 +84,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration with schema", async () => {
+      // Rails: enable_extension "other_schema.hstore" creates it in that schema
+      // Our adapter parses schema-qualified names: "public.citext" → SCHEMA public
       class EnableCitext extends Migration {
         async change() {
-          await this.enableExtension("citext");
+          await this.enableExtension("public.citext");
         }
       }
       await new EnableCitext().run(adapter, "up");

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -9,7 +9,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await adapter.disableExtension("citext", { force: "cascade" }).catch(() => {});
+    await adapter.disableExtension("citext", { force: "cascade" });
   });
   afterEach(async () => {
     await adapter.execute("DROP TABLE IF EXISTS test_citext_tbl").catch(() => {});

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -89,8 +89,12 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.enableExtension("public.citext");
         }
       }
-      await new EnableCitext().run(adapter, "up");
+      const m = new EnableCitext();
+      await m.run(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
+      // Down must strip schema and call DROP EXTENSION IF EXISTS "citext" (not "public.citext")
+      await m.run(adapter, "down");
+      expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("disable extension migration ignores prefix and suffix", async () => {
       await adapter.enableExtension("citext");

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -56,16 +56,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       class CreateEnumMig extends Migration {
         async change() {
           await this.createEnum("color", ["blue", "green"]);
-          await this.createTable("enums", (t) => {
-            (t as any).string("best_color");
-          });
+          await this.createTable("enums");
         }
       }
       const m = new CreateEnumMig();
       await m.run(adapter, "up");
+      // Add an actual enum-typed column so reversal must drop the table before
+      // dropping the enum type (otherwise DROP TYPE fails with dependency error)
+      await adapter.execute(
+        `ALTER TABLE enums ADD COLUMN best_color color NOT NULL DEFAULT 'blue'`,
+      );
       const enumsBefore = await adapter.enumTypes();
       expect(enumsBefore.some(([name]) => name === "color")).toBe(true);
 
+      // Down: drops table first (containing enum column), then drops enum type
       await m.run(adapter, "down");
       const enumsAfter = await adapter.enumTypes();
       expect(enumsAfter.some(([name]) => name === "color")).toBe(false);

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -39,7 +39,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate and revert", async () => {
+    it("migrate and revert", async () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
@@ -49,27 +49,27 @@ describeIfPg("PostgreSQLAdapter", () => {
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate revert create enum", () => {
+    it("migrate revert create enum", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate revert drop enum", () => {
+    it("migrate revert drop enum", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate revert rename enum value", () => {
+    it("migrate revert rename enum value", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate revert add and validate check constraint", () => {
+    it("migrate revert add and validate check constraint", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
     });
-    it.skip("migrate revert add and validate foreign key", () => {
+    it("migrate revert add and validate foreign key", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
       // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -112,12 +112,16 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("migrate revert add and validate check constraint", async () => {
       await adapter.execute(`CREATE TABLE settings (id SERIAL PRIMARY KEY, value INTEGER)`);
 
-      class AddCheckMig extends Migration {
+      class AddAndValidateCheckMig extends Migration {
         async change() {
-          await this.addCheckConstraint("settings", "value >= 0", { name: "positive_value" });
+          await this.addCheckConstraint("settings", "value >= 0", {
+            name: "positive_value",
+            validate: false,
+          });
+          await this.validateCheckConstraint("settings", { name: "positive_value" });
         }
       }
-      const m = new AddCheckMig();
+      const m = new AddAndValidateCheckMig();
       await m.run(adapter, "up");
       const before = await adapter.checkConstraints("settings");
       expect(before.some((c: any) => c.name === "positive_value")).toBe(true);
@@ -130,12 +134,17 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.execute(`CREATE TABLE foos (id SERIAL PRIMARY KEY)`);
       await adapter.execute(`CREATE TABLE bars (id SERIAL PRIMARY KEY, foo_id INTEGER)`);
 
-      class AddFKMig extends Migration {
+      class AddAndValidateFKMig extends Migration {
         async change() {
-          await this.addForeignKey("bars", "foos", { column: "foo_id", name: "fk_bars_foos" });
+          await this.addForeignKey("bars", "foos", {
+            column: "foo_id",
+            name: "fk_bars_foos",
+            validate: false,
+          });
+          await this.validateForeignKey("bars", "foos", { name: "fk_bars_foos" });
         }
       }
-      const m = new AddFKMig();
+      const m = new AddAndValidateFKMig();
       await m.run(adapter, "up");
       expect(await adapter.foreignKeyExists("bars", "foos")).toBe(true);
 

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -1,7 +1,8 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Migration } from "../../index.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -10,69 +11,136 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
   });
   afterEach(async () => {
+    await adapter.execute("DROP TABLE IF EXISTS enums").catch(() => {});
+    await adapter.execute("DROP TABLE IF EXISTS settings").catch(() => {});
+    await adapter.execute("DROP TABLE IF EXISTS bars").catch(() => {});
+    await adapter.execute("DROP TABLE IF EXISTS foos").catch(() => {});
+    await adapter.dropEnum("color", { ifExists: true }).catch(() => {});
     await adapter.close();
   });
 
   describe("PostgresqlInvertibleMigrationTest", () => {
     it.skip("up", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: Migrator infrastructure (schema_migration, Migrator.new) not yet wired for PG
     });
     it.skip("down", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: Migrator infrastructure (schema_migration, Migrator.new) not yet wired for PG
     });
     it.skip("change", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: Migrator infrastructure (schema_migration, Migrator.new) not yet wired for PG
     });
     it.skip("revert", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: Migrator infrastructure (schema_migration, Migrator.new) not yet wired for PG
     });
     it.skip("revert whole migration", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: Migrator infrastructure (schema_migration, Migrator.new) not yet wired for PG
     });
     it("migrate and revert", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      class CreateHorses extends Migration {
+        async change() {
+          await this.createTable("settings", (t) => {
+            t.integer("value");
+          });
+        }
+      }
+      const m = new CreateHorses();
+      await m.run(adapter, "up");
+      expect(await adapter.tableExists("settings")).toBe(true);
+      await m.run(adapter, "down");
+      expect(await adapter.tableExists("settings")).toBe(false);
     });
     it.skip("migrate revert add index with expression", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+      // BLOCKED: expression index reversal requires CommandRecorder inversion for non-name indexes
     });
-    it("migrate revert create enum", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+    it("migrate revert create enum", async () => {
+      class CreateEnumMig extends Migration {
+        async change() {
+          await this.createEnum("color", ["blue", "green"]);
+          await this.createTable("enums", (t) => {
+            (t as any).string("best_color");
+          });
+        }
+      }
+      const m = new CreateEnumMig();
+      await m.run(adapter, "up");
+      const enumsBefore = await adapter.enumTypes();
+      expect(enumsBefore.some(([name]) => name === "color")).toBe(true);
+
+      await m.run(adapter, "down");
+      const enumsAfter = await adapter.enumTypes();
+      expect(enumsAfter.some(([name]) => name === "color")).toBe(false);
+      expect(await adapter.tableExists("enums")).toBe(false);
     });
-    it("migrate revert drop enum", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+    it("migrate revert drop enum", async () => {
+      await adapter.createEnum("color", ["blue", "green"]);
+
+      class DropEnumMig extends Migration {
+        async change() {
+          await this.dropEnum("color", ["blue", "green"], { ifExists: true });
+        }
+      }
+      const m = new DropEnumMig();
+      await m.run(adapter, "up");
+      const enumsAfterDrop = await adapter.enumTypes();
+      expect(enumsAfterDrop.some(([name]) => name === "color")).toBe(false);
+
+      await m.run(adapter, "down");
+      const enumsRestored = await adapter.enumTypes();
+      expect(enumsRestored.some(([name]) => name === "color")).toBe(true);
     });
-    it("migrate revert rename enum value", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+    it("migrate revert rename enum value", async () => {
+      await adapter.createEnum("color", ["blue", "green"]);
+
+      class RenameEnumMig extends Migration {
+        async change() {
+          await this.renameEnumValue("color", { from: "blue", to: "red" });
+        }
+      }
+      const m = new RenameEnumMig();
+      await m.run(adapter, "up");
+      const afterRename = await adapter.enumTypes();
+      const colorValues = afterRename.find(([name]) => name === "color")?.[1] ?? [];
+      expect(colorValues).toContain("red");
+      expect(colorValues).not.toContain("blue");
+
+      await m.run(adapter, "down");
+      const afterRevert = await adapter.enumTypes();
+      const revertedValues = afterRevert.find(([name]) => name === "color")?.[1] ?? [];
+      expect(revertedValues).toContain("blue");
+      expect(revertedValues).not.toContain("red");
     });
-    it("migrate revert add and validate check constraint", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+    it("migrate revert add and validate check constraint", async () => {
+      await adapter.execute(`CREATE TABLE settings (id SERIAL PRIMARY KEY, value INTEGER)`);
+
+      class AddCheckMig extends Migration {
+        async change() {
+          await this.addCheckConstraint("settings", "value >= 0", { name: "positive_value" });
+        }
+      }
+      const m = new AddCheckMig();
+      await m.run(adapter, "up");
+      const before = await adapter.checkConstraints("settings");
+      expect(before.some((c: any) => c.name === "positive_value")).toBe(true);
+
+      await m.run(adapter, "down");
+      const after = await adapter.checkConstraints("settings");
+      expect(after.some((c: any) => c.name === "positive_value")).toBe(false);
     });
-    it("migrate revert add and validate foreign key", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in invertible-migration
-      // ROOT-CAUSE: connection-adapters/postgresql/invertible-migration.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/invertible-migration.ts; affects ~10–47 tests in invertible-migration.test.ts
+    it("migrate revert add and validate foreign key", async () => {
+      await adapter.execute(`CREATE TABLE foos (id SERIAL PRIMARY KEY)`);
+      await adapter.execute(`CREATE TABLE bars (id SERIAL PRIMARY KEY, foo_id INTEGER)`);
+
+      class AddFKMig extends Migration {
+        async change() {
+          await this.addForeignKey("bars", "foos", { column: "foo_id", name: "fk_bars_foos" });
+        }
+      }
+      const m = new AddFKMig();
+      await m.run(adapter, "up");
+      expect(await adapter.foreignKeyExists("bars", "foos")).toBe(true);
+
+      await m.run(adapter, "down");
+      expect(await adapter.foreignKeyExists("bars", "foos")).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2872,8 +2872,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const { schema: toSchema, table: toTbl } = this.parseSchemaQualifiedName(toTable);
     const fk = (fks as any[]).find((f) => {
       const { schema: fSchema, table: fTbl } = this.parseSchemaQualifiedName(String(f.toTable));
-      if (toSchema) return fSchema === toSchema && fTbl === toTbl;
-      return fTbl === toTbl;
+      if (fTbl !== toTbl) return false;
+      // When the FK record has no schema prefix (PostgreSQL omits "public." when it
+      // is on the search path), treat it as matching any schema lookup or "public".
+      if (!fSchema) return !toSchema || toSchema === "public";
+      return fSchema === toSchema;
     });
     if (!fk) throw new ArgumentError(`No foreign key found from ${fromTable} to ${toTable}`);
     await this.validateConstraint(fromTable, fk.name);
@@ -3506,7 +3509,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Enum types
   // ---------------------------------------------------------------------------
 
-  async createEnum(name: string, values: string[]): Promise<void> {
+  async createEnum(
+    name: string,
+    values: string[],
+    _options?: Record<string, unknown>,
+  ): Promise<void> {
     const { schema, table: enumName } = this.parseSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(enumName)}`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2868,8 +2868,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       return;
     }
     const fks = await this.foreignKeys(fromTable);
-    const { table: toTbl } = this.parseSchemaQualifiedName(toTable);
-    const fk = (fks as any[]).find((f) => f.toTable === toTbl || f.toTable === toTable);
+    const { schema: toSchema, table: toTbl } = this.parseSchemaQualifiedName(toTable);
+    const fk = (fks as any[]).find((f) => {
+      const { schema: fSchema, table: fTbl } = this.parseSchemaQualifiedName(String(f.toTable));
+      if (toSchema) return fSchema === toSchema && fTbl === toTbl;
+      return fTbl === toTbl;
+    });
     if (!fk) throw new Error(`No foreign key found from ${fromTable} to ${toTable}`);
     await this.validateConstraint(fromTable, fk.name);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2843,6 +2843,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(`COMMENT ON TABLE ${this.quoteTableName(tableName)} IS ${this.quote(comment)}`);
   }
 
+  /** @internal */
+  async validateConstraint(tableName: string, constraintName: string): Promise<void> {
+    await this.exec(
+      `ALTER TABLE ${this.quoteTableName(tableName)} VALIDATE CONSTRAINT ${this.quoteIdentifier(constraintName)}`,
+    );
+  }
+
+  async validateCheckConstraint(tableName: string, options: { name: string }): Promise<void> {
+    await this.validateConstraint(tableName, options.name);
+  }
+
+  async validateForeignKey(
+    fromTable: string,
+    toTable: string,
+    options?: { name?: string },
+  ): Promise<void> {
+    if (options?.name) {
+      await this.validateConstraint(fromTable, options.name);
+      return;
+    }
+    const fks = await this.foreignKeys(fromTable);
+    const { table: toTbl } = this.parseSchemaQualifiedName(toTable);
+    const fk = (fks as any[]).find((f) => f.toTable === toTbl || f.toTable === toTable);
+    if (!fk) throw new Error(`No foreign key found from ${fromTable} to ${toTable}`);
+    await this.validateConstraint(fromTable, fk.name);
+  }
+
   typeToSql(
     type: string,
     options: {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2218,7 +2218,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return Number(rows[0].count) > 0;
   }
 
-  async enableExtension(name: string): Promise<void> {
+  async enableExtension(name: string, _options?: Record<string, unknown>): Promise<void> {
     const parts = String(name).split(".");
     const extName = parts[parts.length - 1];
     const schema = parts.length > 1 ? parts[parts.length - 2] : null;
@@ -2860,13 +2860,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async validateForeignKey(
     fromTable: string,
-    toTable: string,
+    toTable?: string,
     options?: { name?: string },
   ): Promise<void> {
     if (options?.name) {
       await this.validateConstraint(fromTable, options.name);
       return;
     }
+    if (!toTable) throw new ArgumentError("validateForeignKey requires toTable or options.name");
     const fks = await this.foreignKeys(fromTable);
     const { schema: toSchema, table: toTbl } = this.parseSchemaQualifiedName(toTable);
     const fk = (fks as any[]).find((f) => {
@@ -2874,7 +2875,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       if (toSchema) return fSchema === toSchema && fTbl === toTbl;
       return fTbl === toTbl;
     });
-    if (!fk) throw new Error(`No foreign key found from ${fromTable} to ${toTable}`);
+    if (!fk) throw new ArgumentError(`No foreign key found from ${fromTable} to ${toTable}`);
     await this.validateConstraint(fromTable, fk.name);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2850,8 +2850,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
   }
 
-  async validateCheckConstraint(tableName: string, options: { name: string }): Promise<void> {
-    await this.validateConstraint(tableName, options.name);
+  async validateCheckConstraint(
+    tableName: string,
+    nameOrOptions: string | { name: string },
+  ): Promise<void> {
+    const name = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
+    await this.validateConstraint(tableName, name);
   }
 
   async validateForeignKey(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2232,6 +2232,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name: string,
     options: { force?: "cascade"; schema?: string } = {},
   ): Promise<void> {
+    // Mirrors Rails: _schema, name = name.to_s.split(".").values_at(-2, -1)
+    // Extensions are global in PG — DROP uses only extname, not schema.
+    const parts = String(name).split(".");
+    const extName = parts[parts.length - 1];
     const cascade = options.force === "cascade" ? " CASCADE" : "";
     if (options.schema) {
       await this.withClient(async (client) => {
@@ -2239,7 +2243,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         const originalSearchPath = rows[0]?.search_path as string;
         await client.query(`SELECT set_config('search_path', $1, false)`, [options.schema]);
         try {
-          await client.query(`DROP EXTENSION IF EXISTS ${this.quoteIdentifier(name)}${cascade}`);
+          await client.query(`DROP EXTENSION IF EXISTS ${this.quoteIdentifier(extName)}${cascade}`);
         } finally {
           await client.query(`SELECT set_config('search_path', $1, false)`, [
             originalSearchPath ?? "public",
@@ -2247,7 +2251,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         }
       });
     } else {
-      await this.exec(`DROP EXTENSION IF EXISTS ${this.quoteIdentifier(name)}${cascade}`);
+      await this.exec(`DROP EXTENSION IF EXISTS ${this.quoteIdentifier(extName)}${cascade}`);
     }
   }
 

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -409,12 +409,8 @@ describe("InvertibleMigrationTest", () => {
   it("migrate revert add foreign key with invalid option", async () => {
     // addForeignKey is reversible even with unknown options (they're forwarded, not validated)
     const recorder = new CommandRecorder();
-    recorder.record("addForeignKey", [
-      "horses",
-      "horses",
-      { column: "parent_id", unknownOption: true },
-    ]);
-    const inv = recorder.inverseOf("addForeignKey", ["horses", "horses", { column: "parent_id" }]);
+    const fkArgs: unknown[] = ["horses", "horses", { column: "parent_id", unknownOption: true }];
+    const inv = recorder.inverseOf("addForeignKey", fkArgs);
     expect(inv.cmd).toBe("removeForeignKey");
     expect(inv.args[0]).toBe("horses");
   });

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -197,23 +197,14 @@ describe("InvertibleMigrationTest", () => {
     // If reversal works, changeColumnDefault(from: "Diomed", to: "Sekitoba") ran
     expect(tableExists("horses")).toBe(true);
   });
-  it.skip("migrate revert change column comment", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
-    /* comments not supported */
+  it("migrate revert change column comment", () => {
+    /* changeColumnComment proxy is wired; full test needs PG */
   });
-  it.skip("migrate revert change table comment", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
-    /* comments not supported */
+  it("migrate revert change table comment", () => {
+    /* changeTableComment proxy is wired; full test needs PG */
   });
-  it.skip("migrate enable and disable extension", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
-    /* extensions not supported */
+  it("migrate enable and disable extension", () => {
+    /* enableExtension/disableExtension proxies are wired; full test needs PG */
   });
 
   it("migrate revert drop table", async () => {
@@ -379,17 +370,11 @@ describe("InvertibleMigrationTest", () => {
     expect(upOnlyCalled).toBe(false);
   });
 
-  it.skip("migrate revert add unique constraint with invalid option", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
-    /* unique constraints API not implemented */
+  it("migrate revert add unique constraint with invalid option", () => {
+    /* addUniqueConstraint proxy is wired; full test needs PG (supports_unique_constraints?) */
   });
-  it.skip("migrate revert add foreign key with invalid option", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
-    /* foreign key reversal not supported */
+  it("migrate revert add foreign key with invalid option", () => {
+    /* addForeignKey proxy was already wired; full test needs PG */
   });
   it.skip("migrate revert add check constraint with invalid option", () => {
     // BLOCKED: migration — migration runner gap in invertible-migration

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -4,6 +4,8 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Migration } from "./index.js";
+import { IrreversibleMigration } from "./migration.js";
+import { CommandRecorder } from "./migration/command-recorder.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -198,13 +200,32 @@ describe("InvertibleMigrationTest", () => {
     expect(tableExists("horses")).toBe(true);
   });
   it("migrate revert change column comment", () => {
-    /* changeColumnComment proxy is wired; full test needs PG */
+    const recorder = new CommandRecorder();
+    recorder.record("changeColumnComment", ["horses", "name", { from: "Old", to: "New" }]);
+    const inv = recorder.inverseOf("changeColumnComment", [
+      "horses",
+      "name",
+      { from: "Old", to: "New" },
+    ]);
+    expect(inv.cmd).toBe("changeColumnComment");
+    expect(inv.args).toEqual(["horses", "name", { from: "New", to: "Old" }]);
   });
   it("migrate revert change table comment", () => {
-    /* changeTableComment proxy is wired; full test needs PG */
+    const recorder = new CommandRecorder();
+    recorder.record("changeTableComment", ["horses", { from: "Old", to: "New" }]);
+    const inv = recorder.inverseOf("changeTableComment", ["horses", { from: "Old", to: "New" }]);
+    expect(inv.cmd).toBe("changeTableComment");
+    expect(inv.args).toEqual(["horses", { from: "New", to: "Old" }]);
   });
   it("migrate enable and disable extension", () => {
-    /* enableExtension/disableExtension proxies are wired; full test needs PG */
+    const recorder = new CommandRecorder();
+    const enableInv = recorder.inverseOf("enableExtension", ["hstore"]);
+    expect(enableInv.cmd).toBe("disableExtension");
+    expect(enableInv.args[0]).toBe("hstore");
+
+    const disableInv = recorder.inverseOf("disableExtension", ["hstore"]);
+    expect(disableInv.cmd).toBe("enableExtension");
+    expect(disableInv.args[0]).toBe("hstore");
   });
 
   it("migrate revert drop table", async () => {
@@ -371,10 +392,31 @@ describe("InvertibleMigrationTest", () => {
   });
 
   it("migrate revert add unique constraint with invalid option", () => {
-    /* addUniqueConstraint proxy is wired; full test needs PG (supports_unique_constraints?) */
+    const recorder = new CommandRecorder();
+    // Unknown options pass through without breaking inversion
+    const inv = recorder.inverseOf("addUniqueConstraint", [
+      "horses",
+      "place_id",
+      { unknownOption: true },
+    ]);
+    expect(inv.cmd).toBe("removeUniqueConstraint");
+    expect(inv.args[0]).toBe("horses");
+    // usingIndex makes it irreversible
+    expect(() =>
+      recorder.inverseOf("addUniqueConstraint", ["horses", "place_id", { usingIndex: "my_idx" }]),
+    ).toThrow(IrreversibleMigration);
   });
-  it("migrate revert add foreign key with invalid option", () => {
-    /* addForeignKey proxy was already wired; full test needs PG */
+  it("migrate revert add foreign key with invalid option", async () => {
+    // addForeignKey is reversible even with unknown options (they're forwarded, not validated)
+    const recorder = new CommandRecorder();
+    recorder.record("addForeignKey", [
+      "horses",
+      "horses",
+      { column: "parent_id", unknownOption: true },
+    ]);
+    const inv = recorder.inverseOf("addForeignKey", ["horses", "horses", { column: "parent_id" }]);
+    expect(inv.cmd).toBe("removeForeignKey");
+    expect(inv.args[0]).toBe("horses");
   });
   it.skip("migrate revert add check constraint with invalid option", () => {
     // BLOCKED: migration — migration runner gap in invertible-migration

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -877,11 +877,23 @@ export abstract class Migration {
     columnNameOrOptions?: string | string[] | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
+    // Normalize: if second arg is a plain object it is the options hash (no column).
+    // Mirrors Rails extract_options! semantics for remove_unique_constraint(table, **opts).
+    const isOptsObj =
+      columnNameOrOptions !== null &&
+      typeof columnNameOrOptions === "object" &&
+      !Array.isArray(columnNameOrOptions);
+    const columnName = isOptsObj
+      ? undefined
+      : (columnNameOrOptions as string | string[] | undefined);
+    const opts = isOptsObj
+      ? (columnNameOrOptions as Record<string, unknown>)
+      : (options ?? undefined);
     if (this._recording) {
-      this._recorder.record("removeUniqueConstraint", [tableName, columnNameOrOptions, options]);
+      this._recorder.record("removeUniqueConstraint", [tableName, columnName, opts]);
       return;
     }
-    await (this.connection as any).removeUniqueConstraint(tableName, columnNameOrOptions, options);
+    await (this.connection as any).removeUniqueConstraint(tableName, columnName, opts);
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -417,6 +417,82 @@ export abstract class Migration {
         }
         break;
       }
+      case "changeColumnComment": {
+        const [ccTable, ccCol, ccOpts] = args as [string, string, { from?: unknown; to: unknown }];
+        if (!ccOpts || typeof ccOpts !== "object" || !("from" in ccOpts)) {
+          throw new IrreversibleMigration(
+            "Cannot reverse changeColumnComment without from/to options",
+          );
+        }
+        await this.changeColumnComment(ccTable, ccCol, { from: ccOpts.to, to: ccOpts.from });
+        break;
+      }
+      case "changeTableComment": {
+        const [ctTable, ctOpts] = args as [string, { from?: unknown; to: unknown }];
+        if (!ctOpts || typeof ctOpts !== "object" || !("from" in ctOpts)) {
+          throw new IrreversibleMigration(
+            "Cannot reverse changeTableComment without from/to options",
+          );
+        }
+        await this.changeTableComment(ctTable, { from: ctOpts.to, to: ctOpts.from });
+        break;
+      }
+      case "enableExtension": {
+        const [extName, extOpts] = args as [string, Record<string, unknown>?];
+        await this.disableExtension(extName, extOpts);
+        break;
+      }
+      case "disableExtension": {
+        const [dextName, dextOpts] = args as [string, Record<string, unknown>?];
+        await this.enableExtension(dextName, dextOpts);
+        break;
+      }
+      case "createEnum": {
+        const [enumName, enumValues] = args as [string, string[]];
+        await this.dropEnum(enumName, enumValues);
+        break;
+      }
+      case "dropEnum": {
+        const [deEnumName, deValues] = args as [string, string[] | undefined];
+        if (!deValues) {
+          throw new IrreversibleMigration("Cannot reverse dropEnum without a list of enum values");
+        }
+        await this.createEnum(deEnumName, deValues);
+        break;
+      }
+      case "renameEnumValue": {
+        const [revName, revOpts] = args as [string, { from: string; to: string }];
+        await this.renameEnumValue(revName, { from: revOpts.to, to: revOpts.from });
+        break;
+      }
+      case "addUniqueConstraint": {
+        const [ucTable, ucColumn, ucOpts] = args as [
+          string,
+          string | string[] | undefined,
+          Record<string, unknown>?,
+        ];
+        if (ucOpts?.["usingIndex"]) {
+          throw new IrreversibleMigration(
+            "add_unique_constraint is not reversible if given a using_index.",
+          );
+        }
+        await this.removeUniqueConstraint(ucTable, ucColumn, ucOpts);
+        break;
+      }
+      case "removeUniqueConstraint": {
+        const [rucTable, rucColumn, rucOpts] = args as [
+          string,
+          string | string[] | undefined,
+          Record<string, unknown>?,
+        ];
+        if (!rucColumn) {
+          throw new IrreversibleMigration(
+            "remove_unique_constraint is only reversible if given a column_name.",
+          );
+        }
+        await this.addUniqueConstraint(rucTable, rucColumn, rucOpts);
+        break;
+      }
       default:
         throw new IrreversibleMigration(`Cannot reverse operation: ${cmd}`);
     }
@@ -649,6 +725,101 @@ export abstract class Migration {
     }
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
   }
+  async changeColumnComment(
+    tableName: string,
+    columnName: string,
+    commentOrChanges: string | null | { from?: unknown; to?: unknown },
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("changeColumnComment", [tableName, columnName, commentOrChanges]);
+      return;
+    }
+    await this.schema.changeColumnComment(tableName, columnName, commentOrChanges as string | null);
+  }
+
+  async changeTableComment(
+    tableName: string,
+    commentOrChanges: string | null | { from?: unknown; to?: unknown },
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("changeTableComment", [tableName, commentOrChanges]);
+      return;
+    }
+    await this.schema.changeTableComment(tableName, commentOrChanges as string | null);
+  }
+
+  async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("enableExtension", [name, options]);
+      return;
+    }
+    await (this.connection as any).enableExtension(name, options);
+  }
+
+  async disableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("disableExtension", [name, options]);
+      return;
+    }
+    await (this.connection as any).disableExtension(name, options);
+  }
+
+  async createEnum(
+    name: string,
+    values: string[],
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("createEnum", [name, values, options]);
+      return;
+    }
+    await (this.connection as any).createEnum(name, values, options);
+  }
+
+  async dropEnum(
+    name: string,
+    values?: string[],
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("dropEnum", [name, values, options]);
+      return;
+    }
+    await (this.connection as any).dropEnum(name, values, options);
+  }
+
+  async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("renameEnumValue", [name, options]);
+      return;
+    }
+    await (this.connection as any).renameEnumValue(name, options);
+  }
+
+  async addUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[],
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("addUniqueConstraint", [tableName, columnName, options]);
+      return;
+    }
+    await (this.connection as any).addUniqueConstraint(tableName, columnName, options);
+  }
+
+  async removeUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[],
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("removeUniqueConstraint", [tableName, columnName, options]);
+      return;
+    }
+    await (this.connection as any).removeUniqueConstraint(tableName, columnName, options);
+  }
+
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
     if (this._recording) {
       this._recorder.record("addTimestamps", [tableName, options]);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -52,7 +52,13 @@ function _extractNewCommentValue(
     if (!("to" in v) || (v as { to: unknown }).to === undefined) {
       throw new ArgumentError("change_column_comment / change_table_comment requires a :to value");
     }
-    return (v as { to: unknown }).to as string | null;
+    const to = (v as { to: unknown }).to;
+    if (to !== null && typeof to !== "string") {
+      throw new ArgumentError(
+        `change_column_comment / change_table_comment :to must be a string or null, got ${typeof to}`,
+      );
+    }
+    return to;
   }
   return v as string | null;
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -43,14 +43,16 @@ export {
 import { ActiveRecordError } from "./errors.js";
 
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
-// Returns the `to` value for {from,to} hashes; passes through string|null directly.
-// Objects without a `to` key are not a valid comment value — return null rather than
-// forwarding a plain object to adapter SQL methods.
+// For {from,to} hashes, returns `to` (which may be null to clear a comment).
+// `to: undefined` is rejected — a missing value cannot be forwarded to SQL.
 function _extractNewCommentValue(
   v: string | null | { from?: unknown; to?: unknown },
 ): string | null {
   if (v !== null && typeof v === "object") {
-    return "to" in v ? ((v as { to: unknown }).to as string | null) : null;
+    if (!("to" in v) || (v as { to: unknown }).to === undefined) {
+      throw new ArgumentError("change_column_comment / change_table_comment requires a :to value");
+    }
+    return (v as { to: unknown }).to as string | null;
   }
   return v as string | null;
 }
@@ -432,7 +434,14 @@ export abstract class Migration {
       }
       case "changeColumnComment": {
         const [ccTable, ccCol, ccOpts] = args as [string, string, { from?: unknown; to?: unknown }];
-        if (!ccOpts || typeof ccOpts !== "object" || !("from" in ccOpts) || !("to" in ccOpts)) {
+        if (
+          !ccOpts ||
+          typeof ccOpts !== "object" ||
+          !("from" in ccOpts) ||
+          ccOpts.from === undefined ||
+          !("to" in ccOpts) ||
+          ccOpts.to === undefined
+        ) {
           throw new IrreversibleMigration(
             "change_column_comment is only reversible if given a :from and :to option.",
           );
@@ -442,7 +451,14 @@ export abstract class Migration {
       }
       case "changeTableComment": {
         const [ctTable, ctOpts] = args as [string, { from?: unknown; to?: unknown }];
-        if (!ctOpts || typeof ctOpts !== "object" || !("from" in ctOpts) || !("to" in ctOpts)) {
+        if (
+          !ctOpts ||
+          typeof ctOpts !== "object" ||
+          !("from" in ctOpts) ||
+          ctOpts.from === undefined ||
+          !("to" in ctOpts) ||
+          ctOpts.to === undefined
+        ) {
           throw new IrreversibleMigration(
             "change_table_comment is only reversible if given a :from and :to option.",
           );

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -43,11 +43,14 @@ export {
 import { ActiveRecordError } from "./errors.js";
 
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
+// Returns the `to` value for {from,to} hashes; passes through string|null directly.
+// Objects without a `to` key are not a valid comment value — return null rather than
+// forwarding a plain object to adapter SQL methods.
 function _extractNewCommentValue(
   v: string | null | { from?: unknown; to?: unknown },
 ): string | null {
-  if (v !== null && typeof v === "object" && "to" in v) {
-    return (v as { to: unknown }).to as string | null;
+  if (v !== null && typeof v === "object") {
+    return "to" in v ? ((v as { to: unknown }).to as string | null) : null;
   }
   return v as string | null;
 }
@@ -428,20 +431,20 @@ export abstract class Migration {
         break;
       }
       case "changeColumnComment": {
-        const [ccTable, ccCol, ccOpts] = args as [string, string, { from?: unknown; to: unknown }];
-        if (!ccOpts || typeof ccOpts !== "object" || !("from" in ccOpts)) {
+        const [ccTable, ccCol, ccOpts] = args as [string, string, { from?: unknown; to?: unknown }];
+        if (!ccOpts || typeof ccOpts !== "object" || !("from" in ccOpts) || !("to" in ccOpts)) {
           throw new IrreversibleMigration(
-            "Cannot reverse changeColumnComment without from/to options",
+            "change_column_comment is only reversible if given a :from and :to option.",
           );
         }
         await this.changeColumnComment(ccTable, ccCol, { from: ccOpts.to, to: ccOpts.from });
         break;
       }
       case "changeTableComment": {
-        const [ctTable, ctOpts] = args as [string, { from?: unknown; to: unknown }];
-        if (!ctOpts || typeof ctOpts !== "object" || !("from" in ctOpts)) {
+        const [ctTable, ctOpts] = args as [string, { from?: unknown; to?: unknown }];
+        if (!ctOpts || typeof ctOpts !== "object" || !("from" in ctOpts) || !("to" in ctOpts)) {
           throw new IrreversibleMigration(
-            "Cannot reverse changeTableComment without from/to options",
+            "change_table_comment is only reversible if given a :from and :to option.",
           );
         }
         await this.changeTableComment(ctTable, { from: ctOpts.to, to: ctOpts.from });
@@ -743,8 +746,11 @@ export abstract class Migration {
     }
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
   }
-  async validateCheckConstraint(tableName: string, options: { name: string }): Promise<void> {
-    await (this.connection as any).validateCheckConstraint(tableName, options);
+  async validateCheckConstraint(
+    tableName: string,
+    nameOrOptions: string | { name: string },
+  ): Promise<void> {
+    await (this.connection as any).validateCheckConstraint(tableName, nameOrOptions);
   }
 
   async validateForeignKey(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -840,16 +840,24 @@ export abstract class Migration {
 
   async dropEnum(
     name: string,
-    values?: string[],
+    valuesOrOptions?: string[] | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
+    // Normalize: if second arg is a plain object it is the options hash (no values).
+    // Mirrors Rails drop_enum(name, values = nil, **options) which allows options-only calls.
+    const isOptsObj =
+      valuesOrOptions !== null &&
+      typeof valuesOrOptions === "object" &&
+      !Array.isArray(valuesOrOptions);
+    const values = isOptsObj ? undefined : (valuesOrOptions as string[] | undefined);
+    const opts = isOptsObj ? (valuesOrOptions as Record<string, unknown>) : (options ?? undefined);
     if (this._recording) {
-      this._recorder.record("dropEnum", [name, values, options]);
+      this._recorder.record("dropEnum", [name, values, opts]);
       return;
     }
     // values is only captured for recording (so dropEnum can be inverted to createEnum);
     // the adapter's dropEnum(name, options?) doesn't need values for SQL execution.
-    await (this.connection as any).dropEnum(name, options ?? {});
+    await (this.connection as any).dropEnum(name, opts ?? {});
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -42,6 +42,16 @@ export {
 
 import { ActiveRecordError } from "./errors.js";
 
+// Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
+function _extractNewCommentValue(
+  v: string | null | { from?: unknown; to?: unknown },
+): string | null {
+  if (v !== null && typeof v === "object" && "to" in v) {
+    return (v as { to: unknown }).to as string | null;
+  }
+  return v as string | null;
+}
+
 // Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial) operating on UTF-8 bytes.
 function _crc32(str: string): number {
   const bytes = new TextEncoder().encode(str);
@@ -448,16 +458,24 @@ export abstract class Migration {
         break;
       }
       case "createEnum": {
-        const [enumName, enumValues] = args as [string, string[]];
-        await this.dropEnum(enumName, enumValues);
+        const [enumName, enumValues, enumOpts] = args as [
+          string,
+          string[],
+          Record<string, unknown>?,
+        ];
+        await this.dropEnum(enumName, enumValues, enumOpts);
         break;
       }
       case "dropEnum": {
-        const [deEnumName, deValues] = args as [string, string[] | undefined];
+        const [deEnumName, deValues, deOpts] = args as [
+          string,
+          string[] | undefined,
+          Record<string, unknown>?,
+        ];
         if (!deValues) {
           throw new IrreversibleMigration("Cannot reverse dropEnum without a list of enum values");
         }
-        await this.createEnum(deEnumName, deValues);
+        await this.createEnum(deEnumName, deValues, deOpts);
         break;
       }
       case "renameEnumValue": {
@@ -729,8 +747,12 @@ export abstract class Migration {
     await (this.connection as any).validateCheckConstraint(tableName, options);
   }
 
-  async validateForeignKey(fromTable: string, toTable: string): Promise<void> {
-    await (this.connection as any).validateForeignKey(fromTable, toTable);
+  async validateForeignKey(
+    fromTable: string,
+    toTable: string,
+    options?: { name?: string },
+  ): Promise<void> {
+    await (this.connection as any).validateForeignKey(fromTable, toTable, options);
   }
 
   async changeColumnComment(
@@ -742,7 +764,8 @@ export abstract class Migration {
       this._recorder.record("changeColumnComment", [tableName, columnName, commentOrChanges]);
       return;
     }
-    await this.schema.changeColumnComment(tableName, columnName, commentOrChanges as string | null);
+    const resolved = _extractNewCommentValue(commentOrChanges);
+    await (this.connection as any).changeColumnComment(tableName, columnName, resolved);
   }
 
   async changeTableComment(
@@ -753,7 +776,8 @@ export abstract class Migration {
       this._recorder.record("changeTableComment", [tableName, commentOrChanges]);
       return;
     }
-    await this.schema.changeTableComment(tableName, commentOrChanges as string | null);
+    const resolved = _extractNewCommentValue(commentOrChanges);
+    await (this.connection as any).changeTableComment(tableName, resolved);
   }
 
   async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
@@ -793,7 +817,9 @@ export abstract class Migration {
       this._recorder.record("dropEnum", [name, values, options]);
       return;
     }
-    await (this.connection as any).dropEnum(name, values, options);
+    // values is only captured for recording (so dropEnum can be inverted to createEnum);
+    // the adapter's dropEnum(name, options?) doesn't need values for SQL execution.
+    await (this.connection as any).dropEnum(name, options ?? {});
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -771,10 +771,12 @@ export abstract class Migration {
 
   async validateForeignKey(
     fromTable: string,
-    toTable: string,
+    toTableOrOptions?: string | { name?: string },
     options?: { name?: string },
   ): Promise<void> {
-    await (this.connection as any).validateForeignKey(fromTable, toTable, options);
+    const toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
+    const opts = typeof toTableOrOptions === "object" ? toTableOrOptions : (options ?? undefined);
+    await (this.connection as any).validateForeignKey(fromTable, toTable, opts);
   }
 
   async changeColumnComment(
@@ -866,14 +868,14 @@ export abstract class Migration {
 
   async removeUniqueConstraint(
     tableName: string,
-    columnName?: string | string[],
+    columnNameOrOptions?: string | string[] | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("removeUniqueConstraint", [tableName, columnName, options]);
+      this._recorder.record("removeUniqueConstraint", [tableName, columnNameOrOptions, options]);
       return;
     }
-    await (this.connection as any).removeUniqueConstraint(tableName, columnName, options);
+    await (this.connection as any).removeUniqueConstraint(tableName, columnNameOrOptions, options);
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -725,6 +725,14 @@ export abstract class Migration {
     }
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
   }
+  async validateCheckConstraint(tableName: string, options: { name: string }): Promise<void> {
+    await (this.connection as any).validateCheckConstraint(tableName, options);
+  }
+
+  async validateForeignKey(fromTable: string, toTable: string): Promise<void> {
+    await (this.connection as any).validateForeignKey(fromTable, toTable);
+  }
+
   async changeColumnComment(
     tableName: string,
     columnName: string,

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -451,6 +451,21 @@ export class CommandRecorder {
   }
 
   /** @internal */
+  invertCreateEnum(args: unknown[]): [string, unknown[]] {
+    return ["dropEnum", args];
+  }
+
+  /** @internal */
+  invertEnableExtension(args: unknown[]): [string, unknown[]] {
+    return ["disableExtension", args];
+  }
+
+  /** @internal */
+  invertDisableExtension(args: unknown[]): [string, unknown[]] {
+    return ["enableExtension", args];
+  }
+
+  /** @internal */
   invertDropEnum(args: unknown[]): [string, unknown[]] {
     // Mirror Rails: extract_options! strips trailing hash, then check second positional arg
     const a = args.slice();


### PR DESCRIPTION
## Summary

- Adds 9 `Migration` instance-method proxies (record + delegate) for PG-only DDL: `enableExtension`, `disableExtension`, `createEnum`, `dropEnum`, `renameEnumValue`, `changeColumnComment`, `changeTableComment`, `addUniqueConstraint`, `removeUniqueConstraint`
- Adds non-recording proxies for `validateCheckConstraint` / `validateForeignKey` (match Rails `method_missing` passthrough — not recorded, delegates directly to connection)
- Adds `invertCreateEnum`, `invertEnableExtension`, `invertDisableExtension` to `CommandRecorder` (straight-reversion pairs mirroring Rails `StraightReversions`)
- Adds `_reverseOperation` switch cases for all 9 new commands
- Implements `validateCheckConstraint` / `validateForeignKey` / `validateConstraint` on `PostgreSQLAdapter`
- Un-skips 21 tests with real assertions

## Design notes

- `enableExtension`/`disableExtension`: straight reversions. Both methods strip any schema prefix before execution, matching Rails `enable_extension`/`disable_extension` which use only `extname` for `CREATE/DROP EXTENSION`.
- `createEnum`/`dropEnum`: straight reversion pair; `dropEnum(name, values?, options?)` normalizes second arg (plain-object → options, array → values) matching Rails `extract_options!` semantics; values are recorder-only for inversion, not forwarded to SQL.
- `removeUniqueConstraint` and `dropEnum` both normalize plain-object second arg to options (mirroring Rails `extract_options!`).
- `changeColumnComment`/`changeTableComment`: delegate to `(this.connection as any)` — abstract `SchemaStatements` throws `NotImplementedError`. `_extractNewCommentValue` extracts `to` from `{from,to}` objects, validates it is `string | null`, mirrors Rails `extract_new_comment_value`.
- `validateCheckConstraint`/`validateForeignKey`: not recorded — delegates immediately (mirrors Rails `method_missing` falling through the `CommandRecorder`). `validateCheckConstraint` accepts `string | {name}` for compatibility with both the existing positional-string interface and options-style calls.
- `validateForeignKey` normalizes FK lookup via `parseSchemaQualifiedName`; treats `fSchema = null` (PostgreSQL omits schema for tables on the search_path) as matching `public` or unqualified lookups.

## Known follow-ups

- **`validateForeignKey` search_path matching**: `foreignKeys()` uses `t2.oid::regclass::text` which omits the schema for *any* schema on the current search_path, not just `public`. The current `!fSchema → public/unqualified` heuristic can miss FK lookups when a non-public schema is on the search_path. Proper fix: include `pg_namespace` for `t2` in the `foreignKeys()` query to always return schema-qualified names, then normalize on both sides.

## Test plan

- [x] `pnpm vitest run .../invertible-migration.test.ts` — 24 pass, 5 skip
- [x] `PG_TEST_URL=... pnpm vitest run .../extension-migration.test.ts .../pg/invertible-migration.test.ts` — 16 pass, 6 skip
- [x] `pnpm test:types` — 83 type tests pass
- [x] api:compare: 4954/4958 (neutral delta)
- [x] test:compare: neutral delta
- [x] Build + typecheck pass via pre-commit hook