### PR TITLE
feat(activerecord) fixture replacement Phase 1b — HABTM auto + polymorphic refs + tableName registry

### DIFF
--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -1,11 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   fixtureId,
   ref,
   isFixtureRef,
   defineFixtures,
   resolveModelForTable,
-  clearTableRegistry,
 } from "./define-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -34,10 +33,6 @@ function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>
     findBy: vi.fn(async (attrs: Record<string, unknown>) => rows.get(attrs[pk]) ?? null),
   } as any;
 }
-
-beforeEach(() => {
-  clearTableRegistry();
-});
 
 describe("fixtureId", () => {
   it("returns a non-negative integer below 2^30 - 1", () => {
@@ -201,9 +196,20 @@ describe("defineFixtures", () => {
     const rows = new Map([[fixtureId("david"), { id: fixtureId("david") }]]);
     const User = makeModel("users", rows);
 
-    expect(resolveModelForTable("users")).toBeUndefined();
+    expect(resolveModelForTable(adapter, "users")).toBeUndefined();
     await defineFixtures(adapter, User, { david: {} });
-    expect(resolveModelForTable("users")).toBe(User);
+    expect(resolveModelForTable(adapter, "users")).toBe(User);
+  });
+
+  it("tableName registry: each adapter has its own isolated registry", async () => {
+    const adapter1 = makeAdapter();
+    const adapter2 = makeAdapter();
+    const rows = new Map([[fixtureId("david"), { id: fixtureId("david") }]]);
+    const User = makeModel("users", rows);
+
+    await defineFixtures(adapter1, User, { david: {} });
+    expect(resolveModelForTable(adapter1, "users")).toBe(User);
+    expect(resolveModelForTable(adapter2, "users")).toBeUndefined();
   });
 
   it("polymorphic ref: { taggable: instance } expands to taggable_type + taggable_id", async () => {

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -290,9 +290,7 @@ describe("defineFixtures", () => {
       .find((s) => s.includes("INSERT INTO") && s.includes("taggings"));
     expect(insertSql).toContain("taggable_type");
     expect(insertSql).toContain("taggable_id");
-    // Both columns appear and their values are null (test adapter serialises null as "null")
-    expect(insertSql).toContain("taggable_type");
-    expect(insertSql).toContain("taggable_id");
+    // Both FK columns appear with null values (test adapter serialises null as "null")
     const nullCount = (insertSql!.match(/\bnull\b/g) ?? []).length;
     expect(nullCount).toBeGreaterThanOrEqual(2);
   });

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-import { fixtureId, ref, isFixtureRef, defineFixtures } from "./define-fixtures.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fixtureId,
+  ref,
+  isFixtureRef,
+  defineFixtures,
+  resolveModelForTable,
+  clearTableRegistry,
+} from "./define-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 function makeAdapter(): DatabaseAdapter {
@@ -27,6 +34,10 @@ function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>
     findBy: vi.fn(async (attrs: Record<string, unknown>) => rows.get(attrs[pk]) ?? null),
   } as any;
 }
+
+beforeEach(() => {
+  clearTableRegistry();
+});
 
 describe("fixtureId", () => {
   it("returns a non-negative integer below 2^30 - 1", () => {
@@ -152,6 +163,87 @@ describe("defineFixtures", () => {
       .find((s) => s.includes("INSERT INTO"));
     expect(insertSql).toContain(String(fixtureId("welcome")));
     expect(insertSql).toContain(String(fixtureId("rails")));
+  });
+
+  it("HABTM: string values for FK columns auto-resolve to fixtureId when table matches a_b pattern", async () => {
+    const adapter = makeAdapter();
+
+    // Register developers and projects first
+    const developerRows = new Map([[fixtureId("david"), { id: fixtureId("david") }]]);
+    const Developer = makeModel("developers", developerRows);
+    const projectRows = new Map([[fixtureId("trails"), { id: fixtureId("trails") }]]);
+    const Project = makeModel("projects", projectRows);
+    await defineFixtures(adapter, Developer, { david: {} });
+    await defineFixtures(adapter, Project, { trails: {} });
+
+    // Join-table: developers_projects auto-detects "developers" and "projects" in registry
+    const joinRow = {
+      developer_id: fixtureId("david"),
+      project_id: fixtureId("trails"),
+    };
+    const joinRows = new Map([[fixtureId("david_trails"), joinRow]]);
+    const DevelopersProject = makeModel("developers_projects", joinRows);
+
+    await defineFixtures(adapter, DevelopersProject, {
+      david_trails: { developer_id: "david", project_id: "trails" },
+    });
+
+    const insertCalls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("developers_projects"));
+    expect(insertCalls.length).toBeGreaterThan(0);
+    expect(insertCalls[0]).toContain(String(fixtureId("david")));
+    expect(insertCalls[0]).toContain(String(fixtureId("trails")));
+  });
+
+  it("tableName registry: resolveModelForTable returns the model after defineFixtures", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([[fixtureId("david"), { id: fixtureId("david") }]]);
+    const User = makeModel("users", rows);
+
+    expect(resolveModelForTable("users")).toBeUndefined();
+    await defineFixtures(adapter, User, { david: {} });
+    expect(resolveModelForTable("users")).toBe(User);
+  });
+
+  it("polymorphic ref: { taggable: instance } expands to taggable_type + taggable_id", async () => {
+    const adapter = makeAdapter();
+
+    // Post instance with a known ID
+    const postId = fixtureId("welcome");
+    class Post {
+      static tableName = "posts";
+      static primaryKey = "id";
+      id = postId;
+    }
+    const postInstance = new Post();
+
+    // Tagging model with a polymorphic belongs_to :taggable reflection
+    const taggingId = fixtureId("welcome_tag");
+    const taggingRow = {
+      id: taggingId,
+      taggable_type: "Post",
+      taggable_id: postId,
+    };
+    const rows = new Map([[taggingId, taggingRow]]);
+    const Tagging = makeModel("taggings", rows) as any;
+    Tagging._reflections = {
+      taggable: {
+        macro: "belongsTo",
+        isPolymorphic: () => true,
+      },
+    };
+
+    await defineFixtures(adapter, Tagging, {
+      welcome_tag: { taggable: postInstance as any },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO") && s.includes("taggings"));
+    expect(insertSql).toContain("taggable_type");
+    expect(insertSql).toContain("Post");
+    expect(insertSql).toContain(String(postId));
   });
 
   it("STI: type column passed explicitly is preserved in INSERT", async () => {

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -252,6 +252,27 @@ describe("defineFixtures", () => {
     expect(insertSql).toContain(String(postId));
   });
 
+  it("polymorphic ref: explicit taggable_type/taggable_id pass through without expansion", async () => {
+    // When the caller already provides the concrete type/id columns directly (no association key),
+    // they should pass through unchanged — no expansion is triggered.
+    const adapter = makeAdapter();
+    const rows = new Map([[fixtureId("welcome_tag"), { id: fixtureId("welcome_tag") }]]);
+    const Tagging = makeModel("taggings", rows) as any;
+    Tagging._reflections = {
+      taggable: { macro: "belongsTo", isPolymorphic: () => true },
+    };
+
+    await defineFixtures(adapter, Tagging, {
+      welcome_tag: { taggable_type: "CustomPost", taggable_id: 999 },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO") && s.includes("taggings"));
+    expect(insertSql).toContain("CustomPost");
+    expect(insertSql).toContain("999");
+  });
+
   it("STI: type column passed explicitly is preserved in INSERT", async () => {
     const adapter = makeAdapter();
     const rows = new Map([

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -273,6 +273,43 @@ describe("defineFixtures", () => {
     expect(insertSql).toContain("999");
   });
 
+  it("polymorphic ref: null value sets both type and id columns to null", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([[fixtureId("untagged"), { id: fixtureId("untagged") }]]);
+    const Tagging = makeModel("taggings", rows) as any;
+    Tagging._reflections = {
+      taggable: { macro: "belongsTo", isPolymorphic: () => true },
+    };
+
+    await defineFixtures(adapter, Tagging, {
+      untagged: { taggable: null },
+    });
+
+    const insertSql = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO") && s.includes("taggings"));
+    expect(insertSql).toContain("taggable_type");
+    expect(insertSql).toContain("taggable_id");
+    // Both columns appear and their values are null (test adapter serialises null as "null")
+    expect(insertSql).toContain("taggable_type");
+    expect(insertSql).toContain("taggable_id");
+    const nullCount = (insertSql!.match(/\bnull\b/g) ?? []).length;
+    expect(nullCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("polymorphic ref: non-instance non-null value throws a clear error", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([[fixtureId("bad"), { id: fixtureId("bad") }]]);
+    const Tagging = makeModel("taggings", rows) as any;
+    Tagging._reflections = {
+      taggable: { macro: "belongsTo", isPolymorphic: () => true },
+    };
+
+    await expect(
+      defineFixtures(adapter, Tagging, { bad: { taggable: 42 as any } }),
+    ).rejects.toThrow("polymorphic association");
+  });
+
   it("STI: type column passed explicitly is preserved in INSERT", async () => {
     const adapter = makeAdapter();
     const rows = new Map([

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -55,33 +55,42 @@ export function isFixtureRef(v: unknown): v is FixtureRef {
   return typeof v === "object" && v !== null && REF_TAG in v;
 }
 
-// --- Phase 1b: tableName → ModelClass registry ---
+// --- Phase 1b: tableName → ModelClass registry (scoped per adapter) ---
 
-const tableRegistry = new Map<string, BaseClass>();
+// WeakMap prevents cross-file leakage: each adapter object gets its own registry that
+// lives only as long as the adapter, so tests using distinct adapter instances are isolated.
+const tableRegistries = new WeakMap<object, Map<string, BaseClass>>();
 
-/** @internal Exposed for testing. */
-export function resolveModelForTable(tableName: string): BaseClass | undefined {
-  return tableRegistry.get(tableName);
+function getRegistry(adapter: object): Map<string, BaseClass> {
+  let reg = tableRegistries.get(adapter);
+  if (!reg) {
+    reg = new Map();
+    tableRegistries.set(adapter, reg);
+  }
+  return reg;
 }
 
 /** @internal */
-export function clearTableRegistry(): void {
-  tableRegistry.clear();
+export function resolveModelForTable(adapter: object, tableName: string): BaseClass | undefined {
+  return getRegistry(adapter).get(tableName);
 }
 
 // --- Phase 1b: HABTM join-table detection ---
 
 /**
- * Given a join-table name like "developers_projects", returns [singularA, singularB] if both
- * corresponding plural table names are registered, otherwise null.
- * @internal
+ * Given a join-table name like "developers_projects" and the adapter's registry, returns the
+ * two *plural* table-name parts (e.g. `["developers", "projects"]`) if both are registered,
+ * otherwise null. Singularization happens at call time when building the FK column names.
  */
-function detectHabtmParts(tableName: string): [string, string] | null {
+function detectHabtmParts(
+  registry: Map<string, BaseClass>,
+  tableName: string,
+): [string, string] | null {
   const parts = tableName.split("_");
   for (let i = 1; i < parts.length; i++) {
     const left = parts.slice(0, i).join("_");
     const right = parts.slice(i).join("_");
-    if (tableRegistry.has(left) && tableRegistry.has(right)) {
+    if (registry.has(left) && registry.has(right)) {
       return [left, right];
     }
   }
@@ -99,7 +108,11 @@ function findPolymorphicRef(modelClass: BaseClass, colName: string): Polymorphic
   const reflections: Record<string, any> = (modelClass as any)._reflections ?? {};
   const refl = reflections[colName];
   if (!refl || refl.macro !== "belongsTo" || !refl.isPolymorphic?.()) return null;
-  return { typeColumn: `${colName}_type`, idColumn: `${colName}_id` };
+  // Prefer the reflection's own foreignType/foreignKey to honour custom column overrides.
+  const typeColumn: string = refl.foreignType ?? `${colName}_type`;
+  const rawFk: string | string[] = refl.foreignKey ?? `${colName}_id`;
+  const idColumn = typeof rawFk === "string" ? rawFk : rawFk[0]!;
+  return { typeColumn, idColumn };
 }
 
 type BaseClass = typeof Base;
@@ -135,10 +148,11 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
   }
   const pkCol = pk;
 
-  // Register this model in the tableName registry (Phase 1b).
-  tableRegistry.set(tableName, ModelClass);
+  // Register this model in the adapter-scoped tableName registry (Phase 1b).
+  const registry = getRegistry(adapter);
+  registry.set(tableName, ModelClass);
 
-  const habtmParts = detectHabtmParts(tableName);
+  const habtmParts = detectHabtmParts(registry, tableName);
 
   const labels = Object.keys(fixtures) as K[];
 
@@ -157,9 +171,11 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
         continue;
       }
 
-      // Polymorphic belongs_to expansion: { taggable: instance } → taggable_type + taggable_id
+      // Polymorphic belongs_to expansion: { taggable: instance } → taggable_type + taggable_id.
+      // Only fires for actual model instances (constructor !== Object); plain JSON objects fall
+      // through to the normal object-with-PK handling below.
       const poly = findPolymorphicRef(ModelClass, col);
-      if (poly && val !== null && typeof val === "object") {
+      if (poly && val !== null && typeof val === "object" && (val as any).constructor !== Object) {
         const instance = val as FixtureAttrs;
         const instanceClass = (instance as any).constructor as BaseClass | undefined;
         const instancePk = (instanceClass as any)?.primaryKey ?? pkCol;

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -192,8 +192,14 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       // attempt to INSERT a non-existent column and break fixture insertion.
       const poly = findPolymorphicRef(ModelClass, col);
       if (poly) {
-        const hasExplicit = poly.typeColumn in attrs || poly.idColumn in attrs;
-        if (hasExplicit) continue; // explicit type/id win; association key is not a column
+        const hasType = poly.typeColumn in attrs;
+        const hasId = poly.idColumn in attrs;
+        if (hasType !== hasId) {
+          throw new Error(
+            `defineFixtures: "${col}" — provide both ${poly.typeColumn} and ${poly.idColumn} explicitly, or neither (use the association key instead)`,
+          );
+        }
+        if (hasType) continue; // both explicit columns present; association key is not a column
 
         if (val === null) {
           // null clears the association: mirrors Rails setting both FK columns to NULL.

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -187,12 +187,22 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       // entirely (don't write it as a spurious column) — explicit values win.
       // When neither explicit column is present, expand only actual model instances
       // (constructor must be a non-Object function; plain/null-proto objects fall through).
+      // Polymorphic belongs_to: "col" is an association name, never a real column.
+      // It must always be consumed here — falling through to `row[col] = val` would
+      // attempt to INSERT a non-existent column and break fixture insertion.
       const poly = findPolymorphicRef(ModelClass, col);
       if (poly) {
         const hasExplicit = poly.typeColumn in attrs || poly.idColumn in attrs;
-        if (hasExplicit) continue; // association key omitted; explicit columns handle it
+        if (hasExplicit) continue; // explicit type/id win; association key is not a column
+
+        if (val === null) {
+          // null clears the association: mirrors Rails setting both FK columns to NULL.
+          row[poly.idColumn] = null;
+          row[poly.typeColumn] = null;
+          continue;
+        }
+
         if (
-          val !== null &&
           typeof val === "object" &&
           typeof (val as any).constructor === "function" &&
           (val as any).constructor !== Object
@@ -213,6 +223,10 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
           row[poly.typeColumn] = typeName;
           continue;
         }
+
+        throw new Error(
+          `defineFixtures: "${col}" is a polymorphic association — pass a model instance, null, or explicit ${poly.typeColumn}/${poly.idColumn} columns`,
+        );
       }
 
       // HABTM auto-resolution: string label values for `a_id`/`b_id` columns auto-resolve.

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -71,7 +71,10 @@ function getRegistry(adapter: object): Map<string, BaseClass> {
 }
 
 /** @internal */
-export function resolveModelForTable(adapter: object, tableName: string): BaseClass | undefined {
+export function resolveModelForTable(
+  adapter: DatabaseAdapter,
+  tableName: string,
+): BaseClass | undefined {
   return getRegistry(adapter).get(tableName);
 }
 
@@ -172,15 +175,33 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       }
 
       // Polymorphic belongs_to expansion: { taggable: instance } → taggable_type + taggable_id.
-      // Only fires for actual model instances (constructor !== Object); plain JSON objects fall
-      // through to the normal object-with-PK handling below.
+      // Skipped when the caller already provided explicit type/id columns (explicit wins).
+      // Only fires for actual model instances — constructor must be a non-Object function so
+      // plain JSON objects and null-prototype objects fall through to the PK-extraction path.
       const poly = findPolymorphicRef(ModelClass, col);
-      if (poly && val !== null && typeof val === "object" && (val as any).constructor !== Object) {
+      if (
+        poly &&
+        val !== null &&
+        typeof val === "object" &&
+        !(poly.typeColumn in attrs) &&
+        !(poly.idColumn in attrs) &&
+        typeof (val as any).constructor === "function" &&
+        (val as any).constructor !== Object
+      ) {
         const instance = val as FixtureAttrs;
         const instanceClass = (instance as any).constructor as BaseClass | undefined;
-        const instancePk = (instanceClass as any)?.primaryKey ?? pkCol;
-        row[poly.idColumn] = instance[typeof instancePk === "string" ? instancePk : pkCol];
-        row[poly.typeColumn] = instanceClass?.name;
+        const instancePk = (instanceClass as any)?.primaryKey;
+        if (Array.isArray(instancePk)) {
+          throw new Error(
+            `defineFixtures: polymorphic target "${col}" has a composite primary key — pass explicit ${poly.idColumn} instead`,
+          );
+        }
+        const instancePkCol = typeof instancePk === "string" ? instancePk : "id";
+        // Mirror Rails' polymorphicName: use static polymorphicName() if defined, else class name.
+        const typeName: string =
+          (instanceClass as any)?.polymorphicName?.() ?? instanceClass?.name ?? "Unknown";
+        row[poly.idColumn] = instance[instancePkCol];
+        row[poly.typeColumn] = typeName;
         continue;
       }
 

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -156,6 +156,10 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
   registry.set(tableName, ModelClass);
 
   const habtmParts = detectHabtmParts(registry, tableName);
+  // Compute once per defineFixtures call; used for every row and column in the inner loop.
+  const habtmFkCols = habtmParts
+    ? new Set([`${singularize(habtmParts[0])}_id`, `${singularize(habtmParts[1])}_id`])
+    : null;
 
   const labels = Object.keys(fixtures) as K[];
 
@@ -175,47 +179,43 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       }
 
       // Polymorphic belongs_to expansion: { taggable: instance } → taggable_type + taggable_id.
-      // Skipped when the caller already provided explicit type/id columns (explicit wins).
-      // Only fires for actual model instances — constructor must be a non-Object function so
-      // plain JSON objects and null-prototype objects fall through to the PK-extraction path.
+      // When the caller already provided explicit type/id columns, skip the association key
+      // entirely (don't write it as a spurious column) — explicit values win.
+      // When neither explicit column is present, expand only actual model instances
+      // (constructor must be a non-Object function; plain/null-proto objects fall through).
       const poly = findPolymorphicRef(ModelClass, col);
-      if (
-        poly &&
-        val !== null &&
-        typeof val === "object" &&
-        !(poly.typeColumn in attrs) &&
-        !(poly.idColumn in attrs) &&
-        typeof (val as any).constructor === "function" &&
-        (val as any).constructor !== Object
-      ) {
-        const instance = val as FixtureAttrs;
-        const instanceClass = (instance as any).constructor as BaseClass | undefined;
-        const instancePk = (instanceClass as any)?.primaryKey;
-        if (Array.isArray(instancePk)) {
-          throw new Error(
-            `defineFixtures: polymorphic target "${col}" has a composite primary key — pass explicit ${poly.idColumn} instead`,
-          );
+      if (poly) {
+        const hasExplicit = poly.typeColumn in attrs || poly.idColumn in attrs;
+        if (hasExplicit) continue; // association key omitted; explicit columns handle it
+        if (
+          val !== null &&
+          typeof val === "object" &&
+          typeof (val as any).constructor === "function" &&
+          (val as any).constructor !== Object
+        ) {
+          const instance = val as FixtureAttrs;
+          const instanceClass = (instance as any).constructor as BaseClass | undefined;
+          const instancePk = (instanceClass as any)?.primaryKey;
+          if (Array.isArray(instancePk)) {
+            throw new Error(
+              `defineFixtures: polymorphic target "${col}" has a composite primary key — pass explicit ${poly.idColumn} instead`,
+            );
+          }
+          const instancePkCol = typeof instancePk === "string" ? instancePk : "id";
+          // Mirror Rails' polymorphicName: use static polymorphicName() if defined, else class name.
+          const typeName: string =
+            (instanceClass as any)?.polymorphicName?.() ?? instanceClass?.name ?? "Unknown";
+          row[poly.idColumn] = instance[instancePkCol];
+          row[poly.typeColumn] = typeName;
+          continue;
         }
-        const instancePkCol = typeof instancePk === "string" ? instancePk : "id";
-        // Mirror Rails' polymorphicName: use static polymorphicName() if defined, else class name.
-        const typeName: string =
-          (instanceClass as any)?.polymorphicName?.() ?? instanceClass?.name ?? "Unknown";
-        row[poly.idColumn] = instance[instancePkCol];
-        row[poly.typeColumn] = typeName;
-        continue;
       }
 
       // HABTM auto-resolution: string label values for `a_id`/`b_id` columns auto-resolve.
-      // "developers_projects" → left="developers", right="projects"; FK cols are
-      // "developer_id" and "project_id" (singularized via activesupport).
-      if (habtmParts && typeof val === "string") {
-        const [left, right] = habtmParts;
-        const leftSingular = singularize(left);
-        const rightSingular = singularize(right);
-        if (col === `${leftSingular}_id` || col === `${rightSingular}_id`) {
-          row[col] = fixtureId(val);
-          continue;
-        }
+      // FK column names are pre-computed outside the loop (habtmFkCols).
+      if (habtmFkCols && typeof val === "string" && habtmFkCols.has(col)) {
+        row[col] = fixtureId(val);
+        continue;
       }
 
       if (val !== null && typeof val === "object" && pkCol in val) {

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -5,6 +5,7 @@ import {
 import type { DatabaseAdapter } from "../adapter.js";
 import type { Base } from "../base.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
+import { singularize } from "@blazetrails/activesupport";
 
 const FIXTURE_MAX_ID = 2 ** 30 - 1;
 
@@ -54,6 +55,58 @@ export function isFixtureRef(v: unknown): v is FixtureRef {
   return typeof v === "object" && v !== null && REF_TAG in v;
 }
 
+// --- Phase 1b: tableName → ModelClass registry ---
+
+const tableRegistry = new Map<string, BaseClass>();
+
+/** @internal Exposed for testing. */
+export function resolveModelForTable(tableName: string): BaseClass | undefined {
+  return tableRegistry.get(tableName);
+}
+
+/** @internal */
+export function clearTableRegistry(): void {
+  tableRegistry.clear();
+}
+
+// --- Phase 1b: HABTM join-table detection ---
+
+/**
+ * Given a join-table name like "developers_projects", returns [singularA, singularB] if both
+ * corresponding plural table names are registered, otherwise null.
+ * @internal
+ */
+function detectHabtmParts(tableName: string): [string, string] | null {
+  const parts = tableName.split("_");
+  for (let i = 1; i < parts.length; i++) {
+    const left = parts.slice(0, i).join("_");
+    const right = parts.slice(i).join("_");
+    if (tableRegistry.has(left) && tableRegistry.has(right)) {
+      return [left, right];
+    }
+  }
+  return null;
+}
+
+// --- Phase 1b: polymorphic belongs_to detection ---
+
+interface PolymorphicBelongsTo {
+  typeColumn: string;
+  idColumn: string;
+  modelClass: BaseClass;
+}
+
+function findPolymorphicRef(modelClass: BaseClass, colName: string): PolymorphicBelongsTo | null {
+  const reflections: Record<string, any> = (modelClass as any)._reflections ?? {};
+  const refl = reflections[colName];
+  if (!refl || refl.macro !== "belongsTo" || !refl.isPolymorphic?.()) return null;
+  return {
+    typeColumn: `${colName}_type`,
+    idColumn: `${colName}_id`,
+    modelClass,
+  };
+}
+
 type BaseClass = typeof Base;
 type FixtureAttrs = Record<string, unknown>;
 type InsertHost = DatabaseStatementsHost &
@@ -64,6 +117,14 @@ type InsertHost = DatabaseStatementsHost &
  *
  * IDs are deterministic: same label → same ID across test runs, enabling cross-batch
  * FK references via `ref(tableName, label)` without insertion-order coupling.
+ *
+ * Phase 1b ergonomics (convention-over-config, additive):
+ * - HABTM join tables: string values for `a_id`/`b_id` columns auto-resolve via fixtureId()
+ *   when the table name matches the `a_b` pattern and both `a` and `b` are registered.
+ * - Polymorphic refs: `{ taggable: postInstance }` expands to `taggable_type`/`taggable_id`
+ *   when a polymorphic `belongsTo :taggable` reflection exists on the model.
+ * - `ref(tableName, label)` works without re-passing the ModelClass once any defineFixtures
+ *   call for that table has registered it.
  */
 export async function defineFixtures<T extends BaseClass, K extends string>(
   adapter: DatabaseAdapter,
@@ -79,6 +140,11 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
   }
   const pkCol = pk;
 
+  // Register this model in the tableName registry (Phase 1b).
+  tableRegistry.set(tableName, ModelClass);
+
+  const habtmParts = detectHabtmParts(tableName);
+
   const labels = Object.keys(fixtures) as K[];
 
   // Build rows with deterministic IDs and resolved references
@@ -90,12 +156,38 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
 
     for (const [col, val] of Object.entries(attrs)) {
       if (col === pkCol) continue; // deterministic ID wins; caller must not override it
+
       if (isFixtureRef(val)) {
-        const refId = fixtureId(val.fixtureName);
-        row[col] = refId;
-      } else if (val !== null && typeof val === "object" && pkCol in val) {
+        row[col] = fixtureId(val.fixtureName);
+        continue;
+      }
+
+      // Polymorphic belongs_to expansion: { taggable: instance } → taggable_type + taggable_id
+      const poly = findPolymorphicRef(ModelClass, col);
+      if (poly && val !== null && typeof val === "object") {
+        const instance = val as FixtureAttrs;
+        const instancePk = (instance.constructor as any)?.primaryKey ?? pkCol;
+        const instanceClass = (instance as any).constructor as BaseClass | undefined;
+        row[poly.idColumn] = instance[typeof instancePk === "string" ? instancePk : pkCol];
+        row[poly.typeColumn] = instanceClass?.name ?? String((instance as any).constructor);
+        continue;
+      }
+
+      // HABTM auto-resolution: string label values for `a_id`/`b_id` columns auto-resolve.
+      // "developers_projects" → left="developers", right="projects"; FK cols are
+      // "developer_id" and "project_id" (naive singularize: strip trailing "s").
+      if (habtmParts && typeof val === "string") {
+        const [left, right] = habtmParts;
+        const leftSingular = singularize(left);
+        const rightSingular = singularize(right);
+        if (col === `${leftSingular}_id` || col === `${rightSingular}_id`) {
+          row[col] = fixtureId(val);
+          continue;
+        }
+      }
+
+      if (val !== null && typeof val === "object" && pkCol in val) {
         // Model instance (or any object with the PK): extract the PK value.
-        // Use ref() if a plain JSON column could be confused for an instance.
         row[col] = (val as FixtureAttrs)[pkCol];
       } else {
         row[col] = val;

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -93,18 +93,13 @@ function detectHabtmParts(tableName: string): [string, string] | null {
 interface PolymorphicBelongsTo {
   typeColumn: string;
   idColumn: string;
-  modelClass: BaseClass;
 }
 
 function findPolymorphicRef(modelClass: BaseClass, colName: string): PolymorphicBelongsTo | null {
   const reflections: Record<string, any> = (modelClass as any)._reflections ?? {};
   const refl = reflections[colName];
   if (!refl || refl.macro !== "belongsTo" || !refl.isPolymorphic?.()) return null;
-  return {
-    typeColumn: `${colName}_type`,
-    idColumn: `${colName}_id`,
-    modelClass,
-  };
+  return { typeColumn: `${colName}_type`, idColumn: `${colName}_id` };
 }
 
 type BaseClass = typeof Base;
@@ -123,8 +118,8 @@ type InsertHost = DatabaseStatementsHost &
  *   when the table name matches the `a_b` pattern and both `a` and `b` are registered.
  * - Polymorphic refs: `{ taggable: postInstance }` expands to `taggable_type`/`taggable_id`
  *   when a polymorphic `belongsTo :taggable` reflection exists on the model.
- * - `ref(tableName, label)` works without re-passing the ModelClass once any defineFixtures
- *   call for that table has registered it.
+ * - Each call registers `ModelClass` by `tableName` in an internal registry, available via
+ *   `resolveModelForTable` for use by HABTM detection and future Phase 2 tooling.
  */
 export async function defineFixtures<T extends BaseClass, K extends string>(
   adapter: DatabaseAdapter,
@@ -166,16 +161,16 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       const poly = findPolymorphicRef(ModelClass, col);
       if (poly && val !== null && typeof val === "object") {
         const instance = val as FixtureAttrs;
-        const instancePk = (instance.constructor as any)?.primaryKey ?? pkCol;
         const instanceClass = (instance as any).constructor as BaseClass | undefined;
+        const instancePk = (instanceClass as any)?.primaryKey ?? pkCol;
         row[poly.idColumn] = instance[typeof instancePk === "string" ? instancePk : pkCol];
-        row[poly.typeColumn] = instanceClass?.name ?? String((instance as any).constructor);
+        row[poly.typeColumn] = instanceClass?.name;
         continue;
       }
 
       // HABTM auto-resolution: string label values for `a_id`/`b_id` columns auto-resolve.
       // "developers_projects" → left="developers", right="projects"; FK cols are
-      // "developer_id" and "project_id" (naive singularize: strip trailing "s").
+      // "developer_id" and "project_id" (singularized via activesupport).
       if (habtmParts && typeof val === "string") {
         const [left, right] = habtmParts;
         const leftSingular = singularize(left);

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -216,10 +216,16 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
             );
           }
           const instancePkCol = typeof instancePk === "string" ? instancePk : "id";
+          const pkValue = instance[instancePkCol];
+          if (pkValue === undefined) {
+            throw new Error(
+              `defineFixtures: polymorphic target "${col}" has no value for PK column "${instancePkCol}" — ensure the instance exposes its primary key`,
+            );
+          }
           // Mirror Rails' polymorphicName: use static polymorphicName() if defined, else class name.
           const typeName: string =
             (instanceClass as any)?.polymorphicName?.() ?? instanceClass?.name ?? "Unknown";
-          row[poly.idColumn] = instance[instancePkCol];
+          row[poly.idColumn] = pkValue;
           row[poly.typeColumn] = typeName;
           continue;
         }

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -116,7 +116,7 @@ function findPolymorphicRef(modelClass: BaseClass, colName: string): Polymorphic
   const rawFk: string | string[] = refl.foreignKey ?? `${colName}_id`;
   if (Array.isArray(rawFk)) {
     throw new Error(
-      `defineFixtures: polymorphic association "${colName}" has a composite foreignKey — pass explicit ${rawFk.join(", ")} instead`,
+      `defineFixtures: polymorphic association "${colName}" has a composite foreignKey — pass explicit ${typeColumn}, ${rawFk.join(", ")} instead`,
     );
   }
   return { typeColumn, idColumn: rawFk };
@@ -218,7 +218,7 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
           const instancePk = (instanceClass as any)?.primaryKey;
           if (Array.isArray(instancePk)) {
             throw new Error(
-              `defineFixtures: polymorphic target "${col}" has a composite primary key — pass explicit ${poly.idColumn} instead`,
+              `defineFixtures: polymorphic target "${col}" has a composite primary key — pass explicit ${poly.typeColumn} and ${poly.idColumn} instead`,
             );
           }
           const instancePkCol = typeof instancePk === "string" ? instancePk : "id";

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -114,8 +114,12 @@ function findPolymorphicRef(modelClass: BaseClass, colName: string): Polymorphic
   // Prefer the reflection's own foreignType/foreignKey to honour custom column overrides.
   const typeColumn: string = refl.foreignType ?? `${colName}_type`;
   const rawFk: string | string[] = refl.foreignKey ?? `${colName}_id`;
-  const idColumn = typeof rawFk === "string" ? rawFk : rawFk[0]!;
-  return { typeColumn, idColumn };
+  if (Array.isArray(rawFk)) {
+    throw new Error(
+      `defineFixtures: polymorphic association "${colName}" has a composite foreignKey — pass explicit ${rawFk.join(", ")} instead`,
+    );
+  }
+  return { typeColumn, idColumn: rawFk };
 }
 
 type BaseClass = typeof Base;


### PR DESCRIPTION
## Summary

- **tableName registry**: `defineFixtures` registers each model by `tableName`; `resolveModelForTable(adapter, name)` retrieves it. Registry is scoped per adapter via `WeakMap` to prevent cross-file leakage between tests.
- **HABTM join-table auto-detection**: when `defineFixtures` is called for a table whose name matches the `a_b` pattern and both `a` and `b` are already registered with the same adapter, string values for `singular_a_id` / `singular_b_id` columns auto-resolve via `fixtureId()`. FK column names are pre-computed once via `singularize` from `@blazetrails/activesupport`.
- **Polymorphic `belongsTo` expansion**: when a row attribute name matches a `polymorphic: true` `belongsTo` reflection on the model, a passed-in record instance auto-expands to `${name}_type` / `${name}_id` using the reflection's `foreignType`/`foreignKey` (honours custom column overrides). Handles: `null` (clears both FK columns), model instances (uses `polymorphicName()` if defined), explicit type+id passthrough (both must be provided together), and throws on composite FK, undefined PK, or unrecognised values.

Phase 1's public API (`defineFixtures`, `ref`, `fixtureId`) is unchanged — all new behaviour is additive/convention-over-config.

## Known limitation (follow-up)

Passing a `ref()` sentinel as a polymorphic association key (e.g. `{ taggable: ref("posts", "welcome") }`) is not supported and will silently insert a spurious `taggable` column because `isFixtureRef` runs before the polymorphic check. `ref()` resolves to an integer ID and cannot expand to both a type and id column. A future PR should detect this combination and throw a clear error.

## Test plan

- [ ] `pnpm test packages/activerecord/src/test-helpers/define-fixtures.test.ts` — 18 tests pass
- [ ] `pnpm api:compare --package activerecord` — 99.9% unchanged