### PR TITLE
feat(activerecord): PG connection Slot A — SQLSubscriber test helper + 7 logs_name unskips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/connection_test.rb
  */
 import { it, expect, describe, beforeEach, afterEach } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, SQLSubscriber } from "./test-helper.js";
 
 describeIfPg("PostgresqlConnectionTest", () => {
   let adapter: PostgreSQLAdapter;
@@ -56,53 +56,84 @@ describeIfPg("PostgresqlConnectionTest", () => {
     // Requires reset!() with an open transaction
   });
 
-  it.skip("tables logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("tables logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.tables();
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("indexes logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("indexes logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.indexes("items");
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("table exists logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("table exists logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.tableExists("items");
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("table alias length logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("table alias length logs name", async () => {
+    // Rails resets @max_identifier_length to force a query via table_alias_length.
+    // Our PG adapter exposes this as maxIdentifierLength() — reset the cache and call it.
+    (adapter as unknown as { _maxIdentifierLength: number | null })._maxIdentifierLength = null;
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.maxIdentifierLength();
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("current database logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("current database logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.currentDatabase();
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("encoding logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("encoding logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.encoding();
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
-  it.skip("schema names logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("schema names logs name", async () => {
+    const subscriber = new SQLSubscriber();
+    subscriber.subscribe();
+    try {
+      await adapter.schemaNames();
+      expect(subscriber.logged[0][1]).toBe("SCHEMA");
+    } finally {
+      subscriber.unsubscribe();
+    }
   });
 
   it.skip("statement key is logged", async () => {

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -6,12 +6,16 @@ import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, SQLSubscriber } from "./t
 
 describeIfPg("PostgresqlConnectionTest", () => {
   let adapter: PostgreSQLAdapter;
+  let subscriber: SQLSubscriber;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    subscriber = new SQLSubscriber();
+    subscriber.start();
   });
 
   afterEach(async () => {
+    subscriber.stop();
     await adapter.close();
   });
 
@@ -57,90 +61,46 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("tables logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.tables();
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    await adapter.tables();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("indexes logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.indexes("items");
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    // "pg_class" substituted for Rails' "items" — no fixture tables at adapter test level
+    await adapter.indexes("pg_class");
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("table exists logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.tableExists("items");
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    // "pg_class" substituted for Rails' "items" — no fixture tables at adapter test level
+    await adapter.tableExists("pg_class");
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("table alias length logs name", async () => {
-    // Rails resets @max_identifier_length to force a query via table_alias_length.
-    // Our PG adapter exposes this as maxIdentifierLength() — reset the cache and call it.
+    // Reset cached value to force a schemaQuery, mirroring Rails' instance_variable_set(@max_identifier_length, nil)
     (adapter as unknown as { _maxIdentifierLength: number | null })._maxIdentifierLength = null;
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.maxIdentifierLength();
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    await adapter.maxIdentifierLength();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("current database logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.currentDatabase();
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    await adapter.currentDatabase();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("encoding logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.encoding();
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    await adapter.encoding();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("schema names logs name", async () => {
-    const subscriber = new SQLSubscriber();
-    subscriber.subscribe();
-    try {
-      await adapter.schemaNames();
-      expect(subscriber.logged[0][1]).toBe("SCHEMA");
-    } finally {
-      subscriber.unsubscribe();
-    }
+    await adapter.schemaNames();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it.skip("statement key is logged", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber payload inspection and prepared statement name tracking
+    // BLOCKED: prepared-statements — execQuery with prepare:true and statement_name in payload not yet wired
   });
 
   it.skip("prepare false with binds", async () => {

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -2,7 +2,7 @@ import { describe } from "vitest";
 import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
-import { Notifications } from "@blazetrails/activesupport";
+import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber } from "@blazetrails/activesupport";
 
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
@@ -65,13 +65,15 @@ export class SQLSubscriber {
   private _sub: NotificationSubscriber | null = null;
 
   subscribe(): void {
+    this.unsubscribe();
     this._sub = Notifications.subscribe("sql.active_record", (event) => {
       const p = event.payload as Record<string, unknown>;
       this.payloads.push(p);
-      const sql = String(p.sql ?? "")
-        .replace(/\s+/g, " ")
-        .trim();
-      this.logged.push([sql, String(p.name ?? ""), (p.binds as unknown[]) ?? []]);
+      this.logged.push([
+        squish(String(p.sql ?? "")),
+        String(p.name ?? ""),
+        (p.binds as unknown[]) ?? [],
+      ]);
     });
   }
 

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -2,6 +2,8 @@ import { describe } from "vitest";
 import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
+import { Notifications } from "@blazetrails/activesupport";
+import type { NotificationSubscriber } from "@blazetrails/activesupport";
 
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
 
@@ -52,3 +54,31 @@ export async function withNativeDatabaseTypeOverrides<T>(
 }
 
 export { PostgreSQLAdapter };
+
+/**
+ * Mirrors Rails' SQLSubscriber test helper from activerecord/test/cases/helper.rb.
+ * Records sql.active_record notifications so tests can assert on payload fields.
+ */
+export class SQLSubscriber {
+  readonly logged: Array<[string, string, unknown[]]> = [];
+  readonly payloads: Array<Record<string, unknown>> = [];
+  private _sub: NotificationSubscriber | null = null;
+
+  subscribe(): void {
+    this._sub = Notifications.subscribe("sql.active_record", (event) => {
+      const p = event.payload as Record<string, unknown>;
+      this.payloads.push(p);
+      const sql = String(p.sql ?? "")
+        .replace(/\s+/g, " ")
+        .trim();
+      this.logged.push([sql, String(p.name ?? ""), (p.binds as unknown[]) ?? []]);
+    });
+  }
+
+  unsubscribe(): void {
+    if (this._sub) {
+      Notifications.unsubscribe(this._sub);
+      this._sub = null;
+    }
+  }
+}

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -3,7 +3,7 @@ import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
 import { Notifications, squish } from "@blazetrails/activesupport";
-import type { NotificationSubscriber } from "@blazetrails/activesupport";
+import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
 
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
 
@@ -64,9 +64,9 @@ export class SQLSubscriber {
   readonly payloads: Array<Record<string, unknown>> = [];
   private _sub: NotificationSubscriber | null = null;
 
-  subscribe(): void {
-    this.unsubscribe();
-    this._sub = Notifications.subscribe("sql.active_record", (event) => {
+  start(): void {
+    this.stop();
+    this._sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
       const p = event.payload as Record<string, unknown>;
       this.payloads.push(p);
       this.logged.push([
@@ -77,7 +77,7 @@ export class SQLSubscriber {
     });
   }
 
-  unsubscribe(): void {
+  stop(): void {
     if (this._sub) {
       Notifications.unsubscribe(this._sub);
       this._sub = null;


### PR DESCRIPTION
## Summary

- Adds `SQLSubscriber` test helper to `packages/activerecord/src/adapters/postgresql/test-helper.ts` — mirrors Rails' `SQLSubscriber` from `activerecord/test/cases/helper.rb`; subscribes to `sql.active_record` notifications and records `[sql, name, binds]` triples + raw payloads
- Un-skips and implements 7 `*_logs_name` tests in `connection.test.ts`: tables, indexes, table exists, table alias length, current database, encoding, schema names — each asserts the first logged name is `"SCHEMA"`
- No new source code; uses existing `Notifications.subscribe` + `schemaQuery` infrastructure

## Test plan

- [ ] `PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test pnpm test packages/activerecord/src/adapters/postgresql/connection.test.ts` — 28 pass, 6 skip (unchanged blocked tests)