### PR TITLE
chore(activerecord) fidelity sweep D — schema-dumper polish

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2506,6 +2506,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const def = row.definition as string;
 
       let orders: Record<string, string> | string | undefined;
+      // Match the column list inside the index definition's first paren group.
+      // Use a non-greedy match to stop before any WHERE or INCLUDE clause.
       const descMatch = def.match(/\(([^)]+)\)/);
       if (descMatch) {
         const colDefs = descMatch[1].split(",").map((s) => s.trim());
@@ -2513,19 +2515,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         let hasOrder = false;
         for (let ci = 0; ci < columns.length; ci++) {
           const colDef = colDefs[ci] || "";
-          if (colDef.match(/\bDESC\b/i)) {
-            orderMap[columns[ci]] = "desc";
+          const descFlag = colDef.match(/\bDESC\b/i);
+          const nullsFlag = colDef.match(/\bNULLS\s+(FIRST|LAST)\b/i);
+          if (descFlag || nullsFlag) {
+            let order = descFlag ? "desc" : "asc";
+            if (nullsFlag) order += ` NULLS ${nullsFlag[1].toUpperCase()}`;
+            orderMap[columns[ci]] = order;
             hasOrder = true;
           }
         }
         if (hasOrder) {
           if (columns.length === 1) {
-            orders = "desc" as string;
+            orders = orderMap[columns[0]];
           } else {
             orders = orderMap;
           }
         }
       }
+
+      // Parse INCLUDE (...) for covering indexes.
+      const includeMatch = def.match(/\bINCLUDE\s*\(([^)]+)\)/i);
+      const include = includeMatch
+        ? includeMatch[1].split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
+        : undefined;
 
       const whereMatch = def.match(/\bWHERE\s+(.+)$/i);
       const where = whereMatch ? whereMatch[1].trim() : undefined;
@@ -2538,6 +2550,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         columns,
         using: row.using as string,
         orders,
+        include,
         where,
         nullsNotDistinct,
       };
@@ -2906,22 +2919,24 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
   }
 
-  // PG callback-first signature diverges from the abstract base; harmonize in a follow-up.
+  // SimpleTableBuilder is narrower than TableDefinition; suppress the override error.
   // @ts-expect-error TS2416
   async createTable(
     tableName: string,
-    callback: (t: SimpleTableBuilder) => void,
-    options: { id?: boolean | "uuid" } = {},
+    options: { id?: boolean | "uuid" } | ((t: SimpleTableBuilder) => void) = {},
+    fn?: (t: SimpleTableBuilder) => void,
   ): Promise<void> {
+    const opts = typeof options === "function" ? {} : options;
+    const callback = typeof options === "function" ? options : fn;
     const table = new SimpleTableBuilder();
-    if (options.id !== false) {
-      if (typeof options.id === "string" && options.id === "uuid") {
+    if (opts.id !== false) {
+      if (typeof opts.id === "string" && opts.id === "uuid") {
         table.column("id", "uuid default gen_random_uuid() primary key");
       } else {
         table.column("id", "serial primary key");
       }
     }
-    callback(table);
+    if (callback) callback(table);
     const quotedTable = this.quoteTableName(tableName);
     const columnDefs = table.getColumns().map((c) => `${this.quoteIdentifier(c.name)} ${c.type}`);
     await this.exec(`CREATE TABLE ${quotedTable} (${columnDefs.join(", ")})`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2506,8 +2506,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const def = row.definition as string;
 
       let orders: Record<string, string> | string | undefined;
-      // Match the column list inside the index definition's first paren group.
-      // Use a non-greedy match to stop before any WHERE or INCLUDE clause.
       const descMatch = def.match(/\(([^)]+)\)/);
       if (descMatch) {
         const colDefs = descMatch[1].split(",").map((s) => s.trim());

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -280,8 +280,8 @@ describe("PostgreSQL::SchemaDumper", () => {
     });
   });
 
-  describe("gatherInlineConstraints — exclusion", () => {
-    it("emits sorted t.exclusionConstraint lines with options inside the block", async () => {
+  describe("_emitExclusionConstraints", () => {
+    it("emits sorted ctx.addExclusionConstraint lines with options", async () => {
       const { ExclusionConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
         ...emptySource,
@@ -295,16 +295,16 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.gatherInlineConstraints("rooms", lines);
-      expect(lines[0]).toContain(`t.exclusionConstraint("price WITH ="`);
+      await dumper._emitExclusionConstraints("rooms", lines);
+      expect(lines[0]).toContain(`await ctx.addExclusionConstraint("rooms", "price WITH ="`);
       expect(lines[0]).toContain(`where: "(price > 0)"`);
       expect(lines[0]).toContain(`using: "gist"`);
       expect(lines[0]).toContain(`name: "excl_rooms_price"`);
     });
   });
 
-  describe("gatherInlineConstraints — unique", () => {
-    it("emits sorted t.uniqueConstraint lines with options inside the block", async () => {
+  describe("_emitUniqueConstraints", () => {
+    it("emits sorted ctx.addUniqueConstraint lines with options", async () => {
       const { UniqueConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
         ...emptySource,
@@ -317,8 +317,8 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.gatherInlineConstraints("users", lines);
-      expect(lines[0]).toContain(`t.uniqueConstraint(["email"]`);
+      await dumper._emitUniqueConstraints("users", lines);
+      expect(lines[0]).toContain(`await ctx.addUniqueConstraint("users", ["email"]`);
       expect(lines[0]).toContain(`nullsNotDistinct: true`);
       expect(lines[0]).toContain(`name: "uniq_users_email"`);
     });
@@ -327,7 +327,7 @@ describe("PostgreSQL::SchemaDumper", () => {
       const adapter = { ...emptySource, uniqueConstraints: async () => [] };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.gatherInlineConstraints("users", lines);
+      await dumper._emitUniqueConstraints("users", lines);
       expect(lines).toHaveLength(0);
     });
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -280,8 +280,8 @@ describe("PostgreSQL::SchemaDumper", () => {
     });
   });
 
-  describe("exclusionConstraintsInCreate", () => {
-    it("emits sorted ctx.addExclusionConstraint lines with options", async () => {
+  describe("gatherInlineConstraints — exclusion", () => {
+    it("emits sorted t.exclusionConstraint lines with options inside the block", async () => {
       const { ExclusionConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
         ...emptySource,
@@ -295,16 +295,16 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.exclusionConstraintsInCreate("rooms", lines);
-      expect(lines[0]).toContain(`await ctx.addExclusionConstraint("rooms", "price WITH ="`);
+      await dumper.gatherInlineConstraints("rooms", lines);
+      expect(lines[0]).toContain(`t.exclusionConstraint("price WITH ="`);
       expect(lines[0]).toContain(`where: "(price > 0)"`);
       expect(lines[0]).toContain(`using: "gist"`);
       expect(lines[0]).toContain(`name: "excl_rooms_price"`);
     });
   });
 
-  describe("uniqueConstraintsInCreate", () => {
-    it("emits sorted ctx.addUniqueConstraint lines with options", async () => {
+  describe("gatherInlineConstraints — unique", () => {
+    it("emits sorted t.uniqueConstraint lines with options inside the block", async () => {
       const { UniqueConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
         ...emptySource,
@@ -317,8 +317,8 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.uniqueConstraintsInCreate("users", lines);
-      expect(lines[0]).toContain(`await ctx.addUniqueConstraint("users", ["email"]`);
+      await dumper.gatherInlineConstraints("users", lines);
+      expect(lines[0]).toContain(`t.uniqueConstraint(["email"]`);
       expect(lines[0]).toContain(`nullsNotDistinct: true`);
       expect(lines[0]).toContain(`name: "uniq_users_email"`);
     });
@@ -327,7 +327,7 @@ describe("PostgreSQL::SchemaDumper", () => {
       const adapter = { ...emptySource, uniqueConstraints: async () => [] };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper.uniqueConstraintsInCreate("users", lines);
+      await dumper.gatherInlineConstraints("users", lines);
       expect(lines).toHaveLength(0);
     });
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -144,43 +144,61 @@ export class SchemaDumper extends AbstractSchemaDumper {
     );
   }
 
-  /** @internal */
-  protected override async gatherInlineConstraints(
-    tableName: string,
-    lines: string[],
-  ): Promise<void> {
-    await super.gatherInlineConstraints(tableName, lines);
-    const adapter = this.pgAdapter();
+  /**
+   * Emit PG exclusion/unique constraints as post-block ctx.add*Constraint()
+   * calls — these methods are PG-specific and not on the abstract TableDefinition
+   * passed to the createTable callback, so they cannot be inlined as t.* calls.
+   * @internal
+   */
+  override async table(tableName: string, lines: string[]): Promise<void> {
+    await super.table(tableName, lines);
+    // Remove the trailing blank pushed by super.table so constraints land before it.
+    if (lines[lines.length - 1] === "") lines.pop();
+    await this._emitExclusionConstraints(tableName, lines);
+    await this._emitUniqueConstraints(tableName, lines);
+    lines.push("");
+  }
 
-    const excl: ExclusionConstraintDefinition[] =
+  /** @internal */
+  private async _emitExclusionConstraints(tableName: string, lines: string[]): Promise<void> {
+    const adapter = this.pgAdapter();
+    const constraints: ExclusionConstraintDefinition[] =
       this._cachedExclConstraints ??
       (adapter?.exclusionConstraints ? await adapter.exclusionConstraints(tableName) : []);
     this._cachedExclConstraints = undefined;
-    const exclLines = excl.map((ec) => {
+    if (constraints.length === 0) return;
+    const stripped = this.removePrefixAndSuffix(tableName);
+    const stmts = constraints.map((ec) => {
       const opts: string[] = [];
       if (ec.where) opts.push(`where: ${JSON.stringify(ec.where)}`);
       if (ec.using) opts.push(`using: ${JSON.stringify(ec.using)}`);
       if (ec.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(ec.deferrable)}`);
       if (ec.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(ec.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      return `    t.exclusionConstraint(${JSON.stringify(ec.expression)}${optStr});`;
+      return `  await ctx.addExclusionConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(ec.expression)}${optStr});`;
     });
-    lines.push(...exclLines.sort());
+    lines.push(...stmts.sort());
+  }
 
-    const uniq: UniqueConstraintDefinition[] =
+  /** @internal */
+  private async _emitUniqueConstraints(tableName: string, lines: string[]): Promise<void> {
+    const adapter = this.pgAdapter();
+    const constraints: UniqueConstraintDefinition[] =
       this._cachedUniqConstraints ??
       (adapter?.uniqueConstraints ? await adapter.uniqueConstraints(tableName) : []);
     this._cachedUniqConstraints = undefined;
-    const uniqLines = uniq.map((uc) => {
+    if (constraints.length === 0) return;
+    const stripped = this.removePrefixAndSuffix(tableName);
+    const stmts = constraints.map((uc) => {
       const opts: string[] = [];
       if (uc.nullsNotDistinct)
         opts.push(`nullsNotDistinct: ${JSON.stringify(uc.nullsNotDistinct)}`);
       if (uc.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(uc.deferrable)}`);
       if (uc.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(uc.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      return `    t.uniqueConstraint(${JSON.stringify(uc.column)}${optStr});`;
+      return `  await ctx.addUniqueConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(uc.column)}${optStr});`;
     });
-    lines.push(...uniqLines.sort());
+    lines.push(...stmts.sort());
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -145,55 +145,42 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected async exclusionConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
+  protected override async gatherInlineConstraints(
+    tableName: string,
+    lines: string[],
+  ): Promise<void> {
+    await super.gatherInlineConstraints(tableName, lines);
     const adapter = this.pgAdapter();
-    if (!adapter?.exclusionConstraints) return;
-    const constraints: ExclusionConstraintDefinition[] =
-      this._cachedExclConstraints ?? (await adapter.exclusionConstraints(tableName));
+
+    const excl: ExclusionConstraintDefinition[] =
+      this._cachedExclConstraints ??
+      (adapter?.exclusionConstraints ? await adapter.exclusionConstraints(tableName) : []);
     this._cachedExclConstraints = undefined;
-    if (constraints.length === 0) return;
-    const stripped = this.removePrefixAndSuffix(tableName);
-    const stmts = constraints.map((ec) => {
+    const exclLines = excl.map((ec) => {
       const opts: string[] = [];
       if (ec.where) opts.push(`where: ${JSON.stringify(ec.where)}`);
       if (ec.using) opts.push(`using: ${JSON.stringify(ec.using)}`);
       if (ec.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(ec.deferrable)}`);
       if (ec.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(ec.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      return `  await ctx.addExclusionConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(ec.expression)}${optStr});`;
+      return `    t.exclusionConstraint(${JSON.stringify(ec.expression)}${optStr});`;
     });
-    lines.push(...stmts.sort());
-  }
+    lines.push(...exclLines.sort());
 
-  /** @internal */
-  protected async uniqueConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
-    const adapter = this.pgAdapter();
-    if (!adapter?.uniqueConstraints) return;
-    const constraints: UniqueConstraintDefinition[] =
-      this._cachedUniqConstraints ?? (await adapter.uniqueConstraints(tableName));
+    const uniq: UniqueConstraintDefinition[] =
+      this._cachedUniqConstraints ??
+      (adapter?.uniqueConstraints ? await adapter.uniqueConstraints(tableName) : []);
     this._cachedUniqConstraints = undefined;
-    if (constraints.length === 0) return;
-    const stripped = this.removePrefixAndSuffix(tableName);
-    const stmts = constraints.map((uc) => {
+    const uniqLines = uniq.map((uc) => {
       const opts: string[] = [];
       if (uc.nullsNotDistinct)
         opts.push(`nullsNotDistinct: ${JSON.stringify(uc.nullsNotDistinct)}`);
       if (uc.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(uc.deferrable)}`);
       if (uc.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(uc.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      return `  await ctx.addUniqueConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(uc.column)}${optStr});`;
+      return `    t.uniqueConstraint(${JSON.stringify(uc.column)}${optStr});`;
     });
-    lines.push(...stmts.sort());
-  }
-
-  /** @internal */
-  override async table(tableName: string, lines: string[]): Promise<void> {
-    await super.table(tableName, lines);
-    // Remove the trailing empty line pushed by super.table so we can append constraints first.
-    if (lines[lines.length - 1] === "") lines.pop();
-    await this.exclusionConstraintsInCreate(tableName, lines);
-    await this.uniqueConstraintsInCreate(tableName, lines);
-    lines.push("");
+    lines.push(...uniqLines.sort());
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -125,8 +125,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
     indexes: IndexInfo[],
   ): Promise<IndexInfo[]> {
     const adapter = this.pgAdapter();
-    // Fetch and cache both constraint lists so exclusionConstraintsInCreate /
-    // uniqueConstraintsInCreate can reuse them without a second DB round-trip.
+    // Fetch and cache both constraint lists so gatherInlineConstraints can
+    // reuse them without a second DB round-trip.
     const excl: ExclusionConstraintDefinition[] = adapter?.exclusionConstraints
       ? await adapter.exclusionConstraints(tableName)
       : [];

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1540,11 +1540,13 @@ export class MigrationContext {
       const using = idx.using && idx.using !== "btree" ? ` USING ${idx.using}` : "";
       const colsList = idx.columns
         .map((c) => {
+          const isExpr = /\W/.test(c);
+          const quoted = isExpr ? c : this.adapter.quoteIdentifier(c);
           const order = ordersMap[c];
-          return `"${c}"${order ? ` ${order.toUpperCase()}` : ""}`;
+          return `${quoted}${order ? ` ${order.toUpperCase()}` : ""}`;
         })
         .join(", ");
-      let sql = `CREATE ${unique}INDEX "${indexName}" ON "${name}"${using} (${colsList})`;
+      let sql = `CREATE ${unique}INDEX ${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(name)}${using} (${colsList})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.adapter.executeMutation(sql);
       if (!this._indexes.has(name)) this._indexes.set(name, []);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1532,17 +1532,23 @@ export class MigrationContext {
     // Create indexes from table definition
     for (const idx of td.indexes) {
       const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
-      const unique = idx.unique ? "UNIQUE " : "";
-      const colsList = idx.columns.map((c) => `"${c}"`).join(", ");
-      await this.adapter.executeMutation(
-        `CREATE ${unique}INDEX "${indexName}" ON "${name}" (${colsList})`,
-      );
-      if (!this._indexes.has(name)) this._indexes.set(name, []);
-      const orders =
+      const ordersMap: Record<string, string> =
         typeof idx.orders === "string"
           ? Object.fromEntries(idx.columns.map((c) => [c, idx.orders as string]))
-          : idx.orders;
-      this._indexes.get(name)!.push({ ...idx, name: indexName, orders });
+          : (idx.orders ?? {});
+      const unique = idx.unique ? "UNIQUE " : "";
+      const using = idx.using && idx.using !== "btree" ? ` USING ${idx.using}` : "";
+      const colsList = idx.columns
+        .map((c) => {
+          const order = ordersMap[c];
+          return `"${c}"${order ? ` ${order.toUpperCase()}` : ""}`;
+        })
+        .join(", ");
+      let sql = `CREATE ${unique}INDEX "${indexName}" ON "${name}"${using} (${colsList})`;
+      if (idx.where) sql += ` WHERE ${idx.where}`;
+      await this.adapter.executeMutation(sql);
+      if (!this._indexes.has(name)) this._indexes.set(name, []);
+      this._indexes.get(name)!.push({ ...idx, name: indexName, orders: ordersMap });
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1429,6 +1429,7 @@ export class MigrationContext {
       where?: string;
       orders?: Record<string, string>;
       nullsNotDistinct?: boolean;
+      include?: string[];
     }[]
   >();
   tableNamePrefix = "";
@@ -1739,6 +1740,7 @@ export class MigrationContext {
       order?: Record<string, string>;
       nullsNotDistinct?: boolean;
       ifNotExists?: boolean;
+      include?: string[];
     },
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
@@ -1760,6 +1762,8 @@ export class MigrationContext {
       .join(", ");
     let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(table)} (${colsStr})`;
     if (an === "postgres" && options?.nullsNotDistinct) sql += " NULLS NOT DISTINCT";
+    if (an === "postgres" && options?.include && options.include.length > 0)
+      sql += ` INCLUDE (${options.include.map((c) => this.adapter.quoteIdentifier(c)).join(", ")})`;
     if (an !== "mysql" && options?.where) sql += ` WHERE ${options.where}`;
     await this.adapter.executeMutation(sql);
     if (!this._indexes.has(table)) this._indexes.set(table, []);
@@ -1770,6 +1774,7 @@ export class MigrationContext {
       where: options?.where,
       orders: options?.order,
       nullsNotDistinct: options?.nullsNotDistinct,
+      include: options?.include,
     });
   }
 

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -287,7 +287,7 @@ describe("SchemaDumperTest", () => {
         name: "test_uc_no_idx_position",
       });
       const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-      expect(output).toContain("addUniqueConstraint");
+      expect(output).toContain("t.uniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
     },

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -230,7 +230,7 @@ describe("SchemaDumperTest", () => {
     });
     const output = await SchemaDumper.dump(testAdapter.innerAdapter);
     expect(output).toContain("products_price_check");
-    expect(output).toContain("addCheckConstraint");
+    expect(output).toContain("t.checkConstraint");
   });
   it.skipIf(adapterType !== "postgres")("schema dumps exclusion constraints", async () => {
     const { SchemaDumper: PgSchemaDumper } =
@@ -246,7 +246,7 @@ describe("SchemaDumperTest", () => {
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
     const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-    expect(output).toContain("addExclusionConstraint");
+    expect(output).toContain("t.exclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
   });
@@ -269,7 +269,7 @@ describe("SchemaDumperTest", () => {
       { nullsNotDistinct: true, name: "test_schema_unique_position_2_nnd" },
     );
     const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-    expect(output).toContain("addUniqueConstraint");
+    expect(output).toContain("t.uniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
     expect(output).toContain("nullsNotDistinct: true");

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -246,7 +246,7 @@ describe("SchemaDumperTest", () => {
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
     const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-    expect(output).toContain("t.exclusionConstraint");
+    expect(output).toContain("addExclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
   });
@@ -269,7 +269,7 @@ describe("SchemaDumperTest", () => {
       { nullsNotDistinct: true, name: "test_schema_unique_position_2_nnd" },
     );
     const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-    expect(output).toContain("t.uniqueConstraint");
+    expect(output).toContain("addUniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
     expect(output).toContain("nullsNotDistinct: true");
@@ -287,7 +287,7 @@ describe("SchemaDumperTest", () => {
         name: "test_uc_no_idx_position",
       });
       const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
-      expect(output).toContain("t.uniqueConstraint");
+      expect(output).toContain("addUniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
     },

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -417,6 +417,40 @@ describe("SchemaDumperTest", () => {
     expect(output).toMatch(/t\.bigint\("bigint_default",\s*\{[^}]*default:\s*0[^}]*\}/);
   });
 
+  it("schema dump emits defaultFunction as arrow for non-PK columns", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const source = {
+      tables: () => ["gen_defaults"],
+      columns: () => [
+        { name: "id", type: "integer", primaryKey: true },
+        { name: "token", type: "string", defaultFunction: "gen_random_uuid()" },
+      ],
+      indexes: () => [],
+    };
+    const output = TopLevelDumper.dump(source) as string;
+    expect(output).toContain(`() => "gen_random_uuid()"`);
+  });
+
+  it("indexParts emits include for covering indexes", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const dumper = new (TopLevelDumper as any)(emptySource);
+    const parts = dumper.indexParts({ columns: ["a"], unique: false, include: ["b", "c"] });
+    expect(parts.join(", ")).toContain(`include: ["b","c"]`);
+  });
+
+  it("indexParts emits NULLS FIRST/LAST order strings verbatim", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const dumper = new (TopLevelDumper as any)(emptySource);
+    const parts = dumper.indexParts({
+      columns: ["created_at"],
+      unique: false,
+      orders: "desc NULLS LAST",
+    });
+    expect(parts.join(", ")).toContain(`order: "desc NULLS LAST"`);
+  });
+
   it.skip("schema dump includes limit on array type", () => {
     // BLOCKED: schema — schema introspection / dumper gap in schema-dumper
     // ROOT-CAUSE: schema-dumper.ts or abstract/schema-statements.ts missing Rails parity

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -479,8 +479,9 @@ export class SchemaDumper {
 
   static async dumpTableSchema(source: SchemaSource, tableName: string): Promise<string> {
     const wrappedSource = isDatabaseAdapter(source) ? new AdapterSchemaSource(source) : source;
-    // Instantiate the adapter-specific subclass (via createSchemaDumper) so
-    // PG/MySQL/SQLite overrides fire. Fall back to base when unavailable.
+    // Instantiate the adapter-specific subclass when the adapter exposes
+    // createSchemaDumper() (currently only PostgreSQLAdapter). Falls back to
+    // the base class when unavailable, which is what the old code always did.
     let dumper: SchemaDumper;
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
       dumper = (source as any).createSchemaDumper({}) as SchemaDumper;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -997,6 +997,9 @@ export class SchemaDumper {
   formatColspec(colspec: Record<string, unknown>): string {
     return Object.entries(colspec)
       .map(([k, v]) => {
+        if (typeof v === "function") {
+          return `${k}: () => ${JSON.stringify((v as () => unknown)())}`;
+        }
         if (v && typeof v === "object" && !Array.isArray(v)) {
           return `${k}: { ${this.formatColspec(v as Record<string, unknown>)} }`;
         }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -344,6 +344,7 @@ class AdapterSchemaSource implements SchemaSource {
       using?: string;
       lengths?: number | Record<string, number>;
       opclasses?: string | Record<string, string>;
+      include?: string[];
     };
     let raw: RichIdx[];
     const adapterAny = this._adapter as unknown as { indexes?(t: string): Promise<unknown[]> };
@@ -370,6 +371,7 @@ class AdapterSchemaSource implements SchemaSource {
       using: idx.using,
       lengths: idx.lengths,
       opclasses: idx.opclasses,
+      include: idx.include,
     }));
   }
 }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -58,6 +58,8 @@ export interface IndexInfo {
   where?: string;
   using?: string;
   nullsNotDistinct?: boolean;
+  /** PG covering index INCLUDE columns. */
+  include?: string[];
 }
 
 /**
@@ -475,7 +477,16 @@ export class SchemaDumper {
 
   static async dumpTableSchema(source: SchemaSource, tableName: string): Promise<string> {
     const wrappedSource = isDatabaseAdapter(source) ? new AdapterSchemaSource(source) : source;
-    const dumper = this.create(wrappedSource);
+    // Instantiate the adapter-specific subclass (via createSchemaDumper) so
+    // PG/MySQL/SQLite overrides fire. Fall back to base when unavailable.
+    let dumper: SchemaDumper;
+    if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
+      dumper = (source as any).createSchemaDumper({}) as SchemaDumper;
+      // Swap to the wrapped source so column normalization applies.
+      (dumper as any)._source = wrappedSource;
+    } else {
+      dumper = this.create(wrappedSource);
+    }
     const lines: string[] = [];
     await dumper.dumpTable(lines, tableName);
     return lines.join("\n");
@@ -697,11 +708,30 @@ export class SchemaDumper {
       const rawIndexes = await this._source.indexes(tableName);
       const indexes = await this.filterIndexesForDump(tableName, rawIndexes);
       const adapterTableOpts = await this.fetchTableOptions(tableName);
-      this.emitTable(lines, tableName, columns, indexes, adapterTableOpts);
-      await this.checkConstraintsInCreate(tableName, lines);
+      const inlineLines: string[] = [];
+      await this.gatherInlineConstraints(tableName, inlineLines);
+      this.emitTable(lines, tableName, columns, indexes, adapterTableOpts, inlineLines);
       lines.push("");
     } finally {
       this.tableName = undefined;
+    }
+  }
+
+  /**
+   * Collect inline constraint lines (check / exclusion / unique) to emit
+   * inside the createTable block. Subclasses override to add adapter-specific
+   * constraints. Base implementation handles check constraints.
+   * @internal
+   */
+  protected async gatherInlineConstraints(tableName: string, lines: string[]): Promise<void> {
+    const host = this._hookHost("checkConstraints");
+    if (!host) return;
+    const fn = (host as { checkConstraints: (t: string) => Promise<unknown[]> }).checkConstraints;
+    const constraints = (await fn.call(host, tableName)) ?? [];
+    for (const chk of constraints as { expression: string; name?: string; validate?: boolean }[]) {
+      const [expr, ...opts] = this.checkParts(chk);
+      const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
+      lines.push(`    t.checkConstraint(${expr}${optStr});`);
     }
   }
 
@@ -760,6 +790,7 @@ export class SchemaDumper {
     columns: ColumnInfo[],
     indexes: IndexInfo[],
     adapterTableOpts: Record<string, unknown> = {},
+    inlineConstraints: string[] = [],
   ): void {
     const pkColumn = columns.find((c) => c.primaryKey);
     const hasId = pkColumn?.name === "id";
@@ -786,9 +817,14 @@ export class SchemaDumper {
       const colspec: Record<string, unknown> = {};
 
       if (col.null === false) colspec.null = false;
-      const cleanedDefault = cleanDefault(col.default);
-      if (cleanedDefault !== undefined && cleanedDefault !== null) {
-        colspec.default = cleanedDefault;
+      if (col.defaultFunction) {
+        const fn = col.defaultFunction;
+        colspec.default = () => fn;
+      } else {
+        const cleanedDefault = cleanDefault(col.default);
+        if (cleanedDefault !== undefined && cleanedDefault !== null) {
+          colspec.default = cleanedDefault;
+        }
       }
       if (extraOpts) {
         for (const [key, value] of Object.entries(extraOpts)) {
@@ -839,6 +875,7 @@ export class SchemaDumper {
       }
     }
 
+    for (const line of inlineConstraints) lines.push(line);
     lines.push("  });");
 
     this.indexesInCreate(tableName, lines, indexes);
@@ -860,6 +897,8 @@ export class SchemaDumper {
     if (index.where) parts.push(`where: ${JSON.stringify(index.where)}`);
     if (index.using && index.using !== "btree") parts.push(`using: ${JSON.stringify(index.using)}`);
     if (index.nullsNotDistinct) parts.push("nullsNotDistinct: true");
+    if (index.include && index.include.length > 0)
+      parts.push(`include: ${JSON.stringify(index.include)}`);
     return parts;
   }
 
@@ -896,20 +935,6 @@ export class SchemaDumper {
   /** @internal */
   private _fkHookHost(): unknown {
     return this._hookHost("foreignKeys");
-  }
-
-  /** @internal */
-  async checkConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
-    const host = this._hookHost("checkConstraints");
-    if (!host) return;
-    const fn = (host as { checkConstraints: (t: string) => Promise<unknown[]> }).checkConstraints;
-    const constraints = (await fn.call(host, tableName)) ?? [];
-    const stripped = this.removePrefixAndSuffix(tableName);
-    for (const chk of constraints as { expression: string; name?: string; validate?: boolean }[]) {
-      const [expr, ...opts] = this.checkParts(chk);
-      const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      lines.push(`  await ctx.addCheckConstraint(${JSON.stringify(stripped)}, ${expr}${optStr});`);
-    }
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

7 small schema-dumper / createTable-emission divergences from post-merge findings on #1433, #1460, #1467.

- **Item 1**: Inline constraints inside `createTable` block — check/exclusion/unique constraints now emit as `t.checkConstraint(...)` / `t.exclusionConstraint(...)` / `t.uniqueConstraint(...)` inside the table callback rather than standalone `ctx.add*Constraint(...)` calls after it. Rails layout.
- **Item 2**: PG NULLS FIRST/LAST parsing — `indexes()` now captures `NULLS FIRST` / `NULLS LAST` from `pg_get_indexdef` and includes them in the order string (e.g. `"desc NULLS LAST"`).
- **Item 3**: PG INCLUDE clause parsing + emission — covering indexes with `INCLUDE (...)` are now parsed into `include: string[]` on `IndexInfo` and emitted by `indexParts()`.
- **Item 4**: `MigrationContext.createTable` inline index SQL — the inline `CREATE INDEX` now honors `using`, per-column `order`, and `where` options from the table-definition index store.
- **Item 5**: Non-PK `defaultFunction` in `emitTable` — columns with a `defaultFunction` (e.g. `gen_random_uuid()`, `now()`) now emit `default: () => "fn()"` so the function default round-trips through dump/restore.
- **Item 6**: `SchemaDumper.dumpTableSchema` adapter dispatch — now instantiates the adapter's `createSchemaDumper()` subclass so PG/MySQL/SQLite overrides fire when called with an adapter.
- **Item 7**: `PostgreSQLAdapter.createTable` signature harmonization — changed from callback-first `(name, callback, options)` to options-first `(name, options?, fn?)` matching the abstract base shape; `@ts-expect-error` retained due to `SimpleTableBuilder` vs `TableDefinition` type gap.