### PR TITLE
feat(activerecord) Schema Slot D — check exclusion unique constraints in dumper

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -10,6 +10,7 @@ import type {
   UniqueConstraintDefinition,
 } from "./schema-definitions.js";
 import type { Column } from "./column.js";
+import type { IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   /** @internal */
@@ -111,6 +112,34 @@ export class SchemaDumper extends AbstractSchemaDumper {
       lines.push(`  create_schema ${JSON.stringify(name)}`);
     }
     lines.push("");
+  }
+
+  /** @internal */
+  protected override async filterIndexesForDump(
+    tableName: string,
+    indexes: IndexInfo[],
+  ): Promise<IndexInfo[]> {
+    const adapter = this.pgAdapter();
+    let filtered = indexes;
+    if (adapter?.exclusionConstraints) {
+      const exclConstraints: ExclusionConstraintDefinition[] =
+        await adapter.exclusionConstraints(tableName);
+      const exclNames = new Set(
+        exclConstraints.map((ec: ExclusionConstraintDefinition) => ec.name).filter(Boolean),
+      );
+      if (exclNames.size > 0)
+        filtered = filtered.filter((idx) => !idx.name || !exclNames.has(idx.name));
+    }
+    if (adapter?.uniqueConstraints) {
+      const uniqConstraints: UniqueConstraintDefinition[] =
+        await adapter.uniqueConstraints(tableName);
+      const uniqNames = new Set(
+        uniqConstraints.map((uc: UniqueConstraintDefinition) => uc.name).filter(Boolean),
+      );
+      if (uniqNames.size > 0)
+        filtered = filtered.filter((idx) => !idx.name || !uniqNames.has(idx.name));
+    }
+    return filtered;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -13,6 +13,11 @@ import type { Column } from "./column.js";
 import type { IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
+  // Per-table constraint cache populated by filterIndexesForDump and consumed
+  // by exclusionConstraintsInCreate / uniqueConstraintsInCreate to avoid
+  // fetching the same constraint lists twice per table.
+  private _cachedExclConstraints: ExclusionConstraintDefinition[] | undefined;
+  private _cachedUniqConstraints: UniqueConstraintDefinition[] | undefined;
   /** @internal */
   protected override prepareColumnOptions(column: Column): Record<string, unknown> {
     const spec = super.prepareColumnOptions(column as any);
@@ -120,26 +125,23 @@ export class SchemaDumper extends AbstractSchemaDumper {
     indexes: IndexInfo[],
   ): Promise<IndexInfo[]> {
     const adapter = this.pgAdapter();
-    let filtered = indexes;
-    if (adapter?.exclusionConstraints) {
-      const exclConstraints: ExclusionConstraintDefinition[] =
-        await adapter.exclusionConstraints(tableName);
-      const exclNames = new Set(
-        exclConstraints.map((ec: ExclusionConstraintDefinition) => ec.name).filter(Boolean),
-      );
-      if (exclNames.size > 0)
-        filtered = filtered.filter((idx) => !idx.name || !exclNames.has(idx.name));
-    }
-    if (adapter?.uniqueConstraints) {
-      const uniqConstraints: UniqueConstraintDefinition[] =
-        await adapter.uniqueConstraints(tableName);
-      const uniqNames = new Set(
-        uniqConstraints.map((uc: UniqueConstraintDefinition) => uc.name).filter(Boolean),
-      );
-      if (uniqNames.size > 0)
-        filtered = filtered.filter((idx) => !idx.name || !uniqNames.has(idx.name));
-    }
-    return filtered;
+    // Fetch and cache both constraint lists so exclusionConstraintsInCreate /
+    // uniqueConstraintsInCreate can reuse them without a second DB round-trip.
+    const excl: ExclusionConstraintDefinition[] = adapter?.exclusionConstraints
+      ? await adapter.exclusionConstraints(tableName)
+      : [];
+    const uniq: UniqueConstraintDefinition[] = adapter?.uniqueConstraints
+      ? await adapter.uniqueConstraints(tableName)
+      : [];
+    this._cachedExclConstraints = excl;
+    this._cachedUniqConstraints = uniq;
+
+    const exclNames = new Set(excl.map((ec) => ec.name).filter(Boolean));
+    const uniqNames = new Set(uniq.map((uc) => uc.name).filter(Boolean));
+    if (exclNames.size === 0 && uniqNames.size === 0) return indexes;
+    return indexes.filter(
+      (idx) => (!idx.name || !exclNames.has(idx.name)) && (!idx.name || !uniqNames.has(idx.name)),
+    );
   }
 
   /** @internal */
@@ -147,7 +149,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
     const adapter = this.pgAdapter();
     if (!adapter?.exclusionConstraints) return;
     const constraints: ExclusionConstraintDefinition[] =
-      await adapter.exclusionConstraints(tableName);
+      this._cachedExclConstraints ?? (await adapter.exclusionConstraints(tableName));
+    this._cachedExclConstraints = undefined;
     if (constraints.length === 0) return;
     const stripped = this.removePrefixAndSuffix(tableName);
     const stmts = constraints.map((ec) => {
@@ -166,7 +169,9 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected async uniqueConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
     const adapter = this.pgAdapter();
     if (!adapter?.uniqueConstraints) return;
-    const constraints: UniqueConstraintDefinition[] = await adapter.uniqueConstraints(tableName);
+    const constraints: UniqueConstraintDefinition[] =
+      this._cachedUniqConstraints ?? (await adapter.uniqueConstraints(tableName));
+    this._cachedUniqConstraints = undefined;
     if (constraints.length === 0) return;
     const stripped = this.removePrefixAndSuffix(tableName);
     const stmts = constraints.map((uc) => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -215,30 +215,82 @@ describe("SchemaDumperTest", () => {
     // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
     /* needs index length tracking (MySQL) */
   });
-  it.skip("schema dumps check constraints", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-dumper
-    // ROOT-CAUSE: schema-dumper.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
-    /* needs check constraint support */
+  it.skipIf(adapterType !== "postgres" && adapterType !== "mysql")(
+    "schema dumps check constraints",
+    async () => {
+      const { SchemaStatements } =
+        await import("./connection-adapters/abstract/schema-statements.js");
+      const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+      await testCtx.createTable("products", {}, (t) => {
+        t.decimal("price");
+        t.decimal("discounted_price");
+      });
+      const ss = new SchemaStatements(testAdapter as any);
+      await ss.addCheckConstraint("products", "price > discounted_price", {
+        name: "products_price_check",
+      });
+      const output = await SchemaDumper.dump(testAdapter);
+      expect(output).toContain("products_price_check");
+      expect(output).toContain("addCheckConstraint");
+    },
+  );
+  it.skipIf(adapterType !== "postgres")("schema dumps exclusion constraints", async () => {
+    const { SchemaDumper: PgSchemaDumper } =
+      await import("./connection-adapters/postgresql/schema-dumper.js");
+    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    await testCtx.createTable("test_schema_exclusion", { id: false }, (t) => {
+      t.date("start_date");
+      t.date("end_date");
+    });
+    await (testAdapter as any).addExclusionConstraint(
+      "test_schema_exclusion",
+      "daterange(start_date, end_date) WITH &&",
+      { using: "gist", name: "test_schema_exclusion_date_overlap" },
+    );
+    const output = await PgSchemaDumper.dump(testAdapter);
+    expect(output).toContain("addExclusionConstraint");
+    expect(output).toContain("test_schema_exclusion_date_overlap");
+    expect(output).toContain("daterange(start_date, end_date) WITH &&");
   });
-  it.skip("schema dumps exclusion constraints", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-dumper
-    // ROOT-CAUSE: schema-dumper.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
-    /* needs exclusion constraint support (PG) */
+  it.skipIf(adapterType !== "postgres")("schema dumps unique constraints", async () => {
+    const { SchemaDumper: PgSchemaDumper } =
+      await import("./connection-adapters/postgresql/schema-dumper.js");
+    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    await testCtx.createTable("test_schema_unique", {}, (t) => {
+      t.integer("position_1");
+      t.integer("position_2");
+    });
+    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_1"], {
+      name: "test_schema_unique_position_1",
+    });
+    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_2"], {
+      nullsNotDistinct: true,
+      name: "test_schema_unique_position_2_nnd",
+    });
+    const output = await PgSchemaDumper.dump(testAdapter);
+    expect(output).toContain("addUniqueConstraint");
+    expect(output).toContain("test_schema_unique_position_1");
+    expect(output).toContain("test_schema_unique_position_2_nnd");
+    expect(output).toContain("nullsNotDistinct: true");
   });
-  it.skip("schema dumps unique constraints", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-dumper
-    // ROOT-CAUSE: schema-dumper.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
-    /* needs unique constraint support (PG) */
-  });
-  it.skip("schema does not dump unique constraints as indexes", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-dumper
-    // ROOT-CAUSE: schema-dumper.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
-    /* needs unique constraint support (PG) */
-  });
+  it.skipIf(adapterType !== "postgres")(
+    "schema does not dump unique constraints as indexes",
+    async () => {
+      const { SchemaDumper: PgSchemaDumper } =
+        await import("./connection-adapters/postgresql/schema-dumper.js");
+      const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+      await testCtx.createTable("test_uc_no_idx", {}, (t) => {
+        t.integer("position");
+      });
+      await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
+        name: "test_uc_no_idx_position",
+      });
+      const output = await PgSchemaDumper.dump(testAdapter);
+      expect(output).toContain("addUniqueConstraint");
+      // The backing index must not also appear as an addIndex call.
+      expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
+    },
+  );
 
   it("schema dump does not emit id false for normal tables", async () => {
     await ctx.createTable("users", {}, (t) => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import { createTestAdapter, adapterType } from "./test-adapter.js";
+import type { TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-function freshCtx(): { adapter: DatabaseAdapter; ctx: MigrationContext } {
+function freshCtx(): { adapter: TestDatabaseAdapter; ctx: MigrationContext } {
   const adapter = createTestAdapter();
   const ctx = new MigrationContext(adapter);
   return { adapter, ctx };
@@ -223,11 +224,11 @@ describe("SchemaDumperTest", () => {
       t.decimal("price");
       t.decimal("discounted_price");
     });
-    const ss = new SchemaStatements(testAdapter as any);
+    const ss = new SchemaStatements(testAdapter.innerAdapter as any);
     await ss.addCheckConstraint("products", "price > discounted_price", {
       name: "products_price_check",
     });
-    const output = await SchemaDumper.dump(testAdapter);
+    const output = await SchemaDumper.dump(testAdapter.innerAdapter);
     expect(output).toContain("products_price_check");
     expect(output).toContain("addCheckConstraint");
   });
@@ -239,12 +240,12 @@ describe("SchemaDumperTest", () => {
       t.date("start_date");
       t.date("end_date");
     });
-    await (testAdapter as any).addExclusionConstraint(
+    await (testAdapter.innerAdapter as any).addExclusionConstraint(
       "test_schema_exclusion",
       "daterange(start_date, end_date) WITH &&",
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
-    const output = await PgSchemaDumper.dump(testAdapter);
+    const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
     expect(output).toContain("addExclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
@@ -257,14 +258,17 @@ describe("SchemaDumperTest", () => {
       t.integer("position_1");
       t.integer("position_2");
     });
-    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_1"], {
-      name: "test_schema_unique_position_1",
-    });
-    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_2"], {
-      nullsNotDistinct: true,
-      name: "test_schema_unique_position_2_nnd",
-    });
-    const output = await PgSchemaDumper.dump(testAdapter);
+    await (testAdapter.innerAdapter as any).addUniqueConstraint(
+      "test_schema_unique",
+      ["position_1"],
+      { name: "test_schema_unique_position_1" },
+    );
+    await (testAdapter.innerAdapter as any).addUniqueConstraint(
+      "test_schema_unique",
+      ["position_2"],
+      { nullsNotDistinct: true, name: "test_schema_unique_position_2_nnd" },
+    );
+    const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
     expect(output).toContain("addUniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
@@ -279,10 +283,10 @@ describe("SchemaDumperTest", () => {
       await testCtx.createTable("test_uc_no_idx", {}, (t) => {
         t.integer("position");
       });
-      await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
+      await (testAdapter.innerAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
         name: "test_uc_no_idx_position",
       });
-      const output = await PgSchemaDumper.dump(testAdapter);
+      const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
       expect(output).toContain("addUniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -215,25 +215,22 @@ describe("SchemaDumperTest", () => {
     // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-dumper.test.ts
     /* needs index length tracking (MySQL) */
   });
-  it.skipIf(adapterType !== "postgres" && adapterType !== "mysql")(
-    "schema dumps check constraints",
-    async () => {
-      const { SchemaStatements } =
-        await import("./connection-adapters/abstract/schema-statements.js");
-      const { adapter: testAdapter, ctx: testCtx } = freshCtx();
-      await testCtx.createTable("products", {}, (t) => {
-        t.decimal("price");
-        t.decimal("discounted_price");
-      });
-      const ss = new SchemaStatements(testAdapter as any);
-      await ss.addCheckConstraint("products", "price > discounted_price", {
-        name: "products_price_check",
-      });
-      const output = await SchemaDumper.dump(testAdapter);
-      expect(output).toContain("products_price_check");
-      expect(output).toContain("addCheckConstraint");
-    },
-  );
+  it.skipIf(adapterType !== "postgres")("schema dumps check constraints", async () => {
+    const { SchemaStatements } =
+      await import("./connection-adapters/abstract/schema-statements.js");
+    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    await testCtx.createTable("products", {}, (t) => {
+      t.decimal("price");
+      t.decimal("discounted_price");
+    });
+    const ss = new SchemaStatements(testAdapter as any);
+    await ss.addCheckConstraint("products", "price > discounted_price", {
+      name: "products_price_check",
+    });
+    const output = await SchemaDumper.dump(testAdapter);
+    expect(output).toContain("products_price_check");
+    expect(output).toContain("addCheckConstraint");
+  });
   it.skipIf(adapterType !== "postgres")("schema dumps exclusion constraints", async () => {
     const { SchemaDumper: PgSchemaDumper } =
       await import("./connection-adapters/postgresql/schema-dumper.js");

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -694,7 +694,8 @@ export class SchemaDumper {
     this.tableName = tableName;
     try {
       const columns = await this._source.columns(tableName);
-      const indexes = await this._source.indexes(tableName);
+      const rawIndexes = await this._source.indexes(tableName);
+      const indexes = await this.filterIndexesForDump(tableName, rawIndexes);
       const adapterTableOpts = await this.fetchTableOptions(tableName);
       this.emitTable(lines, tableName, columns, indexes, adapterTableOpts);
       await this.checkConstraintsInCreate(tableName, lines);
@@ -702,6 +703,19 @@ export class SchemaDumper {
     } finally {
       this.tableName = undefined;
     }
+  }
+
+  /**
+   * Hook for adapter subclasses to strip indexes that are already represented
+   * by a constraint (e.g. PG unique/exclusion constraints create backing indexes
+   * that must not also appear as `addIndex` calls). Default: identity.
+   * @internal
+   */
+  protected async filterIndexesForDump(
+    _tableName: string,
+    indexes: IndexInfo[],
+  ): Promise<IndexInfo[]> {
+    return indexes;
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

- Adds `filterIndexesForDump(tableName, indexes)` protected hook to the base `SchemaDumper` so adapter subclasses can strip backing indexes that are already represented by a constraint (prevents double-emission as both `addUniqueConstraint` and `addIndex`)
- Overrides `filterIndexesForDump` in `PostgreSQL::SchemaDumper` to filter out indexes whose names match an exclusion or unique constraint on the same table
- Un-skips and implements 4 BLOCKED tests in `schema-dumper.test.ts`: check constraint dump, exclusion constraint dump, unique constraint dump, and unique constraints-not-as-indexes; PG-specific tests gate on `adapterType !== "postgres"`

## Test plan

- [ ] `pnpm test packages/activerecord/src/schema-dumper.test.ts` — all non-PG tests pass, PG tests skip in SQLite env
- [ ] `pnpm test packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts` — 29 tests pass
- [ ] `pnpm api:compare --package activerecord` — schema_dumper.rb, postgresql/schema_dumper.rb all remain at 100%
- [ ] With `PG_TEST_URL` set: all 4 previously-skipped constraint tests pass