### PR TITLE
refactor(activemodel) Errors<TBase> — PR A: generic with object default

### DIFF
--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, expectTypeOf } from "vitest";
 import { Model, Errors, I18n, StrictValidationFailed } from "./index.js";
 import { Error as ActiveModelError } from "./error.js";
 
@@ -1135,5 +1135,40 @@ describe("ErrorsTest", () => {
     const e = new Errors(null);
     e.add("name", "blank");
     expect(e.ofKind("name", "nonexistent type xyz")).toBe(false);
+  });
+});
+
+describe("Errors<TBase> type parameter", () => {
+  interface User {
+    name: string;
+    age: number;
+  }
+
+  it("base getter returns TBase | null", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    expectTypeOf(e.base).toEqualTypeOf<User | null>();
+  });
+
+  it("add() type callback receives TBase | null", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    e.add("name", (record, _opts) => {
+      expectTypeOf(record).toEqualTypeOf<User | null>();
+      return "invalid";
+    });
+  });
+
+  it("add() message callback receives TBase | null", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    e.add("name", "invalid", {
+      message: (record) => {
+        expectTypeOf(record).toEqualTypeOf<User | null>();
+        return "bad";
+      },
+    });
+  });
+
+  it("default Errors (= object) still compiles", () => {
+    const e = new Errors<object>({} as object);
+    expectTypeOf(e.base).toEqualTypeOf<object | null>();
   });
 });

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1171,4 +1171,48 @@ describe("Errors<TBase> type parameter", () => {
     const e = new Errors<object>({} as object);
     expectTypeOf(e.base).toEqualTypeOf<object | null>();
   });
+
+  it("unparameterized Errors annotation compiles (default = object)", () => {
+    // Proves the `= object` default is in effect: the type annotation `Errors`
+    // (no type arg) is accepted and `base` resolves to `object | null`.
+    const e: Errors = new Errors({} as object);
+    expectTypeOf(e.base).toEqualTypeOf<object | null>();
+  });
+
+  it("where() type callback receives TBase | null", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    e.where("name", (record, _opts) => {
+      expectTypeOf(record).toEqualTypeOf<User | null>();
+      return "invalid";
+    });
+  });
+
+  it("copyBang accepts Errors<U> for a different U", () => {
+    interface Post {
+      title: string;
+    }
+    const userErrors = new Errors<User>({ name: "Alice", age: 30 });
+    const postErrors = new Errors<Post>({ title: "Hello" });
+    // Must compile: cross-model copy is valid (Rails copy! just rebinds base).
+    expectTypeOf(userErrors.copyBang<Post>).toBeFunction();
+    userErrors.copyBang(postErrors);
+  });
+
+  it("mergeBang accepts Errors<U> for a different U", () => {
+    interface Post {
+      title: string;
+    }
+    const userErrors = new Errors<User>({ name: "Alice", age: 30 });
+    const postErrors = new Errors<Post>({ title: "Hello" });
+    expectTypeOf(userErrors.mergeBang<Post>).toBeFunction();
+    userErrors.mergeBang(postErrors);
+  });
+
+  it("normalizeArguments() type callback receives TBase | null", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    e.normalizeArguments("name", (record, _opts) => {
+      expectTypeOf(record).toEqualTypeOf<User | null>();
+      return "invalid";
+    });
+  });
 });

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1178,11 +1178,6 @@ describe("Errors<TBase> type parameter", () => {
     });
   });
 
-  it("default Errors (= object) still compiles", () => {
-    const e = new Errors<object>({} as object);
-    expectTypeOf(e.base).toEqualTypeOf<object | null>();
-  });
-
   it("unparameterized Errors annotation compiles (default = object)", () => {
     // Proves the `= object` default is in effect: the type annotation `Errors`
     // (no type arg) is accepted and `base` resolves to `object | null`.

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1167,6 +1167,17 @@ describe("Errors<TBase> type parameter", () => {
     });
   });
 
+  it("add() message callback receives TBase | null and options (two-arg form)", () => {
+    const e = new Errors<User>({ name: "Alice", age: 30 });
+    e.add("name", "invalid", {
+      message: (record, opts) => {
+        expectTypeOf(record).toEqualTypeOf<User | null>();
+        expectTypeOf(opts).toEqualTypeOf<Record<string, unknown>>();
+        return "bad";
+      },
+    });
+  });
+
   it("default Errors (= object) still compiles", () => {
     const e = new Errors<object>({} as object);
     expectTypeOf(e.base).toEqualTypeOf<object | null>();
@@ -1198,6 +1209,16 @@ describe("Errors<TBase> type parameter", () => {
     userErrors.copyBang(postErrors);
   });
 
+  it("copy alias accepts Errors<U> for a different U", () => {
+    interface Post {
+      title: string;
+    }
+    const userErrors = new Errors<User>({ name: "Alice", age: 30 });
+    const postErrors = new Errors<Post>({ title: "Hello" });
+    expectTypeOf(userErrors.copy<Post>).toBeFunction();
+    userErrors.copy(postErrors);
+  });
+
   it("mergeBang accepts Errors<U> for a different U", () => {
     interface Post {
       title: string;
@@ -1206,6 +1227,16 @@ describe("Errors<TBase> type parameter", () => {
     const postErrors = new Errors<Post>({ title: "Hello" });
     expectTypeOf(userErrors.mergeBang<Post>).toBeFunction();
     userErrors.mergeBang(postErrors);
+  });
+
+  it("merge alias accepts Errors<U> for a different U", () => {
+    interface Post {
+      title: string;
+    }
+    const userErrors = new Errors<User>({ name: "Alice", age: 30 });
+    const postErrors = new Errors<Post>({ title: "Hello" });
+    expectTypeOf(userErrors.merge<Post>).toBeFunction();
+    userErrors.merge(postErrors);
   });
 
   it("normalizeArguments() type callback receives TBase | null", () => {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -312,7 +312,7 @@ export class Errors<TBase extends object = object> {
    *   end
    */
   mergeBang<U extends object>(other: Errors<U>): void {
-    if ((other as unknown) === this) return;
+    if (Object.is(other, this)) return;
     for (const error of other._errors) {
       this.import(error);
     }

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -1,6 +1,3 @@
-/** The model instance that owns this Errors collection. */
-type ModelBase = object | null;
-
 import { Error as ActiveModelError } from "./error.js";
 import { NestedError } from "./nested-error.js";
 
@@ -22,15 +19,15 @@ const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
  *
  * Mirrors: ActiveModel::Errors
  */
-export class Errors {
+export class Errors<TBase extends object = object> {
   private _errors: ActiveModelError[] = [];
-  private _base: ModelBase;
+  private _base: TBase | null;
 
-  constructor(base: ModelBase) {
+  constructor(base: TBase | null) {
     this._base = base;
   }
 
-  get base(): ModelBase {
+  get base(): TBase | null {
     return this._base;
   }
 
@@ -58,8 +55,10 @@ export class Errors {
    */
   add(
     attribute: string,
-    type: string | ((record: ModelBase, options: Record<string, unknown>) => string) = "invalid",
-    options?: { message?: string | ((record: ModelBase) => string) } & Record<string, unknown>,
+    type: string | ((record: TBase | null, options: Record<string, unknown>) => string) = "invalid",
+    options?: {
+      message?: string | ((record: TBase | null) => string);
+    } & Record<string, unknown>,
   ): ActiveModelError {
     const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
     const error = new ActiveModelError(this._base, normAttr, normType, normOpts);
@@ -86,7 +85,7 @@ export class Errors {
    */
   normalizeArguments(
     attribute: string,
-    type: string | ((record: ModelBase, options: Record<string, unknown>) => string),
+    type: string | ((record: TBase | null, options: Record<string, unknown>) => string),
     options?: Record<string, unknown>,
   ): [string, string, Record<string, unknown>] {
     const opts = { ...(options ?? {}) };
@@ -109,7 +108,7 @@ export class Errors {
    */
   where(
     attribute: string,
-    type?: string | ((record: ModelBase, options: Record<string, unknown>) => string),
+    type?: string | ((record: TBase | null, options: Record<string, unknown>) => string),
     options?: Record<string, unknown>,
   ): ActiveModelError[] {
     if (type === undefined) {
@@ -292,12 +291,12 @@ export class Errors {
    *     @errors.each { |error| error.instance_variable_set(:@base, @base) }
    *   end
    */
-  copyBang(other: Errors): void {
+  copyBang<U extends object>(other: Errors<U>): void {
     this._errors = other._errors.map((e) => e.dupWithBase(this._base));
   }
 
   /** Alias for `copyBang` — Rails ships only `copy!`. */
-  copy(other: Errors): void {
+  copy<U extends object>(other: Errors<U>): void {
     this.copyBang(other);
   }
 
@@ -312,15 +311,15 @@ export class Errors {
    *     other.errors.each { |error| import(error) }
    *   end
    */
-  mergeBang(other: Errors): void {
-    if (other === this) return;
+  mergeBang<U extends object>(other: Errors<U>): void {
+    if ((other as unknown) === this) return;
     for (const error of other._errors) {
       this.import(error);
     }
   }
 
   /** Alias for `mergeBang` — Rails ships only `merge!`. */
-  merge(other: Errors): void {
+  merge<U extends object>(other: Errors<U>): void {
     this.mergeBang(other);
   }
 

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -57,7 +57,7 @@ export class Errors<TBase extends object = object> {
     attribute: string,
     type: string | ((record: TBase | null, options: Record<string, unknown>) => string) = "invalid",
     options?: {
-      message?: string | ((record: TBase | null) => string);
+      message?: string | ((record: TBase | null, options: Record<string, unknown>) => string);
     } & Record<string, unknown>,
   ): ActiveModelError {
     const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);


### PR DESCRIPTION
## Summary

- `class Errors<TBase extends object = object>` — `_base` narrows from `object | null` to `TBase | null`
- Callback signatures in `add()`, `where()`, `normalizeArguments()` now use `TBase | null` instead of `object | null`, so callers that pass a typed lambda get their record typed
- `copyBang` / `copy` / `mergeBang` / `merge` now use `<U extends object>` so cross-model copies remain accepted
- `= object` default keeps every existing call site compiling unchanged — no activerecord changes needed

## Part of series

- **PR A (this)** — activemodel only, generic with `= object` default
- PR B — thread `TBase` through `NestedError` and `Validator`/`EachValidator`
- PR C — wire actual model types at activerecord call sites

## Test plan

- [ ] All 140 `errors.test.ts` tests pass
- [ ] Full `vitest run --project other` passes
- [ ] Root typecheck clean (pre-existing errors only)