### PR TITLE
feat(activerecord): pg uuid — SchemaDumper UUID-PK test bodies + annotation cleanup (audit Slot A)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { isValidUuid, normalizeUuid } from "../../connection-adapters/postgresql/oid/uuid.js";
 import { SchemaDumper } from "../../schema-dumper.js";
+import { SchemaStatements } from "../../connection-adapters/abstract/schema-statements.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -648,7 +649,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids");
         expect(output).toMatch(/createTable\("pg_uuids".*id: "uuid"/);
-        expect(output).toMatch(/default: "gen_random_uuid\(\)"/);
+        expect(output).toMatch(/default: \(\) => "gen_random_uuid\(\)"/);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS pg_uuids`);
       }
@@ -656,20 +657,21 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("schema dumper for uuid primary key with custom default", async () => {
       await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_2`);
-      await adapter.exec(`
-        CREATE OR REPLACE FUNCTION my_uuid_generator() RETURNS uuid
-        AS $$ SELECT gen_random_uuid() $$ LANGUAGE SQL VOLATILE
-      `);
-      await adapter.exec(`
-        CREATE TABLE pg_uuids_2 (
-          id uuid DEFAULT my_uuid_generator() PRIMARY KEY,
-          name text
-        )
-      `);
+      await adapter.exec(`DROP FUNCTION IF EXISTS my_uuid_generator()`);
       try {
+        await adapter.exec(`
+          CREATE OR REPLACE FUNCTION my_uuid_generator() RETURNS uuid
+          AS $$ SELECT gen_random_uuid() $$ LANGUAGE SQL VOLATILE
+        `);
+        await adapter.exec(`
+          CREATE TABLE pg_uuids_2 (
+            id uuid DEFAULT my_uuid_generator() PRIMARY KEY,
+            name text
+          )
+        `);
         const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids_2");
         expect(output).toMatch(
-          /createTable\("pg_uuids_2".*id: "uuid".*default: "my_uuid_generator\(\)"/,
+          /createTable\("pg_uuids_2".*id: "uuid".*default: \(\) => "my_uuid_generator\(\)"/,
         );
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_2`);
@@ -688,10 +690,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids_3");
         expect(output).toMatch(
-          /createTable\("pg_uuids_3".*id: "uuid".*default: "gen_random_uuid\(\)"/,
+          /createTable\("pg_uuids_3".*id: "uuid".*default: \(\) => "gen_random_uuid\(\)"/,
         );
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_3`);
+      }
+    });
+
+    it("createTable round-trips uuid PK default", async () => {
+      const ss = new SchemaStatements(adapter);
+      await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_rt`);
+      try {
+        await ss.createTable("pg_uuids_rt", {
+          id: "uuid",
+          default: () => "gen_random_uuid()",
+          force: "cascade",
+        });
+        const rows = await adapter.execute(
+          `SELECT column_default FROM information_schema.columns
+           WHERE table_name = 'pg_uuids_rt' AND column_name = 'id'`,
+        );
+        expect(rows[0].column_default).toMatch(/gen_random_uuid/);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_rt`);
       }
     });
 

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { isValidUuid, normalizeUuid } from "../../connection-adapters/postgresql/oid/uuid.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -215,20 +216,15 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it.skip("uuid schema dump", async () => {
-      // BLOCKED: adapter-pg — SchemaDumper does not emit uuid primary key syntax
-      // ROOT-CAUSE: SchemaDumper.dumpTableSchema emits `force: :cascade` but not
-      // `id: :uuid, default: -> { "gen_random_uuid()" }` for UUID primary key tables.
-      // connection-adapters/abstract/schema-dumper.ts needs to detect uuid-typed id columns
-      // and emit the appropriate `id:` option. ~30 LOC in schema-dumper.ts.
-      // SCOPE: ~30 LOC; unblocks uuid schema dump + all "schema dumper for uuid primary key" tests.
+    it("uuid schema dump", async () => {
+      const output = await SchemaDumper.dumpTableSchema(adapter, "uuid_data_type");
+      expect(output).toContain("uuid_data_type");
+      expect(output).toMatch(/"guid".*"uuid"/);
     });
     it.skip("uuid migration", async () => {
-      // BLOCKED: adapter-pg — migration framework not implemented
-      // ROOT-CAUSE: ActiveRecord::Migration.new.create_table :uuid_migration_test, id: :uuid
-      // requires the migration DSL. The adapter's createTable() is implemented but the
-      // migration class wrapper is not. Not a uuid-specific gap.
-      // SCOPE: Migration framework is a separate multi-PR effort.
+      // BLOCKED: migration framework — ActiveRecord::Migration class wrapper not implemented.
+      // The adapter's createTable() is implemented and verified by "uuid primary key" above.
+      // Not uuid-specific; separate multi-PR effort.
     });
 
     it("uuid gen random uuid", async () => {
@@ -316,11 +312,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("uuid association", async () => {
-      // BLOCKED: adapter-pg — belongs_to/has_many association framework not wired for UUID FK
-      // ROOT-CAUSE: AR association loading (belongs_to :uuid_tag) requires the associations
-      // layer to find related records using UUID foreign keys. The associations framework
-      // is implemented but not connected to the UUID OID type for FK binding.
-      // SCOPE: ~20 LOC — association query builder needs to use Uuid#cast for FK values.
+      // BLOCKED: Slot B — associations + UUID FK binding. The associations framework
+      // exists but doesn't route FK values through the Uuid OID type when building queries.
+      // SCOPE: ~20 LOC in association query builder (Uuid#cast for FK values).
     });
 
     it("uuid foreign key", async () => {
@@ -560,11 +554,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("uniqueness validation ignores uuid", () => {
-      // BLOCKED: adapter-pg — AR uniqueness validator not wired for UUID type bypass
-      // ROOT-CAUSE: Rails' UniquenessValidator skips the case-insensitive check when
-      // the column type is uuid (since UUIDs are already normalized to lowercase).
-      // Our UniquenessValidator doesn't yet call typeForAttribute to check for UUID type.
-      // SCOPE: ~10 LOC in validations/uniqueness.ts; low priority.
+      // BLOCKED: Slot C — UniquenessValidator UUID-aware case-insensitive bypass.
+      // Rails skips the case-insensitive LOWER() comparison when the column is uuid
+      // (UUIDs are already normalized). Our validator doesn't check typeForAttribute.
+      // SCOPE: ~10 LOC in validations/uniqueness.ts.
     });
   });
 
@@ -643,28 +636,71 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it.skip("schema dumper for uuid primary key", () => {
-      // BLOCKED: adapter-pg — SchemaDumper does not emit id: :uuid for UUID PK tables
-      // ROOT-CAUSE: SchemaDumper.dumpTableSchema doesn't detect that the id column is uuid
-      // type and emit `id: :uuid`. Rails checks column.sql_type == "uuid" for the id column
-      // and emits `id: :uuid, default: nil` or `default: -> { "gen_random_uuid()" }`.
-      // SCOPE: ~30 LOC in connection-adapters/abstract/schema-dumper.ts; unblocks 6 tests.
+    it("schema dumper for uuid primary key", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS pg_uuids`);
+      await adapter.exec(`
+        CREATE TABLE pg_uuids (
+          id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+          name text,
+          other_uuid uuid DEFAULT gen_random_uuid()
+        )
+      `);
+      try {
+        const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids");
+        expect(output).toMatch(/createTable\("pg_uuids".*id: "uuid"/);
+        expect(output).toMatch(/default: "gen_random_uuid\(\)"/);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS pg_uuids`);
+      }
     });
-    it.skip("schema dumper for uuid primary key with custom default", () => {
-      // BLOCKED: adapter-pg — same as "schema dumper for uuid primary key"
-      // ROOT-CAUSE: Also needs SchemaDumper to emit the custom default lambda expression
-      // for uuid columns, e.g. `default: -> { "gen_random_uuid()" }`.
-      // SCOPE: Same fix as above.
+
+    it("schema dumper for uuid primary key with custom default", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_2`);
+      await adapter.exec(`
+        CREATE OR REPLACE FUNCTION my_uuid_generator() RETURNS uuid
+        AS $$ SELECT gen_random_uuid() $$ LANGUAGE SQL VOLATILE
+      `);
+      await adapter.exec(`
+        CREATE TABLE pg_uuids_2 (
+          id uuid DEFAULT my_uuid_generator() PRIMARY KEY,
+          name text
+        )
+      `);
+      try {
+        const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids_2");
+        expect(output).toMatch(
+          /createTable\("pg_uuids_2".*id: "uuid".*default: "my_uuid_generator\(\)"/,
+        );
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_2`);
+        await adapter.exec(`DROP FUNCTION IF EXISTS my_uuid_generator()`);
+      }
     });
-    it.skip("schema dumper for uuid primary key default", () => {
-      // BLOCKED: adapter-pg — same as "schema dumper for uuid primary key"
-      // ROOT-CAUSE: SchemaDumper id: :uuid emission gap.
-      // SCOPE: Same fix as above.
+
+    it("schema dumper for uuid primary key default", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_3`);
+      await adapter.exec(`
+        CREATE TABLE pg_uuids_3 (
+          id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+          name text
+        )
+      `);
+      try {
+        const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids_3");
+        expect(output).toMatch(
+          /createTable\("pg_uuids_3".*id: "uuid".*default: "gen_random_uuid\(\)"/,
+        );
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_3`);
+      }
     });
+
     it.skip("schema dumper for uuid primary key default in legacy migration", () => {
-      // BLOCKED: adapter-pg — same as "schema dumper for uuid primary key"
-      // ROOT-CAUSE: SchemaDumper id: :uuid emission gap + legacy migration flavor.
-      // SCOPE: Same fix as above.
+      // BLOCKED: migration framework — ActiveRecord::Migration[5.0] legacy-flavor migration
+      // semantics are not implemented. Once an id: :uuid table is created via the legacy
+      // migrator (with implicit gen_random_uuid default), schema dump emission already
+      // works (see "schema dumper for uuid primary key default" above).
+      // SCOPE: Migration framework — separate multi-PR effort.
     });
   });
 
@@ -688,46 +724,49 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it.skip("schema dumper for uuid primary key with default override via nil", () => {
-      // BLOCKED: adapter-pg — same as "schema dumper for uuid primary key"
-      // ROOT-CAUSE: SchemaDumper id: :uuid emission + nil default handling (id: :uuid, default: nil).
-      // SCOPE: Same fix as "schema dumper for uuid primary key".
+    it("schema dumper for uuid primary key with default override via nil", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_nil`);
+      await adapter.exec(`
+        CREATE TABLE pg_uuids_nil (
+          id uuid PRIMARY KEY,
+          name text
+        )
+      `);
+      try {
+        const output = await SchemaDumper.dumpTableSchema(adapter, "pg_uuids_nil");
+        expect(output).toMatch(/createTable\("pg_uuids_nil".*id: "uuid".*default: null/);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_nil`);
+      }
     });
+
     it.skip("schema dumper for uuid primary key with default nil in legacy migration", () => {
-      // BLOCKED: adapter-pg — same as "schema dumper for uuid primary key"
-      // ROOT-CAUSE: SchemaDumper id: :uuid + nil default + legacy migration flavor.
-      // SCOPE: Same fix as "schema dumper for uuid primary key".
+      // BLOCKED: migration framework — ActiveRecord::Migration[5.0] legacy-flavor migration
+      // semantics are not implemented. Schema dump emission for `id: :uuid, default: nil`
+      // is already covered by "schema dumper for uuid primary key with default override via nil".
+      // SCOPE: Migration framework — separate multi-PR effort.
     });
   });
 
   describe("PostgreSQLUUIDTestInverseOf", () => {
     it.skip("collection association with uuid", () => {
-      // BLOCKED: adapter-pg — has_many association with uuid FK + inverse_of not wired
-      // ROOT-CAUSE: Rails' has_many :uuid_tags, foreign_key: :tag_id requires association
-      // loading to bind UUID foreign key values through the Uuid OID type. Also needs
-      // inverse_of reflection to avoid duplicate queries. Not a uuid-specific gap but
-      // an association framework gap that affects uuid FK columns.
-      // SCOPE: Association framework; separate multi-PR effort.
+      // BLOCKED: Slot B — has_many UUID FK binding + inverse_of. Needs association
+      // loading to route FK values through Uuid#cast and an inverse_of reflection path.
     });
     it.skip("find with uuid", () => {
-      // BLOCKED: adapter-pg — has_many association with uuid FK
-      // ROOT-CAUSE: Same as "collection association with uuid" — association loading gap.
-      // SCOPE: Association framework.
+      // BLOCKED: Slot B — has_many UUID FK binding (same root cause as
+      // "collection association with uuid").
     });
     it.skip("find by with uuid", () => {
-      // BLOCKED: adapter-pg — has_many association with uuid FK
-      // ROOT-CAUSE: Same as "collection association with uuid" — association loading gap.
-      // SCOPE: Association framework.
+      // BLOCKED: Slot B — has_many UUID FK binding (same root cause as
+      // "collection association with uuid").
     });
   });
 
   describe("PostgreSQLUUIDHasManyThroughDisableJoinsTest", () => {
     it.skip("uuid primary key and disable joins with delegate cache", () => {
-      // BLOCKED: adapter-pg — hasManyThrough with disableJoins + UUID PK not implemented
-      // ROOT-CAUSE: Rails' has_many :through with disable_joins: true uses a separate
-      // query per association and caches the delegate class. Requires hasManyThrough
-      // implementation + disableJoins option + delegate cache. Not uuid-specific.
-      // SCOPE: hasManyThrough + disableJoins; separate PR effort.
+      // BLOCKED: hasManyThrough + disableJoins not implemented (not uuid-specific).
+      // Separate PR effort; uuid PK emission verified by Slot A schema-dump tests above.
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -593,6 +593,7 @@ export class TableDefinition {
       as?: string;
       options?: string;
       comment?: string;
+      default?: unknown;
     } = {},
   ) {
     this.tableName = tableName;
@@ -607,7 +608,9 @@ export class TableDefinition {
 
     if (this._id !== false) {
       const pkType = (typeof this._id === "string" ? this._id : "primary_key") as ColumnType;
-      this.columns.push(this.newColumnDefinition("id", pkType, { primaryKey: true }));
+      const pkOpts: Record<string, unknown> = { primaryKey: true };
+      if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
+      this.columns.push(this.newColumnDefinition("id", pkType, pkOpts));
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -72,7 +72,12 @@ export class SchemaStatements {
   async createTable(
     name: string,
     optionsOrFn?:
-      | { id?: boolean | "uuid"; force?: boolean | "cascade"; ifNotExists?: boolean }
+      | {
+          id?: boolean | "uuid";
+          force?: boolean | "cascade";
+          ifNotExists?: boolean;
+          default?: unknown;
+        }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
@@ -80,6 +85,7 @@ export class SchemaStatements {
       id?: boolean | "uuid";
       force?: boolean | "cascade";
       ifNotExists?: boolean;
+      default?: unknown;
     } = {};
     let definer: ((t: TableDefinition) => void) | undefined;
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -550,7 +550,12 @@ export abstract class Migration {
   async createTable(
     name: string,
     optionsOrFn?:
-      | { id?: boolean | "uuid"; force?: boolean | "cascade"; ifNotExists?: boolean }
+      | {
+          id?: boolean | "uuid";
+          force?: boolean | "cascade";
+          ifNotExists?: boolean;
+          default?: unknown;
+        }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
@@ -1431,6 +1436,7 @@ export class MigrationContext {
       force?: boolean | "cascade";
       ifNotExists?: boolean;
       id?: boolean | "uuid";
+      default?: unknown;
     },
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
@@ -1450,6 +1456,7 @@ export class MigrationContext {
     }
     const td = new TableDefinition(name, {
       id: options?.id,
+      default: options?.default,
       adapterName: this._adapterName,
       adapter: this.adapter,
     });

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -329,7 +329,7 @@ class AdapterSchemaSource implements SchemaSource {
       primaryKey: col.primaryKey,
       null: col.null,
       default: col.default,
-      defaultFunction: (col as any).defaultFunction ?? null,
+      defaultFunction: col.defaultFunction ?? null,
       limit: col.limit ?? undefined,
       precision: col.precision === undefined ? undefined : col.precision,
       scale: col.scale ?? undefined,
@@ -686,8 +686,15 @@ export class SchemaDumper {
    */
   protected primaryKeyTableOptions(column: ColumnInfo): Record<string, unknown> {
     if (column.type === "uuid") {
-      const def = column.defaultFunction ?? cleanDefault(column.default);
-      return { id: "uuid", default: def == null ? null : def };
+      const fn = column.defaultFunction;
+      if (typeof fn === "string" && fn.length > 0) {
+        // Emit as arrow returning the SQL expression — mirrors Rails'
+        // `default: -> { "gen_random_uuid()" }` and round-trips through
+        // `quoteDefaultExpression`, which routes function defaults to raw SQL.
+        return { id: "uuid", default: () => fn };
+      }
+      const literal = cleanDefault(column.default);
+      return { id: "uuid", default: literal == null ? null : literal };
     }
     return {};
   }
@@ -915,7 +922,15 @@ export class SchemaDumper {
   formatOptions(options: Record<string, unknown>): string {
     const isIdent = /^[a-zA-Z_$][\w$]*$/;
     return Object.entries(options)
-      .map(([k, v]) => `${isIdent.test(k) ? k : JSON.stringify(k)}: ${JSON.stringify(v)}`)
+      .map(([k, v]) => {
+        const key = isIdent.test(k) ? k : JSON.stringify(k);
+        if (typeof v === "function") {
+          // Emit as an arrow returning the SQL expression — mirrors Rails'
+          // `-> { "fn()" }` syntax in dumped `schema.rb`.
+          return `${key}: () => ${JSON.stringify((v as () => unknown)())}`;
+        }
+        return `${key}: ${JSON.stringify(v)}`;
+      })
       .join(", ");
   }
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -41,6 +41,7 @@ export interface ColumnInfo {
   primaryKey?: boolean;
   null?: boolean;
   default?: unknown;
+  defaultFunction?: string | null;
   limit?: number | null;
   precision?: number | null;
   scale?: number | null;
@@ -328,6 +329,7 @@ class AdapterSchemaSource implements SchemaSource {
       primaryKey: col.primaryKey,
       null: col.null,
       default: col.default,
+      defaultFunction: (col as any).defaultFunction ?? null,
       limit: col.limit ?? undefined,
       precision: col.precision === undefined ? undefined : col.precision,
       scale: col.scale ?? undefined,
@@ -680,7 +682,13 @@ export class SchemaDumper {
     const stripped = this.removePrefixAndSuffix(tableName);
 
     const tableOpts: Record<string, unknown> = {};
-    if (!hasId) tableOpts.id = false;
+    if (!hasId) {
+      tableOpts.id = false;
+    } else if (pkColumn && pkColumn.type === "uuid") {
+      tableOpts.id = "uuid";
+      const pkDefault = pkColumn.defaultFunction ?? cleanDefault(pkColumn.default);
+      tableOpts.default = pkDefault == null ? null : pkDefault;
+    }
     tableOpts.force = "cascade";
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -262,7 +262,7 @@ function sqlTypeToDsl(sqlType: string): DslMapping {
  * Clean up a PG default expression to a human-readable literal value.
  * E.g. "'happy'::mood" -> "happy", "'192.168.1.1'::inet" -> "192.168.1.1"
  */
-function cleanDefault(raw: unknown): unknown {
+export function cleanDefault(raw: unknown): unknown {
   if (raw === null || raw === undefined) return raw;
   const str = String(raw);
 
@@ -671,6 +671,27 @@ export class SchemaDumper {
     }
   }
 
+  /**
+   * DSL-typed primary-key options merged into `create_table` for non-default
+   * primary keys. Mirrors Rails' `column_spec_for_primary_key` call in
+   * `SchemaDumper#table` — but returns plain JS values for our TS DSL
+   * emitter rather than Ruby-format strings.
+   *
+   * Note: `SchemaDumper.dumpTableSchema(adapter, ...)` instantiates the base
+   * class (not an adapter-specific subclass), so this default branches on
+   * `column.type` directly. Rails has the same single dispatch point — its
+   * `column_spec_for_primary_key` lives on the adapter subclass, but our
+   * factory path doesn't pick that subclass yet, so we centralize.
+   * @internal
+   */
+  protected primaryKeyTableOptions(column: ColumnInfo): Record<string, unknown> {
+    if (column.type === "uuid") {
+      const def = column.defaultFunction ?? cleanDefault(column.default);
+      return { id: "uuid", default: def == null ? null : def };
+    }
+    return {};
+  }
+
   private emitTable(
     lines: string[],
     tableName: string,
@@ -684,10 +705,8 @@ export class SchemaDumper {
     const tableOpts: Record<string, unknown> = {};
     if (!hasId) {
       tableOpts.id = false;
-    } else if (pkColumn && pkColumn.type === "uuid") {
-      tableOpts.id = "uuid";
-      const pkDefault = pkColumn.defaultFunction ?? cleanDefault(pkColumn.default);
-      tableOpts.default = pkDefault == null ? null : pkDefault;
+    } else if (pkColumn) {
+      Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
     }
     tableOpts.force = "cascade";
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;


### PR DESCRIPTION
## Summary
- Wire `id: \"uuid\"` emission into `SchemaDumper.emitTable` for UUID primary-key tables; thread `defaultFunction` through `AdapterSchemaSource` so the PK default expression (`gen_random_uuid()`, custom generators, or `nil` override) round-trips into the dumped DSL.
- Un-skip 5 SchemaDumper UUID-PK test stubs in `uuid.test.ts` against live PG.
- Sharpen the remaining BLOCKED annotations to point at Slot B (associations + UUID FK binding) and Slot C (UniquenessValidator UUID bypass).

## Audit note
The audit (`docs/activerecord-100-clusters.md#pg-uuid-residual-cluster`) said the dumper helpers were already wired — they exist (`columnSpecForPrimaryKey`, `isExplicitPrimaryKeyDefault`, `defaultPrimaryKeyType`) but `emitTable` itself wasn't calling them, so live UUID PK tables silently lost their `id: :uuid` option. The fix inlines a minimal check in `emitTable` (uuid type → emit `id` + `default`) rather than restructuring through the abstract subclass hierarchy.

## Test plan
- [x] `pnpm exec vitest run packages/activerecord/src/adapters/postgresql/uuid.test.ts` against live PG (48 pass, 9 skipped — Slots B/C)
- [x] `pnpm exec vitest run` schema-dumper suites (pg/mysql/sqlite/abstract) — no regressions
- [x] `pnpm api:compare` — `4951/4958` unchanged