### PR TITLE
feat(activerecord): pg-adapter — Enum OID + Column.defaultFunction + ErrorReporter dispatch (audit Slot C)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -820,9 +820,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("unparsed defaults are at least set when saving", async () => {
       await adapter.exec(
-        `CREATE TABLE "ex" (id SERIAL PRIMARY KEY, number INTEGER NOT NULL DEFAULT (4 + 4) * 2 / 4)`,
+        `CREATE TABLE "ex_unparsed_defaults" (id SERIAL PRIMARY KEY, number INTEGER NOT NULL DEFAULT (4 + 4) * 2 / 4)`,
       );
-      const cols = await adapter.columns("ex");
+      const cols = await adapter.columns("ex_unparsed_defaults");
       const numberCol = cols.find((c) => c.name === "number")!;
       // Rails: arithmetic-expression defaults — extract_value_from_default and
       // extract_default_function both return nil; the column carries neither a
@@ -830,8 +830,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       // on INSERT, so save! must NOT emit `number = NULL`.
       expect(numberCol.default).toBeNull();
       expect(numberCol.defaultFunction == null).toBe(true);
-      await adapter.exec(`INSERT INTO "ex" DEFAULT VALUES`);
-      const rows = await adapter.execute(`SELECT number FROM "ex"`);
+      await adapter.exec(`INSERT INTO "ex_unparsed_defaults" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT number FROM "ex_unparsed_defaults"`);
       expect(Number(rows[0].number)).toBe(4);
     });
     it("only check for insensitive comparison capability once", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -808,11 +808,31 @@ describeIfPg("PostgreSQLAdapter", () => {
       // directly. 57P01 → ConnectionNotEstablished translation is verified by the
       // reconnection_error test above (fake pool injection path).
     });
-    it.skip("reload type map for newly defined types", async () => {
-      // BLOCKED: TypeMapInitializer registers enum OIDs as generic types, not OID::Enum.
+    it("reload type map for newly defined types", async () => {
+      const { Enum: OidEnum } = await import("../../connection-adapters/postgresql/oid/enum.js");
+      await adapter.createEnum("feeling", ["good", "bad"]);
+      try {
+        const result = await adapter.execQuery(`SELECT 'good'::feeling AS feeling`);
+        expect(result.columnTypes["feeling"]).toBeInstanceOf(OidEnum);
+      } finally {
+        await adapter.dropEnum("feeling", { ifExists: true });
+      }
     });
-    it.skip("unparsed defaults are at least set when saving", async () => {
-      // BLOCKED: Column.defaultFunction null for arithmetic defaults; reload() gap.
+    it("unparsed defaults are at least set when saving", async () => {
+      await adapter.exec(
+        `CREATE TABLE "ex" (id SERIAL PRIMARY KEY, number INTEGER NOT NULL DEFAULT (4 + 4) * 2 / 4)`,
+      );
+      const cols = await adapter.columns("ex");
+      const numberCol = cols.find((c) => c.name === "number")!;
+      // Rails: arithmetic-expression defaults — extract_value_from_default and
+      // extract_default_function both return nil; the column carries neither a
+      // literal default nor a SQL function. The DB still applies the default
+      // on INSERT, so save! must NOT emit `number = NULL`.
+      expect(numberCol.default).toBeNull();
+      expect(numberCol.defaultFunction == null).toBe(true);
+      await adapter.exec(`INSERT INTO "ex" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT number FROM "ex"`);
+      expect(Number(rows[0].number)).toBe(4);
     });
     it("only check for insensitive comparison capability once", async () => {
       await adapter.execute(`CREATE DOMAIN example_type AS integer`);
@@ -893,9 +913,26 @@ describeIfPg("PostgreSQLAdapter", () => {
         ).rejects.toBeInstanceOf(SQLWarning);
       });
 
-      it.skip("reports when behaviour report", async () => {
-        // BLOCKED: Requires Rails.error / ErrorReporter global singleton.
-        // ErrorReporter class exists (activesupport) but not yet wired as Rails.error.
+      it("reports when behaviour report", async () => {
+        const { ErrorReporter, setErrorReporter } = await import("@blazetrails/activesupport");
+        PostgreSQLAdapter.dbWarningsAction = "report";
+        const reporter = new ErrorReporter();
+        const events: Array<{ error: Error; handled: boolean }> = [];
+        reporter.subscribe({
+          report: ({ error, handled }) => {
+            events.push({ error, handled });
+          },
+        });
+        setErrorReporter(reporter);
+        try {
+          await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
+          expect(events).toHaveLength(1);
+          expect(events[0].error).toBeInstanceOf(SQLWarning);
+          expect(events[0].error.message).toBe("PostgreSQL SQL warning");
+          expect(events[0].handled).toBe(true);
+        } finally {
+          setErrorReporter(null);
+        }
       });
 
       it("warnings behaviour can be customized with a proc", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4645,10 +4645,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * @internal
    */
   hasDefaultFunction(defaultValue: unknown, defaultExpr: string): boolean {
-    return (
-      defaultValue == null &&
-      /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/.test(defaultExpr)
-    );
+    return defaultValue == null && DEFAULT_FUNCTION_RE.test(defaultExpr);
   }
 
   /**
@@ -5053,11 +5050,19 @@ function splitPgDefault(raw: string | null): { literal: unknown; fn: string | nu
   // expression defaults like `(((4 + 4) * 2) / 4)` match none of these and
   // Rails reflects them with both `default` and `default_function` as nil
   // (the DB still applies the default on INSERT).
-  if (/\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/.test(raw)) {
+  if (DEFAULT_FUNCTION_RE.test(raw)) {
     return { literal: null, fn: raw };
   }
   return { literal: null, fn: null };
 }
+
+/**
+ * Mirrors: PostgreSQLAdapter#has_default_function? regex
+ * (postgresql_adapter.rb:786). A function call, parenthesized cast, or
+ * CURRENT_DATE/CURRENT_TIMESTAMP — anything else is a literal default or
+ * unrecognized expression and does not populate Column#default_function.
+ */
+const DEFAULT_FUNCTION_RE = /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/;
 
 /**
  * Normalize a `pg_catalog.format_type(...)` string to the typname the

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,12 @@
 import pg from "pg";
 import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
-import { singularize, underscore, Notifications, getCrypto } from "@blazetrails/activesupport";
+import {
+  singularize,
+  underscore,
+  Notifications,
+  getCrypto,
+  getErrorReporter,
+} from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
@@ -1025,7 +1031,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           if (logger?.warn) logger.warn(msg);
           else console.warn(msg);
         }
-        // TODO(report): Rails calls `Rails.error.report(warning, handled: true)`; deferred until wired.
+        if (action === "report") {
+          // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
+          // (active_record.rb:248–249). When no reporter is wired, silently no-op
+          // — Rails' Rails.error always exists in a booted app, but our
+          // activesupport accessor is opt-in.
+          getErrorReporter()?.report(sw, { handled: true });
+        }
         if (typeof action === "function") action(sw);
       }
     } finally {
@@ -5035,9 +5047,16 @@ function splitPgDefault(raw: string | null): { literal: unknown; fn: string | nu
   if (/^-?\d+(?:\.\d+)?$/.test(raw)) return { literal: raw, fn: null };
   if (raw === "true" || raw === "false") return { literal: raw === "true", fn: null };
   if (raw === "NULL") return { literal: null, fn: null };
-  // Everything else (nextval, CURRENT_TIMESTAMP, gen_random_uuid(), etc.)
-  // is a SQL expression.
-  return { literal: null, fn: raw };
+  // Everything else: only treat as a SQL function expression if it matches
+  // Rails' has_default_function? regex — a function call, a parenthesized
+  // expression with a cast, or CURRENT_DATE/CURRENT_TIMESTAMP. Arithmetic-
+  // expression defaults like `(((4 + 4) * 2) / 4)` match none of these and
+  // Rails reflects them with both `default` and `default_function` as nil
+  // (the DB still applies the default on INSERT).
+  if (/\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/.test(raw)) {
+    return { literal: null, fn: raw };
+  }
+  return { literal: null, fn: null };
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -15,14 +15,8 @@ export class Enum extends ValueType<string> {
     return "enum";
   }
 
-  /** Rails' cast_value is `value.to_s` — matches `String(value)` here. */
-  cast(value: unknown): string | null {
-    if (value == null) return null;
+  /** @internal Mirrors: PostgreSQL::OID::Enum#cast_value (enum.rb:13). */
+  protected override castValue(value: unknown): string {
     return String(value);
   }
-}
-
-/** @internal */
-function castValue(value: unknown): string {
-  return String(value);
 }

--- a/packages/activesupport/src/error-reporter.ts
+++ b/packages/activesupport/src/error-reporter.ts
@@ -210,3 +210,21 @@ export class ErrorReporter {
     }
   }
 }
+
+/**
+ * Process-wide ErrorReporter accessor — Rails' `Rails.error` analogue.
+ * The reporter is opt-in; callers wire it via `setErrorReporter` (typically
+ * a Railtie initializer). Adapter code that wants to forward warnings via
+ * `:report` reads `getErrorReporter()` and no-ops when nothing is set.
+ */
+let _globalErrorReporter: ErrorReporter | null = null;
+
+/** @internal Mirrors: `Rails.error`. Returns null when no reporter is set. */
+export function getErrorReporter(): ErrorReporter | null {
+  return _globalErrorReporter;
+}
+
+/** @internal Mirrors: `Rails.define_singleton_method(:error) { reporter }`. */
+export function setErrorReporter(reporter: ErrorReporter | null): void {
+  _globalErrorReporter = reporter;
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -366,7 +366,7 @@ export {
 // KeyGenerator uses getCrypto() adapter — import from "@blazetrails/activesupport/key-generator"
 export { BacktraceCleaner } from "./backtrace-cleaner.js";
 export { OrderedHash } from "./ordered-hash.js";
-export { ErrorReporter } from "./error-reporter.js";
+export { ErrorReporter, getErrorReporter, setErrorReporter } from "./error-reporter.js";
 export type {
   ErrorSeverity,
   ErrorContext,


### PR DESCRIPTION
## Summary

Three independent small impls in the PG type-map / runtime-config orbit (audit Slot C); three test bodies ported from Rails `postgresql_adapter_test.rb`. ~85 LOC.

- **Enum OID** was already registered in `TypeMapInitializer.registerEnumType`. Ported the Rails test body that asserts `execQuery` populates `columnTypes` with an `OID::Enum` instance after `create_enum`.
- **`Column.defaultFunction` for arithmetic-expression defaults.** `splitPgDefault` previously routed every non-literal `pg_attrdef` expression through `defaultFunction`. Rails' `has_default_function?` is narrower (function call, parenthesized cast, or `CURRENT_DATE`/`CURRENT_TIMESTAMP`), so arithmetic-expression defaults like `(((4 + 4) * 2) / 4)` now reflect with both `default` and `defaultFunction` as `null` — the DB still applies the default on INSERT.
- **ErrorReporter `:report` dispatch.** `activesupport` now exposes a process-wide `ErrorReporter` accessor (`getErrorReporter` / `setErrorReporter`) — Rails' `Rails.error` analogue. PG's `_flushWarnings` consults it for the `:report` action, matching `active_record.rb:248–249`.

3 newly-unskipped tests:
- `reload type map for newly defined types`
- `unparsed defaults are at least set when saving`
- `reports when behaviour report`

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts` (PG live) — 3 newly-un-skipped + 133 others pass
- [x] `pnpm api:compare --package activerecord` — 4951/4958 unchanged (audit Slot C didn't add new Rails-named methods)
- [x] `tsc --build` + lint clean (lint-staged in commit hook)