### PR TITLE
refactor(activemodel) Errors<TBase> — PR C: wire model types into consumers

### DIFF
--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, afterEach, expectTypeOf } from "vitest";
-import { Model, Errors, I18n, StrictValidationFailed } from "./index.js";
+import {
+  Model,
+  Errors,
+  I18n,
+  StrictValidationFailed,
+  Validator,
+  EachValidator,
+  BlockValidator,
+} from "./index.js";
 import { Error as ActiveModelError } from "./error.js";
+import type { ValidatableRecord } from "./validator.js";
 
 describe("ErrorsTest", () => {
   // =========================================================================
@@ -1240,5 +1249,46 @@ describe("Errors<TBase> type parameter", () => {
       expectTypeOf(record).toEqualTypeOf<User | null>();
       return "invalid";
     });
+  });
+});
+
+describe("ValidatableRecord<TBase> type tests", () => {
+  interface User {
+    name: string;
+    age: number;
+  }
+  interface Post {
+    title: string;
+  }
+
+  it("ValidatableRecord<User>.errors is Errors<User>", () => {
+    type R = ValidatableRecord<User>;
+    expectTypeOf<R["errors"]>().toEqualTypeOf<Errors<User>>();
+  });
+
+  it("Errors<User> and Errors<Post> are not mutually assignable", () => {
+    expectTypeOf<Errors<User>>().not.toMatchTypeOf<Errors<Post>>();
+    expectTypeOf<Errors<Post>>().not.toMatchTypeOf<Errors<User>>();
+  });
+
+  it("Validator<User>.validate receives ValidatableRecord<User>", () => {
+    abstract class UserValidator extends Validator<User> {}
+    expectTypeOf<Parameters<UserValidator["validate"]>[0]>().toEqualTypeOf<
+      ValidatableRecord<User>
+    >();
+  });
+
+  it("EachValidator<User>.validateEach receives ValidatableRecord<User>", () => {
+    class UserEachValidator extends EachValidator<User> {
+      validateEach(_record: ValidatableRecord<User>, _attr: string, _val: unknown): void {}
+    }
+    expectTypeOf<Parameters<UserEachValidator["validateEach"]>[0]>().toEqualTypeOf<
+      ValidatableRecord<User>
+    >();
+  });
+
+  it("BlockValidator<User> callback receives ValidatableRecord<User>", () => {
+    type BlockFn = ConstructorParameters<typeof BlockValidator<User>>[1];
+    expectTypeOf<Parameters<BlockFn>[0]>().toEqualTypeOf<ValidatableRecord<User>>();
   });
 });

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1271,6 +1271,11 @@ describe("ValidatableRecord<TBase> type tests", () => {
     expectTypeOf<Errors<Post>>().not.toMatchTypeOf<Errors<User>>();
   });
 
+  it("ValidatableRecord<User> and ValidatableRecord<Post> are not mutually assignable", () => {
+    expectTypeOf<ValidatableRecord<User>>().not.toMatchTypeOf<ValidatableRecord<Post>>();
+    expectTypeOf<ValidatableRecord<Post>>().not.toMatchTypeOf<ValidatableRecord<User>>();
+  });
+
   it("Validator<User>.validate receives ValidatableRecord<User>", () => {
     abstract class UserValidator extends Validator<User> {}
     expectTypeOf<Parameters<UserValidator["validate"]>[0]>().toEqualTypeOf<
@@ -1290,5 +1295,15 @@ describe("ValidatableRecord<TBase> type tests", () => {
   it("BlockValidator<User> callback receives ValidatableRecord<User>", () => {
     type BlockFn = ConstructorParameters<typeof BlockValidator<User>>[1];
     expectTypeOf<Parameters<BlockFn>[0]>().toEqualTypeOf<ValidatableRecord<User>>();
+  });
+
+  it("Model subclass .errors resolves to Errors<ConcreteModel>", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const p = new Person();
+    expectTypeOf(p.errors).toEqualTypeOf<Errors<Person>>();
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1231,7 +1231,7 @@ export class Model {
 
   _attributes: AttributeSet = new AttributeSet();
   _accessedFields: Set<string> = new Set();
-  errors!: Errors;
+  errors!: Errors<this>;
   _dirty!: DirtyTracker;
 
   /**

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -48,8 +48,8 @@ export const _defineAfterModelCallback = _defineAfterModelCallbackImpl;
  *
  * @internal Rails-private helper.
  */
-export function initInternals(this: ValidationsInternalsHost): void {
-  this.errors = new Errors(this);
+export function initInternals<TBase extends object>(this: ValidationsInternalsHost<TBase>): void {
+  this.errors = new Errors(this as unknown as TBase);
   this._validationContext = null;
   this._contextForValidation = undefined;
 }
@@ -59,8 +59,8 @@ export function initInternals(this: ValidationsInternalsHost): void {
  * the validation-related fields satisfies it without circular imports
  * back to `Model`.
  */
-export interface ValidationsInternalsHost {
-  errors: Errors;
+export interface ValidationsInternalsHost<TBase extends object = object> {
+  errors: Errors<TBase>;
   _validationContext: string | string[] | null;
   _contextForValidation?: ValidationContext;
 }
@@ -323,8 +323,8 @@ export function runValidationsBang(this: RunValidationsHost): boolean {
 /**
  * Host shape consumed by `runValidationsBang`.
  */
-export interface RunValidationsHost {
-  errors: Errors;
+export interface RunValidationsHost<TBase extends object = object> {
+  errors: Errors<TBase>;
   _runValidateCallbacks(): void;
 }
 
@@ -335,7 +335,9 @@ export interface RunValidationsHost {
  *
  * @internal Rails-private helper.
  */
-export function raiseValidationError(this: { errors: Errors }): never {
+export function raiseValidationError<TBase extends object = object>(this: {
+  errors: Errors<TBase>;
+}): never {
   throw new ValidationError(this);
 }
 

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Model } from "../index.js";
+import { Model, Errors } from "../index.js";
 import { prepareValueForValidation } from "./numericality.js";
 
 describe("NumericalityValidationTest", () => {
@@ -658,12 +658,11 @@ describe("numericality with in: range", () => {
     // reaches isNumber.
     const { NumericalityValidator } = await import("./numericality.js");
     const v = new NumericalityValidator({ attributes: ["x"] });
-    const errors: Array<[string, string]> = [];
-    const stubRecord = {
-      errors: { add: (attr: string, key: string) => errors.push([attr, key]) },
-    };
+    const errs = new Errors(null);
+    const stubRecord = { errors: errs };
     v.validateEach(stubRecord, "x", { not: "a number" });
-    expect(errors).toEqual([["x", "not_a_number"]]);
+    expect(errs.get("x")).toHaveLength(1);
+    expect(errs.where("x", "not_a_number")).toHaveLength(1);
   });
 
   it("validates against the raw before-type-cast value (prepareValueForValidation)", () => {

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Model } from "../index.js";
+import { Model, Errors } from "../index.js";
 import { WithValidator } from "./with.js";
 
 describe("ValidatesWithTest", () => {
@@ -286,7 +286,7 @@ describe("ValidatesWithTest", () => {
 describe("WithValidator arity dispatch", () => {
   it("calls zero-arity method without arguments", () => {
     const spy = vi.fn();
-    const record = { myCheck: spy, errors: { add: vi.fn() } };
+    const record = { myCheck: spy, errors: new Errors(null) };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
     expect(spy).toHaveBeenCalledWith();
@@ -299,7 +299,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(attr: string) {
         capturedArg = attr;
       },
-      errors: { add: vi.fn() },
+      errors: new Errors(null),
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
@@ -316,7 +316,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(...args: unknown[]) {
         received.push(...args);
       },
-      errors: { add: vi.fn() },
+      errors: new Errors(null),
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
@@ -330,7 +330,7 @@ describe("WithValidator arity dispatch", () => {
       myCheck(attr: string = "") {
         capturedArg = attr;
       },
-      errors: { add: vi.fn() },
+      errors: new Errors(null),
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -1,8 +1,9 @@
 import { isBlank, underscore } from "@blazetrails/activesupport";
+import type { Errors } from "./errors.js";
 
 /** Minimum shape required of a record passed to validators. */
 export interface ValidatableRecord<TBase extends object = object> {
-  errors: { add(attribute: string, type?: string, options?: Record<string, unknown>): void };
+  errors: Errors<TBase>;
 }
 
 /**


### PR DESCRIPTION
## What

Wires `Errors<TBase>` through the activemodel consumer chain so `TBase` is non-phantom everywhere.

### 1. `ValidatableRecord<TBase>.errors: Errors<TBase>` (`validator.ts`)

Previously `errors` was a loose structural type `{ add(...) }`. Now it's `Errors<TBase>`, making `ValidatableRecord<User>` and `ValidatableRecord<Post>` structurally distinct.

### 2. `ValidationsInternalsHost<TBase>` and `RunValidationsHost<TBase>` (`validations.ts:62,326`)

Both host interfaces now carry `errors: Errors<TBase>`. `initInternals` gains `<TBase extends object>` so `new Errors(this)` is typed correctly.

### 3. `raiseValidationError` (`validations.ts:338`)

Function-level generic `<TBase extends object = object>` added to match the `Errors<TBase>` `this` constraint.

### 4. `Model.errors!: Errors<this>` (`model.ts:1234`)

Uses the polymorphic `this` type so subclasses get `Errors<ConcreteModel>`.

### 5. Test stub fixes (`validations/with-validation.test.ts`, `validations/numericality-validation.test.ts`)

Five test sites used `{ errors: { add: vi.fn() } }` duck-typed stubs. Replaced with real `Errors(null)` instances to satisfy the tightened interface.

### 6. Type-level tests (`errors.test.ts`)

New `ValidatableRecord<TBase> type tests` describe block:
- `ValidatableRecord<User>.errors` resolves to `Errors<User>`
- `Errors<User>` and `Errors<Post>` are NOT mutually assignable (contravariant `add()` callback)
- `Validator<User>.validate`, `EachValidator<User>.validateEach`, `BlockValidator<User>` callback all receive `ValidatableRecord<User>`

## What's deferred (PR D)

**AR `nested-error.ts`**: `NestedError` passes `association.owner` (typed `object | null`) as `TBase`. Threading a real model type requires `AssociationLike` to become generic, which cascades into the association reflection layer. Separate arc, ~50 LOC.

## Size

6 files changed, 73 insertions(+), 21 deletions(+) — well within 300 LOC ceiling.