### PR TITLE
feat(activerecord): pg-adapter — caseInsensitiveComparison + OID warn dedup + decodeDates (audit Slot B)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -329,9 +329,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("only warn on first encounter of unrecognized oid", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
-        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
-        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
-        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
+        // execQuery goes through getOidType which triggers the dedup logic.
+        // execute() bypasses OID resolution so it cannot trigger the warn.
+        await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
+        await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
+        await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
         const oidWarns = warnSpy.mock.calls.filter(
           (c) => typeof c[0] === "string" && /unknown OID \d+/.test(c[0]),
         );
@@ -787,16 +789,15 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("only check for insensitive comparison capability once", async () => {
       await adapter.execute(`CREATE DOMAIN example_type AS integer`);
       try {
-        await adapter.exec(
-          `CREATE TABLE "ex_compare" ("id" SERIAL PRIMARY KEY, "number" example_type)`,
-        );
-        const table = new Arel.Table("ex_compare");
-        const attribute = table.get("number");
-        const executeSpy = vi.spyOn(adapter, "execute");
-        await adapter.caseInsensitiveComparison(attribute, "foo");
-        const callsAfterFirst = executeSpy.mock.calls.length;
-        await adapter.caseInsensitiveComparison(attribute, "foo");
-        expect(executeSpy.mock.calls.length).toBe(callsAfterFirst);
+        // canPerformCaseInsensitiveComparisonFor does the pg_proc lookup via schemaQuery.
+        // Spy on schemaQuery to verify the cache prevents a second DB round-trip.
+        const schemaQuerySpy = vi.spyOn(adapter, "schemaQuery");
+        const col = { sqlType: "example_type" };
+        await adapter.canPerformCaseInsensitiveComparisonFor(col);
+        const callsAfterFirst = schemaQuerySpy.mock.calls.length;
+        await adapter.canPerformCaseInsensitiveComparisonFor(col);
+        expect(schemaQuerySpy.mock.calls.length).toBe(callsAfterFirst);
+        schemaQuerySpy.mockRestore();
       } finally {
         await adapter.execute(`DROP DOMAIN example_type CASCADE`);
       }

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -326,8 +326,22 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("only reload type map once for every unrecognized type", async () => {
       // BLOCKED: assert_queries_count needed; SQLCounter doesn't isolate pg_type queries.
     });
-    it.skip("only warn on first encounter of unrecognized oid", async () => {
-      // BLOCKED: getOidType warns on every miss; needs a Set to deduplicate per OID.
+    it("only warn on first encounter of unrecognized oid", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
+        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
+        await adapter.execute(`select 'pg_catalog.pg_class'::regclass`);
+        const oidWarns = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && /unknown OID \d+/.test(c[0]),
+        );
+        expect(oidWarns).toHaveLength(1);
+        expect(oidWarns[0][0]).toMatch(
+          /unknown OID \d+: failed to recognize type of 'regclass'\. It will be treated as String\./,
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
     it("extension enabled", async () => {
       await adapter.enableExtension("citext");
@@ -770,8 +784,22 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("unparsed defaults are at least set when saving", async () => {
       // BLOCKED: Column.defaultFunction null for arithmetic defaults; reload() gap.
     });
-    it.skip("only check for insensitive comparison capability once", async () => {
-      // BLOCKED: caseInsensitiveComparison() + per-type cache not yet implemented.
+    it("only check for insensitive comparison capability once", async () => {
+      await adapter.execute(`CREATE DOMAIN example_type AS integer`);
+      try {
+        await adapter.exec(
+          `CREATE TABLE "ex_compare" ("id" SERIAL PRIMARY KEY, "number" example_type)`,
+        );
+        const table = new Arel.Table("ex_compare");
+        const attribute = table.get("number");
+        const executeSpy = vi.spyOn(adapter, "execute");
+        await adapter.caseInsensitiveComparison(attribute, "foo");
+        const callsAfterFirst = executeSpy.mock.calls.length;
+        await adapter.caseInsensitiveComparison(attribute, "foo");
+        expect(executeSpy.mock.calls.length).toBe(callsAfterFirst);
+      } finally {
+        await adapter.execute(`DROP DOMAIN example_type CASCADE`);
+      }
     });
     it("extensions omits current schema name", async () => {
       const wasEnabled = await adapter.extensionEnabled("hstore");
@@ -889,8 +917,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(d.day).toBe(15);
     });
 
-    it.skip("date decoding disabled", async () => {
-      // BLOCKED: Adapter always decodes DATE as Temporal.PlainDate; needs PostgreSQLAdapter.decodeDates flag.
+    it("date decoding disabled", async () => {
+      const saved = PostgreSQLAdapter.decodeDates;
+      PostgreSQLAdapter.decodeDates = false;
+      const localAdapter = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await localAdapter.exec(`CREATE TABLE "ex_dates_off" ("id" SERIAL PRIMARY KEY, "d" DATE)`);
+        await localAdapter.exec(`INSERT INTO "ex_dates_off" ("d") VALUES ('2024-01-01')`);
+        const rows = await localAdapter.execute(`SELECT "d" FROM "ex_dates_off"`);
+        expect(rows[0].d).toBe("2024-01-01");
+      } finally {
+        await localAdapter.exec(`DROP TABLE IF EXISTS "ex_dates_off"`);
+        await localAdapter.close();
+        PostgreSQLAdapter.decodeDates = saved;
+      }
     });
 
     it("disable extension with schema", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -788,17 +788,17 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("only check for insensitive comparison capability once", async () => {
       await adapter.execute(`CREATE DOMAIN example_type AS integer`);
+      const schemaQuerySpy = vi.spyOn(adapter, "schemaQuery");
       try {
         // canPerformCaseInsensitiveComparisonFor does the pg_proc lookup via schemaQuery.
         // Spy on schemaQuery to verify the cache prevents a second DB round-trip.
-        const schemaQuerySpy = vi.spyOn(adapter, "schemaQuery");
         const col = { sqlType: "example_type" };
         await adapter.canPerformCaseInsensitiveComparisonFor(col);
         const callsAfterFirst = schemaQuerySpy.mock.calls.length;
         await adapter.canPerformCaseInsensitiveComparisonFor(col);
         expect(schemaQuerySpy.mock.calls.length).toBe(callsAfterFirst);
-        schemaQuerySpy.mockRestore();
       } finally {
+        schemaQuerySpy.mockRestore();
         await adapter.execute(`DROP DOMAIN example_type CASCADE`);
       }
     });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1209,12 +1209,13 @@ export class AbstractAdapter implements Quoting {
   }
 
   /** @internal */
-  async caseInsensitiveComparison(attribute: Nodes.Attribute, value: unknown): Promise<Nodes.Node> {
-    const column = await this.columnForAttribute(attribute);
-    if (column && (await this.canPerformCaseInsensitiveComparisonFor(column))) {
-      return attribute.lower().eq((attribute.relation as any).lower(value));
-    }
-    return attribute.eq(value);
+  caseInsensitiveComparison(
+    attribute: Nodes.Attribute,
+    value: unknown,
+  ): Nodes.Node | Promise<Nodes.Node> {
+    // Default: canPerformCaseInsensitiveComparisonFor returns true, so always LOWER.
+    // Adapters that need async column inspection (e.g. PG) override this whole method.
+    return attribute.lower().eq((attribute.relation as any).lower(value));
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1208,13 +1208,18 @@ export class AbstractAdapter implements Quoting {
     return attribute.eq(value);
   }
 
-  caseInsensitiveComparison(_attribute: unknown, _value: unknown): unknown {
-    return null;
+  /** @internal */
+  async caseInsensitiveComparison(attribute: Nodes.Attribute, value: unknown): Promise<Nodes.Node> {
+    const column = await this.columnForAttribute(attribute);
+    if (column && (await this.canPerformCaseInsensitiveComparisonFor(column))) {
+      return attribute.lower().eq((attribute.relation as any).lower(value));
+    }
+    return attribute.eq(value);
   }
 
   /** @internal */
   canPerformCaseInsensitiveComparisonFor(_column: unknown): boolean | Promise<boolean> {
-    return false;
+    return true;
   }
 
   isDefaultIndexType(_index: unknown): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1213,7 +1213,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   /** @internal */
-  canPerformCaseInsensitiveComparisonFor(_column: unknown): boolean {
+  canPerformCaseInsensitiveComparisonFor(_column: unknown): boolean | Promise<boolean> {
     return false;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -306,7 +306,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         types: {
           getTypeParser: (oid: number, format?: string) =>
             oid === 1082 && !PostgreSQLAdapter.decodeDates
-              ? pg.types.getTypeParser(oid, (format ?? "text") as "text" | "binary")
+              ? (v: unknown) => v
               : getTemporalTypeParser(oid, format),
         },
       };
@@ -374,10 +374,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // When decodeDates is false, skip the date parser (OID 1082) so
           // pg returns the raw string — mirrors Rails' decode_dates flag.
           if (oid === 1082 && !PostgreSQLAdapter.decodeDates) {
-            return (
-              userGetTypeParser?.(oid, format) ??
-              pg.types.getTypeParser(oid, (format ?? "text") as "text" | "binary")
-            );
+            return userGetTypeParser?.(oid, format) ?? ((v: unknown) => v);
           }
           // For all other OIDs, respect any user-supplied parser first, then
           // delegate to getTemporalTypeParser which falls back to pg built-ins.
@@ -535,6 +532,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Mirrors: PostgreSQLAdapter#case_insensitive_comparison (via AbstractAdapter).
+   * Async override: looks up the column type and checks pg_proc before emitting LOWER.
+   * @internal
+   */
+  override async caseInsensitiveComparison(
+    attribute: Nodes.Attribute,
+    value: unknown,
+  ): Promise<Nodes.Node> {
+    const column = await this.columnForAttribute(attribute);
+    if (column && (await this.canPerformCaseInsensitiveComparisonFor(column))) {
+      return attribute.lower().eq((attribute.relation as any).lower(value));
+    }
+    return attribute.eq(value);
+  }
+
+  /**
    * Mirrors: PostgreSQLAdapter#can_perform_case_insensitive_comparison_for?(column).
    * Queries pg_proc once per sql_type and caches the result.
    * citext is pre-seeded as false — case-insensitive by definition, LOWER() unnecessary.
@@ -544,6 +557,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sqlType?: string | null;
   }): Promise<boolean> {
     const sqlType = column.sqlType ?? "";
+    if (!sqlType) {
+      this._caseInsensitiveCache.set(sqlType, false);
+      return false;
+    }
     if (this._caseInsensitiveCache.has(sqlType)) {
       return this._caseInsensitiveCache.get(sqlType)!;
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -306,7 +306,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         types: {
           getTypeParser: (oid: number, format?: string) =>
             oid === 1082 && !PostgreSQLAdapter.decodeDates
-              ? (v: unknown) => v
+              ? format === "binary"
+                ? pg.types.getTypeParser(oid, "binary")
+                : (v: unknown) => v
               : getTemporalTypeParser(oid, format),
         },
       };
@@ -374,7 +376,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // When decodeDates is false, skip the date parser (OID 1082) so
           // pg returns the raw string — mirrors Rails' decode_dates flag.
           if (oid === 1082 && !PostgreSQLAdapter.decodeDates) {
-            return userGetTypeParser?.(oid, format) ?? ((v: unknown) => v);
+            const fallback =
+              format === "binary" ? pg.types.getTypeParser(oid, "binary") : (v: unknown) => v;
+            return userGetTypeParser?.(oid, format) ?? fallback;
           }
           // For all other OIDs, respect any user-supplied parser first, then
           // delegate to getTemporalTypeParser which falls back to pg built-ins.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -535,29 +535,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Mirrors: PostgreSQLAdapter#case_insensitive_comparison (via AbstractAdapter).
-   * Returns a LOWER(attr) = LOWER(value) node when the column type supports it,
-   * otherwise falls back to a plain equality node.
-   * @internal
-   */
-  override async caseInsensitiveComparison(
-    attribute: Nodes.Attribute,
-    value: unknown,
-  ): Promise<Nodes.Node> {
-    const column = await this.columnForAttribute(attribute);
-    if (column && (await this.canPerformCaseInsensitiveComparisonFor(column))) {
-      return attribute.lower().eq((attribute.relation as any).lower(value));
-    }
-    return attribute.eq(value);
-  }
-
-  /**
    * Mirrors: PostgreSQLAdapter#can_perform_case_insensitive_comparison_for?(column).
    * Queries pg_proc once per sql_type and caches the result.
    * citext is pre-seeded as false — case-insensitive by definition, LOWER() unnecessary.
    * @internal
    */
-  async canPerformCaseInsensitiveComparisonFor(column: {
+  override async canPerformCaseInsensitiveComparisonFor(column: {
     sqlType?: string | null;
   }): Promise<boolean> {
     const sqlType = column.sqlType ?? "";
@@ -565,20 +548,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       return this._caseInsensitiveCache.get(sqlType)!;
     }
     const sql = `
-      SELECT exists(
-        SELECT * FROM pg_proc
-        WHERE proname = 'lower'
-          AND proargtypes = ARRAY[${this.quote(sqlType)}::regtype]::oidvector
-      ) OR exists(
-        SELECT * FROM pg_proc
-        INNER JOIN pg_cast
-          ON ARRAY[casttarget]::oidvector = proargtypes
-        WHERE proname = 'lower'
-          AND castsource = ${this.quote(sqlType)}::regtype
-      )`;
-    const rows = await this.execute(sql);
-    const row = rows[0] ?? {};
-    const result = Object.values(row).some((v) => v === true);
+      SELECT (
+        exists(
+          SELECT * FROM pg_proc
+          WHERE proname = 'lower'
+            AND proargtypes = ARRAY[${this.quote(sqlType)}::regtype]::oidvector
+        ) OR exists(
+          SELECT * FROM pg_proc
+          INNER JOIN pg_cast
+            ON ARRAY[casttarget]::oidvector = proargtypes
+          WHERE proname = 'lower'
+            AND castsource = ${this.quote(sqlType)}::regtype
+        )
+      ) AS can_lower`;
+    const rows = await this.schemaQuery(sql);
+    const result = (rows[0]?.can_lower as boolean) === true;
     this._caseInsensitiveCache.set(sqlType, result);
     return result;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -202,6 +202,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Pass this value as `unlogged` when constructing a PostgreSQL TableDefinition.
   static createUnloggedTables = false;
 
+  /** Mirrors: PostgreSQLAdapter.decode_dates class_attribute (postgresql_adapter.rb:132). */
+  static decodeDates = true;
+
   private static _spCounter = 0;
   private _driverPool: pg.Pool | null;
   private _pgPoolOptions: pg.PoolConfig | null = null;
@@ -212,6 +215,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _maxIdentifierLength: number | null = null;
   private _useInsertReturning = true;
   private _minMessages = "warning";
+  private _warnedOids = new Set<number>();
+  private _caseInsensitiveCache: Map<string, boolean> = new Map([["citext", false]]);
   private _sessionVariables: Record<string, string | number | boolean | null | "default"> = {};
   private _configuredClients = new WeakSet<pg.PoolClient>();
   // Per-pg.Client statement pool. PG's prepared statements are
@@ -298,7 +303,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._sessionVariables = {};
       this._pgPoolOptions = {
         connectionString: config,
-        types: { getTypeParser: getTemporalTypeParser },
+        types: {
+          getTypeParser: (oid: number, format?: string) =>
+            oid === 1082 && !PostgreSQLAdapter.decodeDates
+              ? pg.types.getTypeParser(oid, (format ?? "text") as "text" | "binary")
+              : getTemporalTypeParser(oid, format),
+        },
       };
       this._driverPool = new pg.Pool(this._pgPoolOptions);
       return;
@@ -361,6 +371,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.
+          // When decodeDates is false, skip the date parser (OID 1082) so
+          // pg returns the raw string — mirrors Rails' decode_dates flag.
+          if (oid === 1082 && !PostgreSQLAdapter.decodeDates) {
+            return (
+              userGetTypeParser?.(oid, format) ??
+              pg.types.getTypeParser(oid, (format ?? "text") as "text" | "binary")
+            );
+          }
           // For all other OIDs, respect any user-supplied parser first, then
           // delegate to getTemporalTypeParser which falls back to pg built-ins.
           if (TEMPORAL_OIDS.has(oid) && (format === "text" || !format)) {
@@ -463,9 +481,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       await this.loadAdditionalTypes([oid]);
     }
     return this.typeMap.fetch(oid, fmod, sqlType, () => {
-      console.warn(
-        `unknown OID ${oid}: failed to recognize type of '${columnName}'. It will be treated as String.`,
-      );
+      if (!this._warnedOids.has(oid)) {
+        this._warnedOids.add(oid);
+        console.warn(
+          `unknown OID ${oid}: failed to recognize type of '${columnName}'. It will be treated as String.`,
+        );
+      }
       const fallback = new ValueType();
       this.typeMap.registerType(oid, fallback);
       return fallback;
@@ -511,6 +532,55 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // building Column objects, so OIDs are registered by the time this is
     // called for type-casting during attribute reads.
     return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => new ValueType());
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#case_insensitive_comparison (via AbstractAdapter).
+   * Returns a LOWER(attr) = LOWER(value) node when the column type supports it,
+   * otherwise falls back to a plain equality node.
+   * @internal
+   */
+  override async caseInsensitiveComparison(
+    attribute: Nodes.Attribute,
+    value: unknown,
+  ): Promise<Nodes.Node> {
+    const column = await this.columnForAttribute(attribute);
+    if (column && (await this.canPerformCaseInsensitiveComparisonFor(column))) {
+      return attribute.lower().eq((attribute.relation as any).lower(value));
+    }
+    return attribute.eq(value);
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#can_perform_case_insensitive_comparison_for?(column).
+   * Queries pg_proc once per sql_type and caches the result.
+   * citext is pre-seeded as false — case-insensitive by definition, LOWER() unnecessary.
+   * @internal
+   */
+  async canPerformCaseInsensitiveComparisonFor(column: {
+    sqlType?: string | null;
+  }): Promise<boolean> {
+    const sqlType = column.sqlType ?? "";
+    if (this._caseInsensitiveCache.has(sqlType)) {
+      return this._caseInsensitiveCache.get(sqlType)!;
+    }
+    const sql = `
+      SELECT exists(
+        SELECT * FROM pg_proc
+        WHERE proname = 'lower'
+          AND proargtypes = ARRAY[${this.quote(sqlType)}::regtype]::oidvector
+      ) OR exists(
+        SELECT * FROM pg_proc
+        INNER JOIN pg_cast
+          ON ARRAY[casttarget]::oidvector = proargtypes
+        WHERE proname = 'lower'
+          AND castsource = ${this.quote(sqlType)}::regtype
+      )`;
+    const rows = await this.execute(sql);
+    const row = rows[0] ?? {};
+    const result = Object.values(row).some((v) => v === true);
+    this._caseInsensitiveCache.set(sqlType, result);
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **`caseInsensitiveComparison`** override on `PostgreSQLAdapter` — returns `LOWER(attr) = LOWER(value)` when the column type has a `lower()` function in pg_proc; falls back to plain `attr = value`. Mirrors Rails' abstract adapter dispatch + PG private `can_perform_case_insensitive_comparison_for?`.
- **`canPerformCaseInsensitiveComparisonFor` cache** — per-`sqlType` memoization via `_caseInsensitiveCache: Map<string, boolean>`, seeded with `citext → false`. Queries pg_proc only once per type.
- **OID warn deduplication** — `_warnedOids: Set<number>` guards `getOidType`'s `console.warn` call; first encounter emits the warning, subsequent ones are silent.
- **`PostgreSQLAdapter.decodeDates` static flag** — defaults `true` (our adapter already decodes dates). When `false`, OID 1082 (DATE) is excluded from the Temporal parser table so pg returns raw strings. Gates both the string-config and object-config pool construction paths.

## Un-skips

- `only check for insensitive comparison capability once`
- `only warn on first encounter of unrecognized oid`
- `date decoding disabled`

## Verify

- `pnpm api:compare --package activerecord` — `4954/4958` unchanged (baseline pre-existing on main).
- `pnpm test:types` — passes.
- `pnpm lint` — passes.
- Integration tests require PG; run locally against `rails_js_test`.