### PR TITLE
refactor(activerecord) abstract schema-creation — remove MySQL leakage via this.adapter polymorphic dispatch

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -24,28 +24,8 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
-import {
-  quoteIdentifier as mysqlQuoteIdentifier,
-  quoteTableName as mysqlQuoteTableName,
-} from "../mysql/quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-
-/** @internal */
-function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
-  if (name === "mysql") {
-    return {
-      quoteIdentifier: (n) => mysqlQuoteIdentifier(n),
-      quoteTableName: (n) => mysqlQuoteTableName(n),
-      quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
-    };
-  }
-  return {
-    quoteIdentifier: (n) => abstractQuoteIdentifier(n),
-    quoteTableName: (n) => abstractQuoteTableName(n),
-    quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
-  };
-}
 
 type Definition =
   | TableDefinition
@@ -64,7 +44,11 @@ export class SchemaCreation {
     protected adapterName: "sqlite" | "postgres" | "mysql",
     adapter?: SchemaQuoter,
   ) {
-    this.adapter = adapter ?? quoterForAdapterName(adapterName);
+    this.adapter = adapter ?? {
+      quoteIdentifier: abstractQuoteIdentifier,
+      quoteTableName: abstractQuoteTableName,
+      quoteDefaultExpression: abstractQuoteDefaultExpression,
+    };
   }
 
   protected supportsPartialIndex(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -3,29 +3,9 @@ import {
   quoteTableName as abstractQuoteTableName,
   quoteDefaultExpression as abstractQuoteDefaultExpression,
 } from "./quoting.js";
-import {
-  quoteIdentifier as mysqlQuoteIdentifier,
-  quoteTableName as mysqlQuoteTableName,
-} from "../mysql/quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { singularize, pluralize } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
-
-/** @internal */
-function quoterForAdapterName(name: "sqlite" | "postgres" | "mysql"): SchemaQuoter {
-  if (name === "mysql") {
-    return {
-      quoteIdentifier: (n) => mysqlQuoteIdentifier(n),
-      quoteTableName: (n) => mysqlQuoteTableName(n),
-      quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
-    };
-  }
-  return {
-    quoteIdentifier: (n) => abstractQuoteIdentifier(n),
-    quoteTableName: (n) => abstractQuoteTableName(n),
-    quoteDefaultExpression: (v) => abstractQuoteDefaultExpression(v),
-  };
-}
 
 /**
  * Column type mapping.
@@ -598,7 +578,11 @@ export class TableDefinition {
   ) {
     this.tableName = tableName;
     this._adapterName = tdOptions.adapterName ?? "sqlite";
-    this._adapter = tdOptions.adapter ?? quoterForAdapterName(this._adapterName);
+    this._adapter = tdOptions.adapter ?? {
+      quoteIdentifier: abstractQuoteIdentifier,
+      quoteTableName: abstractQuoteTableName,
+      quoteDefaultExpression: abstractQuoteDefaultExpression,
+    };
     this._id = tdOptions.id ?? true;
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -18,7 +18,8 @@ import {
   TableDefinition,
 } from "../abstract/schema-definitions.js";
 import { singularize, underscore } from "@blazetrails/activesupport";
-import { quoteColumnName, quoteTableName, quoteString as mysqlQuoteString } from "./quoting.js";
+import { quoteIdentifier, quoteTableName, quoteString as mysqlQuoteString } from "./quoting.js";
+import { quoteDefaultExpression } from "../abstract/quoting.js";
 
 /** MySQL-specific column options — extends the abstract ColumnOptions with `onUpdate`. */
 export type MysqlAddColumnOptions = ColumnOptions & { onUpdate?: string };
@@ -45,7 +46,11 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected _mariadb = false;
 
   constructor() {
-    super("mysql");
+    super("mysql", {
+      quoteIdentifier: quoteIdentifier,
+      quoteTableName: quoteTableName,
+      quoteDefaultExpression: quoteDefaultExpression,
+    });
   }
 
   visitAddForeignKey(fromTable: string, toTable: string, options: Record<string, unknown>): string {
@@ -55,8 +60,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const fromIdentifier = fromTable.includes(".") ? fromTable.split(".").pop()! : fromTable;
     const name = (options.name as string) ?? `fk_rails_${fromIdentifier}_${column}`;
 
-    let sql = `ALTER TABLE ${quoteTableName(fromTable)} ADD CONSTRAINT ${quoteColumnName(name)} `;
-    sql += `FOREIGN KEY (${quoteColumnName(column)}) REFERENCES ${quoteTableName(toTable)} (${quoteColumnName(primaryKey)})`;
+    let sql = `ALTER TABLE ${this.adapter.quoteTableName(fromTable)} ADD CONSTRAINT ${this.adapter.quoteIdentifier(name)} `;
+    sql += `FOREIGN KEY (${this.adapter.quoteIdentifier(column)}) REFERENCES ${this.adapter.quoteTableName(toTable)} (${this.adapter.quoteIdentifier(primaryKey)})`;
 
     if (options.onDelete) {
       sql += ` ${this.actionSql("DELETE", options.onDelete as ReferentialAction)}`;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -17,6 +17,8 @@ import type {
   ColumnType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
+import { quoteIdentifier, quoteTableName } from "./quoting.js";
+import { quoteDefaultExpression } from "../abstract/quoting.js";
 
 /**
  * MySQL-specific column type methods mixed into TableDefinition.
@@ -49,7 +51,15 @@ export class TableDefinition extends AbstractTableDefinition {
       collation?: string | null;
     } = {},
   ) {
-    super(tableName, { ...options, adapterName: "mysql" });
+    super(tableName, {
+      ...options,
+      adapterName: "mysql",
+      adapter: {
+        quoteIdentifier: quoteIdentifier,
+        quoteTableName: quoteTableName,
+        quoteDefaultExpression: quoteDefaultExpression,
+      },
+    });
     this.charset = options.charset ?? null;
     this.collation = options.collation ?? null;
   }


### PR DESCRIPTION
## Summary

- Deletes `quoterForAdapterName` from `abstract/schema-definitions.ts` and `abstract/schema-creation.ts` — both files imported MySQL-specific quoting functions solely to build a fallback `SchemaQuoter`
- The abstract-file fallback now uses the abstract quoter inline (no MySQL knowledge required)
- `MySQL::SchemaCreation` constructor now passes a MySQL-specific `SchemaQuoter` to `super()` directly, so `this.adapter` dispatches correctly even when no live adapter object is provided (e.g. in unit tests)

## Test plan

- [ ] `pnpm test` on all three schema-creation test files (mysql, pg, sqlite3) — 38/38 pass
- [ ] `pnpm api:compare --package activerecord` — 4955/4958 (99.9%), no regression