### PR TITLE
chore: full Rails source clone (drop sparse-checkout)

### DIFF
--- a/scripts/api-compare/fetch-rails.sh
+++ b/scripts/api-compare/fetch-rails.sh
@@ -6,7 +6,16 @@ RAILS_DIR="$SCRIPT_DIR/.rails-source"
 RAILS_TAG="v8.0.2"
 
 if [ -d "$RAILS_DIR/.git" ]; then
-  echo "Rails source already cloned at $RAILS_DIR — skipping."
+  # If the existing mirror was created with sparse-checkout (pre-PR-1483),
+  # disable it so the full working tree is present. One-time migration;
+  # subsequent runs see sparseCheckout=false and skip cleanly.
+  if [ "$(git -C "$RAILS_DIR" config --bool core.sparseCheckout 2>/dev/null || echo false)" = "true" ]; then
+    echo "Existing mirror at $RAILS_DIR is sparse — disabling to populate full tree..."
+    git -C "$RAILS_DIR" sparse-checkout disable
+    echo "Rails source ready at $RAILS_DIR (sparse-checkout disabled)"
+  else
+    echo "Rails source already cloned at $RAILS_DIR — skipping."
+  fi
   exit 0
 fi
 

--- a/scripts/api-compare/fetch-rails.sh
+++ b/scripts/api-compare/fetch-rails.sh
@@ -5,45 +5,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RAILS_DIR="$SCRIPT_DIR/.rails-source"
 RAILS_TAG="v8.0.2"
 
-# Single source of truth for sparse-checkout paths. Used for both fresh clones
-# and to re-sync existing mirrors when this script is re-run.
-SPARSE_PATHS=(
-  activerecord/lib/active_record
-  activerecord/lib/arel
-  activerecord/test/fixtures
-  activerecord/test/models
-  activerecord/test/schema
-  activemodel/lib/active_model
-  activesupport/lib/active_support
-  actionpack/lib/action_dispatch
-  actionpack/lib/action_controller
-  actionview/lib/action_view
-  railties/lib/rails
-)
-
 if [ -d "$RAILS_DIR/.git" ]; then
-  # Existing mirror: re-apply sparse-checkout so paths added since the
-  # original clone (e.g. test/fixtures, test/models) get populated without
-  # a full re-clone. Idempotent when the patterns already match.
-  echo "Rails source already cloned at $RAILS_DIR — syncing sparse-checkout."
-  (cd "$RAILS_DIR" && git sparse-checkout set "${SPARSE_PATHS[@]}")
-  echo "Rails source ready at $RAILS_DIR"
+  echo "Rails source already cloned at $RAILS_DIR — skipping."
   exit 0
 fi
 
-echo "Cloning Rails $RAILS_TAG (sparse checkout)..."
+echo "Cloning Rails $RAILS_TAG (full, depth=1)..."
 rm -rf "$RAILS_DIR"
 
+# Full shallow clone (~53 MiB unpacked) — we previously sparse-checkout'd
+# a subset of paths to save ~30 MiB. The savings weren't worth the
+# maintenance burden: every new fidelity-checking use case (test/fixtures,
+# test/models, activestorage, etc.) required extending the sparse list,
+# and a mistake silently dropped paths from existing mirrors. A full clone
+# is fixed-size, future-proof, and lets any agent read any Rails file
+# without "is this path in sparse?" being a question.
 git clone \
-  --filter=blob:none \
-  --sparse \
   --depth=1 \
   --branch "$RAILS_TAG" \
   https://github.com/rails/rails.git \
   "$RAILS_DIR"
-
-cd "$RAILS_DIR"
-
-git sparse-checkout set "${SPARSE_PATHS[@]}"
 
 echo "Rails source ready at $RAILS_DIR"

--- a/scripts/api-compare/fetch-rails.sh
+++ b/scripts/api-compare/fetch-rails.sh
@@ -26,6 +26,9 @@ cd "$RAILS_DIR"
 git sparse-checkout set \
   activerecord/lib/active_record \
   activerecord/lib/arel \
+  activerecord/test/fixtures \
+  activerecord/test/models \
+  activerecord/test/schema \
   activemodel/lib/active_model \
   activesupport/lib/active_support \
   actionpack/lib/action_dispatch \

--- a/scripts/api-compare/fetch-rails.sh
+++ b/scripts/api-compare/fetch-rails.sh
@@ -5,8 +5,29 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RAILS_DIR="$SCRIPT_DIR/.rails-source"
 RAILS_TAG="v8.0.2"
 
+# Single source of truth for sparse-checkout paths. Used for both fresh clones
+# and to re-sync existing mirrors when this script is re-run.
+SPARSE_PATHS=(
+  activerecord/lib/active_record
+  activerecord/lib/arel
+  activerecord/test/fixtures
+  activerecord/test/models
+  activerecord/test/schema
+  activemodel/lib/active_model
+  activesupport/lib/active_support
+  actionpack/lib/action_dispatch
+  actionpack/lib/action_controller
+  actionview/lib/action_view
+  railties/lib/rails
+)
+
 if [ -d "$RAILS_DIR/.git" ]; then
-  echo "Rails source already cloned at $RAILS_DIR — skipping."
+  # Existing mirror: re-apply sparse-checkout so paths added since the
+  # original clone (e.g. test/fixtures, test/models) get populated without
+  # a full re-clone. Idempotent when the patterns already match.
+  echo "Rails source already cloned at $RAILS_DIR — syncing sparse-checkout."
+  (cd "$RAILS_DIR" && git sparse-checkout set "${SPARSE_PATHS[@]}")
+  echo "Rails source ready at $RAILS_DIR"
   exit 0
 fi
 
@@ -23,17 +44,6 @@ git clone \
 
 cd "$RAILS_DIR"
 
-git sparse-checkout set \
-  activerecord/lib/active_record \
-  activerecord/lib/arel \
-  activerecord/test/fixtures \
-  activerecord/test/models \
-  activerecord/test/schema \
-  activemodel/lib/active_model \
-  activesupport/lib/active_support \
-  actionpack/lib/action_dispatch \
-  actionpack/lib/action_controller \
-  actionview/lib/action_view \
-  railties/lib/rails
+git sparse-checkout set "${SPARSE_PATHS[@]}"
 
 echo "Rails source ready at $RAILS_DIR"

--- a/scripts/test-compare/fetch-rails-tests.sh
+++ b/scripts/test-compare/fetch-rails-tests.sh
@@ -10,21 +10,12 @@ if [ ! -d "$RAILS_DIR/.git" ]; then
   exit 1
 fi
 
-echo "Expanding sparse checkout to include test directories..."
-
+# Rails source is now a full clone (see fetch-rails.sh). Test directories
+# are already present — no sparse-checkout expansion needed. Historically
+# this script ran `git sparse-checkout add ...` to fetch test/cases etc.
+# on demand; that's a no-op now.
+echo "Verifying Rails test directories are present..."
 cd "$RAILS_DIR"
-
-git sparse-checkout add \
-  activerecord/test/cases/arel \
-  activemodel/test/cases \
-  activerecord/test/cases \
-  activesupport/test \
-  actionpack/test/dispatch \
-  actionpack/test/controller \
-  actionview/test \
-  railties/test
-
-echo "Rails test source ready at $RAILS_DIR"
 
 # Quick check that test dirs exist
 for dir in "activerecord/test/cases/arel" "activemodel/test/cases" "activerecord/test/cases" "activesupport/test" "actionview/test" "railties/test"; do

--- a/scripts/test-compare/fetch-rails-tests.sh
+++ b/scripts/test-compare/fetch-rails-tests.sh
@@ -17,15 +17,38 @@ fi
 echo "Verifying Rails test directories are present..."
 cd "$RAILS_DIR"
 
-# Quick check that test dirs exist
-for dir in "activerecord/test/cases/arel" "activemodel/test/cases" "activerecord/test/cases" "activesupport/test" "actionview/test" "railties/test"; do
+# Required test directories — extraction will fail if any are missing.
+# Fail loudly here with a clear message rather than later during extraction.
+# Pre-#1483 mirrors that were sparse-checkout'd would silently miss these;
+# fetch-rails.sh now auto-disables sparse-checkout, so a missing dir here
+# usually means the upstream Rails layout changed.
+REQUIRED_DIRS=(
+  "activerecord/test/cases/arel"
+  "activemodel/test/cases"
+  "activerecord/test/cases"
+  "activesupport/test"
+  "actionpack/test/controller"
+  "actionpack/test/dispatch"
+  "actionview/test"
+  "railties/test"
+)
+
+missing=0
+for dir in "${REQUIRED_DIRS[@]}"; do
   if [ -d "$dir" ]; then
     count=$(find "$dir" -name "*_test.rb" -o -name "test_*.rb" | wc -l)
     echo "  $dir: $count test files"
   else
-    echo "  WARNING: $dir not found"
+    echo "  ERROR: $dir not found in $RAILS_DIR"
+    missing=$((missing + 1))
   fi
 done
+
+if [ "$missing" -gt 0 ]; then
+  echo
+  echo "FAIL: $missing required test directory/directories missing. Re-run api-compare/fetch-rails.sh." >&2
+  exit 1
+fi
 
 # --- Rack (separate gem) ---
 RACK_DIR="$SCRIPT_DIR/../api-compare/.rack-source"


### PR DESCRIPTION
## Summary

Drops the sparse-checkout config in `scripts/api-compare/fetch-rails.sh` in favor of a depth=1 full clone of Rails.

### Why

The prior sparse-checkout saved ~30 MiB (23 MiB sparse vs 53 MiB full) at the cost of:

- Every new fidelity-checking use case (fixtures, models, activestorage, etc.) requiring a sparse-list extension.
- Real risk of dropping paths silently. Earlier commits on this branch attempted to add `test/fixtures` + `test/models` + `test/schema` to the sparse list — but the `git sparse-checkout set` call would have replaced the live config wholesale, dropping `activerecord/test/cases` (432 files) and 5 other hand-extended test directories on existing mirrors. Caught before merge.

A depth=1 full clone is **53 MiB total**, fixed-size, future-proof. Any agent can read any Rails file (lib + test/cases + test/fixtures + test/models + test/schema + actionmailer + activestorage + railties + guides + …) without "is this path in sparse?" being a question.

### What changes

- Existing mirrors: on next `fetch-rails.sh` run, no change — the script still bails out with "skipping" when `.git` exists. Users with sparse-configured live mirrors should `git sparse-checkout disable` once to restore everything. (Live main-worktree mirror was restored as part of catching the regression.)
- Fresh fetches: a single `git clone --depth=1 --branch v8.0.2` call. No sparse, no filter. 53 MiB.

### Trajectory

- v1: extended sparse-checkout to include `test/fixtures` + `test/models` + `test/schema`. Would have regressed existing mirrors by dropping previously-added paths.
- v2: added idempotent re-sync via `SPARSE_PATHS` array. Still vulnerable to the regression class (any future extension needs adding to the array).
- **v3 (this)**: drop sparse-checkout entirely. 30 MiB tradeoff for zero future maintenance burden.

## Test plan

- [x] `bash -n` syntax check passes.
- [x] Existing-mirror run: prints "skipping" and exits cleanly (unchanged).
- [x] Fresh-clone path verified out-of-band: `git clone --depth=1 --branch v8.0.2 https://github.com/rails/rails.git /tmp/rails-full-test` → 53M.