### PR TITLE
feat(activerecord) Migration Slot G — MySQL utf8mb4 init plus renameIndex-on-FK parity

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -16,8 +16,8 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("SchemaMigrationsTest", () => {
-    // Fixture tables for the renameIndex test — mirrors Rails' engines/cars fixtures
-    beforeEach(async () => {
+    it("renaming index on foreign key", async () => {
+      // Fixture tables — mirrors Rails' engines/cars fixtures
       await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
       await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
       await adapter.executeMutation(
@@ -26,22 +26,20 @@ describeIfMysql("Mysql2Adapter", () => {
       await adapter.executeMutation(
         "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `car_id` BIGINT) ENGINE=InnoDB",
       );
-    });
-    afterEach(async () => {
-      await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
-      await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
-    });
+      try {
+        await adapter.addIndex("engines", "car_id");
+        await adapter.addForeignKey("engines", "cars", { name: "fk_engines_cars" });
 
-    it("renaming index on foreign key", async () => {
-      await adapter.addIndex("engines", "car_id");
-      await adapter.addForeignKey("engines", "cars", { name: "fk_engines_cars" });
+        await adapter.renameIndex("engines", "index_engines_on_car_id", "idx_renamed");
+        const idxNames = (await adapter.indexes("engines")).map((i: { name: string }) => i.name);
+        expect(idxNames).toContain("idx_renamed");
+        expect(idxNames).not.toContain("index_engines_on_car_id");
 
-      await adapter.renameIndex("engines", "index_engines_on_car_id", "idx_renamed");
-      const idxNames = (await adapter.indexes("engines")).map((i: { name: string }) => i.name);
-      expect(idxNames).toContain("idx_renamed");
-      expect(idxNames).not.toContain("index_engines_on_car_id");
-
-      await adapter.removeForeignKey("engines", { name: "fk_engines_cars" });
+        await adapter.removeForeignKey("engines", { name: "fk_engines_cars" });
+      } finally {
+        await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+      }
     });
 
     it("initializes schema migrations for encoding utf8mb4", async () => {
@@ -77,8 +75,9 @@ async function withEncodingUtf8mb4(adapter: Mysql2Adapter, fn: () => Promise<voi
     "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME " +
       "FROM information_schema.schemata WHERE schema_name = DATABASE()",
   )) as Array<Record<string, string>>;
-  const originalCharset = rows[0]?.DEFAULT_CHARACTER_SET_NAME ?? "utf8mb4";
-  const originalCollation = rows[0]?.DEFAULT_COLLATION_NAME ?? "utf8mb4_unicode_ci";
+  if (!rows[0]) throw new Error("Could not read database charset from information_schema.schemata");
+  const originalCharset = rows[0].DEFAULT_CHARACTER_SET_NAME;
+  const originalCollation = rows[0].DEFAULT_COLLATION_NAME;
 
   await adapter.executeMutation("ALTER DATABASE DEFAULT CHARACTER SET utf8mb4");
   try {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -1,7 +1,9 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SchemaMigration } from "../../schema-migration.js";
+import { InternalMetadata } from "../../internal-metadata.js";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 
 describeIfMysql("Mysql2Adapter", () => {
@@ -14,20 +16,76 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("SchemaMigrationsTest", () => {
-    it.skip("renaming index on foreign key", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in schema-migrations
-      // ROOT-CAUSE: adapters/mysql2/schema-migrations.ts or abstract-mysql-adapter/schema-migrations.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/schema-migrations.ts; affects ~10–26 tests in schema-migrations.test.ts
+    // Fixture tables for the renameIndex test — mirrors Rails' engines/cars fixtures
+    beforeEach(async () => {
+      await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+      await adapter.executeMutation(
+        "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
+      );
+      await adapter.executeMutation(
+        "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `car_id` BIGINT) ENGINE=InnoDB",
+      );
     });
-    it.skip("initializes schema migrations for encoding utf8mb4", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in schema-migrations
-      // ROOT-CAUSE: adapters/mysql2/schema-migrations.ts or abstract-mysql-adapter/schema-migrations.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/schema-migrations.ts; affects ~10–26 tests in schema-migrations.test.ts
+    afterEach(async () => {
+      await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
     });
-    it.skip("initializes internal metadata for encoding utf8mb4", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in schema-migrations
-      // ROOT-CAUSE: adapters/mysql2/schema-migrations.ts or abstract-mysql-adapter/schema-migrations.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/schema-migrations.ts; affects ~10–26 tests in schema-migrations.test.ts
+
+    it("renaming index on foreign key", async () => {
+      await adapter.addIndex("engines", "car_id");
+      await adapter.addForeignKey("engines", "cars", { name: "fk_engines_cars" });
+
+      await adapter.renameIndex("engines", "index_engines_on_car_id", "idx_renamed");
+      const idxNames = (await adapter.indexes("engines")).map((i: { name: string }) => i.name);
+      expect(idxNames).toContain("idx_renamed");
+      expect(idxNames).not.toContain("index_engines_on_car_id");
+
+      await adapter.removeForeignKey("engines", { name: "fk_engines_cars" });
+    });
+
+    it("initializes schema migrations for encoding utf8mb4", async () => {
+      await withEncodingUtf8mb4(adapter, async () => {
+        const schemaMigration = new SchemaMigration(adapter);
+        const tableName = schemaMigration.tableName;
+        await adapter.dropTable(tableName, { ifExists: true });
+        await schemaMigration.createTable();
+        expect(await adapter.columnExists(tableName, "version")).toBe(true);
+      });
+    });
+
+    it("initializes internal metadata for encoding utf8mb4", async () => {
+      await withEncodingUtf8mb4(adapter, async () => {
+        const internalMetadata = new InternalMetadata(adapter);
+        const tableName = internalMetadata.tableName;
+        await adapter.dropTable(tableName, { ifExists: true });
+        await internalMetadata.createTable();
+        expect(await adapter.columnExists(tableName, "key")).toBe(true);
+        // Restore environment entry so other tests don't see a missing metadata row
+        await internalMetadata.createTableAndSetFlags("test");
+      });
     });
   });
 });
+
+/**
+ * Mirrors Rails' `with_encoding_utf8mb4` helper — changes the test database's default
+ * character set to utf8mb4, runs the block, then restores the original charset/collation.
+ */
+async function withEncodingUtf8mb4(adapter: Mysql2Adapter, fn: () => Promise<void>): Promise<void> {
+  const rows = (await adapter.execute(
+    "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME " +
+      "FROM information_schema.schemata WHERE schema_name = DATABASE()",
+  )) as Array<Record<string, string>>;
+  const originalCharset = rows[0]?.DEFAULT_CHARACTER_SET_NAME ?? "utf8mb4";
+  const originalCollation = rows[0]?.DEFAULT_COLLATION_NAME ?? "utf8mb4_unicode_ci";
+
+  await adapter.executeMutation("ALTER DATABASE DEFAULT CHARACTER SET utf8mb4");
+  try {
+    await fn();
+  } finally {
+    await adapter.executeMutation(
+      `ALTER DATABASE DEFAULT CHARACTER SET ${originalCharset} COLLATE ${originalCollation}`,
+    );
+  }
+}

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -469,7 +469,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
     await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME INDEX ` +
-        `${this.quoteTableName(oldName)} TO ${this.quoteTableName(newName)}`,
+        `${this.quoteIdentifier(oldName)} TO ${this.quoteIdentifier(newName)}`,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -459,9 +459,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
-    void tableName;
-    void oldName;
-    void newName;
+    await this.getDatabaseVersion();
+    this.schemaStatements().validateIndexLengthBang(tableName, newName);
+    if (!this.supportsRenameIndex()) {
+      throw new Error(
+        "renameIndex requires MySQL >= 5.7.6 or MariaDB >= 10.5.2; upgrade your server to use this feature",
+      );
+    }
+    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
+      `ALTER TABLE ${this.quoteTableName(tableName)} RENAME INDEX ` +
+        `${this.quoteTableName(oldName)} TO ${this.quoteTableName(newName)}`,
+    );
   }
 
   async changeColumnDefault(
@@ -543,9 +551,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    void tableName;
-    void columnName;
-    void options;
+    await this.schemaStatements().addIndex(tableName, columnName, options);
   }
 
   buildCreateIndexDefinition(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -48,6 +48,7 @@ import {
 import {
   ChangeColumnDefinition,
   ColumnDefinition,
+  CreateIndexDefinition,
   ForeignKeyDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
@@ -551,7 +552,32 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    await this.schemaStatements().addIndex(tableName, columnName, options);
+    const cols = Array.isArray(columnName) ? columnName : [columnName];
+    const indexName =
+      (options.name as string | undefined) ?? `index_${tableName}_on_${cols.join("_and_")}`;
+    this.schemaStatements().validateIndexLengthBang(tableName, indexName);
+    if (
+      options.ifNotExists &&
+      (await this.schemaStatements().indexExists(tableName, cols, { name: indexName }))
+    ) {
+      return;
+    }
+    const idx = new IndexDefinition(tableName, indexName, !!options.unique, cols, {
+      where: options.where as string | undefined,
+      using: options.using as string | undefined,
+      type: options.type as string | undefined,
+      lengths: (options.length ?? {}) as Record<string, number>,
+      orders: (options.order ?? {}) as Record<string, string>,
+      comment: options.comment as string | undefined,
+      include: options.include as string[] | undefined,
+    });
+    const algorithmClause = this.schemaStatements().indexAlgorithm(
+      options.algorithm as string | undefined,
+    );
+    const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
+    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
+      new MysqlSchemaCreation().accept(createDef),
+    );
   }
 
   buildCreateIndexDefinition(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -481,9 +481,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * @internal
    */
   protected async _execMutation(sql: string): Promise<void> {
-    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
-      sql,
-    );
+    const exec = (this as unknown as { executeMutation?: (sql: string) => Promise<number> })
+      .executeMutation;
+    if (typeof exec !== "function") {
+      throw new Error(
+        `${this.constructor.name} must implement executeMutation() to use DDL helpers`,
+      );
+    }
+    await exec.call(this, sql);
   }
 
   async changeColumnDefault(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -467,9 +467,22 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         "renameIndex requires MySQL >= 5.7.6 or MariaDB >= 10.5.2; upgrade your server to use this feature",
       );
     }
-    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
+    await this._execMutation(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME INDEX ` +
         `${this.quoteIdentifier(oldName)} TO ${this.quoteIdentifier(newName)}`,
+    );
+  }
+
+  /**
+   * Execute a DDL/DML statement on the concrete adapter.
+   * AbstractMysqlAdapter itself does not hold a connection; this delegates to
+   * the concrete subclass (Mysql2Adapter, TrilogyAdapter) which implements
+   * executeMutation on DatabaseAdapter.
+   * @internal
+   */
+  protected async _execMutation(sql: string): Promise<void> {
+    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
+      sql,
     );
   }
 
@@ -552,32 +565,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    const cols = Array.isArray(columnName) ? columnName : [columnName];
-    const indexName =
-      (options.name as string | undefined) ?? `index_${tableName}_on_${cols.join("_and_")}`;
-    this.schemaStatements().validateIndexLengthBang(tableName, indexName);
-    if (
-      options.ifNotExists &&
-      (await this.schemaStatements().indexExists(tableName, cols, { name: indexName }))
-    ) {
+    const ss = this.schemaStatements();
+    const [idx, algorithmClause, ifNotExists] = ss.addIndexOptions(tableName, columnName, options);
+    if (ifNotExists && (await ss.indexExists(tableName, idx.columns, { name: idx.name }))) {
       return;
     }
-    const idx = new IndexDefinition(tableName, indexName, !!options.unique, cols, {
-      where: options.where as string | undefined,
-      using: options.using as string | undefined,
-      type: options.type as string | undefined,
-      lengths: (options.length ?? {}) as Record<string, number>,
-      orders: (options.order ?? {}) as Record<string, string>,
-      comment: options.comment as string | undefined,
-      include: options.include as string[] | undefined,
-    });
-    const algorithmClause = this.schemaStatements().indexAlgorithm(
-      options.algorithm as string | undefined,
-    );
     const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
-    await (this as unknown as { executeMutation(sql: string): Promise<number> }).executeMutation(
-      new MysqlSchemaCreation().accept(createDef),
-    );
+    await this._execMutation(new MysqlSchemaCreation().accept(createDef));
   }
 
   buildCreateIndexDefinition(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -20,6 +20,7 @@ import {
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { quoteIdentifier, quoteTableName, quoteString as mysqlQuoteString } from "./quoting.js";
 import { quoteDefaultExpression } from "../abstract/quoting.js";
+import { addOptionsForIndexColumns } from "./schema-statements.js";
 
 /** MySQL-specific column options — extends the abstract ColumnOptions with `onUpdate`. */
 export type MysqlAddColumnOptions = ColumnOptions & { onUpdate?: string };
@@ -140,6 +141,20 @@ export class SchemaCreation extends AbstractSchemaCreation {
     parts.push(`(${this.quotedColumns(o)})`);
 
     return this.addSqlCommentBang(parts.join(" "), o.comment);
+  }
+
+  /** @internal */
+  protected override quotedColumns(o: { columns: string | string[] }): string {
+    if (typeof o.columns === "string") return o.columns;
+    const idx = o as IndexDefinition;
+    const quotedMap = new Map<string, string>(
+      o.columns.map((c) => [c, this.adapter.quoteIdentifier(c)]),
+    );
+    addOptionsForIndexColumns(quotedMap, {
+      length: idx.lengths as Record<string, number> | number | undefined,
+      order: idx.orders as Record<string, string> | string | undefined,
+    });
+    return [...quotedMap.values()].join(", ");
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -850,14 +850,14 @@ describeIfMysql("Mysql2Adapter", () => {
 // Unit tests that do not require a live MySQL connection.
 describe("Mysql2Adapter unit", () => {
   describe("_buildInitSql", () => {
-    it("includes SET NAMES when charset is configured", () => {
+    it("includes SET NAMES when charset is configured", async () => {
       const adapter = new Mysql2Adapter({ host: "localhost", charset: "utf8mb4" });
       const sql = (adapter as any)._buildInitSql() as string;
       expect(sql).toMatch(/^SET NAMES utf8mb4,/);
-      adapter.close();
+      await adapter.close();
     });
 
-    it("includes SET NAMES with COLLATE when both charset and collation are configured", () => {
+    it("includes SET NAMES with COLLATE when both charset and collation are configured", async () => {
       const adapter = new Mysql2Adapter({
         host: "localhost",
         charset: "utf8mb4",
@@ -865,21 +865,21 @@ describe("Mysql2Adapter unit", () => {
       } as any);
       const sql = (adapter as any)._buildInitSql() as string;
       expect(sql).toMatch(/^SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci,/);
-      adapter.close();
+      await adapter.close();
     });
 
-    it("includes SET NAMES when Rails-style encoding is configured", () => {
+    it("includes SET NAMES when Rails-style encoding is configured", async () => {
       const adapter = new Mysql2Adapter({ host: "localhost", encoding: "utf8mb4" } as any);
       const sql = (adapter as any)._buildInitSql() as string;
       expect(sql).toMatch(/^SET NAMES utf8mb4,/);
-      adapter.close();
+      await adapter.close();
     });
 
-    it("omits SET NAMES when no charset is configured", () => {
+    it("omits SET NAMES when no charset is configured", async () => {
       const adapter = new Mysql2Adapter({ host: "localhost" });
       const sql = (adapter as any)._buildInitSql() as string;
       expect(sql).not.toContain("NAMES");
-      adapter.close();
+      await adapter.close();
     });
 
     it("throws for invalid charset", () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -846,3 +846,46 @@ describeIfMysql("Mysql2Adapter", () => {
     });
   });
 });
+
+// Unit tests that do not require a live MySQL connection.
+describe("Mysql2Adapter unit", () => {
+  describe("_buildInitSql", () => {
+    it("includes SET NAMES when charset is configured", () => {
+      const adapter = new Mysql2Adapter({ host: "localhost", charset: "utf8mb4" });
+      const sql = (adapter as any)._buildInitSql() as string;
+      expect(sql).toMatch(/^SET NAMES utf8mb4,/);
+      adapter.close();
+    });
+
+    it("includes SET NAMES with COLLATE when both charset and collation are configured", () => {
+      const adapter = new Mysql2Adapter({
+        host: "localhost",
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      } as any);
+      const sql = (adapter as any)._buildInitSql() as string;
+      expect(sql).toMatch(/^SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci,/);
+      adapter.close();
+    });
+
+    it("includes SET NAMES when Rails-style encoding is configured", () => {
+      const adapter = new Mysql2Adapter({ host: "localhost", encoding: "utf8mb4" } as any);
+      const sql = (adapter as any)._buildInitSql() as string;
+      expect(sql).toMatch(/^SET NAMES utf8mb4,/);
+      adapter.close();
+    });
+
+    it("omits SET NAMES when no charset is configured", () => {
+      const adapter = new Mysql2Adapter({ host: "localhost" });
+      const sql = (adapter as any)._buildInitSql() as string;
+      expect(sql).not.toContain("NAMES");
+      adapter.close();
+    });
+
+    it("throws for invalid charset", () => {
+      expect(
+        () => new Mysql2Adapter({ host: "localhost", charset: "utf8'; DROP TABLE x; --" }),
+      ).toThrow(/Invalid MySQL charset/);
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1449,8 +1449,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
     // Mirrors Rails: `if @config[:encoding]` → `SET NAMES encoding [COLLATE collation], ...`
     // mysql2's `charset` pool option corresponds to Rails' database.yml `encoding:`.
+    const SAFE_CHARSET_RE = /^[A-Za-z0-9_]+$/;
     const charset = this._poolConfig.charset as string | undefined;
     const charsetCollation = (this._poolConfig as { collation?: string }).collation;
+    if (charset && !SAFE_CHARSET_RE.test(charset)) {
+      throw new Error(`Invalid MySQL charset: ${JSON.stringify(charset)}`);
+    }
+    if (charsetCollation && !SAFE_CHARSET_RE.test(charsetCollation)) {
+      throw new Error(`Invalid MySQL collation: ${JSON.stringify(charsetCollation)}`);
+    }
     let namesPart = "";
     if (charset) {
       namesPart = `NAMES ${charset}`;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1446,7 +1446,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       });
 
     const sessionClauses = [sqlModeClause, ...varClauses].filter(Boolean).join(", ");
-    return `SET time_zone = '+00:00', ${sessionClauses}`;
+
+    // Mirrors Rails: `if @config[:encoding]` → `SET NAMES encoding [COLLATE collation], ...`
+    // mysql2's `charset` pool option corresponds to Rails' database.yml `encoding:`.
+    const charset = this._poolConfig.charset as string | undefined;
+    const charsetCollation = (this._poolConfig as { collation?: string }).collation;
+    let namesPart = "";
+    if (charset) {
+      namesPart = `NAMES ${charset}`;
+      if (charsetCollation) namesPart += ` COLLATE ${charsetCollation}`;
+      namesPart += ", ";
+    }
+
+    return `SET ${namesPart}time_zone = '+00:00', ${sessionClauses}`;
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1450,7 +1450,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Mirrors Rails: `if @config[:encoding]` → `SET NAMES encoding [COLLATE collation], ...`
     // mysql2's `charset` pool option corresponds to Rails' database.yml `encoding:`.
     const SAFE_CHARSET_RE = /^[A-Za-z0-9_]+$/;
-    const charset = this._poolConfig.charset as string | undefined;
+    // mysql2 uses `charset`; Rails database.yml uses `encoding`. Support both, preferring charset.
+    const charset =
+      (this._poolConfig.charset as string | undefined) ??
+      (this._poolConfig as { encoding?: string }).encoding;
     const charsetCollation = (this._poolConfig as { collation?: string }).collation;
     if (charset && !SAFE_CHARSET_RE.test(charset)) {
       throw new Error(`Invalid MySQL charset: ${JSON.stringify(charset)}`);


### PR DESCRIPTION
## Summary

- Implements `renameIndex` in `AbstractMysqlAdapter` using `ALTER TABLE … RENAME INDEX …` (MySQL >= 5.7.6 / MariaDB >= 10.5.2); replaces the no-op stub; uses `quoteIdentifier` (not `quoteTableName`) for index names
- Implements `AbstractMysqlAdapter#addIndex` inline using `MysqlSchemaCreation` directly — builds `IndexDefinition` with prefix lengths, orders, USING, ALGORITHM, FULLTEXT/SPATIAL type and calls `MysqlSchemaCreation.accept(CreateIndexDefinition)` for correct MySQL DDL
- Overrides `MysqlSchemaCreation#quotedColumns` to apply prefix lengths and per-column ORDER via `addOptionsForIndexColumns`, fixing a pre-existing gap where `CREATE INDEX` silently dropped `length:` options
- Wires `SET NAMES charset [COLLATE collation]` into `_buildInitSql`; supports both `charset` (mysql2 native) and `encoding` (Rails database.yml style) config keys; validates both against `/^[A-Za-z0-9_]+$/` to prevent injection
- Un-skips all 3 tests in `schema-migrations.test.ts` with Rails-mirrored bodies: renameIndex-on-FK round-trip (fixtures scoped to that test with try/finally), utf8mb4 schema_migrations init, utf8mb4 ar_internal_metadata init

## Test plan

- [ ] Live MySQL: `MYSQL_TEST_URL=mysql://root@localhost:3306/rails_js_test pnpm exec vitest run packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts`
- [ ] Lint / typecheck: CI runs on push
- [ ] `pnpm api:compare --package activerecord` still shows 99.9%