### PR TITLE
feat(activerecord) fixture replacement Phase 3a — topics + posts + comments fixture data

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/comments.ts
@@ -1,0 +1,24 @@
+import { ref } from "../define-fixtures.js";
+
+/**
+ * Canonical fixture data for the Rails `comments` table.
+ * Mirrors activerecord/test/fixtures/comments.yml.
+ * Use via defineFixtures(adapter, Comment, commentFixtureData).
+ */
+export const commentFixtureData = {
+  greetings: {
+    body: "Thank you for the welcome",
+    post_id: ref("posts", "welcome"),
+    type: "Comment",
+  },
+  more_greetings: {
+    body: "Hello my friend!",
+    post_id: ref("posts", "welcome"),
+    type: "Comment",
+  },
+  does_it_hurt: {
+    body: "Don't think too hard about it",
+    post_id: ref("posts", "thinking"),
+    type: "Comment",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/comments.ts
@@ -1,10 +1,6 @@
 import { ref } from "../define-fixtures.js";
 
-/**
- * Canonical fixture data for the Rails `comments` table.
- * Mirrors activerecord/test/fixtures/comments.yml.
- * Use via defineFixtures(adapter, Comment, commentFixtureData).
- */
+// activerecord/test/fixtures/comments.yml
 export const commentFixtureData = {
   greetings: {
     body: "Thank you for the welcome",
@@ -18,7 +14,7 @@ export const commentFixtureData = {
   },
   does_it_hurt: {
     body: "Don't think too hard about it",
-    post_id: ref("posts", "thinking"),
-    type: "Comment",
+    post_id: ref("posts", "sti_comments"),
+    type: "SpecialComment",
   },
 };

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -96,8 +96,9 @@ describe("postFixtureData", () => {
   });
 
   it("posts reference authors table via ref()", () => {
-    expect(isFixtureRef(postFixtureData.welcome.author_id)).toBe(true);
-    expect((postFixtureData.welcome.author_id as any).tableName).toBe("authors");
+    const authorRef = postFixtureData.welcome.author_id as FixtureRef;
+    expect(isFixtureRef(authorRef)).toBe(true);
+    expect(authorRef.tableName).toBe("authors");
   });
 });
 

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseAdapter } from "../../adapter.js";
+import { defineFixtures, fixtureId, isFixtureRef } from "../define-fixtures.js";
+import { topicFixtureData } from "./topics.js";
+import { postFixtureData } from "./posts.js";
+import { commentFixtureData } from "./comments.js";
+
+function makeAdapter(): DatabaseAdapter {
+  return {
+    adapterName: "sqlite" as const,
+    execute: vi.fn(async () => []),
+    executeMutation: vi.fn(async () => 0),
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    createSavepoint: vi.fn(async () => {}),
+    releaseSavepoint: vi.fn(async () => {}),
+    rollbackToSavepoint: vi.fn(async () => {}),
+    isNoDatabaseError: () => false,
+    quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+    quoteTableName: (n: string) => `"${n}"`,
+    quoteColumnName: (n: string) => `"${n}"`,
+  } as unknown as DatabaseAdapter;
+}
+
+function makeModel(tableName: string, pk = "id") {
+  const rows = new Map<unknown, Record<string, unknown>>();
+  const Model = {
+    tableName,
+    primaryKey: pk,
+    findBy: vi.fn(async (attrs: Record<string, unknown>) => {
+      const val = attrs[pk];
+      return rows.get(val) ?? null;
+    }),
+    _rows: rows,
+  } as any;
+  return Model;
+}
+
+function seedRows(
+  Model: ReturnType<typeof makeModel>,
+  label: string,
+  extra: Record<string, unknown> = {},
+) {
+  const id = fixtureId(label);
+  Model._rows.set(id, { id, ...extra });
+}
+
+describe("topicFixtureData", () => {
+  it("exports five fixtures with correct keys", () => {
+    const keys = Object.keys(topicFixtureData);
+    expect(keys).toEqual(["first", "second", "third", "fourth", "fifth"]);
+  });
+
+  it("first fixture has expected data", () => {
+    expect(topicFixtureData.first).toMatchObject({
+      title: "The First Topic",
+      author_name: "David",
+      approved: false,
+      type: "Topic",
+    });
+  });
+
+  it("second fixture has Mary as author and a cross-ref to first", () => {
+    expect(topicFixtureData.second.author_name).toBe("Mary");
+    expect(isFixtureRef(topicFixtureData.second.parent_id)).toBe(true);
+    const parentRef = topicFixtureData.second.parent_id as ReturnType<
+      typeof import("../define-fixtures.js").ref
+    >;
+    expect((parentRef as any).fixtureName).toBe("first");
+    expect((parentRef as any).tableName).toBe("topics");
+  });
+
+  it("defineFixtures resolves cross-refs: second.parent_id equals fixtureId(first)", async () => {
+    const adapter = makeAdapter();
+    const Topic = makeModel("topics");
+    for (const k of Object.keys(topicFixtureData) as Array<keyof typeof topicFixtureData>) {
+      seedRows(Topic, k, { title: topicFixtureData[k].title });
+    }
+
+    const topics = await defineFixtures(adapter, Topic, topicFixtureData);
+    expect(topics.first).toBeTruthy();
+    expect(topics.second).toBeTruthy();
+
+    const insertSqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("topics"));
+    const secondInsert = insertSqls.find((s) => s.includes(String(fixtureId("second"))));
+    expect(secondInsert).toBeTruthy();
+    expect(secondInsert).toContain(String(fixtureId("first")));
+  });
+});
+
+describe("postFixtureData", () => {
+  it("exports welcome and thinking posts", () => {
+    expect(postFixtureData.welcome.title).toBe("Welcome to the weblog");
+    expect(postFixtureData.thinking.title).toBe("So I was thinking");
+  });
+
+  it("posts reference authors table via ref()", () => {
+    expect(isFixtureRef(postFixtureData.welcome.author_id)).toBe(true);
+    expect((postFixtureData.welcome.author_id as any).tableName).toBe("authors");
+  });
+});
+
+describe("commentFixtureData", () => {
+  it("greetings comment references welcome post via ref()", () => {
+    expect(commentFixtureData.greetings.body).toBe("Thank you for the welcome");
+    expect(isFixtureRef(commentFixtureData.greetings.post_id)).toBe(true);
+    expect((commentFixtureData.greetings.post_id as any).fixtureName).toBe("welcome");
+    expect((commentFixtureData.greetings.post_id as any).tableName).toBe("posts");
+  });
+
+  it("defineFixtures resolves comment→post cross-ref correctly", async () => {
+    const adapter = makeAdapter();
+    const Comment = makeModel("comments");
+    for (const k of Object.keys(commentFixtureData) as Array<keyof typeof commentFixtureData>) {
+      seedRows(Comment, k);
+    }
+
+    await defineFixtures(adapter, Comment, commentFixtureData);
+
+    const insertSqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("comments"));
+    const greetingsInsert = insertSqls.find((s) => s.includes(String(fixtureId("greetings"))));
+    expect(greetingsInsert).toBeTruthy();
+    expect(greetingsInsert).toContain(String(fixtureId("welcome")));
+  });
+});

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DatabaseAdapter } from "../../adapter.js";
-import { defineFixtures, fixtureId, isFixtureRef } from "../define-fixtures.js";
+import { defineFixtures, fixtureId, isFixtureRef, type FixtureRef } from "../define-fixtures.js";
 import { topicFixtureData } from "./topics.js";
 import { postFixtureData } from "./posts.js";
 import { commentFixtureData } from "./comments.js";
@@ -63,12 +63,10 @@ describe("topicFixtureData", () => {
 
   it("second fixture has Mary as author and a cross-ref to first", () => {
     expect(topicFixtureData.second.author_name).toBe("Mary");
-    expect(isFixtureRef(topicFixtureData.second.parent_id)).toBe(true);
-    const parentRef = topicFixtureData.second.parent_id as ReturnType<
-      typeof import("../define-fixtures.js").ref
-    >;
-    expect((parentRef as any).fixtureName).toBe("first");
-    expect((parentRef as any).tableName).toBe("topics");
+    const parentRef = topicFixtureData.second.parent_id as FixtureRef;
+    expect(isFixtureRef(parentRef)).toBe(true);
+    expect(parentRef.fixtureName).toBe("first");
+    expect(parentRef.tableName).toBe("topics");
   });
 
   it("defineFixtures resolves cross-refs: second.parent_id equals fixtureId(first)", async () => {
@@ -106,9 +104,17 @@ describe("postFixtureData", () => {
 describe("commentFixtureData", () => {
   it("greetings comment references welcome post via ref()", () => {
     expect(commentFixtureData.greetings.body).toBe("Thank you for the welcome");
-    expect(isFixtureRef(commentFixtureData.greetings.post_id)).toBe(true);
-    expect((commentFixtureData.greetings.post_id as any).fixtureName).toBe("welcome");
-    expect((commentFixtureData.greetings.post_id as any).tableName).toBe("posts");
+    const postRef = commentFixtureData.greetings.post_id as FixtureRef;
+    expect(isFixtureRef(postRef)).toBe(true);
+    expect(postRef.fixtureName).toBe("welcome");
+    expect(postRef.tableName).toBe("posts");
+  });
+
+  it("does_it_hurt is a SpecialComment on sti_comments post", () => {
+    expect(commentFixtureData.does_it_hurt.type).toBe("SpecialComment");
+    const postRef = commentFixtureData.does_it_hurt.post_id as FixtureRef;
+    expect(isFixtureRef(postRef)).toBe(true);
+    expect(postRef.fixtureName).toBe("sti_comments");
   });
 
   it("defineFixtures resolves comment→post cross-ref correctly", async () => {

--- a/packages/activerecord/src/test-helpers/fixtures/posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/posts.ts
@@ -1,10 +1,6 @@
 import { ref } from "../define-fixtures.js";
 
-/**
- * Canonical fixture data for the Rails `posts` table.
- * Mirrors activerecord/test/fixtures/posts.yml.
- * Use via defineFixtures(adapter, Post, postFixtureData).
- */
+// activerecord/test/fixtures/posts.yml
 export const postFixtureData = {
   welcome: {
     title: "Welcome to the weblog",

--- a/packages/activerecord/src/test-helpers/fixtures/posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/posts.ts
@@ -1,0 +1,27 @@
+import { ref } from "../define-fixtures.js";
+
+/**
+ * Canonical fixture data for the Rails `posts` table.
+ * Mirrors activerecord/test/fixtures/posts.yml.
+ * Use via defineFixtures(adapter, Post, postFixtureData).
+ */
+export const postFixtureData = {
+  welcome: {
+    title: "Welcome to the weblog",
+    body: "Such a lovely day",
+    type: "Post",
+    author_id: ref("authors", "david"),
+  },
+  thinking: {
+    title: "So I was thinking",
+    body: "like I hopefully always am",
+    type: "Post",
+    author_id: ref("authors", "david"),
+  },
+  sti_comments: {
+    title: "A test of aggregates",
+    body: "a post with many comments of different types",
+    type: "Post",
+    author_id: ref("authors", "david"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/topics.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/topics.ts
@@ -1,10 +1,6 @@
 import { ref } from "../define-fixtures.js";
 
-/**
- * Canonical fixture data for the Rails `topics` table.
- * Mirrors activerecord/test/fixtures/topics.yml.
- * Use via defineFixtures(adapter, Topic, topicFixtureData).
- */
+// activerecord/test/fixtures/topics.yml
 export const topicFixtureData = {
   first: {
     title: "The First Topic",

--- a/packages/activerecord/src/test-helpers/fixtures/topics.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/topics.ts
@@ -1,0 +1,41 @@
+import { ref } from "../define-fixtures.js";
+
+/**
+ * Canonical fixture data for the Rails `topics` table.
+ * Mirrors activerecord/test/fixtures/topics.yml.
+ * Use via defineFixtures(adapter, Topic, topicFixtureData).
+ */
+export const topicFixtureData = {
+  first: {
+    title: "The First Topic",
+    author_name: "David",
+    content: "Have a nice day",
+    approved: false,
+    replies_count: 1,
+    type: "Topic",
+  },
+  second: {
+    title: "The Second Topic of the day",
+    author_name: "Mary",
+    approved: true,
+    parent_id: ref("topics", "first"),
+    type: "Reply",
+  },
+  third: {
+    title: "The Third Topic of the day",
+    approved: true,
+    parent_id: ref("topics", "first"),
+    type: "Reply",
+  },
+  fourth: {
+    title: "The Fourth Topic of the day",
+    approved: true,
+    parent_id: ref("topics", "first"),
+    type: "Reply",
+  },
+  fifth: {
+    title: "The Fifth Topic of the day",
+    approved: true,
+    type: "Topic",
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `packages/activerecord/src/test-helpers/fixtures/topics.ts` — 5 Rails-canonical topic fixtures (first/second/third/fourth/fifth) with self-referential `parent_id` cross-refs via `ref()`
- Adds `packages/activerecord/src/test-helpers/fixtures/posts.ts` — 3 post fixtures (welcome/thinking/sti_comments) with `author_id` refs into the `authors` table
- Adds `packages/activerecord/src/test-helpers/fixtures/comments.ts` — 3 comment fixtures (greetings/more_greetings/does_it_hurt) with `post_id` refs into `posts`
- Adds `fixtures.test.ts` smoke test: data shape assertions + `defineFixtures` round-trip verifying cross-ref resolution (8 tests, 36 total pass)

Part of the fixture-replacement-plan.md Phase 3 batch series. Phases 1 (#1470), 1b (#1471), Sweep E (#1477) already merged.

## Follow-ups

- Phase 3b: `authors`, `books`, `author_addresses` fixtures (preloader cluster)
- Phase 3c: `developers`, `projects`, `developers_projects` HABTM fixtures
- Phase 3d: `companies`, `accounts` STI + polymorphic fixtures
- The 3 `BLOCKED: fixture` tests in `base.test.ts` also need `with_env_tz` support and Phase 2 `useFixtures` wiring before they can un-skip

## Test plan

- [x] `pnpm test packages/activerecord/src/test-helpers` — 36 tests pass
- [x] Build + typecheck pass (pre-commit hook)