### PR TITLE
refactor(activemodel) mixin host typing — replace this:any and AnyRecord=any with declared host interfaces

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -111,8 +111,15 @@ export class AttributeMethodPattern {
 // ClassMethods — assigned directly to Model's static side
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = any;
+/** Minimum shape required of an instance accessed through a generated attribute method closure. */
+interface ReadWriteHost {
+  readAttribute(name: string): unknown;
+  writeAttribute(name: string, value: unknown): void;
+  [key: string]: unknown;
+}
+
+/** Function extended with a generated-method marker. */
+type TaggedFn = ((...args: unknown[]) => unknown) & { __generatedAttributeMethod?: boolean };
 
 export interface AttributeMethodHost {
   _attributeDefinitions: Map<string, { name: string }>;
@@ -120,7 +127,7 @@ export interface AttributeMethodHost {
   _attributeAliases: Record<string, string>;
   _aliasesByAttributeName: Map<string, string[]>;
   _generatedMethods: Set<string>;
-  prototype: AnyRecord;
+  prototype: { [key: string]: unknown };
 }
 
 function ensureOwnPatterns(host: AttributeMethodHost): void {
@@ -194,13 +201,13 @@ export function aliasAttribute(this: AttributeMethodHost, newName: string, oldNa
 
   // Define the direct alias property (bare name → original)
   ensureOwnGeneratedMethods(this);
-  const getter = function (this: AnyRecord) {
+  const getter: TaggedFn = function (this: ReadWriteHost) {
     return this.readAttribute(oldName);
   };
-  (getter as AnyRecord).__generatedAttributeMethod = true;
+  getter.__generatedAttributeMethod = true;
   Object.defineProperty(this.prototype, newName, {
     get: getter,
-    set(this: AnyRecord, value: unknown) {
+    set(this: ReadWriteHost, value: unknown) {
       this.writeAttribute(oldName, value);
     },
     configurable: true,
@@ -223,7 +230,7 @@ export function undefineAttributeMethods(this: AttributeMethodHost): void {
     if (!desc) continue;
     // Only delete if the method is still the generated one (has our marker)
     const fn = desc.value ?? desc.get;
-    if (fn && (fn as AnyRecord).__generatedAttributeMethod) {
+    if (fn && (fn as TaggedFn).__generatedAttributeMethod) {
       delete this.prototype[methodName];
     }
   }
@@ -269,10 +276,10 @@ export function defineAttributeMethodPattern(
   const methodName = pattern.methodName(attrName);
   if (host.prototype[methodName] !== undefined && !options?.override) return;
   ensureOwnGeneratedMethods(host);
-  const fn = function (this: AnyRecord) {
+  const fn: TaggedFn = function (this: ReadWriteHost) {
     return this.readAttribute(attrName);
   };
-  (fn as AnyRecord).__generatedAttributeMethod = true;
+  fn.__generatedAttributeMethod = true;
   Object.defineProperty(host.prototype, methodName, {
     value: fn,
     writable: true,
@@ -308,14 +315,14 @@ export function aliasAttributeMethodDefinition(
   const methodName = pattern.methodName(newName);
   const targetName = pattern.methodName(oldName);
   ensureOwnGeneratedMethods(host);
-  const fn = function (this: AnyRecord, ...args: unknown[]) {
+  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
     const target = this[targetName];
     if (typeof target === "function") {
-      return target.apply(this, args);
+      return (target as (...a: unknown[]) => unknown).apply(this, args);
     }
     return this.readAttribute(oldName);
   };
-  (fn as AnyRecord).__generatedAttributeMethod = true;
+  fn.__generatedAttributeMethod = true;
   Object.defineProperty(host.prototype, methodName, {
     value: fn,
     writable: true,
@@ -476,16 +483,16 @@ export function defineProxyCall(
   attrName: string,
 ): void {
   ensureOwnGeneratedMethods(this);
-  const fn = function (this: AnyRecord, ...args: unknown[]) {
+  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
     const handler = this[proxyTarget];
     if (typeof handler !== "function") {
       throw new MissingAttributeError(
         `attribute_missing dispatch failed: ${proxyTarget} not defined`,
       );
     }
-    return handler.call(this, attrName, ...args);
+    return (handler as (...a: unknown[]) => unknown).call(this, attrName, ...args);
   };
-  (fn as AnyRecord).__generatedAttributeMethod = true;
+  fn.__generatedAttributeMethod = true;
   Object.defineProperty(this.prototype, name, { value: fn, writable: true, configurable: true });
   this._generatedMethods.add(name);
 }
@@ -509,7 +516,7 @@ export function defineCall(
 // Instance-level Rails privates (attribute_methods.rb)
 // ---------------------------------------------------------------------------
 
-type InstanceHost = {
+export type InstanceHost = {
   _attributes?: { has(name: string): boolean };
   _attributeMethodPatterns?: AttributeMethodPattern[];
   constructor: AttributeMethodHost;

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -27,8 +27,16 @@ export interface AttributeRegistrationClassMethods {
 
 export type AttributeRegistration = AttributeRegistrationClassMethods;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyAttributeHost = any;
+export interface AttributeHostInternals {
+  _cachedDefaultAttributes?: AttributeSet | null;
+  _attributesBuilder?: unknown;
+  _attributeDefinitions?: Map<
+    string,
+    { name: string; type?: Type; virtual?: boolean; userProvidedDefault?: boolean }
+  >;
+  _pendingAttributeModifications?: PendingModification[];
+  _attributeAliases?: Record<string, string>;
+}
 
 // ---------------------------------------------------------------------------
 // Pending modification structs
@@ -107,12 +115,17 @@ export class PendingDecorator implements PendingModification {
  * Mirrors: ActiveSupport::DescendantsTracker registration triggered by
  * Class.inherited in Rails.
  */
-export function registerWithSuperclass(cls: AnyAttributeHost): void {
-  const superclass = Object.getPrototypeOf(cls);
-  if (!superclass || superclass === Function.prototype) return;
+type HostAsClass = new (...args: unknown[]) => unknown;
+
+export function registerWithSuperclass(cls: AttributeHostInternals): void {
+  const superclass = Object.getPrototypeOf(cls) as AttributeHostInternals;
+  if (!superclass || (superclass as unknown) === Function.prototype) return;
   // Only register if the superclass participates in the attribute system.
   if (!("_attributeDefinitions" in superclass)) return;
-  DescendantsTracker.registerSubclass(superclass, cls);
+  DescendantsTracker.registerSubclass(
+    superclass as unknown as HostAsClass,
+    cls as unknown as HostAsClass,
+  );
 }
 
 /**
@@ -124,10 +137,10 @@ export function registerWithSuperclass(cls: AnyAttributeHost): void {
  *
  * @internal
  */
-export function resetDefaultAttributes(cls: AnyAttributeHost): void {
+export function resetDefaultAttributes(cls: AttributeHostInternals): void {
   resetDefaultAttributesBang.call(cls);
-  for (const sub of DescendantsTracker.subclasses(cls)) {
-    resetDefaultAttributes(sub);
+  for (const sub of DescendantsTracker.subclasses(cls as unknown as HostAsClass)) {
+    resetDefaultAttributes(sub as unknown as AttributeHostInternals);
   }
 }
 
@@ -135,8 +148,9 @@ export function resetDefaultAttributes(cls: AnyAttributeHost): void {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function collectPendingModifications(cls: AnyAttributeHost): PendingModification[] {
-  if (!cls || cls === Function.prototype || !cls._pendingAttributeModifications) return [];
+function collectPendingModifications(cls: AttributeHostInternals): PendingModification[] {
+  if (!cls || (cls as unknown) === Function.prototype || !cls._pendingAttributeModifications)
+    return [];
   const superMods = collectPendingModifications(Object.getPrototypeOf(cls));
   const own = Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")
     ? (cls._pendingAttributeModifications as PendingModification[])
@@ -150,7 +164,7 @@ function collectPendingModifications(cls: AnyAttributeHost): PendingModification
  * @internal
  */
 export function applyPendingAttributeModifications(
-  cls: AnyAttributeHost,
+  cls: AttributeHostInternals,
   attributeSet: AttributeSet,
 ): void {
   for (const mod of collectPendingModifications(cls)) {
@@ -168,7 +182,7 @@ export function applyPendingAttributeModifications(
  *
  * Mirrors: the PendingType push inside ActiveModel::AttributeRegistration#attribute
  */
-export function pushPendingType(cls: AnyAttributeHost, name: string, type: Type): void {
+export function pushPendingType(cls: AttributeHostInternals, name: string, type: Type): void {
   pendingAttributeModifications.call(cls).push(new PendingType(name, type));
 }
 
@@ -178,7 +192,11 @@ export function pushPendingType(cls: AnyAttributeHost, name: string, type: Type)
  *
  * Mirrors: the PendingDefault push inside ActiveModel::AttributeRegistration#attribute
  */
-export function pushPendingDefault(cls: AnyAttributeHost, name: string, value: unknown): void {
+export function pushPendingDefault(
+  cls: AttributeHostInternals,
+  name: string,
+  value: unknown,
+): void {
   pendingAttributeModifications.call(cls).push(new PendingDefault(name, value));
 }
 
@@ -189,7 +207,7 @@ export function pushPendingDefault(cls: AnyAttributeHost, name: string, value: u
  * Mirrors: the PendingDecorator push inside ActiveModel::AttributeRegistration#decorate_attributes
  */
 export function pushPendingDecorator(
-  cls: AnyAttributeHost,
+  cls: AttributeHostInternals,
   names: string[] | null,
   decorator: (name: string, type: Type) => Type,
 ): void {
@@ -204,7 +222,7 @@ export function pushPendingDecorator(
  *
  * AR overrides this to seed from columnsHash first, then replay.
  */
-export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
+export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
   if (!this._cachedDefaultAttributes) {
     // Register with our superclass so resetDefaultAttributes() cascades to us
     // when the superclass gains new attribute declarations. Mirrors the
@@ -228,7 +246,7 @@ export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
  * see the decorated type without waiting for _defaultAttributes to be rebuilt.
  */
 export function decorateAttributes(
-  this: AnyAttributeHost,
+  this: AttributeHostInternals,
   names: string[] | null,
   decorator: (name: string, type: Type) => Type,
 ): void {
@@ -261,7 +279,7 @@ export function decorateAttributes(
  * Wraps the cast-types record in a Proxy so unknown keys return a fallback
  * ValueType — same effect as Rails setting `hash.default = Type.default_value`.
  */
-export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
+export function attributeTypes(this: AttributeHostInternals): Record<string, Type> {
   const cast = _defaultAttributes.call(this).castTypes();
   return new Proxy(cast, {
     get(target, prop, receiver) {
@@ -280,7 +298,7 @@ export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
  * Delegates to attributeTypes — single codepath. Returns a fallback ValueType
  * for unknown names (never null), matching Rails' Type.default_value behavior.
  */
-export function typeForAttribute(this: AnyAttributeHost, name: string): Type {
+export function typeForAttribute(this: AttributeHostInternals, name: string): Type {
   const resolved = resolveAttributeName.call(this, name);
   return attributeTypes.call(this)[resolved];
 }
@@ -292,7 +310,7 @@ export function typeForAttribute(this: AnyAttributeHost, name: string): Type {
  *
  * @internal Rails-private helper.
  */
-export function pendingAttributeModifications(this: AnyAttributeHost): PendingModification[] {
+export function pendingAttributeModifications(this: AttributeHostInternals): PendingModification[] {
   if (!Object.prototype.hasOwnProperty.call(this, "_pendingAttributeModifications")) {
     this._pendingAttributeModifications = [];
   }
@@ -307,7 +325,7 @@ export function pendingAttributeModifications(this: AnyAttributeHost): PendingMo
  *
  * @internal Rails-private helper.
  */
-export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
+export function resetDefaultAttributesBang(this: AttributeHostInternals): void {
   this._cachedDefaultAttributes = null;
   // _attributesBuilder is an AR-specific derived cache. Shadow with undefined
   // so prototype-chain lookup never returns a stale superclass builder after
@@ -324,7 +342,7 @@ export function resetDefaultAttributesBang(this: AnyAttributeHost): void {
  *
  * @internal Rails-private helper.
  */
-export function resolveAttributeName(this: AnyAttributeHost, name: string): string {
+export function resolveAttributeName(this: AttributeHostInternals, name: string): string {
   return name;
 }
 
@@ -336,7 +354,7 @@ export function resolveAttributeName(this: AnyAttributeHost, name: string): stri
  * @internal Rails-private helper.
  */
 export function resolveTypeName(
-  this: AnyAttributeHost,
+  this: AttributeHostInternals,
   name: string,
   _options?: Record<string, unknown>,
 ): Type {
@@ -351,6 +369,10 @@ export function resolveTypeName(
  *
  * @internal Rails-private helper.
  */
-export function hookAttributeType(this: AnyAttributeHost, _attribute: string, type: Type): Type {
+export function hookAttributeType(
+  this: AttributeHostInternals,
+  _attribute: string,
+  type: Type,
+): Type {
   return type;
 }

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -16,6 +16,7 @@ import {
   pushPendingDefault,
   resetDefaultAttributes,
 } from "./attribute-registration.js";
+import { type InstanceHost } from "./attribute-methods.js";
 
 export interface AttributeDefinition {
   name: string;
@@ -232,30 +233,31 @@ export class Attributes {
 // Rails privates surfaced by attributes.rb
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyInstanceHost = any;
-
 /** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
-export function isAttributeMethod(this: AnyInstanceHost, attrName: string): boolean {
+export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
   return _isAttributeMethod.call(this, attrName);
 }
 
 /** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
 export function matchedAttributeMethod(
-  this: AnyInstanceHost,
+  this: InstanceHost,
   methodName: string,
 ): { proxyTarget: string; attrName: string } | null {
   return _matchedAttributeMethod.call(this, methodName);
 }
 
 /** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
-export function missingAttribute(this: AnyInstanceHost, attrName: string): never {
+export function missingAttribute(this: InstanceHost, attrName: string): never {
   return _missingAttribute.call(this, attrName);
 }
 
 /** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
-export function _readAttribute(this: AnyInstanceHost, attr: string): unknown {
-  return __readAttribute.call(this, attr);
+export function _readAttribute(this: InstanceHost, attr: string): unknown {
+  type ReadAttributeThis = InstanceHost & {
+    _attributes?: { fetchValue(name: string): unknown };
+    _readAttribute?(name: string): unknown;
+  };
+  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
 }
 
 type AttributeInstanceHost = { _attributes: AttributeSet };

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -1,7 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = any;
-
 import { ArgumentError } from "./attribute-assignment.js";
+
+/** Minimum shape required of a record object threaded through a callback chain. */
+export type CallbackRecord = object;
 
 /**
  * Callbacks mixin contract — defines model callback registration.
@@ -32,15 +32,13 @@ export type Callbacks = CallbacksClassMethods;
  *
  * Mirrors: ActiveModel::Callbacks.define_model_callbacks
  */
-/* eslint-disable @typescript-eslint/no-explicit-any -- mixin `this` must accept any class constructor */
-export function defineModelCallbacks(this: any, event: string, ...rest: string[]): void;
+export function defineModelCallbacks(this: object, event: string, ...rest: string[]): void;
 export function defineModelCallbacks(
-  this: any,
+  this: object,
   event: string,
   ...rest: [...string[], DefineModelCallbacksOptions]
 ): void;
-export function defineModelCallbacks(this: any, ...args: unknown[]): void {
-  /* eslint-enable @typescript-eslint/no-explicit-any */
+export function defineModelCallbacks(this: object, ...args: unknown[]): void {
   let options: DefineModelCallbacksOptions = {};
   const eventNames: string[] = [];
 
@@ -97,9 +95,7 @@ export function defineModelCallbacks(this: any, ...args: unknown[]): void {
   }
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any -- mixin host accepts any class constructor */
-type CallbackHost = any;
-/* eslint-enable @typescript-eslint/no-explicit-any */
+type CallbackHost = object;
 
 /**
  * Define a `before<Event>` class method that registers a before callback.
@@ -187,10 +183,10 @@ function resolveCallback(
     throw new ArgumentError(`Callback object must implement ${methodName} or ${camelMethod}`);
   }
   if (timing === "around") {
-    return ((record: AnyRecord, proceed: () => void | Promise<void>) =>
+    return ((record: CallbackRecord, proceed: () => void | Promise<void>) =>
       method.call(fnOrObject, record, proceed)) as AroundCallbackFn;
   }
-  return ((record: AnyRecord) => method.call(fnOrObject, record)) as CallbackFn;
+  return ((record: CallbackRecord) => method.call(fnOrObject, record)) as CallbackFn;
 }
 
 /**
@@ -208,9 +204,9 @@ function resolveCallback(
  * wrapped block may be async (e.g., DB operations in persistence). Around
  * callbacks that wrap async blocks should await proceed().
  */
-export type CallbackFn = (record: AnyRecord) => void | boolean | Promise<void | boolean>;
+export type CallbackFn = (record: CallbackRecord) => void | boolean | Promise<void | boolean>;
 export type AroundCallbackFn = (
-  record: AnyRecord,
+  record: CallbackRecord,
   proceed: () => void | Promise<void>,
 ) => void | Promise<void>;
 
@@ -241,9 +237,9 @@ function swallowRejection(v: unknown): void {
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
 
-export interface CallbackConditions<TRecord = AnyRecord> {
-  if?: (record: TRecord) => boolean;
-  unless?: (record: TRecord) => boolean;
+export interface CallbackConditions<TRecord = CallbackRecord> {
+  if?(record: TRecord): boolean;
+  unless?(record: TRecord): boolean;
   prepend?: boolean;
   on?: string | string[];
 }
@@ -330,7 +326,7 @@ export class CallbackChain {
     }
   }
 
-  private _shouldRun(entry: CallbackEntry, record: AnyRecord): boolean {
+  private _shouldRun(entry: CallbackEntry, record: CallbackRecord): boolean {
     if (entry.conditions?.if && !entry.conditions.if(record)) return false;
     if (entry.conditions?.unless && entry.conditions.unless(record)) return false;
     if (
@@ -340,7 +336,7 @@ export class CallbackChain {
       const allowed = Array.isArray(entry.conditions.on)
         ? entry.conditions.on
         : [entry.conditions.on];
-      const action: string | undefined = record._transactionAction;
+      const action = (record as { _transactionAction?: string })._transactionAction;
       if (!action || !allowed.includes(action)) return false;
     }
     return true;
@@ -406,17 +402,17 @@ export class CallbackChain {
    */
   runBefore(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts: RunCallbacksOptions & { strict: "sync" },
   ): boolean;
   runBefore(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean>;
   runBefore(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
     const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
@@ -456,17 +452,17 @@ export class CallbackChain {
    */
   runAfter(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts: RunCallbacksOptions & { strict: "sync" },
   ): void;
   runAfter(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): void | Promise<void>;
   runAfter(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): void | Promise<void> {
     const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
@@ -503,19 +499,19 @@ export class CallbackChain {
    */
   runCallbacks(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     block: () => unknown,
     opts: RunCallbacksOptions & { strict: "sync" },
   ): boolean;
   runCallbacks(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean>;
   runCallbacks(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
@@ -531,7 +527,7 @@ export class CallbackChain {
 
   private _runAroundBlockAndAfter(
     event: CallbackEvent,
-    record: AnyRecord,
+    record: CallbackRecord,
     block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -15,15 +15,18 @@ export interface Conversion {
   toPartialPath(): string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyConversionHost = any;
+interface ConversionHost {
+  name: string;
+  modelName?: { collection: string; element: string };
+  _cachedToPartialPath?: string;
+}
 
 /**
  * Class-level cache for toPartialPath.
  *
  * Mirrors: ActiveModel::Conversion::ClassMethods#_to_partial_path
  */
-export function _toPartialPath(this: AnyConversionHost): string {
+export function _toPartialPath(this: ConversionHost): string {
   if (!this._cachedToPartialPath) {
     if (this.modelName != null) {
       const mn = this.modelName;

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -6,6 +6,7 @@ import {
   matchedAttributeMethod as _matchedAttributeMethod,
   missingAttribute as _missingAttribute,
   _readAttribute as __readAttribute,
+  type InstanceHost,
 } from "./attribute-methods.js";
 
 /**
@@ -420,30 +421,31 @@ export class DirtyTracker {
 // Rails privates surfaced by dirty.rb
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyInstanceHost = any;
-
 /** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
-export function isAttributeMethod(this: AnyInstanceHost, attrName: string): boolean {
+export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
   return _isAttributeMethod.call(this, attrName);
 }
 
 /** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
 export function matchedAttributeMethod(
-  this: AnyInstanceHost,
+  this: InstanceHost,
   methodName: string,
 ): { proxyTarget: string; attrName: string } | null {
   return _matchedAttributeMethod.call(this, methodName);
 }
 
 /** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
-export function missingAttribute(this: AnyInstanceHost, attrName: string): never {
+export function missingAttribute(this: InstanceHost, attrName: string): never {
   return _missingAttribute.call(this, attrName);
 }
 
 /** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
-export function _readAttribute(this: AnyInstanceHost, attr: string): unknown {
-  return __readAttribute.call(this, attr);
+export function _readAttribute(this: InstanceHost, attr: string): unknown {
+  type ReadAttributeThis = InstanceHost & {
+    _attributes?: { fetchValue(name: string): unknown };
+    _readAttribute?(name: string): unknown;
+  };
+  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
 }
 
 type DirtyDispatchHost = {

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -1,8 +1,17 @@
 import { humanize, underscore, deepDup } from "@blazetrails/activesupport";
 import { I18n } from "./i18n.js";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = any;
+/** The model instance that owns this error. Rails tests pass null for base-only errors. */
+type ModelBase = object | null;
+
+/** Shape of a model class accessed for I18n/human-attribute lookups. */
+interface ModelClass {
+  name?: string;
+  i18nScope?: string;
+  modelName?: { i18nKey?: string };
+  humanAttributeName?: (attr: string) => string;
+  lookupAncestors?: () => ModelClass[];
+}
 
 // Rails `CALLBACKS_OPTIONS` / `MESSAGE_OPTIONS` — option keys that are
 // stripped from the identity of an error for strict-match / hash purposes
@@ -68,14 +77,14 @@ function optionsEqual(a: unknown, b: unknown): boolean {
 export class Error {
   static i18nCustomizeFullMessage: boolean = false;
 
-  readonly base: AnyRecord;
+  readonly base: ModelBase;
   readonly attribute: string;
   readonly type: string;
   readonly rawType: string;
   readonly options: Record<string, unknown>;
 
   constructor(
-    base: AnyRecord,
+    base: ModelBase,
     attribute: string,
     type: string = "invalid",
     options: Record<string, unknown> = {},
@@ -103,7 +112,7 @@ export class Error {
    * between `type` and `rawType` when a NestedError-style override was in
    * play.
    */
-  dupWithBase(newBase: AnyRecord): Error {
+  dupWithBase(newBase: ModelBase): Error {
     return new Error(newBase, this.attribute, this.type, deepDup(this.options), this.rawType);
   }
 
@@ -206,7 +215,7 @@ export class Error {
    *
    * @internal Rails-private helper.
    */
-  protected attributesForHash(): [AnyRecord, string, string, Record<string, unknown>] {
+  protected attributesForHash(): [ModelBase, string, string, Record<string, unknown>] {
     const own: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(this.options)) {
       if (!CALLBACKS_OPTIONS.has(k)) own[k] = v;
@@ -230,9 +239,9 @@ export class Error {
     });
   }
 
-  static fullMessage(attribute: string, message: string, base: AnyRecord): string {
+  static fullMessage(attribute: string, message: string, base: ModelBase): string {
     if (attribute === "base") return message;
-    const modelClass = base?.constructor;
+    const modelClass = base?.constructor as ModelClass | undefined;
     const rawScope = modelClass?.i18nScope;
     const i18nScope = typeof rawScope === "string" ? rawScope : "activemodel";
 
@@ -249,7 +258,7 @@ export class Error {
     let format: string;
     if (Error.i18nCustomizeFullMessage) {
       const modelKey =
-        (modelClass as AnyRecord)?.modelName?.i18nKey ??
+        (modelClass as ModelClass)?.modelName?.i18nKey ??
         (modelClass?.name ? underscore(modelClass.name) : undefined);
       const defaults: string[] = [];
       if (modelKey) {
@@ -289,13 +298,13 @@ export class Error {
   static generateMessage(
     attribute: string,
     type: string,
-    base: AnyRecord,
+    base: ModelBase,
     options: Record<string, unknown> = {},
   ): string {
     const msgOpt = options.message;
     // Proc/lambda message: call with (base, options) and return result.
     if (typeof msgOpt === "function") {
-      const result = (msgOpt as (b: AnyRecord, o: Record<string, unknown>) => unknown)(
+      const result = (msgOpt as (b: ModelBase, o: Record<string, unknown>) => unknown)(
         base,
         options,
       );
@@ -310,9 +319,9 @@ export class Error {
       return Error.interpolate(msgOpt, options);
     }
 
-    const modelClass = base?.constructor;
+    const modelClass = base?.constructor as ModelClass | undefined;
     const modelKey =
-      (modelClass as AnyRecord)?.modelName?.i18nKey ??
+      modelClass?.modelName?.i18nKey ??
       (modelClass?.name ? underscore(modelClass.name) : undefined);
     const humanAttr = modelClass?.humanAttributeName
       ? modelClass.humanAttributeName(attribute)
@@ -321,7 +330,8 @@ export class Error {
     const i18nOptions: Record<string, unknown> = {
       model: modelKey,
       attribute: humanAttr,
-      value: base && attribute !== "base" ? base[attribute] : undefined,
+      value:
+        base && attribute !== "base" ? (base as Record<string, unknown>)[attribute] : undefined,
       object: base,
       ...options,
     };

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = any;
+/** The model instance that owns this Errors collection. */
+type ModelBase = object | null;
 
 import { Error as ActiveModelError } from "./error.js";
 import { NestedError } from "./nested-error.js";
@@ -24,13 +24,13 @@ const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
  */
 export class Errors {
   private _errors: ActiveModelError[] = [];
-  private _base: AnyRecord;
+  private _base: ModelBase;
 
-  constructor(base: AnyRecord) {
+  constructor(base: ModelBase) {
     this._base = base;
   }
 
-  get base(): AnyRecord {
+  get base(): ModelBase {
     return this._base;
   }
 
@@ -58,8 +58,8 @@ export class Errors {
    */
   add(
     attribute: string,
-    type: string | ((record: AnyRecord, options: Record<string, unknown>) => string) = "invalid",
-    options?: { message?: string | ((record: AnyRecord) => string) } & Record<string, unknown>,
+    type: string | ((record: ModelBase, options: Record<string, unknown>) => string) = "invalid",
+    options?: { message?: string | ((record: ModelBase) => string) } & Record<string, unknown>,
   ): ActiveModelError {
     const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
     const error = new ActiveModelError(this._base, normAttr, normType, normOpts);
@@ -86,7 +86,7 @@ export class Errors {
    */
   normalizeArguments(
     attribute: string,
-    type: string | ((record: AnyRecord, options: Record<string, unknown>) => string),
+    type: string | ((record: ModelBase, options: Record<string, unknown>) => string),
     options?: Record<string, unknown>,
   ): [string, string, Record<string, unknown>] {
     const opts = { ...(options ?? {}) };
@@ -109,7 +109,7 @@ export class Errors {
    */
   where(
     attribute: string,
-    type?: string | ((record: AnyRecord, options: Record<string, unknown>) => string),
+    type?: string | ((record: ModelBase, options: Record<string, unknown>) => string),
     options?: Record<string, unknown>,
   ): ActiveModelError[] {
     if (type === undefined) {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -31,7 +31,7 @@ import {
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions, coerceForJson } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
-import type { ConditionalOptions, ConditionFn } from "./validator.js";
+import type { ConditionalOptions, ConditionFn, ValidatableRecord } from "./validator.js";
 import { evaluateCondition } from "./validator.js";
 import {
   AttributeMethodPattern,
@@ -83,7 +83,7 @@ type AnyRecord = any;
  * `_validators` / `validators()` / `validatorsOn()` so the stored value
  * type matches what we actually accept at registration.
  */
-type ValidatorLike = ValidatorBase | EachValidator | { validate(record: AnyRecord): void };
+type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
@@ -497,7 +497,7 @@ export class Model {
       | {
           new (
             options: Record<string, unknown>,
-          ): ValidatorBase | { validate(record: AnyRecord): void };
+          ): ValidatorBase | { validate(record: ValidatableRecord): void };
         }
       | (ConditionalOptions & { strict?: boolean; [key: string]: unknown })
     >
@@ -522,15 +522,18 @@ export class Model {
         ? [rawExplicit]
         : null;
 
+    type ValidatorCheckable = { checkValidity?(): void; checkValidityBang?(): void };
     for (const klass of args as Array<{
-      new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
+      new (
+        options: Record<string, unknown>,
+      ): ValidatorBase | { validate(record: ValidatableRecord): void };
     }>) {
       const validator = new klass(rest);
       if (!(validator instanceof EachValidator)) {
-        if (typeof (validator as AnyRecord).checkValidity === "function") {
-          (validator as AnyRecord).checkValidity();
-        } else if (typeof (validator as AnyRecord).checkValidityBang === "function") {
-          (validator as AnyRecord).checkValidityBang();
+        if (typeof (validator as ValidatorCheckable).checkValidity === "function") {
+          (validator as ValidatorCheckable).checkValidity!();
+        } else if (typeof (validator as ValidatorCheckable).checkValidityBang === "function") {
+          (validator as ValidatorCheckable).checkValidityBang!();
         }
       }
       this._registerValidator(validator, explicitAttributes);
@@ -1119,8 +1122,8 @@ export class Model {
     explicitAttributes?: readonly string[] | null,
   ): void {
     this._ensureOwnValidators();
-    const fromInstance = (validator as AnyRecord).attributes;
-    const fromOptions = (validator as AnyRecord).options?.attributes;
+    const fromInstance = (validator as { attributes?: unknown }).attributes;
+    const fromOptions = (validator as { options?: { attributes?: unknown } }).options?.attributes;
     const rawAttrs =
       explicitAttributes && explicitAttributes.length > 0
         ? explicitAttributes
@@ -2121,7 +2124,7 @@ export class Model {
    * Mirrors: ActiveModel::AttributeMethods#respond_to?
    */
   respondTo(method: string): boolean {
-    if (typeof (this as AnyRecord)[method] === "function") return true;
+    if (typeof (this as unknown as Record<string, unknown>)[method] === "function") return true;
     if (this._attributes.has(method)) return true;
     return false;
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -31,14 +31,8 @@ import {
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions, coerceForJson } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
-
-/**
- * Anything `validates_with` accepts: a full `Validator`/`EachValidator`
- * subclass, or any class that just implements `validate(record)`. Used by
- * `_validators` / `validators()` / `validatorsOn()` so the stored value
- * type matches what we actually accept at registration.
- */
-type ValidatorLike = ValidatorBase | EachValidator | { validate(record: AnyRecord): void };
+import type { ConditionalOptions, ConditionFn } from "./validator.js";
+import { evaluateCondition } from "./validator.js";
 import {
   AttributeMethodPattern,
   attributeMethodPrefix,
@@ -55,8 +49,6 @@ import {
   attributeWriterMissing as defaultAttributeWriterMissing,
   ArgumentError,
 } from "./attribute-assignment.js";
-import type { ConditionalOptions, ConditionFn, AnyRecord } from "./validator.js";
-import { evaluateCondition } from "./validator.js";
 import { PresenceValidator } from "./validations/presence.js";
 import { AbsenceValidator } from "./validations/absence.js";
 import { LengthValidator } from "./validations/length.js";
@@ -78,8 +70,20 @@ import {
   resolveAttributeName as _resolveAttributeNameHelper,
   resolveTypeName as _resolveTypeNameHelper,
   hookAttributeType as _hookAttributeTypeHelper,
+  type AttributeHostInternals,
 } from "./attribute-registration.js";
 import { _toPartialPath } from "./conversion.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRecord = any;
+
+/**
+ * Anything `validates_with` accepts: a full `Validator`/`EachValidator`
+ * subclass, or any class that just implements `validate(record)`. Used by
+ * `_validators` / `validators()` / `validatorsOn()` so the stored value
+ * type matches what we actually accept at registration.
+ */
+type ValidatorLike = ValidatorBase | EachValidator | { validate(record: AnyRecord): void };
 
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
@@ -132,17 +136,17 @@ export class Model {
 
   /** @internal Rails-private helper. */
   static pendingAttributeModifications(): ReturnType<typeof _pendingAttributeModificationsHelper> {
-    return _pendingAttributeModificationsHelper.call(this);
+    return _pendingAttributeModificationsHelper.call(this as unknown as AttributeHostInternals);
   }
 
   /** @internal Rails-private helper. */
   static resetDefaultAttributesBang(): void {
-    _resetDefaultAttributesBangHelper.call(this);
+    _resetDefaultAttributesBangHelper.call(this as unknown as AttributeHostInternals);
   }
 
   /** @internal Rails-private helper. */
   static resolveAttributeName(name: string): string {
-    return _resolveAttributeNameHelper.call(this, name);
+    return _resolveAttributeNameHelper.call(this as unknown as AttributeHostInternals, name);
   }
 
   /** @internal Rails-private helper. */
@@ -150,7 +154,7 @@ export class Model {
     name: string,
     options?: Record<string, unknown>,
   ): import("./type/value.js").Type {
-    return _resolveTypeNameHelper.call(this, name, options);
+    return _resolveTypeNameHelper.call(this as unknown as AttributeHostInternals, name, options);
   }
 
   /** @internal Rails-private helper. */
@@ -158,7 +162,11 @@ export class Model {
     attribute: string,
     type: import("./type/value.js").Type,
   ): import("./type/value.js").Type {
-    return _hookAttributeTypeHelper.call(this, attribute, type);
+    return _hookAttributeTypeHelper.call(
+      this as unknown as AttributeHostInternals,
+      attribute,
+      type,
+    );
   }
 
   static attributeNames(): string[] {

--- a/packages/activemodel/src/nested-error.ts
+++ b/packages/activemodel/src/nested-error.ts
@@ -18,7 +18,7 @@ export class NestedError extends ActiveModelError {
   readonly innerError: ErrorLike;
 
   constructor(
-    base: unknown,
+    base: object | null,
     innerError: ErrorLike,
     options?: { attribute?: string; type?: string },
   ) {
@@ -52,7 +52,7 @@ export class NestedError extends ActiveModelError {
    * Inner error's own `base` is preserved (the inner error belongs to the
    * inner model, not the outer one) — only the NestedError's base changes.
    */
-  override dupWithBase(newBase: unknown): NestedError {
+  override dupWithBase(newBase: object | null): NestedError {
     const inner = this.innerError;
     const innerDup: ErrorLike =
       inner instanceof ActiveModelError

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -1,7 +1,15 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = any;
+/** Minimum shape required of a record object passed to serialization helpers. */
+export interface SerializationRecord {
+  [key: string]: unknown;
+  _attributes?: unknown;
+  attributes?: Record<string, unknown>;
+  readAttribute?: (key: string) => unknown;
+  _preloadedAssociations?: Map<string, unknown> | null;
+  _cachedAssociations?: Map<string, unknown> | null;
+  constructor: { name: string; _attributeDefinitions?: unknown };
+}
 
 /**
  * Set `key` on `target` as an own data property, even when `key` is
@@ -52,7 +60,7 @@ export interface SerializeOptions {
  * (serialization.rb:111-138)
  */
 export function serializableHash(
-  record: AnyRecord,
+  record: SerializationRecord,
   options: SerializeOptions = {},
 ): Record<string, unknown> {
   // Prefer an instance-level override (Rails' subclass-override
@@ -78,7 +86,7 @@ export function serializableHash(
   if (options.methods) {
     for (const method of options.methods) {
       if (typeof record[method] === "function") {
-        safeSet(result, method, record[method]());
+        safeSet(result, method, (record[method] as () => unknown)());
       } else if (method in record) {
         safeSet(result, method, record[method]);
       } else {
@@ -94,10 +102,14 @@ export function serializableHash(
       safeSet(
         result,
         assocName,
-        records.map((r: AnyRecord) => serializableHash(r, opts)),
+        records.map((r: SerializationRecord) => serializableHash(r, opts)),
       );
-    } else if (records && typeof records === "object" && (records as AnyRecord)._attributes) {
-      safeSet(result, assocName, serializableHash(records, opts));
+    } else if (
+      records &&
+      typeof records === "object" &&
+      (records as unknown as SerializationRecord)._attributes
+    ) {
+      safeSet(result, assocName, serializableHash(records as unknown as SerializationRecord, opts));
     } else {
       safeSet(result, assocName, records);
     }
@@ -122,11 +134,21 @@ export function serializableHash(
  *
  * @internal Rails-private helper.
  */
-export function attributeNamesForSerialization(record: AnyRecord): string[] {
-  const attrStore = record._attributes;
+type AttributeStore =
+  | { keys(): string[]; fetchValue(key: string): unknown }
+  | Map<string, unknown>
+  | null
+  | undefined;
+
+export function attributeNamesForSerialization(record: SerializationRecord): string[] {
+  const attrStore = record._attributes as AttributeStore;
   let keys: string[];
-  if (attrStore && typeof attrStore.keys === "function" && !(attrStore instanceof Map)) {
-    keys = attrStore.keys();
+  if (
+    attrStore &&
+    typeof (attrStore as { keys?: unknown }).keys === "function" &&
+    !(attrStore instanceof Map)
+  ) {
+    keys = (attrStore as { keys(): string[] }).keys();
   } else if (attrStore instanceof Map) {
     keys = Array.from(attrStore.keys());
   } else if (record.attributes) {
@@ -135,7 +157,7 @@ export function attributeNamesForSerialization(record: AnyRecord): string[] {
     keys = [];
   }
 
-  const defs = record.constructor?._attributeDefinitions as
+  const defs = record.constructor._attributeDefinitions as
     | Map<string, { virtual?: boolean }>
     | undefined;
   if (defs) {
@@ -160,15 +182,15 @@ export function attributeNamesForSerialization(record: AnyRecord): string[] {
  * @internal Rails-private helper.
  */
 export function serializableAttributes(
-  record: AnyRecord,
+  record: SerializationRecord,
   attributeNames: readonly string[],
 ): Record<string, unknown> {
-  const attrStore = record._attributes;
+  const attrStore = record._attributes as AttributeStore;
   const result: Record<string, unknown> = {};
   for (const key of attributeNames) {
     let value: unknown;
-    if (attrStore && typeof attrStore.fetchValue === "function") {
-      value = attrStore.fetchValue(key);
+    if (attrStore && typeof (attrStore as { fetchValue?: unknown }).fetchValue === "function") {
+      value = (attrStore as { fetchValue(k: string): unknown }).fetchValue(key);
     } else if (attrStore instanceof Map) {
       value = attrStore.get(key);
     } else if (record.readAttribute) {
@@ -206,7 +228,7 @@ export function serializableAttributes(
  * @internal Rails-private helper.
  */
 export function serializableAddIncludes(
-  record: AnyRecord,
+  record: SerializationRecord,
   options: SerializeOptions = {},
   callback: (association: string, records: unknown, opts: SerializeOptions) => void,
 ): void {

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -5,6 +5,7 @@ import {
   serializableAddIncludes,
   coerceForJson,
   type SerializeOptions,
+  type SerializationRecord,
 } from "../serialization.js";
 import { ModelName } from "../naming.js";
 
@@ -50,11 +51,14 @@ export class JSON {
   // model.ts:1179-1185 pattern).
   protected static _modelName?: ModelName;
 
+  /** Plain attribute store for lightweight adopters; subclasses override with their storage shape. */
+  declare attributes: Record<string, unknown>;
+
   // Rails: included do; extend ActiveModel::Naming; end — surfaces
   // model_name on the host class. Subclasses override to customize.
   static get modelName(): ModelName {
     if (!this._modelName || this._modelName.name !== this.name) {
-      this._modelName = new ModelName(this.name, { klass: this as unknown as { name: string } });
+      this._modelName = new ModelName(this.name, { klass: this });
     }
     return this._modelName;
   }
@@ -68,7 +72,7 @@ export class JSON {
    * `:methods`, `:include`.
    */
   serializableHash(options?: SerializeOptions): Record<string, unknown> {
-    return serializableHash(this as unknown as Parameters<typeof serializableHash>[0], options);
+    return serializableHash(this as unknown as SerializationRecord, options);
   }
 
   /**
@@ -78,7 +82,7 @@ export class JSON {
    * @internal Rails-private helper.
    */
   protected attributeNamesForSerialization(): string[] {
-    return attributeNamesForSerialization(this);
+    return attributeNamesForSerialization(this as unknown as SerializationRecord);
   }
 
   /**
@@ -88,7 +92,7 @@ export class JSON {
    * @internal Rails-private helper.
    */
   protected serializableAttributes(attributeNames: readonly string[]): Record<string, unknown> {
-    return serializableAttributes(this, attributeNames);
+    return serializableAttributes(this as unknown as SerializationRecord, attributeNames);
   }
 
   /**
@@ -101,7 +105,7 @@ export class JSON {
     options: SerializeOptions = {},
     callback: (association: string, records: unknown, opts: SerializeOptions) => void = () => {},
   ): void {
-    serializableAddIncludes(this, options, callback);
+    serializableAddIncludes(this as unknown as SerializationRecord, options, callback);
   }
 
   /**
@@ -168,10 +172,7 @@ export class JSON {
         );
       }
     }
-    (this as unknown as { attributes: Record<string, unknown> }).attributes = hash as Record<
-      string,
-      unknown
-    >;
+    this.attributes = hash as Record<string, unknown>;
     return this;
   }
 

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1375,7 +1375,12 @@ describe("validatesEach", () => {
               record.errors.add(attr, "invalid", { message: "must be non-negative" });
             }
           },
-          { if: (record) => record.readAttribute("price") !== null },
+          {
+            if: (record) =>
+              (record as unknown as { readAttribute(a: string): unknown }).readAttribute(
+                "price",
+              ) !== null,
+          },
         );
       }
     }

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 
 /**
@@ -24,7 +24,7 @@ export interface HelperMethods {
 }
 
 export class AbsenceValidator extends EachValidator {
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (!isBlank(value)) {
       record.errors.add(attribute, "present", this.filteredErrorOptions());
     }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { inspectAccessor } from "./_accessor.js";
 
 /**
@@ -51,7 +51,7 @@ export class AcceptanceValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isAcceptableOption: typeof isAcceptableOption;
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
     if (!this.isAcceptableOption(value)) {

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 import { COMPARE_CHECKS, errorOptions } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
@@ -63,7 +63,7 @@ export class ComparisonValidator extends EachValidator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     for (const optKey of COMPARE_CHECKS) {
       const raw = (this.options as Record<string, unknown>)[optKey];
       if (raw === undefined) continue;

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { humanize } from "@blazetrails/activesupport";
 import { inspectAccessor } from "./_accessor.js";
 
@@ -12,12 +12,17 @@ export class ConfirmationValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isConfirmationValueEqual: typeof isConfirmationValueEqual;
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     const confirmationAttr = `${attribute}Confirmation`;
-    const confirmation = record.readAttribute?.(confirmationAttr) ?? record[confirmationAttr];
+    const rec = record as unknown as Record<string, unknown>;
+    const confirmation =
+      (rec.readAttribute as ((a: string) => unknown) | undefined)?.(confirmationAttr) ??
+      rec[confirmationAttr];
     if (confirmation == null) return;
     if (!this.isConfirmationValueEqual(record, attribute, value, confirmation)) {
-      const modelClass = (record as AnyRecord).constructor;
+      const modelClass = rec.constructor as
+        | { humanAttributeName?: (a: string) => string }
+        | undefined;
       const humanAttr = modelClass?.humanAttributeName
         ? modelClass.humanAttributeName(attribute)
         : humanize(attribute);
@@ -92,7 +97,7 @@ export function setupBang(this: ConfirmationHost, klass: unknown): void {
  */
 export function isConfirmationValueEqual(
   this: { options: Record<string, unknown> },
-  _record: AnyRecord,
+  _record: ValidatableRecord,
   _attribute: string,
   value: unknown,
   confirmed: unknown,

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import {
   checkValidityBang,
   delimiter,
@@ -43,7 +43,7 @@ export class ExclusionValidator extends EachValidator {
     checkValidityBang.call(this);
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (this.isInclude(record, value)) {
       record.errors.add(attribute, "exclusion", exceptInWithinMergeValue(this.options, value));
     }

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { resolveValue } from "./resolve-value.js";
 
 /**
@@ -46,7 +46,7 @@ export class FormatValidator extends EachValidator {
     this.checkOptionsValidity("without");
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     // Rails uses Ruby truthiness on options[:with] / options[:without] —
     // nil/false skip the branch entirely. Mirror that so an explicit
     // `null` / `false` option doesn't crash at .test time.
@@ -76,7 +76,7 @@ export class FormatValidator extends EachValidator {
  */
 export function recordError(
   this: { options: Record<string, unknown> },
-  record: AnyRecord,
+  record: ValidatableRecord,
   attribute: string,
   name: "with" | "without",
   value: unknown,

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import {
   checkValidityBang,
   delimiter,
@@ -44,7 +44,7 @@ export class InclusionValidator extends EachValidator {
     checkValidityBang.call(this);
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (!this.isInclude(record, value)) {
       record.errors.add(attribute, "inclusion", exceptInWithinMergeValue(this.options, value));
     }

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { resolveValue } from "./resolve-value.js";
 
 /**
@@ -117,7 +117,7 @@ export class LengthValidator extends EachValidator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     // Rails length.rb:50 — `value.respond_to?(:length) ? value.length : value.to_s.length`.
     // For nil → 0 (nil.to_s.length); for non-nil values without a .length
     // (numbers, booleans, plain objects) → String(value).length.
@@ -186,7 +186,7 @@ export class LengthValidator extends EachValidator {
  */
 function resolveLengthOpt(
   this: { resolveValue(record: unknown, value: unknown): unknown },
-  record: AnyRecord,
+  record: ValidatableRecord,
   raw: unknown,
 ): number | undefined {
   if (raw === undefined || raw === null) return undefined;

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -1,10 +1,10 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { isBlank, RoundingHelper } from "@blazetrails/activesupport";
 import { errorOptions } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
 
-type NumericValue = number | ((record: AnyRecord) => number) | string;
+type NumericValue = number | ((record: ValidatableRecord) => number) | string;
 
 /**
  * Mirrors: ActiveModel::Validations::NumericalityValidator (numericality.rb)
@@ -48,7 +48,7 @@ export class NumericalityValidator extends EachValidator {
 
   private resolveNumeric(
     val: NumericValue | undefined,
-    record: AnyRecord,
+    record: ValidatableRecord,
     precision: number,
     scale?: number,
   ): number | undefined {
@@ -90,7 +90,7 @@ export class NumericalityValidator extends EachValidator {
    * an integer column casting "abc" to null mustn't bypass the check
    * (numericality.rb's validate_each operates on raw input).
    */
-  override validate(record: AnyRecord): void {
+  override validate(record: ValidatableRecord): void {
     for (const attribute of this.attributes) {
       // Reuses EachValidator.readAttributeForValidation so the lookup
       // chain stays in one place. The flow then runs through
@@ -106,7 +106,7 @@ export class NumericalityValidator extends EachValidator {
   }
 
   validateEach(
-    record: AnyRecord,
+    record: ValidatableRecord,
     attribute: string,
     value: unknown,
     precision = 15,
@@ -402,7 +402,7 @@ export function optionAsNumber(
   this: {
     resolveValue(record: unknown, value: unknown): unknown;
   },
-  record: AnyRecord,
+  record: ValidatableRecord,
   optionValue: unknown,
   precision: number,
   scale?: number,
@@ -488,7 +488,7 @@ export function isAllowOnlyInteger(
     options: Record<string, unknown>;
     resolveValue(record: unknown, value: unknown): unknown;
   },
-  record: AnyRecord,
+  record: ValidatableRecord,
 ): boolean {
   // Ruby truthiness: only nil/false count as false. Boolean(0) and
   // Boolean('') would diverge (Ruby treats both as truthy), so use the
@@ -538,7 +538,7 @@ interface RecordWithRawAttribute {
 export function prepareValueForValidation(
   this: unknown,
   value: unknown,
-  record: AnyRecord,
+  record: ValidatableRecord,
   attrName: string,
 ): unknown {
   // Rails has an early `return value if record_attribute_changed_in_place?`
@@ -557,7 +557,7 @@ export function prepareValueForValidation(
   // Rails per-attribute generated `${attr}_before_type_cast` methods.
   // Duck-type the lookup so other hosts implementing the same shape
   // (or AR Base subclasses) work too.
-  const r = record as RecordWithRawAttribute;
+  const r = record as unknown as RecordWithRawAttribute;
   let rawValue: unknown;
   if (typeof r.cameFromUser === "function") {
     if (r.cameFromUser(attrName)) {
@@ -589,8 +589,11 @@ export function prepareValueForValidation(
  *
  * @internal Rails-private helper.
  */
-export function isRecordAttributeChangedInPlace(record: AnyRecord, attrName: string): boolean {
-  const r = record as RecordWithRawAttribute;
+export function isRecordAttributeChangedInPlace(
+  record: ValidatableRecord,
+  attrName: string,
+): boolean {
+  const r = record as unknown as RecordWithRawAttribute;
   return typeof r.attributeChangedInPlace === "function" && r.attributeChangedInPlace(attrName);
 }
 

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -1,9 +1,9 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 
 export class PresenceValidator extends EachValidator {
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (isBlank(value)) {
       record.errors.add(attribute, "blank", this.filteredErrorOptions());
     }

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -286,7 +286,7 @@ describe("ValidatesWithTest", () => {
 describe("WithValidator arity dispatch", () => {
   it("calls zero-arity method without arguments", () => {
     const spy = vi.fn();
-    const record = { myCheck: spy };
+    const record = { myCheck: spy, errors: { add: vi.fn() } };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
     expect(spy).toHaveBeenCalledWith();
@@ -299,6 +299,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(attr: string) {
         capturedArg = attr;
       },
+      errors: { add: vi.fn() },
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
@@ -315,6 +316,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(...args: unknown[]) {
         received.push(...args);
       },
+      errors: { add: vi.fn() },
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
@@ -328,6 +330,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(attr: string = "") {
         capturedArg = attr;
       },
+      errors: { add: vi.fn() },
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -1,5 +1,5 @@
 import { EachValidator } from "../validator.js";
-import type { AnyRecord } from "../validator.js";
+import type { ValidatableRecord } from "../validator.js";
 
 export class WithValidator extends EachValidator {
   override checkValidity(): void {
@@ -12,9 +12,9 @@ export class WithValidator extends EachValidator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, _value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, _value: unknown): void {
     const methodName = this.options.with as string;
-    const method = record[methodName];
+    const method = (record as unknown as Record<string, unknown>)[methodName];
     if (typeof method !== "function") {
       throw new globalThis.Error(
         `WithValidator expected ${methodName} to be a function on the record`,

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -1,7 +1,9 @@
 import { isBlank, underscore } from "@blazetrails/activesupport";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyRecord = any;
+/** Minimum shape required of a record passed to validators. */
+export interface ValidatableRecord {
+  errors: { add(attribute: string, type?: string, options?: Record<string, unknown>): void };
+}
 
 /**
  * Universal validator control keys recognised by `validates(...)`.
@@ -26,7 +28,7 @@ const FILTER_FROM_ERROR_OPTIONS = VALIDATOR_DEFAULT_KEYS.filter(
   (k) => k !== "strict",
 ) as readonly string[];
 
-export type ConditionFn = ((record: AnyRecord) => boolean) | string;
+export type ConditionFn = ((record: ValidatableRecord) => boolean) | string;
 
 export interface ConditionalOptions {
   if?: ConditionFn | ConditionFn[];
@@ -41,14 +43,15 @@ export interface ConditionalOptions {
   on?: string | string[];
 }
 
-export function evaluateCondition(record: AnyRecord, cond: ConditionFn): boolean {
+export function evaluateCondition(record: ValidatableRecord, cond: ConditionFn): boolean {
   if (typeof cond === "function") return cond(record);
-  const method = record[cond];
-  if (typeof method === "function") return method.call(record);
-  return !!method;
+  const rec = record as unknown as Record<string, unknown>;
+  const method = rec[cond];
+  if (typeof method === "function") return (method as () => boolean).call(record);
+  return !!rec[cond];
 }
 
-export function shouldValidate(record: AnyRecord, options: ConditionalOptions): boolean {
+export function shouldValidate(record: ValidatableRecord, options: ConditionalOptions): boolean {
   if (options.if !== undefined) {
     const conds = Array.isArray(options.if) ? options.if : [options.if];
     for (const cond of conds) {
@@ -86,7 +89,7 @@ export abstract class Validator {
     return (this.constructor as typeof Validator).kind;
   }
 
-  abstract validate(_record: AnyRecord): void;
+  abstract validate(_record: ValidatableRecord): void;
 }
 
 /**
@@ -117,17 +120,18 @@ export class EachValidator extends Validator {
    * NumericalityValidator) reuse this helper so the lookup chain
    * stays in one place.
    */
-  protected readAttributeForValidation(record: AnyRecord, attribute: string): unknown {
-    if (typeof record.readAttributeForValidation === "function") {
-      return record.readAttributeForValidation(attribute);
+  protected readAttributeForValidation(record: ValidatableRecord, attribute: string): unknown {
+    const rec = record as unknown as Record<string, unknown>;
+    if (typeof rec.readAttributeForValidation === "function") {
+      return (rec.readAttributeForValidation as (a: string) => unknown)(attribute);
     }
-    if (typeof record.readAttribute === "function") {
-      return record.readAttribute(attribute);
+    if (typeof rec.readAttribute === "function") {
+      return (rec.readAttribute as (a: string) => unknown)(attribute);
     }
-    return record[attribute];
+    return rec[attribute];
   }
 
-  validate(record: AnyRecord): void {
+  validate(record: ValidatableRecord): void {
     for (const attribute of this.attributes) {
       let value = this.readAttributeForValidation(record, attribute);
       if (value == null && this.options.allowNil === true) continue;
@@ -147,13 +151,13 @@ export class EachValidator extends Validator {
    */
   protected prepareValueForValidation(
     value: unknown,
-    _record: AnyRecord,
+    _record: ValidatableRecord,
     _attribute: string,
   ): unknown {
     return value;
   }
 
-  validateEach(_record: AnyRecord, _attribute: string, _value: unknown): void {
+  validateEach(_record: ValidatableRecord, _attribute: string, _value: unknown): void {
     throw new Error("Subclasses must implement validateEach(record, attribute, value)");
   }
 
@@ -191,17 +195,17 @@ export class EachValidator extends Validator {
  * Mirrors: ActiveModel::BlockValidator
  */
 export class BlockValidator extends EachValidator {
-  private block: (record: AnyRecord, attribute: string, value: unknown) => void;
+  private block: (record: ValidatableRecord, attribute: string, value: unknown) => void;
 
   constructor(
     options: Record<string, unknown> & { attributes?: string | string[] },
-    block: (record: AnyRecord, attribute: string, value: unknown) => void,
+    block: (record: ValidatableRecord, attribute: string, value: unknown) => void,
   ) {
     super(options);
     this.block = block;
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     this.block(record, attribute, value);
   }
 }

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -1,7 +1,7 @@
 import { NestedError as ActiveModelNestedError } from "@blazetrails/activemodel";
 
 interface AssociationLike {
-  owner: unknown;
+  owner: object | null;
   reflection: { name: string };
   isCollection?(): boolean;
   target?: unknown[];


### PR DESCRIPTION
## Summary

Three groups of changes (four commits):

### 1. `defineModelCallbacks` host (`callbacks.ts`)

- `this: any` → `this: object` on all three overloads; `CallbackHost = any` → `object`
- Introduce `export type CallbackRecord = object` to replace `AnyRecord = any` throughout the callback chain (`CallbackFn`, `AroundCallbackFn`, `CallbackConditions`)
- Use method-signature form on `CallbackConditions.if/unless` (bivariant) so `CallbackConditions<InstanceType<T>>` stays assignable to `CallbackConditions<object>`

### 2. JSON serializer host (`serializers/json.ts`)

- Static `modelName` getter: `this as unknown as { name: string }` → `this` (satisfies `ModelLike` structurally)
- `serializableHash`: cast through `SerializationRecord` instead of `Parameters<typeof serializableHash>[0]`
- `fromJson`: `(this as unknown as { attributes: ... }).attributes = hash` → `this.attributes = hash` after adding `declare attributes` (no runtime code; subclass prototype accessors still win)

### 3. `AnyRecord = any` sweep across activemodel

| File | Replacement |
|------|-------------|
| `serialization.ts` | `export interface SerializationRecord` — typed optional slots + index sig |
| `validator.ts` | `export interface ValidatableRecord` — `{ errors.add }` as public mixin contract |
| `error.ts` / `errors.ts` | `ModelBase = object\|null`; `ModelClass` interface for I18n/humanize lookups |
| `conversion.ts` | `ConversionHost` interface — name, modelName?, _cachedToPartialPath? |
| `dirty.ts` / `attributes.ts` | `AnyInstanceHost` → imported `InstanceHost` from `attribute-methods` |
| `attribute-methods.ts` | `ReadWriteHost` for closure `this:`, `TaggedFn` for marker property; `InstanceHost` exported |
| `attribute-registration.ts` | `export interface AttributeHostInternals`; `HostAsClass` for DescendantsTracker |

### 4. Follow-up cleanup in `model.ts`

- `ValidatorLike` uses `ValidatableRecord` instead of `AnyRecord` for the duck-typed validator arm
- `validatesWith` class duck types use `ValidatableRecord`
- `_registerValidator` introspection uses explicit interface casts instead of `as AnyRecord`
- Remaining `AnyRecord` in `model.ts`: local alias used only for normalizes() option coercions (10 casts) and internal callback lambdas where the public API must accept any callable

### Notes

- `activerecord/associations/nested-error.ts`: `owner: object | null` to match `ModelBase`
- Pre-existing failures in `scripts/api-compare/extract-ts-api.test.ts` (5 tests) are unrelated to this PR