### PR TITLE
feat(activerecord) fixture replacement Phase 3d — companies (STI) + accounts fixture data

### DIFF
--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -43,6 +43,7 @@ export interface TestFixtures {
   Developer: typeof Base;
   Project: typeof Base;
   Company: typeof Base;
+  Account: typeof Base;
   Topic: typeof Base;
   Book: typeof Base;
   Person: typeof Base;
@@ -257,6 +258,18 @@ export function createFixtures(existingAdapter?: DatabaseAdapter): TestFixtures 
     }
   }
 
+  // ── Account ─────────────────────────────────────────────────────────
+  class Account extends Base {
+    static {
+      this._tableName = "accounts";
+      this.attribute("firm_id", "integer");
+      this.attribute("credit_limit", "integer");
+      this.attribute("firm_name", "string");
+      this.attribute("status", "string");
+      this.adapter = adapter;
+    }
+  }
+
   // ── Register models ─────────────────────────────────────────────────
   const models = {
     Author,
@@ -278,6 +291,7 @@ export function createFixtures(existingAdapter?: DatabaseAdapter): TestFixtures 
     Topic,
     Book,
     Person,
+    Account,
   };
 
   for (const [name, model] of Object.entries(models)) {
@@ -392,6 +406,12 @@ export function createFixtures(existingAdapter?: DatabaseAdapter): TestFixtures 
 
   // Company associations (self-referential firm)
   Associations.belongsTo.call(Company, "firm", {
+    className: "Company",
+    foreignKey: "firm_id",
+  });
+
+  // Account associations
+  Associations.belongsTo.call(Account, "firm", {
     className: "Company",
     foreignKey: "firm_id",
   });

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -219,6 +219,7 @@ export function createFixtures(existingAdapter?: DatabaseAdapter): TestFixtures 
       this.attribute("type", "string");
       this.attribute("firm_id", "integer");
       this.attribute("client_of", "integer");
+      this.attribute("firm_name", "string");
       this.adapter = adapter;
     }
   }

--- a/packages/activerecord/src/test-helpers/fixtures/accounts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/accounts.ts
@@ -1,0 +1,37 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/accounts.yml
+// Belongs to Company (firm_id FK). Schema gap: Rails schema also carries
+// transactions_count (counter_cache on companies) — omitted; test-fixtures.ts
+// Account only declares firm_id/credit_limit/firm_name/status.
+export const accountFixtureData = {
+  signals37: {
+    firm_id: ref("companies", "first_firm"),
+    credit_limit: 50,
+    firm_name: "37signals",
+    status: "active",
+  },
+  unknown: {
+    credit_limit: 50,
+  },
+  rails_core_account: {
+    firm_id: ref("companies", "rails_core"),
+    credit_limit: 50,
+    status: "suspended",
+  },
+  last_account: {
+    firm_id: ref("companies", "first_client"),
+    credit_limit: 60,
+    status: "trial",
+  },
+  rails_core_account_2: {
+    firm_id: ref("companies", "rails_core"),
+    credit_limit: 55,
+    status: "active",
+  },
+  odegy_account: {
+    firm_id: ref("companies", "odegy"),
+    credit_limit: 53,
+    status: "trial",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/accounts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/accounts.ts
@@ -2,7 +2,7 @@ import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/accounts.yml
 // Belongs to Company (firm_id FK). Schema gap: Rails schema also carries
-// transactions_count (counter_cache on companies) — omitted; test-fixtures.ts
+// transactions_count (counter_cache column on accounts) — omitted; test-fixtures.ts
 // Account only declares firm_id/credit_limit/firm_name/status.
 export const accountFixtureData = {
   signals37: {

--- a/packages/activerecord/src/test-helpers/fixtures/companies.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/companies.ts
@@ -1,0 +1,73 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/companies.yml
+// STI hierarchy: Company (base) / Firm / Client / DependentFirm / ExclusivelyDependentFirm
+// Schema gap: Rails schema also carries rating, description, ruby_on_rails_id, account_id,
+// account_limit, metadata — omitted; test-fixtures.ts Company only declares name/type/firm_id/client_of.
+// first_firm.firm_id is a self-ref in the Rails YAML (id=1 pointing to itself); omitted to avoid
+// circular insertion ordering issues.
+export const companyFixtureData = {
+  first_firm: {
+    type: "Firm",
+    name: "37signals",
+    // firm_name exists in Rails YAML but is not a column — stored as firm_name on clients only
+  },
+  first_client: {
+    type: "Client",
+    firm_id: ref("companies", "first_firm"),
+    // client_of: 2 (first_client itself in Rails YAML — omitted, self-circular)
+    name: "Summit",
+    firm_name: "37signals",
+  },
+  second_client: {
+    type: "Client",
+    firm_id: ref("companies", "first_firm"),
+    client_of: ref("companies", "first_firm"),
+    name: "Microsoft",
+  },
+  another_firm: {
+    type: "Firm",
+    name: "Flamboyant Software",
+  },
+  another_client: {
+    type: "Client",
+    firm_id: ref("companies", "another_firm"),
+    client_of: ref("companies", "another_firm"),
+    name: "Ex Nihilo",
+  },
+  a_third_client: {
+    type: "Client",
+    firm_id: ref("companies", "another_firm"),
+    client_of: ref("companies", "another_firm"),
+    name: "Ex Nihilo Part Deux",
+  },
+  rails_core: {
+    type: "DependentFirm",
+    name: "RailsCore",
+  },
+  leetsoft: {
+    // no type in Rails YAML — falls back to Company base class
+    name: "Leetsoft",
+    client_of: ref("companies", "rails_core"),
+  },
+  jadedpixel: {
+    // no type in Rails YAML — falls back to Company base class
+    name: "Jadedpixel",
+    client_of: ref("companies", "rails_core"),
+  },
+  odegy: {
+    type: "ExclusivelyDependentFirm",
+    name: "Odegy",
+  },
+  another_first_firm_client: {
+    type: "Client",
+    firm_id: ref("companies", "first_firm"),
+    client_of: ref("companies", "first_firm"),
+    name: "Apex",
+    firm_name: "37signals",
+  },
+  recursive_association_fk: {
+    type: "Firm",
+    name: "RVshare",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/companies.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/companies.ts
@@ -2,20 +2,20 @@ import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/companies.yml
 // STI hierarchy: Company (base) / Firm / Client / DependentFirm / ExclusivelyDependentFirm
-// Schema gap: Rails schema also carries rating, description, ruby_on_rails_id, account_id,
-// account_limit, metadata — omitted; test-fixtures.ts Company only declares name/type/firm_id/client_of.
-// first_firm.firm_id is a self-ref in the Rails YAML (id=1 pointing to itself); omitted to avoid
-// circular insertion ordering issues.
+// Schema gap: Rails schema also carries rating (bigint), description, account_id, status (integer
+// enum) — omitted; test-fixtures.ts Company declares name/type/firm_id/client_of/firm_name.
+// first_firm.firm_id is a self-ref in Rails YAML (points to its own row); ref() resolves IDs
+// deterministically so there is no insertion-ordering issue.
 export const companyFixtureData = {
   first_firm: {
     type: "Firm",
     name: "37signals",
-    // firm_name exists in Rails YAML but is not a column — stored as firm_name on clients only
+    firm_id: ref("companies", "first_firm"),
   },
   first_client: {
     type: "Client",
     firm_id: ref("companies", "first_firm"),
-    // client_of: 2 (first_client itself in Rails YAML — omitted, self-circular)
+    client_of: ref("companies", "first_client"),
     name: "Summit",
     firm_name: "37signals",
   },

--- a/packages/activerecord/src/test-helpers/fixtures/companies.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/companies.ts
@@ -2,10 +2,10 @@ import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/companies.yml
 // STI hierarchy: Company (base) / Firm / Client / DependentFirm / ExclusivelyDependentFirm
-// Schema gap: Rails schema also carries rating (bigint), description, account_id, status (integer
-// enum) — omitted; test-fixtures.ts Company declares name/type/firm_id/client_of/firm_name.
-// first_firm.firm_id is a self-ref in Rails YAML (points to its own row); ref() resolves IDs
-// deterministically so there is no insertion-ordering issue.
+// Schema gap: Rails schema also carries rating (bigint), description, account_id, and status
+// (integer enum) — omitted; test-fixtures.ts Company declares name/type/firm_id/client_of/firm_name.
+// first_firm.firm_id and first_client.client_of are self-refs in the Rails YAML; ref() resolves
+// IDs deterministically so there is no insertion-ordering issue.
 export const companyFixtureData = {
   first_firm: {
     type: "Firm",

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -7,6 +7,8 @@ import { commentFixtureData } from "./comments.js";
 import { authorFixtureData } from "./authors.js";
 import { bookFixtureData } from "./books.js";
 import { authorAddressFixtureData } from "./author-addresses.js";
+import { companyFixtureData } from "./companies.js";
+import { accountFixtureData } from "./accounts.js";
 
 function makeAdapter(): DatabaseAdapter {
   return {
@@ -208,6 +210,119 @@ describe("bookFixtureData", () => {
     const awdrInsert = insertSqls.find((s) => s.includes(String(fixtureId("awdr"))));
     expect(awdrInsert).toBeTruthy();
     expect(awdrInsert).toContain(String(fixtureId("david")));
+  });
+});
+
+describe("companyFixtureData", () => {
+  it("exports all 12 Rails companies fixtures", () => {
+    expect(Object.keys(companyFixtureData)).toEqual([
+      "first_firm",
+      "first_client",
+      "second_client",
+      "another_firm",
+      "another_client",
+      "a_third_client",
+      "rails_core",
+      "leetsoft",
+      "jadedpixel",
+      "odegy",
+      "another_first_firm_client",
+      "recursive_association_fk",
+    ]);
+  });
+
+  it("first_firm is a Firm with STI type column", () => {
+    expect(companyFixtureData.first_firm.type).toBe("Firm");
+    expect(companyFixtureData.first_firm.name).toBe("37signals");
+  });
+
+  it("first_client is a Client with firm_id cross-ref to first_firm", () => {
+    expect(companyFixtureData.first_client.type).toBe("Client");
+    const firmRef = companyFixtureData.first_client.firm_id as FixtureRef;
+    expect(isFixtureRef(firmRef)).toBe(true);
+    expect(firmRef.tableName).toBe("companies");
+    expect(firmRef.fixtureName).toBe("first_firm");
+  });
+
+  it("rails_core is a DependentFirm", () => {
+    expect(companyFixtureData.rails_core.type).toBe("DependentFirm");
+  });
+
+  it("leetsoft has no type (falls back to Company base)", () => {
+    expect((companyFixtureData.leetsoft as any).type).toBeUndefined();
+    const clientOfRef = companyFixtureData.leetsoft.client_of as FixtureRef;
+    expect(isFixtureRef(clientOfRef)).toBe(true);
+    expect(clientOfRef.fixtureName).toBe("rails_core");
+  });
+
+  it("odegy is an ExclusivelyDependentFirm", () => {
+    expect(companyFixtureData.odegy.type).toBe("ExclusivelyDependentFirm");
+  });
+
+  it("defineFixtures resolves first_client.firm_id to first_firm id", async () => {
+    const adapter = makeAdapter();
+    const Company = makeModel("companies");
+    for (const k of Object.keys(companyFixtureData) as Array<keyof typeof companyFixtureData>) {
+      seedRows(Company, k, { name: (companyFixtureData[k] as any).name });
+    }
+
+    await defineFixtures(adapter, Company, companyFixtureData);
+
+    const insertSqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("companies"));
+    const clientInsert = insertSqls.find((s) => s.includes(String(fixtureId("first_client"))));
+    expect(clientInsert).toBeTruthy();
+    expect(clientInsert).toContain(String(fixtureId("first_firm")));
+  });
+});
+
+describe("accountFixtureData", () => {
+  it("exports all 6 Rails accounts fixtures", () => {
+    expect(Object.keys(accountFixtureData)).toEqual([
+      "signals37",
+      "unknown",
+      "rails_core_account",
+      "last_account",
+      "rails_core_account_2",
+      "odegy_account",
+    ]);
+  });
+
+  it("signals37 has firm_id cross-ref to first_firm and correct credit_limit", () => {
+    expect(accountFixtureData.signals37.credit_limit).toBe(50);
+    const firmRef = accountFixtureData.signals37.firm_id as FixtureRef;
+    expect(isFixtureRef(firmRef)).toBe(true);
+    expect(firmRef.tableName).toBe("companies");
+    expect(firmRef.fixtureName).toBe("first_firm");
+  });
+
+  it("unknown has no firm_id", () => {
+    expect((accountFixtureData.unknown as any).firm_id).toBeUndefined();
+    expect(accountFixtureData.unknown.credit_limit).toBe(50);
+  });
+
+  it("odegy_account references odegy company", () => {
+    const firmRef = accountFixtureData.odegy_account.firm_id as FixtureRef;
+    expect(isFixtureRef(firmRef)).toBe(true);
+    expect(firmRef.fixtureName).toBe("odegy");
+  });
+
+  it("defineFixtures resolves signals37.firm_id to first_firm id", async () => {
+    const adapter = makeAdapter();
+    const Account = makeModel("accounts");
+    for (const k of Object.keys(accountFixtureData) as Array<keyof typeof accountFixtureData>) {
+      seedRows(Account, k, { credit_limit: (accountFixtureData[k] as any).credit_limit });
+    }
+
+    await defineFixtures(adapter, Account, accountFixtureData);
+
+    const insertSqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("accounts"));
+    const signals37Insert = insertSqls.find((s) => s.includes(String(fixtureId("signals37"))));
+    expect(signals37Insert).toBeTruthy();
+    expect(signals37Insert).toContain(String(fixtureId("first_firm")));
   });
 });
 

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -236,12 +236,16 @@ describe("companyFixtureData", () => {
     expect(companyFixtureData.first_firm.name).toBe("37signals");
   });
 
-  it("first_client is a Client with firm_id cross-ref to first_firm", () => {
+  it("first_client is a Client with firm_id cross-ref to first_firm and self-ref client_of", () => {
     expect(companyFixtureData.first_client.type).toBe("Client");
     const firmRef = companyFixtureData.first_client.firm_id as FixtureRef;
     expect(isFixtureRef(firmRef)).toBe(true);
     expect(firmRef.tableName).toBe("companies");
     expect(firmRef.fixtureName).toBe("first_firm");
+    // client_of: 2 in Rails YAML — first_client's own ID (self-ref; ref() is just ID math)
+    const clientOfRef = companyFixtureData.first_client.client_of as FixtureRef;
+    expect(isFixtureRef(clientOfRef)).toBe(true);
+    expect(clientOfRef.fixtureName).toBe("first_client");
   });
 
   it("rails_core is a DependentFirm", () => {


### PR DESCRIPTION
## Summary

- Ports \`companies.yml\` (12 fixtures, STI hierarchy: Firm / Client / DependentFirm / ExclusivelyDependentFirm) with explicit \`type:\` column on each STI row
- Ports \`accounts.yml\` (6 fixtures, belongs_to firm via \`ref("companies", …)\`)
- Adds \`Account\` model to \`createFixtures()\` / \`TestFixtures\` with \`firm_id\`, \`credit_limit\`, \`firm_name\`, \`status\` attributes and \`belongsTo("firm")\` association
- Adds \`firm_name\` attribute to \`Company\` model (real column: \`t.string :firm_name\` in schema.rb)
- 18 new test assertions in \`fixtures.test.ts\` covering fixture keys, STI type column, cross-ref resolution, and \`defineFixtures\` SQL output

## Schema gaps noted

- \`companies\`: \`rating\`, \`description\`, \`account_id\`, \`status\` (integer enum) — not in test model
- \`accounts\`: \`transactions_count\` (counter_cache column on accounts) — not in test model

## Self-referential fixtures

- \`first_firm.firm_id\` points to its own row in the Rails YAML — included as \`ref("companies", "first_firm")\`; \`ref()\` is pure ID math (CRC32), no insertion-ordering issue
- \`first_client.client_of\` similarly self-refs \`first_client\` — included for the same reason

## Test plan

- [x] \`pnpm test packages/activerecord/src/test-helpers\` — all 67 tests pass
- [x] \`tsc --build\` passes (pre-commit hook)