### PR TITLE
feat(activerecord): mysql warnings — infrastructure + driver capture (audit Slot A, 9 un-skips)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -1,6 +1,34 @@
 import { describe } from "vitest";
 import mysql from "mysql2/promise";
+import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { Mysql2Adapter } from "../../connection-adapters/mysql2-adapter.js";
+import type { SQLWarning } from "../../errors.js";
+
+/**
+ * Scope an `AbstractMysqlAdapter.dbWarningsAction` (+ optional ignore list)
+ * to a single block, restoring the prior values afterwards even on throw.
+ * Mirrors: Rails' `ActiveRecord::TestCase#with_db_warnings_action`.
+ */
+export async function withDbWarningsAction(
+  action: "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void),
+  warningsToIgnore: (string | RegExp)[] | (() => Promise<void> | void),
+  fn?: () => Promise<void> | void,
+): Promise<void> {
+  const body = (
+    typeof warningsToIgnore === "function" ? warningsToIgnore : fn
+  ) as () => Promise<void> | void;
+  const ignore = Array.isArray(warningsToIgnore) ? warningsToIgnore : [];
+  const savedAction = AbstractMysqlAdapter.dbWarningsAction;
+  const savedIgnore = AbstractMysqlAdapter.dbWarningsIgnore;
+  AbstractMysqlAdapter.dbWarningsAction = action;
+  AbstractMysqlAdapter.dbWarningsIgnore = ignore;
+  try {
+    await body();
+  } finally {
+    AbstractMysqlAdapter.dbWarningsAction = savedAction;
+    AbstractMysqlAdapter.dbWarningsIgnore = savedIgnore;
+  }
+}
 
 export const MYSQL_TEST_URL =
   process.env.MYSQL_TEST_URL ?? "mysql://root@localhost:3306/rails_js_test";

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -1,8 +1,14 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describeIfMysql,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+  withDbWarningsAction,
+} from "./test-helper.js";
+import { SQLWarning } from "../../errors.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -11,53 +17,98 @@ describeIfMysql("Mysql2Adapter", () => {
   });
   afterEach(async () => {
     await adapter.close();
+    vi.restoreAllMocks();
   });
 
   describe("WarningsTest", () => {
-    it.skip("db_warnings_action :raise on warning", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+    it("db_warnings_action :raise on warning", async () => {
+      await withDbWarningsAction("raise", async () => {
+        await expect(adapter.execute(`SELECT 1 + 'foo'`)).rejects.toBeInstanceOf(SQLWarning);
+      });
     });
-    it.skip("db_warnings_action :ignore on warning", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action :ignore on warning", async () => {
+      await withDbWarningsAction("ignore", async () => {
+        const rows = await adapter.execute(`SELECT 1 + 'foo' AS v`);
+        expect(rows[0]?.v).toBe(1);
+      });
     });
-    it.skip("db_warnings_action :log on warning", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action :log on warning", async () => {
+      await withDbWarningsAction("log", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        await adapter.execute(`SELECT 1 + 'foo'`);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`[ActiveRecord::SQLWarning] Truncated incorrect DOUBLE value`),
+        );
+      });
     });
-    it.skip("db_warnings_action :report on warning", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action :report on warning", async () => {
+      // Rails dispatches to ActiveSupport::ErrorReporter; we have no global
+      // singleton yet (same gap PostgreSQLAdapter documents). Accept the
+      // "report" action without crashing — the warning is silently dropped.
+      await withDbWarningsAction("report", async () => {
+        await expect(adapter.execute(`SELECT 1 + 'foo'`)).resolves.toBeDefined();
+      });
     });
-    it.skip("db_warnings_action custom proc on warning", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action custom proc on warning", async () => {
+      let captured: SQLWarning | null = null;
+      await withDbWarningsAction(
+        (w) => {
+          captured = w;
+        },
+        async () => {
+          await adapter.execute(`SELECT 1 + 'foo'`);
+        },
+      );
+      expect(captured).toBeInstanceOf(SQLWarning);
+      expect((captured as unknown as SQLWarning).message).toBe(
+        `Truncated incorrect DOUBLE value: 'foo'`,
+      );
+      expect((captured as unknown as SQLWarning).level).toBe("Warning");
     });
-    it.skip("db_warnings_action allows a list of warnings to ignore", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action allows a list of warnings to ignore", async () => {
+      await withDbWarningsAction("raise", [/Truncated incorrect DOUBLE value/], async () => {
+        const rows = await adapter.execute(`SELECT 1 + 'foo' AS v`);
+        expect(rows[0]?.v).toBe(1);
+      });
     });
-    it.skip("db_warnings_action allows a list of codes to ignore", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action allows a list of codes to ignore", async () => {
+      await withDbWarningsAction("raise", ["1292"], async () => {
+        const rows = await adapter.execute(`SELECT 1 + 'foo' AS v`);
+        expect(rows[0]?.v).toBe(1);
+      });
     });
-    it.skip("db_warnings_action ignores note level warnings", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action ignores note level warnings", async () => {
+      await withDbWarningsAction("raise", async () => {
+        await expect(
+          adapter.execute("DROP TABLE IF EXISTS non_existent_table_warnings_test"),
+        ).resolves.toBeDefined();
+      });
     });
-    it.skip("db_warnings_action handles when warning_count does not match returned warnings", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in warnings
-      // ROOT-CAUSE: adapters/mysql2/warnings.ts or abstract-mysql-adapter/warnings.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/warnings.ts; affects ~10–26 tests in warnings.test.ts
+
+    it("db_warnings_action handles when warning_count does not match returned warnings", async () => {
+      await withDbWarningsAction("raise", async () => {
+        // Force warning_count to 1 even though SHOW WARNINGS will return [].
+        vi.spyOn(
+          adapter as unknown as { _warningCount: () => Promise<number> },
+          "_warningCount",
+        ).mockResolvedValue(1);
+        try {
+          await adapter.execute(`SELECT 'x'`);
+          throw new Error("expected SQLWarning");
+        } catch (e) {
+          expect(e).toBeInstanceOf(SQLWarning);
+          expect((e as SQLWarning).message).toBe(
+            `Query had warning_count=1 but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration.`,
+          );
+        }
+      });
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -18,6 +18,7 @@ import {
   MismatchedForeignKey,
   NotNullViolation,
   RecordNotUnique,
+  SQLWarning,
   StatementInvalid,
   ValueTooLong,
   sqlTypeToMigrationKeyword,
@@ -124,6 +125,16 @@ const MYSQL_ADAPTER_ESCAPE_MAP: Record<string, string> = {
 
 export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
+
+  /**
+   * Behaviour when MySQL emits a warning. Mirrors `ActiveRecord.db_warnings_action`.
+   * One of "ignore" | "log" | "raise" | "report" | (warning) => void.
+   */
+  static dbWarningsAction: "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void) =
+    "ignore";
+
+  /** Allow-list of warning messages or codes to skip. Mirrors `ActiveRecord.db_warnings_ignore`. */
+  static dbWarningsIgnore: (string | RegExp)[] = [];
 
   /**
    * Return Column objects for a table. Concrete adapters (Mysql2Adapter,
@@ -1043,9 +1054,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return Promise.resolve();
   }
 
-  /** @internal */
+  /** @internal Mirrors: AbstractMysqlAdapter#warning_ignored? */
   override isWarningIgnored(warning: { level?: string; [k: string]: unknown }): boolean {
-    return warning.level === "Note";
+    if (warning.level === "Note") return true;
+    return super.isWarningIgnored(warning);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -8,7 +8,12 @@ import {
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
 import { Version } from "./abstract-adapter.js";
-import { MismatchedForeignKey, NoDatabaseError, NotImplementedError } from "../errors.js";
+import {
+  MismatchedForeignKey,
+  NoDatabaseError,
+  NotImplementedError,
+  SQLWarning,
+} from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
@@ -427,8 +432,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           : await conn.query(driverSql, driverBinds);
         const r = rows as Record<string, unknown>[];
         payload.row_count = Array.isArray(r) ? r.length : 0;
+        await this._handleWarningsOn(conn, driverSql);
         return r;
       } catch (e: any) {
+        if (e instanceof SQLWarning) {
+          payload.exception = e;
+          payload.exception_object = e;
+          throw e;
+        }
         // getConn() itself can throw (pool exhausted / connection
         // refused / closed pool); catching here lets subscribers see
         // acquisition failures as `payload.exception` too. Query-level
@@ -478,6 +489,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         this.dirtyCurrentTransaction();
         const info = result as mysql.ResultSetHeader;
         payload.row_count = info.affectedRows ?? 0;
+        await this._handleWarningsOn(conn, driverSql);
 
         // For INSERT, return the last inserted ID (or affected rows for multi-row)
         if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
@@ -490,6 +502,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // For UPDATE/DELETE, return affected rows
         return info.affectedRows;
       } catch (e: any) {
+        if (e instanceof SQLWarning) {
+          payload.exception = e;
+          payload.exception_object = e;
+          throw e;
+        }
         // Guard acquisition failures (pool exhausted / refused /
         // closed) so subscribers still see `payload.exception`. Driver
         // errors (ER_DUP_ENTRY etc.) are translated to Rails' typed
@@ -1307,6 +1324,75 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       });
     });
     return pool;
+  }
+
+  /**
+   * Query `SHOW COUNT(*) WARNINGS` to learn how many warnings the most
+   * recent statement on `conn` produced. SHOW statements do not reset the
+   * warning list (unlike a normal SELECT), so the subsequent SHOW WARNINGS
+   * still returns the rows.
+   *
+   * Exposed as a protected method so tests can stub it via `vi.spyOn` to
+   * exercise the "warning_count does not match returned warnings" branch.
+   * @internal
+   */
+  protected async _warningCount(conn: mysql.PoolConnection): Promise<number> {
+    const [rows] = await conn.query("SHOW COUNT(*) WARNINGS");
+    const row = (rows as Record<string, unknown>[])[0];
+    if (!row) return 0;
+    const v = Object.values(row)[0];
+    return typeof v === "number" ? v : Number(v) || 0;
+  }
+
+  /**
+   * Read pending warnings for `conn`, filter via {@link isWarningIgnored},
+   * and dispatch per the configured `dbWarningsAction`. Runs after every
+   * successful query in {@link execute}/{@link executeMutation} while the
+   * pool connection is still held — warnings are connection-scoped.
+   *
+   * Mirrors: AbstractMysqlAdapter#handle_warnings.
+   * @internal
+   */
+  protected async _handleWarningsOn(
+    conn: mysql.PoolConnection | undefined,
+    sql: string,
+  ): Promise<void> {
+    if (!conn) return;
+    const ctor = this.constructor as typeof Mysql2Adapter;
+    const action = ctor.dbWarningsAction;
+    if (!action || action === "ignore") return;
+    const count = await this._warningCount(conn);
+    if (count === 0) return;
+    const [rawRows] = await conn.query("SHOW WARNINGS");
+    let rows = rawRows as Array<{ Level?: string; Code?: number | string; Message?: string }>;
+    if (rows.length === 0) {
+      rows = [
+        {
+          Level: "Warning",
+          Code: undefined,
+          Message: `Query had warning_count=${count} but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration.`,
+        },
+      ];
+    }
+    for (const row of rows) {
+      const level = row.Level ?? null;
+      const code = row.Code == null ? null : String(row.Code);
+      const message = row.Message ?? "";
+      const warning = new SQLWarning(message, code, level, sql);
+      if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
+        continue;
+      if (action === "raise") throw warning;
+      if (action === "log") {
+        const logger = this.logger as { warn?: (msg: string) => void } | null;
+        const codeSuffix = code ? ` (${code})` : "";
+        const line = `[ActiveRecord::SQLWarning] ${message}${codeSuffix}`;
+        if (logger?.warn) logger.warn(line);
+        else console.warn(line);
+      }
+      // TODO(report): wire Rails.error.report(warning, handled: true) when ErrorReporter
+      // is exposed as a global singleton — same gap as PostgreSQLAdapter._flushWarnings.
+      if (typeof action === "function") action(warning);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Mirror PostgreSQLAdapter's `db_warnings_action` plumbing onto the MySQL side. Closes the audit Slot A `MySQL warnings` cluster.

- `AbstractMysqlAdapter`: static `dbWarningsAction` (default `"ignore"`) + `dbWarningsIgnore`; `isWarningIgnored` chains `super` so the ignore allow-list also applies on the MySQL side.
- `Mysql2Adapter._handleWarningsOn(conn, sql)`: runs `SHOW COUNT(*) WARNINGS` + `SHOW WARNINGS` while the pool connection is still held, builds `SQLWarning` rows, filters via `isWarningIgnored`, and dispatches to `raise` / `log` / `report` / proc. Wired into `execute()` and `executeMutation()`; `SQLWarning` bypasses driver-error translation.
- `_warningCount` is a protected method so tests can stub it via `vi.spyOn` for the "warning_count does not match returned warnings" branch.
- `withDbWarningsAction` test helper mirrors Rails' test-case helper.
- Un-skip the 9 `warnings_test.rb` tests against MariaDB.

LOC: 4 files, +226 / -49.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts` against MariaDB — 9/9 pass.
- [x] `pnpm api:compare --package activerecord` — `abstract_mysql_adapter.rb` and `mysql2_adapter.rb` remain at 100%; overall 4951/4958 unchanged.
- [x] `pnpm typecheck` + lint — clean on touched files.

## Out of scope

- `:report` dispatch — the test only asserts that `report` doesn't crash. `Rails.error.report(warning, handled: true)` is deferred until `ActiveSupport::ErrorReporter` is exposed as a global singleton (same gap PostgreSQLAdapter documents at `_flushWarnings`).
- `TrilogyAdapter` driver-side capture — the static fields land on the shared `AbstractMysqlAdapter`, but the `SHOW WARNINGS` driver wiring is Mysql2-only for now.