### PR TITLE
refactor(activemodel) eliminate any from public error/validation APIs

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -57,8 +57,7 @@ export function attribute(
   this: {
     _attributeDefinitions: Map<string, AttributeDefinition>;
     prototype: object;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    _cachedDefaultAttributes?: any;
+    _cachedDefaultAttributes?: AttributeSet | null;
   },
   name: string,
   typeName: string,

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -446,7 +446,7 @@ export class UnknownAttributeError<TRecord extends object = object> extends glob
   readonly attribute: string;
 
   constructor(record: TRecord, attribute: string) {
-    const model = record?.constructor?.name ?? "Record";
+    const model = record.constructor?.name ?? "Record";
     super(`unknown attribute '${attribute}' for ${model}.`);
     this.name = "UnknownAttributeError";
     this.record = record;

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -441,13 +441,11 @@ export class StrictValidationFailed extends globalThis.Error {
  *
  * Mirrors: ActiveModel::UnknownAttributeError
  */
-export class UnknownAttributeError extends globalThis.Error {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly record: any;
+export class UnknownAttributeError<TRecord extends object = object> extends globalThis.Error {
+  readonly record: TRecord;
   readonly attribute: string;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(record: any, attribute: string) {
+  constructor(record: TRecord, attribute: string) {
     const model = record?.constructor?.name ?? "Record";
     super(`unknown attribute '${attribute}' for ${model}.`);
     this.name = "UnknownAttributeError";

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./errors.js";
 export { NestedError } from "./nested-error.js";
 export { ValidationError, ValidationContext } from "./validations.js";
+export type { ModelWithErrors } from "./validations.js";
 export { Validator, EachValidator, BlockValidator } from "./validator.js";
 export {
   MissingAttributeError,
@@ -55,6 +56,7 @@ export { AcceptsMultiparameterTime } from "./type/helpers/accepts-multiparameter
 export { MutableModule } from "./type/helpers/mutable.js";
 export type { Mutable } from "./type/helpers/mutable.js";
 export { ModelName } from "./naming.js";
+export type { ModelLike } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
 export { CallbackChain } from "./callbacks.js";
 export type { CallbackConditions } from "./callbacks.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -18,7 +18,7 @@ import {
 } from "./translation.js";
 import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
-import { ModelName } from "./naming.js";
+import { ModelLike, ModelName } from "./naming.js";
 import { DirtyTracker, initInternals as dirtyInitInternals } from "./dirty.js";
 import {
   CallbackChain,
@@ -1196,8 +1196,8 @@ export class Model {
 
   static get modelName(): ModelName {
     if (!this._modelName || this._modelName.name !== this.name) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Model satisfies ModelLike but TS can't prove it due to circular types
-      this._modelName = new ModelName(this.name, { klass: this as any });
+      // Model satisfies ModelLike but TS can't prove it due to circular types.
+      this._modelName = new ModelName(this.name, { klass: this as unknown as ModelLike });
     }
     return this._modelName;
   }

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -64,7 +64,7 @@ export namespace Naming {
 }
 import { I18n } from "./i18n.js";
 
-interface ModelLike {
+export interface ModelLike {
   readonly name: string;
   i18nScope?: string;
   lookupAncestors?: () => ModelLike[];

--- a/packages/activemodel/src/nested-error.ts
+++ b/packages/activemodel/src/nested-error.ts
@@ -18,8 +18,7 @@ export class NestedError extends ActiveModelError {
   readonly innerError: ErrorLike;
 
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    base: any,
+    base: unknown,
     innerError: ErrorLike,
     options?: { attribute?: string; type?: string },
   ) {
@@ -53,8 +52,7 @@ export class NestedError extends ActiveModelError {
    * Inner error's own `base` is preserved (the inner error belongs to the
    * inner model, not the outer one) — only the NestedError's base changes.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override dupWithBase(newBase: any): NestedError {
+  override dupWithBase(newBase: unknown): NestedError {
     const inner = this.innerError;
     const innerDup: ErrorLike =
       inner instanceof ActiveModelError

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -135,13 +135,12 @@ function _walkAncestors(
   start: object,
 ): Array<{ new (...args: never[]): unknown; modelName: ModelName }> {
   const result: Array<{ new (...args: never[]): unknown; modelName: ModelName }> = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let klass: any = start;
+  let klass: object | null = start;
   while (klass != null && klass !== Function.prototype && klass !== Object.prototype) {
-    if (klass.modelName != null) {
+    if ((klass as { modelName?: unknown }).modelName != null) {
       result.push(klass as { new (...args: never[]): unknown; modelName: ModelName });
     }
-    klass = Object.getPrototypeOf(klass);
+    klass = Object.getPrototypeOf(klass) as object | null;
   }
   return result;
 }

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -134,16 +134,16 @@ export interface ValidationsClassMethods {
   inherited(subclass: unknown): void;
 }
 
-/**
- * Raised by validateBang when validation fails.
- *
- * Mirrors: ActiveModel::ValidationError
- */
 /** Minimum shape required by ValidationError. */
 export interface ModelWithErrors {
   errors: { fullMessages: string[] };
 }
 
+/**
+ * Raised by validateBang when validation fails.
+ *
+ * Mirrors: ActiveModel::ValidationError
+ */
 export class ValidationError<TModel extends ModelWithErrors = ModelWithErrors>
   extends globalThis.Error
 {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -139,9 +139,15 @@ export interface ValidationsClassMethods {
  *
  * Mirrors: ActiveModel::ValidationError
  */
-export class ValidationError extends globalThis.Error {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly model: any;
+/** Minimum shape required by ValidationError. */
+export interface ModelWithErrors {
+  errors: { fullMessages: string[] };
+}
+
+export class ValidationError<TModel extends ModelWithErrors = ModelWithErrors>
+  extends globalThis.Error
+{
+  readonly model: TModel;
 
   // Mirrors Rails `ActiveModel::ValidationError#initialize`
   // (activemodel/lib/active_model/validations.rb:496-500):
@@ -153,12 +159,11 @@ export class ValidationError extends globalThis.Error {
   //                  errors: errors, default: :"errors.messages.model_invalid"))
   //   end
   //
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(model: any) {
+  constructor(model: TModel) {
     const errors = model.errors.fullMessages.join(", ");
     // Match the guard used by `error.ts`'s I18n lookups — only treat
     // `i18nScope` as a scope when the class actually exposes a string.
-    const rawScope = model.constructor?.i18nScope;
+    const rawScope = (model as { constructor?: { i18nScope?: unknown } }).constructor?.i18nScope;
     const scope = typeof rawScope === "string" ? rawScope : "activemodel";
     const message = I18n.t(`${scope}.errors.messages.model_invalid`, {
       errors,


### PR DESCRIPTION
## Summary

- `UnknownAttributeError<TRecord extends object = object>` — record field now typed
- `ValidationError<TModel extends ModelWithErrors = ModelWithErrors>` — new `ModelWithErrors` interface bounds the minimum errors shape
- `NestedError` constructor/`dupWithBase` widened from `any` to `unknown`
- `_walkAncestors` in translation.ts: `klass: object | null` instead of `any`
- `attribute()` host shape: `_cachedDefaultAttributes?: AttributeSet | null` instead of `any`
- `Model.modelName` getter: `this as unknown as ModelLike`; exports `ModelLike` from naming.ts

**Follow-up (PR 2)**: `defineModelCallbacks this: any` → `CallbackHost` interface; `model.ts normalizes() as any` slices; `@internal` annotations on big-integer/numeric legitimate uses.

## Test plan

- [x] All activemodel tests pass
- [x] No new type errors in activemodel or activerecord from these changes
- [x] `tsc --build` passes