### PR TITLE
feat(activerecord): pg datatype — delete 9 stale stubs + 6 fixture-backed un-skips (audit Slot A)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -31,12 +31,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_times";
       static {
         this.adapter = a;
-        // Rails declares `attribute :time_interval, :string` and
-        // `attribute :scaled_time_interval, :interval` on the model.
-        // The :interval override is redundant with column reflection;
-        // the :string override is only exercised by `time values` /
-        // `update large time in seconds`, which are blocked on the
-        // IntervalStyle = iso_8601 connection setting (see those skips).
+        this.attribute("time_interval", "string");
+        this.attribute("scaled_time_interval", "interval");
       }
     }
     await PostgresqlTime.loadSchema();
@@ -84,19 +80,32 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(first).toBeDefined();
     });
 
-    it.skip("time values", async () => {
-      // BLOCKED: pg-interval-style — driver returns intervals in 'postgres' format ("-1 years -2 days"),
-      // not ISO 8601 ("P-1Y-2D"). Rails sets `IntervalStyle = iso_8601` per connection.
-      // ROOT-CAUSE: postgresql-adapter does not set `IntervalStyle = iso_8601` on connect.
-      // SCOPE: ~5 LOC in postgresql-adapter.ts configureConnection; un-blocks this test and
-      // update_large_time_in_seconds.
+    it("time values", async () => {
+      const M = await setupTimesTable();
+      await adapter.exec(
+        `INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')`,
+      );
+      const first = await (M as any).find(1);
+      expect((first as any).time_interval).toBe("P-1Y-2D");
+      const { Duration } = await import("@blazetrails/activesupport");
+      expect((first as any).scaled_time_interval).toEqual(Duration.days(-21));
     });
 
-    it.skip("update large time in seconds", async () => {
-      // BLOCKED: pg-interval-style — same root cause as `time values`. Round-trip of a numeric
-      // seconds count (70.years.to_f) into an interval column requires the driver to return the
-      // value as an ISO8601 string for Duration.parse on read-back.
-      // SCOPE: ~5 LOC in postgresql-adapter.ts configureConnection (IntervalStyle = iso_8601).
+    it("update large time in seconds", async () => {
+      const M = await setupTimesTable();
+      await adapter.exec(
+        `INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')`,
+      );
+      const first = await (M as any).find(1);
+      const { Duration } = await import("@blazetrails/activesupport");
+      const seventyYearsSeconds = Duration.years(70).inSeconds();
+      (first as any).scaled_time_interval = seventyYearsSeconds;
+      expect(await (first as any).save()).toBeTruthy();
+      await (first as any).reload();
+      // Rails' assert_equal on Duration compares total seconds, not parts —
+      // PG stores numeric seconds as hours/minutes, so the value round-trips
+      // with the same inSeconds() but different shape.
+      expect((first as any).scaled_time_interval.eql(Duration.years(70))).toBe(true);
     });
 
     it("oid values", async () => {

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -11,88 +11,110 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS ex CASCADE`);
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_times CASCADE`);
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_oids CASCADE`);
     await adapter.close();
   });
 
+  async function setupTimesTable() {
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_times`);
+    await adapter.exec(`
+      CREATE TABLE postgresql_times (
+        id serial primary key,
+        time_interval interval,
+        scaled_time_interval interval
+      )
+    `);
+    const { Base } = await import("../../index.js");
+    const a = adapter;
+    class PostgresqlTime extends Base {
+      static tableName = "postgresql_times";
+      static {
+        this.adapter = a;
+        // Rails declares `attribute :time_interval, :string` and
+        // `attribute :scaled_time_interval, :interval` on the model.
+        // The :interval override is redundant with column reflection;
+        // the :string override is only exercised by `time values` /
+        // `update large time in seconds`, which are blocked on the
+        // IntervalStyle = iso_8601 connection setting (see those skips).
+      }
+    }
+    await PostgresqlTime.loadSchema();
+    return PostgresqlTime;
+  }
+
+  async function setupOidsTable() {
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_oids`);
+    await adapter.exec(`
+      CREATE TABLE postgresql_oids (
+        id serial primary key,
+        obj_id oid
+      )
+    `);
+    const { Base } = await import("../../index.js");
+    const a = adapter;
+    class PostgresqlOid extends Base {
+      static tableName = "postgresql_oids";
+      static {
+        this.adapter = a;
+      }
+    }
+    await PostgresqlOid.loadSchema();
+    return PostgresqlOid;
+  }
+
   describe("PostgreSQLDatatypeTest", () => {
-    it.skip("money column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
+    it("data type of time types", async () => {
+      const M = await setupTimesTable();
+      await adapter.exec(
+        `INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')`,
+      );
+      const first = await (M as any).find(1);
+      expect((M as any).columnForAttribute("time_interval").type).toBe("interval");
+      expect((M as any).columnForAttribute("scaled_time_interval").type).toBe("interval");
+      // Touch the loaded record so the find is exercised end-to-end.
+      expect(first).toBeDefined();
     });
-    it.skip("number column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
+
+    it("data type of oid types", async () => {
+      const M = await setupOidsTable();
+      await adapter.exec(`INSERT INTO postgresql_oids (id, obj_id) VALUES (1, 1234)`);
+      const first = await (M as any).find(1);
+      expect((M as any).columnForAttribute("obj_id").type).toBe("oid");
+      expect(first).toBeDefined();
     });
-    it.skip("time column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("date column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("timestamp column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("boolean column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("text column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("binary column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("oid column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-    });
-    it.skip("data type of time types", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-      // Requires AR model with interval column; no adapter-level equivalent
-    });
-    it.skip("data type of oid types", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-      // Requires AR model with oid column; no adapter-level equivalent
-    });
+
     it.skip("time values", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-      // Requires AR model (PostgresqlTime); no adapter-level equivalent
+      // BLOCKED: pg-interval-style — driver returns intervals in 'postgres' format ("-1 years -2 days"),
+      // not ISO 8601 ("P-1Y-2D"). Rails sets `IntervalStyle = iso_8601` per connection.
+      // ROOT-CAUSE: postgresql-adapter does not set `IntervalStyle = iso_8601` on connect.
+      // SCOPE: ~5 LOC in postgresql-adapter.ts configureConnection; un-blocks this test and
+      // update_large_time_in_seconds.
     });
+
     it.skip("update large time in seconds", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
+      // BLOCKED: pg-interval-style — same root cause as `time values`. Round-trip of a numeric
+      // seconds count (70.years.to_f) into an interval column requires the driver to return the
+      // value as an ISO8601 string for Duration.parse on read-back.
+      // SCOPE: ~5 LOC in postgresql-adapter.ts configureConnection (IntervalStyle = iso_8601).
     });
-    it.skip("oid values", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
-      // Requires AR model (PostgresqlOid); no adapter-level equivalent
+
+    it("oid values", async () => {
+      const M = await setupOidsTable();
+      await adapter.exec(`INSERT INTO postgresql_oids (id, obj_id) VALUES (1, 1234)`);
+      const first = await (M as any).find(1);
+      expect(Number((first as any).obj_id)).toBe(1234);
     });
-    it.skip("update oid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in datatype
-      // ROOT-CAUSE: connection-adapters/postgresql/datatype.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/datatype.ts; affects ~10–47 tests in datatype.test.ts
+
+    it("update oid", async () => {
+      const M = await setupOidsTable();
+      await adapter.exec(`INSERT INTO postgresql_oids (id, obj_id) VALUES (1, 1234)`);
+      const first = await (M as any).find(1);
+      const newValue = 2147483648;
+      (first as any).obj_id = newValue;
+      expect(await (first as any).save()).toBeTruthy();
+      await (first as any).reload();
+      expect(Number((first as any).obj_id)).toBe(newValue);
     });
 
     it("text columns are limitless the upper limit is one GB", async () => {

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -88,7 +88,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       const first = await (M as any).find(1);
       expect((first as any).time_interval).toBe("P-1Y-2D");
       const { Duration } = await import("@blazetrails/activesupport");
-      expect((first as any).scaled_time_interval).toEqual(Duration.days(-21));
+      // Rails' assert_equal on Duration compares total seconds, not parts.
+      expect((first as any).scaled_time_interval.eql(Duration.days(-21))).toBe(true);
     });
 
     it("update large time in seconds", async () => {

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -103,7 +103,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const M = await setupOidsTable();
       await adapter.exec(`INSERT INTO postgresql_oids (id, obj_id) VALUES (1, 1234)`);
       const first = await (M as any).find(1);
-      expect(Number((first as any).obj_id)).toBe(1234);
+      expect((first as any).obj_id).toBe(1234);
     });
 
     it("update oid", async () => {
@@ -114,7 +114,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       (first as any).obj_id = newValue;
       expect(await (first as any).save()).toBeTruthy();
       await (first as any).reload();
-      expect(Number((first as any).obj_id)).toBe(newValue);
+      expect((first as any).obj_id).toBe(newValue);
     });
 
     it("text columns are limitless the upper limit is one GB", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -306,12 +306,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._pgPoolOptions = {
         connectionString: config,
         types: {
-          getTypeParser: (oid: number, format?: string) =>
-            oid === 1082 && !PostgreSQLAdapter.decodeDates
+          getTypeParser: (oid: number, format?: string) => {
+            // PG interval (OID 1186): return the raw ISO 8601 string so the
+            // AR Interval type can Duration.parse() it (Rails sets
+            // intervalstyle = iso_8601 per connection).
+            if (oid === 1186 && format !== "binary") return (v: unknown) => v;
+            return oid === 1082 && !PostgreSQLAdapter.decodeDates
               ? format === "binary"
                 ? pg.types.getTypeParser(oid, "binary")
                 : (v: unknown) => v
-              : getTemporalTypeParser(oid, format),
+              : getTemporalTypeParser(oid, format);
+          },
         },
       };
       this._driverPool = new pg.Pool(this._pgPoolOptions);
@@ -377,6 +382,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.
           // When decodeDates is false, skip the date parser (OID 1082) so
           // pg returns the raw string — mirrors Rails' decode_dates flag.
+          // PG interval (OID 1186): return raw ISO 8601 string for AR
+          // Interval (intervalstyle = iso_8601 is set on connect).
+          if (oid === 1186 && format !== "binary") {
+            const fallback = (v: unknown) => v;
+            return userGetTypeParser?.(oid, format) ?? fallback;
+          }
           if (oid === 1082 && !PostgreSQLAdapter.decodeDates) {
             const fallback =
               format === "binary" ? pg.types.getTypeParser(oid, "binary") : (v: unknown) => v;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -63,6 +63,7 @@ import {
 import { getTypeParser as getTemporalTypeParser } from "./postgresql/temporal-type-parsers.js";
 
 const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
+const OID_INTERVAL = 1186;
 import { READ_QUERY } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 import {
@@ -310,7 +311,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             // PG interval (OID 1186): return the raw ISO 8601 string so the
             // AR Interval type can Duration.parse() it (Rails sets
             // intervalstyle = iso_8601 per connection).
-            if (oid === 1186 && format !== "binary") return (v: unknown) => v;
+            if (oid === OID_INTERVAL && format !== "binary") return (v: unknown) => v;
             return oid === 1082 && !PostgreSQLAdapter.decodeDates
               ? format === "binary"
                 ? pg.types.getTypeParser(oid, "binary")
@@ -384,7 +385,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // pg returns the raw string — mirrors Rails' decode_dates flag.
           // PG interval (OID 1186): return raw ISO 8601 string for AR
           // Interval (intervalstyle = iso_8601 is set on connect).
-          if (oid === 1186 && format !== "binary") {
+          if (oid === OID_INTERVAL && format !== "binary") {
             const fallback = (v: unknown) => v;
             return userGetTypeParser?.(oid, format) ?? fallback;
           }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -15,6 +15,7 @@ import {
   StringType,
   TimeType,
   Type,
+  typeRegistry,
 } from "@blazetrails/activemodel";
 
 import { Date as OidDate } from "./oid/date.js";
@@ -40,6 +41,12 @@ import { Timestamp } from "./oid/timestamp.js";
 import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
 import { Xml } from "./oid/xml.js";
+
+// Rails registers PG's :interval type into the AM type registry so that
+// `attribute :col, :interval` resolves on AR-PG models. Mirror that here
+// as a module side-effect — AR-side type.ts already does the same for
+// the built-in AR types (date/datetime/time/text/json).
+typeRegistry.register("interval", () => new Interval());
 
 /**
  * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -502,6 +502,8 @@ describe("DurationTest", () => {
       "P-1Y-1W",
       "-P1YT",
       "+P1YT",
+      "P1.5YT",
+      "P1,5YT",
       "-P-1Y", // mixed overall sign + per-component sign would double-negate
     ];
     for (const pattern of invalid) {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -496,6 +496,8 @@ describe("DurationTest", () => {
       ".P1Y",
       "-P",
       "-PT",
+      "+P",
+      "+PT",
       "-P-1Y", // mixed overall sign + per-component sign would double-negate
     ];
     for (const pattern of invalid) {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -500,6 +500,8 @@ describe("DurationTest", () => {
       "+PT",
       "P-1YT",
       "P-1Y-1W",
+      "-P1YT",
+      "+P1YT",
       "-P-1Y", // mixed overall sign + per-component sign would double-negate
     ];
     for (const pattern of invalid) {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -484,10 +484,30 @@ describe("DurationTest", () => {
   });
 
   it("iso8601 parsing wrong patterns with raise", () => {
-    const invalid = ["", "P", "PT", "P1YT", "T", "PW", "P1Y1W", "~P1Y", ".P1Y"];
+    const invalid = [
+      "",
+      "P",
+      "PT",
+      "P1YT",
+      "T",
+      "PW",
+      "P1Y1W",
+      "~P1Y",
+      ".P1Y",
+      "-P",
+      "-PT",
+      "-P-1Y", // mixed overall sign + per-component sign would double-negate
+    ];
     for (const pattern of invalid) {
       expect(() => Duration.parse(pattern)).toThrow();
     }
+  });
+
+  it("iso8601 parsing per-component negatives (PG intervalstyle=iso_8601)", () => {
+    // PG emits e.g. "P-1Y-2D" for "1 year 2 days ago".
+    expect(Duration.parse("P-1Y-2D").eql(Duration.years(-1).plus(Duration.days(-2)))).toBe(true);
+    expect(Duration.parse("P-21D").eql(Duration.days(-21))).toBe(true);
+    expect(Duration.parse("PT-3H").eql(Duration.hours(-3))).toBe(true);
   });
 
   it("iso8601 output", () => {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -498,6 +498,8 @@ describe("DurationTest", () => {
       "-PT",
       "+P",
       "+PT",
+      "P-1YT",
+      "P-1Y-1W",
       "-P-1Y", // mixed overall sign + per-component sign would double-negate
     ];
     for (const pattern of invalid) {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -322,8 +322,11 @@ export class Duration {
       if (p.test(iso)) throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
     }
 
+    // PG's intervalstyle=iso_8601 emits per-component signs (e.g. "P-1Y-2D"),
+    // so allow an optional leading `-` on each component in addition to the
+    // single overall sign Rails uses.
     const pattern =
-      /^([+-])?P(?:(\d+(?:[.,]\d+)?)Y)?(?:(\d+(?:[.,]\d+)?)M)?(?:(\d+(?:[.,]\d+)?)W)?(?:(\d+(?:[.,]\d+)?)D)?(?:T(?:(\d+(?:[.,]\d+)?)H)?(?:(\d+(?:[.,]\d+)?)M)?(?:(\d+(?:[.,]\d+)?)S)?)?$/;
+      /^([+-])?P(?:(-?\d+(?:[.,]\d+)?)Y)?(?:(-?\d+(?:[.,]\d+)?)M)?(?:(-?\d+(?:[.,]\d+)?)W)?(?:(-?\d+(?:[.,]\d+)?)D)?(?:T(?:(-?\d+(?:[.,]\d+)?)H)?(?:(-?\d+(?:[.,]\d+)?)M)?(?:(-?\d+(?:[.,]\d+)?)S)?)?$/;
 
     const match = pattern.exec(iso.replace(/,/g, "."));
     if (!match) throw new Error(`Invalid ISO 8601 duration: "${iso}"`);

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -331,6 +331,12 @@ export class Duration {
     const match = pattern.exec(iso.replace(/,/g, "."));
     if (!match) throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
 
+    // Reject mixing the overall `-` sign with any per-component `-`: combining
+    // them would silently double-negate (e.g. "-P-1Y" parsing to +1Y).
+    if (match[1] === "-" && match.slice(2).some((c) => c?.startsWith("-"))) {
+      throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
+    }
+
     const sign = match[1] === "-" ? -1 : 1;
     const parse = (s: string | undefined) => (s ? parseFloat(s.replace(",", ".")) * sign : 0);
 

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -321,8 +321,14 @@ export class Duration {
       throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
     }
 
+    // A trailing `T` (e.g. "P1YT", "P1.5YT") is invalid: the time designator
+    // requires at least one of H/M/S after it. The main regex's optional time
+    // group would otherwise accept these.
+    if (iso.endsWith("T")) {
+      throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
+    }
+
     const moreInvalidPatterns = [
-      /^[+-]?P-?\d+YT$/,
       /^[+-]?PW$/,
       /^[+-]?P-?\d+Y-?\d+W/,
       /^[+-]?P-?\d+\.\d+Y-?\d+\.\d+M/,

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -313,6 +313,8 @@ export class Duration {
       iso === "PT" ||
       iso === "-P" ||
       iso === "-PT" ||
+      iso === "+P" ||
+      iso === "+PT" ||
       iso === "T" ||
       /^[~.]/.test(iso)
     ) {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -322,11 +322,11 @@ export class Duration {
     }
 
     const moreInvalidPatterns = [
-      /^P-?\d+YT$/,
-      /^PW$/,
-      /^P-?\d+Y-?\d+W/,
-      /^P-?\d+\.\d+Y-?\d+\.\d+M/,
-      /^P-?\d+\.\d+MT-?\d+\.\d+S/,
+      /^[+-]?P-?\d+YT$/,
+      /^[+-]?PW$/,
+      /^[+-]?P-?\d+Y-?\d+W/,
+      /^[+-]?P-?\d+\.\d+Y-?\d+\.\d+M/,
+      /^[+-]?P-?\d+\.\d+MT-?\d+\.\d+S/,
     ];
     for (const p of moreInvalidPatterns) {
       if (p.test(iso)) throw new Error(`Invalid ISO 8601 duration: "${iso}"`);

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -307,7 +307,15 @@ export class Duration {
 
   // ISO 8601 parsing
   static parse(iso: string): Duration {
-    if (!iso || iso === "P" || iso === "PT" || iso === "T" || /^[~.]/.test(iso)) {
+    if (
+      !iso ||
+      iso === "P" ||
+      iso === "PT" ||
+      iso === "-P" ||
+      iso === "-PT" ||
+      iso === "T" ||
+      /^[~.]/.test(iso)
+    ) {
       throw new Error(`Invalid ISO 8601 duration: "${iso}"`);
     }
 

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -322,11 +322,11 @@ export class Duration {
     }
 
     const moreInvalidPatterns = [
-      /^P\d+YT$/,
+      /^P-?\d+YT$/,
       /^PW$/,
-      /^P\d+Y\d+W/,
-      /^P\d+\.\d+Y\d+\.\d+M/,
-      /^P\d+\.\d+MT\d+\.\d+S/,
+      /^P-?\d+Y-?\d+W/,
+      /^P-?\d+\.\d+Y-?\d+\.\d+M/,
+      /^P-?\d+\.\d+MT-?\d+\.\d+S/,
     ];
     for (const p of moreInvalidPatterns) {
       if (p.test(iso)) throw new Error(`Invalid ISO 8601 duration: "${iso}"`);

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -348,7 +348,7 @@ export class Duration {
     }
 
     const sign = match[1] === "-" ? -1 : 1;
-    const parse = (s: string | undefined) => (s ? parseFloat(s.replace(",", ".")) * sign : 0);
+    const parse = (s: string | undefined) => (s ? parseFloat(s) * sign : 0);
 
     return new Duration({
       years: parse(match[2]),


### PR DESCRIPTION
## Audit Slot A — pg-datatype

**Audit:** 9 of 15 skipped tests in `datatype.test.ts` were stale legacy names (e.g. `money column`, `text column`) from an older Rails-era datatype suite long-since split into dedicated per-type files (`money_test.rb`, `numbers_test.rb`, `bytea_test.rb`, ...) that we already mirror as separate `*.test.ts` files. **Delete, don't rename.**

The remaining 6 map to real tests in current Rails `datatype_test.rb` and exercise full AR-Base round-trips against two fixture tables (`postgresql_times`, `postgresql_oids`).

## Changes
- **Delete** 9 stale skipped stubs (no Rails counterpart).
- **Add** `postgresql_times` (interval + interval) and `postgresql_oids` (oid) fixture infra inline (matches `infinity.test.ts` pattern).
- **Implement** all 6 Rails-mirror tests:
  - `data type of time types`, `data type of oid types`
  - `oid values`, `update oid`
  - `time values`, `update large time in seconds`
- **Wire PG interval through to AR:**
  - Register `Interval` in the AM `typeRegistry` (`type-map-init.ts`) so `attribute :col, :interval` resolves on AR-PG models.
  - Override pg pool `getTypeParser` for OID 1186 to return the raw ISO 8601 string — `Interval#cast` then runs `Duration.parse` on it. `intervalstyle = iso_8601` is already set per connection.
  - Extend `Duration.parse` regex to accept per-component negative signs (PG emits `P-1Y-2D`). Reject mixed overall-sign + per-component-sign to avoid silent double-negation.

## Verify
- `pnpm vitest run packages/activerecord/src/adapters/postgresql/datatype.test.ts` against live PG: **9/9 passed**.
- `pnpm test:compare`: `adapters/postgresql/datatype.test.ts` **3/9 → 9/9 passing** (0 skipped, 0 missing).
- `pnpm api:compare --package activerecord`: 4951/4958 (99.9%) unchanged.
- `pnpm typecheck` + `pnpm lint`: pass.