### PR TITLE
chore(test): cap vitest worker count to 4 to prevent local saturation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,9 @@ import path from "path";
 
 // AR_DB_FORKS (read in test-setup-worker-db.ts) sets the advisory-lock slot
 // pool size. TRAILS_TEST_FORKS caps the vitest worker count for both pools so
-// that concurrent local worktrees don't saturate the machine. Defaults to 6;
-// raise with TRAILS_TEST_FORKS=N for a solo full run.
+// that concurrent local worktrees don't saturate the machine. Precedence:
+// TRAILS_TEST_FORKS > AR_DB_FORKS > 6. Raise with TRAILS_TEST_FORKS=N for a
+// solo full run; CI sets AR_DB_FORKS=4 so those jobs stay at 4 workers.
 
 const SHARED_EXCLUDE = [
   "**/node_modules/**",
@@ -13,7 +14,8 @@ const SHARED_EXCLUDE = [
   "packages/*/dx-tests/**",
 ];
 
-const TEST_FORKS = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "6");
+const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
+const TEST_FORKS = Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : 6;
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 // AR_DB_FORKS (read in test-setup-worker-db.ts) sets the advisory-lock slot
-// pool size. Worker count is no longer pinned to it: vitest spawns freely and
-// workers queue on advisory locks when all slots are held.
+// pool size. TRAILS_TEST_FORKS caps the vitest worker count for both pools so
+// that concurrent local worktrees don't saturate the machine. Defaults to 6;
+// raise with TRAILS_TEST_FORKS=N for a solo full run.
 
 const SHARED_EXCLUDE = [
   "**/node_modules/**",
@@ -11,6 +12,8 @@ const SHARED_EXCLUDE = [
   "packages/website/**",
   "packages/*/dx-tests/**",
 ];
+
+const TEST_FORKS = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "6");
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(
@@ -109,9 +112,7 @@ export default defineConfig({
           // regression slips through.
           retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
           pool: "forks",
-          // Worker count is intentionally uncapped: advisory locks in
-          // test-setup-worker-db.ts bound real DB concurrency to AR_DB_FORKS
-          // slots, so extra workers simply wait for a free slot.
+          poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },
       {
@@ -127,6 +128,7 @@ export default defineConfig({
           ],
           exclude: ["packages/activerecord/**", ...SHARED_EXCLUDE],
           setupFiles: ["./packages/activerecord/src/test-setup.ts"],
+          poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },
     ],


### PR DESCRIPTION
## Summary

- Adds `TRAILS_TEST_FORKS` env var (default `6`) that caps vitest worker
  count for both the AR forks pool (`maxForks`) and the non-AR pool
  (`maxForks` — vitest 3.x defaults to `pool=forks` for both).
- On this machine (`os.availableParallelism() = 24`), vitest was spawning up
  to 24 workers per worktree. With multiple agent worktrees running tests
  simultaneously that saturates CPU and makes all runs slow.
- CI postgres/mariadb jobs set `AR_DB_FORKS=4` which `TEST_FORKS` also reads
  as a fallback, so those jobs remain at 4 workers. The unit-tests CI job
  (arel/activemodel/activesupport) gains a cap of 6 — fine for that runner.
- To run faster locally when no other worktrees are active:
  `TRAILS_TEST_FORKS=16 pnpm test`

## Investigation notes

Prior config comment said "Worker count is intentionally uncapped: advisory
locks bound DB concurrency to AR_DB_FORKS slots, so extra workers simply
wait for a free slot." That's correct for DB isolation — the cap doesn't
change DB safety — but idle-waiting workers still consume memory and
scheduler pressure. Capping eliminates the waste without changing test
correctness.

Note: the non-AR "other" pool also needed `poolOptions.forks.maxForks` (not
`poolOptions.threads.maxThreads`) because vitest 3.x defaults to `forks`
pool, not `threads`.

## Test plan

- [x] `pnpm vitest run packages/activesupport/src/inflector.test.ts` passes
- [ ] Full AR tests pass locally with `PG_TEST_URL` set