### PR TITLE
feat(activerecord): PG UUID Slot C — UniquenessValidator UUID-aware case-insensitive bypass

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -554,11 +554,44 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(normalizeUuid("A0EEBC999C0B4EF8BB6D6BB9BD380A11")).toBe(expected);
     });
 
-    it.skip("uniqueness validation ignores uuid", () => {
-      // BLOCKED: Slot C — UniquenessValidator UUID-aware case-insensitive bypass.
-      // Rails skips the case-insensitive LOWER() comparison when the column is uuid
-      // (UUIDs are already normalized). Our validator doesn't check typeForAttribute.
-      // SCOPE: ~10 LOC in validations/uniqueness.ts.
+    it("uniqueness validation ignores uuid", async () => {
+      // Rails: can_perform_case_insensitive_comparison_for? returns false for uuid
+      // (no lower(uuid) in PG), so case_insensitive_comparison falls back to eq().
+      // Our fix: check typeForAttribute("guid").type === "uuid" and skip LOWER().
+      await adapter.exec(`DROP TABLE IF EXISTS uuid_uniqueness_validation_test`);
+      await adapter.exec(`
+        CREATE TABLE uuid_uniqueness_validation_test (
+          id serial primary key,
+          guid uuid UNIQUE
+        )
+      `);
+      try {
+        const { Base } = await import("../../index.js");
+        class UuidUniq extends Base {
+          static tableName = "uuid_uniqueness_validation_test";
+          static {
+            this.adapter = adapter;
+            this.validatesUniqueness("guid", { caseSensitive: false });
+          }
+        }
+        await UuidUniq.loadSchema();
+
+        const uuid = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+        const r1 = await UuidUniq.create({ guid: uuid });
+        expect(r1.isPersisted()).toBe(true);
+
+        // Duplicate — should fail validation, not throw a DB error about lower(uuid).
+        const r2 = new UuidUniq({ guid: uuid });
+        const saved = await r2.save();
+        expect(saved).toBe(false);
+        expect(r2.errors.on("guid")).toBeTruthy();
+
+        // Different UUID — should save fine.
+        const r3 = new UuidUniq({ guid: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" });
+        expect(await r3.save()).toBe(true);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS uuid_uniqueness_validation_test`);
+      }
     });
   });
 

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -316,10 +316,14 @@ function buildRelation(
       // UUID columns are already canonical lowercase — skip LOWER() to match Rails,
       // which returns false from can_perform_case_insensitive_comparison_for? for uuid
       // (PG has no lower(uuid) function). Use plain equality instead.
+      const typeObj =
+        typeof klass.typeForAttribute === "function" ? klass.typeForAttribute(attribute) : null;
       const colType =
-        typeof klass.typeForAttribute === "function"
-          ? (klass.typeForAttribute(attribute) as { type?: string } | null)?.type
-          : null;
+        typeObj == null
+          ? null
+          : typeof (typeObj as any).type === "function"
+            ? (typeObj as any).type()
+            : (typeObj as any).type;
       if (colType !== "uuid") {
         comparison = adapter?.caseInsensitiveComparison?.(attr, bind) ?? null;
         if (comparison == null && typeof value === "string") {

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -313,13 +313,22 @@ function buildRelation(
     } else if (options.caseSensitive) {
       comparison = adapter?.caseSensitiveComparison?.(attr, bind) ?? null;
     } else {
-      comparison = adapter?.caseInsensitiveComparison?.(attr, bind) ?? null;
-      if (comparison == null && typeof value === "string") {
-        // No native CI form — fall back to LOWER() with a lowercased bind.
-        // Keeps the bind parameterized so the prepared-statement cache
-        // stays effective.
-        const lowerBind = pb.buildBindAttribute(attribute, value.toLowerCase());
-        comparison = attr.lower().eq(lowerBind);
+      // UUID columns are already canonical lowercase — skip LOWER() to match Rails,
+      // which returns false from can_perform_case_insensitive_comparison_for? for uuid
+      // (PG has no lower(uuid) function). Use plain equality instead.
+      const colType =
+        typeof klass.typeForAttribute === "function"
+          ? (klass.typeForAttribute(attribute) as { type?: string } | null)?.type
+          : null;
+      if (colType !== "uuid") {
+        comparison = adapter?.caseInsensitiveComparison?.(attr, bind) ?? null;
+        if (comparison == null && typeof value === "string") {
+          // No native CI form — fall back to LOWER() with a lowercased bind.
+          // Keeps the bind parameterized so the prepared-statement cache
+          // stays effective.
+          const lowerBind = pb.buildBindAttribute(attribute, value.toLowerCase());
+          comparison = attr.lower().eq(lowerBind);
+        }
       }
     }
     if (comparison != null && typeof base.where === "function") {


### PR DESCRIPTION
## Summary

- When `caseSensitive: false` is passed for a `uuid` column, Rails skips the `LOWER()` wrapper because PG has no `lower(uuid)` function — `can_perform_case_insensitive_comparison_for?` returns false for uuid types.
- Our `buildRelation` always applied `LOWER()` as a fallback when the adapter had no native case-insensitive comparison, causing PG to throw "function lower(uuid) does not exist".
- Fix: check `typeForAttribute(attribute).type === "uuid"` before the case-insensitive branch and use plain equality instead.

## Test

Un-skipped `"uniqueness validation ignores uuid"` in `uuid.test.ts` (PG-only, runs in CI). The test verifies duplicate detection works with `caseSensitive: false` on a uuid column without a DB error.

## Verification

- `pnpm vitest run .../uniqueness-validation.test.ts` — 100/100
- `pnpm api:compare --package activerecord` — 4955/4958 (99.9%), unchanged
- LOC: 54 additions + deletions