### PR TITLE
feat(activerecord): encryption — lazy previousSchemes + store_accessor + insert defaults (audit Slot C)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2014,6 +2014,7 @@ export class Base extends Model {
   declare static leftJoins: typeof Querying.leftJoins;
   declare static leftOuterJoins: typeof Querying.leftOuterJoins;
   declare static none: typeof Querying.none;
+  declare static insert: typeof Querying.insert;
   declare static insertAll: typeof Querying.insertAll;
   declare static upsertAll: typeof Querying.upsertAll;
   declare static updateAll: typeof Querying.updateAll;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -25,7 +25,7 @@ import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
-import { globalPreviousSchemesFor, EncryptableRecord } from "./encryption/encryptable-record.js";
+import { EncryptableRecord } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
 import {
@@ -164,10 +164,11 @@ function buildScheme(options: EncryptsOptions): Scheme {
       ? schemeOptions
       : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
 
-  const base = new Scheme(coreOpts);
-  const globalPrevious = globalPreviousSchemesFor(base);
-  const allPrevious = [...globalPrevious, ...localPrevious];
-  return allPrevious.length > 0 ? new Scheme({ ...coreOpts, previousSchemes: allPrevious }) : base;
+  // Only pass locally-declared previous schemes — global ones are resolved lazily
+  // in EncryptedAttributeType at serialize/deserialize time.
+  return localPrevious.length > 0
+    ? new Scheme({ ...coreOpts, previousSchemes: localPrevious })
+    : new Scheme(coreOpts);
 }
 
 interface PendingEncryption {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -368,7 +368,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
 
   it("encrypts store attributes with accessors", async () => {
     const TrafficLight = makeEncryptedTrafficLightWithStoreState(freshAdapter());
-    new TrafficLight();
     const light = new (TrafficLight as any)();
     // Set via JS property assignment so the storeAccessor setter fires.
     light.color = "red";

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -15,6 +15,7 @@ import {
   makeEncryptedBookWithSerializedFirstBinary,
   makeEncryptedBookWithSerializedSecondBinary,
   makeEncryptedBookWithCustomCompressor,
+  makeEncryptedTrafficLightWithStoreState,
   makeFreshModel,
   makeKeyProvider,
   assertEncryptedAttribute,
@@ -295,14 +296,19 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect("name" in book.previousChanges).toBe(true);
   });
 
-  it.skip("encryption schemes are resolved when used, not when declared", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
-    // Global previous schemes (config.previous) are baked into the scheme at
-    // encrypts() time. Supporting lazy re-evaluation after configure() requires
-    // making globalPreviousSchemesFor run at serialize/deserialize time, not at
-    // class definition time — a larger refactor.
+  it("encryption schemes are resolved when used, not when declared", () => {
+    // Declare the model BEFORE configuring supportSha1ForNonDeterministicEncryption.
+    // Global previous schemes must be resolved lazily (at previousTypes access time),
+    // not eagerly at encrypts() call time — mirrors Rails' lazy previous_schemes behavior.
+    const Post = makeFreshModel(freshAdapter(), { id: "integer", title: "string" });
+    Post.encrypts("title");
+
+    configureEncryption({ primaryKey: "the primary key", keyDerivationSalt: "the salt" });
+    Configurable.config.supportSha1ForNonDeterministicEncryption = true;
+
+    const type = Post.typeForAttribute("title");
+    // One lazy-resolved global previous scheme (the SHA1 key provider).
+    expect(type.previousTypes).toHaveLength(1);
   });
 
   it("isEncryptedAttribute identifies encrypted vs plain attributes", () => {
@@ -360,10 +366,15 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect(reloaded.settings).toEqual(settings);
   });
 
-  it.skip("encrypts store attributes with accessors", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
+  it("encrypts store attributes with accessors", async () => {
+    const TrafficLight = makeEncryptedTrafficLightWithStoreState(freshAdapter());
+    new TrafficLight();
+    const light = new (TrafficLight as any)();
+    // Set via JS property assignment so the storeAccessor setter fires.
+    light.color = "red";
+    await light.save();
+    expect(light.color).toBe("red");
+    await assertEncryptedAttribute(light, "state", { color: "red" });
   });
   it("encryption errors when saving records will raise the error and don't save anything", async () => {
     const Book = makeBookThatWillFailToEncryptName(freshAdapter());
@@ -469,11 +480,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     await assertEncryptedAttribute(book, "name", "<untitled>");
   });
 
-  it.skip("loading records with encrypted attributes defined on columns with default values", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
-    // requires upsert/insert_on_duplicate_update support
+  it("loading records with encrypted attributes defined on columns with default values", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    new Book();
+    // Base.insert is a thin single-record wrapper around insertAll; values are
+    // serialized through the attribute type so name is encrypted in the DB.
+    await Book.insert({ name: "<untitled>" });
+    const book = await Book.last();
+    expect(book.name).toBe("<untitled>");
   });
   it("can dump and load records that use encryption", async () => {
     // Mirrors Rails' Marshal.dump/Marshal.load test: after serializing a model's raw
@@ -583,11 +597,16 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     await assertEncryptedAttribute(await Book2.create({ logo: jsonBytes }), "logo", jsonBytes);
   });
   it.skip("deterministic ciphertexts remain constant", () => {
-    // BLOCKED: encryption — encryption subsystem gap in encryptable-record
-    // ROOT-CAUSE: encryption/encryptable-record.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in encryption/encryptable-record.ts; affects ~6–28 tests in encryptable-record.test.ts
-    // Requires exact Rails-compatible test key configuration to decrypt the
-    // hardcoded ciphertext. Deferred until key derivation parity is confirmed.
+    // BLOCKED: message-serializer format divergence — not a key-derivation gap.
+    // MRI Rails' MessageSerializer stores cipher headers (iv, at) as
+    // Base64.strict_encode64(raw_bytes) — single base64 of raw bytes.
+    // Our MessageSerializer stores them as base64(utf8(base64_string)) —
+    // double-base64 — because Aes256Gcm.encrypt adds headers as already-
+    // base64-encoded strings and encodeIfNeeded re-encodes them.
+    // Key derivation parity IS confirmed (SHA1, 65536 iters, same salt/password
+    // correctly produce the right AES key), but the serialized ciphertext format
+    // differs. Fixing requires changing Aes256Gcm to store raw bytes in headers
+    // and would be a breaking change for existing stored ciphertexts.
   });
 
   it("can compress data with custom compressor", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -2,7 +2,7 @@ import { Scheme, type SchemeOptions } from "./scheme.js";
 import { getEncryptionContext, withoutEncryption as _withoutEncryption } from "./context.js";
 import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator } from "@blazetrails/activemodel";
-import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { EncryptedAttributeType, setGlobalPreviousSchemesFn } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -73,18 +73,23 @@ export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
 
 /**
  * Mirrors Rails' EncryptableRecord#scheme_for.
- * Builds the scheme with global previous schemes prepended to any
- * per-attribute previousSchemes declared in options.
+ * Builds the scheme with only locally-declared previousSchemes; global previous
+ * schemes are resolved lazily in EncryptedAttributeType at serialize/deserialize
+ * time so that configure() calls after encrypts() are picked up automatically.
  *
  * @internal
  */
 function schemeFor(options: SchemeOptions): Scheme {
   const { previousSchemes: localPrevious = [], ...rest } = options;
-  const base = new Scheme(rest);
-  const globalPrevious = globalPreviousSchemesFor(base);
-  const allPrevious = [...globalPrevious, ...localPrevious];
-  return allPrevious.length > 0 ? new Scheme({ ...rest, previousSchemes: allPrevious }) : base;
+  return localPrevious.length > 0
+    ? new Scheme({ ...rest, previousSchemes: localPrevious })
+    : new Scheme(rest);
 }
+
+// Register the global-previous-schemes provider into EncryptedAttributeType.
+// Called at module load time — always runs before any EncryptedAttributeType
+// accesses previousTypes because this module is loaded via encryption.ts first.
+setGlobalPreviousSchemesFn(globalPreviousSchemesFor);
 
 const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
 

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -157,7 +157,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     const key = `${this.supportUnencryptedData}:${_globalPreviousVersion}`;
     if (!this._previousTypesMemo || this._previousTypesMemoKey !== key) {
       this._previousTypesMemo = this.buildPreviousTypesFor(
-        this._effectivePreviousSchemesIncludingCleanText(),
+        this.previousSchemesIncludingCleanText(),
       );
       this._previousTypesMemoKey = key;
     }
@@ -186,7 +186,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   /** @internal */
-  private _effectivePreviousSchemesIncludingCleanText(): Scheme[] {
+  private previousSchemesIncludingCleanText(): Scheme[] {
     const schemes = [...this._effectivePreviousSchemes()];
     if (this.supportUnencryptedData) schemes.push(this.cleanTextScheme());
     return schemes;

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -17,6 +17,21 @@ import {
   replaceUnencodable as _replaceUnencodable,
 } from "./encoding-helpers.js";
 
+// Injectable provider for global previous schemes — set by encryptable-record.ts
+// to avoid the circular import cycle (encryptable-record → encrypted-attribute-type → encryptable-record).
+let _globalPreviousSchemesFn: ((scheme: Scheme) => Scheme[]) | null = null;
+let _globalPreviousVersion = 0;
+
+/** @internal */
+export function setGlobalPreviousSchemesFn(fn: (scheme: Scheme) => Scheme[]): void {
+  _globalPreviousSchemesFn = fn;
+  _globalPreviousVersion++;
+}
+
+Configurable.onConfigure(() => {
+  _globalPreviousVersion++;
+});
+
 /**
  * An ActiveModel type that encrypts/decrypts attribute values. This is
  * the central piece connecting the encryption system with `encrypts`
@@ -32,8 +47,11 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private _default?: unknown;
   private _encryptor: EncryptorLike;
   private _previousTypesMemo?: EncryptedAttributeType[];
-  private _previousTypesMemoKey?: boolean;
+  private _previousTypesMemoKey?: string;
+  private _effectivePrevMemo?: Scheme[];
+  private _effectivePrevVersion = -1;
   private _serializeWithOldestMemo?: boolean;
+  private _serializeWithOldestVersion = -1;
 
   constructor(options: {
     scheme: Scheme;
@@ -96,6 +114,12 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.serializeWithCurrent(value);
   }
 
+  // Encryption must always run through serialize, not the cast-value shortcut.
+  // insertAll prefers serializeCastValue; override so it always encrypts.
+  override serializeCastValue(value: unknown): unknown {
+    return this.serialize(value);
+  }
+
   override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const oldValue = rawOldValue === null ? null : this.deserialize(rawOldValue);
     return oldValue !== newValue;
@@ -104,6 +128,14 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   isEncrypted(value: unknown): boolean {
     if (typeof value !== "string") return false;
     return this.scheme.withContext(() => this._encryptor.isEncrypted(value));
+  }
+
+  // Delegate store accessor dispatch to the castType so store_accessor works
+  // with encrypted JSON/hstore columns without needing a separate store() call.
+  accessor(): unknown {
+    return typeof (this.castType as any).accessor === "function"
+      ? (this.castType as any).accessor()
+      : undefined;
   }
 
   get deterministic(): boolean {
@@ -119,13 +151,13 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   get previousTypes(): EncryptedAttributeType[] {
-    // Memoize on supportUnencryptedData so the clean-text scheme gets
-    // recomputed if the config toggles at runtime (Rails does the same
-    // via @previous_types[support_unencrypted_data?]).
-    const key = this.supportUnencryptedData;
+    // Key on both supportUnencryptedData and the global-previous version counter
+    // so the list is recomputed whenever config changes (e.g. configure() called
+    // after encrypts() is declared — the lazy-resolution contract).
+    const key = `${this.supportUnencryptedData}:${_globalPreviousVersion}`;
     if (!this._previousTypesMemo || this._previousTypesMemoKey !== key) {
       this._previousTypesMemo = this.buildPreviousTypesFor(
-        this.previousSchemesIncludingCleanText(),
+        this._effectivePreviousSchemesIncludingCleanText(),
       );
       this._previousTypesMemoKey = key;
     }
@@ -141,15 +173,28 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   /** @internal */
-  private previousSchemesIncludingCleanText(): Scheme[] {
-    const schemes = [...(this.scheme.previousSchemes ?? [])];
+  private _effectivePreviousSchemes(): Scheme[] {
+    // Previous types are already derived from global+local schemes at the
+    // top-level — don't re-expand globals or we get infinite recursion.
+    if (this._previousType) return this.scheme.previousSchemes ?? [];
+    if (this._effectivePrevVersion !== _globalPreviousVersion) {
+      const global = _globalPreviousSchemesFn ? _globalPreviousSchemesFn(this.scheme) : [];
+      this._effectivePrevMemo = [...global, ...(this.scheme.previousSchemes ?? [])];
+      this._effectivePrevVersion = _globalPreviousVersion;
+    }
+    return this._effectivePrevMemo!;
+  }
+
+  /** @internal */
+  private _effectivePreviousSchemesIncludingCleanText(): Scheme[] {
+    const schemes = [...this._effectivePreviousSchemes()];
     if (this.supportUnencryptedData) schemes.push(this.cleanTextScheme());
     return schemes;
   }
 
   /** @internal */
   private previousTypesWithoutCleanText(): EncryptedAttributeType[] {
-    return this.buildPreviousTypesFor(this.scheme.previousSchemes ?? []);
+    return this.buildPreviousTypesFor(this._effectivePreviousSchemes());
   }
 
   /** @internal */
@@ -195,7 +240,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
       });
     } catch (error) {
       if (!(error instanceof BaseEncryptionError)) throw error;
-      if (this.scheme.previousSchemes.length === 0)
+      if (this._effectivePreviousSchemes().length === 0)
         return this.handleDeserializeError(error, value);
       return this.tryToDeserializeWithPreviousEncryptedTypes(value);
     }
@@ -227,9 +272,12 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private isSerializeWithOldest(): boolean {
-    this._serializeWithOldestMemo ??=
-      this.scheme.isFixed() && this.scheme.previousSchemes.length > 0;
-    return this._serializeWithOldestMemo;
+    if (this._serializeWithOldestVersion !== _globalPreviousVersion) {
+      this._serializeWithOldestMemo =
+        this.scheme.isFixed() && this._effectivePreviousSchemes().length > 0;
+      this._serializeWithOldestVersion = _globalPreviousVersion;
+    }
+    return this._serializeWithOldestMemo!;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -277,6 +277,25 @@ export function makeBookThatWillFailToEncryptName(adapter: DatabaseAdapter) {
 }
 
 /**
+ * EncryptedTrafficLightWithStoreState: `state` is a JSON store column (encrypted),
+ * with `color` exposed as a storeAccessor into it.
+ * Mirrors Rails' EncryptedTrafficLightWithStoreState fixture.
+ */
+export function makeEncryptedTrafficLightWithStoreState(adapter: DatabaseAdapter) {
+  return class EncryptedTrafficLightWithStoreState extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("state", "json");
+      this.adapter = adapter;
+      this.encrypts("state");
+      // storeAccessorFor delegates to EncryptedAttributeType.accessor() which
+      // forwards to JsonType.accessor(), so no separate store() call is needed.
+      this.storeAccessor("state", { accessors: ["color"] });
+    }
+  } as any;
+}
+
+/**
  * EncryptedBookWithBinary: logo is a binary attribute, encrypted.
  * Mirrors Rails' EncryptedBookWithBinary fixture (book_encrypted.rb).
  */
@@ -397,6 +416,16 @@ function _valuesEqual(readValue: unknown, expectedValue: unknown): boolean {
   if (
     Array.isArray(readValue) &&
     Array.isArray(expectedValue) &&
+    JSON.stringify(readValue) === JSON.stringify(expectedValue)
+  )
+    return true;
+  if (
+    typeof readValue === "object" &&
+    readValue !== null &&
+    !Array.isArray(readValue) &&
+    typeof expectedValue === "object" &&
+    expectedValue !== null &&
+    !Array.isArray(expectedValue) &&
     JSON.stringify(readValue) === JSON.stringify(expectedValue)
   )
     return true;

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -285,6 +285,15 @@ export function none<T extends typeof Base>(this: T): Relation<InstanceType<T>> 
 // matching `delegate(*QUERYING_METHODS, to: :all)`.
 // ---------------------------------------------------------------------------
 
+/** Mirrors: ActiveRecord::Querying#insert */
+export function insert<T extends typeof Base>(
+  this: T,
+  record: Record<string, unknown>,
+  options?: Parameters<Relation<InstanceType<T>>["insertAll"]>[1],
+): Promise<number> {
+  return this.all().insertAll([record], options);
+}
+
 /** Mirrors: ActiveRecord::Querying#insert_all */
 export function insertAll<T extends typeof Base>(
   this: T,

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -289,9 +289,9 @@ export function none<T extends typeof Base>(this: T): Relation<InstanceType<T>> 
 export function insert<T extends typeof Base>(
   this: T,
   record: Record<string, unknown>,
-  options?: Parameters<Relation<InstanceType<T>>["insertAll"]>[1],
+  options?: Parameters<Relation<InstanceType<T>>["insert"]>[1],
 ): Promise<number> {
-  return this.all().insertAll([record], options);
+  return this.all().insert(record, options);
 }
 
 /** Mirrors: ActiveRecord::Querying#insert_all */


### PR DESCRIPTION
## Summary

- **Lazy `previousSchemes`**: Global previous schemes (`config.previous`) are now resolved lazily at serialize/deserialize time rather than baked in at `encrypts()` declaration time. A module-level injectable callback (`setGlobalPreviousSchemesFn`) in `EncryptedAttributeType` breaks the circular import; `encryptable-record.ts` and `encryption.ts` both stop eagerly computing globals.
- **Encrypted `store_accessor`**: `EncryptedAttributeType` now exposes `accessor()` delegating to its `castType` (e.g. `JsonType.accessor()` → `StringKeyedHashAccessor`), so `storeAccessorFor` finds the right accessor without requiring a separate `store()` call. Adds `makeEncryptedTrafficLightWithStoreState` fixture.
- **`Base.insert` wrapper**: Thin single-record wrapper around `insertAll` in `querying.ts` + `declare static insert` on `Base`. Also fixes `EncryptedAttributeType.serializeCastValue` to delegate to `serialize` so the `insertAll` path correctly encrypts values.
- **Deterministic ciphertext byte-parity**: Sharpened skip — key derivation parity is confirmed (SHA1, 65536 iters, correct salt/password), but our `MessageSerializer` stores cipher headers as double-base64 (base64-of-base64-string) while MRI Rails uses single-base64 of raw bytes. Cross-format decryption would require changing `Aes256Gcm` to store raw bytes in headers — a breaking change for existing stored data.

## Test results

- 3 newly un-skipped: "encryption schemes are resolved when used, not when declared", "encrypts store attributes with accessors", "loading records with encrypted attributes defined on columns with default values"
- 1 sharpened-skipped: "deterministic ciphertexts remain constant" (message-serializer format divergence documented)
- 57/58 passing, 1 skipped; full activerecord suite 10,879 passing

## LOC

206 LOC total (159 additions + 47 deletions), under the 300 ceiling

## Follow-ups

- Fix `MessageSerializer` to store cipher headers as raw bytes (single base64) for cross-Rails-format compatibility — would unblock "deterministic ciphertexts remain constant"
- Fix model constructor to use `assignAttributes` path (which invokes JS property setters) instead of `writeAttribute` — would allow `Model.create({ storeAccessorKey: value })` to work directly