### PR TITLE
feat(activerecord) PG-schema Slots B+C — COMMENT ON TABLE + PARTITION BY dump + createJoinTable schema-qualified

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/partitions.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/partitions.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/partitions_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -14,15 +14,35 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlPartitionsTest", () => {
-    it.skip("partition table", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in partitions
-      // ROOT-CAUSE: connection-adapters/postgresql/partitions.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/partitions.ts; affects ~10–47 tests in partitions.test.ts
+    it("partition table", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE partition_test_parent (id integer, grp integer) PARTITION BY LIST (grp)`,
+        );
+        await adapter.exec(
+          `CREATE TABLE partition_test_child PARTITION OF partition_test_parent FOR VALUES IN (1)`,
+        );
+        const tables = await adapter.tables();
+        expect(tables).toContain("partition_test_parent");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS partition_test_child`);
+        await adapter.exec(`DROP TABLE IF EXISTS partition_test_parent`);
+      }
     });
-    it.skip("partitions table exists", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in partitions
-      // ROOT-CAUSE: connection-adapters/postgresql/partitions.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/partitions.ts; affects ~10–47 tests in partitions.test.ts
+    it("partitions table exists", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE partition_exists_parent (id integer, grp integer) PARTITION BY LIST (grp)`,
+        );
+        await adapter.exec(
+          `CREATE TABLE partition_exists_child PARTITION OF partition_exists_parent FOR VALUES IN (1)`,
+        );
+        expect(await adapter.tableExists("partition_exists_parent")).toBe(true);
+        expect(await adapter.tableExists("partition_exists_child")).toBe(true);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS partition_exists_child`);
+        await adapter.exec(`DROP TABLE IF EXISTS partition_exists_parent`);
+      }
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -665,10 +665,19 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("SchemaJoinTablesTest", () => {
-    it.skip("create join table", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("create join table", async () => {
+      try {
+        await adapter.exec(`CREATE SCHEMA IF NOT EXISTS some_schema`);
+        await adapter.createJoinTable("some_schema.users", "some_schema.roles");
+        expect(await adapter.tableExists("some_schema.roles_users")).toBe(true);
+        const cols = await adapter.columns("some_schema.roles_users");
+        const colNames = cols.map((c) => c.name);
+        expect(colNames).toContain("role_id");
+        expect(colNames).toContain("user_id");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS some_schema.roles_users`);
+        await adapter.exec(`DROP SCHEMA IF EXISTS some_schema CASCADE`);
+      }
     });
   });
 
@@ -699,15 +708,29 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("SchemaCreateTableOptionsTest", () => {
-    it.skip("list partition options is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("list partition options is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE list_partitioned (id integer, city varchar(50)) PARTITION BY LIST (city)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "list_partitioned");
+        expect(lines.join("\n")).toContain(`options: "PARTITION BY LIST (city)"`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS list_partitioned`);
+      }
     });
-    it.skip("range partition options is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("range partition options is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE range_partitioned (id integer, amount integer) PARTITION BY RANGE (amount)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "range_partitioned");
+        expect(lines.join("\n")).toContain(`options: "PARTITION BY RANGE (amount)"`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS range_partitioned`);
+      }
     });
     it("inherited table options is dumped", async () => {
       try {
@@ -737,10 +760,15 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(`DROP TABLE IF EXISTS vehicles`);
       }
     });
-    it.skip("no partition options are dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("no partition options are dumped", async () => {
+      try {
+        await adapter.exec(`CREATE TABLE regular_table (id integer, name varchar(50))`);
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "regular_table");
+        expect(lines.join("\n")).not.toContain("PARTITION BY");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS regular_table`);
+      }
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -770,5 +770,26 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(`DROP TABLE IF EXISTS regular_table`);
       }
     });
+    it("table comment is dumped and round-trips via createTable", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE commented_table (id serial primary key, name varchar(50))`,
+        );
+        await adapter.exec(`COMMENT ON TABLE commented_table IS 'a test table'`);
+        const lines: string[] = [];
+        await adapter.createSchemaDumper({}).dumpTable(lines, "commented_table");
+        const dump = lines.join("\n");
+        expect(dump).toContain(`comment: "a test table"`);
+        await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
+        // Round-trip: createTable with comment: re-applies the comment via changeTableComment
+        const ss = adapter.schemaStatements();
+        await ss.createTable("commented_table", { comment: "a test table" }, (t) => {
+          t.string("name");
+        });
+        expect(await adapter.tableComment("commented_table")).toBe("a test table");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
+      }
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -271,7 +271,9 @@ export interface AbstractAdapter {
   createJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string } | ((t: TableDefinition) => void),
+    options?:
+      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
+      | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
   dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -63,7 +63,7 @@ import {
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting-interface.js";
 import { include } from "@blazetrails/activesupport";
-import { SchemaStatements } from "./abstract/schema-statements.js";
+import { SchemaStatements, type JoinTableOptions } from "./abstract/schema-statements.js";
 import { Savepoints as SavepointsMixin } from "./abstract/savepoints.js";
 import {
   maxIdentifierLength,
@@ -271,9 +271,7 @@ export interface AbstractAdapter {
   createJoinTable(
     table1: string,
     table2: string,
-    options?:
-      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
-      | ((t: TableDefinition) => void),
+    options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
   dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -376,6 +376,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return true;
   }
 
+  supportsCommentsInCreate(): boolean {
+    return true;
+  }
+
   supportsDdlTransactions(): boolean {
     return false;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -563,10 +563,16 @@ export class SchemaStatements {
   async createJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string } | ((t: TableDefinition) => void),
+    options?:
+      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
+      | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    let opts: { tableName?: string } = {};
+    let opts: {
+      tableName?: string;
+      columnOptions?: Record<string, unknown>;
+      [key: string]: unknown;
+    } = {};
     let definer: ((t: TableDefinition) => void) | undefined;
     if (typeof options === "function") {
       definer = options;
@@ -574,10 +580,12 @@ export class SchemaStatements {
       opts = options;
       definer = fn;
     }
-    const tableName = opts.tableName ?? [table1, table2].sort().join("_");
+    const tableName = this.findJoinTableName(table1, table2, opts);
+    const t1Col = `${this.referenceNameForTable(table1)}_id`;
+    const t2Col = `${this.referenceNameForTable(table2)}_id`;
     await this.createTable(tableName, { id: false }, (t) => {
-      t.integer(`${table1.replace(/s$/, "")}_id`);
-      t.integer(`${table2.replace(/s$/, "")}_id`);
+      t.integer(t1Col);
+      t.integer(t2Col);
       if (definer) definer(t);
     });
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -581,16 +581,35 @@ export class SchemaStatements {
       definer = fn;
     }
     const tableName = this.findJoinTableName(table1, table2, opts);
-    const { columnOptions = {}, tableName: _t, ...rest } = opts;
+    const {
+      columnOptions = {},
+      tableName: _t,
+      force,
+      ifNotExists,
+      options: tableOptions,
+      comment,
+      temporary,
+    } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
     const t1Ref = this.referenceNameForTable(table1);
     const t2Ref = this.referenceNameForTable(table2);
 
-    await this.createTable(tableName, { ...rest, id: false } as any, (t) => {
-      t.references(t1Ref, mergedColOpts);
-      t.references(t2Ref, mergedColOpts);
-      if (definer) definer(t);
-    });
+    await this.createTable(
+      tableName,
+      {
+        id: false,
+        ...(force !== undefined && { force: force as boolean | "cascade" }),
+        ...(ifNotExists !== undefined && { ifNotExists: ifNotExists as boolean }),
+        ...(tableOptions !== undefined && { options: tableOptions as string }),
+        ...(comment !== undefined && { comment: comment as string }),
+        ...(temporary !== undefined && { temporary: temporary as boolean }),
+      },
+      (t) => {
+        t.references(t1Ref, mergedColOpts);
+        t.references(t2Ref, mergedColOpts);
+        if (definer) definer(t);
+      },
+    );
   }
 
   async dropJoinTable(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -135,6 +135,23 @@ export class SchemaStatements {
 
     await this.adapter.executeMutation(td.toSql());
 
+    // Rails: if supports_comments? && !supports_comments_in_create?
+    //   change_table_comment(table_name, comment) if options[:comment].present?
+    if (options.comment != null) {
+      const adapterWithComments = this.adapter as {
+        supportsComments?: () => boolean;
+        supportsCommentsInCreate?: () => boolean;
+        changeTableComment?: (name: string, comment: string | null) => Promise<void>;
+      };
+      if (
+        adapterWithComments.supportsComments?.() &&
+        !adapterWithComments.supportsCommentsInCreate?.() &&
+        typeof adapterWithComments.changeTableComment === "function"
+      ) {
+        await adapterWithComments.changeTableComment(name, options.comment);
+      }
+    }
+
     for (const idx of td.indexes) {
       await this.addIndex(name, idx.columns, {
         unique: idx.unique,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -39,6 +39,19 @@ import { SchemaDumper } from "./schema-dumper.js";
 
 export { assertSchemaAdapter } from "./assert-schema-adapter.js";
 
+/** Options accepted by `createJoinTable`. Extends the `createTable` option set with join-specific keys. */
+export type JoinTableOptions = {
+  tableName?: string;
+  columnOptions?: Record<string, unknown>;
+  id?: boolean | "uuid";
+  force?: boolean | "cascade";
+  ifNotExists?: boolean;
+  options?: string;
+  comment?: string;
+  temporary?: boolean;
+  as?: string;
+};
+
 /** @internal */
 function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Record<string, T> {
   if (typeof opt === "object" && opt !== null) return opt as Record<string, T>;
@@ -580,16 +593,10 @@ export class SchemaStatements {
   async createJoinTable(
     table1: string,
     table2: string,
-    options?:
-      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
-      | ((t: TableDefinition) => void),
+    options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    let opts: {
-      tableName?: string;
-      columnOptions?: Record<string, unknown>;
-      [key: string]: unknown;
-    } = {};
+    let opts: JoinTableOptions = {};
     let definer: ((t: TableDefinition) => void) | undefined;
     if (typeof options === "function") {
       definer = options;
@@ -598,35 +605,16 @@ export class SchemaStatements {
       definer = fn;
     }
     const tableName = this.findJoinTableName(table1, table2, opts);
-    const {
-      columnOptions = {},
-      tableName: _t,
-      force,
-      ifNotExists,
-      options: tableOptions,
-      comment,
-      temporary,
-    } = opts;
+    const { columnOptions = {}, tableName: _t, ...tableOpts } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
     const t1Ref = this.referenceNameForTable(table1);
     const t2Ref = this.referenceNameForTable(table2);
 
-    await this.createTable(
-      tableName,
-      {
-        id: false,
-        ...(force !== undefined && { force: force as boolean | "cascade" }),
-        ...(ifNotExists !== undefined && { ifNotExists: ifNotExists as boolean }),
-        ...(tableOptions !== undefined && { options: tableOptions as string }),
-        ...(comment !== undefined && { comment: comment as string }),
-        ...(temporary !== undefined && { temporary: temporary as boolean }),
-      },
-      (t) => {
-        t.references(t1Ref, mergedColOpts);
-        t.references(t2Ref, mergedColOpts);
-        if (definer) definer(t);
-      },
-    );
+    await this.createTable(tableName, { ...tableOpts, id: false }, (t) => {
+      t.references(t1Ref, mergedColOpts);
+      t.references(t2Ref, mergedColOpts);
+      if (definer) definer(t);
+    });
   }
 
   async dropJoinTable(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -598,7 +598,7 @@ export class SchemaStatements {
     table2: string,
     options?: { tableName?: string },
   ): Promise<void> {
-    const tableName = options?.tableName ?? [table1, table2].sort().join("_");
+    const tableName = this.findJoinTableName(table1, table2, options ?? {});
     await this.dropTable(tableName);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -581,11 +581,13 @@ export class SchemaStatements {
       definer = fn;
     }
     const tableName = this.findJoinTableName(table1, table2, opts);
+    const { columnOptions = {} } = opts;
     const t1Col = `${this.referenceNameForTable(table1)}_id`;
     const t2Col = `${this.referenceNameForTable(table2)}_id`;
+    const colOpts = { null: false, ...columnOptions } as ColumnOptions;
     await this.createTable(tableName, { id: false }, (t) => {
-      t.integer(t1Col);
-      t.integer(t2Col);
+      t.integer(t1Col, colOpts);
+      t.integer(t2Col, colOpts);
       if (definer) definer(t);
     });
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -581,13 +581,14 @@ export class SchemaStatements {
       definer = fn;
     }
     const tableName = this.findJoinTableName(table1, table2, opts);
-    const { columnOptions = {} } = opts;
-    const t1Col = `${this.referenceNameForTable(table1)}_id`;
-    const t2Col = `${this.referenceNameForTable(table2)}_id`;
-    const colOpts = { null: false, ...columnOptions } as ColumnOptions;
-    await this.createTable(tableName, { id: false }, (t) => {
-      t.integer(t1Col, colOpts);
-      t.integer(t2Col, colOpts);
+    const { columnOptions = {}, tableName: _t, ...rest } = opts;
+    const mergedColOpts = { null: false, index: false, ...columnOptions };
+    const t1Ref = this.referenceNameForTable(table1);
+    const t2Ref = this.referenceNameForTable(table2);
+
+    await this.createTable(tableName, { ...rest, id: false } as any, (t) => {
+      t.references(t1Ref, mergedColOpts);
+      t.references(t2Ref, mergedColOpts);
       if (definer) definer(t);
     });
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -150,7 +150,7 @@ export class SchemaStatements {
 
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
-    if (options.comment != null) {
+    if (options.comment != null && options.comment.length > 0) {
       const adapterWithComments = this.adapter as {
         supportsComments?: () => boolean;
         supportsCommentsInCreate?: () => boolean;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2900,16 +2900,35 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       definer = fn;
     }
     const joinName = opts.tableName ?? deriveJoinTableName(table1, table2);
-    const { columnOptions = {}, tableName: _t, ...rest } = opts;
+    const {
+      columnOptions = {},
+      tableName: _t,
+      force,
+      ifNotExists,
+      options: tableOptions,
+      comment,
+      temporary,
+    } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
     const ss = this.schemaStatements(this as unknown as DatabaseAdapter);
     const t1Ref = ss.referenceNameForTable(table1);
     const t2Ref = ss.referenceNameForTable(table2);
-    await ss.createTable(joinName, { ...rest, id: false } as any, (td) => {
-      td.references(t1Ref, mergedColOpts as any);
-      td.references(t2Ref, mergedColOpts as any);
-      if (definer) definer(td as unknown as AbstractTableDefinition);
-    });
+    await ss.createTable(
+      joinName,
+      {
+        id: false,
+        ...(force !== undefined && { force: force as boolean | "cascade" }),
+        ...(ifNotExists !== undefined && { ifNotExists: ifNotExists as boolean }),
+        ...(tableOptions !== undefined && { options: tableOptions as string }),
+        ...(comment !== undefined && { comment: comment as string }),
+        ...(temporary !== undefined && { temporary: temporary as boolean }),
+      },
+      (td) => {
+        td.references(t1Ref, mergedColOpts);
+        td.references(t2Ref, mergedColOpts);
+        if (definer) definer(td as unknown as AbstractTableDefinition);
+      },
+    );
   }
 
   // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2873,6 +2873,42 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
+  // createJoinTable override adapts the callback-first createTable API for join tables.
+  // @ts-expect-error TS2416
+  async createJoinTable(
+    table1: string,
+    table2: string,
+    options?: { tableName?: string; [key: string]: unknown } | ((t: SimpleTableBuilder) => void),
+    fn?: (t: SimpleTableBuilder) => void,
+  ): Promise<void> {
+    let tableName: string | undefined;
+    let definer: ((t: SimpleTableBuilder) => void) | undefined;
+    if (typeof options === "function") {
+      definer = options;
+    } else if (options) {
+      tableName = options.tableName;
+      definer = fn;
+    }
+    const joinName =
+      tableName ??
+      [table1, table2]
+        .sort()
+        .join("\0")
+        .replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3")
+        .replaceAll("\0", "_");
+    const t1Col = `${singularize(table1.split(".").at(-1) ?? table1)}_id`;
+    const t2Col = `${singularize(table2.split(".").at(-1) ?? table2)}_id`;
+    await this.createTable(
+      joinName,
+      (t: SimpleTableBuilder) => {
+        t.integer(t1Col);
+        t.integer(t2Col);
+        if (definer) definer(t);
+      },
+      { id: false },
+    );
+  }
+
   // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.
   // @ts-expect-error TS2416
   async createTable(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2896,9 +2896,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const joinName = opts.tableName ?? deriveJoinTableName(table1, table2);
     const { columnOptions = {}, tableName: _t, ...tableOpts } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
+    const t1Ref = this.referenceNameForTable(table1);
+    const t2Ref = this.referenceNameForTable(table2);
     const ss = this.schemaStatements(this as unknown as DatabaseAdapter);
-    const t1Ref = ss.referenceNameForTable(table1);
-    const t2Ref = ss.referenceNameForTable(table2);
     await ss.createTable(joinName, { ...tableOpts, id: false }, (td) => {
       td.references(t1Ref, mergedColOpts);
       td.references(t2Ref, mergedColOpts);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -92,6 +92,7 @@ import {
   type ColumnType,
   type ReferentialAction,
 } from "./abstract/schema-definitions.js";
+import { joinTableName as deriveJoinTableName } from "../migration/join-table.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
 import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
@@ -2889,13 +2890,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       tableName = options.tableName;
       definer = fn;
     }
-    const joinName =
-      tableName ??
-      [table1, table2]
-        .sort()
-        .join("\0")
-        .replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3")
-        .replaceAll("\0", "_");
+    const joinName = tableName ?? deriveJoinTableName(table1, table2);
     const t1Col = `${singularize(table1.split(".").at(-1) ?? table1)}_id`;
     const t2Col = `${singularize(table2.split(".").at(-1) ?? table2)}_id`;
     await this.createTable(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -89,6 +89,7 @@ import {
   ChangeColumnDefaultDefinition,
   ColumnDefinition,
   ForeignKeyDefinition,
+  TableDefinition as AbstractTableDefinition,
   type ColumnType,
   type ReferentialAction,
 } from "./abstract/schema-definitions.js";
@@ -2874,16 +2875,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  // createJoinTable override adapts the callback-first createTable API for join tables.
-  // @ts-expect-error TS2416
+  // createJoinTable override: bridges the callback-first createTable API.
+  // Signature matches AbstractAdapter so no @ts-expect-error is needed.
+  // The definer receives a SimpleTableBuilder cast as AbstractTableDefinition;
+  // callers that use only integer/string/boolean helpers work fine in practice.
   async createJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string; [key: string]: unknown } | ((t: SimpleTableBuilder) => void),
-    fn?: (t: SimpleTableBuilder) => void,
+    options?:
+      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
+      | ((t: AbstractTableDefinition) => void),
+    fn?: (t: AbstractTableDefinition) => void,
   ): Promise<void> {
     let tableName: string | undefined;
-    let definer: ((t: SimpleTableBuilder) => void) | undefined;
+    let definer: ((t: AbstractTableDefinition) => void) | undefined;
     if (typeof options === "function") {
       definer = options;
     } else if (options) {
@@ -2893,12 +2898,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const joinName = tableName ?? deriveJoinTableName(table1, table2);
     const t1Col = `${singularize(table1.split(".").at(-1) ?? table1)}_id`;
     const t2Col = `${singularize(table2.split(".").at(-1) ?? table2)}_id`;
-    await this.createTable(
+
+    await (this as any).createTable(
       joinName,
       (t: SimpleTableBuilder) => {
         t.integer(t1Col);
         t.integer(t2Col);
-        if (definer) definer(t);
+
+        if (definer) (definer as (t: any) => void)(t);
       },
       { id: false },
     );

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2902,9 +2902,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const joinName = opts.tableName ?? deriveJoinTableName(table1, table2);
     const { columnOptions = {}, tableName: _t, ...rest } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
-    const t1Ref = singularize(table1.split(".").at(-1) ?? table1);
-    const t2Ref = singularize(table2.split(".").at(-1) ?? table2);
     const ss = this.schemaStatements(this as unknown as DatabaseAdapter);
+    const t1Ref = ss.referenceNameForTable(table1);
+    const t2Ref = ss.referenceNameForTable(table2);
     await ss.createTable(joinName, { ...rest, id: false } as any, (td) => {
       td.references(t1Ref, mergedColOpts as any);
       td.references(t2Ref, mergedColOpts as any);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -59,7 +59,7 @@ import {
 } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
-import type { SchemaStatements } from "./abstract/schema-statements.js";
+import type { SchemaStatements, JoinTableOptions } from "./abstract/schema-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   transactionIsolationLevels,
@@ -2882,16 +2882,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async createJoinTable(
     table1: string,
     table2: string,
-    options?:
-      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
-      | ((t: AbstractTableDefinition) => void),
+    options?: JoinTableOptions | ((t: AbstractTableDefinition) => void),
     fn?: (t: AbstractTableDefinition) => void,
   ): Promise<void> {
-    let opts: {
-      tableName?: string;
-      columnOptions?: Record<string, unknown>;
-      [key: string]: unknown;
-    } = {};
+    let opts: JoinTableOptions = {};
     let definer: ((t: AbstractTableDefinition) => void) | undefined;
     if (typeof options === "function") {
       definer = options;
@@ -2900,35 +2894,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       definer = fn;
     }
     const joinName = opts.tableName ?? deriveJoinTableName(table1, table2);
-    const {
-      columnOptions = {},
-      tableName: _t,
-      force,
-      ifNotExists,
-      options: tableOptions,
-      comment,
-      temporary,
-    } = opts;
+    const { columnOptions = {}, tableName: _t, ...tableOpts } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
     const ss = this.schemaStatements(this as unknown as DatabaseAdapter);
     const t1Ref = ss.referenceNameForTable(table1);
     const t2Ref = ss.referenceNameForTable(table2);
-    await ss.createTable(
-      joinName,
-      {
-        id: false,
-        ...(force !== undefined && { force: force as boolean | "cascade" }),
-        ...(ifNotExists !== undefined && { ifNotExists: ifNotExists as boolean }),
-        ...(tableOptions !== undefined && { options: tableOptions as string }),
-        ...(comment !== undefined && { comment: comment as string }),
-        ...(temporary !== undefined && { temporary: temporary as boolean }),
-      },
-      (td) => {
-        td.references(t1Ref, mergedColOpts);
-        td.references(t2Ref, mergedColOpts);
-        if (definer) definer(td as unknown as AbstractTableDefinition);
-      },
-    );
+    await ss.createTable(joinName, { ...tableOpts, id: false }, (td) => {
+      td.references(t1Ref, mergedColOpts);
+      td.references(t2Ref, mergedColOpts);
+      if (definer) definer(td as unknown as AbstractTableDefinition);
+    });
   }
 
   // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2875,10 +2875,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  // createJoinTable override: bridges the callback-first createTable API.
-  // Signature matches AbstractAdapter so no @ts-expect-error is needed.
-  // The definer receives a SimpleTableBuilder cast as AbstractTableDefinition;
-  // callers that use only integer/string/boolean helpers work fine in practice.
+  // createJoinTable override: bypasses the callback-first createTable API by
+  // routing through schemaStatements().createTable, which uses the abstract
+  // options-first form and builds a real TableDefinition with correct column
+  // options (null: false) and full DSL support for the definer callback.
   async createJoinTable(
     table1: string,
     table2: string,
@@ -2887,28 +2887,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       | ((t: AbstractTableDefinition) => void),
     fn?: (t: AbstractTableDefinition) => void,
   ): Promise<void> {
-    let tableName: string | undefined;
+    let opts: {
+      tableName?: string;
+      columnOptions?: Record<string, unknown>;
+      [key: string]: unknown;
+    } = {};
     let definer: ((t: AbstractTableDefinition) => void) | undefined;
     if (typeof options === "function") {
       definer = options;
     } else if (options) {
-      tableName = options.tableName;
+      opts = options;
       definer = fn;
     }
-    const joinName = tableName ?? deriveJoinTableName(table1, table2);
-    const t1Col = `${singularize(table1.split(".").at(-1) ?? table1)}_id`;
-    const t2Col = `${singularize(table2.split(".").at(-1) ?? table2)}_id`;
-
-    await (this as any).createTable(
-      joinName,
-      (t: SimpleTableBuilder) => {
-        t.integer(t1Col);
-        t.integer(t2Col);
-
-        if (definer) (definer as (t: any) => void)(t);
-      },
-      { id: false },
-    );
+    const joinName = opts.tableName ?? deriveJoinTableName(table1, table2);
+    const { columnOptions = {}, tableName: _t, ...rest } = opts;
+    const mergedColOpts = { null: false, index: false, ...columnOptions };
+    const t1Ref = singularize(table1.split(".").at(-1) ?? table1);
+    const t2Ref = singularize(table2.split(".").at(-1) ?? table2);
+    const ss = this.schemaStatements(this as unknown as DatabaseAdapter);
+    await ss.createTable(joinName, { ...rest, id: false } as any, (td) => {
+      td.references(t1Ref, mergedColOpts as any);
+      td.references(t2Ref, mergedColOpts as any);
+      if (definer) definer(td as unknown as AbstractTableDefinition);
+    });
   }
 
   // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -928,7 +928,9 @@ export abstract class Migration {
   async createJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string } | ((t: TableDefinition) => void),
+    options?:
+      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
+      | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
     if (this._recording) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -15,6 +15,7 @@ import {
 import {
   SchemaStatements,
   assertSchemaAdapter,
+  type JoinTableOptions,
 } from "./connection-adapters/abstract/schema-statements.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
@@ -928,9 +929,7 @@ export abstract class Migration {
   async createJoinTable(
     table1: string,
     table2: string,
-    options?:
-      | { tableName?: string; columnOptions?: Record<string, unknown>; [key: string]: unknown }
-      | ((t: TableDefinition) => void),
+    options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
     if (this._recording) {
@@ -1478,6 +1477,20 @@ export class MigrationContext {
     });
     if (fn) fn(td);
     await this.adapter.executeMutation(td.toSql());
+    if (options?.comment != null) {
+      const adapterWithComments = this.adapter as {
+        supportsComments?: () => boolean;
+        supportsCommentsInCreate?: () => boolean;
+        changeTableComment?: (name: string, comment: string | null) => Promise<void>;
+      };
+      if (
+        adapterWithComments.supportsComments?.() &&
+        !adapterWithComments.supportsCommentsInCreate?.() &&
+        typeof adapterWithComments.changeTableComment === "function"
+      ) {
+        await adapterWithComments.changeTableComment(name, options.comment);
+      }
+    }
     this._tables.add(name);
     const cols = new Set<string>();
     for (const col of td.columns) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1477,7 +1477,7 @@ export class MigrationContext {
     });
     if (fn) fn(td);
     await this.adapter.executeMutation(td.toSql());
-    if (options?.comment != null) {
+    if (options?.comment != null && options.comment.length > 0) {
       const adapterWithComments = this.adapter as {
         supportsComments?: () => boolean;
         supportsCommentsInCreate?: () => boolean;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1449,6 +1449,8 @@ export class MigrationContext {
       ifNotExists?: boolean;
       id?: boolean | "uuid";
       default?: unknown;
+      options?: string;
+      comment?: string;
     },
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
@@ -1469,6 +1471,8 @@ export class MigrationContext {
     const td = new TableDefinition(name, {
       id: options?.id,
       default: options?.default,
+      options: options?.options,
+      comment: options?.comment,
       adapterName: this._adapterName,
       adapter: this.adapter,
     });

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -753,6 +753,24 @@ describe("SchemaDumperAdapterTest", () => {
     const result = await TopLevelDumper.dumpWithVersion(adapter);
     expect(result).toContain("Schema version: 20240201000000");
   });
+
+  it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const source = {
+      tables: () => ["users"],
+      columns: () => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: () => [],
+    };
+    class CommentDumper extends TopLevelDumper {
+      protected override fetchTableOptions(_tableName: string): Record<string, unknown> {
+        return { comment: "user accounts" };
+      }
+    }
+    const dumper = CommentDumper.create(source as any);
+    const lines: string[] = [];
+    await (dumper as any).table("users", lines);
+    expect(lines.join("\n")).toContain(`comment: "user accounts"`);
+  });
 });
 
 describe("SchemaDumper async header ordering", () => {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -759,6 +759,7 @@ export class SchemaDumper {
     }
     tableOpts.force = "cascade";
     if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
+    if (typeof adapterTableOpts.comment === "string") tableOpts.comment = adapterTableOpts.comment;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -759,7 +759,8 @@ export class SchemaDumper {
     }
     tableOpts.force = "cascade";
     if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
-    if (typeof adapterTableOpts.comment === "string") tableOpts.comment = adapterTableOpts.comment;
+    if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.length > 0)
+      tableOpts.comment = adapterTableOpts.comment;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);


### PR DESCRIPTION
## Summary

Bundles PG-schema audit cluster Slots B and C from `docs/activerecord-100-clusters.md`.

**Slot B — emitTable comment + PARTITION BY dump:**
- `emitTable` forwards `comment` (non-empty strings only, matching Rails `present?`) from `fetchTableOptions` into the `createTable` options string alongside the existing `options` forwarding for INHERITS/PARTITION BY.
- `SchemaStatements.createTable` now calls `changeTableComment` after `CREATE TABLE` when `supportsComments() && !supportsCommentsInCreate()` (PG path), mirroring Rails' post-create comment hook.
- `MigrationContext.createTable` mirrors the same `changeTableComment` dispatch.
- `AbstractMysqlAdapter` overrides `supportsCommentsInCreate(): true` to prevent a redundant post-create comment call (MySQL already emits it inline in `CREATE TABLE`).
- `MigrationContext.createTable` widened to accept `options` and `comment`, forwarding both to `TableDefinition` so dumped schemas type-check and round-trip.
- Fills in 5 previously-BLOCKED test bodies: "list partition options is dumped", "range partition options is dumped", "no partition options are dumped" (SchemaCreateTableOptionsTest), plus "partition table" and "partitions table exists" (PostgresqlPartitionsTest).
- New live-PG test: "table comment is dumped and round-trips via createTable".

**Slot C — createJoinTable schema-qualified:**
- Introduced `JoinTableOptions` (exported type enumerating the concrete `createTable` options + `tableName`/`columnOptions`); no `[key: string]: unknown` per review #7 which confirmed named keys prevent silent drops.
- `SchemaStatements.createJoinTable` uses `findJoinTableName` + `referenceNameForTable` for schema-qualified names; `dropJoinTable` aligned to the same helper.
- `columnOptions` wired with `null: false, index: false` defaults (Rails parity); `...tableOpts` spread is type-safe because `JoinTableOptions` is a closed type.
- `PostgreSQLAdapter.createJoinTable` override routes through `this.schemaStatements().createTable` for a real `TableDefinition` (full DSL, correct `null: false`). Uses `this.referenceNameForTable` (PG's `parseSchemaQualifiedName`-backed override) for quoted-identifier correctness.
- Fills in "create join table" (SchemaJoinTablesTest).

## Remaining known gap (Copilot review #10)

`JoinTableOptions` omits `default?: unknown` from the `createTable` option set. This is intentional: join tables always use `id: false`, so a primary-key default is not applicable. Adding `[key: string]: unknown` was explicitly rejected in review #7 to prevent silent option drops. If `default` or other `createTable` keys are ever needed on join tables, `JoinTableOptions` can be extended in a targeted PR.

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/adapters/postgresql/schema.test.ts packages/activerecord/src/adapters/postgresql/partitions.test.ts` — 7 new tests pass (PG required)
- [ ] `pnpm vitest run packages/activerecord/src/schema-dumper.test.ts` — comment forwarding unit test passes without PG
- [ ] `pnpm run api:compare --package activerecord` — 4955/4958 (no regression)