### PR TITLE
fix(activerecord): restore api:compare → 100% (4 method-name regressions from #1421/#1423)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -388,6 +388,17 @@ export function quotedDate(
   return abstractQuotedDate(value);
 }
 
+/**
+ * Mirrors: PostgreSQL::Quoting#encode_range. Serializes a Range to PG's
+ * range literal: `[begin,end)` or `[begin,end]` depending on excludeEnd.
+ * @internal
+ */
+export function encodeRange(range: Range): string {
+  const begin = typeCastRangeValue(range.begin);
+  const end = typeCastRangeValue(range.end);
+  return `[${begin},${end}${range.excludeEnd ? ")" : "]"}`;
+}
+
 /** @internal */
 function encodeMultirange(value: MultiRange): string {
   return `{${value.ranges.map((r) => r.toString()).join(",")}}`;

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -124,7 +124,7 @@ export class InsertAll {
   /** @internal Async init: resolves uniqueByColumns via cache.indexes() then finalizes updatableColumns. */
   private async _populateUpdatableColumns(): Promise<void> {
     if (this._updatableColumns) return;
-    const exclude = new Set([...this.readonlyColumns(), ...(await this._uniqueByColumns())]);
+    const exclude = new Set([...this.readonlyColumns(), ...(await this.uniqueByColumns())]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {
         exclude.add(col);
@@ -238,8 +238,8 @@ export class InsertAll {
   }
 
   /** @internal */
-  private async _uniqueByColumns(): Promise<string[]> {
-    return this._findUniqueIndexFor(this.uniqueBy);
+  private async uniqueByColumns(): Promise<string[]> {
+    return this.findUniqueIndexFor(this.uniqueBy);
   }
 
   /** @internal */
@@ -295,11 +295,11 @@ export class InsertAll {
   }
 
   /** @internal */
-  private async _findUniqueIndexFor(uniqueBy: string | string[] | undefined): Promise<string[]> {
+  private async findUniqueIndexFor(uniqueBy: string | string[] | undefined): Promise<string[]> {
     const nameOrCols =
       uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
     const sortedMatch = [...nameOrCols].sort().join(",");
-    const idx = (await this._uniqueIndexes()).find(
+    const idx = (await this.uniqueIndexes()).find(
       (i: any) =>
         nameOrCols.includes(i.name) ||
         (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
@@ -325,7 +325,7 @@ export class InsertAll {
    * BoundSchemaReflection with a one-arg indexes()) — the two-arg call would
    * misalign and pass the pool object as tableName.
    */
-  private async _uniqueIndexes(): Promise<unknown[]> {
+  private async uniqueIndexes(): Promise<unknown[]> {
     const conn = this.connection as any;
     const cache = conn.schemaCache;
     if (!cache || typeof cache.indexes !== "function") return [];


### PR DESCRIPTION
## Summary

Restore `pnpm api:compare --package activerecord` to 100% on the two regressed files.

### Root causes

**insert-all.ts (3 misses, from #1423)** — that PR renamed three methods with a `_` prefix to signal "internal":
- `findUniqueIndexFor` → `_findUniqueIndexFor`
- `uniqueIndexes` → `_uniqueIndexes`
- `uniqueByColumns` → `_uniqueByColumns`

Rails has these as public-named methods (`find_unique_index_for`, `unique_indexes`, `unique_by_columns`). The `_` prefix drops them from the api:compare surface. Fix: drop the prefix; visibility stays `private` and `@internal` JSDoc carries the Rails-private signal (api:compare reads name-only).

**postgresql/quoting.ts (1 miss, from #1421)** — the revert of fidelity-sweep A dropped `encodeRange`. Restored as a named export with `@internal` JSDoc, mirroring `PostgreSQL::Quoting#encode_range`:

```ts
export function encodeRange(range: Range): string {
  const begin = typeCastRangeValue(range.begin);
  const end = typeCastRangeValue(range.end);
  return `[${begin},${end}${range.excludeEnd ? ")" : "]"}`;
}
```

### Result

- `connection-adapters/postgresql/quoting.ts`: 22/23 → **23/23**
- `insert-all.ts`: 30/33 → **33/33**

(Remaining overall package miss is 3/4958 in `migration.rb` and `schema_definitions.rb` — pre-existing, out of scope for this story.)

## Test plan

- [x] `pnpm api:compare --package activerecord` — both targeted files at 100%
- [x] `pnpm exec vitest run --project activerecord packages/activerecord/src/insert-all.test.ts` — 58 passed
- [x] `pnpm lint --fix` clean (no new errors)
- [x] 17 insertions / 6 deletions — within ~20 LOC target