### PR TITLE
feat(activerecord) Has-one Slot A — wire HasOneThroughAssociation.replace through createThroughRecord

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -33,9 +33,6 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     if (record) (this as any).raiseOnTypeMismatchBang?.(record);
     const assigningAnother = this.target !== record;
     if (assigningAnother || (record as any)?.hasChangesToSave?.()) {
-      if (record) {
-        this.setInverseInstance(record);
-      }
       if (save) {
         // Store pending regardless of owner.isPersisted() — for new owners,
         // persistReplace runs after owner.save() when owner is now persisted.

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -5,7 +5,7 @@ import {
   HasOneThroughCantAssociateThroughHasOneOrManyReflection,
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
-import { compositeQueryConstraintsList } from "../persistence.js";
+import { queryConstraintsList } from "../persistence.js";
 
 function safeKlass(refl: { klass?: unknown } | null | undefined): any {
   try {
@@ -21,6 +21,54 @@ function safeKlass(refl: { klass?: unknown } | null | undefined): any {
 export class HasOneThroughAssociation extends HasOneAssociation {
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation#replace
+   *
+   * Dispatches through createThroughRecord instead of setting a direct FK.
+   * DB work is deferred via _pendingReplace and flushed by persistReplace.
+   */
+  protected override replace(record: Base | null, save = true): void {
+    if (record) (this as any).raiseOnTypeMismatchBang?.(record);
+    const assigningAnother = this.target !== record;
+    if (assigningAnother || (record as any)?.hasChangesToSave?.()) {
+      if (record) {
+        this.setInverseInstance(record);
+      }
+      if (save) {
+        // Store pending regardless of owner.isPersisted() — for new owners,
+        // persistReplace runs after owner.save() when owner is now persisted.
+        if (this._pendingReplace) {
+          const wasAssignedAnother =
+            this._pendingReplace.previousTarget !== this._pendingReplace.record;
+          if (wasAssignedAnother && record === this._pendingReplace.previousTarget) {
+            this._pendingReplace = null;
+          } else {
+            this._pendingReplace.record = record;
+          }
+        } else {
+          this._pendingReplace = { record, previousTarget: this.target };
+        }
+      }
+    }
+    this.target = record;
+    this.loadedBang();
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation — deferred DB flush.
+   *
+   * Called by autosave after owner.save(). Calls createThroughRecord which
+   * creates/updates/destroys the join-model record as needed.
+   */
+  override async persistReplace(): Promise<void> {
+    const pending = this._pendingReplace;
+    if (!pending) return;
+    await transaction(this, async () => {
+      await createThroughRecord(this, pending.record, true);
+    });
+    this._pendingReplace = null;
   }
 }
 
@@ -155,12 +203,16 @@ function constructJoinAttributes(
     sourceRefl.primaryKey ??
     "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  const compositeConstraints: string[] = reflKlass
-    ? compositeQueryConstraintsList.call(reflKlass)
-    : [];
+  // compositeQueryConstraintsList falls back to the PK for simple models, which would
+  // incorrectly trigger the "pass object" branch. Only use explicit query_constraints.
+  const explicitConstraints: string[] | null = reflKlass
+    ? queryConstraintsList.call(reflKlass)
+    : null;
+  const compositeConstraints: string[] = explicitConstraints ?? [];
 
   let joinAttributes: Record<string, unknown>;
   if (
+    explicitConstraints &&
     pkArr.length === compositeConstraints.length &&
     pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
     !refl.options?.sourceType

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -200,16 +200,15 @@ function constructJoinAttributes(
     sourceRefl.primaryKey ??
     "id";
   const pkArr: string[] = Array.isArray(assocPk) ? assocPk : [assocPk];
-  // compositeQueryConstraintsList falls back to the PK for simple models, which would
-  // incorrectly trigger the "pass object" branch. Only use explicit query_constraints.
-  const explicitConstraints: string[] | null = reflKlass
-    ? queryConstraintsList.call(reflKlass)
-    : null;
-  const compositeConstraints: string[] = explicitConstraints ?? [];
+  // compositeQueryConstraintsList falls back to the PK for simple string PKs, which would
+  // incorrectly trigger the "pass object" branch. queryConstraintsList returns null for
+  // simple single-PK models (avoiding that branch) and the composite PK for CPK models.
+  const queryConstraints: string[] | null = reflKlass ? queryConstraintsList.call(reflKlass) : null;
+  const compositeConstraints: string[] = queryConstraints ?? [];
 
   let joinAttributes: Record<string, unknown>;
   if (
-    explicitConstraints &&
+    queryConstraints &&
     pkArr.length === compositeConstraints.length &&
     pkArr.every((k: string, i: number) => k === compositeConstraints[i]) &&
     !refl.options?.sourceType

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -30,7 +30,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * DB work is deferred via _pendingReplace and flushed by persistReplace.
    */
   protected override replace(record: Base | null, save = true): void {
-    if (record) (this as any).raiseOnTypeMismatchBang?.(record);
+    if (record) (this as any).raiseOnTypeMismatchBang(record);
     const assigningAnother = this.target !== record;
     if (assigningAnother || (record as any)?.hasChangesToSave?.()) {
       if (save) {

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -649,14 +649,18 @@ describe("HasOneThroughAssociationsTest", () => {
 
   it("has one through relationship cannot have a counter cache", () => {
     expect(() => {
-      class Thing extends Base {}
-      Associations.hasOne.call(Thing, "other_thing", { className: "OtherThing" });
+      class Thing extends Base {
+        static {
+          this.adapter = adapter;
+        }
+      }
+      registerModel(Thing);
       Associations.hasOne.call(Thing, "club_thing", {
         className: "Club",
-        through: "other_thing",
+        through: "membership",
         counterCache: true,
       });
-    }).toThrow(Error);
+    }).toThrow(/counter_cache/);
   });
 
   it.skip("has one through do not cache association reader if the though method has default scopes", () => {

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -12,6 +12,7 @@ import {
   buildThroughAssociation,
   createThroughAssociation,
 } from "../associations.js";
+import { HasOneThroughCantAssociateThroughCollection } from "./errors.js";
 
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
@@ -550,18 +551,34 @@ describe("HasOneThroughAssociationsTest", () => {
     // Requires default scope on join model
   });
 
-  it.skip("has one through many raises exception", () => {
-    // BLOCKED: associations — has-one-through feature gap
-    // ROOT-CAUSE: associations/has-one-through-associations.ts or preloader.ts missing has-one-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-one-through-associations.test.ts
-    // Requires exception on has-one through has-many
+  it("has one through many raises exception", () => {
+    class ManyMember extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(ManyMember);
+    Associations.hasMany.call(ManyMember, "memberships", {
+      className: "Membership",
+      foreignKey: "member_id",
+    });
+    Associations.hasOne.call(ManyMember, "clubThroughMany", {
+      className: "Club",
+      through: "memberships",
+      source: "club",
+    });
+    const rec = new ManyMember({ name: "Test" });
+    // Accessing the through-collection association should raise
+    expect(() => rec.association("clubThroughMany")).toThrow(
+      HasOneThroughCantAssociateThroughCollection,
+    );
   });
 
   it.skip("has one through polymorphic association", () => {
-    // BLOCKED: associations — has-one-through feature gap
-    // ROOT-CAUSE: associations/has-one-through-associations.ts or preloader.ts missing has-one-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-one-through-associations.test.ts
-    // Requires polymorphic through association
+    // BLOCKED: reflection — isPolymorphic() checks options.polymorphic but not options.as
+    // ROOT-CAUSE: ThroughReflection.isPolymorphic() needs to recognize has_one :as as polymorphic
+    // SCOPE: ~10 LOC fix in reflection.ts; unblocks HasOneAssociationPolymorphicThroughError guard
   });
 
   it("has one through belongs to should update when the through foreign key changes", async () => {
@@ -610,11 +627,17 @@ describe("HasOneThroughAssociationsTest", () => {
     expect(loadedMembership!.club_id).toBe(club.id);
   });
 
-  it.skip("assigning has one through belongs to with new record owner", () => {
-    // BLOCKED: associations — has-one-through feature gap
-    // ROOT-CAUSE: associations/has-one-through-associations.ts or preloader.ts missing has-one-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-one-through-associations.test.ts
-    // Requires assignment with new record owner
+  it("assigning has one through belongs to with new record owner", async () => {
+    const club = await Club.create({ name: "Rails Club" });
+    const member = new Member({ name: "New Member" });
+    // Assign club via through association on a new (unsaved) owner
+    (member.association("club") as any).writer(club);
+    expect(member.association("club").target).toBe(club);
+    await member.save();
+    // After save, membership should be created linking member to club
+    const memberships = await Membership.all().where({ member_id: member.id }).toArray();
+    expect(memberships.length).toBe(1);
+    expect(memberships[0].readAttribute("club_id")).toBe(club.id);
   });
 
   it.skip("has one through with custom select on join model default scope", () => {
@@ -624,11 +647,16 @@ describe("HasOneThroughAssociationsTest", () => {
     // Requires custom select on join model
   });
 
-  it.skip("has one through relationship cannot have a counter cache", () => {
-    // BLOCKED: associations — has-one-through feature gap
-    // ROOT-CAUSE: associations/has-one-through-associations.ts or preloader.ts missing has-one-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-one-through-associations.test.ts
-    // Requires counter cache restriction
+  it("has one through relationship cannot have a counter cache", () => {
+    expect(() => {
+      class Thing extends Base {}
+      Associations.hasOne.call(Thing, "other_thing", { className: "OtherThing" });
+      Associations.hasOne.call(Thing, "club_thing", {
+        className: "Club",
+        through: "other_thing",
+        counterCache: true,
+      });
+    }).toThrow(Error);
   });
 
   it.skip("has one through do not cache association reader if the though method has default scopes", () => {


### PR DESCRIPTION
## Summary

- Override `replace`/`persistReplace` on `HasOneThroughAssociation` so that `member.club = newClub` dispatches through `createThroughRecord` (creates/updates/destroys the join model) rather than the parent `HasOneAssociation` FK-nullification path
- Fix `constructJoinAttributes` to use `queryConstraintsList` (explicit constraints only) instead of `compositeQueryConstraintsList` (which falls back to PK for simple models, causing the "pass object" CPK branch to fire incorrectly and drop the `club_id` FK value)
- Un-skips 3 tests: `assigning has one through belongs to with new record owner`, `has one through many raises exception`, `has one through relationship cannot have a counter cache`

## Design

`replace` stores `_pendingReplace` (same deferred pattern as `HasOneAssociation`), and `persistReplace` is overridden to call `createThroughRecord` instead of FK nullification. This runs after `owner.save()` via `flushPendingReplaces`, so new-record owners work correctly (owner is persisted by the time `persistReplace` fires).

## Follow-ups

- Slots B/C/D from the associations has-one cluster (fixture infrastructure, validation surface, annotation cleanup)
- `isPolymorphic()` in `ThroughReflection` should check `options.as` in addition to `options.polymorphic` to properly raise `HasOneAssociationPolymorphicThroughError` (~10 LOC)