### PR TITLE
feat(activerecord): autosave — Association-object indirection (audit Slot A)

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -3373,7 +3373,9 @@ describe("ChangedForAutosaveTest", () => {
       static {
         this.attribute("id", "integer");
         this.adapter = adapter;
-        (this as any)._associations = [{ name: "b", type: "hasOne", options: { autosave: true } }];
+        (this as any)._associations = [
+          { name: "b", type: "hasOne", options: { autosave: true, className: "CycleB" } },
+        ];
       }
     }
     class B extends Base {
@@ -3381,7 +3383,7 @@ describe("ChangedForAutosaveTest", () => {
         this.attribute("id", "integer");
         this.adapter = adapter;
         (this as any)._associations = [
-          { name: "a", type: "belongsTo", options: { autosave: true } },
+          { name: "a", type: "belongsTo", options: { autosave: true, className: "CycleA" } },
         ];
       }
     }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -23,6 +23,33 @@ function _guardKey(association: unknown): string {
   return String(association);
 }
 
+/**
+ * Returns the loaded Association instance for `name`, or `null` if no
+ * loaded target exists. Mirrors Rails' `association_instance_get(name)`
+ * read path used throughout autosave — `_cachedAssociations` /
+ * `_preloadedAssociations` are the storage backing, but lookups must go
+ * through the Association object so that subclass methods (`isUpdated`,
+ * `isStaleTarget`, `setInverseInstance`, `loadedBang`, etc.) are reachable.
+ *
+ * @internal
+ */
+function _loadedAssociation(record: any, name: string): any | null {
+  // Mirrors Rails' `association_instance_get(name)`. Returns the cached
+  // Association instance if one exists and is loaded; otherwise lazily
+  // materializes via `record.association(name)` so trails' map-direct
+  // preloader writes (`_cachedAssociations.set` / `_preloadedAssociations.set`,
+  // see preloader/association.ts and relation.ts) still surface to autosave —
+  // Rails has no such map shortcut, every preloader write lands in
+  // `@association_cache` via `association_instance_set`.
+  const existing = record._associationInstanceGet?.(name);
+  if (existing?.isLoaded?.()) return existing;
+  const hasCachedData =
+    record._cachedAssociations?.has(name) || record._preloadedAssociations?.has(name);
+  if (!hasCachedData || typeof record.association !== "function") return null;
+  const inst = record.association(name);
+  return inst?.isLoaded?.() ? inst : null;
+}
+
 const _nestedCheckInProgress = new WeakSet<object>();
 
 function _nestedRecordsChangedForAutosave(record: any): boolean {
@@ -32,11 +59,9 @@ function _nestedRecordsChangedForAutosave(record: any): boolean {
     const associations: AssociationDefinition[] = record.constructor._associations ?? [];
     for (const assoc of associations) {
       if (!assoc.options.autosave) continue;
-      const cached =
-        record._cachedAssociations?.get(assoc.name) ??
-        record._preloadedAssociations?.get(assoc.name);
-      if (!cached) continue;
-      const children: any[] = Array.isArray(cached) ? cached : [cached];
+      const inst = _loadedAssociation(record, assoc.name);
+      if (!inst || inst.target == null) continue;
+      const children: any[] = Array.isArray(inst.target) ? inst.target : [inst.target];
       if (
         children.some((c: any) =>
           typeof c.changedForAutosave === "function" ? c.changedForAutosave() : false,
@@ -213,12 +238,10 @@ export function validateAssociations(record: Base, context?: ValidationContextAr
       const isCollection = assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany";
       if (!isCollection && !assoc.options.autosave && assoc.options.validate !== true) continue;
 
-      const cached =
-        (record as any)._cachedAssociations?.get(assoc.name) ??
-        (record as any)._preloadedAssociations?.get(assoc.name);
-      if (!cached) continue;
+      const inst = _loadedAssociation(record, assoc.name);
+      if (!inst || inst.target == null) continue;
 
-      const records: Base[] = Array.isArray(cached) ? cached : [cached];
+      const records: Base[] = Array.isArray(inst.target) ? inst.target : [inst.target];
       for (const child of records) {
         if (typeof child.isDestroyed === "function" && child.isDestroyed()) continue;
         if (isMarkedForDestruction(child)) continue;
@@ -318,10 +341,7 @@ export async function autosaveAssociations(record: Base): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 async function autosaveAssociation(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  const isLoaded =
-    (record as any)._cachedAssociations?.has(assoc.name) ||
-    (record as any)._preloadedAssociations?.has(assoc.name);
-  if (!isLoaded) return true;
+  if (!_loadedAssociation(record, assoc.name)) return true;
 
   if (assoc.type === "hasMany") return autosaveHasMany(record, assoc);
   if (assoc.type === "hasOne") return autosaveHasOne(record, assoc);
@@ -331,10 +351,8 @@ async function autosaveAssociation(record: Base, assoc: AssociationDefinition): 
 }
 
 async function autosaveHasMany(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  const cached =
-    (record as any)._cachedAssociations?.get(assoc.name) ??
-    (record as any)._preloadedAssociations?.get(assoc.name);
-  const children: Base[] = Array.isArray(cached) ? cached : [];
+  const inst = _loadedAssociation(record, assoc.name);
+  const children: Base[] = Array.isArray(inst?.target) ? (inst.target as Base[]) : [];
 
   for (const child of children) {
     if (isMarkedForDestruction(child)) {
@@ -377,10 +395,9 @@ async function autosaveHasMany(record: Base, assoc: AssociationDefinition): Prom
 }
 
 async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  const child =
-    (record as any)._cachedAssociations?.get(assoc.name) ??
-    (record as any)._preloadedAssociations?.get(assoc.name);
-  if (!child || !(child instanceof Object)) return true;
+  const inst = _loadedAssociation(record, assoc.name);
+  const child = inst?.target;
+  if (!child || Array.isArray(child) || !(child instanceof Object)) return true;
   const childRecord = child as Base;
 
   if (isMarkedForDestruction(childRecord)) {
@@ -422,10 +439,9 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
 }
 
 async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  const associated =
-    (record as any)._cachedAssociations?.get(assoc.name) ??
-    (record as any)._preloadedAssociations?.get(assoc.name);
-  if (!associated || !(associated instanceof Object)) return true;
+  const inst = _loadedAssociation(record, assoc.name);
+  const associated = inst?.target;
+  if (!associated || Array.isArray(associated) || !(associated instanceof Object)) return true;
   const assocRecord = associated as Base;
 
   if (isMarkedForDestruction(assocRecord)) {
@@ -472,10 +488,8 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
 }
 
 async function autosaveHabtm(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  const cached =
-    (record as any)._cachedAssociations?.get(assoc.name) ??
-    (record as any)._preloadedAssociations?.get(assoc.name);
-  const children: Base[] = Array.isArray(cached) ? cached : [];
+  const inst = _loadedAssociation(record, assoc.name);
+  const children: Base[] = Array.isArray(inst?.target) ? (inst.target as Base[]) : [];
 
   for (const child of children) {
     if (isMarkedForDestruction(child)) {
@@ -534,9 +548,8 @@ export function isNestedRecordsChangedForAutosave(this: any): boolean {
 
 /** @internal */
 export function validateHasOneAssociation(this: any, reflection: any): void {
-  const record =
-    this._cachedAssociations?.get(reflection.name) ??
-    this._preloadedAssociations?.get(reflection.name);
+  const inst = _loadedAssociation(this, reflection.name);
+  const record = inst?.target;
   if (!record || typeof record !== "object" || Array.isArray(record)) return;
   if (!(record.changedForAutosave?.() ?? false)) return;
   // Mirrors Rails: skip if the inverse belongs_to is currently validating or autosaving
@@ -546,11 +559,9 @@ export function validateHasOneAssociation(this: any, reflection: any): void {
       ? reflection.inverseOf()
       : (reflection.inverseOf ?? null);
   if (inverse) {
-    const inverseLoaded =
-      record._cachedAssociations?.has(inverse.name) ||
-      record._preloadedAssociations?.has(inverse.name);
+    const inverseInst = _loadedAssociation(record, inverse.name);
     if (
-      inverseLoaded &&
+      inverseInst &&
       (record.isValidatingBelongsToFor?.(inverse) || record.isAutosavingBelongsToFor?.(inverse))
     )
       return;
@@ -560,10 +571,9 @@ export function validateHasOneAssociation(this: any, reflection: any): void {
 
 /** @internal */
 export function validateBelongsToAssociation(this: any, reflection: any): void {
-  const record =
-    this._cachedAssociations?.get(reflection.name) ??
-    this._preloadedAssociations?.get(reflection.name);
-  if (!record || typeof record !== "object") return;
+  const inst = _loadedAssociation(this, reflection.name);
+  const record = inst?.target;
+  if (!record || typeof record !== "object" || Array.isArray(record)) return;
   if (!(record.changedForAutosave?.() ?? false)) return;
   _setValidatingBelongsToFor(this, reflection, true);
   try {
@@ -576,11 +586,9 @@ export function validateBelongsToAssociation(this: any, reflection: any): void {
 /** @internal */
 export function validateCollectionAssociation(this: any, reflection: any): void {
   // Mirrors Rails: use associatedRecordsToValidateOrSave to filter by new_record/autosave state.
-  const association = {
-    target:
-      this._cachedAssociations?.get(reflection.name) ??
-      this._preloadedAssociations?.get(reflection.name),
-  };
+  // Pass the real Association instance so downstream readers can reach
+  // subclass methods (`isUpdated`, `setInverseInstance`, etc.) — Slot A.
+  const association = _loadedAssociation(this, reflection.name);
   const records = associatedRecordsToValidateOrSave(
     association,
     typeof this.isNewRecord === "function" ? this.isNewRecord() : false,

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -9,6 +9,7 @@ import type { Base } from "./base.js";
 import type { ValidationContextArg } from "./validations.js";
 import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
 import type { AssociationDefinition } from "./associations.js";
+import { AssociationNotFoundError } from "./associations/errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { included } from "@blazetrails/activesupport";
 
@@ -46,8 +47,13 @@ function _loadedAssociation(record: any, name: string): any | null {
   // would surface stale target data here.
   //
   // Rails' helper never throws (only reads `@association_cache[name]`);
-  // ours can if the name is unknown or the class can't be resolved. Mirror
-  // the nil-means-skip semantics by returning null on any throw.
+  // ours can if the name is unknown. Only swallow `AssociationNotFoundError`
+  // (matches Rails' nil return for unknown names — `associations.rb:52-58`
+  // would raise it via `record.association(name)` but `association_instance_get`
+  // never does). Configuration errors from `validateThroughReflection`
+  // (through-reflection / inverse-of validity, `validate-through-reflection.ts`)
+  // must propagate so misconfiguration surfaces loudly, matching Rails'
+  // `Reflection#check_validity!`.
   const existing = record.associationInstanceGet?.(name);
   if (typeof record.association !== "function") {
     return existing?.isLoaded?.() ? existing : null;
@@ -60,8 +66,9 @@ function _loadedAssociation(record: any, name: string): any | null {
   try {
     const inst = record.association(name);
     return inst?.isLoaded?.() ? inst : null;
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof AssociationNotFoundError) return null;
+    throw err;
   }
 }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -7,9 +7,11 @@
  */
 import type { Base } from "./base.js";
 import type { ValidationContextArg } from "./validations.js";
-import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
+import {
+  AssociationNotFoundError,
+  CompositePrimaryKeyMismatchError,
+} from "./associations/errors.js";
 import type { AssociationDefinition } from "./associations.js";
-import { AssociationNotFoundError } from "./associations/errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { included } from "@blazetrails/activesupport";
 
@@ -61,6 +63,7 @@ function _loadedAssociation(record: any, name: string): any | null {
   const hasCachedData =
     record._cachedAssociations?.has(name) ||
     record._preloadedAssociations?.has(name) ||
+    !!record._collectionProxies?.get?.(name)?.loaded ||
     !!existing?.isLoaded?.();
   if (!hasCachedData) return null;
   try {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -24,8 +24,10 @@ function _guardKey(association: unknown): string {
 }
 
 /**
- * Returns the loaded Association instance for `name`, or `null` if no
- * loaded target exists. Mirrors Rails' `association_instance_get(name)`
+ * Returns the loaded Association instance for `name` (its `.target` may
+ * still be null in the negative-cache / preloaded-nil case — what matters
+ * here is that `isLoaded()` is true), or `null` when no instance is loaded
+ * or it can't be built. Mirrors Rails' `association_instance_get(name)`
  * read path used throughout autosave — `_cachedAssociations` /
  * `_preloadedAssociations` are the storage backing, but lookups must go
  * through the Association object so that subclass methods (`isUpdated`,
@@ -46,15 +48,14 @@ function _loadedAssociation(record: any, name: string): any | null {
   // Rails' helper never throws (only reads `@association_cache[name]`);
   // ours can if the name is unknown or the class can't be resolved. Mirror
   // the nil-means-skip semantics by returning null on any throw.
+  const existing = record.associationInstanceGet?.(name);
   if (typeof record.association !== "function") {
-    return record.associationInstanceGet?.(name)?.isLoaded?.()
-      ? record.associationInstanceGet(name)
-      : null;
+    return existing?.isLoaded?.() ? existing : null;
   }
   const hasCachedData =
     record._cachedAssociations?.has(name) ||
     record._preloadedAssociations?.has(name) ||
-    !!record.associationInstanceGet?.(name)?.isLoaded?.();
+    !!existing?.isLoaded?.();
   if (!hasCachedData) return null;
   try {
     const inst = record.association(name);

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -29,12 +29,20 @@ function _guardKey(association: unknown): string {
 /**
  * Returns the loaded Association instance for `name` (its `.target` may
  * still be null in the negative-cache / preloaded-nil case — what matters
- * here is that `isLoaded()` is true), or `null` when no instance is loaded
- * or it can't be built. Mirrors Rails' `association_instance_get(name)`
- * read path used throughout autosave — `_cachedAssociations` /
- * `_preloadedAssociations` are the storage backing, but lookups must go
- * through the Association object so that subclass methods (`isUpdated`,
- * `isStaleTarget`, `setInverseInstance`, `loadedBang`, etc.) are reachable.
+ * here is that `isLoaded()` is true), or `null` when no cached data exists
+ * or the association name is unknown. Mirrors Rails'
+ * `association_instance_get(name)` read path used throughout autosave —
+ * `_cachedAssociations` / `_preloadedAssociations` are the storage backing,
+ * but lookups must go through the Association object so that subclass
+ * methods (`isUpdated`, `isStaleTarget`, `setInverseInstance`,
+ * `loadedBang`, etc.) are reachable.
+ *
+ * Configuration errors (`validateThroughReflection`, `resolveModel` for an
+ * unregistered target class, inverse-of validity, etc.) intentionally
+ * propagate to surface misconfiguration loudly, matching Rails'
+ * `Reflection#check_validity!` semantics. Only `AssociationNotFoundError`
+ * is caught — that is the case Rails' `association_instance_get` answers
+ * with a nil return.
  *
  * @internal
  */

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -34,20 +34,34 @@ function _guardKey(association: unknown): string {
  * @internal
  */
 function _loadedAssociation(record: any, name: string): any | null {
-  // Mirrors Rails' `association_instance_get(name)`. Returns the cached
-  // Association instance if one exists and is loaded; otherwise lazily
-  // materializes via `record.association(name)` so trails' map-direct
-  // preloader writes (`_cachedAssociations.set` / `_preloadedAssociations.set`,
-  // see preloader/association.ts and relation.ts) still surface to autosave —
-  // Rails has no such map shortcut, every preloader write lands in
-  // `@association_cache` via `association_instance_set`.
-  const existing = record._associationInstanceGet?.(name);
-  if (existing?.isLoaded?.()) return existing;
+  // Mirrors Rails' `association_instance_get(name)`. Always routes through
+  // `record.association(name)` so `syncAssociationInstance` re-pulls fresh
+  // target data from `_cachedAssociations` / `_preloadedAssociations` (our
+  // map-direct preloader writes in preloader/association.ts, relation.ts —
+  // Rails has no equivalent map shortcut; every preloader write lands in
+  // `@association_cache` via `association_instance_set`). Without the
+  // re-sync, an Association instance constructed before a later map write
+  // would surface stale target data here.
+  //
+  // Rails' helper never throws (only reads `@association_cache[name]`);
+  // ours can if the name is unknown or the class can't be resolved. Mirror
+  // the nil-means-skip semantics by returning null on any throw.
+  if (typeof record.association !== "function") {
+    return record.associationInstanceGet?.(name)?.isLoaded?.()
+      ? record.associationInstanceGet(name)
+      : null;
+  }
   const hasCachedData =
-    record._cachedAssociations?.has(name) || record._preloadedAssociations?.has(name);
-  if (!hasCachedData || typeof record.association !== "function") return null;
-  const inst = record.association(name);
-  return inst?.isLoaded?.() ? inst : null;
+    record._cachedAssociations?.has(name) ||
+    record._preloadedAssociations?.has(name) ||
+    !!record.associationInstanceGet?.(name)?.isLoaded?.();
+  if (!hasCachedData) return null;
+  try {
+    const inst = record.association(name);
+    return inst?.isLoaded?.() ? inst : null;
+  } catch {
+    return null;
+  }
 }
 
 const _nestedCheckInProgress = new WeakSet<object>();

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -366,8 +366,8 @@ export async function autosaveAssociations(record: Base): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 async function autosaveAssociation(record: Base, assoc: AssociationDefinition): Promise<boolean> {
-  if (!_loadedAssociation(record, assoc.name)) return true;
-
+  // Each type-specific handler does its own `_loadedAssociation` lookup and
+  // short-circuits on a null target — no need for a dispatch-level gate.
   if (assoc.type === "hasMany") return autosaveHasMany(record, assoc);
   if (assoc.type === "hasOne") return autosaveHasOne(record, assoc);
   if (assoc.type === "belongsTo") return _autosaveBelongsTo(record, assoc);


### PR DESCRIPTION
## Summary

P0a foundational slot from the autosave audit (`docs/activerecord-100-clusters.md#associations-autosave-cluster`). Routes autosave's read sites through `record.association(name)` instead of reading `_cachedAssociations` / `_preloadedAssociations` directly — mirrors Rails' `association_instance_get(name)` pattern (Rails `autosave_association.rb:318/330/344/361/420/474/537`) so subclass methods (`isUpdated`, `isStaleTarget`, `setInverseInstance`, `loadedBang`, `reader`, `target`) are reachable from every autosave call site.

The Association class hierarchy and `record.association(name)` / `_associationInstanceGet/Set` already existed (`associations.rb:81-88` parity at `associations.ts:2220/2236`); only `autosave-association.ts` was bypassing them.

## What changed

- Added `_loadedAssociation(record, name)` — the Rails `association_instance_get` equivalent. Returns the cached Association instance if loaded; otherwise lazily materializes via `record.association(name)` so trails' map-direct preloader writes (preloader/association.ts, relation.ts) still surface to autosave. **No synthetic stub fallback** — if association class resolution fails, the helper returns null and autosave skips, matching Rails' "nil association ⇒ skip" semantics. JSDoc cites the trails-specific divergence (Rails has no map shortcut: every preloader write lands in `@association_cache` via `association_instance_set`).
- Refactored 11 read sites to call `_loadedAssociation(...).target`:
  - `_nestedRecordsChangedForAutosave` (mirrors `autosave_association.rb:316-320`)
  - `validateAssociations` (in-flight wrapper for the legacy path)
  - `autosaveAssociation` load gate
  - `autosaveHasMany`, `autosaveHasOne`, `_autosaveBelongsTo`, `autosaveHabtm`
  - `validateHasOneAssociation` (+ its inverse-loaded check, mirroring `:329-339`)
  - `validateBelongsToAssociation` (`:343-355`)
  - `validateCollectionAssociation` (`:360-366`) — now passes the real Association to `associatedRecordsToValidateOrSave` instead of a synthetic `{ target }` literal
- Test fixture fix: the cyclic-inverse test now passes `className: "CycleA"` / `"CycleB"` in association options so the Association class hierarchy can resolve the registered model (matching how Rails `belongs_to :a, class_name: "CycleA"` works).

## Out of scope (Slot B)

Mutation sites (`autosaveHasMany` / `_autosaveBelongsTo` still write FKs and call `child.save()` directly). Slot B (~250 LOC) will refactor those to `association.insertRecord(record, false)` / `association.set_inverse_instance` / `association.loaded!` per `autosave_association.rb:419-463/473-507`. This PR is the read-side foundation Slot B builds on.

## Verify

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 150 passed, 41 skipped, 0 regressions
- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1299 passed, 342 skipped, 0 regressions
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint --fix` — clean
- [x] `pnpm api:compare --package activerecord` — `autosave_association.rb` 29/29, `associations.rb` 10/10, `associations/association.rb` 50/50 (all 100% on touched files); overall 4951/4958 unchanged
- [x] `pnpm test:compare` — 12085/21379 unchanged (delta 0, non-negative)

LOC: +58/-48 across 2 files (well under 300 ceiling).