### PR TITLE
fix(activerecord): MySQL quoting Phase 2 — route value-quoting through adapter.quote

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -176,7 +176,7 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
 
   it("adapter.quote escapes injection attempt — single quote, backslash, control chars", async () => {
     const adapter = await makeAdapter();
-    const injection = "'; DROP TABLE users; --";
+    const injection = "'; DROP TABLE users; --\\\0\n\r\x1a";
     const quoted = adapter.quote(injection);
     // Must start and end with surrounding single quotes
     expect(quoted.startsWith("'")).toBe(true);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -153,3 +153,44 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     expect(sql).not.toContain("DEFAULT 'json_array()'");
   });
 });
+
+describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", () => {
+  async function makeAdapter() {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    return Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
+      typeof AbstractMysqlAdapter
+    >;
+  }
+
+  it("adapter.quote(s) wraps result in single quotes", async () => {
+    const adapter = await makeAdapter();
+    const result = adapter.quote("hello");
+    expect(result).toBe("'hello'");
+  });
+
+  it("adapter.quoteString(s) is escape-only — no surrounding quotes", async () => {
+    const adapter = await makeAdapter();
+    const result = adapter.quoteString("hello");
+    expect(result).toBe("hello");
+  });
+
+  it("adapter.quote strips injection attempt — single quote, backslash, control chars", async () => {
+    const adapter = await makeAdapter();
+    const injection = "'; DROP TABLE users; --";
+    const quoted = adapter.quote(injection);
+    // Must start and end with surrounding single quotes
+    expect(quoted.startsWith("'")).toBe(true);
+    expect(quoted.endsWith("'")).toBe(true);
+    // Must not contain an unescaped bare single quote inside (other than surrounding)
+    const inner = quoted.slice(1, -1);
+    expect(inner).not.toMatch(/(?<!')'(?!')/);
+  });
+
+  it("adapter.quote is consistent with standalone quote for strings containing single quotes and backslashes", async () => {
+    const { quote: standaloneQuote } = await import("./mysql/quoting.js");
+    const adapter = await makeAdapter();
+    for (const s of ["it's", "back\\slash", "\0null\nbyte\rreturn\x1aeof", "'; DROP TABLE t; --"]) {
+      expect(adapter.quote(s)).toBe(standaloneQuote(s));
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -174,7 +174,7 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
     expect(result).toBe("hello");
   });
 
-  it("adapter.quote strips injection attempt — single quote, backslash, control chars", async () => {
+  it("adapter.quote escapes injection attempt — single quote, backslash, control chars", async () => {
     const adapter = await makeAdapter();
     const injection = "'; DROP TABLE users; --";
     const quoted = adapter.quote(injection);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -181,9 +181,16 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
     // Must start and end with surrounding single quotes
     expect(quoted.startsWith("'")).toBe(true);
     expect(quoted.endsWith("'")).toBe(true);
-    // Must not contain an unescaped bare single quote inside (other than surrounding)
     const inner = quoted.slice(1, -1);
+    // Single quote must be escaped (no unescaped bare single quote)
     expect(inner).not.toMatch(/(?<!')'(?!')/);
+    // Backslash must be doubled
+    expect(inner).toContain("\\\\");
+    // Control chars must be escaped — no raw bytes
+    expect(inner).not.toContain("\0");
+    expect(inner).not.toContain("\n");
+    expect(inner).not.toContain("\r");
+    expect(inner).not.toContain("\x1a");
   });
 
   it("adapter.quote is consistent with standalone quote for strings containing single quotes and backslashes", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -30,7 +30,6 @@ import {
   type MysqlAddColumnOptions,
 } from "./mysql/schema-creation.js";
 import {
-  quoteString as mysqlQuoteString,
   quote as mysqlQuote,
   typeCast as mysqlTypeCast,
   castBoundValue as mysqlCastBoundValue,
@@ -586,7 +585,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   addSqlCommentBang(sql: string, comment: string): string {
-    if (comment) return `${sql} COMMENT ${mysqlQuoteString(comment)}`;
+    if (comment) return `${sql} COMMENT ${this.quote(comment)}`;
     return sql;
   }
 
@@ -722,9 +721,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * (`abstract/quoting-interface.ts`). Mirrors Rails MySQL
    * `quote_string` (`abstract_mysql_adapter.rb`): backslash-escapes
    * `'` and the control chars MySQL's wire protocol requires (`\0 \n
-   * \r \Z \\`). Distinct from the per-module `mysqlQuoteString`
-   * standalone, which wraps with surrounding `'...'` for SQL-literal
-   * contexts.
+   * \r \Z \\`). Distinct from `quote()`, which wraps with surrounding
+   * `'...'` for SQL-literal contexts.
    */
   override quoteString(s: string): string {
     return s.replace(QUOTE_STRING_RE, (ch) => QUOTE_STRING_MAP[ch] ?? ch);
@@ -1322,7 +1320,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       .join(", ");
     parts.push(`(${quotedCols})`);
     let idxSql = parts.join(" ");
-    if (comment) idxSql += ` COMMENT ${mysqlQuoteString(comment)}`;
+    if (comment) idxSql += ` COMMENT ${this.quote(comment)}`;
     return algorithmSql ? `ADD ${idxSql}, ${algorithmSql}` : `ADD ${idxSql}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -15,7 +15,6 @@ import {
   SQLWarning,
 } from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
-import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
@@ -237,7 +236,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       }
       // Mirrors Rails Mysql2Adapter#initialize: always ensure FOUND_ROWS is set.
       this._poolConfig = { uri, waitTimeout, flags: ["FOUND_ROWS"] };
-      this._driverPool = Mysql2Adapter.newClient(this._poolConfig);
+      this._driverPool = Mysql2Adapter.newClient(
+        this._poolConfig,
+        this._buildConfigureConnectionClauses(),
+      );
       return;
     }
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
@@ -280,7 +282,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       waitTimeout,
       variables,
     };
-    this._driverPool = Mysql2Adapter.newClient(this._poolConfig);
+    this._driverPool = Mysql2Adapter.newClient(
+      this._poolConfig,
+      this._buildConfigureConnectionClauses(),
+    );
   }
 
   /** Returns true for raw mysql2 errors that indicate the database doesn't exist (ER_BAD_DB_ERROR). */
@@ -297,7 +302,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // close() sets _permanentlyClosed so we don't silently reopen after teardown.
     if (!this._driverPool) {
       if (this._permanentlyClosed) throw new Error("Mysql2Adapter: connection is closed");
-      this._driverPool = Mysql2Adapter.newClient(this._poolConfig);
+      this._driverPool = Mysql2Adapter.newClient(
+        this._poolConfig,
+        this._buildConfigureConnectionClauses(),
+      );
       this._activeState = true;
     }
     try {
@@ -1056,7 +1064,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   override reconnectBang(): void {
     if (this._permanentlyClosed) throw new Error("Mysql2Adapter: connection is closed");
     this.disconnectBang();
-    this._driverPool = Mysql2Adapter.newClient(this._poolConfig);
+    this._driverPool = Mysql2Adapter.newClient(
+      this._poolConfig,
+      this._buildConfigureConnectionClauses(),
+    );
     this._activeState = true;
   }
 
@@ -1163,9 +1174,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
          USING (constraint_schema, constraint_name)
        WHERE fk.referenced_column_name IS NOT NULL
          AND fk.table_schema = DATABASE()
-         AND fk.table_name = ${mysqlQuoteString(tableName)}
+         AND fk.table_name = ${this.quote(tableName)}
          AND rc.constraint_schema = DATABASE()
-         AND rc.table_name = ${mysqlQuoteString(tableName)}
+         AND rc.table_name = ${this.quote(tableName)}
        ORDER BY fk.constraint_name, fk.ordinal_position`,
     )) as Array<Record<string, unknown>>;
 
@@ -1267,7 +1278,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return false;
   }
 
-  static newClient(config: mysql.PoolOptions & MysqlAdapterOptions): mysql.Pool {
+  static newClient(config: mysql.PoolOptions & MysqlAdapterOptions, initSql: string): mysql.Pool {
     // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
     // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
     // and a JS number for smaller values. Both are handled by BigIntegerType.cast().
@@ -1277,22 +1288,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Compose our Temporal typeCast with any user-supplied typeCast so callers
     // can still intercept non-temporal fields (e.g. custom ENUM handling) without
     // losing Temporal parsing on temporal columns.
+
     const {
-      strict,
-      waitTimeout,
-      variables: configVars,
       typeCast: userTypeCast,
+      strict: _strict,
+      waitTimeout: _wt,
+      variables: _vars,
       ...poolOptions
     } = config;
-    // Build configure_connection SET clauses before createPool — mirrors AbstractMysqlAdapter#configure_connection.
-    // time_zone is included here so all session setup is sent as ONE query, queued
-    // synchronously in the 'connection' handler before mysql2 adds the connection to its
-    // free-connection list. A second chained rawConn.query() inside the callback of the
-    // first would race against the caller's query (mysql2 makes the connection available
-    // after emitting 'connection', before our callbacks fire).
-    // Computed before createPool so a validation throw (e.g. bad variable name) doesn't leak a live pool.
-    const sessionClauses = buildConfigureConnectionClauses(strict, waitTimeout, configVars);
-    const initSql = `SET time_zone = '+00:00', ${sessionClauses}`;
 
     const composedTypeCast =
       typeof userTypeCast === "function"
@@ -1394,70 +1397,69 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       if (typeof action === "function") action(warning);
     }
   }
-}
 
-// Mirrors AbstractMysqlAdapter#configure_connection.
-// Returns the comma-separated SET clause list (without the SET keyword) for
-// wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
-// The caller prepends additional clauses (e.g. time_zone) so everything is
-// sent as one atomic SET statement.
-function buildConfigureConnectionClauses(
-  strict: boolean | "default" | undefined,
-  waitTimeout: number | string | undefined,
-  configVars: Record<string, string | number | boolean | null | ":default" | "default"> | undefined,
-): string {
-  const vars: Record<string, string | number | boolean | null | ":default" | "default"> = {
-    ...(configVars ?? {}),
-  };
+  // Mirrors AbstractMysqlAdapter#configure_connection.
+  // Returns the comma-separated SET clause list (without the SET keyword) for
+  // wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
+  // The caller prepends additional clauses (e.g. time_zone) so everything is
+  // sent as one atomic SET statement.
+  /** @internal */
+  private _buildConfigureConnectionClauses(): string {
+    const { strict, waitTimeout, variables: configVars } = this._poolConfig;
+    const vars: Record<string, string | number | boolean | null | ":default" | "default"> = {
+      ...(configVars ?? {}),
+    };
 
-  // Validate variable names before interpolating into SQL — matches the pattern used
-  // by PostgreSQLAdapter and SQLite3Adapter to catch misconfigured keys early.
-  const SAFE_VAR_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-  for (const k of Object.keys(vars)) {
-    if (!SAFE_VAR_NAME.test(k)) {
-      throw new Error(`Invalid MySQL session variable name: ${JSON.stringify(k)}`);
+    // Validate variable names before interpolating into SQL — matches the pattern used
+    // by PostgreSQLAdapter and SQLite3Adapter to catch misconfigured keys early.
+    const SAFE_VAR_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+    for (const k of Object.keys(vars)) {
+      if (!SAFE_VAR_NAME.test(k)) {
+        throw new Error(`Invalid MySQL session variable name: ${JSON.stringify(k)}`);
+      }
     }
-  }
 
-  const wt = typeof waitTimeout === "string" ? parseInt(waitTimeout, 10) : waitTimeout;
-  vars["wait_timeout"] = Number.isInteger(wt) ? (wt as number) : 2147483;
+    const wt = typeof waitTimeout === "string" ? parseInt(waitTimeout, 10) : waitTimeout;
+    vars["wait_timeout"] = Number.isInteger(wt) ? (wt as number) : 2147483;
 
-  const DEFAULTS = new Set([":default", "default"]);
+    const DEFAULTS = new Set([":default", "default"]);
 
-  let sqlMode: string | undefined;
-  const varSqlMode = vars["sql_mode"];
-  if (varSqlMode !== undefined && varSqlMode !== null) {
-    // Mirrors Rails: `if sql_mode = variables.delete("sql_mode")` — nil is falsy in Ruby,
-    // so null falls through to the strict-mode branch below.
-    delete vars["sql_mode"];
-    sqlMode = mysqlQuoteString(String(varSqlMode));
-  } else if (!DEFAULTS.has(strict as string)) {
-    if (strict !== false) {
-      sqlMode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')";
+    let sqlMode: string | undefined;
+    const varSqlMode = vars["sql_mode"];
+    if (varSqlMode !== undefined && varSqlMode !== null) {
+      // Mirrors Rails: `if sql_mode = variables.delete("sql_mode")` — nil is falsy in Ruby,
+      // so null falls through to the strict-mode branch below.
+      delete vars["sql_mode"];
+      sqlMode = this.quote(String(varSqlMode));
+    } else if (!DEFAULTS.has(strict as string)) {
+      if (strict !== false) {
+        sqlMode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')";
+      } else {
+        sqlMode = "REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')";
+        sqlMode = `REPLACE(${sqlMode}, 'STRICT_ALL_TABLES', '')`;
+        sqlMode = `REPLACE(${sqlMode}, 'TRADITIONAL', '')`;
+      }
+      sqlMode = `CONCAT(${sqlMode}, ',NO_AUTO_VALUE_ON_ZERO')`;
     } else {
-      sqlMode = "REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')";
-      sqlMode = `REPLACE(${sqlMode}, 'STRICT_ALL_TABLES', '')`;
-      sqlMode = `REPLACE(${sqlMode}, 'TRADITIONAL', '')`;
+      // strict: "default" — sync session to global, counteracting mysql2 Node.js
+      // CLIENT_IGNORE_SPACE flag which otherwise adds IGNORE_SPACE to session sql_mode.
+      sqlMode = "@@GLOBAL.sql_mode";
     }
-    sqlMode = `CONCAT(${sqlMode}, ',NO_AUTO_VALUE_ON_ZERO')`;
-  } else {
-    // strict: "default" — sync session to global, counteracting mysql2 Node.js
-    // CLIENT_IGNORE_SPACE flag which otherwise adds IGNORE_SPACE to session sql_mode.
-    sqlMode = "@@GLOBAL.sql_mode";
+
+    const sqlModeClause = sqlMode ? `@@SESSION.sql_mode = ${sqlMode}` : "";
+
+    const varClauses = Object.entries(vars)
+      .filter(([, v]) => v !== null && v !== undefined)
+      .map(([k, v]) => {
+        if (DEFAULTS.has(String(v))) return `@@SESSION.${k} = DEFAULT`;
+        if (typeof v === "number") return `@@SESSION.${k} = ${v}`;
+        if (typeof v === "boolean") return `@@SESSION.${k} = '${v ? 1 : 0}'`;
+        return `@@SESSION.${k} = ${this.quote(String(v))}`;
+      });
+
+    const sessionClauses = [sqlModeClause, ...varClauses].filter(Boolean).join(", ");
+    return `SET time_zone = '+00:00', ${sessionClauses}`;
   }
-
-  const sqlModeClause = sqlMode ? `@@SESSION.sql_mode = ${sqlMode}` : "";
-
-  const varClauses = Object.entries(vars)
-    .filter(([, v]) => v !== null && v !== undefined)
-    .map(([k, v]) => {
-      if (DEFAULTS.has(String(v))) return `@@SESSION.${k} = DEFAULT`;
-      if (typeof v === "number") return `@@SESSION.${k} = ${v}`;
-      if (typeof v === "boolean") return `@@SESSION.${k} = '${v ? 1 : 0}'`;
-      return `@@SESSION.${k} = ${mysqlQuoteString(String(v))}`;
-    });
-
-  return [sqlModeClause, ...varClauses].filter(Boolean).join(", ");
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -236,10 +236,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       }
       // Mirrors Rails Mysql2Adapter#initialize: always ensure FOUND_ROWS is set.
       this._poolConfig = { uri, waitTimeout, flags: ["FOUND_ROWS"] };
-      this._driverPool = Mysql2Adapter.newClient(
-        this._poolConfig,
-        this._buildConfigureConnectionClauses(),
-      );
+      this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
       return;
     }
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
@@ -282,10 +279,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       waitTimeout,
       variables,
     };
-    this._driverPool = Mysql2Adapter.newClient(
-      this._poolConfig,
-      this._buildConfigureConnectionClauses(),
-    );
+    this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
   }
 
   /** Returns true for raw mysql2 errors that indicate the database doesn't exist (ER_BAD_DB_ERROR). */
@@ -302,10 +296,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // close() sets _permanentlyClosed so we don't silently reopen after teardown.
     if (!this._driverPool) {
       if (this._permanentlyClosed) throw new Error("Mysql2Adapter: connection is closed");
-      this._driverPool = Mysql2Adapter.newClient(
-        this._poolConfig,
-        this._buildConfigureConnectionClauses(),
-      );
+      this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
       this._activeState = true;
     }
     try {
@@ -1064,10 +1055,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   override reconnectBang(): void {
     if (this._permanentlyClosed) throw new Error("Mysql2Adapter: connection is closed");
     this.disconnectBang();
-    this._driverPool = Mysql2Adapter.newClient(
-      this._poolConfig,
-      this._buildConfigureConnectionClauses(),
-    );
+    this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
     this._activeState = true;
   }
 
@@ -1404,7 +1392,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // for wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
   // Called before createPool so a validation throw doesn't leak a live pool.
   /** @internal */
-  private _buildConfigureConnectionClauses(): string {
+  private _buildInitSql(): string {
     const { strict, waitTimeout, variables: configVars } = this._poolConfig;
     const vars: Record<string, string | number | boolean | null | ":default" | "default"> = {
       ...(configVars ?? {}),

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1278,6 +1278,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return false;
   }
 
+  /** @internal */
   static newClient(config: mysql.PoolOptions & MysqlAdapterOptions, initSql: string): mysql.Pool {
     // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
     // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
@@ -1399,10 +1400,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   // Mirrors AbstractMysqlAdapter#configure_connection.
-  // Returns the comma-separated SET clause list (without the SET keyword) for
-  // wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
-  // The caller prepends additional clauses (e.g. time_zone) so everything is
-  // sent as one atomic SET statement.
+  // Builds and returns the full SET statement (including the SET keyword and time_zone)
+  // for wait_timeout, sql_mode (per strict flag), and arbitrary session variables.
+  // Called before createPool so a validation throw doesn't leak a live pool.
   /** @internal */
   private _buildConfigureConnectionClauses(): string {
     const { strict, waitTimeout, variables: configVars } = this._poolConfig;


### PR DESCRIPTION
## Summary

- Routes all 5 value-quoting call sites from the standalone `mysqlQuoteString` import through `this.quote()` so they use the same escape path as the rest of the adapter
- Promotes `buildConfigureConnectionClauses` from a module-level free function to a private instance method `_buildConfigureConnectionClauses()` so `this` is in scope for lines 1433/1457; `static newClient` now accepts a pre-computed `initSql: string` instead of computing it internally
- Removes the unused `quoteString as mysqlQuoteString` imports from both `abstract-mysql-adapter.ts` and `mysql2-adapter.ts`
- Adds 4 quoting consistency tests confirming `adapter.quote`/`quoteString` contract and injection safety

## Context

Phase 1 (PR #1442) introduced `AbstractMysqlAdapter.quoteString` as escape-only (no surrounding quotes) while the standalone module `quoteString` from `mysql/quoting.ts` wraps with `'...'`. This divergence means `adapter.quote(x)` and `adapter.quoteString(x)` produce different strings for the same input. This PR closes the gap at the call sites by routing them through `adapter.quote()` which is the correct SQL-literal interface.

The standalone `quoteString` export is intentionally NOT deleted — that is Phase 3.

## Test plan

- [ ] `pnpm run test -- run src/connection-adapters/abstract-mysql-adapter.test.ts` — all 4 new quoting tests pass
- [ ] `pnpm api:compare --package activerecord` — 4955/4958 (no regression)