### PR TITLE
feat(activerecord): pg-adapter — test infra (withSecondAdapter + translate-exception SQLSTATE wiring, audit Slot D)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -270,7 +270,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         const pidRows = await adapter.execute(`SELECT pg_backend_pid() AS pid`);
         pid = (pidRows[0] as { pid: number }).pid;
-        const sleepPromise = adapter.execute(`SELECT pg_sleep(10)`);
+        const sleepPromise = adapter.execute(`SELECT pg_sleep(2)`);
         // Give pg_sleep a moment to begin executing before we cancel it.
         await new Promise<void>((resolve) => setTimeout(resolve, 50));
         await withSecondAdapter(PG_TEST_URL, async (adapter2) => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -266,14 +266,24 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Use a transaction so that pg_backend_pid() and pg_sleep() share the same
       // pooled connection — otherwise two execute() calls get different PG backends.
       await adapter.beginTransaction();
-      let pid: number;
       try {
         const pidRows = await adapter.execute(`SELECT pg_backend_pid() AS pid`);
-        pid = (pidRows[0] as { pid: number }).pid;
-        const sleepPromise = adapter.execute(`SELECT pg_sleep(2)`);
-        // Give pg_sleep a moment to begin executing before we cancel it.
-        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        const pid = (pidRows[0] as { pid: number }).pid;
+        const sleepPromise = adapter.execute(`SELECT pg_sleep(10)`);
+        // Attach a no-op handler synchronously so Node never flags this as an
+        // unhandled rejection during the gap before the expect() runs.
+        sleepPromise.catch(() => {});
+        // Poll pg_stat_activity until the pg_sleep query is observed as active on
+        // this backend, so the cancel always arrives after execution has started.
         await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+          const deadline = Date.now() + 2000;
+          while (Date.now() < deadline) {
+            const rows = await adapter2.execute(
+              `SELECT 1 FROM pg_stat_activity WHERE pid = ${pid} AND query LIKE '%pg_sleep%' AND state = 'active'`,
+            );
+            if (rows.length > 0) break;
+            await new Promise<void>((r) => setTimeout(r, 10));
+          }
           await adapter2.execute(`SELECT pg_cancel_backend(${pid})`);
         });
         await expect(sleepPromise).rejects.toBeInstanceOf(QueryCanceled);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -13,6 +13,7 @@ import {
   LockWaitTimeout,
   NotNullViolation,
   QueryCanceled,
+  RangeError as ActiveRecordRangeError,
   RecordNotUnique,
   SerializationFailure,
   SQLWarning,
@@ -251,7 +252,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`CREATE TABLE "ex_num" ("id" SERIAL PRIMARY KEY, "val" SMALLINT)`);
       await expect(
         adapter.executeMutation(`INSERT INTO "ex_num" ("val") VALUES (99999)`),
-      ).rejects.toThrow(/out of range/i);
+      ).rejects.toBeInstanceOf(ActiveRecordRangeError);
     });
 
     it("translate exception invalid text representation", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -8,12 +8,17 @@ import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import * as Arel from "@blazetrails/arel";
 import {
   ConnectionNotEstablished,
+  Deadlocked,
   InvalidForeignKey,
+  LockWaitTimeout,
   NotNullViolation,
+  QueryCanceled,
   RecordNotUnique,
+  SerializationFailure,
   SQLWarning,
   ValueTooLong,
 } from "../../errors.js";
+import { withSecondAdapter } from "../../test-helpers/second-connection.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -195,11 +200,51 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).rejects.toBeInstanceOf(ValueTooLong);
     });
 
-    it.skip("translate exception lock wait timeout", async () => {
-      // BLOCKED: Two concurrent connections required (lock_timeout, SQLSTATE 55P03).
+    it("translate exception lock wait timeout", async () => {
+      await adapter.exec(`CREATE TABLE "ex_lock" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
+      await adapter.executeMutation(`INSERT INTO "ex_lock" ("val") VALUES (1)`);
+      await adapter.beginTransaction();
+      try {
+        await adapter.execute(`SELECT * FROM "ex_lock" WHERE id = 1 FOR UPDATE`);
+        await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+          await adapter2.beginTransaction();
+          try {
+            await adapter2.execute(`SET LOCAL lock_timeout = '100ms'`);
+            await expect(
+              adapter2.execute(`SELECT * FROM "ex_lock" WHERE id = 1 FOR UPDATE`),
+            ).rejects.toBeInstanceOf(LockWaitTimeout);
+          } finally {
+            await adapter2.rollback();
+          }
+        });
+      } finally {
+        await adapter.rollback();
+      }
     });
-    it.skip("translate exception deadlock", async () => {
-      // BLOCKED: Two concurrent connections required (deadlock, SQLSTATE 40P01).
+    it("translate exception deadlock", async () => {
+      await adapter.exec(`CREATE TABLE "ex_dl" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
+      await adapter.executeMutation(`INSERT INTO "ex_dl" ("val") VALUES (1)`);
+      await adapter.executeMutation(`INSERT INTO "ex_dl" ("val") VALUES (2)`);
+      // conn1 locks row 1, conn2 locks row 2, then each tries to lock the other's row
+      await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+        await adapter.beginTransaction();
+        await adapter2.beginTransaction();
+        try {
+          await adapter.execute(`SELECT * FROM "ex_dl" WHERE id = 1 FOR UPDATE`);
+          await adapter2.execute(`SELECT * FROM "ex_dl" WHERE id = 2 FOR UPDATE`);
+          const [result1, result2] = await Promise.allSettled([
+            adapter.execute(`SELECT * FROM "ex_dl" WHERE id = 2 FOR UPDATE`),
+            adapter2.execute(`SELECT * FROM "ex_dl" WHERE id = 1 FOR UPDATE`),
+          ]);
+          const errors = [result1, result2]
+            .filter((r) => r.status === "rejected")
+            .map((r) => (r as PromiseRejectedResult).reason);
+          expect(errors.some((e) => e instanceof Deadlocked)).toBe(true);
+        } finally {
+          await adapter.rollback().catch(() => {});
+          await adapter2.rollback().catch(() => {});
+        }
+      });
     });
 
     it("translate exception numeric value out of range", async () => {
@@ -216,11 +261,50 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).rejects.toThrow(/invalid input|integer/i);
     });
 
-    it.skip("translate exception query cancelled", async () => {
-      // BLOCKED: Requires pg_cancel_backend from a second connection (SQLSTATE 57014).
+    it("translate exception query cancelled", async () => {
+      // Use a transaction so that pg_backend_pid() and pg_sleep() share the same
+      // pooled connection — otherwise two execute() calls get different PG backends.
+      await adapter.beginTransaction();
+      let pid: number;
+      try {
+        const pidRows = await adapter.execute(`SELECT pg_backend_pid() AS pid`);
+        pid = (pidRows[0] as { pid: number }).pid;
+        const sleepPromise = adapter.execute(`SELECT pg_sleep(10)`);
+        // Give pg_sleep a moment to begin executing before we cancel it.
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+          await adapter2.execute(`SELECT pg_cancel_backend(${pid})`);
+        });
+        await expect(sleepPromise).rejects.toBeInstanceOf(QueryCanceled);
+      } finally {
+        await adapter.rollback().catch(() => {});
+      }
     });
-    it.skip("translate exception serialization failure", async () => {
-      // BLOCKED: Requires two concurrent SERIALIZABLE transactions (SQLSTATE 40001).
+    it("translate exception serialization failure", async () => {
+      await adapter.exec(`CREATE TABLE "ex_ser" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
+      await adapter.executeMutation(`INSERT INTO "ex_ser" (val) VALUES (0)`);
+      await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+        // Both transactions get their snapshots before either commits.
+        await adapter.beginIsolatedDbTransaction("serializable");
+        await adapter2.beginIsolatedDbTransaction("serializable");
+        try {
+          // Both read the same row (establishes the SSI read-set).
+          await adapter.execute(`SELECT * FROM "ex_ser"`);
+          await adapter2.execute(`SELECT * FROM "ex_ser"`);
+          // Both write to that row.
+          await adapter.execute(`UPDATE "ex_ser" SET val = 1`);
+          // adapter commits first.
+          await adapter.commit();
+          // adapter2's write waits for adapter's lock, then writes.
+          await adapter2.execute(`UPDATE "ex_ser" SET val = 2`);
+          // PG SSI detects the rw-anti-dependency cycle; one transaction must abort.
+          await expect(adapter2.commit()).rejects.toBeInstanceOf(SerializationFailure);
+        } catch (e) {
+          await adapter.rollback().catch(() => {});
+          await adapter2.rollback().catch(() => {});
+          if (!(e instanceof SerializationFailure)) throw e;
+        }
+      });
     });
     it.skip("type map", async () => {
       // BLOCKED: typeMap is HashLookupTypeMap, not pg-driver PG::TypeMapByOid.
@@ -487,7 +571,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("reconnect after bad connection on check version", async () => {
-      // BLOCKED: No raw_connection handle; can't simulate server_version=0 on reconnect.
+      // BLOCKED: Rails stubs raw_connection.server_version=0 on the PG::Connection to
+      // simulate a bad version check during reconnect!. Our adapter uses a pg.Pool
+      // (accessible via _driverPoolForTest()) rather than a single PG::Connection, so
+      // there is no equivalent low-level server_version stub point.
     });
 
     it("primary key works tables containing capital letters", async () => {
@@ -661,7 +748,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await expect(adapter.execute(null as any)).rejects.toBeInstanceOf(TypeError);
     });
     it.skip("translate no connection exception to not established", async () => {
-      // BLOCKED: pg_terminate_backend + raw PG::Connection#send_query needed; not exposed by pg driver.
+      // BLOCKED: Rails calls raw_connection.send_query("SELECT 1") directly on the
+      // PG::Connection to put it in CONNECTION_BAD state without waiting for the result.
+      // The pg npm driver doesn't expose send_query; _driverPoolForTest() gives the
+      // pg.Pool but no single-connection send_query equivalent exists.
     });
     it.skip("reload type map for newly defined types", async () => {
       // BLOCKED: TypeMapInitializer registers enum OIDs as generic types, not OID::Enum.
@@ -827,8 +917,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("reconnection error", () => {
-      // BLOCKED: Requires stubbing pg.Pool.connect() to throw PG::ConnectionBad.
-      // No public hook to inject a failing connection for this error path.
+      // BLOCKED: Rails creates a fake PG::Connection object with a reset() that
+      // throws PG::ConnectionBad, then stubs PG.connect to throw. The pg npm
+      // driver doesn't expose equivalent interception points.
     });
 
     it("database exists returns true when the database exists", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -36,11 +36,15 @@ import type {
 import {
   ConnectionNotEstablished,
   DatabaseConnectionError,
+  Deadlocked,
   InvalidForeignKey,
+  LockWaitTimeout,
   NoDatabaseError,
   NotNullViolation,
   PreparedStatementCacheExpired,
+  QueryCanceled,
   RecordNotUnique,
+  SerializationFailure,
   StatementInvalid,
   ValueTooLong,
   SQLWarning,
@@ -3704,6 +3708,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         return new NotNullViolation(msg, { sql, binds, cause });
       case "22001": // string_data_right_truncation
         return new ValueTooLong(msg, { sql, binds, cause });
+      case "40001": // serialization_failure
+        return new SerializationFailure(msg, { sql, binds, cause });
+      case "40P01": // deadlock_detected
+        return new Deadlocked(msg, { sql, binds, cause });
+      case "55P03": // lock_not_available
+        return new LockWaitTimeout(msg, { sql, binds, cause });
+      case "57014": // query_canceled
+        return new QueryCanceled(msg, { sql, binds, cause });
       default:
         // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
         // 5-char shape alone isn't enough — Node system errors like

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -35,6 +35,7 @@ import type {
 } from "../adapter.js";
 import {
   ConnectionNotEstablished,
+  DatabaseAlreadyExists,
   DatabaseConnectionError,
   Deadlocked,
   InvalidForeignKey,
@@ -43,6 +44,7 @@ import {
   NotNullViolation,
   PreparedStatementCacheExpired,
   QueryCanceled,
+  RangeError as ARRangeError,
   RecordNotUnique,
   SerializationFailure,
   StatementInvalid,
@@ -3708,10 +3710,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         return new NotNullViolation(msg, { sql, binds, cause });
       case "22001": // string_data_right_truncation
         return new ValueTooLong(msg, { sql, binds, cause });
+      case "22003": // numeric_value_out_of_range
+        return new ARRangeError(msg, { sql, binds, cause });
       case "40001": // serialization_failure
         return new SerializationFailure(msg, { sql, binds, cause });
       case "40P01": // deadlock_detected
         return new Deadlocked(msg, { sql, binds, cause });
+      case "42P04": // duplicate_database
+        return new DatabaseAlreadyExists(msg, { sql, binds, cause });
       case "55P03": // lock_not_available
         return new LockWaitTimeout(msg, { sql, binds, cause });
       case "57014": // query_canceled

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -44,7 +44,7 @@ import {
   NotNullViolation,
   PreparedStatementCacheExpired,
   QueryCanceled,
-  RangeError as ARRangeError,
+  RangeError as ActiveRecordRangeError,
   RecordNotUnique,
   SerializationFailure,
   StatementInvalid,
@@ -3711,7 +3711,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       case "22001": // string_data_right_truncation
         return new ValueTooLong(msg, { sql, binds, cause });
       case "22003": // numeric_value_out_of_range
-        return new ARRangeError(msg, { sql, binds, cause });
+        return new ActiveRecordRangeError(msg, { sql, binds, cause });
       case "40001": // serialization_failure
         return new SerializationFailure(msg, { sql, binds, cause });
       case "40P01": // deadlock_detected

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -505,6 +505,17 @@ export class DatabaseVersionError extends ActiveRecordError {
   }
 }
 
+/** Mirrors `ActiveRecord::RangeError`. */
+export class RangeError extends StatementInvalid {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "RangeError";
+  }
+}
+
 export class DatabaseAlreadyExists extends StatementInvalid {
   constructor(
     message?: string,

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -287,6 +287,17 @@ export class LockWaitTimeout extends StatementInvalid {
   }
 }
 
+/** Mirrors `ActiveRecord::QueryCanceled`. */
+export class QueryCanceled extends QueryAborted {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "QueryCanceled";
+  }
+}
+
 export class WrappedDatabaseException extends StatementInvalid {
   constructor(
     message?: string,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -229,6 +229,7 @@ export {
   Deadlocked,
   LockWaitTimeout,
   QueryCanceled,
+  RangeError,
 } from "./errors.js";
 export {
   ReadonlyAttributeError,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -228,6 +228,7 @@ export {
   SerializationFailure,
   Deadlocked,
   LockWaitTimeout,
+  QueryCanceled,
 } from "./errors.js";
 export {
   ReadonlyAttributeError,

--- a/packages/activerecord/src/test-helpers/second-connection.ts
+++ b/packages/activerecord/src/test-helpers/second-connection.ts
@@ -15,7 +15,7 @@ import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js"
  */
 export async function withSecondAdapter<T>(
   url: string,
-  fn: (adapter: PostgreSQLAdapter) => Promise<T>,
+  fn: (adapter: PostgreSQLAdapter) => T | Promise<T>,
 ): Promise<T> {
   const adapter = new PostgreSQLAdapter(url);
   try {

--- a/packages/activerecord/src/test-helpers/second-connection.ts
+++ b/packages/activerecord/src/test-helpers/second-connection.ts
@@ -21,6 +21,6 @@ export async function withSecondAdapter<T>(
   try {
     return await fn(adapter);
   } finally {
-    await adapter.close();
+    await adapter.close().catch(() => {});
   }
 }

--- a/packages/activerecord/src/test-helpers/second-connection.ts
+++ b/packages/activerecord/src/test-helpers/second-connection.ts
@@ -1,0 +1,26 @@
+/**
+ * Helper for tests that require a second independent database connection.
+ *
+ * Rails uses `@connection.pool.checkout` to obtain a second connection from the
+ * same pool. We instead create a fresh `PostgreSQLAdapter` pointing at the same
+ * URL, so the two adapters have fully independent connection pools with no
+ * shared state.
+ */
+
+import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+
+/**
+ * Opens a second `PostgreSQLAdapter` for the given URL, calls `fn` with it,
+ * then closes the adapter on the way out (success or failure).
+ */
+export async function withSecondAdapter<T>(
+  url: string,
+  fn: (adapter: PostgreSQLAdapter) => Promise<T>,
+): Promise<T> {
+  const adapter = new PostgreSQLAdapter(url);
+  try {
+    return await fn(adapter);
+  } finally {
+    await adapter.close();
+  }
+}


### PR DESCRIPTION
## Summary

- **\`withSecondAdapter\` helper** (\`test-helpers/second-connection.ts\`): opens a second independent \`PostgreSQLAdapter\` for two-connection test scenarios, tears it down on exit.
- **SQLSTATE wiring in \`_translateException\`** — completes Rails parity for all six cases that were previously falling through to \`StatementInvalid\`:
  - \`22003\` → \`RangeError\` (numeric_value_out_of_range)
  - \`40001\` → \`SerializationFailure\` (serialization_failure)
  - \`40P01\` → \`Deadlocked\` (deadlock_detected)
  - \`42P04\` → \`DatabaseAlreadyExists\` (duplicate_database)
  - \`55P03\` → \`LockWaitTimeout\` (lock_not_available)
  - \`57014\` → \`QueryCanceled\` (query_canceled)
- **\`QueryCanceled\` and \`RangeError\` error classes**: new classes mirroring \`ActiveRecord::QueryCanceled < QueryAborted\` and \`ActiveRecord::RangeError < StatementInvalid\`.
- **4 un-skips** in \`postgresql-adapter.test.ts\`: translate exception lock wait timeout, deadlock, query cancelled, serialization failure — all pass with live PG.

## Notes

\`rawConnection()\` was not added — it conflicts with \`AbstractAdapter#rawConnection\` (returns \`DatabaseAdapter | null\`). The existing \`_driverPoolForTest()\` serves the same purpose for tests; annotations on remaining blocked tests updated to reflect this.

## Follow-ups

- \`reconnection_error\` and \`reconnect after bad connection on check version\` remain skipped — both require Ruby-specific stub patterns with no pg-npm equivalent.
- \`translate no connection exception to not established\` remains skipped — requires \`PG::Connection#send_query\` which pg-npm doesn't expose.