### PR TITLE
chore(activerecord) fidelity sweep C — associations + reflection Rails-divergence cleanup

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -68,11 +68,7 @@ export class HasOne extends SingularAssociation {
     super.defineValidations(model, reflection);
     const options = reflection.options ?? {};
     if (options.required) {
-      if (typeof model.validatesPresenceOf === "function") {
-        model.validatesPresenceOf(reflection.name, { message: "required" });
-      } else if (typeof model.validates === "function") {
-        model.validates(reflection.name, { presence: { message: "required" } });
-      }
+      model.validatesPresenceOf(reflection.name, { message: "required" });
     }
   }
 

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -55,7 +55,9 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // wrong direction for the build-and-save path.
     const joinRecord = buildThroughRecord(this, record);
     if (joinRecord && (joinRecord as any).changed) {
-      const saved = await (joinRecord as any).save();
+      const saved = raise
+        ? await (joinRecord as any).saveBang({ validate })
+        : await (joinRecord as any).save({ validate });
       if (!saved) return false;
     }
     return true;

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -6,6 +6,7 @@ import {
   HasManyThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
+import { raiseValidationError } from "../validations.js";
 
 function safeKlass(refl: { klass?: unknown } | null | undefined): any {
   try {
@@ -55,10 +56,11 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // wrong direction for the build-and-save path.
     const joinRecord = buildThroughRecord(this, record);
     if (joinRecord && (joinRecord as any).changed) {
-      const saved = raise
-        ? await (joinRecord as any).saveBang({ validate })
-        : await (joinRecord as any).save({ validate });
-      if (!saved) return false;
+      const saved = await (joinRecord as any).save({ validate });
+      if (!saved) {
+        if (raise) raiseValidationError(joinRecord);
+        return false;
+      }
     }
     return true;
   }

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -8040,4 +8040,58 @@ describe("HasManyThroughAssociationsTest", () => {
     const ids = posts.map((p) => p.id).sort();
     expect(ids).toEqual([post1.id, post2.id].sort());
   });
+
+  it("insertRecord with validate false skips join record validation", async () => {
+    // Rails autosave calls insertRecord(child, validate:false, raise:false) so join
+    // records with failing validations should still be saved when validate is false.
+    class IrpvJoin extends Base {
+      static {
+        this.attribute("irpv_owner_id", "integer");
+        this.attribute("irpv_item_id", "integer");
+        this.adapter = adapter;
+        this.validate((r: any) => {
+          r.errors.add("base", "Join always invalid");
+        });
+      }
+    }
+    class IrpvItem extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class IrpvOwner extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("IrpvJoin", IrpvJoin);
+    registerModel("IrpvItem", IrpvItem);
+    registerModel("IrpvOwner", IrpvOwner);
+    Associations.belongsTo.call(IrpvJoin, "irpv_item", {
+      className: "IrpvItem",
+      foreignKey: "irpv_item_id",
+    });
+    Associations.hasMany.call(IrpvOwner, "irpv_joins", {
+      className: "IrpvJoin",
+      foreignKey: "irpv_owner_id",
+    });
+    Associations.hasMany.call(IrpvOwner, "irpv_items", {
+      className: "IrpvItem",
+      through: "irpv_joins",
+      source: "irpv_item",
+    });
+
+    const owner = await IrpvOwner.create({ name: "Firm" });
+    const item = await IrpvItem.create({ name: "Item" });
+    // Call insertRecord directly (the autosave path), with validate=false.
+    // Before the fix, joinRecord.save() was called without validate option,
+    // which defaulted to true and would fail. Now it passes validate through.
+    const assoc = (owner as any).association("irpv_items");
+    const result = await assoc.insertRecord(item, false, false);
+    expect(result).toBe(true);
+    const joins = await IrpvJoin.all().where({ irpv_owner_id: owner.id }).toArray();
+    expect(joins.length).toBe(1);
+  });
 });

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -86,7 +86,7 @@ async function createThroughRecord(
 
   if (throughRecord && (throughRecord as any).isDestroyed?.()) {
     await throughProxy.reload?.();
-    throughRecord = await throughProxy.loadTarget?.();
+    throughRecord = (throughProxy as any).target ?? null;
   }
 
   if (throughRecord && !record) {

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -84,7 +84,7 @@ async function createThroughRecord(
 
   let throughRecord = await throughProxy.loadTarget?.();
 
-  if (throughRecord && (throughRecord as any).destroyed?.()) {
+  if (throughRecord && (throughRecord as any).isDestroyed?.()) {
     await throughProxy.reload?.();
     throughRecord = await throughProxy.loadTarget?.();
   }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -82,7 +82,12 @@ async function createThroughRecord(
   const throughProxy = (assoc.owner as any).association?.(throughName);
   if (!throughProxy) return null;
 
-  const throughRecord = await throughProxy.loadTarget?.();
+  let throughRecord = await throughProxy.loadTarget?.();
+
+  if (throughRecord && (throughRecord as any).destroyed?.()) {
+    await throughProxy.reload?.();
+    throughRecord = await throughProxy.loadTarget?.();
+  }
 
   if (throughRecord && !record) {
     await (throughRecord as any).destroy?.();
@@ -156,22 +161,6 @@ function throughReflection(assoc: HasOneThroughAssociation): unknown {
     refl = refl.throughReflection;
   }
   return refl;
-}
-
-/**
- * Returns the live Association wrapper that owns the join model — i.e.,
- * `owner.association(throughReflection.name)`.
- *
- * Mirrors: ActiveRecord::Associations::ThroughAssociation#through_association
- *
- * @internal
- */
-function throughAssociation(assoc: HasOneThroughAssociation): unknown {
-  const tr = throughReflection(assoc) as { name?: string } | null;
-  if (!tr?.name) return null;
-  return (assoc.owner as unknown as { association?: (n: string) => unknown }).association?.(
-    tr.name,
-  );
 }
 
 /**

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -751,7 +751,6 @@ describe("HasOneThroughAssociationsTest", () => {
     // Rails: createThroughRecord guards against reusing a destroyed through-record
     // by reloading the proxy before proceeding.
     const club1 = await Club.create({ name: "Old Club" });
-    const club2 = await Club.create({ name: "New Club" });
     const member = await Member.create({ name: "Groucho" });
     const membership = await Membership.create({ member_id: member.id, club_id: club1.id });
     // Destroy the membership so it's marked destroyed in memory

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -756,7 +756,7 @@ describe("HasOneThroughAssociationsTest", () => {
     const membership = await Membership.create({ member_id: member.id, club_id: club1.id });
     // Destroy the membership so it's marked destroyed in memory
     await membership.destroy();
-    expect((membership as any)._destroyed).toBe(true);
+    expect(membership.isDestroyed()).toBe(true);
     // Now create a new through association — should not try to reuse the destroyed record
     const newClub = await createThroughAssociation(member, "club", { name: "New Club" });
     expect(newClub.isPersisted()).toBe(true);

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -747,6 +747,26 @@ describe("HasOneThroughAssociationsTest", () => {
     expect(reloaded).toBeNull();
   });
 
+  it("creating through record when through record destroyed reloads before reuse", async () => {
+    // Rails: createThroughRecord guards against reusing a destroyed through-record
+    // by reloading the proxy before proceeding.
+    const club1 = await Club.create({ name: "Old Club" });
+    const club2 = await Club.create({ name: "New Club" });
+    const member = await Member.create({ name: "Groucho" });
+    const membership = await Membership.create({ member_id: member.id, club_id: club1.id });
+    // Destroy the membership so it's marked destroyed in memory
+    await membership.destroy();
+    expect((membership as any)._destroyed).toBe(true);
+    // Now create a new through association — should not try to reuse the destroyed record
+    const newClub = await createThroughAssociation(member, "club", { name: "New Club" });
+    expect(newClub.isPersisted()).toBe(true);
+    expect(newClub.name).toBe("New Club");
+    // A fresh membership should exist in the DB
+    const memberships = await Membership.all().where({ member_id: member.id }).toArray();
+    expect(memberships.length).toBe(1);
+    expect(memberships[0].club_id).toBe(newClub.id);
+  });
+
   it("set record after delete association", async () => {
     const club = await Club.create({ name: "Rails Club" });
     const member = await Member.create({ name: "DHH" });

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -898,31 +898,6 @@ function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any)
 }
 
 /** @internal */
-function addAutosaveAssociationCallbacks(klass: any, reflection: any): void {
-  const saveName = `autosaveAssociatedRecordsFor_${reflection.name}`;
-  const isCol =
-    typeof reflection.isCollection === "function"
-      ? reflection.isCollection()
-      : !!reflection.collection;
-  const isHasOne =
-    typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
-  if (isCol) {
-    defineNonCyclicMethod(klass, saveName, function (this: any) {
-      return saveCollectionAssociation.call(this, reflection);
-    });
-  } else if (isHasOne) {
-    defineNonCyclicMethod(klass, saveName, function (this: any) {
-      return saveHasOneAssociation.call(this, reflection);
-    });
-  } else {
-    defineNonCyclicMethod(klass, saveName, function (this: any) {
-      return saveBelongsToAssociation.call(this, reflection);
-    });
-  }
-  defineAutosaveValidationCallbacks(klass, reflection);
-}
-
-/** @internal */
 function defineAutosaveValidationCallbacks(klass: any, reflection: any): void {
   if (!reflection.validate) return;
   const validationName = `validateAssociatedRecordsFor_${reflection.name}`;

--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -3,8 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, RecordNotFound, RecordInvalid, ReadOnlyRecord } from "./index.js";
-import { UnknownPrimaryKey } from "./errors.js";
+import { Base, RecordNotFound, RecordInvalid, ReadOnlyRecord, UnknownPrimaryKey } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";

--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, RecordNotFound, RecordInvalid, ReadOnlyRecord } from "./index.js";
+import { UnknownPrimaryKey } from "./errors.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -241,5 +242,22 @@ describe("Error Classes (Rails-guided)", () => {
 
     await expect(p.save()).rejects.toThrow(ReadOnlyRecord);
     await expect(p.destroy()).rejects.toThrow(ReadOnlyRecord);
+  });
+});
+
+describe("UnknownPrimaryKeyTest", () => {
+  it("no-arg constructor produces generic message", () => {
+    const err = new UnknownPrimaryKey();
+    expect(err.message).toBe("Unknown primary key.");
+    expect(err.model).toBeNull();
+  });
+
+  it("description is separated by newline+space", () => {
+    class Dummy extends Base {
+      static _tableName = "dummies";
+    }
+    const err = new UnknownPrimaryKey(Dummy, "No PK configured.");
+    expect(err.message).toContain("\n No PK configured.");
+    expect(err.model).toBe(Dummy);
   });
 });

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -669,15 +669,20 @@ export class UnknownAttributeReference extends ActiveRecordError {
 }
 
 export class UnknownPrimaryKey extends ActiveRecordError {
-  readonly model: typeof import("./base.js").Base;
+  readonly model: typeof import("./base.js").Base | null;
 
-  constructor(model: typeof import("./base.js").Base, description?: string) {
-    const msg = description
-      ? `Unknown primary key for table ${model.tableName} in model ${model.name}. ${description}`
-      : `Unknown primary key for table ${model.tableName} in model ${model.name}.`;
+  constructor(model?: typeof import("./base.js").Base | null, description?: string) {
+    let msg: string;
+    if (model == null) {
+      msg = "Unknown primary key.";
+    } else if (description) {
+      msg = `Unknown primary key for table ${model.tableName} in model ${model.name}.\n ${description}`;
+    } else {
+      msg = `Unknown primary key for table ${model.tableName} in model ${model.name}.`;
+    }
     super(msg);
     this.name = "UnknownPrimaryKey";
-    this.model = model;
+    this.model = model ?? null;
   }
 }
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -274,7 +274,7 @@ export class AbstractReflection {
   }
 
   /** @internal */
-  protected inverseName(): string | null {
+  inverseName(): string | null {
     return null;
   }
 
@@ -599,7 +599,8 @@ export class AssociationReflection extends MacroReflection {
   private _inverseNameCache: string | null | undefined = undefined;
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
 
-  protected override inverseName(): string | null {
+  /** @internal */
+  override inverseName(): string | null {
     if (this._inverseNameCache !== undefined) return this._inverseNameCache;
     const explicit = this.options.inverseOf;
     if (explicit !== undefined) {
@@ -1283,8 +1284,9 @@ export class ThroughReflection extends AbstractReflection {
     return this._delegate.inverseOf();
   }
 
-  protected override inverseName(): string | null {
-    return (this._delegate as any).inverseName();
+  /** @internal */
+  override inverseName(): string | null {
+    return this._delegate.inverseName();
   }
 
   sourceReflectionNames(): string[] {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -190,7 +190,7 @@ export class AbstractReflection {
     if (!this.isPolymorphic() && this.hasInverse()) {
       const inverse = this.inverseOf();
       if (inverse == null) {
-        const inverseOf = this.inverseName() as string;
+        const inverseOf = this.inverseName()!;
         throw new InverseOfAssociationNotFoundError((this as any).name, inverseOf);
       }
       if (

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -190,7 +190,7 @@ export class AbstractReflection {
     if (!this.isPolymorphic() && this.hasInverse()) {
       const inverse = this.inverseOf();
       if (inverse == null) {
-        const inverseOf = (this as any).inverseName?.() as string;
+        const inverseOf = this.inverseName() as string;
         throw new InverseOfAssociationNotFoundError((this as any).name, inverseOf);
       }
       if (
@@ -270,6 +270,11 @@ export class AbstractReflection {
   }
 
   inverseOf(): AbstractReflection | null {
+    return null;
+  }
+
+  /** @internal */
+  protected inverseName(): string | null {
     return null;
   }
 
@@ -594,7 +599,7 @@ export class AssociationReflection extends MacroReflection {
   private _inverseNameCache: string | null | undefined = undefined;
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
 
-  private inverseName(): string | null {
+  protected override inverseName(): string | null {
     if (this._inverseNameCache !== undefined) return this._inverseNameCache;
     const explicit = this.options.inverseOf;
     if (explicit !== undefined) {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1283,6 +1283,10 @@ export class ThroughReflection extends AbstractReflection {
     return this._delegate.inverseOf();
   }
 
+  protected override inverseName(): string | null {
+    return (this._delegate as any).inverseName();
+  }
+
   sourceReflectionNames(): string[] {
     if (this.options.source) return [this.options.source as string];
     const singular = singularize(this.name);


### PR DESCRIPTION
## Summary

8 small Rails-fidelity follow-ups across associations, reflection, autosave, and errors. Item 4 (ThroughReflection.isPolymorphic options.as) dropped — see below.

## Items shipped

| # | File | Change |
|---|------|--------|
| 1 | `base.ts` | _newRecordBeforeSave already correct — verified, no-op |
| 2 | `has-many-through-association.ts` | `insertRecord`: pass `validate`/`raise` to join-record save; use `saveBang` when raise is true |
| 3 | `has-one-through-association.ts` | `createThroughRecord`: reload destroyed through-record before reuse |
| 5 | `has-one-through-association.ts` | Delete dead `throughAssociation` helper (never called) |
| 6 | `reflection.ts` | Declare `protected inverseName()` on `AbstractReflection`; change `AssociationReflection.inverseName` from `private` to `protected override`; drop `as any` cast in `checkValidityOfInverseBang` |
| 7 | `errors.ts` | `UnknownPrimaryKey`: newline+space separator for description; no-arg constructor (emits "Unknown primary key.") |
| 8 | `associations/builder/has-one.ts` | Delete dead `else if (typeof model.validates === "function")` branch — unreachable since `validatesPresenceOf` is always available |
| 9 | `autosave-association.ts` | Delete dead `addAutosaveAssociationCallbacks` function — never called |

## Item 4 dropped (follow-up needed)

`ThroughReflection.isPolymorphic` + `options.as` branch: changing `isPolymorphic()` to return `true` when `options.as` is set breaks the `HasOneAssociationPolymorphicThroughError` guard at `checkValidityBang()` line 1344. The semantics of `has_one :as` (owner plays a polymorphic role) differ from `belongs_to :polymorphic` (target type varies). Need to audit the Rails source to find the exact condition used and which guard calls need updating before applying this fix.