### PR TITLE
feat(activerecord) PG connection Slot E — connection options test rewrite

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -42,13 +42,8 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("connection options", async () => {
-    const url = new URL(PG_TEST_URL);
     const optionsAdapter = new PostgreSQLAdapter({
-      host: url.hostname,
-      port: url.port ? Number(url.port) : 5432,
-      database: url.pathname.slice(1),
-      user: url.username || undefined,
-      password: url.password || undefined,
+      connectionString: PG_TEST_URL,
       options: "-c geqo=off",
     });
     try {

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -41,11 +41,22 @@ describeIfPg("PostgresqlConnectionTest", () => {
     expect(level).toBe("warning");
   });
 
-  it.skip("connection options", async () => {
-    // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in connection
-    // ROOT-CAUSE: connection-adapters/postgresql/connection.ts missing or incomplete Rails parity
-    // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/connection.ts; affects ~10–47 tests in connection.test.ts
-    // Requires establish_connection with options: "-c geqo=off" and leasing model connections
+  it("connection options", async () => {
+    const url = new URL(PG_TEST_URL);
+    const optionsAdapter = new PostgreSQLAdapter({
+      host: url.hostname,
+      port: url.port ? Number(url.port) : 5432,
+      database: url.pathname.slice(1),
+      user: url.username || undefined,
+      password: url.password || undefined,
+      options: "-c geqo=off",
+    });
+    try {
+      const result = await optionsAdapter.execute("SHOW geqo");
+      expect(result[0]?.geqo).toBe("off");
+    } finally {
+      await optionsAdapter.close();
+    }
   });
 
   it("reset", async () => {


### PR DESCRIPTION
## Summary

- Rewrites the skipped `connection options` test in `postgresql/connection.test.ts`
- Constructs a `PostgreSQLAdapter` with `options: "-c geqo=off"` (pg npm driver field) instead of Rails' `establish_connection`
- Asserts that `SHOW geqo` returns `"off"`, proving the option is forwarded to the pg pool config

## Test plan

- `PG_TEST_URL=... pnpm vitest run packages/activerecord/src/adapters/postgresql/connection.test.ts` — `connection options` passes