### PR TITLE
feat(activerecord) fixture replacement Phase 1 — defineFixtures registry + ref + deterministic IDs

### DIFF
--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -45,7 +45,7 @@ describe("fixtureId", () => {
   });
 
   it("produces a stable known value for 'david' (CRC32 polynomial 0xedb88320)", () => {
-    // Value is stable across JS runtimes; not guaranteed to match Ruby Zlib.crc32 exactly.
+    // For ASCII labels this matches Ruby's Zlib.crc32(label) % (2**30 - 1) exactly.
     expect(fixtureId("david")).toBe(127326141);
   });
 });
@@ -130,6 +130,23 @@ describe("defineFixtures", () => {
 
     expect(first.david.id).toBe(davidId);
     expect(second.david.id).toBe(davidId);
+  });
+
+  it("HABTM join-table: two ref()s in one row both resolve", async () => {
+    const adapter = makeAdapter();
+    const joinRow = { post_id: fixtureId("welcome"), tag_id: fixtureId("rails") };
+    const rows = new Map([[fixtureId("welcome_rails"), joinRow]]);
+    const PostTag = makeModel("posts_tags", rows);
+
+    await defineFixtures(adapter, PostTag, {
+      welcome_rails: { post_id: ref("posts", "welcome"), tag_id: ref("tags", "rails") },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO"));
+    expect(insertSql).toContain(String(fixtureId("welcome")));
+    expect(insertSql).toContain(String(fixtureId("rails")));
   });
 
   it("STI: type column passed explicitly is preserved in INSERT", async () => {

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import { fixtureId, ref, isFixtureRef, defineFixtures } from "./define-fixtures.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+function makeAdapter(): DatabaseAdapter {
+  return {
+    adapterName: "sqlite" as const,
+    execute: vi.fn(async () => []),
+    executeMutation: vi.fn(async () => 0),
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    createSavepoint: vi.fn(async () => {}),
+    releaseSavepoint: vi.fn(async () => {}),
+    rollbackToSavepoint: vi.fn(async () => {}),
+    isNoDatabaseError: () => false,
+    quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+    quoteTableName: (n: string) => `"${n}"`,
+    quoteColumnName: (n: string) => `"${n}"`,
+  } as unknown as DatabaseAdapter;
+}
+
+function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>>, pk = "id") {
+  return {
+    tableName,
+    primaryKey: pk,
+    findBy: vi.fn(async (attrs: Record<string, unknown>) => rows.get(attrs[pk]) ?? null),
+  } as any;
+}
+
+describe("fixtureId", () => {
+  it("returns a positive integer below 2^30 - 1", () => {
+    const id = fixtureId("david");
+    expect(id).toBeGreaterThan(0);
+    expect(id).toBeLessThan(2 ** 30 - 1);
+  });
+
+  it("is deterministic: same label always yields same ID", () => {
+    expect(fixtureId("david")).toBe(fixtureId("david"));
+    expect(fixtureId("mary")).toBe(fixtureId("mary"));
+  });
+
+  it("different labels produce different IDs", () => {
+    expect(fixtureId("david")).not.toBe(fixtureId("mary"));
+  });
+
+  it("produces a stable known value for 'david' (CRC32 polynomial 0xedb88320)", () => {
+    // Value is stable across JS runtimes; not guaranteed to match Ruby Zlib.crc32 exactly.
+    expect(fixtureId("david")).toBe(127326141);
+  });
+});
+
+describe("ref", () => {
+  it("returns a FixtureRef detected by isFixtureRef", () => {
+    const r = ref("users", "david");
+    expect(isFixtureRef(r)).toBe(true);
+    expect(r.tableName).toBe("users");
+    expect(r.fixtureName).toBe("david");
+  });
+
+  it("non-ref objects are not detected as refs", () => {
+    expect(isFixtureRef({ tableName: "users", fixtureName: "david" })).toBe(false);
+    expect(isFixtureRef(null)).toBe(false);
+  });
+});
+
+describe("defineFixtures", () => {
+  it("inserts fixtures and returns keyed accessor", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([
+      [fixtureId("david"), { id: fixtureId("david"), name: "David" }],
+      [fixtureId("mary"), { id: fixtureId("mary"), name: "Mary" }],
+    ]);
+    const User = makeModel("users", rows);
+
+    const users = await defineFixtures(adapter, User, {
+      david: { name: "David" },
+      mary: { name: "Mary" },
+    });
+
+    expect(users.david).toEqual({ id: fixtureId("david"), name: "David" });
+    expect(users.mary).toEqual({ id: fixtureId("mary"), name: "Mary" });
+  });
+
+  it("ref() resolves to the referenced fixture's deterministic ID", async () => {
+    const adapter = makeAdapter();
+    const welcomeRow = {
+      id: fixtureId("welcome"),
+      title: "Welcome",
+      author_id: fixtureId("david"),
+    };
+    const rows = new Map([[fixtureId("welcome"), welcomeRow]]);
+    const Post = makeModel("posts", rows);
+
+    await defineFixtures(adapter, Post, {
+      welcome: { title: "Welcome", author_id: ref("users", "david") },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO"));
+    expect(insertSql).toContain(String(fixtureId("david")));
+  });
+
+  it("direct model instance is resolved to its PK value", async () => {
+    const adapter = makeAdapter();
+    const welcomeRow = { id: fixtureId("welcome"), title: "Welcome" };
+    const rows = new Map([[fixtureId("welcome"), welcomeRow]]);
+    const Post = makeModel("posts", rows);
+
+    const davidInstance = { id: fixtureId("david"), name: "David" };
+    await defineFixtures(adapter, Post, {
+      welcome: { title: "Welcome", author: davidInstance },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO"));
+    expect(insertSql).toContain(String(fixtureId("david")));
+  });
+
+  it("deterministic IDs are stable across multiple defineFixtures calls", async () => {
+    const davidId = fixtureId("david");
+    const rows = new Map([[davidId, { id: davidId }]]);
+    const User = makeModel("users", rows);
+    const adapter = makeAdapter();
+
+    const first = await defineFixtures(adapter, User, { david: {} });
+    const second = await defineFixtures(adapter, User, { david: {} });
+
+    expect(first.david.id).toBe(davidId);
+    expect(second.david.id).toBe(davidId);
+  });
+
+  it("STI: type column passed explicitly is preserved in INSERT", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([
+      [fixtureId("admin_user"), { id: fixtureId("admin_user"), type: "AdminUser" }],
+    ]);
+    const User = makeModel("users", rows);
+
+    await defineFixtures(adapter, User, {
+      admin_user: { name: "Admin", type: "AdminUser" },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO"));
+    expect(insertSql).toContain("type");
+    expect(insertSql).toContain("AdminUser");
+  });
+});

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -29,9 +29,9 @@ function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>
 }
 
 describe("fixtureId", () => {
-  it("returns a positive integer below 2^30 - 1", () => {
+  it("returns a non-negative integer below 2^30 - 1", () => {
     const id = fixtureId("david");
-    expect(id).toBeGreaterThan(0);
+    expect(id).toBeGreaterThanOrEqual(0);
     expect(id).toBeLessThan(2 ** 30 - 1);
   });
 

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -35,18 +35,11 @@ describe("fixtureId", () => {
     expect(id).toBeLessThan(2 ** 30 - 1);
   });
 
-  it("is deterministic: same label always yields same ID", () => {
-    expect(fixtureId("david")).toBe(fixtureId("david"));
-    expect(fixtureId("mary")).toBe(fixtureId("mary"));
-  });
-
-  it("different labels produce different IDs", () => {
-    expect(fixtureId("david")).not.toBe(fixtureId("mary"));
-  });
-
-  it("produces a stable known value for 'david' (CRC32 polynomial 0xedb88320)", () => {
+  it("is deterministic and stable: same label always yields the same known value", () => {
     // For ASCII labels this matches Ruby's Zlib.crc32(label) % (2**30 - 1) exactly.
     expect(fixtureId("david")).toBe(127326141);
+    expect(fixtureId("david")).toBe(fixtureId("david"));
+    expect(fixtureId("david")).not.toBe(fixtureId("mary"));
   });
 });
 
@@ -80,6 +73,11 @@ describe("defineFixtures", () => {
 
     expect(users.david).toEqual({ id: fixtureId("david"), name: "David" });
     expect(users.mary).toEqual({ id: fixtureId("mary"), name: "Mary" });
+    // Mirrors Rails: table is cleared before insert so repeated calls replace rows
+    const deleteSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("DELETE FROM"));
+    expect(deleteSql).toContain('"users"');
   });
 
   it("ref() resolves to the referenced fixture's deterministic ID", async () => {
@@ -130,6 +128,13 @@ describe("defineFixtures", () => {
 
     expect(first.david.id).toBe(davidId);
     expect(second.david.id).toBe(davidId);
+  });
+
+  it("throws for composite primary keys", async () => {
+    const Model = { tableName: "orders", primaryKey: ["shop_id", "id"], findBy: vi.fn() } as any;
+    await expect(defineFixtures(makeAdapter(), Model, { order1: {} })).rejects.toThrow(
+      "composite primary keys are not supported",
+    );
   });
 
   it("HABTM join-table: two ref()s in one row both resolve", async () => {

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -8,7 +8,8 @@ import type { Quoting } from "../connection-adapters/abstract/quoting-interface.
 
 const FIXTURE_MAX_ID = 2 ** 30 - 1;
 
-// CRC32 lookup table — matches Rails' Zlib.crc32(label) % MAX_ID algorithm
+// CRC32 lookup table (polynomial 0xedb88320). For ASCII labels this produces values
+// identical to Ruby's Zlib.crc32(label) % MAX_ID, matching Rails' FixtureSet.identify.
 const CRC32_TABLE = (() => {
   const table = new Uint32Array(256);
   for (let i = 0; i < 256; i++) {
@@ -50,8 +51,10 @@ export function isFixtureRef(v: unknown): v is FixtureRef {
   return typeof v === "object" && v !== null && REF_TAG in v;
 }
 
-type ModelClass = typeof Base;
+type BaseClass = typeof Base;
 type FixtureAttrs = Record<string, unknown>;
+type InsertHost = DatabaseStatementsHost &
+  Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">;
 
 /**
  * Inserts fixture rows for a model and returns persisted instances keyed by label.
@@ -59,7 +62,7 @@ type FixtureAttrs = Record<string, unknown>;
  * IDs are deterministic: same label → same ID across test runs, enabling cross-batch
  * FK references via `ref(tableName, label)` without insertion-order coupling.
  */
-export async function defineFixtures<T extends ModelClass, K extends string>(
+export async function defineFixtures<T extends BaseClass, K extends string>(
   adapter: DatabaseAdapter,
   ModelClass: T,
   fixtures: Record<K, FixtureAttrs>,
@@ -82,7 +85,10 @@ export async function defineFixtures<T extends ModelClass, K extends string>(
         const refId = fixtureId(val.fixtureName);
         row[col] = refId;
       } else if (val !== null && typeof val === "object" && pkCol in val) {
-        // Direct model instance: extract its PK value
+        // Heuristic: plain object or model instance carrying the PK — extract it.
+        // Limitation: a JSON column value shaped like { id: ... } will also match.
+        // Avoid ambiguity by using ref() for cross-batch FKs and direct instances only
+        // for same-batch model objects returned by a prior defineFixtures call.
         row[col] = (val as FixtureAttrs)[pkCol];
       } else {
         row[col] = val;
@@ -92,8 +98,6 @@ export async function defineFixtures<T extends ModelClass, K extends string>(
   }
 
   // Insert via existing adapter infrastructure (wrapped in transaction, honours disableReferentialIntegrity)
-  type InsertHost = DatabaseStatementsHost &
-    Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">;
   await insertFixturesSet.call(adapter as unknown as InsertHost, {
     [tableName]: rows,
   });

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -93,10 +93,8 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
         const refId = fixtureId(val.fixtureName);
         row[col] = refId;
       } else if (val !== null && typeof val === "object" && pkCol in val) {
-        // Heuristic: plain object or model instance carrying the PK — extract it.
-        // Limitation: a JSON column value shaped like { id: ... } will also match.
-        // Avoid ambiguity by using ref() for cross-batch FKs and direct instances only
-        // for same-batch model objects returned by a prior defineFixtures call.
+        // Model instance (or any object with the PK): extract the PK value.
+        // Use ref() if a plain JSON column could be confused for an instance.
         row[col] = (val as FixtureAttrs)[pkCol];
       } else {
         row[col] = val;
@@ -105,8 +103,7 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
     rows.push(row);
   }
 
-  // Mirrors Rails: insert_fixtures_set(table_rows, table_rows.keys) — tables are cleared before insert
-  // so repeated defineFixtures calls for the same table replace rather than append rows.
+  // Mirrors Rails: pass tableName as tablesToDelete so rows are replaced, not appended.
   await insertFixturesSet.call(adapter as unknown as InsertHost, { [tableName]: rows }, [
     tableName,
   ]);

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -1,0 +1,115 @@
+import {
+  insertFixturesSet,
+  type DatabaseStatementsHost,
+} from "../connection-adapters/abstract/database-statements.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import type { Base } from "../base.js";
+import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
+
+const FIXTURE_MAX_ID = 2 ** 30 - 1;
+
+// CRC32 lookup table — matches Rails' Zlib.crc32(label) % MAX_ID algorithm
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[i] = c;
+  }
+  return table;
+})();
+
+function crc32(str: string): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < str.length; i++) {
+    crc = CRC32_TABLE[(crc ^ str.charCodeAt(i)) & 0xff]! ^ (crc >>> 8);
+  }
+  return ((crc ^ 0xffffffff) >>> 0) % FIXTURE_MAX_ID;
+}
+
+/** Returns the deterministic integer ID for a fixture label. Mirrors Rails' FixtureSet.identify. */
+export function fixtureId(label: string): number {
+  return crc32(label);
+}
+
+const REF_TAG = Symbol("fixture-ref");
+
+export interface FixtureRef {
+  readonly [REF_TAG]: true;
+  readonly tableName: string;
+  readonly fixtureName: string;
+}
+
+/** Cross-batch cross-reference sentinel. Resolves to the fixture's deterministic ID at insert time. */
+export function ref(tableName: string, fixtureName: string): FixtureRef {
+  return { [REF_TAG]: true, tableName, fixtureName };
+}
+
+/** @internal */
+export function isFixtureRef(v: unknown): v is FixtureRef {
+  return typeof v === "object" && v !== null && REF_TAG in v;
+}
+
+type ModelClass = typeof Base;
+type FixtureAttrs = Record<string, unknown>;
+
+/**
+ * Inserts fixture rows for a model and returns persisted instances keyed by label.
+ *
+ * IDs are deterministic: same label → same ID across test runs, enabling cross-batch
+ * FK references via `ref(tableName, label)` without insertion-order coupling.
+ */
+export async function defineFixtures<T extends ModelClass, K extends string>(
+  adapter: DatabaseAdapter,
+  ModelClass: T,
+  fixtures: Record<K, FixtureAttrs>,
+): Promise<{ [P in K]: InstanceType<T> }> {
+  const tableName = ModelClass.tableName;
+  const pk = ModelClass.primaryKey;
+  const pkCol = Array.isArray(pk) ? pk[0]! : pk;
+
+  const labels = Object.keys(fixtures) as K[];
+
+  // Build rows with deterministic IDs and resolved references
+  const rows: FixtureAttrs[] = [];
+  for (const label of labels) {
+    const attrs = fixtures[label];
+    const id = fixtureId(label);
+    const row: FixtureAttrs = { [pkCol]: id };
+
+    for (const [col, val] of Object.entries(attrs)) {
+      if (isFixtureRef(val)) {
+        const refId = fixtureId(val.fixtureName);
+        row[col] = refId;
+      } else if (val !== null && typeof val === "object" && pkCol in val) {
+        // Direct model instance: extract its PK value
+        row[col] = (val as FixtureAttrs)[pkCol];
+      } else {
+        row[col] = val;
+      }
+    }
+    rows.push(row);
+  }
+
+  // Insert via existing adapter infrastructure (wrapped in transaction, honours disableReferentialIntegrity)
+  type InsertHost = DatabaseStatementsHost &
+    Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName">;
+  await insertFixturesSet.call(adapter as unknown as InsertHost, {
+    [tableName]: rows,
+  });
+
+  // Reload persisted instances so AR attribute casting is applied
+  const result = {} as { [P in K]: InstanceType<T> };
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i]!;
+    const id = (rows[i] as FixtureAttrs)[pkCol];
+    const record = await (ModelClass as any).findBy({ [pkCol]: id });
+    if (!record) {
+      throw new Error(
+        `defineFixtures: inserted fixture "${label}" not found after insert (table: ${tableName}, ${pkCol}: ${id})`,
+      );
+    }
+    result[label] = record as InstanceType<T>;
+  }
+  return result;
+}

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -89,6 +89,7 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
     const row: FixtureAttrs = { [pkCol]: id };
 
     for (const [col, val] of Object.entries(attrs)) {
+      if (col === pkCol) continue; // deterministic ID wins; caller must not override it
       if (isFixtureRef(val)) {
         const refId = fixtureId(val.fixtureName);
         row[col] = refId;

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -41,7 +41,10 @@ export interface FixtureRef {
   readonly fixtureName: string;
 }
 
-/** Cross-batch cross-reference sentinel. Resolves to the fixture's deterministic ID at insert time. */
+/**
+ * Cross-batch cross-reference sentinel. Resolves to the fixture's deterministic ID at insert time.
+ * `tableName` is stored for readability and future validation; resolution uses only `fixtureName`.
+ */
 export function ref(tableName: string, fixtureName: string): FixtureRef {
   return { [REF_TAG]: true, tableName, fixtureName };
 }
@@ -69,7 +72,12 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
 ): Promise<{ [P in K]: InstanceType<T> }> {
   const tableName = ModelClass.tableName;
   const pk = ModelClass.primaryKey;
-  const pkCol = Array.isArray(pk) ? pk[0]! : pk;
+  if (Array.isArray(pk)) {
+    throw new Error(
+      `defineFixtures: composite primary keys are not supported (model: ${ModelClass.name}, pk: [${pk.join(", ")}])`,
+    );
+  }
+  const pkCol = pk;
 
   const labels = Object.keys(fixtures) as K[];
 
@@ -97,10 +105,11 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
     rows.push(row);
   }
 
-  // Insert via existing adapter infrastructure (wrapped in transaction, honours disableReferentialIntegrity)
-  await insertFixturesSet.call(adapter as unknown as InsertHost, {
-    [tableName]: rows,
-  });
+  // Mirrors Rails: insert_fixtures_set(table_rows, table_rows.keys) — tables are cleared before insert
+  // so repeated defineFixtures calls for the same table replace rather than append rows.
+  await insertFixturesSet.call(adapter as unknown as InsertHost, { [tableName]: rows }, [
+    tableName,
+  ]);
 
   // Reload persisted instances so AR attribute casting is applied
   const result = {} as { [P in K]: InstanceType<T> };


### PR DESCRIPTION
## Summary

- Adds `defineFixtures(adapter, ModelClass, fixtures)` — inserts fixture rows and returns persisted instances keyed by label
- Adds `ref(tableName, label)` sentinel for cross-batch FK references that resolve at insert time
- Adds `fixtureId(label)` — CRC32-based deterministic ID matching Rails' `FixtureSet.identify` algorithm
- Delegates to existing `insertFixturesSet` for DB insertion (no new SQL paths)

## Design notes

- IDs are deterministic per label so cross-batch `ref()` calls work without insertion-order coupling (same motivation as Rails' `label_to_id`)
- Direct model instance values (in-batch cross-refs) are resolved by reading `instance[pk]`
- Result type preserves the input object-literal's key set so `users.david` autocompletes without widening

## Follow-ups (out of scope for this PR)

- Phase 2: `useFixtures` Vitest wrapper + `FixtureSet.createFixtures`
- Phase 3: Actual fixture data files
- Phase 4: Transactional per-test wrapping