### PR TITLE
feat(activerecord): PG connection Slot B — execQuery prepare kwarg + statement_name payload

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -398,7 +398,12 @@ export interface DatabaseAdapter {
   selectValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   selectValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   selectRows(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
-  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
+  ): Promise<Result>;
   execInsert(
     sql: string,
     name?: string | null,

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -3,6 +3,8 @@
  */
 import { it, expect, describe, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, SQLSubscriber } from "./test-helper.js";
+import { QueryAttribute } from "../../relation/query-attribute.js";
+import { Value } from "../../type.js";
 
 describeIfPg("PostgresqlConnectionTest", () => {
   let adapter: PostgreSQLAdapter;
@@ -99,15 +101,32 @@ describeIfPg("PostgresqlConnectionTest", () => {
     expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 
-  it.skip("statement key is logged", async () => {
-    // BLOCKED: prepared-statements — execQuery with prepare:true and statement_name in payload not yet wired
+  it("statement key is logged", async () => {
+    const bind = new QueryAttribute("", 1, new Value());
+    await adapter.execQuery("SELECT $1::integer", "SQL", [bind], { prepare: true });
+
+    const payload = subscriber.payloads.find((p) => p["sql"] === "SELECT $1::integer");
+    const stmtName = payload?.["statement_name"] as string | undefined;
+    expect(stmtName).toBeTruthy();
+
+    const res = await adapter.execQuery(`EXPLAIN (FORMAT JSON) EXECUTE ${stmtName}(1)`);
+    const planType = res.columnTypes["QUERY PLAN"];
+    const plan = planType.deserialize(res.rows[0][0]) as unknown[];
+    expect(plan.length).toBeGreaterThan(0);
   });
 
-  it.skip("prepare false with binds", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires QueryAttribute / Relation::QueryAttribute with prepare: false exec_query path
+  it("prepare false with binds", async () => {
+    const origPrepared = adapter.preparedStatements;
+    adapter.preparedStatements = false;
+    try {
+      const bind = new QueryAttribute("", 42, new Value());
+      const result = await adapter.execQuery("SELECT $1::integer", "SQL", [bind], {
+        prepare: false,
+      });
+      expect(result.rows).toEqual([[42]]);
+    } finally {
+      adapter.preparedStatements = origPrepared;
+    }
   });
 
   it.skip("reconnection after actual disconnection with verify", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -281,7 +281,12 @@ export interface AbstractAdapter {
   selectValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   selectValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   selectRows(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
-  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
+  ): Promise<Result>;
   execInsert(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1119,7 +1119,7 @@ export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
     let v: unknown;
     if (b && typeof b === "object" && "valueForDatabase" in b) {
       const vfd = b.valueForDatabase;
-      v = typeof vfd === "function" ? vfd() : vfd;
+      v = typeof vfd === "function" ? b.valueForDatabase() : vfd;
     } else {
       v = b && typeof b === "object" && "value" in b ? b.value : b;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1291,7 +1291,12 @@ export { deleteStatement as remove };
 interface DatabaseStatementsDefaultsHost {
   execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]>;
   executeMutation(sql: string, binds?: unknown[], name?: string): Promise<number>;
-  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
+  ): Promise<Result>;
 }
 
 export const DatabaseStatements = {
@@ -1361,6 +1366,7 @@ export const DatabaseStatements = {
     sql: string,
     name?: string | null,
     binds?: unknown[],
+    _options?: { prepare?: boolean },
   ): Promise<Result> {
     const rows = await this.execute(sql, binds, name ?? "SQL");
     return Result.fromRowHashes(rows);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1113,9 +1113,13 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
  */
 export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
   return (binds ?? []).map((b: any) => {
+    // Rails: `ActiveModel::Attribute === value ? type_cast(value.value_for_database) : type_cast(value)`
+    // valueForDatabase is a getter on real Attribute instances; handle both getter and
+    // function-style mocks by checking presence with "in" then calling if it's a function.
     let v: unknown;
-    if (b && typeof b === "object" && typeof b.valueForDatabase === "function") {
-      v = b.valueForDatabase();
+    if (b && typeof b === "object" && "valueForDatabase" in b) {
+      const vfd = b.valueForDatabase;
+      v = typeof vfd === "function" ? vfd() : vfd;
     } else {
       v = b && typeof b === "object" && "value" in b ? b.value : b;
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -8,6 +8,7 @@
  * cell values through the right OID::Type.
  */
 import { ValueType } from "@blazetrails/activemodel";
+import { Notifications } from "@blazetrails/activesupport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Result } from "../result.js";
@@ -153,5 +154,67 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     expect(varchar.constructor).not.toBe(ValueType);
     const bigint = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" });
     expect(bigint.constructor).not.toBe(ValueType);
+  });
+});
+
+describe("PostgreSQLAdapter#execQuery prepare override", () => {
+  let adapter: PostgreSQLAdapter;
+  let capturedQueryArg: unknown;
+
+  const INT4_OID = 23;
+  const fakeResult = { fields: [{ name: "n", dataTypeID: INT4_OID }], rows: [[1]] };
+
+  beforeEach(() => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+    adapter.typeMap.aliasType(INT4_OID, "int4");
+    capturedQueryArg = undefined;
+    const fakeClient = {
+      query: async (arg: unknown) => {
+        capturedQueryArg = arg;
+        return fakeResult;
+      },
+      release: () => {},
+    };
+    vi.spyOn(adapter as unknown as { getClient: () => unknown }, "getClient").mockResolvedValue(
+      fakeClient,
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (adapter) await adapter.close().catch(() => undefined);
+  });
+
+  it("prepare:true tags statement_name in the sql.active_record payload", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      payloads.push(event.payload as Record<string, unknown>);
+    });
+    try {
+      adapter.preparedStatements = true;
+      await adapter.execQuery("SELECT 1", "SQL", [42], { prepare: true });
+      const payload = payloads.find((p) => p["sql"] === "SELECT 1");
+      expect(payload?.["statement_name"]).toBeTruthy();
+      expect(typeof payload?.["statement_name"]).toBe("string");
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+  });
+
+  it("prepare:false omits statement_name even when preparedStatements is true", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      payloads.push(event.payload as Record<string, unknown>);
+    });
+    try {
+      adapter.preparedStatements = true;
+      await adapter.execQuery("SELECT 1", "SQL", [42], { prepare: false });
+      const payload = payloads.find((p) => p["sql"] === "SELECT 1");
+      expect(payload?.["statement_name"]).toBeUndefined();
+      // non-prepared path: query arg is an object with text (not a named statement)
+      expect((capturedQueryArg as any)?.name).toBeUndefined();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -655,7 +655,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const payload: Record<string, unknown> = {
       sql: rewritten,
       name: name ?? "SQL",
-      binds: bindArray,
+      binds: binds ?? [],
       type_casted_binds: bindArray,
       connection: this,
       row_count: 0,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -626,7 +626,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * this override is the Rails-faithful PG version that actually
    * populates them.
    */
-  override async execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
+  override async execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
+  ): Promise<Result> {
     // Note: we do NOT call materializeTransactions() here. If a lazy tx
     // is pending but un-materialized, a SELECT against an ad-hoc pool
     // client sees pre-tx state — which is correct read-before-write
@@ -641,17 +646,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       fields: Array<{ name: string; dataTypeID: number }>;
       rows: unknown[][];
     }
-    // Convert any Temporal values to SQL strings before pg sees them.
-    // pg's extended/prepared protocol serializes parameters via its own
-    // writer which has no Temporal support.
-    const bindArray = (binds ?? []).map((v) => temporalToBindString(v, "postgres"));
+    // Type-cast bind objects (QueryAttribute) → primitives, then convert
+    // Temporal values to SQL strings before pg sees them.
+    const castBinds = typeCastedBinds(binds);
+    const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
       sql: rewritten,
       name: name ?? "SQL",
       binds: bindArray,
-      type_casted_binds: typeCastedBinds(bindArray),
+      type_casted_binds: bindArray,
       connection: this,
       row_count: 0,
     };
@@ -665,7 +670,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             // duplicate column names and matching the field-index order.
             // Delegates to `_runQuery` so prepared-statement caching and
             // in-txn / out-of-txn cached-plan handling stay in one place.
-            this._runQuery<ArrayQueryResult>(client, rewritten, bindArray, { rowMode: "array" }),
+            this._runQuery<ArrayQueryResult>(client, rewritten, bindArray, {
+              rowMode: "array",
+              prepareOverride: options?.prepare,
+              onPrepared: (stmtName) => {
+                payload.statement_name = stmtName;
+              },
+            }),
           );
           payload.row_count = r.rows?.length ?? 0;
           return r;
@@ -936,16 +947,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     client: pg.PoolClient,
     sql: string,
     binds: unknown[],
-    extra: { rowMode?: "array" } = {},
+    extra: {
+      rowMode?: "array";
+      prepareOverride?: boolean;
+      onPrepared?: (stmtName: string) => void;
+    } = {},
   ): Promise<R> {
-    const prepare = this._shouldPrepare(binds, client);
+    const { prepareOverride, onPrepared, ...queryExtra } = extra;
+    const prepare =
+      prepareOverride === false ? false : (prepareOverride ?? this._shouldPrepare(binds, client));
     const attempt = async (): Promise<R> => {
       if (prepare) {
-        const name = this._preparedNameFor(client, sql);
-        return (await client.query({ name, text: sql, values: binds, ...extra })) as R;
+        const stmtName = this._preparedNameFor(client, sql);
+        onPrepared?.(stmtName);
+        return (await client.query({
+          name: stmtName,
+          text: sql,
+          values: binds,
+          ...queryExtra,
+        })) as R;
       }
-      if (extra.rowMode) {
-        return (await client.query({ text: sql, values: binds, ...extra })) as R;
+      if (queryExtra.rowMode) {
+        return (await client.query({ text: sql, values: binds, ...queryExtra })) as R;
       }
       return (await client.query(sql, binds)) as R;
     };


### PR DESCRIPTION
## Summary

- Add `options?: { prepare?: boolean }` param to `PostgreSQLAdapter#execQuery`
- When `prepare: true`: allocate/reuse the server-side prepared-statement name and tag `payload.statement_name` in the `sql.active_record` notification (mirrors Rails `perform_query`)
- When `prepare: false`: bypass `_shouldPrepare` and force the `exec_params` (non-prepared) path regardless of `preparedStatements` adapter setting
- Type-cast `QueryAttribute` bind objects via `typeCastedBinds()` before passing primitives to pg — fixes the `prepare: false` with bind-object path
- Un-skip 2 connection tests: `"statement key is logged"` and `"prepare false with binds"`

Follows up on #1439 (Slot A — SQLSubscriber).

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/adapters/postgresql/connection.test.ts` — 5 pass, 29 skipped (PG tests skip locally without a server; CI runs them)
- [ ] `pnpm vitest run packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts` — 9 pass
- [ ] `pnpm api:compare --package activerecord` — 4955/4958 (99.9%, unchanged)
- [ ] Full activerecord suite — 10905 pass, 3133 skipped