### PR TITLE
feat(activerecord): connection-pool — role validation + class-hierarchy fallback (audit Slot A)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -548,6 +548,11 @@ export class Base extends Model {
   static _primaryKey: string | string[] = "id";
   static readonly _isActiveRecordBase = true;
 
+  /** Mirrors: ActiveRecord.writing_role */
+  static writingRole = "writing";
+  /** Mirrors: ActiveRecord.reading_role */
+  static readingRole = "reading";
+
   // Mirrors: ActiveRecord::Base.filter_attributes = [] at class definition time.
   static _filterAttributes: (string | RegExp | ((key: string, value: unknown) => unknown))[] = [];
 

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -3,6 +3,7 @@ import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { Base } from "../base.js";
 
 describe("ConnectionHandlerTest", () => {
   let handler: ConnectionHandler;
@@ -177,11 +178,19 @@ describe("ConnectionHandlerTest", () => {
     /* needs Base class integration */
   });
 
-  it.skip("connection specification name should fallback to parent", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in connection-handler
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for pool lifecycle
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in connection-handler.test.ts
-    /* needs class hierarchy connection resolution */
+  it("connection specification name should fallback to parent", () => {
+    class ParentModel extends Base {}
+    class ChildModel extends ParentModel {}
+
+    // Without explicit names both walk up to Base
+    expect(ChildModel.connectionSpecificationName).toBe(ParentModel.connectionSpecificationName);
+
+    // Setting on parent propagates to child via hierarchy walk
+    ParentModel.connectionSpecificationName = "readonly";
+    expect(ChildModel.connectionSpecificationName).toBe("readonly");
+
+    // Cleanup: reset so we don't leak into other tests
+    (ParentModel as any)._connectionSpecificationName = undefined;
   });
 
   it("remove connection should not remove parent", () => {
@@ -291,11 +300,9 @@ describe("ConnectionHandlerTest", () => {
     expect(handler.connectionPools).toHaveLength(1);
   });
 
-  it.skip("default handlers are writing and reading", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in connection-handler
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for pool lifecycle
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in connection-handler.test.ts
-    /* needs role-based handler setup */
+  it("default handlers are writing and reading", () => {
+    expect(Base.writingRole).toBe("writing");
+    expect(Base.readingRole).toBe("reading");
   });
 
   it.skip("connection pool per pid", () => {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -513,6 +513,7 @@ export async function establishConnection(
         [key: string]: unknown;
       },
 ): Promise<void> {
+  if (!modelClass.name) throw new Error("Anonymous class is not allowed.");
   // Clear cached adapters up the prototype chain (Base → ApplicationRecord → Model)
   let current: any = modelClass;
   while (current && typeof current === "function") {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -12,6 +12,7 @@ import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterNameFromConfig } from "./adapter.js";
 import type { AdapterName, DatabaseAdapter } from "./adapter.js";
 import { Result } from "./result.js";
+import { Base } from "./base.js";
 
 /**
  * Close any SQLite/underlying connections still pinned to the pool
@@ -509,11 +510,12 @@ it.skip("pool sets connection visitor", () => {
   /* needs visitor pattern */
 });
 
-it.skip("anonymous class exception", () => {
-  // BLOCKED: connection-pool — connection pool / handler gap in connection-pool
-  // ROOT-CAUSE: connection-adapters/abstract/connection-pool.ts or abstract/connection-handler.ts missing Rails parity for pool lifecycle
-  // SCOPE: ~50–100 LOC fix in connection-adapters/abstract/connection-pool.ts; affects ~10–24 tests in connection-pool.test.ts
-  /* needs class-based pool resolution */
+it("anonymous class exception", async () => {
+  // Anonymous class (no name) cannot establish a connection — mirrors Rails
+  // `raise "Anonymous class is not allowed." unless name`
+  const makeAnon = (): typeof Base => class extends Base {} as unknown as typeof Base;
+  const Anon = makeAnon();
+  await expect(Anon.establishConnection()).rejects.toThrow("Anonymous class is not allowed.");
 });
 
 it.skip("connection notification is called", () => {


### PR DESCRIPTION
## Summary

- **Anonymous-class guard** — `establishConnection` now raises `"Anonymous class is not allowed."` when called on an unnamed class, matching Rails' `resolve_config_for_connection` guard.
- **`writingRole` / `readingRole`** — expose `Base.writingRole = "writing"` and `Base.readingRole = "reading"` (mirrors `ActiveRecord.writing_role` / `reading_role` module accessors from `activerecord/lib/active_record.rb`).
- **Class-hierarchy connection spec name** — `connectionSpecificationName` already walked up the prototype chain; filled in the test verifying this behavior.

## Un-skips (3)

| File | Test |
|------|------|
| `connection-pool.test.ts` | `anonymous class exception` |
| `connection-handler.test.ts` | `connection specification name should fallback to parent` |
| `connection-handler.test.ts` | `default handlers are writing and reading` |

## Remaining skips (out of scope)

- `not setting writing role while using another named role raises` — requires `setup_shared_connection_pool` (Rails fixture helper, Slot B)
- `fixtures dont raise if theres no writing pool config` — same
- `setting writing role while using another named role does not raise` — requires `writing_role` config mutation
- Process-forking tests — Node.js has no `Process.fork` equivalent
- Schema-cache ancestor copy — also requires forking

## Verify

- `pnpm vitest run packages/activerecord/src/connection-adapters/connection-handler.test.ts packages/activerecord/src/connection-pool.test.ts` — passes (84 pass, 34 skipped)
- `pnpm api:compare --package activerecord` — 4954/4958 (unchanged)
- Type checks + lint — pass