### PR TITLE
feat(activerecord): Column#default lazy-deserialize — dumper-layer deserialize plus model-instance cast

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -52,7 +52,7 @@ describe("SchemaDumper schemaDefault with adapter type deserialize", () => {
       { hasDefault: true, default: "1", type: "boolean" },
       new BooleanType(),
     );
-    expect(result).toMatch(/^(true|false|1|0)$/);
+    expect(result).toBe("true");
   });
 
   it("text column with raw string default keeps quoted string", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SchemaDumper } from "./schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
+import { IntegerType, DecimalType, BooleanType, StringType } from "@blazetrails/activemodel";
 
 const emptySource: SchemaSource = {
   tables: () => [],
@@ -21,5 +22,60 @@ describe("SchemaDumper", () => {
 
   it("DEFAULT_DATETIME_PRECISION is 6", () => {
     expect(SchemaDumper.DEFAULT_DATETIME_PRECISION).toBe(6);
+  });
+});
+
+describe("SchemaDumper schemaDefault with adapter type deserialize", () => {
+  function makeAdapterDumper(
+    column: Record<string, unknown>,
+    type:
+      | InstanceType<typeof IntegerType>
+      | InstanceType<typeof DecimalType>
+      | InstanceType<typeof BooleanType>
+      | InstanceType<typeof StringType>,
+  ) {
+    const adapter = { lookupCastTypeFromColumn: () => type };
+    const dumper = SchemaDumper.create(adapter as any);
+    return (dumper as any).schemaDefault(column) as string | undefined;
+  }
+
+  it("integer column with raw string default deserializes to number literal", () => {
+    const result = makeAdapterDumper(
+      { hasDefault: true, default: "5", type: "integer" },
+      new IntegerType(),
+    );
+    expect(result).toBe("5");
+  });
+
+  it("boolean column with raw string default deserializes to true/false literal", () => {
+    const result = makeAdapterDumper(
+      { hasDefault: true, default: "1", type: "boolean" },
+      new BooleanType(),
+    );
+    expect(result).toMatch(/^(true|false|1|0)$/);
+  });
+
+  it("text column with raw string default keeps quoted string", () => {
+    const result = makeAdapterDumper(
+      { hasDefault: true, default: "hello", type: "string" },
+      new StringType(),
+    );
+    expect(result).toBe('"hello"');
+  });
+
+  it("decimal column with raw string default rounds via type", () => {
+    const result = makeAdapterDumper(
+      { hasDefault: true, default: "2.789", type: "decimal" },
+      new DecimalType({ precision: 5, scale: 2 }),
+    );
+    expect(result).toBe('"2.79"');
+  });
+
+  it("null default falls through to schemaExpression", () => {
+    const result = makeAdapterDumper(
+      { hasDefault: true, default: null, defaultFunction: "uuid()" },
+      new StringType(),
+    );
+    expect(result).toContain("uuid()");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -119,9 +119,11 @@ export class SchemaDumper extends BaseSchemaDumper {
     const adapter = this._adapter();
     if (adapter?.lookupCastTypeFromColumn) {
       const type = adapter.lookupCastTypeFromColumn(column);
-      const deserialized = type.deserialize(column.default);
-      if (deserialized == null) return this.schemaExpression(column);
-      return type.typeCastForSchema(deserialized);
+      if (type != null && typeof type.deserialize === "function") {
+        const deserialized = type.deserialize(column.default);
+        if (deserialized == null) return this.schemaExpression(column);
+        return type.typeCastForSchema(deserialized);
+      }
     }
     if (typeof column.default === "string") return JSON.stringify(column.default);
     return String(column.default);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -121,9 +121,7 @@ export class SchemaDumper extends BaseSchemaDumper {
       const type = adapter.lookupCastTypeFromColumn(column);
       const deserialized = type.deserialize(column.default);
       if (deserialized == null) return this.schemaExpression(column);
-      if (typeof type.typeCastForSchema === "function") {
-        return type.typeCastForSchema(deserialized);
-      }
+      return type.typeCastForSchema(deserialized);
     }
     if (typeof column.default === "string") return JSON.stringify(column.default);
     return String(column.default);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -16,6 +16,8 @@ interface Column extends ColumnInfo {
   hasDefault?: boolean;
   defaultFunction?: string | null;
   comment?: string | null;
+  /** Raw SQL type string (e.g. "integer", "varchar(255)") — present on all schema-reflected columns. */
+  sqlType?: string | null;
 }
 
 export class SchemaDumper extends BaseSchemaDumper {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -116,9 +116,23 @@ export class SchemaDumper extends BaseSchemaDumper {
   protected schemaDefault(column: Column): string | undefined {
     if (!column.hasDefault && column.default === undefined) return undefined;
     if (column.default == null) return this.schemaExpression(column);
-    // Represent the default as its schema literal
+    const adapter = this._adapter();
+    if (adapter?.lookupCastTypeFromColumn) {
+      const type = adapter.lookupCastTypeFromColumn(column);
+      const deserialized = type.deserialize(column.default);
+      if (deserialized == null) return this.schemaExpression(column);
+      if (typeof type.typeCastForSchema === "function") {
+        return type.typeCastForSchema(deserialized);
+      }
+    }
     if (typeof column.default === "string") return JSON.stringify(column.default);
     return String(column.default);
+  }
+
+  /** @internal */
+  protected _adapter(): any {
+    const src = (this as any)._source;
+    return src?.adapter ?? src;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -60,28 +60,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
     return this.schemaType(column);
   }
 
-  /**
-   * Mirrors Rails' AbstractAdapter::SchemaDumper#schema_default:
-   *   type = @connection.lookup_cast_type_from_column(column)
-   *   default = type.deserialize(column.default)
-   *   type.type_cast_for_schema(default)
-   * @internal
-   */
-  protected override schemaDefault(column: Column): string | undefined {
-    if (!column.hasDefault) return undefined;
-    if (column.default == null) return this.schemaExpression(column);
-    const adapter = this.pgAdapter();
-    if (adapter?.lookupCastTypeFromColumn) {
-      const type = adapter.lookupCastTypeFromColumn(column);
-      const deserialized = type.deserialize(column.default);
-      if (deserialized == null) return this.schemaExpression(column);
-      if (typeof type.typeCastForSchema === "function") {
-        return type.typeCastForSchema(deserialized);
-      }
-    }
-    return super.schemaDefault(column as any);
-  }
-
   /** @internal */
   protected override schemaExpression(column: Column): string | undefined {
     if (column.isSerial) return undefined;
@@ -189,8 +167,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   private pgAdapter(): any {
-    const src = (this as any)._source;
-    // AdapterSchemaSource wraps the adapter; raw adapter passed directly (e.g. createSchemaDumper)
-    return src?.adapter ?? src;
+    return this._adapter();
   }
 }

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -295,35 +295,56 @@ describe("DefaultTest", () => {
   });
 
   it("default attribute value for datetime", async () => {
-    const adp = freshAdapter();
-    await defineSchema(adp, {
-      events: { start_at: { type: "datetime", default: "2024-01-15 10:00:00" } },
-    });
+    // Verify Change 2: raw datetime string default is deserialized through DateTimeType
+    // so the model default is a Temporal.PlainDateTime, not the raw DB string.
+    const { DateTimeType } = await import("@blazetrails/activemodel");
+    const dtType = new DateTimeType();
+    const mockAdapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => ({
+          start_at: { name: "start_at", sqlType: "datetime", default: "2024-01-15 10:00:00" },
+        }),
+        getCachedColumnsHash: () => undefined,
+        isCached: () => false,
+      },
+      lookupCastTypeFromColumn: () => dtType,
+    };
     class Event extends Base {
       static override tableName = "events";
-      static {
-        this.adapter = adp;
-      }
     }
+    (Event as any).adapter = mockAdapter;
     await loadSchemaFromAdapter.call(Event);
     const val = new Event().start_at;
-    // After Change 2 the default is cast through the type; for SQLite datetime→string columns
-    // the cast returns a Temporal.PlainDateTime (SQLiteDateTimeType) or Date-like object,
-    // not the raw string.
-    expect(typeof val === "string" ? val : String(val)).toContain("2024");
+    // DateTimeType.deserialize("2024-01-15 10:00:00") → Temporal.PlainDateTime
+    expect(val).not.toBeNull();
+    expect(String(val)).toContain("2024");
   });
   it("default attribute value for date", async () => {
-    const adp = freshAdapter();
-    await defineSchema(adp, { events: { on_date: { type: "date", default: "2024-06-01" } } });
+    // Verify Change 2: raw date string default is deserialized through DateType
+    // so the model default is a Temporal.PlainDate, not the raw DB string.
+    const { DateType } = await import("@blazetrails/activemodel");
+    const dateType = new DateType();
+    const mockAdapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => ({
+          on_date: { name: "on_date", sqlType: "date", default: "2024-06-01" },
+        }),
+        getCachedColumnsHash: () => undefined,
+        isCached: () => false,
+      },
+      lookupCastTypeFromColumn: () => dateType,
+    };
     class Event extends Base {
       static override tableName = "events";
-      static {
-        this.adapter = adp;
-      }
     }
+    (Event as any).adapter = mockAdapter;
     await loadSchemaFromAdapter.call(Event);
     const val = new Event().on_date;
-    expect(typeof val === "string" ? val : String(val)).toContain("2024");
+    // DateType.deserialize("2024-06-01") → Temporal.PlainDate
+    expect(val).not.toBeNull();
+    expect(String(val)).toContain("2024");
   });
   it("default attribute value for decimal", async () => {
     // Verify Change 2: column.default "2.78" is cast through DecimalType so

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -347,7 +347,7 @@ describe("DefaultTest", () => {
     expect(String(val)).toContain("2024");
   });
   it("default attribute value for decimal", async () => {
-    // Verify Change 2: column.default "2.78" is cast through DecimalType so
+    // Verify Change 2: column.default "2.789" is deserialized through DecimalType so
     // the model default is the typed decimal string, not the raw DB string.
     const { DecimalType } = await import("@blazetrails/activemodel");
     const decimalType = new DecimalType({ precision: 5, scale: 2 });

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -295,9 +295,10 @@ describe("DefaultTest", () => {
   });
 
   it("default attribute value for datetime", async () => {
-    // Verify Change 2: raw datetime string default is deserialized through DateTimeType
-    // so the model default is a Temporal.PlainDateTime, not the raw DB string.
+    // Attribute.fromDatabase passes the raw column default through type.deserialize,
+    // so a datetime string default becomes a Temporal.Instant on the model instance.
     const { DateTimeType } = await import("@blazetrails/activemodel");
+    const { Temporal } = await import("@blazetrails/activesupport/temporal");
     const dtType = new DateTimeType();
     const mockAdapter = {
       schemaCache: {
@@ -316,14 +317,14 @@ describe("DefaultTest", () => {
     (Event as any).adapter = mockAdapter;
     await loadSchemaFromAdapter.call(Event);
     const val = new Event().start_at;
-    // DateTimeType.deserialize("2024-01-15 10:00:00") → Temporal.PlainDateTime
-    expect(val).not.toBeNull();
-    expect(String(val)).toContain("2024");
+    // DateTimeType.deserialize("2024-01-15 10:00:00") → Temporal.Instant
+    expect(val).toBeInstanceOf(Temporal.Instant);
   });
   it("default attribute value for date", async () => {
-    // Verify Change 2: raw date string default is deserialized through DateType
-    // so the model default is a Temporal.PlainDate, not the raw DB string.
+    // Attribute.fromDatabase passes the raw column default through type.deserialize,
+    // so a date string default becomes a Temporal.PlainDate on the model instance.
     const { DateType } = await import("@blazetrails/activemodel");
+    const { Temporal } = await import("@blazetrails/activesupport/temporal");
     const dateType = new DateType();
     const mockAdapter = {
       schemaCache: {
@@ -343,12 +344,11 @@ describe("DefaultTest", () => {
     await loadSchemaFromAdapter.call(Event);
     const val = new Event().on_date;
     // DateType.deserialize("2024-06-01") → Temporal.PlainDate
-    expect(val).not.toBeNull();
-    expect(String(val)).toContain("2024");
+    expect(val).toBeInstanceOf(Temporal.PlainDate);
   });
   it("default attribute value for decimal", async () => {
-    // Verify Change 2: column.default "2.789" is deserialized through DecimalType so
-    // the model default is the typed decimal string, not the raw DB string.
+    // Attribute.fromDatabase passes raw column default "2.789" through type.deserialize,
+    // so the model default is the rounded decimal "2.79", not the raw DB string.
     const { DecimalType } = await import("@blazetrails/activemodel");
     const decimalType = new DecimalType({ precision: 5, scale: 2 });
     const mockAdapter = {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
+import { loadSchemaFromAdapter } from "./model-schema.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -24,76 +25,33 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("MysqlDefaultExpressionTest", () => {
   it.skip("schema dump includes default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `defaults` table
+    // (uuid column with DEFAULT uuid() expression). Test adapter uses SQLite; no MySQL fixture infra.
   });
   it.skip("schema dump includes default expression with single quotes reflected correctly", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `defaults` table
+    // (char2_concatenated column with DEFAULT CONCAT expression). No MySQL fixture infra.
   });
   it.skip("schema dump datetime includes default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `datetime_defaults` table.
   });
   it.skip("schema dump datetime includes precise default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `datetime_defaults` table.
   });
   it.skip("schema dump datetime includes precise default expression with on update", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `datetime_defaults` table.
   });
   it.skip("schema dump timestamp includes default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `timestamp_defaults` table.
   });
   it.skip("schema dump timestamp includes precise default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `timestamp_defaults` table.
   });
   it.skip("schema dump timestamp includes precise default expression with on update", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `timestamp_defaults` table.
   });
   it.skip("schema dump timestamp without default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires MySQL live connection with pre-existing `timestamp_defaults` table.
   });
 });
 
@@ -205,22 +163,12 @@ describe("DefaultTest", () => {
 
 describe("DefaultsTestWithoutTransactionalFixtures", () => {
   it.skip("mysql not null defaults non strict", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
-    /* fixture-dependent */
+    // BLOCKED: fixture — requires MySQL live connection + strict-mode toggle via `establish_connection`.
+    // No MySQL adapter in test environment; strict-mode reconfiguration not supported in test harness.
   });
   it.skip("mysql not null defaults strict", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
-    /* fixture-dependent */
+    // BLOCKED: fixture — requires MySQL live connection + strict-mode toggle via `establish_connection`.
+    // No MySQL adapter in test environment; strict-mode reconfiguration not supported in test harness.
   });
 });
 
@@ -288,36 +236,32 @@ describe("DefaultStringsTest", () => {
 
 describe("PostgresqlDefaultExpressionTest", () => {
   it.skip("schema dump includes default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires PostgreSQL live connection with pre-existing `defaults` table
+    // (modified_date/modified_time CURRENT_DATE/CURRENT_TIMESTAMP expressions). No PG fixture infra.
   });
 });
 
 describe("Sqlite3DefaultExpressionTest", () => {
   it.skip("schema dump includes default expression", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+    // BLOCKED: fixture — requires pre-existing `defaults` table with expression defaults
+    // (CURRENT_DATE, CURRENT_TIMESTAMP, ABS(RANDOM())). No fixture-table infra in test adapter.
   });
 });
 
 describe("DefaultTest", () => {
   const adapter = freshAdapter();
 
-  it.skip("default attribute value overrides from database", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+  it("default attribute value overrides from database", async () => {
+    const adp = freshAdapter();
+    await defineSchema(adp, { items: { count: { type: "integer", default: 7 } } });
+    class Item extends Base {
+      static override tableName = "items";
+      static {
+        this.adapter = adp;
+      }
+    }
+    await loadSchemaFromAdapter.call(Item);
+    expect(new Item().count).toBe(7);
   });
 
   it("default attribute value for integer", () => {
@@ -350,29 +294,61 @@ describe("DefaultTest", () => {
     expect(new M().active).toBe(true);
   });
 
-  it.skip("default attribute value for datetime", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+  it("default attribute value for datetime", async () => {
+    const adp = freshAdapter();
+    await defineSchema(adp, {
+      events: { start_at: { type: "datetime", default: "2024-01-15 10:00:00" } },
+    });
+    class Event extends Base {
+      static override tableName = "events";
+      static {
+        this.adapter = adp;
+      }
+    }
+    await loadSchemaFromAdapter.call(Event);
+    const val = new Event().start_at;
+    // After Change 2 the default is cast through the type; for SQLite datetime→string columns
+    // the cast returns a Temporal.PlainDateTime (SQLiteDateTimeType) or Date-like object,
+    // not the raw string.
+    expect(typeof val === "string" ? val : String(val)).toContain("2024");
   });
-  it.skip("default attribute value for date", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+  it("default attribute value for date", async () => {
+    const adp = freshAdapter();
+    await defineSchema(adp, { events: { on_date: { type: "date", default: "2024-06-01" } } });
+    class Event extends Base {
+      static override tableName = "events";
+      static {
+        this.adapter = adp;
+      }
+    }
+    await loadSchemaFromAdapter.call(Event);
+    const val = new Event().on_date;
+    expect(typeof val === "string" ? val : String(val)).toContain("2024");
   });
-  it.skip("default attribute value for decimal", () => {
-    // BLOCKED: schema — Column#default not deserialized at schema-dump time
-    // ROOT-CAUSE: newColumnFromField stores raw string (e.g. "5") in column.default; schema dump
-    //   then emits a quoted string instead of the typed value. Fix requires lookupCastType to return
-    //   a type object with deserialize() (currently returns shape-only metadata), then Column stores
-    //   raw + lazily deserializes via castType.deserialize(rawDefault).
-    // SCOPE: ~50 LOC — change lookupCastType return type + Column constructor + newColumnFromField call site
+  it("default attribute value for decimal", async () => {
+    // Verify Change 2: column.default "2.78" is cast through DecimalType so
+    // the model default is the typed decimal string, not the raw DB string.
+    const { DecimalType } = await import("@blazetrails/activemodel");
+    const decimalType = new DecimalType({ precision: 5, scale: 2 });
+    const mockAdapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => ({
+          amount: { name: "amount", sqlType: "decimal(5,2)", default: "2.789" },
+        }),
+        getCachedColumnsHash: () => undefined,
+        isCached: () => false,
+      },
+      lookupCastTypeFromColumn: () => decimalType,
+    };
+    class Order extends Base {
+      static override tableName = "orders";
+    }
+    (Order as any).adapter = mockAdapter;
+    await loadSchemaFromAdapter.call(Order);
+    const val = new Order().amount;
+    // "2.789" cast through DecimalType(scale:2) → "2.79" (rounded to 2 decimal places)
+    expect(val).toBe("2.79");
   });
 
   it("default value for float", () => {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -709,7 +709,7 @@ function applyColumnsHash(
     }
 
     const rawDefault = (column as { default?: unknown }).default ?? null;
-    const defaultValue = rawDefault != null ? (type as any).deserialize(rawDefault) : rawDefault;
+    const defaultValue = rawDefault != null ? type.deserialize(rawDefault) : rawDefault;
     const colLimit = (column as { limit?: number | null }).limit ?? null;
 
     host._attributeDefinitions.set(name, {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -709,10 +709,7 @@ function applyColumnsHash(
     }
 
     const rawDefault = (column as { default?: unknown }).default ?? null;
-    const defaultValue =
-      rawDefault != null && typeof (type as any).cast === "function"
-        ? (type as any).cast(rawDefault)
-        : rawDefault;
+    const defaultValue = rawDefault != null ? (type as any).deserialize(rawDefault) : rawDefault;
     const colLimit = (column as { limit?: number | null }).limit ?? null;
 
     host._attributeDefinitions.set(name, {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -708,8 +708,7 @@ function applyColumnsHash(
       type = existingType.withInnerType(type);
     }
 
-    const rawDefault = (column as { default?: unknown }).default ?? null;
-    const defaultValue = rawDefault != null ? type.deserialize(rawDefault) : rawDefault;
+    const defaultValue = (column as { default?: unknown }).default ?? null;
     const colLimit = (column as { limit?: number | null }).limit ?? null;
 
     host._attributeDefinitions.set(name, {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -708,7 +708,11 @@ function applyColumnsHash(
       type = existingType.withInnerType(type);
     }
 
-    const defaultValue = (column as { default?: unknown }).default ?? null;
+    const rawDefault = (column as { default?: unknown }).default ?? null;
+    const defaultValue =
+      rawDefault != null && typeof (type as any).cast === "function"
+        ? (type as any).cast(rawDefault)
+        : rawDefault;
     const colLimit = (column as { limit?: number | null }).limit ?? null;
 
     host._attributeDefinitions.set(name, {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1059,6 +1059,10 @@ class SchemaAdapter implements DatabaseAdapter {
     return undefined;
   }
 
+  lookupCastTypeFromColumn(column: unknown): unknown {
+    return (this.inner as any).lookupCastTypeFromColumn?.(column);
+  }
+
   async cleanup(): Promise<void> {
     await dropTrackedTables(this.inner);
   }


### PR DESCRIPTION
## Summary

- **Change 1 (schema dump)**: `BaseSchemaDumper.schemaDefault` now calls `adapter.lookupCastTypeFromColumn(column)` → `type.deserialize(column.default)` → `type.typeCastForSchema(deserialized)`, matching Rails' `abstract/schema_dumper.rb` flow. The identical PG-specific `schemaDefault` override is removed since the base handles it. `SchemaAdapter` (test adapter) delegates `lookupCastTypeFromColumn` to inner.
- **Change 2 (model instances)**: `applyColumnsHash` casts `column.default` through `type.cast()` before storing as `defaultValue`, so model instances see typed values (`7` not `"7"` for integer columns with DB defaults).
- **Tests**: 4 skipped `DefaultTest` tests unskipped with implementations. 13 fixture-dependent skips updated with sharpened infra-blocked reason (MySQL/PG live fixtures required). 5 regression tests added to `abstract/schema-dumper.test.ts` covering integer/decimal/boolean/text/null-default paths.

## Follow-ups

- MySQL/PG/SQLite schema-dump tests (13 skipped) remain fixture-blocked — require pre-existing `defaults`/`datetime_defaults`/`timestamp_defaults` tables via live adapter connections.