### PR TITLE
feat(activesupport) callbacks engine — CallbackObject dispatch (PR 2 of activemodel convergence)

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1722,6 +1722,17 @@ describe("CallbackObject dispatch", () => {
     expect(log).toEqual(["after-mixin"]);
   });
 
+  it("skipCallback removes object-form callback by original reference", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = { beforeSave: (t: typeof target) => t.log.push("obj") };
+    setCallback(target, "save", "before", obj);
+    setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn"));
+    skipCallback(target, "save", "before", obj);
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["fn"]);
+  });
+
   it("CallbacksMixin.aroundCallback accepts object form", () => {
     class Model extends CallbacksMixin() {}
     Model.defineCallbacks("save");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1733,6 +1733,19 @@ describe("CallbackObject dispatch", () => {
     expect(target.log).toEqual(["fn"]);
   });
 
+  it("skipCallback matches object by reference after chain inheritance clone", () => {
+    const parent = { log: [] as string[] };
+    defineCallbacks(parent, "save");
+    const obj = { beforeSave: (t: typeof parent) => t.log.push("obj") };
+    setCallback(parent, "save", "before", obj);
+
+    // simulate inheritance: getCallbackChains copies the chain when a child prototype is used
+    const child = Object.create(parent) as typeof parent;
+    skipCallback(child, "save", "before", obj);
+    runCallbacks(child, "save");
+    expect(child.log).toEqual([]);
+  });
+
   it("CallbacksMixin.aroundCallback accepts object form", () => {
     class Model extends CallbacksMixin() {}
     Model.defineCallbacks("save");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1711,4 +1711,30 @@ describe("CallbackObject dispatch", () => {
     (inst as any).runCallbacks("save");
     expect(log).toEqual(["mixin-obj"]);
   });
+
+  it("CallbacksMixin.afterCallback accepts object form", () => {
+    class Model extends CallbacksMixin() {}
+    Model.defineCallbacks("save");
+    const log: string[] = [];
+    Model.afterCallback("save", { afterSave: () => log.push("after-mixin") });
+    const inst = new Model();
+    (inst as any).runCallbacks("save");
+    expect(log).toEqual(["after-mixin"]);
+  });
+
+  it("CallbacksMixin.aroundCallback accepts object form", () => {
+    class Model extends CallbacksMixin() {}
+    Model.defineCallbacks("save");
+    const log: string[] = [];
+    Model.aroundCallback("save", {
+      aroundSave: (_: unknown, next: () => void) => {
+        log.push("pre");
+        next();
+        log.push("post");
+      },
+    });
+    const inst = new Model();
+    (inst as any).runCallbacks("save", () => log.push("body"));
+    expect(log).toEqual(["pre", "body", "post"]);
+  });
 });

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1620,3 +1620,95 @@ describe("Callbacks — async propagation", () => {
     expect(() => runCallbacks(t, "v", undefined, { strict: "sync" })).toThrow(/sync chain/);
   });
 });
+
+describe("CallbackObject dispatch", () => {
+  it("before — calls beforeSave on the object", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = { beforeSave: (t: typeof target) => t.log.push("before-obj") };
+    setCallback(target, "save", "before", obj);
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["before-obj"]);
+  });
+
+  it("after — calls afterSave on the object", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = { afterSave: (t: typeof target) => t.log.push("after-obj") };
+    setCallback(target, "save", "after", obj);
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["after-obj"]);
+  });
+
+  it("around — calls aroundSave with target and proceed", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = {
+      aroundSave: (t: typeof target, next: () => void) => {
+        t.log.push("around-pre");
+        next();
+        t.log.push("around-post");
+      },
+    };
+    setCallback(target, "save", "around", obj);
+    runCallbacks(target, "save", () => target.log.push("body"));
+    expect(target.log).toEqual(["around-pre", "body", "around-post"]);
+  });
+
+  it("missing method throws at registration time", () => {
+    const target = {};
+    defineCallbacks(target, "save");
+    const obj = { afterSave: () => {} };
+    expect(() => setCallback(target, "save", "before", obj)).toThrow(/beforeSave/);
+  });
+
+  it("object method called with correct this binding", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = {
+      label: "my-obj",
+      beforeSave(t: typeof target) {
+        t.log.push(this.label);
+      },
+    };
+    setCallback(target, "save", "before", obj);
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["my-obj"]);
+  });
+
+  it("mixed chain: function + object + function all run", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn1"));
+    setCallback(target, "save", "before", { beforeSave: (t: typeof target) => t.log.push("obj") });
+    setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn2"));
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["fn1", "obj", "fn2"]);
+  });
+
+  it("async object method — chain returns Promise", async () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = {
+      beforeSave: async (t: typeof target) => {
+        await Promise.resolve();
+        t.log.push("async-obj");
+      },
+    };
+    setCallback(target, "save", "before", obj);
+    const r = runCallbacks(target, "save");
+    expect(r).toBeInstanceOf(Promise);
+    await r;
+    expect(target.log).toEqual(["async-obj"]);
+  });
+
+  it("CallbacksMixin.beforeCallback accepts object form", () => {
+    class Model extends CallbacksMixin() {}
+    Model.defineCallbacks("save");
+    const log: string[] = [];
+    Model.beforeCallback("save", { beforeSave: () => log.push("mixin-obj") });
+    const inst = new Model();
+    (inst as any).runCallbacks("save");
+    expect(log).toEqual(["mixin-obj"]);
+  });
+});

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -439,6 +439,8 @@ export class Callback {
   readonly filter: AnyCallback | string | symbol;
   readonly options: CallbackOptions;
   readonly chainConfig: DefineCallbacksOptions;
+  /** Preserved when registered via a CallbackObject so skipCallback can match by original reference. */
+  readonly originalObject?: CallbackObject;
 
   private _compiled: Before | After | Around | undefined;
 
@@ -448,18 +450,21 @@ export class Callback {
     kind: CallbackKind,
     options: CallbackOptions = {},
     chainConfig: DefineCallbacksOptions = {},
+    originalObject?: CallbackObject,
   ) {
     this.name = name;
     this.filter = filter;
     this.kind = kind;
     this.options = options;
     this.chainConfig = chainConfig;
+    this.originalObject = originalObject;
   }
 
-  matches(kind: CallbackKind, filter?: AnyCallback | string | symbol): boolean {
+  matches(kind: CallbackKind, filter?: AnyCallback | string | symbol | CallbackObject): boolean {
     if (this.kind !== kind) return false;
-    if (filter && this.filter !== filter) return false;
-    return true;
+    if (filter === undefined) return true;
+    if (typeof filter === "object" && filter !== null) return this.originalObject === filter;
+    return this.filter === filter;
   }
 
   mergeConditionalOptions(
@@ -708,7 +713,7 @@ export class CallbackChain {
     this.chain.unshift(callback);
   }
 
-  remove(kind: CallbackKind, filter?: AnyCallback | string | symbol): void {
+  remove(kind: CallbackKind, filter?: AnyCallback | string | symbol | CallbackObject): void {
     this.chain = this.chain.filter((cb) => !cb.matches(kind, filter));
   }
 
@@ -1047,7 +1052,7 @@ export interface ClassMethods<T extends object = object> {
     callback: AroundCallback<T> | CallbackObject,
     options?: CallbackOptions<T>,
   ): void;
-  skipCallback(name: string, kind: CallbackKind, callback?: AnyCallback<T>): void;
+  skipCallback(name: string, kind: CallbackKind, callback?: AnyCallback<T> | CallbackObject): void;
   resetCallbacks(name: string): void;
 }
 
@@ -1098,16 +1103,17 @@ export namespace Callbacks {
     if (!chain) {
       throw new Error(`No callback chain "${name}" defined. Call defineCallbacks first.`);
     }
-    const resolved =
-      typeof callback === "object" && callback !== null
-        ? resolveCallbackObject<T>(callback as CallbackObject, kind, name)
-        : (callback as AnyCallback<T>);
+    const isObj = typeof callback === "object" && callback !== null;
+    const resolved = isObj
+      ? resolveCallbackObject<T>(callback as CallbackObject, kind, name)
+      : (callback as AnyCallback<T>);
     const entry = new Callback(
       name,
       resolved as AnyCallback,
       kind,
       options as CallbackOptions,
       chain.config,
+      isObj ? (callback as CallbackObject) : undefined,
     );
     if (options.prepend) {
       chain.prepend(entry);
@@ -1120,12 +1126,12 @@ export namespace Callbacks {
     target: T,
     name: string,
     kind: CallbackKind,
-    callback?: AnyCallback<T>,
+    callback?: AnyCallback<T> | CallbackObject,
   ): void {
     const chains = getCallbackChains(target);
     const chain = chains.get(name);
     if (!chain) return;
-    chain.remove(kind, callback as AnyCallback | undefined);
+    chain.remove(kind, callback as AnyCallback | CallbackObject | undefined);
   }
 
   export function resetCallbacks(target: object, name: string): void {
@@ -1190,7 +1196,7 @@ export function skipCallback<T extends object>(
   target: T,
   name: string,
   kind: CallbackKind,
-  callback?: AnyCallback<T>,
+  callback?: AnyCallback<T> | CallbackObject,
 ): void {
   Callbacks.skipCallback(target, name, kind, callback);
 }
@@ -1263,7 +1269,7 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
       this: { prototype: T },
       name: string,
       kind: CallbackKind,
-      callback?: AnyCallback<T>,
+      callback?: AnyCallback<T> | CallbackObject,
     ): void {
       skipCallback(this.prototype, name, kind, callback);
     }

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -491,6 +491,7 @@ export class Callback {
         unless: [...existingUnless, ...ifOption],
       },
       chain.config,
+      this.originalObject,
     );
   }
 
@@ -998,7 +999,9 @@ export function __updateCallbacks(
     const chain = target.getCallbacks(name);
     const dup = new CallbackChain(chain.name, chain.config);
     chain.entries.forEach((e) =>
-      dup.append(new Callback(e.name, e.filter, e.kind, { ...e.options }, dup.config)),
+      dup.append(
+        new Callback(e.name, e.filter, e.kind, { ...e.options }, dup.config, e.originalObject),
+      ),
     );
     fn(target, dup);
     target.setCallbacks(name, dup);
@@ -1068,7 +1071,14 @@ function getCallbackChains(target: object): Map<string, CallbackChain> {
         const newChain = new CallbackChain(chain.name, chain.config);
         for (const entry of chain.entries) {
           newChain.append(
-            new Callback(entry.name, entry.filter, entry.kind, entry.options, newChain.config),
+            new Callback(
+              entry.name,
+              entry.filter,
+              entry.kind,
+              entry.options,
+              newChain.config,
+              entry.originalObject,
+            ),
           );
         }
         own.set(name, newChain);

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -66,7 +66,7 @@ function resolveCallbackObject<T extends object>(
   name: string,
 ): AnyCallback<T> {
   const camelName = name.charAt(0).toUpperCase() + name.slice(1);
-  const methodName = `${kind}${camelName}`; // e.g., beforeSave
+  const methodName = `${kind}${camelName}`;
   const method = obj[methodName] as ((...args: any[]) => unknown) | undefined;
   if (typeof method !== "function") {
     throw new Error(

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -37,6 +37,49 @@ export type AnyCallback<T extends object = object> =
   | AfterCallback<T>
   | AroundCallback<T>;
 
+/**
+ * Object form for callbacks. Mirrors activemodel's object-callback dispatch.
+ * The object must implement a method named after the kind and event:
+ * `beforeSave`, `afterSave`, or `aroundSave` for an event named `"save"`.
+ *
+ * @example
+ * ```ts
+ * const logger = {
+ *   beforeSave(record: MyModel) { console.log("saving", record); },
+ *   afterSave(record: MyModel)  { console.log("saved",  record); },
+ * };
+ * setCallback(target, "save", "before", logger);
+ * setCallback(target, "save", "after",  logger);
+ * ```
+ */
+export type CallbackObject = { [key: string]: unknown };
+
+/**
+ * Resolves an object-form callback to a plain function, matching the Rails
+ * activemodel `resolveCallback` dispatch. Throws if the required method
+ * (e.g. `beforeSave` for kind=before, name=save) is absent.
+ * @internal
+ */
+function resolveCallbackObject<T extends object>(
+  obj: CallbackObject,
+  kind: CallbackKind,
+  name: string,
+): AnyCallback<T> {
+  const camelName = name.charAt(0).toUpperCase() + name.slice(1);
+  const methodName = `${kind}${camelName}`; // e.g., beforeSave
+  const method = obj[methodName] as ((...args: any[]) => unknown) | undefined;
+  if (typeof method !== "function") {
+    throw new Error(
+      `Callback object must implement ${methodName} (for kind="${kind}", name="${name}")`,
+    );
+  }
+  if (kind === "around") {
+    return ((target: T, proceed: () => void | Promise<void>) =>
+      method.call(obj, target, proceed)) as AroundCallback<T>;
+  }
+  return ((target: T) => method.call(obj, target)) as BeforeCallback<T> | AfterCallback<T>;
+}
+
 export interface RunCallbacksOptions {
   /** If "sync", throw when any callback or block returns a Promise. */
   strict?: "sync";
@@ -989,9 +1032,21 @@ export namespace Filters {
 
 export interface ClassMethods<T extends object = object> {
   defineCallbacks(name: string, options?: DefineCallbacksOptions<T>): void;
-  beforeCallback(name: string, callback: BeforeCallback<T>, options?: CallbackOptions<T>): void;
-  afterCallback(name: string, callback: AfterCallback<T>, options?: CallbackOptions<T>): void;
-  aroundCallback(name: string, callback: AroundCallback<T>, options?: CallbackOptions<T>): void;
+  beforeCallback(
+    name: string,
+    callback: BeforeCallback<T> | CallbackObject,
+    options?: CallbackOptions<T>,
+  ): void;
+  afterCallback(
+    name: string,
+    callback: AfterCallback<T> | CallbackObject,
+    options?: CallbackOptions<T>,
+  ): void;
+  aroundCallback(
+    name: string,
+    callback: AroundCallback<T> | CallbackObject,
+    options?: CallbackOptions<T>,
+  ): void;
   skipCallback(name: string, kind: CallbackKind, callback?: AnyCallback<T>): void;
   resetCallbacks(name: string): void;
 }
@@ -1035,7 +1090,7 @@ export namespace Callbacks {
     target: T,
     name: string,
     kind: CallbackKind,
-    callback: AnyCallback<T>,
+    callback: AnyCallback<T> | CallbackObject,
     options: CallbackOptions<T> = {},
   ): void {
     const chains = getCallbackChains(target);
@@ -1043,9 +1098,13 @@ export namespace Callbacks {
     if (!chain) {
       throw new Error(`No callback chain "${name}" defined. Call defineCallbacks first.`);
     }
+    const resolved =
+      typeof callback === "object" && callback !== null
+        ? resolveCallbackObject<T>(callback as CallbackObject, kind, name)
+        : (callback as AnyCallback<T>);
     const entry = new Callback(
       name,
-      callback as AnyCallback,
+      resolved as AnyCallback,
       kind,
       options as CallbackOptions,
       chain.config,
@@ -1121,7 +1180,7 @@ export function setCallback<T extends object>(
   target: T,
   name: string,
   kind: CallbackKind,
-  callback: AnyCallback<T>,
+  callback: AnyCallback<T> | CallbackObject,
   options: CallbackOptions<T> = {},
 ): void {
   Callbacks.setCallback(target, name, kind, callback, options);
@@ -1176,7 +1235,7 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
     static beforeCallback<T extends object>(
       this: { prototype: T },
       name: string,
-      callback: BeforeCallback<T>,
+      callback: BeforeCallback<T> | CallbackObject,
       options: CallbackOptions<T> = {},
     ): void {
       setCallback(this.prototype, name, "before", callback, options);
@@ -1185,7 +1244,7 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
     static afterCallback<T extends object>(
       this: { prototype: T },
       name: string,
-      callback: AfterCallback<T>,
+      callback: AfterCallback<T> | CallbackObject,
       options: CallbackOptions<T> = {},
     ): void {
       setCallback(this.prototype, name, "after", callback, options);
@@ -1194,7 +1253,7 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
     static aroundCallback<T extends object>(
       this: { prototype: T },
       name: string,
-      callback: AroundCallback<T>,
+      callback: AroundCallback<T> | CallbackObject,
       options: CallbackOptions<T> = {},
     ): void {
       setCallback(this.prototype, name, "around", callback, options);

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -276,6 +276,7 @@ export type {
   BeforeCallback,
   AfterCallback,
   AroundCallback,
+  CallbackObject,
 } from "./callbacks.js";
 
 export { concern, includeConcern, hasConcern } from "./concern.js";


### PR DESCRIPTION
## Summary

- Adds `CallbackObject` type to `@blazetrails/activesupport/callbacks` — an object with event-named methods (`beforeSave`, `afterSave`, `aroundSave`) that can be passed directly to `setCallback` / `beforeCallback` / `afterCallback` / `aroundCallback` / `skipCallback`
- Mirrors the object-callback dispatch in `activemodel`'s `resolveCallback` (packages/activemodel/src/callbacks.ts:172-190): resolves the object to a plain function at registration time using the `${kind}${EventName}` camelCase convention
- Throws at registration if the required method is absent (e.g. passing an `{ afterSave }` object to a `before` callback)
- Preserves the original `CallbackObject` reference on `Callback.originalObject` so `skipCallback(target, name, kind, obj)` removes the right entry by identity — mirrors Rails `matches?` which uses `filter == _filter`
- 11 tests covering: before/after/around dispatch, missing-method error, `this` binding, mixed chains, async methods, `skipCallback` by object reference, and all three `CallbacksMixin` static methods

## Part of activemodel convergence plan

PR 1 (#1492) — async propagation + strict:"sync"  
**PR 2 (this)** — CallbackObject dispatch on activesupport  
PR 3 (next) — wire CallbackObject into activemodel's `defineCallbacks` so both engines share the type  
PR 4 (later) — delete activemodel's engine, reduce to a wrapper over activesupport

## Copilot review responses

**Comment 1 (snake_case fallback):** Not ported. CLAUDE.md enforces camelCase-only project-wide — there is no snake_case anywhere in this codebase, not even for Rails payload keys. Adding `before_save` alongside `beforeSave` would be the only snake_case in the entire project.

**Comment 2 (skipCallback identity):** Fixed. `Callback` now carries `originalObject?: CallbackObject`. `matches()` dispatches to `this.originalObject === filter` when the candidate filter is an object. `skipCallback` / `CallbackChain.remove` / `ClassMethods` interface all accept `CallbackObject` in the optional filter position. Verified with a new test.