### PR TITLE
feat(activerecord) Reflection Slot A — error-type parity (UnknownPrimaryKey + ConfigurationError)

### DIFF
--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -668,6 +668,19 @@ export class UnknownAttributeReference extends ActiveRecordError {
   }
 }
 
+export class UnknownPrimaryKey extends ActiveRecordError {
+  readonly model: typeof import("./base.js").Base;
+
+  constructor(model: typeof import("./base.js").Base, description?: string) {
+    const msg = description
+      ? `Unknown primary key for table ${model.tableName} in model ${model.name}. ${description}`
+      : `Unknown primary key for table ${model.tableName} in model ${model.name}.`;
+    super(msg);
+    this.name = "UnknownPrimaryKey";
+    this.model = model;
+  }
+}
+
 export class MultiparameterAssignmentErrors extends ActiveRecordError {
   readonly errors: Error[];
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -207,6 +207,7 @@ export {
   UnknownAttributeError,
   NameError,
   SQLWarning,
+  UnknownPrimaryKey,
   MultiparameterAssignmentErrors,
   SerializationTypeMismatch,
   ConnectionNotDefined,

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -846,7 +846,7 @@ describe("ReflectionTest", () => {
   it("association primary key raises when missing primary key", () => {
     class NoPkModel extends Base {
       static {
-        this._primaryKey = "" as any;
+        this._primaryKey = "";
         this.adapter = adapter;
       }
     }
@@ -865,7 +865,7 @@ describe("ReflectionTest", () => {
   it("active record primary key raises when missing primary key", () => {
     class NoPkOwner extends Base {
       static {
-        this._primaryKey = "" as any;
+        this._primaryKey = "";
         this.adapter = adapter;
       }
     }

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -27,6 +27,7 @@ import { Table } from "@blazetrails/arel";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { UnknownPrimaryKey } from "./errors.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -842,15 +843,42 @@ describe("ReflectionTest", () => {
     const specialRef = reflectOnAssociation(Author, "specialBooks") as AssociationReflection;
     expect(specialRef.associationPrimaryKey).toBe("isbn");
   });
-  it.skip("association primary key raises when missing primary key", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+  it("association primary key raises when missing primary key", () => {
+    class NoPkModel extends Base {
+      static {
+        this._primaryKey = "" as any;
+        this.adapter = adapter;
+      }
+    }
+    class Owner extends Base {
+      static {
+        this.attribute("no_pk_model_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("NoPkModel", NoPkModel);
+    registerModel("Owner", Owner);
+    Associations.belongsTo.call(Owner, "noPkModel", {});
+    const ref = reflectOnAssociation(Owner, "noPkModel") as AssociationReflection;
+    expect(() => ref.associationPrimaryKey).toThrow(UnknownPrimaryKey);
   });
-  it.skip("active record primary key raises when missing primary key", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+  it("active record primary key raises when missing primary key", () => {
+    class NoPkOwner extends Base {
+      static {
+        this._primaryKey = "" as any;
+        this.adapter = adapter;
+      }
+    }
+    class Target extends Base {
+      static {
+        this.adapter = adapter;
+      }
+    }
+    registerModel("NoPkOwner", NoPkOwner);
+    registerModel("Target", Target);
+    Associations.hasMany.call(NoPkOwner, "targets", {});
+    const ref = reflectOnAssociation(NoPkOwner, "targets") as AssociationReflection;
+    expect(() => ref.activeRecordPrimaryKey).toThrow(UnknownPrimaryKey);
   });
   it("foreign type", () => {
     class Sponsor extends Base {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -33,6 +33,7 @@ import {
   HasOneAssociationPolymorphicThroughError,
   HasOneThroughCantAssociateThroughCollection,
   InverseOfAssociationNotFoundError,
+  InverseOfAssociationRecursiveError,
 } from "./associations/errors.js";
 
 type MacroType = "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany" | "composedOf";
@@ -189,14 +190,14 @@ export class AbstractReflection {
     if (!this.isPolymorphic() && this.hasInverse()) {
       const inverse = this.inverseOf();
       if (inverse == null) {
-        const inverseOf = (this as any)._inverseNameCache as string;
+        const inverseOf = (this as any).inverseName?.() as string;
         throw new InverseOfAssociationNotFoundError((this as any).name, inverseOf);
       }
       if (
         (inverse as any).name === (this as any).name &&
         (inverse as any).activeRecord === (this as any).activeRecord
       ) {
-        throw new ConfigurationError(`Inverse association for ${(this as any).name} is recursive.`);
+        throw new InverseOfAssociationRecursiveError((this as any).name, (inverse as any).name);
       }
     }
   }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -189,7 +189,7 @@ export class AbstractReflection {
     if (!this.isPolymorphic() && this.hasInverse()) {
       const inverse = this.inverseOf();
       if (inverse == null) {
-        const inverseOf = (this as any).options?.inverseOf as string;
+        const inverseOf = (this as any)._inverseNameCache as string;
         throw new InverseOfAssociationNotFoundError((this as any).name, inverseOf);
       }
       if (

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1,5 +1,6 @@
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
+import { ConfigurationError, UnknownPrimaryKey } from "./errors.js";
 import {
   underscore,
   pluralize,
@@ -31,6 +32,7 @@ import {
   HasManyThroughSourceAssociationNotFoundError,
   HasOneAssociationPolymorphicThroughError,
   HasOneThroughCantAssociateThroughCollection,
+  InverseOfAssociationNotFoundError,
 } from "./associations/errors.js";
 
 type MacroType = "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany" | "composedOf";
@@ -187,13 +189,14 @@ export class AbstractReflection {
     if (!this.isPolymorphic() && this.hasInverse()) {
       const inverse = this.inverseOf();
       if (inverse == null) {
-        throw new Error(`Could not find the inverse association for ${(this as any).name}.`);
+        const inverseOf = (this as any).options?.inverseOf as string;
+        throw new InverseOfAssociationNotFoundError((this as any).name, inverseOf);
       }
       if (
         (inverse as any).name === (this as any).name &&
         (inverse as any).activeRecord === (this as any).activeRecord
       ) {
-        throw new Error(`Inverse association for ${(this as any).name} is recursive.`);
+        throw new ConfigurationError(`Inverse association for ${(this as any).name} is recursive.`);
       }
     }
   }
@@ -450,7 +453,7 @@ export class AssociationReflection extends MacroReflection {
     const opts = { ...options };
 
     if (opts.queryConstraints) {
-      throw new Error(
+      throw new ArgumentError(
         `Setting \`queryConstraints:\` option on \`${activeRecord.name}.${name}\` is not allowed. ` +
           `To get the same behavior, use the \`foreignKey\` option instead.`,
       );
@@ -462,7 +465,7 @@ export class AssociationReflection extends MacroReflection {
     }
 
     if (opts.className && typeof opts.className === "function") {
-      throw new Error("A class was passed to `:className` but we are expecting a string.");
+      throw new ArgumentError("A class was passed to `:className` but we are expecting a string.");
     }
 
     super(name, scope, opts, activeRecord);
@@ -515,7 +518,7 @@ export class AssociationReflection extends MacroReflection {
     const ownerPkStr = Array.isArray(ownerPk) ? undefined : ownerPk;
 
     if (primaryQueryConstraints.length > 2) {
-      throw new Error(
+      throw new ConfigurationError(
         `The query constraints list on the \`${this.activeRecord.name}\` model has more than 2 ` +
           `attributes. Active Record is unable to derive the query constraints ` +
           `for the association. You need to explicitly define the query constraints ` +
@@ -524,7 +527,7 @@ export class AssociationReflection extends MacroReflection {
     }
 
     if (ownerPkStr && !primaryQueryConstraints.includes(ownerPkStr)) {
-      throw new Error(
+      throw new ConfigurationError(
         `The query constraints on the \`${this.activeRecord.name}\` model do not include the primary ` +
           `key so Active Record is unable to derive the foreign key constraints for ` +
           `the association. You need to explicitly define the query constraints for this ` +
@@ -542,7 +545,7 @@ export class AssociationReflection extends MacroReflection {
       return [firstKey, foreignKey];
     }
 
-    throw new Error(
+    throw new ConfigurationError(
       `Active Record couldn't correctly interpret the query constraints ` +
         `for the \`${this.activeRecord.name}\` model. The query constraints on \`${this.activeRecord.name}\` are ` +
         `\`${primaryQueryConstraints}\` and the foreign key is \`${foreignKey}\`. ` +
@@ -741,7 +744,7 @@ export class AssociationReflection extends MacroReflection {
 
   protected primaryKeyForModel(klass: typeof Base): string | string[] {
     const pk = klass.primaryKey;
-    if (!pk) throw new Error(`Unknown primary key for ${klass.name}`);
+    if (!pk) throw new UnknownPrimaryKey(klass);
     return pk;
   }
 
@@ -783,7 +786,7 @@ export class AssociationReflection extends MacroReflection {
     // Instance-dependent scopes also receive the owner (arity >= 2).
     // Rails checks scope.arity == 0 because it uses instance_exec for the relation.
     if (this.scope.length > 1) {
-      throw new Error(
+      throw new ArgumentError(
         `The association scope '${this.name}' is instance dependent (the scope ` +
           `block takes more than one argument). Eager loading instance dependent scopes is not supported.`,
       );
@@ -832,9 +835,7 @@ export class AssociationReflection extends MacroReflection {
       if (!name) return null;
       const inverseRelationship = associatedClass._reflectOnAssociation(name);
       if (!inverseRelationship) {
-        throw new Error(
-          `Could not find the inverse association for ${this.name} (:${name} in ${associatedClass.name})`,
-        );
+        throw new InverseOfAssociationNotFoundError(this.name, name, [], associatedClass.name);
       }
       return inverseRelationship;
     }


### PR DESCRIPTION
## Summary

- Adds `UnknownPrimaryKey` error class to `errors.ts` with `model` reference (Rails parity for `ActiveRecord::UnknownPrimaryKey`)
- Converts 9 plain `Error` throw sites in `reflection.ts` to typed AR errors: `UnknownPrimaryKey`, `ConfigurationError`, `ArgumentError`, `InverseOfAssociationNotFoundError`, `InverseOfAssociationRecursiveError`
- Un-skips and implements 2 reflection tests that assert on `UnknownPrimaryKey` throw

## Error mapping

| Site | Before | After |
|------|--------|-------|
| `primaryKeyForModel` | `Error` | `UnknownPrimaryKey` |
| `deriveFkQueryConstraints` (3 sites) | `Error` | `ConfigurationError` |
| `queryConstraints` option guard | `Error` | `ArgumentError` |
| `className`-is-class guard | `Error` | `ArgumentError` |
| `checkEagerLoadableBang` scope arity | `Error` | `ArgumentError` |
| `checkValidityOfInverseBang` inverse not found | `Error` | `InverseOfAssociationNotFoundError` |
| `checkValidityOfInverseBang` recursive | `Error` | `InverseOfAssociationRecursiveError` |
| `polymorphicInverseOf` not found | `Error` | `InverseOfAssociationNotFoundError` |

## Size check

~90 additions + ~25 deletions (within 300 LOC ceiling).