### PR TITLE
feat(activerecord) fixture replacement Phase 2 — useFixtures wrapper plus FixtureSet.createFixtures static

### DIFF
--- a/packages/activerecord/src/test-helpers/fixture-set.ts
+++ b/packages/activerecord/src/test-helpers/fixture-set.ts
@@ -1,0 +1,20 @@
+import { defineFixtures } from "./define-fixtures.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import type { Base } from "../base.js";
+
+type BaseClass = typeof Base;
+type FixtureAttrs = Record<string, unknown>;
+
+/**
+ * Static wrapper around `defineFixtures` that mirrors the Rails
+ * `ActiveRecord::FixtureSet` class surface.
+ */
+export class FixtureSet {
+  static async createFixtures<T extends BaseClass, K extends string>(
+    adapter: DatabaseAdapter,
+    ModelClass: T,
+    fixtures: Record<K, FixtureAttrs>,
+  ): Promise<{ [P in K]: InstanceType<T> }> {
+    return defineFixtures(adapter, ModelClass, fixtures);
+  }
+}

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { FixtureSet } from "./use-fixtures.js";
+import { fixtureId } from "./define-fixtures.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+function makeAdapter(): DatabaseAdapter {
+  return {
+    adapterName: "sqlite" as const,
+    execute: vi.fn(async () => []),
+    executeMutation: vi.fn(async () => 0),
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    createSavepoint: vi.fn(async () => {}),
+    releaseSavepoint: vi.fn(async () => {}),
+    rollbackToSavepoint: vi.fn(async () => {}),
+    isNoDatabaseError: () => false,
+    quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+    quoteTableName: (n: string) => `"${n}"`,
+    quoteColumnName: (n: string) => `"${n}"`,
+  } as unknown as DatabaseAdapter;
+}
+
+function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>>, pk = "id") {
+  return {
+    tableName,
+    primaryKey: pk,
+    findBy: vi.fn(async (attrs: Record<string, unknown>) => rows.get(attrs[pk]) ?? null),
+  } as any;
+}
+
+describe("FixtureSet.createFixtures", () => {
+  it("returns keyed instances by label", async () => {
+    const adapter = makeAdapter();
+    const topicId = fixtureId("rails");
+    const rows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
+    const Topic = makeModel("topics", rows);
+
+    const result = await FixtureSet.createFixtures(adapter, Topic, {
+      rails: { title: "Rails" },
+    });
+
+    expect(result.rails).toMatchObject({ id: topicId });
+  });
+
+  it("all keys in fixture data are returned", async () => {
+    const adapter = makeAdapter();
+    const id1 = fixtureId("first");
+    const id2 = fixtureId("second");
+    const rows = new Map([
+      [id1, { id: id1, title: "First" }],
+      [id2, { id: id2, title: "Second" }],
+    ]);
+    const Topic = makeModel("topics", rows);
+
+    const result = await FixtureSet.createFixtures(adapter, Topic, {
+      first: { title: "First" },
+      second: { title: "Second" },
+    });
+
+    expect(result.first).toMatchObject({ id: id1 });
+    expect(result.second).toMatchObject({ id: id2 });
+  });
+
+  it("multi-set: independent calls for different models each return correct instances", async () => {
+    const adapter = makeAdapter();
+    const topicId = fixtureId("rails");
+    const postId = fixtureId("hello");
+
+    const topicRows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
+    const postRows = new Map([[postId, { id: postId, title: "Hello" }]]);
+
+    const Topic = makeModel("topics", topicRows);
+    const Post = makeModel("posts", postRows);
+
+    const topics = await FixtureSet.createFixtures(adapter, Topic, { rails: { title: "Rails" } });
+    const posts = await FixtureSet.createFixtures(adapter, Post, { hello: { title: "Hello" } });
+
+    expect(topics.rails).toMatchObject({ id: topicId });
+    expect(posts.hello).toMatchObject({ id: postId });
+  });
+
+  it("emits a DELETE before INSERT so rows are replaced (cross-test isolation)", async () => {
+    const adapter = makeAdapter();
+    const id = fixtureId("rails");
+    const rows = new Map([[id, { id, title: "Rails" }]]);
+    const Topic = makeModel("topics", rows);
+
+    await FixtureSet.createFixtures(adapter, Topic, { rails: { title: "Rails" } });
+
+    const sqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => c[0] as string,
+    );
+    expect(sqls.some((s) => s.includes("DELETE FROM"))).toBe(true);
+    expect(sqls.some((s) => s.includes("INSERT INTO"))).toBe(true);
+  });
+});

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -136,7 +136,10 @@ describe("FixtureSet.createFixtures", () => {
     const sqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls.map(
       (c: unknown[]) => c[0] as string,
     );
-    expect(sqls.some((s) => s.includes("DELETE FROM"))).toBe(true);
-    expect(sqls.some((s) => s.includes("INSERT INTO"))).toBe(true);
+    const deleteIdx = sqls.findIndex((s) => s.includes("DELETE FROM"));
+    const insertIdx = sqls.findIndex((s) => s.includes("INSERT INTO"));
+    expect(deleteIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+    expect(deleteIdx).toBeLessThan(insertIdx);
   });
 });

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -123,20 +123,7 @@ describe("useFixtures type contract", () => {
 // --- FixtureSet.createFixtures ---
 
 describe("FixtureSet.createFixtures", () => {
-  it("returns keyed instances by label", async () => {
-    const adapter = makeAdapter();
-    const topicId = fixtureId("rails");
-    const rows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
-    const Topic = makeModel("topics", rows);
-
-    const result = await FixtureSet.createFixtures(adapter, Topic, {
-      rails: { title: "Rails" },
-    });
-
-    expect(result.rails).toMatchObject({ id: topicId });
-  });
-
-  it("all keys in fixture data are returned", async () => {
+  it("returns keyed instances for all declared labels", async () => {
     const adapter = makeAdapter();
     const id1 = fixtureId("first");
     const id2 = fixtureId("second");
@@ -153,22 +140,6 @@ describe("FixtureSet.createFixtures", () => {
 
     expect(result.first).toMatchObject({ id: id1 });
     expect(result.second).toMatchObject({ id: id2 });
-  });
-
-  it("multi-set: independent calls for different models each return correct instances", async () => {
-    const adapter = makeAdapter();
-    const topicId = fixtureId("rails");
-    const postId = fixtureId("hello");
-    const topicRows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
-    const postRows = new Map([[postId, { id: postId, title: "Hello" }]]);
-    const Topic = makeModel("topics", topicRows);
-    const Post = makeModel("posts", postRows);
-
-    const topics = await FixtureSet.createFixtures(adapter, Topic, { rails: { title: "Rails" } });
-    const posts = await FixtureSet.createFixtures(adapter, Post, { hello: { title: "Hello" } });
-
-    expect(topics.rails).toMatchObject({ id: topicId });
-    expect(posts.hello).toMatchObject({ id: postId });
   });
 
   it("emits DELETE before INSERT so rows are replaced (cross-test isolation)", async () => {

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { useFixtures, FixtureSet } from "./use-fixtures.js";
+import { describe, it, expect, expectTypeOf, vi } from "vitest";
+import { useFixtures } from "./use-fixtures.js";
+import { FixtureSet } from "./fixture-set.js";
+import { Base } from "../base.js";
 import { fixtureId } from "./define-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -71,6 +73,50 @@ describe("useFixtures multi-set", () => {
   it("both sets are accessible", () => {
     expect(topics("rails")).toMatchObject({ id: topicId });
     expect(posts("hello")).toMatchObject({ id: postId });
+  });
+});
+
+// --- useFixtures type contract ---
+
+describe("useFixtures type contract", () => {
+  class Topic extends Base {
+    declare title: string;
+    static {
+      this.tableName = "topics";
+      // Stub findBy so the beforeEach registered by useFixtures doesn't require
+      // the full Relation infrastructure during type-assertion tests.
+      this.findBy = vi.fn(async () => new Topic()) as any;
+    }
+  }
+  class Post extends Base {
+    declare body: string;
+    static {
+      this.tableName = "posts";
+      this.findBy = vi.fn(async () => new Post()) as any;
+    }
+  }
+
+  const { topics, posts } = useFixtures(
+    {
+      topics: [Topic, { first: { title: "First" }, second: { title: "Second" } }],
+      posts: [Post, { welcome: { body: "Hi" } }],
+    },
+    () => makeAdapter() as any,
+  );
+
+  it("accessor return type is narrowed to the model instance type", () => {
+    expectTypeOf<ReturnType<typeof topics>>().toEqualTypeOf<Topic>();
+    expectTypeOf<ReturnType<typeof posts>>().toEqualTypeOf<Post>();
+  });
+
+  it(".all() return type is an array of the model instance type", () => {
+    expectTypeOf<ReturnType<typeof topics.all>>().toEqualTypeOf<Topic[]>();
+    expectTypeOf<ReturnType<typeof posts.all>>().toEqualTypeOf<Post[]>();
+  });
+
+  it("label arg is narrowed to declared fixture names only", () => {
+    expectTypeOf<Parameters<typeof topics>[0]>().toEqualTypeOf<"first" | "second">();
+    expectTypeOf<Parameters<typeof posts>[0]>().toEqualTypeOf<"welcome">();
   });
 });
 

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { FixtureSet } from "./use-fixtures.js";
+import { useFixtures, FixtureSet } from "./use-fixtures.js";
 import { fixtureId } from "./define-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -28,6 +28,53 @@ function makeModel(tableName: string, rows: Map<unknown, Record<string, unknown>
     findBy: vi.fn(async (attrs: Record<string, unknown>) => rows.get(attrs[pk]) ?? null),
   } as any;
 }
+
+// --- useFixtures ---
+
+describe("useFixtures", () => {
+  const adapter = makeAdapter();
+  const topicId = fixtureId("rails");
+  const rows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
+  const Topic = makeModel("topics", rows);
+
+  const { topics } = useFixtures({ topics: [Topic, { rails: { title: "Rails" } }] }, () => adapter);
+
+  it("accessor returns the instance by label after beforeEach runs", () => {
+    const t = topics("rails");
+    expect(t).toMatchObject({ id: topicId });
+  });
+
+  it(".all() returns all instances in the set", () => {
+    const all = topics.all();
+    expect(all.length).toBe(1);
+    expect(all[0]).toMatchObject({ id: topicId });
+  });
+});
+
+describe("useFixtures multi-set", () => {
+  const adapter = makeAdapter();
+  const topicId = fixtureId("rails");
+  const postId = fixtureId("hello");
+  const topicRows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
+  const postRows = new Map([[postId, { id: postId, title: "Hello" }]]);
+  const Topic = makeModel("topics", topicRows);
+  const Post = makeModel("posts", postRows);
+
+  const { topics, posts } = useFixtures(
+    {
+      topics: [Topic, { rails: { title: "Rails" } }],
+      posts: [Post, { hello: { title: "Hello" } }],
+    },
+    () => adapter,
+  );
+
+  it("both sets are accessible", () => {
+    expect(topics("rails")).toMatchObject({ id: topicId });
+    expect(posts("hello")).toMatchObject({ id: postId });
+  });
+});
+
+// --- FixtureSet.createFixtures ---
 
 describe("FixtureSet.createFixtures", () => {
   it("returns keyed instances by label", async () => {
@@ -66,10 +113,8 @@ describe("FixtureSet.createFixtures", () => {
     const adapter = makeAdapter();
     const topicId = fixtureId("rails");
     const postId = fixtureId("hello");
-
     const topicRows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
     const postRows = new Map([[postId, { id: postId, title: "Hello" }]]);
-
     const Topic = makeModel("topics", topicRows);
     const Post = makeModel("posts", postRows);
 
@@ -80,7 +125,7 @@ describe("FixtureSet.createFixtures", () => {
     expect(posts.hello).toMatchObject({ id: postId });
   });
 
-  it("emits a DELETE before INSERT so rows are replaced (cross-test isolation)", async () => {
+  it("emits DELETE before INSERT so rows are replaced (cross-test isolation)", async () => {
     const adapter = makeAdapter();
     const id = fixtureId("rails");
     const rows = new Map([[id, { id, title: "Rails" }]]);

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach } from "vitest";
+import { defineFixtures } from "./define-fixtures.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import type { Base } from "../base.js";
+
+type BaseClass = typeof Base;
+type FixtureAttrs = Record<string, unknown>;
+
+type FixtureMap = Record<string, [BaseClass, Record<string, FixtureAttrs>]>;
+
+type FixtureAccessor<T extends BaseClass, K extends string> = {
+  (name: K): InstanceType<T>;
+  all(): InstanceType<T>[];
+};
+
+type UseFixturesResult<M extends FixtureMap> = {
+  [K in keyof M]: M[K] extends [
+    infer T extends BaseClass,
+    Record<infer N extends string, FixtureAttrs>,
+  ]
+    ? FixtureAccessor<T, N>
+    : never;
+};
+
+/**
+ * Vitest helper that inserts fixture rows in a `beforeEach` and cleans them up in `afterEach`.
+ *
+ * Returns an object of typed accessor functions — one per fixture set. Each accessor is callable
+ * by label (`topics("first")`) and has an `.all()` method.
+ *
+ * ```ts
+ * const { topics, posts } = useFixtures(
+ *   { topics: [Topic, topicData], posts: [Post, postData] },
+ *   () => adapter,
+ * );
+ * ```
+ */
+export function useFixtures<M extends FixtureMap>(
+  fixtures: M,
+  getAdapter: () => DatabaseAdapter,
+): UseFixturesResult<M> {
+  // Per-test mutable state: populated in beforeEach, cleared in afterEach.
+  const store: Record<string, Record<string, unknown>> = {};
+
+  beforeEach(async () => {
+    const adapter = getAdapter();
+    for (const [key, [ModelClass, data]] of Object.entries(fixtures)) {
+      const result = await defineFixtures(adapter, ModelClass, data);
+      store[key] = result as Record<string, unknown>;
+    }
+  });
+
+  afterEach(async () => {
+    const adapter = getAdapter();
+    // Delete inserted rows for each declared table.
+    for (const [, [ModelClass]] of Object.entries(fixtures)) {
+      try {
+        await adapter.execute(`DELETE FROM ${adapter.quoteTableName(ModelClass.tableName)}`, []);
+      } catch {
+        // Best-effort cleanup; if the table is gone, ignore.
+      }
+    }
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  });
+
+  const result = {} as UseFixturesResult<M>;
+  for (const key of Object.keys(fixtures)) {
+    const accessor = (name: string) => {
+      const set = store[key];
+      if (!set)
+        throw new Error(`useFixtures: fixture set "${key}" not loaded — call inside a test`);
+      const instance = set[name];
+      if (!instance) throw new Error(`useFixtures: no fixture named "${name}" in set "${key}"`);
+      return instance;
+    };
+    accessor.all = () => {
+      const set = store[key];
+      if (!set)
+        throw new Error(`useFixtures: fixture set "${key}" not loaded — call inside a test`);
+      return Object.values(set);
+    };
+    (result as Record<string, unknown>)[key] = accessor;
+  }
+  return result;
+}
+
+/**
+ * A thin class wrapper around `defineFixtures` that satisfies the static
+ * `FixtureSet.createFixtures(adapter, name, data)` call shape expected by
+ * the virtual-column test (and mirrors the Rails FixtureSet API surface).
+ */
+export class FixtureSet {
+  static async createFixtures<T extends BaseClass, K extends string>(
+    adapter: DatabaseAdapter,
+    ModelClass: T,
+    fixtures: Record<K, FixtureAttrs>,
+  ): Promise<{ [P in K]: InstanceType<T> }> {
+    return defineFixtures(adapter, ModelClass, fixtures);
+  }
+}

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -3,6 +3,8 @@ import { defineFixtures } from "./define-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { Base } from "../base.js";
 
+export { FixtureSet } from "./fixture-set.js";
+
 type BaseClass = typeof Base;
 type FixtureAttrs = Record<string, unknown>;
 
@@ -13,7 +15,7 @@ type FixtureAccessor<T extends BaseClass, K extends string> = {
   all(): InstanceType<T>[];
 };
 
-type UseFixturesResult<M extends FixtureMap> = {
+export type UseFixturesResult<M extends FixtureMap> = {
   [K in keyof M]: M[K] extends [
     infer T extends BaseClass,
     Record<infer N extends string, FixtureAttrs>,
@@ -21,6 +23,16 @@ type UseFixturesResult<M extends FixtureMap> = {
     ? FixtureAccessor<T, N>
     : never;
 };
+
+/** Returns true for "table does not exist" errors from any adapter. */
+function isTableMissingError(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return (
+    msg.includes("no such table") || // SQLite
+    msg.includes("doesn't exist") || // MySQL
+    msg.includes("does not exist") // PostgreSQL
+  );
+}
 
 /**
  * Vitest helper that inserts fixture rows in a `beforeEach` and cleans them up in `afterEach`.
@@ -58,8 +70,8 @@ export function useFixtures<M extends FixtureMap>(
         await adapter.executeMutation(
           `DELETE FROM ${adapter.quoteTableName(ModelClass.tableName)}`,
         );
-      } catch {
-        // Best-effort cleanup; if the table is gone, ignore.
+      } catch (e) {
+        if (!isTableMissingError(e)) throw e;
       }
     }
     for (const key of Object.keys(store)) {
@@ -86,19 +98,4 @@ export function useFixtures<M extends FixtureMap>(
     (result as Record<string, unknown>)[key] = accessor;
   }
   return result;
-}
-
-/**
- * A thin class wrapper around `defineFixtures` that satisfies the static
- * `FixtureSet.createFixtures(adapter, ModelClass, data)` call shape expected by
- * the virtual-column test (and mirrors the Rails FixtureSet API surface).
- */
-export class FixtureSet {
-  static async createFixtures<T extends BaseClass, K extends string>(
-    adapter: DatabaseAdapter,
-    ModelClass: T,
-    fixtures: Record<K, FixtureAttrs>,
-  ): Promise<{ [P in K]: InstanceType<T> }> {
-    return defineFixtures(adapter, ModelClass, fixtures);
-  }
 }

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -52,8 +52,8 @@ export function useFixtures<M extends FixtureMap>(
 
   afterEach(async () => {
     const adapter = getAdapter();
-    // Delete inserted rows for each declared table.
-    for (const [, [ModelClass]] of Object.entries(fixtures)) {
+    // Delete in reverse insertion order to respect FK constraints.
+    for (const [, [ModelClass]] of Object.entries(fixtures).reverse()) {
       try {
         await adapter.execute(`DELETE FROM ${adapter.quoteTableName(ModelClass.tableName)}`, []);
       } catch {
@@ -88,7 +88,7 @@ export function useFixtures<M extends FixtureMap>(
 
 /**
  * A thin class wrapper around `defineFixtures` that satisfies the static
- * `FixtureSet.createFixtures(adapter, name, data)` call shape expected by
+ * `FixtureSet.createFixtures(adapter, ModelClass, data)` call shape expected by
  * the virtual-column test (and mirrors the Rails FixtureSet API surface).
  */
 export class FixtureSet {

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -55,7 +55,9 @@ export function useFixtures<M extends FixtureMap>(
     // Delete in reverse insertion order to respect FK constraints.
     for (const [, [ModelClass]] of Object.entries(fixtures).reverse()) {
       try {
-        await adapter.execute(`DELETE FROM ${adapter.quoteTableName(ModelClass.tableName)}`, []);
+        await adapter.executeMutation(
+          `DELETE FROM ${adapter.quoteTableName(ModelClass.tableName)}`,
+        );
       } catch {
         // Best-effort cleanup; if the table is gone, ignore.
       }


### PR DESCRIPTION
## Summary

- Adds `useFixtures()` Vitest helper in `packages/activerecord/src/test-helpers/use-fixtures.ts` — registers `beforeEach`/`afterEach` hooks that insert fixture rows and clean up via `DELETE FROM` after each test
- Adds `FixtureSet.createFixtures(adapter, ModelClass, data)` static method that delegates to `defineFixtures` — satisfies the blocked `build fixture sql` test in `virtual-column.test.ts`
- Typed accessors: `topics("first")` and `topics.all()` with narrowed return types keyed from the input fixture map

## Notes

- The `virtual-column.test.ts` BLOCKED test only had a comment body (no actual assertions); left as-is since real fixture data (Phase 3) is required to un-skip it
- Phase 3 (fixture data files) and Phase 4 (transactional per-test wrapping) are follow-ups

## Test plan

- [ ] `pnpm test packages/activerecord/src/test-helpers/use-fixtures.test.ts` — 4 tests pass
- [ ] `pnpm tsc --build` — no type errors