### PR TITLE
fix(activerecord): InsertAll.uniqueIndexes — await async cache.indexes (regression: upsertAll on returning DBs)

### DIFF
--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -7,6 +7,8 @@ import { Base, defineEnum } from "./index.js";
 import { InsertAll } from "./insert-all.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -1107,5 +1109,35 @@ describe("insertAll / upsertAll (Rails-guided)", () => {
       () =>
         new InsertAll(Book.all() as any, adapter, [{ id: 1, title: "x" }], { returning: "title" }),
     ).not.toThrow();
+  });
+});
+
+// ==========================================================================
+// Regression: upsertAll on returning DBs (cache miss path)
+// ==========================================================================
+describe("InsertAll async uniqueIndexes regression", () => {
+  it("upsertAll with uniqueBy succeeds when schema cache is cold (returning DB scenario)", async () => {
+    const adapter = createTestAdapter();
+    await defineSchema(adapter, { pkgs: { name: "string", sha: "string" } });
+    const ss = new SchemaStatements(adapter);
+    await ss.addIndex("pkgs", ["sha", "name"], { unique: true, name: "idx_pkgs_sha_name" });
+
+    class Pkg extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("sha", "string");
+        this.adapter = adapter;
+        this._tableName = "pkgs";
+      }
+    }
+
+    // Clear the cache to simulate a returning DB where migrateDb skipped createTable.
+    adapter.schemaCache?.clear();
+
+    // Should succeed — async _uniqueIndexes() fetches from the live DB.
+    await expect(
+      Pkg.upsertAll([{ name: "foo", sha: "abc123" }], { uniqueBy: ["sha", "name"] }),
+    ).resolves.toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -318,21 +318,22 @@ export class InsertAll {
    * Rails schema_cache.indexes() is synchronous; our TS port must be async because the
    * underlying driver call is async. Always await this method.
    *
-   * Uses the adapter's SchemaCache (AbstractAdapter#schema_cache) with the adapter
-   * itself as the pool argument. In production, the adapter's pool is a ConnectionPool
-   * whose withConnection checks out a live connection; in tests the adapter is the
-   * connection itself. BoundSchemaReflection (ConnectionPool#schema_cache) is not used
-   * here because its one-arg signature is pool-bound at construction time.
+   * Uses the adapter's raw SchemaCache (AbstractAdapter#schema_cache) with the
+   * adapter's pool (or the adapter itself in tests) as the pool argument so
+   * SchemaCache.indexes(pool, tableName) can reach connection.indexes() on a
+   * cache miss. We do NOT fall back to ConnectionPool#schemaCache (a
+   * BoundSchemaReflection with a one-arg indexes()) — the two-arg call would
+   * misalign and pass the pool object as tableName.
    */
   private async _uniqueIndexes(): Promise<unknown[]> {
     const conn = this.connection as any;
+    const cache = conn.schemaCache;
+    if (!cache || typeof cache.indexes !== "function") return [];
     // Unwrap one level of adapter wrapping (e.g. TestAdapter → SQLite3Adapter)
     // so the pool we pass to SchemaCache.indexes() can call connection.indexes().
     const pool = conn.pool ?? conn;
-    const cache = conn.schemaCache ?? (pool as any).schemaCache;
-    if (!cache || typeof (cache as any).indexes !== "function") return [];
     const tableName = this.model.arelTable.name;
-    const indexes = await (cache as any).indexes(pool, tableName);
+    const indexes = await cache.indexes(pool, tableName);
     return (indexes as unknown[]).filter((i: any) => i.unique);
   }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -131,9 +131,15 @@ export class InsertAll {
       }
     }
     this._updatableColumns = [...this.keys].filter((k) => !exclude.has(k));
-    // Deferred from configureOnDuplicateUpdateLogic: when onDuplicate==="update" was set
-    // without knowing the updatableColumns count (async index lookup not yet done).
-    if (this.onDuplicate === "update" && this._updatableColumns.length === 0) {
+    // Mirrors Rails' elsif branch: only coerce "update"→"skip" on the auto-generated
+    // update path. Custom SQL (updateSql) and explicit updateOnly are handled earlier
+    // in configureOnDuplicateUpdateLogic and must not be overridden here.
+    if (
+      this.onDuplicate === "update" &&
+      !this.updateSql &&
+      !this.updateOnly &&
+      this._updatableColumns.length === 0
+    ) {
       this.onDuplicate = "skip";
     }
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -111,21 +111,31 @@ export class InsertAll {
 
   async execute(): Promise<number> {
     if (this.inserts.length === 0) return 0;
+    await this._populateUpdatableColumns();
     const dialect = this.connection.adapterName;
     const builder = new Builder(this, dialect);
     return this.connection.executeMutation(builder.toSql());
   }
 
   updatableColumns(): string[] {
-    if (this._updatableColumns) return this._updatableColumns;
-    const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);
+    return this._updatableColumns ?? [];
+  }
+
+  /** @internal Async init: resolves uniqueByColumns via cache.indexes() then finalizes updatableColumns. */
+  private async _populateUpdatableColumns(): Promise<void> {
+    if (this._updatableColumns) return;
+    const exclude = new Set([...this.readonlyColumns(), ...(await this._uniqueByColumns())]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {
         exclude.add(col);
       }
     }
     this._updatableColumns = [...this.keys].filter((k) => !exclude.has(k));
-    return this._updatableColumns;
+    // Deferred from configureOnDuplicateUpdateLogic: when onDuplicate==="update" was set
+    // without knowing the updatableColumns count (async index lookup not yet done).
+    if (this.onDuplicate === "update" && this._updatableColumns.length === 0) {
+      this.onDuplicate = "skip";
+    }
   }
 
   primaryKeys(): string[] {
@@ -211,7 +221,8 @@ export class InsertAll {
     } else if (onDuplicate === "skip") {
       this.onDuplicate = "skip";
     } else if (onDuplicate === "update") {
-      this.onDuplicate = this.updatableColumns().length === 0 ? "skip" : "update";
+      // Finalized in _populateUpdatableColumns() after async uniqueIndexes() resolves.
+      this.onDuplicate = "update";
     }
   }
 
@@ -221,8 +232,8 @@ export class InsertAll {
   }
 
   /** @internal */
-  private uniqueByColumns(): string[] {
-    return this.findUniqueIndexFor(this.uniqueBy);
+  private async _uniqueByColumns(): Promise<string[]> {
+    return this._findUniqueIndexFor(this.uniqueBy);
   }
 
   /** @internal */
@@ -278,11 +289,11 @@ export class InsertAll {
   }
 
   /** @internal */
-  private findUniqueIndexFor(uniqueBy: string | string[] | undefined): string[] {
+  private async _findUniqueIndexFor(uniqueBy: string | string[] | undefined): Promise<string[]> {
     const nameOrCols =
       uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
     const sortedMatch = [...nameOrCols].sort().join(",");
-    const idx = this.uniqueIndexes().find(
+    const idx = (await this._uniqueIndexes()).find(
       (i: any) =>
         nameOrCols.includes(i.name) ||
         (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
@@ -296,12 +307,27 @@ export class InsertAll {
     throw new Error(`No unique index found for ${JSON.stringify(uniqueBy)}`);
   }
 
-  /** @internal */
-  private uniqueIndexes(): unknown[] {
-    const cache = this.model.schemaCache;
-    if (!cache) return [];
-    const indexes = (cache as any).indexes?.(this.model.arelTable.name) ?? [];
-    return (indexes as any[]).filter((i: any) => i.unique);
+  /**
+   * @internal
+   * Rails schema_cache.indexes() is synchronous; our TS port must be async because the
+   * underlying driver call is async. Always await this method.
+   *
+   * Uses the adapter's SchemaCache (AbstractAdapter#schema_cache) with the adapter
+   * itself as the pool argument. In production, the adapter's pool is a ConnectionPool
+   * whose withConnection checks out a live connection; in tests the adapter is the
+   * connection itself. BoundSchemaReflection (ConnectionPool#schema_cache) is not used
+   * here because its one-arg signature is pool-bound at construction time.
+   */
+  private async _uniqueIndexes(): Promise<unknown[]> {
+    const conn = this.connection as any;
+    // Unwrap one level of adapter wrapping (e.g. TestAdapter → SQLite3Adapter)
+    // so the pool we pass to SchemaCache.indexes() can call connection.indexes().
+    const pool = conn.pool ?? conn;
+    const cache = conn.schemaCache ?? (pool as any).schemaCache;
+    if (!cache || typeof (cache as any).indexes !== "function") return [];
+    const tableName = this.model.arelTable.name;
+    const indexes = await (cache as any).indexes(pool, tableName);
+    return (indexes as unknown[]).filter((i: any) => i.unique);
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

`upsertAll` with a non-PK `uniqueBy` threw `"No unique index found for ..."` on all databases, and was most visible on returning DBs where `migrateDb` skips `createTable`.

**Root cause (3 interrelated bugs in `uniqueIndexes()`):**

```ts
// packages/activerecord/src/insert-all.ts:300 (before fix)
private uniqueIndexes(): unknown[] {
  const cache = this.model.schemaCache;  // BUG 2: this is the unbound function, not a cache object
  if (!cache) return [];
  const indexes = (cache as any).indexes?.(this.model.arelTable.name) ?? [];  // BUG 1: not awaited; BUG 3: wrong arg count
  return (indexes as any[]).filter((i: any) => i.unique);
}
```

1. **Not awaited**: `cache.indexes()` is `async` — returns a `Promise`, which has no `.filter()` → always `[]`.
2. **Wrong receiver**: `this.model.schemaCache` is the `schemaCache` static function (assigned via `extend()`), not the cache object. Calling `.indexes?.()` on a function returns `undefined`.
3. **Wrong arg count**: `SchemaCache.indexes(pool, tableName)` requires two arguments; the call passed only one, so `pool=tableName` and `tableName=undefined` → DB lookup always missed.

## Fix

- Make `uniqueIndexes()` → `_uniqueIndexes()` async; await `cache.indexes(pool, tableName)` with the connection as pool so the live DB is queried on a cache miss.
- Cascade async through `_findUniqueIndexFor()` / `_uniqueByColumns()`.
- Defer `_updatableColumns` population (which depends on `uniqueByColumns`) from the constructor into `execute()` via a new `_populateUpdatableColumns()`, so the async lookup is properly awaited before building SQL.
- The `onDuplicate === "update"` → `"skip"` coercion (when no updatable columns remain) is also deferred to `_populateUpdatableColumns()`.

## Regression test

Creates a table with a unique composite index, clears the schema cache to simulate a returning DB, then calls `upsertAll` with `uniqueBy` pointing to that index. Previously threw; now resolves.

## Verify

- `pnpm vitest run packages/activerecord/src/insert-all.test.ts` — 58 passed (was 57 before regression test)
- `pnpm vitest run packages/activerecord/` — 331 files, 10890 tests, no regressions
- `pnpm api:compare --package activerecord` — 4951/4958, unchanged from baseline
- Build + typecheck — clean