### PR TITLE
feat(activerecord): fidelity-sweep B — test-infra + tableOptions + phantom cleanup + i18n + validation (10 items)

### DIFF
--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -322,11 +322,15 @@ const messages: TranslationTree = {
   record_invalid: "Validation failed: %{errors}",
 };
 
+// Rails only defines record_invalid under errors.messages, not activemodel.errors.messages.
+const amMessages = deepDup(messages) as Record<string, unknown>;
+delete amMessages["record_invalid"];
+
 const defaultEnTranslations: TranslationTree = {
   activemodel: {
     errors: {
       format: "%{attribute} %{message}",
-      messages: deepDup(messages) as TranslationTree,
+      messages: amMessages as TranslationTree,
     },
   },
   errors: {

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -876,28 +876,28 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness tsrange preserve usec", async () => {
       // Rails: time_string = "2017-09-26 07:30:59.132451 -0700"; assert time.usec > 0
+      // Verifies sub-millisecond (µs) precision is preserved through the PG round-trip.
       const tz = "Pacific Time (US & Canada)";
       const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2017-09-26T07:30:59.132451-07:00";
       const instant = Temporal.Instant.from(timeString);
+      // Confirm the instant has sub-millisecond precision (µs component = 451 µs)
+      expect(instant.toString()).toContain(".132451");
 
       const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, timeString, false) });
       const range1 = r.ts_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
-        instant.epochMilliseconds,
-      );
+      expect((range1.begin as TimeWithZone).utc().toString()).toBe(instant.toString());
 
       await r.saveBang();
       await r.reload();
       const range2 = r.ts_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
-        instant.epochMilliseconds,
-      );
+      // µs precision round-trips through PostgreSQL tsrange
+      expect((range2.begin as TimeWithZone).utc().toString()).toBe(instant.toString());
     });
     it("create numrange", async () => {
       // Rails: assert_equal_round_trip(@new_range, :num_range, BigDecimal("0.5")...BigDecimal("1"))

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -33,6 +33,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         num_range numrange,
         ts_range tsrange,
         tstz_range tstzrange,
+        ts_ranges tsrange[],
+        tstz_ranges tstzrange[],
         int4_range int4range,
         int8_range int8range,
         float_range floatrange,
@@ -553,8 +555,47 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
       expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
-    it.skip("timezone array awareness tzrange", () => {
-      // DEFERRED to follow-up PR: requires tstz_ranges tstzrange[] column in setup
+    it("timezone array awareness tzrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+
+      const fromStr = "2020-06-15T10:00:00-07:00";
+      const toStr = "2020-06-15T11:00:00-07:00";
+      const fromInstant = Temporal.Instant.from(fromStr);
+      const toInstant = Temporal.Instant.from(toStr);
+
+      // [exclusive, inclusive, endless, beginless]
+      const ranges = [
+        new Range(fromStr, toStr, true),
+        new Range(fromStr, toStr, false),
+        new Range(fromStr, null, true),
+        new Range(null, toStr, false),
+      ];
+      const r = new PostgresqlRangesTz({ tstz_ranges: ranges });
+      const pre = r.tstz_ranges as Range[];
+      expect(pre[0].begin).toBeInstanceOf(TimeWithZone);
+      expect((pre[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((pre[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        fromInstant.epochMilliseconds,
+      );
+
+      await r.saveBang();
+      await r.reload();
+      const post = r.tstz_ranges as Range[];
+      expect(post).toHaveLength(4);
+      expect(post[0].begin).toBeInstanceOf(TimeWithZone);
+      expect((post[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((post[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        fromInstant.epochMilliseconds,
+      );
+      expect((post[0].end as TimeWithZone).utc().epochMilliseconds).toBe(
+        toInstant.epochMilliseconds,
+      );
+      expect(post[2].begin).toBeInstanceOf(TimeWithZone);
+      expect(post[2].end).toBeNull();
+      expect(post[3].begin).toBeNull();
+      expect(post[3].end).toBeInstanceOf(TimeWithZone);
     });
     it("create tstzrange", async () => {
       // Rails: Time.parse("2010-01-01 14:30:00 +0100")...Time.parse("2011-02-02 14:30:00 CDT") → UTC-normalised
@@ -745,8 +786,46 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
       expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
-    it.skip("timezone array awareness tsrange", () => {
-      // DEFERRED to follow-up PR: requires ts_ranges tsrange[] column in setup
+    it("timezone array awareness tsrange", async () => {
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+
+      const fromStr = "2020-06-15T10:00:00-07:00";
+      const toStr = "2020-06-15T11:00:00-07:00";
+      const fromInstant = Temporal.Instant.from(fromStr);
+      const toInstant = Temporal.Instant.from(toStr);
+
+      const ranges = [
+        new Range(fromStr, toStr, true),
+        new Range(fromStr, toStr, false),
+        new Range(fromStr, null, true),
+        new Range(null, toStr, false),
+      ];
+      const r = new PostgresqlRangesTz({ ts_ranges: ranges });
+      const pre = r.ts_ranges as Range[];
+      expect(pre[0].begin).toBeInstanceOf(TimeWithZone);
+      expect((pre[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((pre[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        fromInstant.epochMilliseconds,
+      );
+
+      await r.saveBang();
+      await r.reload();
+      const post = r.ts_ranges as Range[];
+      expect(post).toHaveLength(4);
+      expect(post[0].begin).toBeInstanceOf(TimeWithZone);
+      expect((post[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((post[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        fromInstant.epochMilliseconds,
+      );
+      expect((post[0].end as TimeWithZone).utc().epochMilliseconds).toBe(
+        toInstant.epochMilliseconds,
+      );
+      expect(post[2].begin).toBeInstanceOf(TimeWithZone);
+      expect(post[2].end).toBeNull();
+      expect(post[3].begin).toBeNull();
+      expect(post[3].end).toBeInstanceOf(TimeWithZone);
     });
     it("create tstzrange preserve usec", async () => {
       // Rails: Time.parse("2010-01-01 14:30:00.670277 +0100")...Time.parse("2011-02-02 14:30:00.745125 CDT")
@@ -795,8 +874,30 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       expect(r.ts_range).toBeNull();
     });
-    it.skip("timezone awareness tsrange preserve usec", () => {
-      // DEFERRED to follow-up PR (LOC budget): same infrastructure as basic tests; µs precision
+    it("timezone awareness tsrange preserve usec", async () => {
+      // Rails: time_string = "2017-09-26 07:30:59.132451 -0700"; assert time.usec > 0
+      const tz = "Pacific Time (US & Canada)";
+      const zone = TimeZone.find(tz)!;
+      setZone(tz);
+      const timeString = "2017-09-26T07:30:59.132451-07:00";
+      const instant = Temporal.Instant.from(timeString);
+
+      const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, timeString, false) });
+      const range1 = r.ts_range as Range;
+      expect(range1.begin).toBeInstanceOf(TimeWithZone);
+      expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
+
+      await r.saveBang();
+      await r.reload();
+      const range2 = r.ts_range as Range;
+      expect(range2.begin).toBeInstanceOf(TimeWithZone);
+      expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
+      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
     });
     it("create numrange", async () => {
       // Rails: assert_equal_round_trip(@new_range, :num_range, BigDecimal("0.5")...BigDecimal("1"))

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -833,12 +833,6 @@ describe("BasicsTest", () => {
     expect(u.readAttribute("name")).toBe(null);
   });
 
-  it.skip("model classes with matching names", () => {
-    // BLOCKED: unknown — Ruby module namespace / constant lookup semantics not translatable
-    // ROOT-CAUSE: Node.js has no Ruby Module namespace for matching class names by constant path
-    // SCOPE: ~0 LOC fix; no matching test in Rails base_test.rb — likely permanent
-  });
-
   it.skip("copy table with id", () => {
     // BLOCKED: schema — SQLite copy_table DDL not implemented
     // ROOT-CAUSE: connection-adapters/sqlite3/schema-statements.ts#copyTable not implemented

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -225,7 +225,10 @@ export class Encryptor {
 
   /** @internal */
   private compressIfWorthIt(clearText: string): [string | Buffer, boolean] {
-    if (this._compress && clearText.length > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
+    if (
+      this._compress &&
+      Buffer.byteLength(clearText, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION
+    ) {
       return [this.compress(clearText), true];
     }
     return [clearText, false];

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -226,13 +226,7 @@ export class Encryptor {
   /** @internal */
   private compressIfWorthIt(clearText: string): [string | Buffer, boolean] {
     if (this._compress && clearText.length > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
-      const compressed = this.compress(clearText);
-      // Extra guard: keep uncompressed if deflate doesn't shrink the data (e.g. already-compressed
-      // or high-entropy input). Rails trusts that >140-byte strings are worth compressing. Decrypt
-      // reads the `c` header so the asymmetry is interop-safe.
-      if (compressed.length < clearText.length) {
-        return [compressed, true];
-      }
+      return [this.compress(clearText), true];
     }
     return [clearText, false];
   }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -225,15 +225,12 @@ export class Encryptor {
 
   /** @internal */
   private compressIfWorthIt(clearText: string): [string | Buffer, boolean] {
-    if (
-      this._compress &&
-      Buffer.byteLength(clearText, "utf-8") > THRESHOLD_TO_JUSTIFY_COMPRESSION
-    ) {
+    if (this._compress && clearText.length > THRESHOLD_TO_JUSTIFY_COMPRESSION) {
       const compressed = this.compress(clearText);
       // Extra guard: keep uncompressed if deflate doesn't shrink the data (e.g. already-compressed
       // or high-entropy input). Rails trusts that >140-byte strings are worth compressing. Decrypt
       // reads the `c` header so the asymmetry is interop-safe.
-      if (compressed.length < Buffer.byteLength(clearText, "utf-8")) {
+      if (compressed.length < clearText.length) {
         return [compressed, true];
       }
     }

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -48,8 +48,8 @@ describe("TouchTest", () => {
     // travel 5 minutes — vi.setSystemTime advances the fake clock without resetting it
     vi.setSystemTime(new Date(t0.getTime() + 5 * 60 * 1000));
 
-    // Change lft so the record is dirty and triggers an UPDATE with a new timestamp
-    stamped.writeAttribute("lft", 42);
+    // Mirror lft_will_change! — force-marks lft dirty without changing its value
+    (stamped as any)._dirty.forceChange("lft", stamped.readAttribute("lft"));
     await stamped.save();
 
     const newUpdatedAt = stamped.readAttribute("updated_at");

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -48,8 +48,10 @@ describe("TouchTest", () => {
     // travel 5 minutes — vi.setSystemTime advances the fake clock without resetting it
     vi.setSystemTime(new Date(t0.getTime() + 5 * 60 * 1000));
 
-    // Mirror lft_will_change! — force-marks lft dirty without changing its value
-    (stamped as any)._dirty.forceChange("lft", stamped.readAttribute("lft"));
+    // Mirror lft_will_change! — force-marks lft dirty without changing its value.
+    // Use _attributes.fetchValue (not readAttribute) to match attributeWillChangeBang semantics:
+    // fetchValue doesn't add to _accessedFields.
+    (stamped as any)._dirty.forceChange("lft", (stamped as any)._attributes.fetchValue("lft"));
     await stamped.save();
 
     const newUpdatedAt = stamped.readAttribute("updated_at");

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -70,6 +70,7 @@ describe("TouchTest", () => {
       }
     }
 
+    const prevRecordTimestamps = Mixin.recordTimestamps;
     Mixin.recordTimestamps = false;
     try {
       const mixin = new Mixin();
@@ -77,7 +78,7 @@ describe("TouchTest", () => {
       await mixin.save();
       expect(mixin.readAttribute("updated_at")).toBeNull();
     } finally {
-      Mixin.recordTimestamps = true;
+      Mixin.recordTimestamps = prevRecordTimestamps;
     }
   });
 });

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -1,10 +1,83 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Base } from "./index.js";
+import { createTestAdapter } from "./test-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+
+function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
 
 describe("TouchTest", () => {
-  it.skip("many updates", () => {
-    // BLOCKED: mixin — needs mixins table fixture (lft, updated_at, created_at) + vi.useFakeTimers for travel
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      mixins: { lft: "integer", updated_at: "datetime", created_at: "datetime" },
+    });
   });
-  it.skip("create turned off", () => {
-    // BLOCKED: mixin — needs mixins table fixture; recordTimestamps=false path is implemented
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("many updates", async () => {
+    class Mixin extends Base {
+      static {
+        this.tableName = "mixins";
+        this.attribute("lft", "integer");
+        this.attribute("updated_at", "datetime");
+        this.attribute("created_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+
+    const t0 = new Date("2024-01-01T00:00:00.000Z");
+    vi.useFakeTimers({ now: t0 });
+
+    const stamped = new Mixin();
+    expect(stamped.readAttribute("updated_at")).toBeNull();
+    expect(stamped.readAttribute("created_at")).toBeNull();
+    await stamped.save();
+    const createdAt = stamped.readAttribute("created_at") as unknown;
+    expect(createdAt).not.toBeNull();
+
+    const oldUpdatedAt = stamped.readAttribute("updated_at");
+
+    // travel 5 minutes — vi.setSystemTime advances the fake clock without resetting it
+    vi.setSystemTime(new Date(t0.getTime() + 5 * 60 * 1000));
+
+    // Change lft so the record is dirty and triggers an UPDATE with a new timestamp
+    stamped.writeAttribute("lft", 42);
+    await stamped.save();
+
+    const newUpdatedAt = stamped.readAttribute("updated_at");
+    expect(newUpdatedAt).not.toBeNull();
+    expect(newUpdatedAt).not.toEqual(oldUpdatedAt);
+    // created_at does not change on update
+    expect(stamped.readAttribute("created_at")).toEqual(createdAt);
+  });
+
+  it("create turned off", async () => {
+    class Mixin extends Base {
+      static {
+        this.tableName = "mixins";
+        this.attribute("lft", "integer");
+        this.attribute("updated_at", "datetime");
+        this.attribute("created_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+
+    Mixin.recordTimestamps = false;
+    try {
+      const mixin = new Mixin();
+      expect(mixin.readAttribute("updated_at")).toBeNull();
+      await mixin.save();
+      expect(mixin.readAttribute("updated_at")).toBeNull();
+    } finally {
+      Mixin.recordTimestamps = true;
+    }
   });
 });

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -141,11 +141,4 @@ describe("ModulesTest", () => {
     await p.save();
     expect(p.author_id).toBeNull();
   });
-
-  it.skip("table name in mixins", () => {
-    // BLOCKED: unknown — no matching test in Rails modules_test.rb; likely a phantom from a prior merge
-  });
-  it.skip("inheritance in mixins", () => {
-    // BLOCKED: unknown — no matching test in Rails modules_test.rb; likely a phantom from a prior merge
-  });
 });

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -236,9 +236,8 @@ describe("AssociationValidationTest", () => {
     expect(r.errors.fullMessagesFor("topic")).toEqual(["Topic is invalid"]);
   });
   it.skip("validates associated with create context", () => {
-    // BLOCKED: validation — validator behavior gap in association-validation
-    // ROOT-CAUSE: validations/associated.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in validations/associated.ts; affects ~4–11 tests in association-validation.test.ts
-    /* needs update! and replies.create — complex persistence operations */
+    // BLOCKED: CollectionProxy.create — Rails uses t.replies.create(...) which requires
+    // a live has_many CollectionProxy with .create support. The validation logic in
+    // associated.ts is correct; the blocker is CollectionProxy.create, not associated.ts.
   });
 });

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
@@ -145,14 +146,14 @@ describe("UniquenessValidationTest", () => {
 
   it("validate uniqueness with scope invalid syntax", () => {
     // Rails: assert_raises(ArgumentError) { Reply.validates_uniqueness_of(:content, scope: { parent_id: false }) }
-    // Passes a hash as scope (invalid); uniqueness.ts throws for non-string scope values.
+    // Passes a hash as scope (invalid); validatesUniqueness throws ArgumentError at declaration time.
     expect(() => {
       class Post extends Base {
         static {
           this.validatesUniqueness("title", { scope: { nonexistent_col: false } as any });
         }
       }
-    }).toThrow(/array of strings/);
+    }).toThrow(ArgumentError);
   });
 
   it("validate uniqueness with object scope", async () => {

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -152,7 +152,6 @@ describe("UniquenessValidationTest", () => {
           this.validatesUniqueness("title", { scope: { nonexistent_col: false } as any });
         }
       }
-      new Post();
     }).toThrow(/array of strings/);
   });
 

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -143,21 +143,17 @@ describe("UniquenessValidationTest", () => {
     expect(await p2.save()).toBe(false);
   });
 
-  // Real DBs reject queries referencing nonexistent columns
-  it.skip("validate uniqueness with scope invalid syntax", async () => {
-    // BLOCKED: validation — validator behavior gap in uniqueness-validation
-    // ROOT-CAUSE: validations/uniqueness.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in validations/uniqueness.ts; affects ~4–11 tests in uniqueness-validation.test.ts
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.validatesUniqueness("title", { scope: "nonexistent_col" });
+  it("validate uniqueness with scope invalid syntax", () => {
+    // Rails: assert_raises(ArgumentError) { Reply.validates_uniqueness_of(:content, scope: { parent_id: false }) }
+    // Passes a hash as scope (invalid); uniqueness.ts throws for non-string scope values.
+    expect(() => {
+      class Post extends Base {
+        static {
+          this.validatesUniqueness("title", { scope: { nonexistent_col: false } as any });
+        }
       }
-    }
-    const p = new Post({ title: "ok" });
-    expect(await p.save()).toBe(true);
+      new Post();
+    }).toThrow(/array of strings/);
   });
 
   it("validate uniqueness with object scope", async () => {

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -47,7 +47,7 @@ export function validatesUniqueness(
   } = {},
 ): void {
   // Validate options eagerly to match Rails' ArgumentError at declaration time.
-  validateScopeOption((options as Record<string, unknown>).scope);
+  validateScopeOption(options.scope);
   const klass = this as { _asyncValidations?: Array<unknown> };
   if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
     klass._asyncValidations = [...(klass._asyncValidations ?? [])];

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -5,7 +5,7 @@
  * Builds a query against the model's table to check for existing records
  * with the same value, optionally scoped to other columns.
  */
-import { EachValidator } from "@blazetrails/activemodel";
+import { EachValidator, ArgumentError } from "@blazetrails/activemodel";
 
 /**
  * Register a deferred uniqueness validation to run on save (since uniqueness
@@ -24,13 +24,11 @@ export function validatesUniqueness(
   } = {},
 ): void {
   // Validate options eagerly to match Rails' ArgumentError at declaration time.
-  // No ArgumentError class exists in this codebase; plain Error matches the existing convention
-  // in UniquenessValidator#constructor (same message shape, same throw site pattern).
   const scope = (options as Record<string, unknown>).scope;
   if (scope != null) {
     const scopes = Array.isArray(scope) ? scope : [scope];
     if (!scopes.every((s) => typeof s === "string")) {
-      throw new Error(
+      throw new ArgumentError(
         `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
           "Pass a string or an array of strings instead.",
       );

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -8,6 +8,23 @@
 import { EachValidator, ArgumentError } from "@blazetrails/activemodel";
 
 /**
+ * Shared scope option validation — called eagerly from validatesUniqueness (declaration time)
+ * and from UniquenessValidator#constructor (instantiation time). Mirrors Rails'
+ * ArgumentError raised in UniquenessValidator#initialize for non-symbol :scope values.
+ * @internal
+ */
+function validateScopeOption(scope: unknown): void {
+  if (scope == null) return;
+  const scopes = Array.isArray(scope) ? scope : [scope];
+  if (!scopes.every((s) => typeof s === "string")) {
+    throw new ArgumentError(
+      `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
+        "Pass a string or an array of strings instead.",
+    );
+  }
+}
+
+/**
  * Register a deferred uniqueness validation to run on save (since uniqueness
  * requires a DB round-trip, it's kept off the synchronous validator chain).
  *
@@ -24,16 +41,7 @@ export function validatesUniqueness(
   } = {},
 ): void {
   // Validate options eagerly to match Rails' ArgumentError at declaration time.
-  const scope = (options as Record<string, unknown>).scope;
-  if (scope != null) {
-    const scopes = Array.isArray(scope) ? scope : [scope];
-    if (!scopes.every((s) => typeof s === "string")) {
-      throw new ArgumentError(
-        `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
-          "Pass a string or an array of strings instead.",
-      );
-    }
-  }
+  validateScopeOption((options as Record<string, unknown>).scope);
   const klass = this as { _asyncValidations?: Array<unknown> };
   if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
     klass._asyncValidations = [...(klass._asyncValidations ?? [])];
@@ -57,16 +65,7 @@ export class UniquenessValidator extends EachValidator {
           "Pass a callable instead: `conditions: () => where({ approved: true })`",
       );
     }
-    const scope = options.scope;
-    if (scope != null) {
-      const scopes = Array.isArray(scope) ? scope : [scope];
-      if (!scopes.every((s) => typeof s === "string")) {
-        throw new Error(
-          `${scope} is not a supported format for :scope option. ` +
-            "Pass a string or an array of strings instead: `scope: 'userId'`",
-        );
-      }
-    }
+    validateScopeOption(options.scope);
     if (
       Object.prototype.hasOwnProperty.call(options, "caseSensitive") &&
       typeof options.caseSensitive !== "boolean"

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -24,10 +24,12 @@ export function validatesUniqueness(
   } = {},
 ): void {
   // Validate options eagerly to match Rails' ArgumentError at declaration time.
-  const scope = (options as any).scope;
+  // No ArgumentError class exists in this codebase; plain Error matches the existing convention
+  // in UniquenessValidator#constructor (same message shape, same throw site pattern).
+  const scope = (options as Record<string, unknown>).scope;
   if (scope != null) {
     const scopes = Array.isArray(scope) ? scope : [scope];
-    if (!scopes.every((s: unknown) => typeof s === "string")) {
+    if (!scopes.every((s) => typeof s === "string")) {
       throw new Error(
         `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
           "Pass a string or an array of strings instead.",

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -19,7 +19,7 @@ function validateScopeOption(scope: unknown): void {
   if (!scopes.every((s) => typeof s === "string")) {
     let scopeRepr: string;
     try {
-      scopeRepr = JSON.stringify(scope);
+      scopeRepr = JSON.stringify(scope) ?? String(scope);
     } catch {
       scopeRepr = String(scope);
     }

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -17,8 +17,14 @@ function validateScopeOption(scope: unknown): void {
   if (scope == null) return;
   const scopes = Array.isArray(scope) ? scope : [scope];
   if (!scopes.every((s) => typeof s === "string")) {
+    let scopeRepr: string;
+    try {
+      scopeRepr = JSON.stringify(scope);
+    } catch {
+      scopeRepr = String(scope);
+    }
     throw new ArgumentError(
-      `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
+      `${scopeRepr} is not a supported format for :scope option. ` +
         "Pass a string or an array of strings instead.",
     );
   }

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -23,6 +23,17 @@ export function validatesUniqueness(
     caseSensitive?: boolean;
   } = {},
 ): void {
+  // Validate options eagerly to match Rails' ArgumentError at declaration time.
+  const scope = (options as any).scope;
+  if (scope != null) {
+    const scopes = Array.isArray(scope) ? scope : [scope];
+    if (!scopes.every((s: unknown) => typeof s === "string")) {
+      throw new Error(
+        `${JSON.stringify(scope)} is not a supported format for :scope option. ` +
+          "Pass a string or an array of strings instead.",
+      );
+    }
+  }
   const klass = this as { _asyncValidations?: Array<unknown> };
   if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
     klass._asyncValidations = [...(klass._asyncValidations ?? [])];


### PR DESCRIPTION
## Summary

Bundled cleanup of 7 of the 10 followup items from prior PR reviews. Items implemented:

| # | Source | Item | LOC |
|---|--------|------|-----|
| 1 | #1395 | tsrange/tstzrange array tests — add \`ts_ranges tsrange[]\` + \`tstz_ranges tstzrange[]\` to PG range beforeEach; implement 3 deferred tests | ~40 |
| 2 | #1416 | mixin tests — defineSchema + \`vi.useFakeTimers\` for "many updates" and "create turned off" | ~30 |
| 3 | audit | Remove 3 phantom \`it.skip\` tests with no Rails counterpart: \`modules.test.ts\` ×2, \`base.test.ts\` ×1 | ~−15 |
| 4 | audit | i18n: filter \`record_invalid\` from \`activemodel.errors.messages\` deepDup — Rails only has it under \`errors.messages\` | ~5 |
| 5 | #1407 | \`compressIfWorthIt\`: use \`Buffer.byteLength(clearText, "utf-8")\` (Rails-faithful byte threshold); remove non-Rails inner size guard | ~3 |
| 6 | audit | Uniqueness: restore Rails test body for "validate uniqueness with scope invalid syntax"; add eager scope validation in \`validatesUniqueness\` (shared helper with \`UniquenessValidator#constructor\`) throwing \`ArgumentError\` at declaration time | ~25 |
| 7 | audit | Association: sharpen "validates associated with create context" annotation → \`CollectionProxy.create\` blocker | ~3 |

**Total: ~230 LOC additions + deletions.**

## Deferred items (note for follow-up)

- **#1399 \`with_env_tz\`**: requires new \`defaultSqlTimezone()\` module-level override infrastructure — function doesn't exist yet; non-trivial to add without impacting existing tests.
- **#1404 \`HashAccessor\` json branch**: path is correct — json columns go through \`isStringBacked = false\` path and store plain objects (no double-encode). Regression test deferred.
- **#1407 \`tableOptions()\`**: \`emitTable\` is synchronous; wiring \`tableOptions(tableName)\` requires making the dump loop async — scope creep. Note: overlaps with pg-schema audit Slot B and Schema cluster Slot E.
- **#1420 \`MessageSerializer.encodeIfNeeded\`**: fixing double-base64 requires changing \`Aes256Gcm\` to store raw bytes in headers — breaking change for existing stored ciphertexts per test annotation.

## Verify

- \`pnpm api:compare --package activerecord\` — 4969/4969 unchanged
- \`pnpm vitest run packages/activerecord/\` — newly-unskipped tests pass; everything else green
- \`pnpm test:types\` — pass