### PR TITLE
refactor(activerecord) MySQL quoting Phase 4 — module-mixin conversion for thin delegates

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -230,37 +230,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `quote()` returns `"1"`, breaking call sites that switch between
    * the two through the Quoting interface.
    */
-  override quoteIdentifier(name: string): string {
-    return mysqlQuoteIdentifier(name);
-  }
-
-  override quoteTableName(name: string): string {
-    return mysqlQuoteTableName(name);
-  }
-
-  override quoteColumnName(name: string): string {
-    return mysqlQuoteColumnName(name);
-  }
+  override quoteIdentifier = mysqlQuoteIdentifier;
+  override quoteTableName = mysqlQuoteTableName;
+  override quoteColumnName = mysqlQuoteColumnName;
+  override quotedTrue = mysqlQuotedTrue;
+  override quotedFalse = mysqlQuotedFalse;
+  override unquotedTrue = mysqlUnquotedTrue;
+  override unquotedFalse = mysqlUnquotedFalse;
 
   /** @internal */
   override get arelVisitor(): Visitors.ToSql {
     return new Visitors.MySQL(this);
-  }
-
-  override quotedTrue(): string {
-    return mysqlQuotedTrue();
-  }
-
-  override quotedFalse(): string {
-    return mysqlQuotedFalse();
-  }
-
-  override unquotedTrue(): number {
-    return mysqlUnquotedTrue();
-  }
-
-  override unquotedFalse(): number {
-    return mysqlUnquotedFalse();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -214,7 +214,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * MySQL dialect overrides — backtick identifiers and integer bool
    * coercion. Matches Rails:
    *
-   * - `quote_column_name` / `quote_table_name` — backticks
+   * - `quote_column_name` / `quote_table_name` / `quote_identifier` — backticks
    *   (`mysql/quoting.rb:48-53`).
    * - `unquoted_true` / `unquoted_false` → `1` / `0`
    *   (`mysql/quoting.rb:72-77`).
@@ -223,10 +223,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * these — it inherits `"TRUE"`/`"FALSE"` from `abstract/quoting.rb:166`.
    * Trails MySQL's per-module standalone returns `"1"`/`"0"` (a
    * pre-existing trails-vs-Rails divergence; not addressed here). We
-   * override on the adapter so `quote(true)` and `quotedTrue()` agree
-   * (both `"1"` via the per-module standalone). Without the override
-   * the adapter
-   * would inherit AbstractAdapter#quotedTrue (`"TRUE"`) while
+   * assign them here so `quote(true)` and `quotedTrue()` agree (both
+   * `"1"` via the per-module standalone). Without the assignment the
+   * adapter would inherit AbstractAdapter#quotedTrue (`"TRUE"`) while
    * `quote()` returns `"1"`, breaking call sites that switch between
    * the two through the Quoting interface.
    */


### PR DESCRIPTION
## Summary

- Converts 7 one-line delegate methods on `AbstractMysqlAdapter` (`quoteIdentifier`, `quoteTableName`, `quoteColumnName`, `quotedTrue`, `quotedFalse`, `unquotedTrue`, `unquotedFalse`) into direct class property assignments per the CLAUDE.md module-mixin pattern
- Eliminates the per-method wrapper indirection that caused the original quoting divergence in #1442
- `quote`, `typeCast`, `quoteString`, and `quoteTableNameForAssignment` remain as explicit overrides (non-trivial logic or `this`-dependent dispatch)

This closes out the MySQL quoting consolidation cluster (Phases 1–4). Triage can mark the cluster complete once this lands.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/mysql` — 146 tests pass
- [x] `pnpm api:compare --package activerecord` — abstract-mysql-adapter.rb still at 100%
- [x] Lint + typecheck clean (pre-commit hook passed)