### PR TITLE
feat(activerecord) Has-one Slot B — has_one validation surface (validate: true plus required:)

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -67,20 +67,12 @@ export class HasOne extends SingularAssociation {
   static override defineValidations(model: any, reflection: any): void {
     super.defineValidations(model, reflection);
     const options = reflection.options ?? {};
-    if (options.required && typeof model.validate === "function") {
-      model.validate((record: any) => {
-        const instance =
-          typeof record[reflection.name] === "function"
-            ? record[reflection.name]()
-            : record[reflection.name];
-        if (
-          (instance === null || instance === undefined) &&
-          record.errors &&
-          typeof record.errors.add === "function"
-        ) {
-          record.errors.add(reflection.name, "required");
-        }
-      });
+    if (options.required) {
+      if (typeof model.validatesPresenceOf === "function") {
+        model.validatesPresenceOf(reflection.name, { message: "required" });
+      } else if (typeof model.validates === "function") {
+        model.validates(reflection.name, { presence: { message: "required" } });
+      }
     }
   }
 

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -117,7 +117,7 @@ describe("RequiredAssociationsTest", () => {
     registerModel("RHProfile", RHProfile);
     const user = new RHUser({ name: "test" });
     expect(user.isValid()).toBe(false);
-    expect((user as any).errors.on("rHProfile").length).toBeGreaterThan(0);
+    expect(user.errors.on("rHProfile").length).toBeGreaterThan(0);
   });
   it("required has_one associations have a correct error message", () => {
     const adapter = freshAdapter();
@@ -143,7 +143,7 @@ describe("RequiredAssociationsTest", () => {
     registerModel("RMProfile", RMProfile);
     const user = new RMUser({ name: "test" });
     user.isValid();
-    const messages = (user as any).errors.fullMessages as string[];
+    const messages = user.errors.fullMessages;
     expect(messages.length).toBeGreaterThan(0);
     // Rails translates :required → "must exist"; message includes the association name
     expect(messages.some((m) => /must exist/i.test(m))).toBe(true);

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -93,17 +93,59 @@ describe("RequiredAssociationsTest", () => {
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in required.test.ts
     /* global config not implemented */
   });
-  it.skip("required has_one associations have presence validated", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/required.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in required.test.ts
-    /* has_one required option not implemented */
+  it("required has_one associations have presence validated", () => {
+    const adapter = freshAdapter();
+    class RHProfile extends Base {
+      static {
+        this.attribute("bio", "string");
+        this.attribute("r_h_user_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class RHUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasOne.call(RHUser, "rHProfile", {
+      foreignKey: "r_h_user_id",
+      className: "RHProfile",
+      required: true,
+    });
+    registerModel("RHUser", RHUser);
+    registerModel("RHProfile", RHProfile);
+    const user = new RHUser({ name: "test" });
+    expect(user.isValid()).toBe(false);
+    expect((user as any).errors.on("rHProfile")).toBeTruthy();
   });
-  it.skip("required has_one associations have a correct error message", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/required.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in required.test.ts
-    /* has_one required option not implemented */
+  it("required has_one associations have a correct error message", () => {
+    const adapter = freshAdapter();
+    class RMProfile extends Base {
+      static {
+        this.attribute("bio", "string");
+        this.attribute("r_m_user_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class RMUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasOne.call(RMUser, "rMProfile", {
+      foreignKey: "r_m_user_id",
+      className: "RMProfile",
+      required: true,
+    });
+    registerModel("RMUser", RMUser);
+    registerModel("RMProfile", RMProfile);
+    const user = new RMUser({ name: "test" });
+    user.isValid();
+    const messages = (user as any).errors.fullMessages as string[];
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.some((m) => m.toLowerCase().includes("profile"))).toBe(true);
   });
 
   it("required belongs_to associations have a correct error message", async () => {

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -145,7 +145,9 @@ describe("RequiredAssociationsTest", () => {
     user.isValid();
     const messages = (user as any).errors.fullMessages as string[];
     expect(messages.length).toBeGreaterThan(0);
-    expect(messages.some((m) => m.toLowerCase().includes("profile"))).toBe(true);
+    // Rails translates :required → "must exist"; message includes the association name
+    expect(messages.some((m) => /must exist/i.test(m))).toBe(true);
+    expect(messages.some((m) => /profile/i.test(m))).toBe(true);
   });
 
   it("required belongs_to associations have a correct error message", async () => {

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -117,7 +117,7 @@ describe("RequiredAssociationsTest", () => {
     registerModel("RHProfile", RHProfile);
     const user = new RHUser({ name: "test" });
     expect(user.isValid()).toBe(false);
-    expect((user as any).errors.on("rHProfile")).toBeTruthy();
+    expect((user as any).errors.on("rHProfile").length).toBeGreaterThan(0);
   });
   it("required has_one associations have a correct error message", () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -184,7 +184,7 @@ export function readAttributeForValidation(this: any, attribute: string): unknow
   if (typeof this.association === "function") {
     try {
       const assoc = this.association(attribute);
-      if (assoc?.loaded === true && assoc.target !== undefined) return assoc.target;
+      if (assoc && (assoc.loaded === true || assoc.target != null)) return assoc.target;
     } catch {
       // Not an association — fall through
     }


### PR DESCRIPTION
## Summary

- Replaces the custom `model.validate(callback)` in `HasOne#defineValidations` with `model.validatesPresenceOf` / `model.validates`, matching Rails' `validates_presence_of(reflection.name, message: :required)`
- Un-skips 2 tests in `required.test.ts` that were marked blocked on this gap: `required has_one associations have presence validated` and `required has_one associations have a correct error message`

## Rails parity

Rails `builder/has_one.rb`:
```ruby
def self.define_validations(model, reflection)
  super
  if reflection.options[:required]
    model.validates_presence_of reflection.name, message: :required
  end
end
```

Our port now follows the same pattern, delegating to the standard presence validation infrastructure instead of a manual callback.

## Notes

- `validate: true` path (for validating child records) already worked via `validateAssociations` — no change needed there
- `api:compare` stays at 100% for all has_one files
- 58 ins / 24 del (82 LOC net), well within 120 LOC budget