### PR TITLE
feat(activerecord): PG connection Slot A — SQLSubscriber test helper + 7 logs_name unskips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -2,16 +2,20 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/connection_test.rb
  */
 import { it, expect, describe, beforeEach, afterEach } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, SQLSubscriber } from "./test-helper.js";
 
 describeIfPg("PostgresqlConnectionTest", () => {
   let adapter: PostgreSQLAdapter;
+  let subscriber: SQLSubscriber;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    subscriber = new SQLSubscriber();
+    subscriber.start();
   });
 
   afterEach(async () => {
+    subscriber.stop();
     await adapter.close();
   });
 
@@ -56,60 +60,45 @@ describeIfPg("PostgresqlConnectionTest", () => {
     // Requires reset!() with an open transaction
   });
 
-  it.skip("tables logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("tables logs name", async () => {
+    await adapter.tables();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("indexes logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("indexes logs name", async () => {
+    await adapter.indexes("pg_class");
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("table exists logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("table exists logs name", async () => {
+    await adapter.tableExists("pg_class");
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("table alias length logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("table alias length logs name", async () => {
+    // Reset cached value to force a schemaQuery, mirroring Rails' instance_variable_set(@max_identifier_length, nil)
+    (adapter as unknown as { _maxIdentifierLength: number | null })._maxIdentifierLength = null;
+    await adapter.maxIdentifierLength();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("current database logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("current database logs name", async () => {
+    await adapter.currentDatabase();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("encoding logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("encoding logs name", async () => {
+    await adapter.encoding();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("schema names logs name", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber / ActiveSupport::Notifications query tagging
+  it("schema names logs name", async () => {
+    await adapter.schemaNames();
+    expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it.skip("statement key is logged", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires SQLSubscriber payload inspection and prepared statement name tracking
+    // BLOCKED: prepared-statements — execQuery with prepare:true and statement_name in payload not yet wired
   });
 
   it.skip("prepare false with binds", async () => {

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -66,11 +66,13 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("indexes logs name", async () => {
+    // "pg_class" substituted for Rails' "items" — no fixture tables at adapter test level
     await adapter.indexes("pg_class");
     expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
   it("table exists logs name", async () => {
+    // "pg_class" substituted for Rails' "items" — no fixture tables at adapter test level
     await adapter.tableExists("pg_class");
     expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -2,6 +2,8 @@ import { describe } from "vitest";
 import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
+import { Notifications } from "@blazetrails/activesupport";
+import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
 
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
 
@@ -48,6 +50,35 @@ export async function withNativeDatabaseTypeOverrides<T>(
     return await fn();
   } finally {
     pgDatetimeConfig.nativeDatabaseTypesOverrides = saved;
+  }
+}
+
+/**
+ * Mirrors Rails' ActiveRecord::TestCase::SQLSubscriber.
+ * Records [sql, name, binds] tuples in `logged` and raw payloads in `payloads`.
+ */
+export class SQLSubscriber {
+  readonly logged: [string, string, unknown[]][] = [];
+  readonly payloads: Record<string, unknown>[] = [];
+
+  private _sub: NotificationSubscriber | null = null;
+
+  start(): void {
+    this._sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+      const p = event.payload as Record<string, unknown>;
+      this.payloads.push(p);
+      const sql = typeof p["sql"] === "string" ? p["sql"].replace(/\s+/g, " ").trim() : "";
+      const name = typeof p["name"] === "string" ? p["name"] : "";
+      const binds = Array.isArray(p["binds"]) ? p["binds"] : [];
+      this.logged.push([sql, name, binds]);
+    });
+  }
+
+  stop(): void {
+    if (this._sub) {
+      Notifications.unsubscribe(this._sub);
+      this._sub = null;
+    }
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -64,6 +64,7 @@ export class SQLSubscriber {
   private _sub: NotificationSubscriber | null = null;
 
   start(): void {
+    this.stop();
     this._sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
       const p = event.payload as Record<string, unknown>;
       this.payloads.push(p);

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -2,7 +2,7 @@ import { describe } from "vitest";
 import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
-import { Notifications } from "@blazetrails/activesupport";
+import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
 
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
@@ -68,7 +68,7 @@ export class SQLSubscriber {
     this._sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
       const p = event.payload as Record<string, unknown>;
       this.payloads.push(p);
-      const sql = typeof p["sql"] === "string" ? p["sql"].replace(/\s+/g, " ").trim() : "";
+      const sql = typeof p["sql"] === "string" ? squish(p["sql"]) : "";
       const name = typeof p["name"] === "string" ? p["name"] : "";
       const binds = Array.isArray(p["binds"]) ? p["binds"] : [];
       this.logged.push([sql, name, binds]);


### PR DESCRIPTION
## Summary

- Adds `SQLSubscriber` test helper class to `packages/activerecord/src/adapters/postgresql/test-helper.ts` — mirrors Rails' `ActiveRecord::TestCase::SQLSubscriber` which subscribes to `sql.active_record` notifications and records `[sql, name, binds]` tuples in `logged` plus raw payloads in `payloads`
- Un-skips 7 `logs_name` tests in `connection.test.ts` that verify schema query methods (tables, indexes, tableExists, maxIdentifierLength, currentDatabase, encoding, schemaNames) tag their Notifications payload with `name: "SCHEMA"` via `schemaQuery`
- `statement key is logged` remains skipped (blocked on `execQuery prepare:true` + `statement_name` payload wiring, which is a separate gap)

## How it works

`schemaQuery` in `abstract-adapter.ts` already calls `execute(sql, binds, "SCHEMA")`. `execute` on the PG adapter sets `payload.name = name` and wraps in `Notifications.instrumentAsync("sql.active_record", ...)`. `SQLSubscriber.start()` subscribes and records `payload.name` → these tests simply assert that first logged entry has `name === "SCHEMA"`.

## Test plan

- [ ] PG tests pass in CI under `PG_TEST_URL` environment (7 newly active tests + existing passing tests)
- [ ] Constructor validation tests (5 sync tests) continue to pass without PG
- [ ] Type check passes (pre-commit hook verified)