### PR TITLE
feat(activerecord): MySQL quoting Slot A

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
@@ -43,6 +43,7 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(a.quoteTableName("foo")).toBe("`foo`");
         expect(a.quoteTableName("foo.bar")).toBe("`foo`.`bar`");
       }
+      expect(adapter.quoteColumnName('hel"lo.wol\\d')).toBe('`hel"lo.wol\\d`');
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 
 describeIfMysql("Mysql2Adapter", () => {
@@ -14,45 +14,35 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("QuotingTest", () => {
-    it.skip("cast bound integer", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("cast bound integer", () => {
+      expect(adapter.castBoundValue(42)).toBe("42");
     });
-    it.skip("cast bound big decimal", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("cast bound big decimal", () => {
+      expect(adapter.castBoundValue(4.2)).toBe("4.2");
     });
-    it.skip("cast bound rational", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("cast bound rational", () => {
+      expect(adapter.castBoundValue(0.75)).toBe("0.75");
     });
-    it.skip("cast bound true", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("cast bound true", () => {
+      expect(adapter.castBoundValue(true)).toBe("1");
     });
-    it.skip("cast bound false", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("cast bound false", () => {
+      expect(adapter.castBoundValue(false)).toBe("0");
     });
-    it.skip("quote string", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("quote string", () => {
+      expect(adapter.quoteString("'")).toBe("\\'");
     });
-    it.skip("quote column name", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("quote column name", () => {
+      for (const a of [adapter, Mysql2Adapter]) {
+        expect(a.quoteColumnName("foo")).toBe("`foo`");
+        expect(a.quoteColumnName('hel"lo')).toBe('`hel"lo`');
+      }
     });
-    it.skip("quote table name", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in quoting
-      // ROOT-CAUSE: adapters/mysql2/quoting.ts or abstract-mysql-adapter/quoting.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/quoting.ts; affects ~10–26 tests in quoting.test.ts
+    it("quote table name", () => {
+      for (const a of [adapter, Mysql2Adapter]) {
+        expect(a.quoteTableName("foo")).toBe("`foo`");
+        expect(a.quoteTableName("foo.bar")).toBe("`foo`.`bar`");
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -109,6 +109,17 @@ const ER_TABLE_EXISTS = 1050;
 const RENAME_FUNC_DEFAULT_RE =
   /^(CURRENT_TIMESTAMP(\([0-6]?\))?|NOW(\([0-6]?\))?|CURRENT_DATE|CURRENT_TIME(\([0-6]?\))?|UUID\(\))$/i;
 
+// eslint-disable-next-line no-control-regex
+const QUOTE_STRING_RE = /['\\\x00\n\r\x1a]/g;
+const QUOTE_STRING_MAP: Record<string, string> = {
+  "'": "\\'",
+  "\\": "\\\\",
+  "\0": "\\0",
+  "\n": "\\n",
+  "\r": "\\r",
+  "\x1a": "\\Z",
+};
+
 export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
 
@@ -709,19 +720,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * Escape-only string quoting per the Quoting interface contract
    * (`abstract/quoting-interface.ts`). Mirrors Rails MySQL
-   * `quote_string` (`mysql/quoting.rb`): doubles `'` and backslash-
-   * escapes the same control chars MySQL's wire protocol requires.
-   * Distinct from the per-module `mysqlQuoteString` standalone, which
-   * wraps with surrounding `'...'` for SQL-literal contexts.
+   * `quote_string` (`abstract_mysql_adapter.rb`): backslash-escapes
+   * `'` and the control chars MySQL's wire protocol requires (`\0 \n
+   * \r \Z \\`). Distinct from the per-module `mysqlQuoteString`
+   * standalone, which wraps with surrounding `'...'` for SQL-literal
+   * contexts.
    */
   override quoteString(s: string): string {
-    return s
-      .replace(/\\/g, "\\\\")
-      .replace(/'/g, "\\'")
-      .replace(/\x00/g, "\\0") // eslint-disable-line no-control-regex
-      .replace(/\n/g, "\\n")
-      .replace(/\r/g, "\\r")
-      .replace(/\x1a/g, "\\Z"); // eslint-disable-line no-control-regex
+    return s.replace(QUOTE_STRING_RE, (ch) => QUOTE_STRING_MAP[ch] ?? ch);
   }
 
   static dbconsole(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -109,20 +109,6 @@ const ER_TABLE_EXISTS = 1050;
 const RENAME_FUNC_DEFAULT_RE =
   /^(CURRENT_TIMESTAMP(\([0-6]?\))?|NOW(\([0-6]?\))?|CURRENT_DATE|CURRENT_TIME(\([0-6]?\))?|UUID\(\))$/i;
 
-// Hot-path constants for the escape-only `quoteString` override below.
-// Match `MYSQL_ESCAPE_RE` / `MYSQL_ESCAPE_MAP` in `mysql/quoting.ts`
-// (those are module-private). Hoisted here so each call avoids
-// re-allocating the regex and lookup table.
-// eslint-disable-next-line no-control-regex
-const MYSQL_ADAPTER_ESCAPE_RE = /[\\\x00\n\r\x1a]/g;
-const MYSQL_ADAPTER_ESCAPE_MAP: Record<string, string> = {
-  "\\": "\\\\",
-  "\0": "\\0",
-  "\n": "\\n",
-  "\r": "\\r",
-  "\x1a": "\\Z",
-};
-
 export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
 
@@ -617,6 +603,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlColumnNameWithOrderMatcher();
   }
 
+  static quoteColumnName(name: string): string {
+    return mysqlQuoteColumnName(name);
+  }
+
+  static quoteTableName(name: string): string {
+    return mysqlQuoteTableName(name);
+  }
+
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     void tableName;
     return [];
@@ -722,8 +716,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    */
   override quoteString(s: string): string {
     return s
-      .replace(/'/g, "''")
-      .replace(MYSQL_ADAPTER_ESCAPE_RE, (ch) => MYSQL_ADAPTER_ESCAPE_MAP[ch] ?? ch);
+      .replace(/\\/g, "\\\\")
+      .replace(/'/g, "\\'")
+      .replace(/\x00/g, "\\0") // eslint-disable-line no-control-regex
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")
+      .replace(/\x1a/g, "\\Z"); // eslint-disable-line no-control-regex
   }
 
   static dbconsole(


### PR DESCRIPTION
## Summary

- Fix `AbstractMysqlAdapter#quoteString` to use backslash-escape (`\'`) instead of SQL-standard doubling (`''`) — matches mysql2 `connection.escape()` behavior per Rails
- Add static `quoteColumnName` and `quoteTableName` on `AbstractMysqlAdapter`, mirroring `MySQL::Quoting::ClassMethods`
- Remove now-unused `MYSQL_ADAPTER_ESCAPE_RE` / `MYSQL_ADAPTER_ESCAPE_MAP` constants
- Implement 8 stub test bodies in `adapters/abstract-mysql-adapter/quoting.test.ts` and remove stale BLOCKED annotations

## Test plan

- [ ] `pnpm -w run api:compare --package activerecord` passes (abstract-mysql-adapter 100%, mysql/quoting 100%)
- [ ] 8 tests in `adapters/abstract-mysql-adapter/quoting.test.ts` run and pass when MySQL is available
- [ ] Existing `connection-adapters/mysql/quoting.test.ts` unit tests unchanged

## Follow-up

`adapter.quote("it's")` still returns `'it''s'` (SQL doubling) because `AbstractMysqlAdapter#quote` delegates to the module-level `mysqlQuote()` in `mysql/quoting.ts`, which uses the standalone `quoteString` with `''` doubling. In Rails, `quote()` calls `quote_string()` internally so they're consistent. Fixing this requires updating `mysql/quoting.ts` and the existing test at line 36 (`"'with ''quote'''"`) — separate PR.