### PR TITLE
feat(activerecord): Serialization Slot B — serialized-column join fixture

### DIFF
--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, serialize } from "./index.js";
-import { Associations, modelRegistry } from "./associations.js";
+import { modelRegistry } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -103,6 +103,7 @@ describe("SerializationTest", () => {
         this.attribute("id", "integer");
         this.attribute("name", "string");
         this.adapter = joinAdapter;
+        this.hasMany("serializedPosts", { className: "SerializedPost", foreignKey: "author_id" });
       }
     }
 
@@ -113,16 +114,13 @@ describe("SerializationTest", () => {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = joinAdapter;
+        this.belongsTo("author", { className: "Author" });
+        serialize(this, "title");
       }
     }
-    serialize(SerializedPost, "title");
 
+    registerModel("Author", Author);
     registerModel("SerializedPost", SerializedPost);
-    Associations.hasMany.call(Author, "serializedPosts", {
-      className: "SerializedPost",
-      foreignKey: "author_id",
-    });
-    Associations.belongsTo.call(SerializedPost, "author", { className: "Author" });
 
     try {
       const author = await Author.create({ name: "David" });
@@ -133,6 +131,7 @@ describe("SerializationTest", () => {
         .toArray();
       expect(results.length).toBe(1);
     } finally {
+      modelRegistry.delete("Author");
       modelRegistry.delete("SerializedPost");
     }
   });

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -3,7 +3,8 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base } from "./index.js";
+import { Base, registerModel, serialize } from "./index.js";
+import { Associations, modelRegistry } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -89,11 +90,51 @@ describe("SerializationTest", () => {
     expect(hash.name).toBe("David");
   });
 
-  it.skip("find records by serialized attributes through join", () => {
-    // BLOCKED: serialization — serialized attribute / YAML gap in serialization
-    // ROOT-CAUSE: serialized-attribute.ts#castForDatabase or YAMLCodec not fully implementing Rails parity
-    // SCOPE: ~30 LOC fix in serialized-attribute.ts; affects ~16 tests in serialization.test.ts
-    /* needs associations + serialized columns */
+  it("find records by serialized attributes through join", async () => {
+    const joinAdapter = freshAdapter();
+    await defineSchema(joinAdapter, {
+      authors: { name: "string" },
+      serialized_posts: { author_id: "integer", title: "string" },
+    });
+
+    class Author extends Base {
+      static {
+        this._tableName = "authors";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = joinAdapter;
+      }
+    }
+
+    class SerializedPost extends Base {
+      static {
+        this._tableName = "serialized_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = joinAdapter;
+      }
+    }
+    serialize(SerializedPost, "title");
+
+    registerModel("SerializedPost", SerializedPost);
+    Associations.hasMany.call(Author, "serializedPosts", {
+      className: "SerializedPost",
+      foreignKey: "author_id",
+    });
+    Associations.belongsTo.call(SerializedPost, "author", { className: "Author" });
+
+    try {
+      const author = await Author.create({ name: "David" });
+      await SerializedPost.create({ author_id: author.id, title: "Hello" });
+
+      const results = await Author.joins("serializedPosts")
+        .where({ name: "David", serialized_posts: { title: "Hello" } })
+        .toArray();
+      expect(results.length).toBe(1);
+    } finally {
+      modelRegistry.delete("SerializedPost");
+    }
   });
 
   // Mirrors ActiveRecord::Serialization#serializable_hash — when a model


### PR DESCRIPTION
## Summary

- Un-skips the `find records by serialized attributes through join` test in `serialization.test.ts`
- Adds inline fixture-style `Author` / `SerializedPost` models with `authors` + `serialized_posts` tables
- Wires `hasMany serializedPosts` on Author, `belongsTo author` on SerializedPost, and calls `serialize(SerializedPost, "title")`
- Verifies that `Author.joins("serializedPosts").where(...)` returns the expected 1 result

Closes the Serialization cluster Slot B from `docs/activerecord-100-clusters.md`.

## Test plan
- [x] `pnpm exec vitest run --project activerecord packages/activerecord/src/serialization.test.ts` — 16/16 pass