### PR TITLE
refactor(activerecord) move on: callback option from activemodel to AR transactions

### DIFF
--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -282,36 +282,14 @@ export class CallbackChain {
     fn: CallbackFn | AroundCallbackFn | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
-    // `on:` is a transactional-only option: Rails' `ActiveRecord::Transactions`
-    // uses it to scope `after_commit` / `after_rollback` callbacks to
-    // specific actions (`:create` / `:update` / `:destroy`). For every
-    // other event it's meaningless — silently accepting it would
-    // register a callback whose `on:` filter is never consulted (see
-    // `_shouldRun` below, which only applies `on` for commit/rollback).
-    // Reject at register-time so the error surfaces immediately rather
-    // than at run-time when the callback silently doesn't fire.
-    // Key-presence check (not value check) so `{ on: undefined }` also
-    // rejects — matches `_rejectOnOption`'s `"on" in conditions` and
-    // Rails' "unknown key" semantics. An explicit `on` (even undefined)
-    // signals caller intent that doesn't apply here.
+    // `on:` is synthesized into `if:` by the AR layer (transactions.ts)
+    // before reaching this chain. Reject it here only for non-commit/rollback
+    // events where it can never be meaningful.
     if (conditions && "on" in conditions) {
       if (event !== "commit" && event !== "rollback") {
         throw new ArgumentError(
           `Unknown key: :on. The :on option is only supported for :commit and :rollback callbacks (got :${event})`,
         );
-      }
-      // Validate the value here too so `defineModelCallbacks` helpers
-      // and direct `chain.register` calls surface the same error
-      // Rails raises from `after_commit`/`after_rollback`:
-      // "on conditions … have to be one of [:create, :destroy, :update]".
-      const on = conditions.on;
-      const values = Array.isArray(on) ? on : [on];
-      for (const v of values) {
-        if (v !== "create" && v !== "update" && v !== "destroy") {
-          throw new ArgumentError(
-            `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
-          );
-        }
       }
     }
     const resolved: CallbackFn | AroundCallbackFn =
@@ -329,16 +307,6 @@ export class CallbackChain {
   private _shouldRun(entry: CallbackEntry, record: CallbackRecord): boolean {
     if (entry.conditions?.if && !entry.conditions.if(record)) return false;
     if (entry.conditions?.unless && entry.conditions.unless(record)) return false;
-    if (
-      entry.conditions?.on !== undefined &&
-      (entry.event === "commit" || entry.event === "rollback")
-    ) {
-      const allowed = Array.isArray(entry.conditions.on)
-        ? entry.conditions.on
-        : [entry.conditions.on];
-      const action = (record as { _transactionAction?: string })._transactionAction;
-      if (!action || !allowed.includes(action)) return false;
-    }
     return true;
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,5 +1,12 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Model, type Type, typeRegistry, pushPendingDecorator } from "@blazetrails/activemodel";
+import {
+  Model,
+  type Type,
+  typeRegistry,
+  pushPendingDecorator,
+  ArgumentError,
+  type CallbackConditions,
+} from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
 import {
   Table,
@@ -2934,6 +2941,68 @@ export class Base extends Model {
    */
   static currentTransaction() {
     return _currentTransactionPublic();
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Transactions::ClassMethods#set_callback
+   *
+   * Intercepts `on:` before it reaches the activemodel chain, synthesizing it
+   * into an `if:` predicate that closes over `isTransactionIncludeAnyAction`.
+   * Rails does the same in transactions.rb#set_callback (lines 304–319).
+   */
+  static override afterCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
+    conditions?: CallbackConditions<InstanceType<T>>,
+  ): void {
+    if (conditions?.on !== undefined) {
+      const fireOn = (Array.isArray(conditions.on) ? conditions.on : [conditions.on]) as string[];
+      const invalid = fireOn.filter((a) => a !== "create" && a !== "update" && a !== "destroy");
+      if (invalid.length > 0) {
+        throw new ArgumentError(
+          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
+        );
+      }
+      const { on: _on, if: existingIf, ...rest } = conditions;
+      const synthIf = (record: InstanceType<T>): boolean =>
+        _isTransactionIncludeAnyAction.call(record as any, fireOn);
+      const combinedIf = existingIf
+        ? (record: InstanceType<T>) => synthIf(record) && existingIf(record)
+        : synthIf;
+      super.afterCommit(fn, { ...rest, if: combinedIf } as CallbackConditions<InstanceType<T>>);
+    } else {
+      super.afterCommit(fn, conditions);
+    }
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Transactions::ClassMethods#set_callback (rollback variant)
+   *
+   * Same `on:` synthesis as afterCommit.
+   */
+  static override afterRollback<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
+    conditions?: CallbackConditions<InstanceType<T>>,
+  ): void {
+    if (conditions?.on !== undefined) {
+      const fireOn = (Array.isArray(conditions.on) ? conditions.on : [conditions.on]) as string[];
+      const invalid = fireOn.filter((a) => a !== "create" && a !== "update" && a !== "destroy");
+      if (invalid.length > 0) {
+        throw new ArgumentError(
+          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
+        );
+      }
+      const { on: _on, if: existingIf, ...rest } = conditions;
+      const synthIf = (record: InstanceType<T>): boolean =>
+        _isTransactionIncludeAnyAction.call(record as any, fireOn);
+      const combinedIf = existingIf
+        ? (record: InstanceType<T>) => synthIf(record) && existingIf(record)
+        : synthIf;
+      super.afterRollback(fn, { ...rest, if: combinedIf } as CallbackConditions<InstanceType<T>>);
+    } else {
+      super.afterRollback(fn, conditions);
+    }
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4,7 +4,6 @@ import {
   type Type,
   typeRegistry,
   pushPendingDecorator,
-  ArgumentError,
   type CallbackConditions,
 } from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
@@ -222,6 +221,7 @@ import {
   rememberTransactionRecordState as _rememberTransactionRecordState,
   restoreTransactionRecordState as _restoreTransactionRecordState,
   isTransactionIncludeAnyAction as _isTransactionIncludeAnyAction,
+  synthOnCondition as _synthOnCondition,
 } from "./transactions.js";
 
 import {
@@ -2955,24 +2955,12 @@ export class Base extends Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    if (conditions?.on !== undefined) {
-      const fireOn = (Array.isArray(conditions.on) ? conditions.on : [conditions.on]) as string[];
-      const invalid = fireOn.filter((a) => a !== "create" && a !== "update" && a !== "destroy");
-      if (invalid.length > 0) {
-        throw new ArgumentError(
-          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
-        );
-      }
-      const { on: _on, if: existingIf, ...rest } = conditions;
-      const synthIf = (record: InstanceType<T>): boolean =>
-        _isTransactionIncludeAnyAction.call(record as any, fireOn);
-      const combinedIf = existingIf
-        ? (record: InstanceType<T>) => synthIf(record) && existingIf(record)
-        : synthIf;
-      super.afterCommit(fn, { ...rest, if: combinedIf } as CallbackConditions<InstanceType<T>>);
-    } else {
-      super.afterCommit(fn, conditions);
-    }
+    super.afterCommit(
+      fn,
+      _synthOnCondition(conditions as Record<string, unknown>) as CallbackConditions<
+        InstanceType<T>
+      >,
+    );
   }
 
   /**
@@ -2985,24 +2973,12 @@ export class Base extends Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    if (conditions?.on !== undefined) {
-      const fireOn = (Array.isArray(conditions.on) ? conditions.on : [conditions.on]) as string[];
-      const invalid = fireOn.filter((a) => a !== "create" && a !== "update" && a !== "destroy");
-      if (invalid.length > 0) {
-        throw new ArgumentError(
-          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
-        );
-      }
-      const { on: _on, if: existingIf, ...rest } = conditions;
-      const synthIf = (record: InstanceType<T>): boolean =>
-        _isTransactionIncludeAnyAction.call(record as any, fireOn);
-      const combinedIf = existingIf
-        ? (record: InstanceType<T>) => synthIf(record) && existingIf(record)
-        : synthIf;
-      super.afterRollback(fn, { ...rest, if: combinedIf } as CallbackConditions<InstanceType<T>>);
-    } else {
-      super.afterRollback(fn, conditions);
-    }
+    super.afterRollback(
+      fn,
+      _synthOnCondition(conditions as Record<string, unknown>) as CallbackConditions<
+        InstanceType<T>
+      >,
+    );
   }
 
   /**

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -747,11 +747,13 @@ export function isTransactionIncludeAnyAction(this: Base, actions: string[]): bo
   return actions.some((action) => {
     switch (action) {
       case "create":
-        return this.isPersisted() && !!r._newRecordBeforeLastCommit;
+        return this.isPersisted() && r._newRecordBeforeLastCommit === true;
       case "update":
-        return !(r._newRecordBeforeLastCommit || this.isDestroyed()) && !!r._triggerUpdateCallback;
+        return (
+          !(r._newRecordBeforeLastCommit || this.isDestroyed()) && r._triggerUpdateCallback === true
+        );
       case "destroy":
-        return !!r._triggerDestroyCallback;
+        return r._triggerDestroyCallback === true;
       default:
         return false;
     }

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -274,18 +274,13 @@ export function beforeCommit(
   fn: CallbackFn,
   options?: CallbackOptions,
 ): void {
-  if (options?.on !== undefined) {
-    const actions = Array.isArray(options.on) ? options.on : [options.on];
-    for (const action of actions) {
-      if (action !== "create" && action !== "update" && action !== "destroy") {
-        throw new ArgumentError(
-          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
-        );
-      }
-    }
-  }
   (modelClass as any)._ensureOwnCallbacks();
-  (modelClass as any)._callbackChain.register("before", "commit", fn, options);
+  (modelClass as any)._callbackChain.register(
+    "before",
+    "commit",
+    fn,
+    synthOnCondition(options as Record<string, unknown>),
+  );
 }
 
 /**
@@ -793,31 +788,30 @@ function prependOption(this: unknown): Record<string, unknown> {
 
 const VALID_TRANSACTION_ACTIONS = new Set(["create", "update", "destroy"]);
 
-// Mirrors: ActiveRecord::Transactions::ClassMethods#set_options_for_callbacks!
-/** @internal */
-function setOptionsForCallbacksBang(
-  args: unknown[],
-  enforcedOptions: Record<string, unknown> = {},
-): void {
-  const lastArg = args[args.length - 1];
-  const options: Record<string, unknown> =
-    lastArg !== null && typeof lastArg === "object" && !Array.isArray(lastArg)
-      ? (args.pop() as Record<string, unknown>)
-      : {};
-  Object.assign(options, enforcedOptions);
-  args.push(options);
-
-  if (options.on) {
-    const fireOn = (Array.isArray(options.on) ? options.on : [options.on]) as string[];
-    assertValidTransactionAction(fireOn);
-    const existingIf = options.if as CallbackFn | CallbackFn[] | undefined;
-    options.if = (record: Base) => {
-      if (!isTransactionIncludeAnyAction.call(record, fireOn)) return false;
-      if (!existingIf) return true;
-      if (Array.isArray(existingIf)) return existingIf.every((fn) => fn(record));
-      return (existingIf as CallbackFn)(record) as boolean;
-    };
-  }
+/**
+ * Synthesize an `on:` option into an `if:` predicate before the conditions
+ * reach the activemodel chain. Mirrors the transformation Rails performs in
+ * `ActiveRecord::Transactions::ClassMethods#set_callback` (transactions.rb:308-315).
+ *
+ * Returns a new conditions object with `on:` removed and a synthesized `if:`
+ * prepended, or the original conditions unchanged when `on:` is absent.
+ *
+ * @internal
+ */
+export function synthOnCondition(
+  conditions: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!conditions || conditions.on === undefined) return conditions;
+  const fireOn = (Array.isArray(conditions.on) ? conditions.on : [conditions.on]) as string[];
+  assertValidTransactionAction(fireOn);
+  const { on: _on, if: existingIf, ...rest } = conditions;
+  const synthIf = (record: Base): boolean => isTransactionIncludeAnyAction.call(record, fireOn);
+  return {
+    ...rest,
+    if: existingIf
+      ? (record: Base) => synthIf(record) && (existingIf as CallbackFn)(record)
+      : synthIf,
+  };
 }
 
 // Mirrors: ActiveRecord::Transactions::ClassMethods#assert_valid_transaction_action


### PR DESCRIPTION
## Summary

- **Layering bug fixed**: `activemodel`'s `_shouldRun` was reading `record._transactionAction` to evaluate the `on:` option — an AR-only concept that leaked into the activemodel layer.
- **AR synthesizes `on:` into `if:`**: `Base.afterCommit` and `Base.afterRollback` now override their `Model` counterparts to transform `on: :create/:update/:destroy` into an `if:` predicate using `isTransactionIncludeAnyAction`, mirroring Rails `transactions.rb:304-319`.
- **`activemodel._shouldRun` is now pure**: No AR concepts (`_transactionAction`) remain in the callback runner.
- **Bonus fix**: `isTransactionIncludeAnyAction` now uses `=== true` guards (matching `isTriggerTransactionalCallbacks`) so fresh instances whose `_triggerDestroyCallback` is an uninitialized prototype method don't produce false positives.

## Rails reference

`activerecord/lib/active_record/transactions.rb:304-319` — `set_callback` override that synthesizes `on:` into an `if:` array before calling `super`.

## Part of callbacks convergence plan

This is PR 3 of the activemodel callbacks convergence plan (`docs/activemodel-callbacks-convergence-plan.md`). Independent of PRs 1/2/4.

## Test plan

- `packages/activerecord/src/transaction-callbacks.test.ts` — all 45 active tests pass
- `packages/activerecord/src/transactions.test.ts` — all 151 active tests pass  
- `packages/activerecord/src/callbacks.test.ts` — all 88 active tests pass
- `packages/activemodel/src/callbacks.test.ts` — all 61 tests pass
- `pnpm api:compare --package activemodel` — 621/621 (100%) ✓
- Full typecheck passes ✓