### PR TITLE
docs(ar100): sync plan + clusters with 2026-05-12 PR landings

### DIFF
--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -10,34 +10,25 @@ When picking a slot to spawn:
 2. Find the matching cluster in this doc for slot details, sequencing, and overlap notes.
 3. Read the relevant `audit-*` reference in the slot description; the audit ran with full Rails-source context and its inventory is the source of truth for the gap shape.
 
-Closed slots are pruned as PRs merge — `git log --grep "audit Slot"` is the closed-work record.
-
 ---
 
 ## Associations-autosave cluster (~940 LOC across 4 remaining slots)
 
-Slots A (#1426) + B (#1434) closed.
+1. **Slot C** (~230 LOC) — Transaction wrapping of autosave chain + `RecordInvalid` raise from saveBang.
+2. **Slot D** (~280 LOC) — `Associations::NestedError` propagation + `errors.indexErrors` + i18n full-message.
+3. **Slot E** (~220 LOC) — CPK / queryConstraints / polymorphic-inverse / custom-context.
+4. **Slot F** (~210 LOC) — Reflection introspection + per-class non-cyclic guard.
 
-3. **Slot C** (~230 LOC) — Transaction wrapping of autosave chain + `RecordInvalid` raise from saveBang.
-4. **Slot D** (~280 LOC) — `Associations::NestedError` propagation + `errors.indexErrors` + i18n full-message.
-5. **Slot E** (~220 LOC) — CPK / queryConstraints / polymorphic-inverse / custom-context.
-6. **Slot F** (~210 LOC) — Reflection introspection + per-class non-cyclic guard.
-
-## Associations-reflection cluster (~900 LOC across 5 slots, from audit-associations-reflection)
+## Associations-reflection cluster (~780 LOC across 4 remaining slots, from audit-associations-reflection)
 
 31 empty-stub tests with generic boilerplate annotation. **Impl is fundamentally complete**; gaps are fixture plumbing + test-body writing + 3 fixture-model gaps.
 
 1. **Slot A** (~80 LOC) — Error-type parity (`UnknownPrimaryKey`, `ConfigurationError` from plain `Error`).
-2. **Slot B** (~120 LOC) — Empty-stub bodies for already-implemented features (`columnForAttribute`, `columnsForAttribute` — re-uses existing impl from `attribute-methods.test.ts` / `calculations.test.ts`).
-3. **Slot C** (~250 LOC) — Polymorphic HMT fixture (Hotel/Department/Chef/CakeDesigner/DrinkDesigner) + scope-chain tests.
-4. **Slot D** (~250 LOC) — Author/Organization essay fixture + dependent tests.
-5. **Slot E** (~200 LOC) — Namespace resolution (`MacroReflection#_klass`) + `sourceType`-as-class guard.
+2. **Slot C** (~250 LOC) — Polymorphic HMT fixture (Hotel/Department/Chef/CakeDesigner/DrinkDesigner) + scope-chain tests.
+3. **Slot D** (~250 LOC) — Author/Organization essay fixture + dependent tests.
+4. **Slot E** (~200 LOC) — Namespace resolution (`MacroReflection#_klass`) + `sourceType`-as-class guard.
 
 3 const_missing/NameError tests → unported-list candidates (Ruby-only language semantics).
-
-## MySQL warnings cluster — **closed via #1435** ✅
-
-Slot A shipped (~240 LOC, 9 unskips, full feature port). Slot B ignore-list delegation rolled into A.
 
 ## MySQL schema cluster (~400 LOC across 3 slots, from audit-mysql-schema)
 
@@ -47,31 +38,13 @@ Slot A shipped (~240 LOC, 9 unskips, full feature port). Slot B ignore-list dele
 2. **Slot B** (~80 LOC) — `temporary:` option propagation on `dropTable` + annotation rewrite.
 3. **Slot C** (~200 LOC) — MySQL fixture/test-helper infrastructure: `posts`, `key_tests`, `lessons_students`/`topics`/`students` fixtures + subclassing `Base` with qualified `db.table` table_name.
 
-## MySQL quoting cluster — Slot A closed ✅ (consolidation cluster below)
-
-Slot A shipped (#1442): instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName`. The post-merge divergence triggered a follow-on 4-phase cleanup — see "MySQL quoting consolidation cluster" below.
-
-## MySQL quoting consolidation cluster — **closed** ✅
-
-All 4 phases shipped: #1447 (abstract leakage) → #1448 (call-site routing) → #1450 (delete invented helpers) → #1451 (module-mixin conversion). Standalone-vs-instance divergence eliminated.
-
 ## PG connection cluster (~130 LOC across 3 remaining slots, from audit-pg-connection)
 
-Slots A (#1439) + B (#1446) closed.
-
-3. **Slot C** (~50 LOC) — PG `resetBang()` override + un-skip 2 reset tests.
-4. **Slot D** (~60 LOC) — `verify!` server-side-disconnect recovery + 1 test.
-5. **Slot E** (~20 LOC) — `connection options` test rewrite (driver supports `-c geqo=off`; just need adapter constructed with that config).
-
-Could bundle as 2 PRs (A+B ~160 LOC and C+D+E ~130 LOC) given size policy — or keep granular if all 5 land quickly.
-
-## PG datatype cluster — **closed via #1432** ✅
-
-Slot A shipped: 9 stale stubs deleted + 2 fixtures added + 6 fixture-backed un-skips.
+1. **Slot C** (~50 LOC) — PG `resetBang()` override + un-skip 2 reset tests.
+2. **Slot D** (~60 LOC) — `verify!` server-side-disconnect recovery + 1 test.
+3. **Slot E** (~20 LOC) — `connection options` test rewrite (driver supports `-c geqo=off`; just need adapter constructed with that config).
 
 ## PG interval cluster (~180 LOC, Slot B remaining)
-
-Slot A closed in #1431 (Rails-aligned test names + 6 fabricated deletions + round-trip verification).
 
 - **Slot B** (~180 LOC) — Interval schema-default extraction + AVG aggregate typecast.
 
@@ -90,9 +63,7 @@ Slot A closed in #1431 (Rails-aligned test names + 6 fabricated deletions + roun
 
 ## PG UUID residual cluster (~250 LOC, Slot B remaining)
 
-Slots A (#1433) + C (#1444) closed.
-
-2. **Slot B** (~250 LOC) — Associations + UUID FK binding.
+- **Slot B** (~250 LOC) — Associations + UUID FK binding.
 
 Plus: 1 test references "migration framework" gap — leave skipped with sharpened annotation.
 
@@ -112,21 +83,9 @@ Plus: MySQL `SchemaDumper.tableCollationCache` is never populated; base `createT
 
 7 tests sharing one Rails setup (`create_table :charset_collations, id: { type: :string, collation: "utf8mb4_bin" }`).
 
-1. **Slot A** (~120–180 LOC) — `createTable` `id` hash form `{ type, collation, ... }` + `ColumnOptions.charset` + test #3 ("add column with charset and collation"). Most other gaps already plumbed in `mysql/schema-creation.ts` (CHARACTER SET / COLLATE) and `newColumnFromField` (reads `Collation` from `SHOW FULL FIELDS`).
+1. **Slot A** (~120–180 LOC) — `createTable` `id` hash form `{ type, collation, ... }` + `ColumnOptions.charset` + test ("add column with charset and collation"). Most other gaps already plumbed in `mysql/schema-creation.ts` (CHARACTER SET / COLLATE) and `newColumnFromField` (reads `Collation` from `SHOW FULL FIELDS`).
 2. **Slot B** (~150–220 LOC) — MySQL `changeColumn` + `buildChangeColumnDefinition` stubs (both empty today). Includes "preserve existing collation for text→text/string" + `:no_collation` sentinel semantics. Unblocks tests 4–7.
 3. **Slot C** (~15 LOC, optional) — BLOCKED annotation cleanup.
-
-## Encryption cluster (closed)
-
-All three slots shipped:
-
-- Slot A — Binary-column encryption fixtures (#1405)
-- Slot B — `messageSerializer` per-encrypts() option pass-through + msgpack fixture (#1409)
-- Slot C — Lazy `previousSchemes` + `store_accessor` + insert/defaults (#1420). One residual: deterministic ciphertext byte-parity with MRI Rails (blocked on `MessageSerializer` double-base64 bug — in post-merge fidelity followups).
-
-## Serialization cluster — **closed** ✅
-
-Slot A (#1404) + Slot B (#1445) shipped.
 
 ## Relation cluster (~1660 LOC across 7 slots, from audit-relation)
 
@@ -137,7 +96,7 @@ Slot A (#1404) + Slot B (#1445) shipped.
 3. **Slot C** (~220 LOC) — WhereChain `associated` / `missing` branches.
 4. **Slot D** (~250 LOC) — Default scope / `all_queries` / unscoped caching invariants.
 5. **Slot E** (~220 LOC) — Batches with composite-PK + ordering edge cases.
-6. ~~**Slot F** — load_async scheduling~~ **DROPPED.** Auditor missed Step 0; would have built sources unported in #1400. 28 affected tests already permanent-skipped.
+6. ~~**Slot F** — load_async scheduling~~ **DROPPED.** Auditor missed Step 0; would have built sources unported. 28 affected tests already permanent-skipped.
 7. **Slot G** (~240 LOC) — `PredicateBuilder.registerHandler` + field-ordered-values + calc grouping.
 8. **Slot H** (~220 LOC) — Relation misc small-surface bundle.
 
@@ -190,32 +149,28 @@ Note: audit worktree didn't have `.rails-source/` populated → slots sized by t
 
 ## Migration cluster (~1210 LOC across 6 remaining slots, from audit-migration)
 
-Slot A closed in #1410.
-
-2. **Slot B** (~220 LOC) — `tableNamePrefix`/`tableNameSuffix` on `MigrationContext`/`Migration` + CTAS + `InvalidMigrationTimestampError`. 6 un-skips.
-3. **Slot C** (~200 LOC) — Advisory-lock seams + `Migrator#runWithoutLock` filtering + migration-detection-without-schema-table. 8 un-skips.
-4. **Slot D** (~250 LOC) — Multi-DB `MigrationContext` factory. 7 un-skips.
-5. **Slot E** (~220 LOC) — Filesystem migration discovery + internal-metadata enable/disable toggle + schema-cache invalidation hooks. 8 un-skips.
-6. **Slot F** (~180 LOC) — Bulk-alter recorder round-trip + `change-column` test reorg. 6 un-skips.
-7. **Slot G** (~140 LOC) — MySQL utf8mb4 init + renameIndex-on-FK adapter parity. 3 un-skips.
+1. **Slot B** (~220 LOC) — `tableNamePrefix`/`tableNameSuffix` on `MigrationContext`/`Migration` + CTAS + `InvalidMigrationTimestampError`. 6 un-skips.
+2. **Slot C** (~200 LOC) — Advisory-lock seams + `Migrator#runWithoutLock` filtering + migration-detection-without-schema-table. 8 un-skips.
+3. **Slot D** (~250 LOC) — Multi-DB `MigrationContext` factory. 7 un-skips.
+4. **Slot E** (~220 LOC) — Filesystem migration discovery + internal-metadata enable/disable toggle + schema-cache invalidation hooks. 8 un-skips.
+5. **Slot F** (~180 LOC) — Bulk-alter recorder round-trip + `change-column` test reorg. 6 un-skips.
+6. **Slot G** (~140 LOC) — MySQL utf8mb4 init + renameIndex-on-FK adapter parity. 3 un-skips.
 
 ## Connection-pool cluster (~640 LOC across 3 remaining slots, from audit-connection-pool)
 
-Slot A closed in #1415. 155 actual skipped (estimate revised down from ~209). Single-process / single-handler / single-shard happy paths all work — gaps cluster around multi-DB / sharding.
+1. **Slot B** (~250 LOC) — `connects_to` + default writing/reading handlers (config-hash establishment).
+2. **Slot C** (~240 LOC) — Shard-selector wiring + `prohibitShardSwapping`.
+3. **Slot D** (~180 LOC) — ActiveSupport::Notifications equivalent for pool events. Likely needs a small shim or piggy-back on existing instrumentation infra.
 
-2. **Slot B** (~250 LOC) — `connects_to` + default writing/reading handlers (config-hash establishment).
-3. **Slot C** (~240 LOC) — Shard-selector wiring + `prohibitShardSwapping`.
-4. **Slot D** (~180 LOC) — ActiveSupport::Notifications equivalent for pool events. Likely needs a small shim or piggy-back on existing instrumentation infra.
-
-**Gap 8 (process-fork lifecycle) was a phantom** — #1416 found `connection_pool_test.rb` has no fork/PID test; the audit reference pointed at `connection_handler_test.rb` work already handled. No action.
+**Gap 8 (process-fork lifecycle) was a phantom** — found `connection_pool_test.rb` has no fork/PID test; the audit reference pointed at `connection_handler_test.rb` work already handled. No action.
 
 ## MySQL active-schema cluster (~680 LOC across 3 remaining slots, from audit-mysql-active-schema)
 
-**Supersedes the previous Schema-cluster Slot G estimate.** Slot A closed in #1413 (SQL-capture test infra + first un-skips). Remaining:
+**Supersedes the previous Schema-cluster Slot G estimate.** Slot A closed (SQL-capture test infra + first un-skips). Remaining:
 
-2. **Slot B** (~220 LOC) — MySQL DDL SQL parity (`dropTable` comma form, `createDatabase`/`recreateDatabase`, `indexAlgorithm` validator).
-3. **Slot C** (~260 LOC) — `addIndex` MySQL output shape + inline `t.index` in `create_table`.
-4. **Slot D** (~200 LOC) — Bulk change-table ALTER coalescing + timestamp tests.
+1. **Slot B** (~220 LOC) — MySQL DDL SQL parity (`dropTable` comma form, `createDatabase`/`recreateDatabase`, `indexAlgorithm` validator).
+2. **Slot C** (~260 LOC) — `addIndex` MySQL output shape + inline `t.index` in `create_table`.
+3. **Slot D** (~200 LOC) — Bulk change-table ALTER coalescing + timestamp tests.
 
 ## MySQL mysql2-adapter cluster (~700 LOC across 3 slots, from audit-mysql-mysql2-adapter)
 
@@ -227,21 +182,9 @@ Slot A closed in #1415. 155 actual skipped (estimate revised down from ~209). Si
 
 ## SQLite adapter cluster (~50 LOC, Slot B remaining)
 
-Slot A closed in #1443 (`strict_strings_by_default` class-config knob + 3 unskips; DQS toggle is a no-op in better-sqlite3 — followups for future driver support).
-
-2. **Slot B — `assertLogged` SCHEMA-event parity** (~50 LOC). 2 test-infra gap tests.
-
-## PG infinity cluster — **closed via #1427** ✅
-
-Slot A shipped: sentinel unification (`Symbol` → `Number.POSITIVE_INFINITY`/`NEGATIVE_INFINITY` for date/datetime), 6 un-skips, fabricated tests pruned. 3 residuals tracked in fidelity followups (~135 LOC: range-bound serialization, `InTimeZone` helper, MySQL `quote()` non-finite guard).
-
-## PG foreign-table cluster — **closed via #1429** ✅
-
-Slot A shipped: 16/17 `foreign_table_test.rb` bodies ported (pure test work; zero adapter changes — the BLOCKED annotation pointing at a non-existent `postgresql/foreign-table.ts` was fabricated). 1 deferred test (`Base.primaryKey` → `adapter.primaryKey(tableName)` for tables without explicit PK) tracked in fidelity followups.
+- **Slot B — `assertLogged` SCHEMA-event parity** (~50 LOC). 2 test-infra gap tests.
 
 ## PG virtual-column cluster (~250 LOC, Slot B remaining)
-
-Slot A closed in #1430 (rewrite TS file to mirror Rails + XML relocation).
 
 - **Slot B** (~250 LOC) — Live-PG round-trip harness + un-skip 5 Rails-mirrored tests. `defineSchema`-less `create_table`; `change_table { |t| t.virtual ... }`; `buildFixtureSql` virtual-column filter.
 
@@ -262,43 +205,37 @@ Plus: `setSchemaSearchPath` unquoted-`$user` rejection + 5 fixture-model gaps (`
 Re-categorization of all 89 `BLOCKED: unknown` annotations. **Single foundational annotation-refresh PR** unblocks downstream slot-sizing:
 
 1. **Slot A — Annotation refresh** (~200 LOC, comment-only). Re-tag all 89 annotations into the controlled vocabulary, moving the Ruby-only language-semantics ones (`modules.test.ts` x7, `mixin.test.ts` x2, `base.test.ts` x1 — `Module#prepend`, `singleton_class`, `Module#ancestors`, constant-path lookup) to `PERMANENT-SKIP` form in `unported-files.ts`.
-2. **Slot B — `insert-all.test.ts` investigation + un-skip** (~250 LOC). **64 of the 89 have stale "`MemoryAdapter accepts any attrs"` comments** that mislead the audit — there is no `MemoryAdapter`; the test setup uses `SchemaAdapter` wrapping a real driver. `InsertAll` impl is at 100% per #1255. Real work: scrub stale comments (largely done in #1416), investigate what's actually skipped, rewrite test bodies to assert against real-adapter behavior.
+2. **Slot B — `insert-all.test.ts` investigation + un-skip** (~250 LOC). **64 of the 89 have stale "`MemoryAdapter accepts any attrs"` comments** that mislead the audit — there is no `MemoryAdapter`; the test setup uses `SchemaAdapter` wrapping a real driver. `InsertAll` impl is at 100% per. Real work: scrub stale comments (largely done), investigate what's actually skipped, rewrite test bodies to assert against real-adapter behavior.
 3. **Slot C — SignedId real-feature gaps** (~140 LOC).
 4. **Slot D — Callbacks `afterCommit` refinements** (~50 LOC).
 5. **Deferred** — Misc small feature closes (~80 LOC); timezone-aware attribute methods (~150 LOC).
 
 ## STI annotation drift (~20 LOC, tests-only)
 
-audit-STI found **no STI implementation gap**. All 6 `BLOCKED: STI` tests are mis-labeled — real causes are missing fixture scopes, UUID PK + touch on polymorphic delegated_type, and PG `CREATE TABLE … INHERITS` schema-dump (closed by pg-schema Slot B above). Single tests-only PR re-annotates the 6 tests under correct categories.
+audit-STI found **no STI implementation gap**. All 6 `BLOCKED: STI` tests are mis-labeled — real causes are missing fixture scopes, UUID PK + touch on polymorphic delegated_type, and PG `CREATE TABLE … INHERITS` schema-dump . Single tests-only PR re-annotates the 6 tests under correct categories.
 
 ## Schema cluster (~1390 LOC across 7 remaining slots + annotation sweep, from audit-schema)
 
-Slot A closed in #1407; Slot B closed in #1418; Slot G superseded by MySQL active-schema cluster.
-
-3. **Slot C** (~80–120 LOC, sized down per #1407) — Index dump metadata (partial `where:`, `order:`, `nulls_not_distinct`, expression indices). ~7 un-skips.
-4. **Slot D** (~220 LOC) — Check / exclusion / unique constraints in dumper. 5 un-skips.
-5. **Slot E** (~200 LOC) — PG type-specific dump + extensions dumping. 11 un-skips.
-6. **Slot F** (~200 LOC) — PG `change_column` type/precision/scale/limit + null/default round-trip + timestamptz. 11 un-skips.
-7. **Slot H** (~280 LOC) — PG schema authorization + qualified-schema (search_path). 22 un-skips.
-8. **Slot I** (~250 LOC, exploratory) — PG partitioning + inheritance introspection in dumper. 6 un-skips.
-9. **Slot J** (~120 LOC) — `Schema.define` with `tableNamePrefix` + bulk-change timestamps default + SchemaCache portable bits. 5 un-skips.
-10. **Slot K** — Annotation normalization across all 128 BLOCKED annotations. Lands AFTER C–J.
+1. **Slot C** (~80–120 LOC) — Index dump metadata (partial `where:`, `order:`, `nulls_not_distinct`, expression indices). ~7 un-skips.
+2. **Slot D** (~220 LOC) — Check / exclusion / unique constraints in dumper. 5 un-skips.
+3. **Slot E** (~200 LOC) — PG type-specific dump + extensions dumping. 11 un-skips.
+4. **Slot F** (~200 LOC) — PG `change_column` type/precision/scale/limit + null/default round-trip + timestamptz. 11 un-skips.
+5. **Slot H** (~280 LOC) — PG schema authorization + qualified-schema (search_path). 22 un-skips.
+6. **Slot I** (~250 LOC, exploratory) — PG partitioning + inheritance introspection in dumper. 6 un-skips.
+7. **Slot J** (~120 LOC) — `Schema.define` with `tableNamePrefix` + bulk-change timestamps default + SchemaCache portable bits. 5 un-skips.
+8. **Slot K** — Annotation normalization across all 128 BLOCKED annotations. Lands AFTER C–J.
 
 ## PG-adapter cluster (~340 LOC across 2 remaining slots)
-
-Slot B closed in #1414; Slot C closed in #1436; Slot D closed in #1411.
 
 1. **Slot A** (~220 LOC) — `execInsert` returning-disabled fallback + `extractTableRefFromInsertSql` helper. 4 un-skips.
 2. **Slot E** (optional, ~120 LOC) — Prepared-statements introspection. 3 un-skips.
 
 ## Transactions cluster (~350 LOC across 3 remaining slots + 1 deferred, from audit-transactions)
 
-Slot A closed in #1417 (2 followup-LOC bugs surfaced: dirty-tracking clobber + isolation-error-type; both in post-merge fidelity followups).
-
-2. **Slot B** (~120 LOC) — Fixture-model gaps: `Topic+Reply`, `Movie` (custom PK), `Cpk::Book` (composite PK). 4 un-skips.
-3. **Slot C** (~80 LOC) — Test helpers: `open_transactions` probe + callback-raises listener. 2–3 un-skips.
-4. **Slot D** — Wire isolation tests through PG-adapter Slot D's `secondConnection` helper. 4–6 un-skips.
-5. **Slot E** (deferred) — Autosave + nested_attributes (depends on `accepts_nested_attributes_for` post-#1239).
+1. **Slot B** (~120 LOC) — Fixture-model gaps: `Topic+Reply`, `Movie` (custom PK), `Cpk::Book` (composite PK). 4 un-skips.
+2. **Slot C** (~80 LOC) — Test helpers: `open_transactions` probe + callback-raises listener. 2–3 un-skips.
+3. **Slot D** — Wire isolation tests through PG-adapter Slot D's `secondConnection` helper. 4–6 un-skips.
+4. **Slot E** (deferred) — Autosave + nested_attributes (depends on `accepts_nested_attributes_for`).
 
 ## `NotImplementedError` elimination initiative (~610 LOC across 7 sweeps)
 
@@ -339,11 +276,11 @@ Mechanical: add these to `scripts/api-compare/unported-files.ts` as `PERMANENT-S
 - `sqlite3-adapter.test.ts` — `loadExtension` / `supports_extensions` (driver doesn't expose).
 - `modules.test.ts` (×7), `mixin.test.ts` (×2), `base.test.ts` (×1) — Ruby `Module#prepend` / `singleton_class` / `Module#ancestors` / constant-path-lookup semantics.
 
-Most of this landed in #1416; remainder is the residual cleanup pass.
+Most of this landed; remainder is the residual cleanup pass.
 
 ### AR query-parity residual — datetime precision (ar-01 / ar-52 / ar-65)
 
-One gap tracked in [`scripts/parity/canonical/query-known-gaps.json`](../scripts/parity/canonical/query-known-gaps.json) (four gaps closed in #854/#856/#863/#899).
+One gap tracked in [`scripts/parity/canonical/query-known-gaps.json`](../scripts/parity/canonical/query-known-gaps.json) (four gaps closed/#856/#863/#899).
 
 **Goal:** `Order.where(created_at: oneWeekAgo..now).toSql()` emits second-precision SQL matching Rails' `quoted_date` (no fractional seconds for unscaled DATETIME columns).
 
@@ -359,12 +296,12 @@ One gap tracked in [`scripts/parity/canonical/query-known-gaps.json`](../scripts
 ... WHERE "orders"."created_at" BETWEEN '2026-04-18 17:53:16' AND '2026-04-25 17:53:16'
 ```
 
-**Root cause.** Trails inlines dates from `Quoted` nodes with full precision. PR #845 added bind extraction for `compileWithBinds`, but `toSql()` still inlines. The gap flakes (closes when frozen-at lands on a whole second).
+**Root cause.** Trails inlines dates from `Quoted` nodes with full precision. added bind extraction for `compileWithBinds`, but `toSql()` still inlines. The gap flakes (closes when frozen-at lands on a whole second).
 
 **Options:**
 
 - **Option A (BindParam-first, ~80 LOC):** In `predicate-builder/basic-object-handler.ts` + `range-handler.ts`, wrap Date values in `new Nodes.BindParam(queryAttribute)` instead of `Quoted`. Add a `quotedDateForBind` branch in `visitBindParam` that truncates to seconds. Don't change `visitQuoted` (INSERT precision preserved).
-- **Option B (parity-runner side):** PR #850's `paramSql` + binds comparison would close this in the diff layer without trails code changes — runner compares binds as ISO 8601 cross-side.
+- **Option B (parity-runner side):**'s `paramSql` + binds comparison would close this in the diff layer without trails code changes — runner compares binds as ISO 8601 cross-side.
 
 **Risk:** Medium — touches every WHERE clause in the suite. Must keep INSERT microsecond precision and numeric/string predicates unchanged. Files touched (Option A): `predicate-builder/basic-object-handler.ts`, `predicate-builder/range-handler.ts`, `arel/src/visitors/to-sql.ts#visitBindParam`, plus `scripts/parity/fixtures/ar-01/`, `ar-52/`, `ar-65/`.
 

--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -14,17 +14,119 @@ Closed slots are pruned as PRs merge — `git log --grep "audit Slot"` is the cl
 
 ---
 
-## Encryption cluster (~250 LOC, Slot C remaining)
+## Associations-autosave cluster (~940 LOC across 4 remaining slots)
 
-Slot A closed in #1405, Slot B closed in #1409. Remaining:
+Slots A (#1426) + B (#1434) closed.
 
-- **Slot C — Lazy previousSchemes + store_accessor + insert/defaults + ciphertext constancy** (~250 LOC). Lazy `previousSchemes` getter invalidated by `Configurable.onConfigure`; `EncryptedTrafficLightWithStoreState` fixture; single-row `Base.insert` wrapper; un-skip 4 tests.
+3. **Slot C** (~230 LOC) — Transaction wrapping of autosave chain + `RecordInvalid` raise from saveBang.
+4. **Slot D** (~280 LOC) — `Associations::NestedError` propagation + `errors.indexErrors` + i18n full-message.
+5. **Slot E** (~220 LOC) — CPK / queryConstraints / polymorphic-inverse / custom-context.
+6. **Slot F** (~210 LOC) — Reflection introspection + per-class non-cyclic guard.
 
-## Serialization cluster (~70 LOC, Slot B remaining)
+## Associations-reflection cluster (~900 LOC across 5 slots, from audit-associations-reflection)
 
-Slot A closed in #1404. Remaining:
+31 empty-stub tests with generic boilerplate annotation. **Impl is fundamentally complete**; gaps are fixture plumbing + test-body writing + 3 fixture-model gaps.
 
-- **Slot B — serialized-column join fixture** (~60–80 LOC, optional). Add fixture-style models to `serialization.test.ts`; un-skip 1 join test.
+1. **Slot A** (~80 LOC) — Error-type parity (`UnknownPrimaryKey`, `ConfigurationError` from plain `Error`).
+2. **Slot B** (~120 LOC) — Empty-stub bodies for already-implemented features (`columnForAttribute`, `columnsForAttribute` — re-uses existing impl from `attribute-methods.test.ts` / `calculations.test.ts`).
+3. **Slot C** (~250 LOC) — Polymorphic HMT fixture (Hotel/Department/Chef/CakeDesigner/DrinkDesigner) + scope-chain tests.
+4. **Slot D** (~250 LOC) — Author/Organization essay fixture + dependent tests.
+5. **Slot E** (~200 LOC) — Namespace resolution (`MacroReflection#_klass`) + `sourceType`-as-class guard.
+
+3 const_missing/NameError tests → unported-list candidates (Ruby-only language semantics).
+
+## MySQL warnings cluster — **closed via #1435** ✅
+
+Slot A shipped (~240 LOC, 9 unskips, full feature port). Slot B ignore-list delegation rolled into A.
+
+## MySQL schema cluster (~400 LOC across 3 slots, from audit-mysql-schema)
+
+8 tests. One real behavior gap + one option drop + 6 fixture/test-helper gaps.
+
+1. **Slot A** (~120 LOC) — `t.float :foo, limit: N` → `FLOAT(N)` MySQL DDL + `indexes()` retains `using` / `type`.
+2. **Slot B** (~80 LOC) — `temporary:` option propagation on `dropTable` + annotation rewrite.
+3. **Slot C** (~200 LOC) — MySQL fixture/test-helper infrastructure: `posts`, `key_tests`, `lessons_students`/`topics`/`students` fixtures + subclassing `Base` with qualified `db.table` table_name.
+
+## MySQL quoting cluster — Slot A closed ✅ (consolidation cluster below)
+
+Slot A shipped (#1442): instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName`. The post-merge divergence triggered a follow-on 4-phase cleanup — see "MySQL quoting consolidation cluster" below.
+
+## MySQL quoting consolidation cluster — **closed** ✅
+
+All 4 phases shipped: #1447 (abstract leakage) → #1448 (call-site routing) → #1450 (delete invented helpers) → #1451 (module-mixin conversion). Standalone-vs-instance divergence eliminated.
+
+## PG connection cluster (~130 LOC across 3 remaining slots, from audit-pg-connection)
+
+Slots A (#1439) + B (#1446) closed.
+
+3. **Slot C** (~50 LOC) — PG `resetBang()` override + un-skip 2 reset tests.
+4. **Slot D** (~60 LOC) — `verify!` server-side-disconnect recovery + 1 test.
+5. **Slot E** (~20 LOC) — `connection options` test rewrite (driver supports `-c geqo=off`; just need adapter constructed with that config).
+
+Could bundle as 2 PRs (A+B ~160 LOC and C+D+E ~130 LOC) given size policy — or keep granular if all 5 land quickly.
+
+## PG datatype cluster — **closed via #1432** ✅
+
+Slot A shipped: 9 stale stubs deleted + 2 fixtures added + 6 fixture-backed un-skips.
+
+## PG interval cluster (~180 LOC, Slot B remaining)
+
+Slot A closed in #1431 (Rails-aligned test names + 6 fabricated deletions + round-trip verification).
+
+- **Slot B** (~180 LOC) — Interval schema-default extraction + AVG aggregate typecast.
+
+## PG long-tail cluster (~1760 LOC across 8 slots, from audit-pg-long-tail)
+
+**73 skipped tests** across 12 PG long-tail files (citext, money, ltree, tsquery, bit-string, geometric, enum, cidr, composite, change-schema-timestamptz, …). **Annotation drift on all 73** — identical generic template points at fictional per-feature OID files. Real gaps live in `schema-statements` / `schema-dumper` / `schema-creation` / adapter helpers / `type-map-init` / schema-definitions DSL. A few features (composite, geometric beyond Point, tsquery serialize) have no source counterpart at all.
+
+1. **Slot A** (~250 LOC) — citext end-to-end.
+2. **Slot B** (~200 LOC) — money column metadata + serialize.
+3. **Slot C** (~250 LOC) — ltree + tsquery + bit-string write/cast.
+4. **Slot D** (~280 LOC) — geometric long-tail OIDs.
+5. **Slot E** (~280 LOC) — enum schema-dump round-trip.
+6. **Slot F** (~150 LOC) — composite Identity fallback.
+7. **Slot G** (~200 LOC) — cidr IPAddr value + prefix-aware changed?
+8. **Slot H** (~150 LOC) — change-schema timestamptz default.
+
+## PG UUID residual cluster (~250 LOC, Slot B remaining)
+
+Slots A (#1433) + C (#1444) closed.
+
+2. **Slot B** (~250 LOC) — Associations + UUID FK binding.
+
+Plus: 1 test references "migration framework" gap — leave skipped with sharpened annotation.
+
+## MySQL table-options cluster (~480 LOC across 2 slots, from audit-mysql-table-options)
+
+9 tests, **all blocked by two foundational gaps** (not per-test):
+
+1. `AbstractMysqlAdapter.tableOptions(tableName)` is a `{}` stub — must parse `SHOW CREATE TABLE` for `charset` / `collation` / `comment` / residual `options:` string.
+2. Base `SchemaDumper.emitTable` never calls `source.tableOptions(table)`; emits TS-DSL `await ctx.createTable(...)` instead of Ruby-mirroring `create_table "name", charset: ..., options: ..., force: :cascade do |t| ...`.
+
+Plus: MySQL `SchemaDumper.tableCollationCache` is never populated; base `createTable` lacks `options`/`charset`/`collation`/composite-`primaryKey`.
+
+1. **Slot A** (~230 LOC) — `tableOptions` parsing + dumper wiring.
+2. **Slot B** (~250 LOC) — Ruby-style dump output + composite PK + remaining tests.
+
+## MySQL charset-collation cluster (~315 LOC across 3 slots, from audit-mysql-charset-collation)
+
+7 tests sharing one Rails setup (`create_table :charset_collations, id: { type: :string, collation: "utf8mb4_bin" }`).
+
+1. **Slot A** (~120–180 LOC) — `createTable` `id` hash form `{ type, collation, ... }` + `ColumnOptions.charset` + test #3 ("add column with charset and collation"). Most other gaps already plumbed in `mysql/schema-creation.ts` (CHARACTER SET / COLLATE) and `newColumnFromField` (reads `Collation` from `SHOW FULL FIELDS`).
+2. **Slot B** (~150–220 LOC) — MySQL `changeColumn` + `buildChangeColumnDefinition` stubs (both empty today). Includes "preserve existing collation for text→text/string" + `:no_collation` sentinel semantics. Unblocks tests 4–7.
+3. **Slot C** (~15 LOC, optional) — BLOCKED annotation cleanup.
+
+## Encryption cluster (closed)
+
+All three slots shipped:
+
+- Slot A — Binary-column encryption fixtures (#1405)
+- Slot B — `messageSerializer` per-encrypts() option pass-through + msgpack fixture (#1409)
+- Slot C — Lazy `previousSchemes` + `store_accessor` + insert/defaults (#1420). One residual: deterministic ciphertext byte-parity with MRI Rails (blocked on `MessageSerializer` double-base64 bug — in post-merge fidelity followups).
+
+## Serialization cluster — **closed** ✅
+
+Slot A (#1404) + Slot B (#1445) shipped.
 
 ## Relation cluster (~1660 LOC across 7 slots, from audit-relation)
 
@@ -123,14 +225,15 @@ Slot A closed in #1415. 155 actual skipped (estimate revised down from ~209). Si
 2. **Slot B — Translate-exception depth: timeout + statement-timeout** (~200 LOC). `read_timeout` → `AdapterTimeout`, `ER_FILSORT_ABORT` / `ER_QUERY_TIMEOUT` → `StatementTimeout`.
 3. **Slot C — Timezone re-sync + db_warnings_action + test-helper infra** (~280 LOC). `query_options[:database_timezone]` plumbing + `with_db_warnings_action`.
 
-## SQLite adapter cluster (~120 LOC, from audit-adapter-sqlite)
+## SQLite adapter cluster (~50 LOC, Slot B remaining)
 
-9 BLOCKED tests in `adapters/sqlite3/sqlite3-adapter.test.ts`. Two real slots + 2 unported-list candidates (folded into Unported-list additions in plan):
+Slot A closed in #1443 (`strict_strings_by_default` class-config knob + 3 unskips; DQS toggle is a no-op in better-sqlite3 — followups for future driver support).
 
-1. **Slot A — `strict_strings_by_default` class-config knob** (~70 LOC). 3 tests; one Rails feature + 2 variations.
 2. **Slot B — `assertLogged` SCHEMA-event parity** (~50 LOC). 2 test-infra gap tests.
 
-## PG infinity cluster (~250 LOC, from audit-pg-infinity)
+## PG infinity cluster (closed — #1427 shipped 6 unskips; 3 deferred to fidelity followups, ~135 LOC residual)
+
+Original: ~250 LOC, from audit-pg-infinity)
 
 **Audit finding: feature is already implemented.** The 18-test file is fabricated; Rails' `infinity_test.rb` has only 9 tests. The 9 extra positive/negative splits + "infinity where clause" name are TS-only inventions.
 
@@ -138,20 +241,21 @@ Slot A closed in #1415. 155 actual skipped (estimate revised down from ~209). Si
 
 **Slot A** (~250 LOC) — Sentinel unification (replace `Symbol` sentinels with `Number.POSITIVE_INFINITY`/`Number.NEGATIVE_INFINITY` for date/datetime types) + prune the 9 fabricated tests + add `PostgresqlInfinity` fixture + `InTimeZone` test helper.
 
-## PG foreign-table cluster (~230 LOC, from audit-pg-foreign-table)
+## PG foreign-table cluster (closed — #1429 shipped 16 unskips; 1 deferred to fidelity followups)
+
+Original: ~230 LOC, from audit-pg-foreign-table)
 
 **Audit finding: feature is already complete** (`foreignTables`/`foreignTableExists` + `dataSourceSql(..., type: "FOREIGN TABLE")` branch). 17 BLOCKED tests are empty stubs; their BLOCKED annotation points at `connection-adapters/postgresql/foreign-table.ts` which **does not exist and need not exist**. Rails creates foreign tables via raw `execute("CREATE FOREIGN TABLE ...")` after `postgres_fdw` setup — no schema-statement methods.
 
 **Slot A** (~200–260 LOC) — Port `foreign_table_test.rb` bodies. Pure test work; zero adapter changes.
 
-## PG virtual-column cluster (~400 LOC, from audit-pg-virtual-column)
+## PG virtual-column cluster (~250 LOC, Slot B remaining)
 
-**Audit finding: feature itself is already implemented.** The 19 BLOCKED tests in `adapters/postgresql/virtual-column.test.ts` are largely fabricated — they don't mirror Rails' `virtual_column_test.rb` (which has only 8 tests). **7 of the 19 tests belong to `xml_test.rb`** and are misplaced in a `PostgresqlXmlTest` describe block.
+Slot A closed in #1430 (rewrite TS file to mirror Rails + XML relocation).
 
-1. **Slot A — Rewrite TS test file to mirror Rails + buildFixtureSql virtual filter** (~150 LOC). Re-locate the 7 XML tests to a new `pg/xml.test.ts`; rewrite the remaining tests to match the 8 Rails-mirrored ones. Drop fabricated tests.
-2. **Slot B — Live-PG round-trip harness + un-skip 5 Rails-mirrored tests** (~250 LOC). `defineSchema`-less `create_table` path; `change_table { |t| t.virtual ... }`; small `buildFixtureSql` virtual-column filter.
+- **Slot B** (~250 LOC) — Live-PG round-trip harness + un-skip 5 Rails-mirrored tests. `defineSchema`-less `create_table`; `change_table { |t| t.virtual ... }`; `buildFixtureSql` virtual-column filter.
 
-Deferred: `test_build_fixture_sql` until fixture feature lands.
+---
 
 ## PG-schema audit cluster (~530 LOC across 3 slots, from audit-pg-schema)
 
@@ -177,9 +281,9 @@ Re-categorization of all 89 `BLOCKED: unknown` annotations. **Single foundationa
 
 audit-STI found **no STI implementation gap**. All 6 `BLOCKED: STI` tests are mis-labeled — real causes are missing fixture scopes, UUID PK + touch on polymorphic delegated_type, and PG `CREATE TABLE … INHERITS` schema-dump (closed by pg-schema Slot B above). Single tests-only PR re-annotates the 6 tests under correct categories.
 
-## Schema cluster (~1540 LOC across 8 remaining slots + annotation sweep, from audit-schema)
+## Schema cluster (~1390 LOC across 7 remaining slots + annotation sweep, from audit-schema)
 
-Slot A closed in #1407; Slot B in flight as #1418; Slot G superseded by MySQL active-schema cluster.
+Slot A closed in #1407; Slot B closed in #1418; Slot G superseded by MySQL active-schema cluster.
 
 3. **Slot C** (~80–120 LOC, sized down per #1407) — Index dump metadata (partial `where:`, `order:`, `nulls_not_distinct`, expression indices). ~7 un-skips.
 4. **Slot D** (~220 LOC) — Check / exclusion / unique constraints in dumper. 5 un-skips.
@@ -190,17 +294,16 @@ Slot A closed in #1407; Slot B in flight as #1418; Slot G superseded by MySQL ac
 9. **Slot J** (~120 LOC) — `Schema.define` with `tableNamePrefix` + bulk-change timestamps default + SchemaCache portable bits. 5 un-skips.
 10. **Slot K** — Annotation normalization across all 128 BLOCKED annotations. Lands AFTER C–J.
 
-## PG-adapter cluster (~620 LOC across 3 remaining slots + 1 optional, from audit-pg-postgresql-adapter)
+## PG-adapter cluster (~340 LOC across 2 remaining slots)
 
-Slot B closed in #1414; Slot D closed in #1411 (as `withSecondAdapter` + SQLSTATE wiring; 3 follow-up residuals in fidelity followups).
+Slot B closed in #1414; Slot C closed in #1436; Slot D closed in #1411.
 
 1. **Slot A** (~220 LOC) — `execInsert` returning-disabled fallback + `extractTableRefFromInsertSql` helper. 4 un-skips.
-2. **Slot C** (~280 LOC) — Enum OID registration + `Column.defaultFunction` arithmetic + ErrorReporter `:report` wiring. 3 un-skips.
-3. **Slot E** (optional, ~120 LOC) — Prepared-statements introspection. 3 un-skips.
+2. **Slot E** (optional, ~120 LOC) — Prepared-statements introspection. 3 un-skips.
 
 ## Transactions cluster (~350 LOC across 3 remaining slots + 1 deferred, from audit-transactions)
 
-Slot A in flight as #1417.
+Slot A closed in #1417 (2 followup-LOC bugs surfaced: dirty-tracking clobber + isolation-error-type; both in post-merge fidelity followups).
 
 2. **Slot B** (~120 LOC) — Fixture-model gaps: `Topic+Reply`, `Movie` (custom PK), `Cpk::Book` (composite PK). 4 un-skips.
 3. **Slot C** (~80 LOC) — Test helpers: `open_transactions` probe + callback-raises listener. 2–3 un-skips.

--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -231,23 +231,13 @@ Slot A closed in #1443 (`strict_strings_by_default` class-config knob + 3 unskip
 
 2. **Slot B — `assertLogged` SCHEMA-event parity** (~50 LOC). 2 test-infra gap tests.
 
-## PG infinity cluster (closed — #1427 shipped 6 unskips; 3 deferred to fidelity followups, ~135 LOC residual)
+## PG infinity cluster — **closed via #1427** ✅
 
-Original: ~250 LOC, from audit-pg-infinity)
+Slot A shipped: sentinel unification (`Symbol` → `Number.POSITIVE_INFINITY`/`NEGATIVE_INFINITY` for date/datetime), 6 un-skips, fabricated tests pruned. 3 residuals tracked in fidelity followups (~135 LOC: range-bound serialization, `InTimeZone` helper, MySQL `quote()` non-finite guard).
 
-**Audit finding: feature is already implemented.** The 18-test file is fabricated; Rails' `infinity_test.rb` has only 9 tests. The 9 extra positive/negative splits + "infinity where clause" name are TS-only inventions.
+## PG foreign-table cluster — **closed via #1429** ✅
 
-**Real gap:** date/datetime infinity is stored as `Symbol` sentinels (`DateInfinity`, `DateNegativeInfinity`) while Rails uses `Float::INFINITY` itself. `assert_equal Float::INFINITY, record.date_field` fails value-equality.
-
-**Slot A** (~250 LOC) — Sentinel unification (replace `Symbol` sentinels with `Number.POSITIVE_INFINITY`/`Number.NEGATIVE_INFINITY` for date/datetime types) + prune the 9 fabricated tests + add `PostgresqlInfinity` fixture + `InTimeZone` test helper.
-
-## PG foreign-table cluster (closed — #1429 shipped 16 unskips; 1 deferred to fidelity followups)
-
-Original: ~230 LOC, from audit-pg-foreign-table)
-
-**Audit finding: feature is already complete** (`foreignTables`/`foreignTableExists` + `dataSourceSql(..., type: "FOREIGN TABLE")` branch). 17 BLOCKED tests are empty stubs; their BLOCKED annotation points at `connection-adapters/postgresql/foreign-table.ts` which **does not exist and need not exist**. Rails creates foreign tables via raw `execute("CREATE FOREIGN TABLE ...")` after `postgres_fdw` setup — no schema-statement methods.
-
-**Slot A** (~200–260 LOC) — Port `foreign_table_test.rb` bodies. Pure test work; zero adapter changes.
+Slot A shipped: 16/17 `foreign_table_test.rb` bodies ported (pure test work; zero adapter changes — the BLOCKED annotation pointing at a non-existent `postgresql/foreign-table.ts` was fabricated). 1 deferred test (`Base.primaryKey` → `adapter.primaryKey(tableName)` for tables without explicit PK) tracked in fidelity followups.
 
 ## PG virtual-column cluster (~250 LOC, Slot B remaining)
 

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -1,6 +1,6 @@
 # ActiveRecord API Parity Plan: 100% closed → post-100% Rails-fidelity stories
 
-**Snapshot 2026-05-11:** `4969/4969 methods (100%) | files: 275/275 | inheritance: 209/209 (100%) | test:compare ~75.6%`.
+**Snapshot 2026-05-12:** `activerecord 4969/4969 methods (100%) | files: 275/275 | inheritance: 209/209 (100%)`. `activemodel 625/625 (100%)` — restored via #1438.
 
 The api:compare scoreboard is **closed**. Everything below is post-100% Rails-fidelity work — test:compare un-skips driven by audit clusters plus accumulated fidelity polish. Each PR targets ~250 LOC (CLAUDE.md hard ceiling 300; range 220–280).
 
@@ -12,38 +12,247 @@ Closed work lives in `git log` — `git log --grep "audit Slot\|fidelity\|un-ski
 
 ## In flight
 
+_(none — all queued work shipped as of this snapshot)_
+
 `gh pr list --state open` is the live picture. Cluster details for in-flight slots live in [`activerecord-100-clusters.md`](activerecord-100-clusters.md).
-
-| PR    | Story                                                                                  |
-| ----- | -------------------------------------------------------------------------------------- |
-| #1417 | Transactions Slot A — fixture/annotation cleanup (~120 LOC)                            |
-| #1418 | Schema Slot B — FK section + ignored-tables + prefix/suffix (~150 LOC)                 |
-| %227  | Encryption Slot C — lazy previousSchemes + store_accessor + insert/defaults (~250 LOC) |
-
-Other panes from this session have either delivered audit reports (triaged into clusters above) or moved their work into the PRs listed.
 
 ---
 
-## Post-merge fidelity followups (~225 LOC, 10 items)
+## Recently closed (P0 wave 1)
 
-> Triage hygiene: two items removed from earlier session triage as stale (Copilot #1419 review caught them): `addUniqueConstraint`/`removeUniqueConstraint` are already implemented in PG with passing tests (#1410 post-pr was outdated); `caseInsensitiveComparison` async runtime-bug is hypothetical — sync-base + no PG override means the call site at `uniqueness.ts:300` safely gets `null` today. Both will be addressed by PG-adapter cluster Slot C's actual scope.
+- **#1426** Autosave Slot A — Association-object indirection ✅ (foundational; B–F downstream now unblocked)
+- **#1427** pg-infinity Slot A — `Float::INFINITY` sentinel unification + 6 unskips ✅ (3 followups in fidelity)
+- **#1428** reflection Slot B — 5 unskips (audit oversized) ✅
+- **#1429** pg-foreign-table Slot A — 16/17 unskips ✅ (1 deferred, fidelity followup)
 
-Small Rails-fidelity polish surfaced via PR reviews + post-merge findings:
+**P0 wave 2 + adjacent (just merged):**
 
-- **~40 LOC** — 3 deferred tsrange/tstzrange array tests (need `ts_ranges`/`tstz_ranges` array columns). (#1395 deferred)
-- **~50 LOC** — `with_env_tz` test-infra (stub `defaultSqlTimezone()` per-block). Unblocks 2 base.test.ts tests. (#1399)
-- **~10 LOC** — i18n minor: `record_invalid` over-populated in `activemodel.errors.messages` namespace. (#1403)
-- **~10 LOC** — Validate `HashAccessor.write` json-branch JSON-stringify behavior. (#1404)
-- **~30 LOC** — Validation audit findings: restore Rails test bodies in 2 validation test files. (audit-validation)
-- **~30 LOC** — `mixin_test.rb` "many updates" + "create turned off" un-skips. Blocked only on fixture wiring: `defineSchema` mixins table + `vi.useFakeTimers` for `travel 5.minutes`. (#1416 followup)
-- **~5 LOC** — Delete 3 phantom `it.skip` tests with no Rails counterpart: 2 in `modules.test.ts`, 1 in `base.test.ts`. (#1416 followup)
-- **~30 LOC** — Wire `tableOptions()` into `schema-dumper.ts:emitTable` so MySQL charset/collation/engine + PG schema options land in the dump. May overlap pg-schema Slot B / Schema Slot E. (#1407 followup)
-- **~10 LOC** — `compressIfWorthIt` in `encryptor.ts` uses UTF-8 byte count; for Latin-1 binary payloads, compression threshold fires earlier than Rails. Round-trip correct but threshold drift. (#1409 followup)
-- **~10 LOC** — `reconnect after bad connection on check version` test residual: needs proxy returning malformed server_version response. (#1411 followup)
+- **#1430** pg-virtual-column Slot A — rewrite to mirror Rails + XML relocation ✅
+- **#1431** pg-interval Slot A — Rails-aligned test names ✅ (Slot B ~180 LOC still open)
+- **#1432** pg-datatype Slot A — 6 fixture-backed + 9 stale deletions ✅ (cluster done)
+- **#1433** pg-uuid-residual Slot A — SchemaDumper UUID-PK + 5 unskips ✅ (B+C still open)
+- **#1435** mysql-warnings Slot A — full feature port + 9 unskips ✅ (cluster done)
+- **#1436** pg-adapter Slot C — Enum OID + defaultFunction + ErrorReporter ✅ (A + E-optional still open)
+- **#1437** api:compare → 100% restoration — 4 regressions from #1421/#1423 fixed ✅
 
-**Closed via #1408:** `_performInsert` block, `_storeAccessorsModules` WeakMap, MySQL non-CT function defaults, `databaseTypeToText` serialized branch + `Serialized.isBinary` delegation, `assertEncryptedAttribute` round-trip.
+**Currently in flight:** _(none)_
 
-**Closed via fidelity-sweep A:** `MigrationLike#up/down` adapter arg (already done), `lookupCastTypeFromJoinDependencies` type (already done), PG `as number` casts (already done), schema-qualified FROM regex (already done), `_compileSelectSql`/visitor consolidation (already done), `_mapTimeWithZoneToUtc` helper (already done), `RangeType.encodeLiteral` workaround, `PostgreSQLWithBinds.visitArelNodesCasted` resolveValueForDatabase, `validateForeignKey` pg_namespace join, `roles.ts` WRITING_ROLE/READING_ROLE + `currentRole`/`preventWrites` wiring, `dropTable` CASCADE PG override, `reconnection_error` test, `translate no connection exception to not established` test, `restoreTransactionRecordState` PK-write guard, `SavepointTransaction`/`RestartParentTransaction` → `TransactionIsolationError`, `ForeignKeyDefinition#isExportNameOnSchemaDump` wired in schema-dumper.
+**P0 wave 3 + adjacent (just merged):**
+
+- **#1434** Autosave Slot B — collection mutation via `Association.insertRecord` ✅
+- **#1438** activemodel api:compare → 100% — yaml-encoder unported + IntegerType.deserialize + inheritance fix ✅
+- **#1439** PG connection Slot A — `SQLSubscriber` test helper + 7 logs_name unskips ✅
+- **#1440** chore(test) — cap vitest worker count to 4 (prevent local saturation) ✅
+- **#1443** SQLite Slot A — `strict_strings_by_default` class config + 3 unskips ✅
+- **#1442** MySQL quoting Slot A — instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName` ✅ (standalone-function divergence: see fidelity followup; full consolidation now a 4-phase cluster — Phase 1 + 2 in flight as %281/%282)
+- **#1444** PG UUID Slot C — UniquenessValidator UUID-aware case-insensitive bypass ✅ (deviates from Rails — adapter-layer in Rails, validator-layer here; ~30 LOC async-bridge followup)
+- **#1445** Serialization Slot B — serialized-column join fixture ✅ (cluster done)
+- **#1446** PG connection Slot B — `execQuery prepare:` kwarg + `statement_name` payload ✅
+- **#1447** MySQL quoting consolidation Phase 1 — remove `quoterForAdapterName` from `abstract/schema-{definitions,creation}.ts` ✅
+- **#1448** MySQL quoting consolidation Phase 2 — 5 call sites routed through `this.quote()` ✅
+- **#1449** Column#default lazy-deserialize — dumper-layer deserialize + model-instance cast ✅ (4 model-default unskips; 13 schema-dump tests still fixture-blocked)
+- **#1450** MySQL quoting Phase 3 — delete invented helpers + internalize standalone `quoteString` ✅
+- **#1451** MySQL quoting Phase 4 — module-mixin conversion for thin delegates ✅ (**cluster closed**)
+- **#1453** Query-cache Phase 1 — context-keyed registry + pin wiring + checkout/checkin attachment ✅ (cross-context cache pollution data-safety bug fixed; Phases 2-4 queued)
+- **#1452** PG json driver-level cast bypass — per-connection `getTypeParser` override for OIDs 114/3802 ✅ (also fixed a latent pre-existing PG `quote()` E-string backslash bug for inline-quoted string values)
+
+## P0 — spawn-next priority
+
+The rest of the inventory is FIFO-by-audit-delivery. P0 items below get spawned first; pick by file-conflict avoidance when running ≥2 in parallel.
+
+### P0a — Foundational (closed)
+
+- ✅ **Autosave Slot A** — Association-object indirection (#1426). Autosave B–F now spawnable.
+
+### P0b — Audit-verified "impl complete, only test work"
+
+| Slot                    | LOC  | Status                                                       |
+| ----------------------- | ---- | ------------------------------------------------------------ |
+| pg-foreign-table A      | ~230 | ✅ #1429 (16 un-skips)                                       |
+| pg-infinity A           | ~250 | ✅ #1427 (6 un-skips, 3 followups)                           |
+| reflection B            | ~120 | ✅ #1428 (5 un-skips, audit oversized)                       |
+| **pg-virtual-column A** | ~150 | %260 in flight                                               |
+| **pg-interval A**       | ~220 | %261 in flight                                               |
+| **pg-datatype A**       | ~220 | open — delete 9 stale + 6 fixture-backed un-skips            |
+| **pg-uuid-residual A**  | ~230 | open — SchemaDumper UUID-PK test bodies + annotation cleanup |
+
+**Remaining P0b**: 2 in flight + 2 open. Wave-1 yield: **27 un-skips** across 4 PRs.
+
+---
+
+## Post-merge fidelity followups (~700 LOC, 26 items)
+
+Small Rails-fidelity polish from PR reviews + post-merge findings. Items closed by recent sweeps are summarized at the end.
+
+### Deferred from sweep B (#1422)
+
+- **~50 LOC** — `with_env_tz` test-infra (stub `defaultSqlTimezone()` per-block via a module-level `_defaultSqlTimezoneOverride` + `withEnvTimezone(zone, fn)` test helper). Unblocks 2 base.test.ts tests. (#1399)
+- **~10 LOC** — `HashAccessor.write` json-branch regression test (path is correct today; needs a defensive test). (#1404)
+- **~30 LOC** — Wire `tableOptions()` into `schema-dumper.ts:emitTable`. Requires making the dump loop async; overlaps pg-schema Slot B / Schema Slot E. (#1407)
+- **~30 LOC** — `MessageSerializer.encodeIfNeeded` double-base64 fix. **Architectural**: requires `Aes256Gcm` to store raw bytes (not base64 strings) in headers — a _breaking change_ for existing stored ciphertexts. Only ship with a migration path. (#1420)
+
+### Reverted from sweep A (#1421)
+
+- **~5 LOC** — Remove `RangeType.encodeLiteral` pre-serialization workaround. Reverted: still load-bearing — removing it broke `range.test.ts > where by attribute with range` (PG `42883: No operator matches`). Real fix needs BindParam range-quoting (next item). (#1390)
+- **~20 LOC** — Fix the BindParam route for range WHERE predicates so range values quote correctly. Unblocks the `RangeType.encodeLiteral` removal. (#1421 followup)
+- **~30 LOC** — `validateForeignKey` `!fSchema → public` heuristic. Reverted: the `pg_namespace` join diverged from Rails (which uses `t2.oid::regclass::text` + `search_path`). Original fragility concern remains for non-public-schema FKs on search_path. Needs a different schema-resolution strategy. (#1410)
+
+### From #1411/#1421 post-pr — test residuals
+
+- **~20 LOC** — `reconnect after bad connection on check version` test: pg-npm pool has no single-connection version-stub hook. Needs `_databaseVersionForTest()` setter or injectable version-check hook. (`translate no connection exception to not established` is now confirmed redundant — 57P01 covered by `reconnection_error` fake-pool injection.) (#1411)
+
+### From #1421 post-pr — transactions
+
+- **~50 LOC** — Dirty-tracking for new-record rollback: `topic.changes["title"]` returns `undefined` instead of `[null, "Jeff"]` after rollback. Root cause deeper than sweep A's guard fix — `state.attributes` snapshot in `rememberTransactionRecordState` captures user-written values, so `redetectChanges` produces no diff. Fix: snapshot _DB-original_ values (null for unsaved new records), or add separate DB-original tracking. (#1417)
+
+### From #1421 post-pr — schema dumper
+
+- **~30 LOC** — `SchemaDumper.fkIgnorePattern` configurability vs `ForeignKeyDefinition.isExportNameOnSchemaDump` hardcoded `fk_rails_` pattern. Either (a) make `isExportNameOnSchemaDump` accept the configured pattern, restoring `fkIgnorePattern` functionality; or (b) deprecate `fkIgnorePattern` since FK now owns the decision (Rails-faithful). (#1418/#1407 followup)
+
+### From #1423 post-pr — insert-all polish
+
+- **~30 LOC** — Add `supportsInsertConflictTarget()` to `DatabaseAdapter` interface + impls (true for sqlite≥3.24, pg, mysql≥8). Wire Rails' guard in `_findUniqueIndexFor` so unsupported adapters raise the proper `ArgumentError` rather than falling through to "No unique index found". (#1423)
+- **~50 LOC** — Thin `IndexDefinition` value class in `connection-adapters/`. Mutate `this.uniqueBy` to it in constructor (post-await in `_populateUpdatableColumns`). Unlocks `ON CONSTRAINT <name>` for PG. (#1423)
+- **~10 LOC** — Add `model.adapter.schemaCacheBound` returning a pool-bound one-arg `indexes(tableName)` form so call sites don't know about the pool. The two-arg signature was the footgun this PR hit. (#1423)
+
+### From #1424 post-pr — PG schema-statements
+
+- **~30 LOC** — Rewire PG mixin chain so `PostgreSQLAdapter#dropTable` delegate can be deleted. Add per-adapter `include(PostgreSQLAdapter, ...)` for PG-specific schema-statements methods. Mirrors Rails' `include PostgreSQL::SchemaStatements`. (#1424)
+- **~50 LOC** — Live PG integration test for `dropTable("parent", { force: "cascade" })` end-to-end. Current tests use a fake adapter. (#1424)
+
+### From audit-as-any-method-calls
+
+- **~10–20 LOC** — Verify 2 `bug-suspected` candidates from the as-any audit: `relation.ts:4965` `(this.spawn() as any).asyncBang()` (possible swallowed promise) + `abstract/database-statements.ts:1827` `(relation as any).arel()` (verify sync on every host). If real, surgical fixes. (audit-as-any-method-calls)
+
+### From #1426 post-pr — autosave A
+
+- **~50 LOC** — Preloader → `associationInstanceSet` migration. Update the ~14 map-direct write sites (preloader/association.ts, preloader/batch.ts, relation.ts:2149-2161, 6 sites in associations.ts) to call `record.associationInstanceSet(name, association)`. Once done, `_loadedAssociation` collapses to a one-line Rails-shaped pure read. (#1426)
+- **~30 LOC** — Wire `custom_validation_context?` branch into `validateHasOneAssociation` / `validateBelongsToAssociation`. Rails autosave_association.rb:332/346. (#1426)
+
+### From #1427 post-pr — pg infinity
+
+- **~40 LOC** — Arel range-bound serialization for `Float::INFINITY` endpoints. Unblocks 2 remaining `where clause with infinite range` tests. Likely a `QueryAttribute.serialize` / range visitor change. (#1427)
+- **~80 LOC** — `InTimeZone` test helper + `time_zone_aware_attributes` integration. Unblocks 1 remaining infinity TZ-aware test. Touches `Base.timeZoneAwareAttributes`, `reset_column_information`, TimeZoneConverter wrapping for sentinel values. (#1427; may need its own slot)
+- **~10 LOC** — MySQL `quote()` non-finite handling (`mysql/quoting.ts:177`). Same bareword bug pg had; no MySQL infinity test surfaced it. Preventive. (#1427)
+- **~5 LOC cleanup** — `persistence.ts:872-880` isDateInfinity branch now too broad post-sentinel-unification; gate on temporal type-name. (#1427)
+- **~5 LOC cleanup** — `temporalToBindString` PG infinity branch may be dead post-PR; trace + delete if confirmed. (#1427)
+
+### From #1428 post-pr — reflection B
+
+- **~30 LOC** — Wire `ensureOptionNotGivenAsClassBang` into ThroughReflection / source-type validation path (defined but never called today). Unblocks `class for source type` test. (#1428)
+- **~50 LOC** — `static set primaryKey(null)` semantics + `Edge` fixture; un-skip `association primary key raises when missing primary key` + `active record primary key raises when missing primary key`. (#1428)
+- **~15 LOC** — Annotation refresh on 22 remaining `reflection.test.ts` stubs (all carry wrong AggregateReflection/ThroughReflection boilerplate; real causes vary). (#1428)
+- **~30 LOC future** — `NullColumn` class so `assert_instance_of NullColumn` Rails asserts can port verbatim. Duck-compatible shape exists; only matters if porting that specific assertion. (#1428)
+
+### From #1429 post-pr — pg foreign-table
+
+- **~30–80 LOC** — Wire `Base.primaryKey` to consult `adapter.primaryKey(tableName)` for tables without explicit PK (foreign tables). Touches `getPrimaryKeyAttr` `?? "id"` sentinel (distinguish "unset" vs "explicitly nil") + `model-schema.ts` PK auto-detection. Affects all models; careful test pass. Un-skips 1 deferred test. (#1429)
+
+### From #1430 post-pr — pg virtual-column
+
+- **~15–30 LOC** — Route `addColumn` through `schemaCreation.accept(AddColumnDefinition)`; fix `visitColumnDefinition` to call `addColumnOptionsBang` instead of `addColumnOptions`. Unblocks `test_non_persisted_column` + `test_change_table` Rails-parity rewrites. (#1430)
+- **~30–80 LOC** — Rewire `emitTable` to use connection-adapter `columnSpec` / `prepareColumnOptions`. Unblocks `test_schema_dumping` and adapter-specific column quirks (enum/array). (#1430)
+- **~50–100 LOC** — Harmonize `PostgreSQLAdapter.createTable` signature with abstract base; delete `SimpleTableBuilder`. Touches `range.test.ts:297` + `invertible-migration.test.ts:41` callers. Leading comment at `postgresql-adapter.ts:2749` already flags this. (#1430)
+
+### From #1431 post-pr — pg interval
+
+- **~30–80 LOC** — Interval **row-read** deserialization. Wire interval column values through `Interval.castValue` in attribute-set materialization or postgresql/oid result deserialization. Unblocks 2 tests (`interval type`, `interval type cast from numeric`). (#1431)
+- **~20 LOC** — `extractValueFromDefault` for interval — route interval defaults through `Interval#typeCastForSchema` in `postgresql/schema-statements.ts` + schema-dumper column-default rendering. Unblocks `schema dump with default value`. (#1431)
+- **~30 LOC** — Aggregate result type-cast — wire `typeForAttribute` through aggregate-result coercion in `calculations.ts`. Unblocks `average interval type`. Benefits more than just interval. (#1431)
+
+### From #1432 post-pr — pg datatype
+
+- **~5 LOC** — PG interval binary-format parser: explicit delegation to `pg.types.getTypeParser(1186, "binary")` or document the text-only assumption. (#1432)
+- **~10 LOC** — Register **other PG-only types** (`Hstore`, `Jsonb`, `Money`, `Inet`, `Cidr`, `Macaddr`, `Bit`, `BitVarying`, `Xml`, `Point`, `Uuid`) on AM `typeRegistry` the same way `Interval` was registered. Without this, `attribute :col, :hstore` etc. throw `Unknown type` on PG models. Likely unblocks Rails-mirror tests in per-type files. (#1432)
+- **~10 LOC** — Lift `columnForAttribute` schema-vs-attribute distinction into JSDoc on `model-schema.ts:493` (Copilot concern). (#1432)
+
+### From #1433 post-pr — pg uuid
+
+- **~20 LOC** — Emit non-PK column `defaultFunction` as `default: () => "fn()"` in `emitTable`, mirroring the PK path. Unblocks function-default round-tripping for all non-PK columns (`gen_random_uuid`, `now`, `CURRENT_TIMESTAMP`). (#1433)
+- **~30 LOC** — Make `SchemaDumper.dumpTableSchema(adapter, ...)` instantiate the adapter's `createSchemaDumper()` class rather than the base — lets PG/MySQL/SQLite-specific overrides fire. Then move `primaryKeyTableOptions` to PG subclass per Rails layout. (#1433)
+- **~40 LOC** — Harmonize `PostgreSQLAdapter.createTable` callback-first signature with abstract `SchemaStatements.createTable` (options-first + optional fn). Removes `@ts-expect-error TS2416` and lets `default` option flow. (#1433)
+
+### From #1435 post-pr — mysql-warnings
+
+- **~15 LOC** — `SQLWarning.connectionPool` field + plumb `this.pool` through `_handleWarningsOn`; add `error.connectionPool === adapter.pool` assertion to the `:raise` test once `Mysql2Adapter#pool` is stable. (#1435)
+- **~30 LOC** — Mirror `_handleWarningsOn` onto `TrilogyAdapter` once Trilogy execute path is live. Driver-row-shape may differ. (#1435)
+- **~10 LOC** — Optimization — Rails reads `@raw_connection.warning_count` directly (mysql2 exposes it as a method); the mysql2 npm driver may expose this via `conn.serverStatus` or protocol packet. Avoids one round-trip per non-ignore query. (#1435)
+- **~20 LOC** — Fold `_handleWarningsOn` into `AbstractMysqlAdapter._handleWarnings(sql)` driven by an abstract `_currentConn()` accessor once Mysql2 `perform_query` is ported per Rails layout. (#1435)
+
+### From #1436 post-pr — pg-adapter Slot C
+
+- **~50 LOC** — Railtie initializer constructing a default `ErrorReporter`, wiring a basic logger subscriber, calling `setErrorReporter()`. Closes the "Rails.error always exists" gap. (#1436)
+- **~60 LOC** — Collapse `splitPgDefault` into `extractValueFromDefault` + `extractDefaultFunction` so parsing lives in the Rails-named instance methods. Update both call sites in `newColumnFromField` (~lines 2671 + 4310). (#1436)
+- **~30 LOC** — Apply `:report` dispatch wiring to MySQL/SQLite `db_warnings_action` paths if/when they grow one. Today only PG honors `db_warnings_action`. (#1436)
+
+### From #1452 post-pr — PG json bypass
+
+- **~5 LOC** — Add a model-save round-trip test for TEXT columns with backslash values (e.g. `"a\\b"`) to exercise the Arel **inline-quoting** path (not the bind-param path). The #1452 regression test uses `executeMutation` (bind params) which doesn't touch `quote()`. The expanded scope of #1452 fixed a pre-existing backslash bug in PG `quote()` that had zero test coverage. (#1452)
+- **~5 LOC** — `abstractQuote` Symbol branch still doubles backslashes without E-string. Zero practical impact (no Symbol description in AR carries `\`) but inconsistent with the String branch fix in #1452. (#1452)
+- **Architectural observation, not a followup** — Rails always uses bind parameters for INSERT/UPDATE values; never inline-quotes via `quote_string`. Our Arel visitor inlines via `quote()`, which is why the E-string fix in #1452 was load-bearing rather than redundant. If we ever wire bind-param extraction (`compileWithBinds`) into the model save path, the PG E-string passthrough becomes a redundant safety net. Note for whoever does that wiring.
+
+### From #1453 post-pr — query-cache Phase 1
+
+- **~30 LOC (Phase 2)** — `_threadQueryCaches` eviction. Map keyed by monotonically-increasing context IDs grows unboundedly in long-lived processes (daemons). Three options: (a) `withExecutionContext` try/finally calls `_cacheConfig.deleteStore(id)`; (b) store the `Store` directly in AsyncLocalStorage instead of a global Map; (c) bounded LRU cap. Decision needed on which fits the `activesupport/async-context-adapter` model. (#1453)
+- **~10 LOC (Phase 2)** — `DatabaseConfig.queryCacheMaxSize` wiring. `ConnectionPoolConfiguration` constructor accepts the param but `ConnectionPool` passes no argument (defaults to 100). Thread `dbConfig.queryCacheMaxSize` through `PoolConfig` → `ConnectionPool` constructor. (#1453)
+- **~20 LOC (Phase 3)** — `enableQueryCacheBang`/`disableQueryCacheBang` at checkout/checkin. Rails propagates pool-level enable/disable state to connections at checkout; today the pool never calls these. Store's `enabled` flag stays false until user code explicitly enables. (#1453)
+- **~20 LOC (Phase 3)** — `withQueryCache(fn)` public API on `ConnectionPool`. Wraps `enableQueryCacheBang` / fn / finally `disableQueryCacheBang + clearQueryCache`. (#1453)
+- **~40 LOC (Phase 4)** — `QueryCache.installExecutorHooks` middleware path. Wires `ExecutorHooks` to enable/disable around each request. Requires `ConnectionHandler` wiring (PR 6 prerequisite). Unblocks 6 pool-attachment tests. (#1453)
+- **Rails divergences (deliberate, more correct under concurrency)** — `_pinnedCount` integer instead of single-reference `@pinned_connection` (Rails uses thread-local single ref); `_queryCacheVersion` shared across contexts (Rails per-thread). Both are safe-over-strict because our `ConnectionPoolConfiguration` is shared across async contexts where Rails' is per-thread via `IsolatedExecutionState`. Documented for future code archaeology. (#1453)
+- **~5 LOC cleanup** — Two redundant `checkoutAndVerify` paths: `ConnectionPoolConfiguration.checkoutAndVerify` (instance method, superseded by direct assigns in `checkout()`/`checkoutAsync()`) and module-level `checkoutAndVerify` (reachable only via `tryToCheckoutNewConnection`, harmless). Decision: remove or wire to canonical path. (#1453)
+
+### From #1449 post-pr — Column#default lazy-deserialize
+
+- **~100–200 LOC (test-infra, not impl)** — Fixture-table infra to unblock the 13 remaining skipped tests (`MysqlDefaultExpressionTest` ×9, `DefaultsTestWithoutTransactionalFixtures` ×2, `PostgresqlDefaultExpressionTest` ×1, `Sqlite3DefaultExpressionTest` ×1). Need a harness mechanism to seed pre-existing fixture tables (`defaults`, `datetime_defaults`, `timestamp_defaults`) analogous to Rails' `fixtures/` directory. Test-infra story, not implementation. (#1449)
+- **~30 LOC** — Promote `sqlType` from optional on `Column` (abstract schema-dumper) to the `ColumnInfo` base interface. It's universally present across all three adapters; the optional declaration is a vestige of the partial migration. (#1449)
+- **Architectural fix shipped, not a followup** — `Column#default lazy-deserialize` was moved from the deferred Architectural section into shipped scope by #1449. The "broad blast radius" framing was overstated — the fix turned out to be two touch points (`BaseSchemaDumper.schemaDefault` deserialize-through-adapter + `model-schema.applyColumnsHash` cast) with no `Column` / `lookupCastType` / `newColumnFromField` changes needed.
+
+### From #1446/#1447/#1448 post-pr — recent sweep
+
+- **~5 LOC** — `typeCastedBinds` in `abstract/quoting.ts:~490` duplicates the one in `abstract/database-statements.ts` and still uses the old `typeof b.valueForDatabase === "function"` check. Unify to the getter-aware `"valueForDatabase" in b` form. Low risk — different call paths. (#1446)
+- **~50–100 LOC (architectural-ish)** — `TableDefinition.toSql()` in `abstract/schema-definitions.ts:~926-1095` still branches on `_adapterName` for type SQL (SERIAL vs BIGINT AUTO_INCREMENT, BYTEA vs BLOB, etc.). Largely redundant with `SchemaCreation.typeToSql()` + `SchemaCreation.visitTableDefinition()` which are more complete. Route through `SchemaCreation.accept()` and delete `toSql()` to complete the polymorphic-dispatch cleanup. (#1447)
+- **~15 LOC (Rails divergence, pre-existing)** — `_buildInitSql` in `mysql2-adapter.ts` omits the `NAMES #{encoding} COLLATE #{collation}` prepend that Rails' `configure_connection` (abstract_mysql_adapter.rb:947-951) emits when `@config[:encoding]` is set. `variables.encoding` from `database.yml` is silently ignored. (#1448)
+- **CI investigation needed (not sized)** — `Received unexpected commandComplete message from backend` flake fired on a client with `_poolUseCount: 3256`. Pre-existing pg pool teardown race when the pool closes while a server-side response is in transit. Worth dedicated investigation if it recurs. (#1446)
+
+### From #1444 post-pr — PG UUID Slot C
+
+- **~30 LOC (Rails divergence + latent bug)** — `caseInsensitiveComparison` is async on PG (queries `pg_proc`) but `UniquenessValidator.buildRelation` is sync, so #1444 moved the UUID bypass into `buildRelation`. **Concrete consequence:** for any non-string non-UUID column type where `canPerformCaseInsensitiveComparisonFor` returns false (custom types with no `lower()` overload), `buildRelation` currently passes a `Promise` to `base.where()`, throwing `ArgumentError: Unsupported argument type`. UUID is fixed; other types are latent. Fix options: (a) make `buildRelation` async and await; (b) expose a sync `canPerformCaseInsensitiveComparisonForSync` on the adapter seeded with known-false types (citext already cached). (#1444)
+- **~10–30 LOC audit** — `typeObj?.type` was caught as a CI bug post-open (`Uuid.type` is a method, not a property — returned the function instead of `"uuid"`). Audit other `.type` reads off type objects across the codebase for the same mistake class. Candidate for fidelity-sweep. (#1444)
+
+### From #1442 post-pr — MySQL quoting Slot A
+
+- **~20 LOC (Rails divergence)** — Standalone module function `quoteString` in `connection-adapters/mysql/quoting.ts:88` still uses SQL-standard `''` doubling. Rails' `MySQL::Quoting#quote_string` (instance) **and** the `quote()` path both use backslash-escape. **Concrete consequence:** `adapter.quote("it's")` returns `'it''s'` (doubling) while `adapter.quoteString("it's")` returns the fixed backslash form — same adapter, two different outputs. Fix: update standalone `quoteString` to backslash-escape, route `quote()` in `abstract-mysql-adapter.ts` through `this.quoteString()` instead of `mysqlQuote()`, update test at `mysql/quoting.test.ts:36`. DDL COMMENT call sites (`abstract-mysql-adapter.ts:578, 1319`) want the full wrapping literal — correct as-is. (#1442)
+
+### From #1434 review — autosave Slot B (Rails divergences, max-cycles deferred)
+
+- **~3 LOC (Rails divergence)** — `base.ts` `save()` captures `prev = _newRecordBeforeSave` and restores in `finally`, but unconditionally overwrites with `wasNewRecord`. Rails' `aroundSaveCollectionAssociation` uses `prev = @new_record_before_save ||= false; @new_record_before_save = !prev && new_record?` — once true, stays true through nested saves. **Concrete consequence:** during re-entrant/nested saves on the same record (e.g. callback chain that re-enters `save` on the parent), the inner autosave dispatch in `_insertCollectionRecord` can incorrectly treat association writes as **updates** (via `record.save(validate:false)`) when the outer scope already marked the parent as new — meaning a fresh insert path (`Association.insertRecord(record, false)` + `setInverseInstance` + counter-cache increment) is skipped. Fix: change `_newRecordBeforeSave = wasNewRecord` to `_newRecordBeforeSave = !prev && wasNewRecord` in `save()`. (#1434 Copilot review #9)
+- **~5 LOC** — `HasManyThroughAssociation#insertRecord(record, validate, raise)` doesn't propagate `validate`/`raise` to the join-record save. Join is saved via `joinRecord.save()` with default options. Diverges from target record save (which honors `validate`) and from Rails bang/non-bang behavior. Fix: pass `validate`; use `saveBang` when `raise` is true. (#1434 Copilot review #10)
+- **Process note** — #1434 scope drifted mid-review: `HasManyThroughAssociation#insertRecord` override originally out-of-scope, included after maintainer rejected the gating workaround. Honest fix mirrored Rails `has_many_through_association.rb:24-34`. Total size still under budget. Documented in PR body. (#1434)
+
+### From #1439 post-pr — PG connection Slot A
+
+- **~10 LOC** — `statement_name` in `sql.active_record` payload for PG prepared-statement path (`_runQuery` / `execQuery` with `prepare: true`). Unblocks "statement key is logged" test. (#1439)
+- **~30 LOC** — `prepare: false` with binds — needs `QueryAttribute`-style bind objects with a `prepare: false` exec path wired through `execQuery`. Unblocks `prepare false with binds` test. (#1439)
+- **~3 LOC** — `tableAliasLength()` override on `PostgreSQLAdapter` returning `this.maxIdentifierLength()`. Blocked by base-class sync `number` return — would widen to `Promise<number> | number`. (#1439)
+- **Test-infra refactor** — Move `SQLSubscriber` from `adapters/postgresql/test-helper.ts` to a shared location when `adapters/abstract-mysql-adapter/connection.test.ts` is un-skipped (Rails defines it on `ActiveRecord::TestCase`). (#1439)
+
+### From #1443 post-pr — SQLite Slot A
+
+- **~5 LOC** — Add `strict` field to `SqliteOpenConfig` in `activesupport/src/sqlite-adapter.ts`. Documents intent for future drivers (e.g. `node:sqlite`) that expose `sqlite3_db_config`. (#1443)
+- **~20 LOC** — better-sqlite3 DQS toggle: when upstream exposes `sqlite3_db_config`, pass `strict` through `Database.Options` in `sqlite-drivers/better-sqlite3.ts:openDatabase`. Then the `configureConnection` pragma block (currently silently ignored) can be removed. (#1443)
+- **Known limitation** — `strict_strings_by_default` is a no-op in current driver: better-sqlite3 compiles with `SQLITE_DQS=0`, so DQS is always off and `assert_nothing_raised` (non-strict accepts index on missing column) cannot be exercised. Documented inline. (#1443)
+
+### From #1437 post-pr — api:compare → 100% restoration
+
+- **Process improvement** — `_`-prefix renames on Rails-named methods silently drop them from `api:compare` surface. Consider extending the `rails-private-jsdoc` ESLint rule to flag `_`-prefixed methods whose Rails counterpart is non-underscored. Permanent guardrail against the regression class. (#1437)
+
+### Closed in recent sweeps
+
+- **Closed via fidelity-sweep A (#1421):** `MigrationLike#up/down` adapter arg, `lookupCastTypeFromJoinDependencies` type, PG `as number` casts, schema-qualified FROM regex, `_compileSelectSql`/visitor consolidation, `_mapTimeWithZoneToUtc` helper, `PostgreSQLWithBinds.visitArelNodesCasted` resolveValueForDatabase, `roles.ts` WRITING_ROLE/READING_ROLE wiring, `restoreTransactionRecordState` PK-write guard (partial — see new ~50 LOC item above), `SavepointTransaction`/`RestartParentTransaction` → `TransactionIsolationError`, `ForeignKeyDefinition#isExportNameOnSchemaDump` wired in schema-dumper, `reconnection_error` test, item-count header sync, ~15 others.
+- **Closed via fidelity-sweep B (#1422):** tsrange/tstzrange array tests, i18n `record_invalid` namespace, validation test bodies, mixin_test ports, phantom test deletions, `compressIfWorthIt` UTF-8 byte-count.
+- **Closed via #1408 / #1423 / #1424:** `_performInsert` block, `_storeAccessorsModules` WeakMap, MySQL non-CT function defaults, `databaseTypeToText` serialized branch + `Serialized.isBinary` delegation, `assertEncryptedAttribute` round-trip (dropped), `InsertAll.uniqueIndexes` async fix (#1423), `SchemaStatements.dropTable` CASCADE PG override (#1424).
+- **Closed via #1437 api:compare restoration:** `_findUniqueIndexFor`/`_uniqueIndexes`/`_uniqueByColumns` underscore prefixes dropped (restore Rails surface names); `encodeRange` named export restored in `pg/quoting.ts`.
+- **Stale items removed in #1419 review (Copilot caught):** `addUniqueConstraint`/`removeUniqueConstraint` adapter methods (already implemented in PG with passing tests); `caseInsensitiveComparison` async runtime-bug (hypothetical only — base sync + no PG override).
 
 ---
 
@@ -57,15 +266,15 @@ Small Rails-fidelity polish surfaced via PR reviews + post-merge findings:
 
 ## Test:compare audits queued (read-only research)
 
-**12 audit task files queued** at `$HOME/.btwhooks/data/github/blazetrailsdev/trails/todo/`. Remaining buckets: PG (datatype / uuid-residual / interval / connection / long-tail), MySQL (warnings / table-options / schema / quoting / charset-collation), 2 associations (autosave / reflection / extras), plus migration-residual.
+**Audit queue closed** — every test:compare audit task filed during this initiative has been delivered (see `git log` for the audit-cluster slot citations and triage history). Remaining work is impl-execution against the 14 audit clusters now in `activerecord-100-clusters.md`.
 
 ---
 
 ## Architectural (deferred; too big for single ~250-LOC slot)
 
-- **Column#default lazy-deserialize broader refactor** (~50 LOC, #1402 sized). MySQL's `lookupCastType` returns shape-only metadata, so `newColumnFromField` stores raw DB strings. Dumper then emits `"5"` not `5`. Fix: `lookupCastType` returns full type → `Column` stores raw + lazy `deserialize()`. **Blocks ~17 tests in `defaults.test.ts`**.
-- **PG `json` driver-level cast bypass** (~80 LOC). `pg` driver always JSON.parses; string assignments don't round-trip. Needs adapter-level intercept.
-- **Connection-pool / per-thread query-cache architecture** (>300 LOC). audit-query-cache Gap 3. Blocks 14 query-cache tests + `_pinnedConnection` lifecycle.
+- ~~**Column#default lazy-deserialize broader refactor**~~ — **shipped via #1449.** Fix turned out to be two touch points (`BaseSchemaDumper.schemaDefault` + `model-schema.applyColumnsHash`), not a Column rewrite. 4 of 17 tests unblocked; 13 still fixture-blocked (see fidelity followups).
+- ~~**PG `json` driver-level cast bypass**~~ — **shipped via #1452.** ~25 LOC, not the originally-sized 80 — the design pass narrowed it to 2 lines in the existing `getTypeParser` closure. As a bonus, the agent caught and fixed a pre-existing PG `quote()` E-string backslash bug.
+- **Connection-pool / per-thread query-cache architecture** (~780 LOC across 4 phases). Phase 1 shipped via #1453 (context-keyed registry + pin wiring). Phases 2-4 queued — see fidelity followups. ~10 actionable test unskips (4 db_config + 6 pool-attachment); other 4 are permanent (GVL/fork/thread skips).
 
 ### Other deferred (need wider design)
 
@@ -90,39 +299,54 @@ Small Rails-fidelity polish surfaced via PR reviews + post-merge findings:
 
 Cluster details in [`activerecord-100-clusters.md`](activerecord-100-clusters.md).
 
-| Group                                     | Open | LOC est.        |
-| ----------------------------------------- | ---- | --------------- |
-| In flight (#1417, #1418, %227)            | 3    | —               |
-| Encryption cluster (C in flight as %227)  | 0    | —               |
-| Serialization cluster                     | 1    | ~70             |
-| Relation cluster                          | 7    | ~1660           |
-| Associations-core cluster                 | 5    | ~910            |
-| Associations-HABTM cluster                | 9    | ~1690           |
-| Associations has-many-through cluster     | 5    | ~1280           |
-| Associations has-one cluster              | 4    | ~480            |
-| Migration cluster                         | 6    | ~1210           |
-| Connection-pool cluster                   | 3    | ~640            |
-| MySQL active-schema cluster               | 3    | ~680            |
-| MySQL mysql2-adapter cluster              | 3    | ~700            |
-| SQLite adapter cluster                    | 2    | ~120            |
-| PG infinity cluster                       | 1    | ~250            |
-| PG foreign-table cluster                  | 1    | ~230            |
-| PG virtual-column cluster                 | 2    | ~400            |
-| PG-schema audit cluster                   | 3    | ~530            |
-| Unknown-triage cluster                    | 4    | ~640            |
-| STI annotation-drift                      | 1    | ~20             |
-| Schema cluster (A closed; B in flight)    | 8    | ~1540           |
-| PG-adapter cluster                        | 3    | ~620            |
-| Transactions cluster (A in flight)        | 3    | ~350            |
-| MySQL onUpdate followups                  | 2    | ~30             |
-| NotImplementedError elimination (Phase 2) | 7    | ~610            |
-| Post-merge fidelity followups             | 10   | ~225            |
-| Doc-hygiene + infra followups             | 3    | ~30             |
-| Test:compare audits queued                | 12   | n/a (read-only) |
-| Architectural deferred                    | 3    | ~410            |
-| Infra-blocked                             | 6    | n/a             |
+| Group                                                   | Open | LOC est.            |
+| ------------------------------------------------------- | ---- | ------------------- |
+| In flight                                               | 0    | —                   |
+| Encryption cluster (all 3 slots closed)                 | 0    | —                   |
+| Serialization cluster                                   | 1    | ~70                 |
+| Relation cluster                                        | 7    | ~1660               |
+| Associations-core cluster                               | 5    | ~910                |
+| Associations-HABTM cluster                              | 9    | ~1690               |
+| Associations has-many-through cluster                   | 5    | ~1280               |
+| Associations has-one cluster                            | 4    | ~480                |
+| Migration cluster                                       | 6    | ~1210               |
+| Connection-pool cluster                                 | 3    | ~640                |
+| MySQL active-schema cluster                             | 3    | ~680                |
+| MySQL mysql2-adapter cluster                            | 3    | ~700                |
+| MySQL warnings cluster (A closed #1435)                 | 0    | —                   |
+| MySQL schema cluster                                    | 3    | ~400                |
+| MySQL quoting cluster                                   | 1    | ~120                |
+| MySQL table-options cluster                             | 2    | ~480                |
+| MySQL charset-collation cluster                         | 3    | ~315                |
+| MySQL onUpdate followups                                | 2    | ~30                 |
+| SQLite adapter cluster                                  | 2    | ~120                |
+| PG-adapter cluster (B+C+D closed; A+E open)             | 2    | ~340                |
+| PG-schema audit cluster                                 | 3    | ~530                |
+| PG infinity cluster (A closed #1427)                    | 0    | —                   |
+| PG foreign-table cluster (A closed #1429)               | 0    | —                   |
+| PG virtual-column cluster (A closed #1430)              | 1    | ~250                |
+| PG datatype cluster (A closed #1432)                    | 0    | —                   |
+| PG interval cluster (A closed #1431; B open)            | 1    | ~180                |
+| PG UUID residual cluster (A closed #1433)               | 2    | ~330                |
+| PG connection cluster                                   | 5    | ~290                |
+| PG long-tail cluster                                    | 8    | ~1760               |
+| Schema cluster (A+B closed)                             | 7    | ~1390               |
+| Transactions cluster (A closed #1417)                   | 3    | ~350                |
+| Unknown-triage cluster                                  | 4    | ~640                |
+| STI annotation-drift                                    | 1    | ~20                 |
+| Associations-autosave cluster (A #1426, B #1434 closed) | 4    | ~940                |
+| Associations-reflection cluster (B closed #1428)        | 4    | ~780                |
+| NotImplementedError elimination (Phase 2)               | 7    | ~610                |
+| `as any` legacy-cast cleanup sweep                      | 1    | ~250                |
+| Post-merge fidelity followups                           | 78   | ~1675               |
+| Doc-hygiene + infra followups                           | 3    | ~30                 |
+| Test:compare audits queued                              | 0    | n/a (all delivered) |
+| Architectural deferred                                  | 3    | ~410                |
+| Infra-blocked                                           | 6    | n/a                 |
 
-**90 actionable work-PR slots + 12 queued audits**, ~14.7k LOC of open Rails-fidelity work. (Associations clusters overlap — real net is ~12k LOC after dedup.)
+**~109 actionable work-PR slots + 0 queued audits**, ~19.7k LOC. P0 fully shipped (#1426–#1437; ~60 un-skips); audit-encryption / pg-foreign-table / pg-infinity / pg-virtual-column / pg-datatype / pg-uuid-residual / mysql-warnings clusters all closed or in-flight on Slot A. Headline P0 yield: **27 un-skips wave 1 + 33 more wave 2** plus autosave A's foundational unblock for autosave B–F.
+
+The two `as any` audits (delivered 2026-05-12) found **zero new critical bugs** post-#1423 — the optional-chain audit returned `0 bug-suspected` and the method-call audit returned `2 bug-suspected` (folded into post-merge fidelity followups above for surgical verification). The high-leverage opportunity is **Sweep B from audit-as-any-method-calls**: ~250 LOC mechanical removal of 52 legacy-cast-removable instance-method casts on `Base` (`(record as any)._readAttribute`, `.save`, `.destroy`, etc. — TS types already declare these). The optional-chain audit's ~110 `legacy-removable` sites are dependent on the same `Base` host-interface tightening; can be folded into the same sweep or land second.
 
 ---
 

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -1,284 +1,196 @@
 # ActiveRecord API Parity Plan: 100% closed → post-100% Rails-fidelity stories
 
-**Snapshot 2026-05-12:** `activerecord 4969/4969 methods (100%) | files: 275/275 | inheritance: 209/209 (100%)`. `activemodel 625/625 (100%)` — restored via #1438.
+**Snapshot 2026-05-12:** `activerecord 4969/4969 methods (100%) | files: 275/275 | inheritance: 209/209 (100%) | activemodel 625/625 (100%)`.
 
 The api:compare scoreboard is **closed**. Everything below is post-100% Rails-fidelity work — test:compare un-skips driven by audit clusters plus accumulated fidelity polish. Each PR targets ~250 LOC (CLAUDE.md hard ceiling 300; range 220–280).
 
-This doc is the **live work tracker** (in-flight, post-merge followups, story count, guardrails). For per-cluster slot detail (slot descriptions, LOC sizing, audit attribution, overlap notes), see [`activerecord-100-clusters.md`](activerecord-100-clusters.md). For workflow + BLOCKED-annotation vocab + audit conventions, see [`test-compare-100-plan.md`](test-compare-100-plan.md).
+This doc is the **live work tracker** (post-merge followups, story count, guardrails). For per-cluster slot detail, see [`activerecord-100-clusters.md`](activerecord-100-clusters.md). For workflow + BLOCKED-annotation vocab + audit conventions, see [`test-compare-100-plan.md`](test-compare-100-plan.md).
 
 Closed work lives in `git log` — `git log --grep "audit Slot\|fidelity\|un-skip" origin/main`. This doc lists only **open work**.
 
 ---
 
-## In flight
+## Post-merge fidelity followups (~1675 LOC)
 
-_(none — all queued work shipped as of this snapshot)_
+Small Rails-fidelity polish from PR reviews. Subsections group items by topic.
 
-`gh pr list --state open` is the live picture. Cluster details for in-flight slots live in [`activerecord-100-clusters.md`](activerecord-100-clusters.md).
+### Deferred from sweep B
 
----
+- **~50 LOC** — `with_env_tz` test-infra (stub `defaultSqlTimezone()` per-block via a module-level `_defaultSqlTimezoneOverride` + `withEnvTimezone(zone, fn)` test helper). Unblocks 2 base.test.ts tests.
+- **~10 LOC** — `HashAccessor.write` json-branch regression test (path is correct today; needs a defensive test).
+- **~30 LOC** — Wire `tableOptions()` into `schema-dumper.ts:emitTable`. Requires making the dump loop async; overlaps pg-schema Slot B / Schema Slot E.
+- **~30 LOC** — `MessageSerializer.encodeIfNeeded` double-base64 fix. **Architectural**: requires `Aes256Gcm` to store raw bytes (not base64 strings) in headers — a _breaking change_ for existing stored ciphertexts. Only ship with a migration path.
 
-## Recently closed (P0 wave 1)
+### Reverted from sweep A
 
-- **#1426** Autosave Slot A — Association-object indirection ✅ (foundational; B–F downstream now unblocked)
-- **#1427** pg-infinity Slot A — `Float::INFINITY` sentinel unification + 6 unskips ✅ (3 followups in fidelity)
-- **#1428** reflection Slot B — 5 unskips (audit oversized) ✅
-- **#1429** pg-foreign-table Slot A — 16/17 unskips ✅ (1 deferred, fidelity followup)
+- **~5 LOC** — Remove `RangeType.encodeLiteral` pre-serialization workaround. Reverted: still load-bearing — removing it broke `range.test.ts > where by attribute with range` (PG `42883: No operator matches`). Real fix needs BindParam range-quoting (next item).
+- **~20 LOC** — Fix the BindParam route for range WHERE predicates so range values quote correctly. Unblocks the `RangeType.encodeLiteral` removal.
+- **~30 LOC** — `validateForeignKey` `!fSchema → public` heuristic. Reverted: the `pg_namespace` join diverged from Rails (which uses `t2.oid::regclass::text` + `search_path`). Original fragility concern remains for non-public-schema FKs on search_path. Needs a different schema-resolution strategy.
 
-**P0 wave 2 + adjacent (just merged):**
+### Test residuals
 
-- **#1430** pg-virtual-column Slot A — rewrite to mirror Rails + XML relocation ✅
-- **#1431** pg-interval Slot A — Rails-aligned test names ✅ (Slot B ~180 LOC still open)
-- **#1432** pg-datatype Slot A — 6 fixture-backed + 9 stale deletions ✅ (cluster done)
-- **#1433** pg-uuid-residual Slot A — SchemaDumper UUID-PK + 5 unskips ✅ (B+C still open)
-- **#1435** mysql-warnings Slot A — full feature port + 9 unskips ✅ (cluster done)
-- **#1436** pg-adapter Slot C — Enum OID + defaultFunction + ErrorReporter ✅ (A + E-optional still open)
-- **#1437** api:compare → 100% restoration — 4 regressions from #1421/#1423 fixed ✅
+- **~20 LOC** — `reconnect after bad connection on check version` test: pg-npm pool has no single-connection version-stub hook. Needs `_databaseVersionForTest()` setter or injectable version-check hook. (`translate no connection exception to not established` is now confirmed redundant — 57P01 covered by `reconnection_error` fake-pool injection.)
 
-**P0 wave 3 + adjacent (just merged):**
+### Transactions
 
-- **#1434** Autosave Slot B — collection mutation via `Association.insertRecord` ✅
-- **#1438** activemodel api:compare → 100% — yaml-encoder unported + IntegerType.deserialize + inheritance fix ✅
-- **#1439** PG connection Slot A — `SQLSubscriber` test helper + 7 logs_name unskips ✅
-- **#1440** chore(test) — cap vitest worker count to 4 (prevent local saturation) ✅
-- **#1443** SQLite Slot A — `strict_strings_by_default` class config + 3 unskips ✅
-- **#1442** MySQL quoting Slot A — instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName` ✅ (standalone-function divergence: see fidelity followup; full 4-phase consolidation shipped — #1447/#1448/#1450/#1451)
-- **#1444** PG UUID Slot C — UniquenessValidator UUID-aware case-insensitive bypass ✅ (deviates from Rails — adapter-layer in Rails, validator-layer here; ~30 LOC async-bridge followup)
-- **#1445** Serialization Slot B — serialized-column join fixture ✅ (cluster done)
-- **#1446** PG connection Slot B — `execQuery prepare:` kwarg + `statement_name` payload ✅
-- **#1447** MySQL quoting consolidation Phase 1 — remove `quoterForAdapterName` from `abstract/schema-{definitions,creation}.ts` ✅
-- **#1448** MySQL quoting consolidation Phase 2 — 5 call sites routed through `this.quote()` ✅
-- **#1449** Column#default lazy-deserialize — dumper-layer deserialize + model-instance cast ✅ (4 model-default unskips; 13 schema-dump tests still fixture-blocked)
-- **#1450** MySQL quoting Phase 3 — delete invented helpers + internalize standalone `quoteString` ✅
-- **#1451** MySQL quoting Phase 4 — module-mixin conversion for thin delegates ✅ (**cluster closed**)
-- **#1453** Query-cache Phase 1 — context-keyed registry + pin wiring + checkout/checkin attachment ✅ (cross-context cache pollution data-safety bug fixed; Phases 2-4 queued)
-- **#1452** PG json driver-level cast bypass — per-connection `getTypeParser` override for OIDs 114/3802 ✅ (also fixed a latent pre-existing PG `quote()` E-string backslash bug for inline-quoted string values)
+- **~50 LOC** — Dirty-tracking for new-record rollback: `topic.changes["title"]` returns `undefined` instead of `[null, "Jeff"]` after rollback. Root cause deeper than sweep A's guard fix — `state.attributes` snapshot in `rememberTransactionRecordState` captures user-written values, so `redetectChanges` produces no diff. Fix: snapshot _DB-original_ values (null for unsaved new records), or add separate DB-original tracking.
 
-## P0 — spawn-next priority
+### Schema dumper
 
-The rest of the inventory is FIFO-by-audit-delivery. P0 items below get spawned first; pick by file-conflict avoidance when running ≥2 in parallel.
+- **~30 LOC** — `SchemaDumper.fkIgnorePattern` configurability vs `ForeignKeyDefinition.isExportNameOnSchemaDump` hardcoded `fk_rails_` pattern. Either (a) make `isExportNameOnSchemaDump` accept the configured pattern, restoring `fkIgnorePattern` functionality; or (b) deprecate `fkIgnorePattern` since FK now owns the decision (Rails-faithful).
 
-### P0a — Foundational (closed)
+### Insert-all polish
 
-- ✅ **Autosave Slot A** — Association-object indirection (#1426). Autosave B–F now spawnable.
+- **~30 LOC** — Add `supportsInsertConflictTarget()` to `DatabaseAdapter` interface + impls (true for sqlite≥3.24, pg, mysql≥8). Wire Rails' guard in `_findUniqueIndexFor` so unsupported adapters raise the proper `ArgumentError` rather than falling through to "No unique index found".
+- **~50 LOC** — Thin `IndexDefinition` value class in `connection-adapters/`. Mutate `this.uniqueBy` to it in constructor (post-await in `_populateUpdatableColumns`). Unlocks `ON CONSTRAINT <name>` for PG.
+- **~10 LOC** — Add `model.adapter.schemaCacheBound` returning a pool-bound one-arg `indexes(tableName)` form so call sites don't know about the pool. The two-arg signature was the footgun this PR hit.
 
-### P0b — Audit-verified "impl complete, only test work" (all closed)
+### PG schema-statements
 
-| Slot                | LOC  | Status                                                          |
-| ------------------- | ---- | --------------------------------------------------------------- |
-| pg-foreign-table A  | ~230 | ✅ #1429 (16 un-skips)                                          |
-| pg-infinity A       | ~250 | ✅ #1427 (6 un-skips, 3 followups)                              |
-| reflection B        | ~120 | ✅ #1428 (5 un-skips, audit oversized)                          |
-| pg-virtual-column A | ~150 | ✅ #1430 (rewrite + XML relocation)                             |
-| pg-interval A       | ~220 | ✅ #1431 (Rails-aligned test names; Slot B ~180 LOC still open) |
-| pg-datatype A       | ~220 | ✅ #1432 (6 fixture-backed un-skips + 9 stale deletions)        |
-| pg-uuid-residual A  | ~230 | ✅ #1433 (SchemaDumper UUID-PK test bodies + 5 un-skips)        |
+- **~30 LOC** — Rewire PG mixin chain so `PostgreSQLAdapter#dropTable` delegate can be deleted. Add per-adapter `include(PostgreSQLAdapter, ...)` for PG-specific schema-statements methods. Mirrors Rails' `include PostgreSQL::SchemaStatements`.
+- **~50 LOC** — Live PG integration test for `dropTable("parent", { force: "cascade" })` end-to-end. Current tests use a fake adapter.
 
-P0b yield: **~50 un-skips** across 7 PRs. Spawn-next priority now moves to the open clusters in [`activerecord-100-clusters.md`](activerecord-100-clusters.md) (associations-autosave C–F, associations-reflection, mysql-schema, mysql-table-options, mysql-charset-collation, pg-long-tail, schema C–J, pg-adapter A/E, transactions B/C, sqlite B).
+### `as any` audit
 
----
+- **~10–20 LOC** — Verify 2 `bug-suspected` candidates from the as-any audit: `relation.ts:4965` `(this.spawn() as any).asyncBang()` (possible swallowed promise) + `abstract/database-statements.ts:1827` `(relation as any).arel()` (verify sync on every host). If real, surgical fixes.
 
-## Post-merge fidelity followups (~1675 LOC, 78 actionable items)
+### Autosave A
 
-Small Rails-fidelity polish from PR reviews + post-merge findings. Each subsection groups items by source PR. Items closed by recent sweeps are summarized at the end (process notes / architectural observations are not counted in the 78).
+- **~50 LOC** — Preloader → `associationInstanceSet` migration. Update the ~14 map-direct write sites (preloader/association.ts, preloader/batch.ts, relation.ts:2149-2161, 6 sites in associations.ts) to call `record.associationInstanceSet(name, association)`. Once done, `_loadedAssociation` collapses to a one-line Rails-shaped pure read.
+- **~30 LOC** — Wire `custom_validation_context?` branch into `validateHasOneAssociation` / `validateBelongsToAssociation`. Rails autosave_association.rb:332/346.
 
-### Deferred from sweep B (#1422)
+### PG infinity
 
-- **~50 LOC** — `with_env_tz` test-infra (stub `defaultSqlTimezone()` per-block via a module-level `_defaultSqlTimezoneOverride` + `withEnvTimezone(zone, fn)` test helper). Unblocks 2 base.test.ts tests. (#1399)
-- **~10 LOC** — `HashAccessor.write` json-branch regression test (path is correct today; needs a defensive test). (#1404)
-- **~30 LOC** — Wire `tableOptions()` into `schema-dumper.ts:emitTable`. Requires making the dump loop async; overlaps pg-schema Slot B / Schema Slot E. (#1407)
-- **~30 LOC** — `MessageSerializer.encodeIfNeeded` double-base64 fix. **Architectural**: requires `Aes256Gcm` to store raw bytes (not base64 strings) in headers — a _breaking change_ for existing stored ciphertexts. Only ship with a migration path. (#1420)
+- **~40 LOC** — Arel range-bound serialization for `Float::INFINITY` endpoints. Unblocks 2 remaining `where clause with infinite range` tests. Likely a `QueryAttribute.serialize` / range visitor change.
+- **~80 LOC** — `InTimeZone` test helper + `time_zone_aware_attributes` integration. Unblocks 1 remaining infinity TZ-aware test. Touches `Base.timeZoneAwareAttributes`, `reset_column_information`, TimeZoneConverter wrapping for sentinel values. (may need its own slot)
+- **~10 LOC** — MySQL `quote()` non-finite handling (`mysql/quoting.ts:177`). Same bareword bug pg had; no MySQL infinity test surfaced it. Preventive.
+- **~5 LOC cleanup** — `persistence.ts:872-880` isDateInfinity branch now too broad post-sentinel-unification; gate on temporal type-name.
+- **~5 LOC cleanup** — `temporalToBindString` PG infinity branch may be dead post-PR; trace + delete if confirmed.
 
-### Reverted from sweep A (#1421)
+### Reflection B
 
-- **~5 LOC** — Remove `RangeType.encodeLiteral` pre-serialization workaround. Reverted: still load-bearing — removing it broke `range.test.ts > where by attribute with range` (PG `42883: No operator matches`). Real fix needs BindParam range-quoting (next item). (#1390)
-- **~20 LOC** — Fix the BindParam route for range WHERE predicates so range values quote correctly. Unblocks the `RangeType.encodeLiteral` removal. (#1421 followup)
-- **~30 LOC** — `validateForeignKey` `!fSchema → public` heuristic. Reverted: the `pg_namespace` join diverged from Rails (which uses `t2.oid::regclass::text` + `search_path`). Original fragility concern remains for non-public-schema FKs on search_path. Needs a different schema-resolution strategy. (#1410)
+- **~30 LOC** — Wire `ensureOptionNotGivenAsClassBang` into ThroughReflection / source-type validation path (defined but never called today). Unblocks `class for source type` test.
+- **~50 LOC** — `static set primaryKey(null)` semantics + `Edge` fixture; un-skip `association primary key raises when missing primary key` + `active record primary key raises when missing primary key`.
+- **~15 LOC** — Annotation refresh on 22 remaining `reflection.test.ts` stubs (all carry wrong AggregateReflection/ThroughReflection boilerplate; real causes vary).
+- **~30 LOC future** — `NullColumn` class so `assert_instance_of NullColumn` Rails asserts can port verbatim. Duck-compatible shape exists; only matters if porting that specific assertion.
 
-### From #1411/#1421 post-pr — test residuals
+### PG foreign-table
 
-- **~20 LOC** — `reconnect after bad connection on check version` test: pg-npm pool has no single-connection version-stub hook. Needs `_databaseVersionForTest()` setter or injectable version-check hook. (`translate no connection exception to not established` is now confirmed redundant — 57P01 covered by `reconnection_error` fake-pool injection.) (#1411)
+- **~30–80 LOC** — Wire `Base.primaryKey` to consult `adapter.primaryKey(tableName)` for tables without explicit PK (foreign tables). Touches `getPrimaryKeyAttr` `?? "id"` sentinel (distinguish "unset" vs "explicitly nil") + `model-schema.ts` PK auto-detection. Affects all models; careful test pass. Un-skips 1 deferred test.
 
-### From #1421 post-pr — transactions
+### PG virtual-column
 
-- **~50 LOC** — Dirty-tracking for new-record rollback: `topic.changes["title"]` returns `undefined` instead of `[null, "Jeff"]` after rollback. Root cause deeper than sweep A's guard fix — `state.attributes` snapshot in `rememberTransactionRecordState` captures user-written values, so `redetectChanges` produces no diff. Fix: snapshot _DB-original_ values (null for unsaved new records), or add separate DB-original tracking. (#1417)
+- **~15–30 LOC** — Route `addColumn` through `schemaCreation.accept(AddColumnDefinition)`; fix `visitColumnDefinition` to call `addColumnOptionsBang` instead of `addColumnOptions`. Unblocks `test_non_persisted_column` + `test_change_table` Rails-parity rewrites.
+- **~30–80 LOC** — Rewire `emitTable` to use connection-adapter `columnSpec` / `prepareColumnOptions`. Unblocks `test_schema_dumping` and adapter-specific column quirks (enum/array).
+- **~50–100 LOC** — Harmonize `PostgreSQLAdapter.createTable` signature with abstract base; delete `SimpleTableBuilder`. Touches `range.test.ts:297` + `invertible-migration.test.ts:41` callers. Leading comment at `postgresql-adapter.ts:2749` already flags this.
 
-### From #1421 post-pr — schema dumper
+### PG interval
 
-- **~30 LOC** — `SchemaDumper.fkIgnorePattern` configurability vs `ForeignKeyDefinition.isExportNameOnSchemaDump` hardcoded `fk_rails_` pattern. Either (a) make `isExportNameOnSchemaDump` accept the configured pattern, restoring `fkIgnorePattern` functionality; or (b) deprecate `fkIgnorePattern` since FK now owns the decision (Rails-faithful). (#1418/#1407 followup)
+- **~30–80 LOC** — Interval **row-read** deserialization. Wire interval column values through `Interval.castValue` in attribute-set materialization or postgresql/oid result deserialization. Unblocks 2 tests (`interval type`, `interval type cast from numeric`).
+- **~20 LOC** — `extractValueFromDefault` for interval — route interval defaults through `Interval#typeCastForSchema` in `postgresql/schema-statements.ts` + schema-dumper column-default rendering. Unblocks `schema dump with default value`.
+- **~30 LOC** — Aggregate result type-cast — wire `typeForAttribute` through aggregate-result coercion in `calculations.ts`. Unblocks `average interval type`. Benefits more than just interval.
 
-### From #1423 post-pr — insert-all polish
+### PG datatype
 
-- **~30 LOC** — Add `supportsInsertConflictTarget()` to `DatabaseAdapter` interface + impls (true for sqlite≥3.24, pg, mysql≥8). Wire Rails' guard in `_findUniqueIndexFor` so unsupported adapters raise the proper `ArgumentError` rather than falling through to "No unique index found". (#1423)
-- **~50 LOC** — Thin `IndexDefinition` value class in `connection-adapters/`. Mutate `this.uniqueBy` to it in constructor (post-await in `_populateUpdatableColumns`). Unlocks `ON CONSTRAINT <name>` for PG. (#1423)
-- **~10 LOC** — Add `model.adapter.schemaCacheBound` returning a pool-bound one-arg `indexes(tableName)` form so call sites don't know about the pool. The two-arg signature was the footgun this PR hit. (#1423)
+- **~5 LOC** — PG interval binary-format parser: explicit delegation to `pg.types.getTypeParser(1186, "binary")` or document the text-only assumption.
+- **~10 LOC** — Register **other PG-only types** (`Hstore`, `Jsonb`, `Money`, `Inet`, `Cidr`, `Macaddr`, `Bit`, `BitVarying`, `Xml`, `Point`, `Uuid`) on AM `typeRegistry` the same way `Interval` was registered. Without this, `attribute :col, :hstore` etc. throw `Unknown type` on PG models. Likely unblocks Rails-mirror tests in per-type files.
+- **~10 LOC** — Lift `columnForAttribute` schema-vs-attribute distinction into JSDoc on `model-schema.ts:493` (Copilot concern).
 
-### From #1424 post-pr — PG schema-statements
+### PG UUID
 
-- **~30 LOC** — Rewire PG mixin chain so `PostgreSQLAdapter#dropTable` delegate can be deleted. Add per-adapter `include(PostgreSQLAdapter, ...)` for PG-specific schema-statements methods. Mirrors Rails' `include PostgreSQL::SchemaStatements`. (#1424)
-- **~50 LOC** — Live PG integration test for `dropTable("parent", { force: "cascade" })` end-to-end. Current tests use a fake adapter. (#1424)
+- **~20 LOC** — Emit non-PK column `defaultFunction` as `default: () => "fn()"` in `emitTable`, mirroring the PK path. Unblocks function-default round-tripping for all non-PK columns (`gen_random_uuid`, `now`, `CURRENT_TIMESTAMP`).
+- **~30 LOC** — Make `SchemaDumper.dumpTableSchema(adapter, ...)` instantiate the adapter's `createSchemaDumper()` class rather than the base — lets PG/MySQL/SQLite-specific overrides fire. Then move `primaryKeyTableOptions` to PG subclass per Rails layout.
+- **~40 LOC** — Harmonize `PostgreSQLAdapter.createTable` callback-first signature with abstract `SchemaStatements.createTable` (options-first + optional fn). Removes `@ts-expect-error TS2416` and lets `default` option flow.
 
-### From audit-as-any-method-calls
+### MySQL warnings
 
-- **~10–20 LOC** — Verify 2 `bug-suspected` candidates from the as-any audit: `relation.ts:4965` `(this.spawn() as any).asyncBang()` (possible swallowed promise) + `abstract/database-statements.ts:1827` `(relation as any).arel()` (verify sync on every host). If real, surgical fixes. (audit-as-any-method-calls)
+- **~15 LOC** — `SQLWarning.connectionPool` field + plumb `this.pool` through `_handleWarningsOn`; add `error.connectionPool === adapter.pool` assertion to the `:raise` test once `Mysql2Adapter#pool` is stable.
+- **~30 LOC** — Mirror `_handleWarningsOn` onto `TrilogyAdapter` once Trilogy execute path is live. Driver-row-shape may differ.
+- **~10 LOC** — Optimization — Rails reads `@raw_connection.warning_count` directly (mysql2 exposes it as a method); the mysql2 npm driver may expose this via `conn.serverStatus` or protocol packet. Avoids one round-trip per non-ignore query.
+- **~20 LOC** — Fold `_handleWarningsOn` into `AbstractMysqlAdapter._handleWarnings(sql)` driven by an abstract `_currentConn()` accessor once Mysql2 `perform_query` is ported per Rails layout.
 
-### From #1426 post-pr — autosave A
+### PG-adapter Slot C
 
-- **~50 LOC** — Preloader → `associationInstanceSet` migration. Update the ~14 map-direct write sites (preloader/association.ts, preloader/batch.ts, relation.ts:2149-2161, 6 sites in associations.ts) to call `record.associationInstanceSet(name, association)`. Once done, `_loadedAssociation` collapses to a one-line Rails-shaped pure read. (#1426)
-- **~30 LOC** — Wire `custom_validation_context?` branch into `validateHasOneAssociation` / `validateBelongsToAssociation`. Rails autosave_association.rb:332/346. (#1426)
+- **~50 LOC** — Railtie initializer constructing a default `ErrorReporter`, wiring a basic logger subscriber, calling `setErrorReporter()`. Closes the "Rails.error always exists" gap.
+- **~60 LOC** — Collapse `splitPgDefault` into `extractValueFromDefault` + `extractDefaultFunction` so parsing lives in the Rails-named instance methods. Update both call sites in `newColumnFromField` (~lines 2671 + 4310).
+- **~30 LOC** — Apply `:report` dispatch wiring to MySQL/SQLite `db_warnings_action` paths if/when they grow one. Today only PG honors `db_warnings_action`.
 
-### From #1427 post-pr — pg infinity
+### PG json bypass
 
-- **~40 LOC** — Arel range-bound serialization for `Float::INFINITY` endpoints. Unblocks 2 remaining `where clause with infinite range` tests. Likely a `QueryAttribute.serialize` / range visitor change. (#1427)
-- **~80 LOC** — `InTimeZone` test helper + `time_zone_aware_attributes` integration. Unblocks 1 remaining infinity TZ-aware test. Touches `Base.timeZoneAwareAttributes`, `reset_column_information`, TimeZoneConverter wrapping for sentinel values. (#1427; may need its own slot)
-- **~10 LOC** — MySQL `quote()` non-finite handling (`mysql/quoting.ts:177`). Same bareword bug pg had; no MySQL infinity test surfaced it. Preventive. (#1427)
-- **~5 LOC cleanup** — `persistence.ts:872-880` isDateInfinity branch now too broad post-sentinel-unification; gate on temporal type-name. (#1427)
-- **~5 LOC cleanup** — `temporalToBindString` PG infinity branch may be dead post-PR; trace + delete if confirmed. (#1427)
+- **~5 LOC** — Add a model-save round-trip test for TEXT columns with backslash values (e.g. `"a\\b"`) to exercise the Arel **inline-quoting** path (not the bind-param path). The regression test uses `executeMutation` (bind params) which doesn't touch `quote()`. The expanded scope of fixed a pre-existing backslash bug in PG `quote()` that had zero test coverage.
+- **~5 LOC** — `abstractQuote` Symbol branch still doubles backslashes without E-string. Zero practical impact (no Symbol description in AR carries `\`) but inconsistent with the String branch fix.
 
-### From #1428 post-pr — reflection B
+### Query-cache Phases 2–4
 
-- **~30 LOC** — Wire `ensureOptionNotGivenAsClassBang` into ThroughReflection / source-type validation path (defined but never called today). Unblocks `class for source type` test. (#1428)
-- **~50 LOC** — `static set primaryKey(null)` semantics + `Edge` fixture; un-skip `association primary key raises when missing primary key` + `active record primary key raises when missing primary key`. (#1428)
-- **~15 LOC** — Annotation refresh on 22 remaining `reflection.test.ts` stubs (all carry wrong AggregateReflection/ThroughReflection boilerplate; real causes vary). (#1428)
-- **~30 LOC future** — `NullColumn` class so `assert_instance_of NullColumn` Rails asserts can port verbatim. Duck-compatible shape exists; only matters if porting that specific assertion. (#1428)
+- **~30 LOC (Phase 2)** — `_threadQueryCaches` eviction. Map keyed by monotonically-increasing context IDs grows unboundedly in long-lived processes (daemons). Three options: (a) `withExecutionContext` try/finally calls `_cacheConfig.deleteStore(id)`; (b) store the `Store` directly in AsyncLocalStorage instead of a global Map; (c) bounded LRU cap. Decision needed on which fits the `activesupport/async-context-adapter` model.
+- **~10 LOC (Phase 2)** — `DatabaseConfig.queryCacheMaxSize` wiring. `ConnectionPoolConfiguration` constructor accepts the param but `ConnectionPool` passes no argument (defaults to 100). Thread `dbConfig.queryCacheMaxSize` through `PoolConfig` → `ConnectionPool` constructor.
+- **~20 LOC (Phase 3)** — `enableQueryCacheBang`/`disableQueryCacheBang` at checkout/checkin. Rails propagates pool-level enable/disable state to connections at checkout; today the pool never calls these. Store's `enabled` flag stays false until user code explicitly enables.
+- **~20 LOC (Phase 3)** — `withQueryCache(fn)` public API on `ConnectionPool`. Wraps `enableQueryCacheBang` / fn / finally `disableQueryCacheBang + clearQueryCache`.
+- **~40 LOC (Phase 4)** — `QueryCache.installExecutorHooks` middleware path. Wires `ExecutorHooks` to enable/disable around each request. Requires `ConnectionHandler` wiring (PR 6 prerequisite). Unblocks 6 pool-attachment tests.
+- **~5 LOC cleanup** — Two redundant `checkoutAndVerify` paths: `ConnectionPoolConfiguration.checkoutAndVerify` (instance method, superseded by direct assigns in `checkout()`/`checkoutAsync()`) and module-level `checkoutAndVerify` (reachable only via `tryToCheckoutNewConnection`, harmless). Decision: remove or wire to canonical path.
 
-### From #1429 post-pr — pg foreign-table
+### Column#default lazy-deserialize
 
-- **~30–80 LOC** — Wire `Base.primaryKey` to consult `adapter.primaryKey(tableName)` for tables without explicit PK (foreign tables). Touches `getPrimaryKeyAttr` `?? "id"` sentinel (distinguish "unset" vs "explicitly nil") + `model-schema.ts` PK auto-detection. Affects all models; careful test pass. Un-skips 1 deferred test. (#1429)
+- **~100–200 LOC (test-infra, not impl)** — Fixture-table infra to unblock the 13 remaining skipped tests (`MysqlDefaultExpressionTest` ×9, `DefaultsTestWithoutTransactionalFixtures` ×2, `PostgresqlDefaultExpressionTest` ×1, `Sqlite3DefaultExpressionTest` ×1). Need a harness mechanism to seed pre-existing fixture tables (`defaults`, `datetime_defaults`, `timestamp_defaults`) analogous to Rails' `fixtures/` directory. Test-infra story, not implementation.
+- **~30 LOC** — Promote `sqlType` from optional on `Column` (abstract schema-dumper) to the `ColumnInfo` base interface. It's universally present across all three adapters; the optional declaration is a vestige of the partial migration.
 
-### From #1430 post-pr — pg virtual-column
+### Recent sweep
 
-- **~15–30 LOC** — Route `addColumn` through `schemaCreation.accept(AddColumnDefinition)`; fix `visitColumnDefinition` to call `addColumnOptionsBang` instead of `addColumnOptions`. Unblocks `test_non_persisted_column` + `test_change_table` Rails-parity rewrites. (#1430)
-- **~30–80 LOC** — Rewire `emitTable` to use connection-adapter `columnSpec` / `prepareColumnOptions`. Unblocks `test_schema_dumping` and adapter-specific column quirks (enum/array). (#1430)
-- **~50–100 LOC** — Harmonize `PostgreSQLAdapter.createTable` signature with abstract base; delete `SimpleTableBuilder`. Touches `range.test.ts:297` + `invertible-migration.test.ts:41` callers. Leading comment at `postgresql-adapter.ts:2749` already flags this. (#1430)
+- **~5 LOC** — `typeCastedBinds` in `abstract/quoting.ts:~490` duplicates the one in `abstract/database-statements.ts` and still uses the old `typeof b.valueForDatabase === "function"` check. Unify to the getter-aware `"valueForDatabase" in b` form. Low risk — different call paths.
+- **~50–100 LOC (architectural-ish)** — `TableDefinition.toSql()` in `abstract/schema-definitions.ts:~926-1095` still branches on `_adapterName` for type SQL (SERIAL vs BIGINT AUTO_INCREMENT, BYTEA vs BLOB, etc.). Largely redundant with `SchemaCreation.typeToSql()` + `SchemaCreation.visitTableDefinition()` which are more complete. Route through `SchemaCreation.accept()` and delete `toSql()` to complete the polymorphic-dispatch cleanup.
+- **~15 LOC (Rails divergence, pre-existing)** — `_buildInitSql` in `mysql2-adapter.ts` omits the `NAMES #{encoding} COLLATE #{collation}` prepend that Rails' `configure_connection` (abstract_mysql_adapter.rb:947-951) emits when `@config[:encoding]` is set. `variables.encoding` from `database.yml` is silently ignored.
+- **CI investigation needed (not sized)** — `Received unexpected commandComplete message from backend` flake fired on a client with `_poolUseCount: 3256`. Pre-existing pg pool teardown race when the pool closes while a server-side response is in transit. Worth dedicated investigation if it recurs.
 
-### From #1431 post-pr — pg interval
+### PG UUID Slot C
 
-- **~30–80 LOC** — Interval **row-read** deserialization. Wire interval column values through `Interval.castValue` in attribute-set materialization or postgresql/oid result deserialization. Unblocks 2 tests (`interval type`, `interval type cast from numeric`). (#1431)
-- **~20 LOC** — `extractValueFromDefault` for interval — route interval defaults through `Interval#typeCastForSchema` in `postgresql/schema-statements.ts` + schema-dumper column-default rendering. Unblocks `schema dump with default value`. (#1431)
-- **~30 LOC** — Aggregate result type-cast — wire `typeForAttribute` through aggregate-result coercion in `calculations.ts`. Unblocks `average interval type`. Benefits more than just interval. (#1431)
+- **~30 LOC (Rails divergence + latent bug)** — `caseInsensitiveComparison` is async on PG (queries `pg_proc`) but `UniquenessValidator.buildRelation` is sync, so moved the UUID bypass into `buildRelation`. **Concrete consequence:** for any non-string non-UUID column type where `canPerformCaseInsensitiveComparisonFor` returns false (custom types with no `lower()` overload), `buildRelation` currently passes a `Promise` to `base.where()`, throwing `ArgumentError: Unsupported argument type`. UUID is fixed; other types are latent. Fix options: (a) make `buildRelation` async and await; (b) expose a sync `canPerformCaseInsensitiveComparisonForSync` on the adapter seeded with known-false types (citext already cached).
+- **~10–30 LOC audit** — `typeObj?.type` was caught as a CI bug post-open (`Uuid.type` is a method, not a property — returned the function instead of `"uuid"`). Audit other `.type` reads off type objects across the codebase for the same mistake class. Candidate for fidelity-sweep.
 
-### From #1432 post-pr — pg datatype
+### MySQL quoting
 
-- **~5 LOC** — PG interval binary-format parser: explicit delegation to `pg.types.getTypeParser(1186, "binary")` or document the text-only assumption. (#1432)
-- **~10 LOC** — Register **other PG-only types** (`Hstore`, `Jsonb`, `Money`, `Inet`, `Cidr`, `Macaddr`, `Bit`, `BitVarying`, `Xml`, `Point`, `Uuid`) on AM `typeRegistry` the same way `Interval` was registered. Without this, `attribute :col, :hstore` etc. throw `Unknown type` on PG models. Likely unblocks Rails-mirror tests in per-type files. (#1432)
-- **~10 LOC** — Lift `columnForAttribute` schema-vs-attribute distinction into JSDoc on `model-schema.ts:493` (Copilot concern). (#1432)
+- **~20 LOC (Rails divergence)** — Standalone module function `quoteString` in `connection-adapters/mysql/quoting.ts:88` still uses SQL-standard `''` doubling. Rails' `MySQL::Quoting#quote_string` (instance) **and** the `quote()` path both use backslash-escape. **Concrete consequence:** `adapter.quote("it's")` returns `'it''s'` (doubling) while `adapter.quoteString("it's")` returns the fixed backslash form — same adapter, two different outputs. Fix: update standalone `quoteString` to backslash-escape, route `quote()` in `abstract-mysql-adapter.ts` through `this.quoteString()` instead of `mysqlQuote()`, update test at `mysql/quoting.test.ts:36`. DDL COMMENT call sites (`abstract-mysql-adapter.ts:578, 1319`) want the full wrapping literal — correct as-is.
 
-### From #1433 post-pr — pg uuid
+### Autosave Slot B
 
-- **~20 LOC** — Emit non-PK column `defaultFunction` as `default: () => "fn()"` in `emitTable`, mirroring the PK path. Unblocks function-default round-tripping for all non-PK columns (`gen_random_uuid`, `now`, `CURRENT_TIMESTAMP`). (#1433)
-- **~30 LOC** — Make `SchemaDumper.dumpTableSchema(adapter, ...)` instantiate the adapter's `createSchemaDumper()` class rather than the base — lets PG/MySQL/SQLite-specific overrides fire. Then move `primaryKeyTableOptions` to PG subclass per Rails layout. (#1433)
-- **~40 LOC** — Harmonize `PostgreSQLAdapter.createTable` callback-first signature with abstract `SchemaStatements.createTable` (options-first + optional fn). Removes `@ts-expect-error TS2416` and lets `default` option flow. (#1433)
+- **~3 LOC (Rails divergence)** — `base.ts` `save()` captures `prev = _newRecordBeforeSave` and restores in `finally`, but unconditionally overwrites with `wasNewRecord`. Rails' `aroundSaveCollectionAssociation` uses `prev = @new_record_before_save ||= false; @new_record_before_save = !prev && new_record?` — once true, stays true through nested saves. **Concrete consequence:** during re-entrant/nested saves on the same record (e.g. callback chain that re-enters `save` on the parent), the inner autosave dispatch in `_insertCollectionRecord` can incorrectly treat association writes as **updates** (via `record.save(validate:false)`) when the outer scope already marked the parent as new — meaning a fresh insert path (`Association.insertRecord(record, false)` + `setInverseInstance` + counter-cache increment) is skipped. Fix: change `_newRecordBeforeSave = wasNewRecord` to `_newRecordBeforeSave = !prev && wasNewRecord` in `save()`.
+- **~5 LOC** — `HasManyThroughAssociation#insertRecord(record, validate, raise)` doesn't propagate `validate`/`raise` to the join-record save. Join is saved via `joinRecord.save()` with default options. Diverges from target record save (which honors `validate`) and from Rails bang/non-bang behavior. Fix: pass `validate`; use `saveBang` when `raise` is true.
 
-### From #1435 post-pr — mysql-warnings
+### PG connection Slot A
 
-- **~15 LOC** — `SQLWarning.connectionPool` field + plumb `this.pool` through `_handleWarningsOn`; add `error.connectionPool === adapter.pool` assertion to the `:raise` test once `Mysql2Adapter#pool` is stable. (#1435)
-- **~30 LOC** — Mirror `_handleWarningsOn` onto `TrilogyAdapter` once Trilogy execute path is live. Driver-row-shape may differ. (#1435)
-- **~10 LOC** — Optimization — Rails reads `@raw_connection.warning_count` directly (mysql2 exposes it as a method); the mysql2 npm driver may expose this via `conn.serverStatus` or protocol packet. Avoids one round-trip per non-ignore query. (#1435)
-- **~20 LOC** — Fold `_handleWarningsOn` into `AbstractMysqlAdapter._handleWarnings(sql)` driven by an abstract `_currentConn()` accessor once Mysql2 `perform_query` is ported per Rails layout. (#1435)
+- **~10 LOC** — `statement_name` in `sql.active_record` payload for PG prepared-statement path (`_runQuery` / `execQuery` with `prepare: true`). Unblocks "statement key is logged" test.
+- **~30 LOC** — `prepare: false` with binds — needs `QueryAttribute`-style bind objects with a `prepare: false` exec path wired through `execQuery`. Unblocks `prepare false with binds` test.
+- **~3 LOC** — `tableAliasLength()` override on `PostgreSQLAdapter` returning `this.maxIdentifierLength()`. Blocked by base-class sync `number` return — would widen to `Promise<number> | number`.
+- **Test-infra refactor** — Move `SQLSubscriber` from `adapters/postgresql/test-helper.ts` to a shared location when `adapters/abstract-mysql-adapter/connection.test.ts` is un-skipped (Rails defines it on `ActiveRecord::TestCase`).
 
-### From #1436 post-pr — pg-adapter Slot C
+### SQLite Slot A
 
-- **~50 LOC** — Railtie initializer constructing a default `ErrorReporter`, wiring a basic logger subscriber, calling `setErrorReporter()`. Closes the "Rails.error always exists" gap. (#1436)
-- **~60 LOC** — Collapse `splitPgDefault` into `extractValueFromDefault` + `extractDefaultFunction` so parsing lives in the Rails-named instance methods. Update both call sites in `newColumnFromField` (~lines 2671 + 4310). (#1436)
-- **~30 LOC** — Apply `:report` dispatch wiring to MySQL/SQLite `db_warnings_action` paths if/when they grow one. Today only PG honors `db_warnings_action`. (#1436)
+- **~5 LOC** — Add `strict` field to `SqliteOpenConfig` in `activesupport/src/sqlite-adapter.ts`. Documents intent for future drivers (e.g. `node:sqlite`) that expose `sqlite3_db_config`.
+- **~20 LOC** — better-sqlite3 DQS toggle: when upstream exposes `sqlite3_db_config`, pass `strict` through `Database.Options` in `sqlite-drivers/better-sqlite3.ts:openDatabase`. Then the `configureConnection` pragma block (currently silently ignored) can be removed.
+- **Known limitation** — `strict_strings_by_default` is a no-op in current driver: better-sqlite3 compiles with `SQLITE_DQS=0`, so DQS is always off and `assert_nothing_raised` (non-strict accepts index on missing column) cannot be exercised. Documented inline.
 
-### From #1452 post-pr — PG json bypass
+### api:compare regression guard
 
-- **~5 LOC** — Add a model-save round-trip test for TEXT columns with backslash values (e.g. `"a\\b"`) to exercise the Arel **inline-quoting** path (not the bind-param path). The #1452 regression test uses `executeMutation` (bind params) which doesn't touch `quote()`. The expanded scope of #1452 fixed a pre-existing backslash bug in PG `quote()` that had zero test coverage. (#1452)
-- **~5 LOC** — `abstractQuote` Symbol branch still doubles backslashes without E-string. Zero practical impact (no Symbol description in AR carries `\`) but inconsistent with the String branch fix in #1452. (#1452)
-- **Architectural observation, not a followup** — Rails always uses bind parameters for INSERT/UPDATE values; never inline-quotes via `quote_string`. Our Arel visitor inlines via `quote()`, which is why the E-string fix in #1452 was load-bearing rather than redundant. If we ever wire bind-param extraction (`compileWithBinds`) into the model save path, the PG E-string passthrough becomes a redundant safety net. Note for whoever does that wiring.
-
-### From #1453 post-pr — query-cache Phase 1
-
-- **~30 LOC (Phase 2)** — `_threadQueryCaches` eviction. Map keyed by monotonically-increasing context IDs grows unboundedly in long-lived processes (daemons). Three options: (a) `withExecutionContext` try/finally calls `_cacheConfig.deleteStore(id)`; (b) store the `Store` directly in AsyncLocalStorage instead of a global Map; (c) bounded LRU cap. Decision needed on which fits the `activesupport/async-context-adapter` model. (#1453)
-- **~10 LOC (Phase 2)** — `DatabaseConfig.queryCacheMaxSize` wiring. `ConnectionPoolConfiguration` constructor accepts the param but `ConnectionPool` passes no argument (defaults to 100). Thread `dbConfig.queryCacheMaxSize` through `PoolConfig` → `ConnectionPool` constructor. (#1453)
-- **~20 LOC (Phase 3)** — `enableQueryCacheBang`/`disableQueryCacheBang` at checkout/checkin. Rails propagates pool-level enable/disable state to connections at checkout; today the pool never calls these. Store's `enabled` flag stays false until user code explicitly enables. (#1453)
-- **~20 LOC (Phase 3)** — `withQueryCache(fn)` public API on `ConnectionPool`. Wraps `enableQueryCacheBang` / fn / finally `disableQueryCacheBang + clearQueryCache`. (#1453)
-- **~40 LOC (Phase 4)** — `QueryCache.installExecutorHooks` middleware path. Wires `ExecutorHooks` to enable/disable around each request. Requires `ConnectionHandler` wiring (PR 6 prerequisite). Unblocks 6 pool-attachment tests. (#1453)
-- **Rails divergences (deliberate, more correct under concurrency)** — `_pinnedCount` integer instead of single-reference `@pinned_connection` (Rails uses thread-local single ref); `_queryCacheVersion` shared across contexts (Rails per-thread). Both are safe-over-strict because our `ConnectionPoolConfiguration` is shared across async contexts where Rails' is per-thread via `IsolatedExecutionState`. Documented for future code archaeology. (#1453)
-- **~5 LOC cleanup** — Two redundant `checkoutAndVerify` paths: `ConnectionPoolConfiguration.checkoutAndVerify` (instance method, superseded by direct assigns in `checkout()`/`checkoutAsync()`) and module-level `checkoutAndVerify` (reachable only via `tryToCheckoutNewConnection`, harmless). Decision: remove or wire to canonical path. (#1453)
-
-### From #1449 post-pr — Column#default lazy-deserialize
-
-- **~100–200 LOC (test-infra, not impl)** — Fixture-table infra to unblock the 13 remaining skipped tests (`MysqlDefaultExpressionTest` ×9, `DefaultsTestWithoutTransactionalFixtures` ×2, `PostgresqlDefaultExpressionTest` ×1, `Sqlite3DefaultExpressionTest` ×1). Need a harness mechanism to seed pre-existing fixture tables (`defaults`, `datetime_defaults`, `timestamp_defaults`) analogous to Rails' `fixtures/` directory. Test-infra story, not implementation. (#1449)
-- **~30 LOC** — Promote `sqlType` from optional on `Column` (abstract schema-dumper) to the `ColumnInfo` base interface. It's universally present across all three adapters; the optional declaration is a vestige of the partial migration. (#1449)
-- **Architectural fix shipped, not a followup** — `Column#default lazy-deserialize` was moved from the deferred Architectural section into shipped scope by #1449. The "broad blast radius" framing was overstated — the fix turned out to be two touch points (`BaseSchemaDumper.schemaDefault` deserialize-through-adapter + `model-schema.applyColumnsHash` cast) with no `Column` / `lookupCastType` / `newColumnFromField` changes needed.
-
-### From #1446/#1447/#1448 post-pr — recent sweep
-
-- **~5 LOC** — `typeCastedBinds` in `abstract/quoting.ts:~490` duplicates the one in `abstract/database-statements.ts` and still uses the old `typeof b.valueForDatabase === "function"` check. Unify to the getter-aware `"valueForDatabase" in b` form. Low risk — different call paths. (#1446)
-- **~50–100 LOC (architectural-ish)** — `TableDefinition.toSql()` in `abstract/schema-definitions.ts:~926-1095` still branches on `_adapterName` for type SQL (SERIAL vs BIGINT AUTO_INCREMENT, BYTEA vs BLOB, etc.). Largely redundant with `SchemaCreation.typeToSql()` + `SchemaCreation.visitTableDefinition()` which are more complete. Route through `SchemaCreation.accept()` and delete `toSql()` to complete the polymorphic-dispatch cleanup. (#1447)
-- **~15 LOC (Rails divergence, pre-existing)** — `_buildInitSql` in `mysql2-adapter.ts` omits the `NAMES #{encoding} COLLATE #{collation}` prepend that Rails' `configure_connection` (abstract_mysql_adapter.rb:947-951) emits when `@config[:encoding]` is set. `variables.encoding` from `database.yml` is silently ignored. (#1448)
-- **CI investigation needed (not sized)** — `Received unexpected commandComplete message from backend` flake fired on a client with `_poolUseCount: 3256`. Pre-existing pg pool teardown race when the pool closes while a server-side response is in transit. Worth dedicated investigation if it recurs. (#1446)
-
-### From #1444 post-pr — PG UUID Slot C
-
-- **~30 LOC (Rails divergence + latent bug)** — `caseInsensitiveComparison` is async on PG (queries `pg_proc`) but `UniquenessValidator.buildRelation` is sync, so #1444 moved the UUID bypass into `buildRelation`. **Concrete consequence:** for any non-string non-UUID column type where `canPerformCaseInsensitiveComparisonFor` returns false (custom types with no `lower()` overload), `buildRelation` currently passes a `Promise` to `base.where()`, throwing `ArgumentError: Unsupported argument type`. UUID is fixed; other types are latent. Fix options: (a) make `buildRelation` async and await; (b) expose a sync `canPerformCaseInsensitiveComparisonForSync` on the adapter seeded with known-false types (citext already cached). (#1444)
-- **~10–30 LOC audit** — `typeObj?.type` was caught as a CI bug post-open (`Uuid.type` is a method, not a property — returned the function instead of `"uuid"`). Audit other `.type` reads off type objects across the codebase for the same mistake class. Candidate for fidelity-sweep. (#1444)
-
-### From #1442 post-pr — MySQL quoting Slot A
-
-- **~20 LOC (Rails divergence)** — Standalone module function `quoteString` in `connection-adapters/mysql/quoting.ts:88` still uses SQL-standard `''` doubling. Rails' `MySQL::Quoting#quote_string` (instance) **and** the `quote()` path both use backslash-escape. **Concrete consequence:** `adapter.quote("it's")` returns `'it''s'` (doubling) while `adapter.quoteString("it's")` returns the fixed backslash form — same adapter, two different outputs. Fix: update standalone `quoteString` to backslash-escape, route `quote()` in `abstract-mysql-adapter.ts` through `this.quoteString()` instead of `mysqlQuote()`, update test at `mysql/quoting.test.ts:36`. DDL COMMENT call sites (`abstract-mysql-adapter.ts:578, 1319`) want the full wrapping literal — correct as-is. (#1442)
-
-### From #1434 review — autosave Slot B (Rails divergences, max-cycles deferred)
-
-- **~3 LOC (Rails divergence)** — `base.ts` `save()` captures `prev = _newRecordBeforeSave` and restores in `finally`, but unconditionally overwrites with `wasNewRecord`. Rails' `aroundSaveCollectionAssociation` uses `prev = @new_record_before_save ||= false; @new_record_before_save = !prev && new_record?` — once true, stays true through nested saves. **Concrete consequence:** during re-entrant/nested saves on the same record (e.g. callback chain that re-enters `save` on the parent), the inner autosave dispatch in `_insertCollectionRecord` can incorrectly treat association writes as **updates** (via `record.save(validate:false)`) when the outer scope already marked the parent as new — meaning a fresh insert path (`Association.insertRecord(record, false)` + `setInverseInstance` + counter-cache increment) is skipped. Fix: change `_newRecordBeforeSave = wasNewRecord` to `_newRecordBeforeSave = !prev && wasNewRecord` in `save()`. (#1434 Copilot review #9)
-- **~5 LOC** — `HasManyThroughAssociation#insertRecord(record, validate, raise)` doesn't propagate `validate`/`raise` to the join-record save. Join is saved via `joinRecord.save()` with default options. Diverges from target record save (which honors `validate`) and from Rails bang/non-bang behavior. Fix: pass `validate`; use `saveBang` when `raise` is true. (#1434 Copilot review #10)
-- **Process note** — #1434 scope drifted mid-review: `HasManyThroughAssociation#insertRecord` override originally out-of-scope, included after maintainer rejected the gating workaround. Honest fix mirrored Rails `has_many_through_association.rb:24-34`. Total size still under budget. Documented in PR body. (#1434)
-
-### From #1439 post-pr — PG connection Slot A
-
-- **~10 LOC** — `statement_name` in `sql.active_record` payload for PG prepared-statement path (`_runQuery` / `execQuery` with `prepare: true`). Unblocks "statement key is logged" test. (#1439)
-- **~30 LOC** — `prepare: false` with binds — needs `QueryAttribute`-style bind objects with a `prepare: false` exec path wired through `execQuery`. Unblocks `prepare false with binds` test. (#1439)
-- **~3 LOC** — `tableAliasLength()` override on `PostgreSQLAdapter` returning `this.maxIdentifierLength()`. Blocked by base-class sync `number` return — would widen to `Promise<number> | number`. (#1439)
-- **Test-infra refactor** — Move `SQLSubscriber` from `adapters/postgresql/test-helper.ts` to a shared location when `adapters/abstract-mysql-adapter/connection.test.ts` is un-skipped (Rails defines it on `ActiveRecord::TestCase`). (#1439)
-
-### From #1443 post-pr — SQLite Slot A
-
-- **~5 LOC** — Add `strict` field to `SqliteOpenConfig` in `activesupport/src/sqlite-adapter.ts`. Documents intent for future drivers (e.g. `node:sqlite`) that expose `sqlite3_db_config`. (#1443)
-- **~20 LOC** — better-sqlite3 DQS toggle: when upstream exposes `sqlite3_db_config`, pass `strict` through `Database.Options` in `sqlite-drivers/better-sqlite3.ts:openDatabase`. Then the `configureConnection` pragma block (currently silently ignored) can be removed. (#1443)
-- **Known limitation** — `strict_strings_by_default` is a no-op in current driver: better-sqlite3 compiles with `SQLITE_DQS=0`, so DQS is always off and `assert_nothing_raised` (non-strict accepts index on missing column) cannot be exercised. Documented inline. (#1443)
-
-### From #1437 post-pr — api:compare → 100% restoration
-
-- **Process improvement** — `_`-prefix renames on Rails-named methods silently drop them from `api:compare` surface. Consider extending the `rails-private-jsdoc` ESLint rule to flag `_`-prefixed methods whose Rails counterpart is non-underscored. Permanent guardrail against the regression class. (#1437)
-
-### Closed in recent sweeps
-
-- **Closed via fidelity-sweep A (#1421):** `MigrationLike#up/down` adapter arg, `lookupCastTypeFromJoinDependencies` type, PG `as number` casts, schema-qualified FROM regex, `_compileSelectSql`/visitor consolidation, `_mapTimeWithZoneToUtc` helper, `PostgreSQLWithBinds.visitArelNodesCasted` resolveValueForDatabase, `roles.ts` WRITING_ROLE/READING_ROLE wiring, `restoreTransactionRecordState` PK-write guard (partial — see new ~50 LOC item above), `SavepointTransaction`/`RestartParentTransaction` → `TransactionIsolationError`, `ForeignKeyDefinition#isExportNameOnSchemaDump` wired in schema-dumper, `reconnection_error` test, item-count header sync, ~15 others.
-- **Closed via fidelity-sweep B (#1422):** tsrange/tstzrange array tests, i18n `record_invalid` namespace, validation test bodies, mixin_test ports, phantom test deletions, `compressIfWorthIt` UTF-8 byte-count.
-- **Closed via #1408 / #1423 / #1424:** `_performInsert` block, `_storeAccessorsModules` WeakMap, MySQL non-CT function defaults, `databaseTypeToText` serialized branch + `Serialized.isBinary` delegation, `assertEncryptedAttribute` round-trip (dropped), `InsertAll.uniqueIndexes` async fix (#1423), `SchemaStatements.dropTable` CASCADE PG override (#1424).
-- **Closed via #1437 api:compare restoration:** `_findUniqueIndexFor`/`_uniqueIndexes`/`_uniqueByColumns` underscore prefixes dropped (restore Rails surface names); `encodeRange` named export restored in `pg/quoting.ts`.
-- **Stale items removed in #1419 review (Copilot caught):** `addUniqueConstraint`/`removeUniqueConstraint` adapter methods (already implemented in PG with passing tests); `caseInsensitiveComparison` async runtime-bug (hypothetical only — base sync + no PG override).
+- **Process improvement** — `_`-prefix renames on Rails-named methods silently drop them from `api:compare` surface. Consider extending the `rails-private-jsdoc` ESLint rule to flag `_`-prefixed methods whose Rails counterpart is non-underscored. Permanent guardrail against the regression class.
 
 ---
 
 ## Doc-hygiene + infra followups
 
-- **Decision** — Root `Gemfile` / `Gemfile.lock`: globalid workstream or not? Currently untracked-and-ambiguous. (#1406)
-- **Follow-up PR** — Run `sync-stats` refresh and clear "pending" disclaimer on README Data Layer Parity test-percentage. Plumbing landed in #1406; refresh itself open.
+- **Decision** — Root `Gemfile` / `Gemfile.lock`: globalid workstream or not? Currently untracked-and-ambiguous.
+- **Follow-up PR** — Run `sync-stats` refresh and clear "pending" disclaimer on README Data Layer Parity test-percentage.
 - **~30 LOC** — `postgresql/temporal-type-parsers.ts` still has one eager `import pg from "pg"` (the last per `browser-compat-plan.md`). Move to lazy registry. Blocks browser-bundle smoke tests.
-
----
-
-## Test:compare audits queued (read-only research)
-
-**Audit queue closed** — every test:compare audit task filed during this initiative has been delivered (see `git log` for the audit-cluster slot citations and triage history). Remaining work is impl-execution against the 14 audit clusters now in `activerecord-100-clusters.md`.
 
 ---
 
 ## Architectural (deferred; too big for single ~250-LOC slot)
 
-- ~~**Column#default lazy-deserialize broader refactor**~~ — **shipped via #1449.** Fix turned out to be two touch points (`BaseSchemaDumper.schemaDefault` + `model-schema.applyColumnsHash`), not a Column rewrite. 4 of 17 tests unblocked; 13 still fixture-blocked (see fidelity followups).
-- ~~**PG `json` driver-level cast bypass**~~ — **shipped via #1452.** ~25 LOC, not the originally-sized 80 — the design pass narrowed it to 2 lines in the existing `getTypeParser` closure. As a bonus, the agent caught and fixed a pre-existing PG `quote()` E-string backslash bug.
-- **Connection-pool / per-thread query-cache architecture** (~780 LOC across 4 phases). Phase 1 shipped via #1453 (context-keyed registry + pin wiring). Phases 2-4 queued — see fidelity followups. ~10 actionable test unskips (4 db_config + 6 pool-attachment); other 4 are permanent (GVL/fork/thread skips).
+- **Connection-pool / per-thread query-cache architecture, Phases 2–4** (~120 LOC remaining). See fidelity followups. ~10 actionable test unskips (4 db_config + 6 pool-attachment); other 4 are permanent (GVL/fork/thread skips).
 
 ### Other deferred (need wider design)
 
-- `_aliasTracker` real semantics on `JoinDependency#joinConstraints`. (#1386)
-- Multirange OID direct lookup via `LEFT JOIN pg_range` — blocked on PG12/13 compat decision. (#1385)
-- `encodeRangeLiteral` ↔ `RangeType.encodeLiteral` consolidation into `range.ts` helper. (#1385)
+- `_aliasTracker` real semantics on `JoinDependency#joinConstraints`.
+- Multirange OID direct lookup via `LEFT JOIN pg_range` — blocked on PG12/13 compat decision.
+- `encodeRangeLiteral` ↔ `RangeType.encodeLiteral` consolidation into `range.ts` helper.
 
 ---
 
@@ -297,54 +209,45 @@ Small Rails-fidelity polish from PR reviews + post-merge findings. Each subsecti
 
 Cluster details in [`activerecord-100-clusters.md`](activerecord-100-clusters.md).
 
-| Group                                                   | Open | LOC est.            |
-| ------------------------------------------------------- | ---- | ------------------- |
-| In flight                                               | 0    | —                   |
-| Encryption cluster (all 3 slots closed)                 | 0    | —                   |
-| Serialization cluster                                   | 1    | ~70                 |
-| Relation cluster                                        | 7    | ~1660               |
-| Associations-core cluster                               | 5    | ~910                |
-| Associations-HABTM cluster                              | 9    | ~1690               |
-| Associations has-many-through cluster                   | 5    | ~1280               |
-| Associations has-one cluster                            | 4    | ~480                |
-| Migration cluster                                       | 6    | ~1210               |
-| Connection-pool cluster                                 | 3    | ~640                |
-| MySQL active-schema cluster                             | 3    | ~680                |
-| MySQL mysql2-adapter cluster                            | 3    | ~700                |
-| MySQL warnings cluster (A closed #1435)                 | 0    | —                   |
-| MySQL schema cluster                                    | 3    | ~400                |
-| MySQL quoting cluster                                   | 1    | ~120                |
-| MySQL table-options cluster                             | 2    | ~480                |
-| MySQL charset-collation cluster                         | 3    | ~315                |
-| MySQL onUpdate followups                                | 2    | ~30                 |
-| SQLite adapter cluster                                  | 2    | ~120                |
-| PG-adapter cluster (B+C+D closed; A+E open)             | 2    | ~340                |
-| PG-schema audit cluster                                 | 3    | ~530                |
-| PG infinity cluster (A closed #1427)                    | 0    | —                   |
-| PG foreign-table cluster (A closed #1429)               | 0    | —                   |
-| PG virtual-column cluster (A closed #1430)              | 1    | ~250                |
-| PG datatype cluster (A closed #1432)                    | 0    | —                   |
-| PG interval cluster (A closed #1431; B open)            | 1    | ~180                |
-| PG UUID residual cluster (A closed #1433)               | 2    | ~330                |
-| PG connection cluster                                   | 5    | ~290                |
-| PG long-tail cluster                                    | 8    | ~1760               |
-| Schema cluster (A+B closed)                             | 7    | ~1390               |
-| Transactions cluster (A closed #1417)                   | 3    | ~350                |
-| Unknown-triage cluster                                  | 4    | ~640                |
-| STI annotation-drift                                    | 1    | ~20                 |
-| Associations-autosave cluster (A #1426, B #1434 closed) | 4    | ~940                |
-| Associations-reflection cluster (B closed #1428)        | 4    | ~780                |
-| NotImplementedError elimination (Phase 2)               | 7    | ~610                |
-| `as any` legacy-cast cleanup sweep                      | 1    | ~250                |
-| Post-merge fidelity followups                           | 78   | ~1675               |
-| Doc-hygiene + infra followups                           | 3    | ~30                 |
-| Test:compare audits queued                              | 0    | n/a (all delivered) |
-| Architectural deferred                                  | 3    | ~410                |
-| Infra-blocked                                           | 6    | n/a                 |
+| Group                                     | Open | LOC est. |
+| ----------------------------------------- | ---- | -------- |
+| Relation cluster                          | 7    | ~1660    |
+| Associations-core cluster                 | 5    | ~910     |
+| Associations-HABTM cluster                | 9    | ~1690    |
+| Associations has-many-through cluster     | 5    | ~1280    |
+| Associations has-one cluster              | 4    | ~480     |
+| Migration cluster                         | 6    | ~1210    |
+| Connection-pool cluster                   | 3    | ~640     |
+| MySQL active-schema cluster               | 3    | ~680     |
+| MySQL mysql2-adapter cluster              | 3    | ~700     |
+| MySQL schema cluster                      | 3    | ~400     |
+| MySQL table-options cluster               | 2    | ~480     |
+| MySQL charset-collation cluster           | 3    | ~315     |
+| MySQL onUpdate followups                  | 2    | ~30      |
+| SQLite adapter cluster                    | 1    | ~50      |
+| PG-adapter cluster                        | 2    | ~340     |
+| PG-schema audit cluster                   | 3    | ~530     |
+| PG virtual-column cluster                 | 1    | ~250     |
+| PG interval cluster                       | 1    | ~180     |
+| PG UUID residual cluster                  | 2    | ~330     |
+| PG connection cluster                     | 3    | ~130     |
+| PG long-tail cluster                      | 8    | ~1760    |
+| Schema cluster                            | 7    | ~1390    |
+| Transactions cluster                      | 3    | ~350     |
+| Unknown-triage cluster                    | 4    | ~640     |
+| STI annotation-drift                      | 1    | ~20      |
+| Associations-autosave cluster             | 4    | ~940     |
+| Associations-reflection cluster           | 4    | ~780     |
+| NotImplementedError elimination (Phase 2) | 7    | ~610     |
+| `as any` legacy-cast cleanup sweep        | 1    | ~250     |
+| Post-merge fidelity followups             | 78   | ~1675    |
+| Doc-hygiene + infra followups             | 3    | ~30      |
+| Architectural deferred                    | 3    | ~410     |
+| Infra-blocked                             | 6    | n/a      |
 
-**~109 actionable work-PR slots + 0 queued audits**, ~19.7k LOC. P0 fully shipped (#1426–#1453; ~60 un-skips across 28 PRs); encryption, mysql-warnings, mysql-quoting consolidation, pg-datatype, serialization, pg-infinity, pg-foreign-table clusters fully closed; autosave A/B, schema A/B, pg-adapter B/C/D, pg-connection A/B, pg-uuid A/C, pg-virtual-column A, pg-interval A, sqlite A, transactions A, reflection B all shipped. Headline P0 yield: **27 un-skips wave 1 + 33 wave 2** plus autosave A's foundational unblock for autosave C–F.
+**~107 actionable work-PR slots + 0 queued audits**, ~19.5k LOC across the clusters above.
 
-The two `as any` audits (delivered 2026-05-12) found **zero new critical bugs** post-#1423 — the optional-chain audit returned `0 bug-suspected` and the method-call audit returned `2 bug-suspected` (folded into post-merge fidelity followups above for surgical verification). The high-leverage opportunity is **Sweep B from audit-as-any-method-calls**: ~250 LOC mechanical removal of 52 legacy-cast-removable instance-method casts on `Base` (`(record as any)._readAttribute`, `.save`, `.destroy`, etc. — TS types already declare these). The optional-chain audit's ~110 `legacy-removable` sites are dependent on the same `Base` host-interface tightening; can be folded into the same sweep or land second.
+The two `as any` audits (delivered 2026-05-12) found **zero new critical bugs** — the optional-chain audit returned `0 bug-suspected` and the method-call audit returned `2 bug-suspected` (folded into post-merge fidelity followups above for surgical verification). The high-leverage opportunity is **Sweep B from audit-as-any-method-calls**: ~250 LOC mechanical removal of 52 legacy-cast-removable instance-method casts on `Base` (`(record as any)._readAttribute`, `.save`, `.destroy`, etc. — TS types already declare these). The optional-chain audit's ~110 `legacy-removable` sites are dependent on the same `Base` host-interface tightening; can be folded into the same sweep or land second.
 
 ---
 
@@ -352,7 +255,7 @@ The two `as any` audits (delivered 2026-05-12) found **zero new critical bugs** 
 
 ### Dual-registry watchpoint
 
-When both a `Base.<X>` static field AND a `<x>.ts` module-level `WeakMap`/`Map` exist for the same concern, treat it as a bug. The live API writes one; helpers read the other; silently. PR #1307 closed `Base._storedAttributes` vs `store.ts:_storedAttributes`. Audit:
+When both a `Base.<X>` static field AND a `<x>.ts` module-level `WeakMap`/`Map` exist for the same concern, treat it as a bug. The live API writes one; helpers read the other; silently. closed `Base._storedAttributes` vs `store.ts:_storedAttributes`. Audit:
 
 ```bash
 grep -rn "new WeakMap<typeof Base\|new Map<.*Base" packages/activerecord/src
@@ -375,4 +278,4 @@ The `prompt-agent` skill auto-appends a "do not delegate / do not recursively sp
 - ESLint rule for `_`-prefixed params on Rails-mirroring methods.
 - `lint:deps` activesupport rule → blocking once missing migrations land.
 - api:compare param-name set comparison.
-- `deprecator` / `gemVersion` / `version` removed from main bundle barrel (#1317); only via `@blazetrails/activerecord/deprecator` subpath.
+- `deprecator` / `gemVersion` / `version` removed from main bundle barrel; only via `@blazetrails/activerecord/deprecator` subpath.

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -35,8 +35,6 @@ _(none — all queued work shipped as of this snapshot)_
 - **#1436** pg-adapter Slot C — Enum OID + defaultFunction + ErrorReporter ✅ (A + E-optional still open)
 - **#1437** api:compare → 100% restoration — 4 regressions from #1421/#1423 fixed ✅
 
-**Currently in flight:** _(none)_
-
 **P0 wave 3 + adjacent (just merged):**
 
 - **#1434** Autosave Slot B — collection mutation via `Association.insertRecord` ✅
@@ -44,7 +42,7 @@ _(none — all queued work shipped as of this snapshot)_
 - **#1439** PG connection Slot A — `SQLSubscriber` test helper + 7 logs_name unskips ✅
 - **#1440** chore(test) — cap vitest worker count to 4 (prevent local saturation) ✅
 - **#1443** SQLite Slot A — `strict_strings_by_default` class config + 3 unskips ✅
-- **#1442** MySQL quoting Slot A — instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName` ✅ (standalone-function divergence: see fidelity followup; full consolidation now a 4-phase cluster — Phase 1 + 2 in flight as %281/%282)
+- **#1442** MySQL quoting Slot A — instance `quoteString` backslash + static `quoteColumnName`/`quoteTableName` ✅ (standalone-function divergence: see fidelity followup; full 4-phase consolidation shipped — #1447/#1448/#1450/#1451)
 - **#1444** PG UUID Slot C — UniquenessValidator UUID-aware case-insensitive bypass ✅ (deviates from Rails — adapter-layer in Rails, validator-layer here; ~30 LOC async-bridge followup)
 - **#1445** Serialization Slot B — serialized-column join fixture ✅ (cluster done)
 - **#1446** PG connection Slot B — `execQuery prepare:` kwarg + `statement_name` payload ✅
@@ -64,25 +62,25 @@ The rest of the inventory is FIFO-by-audit-delivery. P0 items below get spawned 
 
 - ✅ **Autosave Slot A** — Association-object indirection (#1426). Autosave B–F now spawnable.
 
-### P0b — Audit-verified "impl complete, only test work"
+### P0b — Audit-verified "impl complete, only test work" (all closed)
 
-| Slot                    | LOC  | Status                                                       |
-| ----------------------- | ---- | ------------------------------------------------------------ |
-| pg-foreign-table A      | ~230 | ✅ #1429 (16 un-skips)                                       |
-| pg-infinity A           | ~250 | ✅ #1427 (6 un-skips, 3 followups)                           |
-| reflection B            | ~120 | ✅ #1428 (5 un-skips, audit oversized)                       |
-| **pg-virtual-column A** | ~150 | %260 in flight                                               |
-| **pg-interval A**       | ~220 | %261 in flight                                               |
-| **pg-datatype A**       | ~220 | open — delete 9 stale + 6 fixture-backed un-skips            |
-| **pg-uuid-residual A**  | ~230 | open — SchemaDumper UUID-PK test bodies + annotation cleanup |
+| Slot                | LOC  | Status                                                          |
+| ------------------- | ---- | --------------------------------------------------------------- |
+| pg-foreign-table A  | ~230 | ✅ #1429 (16 un-skips)                                          |
+| pg-infinity A       | ~250 | ✅ #1427 (6 un-skips, 3 followups)                              |
+| reflection B        | ~120 | ✅ #1428 (5 un-skips, audit oversized)                          |
+| pg-virtual-column A | ~150 | ✅ #1430 (rewrite + XML relocation)                             |
+| pg-interval A       | ~220 | ✅ #1431 (Rails-aligned test names; Slot B ~180 LOC still open) |
+| pg-datatype A       | ~220 | ✅ #1432 (6 fixture-backed un-skips + 9 stale deletions)        |
+| pg-uuid-residual A  | ~230 | ✅ #1433 (SchemaDumper UUID-PK test bodies + 5 un-skips)        |
 
-**Remaining P0b**: 2 in flight + 2 open. Wave-1 yield: **27 un-skips** across 4 PRs.
+P0b yield: **~50 un-skips** across 7 PRs. Spawn-next priority now moves to the open clusters in [`activerecord-100-clusters.md`](activerecord-100-clusters.md) (associations-autosave C–F, associations-reflection, mysql-schema, mysql-table-options, mysql-charset-collation, pg-long-tail, schema C–J, pg-adapter A/E, transactions B/C, sqlite B).
 
 ---
 
-## Post-merge fidelity followups (~700 LOC, 26 items)
+## Post-merge fidelity followups (~1675 LOC, 78 actionable items)
 
-Small Rails-fidelity polish from PR reviews + post-merge findings. Items closed by recent sweeps are summarized at the end.
+Small Rails-fidelity polish from PR reviews + post-merge findings. Each subsection groups items by source PR. Items closed by recent sweeps are summarized at the end (process notes / architectural observations are not counted in the 78).
 
 ### Deferred from sweep B (#1422)
 
@@ -344,7 +342,7 @@ Cluster details in [`activerecord-100-clusters.md`](activerecord-100-clusters.md
 | Architectural deferred                                  | 3    | ~410                |
 | Infra-blocked                                           | 6    | n/a                 |
 
-**~109 actionable work-PR slots + 0 queued audits**, ~19.7k LOC. P0 fully shipped (#1426–#1437; ~60 un-skips); audit-encryption / pg-foreign-table / pg-infinity / pg-virtual-column / pg-datatype / pg-uuid-residual / mysql-warnings clusters all closed or in-flight on Slot A. Headline P0 yield: **27 un-skips wave 1 + 33 more wave 2** plus autosave A's foundational unblock for autosave B–F.
+**~109 actionable work-PR slots + 0 queued audits**, ~19.7k LOC. P0 fully shipped (#1426–#1453; ~60 un-skips across 28 PRs); encryption, mysql-warnings, mysql-quoting consolidation, pg-datatype, serialization, pg-infinity, pg-foreign-table clusters fully closed; autosave A/B, schema A/B, pg-adapter B/C/D, pg-connection A/B, pg-uuid A/C, pg-virtual-column A, pg-interval A, sqlite A, transactions A, reflection B all shipped. Headline P0 yield: **27 un-skips wave 1 + 33 wave 2** plus autosave A's foundational unblock for autosave C–F.
 
 The two `as any` audits (delivered 2026-05-12) found **zero new critical bugs** post-#1423 — the optional-chain audit returned `0 bug-suspected` and the method-call audit returned `2 bug-suspected` (folded into post-merge fidelity followups above for surgical verification). The high-leverage opportunity is **Sweep B from audit-as-any-method-calls**: ~250 LOC mechanical removal of 52 legacy-cast-removable instance-method casts on `Base` (`(record as any)._readAttribute`, `.save`, `.destroy`, etc. — TS types already declare these). The optional-chain audit's ~110 `legacy-removable` sites are dependent on the same `Base` host-interface tightening; can be folded into the same sweep or land second.
 


### PR DESCRIPTION
## Summary

Status snapshot bringing `docs/activerecord-100-plan.md` and `docs/activerecord-100-clusters.md` up to date with the 28 PRs merged since the prior snapshot (#1426–#1453). Two passes: first commit landed the raw status diff; second commit repaired self-contradictions surfaced by a structured re-read.

## Verification

Every cited PR cross-checked against `git log` — #1404, #1405, #1407, #1409, #1411, #1414, #1415, #1417, #1418, #1420, #1426–#1438, #1439, #1442–#1453 all present. `gh pr list --state open` confirms "In flight: none" — no AR PRs open. New audit clusters (associations-reflection, mysql-schema, mysql-table-options, mysql-charset-collation, pg-long-tail) describe work with no git-log evidence of silent closures.

## Pass-2 repairs (commit 2)

- P0b table claimed 4 slots `%260/%261/open` while the prose 10 lines above marked the same PRs closed (#1430–#1433). Rewrote table — all 7 rows ✅.
- Duplicate `Currently in flight: _(none)_` stub between wave 2 and wave 3 lists deleted.
- Stale `%281/%282` placeholders in the #1442 line replaced with the shipped consolidation PR numbers (#1447/#1448/#1450/#1451).
- Fidelity-followups header said "~700 LOC, 26 items" but the story-count table said "78 / ~1675" — header corrected to match (table was right).
- Summary line bumped from "#1426–#1437" to "#1426–#1453" with an enumerated closure list.
- clusters.md: pg-infinity / pg-foreign-table closed-status headers no longer carry their original open-slot prose body; collapsed to a one-paragraph shipped-summary each.

## Size note

406 additions + 92 deletions across two commits = **~406 LOC, over the 300 ceiling**. Docs-only status snapshot; splitting plan.md from clusters.md would fragment a single coherent moment-in-time picture. Requesting one-time ceiling exception per file-coupling.

## Test plan

- [x] `pnpm build` clean (lint-staged hook ran prettier on both commits)
- [x] Docs-only — no code paths exercised
- [x] Self-grade pass: A after pass-2 repairs