### PR TITLE
feat(activerecord) fixture replacement Phase 3c — developers + projects + developers_projects HABTM fixture data

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/developers-projects.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/developers-projects.ts
@@ -1,0 +1,23 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/developers_projects.yml
+// HABTM join table — no synthetic id; developer_id + project_id are the composite key.
+// Schema gap: joined_on exists in Rails YAML but is not declared in test-fixtures.ts.
+export const developersProjectsFixtureData = {
+  david_action_controller: {
+    developer_id: ref("developers", "david"),
+    project_id: ref("projects", "action_controller"),
+  },
+  david_active_record: {
+    developer_id: ref("developers", "david"),
+    project_id: ref("projects", "active_record"),
+  },
+  jamis_active_record: {
+    developer_id: ref("developers", "jamis"),
+    project_id: ref("projects", "active_record"),
+  },
+  poor_jamis_active_record: {
+    developer_id: ref("developers", "poor_jamis"),
+    project_id: ref("projects", "active_record"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/developers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/developers.ts
@@ -1,0 +1,24 @@
+// activerecord/test/fixtures/developers.yml
+// Schema gap: shared_computers exists in Rails YAML but is not declared in test-fixtures.ts Developer.
+export const developerFixtureData = {
+  david: {
+    name: "David",
+    salary: 80000,
+  },
+  jamis: {
+    name: "Jamis",
+    salary: 150000,
+  },
+  dev_3: { name: "fixture_3", salary: 100000 },
+  dev_4: { name: "fixture_4", salary: 100000 },
+  dev_5: { name: "fixture_5", salary: 100000 },
+  dev_6: { name: "fixture_6", salary: 100000 },
+  dev_7: { name: "fixture_7", salary: 100000 },
+  dev_8: { name: "fixture_8", salary: 100000 },
+  dev_9: { name: "fixture_9", salary: 100000 },
+  dev_10: { name: "fixture_10", salary: 100000 },
+  poor_jamis: {
+    name: "Jamis",
+    salary: 9000,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -216,7 +216,6 @@ describe("bookFixtureData", () => {
   });
 });
 
-<<<<<<< HEAD
 describe("companyFixtureData", () => {
   it("exports all 12 Rails companies fixtures", () => {
     expect(Object.keys(companyFixtureData)).toEqual([
@@ -334,8 +333,6 @@ describe("accountFixtureData", () => {
   });
 });
 
-||||||| parent of 28fa2ba99 (feat(activerecord) fixture replacement Phase 3c — developers + projects + developers_projects HABTM fixture data)
-=======
 describe("developerFixtureData", () => {
   it("exports david, jamis, dev_3..dev_10, poor_jamis", () => {
     const keys = Object.keys(developerFixtureData);
@@ -396,7 +393,6 @@ describe("developersProjectsFixtureData", () => {
   });
 });
 
->>>>>>> 28fa2ba99 (feat(activerecord) fixture replacement Phase 3c — developers + projects + developers_projects HABTM fixture data)
 describe("authorAddressFixtureData", () => {
   it("exports david_address, david_address_extra, mary_address, bob_address", () => {
     expect(Object.keys(authorAddressFixtureData)).toEqual([

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DatabaseAdapter } from "../../adapter.js";
-import {
-  defineFixtures,
-  fixtureId,
-  isFixtureRef,
-  ref,
-  type FixtureRef,
-} from "../define-fixtures.js";
+import { defineFixtures, fixtureId, isFixtureRef, type FixtureRef } from "../define-fixtures.js";
 import { topicFixtureData } from "./topics.js";
 import { postFixtureData } from "./posts.js";
 import { commentFixtureData } from "./comments.js";
@@ -356,7 +350,8 @@ describe("developerFixtureData", () => {
     expect(developerFixtureData.david.salary).toBe(80000);
   });
 
-  it("poor_jamis has low salary", () => {
+  it("jamis has high salary, poor_jamis has low salary", () => {
+    expect(developerFixtureData.jamis.salary).toBe(150000);
     expect(developerFixtureData.poor_jamis.salary).toBe(9000);
   });
 
@@ -390,30 +385,14 @@ describe("developersProjectsFixtureData", () => {
   });
 
   it("david_active_record refs david in developers and active_record in projects", () => {
-    const devRef = developersProjectsFixtureData.david_active_record.developer_id as ReturnType<
-      typeof ref
-    >;
-    const projRef = developersProjectsFixtureData.david_active_record.project_id as ReturnType<
-      typeof ref
-    >;
+    const devRef = developersProjectsFixtureData.david_active_record.developer_id as FixtureRef;
+    const projRef = developersProjectsFixtureData.david_active_record.project_id as FixtureRef;
     expect(isFixtureRef(devRef)).toBe(true);
     expect(devRef.tableName).toBe("developers");
     expect(devRef.fixtureName).toBe("david");
     expect(isFixtureRef(projRef)).toBe(true);
     expect(projRef.tableName).toBe("projects");
     expect(projRef.fixtureName).toBe("active_record");
-  });
-
-  it("ref values resolve to fixtureId of their target fixture", () => {
-    const devRef = developersProjectsFixtureData.david_active_record.developer_id as ReturnType<
-      typeof ref
-    >;
-    const projRef = developersProjectsFixtureData.david_active_record.project_id as ReturnType<
-      typeof ref
-    >;
-    // fixtureId resolution is the contract: ref carries table + label, consumer resolves via fixtureId
-    expect(fixtureId(devRef.fixtureName)).toBe(fixtureId("david"));
-    expect(fixtureId(projRef.fixtureName)).toBe(fixtureId("active_record"));
   });
 });
 

--- a/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fixtures.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DatabaseAdapter } from "../../adapter.js";
-import { defineFixtures, fixtureId, isFixtureRef, type FixtureRef } from "../define-fixtures.js";
+import {
+  defineFixtures,
+  fixtureId,
+  isFixtureRef,
+  ref,
+  type FixtureRef,
+} from "../define-fixtures.js";
 import { topicFixtureData } from "./topics.js";
 import { postFixtureData } from "./posts.js";
 import { commentFixtureData } from "./comments.js";
@@ -9,6 +15,9 @@ import { bookFixtureData } from "./books.js";
 import { authorAddressFixtureData } from "./author-addresses.js";
 import { companyFixtureData } from "./companies.js";
 import { accountFixtureData } from "./accounts.js";
+import { developerFixtureData } from "./developers.js";
+import { projectFixtureData } from "./projects.js";
+import { developersProjectsFixtureData } from "./developers-projects.js";
 
 function makeAdapter(): DatabaseAdapter {
   return {
@@ -213,6 +222,7 @@ describe("bookFixtureData", () => {
   });
 });
 
+<<<<<<< HEAD
 describe("companyFixtureData", () => {
   it("exports all 12 Rails companies fixtures", () => {
     expect(Object.keys(companyFixtureData)).toEqual([
@@ -330,6 +340,84 @@ describe("accountFixtureData", () => {
   });
 });
 
+||||||| parent of 28fa2ba99 (feat(activerecord) fixture replacement Phase 3c — developers + projects + developers_projects HABTM fixture data)
+=======
+describe("developerFixtureData", () => {
+  it("exports david, jamis, dev_3..dev_10, poor_jamis", () => {
+    const keys = Object.keys(developerFixtureData);
+    expect(keys).toContain("david");
+    expect(keys).toContain("jamis");
+    expect(keys).toContain("poor_jamis");
+    expect(keys.filter((k) => k.startsWith("dev_"))).toHaveLength(8);
+  });
+
+  it("david has correct name and salary", () => {
+    expect(developerFixtureData.david.name).toBe("David");
+    expect(developerFixtureData.david.salary).toBe(80000);
+  });
+
+  it("poor_jamis has low salary", () => {
+    expect(developerFixtureData.poor_jamis.salary).toBe(9000);
+  });
+
+  it("defineFixtures inserts david", async () => {
+    const adapter = makeAdapter();
+    const Developer = makeModel("developers");
+    for (const k of Object.keys(developerFixtureData) as Array<keyof typeof developerFixtureData>) {
+      seedRows(Developer, k, { name: developerFixtureData[k].name });
+    }
+    await defineFixtures(adapter, Developer, developerFixtureData);
+    const insertSqls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .filter((s) => s.includes("INSERT INTO") && s.includes("developers"));
+    expect(insertSqls.some((s) => s.includes(String(fixtureId("david"))))).toBe(true);
+  });
+});
+
+describe("projectFixtureData", () => {
+  it("exports active_record and action_controller", () => {
+    expect(Object.keys(projectFixtureData)).toEqual(["active_record", "action_controller"]);
+  });
+
+  it("active_record has correct name", () => {
+    expect(projectFixtureData.active_record.name).toBe("Active Record");
+  });
+});
+
+describe("developersProjectsFixtureData", () => {
+  it("exports four join rows", () => {
+    expect(Object.keys(developersProjectsFixtureData)).toHaveLength(4);
+  });
+
+  it("david_active_record refs david in developers and active_record in projects", () => {
+    const devRef = developersProjectsFixtureData.david_active_record.developer_id as ReturnType<
+      typeof ref
+    >;
+    const projRef = developersProjectsFixtureData.david_active_record.project_id as ReturnType<
+      typeof ref
+    >;
+    expect(isFixtureRef(devRef)).toBe(true);
+    expect(devRef.tableName).toBe("developers");
+    expect(devRef.fixtureName).toBe("david");
+    expect(isFixtureRef(projRef)).toBe(true);
+    expect(projRef.tableName).toBe("projects");
+    expect(projRef.fixtureName).toBe("active_record");
+  });
+
+  it("ref values resolve to fixtureId of their target fixture", () => {
+    const devRef = developersProjectsFixtureData.david_active_record.developer_id as ReturnType<
+      typeof ref
+    >;
+    const projRef = developersProjectsFixtureData.david_active_record.project_id as ReturnType<
+      typeof ref
+    >;
+    // fixtureId resolution is the contract: ref carries table + label, consumer resolves via fixtureId
+    expect(fixtureId(devRef.fixtureName)).toBe(fixtureId("david"));
+    expect(fixtureId(projRef.fixtureName)).toBe(fixtureId("active_record"));
+  });
+});
+
+>>>>>>> 28fa2ba99 (feat(activerecord) fixture replacement Phase 3c — developers + projects + developers_projects HABTM fixture data)
 describe("authorAddressFixtureData", () => {
   it("exports david_address, david_address_extra, mary_address, bob_address", () => {
     expect(Object.keys(authorAddressFixtureData)).toEqual([

--- a/packages/activerecord/src/test-helpers/fixtures/projects.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/projects.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/projects.yml
+export const projectFixtureData = {
+  active_record: {
+    name: "Active Record",
+  },
+  action_controller: {
+    name: "Active Controller",
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `developerFixtureData` (`developers.ts`) — 11 fixtures matching Rails YAML: david, jamis, dev_3..dev_10, poor_jamis. Schema gap: `shared_computers` omitted (not declared in test-fixtures.ts).
- Adds `projectFixtureData` (`projects.ts`) — 2 fixtures: active_record, action_controller.
- Adds `developersProjectsFixtureData` (`developers-projects.ts`) — 4 HABTM join rows with `ref()` cross-refs to both sides. Schema gap: `joined_on` omitted (not declared).
- Extends `fixtures.test.ts` with smoke tests for all three: key enumeration, field values, ref structure, and fixtureId resolution.

## Phases shipped
#1470 (Phase 1), #1471 (Phase 1b), #1480 (Phase 2), #1481 (Phase 3a), #1484 (Phase 3b)

## Notes
HABTM join table (`developers_projects`) uses explicit `ref()` for both FK columns rather than the string-label HABTM auto-detection path, since the test fixture data provides explicit cross-references. `joined_on` is omitted as a schema gap — not declared on the test model.