### PR TITLE
feat(activerecord) PG connection Slot C — resetBang override plus 2 reset unskips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -48,18 +48,27 @@ describeIfPg("PostgresqlConnectionTest", () => {
     // Requires establish_connection with options: "-c geqo=off" and leasing model connections
   });
 
-  it.skip("reset", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires reset!() — clears session config and returns connection to clean state
+  it("reset", async () => {
+    await adapter.execute("SET geqo TO off");
+    const before = await adapter.execute("SHOW geqo");
+    expect(before[0]?.geqo).toBe("off");
+
+    await adapter.resetBang();
+
+    const after = await adapter.execute("SHOW geqo");
+    expect(after[0]?.geqo).toBe("on");
   });
 
-  it.skip("reset with transaction", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires reset!() with an open transaction
+  it("reset with transaction", async () => {
+    await adapter.execute("SET geqo TO off");
+    const before = await adapter.execute("SHOW geqo");
+    expect(before[0]?.geqo).toBe("off");
+
+    await adapter.beginTransaction();
+    await adapter.resetBang();
+
+    const after = await adapter.execute("SHOW geqo");
+    expect(after[0]?.geqo).toBe("on");
   });
 
   it("tables logs name", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1816,16 +1816,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Mirrors Rails' `PostgreSQLAdapter#reset!`. Rails issues ROLLBACK (if in
    * a transaction), DISCARD ALL, then re-runs configure_connection on the
    * single raw connection. pg doesn't expose PQreset; the pool equivalent is
-   * to ROLLBACK any open transaction on the held client, then tear down the
-   * entire pool — discarding all physical connections and their session state.
-   * New checkouts are configured on first use via `_maybeConfigureConnection`,
-   * matching Rails' `super` call.
+   * to fire a best-effort ROLLBACK on the held client (if any), then tear
+   * down the entire pool — discarding all physical connections and their
+   * session state. The rollback is fire-and-forget so reconnect() always runs
+   * even if the connection is already broken, matching Rails' error-tolerant
+   * reset semantics. New checkouts are configured on first use via
+   * `_maybeConfigureConnection`, matching Rails' `super` call.
    *
    * @internal
    */
-  override async resetBang(): Promise<void> {
+  override resetBang(): void {
     if (this._client) {
-      await this._client.query("ROLLBACK");
+      const client = this._client;
+      this._client = null;
+      client.query("ROLLBACK").then(
+        () => client.release(),
+        (err) => client.release(err instanceof Error ? err : new Error(String(err))),
+      );
     }
     this.reconnect();
     super.resetBang();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1827,6 +1827,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override resetBang(): void {
     if (this._client) {
+      this._cancelAnyRunningQuery();
       const client = this._client;
       this._client = null;
       client.query("ROLLBACK").then(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1813,6 +1813,31 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Mirrors Rails' `PostgreSQLAdapter#reset!`. Issues `DISCARD ALL` on the
+   * current connection to clear session state (temp tables, prepared
+   * statements, `SET` variables), rolls back any open transaction first,
+   * then re-runs `configure_connection`. The pg npm driver does not expose
+   * PQreset; the equivalent is to roll back any open transaction, then tear
+   * down the pool so all physical connections (and their session state) are
+   * discarded. The new pool's connections are configured on first checkout
+   * via `_maybeConfigureConnection`, matching Rails' `super` call.
+   *
+   * @internal
+   */
+  override async resetBang(): Promise<void> {
+    if (!this._driverPool) {
+      this.reconnect();
+      super.resetBang();
+      return;
+    }
+    if (this._client && this._inTransaction) {
+      await this._client.query("ROLLBACK");
+    }
+    this.reconnect();
+    super.resetBang();
+  }
+
+  /**
    * Mirrors Rails' `PostgreSQLAdapter#configure_connection`. Applies
    * per-connection settings (standard_conforming_strings, intervalstyle,
    * client_min_messages, session variables). Delegates to the internal

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1829,6 +1829,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (this._client) {
       this._cancelAnyRunningQuery();
       const client = this._client;
+      this._releaseStatementPool(client);
       this._client = null;
       client.query("ROLLBACK").then(
         () => client.release(),

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1813,24 +1813,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Mirrors Rails' `PostgreSQLAdapter#reset!`. Issues `DISCARD ALL` on the
-   * current connection to clear session state (temp tables, prepared
-   * statements, `SET` variables), rolls back any open transaction first,
-   * then re-runs `configure_connection`. The pg npm driver does not expose
-   * PQreset; the equivalent is to roll back any open transaction, then tear
-   * down the pool so all physical connections (and their session state) are
-   * discarded. The new pool's connections are configured on first checkout
-   * via `_maybeConfigureConnection`, matching Rails' `super` call.
+   * Mirrors Rails' `PostgreSQLAdapter#reset!`. Rails issues ROLLBACK (if in
+   * a transaction), DISCARD ALL, then re-runs configure_connection on the
+   * single raw connection. pg doesn't expose PQreset; the pool equivalent is
+   * to ROLLBACK any open transaction on the held client, then tear down the
+   * entire pool — discarding all physical connections and their session state.
+   * New checkouts are configured on first use via `_maybeConfigureConnection`,
+   * matching Rails' `super` call.
    *
    * @internal
    */
   override async resetBang(): Promise<void> {
-    if (!this._driverPool) {
-      this.reconnect();
-      super.resetBang();
-      return;
-    }
-    if (this._client && this._inTransaction) {
+    if (this._client) {
       await this._client.query("ROLLBACK");
     }
     this.reconnect();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1832,7 +1832,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._client = null;
       client.query("ROLLBACK").then(
         () => client.release(),
-        (err) => client.release(err instanceof Error ? err : new Error(String(err))),
+        (err) => client.release(toError(err)),
       );
     }
     this.reconnect();


### PR DESCRIPTION
## Summary

- Adds `resetBang()` override on `PostgreSQLAdapter` mirroring Rails' `PostgreSQLAdapter#reset!`
- Rails' reset issues ROLLBACK (if in transaction), then `DISCARD ALL`, then re-runs `configure_connection`. The pg npm driver doesn't expose PQreset; equivalent is to ROLLBACK any open transaction on the active client, then call `reconnect()` to tear down the pool (discarding all physical connections and their session state) and bring up a fresh one. New pool connections are configured on first checkout via `_maybeConfigureConnection`, matching Rails' `super` call.
- Un-skips 2 reset tests in `adapters/postgresql/connection.test.ts`

## Test plan

- [x] `pnpm vitest run "adapters/postgresql/connection"` — 32 passed, 2 skipped (pre-existing: connection options + reconnection after actual disconnection with verify)
- [x] `pnpm api:compare --package activerecord` — 4955/4958 (99.9%), no regression
- [x] TypeScript build passes (lint hook)