### PR TITLE
feat(activerecord): SQLite Slot A — strict_strings_by_default class config

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -49,6 +49,9 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   // String values must be identifier-like enum words (e.g. "WAL", "NORMAL") — arbitrary
   // strings are warned and skipped. Numbers and booleans are always accepted (boolean → "1"/"0").
   pragmas?: Record<string, string | number | boolean>;
+  // Mirrors: database.yml `strict:` — disables double-quoted string literal fallback
+  // (DQS) at the connection level. Defaults to SQLite3Adapter.strictStringsByDefault.
+  strict?: boolean;
 }
 
 /**

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -604,23 +604,29 @@ describe("SQLite3AdapterTest", () => {
   it("strict strings by default and true in database yml", async () => {
     // Explicit strict: true in options always enables strict mode.
     const conn = new SQLite3Adapter(":memory:", { strict: true });
-    expect(conn.strictStrings).toBe(true);
-    await conn.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
-    await expect(
-      conn.exec(`CREATE INDEX "idx_non_existent" ON "testings" ("non_existent")`),
-    ).rejects.toThrow(/no such column/i);
-    await conn.close();
+    try {
+      expect(conn.strictStrings).toBe(true);
+      await conn.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
+      await expect(
+        conn.exec(`CREATE INDEX "idx_non_existent" ON "testings" ("non_existent")`),
+      ).rejects.toThrow(/no such column/i);
+    } finally {
+      await conn.close();
+    }
 
     // Explicit strict: true also overrides the class config (still strict).
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new SQLite3Adapter(":memory:", { strict: true });
-      expect(strict.strictStrings).toBe(true);
-      await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
-      await expect(
-        strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
-      ).rejects.toThrow(/no such column/i);
-      await strict.close();
+      try {
+        expect(strict.strictStrings).toBe(true);
+        await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
+        await expect(
+          strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
+        ).rejects.toThrow(/no such column/i);
+      } finally {
+        await strict.close();
+      }
     } finally {
       SQLite3Adapter.strictStringsByDefault = false;
     }
@@ -629,18 +635,24 @@ describe("SQLite3AdapterTest", () => {
   it("strict strings by default and false in database yml", async () => {
     // Explicit strict: false in options disables strict mode.
     const conn = new SQLite3Adapter(":memory:", { strict: false });
-    expect(conn.strictStrings).toBe(false);
-    // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
-    // — strict: false keeps DQS enabled so the index creation succeeds silently.
-    // Omitted here for the same reason as test 1 (better-sqlite3 SQLITE_DQS=0).
-    await conn.close();
+    try {
+      expect(conn.strictStrings).toBe(false);
+      // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
+      // — strict: false keeps DQS enabled so the index creation succeeds silently.
+      // Omitted here for the same reason as test 1 (better-sqlite3 SQLITE_DQS=0).
+    } finally {
+      await conn.close();
+    }
 
     // Explicit strict: false overrides strictStringsByDefault = true.
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new SQLite3Adapter(":memory:", { strict: false });
-      expect(strict.strictStrings).toBe(false);
-      await strict.close();
+      try {
+        expect(strict.strictStrings).toBe(false);
+      } finally {
+        await strict.close();
+      }
     } finally {
       SQLite3Adapter.strictStringsByDefault = false;
     }

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -579,6 +579,11 @@ describe("SQLite3AdapterTest", () => {
     expect(SQLite3Adapter.strictStringsByDefault).toBe(false);
     const conn = new SQLite3Adapter(":memory:");
     expect(conn.strictStrings).toBe(false);
+    // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
+    // — non-strict connections allow DQS fallback so unknown double-quoted
+    //   identifiers are treated as string literals and the index is created
+    //   silently. better-sqlite3 compiles SQLite with SQLITE_DQS=0 (always off),
+    //   so this assertion is omitted — DQS cannot be re-enabled via PRAGMA here.
     await conn.close();
 
     // Setting the class config propagates to new connections.
@@ -625,6 +630,9 @@ describe("SQLite3AdapterTest", () => {
     // Explicit strict: false in options disables strict mode.
     const conn = new SQLite3Adapter(":memory:", { strict: false });
     expect(conn.strictStrings).toBe(false);
+    // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
+    // — strict: false keeps DQS enabled so the index creation succeeds silently.
+    // Omitted here for the same reason as test 1 (better-sqlite3 SQLITE_DQS=0).
     await conn.close();
 
     // Explicit strict: false overrides strictStringsByDefault = true.

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -574,30 +574,68 @@ describe("SQLite3AdapterTest", () => {
     fs.unlinkSync(tmpFile);
   });
 
-  // Rails' SQLite3Adapter has a class-level `strict_strings_by_default` setting that
-  // controls whether string-typed WHERE values require exact binary matching. When
-  // disabled (default), Rails performs a loose match and assert_nothing_raised;
-  // when enabled or set true in database.yml, loose matches raise. Trails' adapter
-  // does not yet implement this config knob.
-  it.skip("strict strings by default", () => {
-    // BLOCKED: adapter-sqlite — SQLite-specific adapter gap in sqlite3-adapter
-    // ROOT-CAUSE: adapters/sqlite3/sqlite3-adapter.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in adapters/sqlite3/sqlite3-adapter.ts; affects ~1–17 tests in sqlite3-adapter.test.ts
-    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
+  it("strict strings by default", async () => {
+    // Default class config is false — new connections are non-strict.
+    expect(SQLite3Adapter.strictStringsByDefault).toBe(false);
+    const conn = new SQLite3Adapter(":memory:");
+    expect(conn.strictStrings).toBe(false);
+    await conn.close();
+
+    // Setting the class config propagates to new connections.
+    SQLite3Adapter.strictStringsByDefault = true;
+    try {
+      const strict = new SQLite3Adapter(":memory:");
+      expect(strict.strictStrings).toBe(true);
+      await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
+      await expect(
+        strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
+      ).rejects.toThrow(/no such column/i);
+      await strict.close();
+    } finally {
+      SQLite3Adapter.strictStringsByDefault = false;
+    }
   });
 
-  it.skip("strict strings by default and true in database yml", () => {
-    // BLOCKED: adapter-sqlite — SQLite-specific adapter gap in sqlite3-adapter
-    // ROOT-CAUSE: adapters/sqlite3/sqlite3-adapter.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in adapters/sqlite3/sqlite3-adapter.ts; affects ~1–17 tests in sqlite3-adapter.test.ts
-    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
+  it("strict strings by default and true in database yml", async () => {
+    // Explicit strict: true in options always enables strict mode.
+    const conn = new SQLite3Adapter(":memory:", { strict: true });
+    expect(conn.strictStrings).toBe(true);
+    await conn.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
+    await expect(
+      conn.exec(`CREATE INDEX "idx_non_existent" ON "testings" ("non_existent")`),
+    ).rejects.toThrow(/no such column/i);
+    await conn.close();
+
+    // Explicit strict: true also overrides the class config (still strict).
+    SQLite3Adapter.strictStringsByDefault = true;
+    try {
+      const strict = new SQLite3Adapter(":memory:", { strict: true });
+      expect(strict.strictStrings).toBe(true);
+      await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
+      await expect(
+        strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
+      ).rejects.toThrow(/no such column/i);
+      await strict.close();
+    } finally {
+      SQLite3Adapter.strictStringsByDefault = false;
+    }
   });
 
-  it.skip("strict strings by default and false in database yml", () => {
-    // BLOCKED: adapter-sqlite — SQLite-specific adapter gap in sqlite3-adapter
-    // ROOT-CAUSE: adapters/sqlite3/sqlite3-adapter.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in adapters/sqlite3/sqlite3-adapter.ts; affects ~1–17 tests in sqlite3-adapter.test.ts
-    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
+  it("strict strings by default and false in database yml", async () => {
+    // Explicit strict: false in options disables strict mode.
+    const conn = new SQLite3Adapter(":memory:", { strict: false });
+    expect(conn.strictStrings).toBe(false);
+    await conn.close();
+
+    // Explicit strict: false overrides strictStringsByDefault = true.
+    SQLite3Adapter.strictStringsByDefault = true;
+    try {
+      const strict = new SQLite3Adapter(":memory:", { strict: false });
+      expect(strict.strictStrings).toBe(false);
+      await strict.close();
+    } finally {
+      SQLite3Adapter.strictStringsByDefault = false;
+    }
   });
 
   it("rowid column", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2118,11 +2118,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // with SQLITE_DQS=0 and silently ignores these pragmas (returns []); other
     // drivers may throw on unrecognised pragmas, so we guard with try/catch.
     const dqsValue = this._strict ? "OFF" : "ON";
-    try {
-      this.driver.pragma(`dqs_ddl = ${dqsValue}`);
-      this.driver.pragma(`dqs_dml = ${dqsValue}`);
-    } catch {
-      // Pragma unsupported by this driver build — DQS state is driver-defined.
+    for (const dqsPragma of ["dqs_ddl", "dqs_dml"]) {
+      try {
+        this.driver.pragma(`${dqsPragma} = ${dqsValue}`);
+      } catch (e) {
+        console.warn(
+          `SQLite DQS pragma '${dqsPragma}' failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
     }
     const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2115,11 +2115,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     }
     // Best-effort: set DQS for drivers that support it (e.g. node:sqlite with a
     // build that exposes SQLITE_DBCONFIG_DQS_*). better-sqlite3 compiles SQLite
-    // with SQLITE_DQS=0 and does not recognise these pragmas, so DQS is always
-    // off in that driver regardless of the strict setting.
+    // with SQLITE_DQS=0 and silently ignores these pragmas (returns []); other
+    // drivers may throw on unrecognised pragmas, so we guard with try/catch.
     const dqsValue = this._strict ? "OFF" : "ON";
-    this.driver.pragma(`dqs_ddl = ${dqsValue}`);
-    this.driver.pragma(`dqs_dml = ${dqsValue}`);
+    try {
+      this.driver.pragma(`dqs_ddl = ${dqsValue}`);
+      this.driver.pragma(`dqs_dml = ${dqsValue}`);
+    } catch {
+      // Pragma unsupported by this driver build — DQS state is driver-defined.
+    }
     const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {
       // Validate pragma name is a safe SQLite identifier before interpolating.

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -193,6 +193,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * Whether this connection was opened with strict-strings mode (DQS disabled).
    * Reflects the resolved value of the `strict` constructor option, which
    * defaults to `SQLite3Adapter.strictStringsByDefault`.
+   * @internal
    */
   get strictStrings(): boolean {
     return this._strict;
@@ -225,6 +226,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     this._memoryDatabase = SQLite3Adapter._isMemoryFilename(filename);
     this._readonly = options.readonly ?? false;
     this._strict = options.strict ?? SQLite3Adapter.strictStringsByDefault;
+    (this._config as SQLite3AdapterOptions).strict = this._strict;
     // Rails: `SQLite3Adapter#default_prepared_statements` inherits the
     // abstract adapter's `true`. Mirror that default and let options
     // override per connection.
@@ -2111,12 +2113,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         }
       }
     }
-    // Mirror Rails strict_strings_by_default: when strict, disable the DQS
-    // fallback so unknown double-quoted identifiers raise "no such column"
-    // instead of being silently treated as string literals. When non-strict,
-    // explicitly enable DQS because better-sqlite3 compiles SQLite with
-    // SQLITE_DQS=0 (off by default), so we must opt back in to match Rails'
-    // non-strict behavior where double-quoted string literals are permitted.
+    // Best-effort: set DQS for drivers that support it (e.g. node:sqlite with a
+    // build that exposes SQLITE_DBCONFIG_DQS_*). better-sqlite3 compiles SQLite
+    // with SQLITE_DQS=0 and does not recognise these pragmas, so DQS is always
+    // off in that driver regardless of the strict setting.
     const dqsValue = this._strict ? "OFF" : "ON";
     this.driver.pragma(`dqs_ddl = ${dqsValue}`);
     this.driver.pragma(`dqs_dml = ${dqsValue}`);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -125,6 +125,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return _isSqliteMissingDbError(error);
   }
 
+  /**
+   * When true, new connections inherit `strict: true` unless the caller
+   * explicitly passes `strict: false`. Mirrors Rails' class_attribute.
+   */
+  static strictStringsByDefault: boolean = false;
+
   static columnNameMatcher(): RegExp {
     // Mirrors Rails SQLite3 column_name_matcher. Uses "..." quoted identifiers
     // (SQLite double-quote escaping: "" inside quotes). Strict 0-or-1 function
@@ -162,6 +168,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private _inTransaction = false;
   private _savepointCounter = 0;
   private _readonly: boolean;
+  private _strict: boolean;
   private _preventWrites = false;
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
@@ -180,6 +187,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const q = filename.indexOf("?");
     if (q === -1) return false;
     return new URLSearchParams(filename.slice(q + 1)).get("mode") === "memory";
+  }
+
+  /**
+   * Whether this connection was opened with strict-strings mode (DQS disabled).
+   * Reflects the resolved value of the `strict` constructor option, which
+   * defaults to `SQLite3Adapter.strictStringsByDefault`.
+   */
+  get strictStrings(): boolean {
+    return this._strict;
   }
 
   /**
@@ -208,6 +224,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     this._filename = filename;
     this._memoryDatabase = SQLite3Adapter._isMemoryFilename(filename);
     this._readonly = options.readonly ?? false;
+    this._strict = options.strict ?? SQLite3Adapter.strictStringsByDefault;
     // Rails: `SQLite3Adapter#default_prepared_statements` inherits the
     // abstract adapter's `true`. Mirror that default and let options
     // override per connection.
@@ -2094,6 +2111,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         }
       }
     }
+    // Mirror Rails strict_strings_by_default: when strict, disable the DQS
+    // fallback so unknown double-quoted identifiers raise "no such column"
+    // instead of being silently treated as string literals. When non-strict,
+    // explicitly enable DQS because better-sqlite3 compiles SQLite with
+    // SQLITE_DQS=0 (off by default), so we must opt back in to match Rails'
+    // non-strict behavior where double-quoted string literals are permitted.
+    const dqsValue = this._strict ? "OFF" : "ON";
+    this.driver.pragma(`dqs_ddl = ${dqsValue}`);
+    this.driver.pragma(`dqs_dml = ${dqsValue}`);
     const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {
       // Validate pragma name is a safe SQLite identifier before interpolating.


### PR DESCRIPTION
## Summary

- Adds `SQLite3Adapter.strictStringsByDefault` static class property (defaults `false`), mirroring Rails' `class_attribute :strict_strings_by_default`
- Adds `strict?: boolean` to `SQLite3AdapterOptions`; constructor resolves it from the class config when not provided
- Wires into `configureConnection` via `PRAGMA dqs_ddl`/`dqs_dml` to control SQLite's double-quoted string literal fallback (DQS)
- Exposes `strictStrings: boolean` instance getter for test/introspection use
- Un-skips 3 BLOCKED tests and fills in test bodies

## Notes

`better-sqlite3` compiles SQLite with `SQLITE_DQS=0` and the `dqs_ddl`/`dqs_dml` pragmas are not recognized at runtime, so the actual DQS behavioral difference cannot be observed in this driver. The pragma calls are correct per the SQLite spec and will take effect if a driver is used that exposes DQS control. Tests verify the class-config wiring and the `strict: true` raises-on-nonexistent-column behavior (which is universal with DQS=0).