### PR TITLE
feat(activerecord): mysql active-schema — SQL-capture test infra + first un-skips (audit Slot A)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -1,8 +1,9 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { captureSql } from "../../testing/sql-capture.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -15,74 +16,76 @@ describeIfMysql("Mysql2Adapter", () => {
 
   describe("ActiveSchemaTest", () => {
     it.skip("add index", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — addIndex stub in abstract-mysql-adapter.ts does nothing (no-op body)
+      // ROOT-CAUSE: AbstractMysqlAdapter#addIndex at connection-adapters/abstract-mysql-adapter.ts:550 is a void stub;
+      //   needs to build+emit the CREATE INDEX SQL via MysqlSchemaCreation
+      // SCOPE: ~30–60 LOC in abstract-mysql-adapter.ts addIndex; unblocks ~10 addIndex sub-tests
     });
     it.skip("index in create", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — createTable callback form needed + index-in-create emission
+      // ROOT-CAUSE: MySQL createTable does not wire up inline INDEX clauses from TableDefinition.index()
+      // SCOPE: Slot B (mysql DDL parity)
     });
     it.skip("index in bulk change", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — changeTable bulk-mode not implemented for MySQL
+      // ROOT-CAUSE: AbstractMysqlAdapter bulk change_table path missing
+      // SCOPE: Slot B (mysql DDL parity)
     });
-    it.skip("drop table", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+    it("drop table", async () => {
+      const sqls = await captureSql(() => adapter.dropTable("people"));
+      expect(sqls[0]).toBe("DROP TABLE `people`");
     });
     it.skip("drop tables", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — multi-table DROP TABLE emits N separate statements instead of one
+      // ROOT-CAUSE: abstract/schema-statements.ts#dropTable loops over tableNames calling executeMutation
+      //   once per table; Rails MySQL emits "DROP TABLE `a`, `b`" in a single statement
+      // SCOPE: ~10 LOC override on AbstractMysqlAdapter to join names into one DROP TABLE call
     });
     it.skip("create mysql database with encoding", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — createDatabase not implemented
+      // ROOT-CAUSE: AbstractMysqlAdapter#createDatabase method missing
+      // SCOPE: Slot B (mysql DDL parity)
     });
     it.skip("recreate mysql database with encoding", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — recreateDatabase not implemented
+      // ROOT-CAUSE: AbstractMysqlAdapter#recreateDatabase method missing
+      // SCOPE: Slot B (mysql DDL parity)
     });
     it.skip("add column", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — SQL type case mismatch
+      // ROOT-CAUSE: abstract/schema-creation.ts#typeToSql emits uppercase "VARCHAR(255)" but Rails MySQL
+      //   uses lowercase "varchar(255)" from nativeDatabaseTypes
+      // SCOPE: ~10 LOC in MysqlSchemaCreation to override typeToSql using nativeDatabaseTypes; Slot B
     });
     it.skip("add column with limit", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — SQL type case mismatch (same as "add column")
+      // ROOT-CAUSE: typeToSql emits "VARCHAR(32)" not "varchar(32)"
+      // SCOPE: same fix as "add column"; Slot B
     });
-    it.skip("drop table with specific database", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+    it("drop table with specific database", async () => {
+      const sqls = await captureSql(() => adapter.dropTable("otherdb.people"));
+      expect(sqls[0]).toBe("DROP TABLE `otherdb`.`people`");
     });
     it.skip("drop tables with specific database", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — multi-table DROP TABLE emits N separate statements (same as "drop tables")
+      // ROOT-CAUSE: same as "drop tables" — needs single-statement override on AbstractMysqlAdapter
+      // SCOPE: same fix as "drop tables"; Slot B
     });
     it.skip("add timestamps", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — SQL type case mismatch for datetime column
+      // ROOT-CAUSE: addTimestamps calls addColumn with "datetime" type → typeToSql emits "DATETIME(6)"
+      //   but Rails MySQL emits "datetime"; also requires a real table (with_real_execute scope)
+      // SCOPE: Slot B (mysql DDL parity + typeToSql fix)
     });
     it.skip("remove timestamps", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — requires a real table (with_real_execute scope) and datetime type fix
+      // ROOT-CAUSE: needs live table for add/remove; also datetime type case gap
+      // SCOPE: Slot B
     });
     it.skip("indexes in create", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in active-schema
-      // ROOT-CAUSE: adapters/mysql2/active-schema.ts or abstract-mysql-adapter/active-schema.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/active-schema.ts; affects ~10–26 tests in active-schema.test.ts
+      // BLOCKED: adapter-mysql — createTable TEMPORARY + AS SELECT not implemented
+      // ROOT-CAUSE: createTable options.temporary and options.as not wired in MysqlSchemaCreation
+      // SCOPE: Slot B (mysql DDL parity)
     });
   });
 });

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -9,7 +9,7 @@
  * subscribing to the notification and collecting the payloads.
  *
  * Usage:
- *   const sqls = await captureSql(adapter, () => adapter.addIndex("t", "c"));
+ *   const sqls = await captureSql(() => adapter.addIndex("t", "c"));
  *   expect(sqls[0]).toBe("CREATE INDEX ...");
  */
 
@@ -28,6 +28,8 @@ export async function captureSql(fn: () => Promise<unknown>): Promise<string[]> 
   });
   try {
     await fn();
+  } catch {
+    // stub mode — execution is not the point; SQL capture is
   } finally {
     Notifications.unsubscribe(sub);
   }

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -1,0 +1,35 @@
+/**
+ * captureSql — subscribe to sql.active_record during a callback and return
+ * the SQL strings emitted, without actually executing them against a real DB.
+ *
+ * Mirrors the setup/teardown stub pattern in Rails'
+ * activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb:
+ * the test monkey-patches `connection.execute` to instrument the SQL and
+ * return it instead of running it.  We achieve the same effect here by
+ * subscribing to the notification and collecting the payloads.
+ *
+ * Usage:
+ *   const sqls = await captureSql(adapter, () => adapter.addIndex("t", "c"));
+ *   expect(sqls[0]).toBe("CREATE INDEX ...");
+ */
+
+import { Notifications } from "@blazetrails/activesupport";
+
+/**
+ * Runs `fn` and returns every SQL string emitted via `sql.active_record`
+ * during its execution.  Subscription is cleaned up afterward.
+ * @internal
+ */
+export async function captureSql(fn: () => Promise<unknown>): Promise<string[]> {
+  const sqls: string[] = [];
+  const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+    const sql: unknown = event.payload?.sql;
+    if (typeof sql === "string") sqls.push(sql);
+  });
+  try {
+    await fn();
+  } finally {
+    Notifications.unsubscribe(sub);
+  }
+  return sqls;
+}

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -1,12 +1,15 @@
 /**
  * captureSql — subscribe to sql.active_record during a callback and return
- * the SQL strings emitted, without actually executing them against a real DB.
+ * the SQL strings emitted.
  *
  * Mirrors the setup/teardown stub pattern in Rails'
  * activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb:
  * the test monkey-patches `connection.execute` to instrument the SQL and
- * return it instead of running it.  We achieve the same effect here by
- * subscribing to the notification and collecting the payloads.
+ * return it instead of running it.  We subscribe to the notification instead.
+ * SQL strings are collected from the payload before any error propagates
+ * (Notifications.instrumentAsync fires _notify in its finally block), so
+ * errors from fn() are swallowed — matching Rails' stub-mode where execute
+ * never throws.  Tables referenced in tests need not exist.
  *
  * Usage:
  *   const sqls = await captureSql(() => adapter.addIndex("t", "c"));
@@ -20,7 +23,7 @@ import { Notifications } from "@blazetrails/activesupport";
  * during its execution.  Subscription is cleaned up afterward.
  * @internal
  */
-export async function captureSql(fn: () => Promise<unknown>): Promise<string[]> {
+export async function captureSql(fn: () => void | Promise<void>): Promise<string[]> {
   const sqls: string[] = [];
   const sub = Notifications.subscribe("sql.active_record", (event: any) => {
     const sql: unknown = event.payload?.sql;
@@ -29,7 +32,7 @@ export async function captureSql(fn: () => Promise<unknown>): Promise<string[]> 
   try {
     await fn();
   } catch {
-    // stub mode — execution is not the point; SQL capture is
+    // intentional: mirrors Rails stub-mode where execute never throws
   } finally {
     Notifications.unsubscribe(sub);
   }


### PR DESCRIPTION
## Summary

- New `captureSql(fn)` helper at `src/testing/sql-capture.ts` — subscribes to `sql.active_record` during a callback and returns the emitted SQL strings, mirroring the execute-stub pattern Rails uses in `active_schema_test.rb`
- Un-skips 2 tests: `drop table` and `drop table with specific database` (both pass via the existing abstract schema-statements path)
- Sharpens BLOCKED annotations for the remaining 12 tests: each now names the exact gap (addIndex stub, multi-table DROP needing single-statement override, typeToSql uppercase vs lowercase, missing createDatabase/recreateDatabase, bulk changeTable not implemented)

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts` — 2 pass (when MySQL is available), remainder skipped
- [ ] `pnpm api:compare --package activerecord` — 4954/4958 unchanged
- [ ] `pnpm test:types` — 83 pass, no errors

## Follow-ups (Slots B/C/D)

- **Slot B**: Fix typeToSql case (varchar not VARCHAR), addIndex stub, multi-table DROP, createDatabase/recreateDatabase, bulk changeTable
- **Slot C/D**: index-in-create, indexes-in-create (TEMPORARY + AS SELECT), add/remove timestamps