### PR TITLE
fix(activerecord) ConnectionPool#withConnection waits for a connection instead of failing fast

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -603,7 +603,7 @@ export class ConnectionPool implements ReapablePool {
     }
   }
 
-  async withConnection<T>(
+  withConnection<T>(
     fn: (conn: DatabaseAdapter) => T | Promise<T>,
     options: { preventPermanentCheckout?: boolean; checkoutTimeout?: number } = {},
   ): Promise<T> {
@@ -616,24 +616,57 @@ export class ConnectionPool implements ReapablePool {
       if (preventPermanent && !stickyWas) lease.sticky = stickyWas;
     };
 
-    if (lease.connection) {
+    // Track whether we acquired the connection here (vs it being pre-leased).
+    const wasPreLeased = !!lease.connection;
+
+    // Wrap fn execution + cleanup into one place to avoid duplication across paths.
+    const runFn = (): Promise<T> => {
+      let result: T | Promise<T>;
       try {
-        return await fn(lease.connection);
-      } finally {
+        result = fn(lease.connection!);
+      } catch (err) {
         restoreSticky();
+        if (!wasPreLeased && !lease.sticky) this.releaseConnection();
+        return Promise.reject(err) as Promise<T>;
       }
+      return Promise.resolve(result).then(
+        (v) => {
+          restoreSticky();
+          if (!wasPreLeased && !lease.sticky) this.releaseConnection();
+          return v;
+        },
+        (e) => {
+          restoreSticky();
+          if (!wasPreLeased && !lease.sticky) this.releaseConnection();
+          throw e;
+        },
+      );
+    };
+
+    if (lease.connection) {
+      return runFn();
     }
 
-    lease.connection = await this.checkoutAsync(options.checkoutTimeout);
+    // Fast path: connection immediately available — stay synchronous.
     try {
-      const result = await fn(lease.connection);
+      lease.connection = this.checkout();
+      return runFn();
+    } catch (err) {
+      if (err instanceof ConnectionTimeoutError) {
+        // Pool saturated — wait asynchronously for a connection to become free.
+        return this.checkoutAsync(options.checkoutTimeout).then(
+          (conn) => {
+            lease.connection = conn;
+            return runFn();
+          },
+          (checkoutErr) => {
+            restoreSticky();
+            throw checkoutErr;
+          },
+        );
+      }
       restoreSticky();
-      if (!lease.sticky) this.releaseConnection();
-      return result;
-    } catch (error) {
-      restoreSticky();
-      if (!lease.sticky) this.releaseConnection();
-      throw error;
+      throw err;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -675,8 +675,8 @@ export class ConnectionPool implements ReapablePool {
       lease.connection = this.checkout();
       return runWithConn();
     } catch (err) {
-      if (err instanceof ConnectionTimeoutError) {
-        // Pool saturated — wait asynchronously for a connection to become free.
+      if (err instanceof ConnectionTimeoutError && "checkoutTimeout" in options) {
+        // Pool saturated and caller explicitly opted in — wait for a free connection.
         return this.checkoutAsync(options.checkoutTimeout).then(
           (conn) => {
             lease.connection = conn;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -616,53 +616,71 @@ export class ConnectionPool implements ReapablePool {
       if (preventPermanent && !stickyWas) lease.sticky = stickyWas;
     };
 
-    const wasPreLeased = !!lease.connection;
-
-    const cleanup = () => {
-      restoreSticky();
-      if (!wasPreLeased && !lease.sticky) this.releaseConnection();
-    };
-
-    // Run fn and manage cleanup. Returns T when fn is sync, Promise<T> when async.
-    const runFn = (): T | Promise<T> => {
+    // Common pre-leased path — mirrors the original exactly; no extra closures.
+    if (lease.connection) {
       let result: T | Promise<T>;
       try {
-        result = fn(lease.connection!);
+        result = fn(lease.connection);
       } catch (err) {
-        cleanup();
+        restoreSticky();
         throw err;
       }
       if (result !== null && result !== undefined && typeof (result as any).then === "function") {
         return Promise.resolve(result).then(
           (v) => {
-            cleanup();
+            restoreSticky();
             return v;
           },
           (e) => {
-            cleanup();
+            restoreSticky();
             throw e;
           },
         );
       }
-      cleanup();
+      restoreSticky();
+      return result;
+    }
+
+    // Acquire path — checkout a new connection, then run fn.
+    const releaseOnDone = () => {
+      restoreSticky();
+      if (!lease.sticky) this.releaseConnection();
+    };
+
+    const runWithConn = (): T | Promise<T> => {
+      let result: T | Promise<T>;
+      try {
+        result = fn(lease.connection!);
+      } catch (err) {
+        releaseOnDone();
+        throw err;
+      }
+      if (result !== null && result !== undefined && typeof (result as any).then === "function") {
+        return Promise.resolve(result).then(
+          (v) => {
+            releaseOnDone();
+            return v;
+          },
+          (e) => {
+            releaseOnDone();
+            throw e;
+          },
+        );
+      }
+      releaseOnDone();
       return result;
     };
 
-    if (lease.connection) {
-      return runFn();
-    }
-
-    // Fast path: connection immediately available.
     try {
       lease.connection = this.checkout();
-      return runFn();
+      return runWithConn();
     } catch (err) {
       if (err instanceof ConnectionTimeoutError) {
         // Pool saturated — wait asynchronously for a connection to become free.
         return this.checkoutAsync(options.checkoutTimeout).then(
           (conn) => {
             lease.connection = conn;
-            return runFn();
+            return runWithConn();
           },
           (checkoutErr) => {
             restoreSticky();

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -619,28 +619,37 @@ export class ConnectionPool implements ReapablePool {
     // Track whether we acquired the connection here (vs it being pre-leased).
     const wasPreLeased = !!lease.connection;
 
+    const cleanup = () => {
+      restoreSticky();
+      if (!wasPreLeased && !lease.sticky) this.releaseConnection();
+    };
+
     // Wrap fn execution + cleanup into one place to avoid duplication across paths.
     const runFn = (): Promise<T> => {
       let result: T | Promise<T>;
       try {
         result = fn(lease.connection!);
       } catch (err) {
-        restoreSticky();
-        if (!wasPreLeased && !lease.sticky) this.releaseConnection();
+        cleanup();
         return Promise.reject(err) as Promise<T>;
       }
-      return Promise.resolve(result).then(
-        (v) => {
-          restoreSticky();
-          if (!wasPreLeased && !lease.sticky) this.releaseConnection();
-          return v;
-        },
-        (e) => {
-          restoreSticky();
-          if (!wasPreLeased && !lease.sticky) this.releaseConnection();
-          throw e;
-        },
-      );
+      // For async callbacks, defer cleanup until the returned Promise settles.
+      // For sync callbacks, run cleanup immediately to match the pre-change behaviour
+      // and avoid creating an extra Promise on the common path.
+      if (result !== null && result !== undefined && typeof (result as any).then === "function") {
+        return Promise.resolve(result).then(
+          (v) => {
+            cleanup();
+            return v;
+          },
+          (e) => {
+            cleanup();
+            throw e;
+          },
+        );
+      }
+      cleanup();
+      return Promise.resolve(result as T);
     };
 
     if (lease.connection) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -675,7 +675,7 @@ export class ConnectionPool implements ReapablePool {
         );
       }
       restoreSticky();
-      throw err;
+      return Promise.reject(err) as Promise<T>;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -675,7 +675,7 @@ export class ConnectionPool implements ReapablePool {
       lease.connection = this.checkout();
       return runWithConn();
     } catch (err) {
-      if (err instanceof ConnectionTimeoutError && "checkoutTimeout" in options) {
+      if (err instanceof ConnectionTimeoutError && options.checkoutTimeout !== undefined) {
         // Pool saturated and caller explicitly opted in — wait for a free connection.
         return this.checkoutAsync(options.checkoutTimeout).then(
           (conn) => {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -603,10 +603,10 @@ export class ConnectionPool implements ReapablePool {
     }
   }
 
-  withConnection<T>(
-    fn: (conn: DatabaseAdapter) => T,
-    options: { preventPermanentCheckout?: boolean } = {},
-  ): T {
+  async withConnection<T>(
+    fn: (conn: DatabaseAdapter) => T | Promise<T>,
+    options: { preventPermanentCheckout?: boolean; checkoutTimeout?: number } = {},
+  ): Promise<T> {
     const preventPermanent = options.preventPermanentCheckout ?? false;
     const lease = this._connectionLease();
     const stickyWas = lease.sticky;
@@ -618,21 +618,15 @@ export class ConnectionPool implements ReapablePool {
 
     if (lease.connection) {
       try {
-        return fn(lease.connection);
+        return await fn(lease.connection);
       } finally {
         restoreSticky();
       }
     }
 
-    lease.connection = this.checkout();
+    lease.connection = await this.checkoutAsync(options.checkoutTimeout);
     try {
-      const result = fn(lease.connection);
-      if (result && typeof (result as any).then === "function") {
-        return Promise.resolve(result).finally(() => {
-          restoreSticky();
-          if (!lease.sticky) this.releaseConnection();
-        }) as T;
-      }
+      const result = await fn(lease.connection);
       restoreSticky();
       if (!lease.sticky) this.releaseConnection();
       return result;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -606,7 +606,7 @@ export class ConnectionPool implements ReapablePool {
   withConnection<T>(
     fn: (conn: DatabaseAdapter) => T | Promise<T>,
     options: { preventPermanentCheckout?: boolean; checkoutTimeout?: number } = {},
-  ): Promise<T> {
+  ): T | Promise<T> {
     const preventPermanent = options.preventPermanentCheckout ?? false;
     const lease = this._connectionLease();
     const stickyWas = lease.sticky;
@@ -616,7 +616,6 @@ export class ConnectionPool implements ReapablePool {
       if (preventPermanent && !stickyWas) lease.sticky = stickyWas;
     };
 
-    // Track whether we acquired the connection here (vs it being pre-leased).
     const wasPreLeased = !!lease.connection;
 
     const cleanup = () => {
@@ -624,18 +623,15 @@ export class ConnectionPool implements ReapablePool {
       if (!wasPreLeased && !lease.sticky) this.releaseConnection();
     };
 
-    // Wrap fn execution + cleanup into one place to avoid duplication across paths.
-    const runFn = (): Promise<T> => {
+    // Run fn and manage cleanup. Returns T when fn is sync, Promise<T> when async.
+    const runFn = (): T | Promise<T> => {
       let result: T | Promise<T>;
       try {
         result = fn(lease.connection!);
       } catch (err) {
         cleanup();
-        return Promise.reject(err) as Promise<T>;
+        throw err;
       }
-      // For async callbacks, defer cleanup until the returned Promise settles.
-      // For sync callbacks, run cleanup immediately to match the pre-change behaviour
-      // and avoid creating an extra Promise on the common path.
       if (result !== null && result !== undefined && typeof (result as any).then === "function") {
         return Promise.resolve(result).then(
           (v) => {
@@ -649,14 +645,14 @@ export class ConnectionPool implements ReapablePool {
         );
       }
       cleanup();
-      return Promise.resolve(result as T);
+      return result;
     };
 
     if (lease.connection) {
       return runFn();
     }
 
-    // Fast path: connection immediately available — stay synchronous.
+    // Fast path: connection immediately available.
     try {
       lease.connection = this.checkout();
       return runFn();
@@ -675,7 +671,7 @@ export class ConnectionPool implements ReapablePool {
         );
       }
       restoreSticky();
-      return Promise.reject(err) as Promise<T>;
+      throw err;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -671,26 +671,32 @@ export class ConnectionPool implements ReapablePool {
       return result;
     };
 
+    let checkoutErr: unknown;
     try {
       lease.connection = this.checkout();
-      return runWithConn();
     } catch (err) {
-      if (err instanceof ConnectionTimeoutError && options.checkoutTimeout !== undefined) {
-        // Pool saturated and caller explicitly opted in — wait for a free connection.
-        return this.checkoutAsync(options.checkoutTimeout).then(
-          (conn) => {
-            lease.connection = conn;
-            return runWithConn();
-          },
-          (checkoutErr) => {
-            restoreSticky();
-            throw checkoutErr;
-          },
-        );
-      }
-      restoreSticky();
-      throw err;
+      checkoutErr = err;
     }
+
+    if (checkoutErr === undefined) {
+      return runWithConn();
+    }
+
+    if (checkoutErr instanceof ConnectionTimeoutError && options.checkoutTimeout !== undefined) {
+      // Pool saturated and caller explicitly opted in — wait for a free connection.
+      return this.checkoutAsync(options.checkoutTimeout).then(
+        (conn) => {
+          lease.connection = conn;
+          return runWithConn();
+        },
+        (asyncErr) => {
+          restoreSticky();
+          throw asyncErr;
+        },
+      );
+    }
+    restoreSticky();
+    throw checkoutErr;
   }
 
   // --- Pool statistics ---

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -33,17 +33,17 @@ describe("ConnectionHandlingTest", () => {
     Base.connectionHandler.clearAllConnectionsBang();
   });
 
-  it("#with_connection lease the connection for the duration of the block", () => {
+  it("#with_connection lease the connection for the duration of the block", async () => {
     const pool = Base.connectionPool();
     expect(pool.activeConnection).toBeNull();
-    Base.withConnection((conn) => {
+    await Base.withConnection((conn) => {
       expect(conn).toBeTruthy();
       expect(pool.activeConnection).toBeTruthy();
     });
   });
 
-  it("#lease_connection makes the lease permanent even inside #with_connection", () => {
-    Base.withConnection(() => {
+  it("#lease_connection makes the lease permanent even inside #with_connection", async () => {
+    await Base.withConnection(() => {
       const leased = Base.leaseConnection();
       expect(leased).toBeTruthy();
     });
@@ -58,17 +58,17 @@ describe("ConnectionHandlingTest", () => {
     // SCOPE: ~50–100 LOC fix in connection-adapters/abstract/connection-pool.ts; affects ~10–24 tests in connection-handling.test.ts
   });
 
-  it("#with_connection use the already leased connection if available", () => {
+  it("#with_connection use the already leased connection if available", async () => {
     const leased = Base.leaseConnection();
-    Base.withConnection((conn) => {
+    await Base.withConnection((conn) => {
       expect(conn).toBe(leased);
     });
     Base.releaseConnection();
   });
 
-  it("#with_connection is reentrant", () => {
-    Base.withConnection((outer) => {
-      Base.withConnection((inner) => {
+  it("#with_connection is reentrant", async () => {
+    await Base.withConnection(async (outer) => {
+      await Base.withConnection((inner) => {
         expect(inner).toBe(outer);
       });
     });
@@ -338,8 +338,8 @@ describe("ConnectionHandlingTest", () => {
     Base.releaseConnection();
   });
 
-  it("#connection returns the active connection inside withConnection", () => {
-    Base.withConnection((leased) => {
+  it("#connection returns the active connection inside withConnection", async () => {
+    await Base.withConnection((leased) => {
       const conn = Base.connection();
       expect(conn).toBe(leased);
     });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -284,7 +284,11 @@ export function withConnection<T>(
   fn: (conn: DatabaseAdapter) => T | Promise<T>,
   options?: { preventPermanentCheckout?: boolean; checkoutTimeout?: number },
 ): Promise<T> {
-  return Promise.resolve(connectionPool.call(this).withConnection(fn, options)) as Promise<T>;
+  try {
+    return Promise.resolve(connectionPool.call(this).withConnection(fn, options)) as Promise<T>;
+  } catch (err) {
+    return Promise.reject(err) as Promise<T>;
+  }
 }
 
 export function connectionDbConfig(this: typeof Base) {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -284,7 +284,7 @@ export function withConnection<T>(
   fn: (conn: DatabaseAdapter) => T | Promise<T>,
   options?: { preventPermanentCheckout?: boolean; checkoutTimeout?: number },
 ): Promise<T> {
-  return connectionPool.call(this).withConnection(fn, options);
+  return Promise.resolve(connectionPool.call(this).withConnection(fn, options)) as Promise<T>;
 }
 
 export function connectionDbConfig(this: typeof Base) {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -281,9 +281,9 @@ export function releaseConnection(this: typeof Base): boolean {
 
 export function withConnection<T>(
   this: typeof Base,
-  fn: (conn: DatabaseAdapter) => T,
-  options?: { preventPermanentCheckout?: boolean },
-): T {
+  fn: (conn: DatabaseAdapter) => T | Promise<T>,
+  options?: { preventPermanentCheckout?: boolean; checkoutTimeout?: number },
+): Promise<T> {
   return connectionPool.call(this).withConnection(fn, options);
 }
 

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -199,9 +199,12 @@ it("withConnection waits for a released connection when pool is saturated", asyn
   const held = pool.checkout();
 
   let connSeen: DatabaseAdapter | undefined;
-  const waiter = pool.withConnection((conn) => {
-    connSeen = conn;
-  });
+  const waiter = pool.withConnection(
+    (conn) => {
+      connSeen = conn;
+    },
+    { checkoutTimeout: 5 },
+  );
   pool.checkin(held);
   await waiter;
   expect(connSeen).toBe(held);

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -144,7 +144,7 @@ it.skip("released connection moves between threads", () => {
 
 it("with connection", async () => {
   const pool = makePool();
-  const result = pool.withConnection((conn) => {
+  const result = await pool.withConnection((conn) => {
     expect(conn).toBeTruthy();
     return "ok";
   });
@@ -167,11 +167,11 @@ it("with connection", async () => {
   expect(pool.stat().busy).toBe(0);
 });
 
-it("with connection prevent permanent checkout releases connection", () => {
+it("with connection prevent permanent checkout releases connection", async () => {
   const pool = makePool();
   pool.leaseConnection();
   expect(pool.activeConnection).toBeTruthy();
-  pool.withConnection(
+  await pool.withConnection(
     (conn) => {
       expect(conn).toBeTruthy();
     },
@@ -182,9 +182,9 @@ it("with connection prevent permanent checkout releases connection", () => {
   pool.releaseConnection();
 });
 
-it("with connection prevent permanent checkout on fresh lease releases", () => {
+it("with connection prevent permanent checkout on fresh lease releases", async () => {
   const pool = makePool();
-  pool.withConnection(
+  await pool.withConnection(
     (conn) => {
       expect(conn).toBeTruthy();
     },
@@ -192,6 +192,29 @@ it("with connection prevent permanent checkout on fresh lease releases", () => {
   );
   // No prior sticky lease, so connection should be released
   expect(pool.activeConnection).toBeNull();
+});
+
+it("withConnection waits for a released connection when pool is saturated", async () => {
+  const pool = makePool(1);
+  const held = pool.checkout();
+
+  const waiter = pool.withConnection((conn) => conn);
+  pool.checkin(held);
+  const resolved = await waiter;
+  expect(resolved).toBe(held);
+  pool.checkin(resolved);
+});
+
+it("withConnection rejects with ConnectionTimeoutError when pool stays saturated past timeout", async () => {
+  const { ConnectionTimeoutError } = await import("./errors.js");
+  vi.useFakeTimers();
+  const pool = makePool(1);
+  pool.checkout();
+
+  const waiter = pool.withConnection(() => {}, { checkoutTimeout: 0.05 });
+  await vi.runAllTimersAsync();
+  await expect(waiter).rejects.toThrow(ConnectionTimeoutError);
+  vi.useRealTimers();
 });
 
 it.skip("new connection no query", () => {
@@ -437,13 +460,13 @@ it("automatic reconnect restores after disconnect", () => {
   pool.releaseConnection();
 });
 
-it("automatic reconnect can be disabled", () => {
+it("automatic reconnect can be disabled", async () => {
   const pool = makePool();
   pool.disconnectBang();
   pool.automaticReconnect = false;
 
   expect(() => pool.leaseConnection()).toThrow(/automatic_reconnect is disabled/);
-  expect(() => pool.withConnection(() => {})).toThrow(/automatic_reconnect is disabled/);
+  await expect(pool.withConnection(() => {})).rejects.toThrow(/automatic_reconnect is disabled/);
 });
 
 it("disconnect calls disconnectBang on each pooled connection", () => {
@@ -818,7 +841,7 @@ describe("ConnectionPool schema cache", () => {
     });
     const pool = new ConnectionPool(pc);
     try {
-      const cache = pool.withConnection(
+      const cache = await pool.withConnection(
         (conn) => (conn as unknown as { schemaCache: unknown }).schemaCache,
       );
       // The key regression: adapter.schemaCache must be a plain

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -221,8 +221,11 @@ it("withConnection rejects with ConnectionTimeoutError when pool stays saturated
     pool.checkout();
 
     const waiter = pool.withConnection(() => {}, { checkoutTimeout: 0.05 });
+    // Attach the rejection handler before advancing timers to avoid an
+    // unhandled-rejection window during IPC serialization.
+    const assertion = expect(waiter).rejects.toThrow(ConnectionTimeoutError);
     await vi.runAllTimersAsync();
-    await expect(waiter).rejects.toThrow(ConnectionTimeoutError);
+    await assertion;
   } finally {
     vi.useRealTimers();
   }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -210,13 +210,16 @@ it("withConnection waits for a released connection when pool is saturated", asyn
 it("withConnection rejects with ConnectionTimeoutError when pool stays saturated past timeout", async () => {
   const { ConnectionTimeoutError } = await import("./errors.js");
   vi.useFakeTimers();
-  const pool = makePool(1);
-  pool.checkout();
+  try {
+    const pool = makePool(1);
+    pool.checkout();
 
-  const waiter = pool.withConnection(() => {}, { checkoutTimeout: 0.05 });
-  await vi.runAllTimersAsync();
-  await expect(waiter).rejects.toThrow(ConnectionTimeoutError);
-  vi.useRealTimers();
+    const waiter = pool.withConnection(() => {}, { checkoutTimeout: 0.05 });
+    await vi.runAllTimersAsync();
+    await expect(waiter).rejects.toThrow(ConnectionTimeoutError);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 it.skip("new connection no query", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -202,7 +202,9 @@ it("withConnection waits for a released connection when pool is saturated", asyn
   pool.checkin(held);
   const resolved = await waiter;
   expect(resolved).toBe(held);
-  pool.checkin(resolved);
+  // withConnection releases the connection after fn returns — pool should be idle
+  expect(pool.stat().busy).toBe(0);
+  expect(pool.stat().idle).toBe(1);
 });
 
 it("withConnection rejects with ConnectionTimeoutError when pool stays saturated past timeout", async () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -198,10 +198,13 @@ it("withConnection waits for a released connection when pool is saturated", asyn
   const pool = makePool(1);
   const held = pool.checkout();
 
-  const waiter = pool.withConnection((conn) => conn);
+  let connSeen: DatabaseAdapter | undefined;
+  const waiter = pool.withConnection((conn) => {
+    connSeen = conn;
+  });
   pool.checkin(held);
-  const resolved = await waiter;
-  expect(resolved).toBe(held);
+  await waiter;
+  expect(connSeen).toBe(held);
   // withConnection releases the connection after fn returns — pool should be idle
   expect(pool.stat().busy).toBe(0);
   expect(pool.stat().idle).toBe(1);
@@ -471,7 +474,7 @@ it("automatic reconnect can be disabled", async () => {
   pool.automaticReconnect = false;
 
   expect(() => pool.leaseConnection()).toThrow(/automatic_reconnect is disabled/);
-  await expect(pool.withConnection(() => {})).rejects.toThrow(/automatic_reconnect is disabled/);
+  expect(() => pool.withConnection(() => {})).toThrow(/automatic_reconnect is disabled/);
 });
 
 it("disconnect calls disconnectBang on each pooled connection", () => {


### PR DESCRIPTION
## Summary

- `withConnection` now uses `checkoutAsync` as an **opt-in slow path**: when the pool is saturated and the caller explicitly passes `{ checkoutTimeout: N }` (with a non-undefined value), it queues as a waiter instead of throwing immediately
- Without `checkoutTimeout`, behavior is unchanged — synchronous `checkout()` throws `ConnectionTimeoutError` on saturation (preserves fail-fast semantics and avoids pending-Promise accumulation under load)
- The duck-type check (`typeof result.then === 'function'`) is retained on both paths; return type is `T | Promise<T>` rather than uniformly async
- Adds `checkoutTimeout` option to `withConnection` so callers can opt into waiting
- Updates `connection-handling.ts` so `Base.withConnection` returns `Promise<T>` (wraps via `Promise.resolve`)

## Tests

- Updated existing `withConnection` tests to `await` the call
- **New:** saturate-then-release test — waiter (with explicit `checkoutTimeout`) resolves with the released connection
- **New:** saturate-and-hold test — waiter rejects with `ConnectionTimeoutError` after timeout (fake timers)

## Known concerns (deferred, max Copilot review cycles reached)

- **Pattern duplication:** The then-detect + cleanup pattern is inlined three times (pre-leased branch, `runWithConn`, async-checkout continuation). Each copy has intentionally different semantics (pre-leased only calls `restoreSticky`; acquire path also calls `releaseConnection`), so a shared helper would need to parameterize that difference. Deferred as a follow-up refactor.

## Out of scope (follow-ups per plan)

- `buildAsyncExecutor` returning `null` (line 986) — Promise-bounded semaphore
- `ExecutorHooks` wiring — pending ConnectionHandler PR 6
- Middleware-level `withExecutionContext` integration in actionpack