### PR TITLE
refactor(arel,activemodel): type loose-ends — registry/ToSql ctor + normalizes() as-any

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -207,17 +207,15 @@ export class Model {
     let options: Record<string, unknown> = {};
     let fn: (value: unknown) => unknown;
     const lastArg = args[args.length - 1];
+    let attributes: string[];
     if (typeof lastArg === "object" && lastArg !== null && !Array.isArray(lastArg)) {
       options = lastArg as Record<string, unknown>;
       fn = args[args.length - 2] as (value: unknown) => unknown;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      args = args.slice(0, -2) as any;
+      attributes = args.slice(0, -2) as unknown as string[];
     } else {
       fn = lastArg as (value: unknown) => unknown;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      args = args.slice(0, -1) as any;
+      attributes = args.slice(0, -1) as unknown as string[];
     }
-    const attributes = args as unknown as string[];
     const applyToNil = !!options.applyToNil;
 
     for (const attr of attributes) {

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -77,12 +77,25 @@ export interface NodeVisitor<T> {
   visit(node: Node): T;
 }
 
+// ArelConnection lives in visitors/to-sql.ts which imports Node — a direct
+// import would create a cycle. `never` satisfies the contravariant bound:
+// every concrete connection type is a subtype of never (bottom type), so
+// any `new (connection?: ConcreteConnection)` ctor is assignable here.
+type ToSqlCtor = new (connection?: never) => { compile(node: Node): string };
+
+interface NodeRegistry {
+  Not?: new (expr: Node) => Node;
+  Grouping?: new (expr: Node) => Node;
+  Or?: new (children: Node[]) => Node;
+  And?: new (children: Node[]) => Node;
+  ToSql?: ToSqlCtor;
+}
+
 // Registry for breaking circular dependencies.
 // Populated by the index module after all classes are loaded.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const _registry: Record<string, (new (...args: any[]) => any) | undefined> = {};
+const _registry: NodeRegistry = {};
 
-function assertRegistered(name: string): void {
+function assertRegistered(name: keyof NodeRegistry): void {
   if (!_registry[name]) {
     throw new Error(
       `Node.${name} requires the arel registry. Import from "@blazetrails/arel" instead of deep-importing node classes.`,
@@ -95,8 +108,7 @@ export function registerNodeDeps(deps: {
   Grouping: new (expr: Node) => Node;
   Or: new (children: Node[]) => Node;
   And: new (children: Node[]) => Node;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ToSql: new (...args: any[]) => { compile(node: Node): string };
+  ToSql: ToSqlCtor;
 }): void {
   _registry.Not = deps.Not;
   _registry.Grouping = deps.Grouping;

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -78,9 +78,9 @@ export interface NodeVisitor<T> {
 }
 
 // ArelConnection lives in visitors/to-sql.ts which imports Node — a direct
-// import would create a cycle. `never` satisfies the contravariant bound:
-// every concrete connection type is a subtype of never (bottom type), so
-// any `new (connection?: ConcreteConnection)` ctor is assignable here.
+// import would create a cycle. `never` satisfies the contravariant param
+// check: TS requires `never extends ConcreteConnection`, which holds because
+// never is a subtype of everything (bottom type).
 type ToSqlCtor = new (connection?: never) => { compile(node: Node): string };
 
 interface NodeRegistry {


### PR DESCRIPTION
## Summary

Follow-up to #1474 (arel) and #1475 (activemodel) — the remaining `any` cleanup items that were individually too small to warrant a PR cycle.

**arel** — `packages/arel/src/nodes/node.ts`

- **`_registry` type** (line 83): replaced `Record<string, (new (...args: any[]) => any) | undefined>` with a typed `NodeRegistry` interface whose five entries carry their exact constructor signatures.
- **`registerNodeDeps.ToSql` ctor** (line 99): replaced `new (...args: any[]) => { compile }` with `ToSqlCtor = new (connection?: never) => { compile }`. `ArelConnection` lives in `visitors/to-sql.ts` which imports `Node` — a direct import creates a cycle. Using `never` as the connection bound satisfies the contravariant check: every concrete `new (connection?: ArelConnection)` ctor is assignable to a target that only expects `undefined`.

**activemodel** — `packages/activemodel/src/model.ts`

- **`normalizes()` arg slicing** (lines 214, 218): introduced a local `attributes: string[]` variable instead of reassigning `args`. The two `args = args.slice(...) as any` casts become `attributes = args.slice(...) as unknown as string[]`.

## Items deferred (not in this PR)

The following items from the original checklist were already resolved in prior commits or were out of scope:

- `big-integer.ts` `@internal` annotation: `castValue` already carries `/** @internal Rails-private helper. */`; the `as unknown as number` casts are documented by the existing comment.
- `type/helpers/numeric.ts:53` `AbstractValueTypeCtor<T>`: already has an eslint-disable comment explaining why `any[]` is required.
- `translation.ts:139` `klass: any`: already typed as `object | null` in current code.
- `attributes.ts:61` `_cachedDefaultAttributes?: any`: already typed as `AttributeSet | null` in current code.
- `attribute-set/codecs/{json,yaml}.ts` structural guards: both files already have `isPlainObject` guards before the cast.