### PR TITLE
feat(activerecord) pg-schema INHERITS dump — wire tableOptions through SchemaDumper.emitTable

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -709,11 +709,31 @@ describeIfPg("PostgreSQLAdapter", () => {
       // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
     });
-    it.skip("inherited table options is dumped", () => {
-      // BLOCKED: pg-schema — requires schema-dump support for CREATE TABLE ... INHERITS (PostgreSQL table inheritance); no STI routing gap
+    it("inherited table options is dumped", async () => {
+      await adapter.exec(`CREATE TABLE transportation_modes (name varchar(50), kind varchar(50))`);
+      await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes)`);
+      try {
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toMatch(`options: "INHERITS (transportation_modes)"`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+        await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
+      }
     });
-    it.skip("multiple inherited table options is dumped", () => {
-      // BLOCKED: pg-schema — requires schema-dump support for CREATE TABLE ... INHERITS (PostgreSQL table inheritance); no STI routing gap
+    it("multiple inherited table options is dumped", async () => {
+      await adapter.exec(`CREATE TABLE vehicles (name varchar(50))`);
+      await adapter.exec(`CREATE TABLE transportation_modes (kind varchar(50))`);
+      await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes, vehicles)`);
+      try {
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toMatch(`options: "INHERITS (transportation_modes, vehicles)"`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+        await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
+        await adapter.exec(`DROP TABLE IF EXISTS vehicles`);
+      }
     });
     it.skip("no partition options are dumped", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -710,14 +710,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
     });
     it.skip("inherited table options is dumped", () => {
-      // BLOCKED: STI — single-table inheritance routing gap
-      // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-      // SCOPE: ~50 LOC fix in inheritance.ts; affects this test + others sharing STI root cause
+      // BLOCKED: pg-schema — requires schema-dump support for CREATE TABLE ... INHERITS (PostgreSQL table inheritance); no STI routing gap
     });
     it.skip("multiple inherited table options is dumped", () => {
-      // BLOCKED: STI — single-table inheritance routing gap
-      // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-      // SCOPE: ~50 LOC fix in inheritance.ts; affects this test + others sharing STI root cause
+      // BLOCKED: pg-schema — requires schema-dump support for CREATE TABLE ... INHERITS (PostgreSQL table inheritance); no STI routing gap
     });
     it.skip("no partition options are dumped", () => {
       // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -710,25 +710,27 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
     });
     it("inherited table options is dumped", async () => {
-      await adapter.exec(`CREATE TABLE transportation_modes (name varchar(50), kind varchar(50))`);
-      await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes)`);
       try {
+        await adapter.exec(
+          `CREATE TABLE transportation_modes (name varchar(50), kind varchar(50))`,
+        );
+        await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes)`);
         const lines: string[] = [];
         await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
-        expect(lines.join("\n")).toMatch(`options: "INHERITS (transportation_modes)"`);
+        expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
         await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
       }
     });
     it("multiple inherited table options is dumped", async () => {
-      await adapter.exec(`CREATE TABLE vehicles (name varchar(50))`);
-      await adapter.exec(`CREATE TABLE transportation_modes (kind varchar(50))`);
-      await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes, vehicles)`);
       try {
+        await adapter.exec(`CREATE TABLE vehicles (name varchar(50))`);
+        await adapter.exec(`CREATE TABLE transportation_modes (kind varchar(50))`);
+        await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes, vehicles)`);
         const lines: string[] = [];
         await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
-        expect(lines.join("\n")).toMatch(`options: "INHERITS (transportation_modes, vehicles)"`);
+        expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes, vehicles)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
         await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -165,7 +165,15 @@ export interface AbstractAdapter {
   createTable(
     name: string,
     optionsOrFn?:
-      | { id?: boolean | "uuid"; force?: boolean | "cascade"; ifNotExists?: boolean }
+      | {
+          id?: boolean | "uuid";
+          force?: boolean | "cascade";
+          ifNotExists?: boolean;
+          options?: string;
+          comment?: string;
+          temporary?: boolean;
+          as?: string;
+        }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -77,6 +77,10 @@ export class SchemaStatements {
           force?: boolean | "cascade";
           ifNotExists?: boolean;
           default?: unknown;
+          options?: string;
+          comment?: string;
+          temporary?: boolean;
+          as?: string;
         }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
@@ -86,6 +90,10 @@ export class SchemaStatements {
       force?: boolean | "cascade";
       ifNotExists?: boolean;
       default?: unknown;
+      options?: string;
+      comment?: string;
+      temporary?: boolean;
+      as?: string;
     } = {};
     let definer: ((t: TableDefinition) => void) | undefined;
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4023,6 +4023,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       WHERE child.relname = ${name}
         AND child.relkind IN ('r','p')
         AND n.nspname = ${schema}
+      ORDER BY i.inhseqno
     `);
     return rows.map((r) => r.name as string);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -162,6 +162,13 @@ export class SchemaDumper extends AbstractSchemaDumper {
     lines.push("");
   }
 
+  /** @internal */
+  protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
+    const adapter = this.pgAdapter();
+    if (!adapter?.tableOptions) return {};
+    return adapter.tableOptions(tableName);
+  }
+
   defaultPrimaryKeyType(): string {
     return "bigserial";
   }

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -154,17 +154,11 @@ describe("DelegatedTypeTest", () => {
   });
 
   it.skip("association uuid", () => {
-    // BLOCKED: STI — single-table inheritance routing gap
-    // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-    // SCOPE: ~50 LOC fix in inheritance.ts; affects ~8–15 tests in delegated-type.test.ts
-    /* needs UUID primary key support */
+    // BLOCKED: uuid-pk — delegated type uses a UUID primary key; no STI routing gap
   });
 
   it.skip("touch account", () => {
-    // BLOCKED: STI — single-table inheritance routing gap
-    // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-    // SCOPE: ~50 LOC fix in inheritance.ts; affects ~8–15 tests in delegated-type.test.ts
-    /* needs touch support on polymorphic association */
+    // BLOCKED: uuid + polymorphic-touch — requires UUID PK + touch on a polymorphic delegated_type association; no STI routing gap
   });
 
   it("builder method", () => {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -1434,13 +1434,13 @@ describe("InheritanceTest", () => {
   });
 
   it.skip("scope inherited properly", async () => {
-    // BLOCKED: fixture — test requires a fixture model with a default_scope on a subclass;
-    // no STI routing gap (STI dispatch works); gap is missing test infrastructure
+    // BLOCKED: default-scope — test requires a fixture model with a default_scope on a subclass;
+    // no STI routing gap (STI dispatch works); gap is missing test fixture model
   });
 
   it.skip("inheritance with default scope", async () => {
-    // BLOCKED: fixture — test requires a fixture model with a default_scope on a subclass;
-    // no STI routing gap (STI dispatch works); gap is missing test infrastructure
+    // BLOCKED: default-scope — test requires a fixture model with a default_scope on a subclass;
+    // no STI routing gap (STI dispatch works); gap is missing test fixture model
   });
 
   it("company descends from active record", async () => {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -1434,17 +1434,13 @@ describe("InheritanceTest", () => {
   });
 
   it.skip("scope inherited properly", async () => {
-    // BLOCKED: STI — single-table inheritance routing gap
-    // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-    // SCOPE: ~50 LOC fix in inheritance.ts; affects this test + others sharing STI root cause
-    // requires default_scope on subclass
+    // BLOCKED: fixture — test requires a fixture model with a default_scope on a subclass;
+    // no STI routing gap (STI dispatch works); gap is missing test infrastructure
   });
 
   it.skip("inheritance with default scope", async () => {
-    // BLOCKED: STI — single-table inheritance routing gap
-    // ROOT-CAUSE: inheritance.ts#instantiateWithCtiMixin or findSubclass not fully wired
-    // SCOPE: ~50 LOC fix in inheritance.ts; affects this test + others sharing STI root cause
-    // requires default_scope
+    // BLOCKED: fixture — test requires a fixture model with a default_scope on a subclass;
+    // no STI routing gap (STI dispatch works); gap is missing test infrastructure
   });
 
   it("company descends from active record", async () => {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -663,12 +663,18 @@ export class SchemaDumper {
     try {
       const columns = await this._source.columns(tableName);
       const indexes = await this._source.indexes(tableName);
-      this.emitTable(lines, tableName, columns, indexes);
+      const adapterTableOpts = await this.fetchTableOptions(tableName);
+      this.emitTable(lines, tableName, columns, indexes, adapterTableOpts);
       await this.checkConstraintsInCreate(tableName, lines);
       lines.push("");
     } finally {
       this.tableName = undefined;
     }
+  }
+
+  /** @internal */
+  protected async fetchTableOptions(_tableName: string): Promise<Record<string, unknown>> {
+    return {};
   }
 
   /**
@@ -699,11 +705,13 @@ export class SchemaDumper {
     return {};
   }
 
-  private emitTable(
+  /** @internal */
+  protected emitTable(
     lines: string[],
     tableName: string,
     columns: ColumnInfo[],
     indexes: IndexInfo[],
+    adapterTableOpts: Record<string, unknown> = {},
   ): void {
     const pkColumn = columns.find((c) => c.primaryKey);
     const hasId = pkColumn?.name === "id";
@@ -716,6 +724,7 @@ export class SchemaDumper {
       Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
     }
     tableOpts.force = "cascade";
+    if (adapterTableOpts.options) tableOpts.options = adapterTableOpts.options;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -724,7 +724,7 @@ export class SchemaDumper {
       Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
     }
     tableOpts.force = "cascade";
-    if (adapterTableOpts.options) tableOpts.options = adapterTableOpts.options;
+    if (adapterTableOpts.options != null) tableOpts.options = adapterTableOpts.options;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -611,14 +611,17 @@ export class SchemaDumper {
       if (this.isIgnored(tableName)) continue;
       const columns = this._source.columns(tableName);
       const indexes = this._source.indexes(tableName);
-      const adapterTableOpts = this.fetchTableOptions(tableName);
-      if (
-        columns instanceof Promise ||
-        indexes instanceof Promise ||
-        adapterTableOpts instanceof Promise
-      ) {
+      if (columns instanceof Promise || indexes instanceof Promise) {
         throw new TypeError(
           "SchemaSource.columns()/indexes() returned a Promise while tables() was synchronous. " +
+            "Use the async schema dumper path (make tables() return a Promise) or ensure all schema methods are synchronous.",
+        );
+      }
+      const adapterTableOpts = this.fetchTableOptions(tableName);
+      if (adapterTableOpts instanceof Promise) {
+        void adapterTableOpts.catch(() => {});
+        throw new TypeError(
+          "fetchTableOptions() returned a Promise while tables() was synchronous. " +
             "Use the async schema dumper path (make tables() return a Promise) or ensure all schema methods are synchronous.",
         );
       }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -737,7 +737,7 @@ export class SchemaDumper {
       Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
     }
     tableOpts.force = "cascade";
-    if (adapterTableOpts.options != null) tableOpts.options = adapterTableOpts.options;
+    if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -611,7 +611,12 @@ export class SchemaDumper {
       if (this.isIgnored(tableName)) continue;
       const columns = this._source.columns(tableName);
       const indexes = this._source.indexes(tableName);
-      if (columns instanceof Promise || indexes instanceof Promise) {
+      const adapterTableOpts = this.fetchTableOptions(tableName);
+      if (
+        columns instanceof Promise ||
+        indexes instanceof Promise ||
+        adapterTableOpts instanceof Promise
+      ) {
         throw new TypeError(
           "SchemaSource.columns()/indexes() returned a Promise while tables() was synchronous. " +
             "Use the async schema dumper path (make tables() return a Promise) or ensure all schema methods are synchronous.",
@@ -619,7 +624,13 @@ export class SchemaDumper {
       }
       this.tableName = tableName;
       try {
-        this.emitTable(lines, tableName, columns as ColumnInfo[], indexes as IndexInfo[]);
+        this.emitTable(
+          lines,
+          tableName,
+          columns as ColumnInfo[],
+          indexes as IndexInfo[],
+          adapterTableOpts,
+        );
         lines.push("");
       } finally {
         this.tableName = undefined;
@@ -673,7 +684,9 @@ export class SchemaDumper {
   }
 
   /** @internal */
-  protected async fetchTableOptions(_tableName: string): Promise<Record<string, unknown>> {
+  protected fetchTableOptions(
+    _tableName: string,
+  ): Record<string, unknown> | Promise<Record<string, unknown>> {
     return {};
   }
 


### PR DESCRIPTION
## Summary

Builds on #1455 (STI annotation drift). Implements the two `SchemaCreateTableOptionsTest` INHERITS tests that were previously `BLOCKED: pg-schema`.

- Adds `fetchTableOptions(tableName)` hook to base `SchemaDumper` (returns `{}` by default)
- `table()` awaits this hook and passes the result into `emitTable()` (promoted from `private` to `protected`, added `adapterTableOpts` param)
- `emitTable()` merges `adapterTableOpts.options` into the `createTable(...)` options object
- `PostgreSQL::SchemaDumper` overrides `fetchTableOptions` to call `adapter.tableOptions(tableName)`, which already returns `{ options: "INHERITS (...)" }` via `inheritedTableNames()`
- Unskips and implements both `inherited table options is dumped` and `multiple inherited table options is dumped`

The PARTITION BY tests remain skipped (different cluster) — they flow through the same path once tackled.