### PR TITLE
chore(activerecord) fidelity sweep E — schema / fixtures / MySQL recent-merge cleanup

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -484,4 +484,29 @@ export interface DatabaseAdapter {
    * @internal
    */
   readonly arelVisitor?: Visitors.ToSql;
+
+  /**
+   * Whether the adapter supports table/column comments.
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#supports_comments?
+   */
+  supportsComments?(): boolean;
+
+  /**
+   * Whether comments can be emitted inline in CREATE TABLE (vs a separate ALTER).
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#supports_comments_in_create?
+   */
+  supportsCommentsInCreate?(): boolean;
+
+  /**
+   * Set or clear the comment on a table after it has been created.
+   * Called by SchemaStatements#createTable when supportsComments() is true but
+   * supportsCommentsInCreate() is false. The second parameter is `string | null`
+   * when called from createTable; MySQL's override also accepts a column-map shape
+   * for `change_table_comment`, hence the wider union in the interface.
+   * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#change_table_comment
+   */
+  changeTableComment?(
+    tableName: string,
+    comment: string | null | Record<string, string | null>,
+  ): Promise<void>;
 }

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -67,7 +67,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       await new EnableCitext().run(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
-      const dump = await adapter.createSchemaDumper({}).dump();
+      const dump = await adapter.createSchemaDumper(adapter).dump();
       expect(dump).toContain(`enable_extension "citext"`);
     });
     it("enable extension migration ignores prefix and suffix", async () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -714,7 +714,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE TABLE list_partitioned (id integer, city varchar(50)) PARTITION BY LIST (city)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "list_partitioned");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "list_partitioned");
         expect(lines.join("\n")).toContain(`options: "PARTITION BY LIST (city)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS list_partitioned`);
@@ -726,7 +726,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE TABLE range_partitioned (id integer, amount integer) PARTITION BY RANGE (amount)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "range_partitioned");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "range_partitioned");
         expect(lines.join("\n")).toContain(`options: "PARTITION BY RANGE (amount)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS range_partitioned`);
@@ -739,7 +739,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes)`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -752,7 +752,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(`CREATE TABLE transportation_modes (kind varchar(50))`);
         await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes, vehicles)`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes, vehicles)"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -764,7 +764,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.exec(`CREATE TABLE regular_table (id integer, name varchar(50))`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "regular_table");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "regular_table");
         expect(lines.join("\n")).not.toContain("PARTITION BY");
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS regular_table`);
@@ -777,7 +777,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         await adapter.exec(`COMMENT ON TABLE commented_table IS 'a test table'`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper({}).dumpTable(lines, "commented_table");
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "commented_table");
         const dump = lines.join("\n");
         expect(dump).toContain(`comment: "a test table"`);
         await adapter.exec(`DROP TABLE IF EXISTS commented_table`);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -150,19 +150,14 @@ export class SchemaStatements {
 
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
-    if (options.comment != null && options.comment.length > 0) {
-      const adapterWithComments = this.adapter as {
-        supportsComments?: () => boolean;
-        supportsCommentsInCreate?: () => boolean;
-        changeTableComment?: (name: string, comment: string | null) => Promise<void>;
-      };
-      if (
-        adapterWithComments.supportsComments?.() &&
-        !adapterWithComments.supportsCommentsInCreate?.() &&
-        typeof adapterWithComments.changeTableComment === "function"
-      ) {
-        await adapterWithComments.changeTableComment(name, options.comment);
-      }
+    if (
+      options.comment != null &&
+      options.comment.length > 0 &&
+      this.adapter.supportsComments?.() &&
+      !this.adapter.supportsCommentsInCreate?.() &&
+      typeof this.adapter.changeTableComment === "function"
+    ) {
+      await this.adapter.changeTableComment(name, options.comment);
     }
 
     for (const idx of td.indexes) {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -679,6 +679,15 @@ describeIfMysql("Mysql2Adapter", () => {
       });
     });
 
+    it("schemaStatements().dropTable supports temporary:true via MigrationContext.schema path", async () => {
+      await adapter.exec("CREATE TEMPORARY TABLE `tmp_sweep_e` (`id` INT)");
+      const schema = adapter.schemaStatements!();
+      await (schema as any).dropTable("tmp_sweep_e", { temporary: true });
+      // If temporary: true wasn't forwarded the SQL would be DROP TABLE (not TEMPORARY),
+      // which would fail on MariaDB / MySQL when only a temp table with that name exists.
+      // The absence of an error confirms the correct SQL was issued.
+    });
+
     it("SchemaCache.addAll populates from MySQL", async () => {
       // Integration with Phase 5's dumpSchemaCache — MySQL now exposes
       // the full surface (dataSources/columns/primaryKey/indexes) the
@@ -818,6 +827,14 @@ describeIfMysql("Mysql2Adapter", () => {
       expect((adapter as any).isTextType("  VARCHAR(255)  ")).toBe(true);
       expect((adapter as any).isTextType("TEXT")).toBe(true);
       expect((adapter as any).isTextType("  INT  ")).toBe(false);
+    });
+
+    it("lookupCastType float vs double limits differ (MariaDB FLOAT fix)", () => {
+      // On MariaDB, information_schema.column_type reports "double" for FLOAT columns.
+      // columns() must use DATA_TYPE ("float") not COLUMN_TYPE ("double") for the limit
+      // lookup so float columns get limit=24 instead of the double limit of 53.
+      expect((adapter as any).lookupCastType("float")?.limit).toBe(24);
+      expect((adapter as any).lookupCastType("double")?.limit).toBe(53);
     });
 
     it("connect is a no-op and leaves the adapter connected", () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -44,9 +44,10 @@ class MysqlSchemaStatements extends SchemaStatements {
     const hasOpts = last !== null && last !== undefined && typeof last === "object";
     const opts = (hasOpts ? last : {}) as { temporary?: boolean };
     if (opts.temporary) {
-      return (this.adapter as Mysql2Adapter).dropTable(...(args as [string]));
+      return (this.adapter as Mysql2Adapter).dropTable(...(args as any));
     }
-    return super.dropTable(...(args as [string]));
+
+    return super.dropTable(...(args as any));
   }
 }
 
@@ -706,8 +707,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return dumper;
   }
 
-  override schemaStatements(host?: import("../adapter.js").DatabaseAdapter): MysqlSchemaStatements {
-    return new MysqlSchemaStatements((host ?? this) as import("../adapter.js").DatabaseAdapter);
+  override schemaStatements(host?: DatabaseAdapter): MysqlSchemaStatements {
+    return new MysqlSchemaStatements((host ?? this) as DatabaseAdapter);
   }
 
   // ── Schema DDL ──

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -21,6 +21,34 @@ import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 import { Text as TextType } from "../type/text.js";
+import type { SchemaSource } from "../schema-dumper.js";
+import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
+import { SchemaStatements } from "./abstract/schema-statements.js";
+
+/**
+ * MySQL-specific SchemaStatements subclass. Extends the base `dropTable` to support
+ * the `temporary: true` option, which emits `DROP TEMPORARY TABLE` — a MySQL/MariaDB
+ * extension required to drop temporary tables without affecting base tables.
+ *
+ * Returned by `Mysql2Adapter#schemaStatements()` so Migration#schema picks it up.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
+ */
+class MysqlSchemaStatements extends SchemaStatements {
+  override async dropTable(
+    ...args:
+      | [string, ...string[]]
+      | [string, ...string[], { ifExists?: boolean; force?: "cascade"; temporary?: boolean }]
+  ): Promise<void> {
+    const last = args[args.length - 1];
+    const hasOpts = last !== null && last !== undefined && typeof last === "object";
+    const opts = (hasOpts ? last : {}) as { temporary?: boolean };
+    if (opts.temporary) {
+      return (this.adapter as Mysql2Adapter).dropTable(...(args as [string]));
+    }
+    return super.dropTable(...(args as [string]));
+  }
+}
 
 /**
  * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
@@ -672,6 +700,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }
   }
 
+  createSchemaDumper(source: SchemaSource, _options: unknown = {}): MysqlSchemaDumper {
+    const dumper = new MysqlSchemaDumper(source);
+    dumper.connection = this;
+    return dumper;
+  }
+
+  override schemaStatements(host?: import("../adapter.js").DatabaseAdapter): MysqlSchemaStatements {
+    return new MysqlSchemaStatements((host ?? this) as import("../adapter.js").DatabaseAdapter);
+  }
+
   // ── Schema DDL ──
 
   /**
@@ -842,10 +880,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       const numPrec = r.num_precision ?? r.NUM_PRECISION ?? r.NUMERIC_PRECISION;
       const numScale = r.num_scale ?? r.NUM_SCALE ?? r.NUMERIC_SCALE;
       // character_maximum_length covers string types; for numeric types (float, int, etc.)
-      // it is NULL, so fall back to the type-map limit (e.g. float→24, double→53).
+      // it is NULL, so fall back to the type-map limit keyed on DATA_TYPE (not COLUMN_TYPE).
+      // On MariaDB, FLOAT COLUMN_TYPE is normalized to "double" which gives limit=53; using
+      // DATA_TYPE ("float") correctly yields limit=24 matching Rails' native_database_types.
       const charLimitVal = charLen != null ? Number(charLen) : null;
       const typeMapLimit =
-        charLimitVal == null ? (this.lookupCastType(sqlType)?.limit ?? null) : null;
+        charLimitVal == null ? (this.lookupCastType(baseType)?.limit ?? null) : null;
       const meta = new SqlTypeMetadata({
         sqlType,
         type: baseType,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -96,6 +96,7 @@ import {
 import { joinTableName as deriveJoinTableName } from "../migration/join-table.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
+import type { SchemaSource } from "../schema-dumper.js";
 import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
 
 const OID_JSON = 114;
@@ -4411,8 +4412,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return new PgTable(tableName, base as SchemaStatementsConstraintLike);
   }
 
-  createSchemaDumper(source: unknown, _options: unknown = {}): PgSchemaDumper {
-    return new PgSchemaDumper(source as any);
+  createSchemaDumper(source: SchemaSource, _options: unknown = {}): PgSchemaDumper {
+    return new PgSchemaDumper(source);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4411,8 +4411,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return new PgTable(tableName, base as SchemaStatementsConstraintLike);
   }
 
-  createSchemaDumper(_options: unknown): PgSchemaDumper {
-    return new PgSchemaDumper(this);
+  createSchemaDumper(source: unknown, _options: unknown = {}): PgSchemaDumper {
+    return new PgSchemaDumper(source as any);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -14,7 +14,7 @@ import type { IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   // Per-table constraint cache populated by filterIndexesForDump and consumed
-  // by exclusionConstraintsInCreate / uniqueConstraintsInCreate to avoid
+  // by _emitExclusionConstraints / _emitUniqueConstraints to avoid
   // fetching the same constraint lists twice per table.
   private _cachedExclConstraints: ExclusionConstraintDefinition[] | undefined;
   private _cachedUniqConstraints: UniqueConstraintDefinition[] | undefined;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -77,6 +77,8 @@ import {
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
+import type { SchemaSource } from "../schema-dumper.js";
+import { SchemaDumper as Sqlite3SchemaDumper } from "./sqlite3/schema-dumper.js";
 
 /**
  * SQLite-specific DateTime type.
@@ -911,6 +913,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       throw new Error("No index name or column specified");
     }
     await this.executeMutation(`DROP INDEX IF EXISTS ${quoteColumnName(indexName)}`);
+  }
+
+  createSchemaDumper(source: SchemaSource, _options: unknown = {}): Sqlite3SchemaDumper {
+    return new Sqlite3SchemaDumper(source);
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#virtual_table_exists?

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -484,9 +484,7 @@ export class SchemaDumper {
     // the base class when unavailable, which is what the old code always did.
     let dumper: SchemaDumper;
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
-      dumper = (source as any).createSchemaDumper({}) as SchemaDumper;
-      // Swap to the wrapped source so column normalization applies.
-      (dumper as any)._source = wrappedSource;
+      dumper = (source as any).createSchemaDumper(wrappedSource, {}) as SchemaDumper;
     } else {
       dumper = this.create(wrappedSource);
     }

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -295,6 +295,19 @@ describe("defineFixtures", () => {
     expect(nullCount).toBeGreaterThanOrEqual(2);
   });
 
+  it("polymorphic ref: ref() on a poly key throws instead of inserting spurious column", async () => {
+    const adapter = makeAdapter();
+    const rows = new Map([[fixtureId("bad"), { id: fixtureId("bad") }]]);
+    const Tagging = makeModel("taggings", rows) as any;
+    Tagging._reflections = {
+      taggable: { macro: "belongsTo", isPolymorphic: () => true },
+    };
+
+    await expect(
+      defineFixtures(adapter, Tagging, { bad: { taggable: ref("posts", "welcome") as any } }),
+    ).rejects.toThrow(/polymorphic association.*model instance/);
+  });
+
   it("polymorphic ref: non-instance non-null value throws a clear error", async () => {
     const adapter = makeAdapter();
     const rows = new Map([[fixtureId("bad"), { id: fixtureId("bad") }]]);

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -177,7 +177,16 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
     for (const [col, val] of Object.entries(attrs)) {
       if (col === pkCol) continue; // deterministic ID wins; caller must not override it
 
+      // Evaluate poly once so both the ref guard and the expansion below share the result.
+      const poly = findPolymorphicRef(ModelClass, col);
+
       if (isFixtureRef(val)) {
+        if (poly) {
+          throw new Error(
+            `defineFixtures: "${col}" is a polymorphic association — pass a model instance instead of ref(). ` +
+              `Use explicit ${poly.typeColumn}/${poly.idColumn} if you need to reference by ID.`,
+          );
+        }
         row[col] = fixtureId(val.fixtureName);
         continue;
       }
@@ -190,7 +199,6 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
       // Polymorphic belongs_to: "col" is an association name, never a real column.
       // It must always be consumed here — falling through to `row[col] = val` would
       // attempt to INSERT a non-existent column and break fixture insertion.
-      const poly = findPolymorphicRef(ModelClass, col);
       if (poly) {
         const hasType = poly.typeColumn in attrs;
         const hasId = poly.idColumn in attrs;


### PR DESCRIPTION
## Summary

Post-merge cleanup from #1467 / #1468 / #1469 / #1471 / #1472. Seven small follow-ups across schema-dumper, fixtures, and MySQL adapter — coherent review surface.

- **Item 1 (bug):** `defineFixtures` poly ref guard — check polymorphic association _before_ `isFixtureRef` so `ref()` on a poly key throws a clear error instead of inserting a spurious column. Test: `ref()` on poly key throws; existing instance-expansion tests still pass.
- **Item 2:** `createSchemaDumper(source, opts)` override added to `Mysql2Adapter` and `Sqlite3Adapter` so `dumpTableSchema` adapter-dispatch picks the right subclass for MySQL/SQLite (was PG-only).
- **Item 3:** Fix stale comment in `postgresql/schema-dumper.ts` — `exclusionConstraintsInCreate` / `uniqueConstraintsInCreate` renamed to `_emitExclusionConstraints` / `_emitUniqueConstraints` in sweep D but comment wasn't updated.
- **Item 4 (bug):** `columns()` on MariaDB: use `DATA_TYPE` (not `COLUMN_TYPE`) for the type-map limit lookup so `FLOAT` columns get `limit: 24` instead of MariaDB's normalized `double` limit of 53. Unit test documents the `lookupCastType` limit divergence.
- **Item 5:** `MysqlSchemaStatements` extends `SchemaStatements` with `temporary: true` support on `dropTable`; `Mysql2Adapter#schemaStatements()` returns it so `Migration#schema.dropTable(name, { temporary: true })` emits `DROP TEMPORARY TABLE`.
- **Item 6:** Promote `supportsComments()`, `supportsCommentsInCreate()`, and `changeTableComment()` from duck-typed cast in `SchemaStatements#createTable` to formal optional methods on the `DatabaseAdapter` interface.
- **Item 7:** `dumpTableSchema` passes `wrappedSource` directly to `createSchemaDumper(source, opts)` instead of patching `_source` after construction; PG's override updated to accept the source parameter.

## Test plan

- [ ] `pnpm test` — define-fixtures + mysql2-adapter unit tests pass
- [ ] `pnpm test:types` — no type errors
- [ ] `pnpm api:compare --package activerecord` — 4950/4958 (99.8%), no regression
- [ ] `pnpm lint` — clean