### PR TITLE
refactor(activerecord) query-cache Phase 1 — context-keyed registry plus pin wiring plus checkout/checkin cache attachment

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -523,10 +523,14 @@ export class ConnectionPool implements ReapablePool {
       if (this._connections && !this._connections.includes(pin.connection)) {
         this._connections.push(pin.connection);
       }
+      (pin.connection as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
       return pin.connection;
     }
     const conn = this._tryAcquire();
-    if (conn) return conn;
+    if (conn) {
+      (conn as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+      return conn;
+    }
 
     const t = timeout ?? this.checkoutTimeout;
     if (!this._available) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -18,8 +18,9 @@ import { SchemaReflection, BoundSchemaReflection } from "../schema-cache.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
 import { ConnectionLeasingQueue } from "./connection-pool/queue.js";
-import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
 import type { TransactionManager } from "./transaction.js";
+import { ConnectionPoolConfiguration, QueryCache, type QueryCacheHost } from "./query-cache.js";
+import { executionContextId } from "./connection-pool/execution-context.js";
 import { SchemaMigration } from "../../schema-migration.js";
 import { InternalMetadata } from "../../internal-metadata.js";
 import { MigrationContext } from "../../migration.js";
@@ -40,26 +41,7 @@ interface PoolManagedConnection {
   expire?(): void;
 }
 
-let _contextIdCounter = 0;
-let _contextStorage: AsyncContext<number> | null = null;
-
-function executionContextId(): number {
-  if (!_contextStorage) {
-    _contextStorage = getAsyncContext().create<number>();
-  }
-  return _contextStorage.getStore() ?? 0;
-}
-
-/**
- * Run a callback in a new isolated execution context.
- * Leases obtained inside will not collide with the outer context.
- */
-export function withExecutionContext<T>(fn: () => T): T {
-  if (!_contextStorage) {
-    _contextStorage = getAsyncContext().create<number>();
-  }
-  return _contextStorage.run(++_contextIdCounter, fn);
-}
+export { withExecutionContext } from "./connection-pool/execution-context.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractPool
@@ -245,6 +227,7 @@ export class ConnectionPool implements ReapablePool {
   private _idleTimeout: number | null;
   private _lastCheckinAt = new Map<DatabaseAdapter, number>();
   private _pinnedConnections = new Map<number, { connection: DatabaseAdapter; depth: number }>();
+  private _cacheConfig: ConnectionPoolConfiguration;
 
   constructor(poolConfig: PoolConfig) {
     this.poolConfig = poolConfig;
@@ -256,6 +239,7 @@ export class ConnectionPool implements ReapablePool {
     this.checkoutTimeout = this.dbConfig.checkoutTimeout;
     this._idleTimeout = this.dbConfig.idleTimeout;
     this._available = new ConnectionLeasingQueue();
+    this._cacheConfig = new ConnectionPoolConfiguration();
 
     this.reaper = new Reaper(this, this.dbConfig.reapingFrequency ?? 0);
     this.reaper.run();
@@ -452,6 +436,7 @@ export class ConnectionPool implements ReapablePool {
     if (!pin) {
       pin = { connection, depth: 0 };
       this._pinnedConnections.set(ctxId, pin);
+      this._cacheConfig.setPinnedConnection(connection as unknown as QueryCacheHost);
     }
     pin.depth++;
 
@@ -502,6 +487,7 @@ export class ConnectionPool implements ReapablePool {
       pin.depth--;
       if (pin.depth === 0) {
         this._pinnedConnections.delete(ctxId);
+        this._cacheConfig.setPinnedConnection(null);
         this.checkin(connection);
       }
     }
@@ -520,9 +506,12 @@ export class ConnectionPool implements ReapablePool {
       if (this._connections && !this._connections.includes(pin.connection)) {
         this._connections.push(pin.connection);
       }
+      (pin.connection as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
       return pin.connection;
     }
-    return this._acquireConnection();
+    const conn = this._acquireConnection();
+    (conn as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+    return conn;
   }
 
   async checkoutAsync(timeout?: number): Promise<DatabaseAdapter> {
@@ -557,6 +546,7 @@ export class ConnectionPool implements ReapablePool {
       throw new ConnectionNotEstablished("Connection pool has been discarded");
     }
     this._checkedOut.add(c);
+    (c as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
     return c;
   }
 
@@ -600,6 +590,7 @@ export class ConnectionPool implements ReapablePool {
     if (this._isConnectionPinned(conn)) return;
     this._connectionLease().clear(conn);
     if (this._checkedOut.has(conn)) {
+      QueryCache.unsetQueryCacheBang.call(conn as unknown as QueryCacheHost);
       this._checkedOut.delete(conn);
       (conn as unknown as PoolManagedConnection).expire?.();
       this._available?.add(conn);
@@ -1310,6 +1301,7 @@ function checkoutAndVerify(pool: Pool, c: DatabaseAdapter): DatabaseAdapter {
     const cleanable = c as unknown as { cleanBang?: () => void; clean?: () => void };
     if (typeof cleanable.cleanBang === "function") cleanable.cleanBang();
     else cleanable.clean?.();
+    (c as unknown as QueryCacheHost)._queryCache = pool._cacheConfig.queryCache;
     return c;
   } catch (err) {
     pool.remove(c);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -456,6 +456,7 @@ export class ConnectionPool implements ReapablePool {
       pin.depth--;
       if (pin.depth === 0) {
         this._pinnedConnections.delete(ctxId);
+        this._cacheConfig.setPinnedConnection(null);
         if (newlyCheckedOut) {
           this.checkin(connection);
         }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -436,7 +436,7 @@ export class ConnectionPool implements ReapablePool {
     if (!pin) {
       pin = { connection, depth: 0 };
       this._pinnedConnections.set(ctxId, pin);
-      this._cacheConfig.setPinnedConnection(connection as unknown as QueryCacheHost);
+      this._cacheConfig.incrementPinnedCount();
     }
     pin.depth++;
 
@@ -456,7 +456,7 @@ export class ConnectionPool implements ReapablePool {
       pin.depth--;
       if (pin.depth === 0) {
         this._pinnedConnections.delete(ctxId);
-        this._cacheConfig.setPinnedConnection(null);
+        this._cacheConfig.decrementPinnedCount();
         if (newlyCheckedOut) {
           this.checkin(connection);
         }
@@ -488,7 +488,7 @@ export class ConnectionPool implements ReapablePool {
       pin.depth--;
       if (pin.depth === 0) {
         this._pinnedConnections.delete(ctxId);
-        this._cacheConfig.setPinnedConnection(null);
+        this._cacheConfig.decrementPinnedCount();
         this.checkin(connection);
       }
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
@@ -1,0 +1,23 @@
+import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+
+let _contextIdCounter = 0;
+let _contextStorage: AsyncContext<number> | null = null;
+
+/** @internal */
+export function executionContextId(): number {
+  if (!_contextStorage) {
+    _contextStorage = getAsyncContext().create<number>();
+  }
+  return _contextStorage.getStore() ?? 0;
+}
+
+/**
+ * Run a callback in a new isolated execution context.
+ * Leases obtained inside will not collide with the outer context.
+ */
+export function withExecutionContext<T>(fn: () => T): T {
+  if (!_contextStorage) {
+    _contextStorage = getAsyncContext().create<number>();
+  }
+  return _contextStorage.run(++_contextIdCounter, fn);
+}

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -141,7 +141,7 @@ export class ConnectionPoolConfiguration {
   private _threadQueryCaches = new QueryCacheRegistry();
   private _queryCacheMaxSize: number | null;
   private _queryCacheVersion = { value: 0 };
-  private _pinnedConnection: QueryCacheHost | null = null;
+  private _pinnedCount = 0;
 
   constructor(queryCacheConfig?: number | false | null) {
     if (queryCacheConfig === 0 || queryCacheConfig === false) {
@@ -211,7 +211,7 @@ export class ConnectionPoolConfiguration {
   }
 
   clearQueryCache(): void {
-    if (this._pinnedConnection) {
+    if (this._pinnedCount > 0) {
       this._queryCacheVersion.value++;
     }
     this.queryCache.clear();
@@ -224,8 +224,13 @@ export class ConnectionPoolConfiguration {
   }
 
   /** @internal */
-  setPinnedConnection(conn: QueryCacheHost | null): void {
-    this._pinnedConnection = conn;
+  incrementPinnedCount(): void {
+    this._pinnedCount++;
+  }
+
+  /** @internal */
+  decrementPinnedCount(): void {
+    this._pinnedCount--;
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,5 +1,6 @@
 import { Notifications } from "@blazetrails/activesupport";
 import { typeCastedBinds, type DatabaseStatementsHost } from "./database-statements.js";
+import { executionContextId } from "./connection-pool/execution-context.js";
 
 const DEFAULT_MAX_SIZE = 100;
 
@@ -217,9 +218,14 @@ export class ConnectionPoolConfiguration {
   }
 
   get queryCache(): Store {
-    return this._threadQueryCaches.computeIfAbsent("default", () => {
+    return this._threadQueryCaches.computeIfAbsent(String(executionContextId()), () => {
       return new Store(this._queryCacheVersion, this._queryCacheMaxSize ?? 0);
     });
+  }
+
+  /** @internal */
+  setPinnedConnection(conn: QueryCacheHost | null): void {
+    this._pinnedConnection = conn;
   }
 }
 

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1230,6 +1230,30 @@ describe("ConnectionPoolConfiguration query cache", () => {
         expect(getCacheConfig()._pinnedConnection).toBeNull();
       });
     });
+
+    it("clears _pinnedConnection on _cacheConfig when beginTransaction throws", async () => {
+      const pool = makeTransactionAwarePool(1);
+      // Prime the pool with one idle connection so pinConnectionBang acquires it.
+      const seed = pool.checkout();
+      pool.checkin(seed);
+      // Swap its transactionManager with one that throws on beginTransaction.
+      (seed as unknown as { _transactionManager: unknown })._transactionManager = {
+        beginTransaction: async () => {
+          throw new Error("begin failed");
+        },
+        get currentTransaction() {
+          return { open: false };
+        },
+      };
+
+      const getCacheConfig = () =>
+        (pool as unknown as { _cacheConfig: { _pinnedConnection: unknown } })._cacheConfig;
+
+      await withExecutionContext(async () => {
+        await expect(pool.pinConnectionBang()).rejects.toThrow("begin failed");
+        expect(getCacheConfig()._pinnedConnection).toBeNull();
+      });
+    });
   });
 
   describe("checkout/checkin cache attachment", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1215,23 +1215,44 @@ describe("ConnectionPoolConfiguration query cache", () => {
   });
 
   describe("pin wiring", () => {
-    it("pinConnectionBang sets _pinnedConnection on _cacheConfig, unpinConnectionBang clears it", async () => {
+    it("pinConnectionBang increments _pinnedCount; unpinConnectionBang decrements it", async () => {
       const pool = makeTransactionAwarePool(1);
 
-      const getCacheConfig = () =>
-        (pool as unknown as { _cacheConfig: { _pinnedConnection: unknown } })._cacheConfig;
+      const pinnedCount = () =>
+        (pool as unknown as { _cacheConfig: { _pinnedCount: number } })._cacheConfig._pinnedCount;
 
-      expect(getCacheConfig()._pinnedConnection).toBeNull();
+      expect(pinnedCount()).toBe(0);
 
       await withExecutionContext(async () => {
         await pool.pinConnectionBang();
-        expect(getCacheConfig()._pinnedConnection).not.toBeNull();
+        expect(pinnedCount()).toBe(1);
         await pool.unpinConnectionBang();
-        expect(getCacheConfig()._pinnedConnection).toBeNull();
+        expect(pinnedCount()).toBe(0);
       });
     });
 
-    it("clears _pinnedConnection on _cacheConfig when beginTransaction throws", async () => {
+    it("two concurrent contexts each contribute to _pinnedCount independently", async () => {
+      const pool = makeTransactionAwarePool(2);
+      const pinnedCount = () =>
+        (pool as unknown as { _cacheConfig: { _pinnedCount: number } })._cacheConfig._pinnedCount;
+
+      await Promise.all([
+        withExecutionContext(async () => {
+          await pool.pinConnectionBang();
+          expect(pinnedCount()).toBeGreaterThanOrEqual(1);
+          await pool.unpinConnectionBang();
+        }),
+        withExecutionContext(async () => {
+          await pool.pinConnectionBang();
+          expect(pinnedCount()).toBeGreaterThanOrEqual(1);
+          await pool.unpinConnectionBang();
+        }),
+      ]);
+
+      expect(pinnedCount()).toBe(0);
+    });
+
+    it("decrements _pinnedCount when beginTransaction throws", async () => {
       const pool = makeTransactionAwarePool(1);
       // Prime the pool with one idle connection so pinConnectionBang acquires it.
       const seed = pool.checkout();
@@ -1246,12 +1267,12 @@ describe("ConnectionPoolConfiguration query cache", () => {
         },
       };
 
-      const getCacheConfig = () =>
-        (pool as unknown as { _cacheConfig: { _pinnedConnection: unknown } })._cacheConfig;
+      const pinnedCount = () =>
+        (pool as unknown as { _cacheConfig: { _pinnedCount: number } })._cacheConfig._pinnedCount;
 
       await withExecutionContext(async () => {
         await expect(pool.pinConnectionBang()).rejects.toThrow("begin failed");
-        expect(getCacheConfig()._pinnedConnection).toBeNull();
+        expect(pinnedCount()).toBe(0);
       });
     });
   });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -3,6 +3,7 @@ import {
   ConnectionPool,
   withExecutionContext,
 } from "./connection-adapters/abstract/connection-pool.js";
+import { Store } from "./connection-adapters/abstract/query-cache.js";
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
@@ -1157,5 +1158,77 @@ describe("adapterNameFromConfig", () => {
   it("defaults unknown to sqlite", () => {
     expect(adapterNameFromConfig(undefined)).toBe("sqlite");
     expect(adapterNameFromConfig("unknown")).toBe("sqlite");
+  });
+});
+
+describe("query-cache Phase 1", () => {
+  describe("Change A — context-keyed cache registry", () => {
+    it("two concurrent execution contexts each get their own Store", async () => {
+      const pool = makePool(2);
+
+      let cacheA: Store | null = null;
+      let cacheB: Store | null = null;
+
+      await Promise.all([
+        withExecutionContext(async () => {
+          const conn = pool.checkout();
+          cacheA = (conn as unknown as { _queryCache: Store | null })._queryCache;
+          pool.checkin(conn);
+        }),
+        withExecutionContext(async () => {
+          const conn = pool.checkout();
+          cacheB = (conn as unknown as { _queryCache: Store | null })._queryCache;
+          pool.checkin(conn);
+        }),
+      ]);
+
+      expect(cacheA).toBeInstanceOf(Store);
+      expect(cacheB).toBeInstanceOf(Store);
+      expect(cacheA).not.toBe(cacheB);
+    });
+
+    it("writing to the cache in context X is not visible in context Y", async () => {
+      const pool = makePool(2);
+      const KEY = "SELECT 1";
+
+      let cacheA: Store | null = null;
+      let cacheB: Store | null = null;
+
+      await withExecutionContext(async () => {
+        const conn = pool.checkout();
+        cacheA = (conn as unknown as { _queryCache: Store | null })._queryCache;
+        cacheA!.enabled = true;
+        await cacheA!.computeIfAbsent(KEY, async () => [{ x: 1 }]);
+        pool.checkin(conn);
+      });
+
+      await withExecutionContext(async () => {
+        const conn = pool.checkout();
+        cacheB = (conn as unknown as { _queryCache: Store | null })._queryCache;
+        pool.checkin(conn);
+      });
+
+      expect(cacheA).not.toBe(cacheB);
+      expect(cacheA!.get(KEY)).toBeDefined();
+      expect(cacheB!.get(KEY)).toBeUndefined();
+    });
+  });
+
+  describe("Change B — pin wiring", () => {
+    it("pinConnectionBang sets _pinnedConnection on _cacheConfig, unpinConnectionBang clears it", async () => {
+      const pool = makeTransactionAwarePool(1);
+
+      const getCacheConfig = () =>
+        (pool as unknown as { _cacheConfig: { _pinnedConnection: unknown } })._cacheConfig;
+
+      expect(getCacheConfig()._pinnedConnection).toBeNull();
+
+      await withExecutionContext(async () => {
+        await pool.pinConnectionBang();
+        expect(getCacheConfig()._pinnedConnection).not.toBeNull();
+        await pool.unpinConnectionBang();
+        expect(getCacheConfig()._pinnedConnection).toBeNull();
+      });
+    });
   });
 });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1161,8 +1161,8 @@ describe("adapterNameFromConfig", () => {
   });
 });
 
-describe("query-cache Phase 1", () => {
-  describe("Change A — context-keyed cache registry", () => {
+describe("ConnectionPoolConfiguration query cache", () => {
+  describe("context-keyed cache registry", () => {
     it("two concurrent execution contexts each get their own Store", async () => {
       const pool = makePool(2);
 
@@ -1214,7 +1214,7 @@ describe("query-cache Phase 1", () => {
     });
   });
 
-  describe("Change B — pin wiring", () => {
+  describe("pin wiring", () => {
     it("pinConnectionBang sets _pinnedConnection on _cacheConfig, unpinConnectionBang clears it", async () => {
       const pool = makeTransactionAwarePool(1);
 
@@ -1228,6 +1228,32 @@ describe("query-cache Phase 1", () => {
         expect(getCacheConfig()._pinnedConnection).not.toBeNull();
         await pool.unpinConnectionBang();
         expect(getCacheConfig()._pinnedConnection).toBeNull();
+      });
+    });
+  });
+
+  describe("checkout/checkin cache attachment", () => {
+    it("checkout attaches a Store; checkin clears it", () => {
+      const pool = makePool(1);
+      const conn = pool.checkout();
+      const qc = (conn as unknown as { _queryCache: Store | null })._queryCache;
+      expect(qc).toBeInstanceOf(Store);
+      pool.checkin(conn);
+      expect((conn as unknown as { _queryCache: Store | null })._queryCache).toBeNull();
+    });
+
+    it("checkoutAsync attaches a Store on the fast (idle) path", async () => {
+      const pool = makePool(1);
+      // Seed one idle connection so _tryAcquire fires.
+      const seed = pool.checkout();
+      pool.checkin(seed);
+
+      await withExecutionContext(async () => {
+        const conn = await pool.checkoutAsync();
+        expect((conn as unknown as { _queryCache: Store | null })._queryCache).toBeInstanceOf(
+          Store,
+        );
+        pool.checkin(conn);
       });
     });
   });


### PR DESCRIPTION
## Summary

- **Change A** — \`ConnectionPoolConfiguration.queryCache\` getter now keys \`_threadQueryCaches\` by \`executionContextId()\` (extracted to \`connection-pool/execution-context.ts\` to avoid a circular dep) instead of the literal string \`"default"\`. Each \`AsyncLocalStorage\` scope gets its own \`Store\`; context 0 (the no-scope fallback) is isolated from real request contexts.

- **Change B** — \`ConnectionPool.pinConnectionBang\` now calls \`_cacheConfig.incrementPinnedCount()\` when creating the first-depth pin for a context, and \`unpinConnectionBang\` calls \`_cacheConfig.decrementPinnedCount()\` when depth returns to 0 (the \`beginTransaction\` error path also decrements). \`clearQueryCache\` bumps \`_queryCacheVersion\` when \`_pinnedCount > 0\`, correctly covering all concurrently-pinned contexts. A single connection reference (\`_pinnedConnection\`) was considered but rejected: it would be cleared by whichever context unpins first, silencing the version-bump for remaining pinned contexts.

- **Change C** — All checkout paths (\`checkout\`, \`checkoutAsync\` pinned path, \`checkoutAsync\` idle fast-path, \`checkoutAsync\` timeout path, module-level \`checkoutAndVerify\`) assign \`connection._queryCache = this._cacheConfig.queryCache\` (the context's \`Store\`) before returning. \`checkin()\` calls \`QueryCache.unsetQueryCacheBang\` to null it out, preventing stale cache from leaking to the next borrower.

## Architecture note

\`executionContextId\` / \`withExecutionContext\` were extracted from \`connection-pool.ts\` into \`connection-pool/execution-context.ts\` and re-exported. This is the only structural change — no public API is added, no tests are unskipped.

## Known follow-up (Phase 2)

\`_threadQueryCaches\` is a plain \`Map<string, Store>\` keyed by monotonically-increasing context IDs. Long-lived processes that create a context per request will accumulate one \`Store\` entry per request. A registry eviction strategy (size cap, \`finally\`-based cleanup in \`withExecutionContext\`, or moving the store into \`AsyncLocalStorage\` directly) is deferred to Phase 2.

## Test plan

- [ ] \`pnpm exec vitest run "connection-pool"\` — all 84 tests pass, 23 skipped
- [ ] Change A: two \`withExecutionContext\` blocks get different \`Store\` instances; writing to one is invisible to the other
- [ ] Change B: \`_pinnedCount\` increments on \`pinConnectionBang\` and decrements on \`unpinConnectionBang\`; two concurrent contexts both contribute to the count and it returns to 0 when both unpin; error path also decrements
- [ ] Change C: \`checkout\` attaches \`Store\`, \`checkin\` clears it; \`checkoutAsync\` idle fast-path also attaches
- [ ] \`pnpm api:compare --package activerecord\` — 4955/4958 (99.9%), no regression

## Out of scope (Phases 2–4)

- \`DatabaseConfig.queryCacheMaxSize\` wiring
- \`enableQueryCacheBang\`/\`disableQueryCacheBang\` calls at checkout/checkin
- \`withQueryCache(fn)\` public API
- \`QueryCache.installExecutorHooks\` middleware
- Any BLOCKED query-cache test unskips