### PR TITLE
chore(activerecord) type audit W1a — Function/Record cleanup + no-unsafe-function-type

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -215,7 +215,6 @@ export default defineConfig(
     files: ["packages/activerecord/src/**/*.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unsafe-function-type": "off",
       "@typescript-eslint/no-this-alias": "off",
       "unused-imports/no-unused-vars": "off",
       "no-empty": "off",

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -113,7 +113,7 @@ export class BelongsTo extends SingularAssociation {
   private static buildFindConditions(
     pk: string | string[],
     fkValue: any,
-  ): Record<string, any> | null {
+  ): Record<string, unknown> | null {
     if (Array.isArray(pk)) {
       const values = Array.isArray(fkValue) ? fkValue : [fkValue];
       if (pk.length !== values.length) return null;
@@ -126,7 +126,7 @@ export class BelongsTo extends SingularAssociation {
 
   static async touchRecord(
     record: any,
-    changes: Record<string, any>,
+    changes: Record<string, unknown>,
     foreignKey: string | string[],
     name: string,
     touch: any,
@@ -136,7 +136,7 @@ export class BelongsTo extends SingularAssociation {
     // Fill missing old FK parts from current attributes for composite keys —
     // unchanged columns have the same old/new value.
     const oldFkValues = fkColumns.map((col) => {
-      const change = changes[col];
+      const change = changes[col] as [unknown, unknown] | undefined;
       if (change) return change[0];
       return typeof (record as any)._readAttribute === "function"
         ? (record as any)._readAttribute(col)
@@ -161,7 +161,7 @@ export class BelongsTo extends SingularAssociation {
             reflection?.options?.foreignType ??
             `${underscore(name)}_type`;
           const typeName =
-            changes[foreignType]?.[0] ??
+            (changes[foreignType] as [unknown, unknown] | undefined)?.[0] ??
             (typeof (record as any)._readAttribute === "function"
               ? (record as any)._readAttribute(foreignType)
               : record[foreignType]);

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -30,11 +30,7 @@ export class CollectionAssociation extends Association {
     }
   }
 
-  static override defineExtensions(
-    model: any,
-    name: string,
-    block?: (...args: unknown[]) => unknown,
-  ): any {
+  static override defineExtensions(model: any, name: string, block?: (...args: any[]) => any): any {
     if (block) {
       const extensionModuleName = `${name.charAt(0).toUpperCase()}${name.slice(1)}AssociationExtension`;
       const extension = { name: extensionModuleName, block };

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -30,7 +30,11 @@ export class CollectionAssociation extends Association {
     }
   }
 
-  static override defineExtensions(model: any, name: string, block?: Function): any {
+  static override defineExtensions(
+    model: any,
+    name: string,
+    block?: (...args: unknown[]) => unknown,
+  ): any {
     if (block) {
       const extensionModuleName = `${name.charAt(0).toUpperCase()}${name.slice(1)}AssociationExtension`;
       const extension = { name: extensionModuleName, block };

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -85,7 +85,10 @@ type DelegatedRelationMethods<T extends Base> = {
  */
 export type AssociationProxy<
   T extends Base = Base,
-  TExtensions extends Record<string, any> = Record<string, any>,
+  TExtensions extends Record<string, (...args: any[]) => any> = Record<
+    string,
+    (...args: any[]) => any
+  >,
 > = CollectionProxy<T> &
   DelegatedRelationMethods<T> &
   TExtensions & {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -252,7 +252,7 @@ function transaction<R>(
   block: (tx?: any) => Promise<R>,
 ): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
-  const klass = safeKlass(tr) as { transaction?: (...args: unknown[]) => unknown } | null;
+  const klass = safeKlass(tr) as { transaction?: (...args: any[]) => any } | null;
   if (klass && typeof klass.transaction === "function") {
     return klass.transaction(block) as Promise<R | undefined>;
   }

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -252,7 +252,7 @@ function transaction<R>(
   block: (tx?: any) => Promise<R>,
 ): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
-  const klass = safeKlass(tr) as { transaction?: Function } | null;
+  const klass = safeKlass(tr) as { transaction?: (...args: unknown[]) => unknown } | null;
   if (klass && typeof klass.transaction === "function") {
     return klass.transaction(block) as Promise<R | undefined>;
   }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -127,7 +127,7 @@ function transaction<R>(
   block: (tx?: any) => Promise<R>,
 ): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
-  const klass = safeKlass(tr) as { transaction?: Function } | null;
+  const klass = safeKlass(tr) as { transaction?: (...args: unknown[]) => unknown } | null;
   if (klass && typeof klass.transaction === "function") {
     return klass.transaction(block) as Promise<R | undefined>;
   }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -127,7 +127,7 @@ function transaction<R>(
   block: (tx?: any) => Promise<R>,
 ): Promise<R | undefined> {
   const tr = throughReflection(assoc) as { klass?: unknown } | null;
-  const klass = safeKlass(tr) as { transaction?: (...args: unknown[]) => unknown } | null;
+  const klass = safeKlass(tr) as { transaction?: (...args: any[]) => any } | null;
   if (klass && typeof klass.transaction === "function") {
     return klass.transaction(block) as Promise<R | undefined>;
   }

--- a/packages/activerecord/src/attribute-methods/composite-primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/composite-primary-key.ts
@@ -8,7 +8,10 @@ interface CompositePKRecord {
   id: unknown;
   readAttribute(name: string): unknown;
   _readAttribute(name: string): unknown;
-  constructor: Function & { primaryKey: string | string[]; compositePrimaryKey: boolean };
+  constructor: (abstract new (...args: any[]) => any) & {
+    primaryKey: string | string[];
+    compositePrimaryKey: boolean;
+  };
 }
 
 /**

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -253,7 +253,7 @@ export function isDestroyable(record: Base): boolean {
   return !record.isNewRecord() && isMarkedForDestruction(record);
 }
 
-export function build(_model: typeof Base, reflection: { options: Record<string, any> }): void {
+export function build(_model: typeof Base, reflection: { options: Record<string, unknown> }): void {
   if (reflection.options.autosave && reflection.options.validate === undefined) {
     reflection.options.validate = true;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1122,8 +1122,12 @@ export class Base extends Model {
   }
 
   // -- Logger --
-  static _logger: { debug?: Function; info?: Function; warn?: Function; error?: Function } | null =
-    null;
+  static _logger: {
+    debug?: (...args: any[]) => void;
+    info?: (...args: any[]) => void;
+    warn?: (...args: any[]) => void;
+    error?: (...args: any[]) => void;
+  } | null = null;
 
   /**
    * Set or get the logger for SQL and lifecycle events.
@@ -1131,16 +1135,21 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.logger
    */
   static get logger(): {
-    debug?: Function;
-    info?: Function;
-    warn?: Function;
-    error?: Function;
+    debug?: (...args: any[]) => void;
+    info?: (...args: any[]) => void;
+    warn?: (...args: any[]) => void;
+    error?: (...args: any[]) => void;
   } | null {
     return this._logger;
   }
 
   static set logger(
-    log: { debug?: Function; info?: Function; warn?: Function; error?: Function } | null,
+    log: {
+      debug?: (...args: any[]) => void;
+      info?: (...args: any[]) => void;
+      warn?: (...args: any[]) => void;
+      error?: (...args: any[]) => void;
+    } | null,
   ) {
     this._logger = log;
   }
@@ -1522,7 +1531,7 @@ export class Base extends Model {
   }
 
   // Scope extension methods: scope name -> Record of extra methods
-  static _scopeExtensions: Map<string, Record<string, Function>> = new Map();
+  static _scopeExtensions: Map<string, Record<string, (...args: any[]) => any>> = new Map();
 
   /**
    * Define a named scope with an optional extension block.

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -193,7 +193,7 @@ function registerCallback(
   modelClass: ModelCtor,
   timing: "before" | "after",
   event: string,
-  fn: Function,
+  fn: (...args: any[]) => unknown,
   options?: AnyCallbackOptions,
 ): void {
   const klass = modelClass as unknown as {
@@ -202,7 +202,7 @@ function registerCallback(
       register(
         timing: "before" | "after",
         event: string,
-        fn: Function,
+        fn: (...args: any[]) => unknown,
         conditions: Record<string, unknown>,
       ): void;
     };

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -3,7 +3,7 @@ import { WRITING_ROLE, READING_ROLE } from "./roles.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import { getFsAsync, getPathAsync, getEnv } from "@blazetrails/activesupport";
-import { DatabaseConfigurations } from "./database-configurations.js";
+import { DatabaseConfigurations, type RawConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
 import { _setAdapterClassResolver } from "./database-configurations/database-config.js";
@@ -605,9 +605,7 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
     configs = DatabaseConfigurations.fromEnv(inMemory);
   } else {
     const raw = await loadConfigFile(modelClass);
-    configs = DatabaseConfigurations.fromEnv(
-      raw as Parameters<typeof DatabaseConfigurations.fromEnv>[0],
-    );
+    configs = DatabaseConfigurations.fromEnv(raw);
   }
   const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
   const primaryConfigs = configs.configsFor({ envName: env, name: "primary" });
@@ -683,7 +681,7 @@ function resolveConfig(
   return { adapterName, url, config: fullConfig };
 }
 
-async function loadConfigFile(modelClass: typeof Base): Promise<Record<string, unknown>> {
+async function loadConfigFile(modelClass: typeof Base): Promise<RawConfigurations> {
   if ((modelClass as any)._configPath) {
     return loadJsonConfig((modelClass as any)._configPath);
   }
@@ -716,7 +714,7 @@ async function loadConfigFile(modelClass: typeof Base): Promise<Record<string, u
   return loadJsonConfig(pathAdapter.resolve(cwd, "config", "database.json"));
 }
 
-async function loadJsonConfig(configPath: string): Promise<Record<string, unknown>> {
+async function loadJsonConfig(configPath: string): Promise<RawConfigurations> {
   try {
     const fsAdapter = await getFsAsync();
     return JSON.parse(fsAdapter.readFileSync(configPath, "utf-8"));

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -605,7 +605,9 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
     configs = DatabaseConfigurations.fromEnv(inMemory);
   } else {
     const raw = await loadConfigFile(modelClass);
-    configs = DatabaseConfigurations.fromEnv(raw);
+    configs = DatabaseConfigurations.fromEnv(
+      raw as Parameters<typeof DatabaseConfigurations.fromEnv>[0],
+    );
   }
   const env = getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
   const primaryConfigs = configs.configsFor({ envName: env, name: "primary" });
@@ -681,7 +683,7 @@ function resolveConfig(
   return { adapterName, url, config: fullConfig };
 }
 
-async function loadConfigFile(modelClass: typeof Base): Promise<Record<string, any>> {
+async function loadConfigFile(modelClass: typeof Base): Promise<Record<string, unknown>> {
   if ((modelClass as any)._configPath) {
     return loadJsonConfig((modelClass as any)._configPath);
   }
@@ -714,7 +716,7 @@ async function loadConfigFile(modelClass: typeof Base): Promise<Record<string, a
   return loadJsonConfig(pathAdapter.resolve(cwd, "config", "database.json"));
 }
 
-async function loadJsonConfig(configPath: string): Promise<Record<string, any>> {
+async function loadJsonConfig(configPath: string): Promise<Record<string, unknown>> {
   try {
     const fsAdapter = await getFsAsync();
     return JSON.parse(fsAdapter.readFileSync(configPath, "utf-8"));

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -106,11 +106,11 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     deterministicKey: Configurable.config.deterministicKey,
   };
   const savedMethods: {
-    where?: Function;
-    exists?: Function;
-    scopeForCreate?: Function;
-    findBy?: Function;
-    serialize?: Function;
+    where?: (...args: any[]) => unknown;
+    exists?: (...args: any[]) => unknown;
+    scopeForCreate?: (...args: any[]) => unknown;
+    findBy?: (...args: any[]) => unknown;
+    serialize?: (...args: any[]) => unknown;
   } = {};
 
   beforeAll(() => {

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -24,9 +24,15 @@ export class ExtendedDeterministicQueries {
    * `config.active_record.encryption.extend_queries`).
    */
   static installSupport(targets: {
-    Relation: { prototype: { where: Function; exists: Function; scopeForCreate: Function } };
-    Base: { findBy: Function };
-    EncryptedAttributeType: { prototype: { serialize: Function } };
+    Relation: {
+      prototype: {
+        where: (...args: any[]) => unknown;
+        exists: (...args: any[]) => unknown;
+        scopeForCreate: (...args: any[]) => unknown;
+      };
+    };
+    Base: { findBy: (...args: any[]) => unknown };
+    EncryptedAttributeType: { prototype: { serialize: (...args: any[]) => unknown } };
   }): void {
     if (this._installed) return;
 
@@ -37,11 +43,14 @@ export class ExtendedDeterministicQueries {
     // nothing; this matches that intent.
     // `prepend()` needs an open object-with-Function-values shape, so
     // cast at the call site rather than widening the public signature.
-    const relProto = targets.Relation.prototype as unknown as Record<string, Function>;
-    const baseTarget = targets.Base as unknown as Record<string, Function>;
+    const relProto = targets.Relation.prototype as unknown as Record<
+      string,
+      (...args: any[]) => unknown
+    >;
+    const baseTarget = targets.Base as unknown as Record<string, (...args: any[]) => unknown>;
     const eatProto = targets.EncryptedAttributeType.prototype as unknown as Record<
       string,
-      Function
+      (...args: any[]) => unknown
     >;
     const missing: string[] = [];
     if (typeof relProto.where !== "function") missing.push("Relation.prototype.where");
@@ -59,18 +68,18 @@ export class ExtendedDeterministicQueries {
 
     prepend(relProto, {
       where(super_, ...args) {
-        return RelationQueries.where(super_, this, args);
+        return RelationQueries.where(super_ as (...args: any[]) => unknown, this, args);
       },
       exists(super_, ...args) {
-        return RelationQueries.isExists(super_, this, args);
+        return RelationQueries.isExists(super_ as (...args: any[]) => unknown, this, args);
       },
       scopeForCreate(super_) {
-        return RelationQueries.scopeForCreate(super_, this);
+        return RelationQueries.scopeForCreate(super_ as (...args: any[]) => unknown, this);
       },
     });
     prepend(baseTarget, {
       findBy(super_, ...args) {
-        return CoreQueries.findBy(super_, this, args);
+        return CoreQueries.findBy(super_ as (...args: any[]) => unknown, this, args);
       },
     });
     prepend(eatProto, {
@@ -197,20 +206,32 @@ export class EncryptedQuery {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQueries
  */
 export class RelationQueries {
-  static where(originalWhere: Function, relation: any, args: unknown[]): unknown {
+  static where(
+    originalWhere: (...args: any[]) => unknown,
+    relation: any,
+    args: unknown[],
+  ): unknown {
     return originalWhere.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
   }
 
-  static isExists(originalExists: Function, relation: any, args: unknown[]): unknown {
+  static isExists(
+    originalExists: (...args: any[]) => unknown,
+    relation: any,
+    args: unknown[],
+  ): unknown {
     return originalExists.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
   }
 
-  static scopeForCreate(originalScopeForCreate: Function, relation: any): Record<string, unknown> {
+  static scopeForCreate(
+    originalScopeForCreate: (...args: any[]) => unknown,
+    relation: any,
+  ): Record<string, unknown> {
     const model = relation.model ?? relation;
     const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
-    if (!encryptedAttrs?.size) return originalScopeForCreate.call(relation);
+    if (!encryptedAttrs?.size)
+      return originalScopeForCreate.call(relation) as Record<string, unknown>;
 
-    const scopeAttrs = originalScopeForCreate.call(relation);
+    const scopeAttrs = originalScopeForCreate.call(relation) as Record<string, unknown>;
     const wheres = relation.whereValuesHash();
     for (const attrName of encryptedAttrs) {
       const type = getAttributeType(model, attrName);
@@ -236,7 +257,7 @@ export class RelationQueries {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::CoreQueries
  */
 export class CoreQueries {
-  static findBy(originalFindBy: Function, klass: any, args: unknown[]): unknown {
+  static findBy(originalFindBy: (...args: any[]) => unknown, klass: any, args: unknown[]): unknown {
     return originalFindBy.call(klass, ...EncryptedQuery.processArguments(klass, args, false));
   }
 }

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -12,7 +12,7 @@ import { withoutEncryption } from "./context.js";
  */
 export class ExtendedDeterministicUniquenessValidator {
   private static _installed = false;
-  private static _originalValidateEach: Function | undefined;
+  private static _originalValidateEach: ((...args: any[]) => unknown) | undefined;
 
   /**
    * Wraps UniquenessValidator#validateEach so uniqueness checks also cover
@@ -26,7 +26,7 @@ export class ExtendedDeterministicUniquenessValidator {
     UniquenessValidator,
     EncryptedUniquenessValidator: EUV,
   }: {
-    UniquenessValidator: { prototype: { validateEach: Function } };
+    UniquenessValidator: { prototype: { validateEach: (...args: any[]) => unknown } };
     EncryptedUniquenessValidator: typeof EncryptedUniquenessValidator;
   }): void {
     if (this._installed) return;
@@ -57,7 +57,9 @@ export class ExtendedDeterministicUniquenessValidator {
   }
 
   /** Restores the original validateEach — for use in test teardown. */
-  static resetSupport(UniquenessValidator: { prototype: { validateEach: Function } }): void {
+  static resetSupport(UniquenessValidator: {
+    prototype: { validateEach: (...args: any[]) => unknown };
+  }): void {
     if (!this._installed || !this._originalValidateEach) return;
     UniquenessValidator.prototype.validateEach = this._originalValidateEach;
     this._installed = false;

--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -21,11 +21,11 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
   let savedExtendQueries: boolean;
   const savedMethods: {
-    where?: Function;
-    exists?: Function;
-    scopeForCreate?: Function;
-    findBy?: Function;
-    serialize?: Function;
+    where?: (...args: any[]) => unknown;
+    exists?: (...args: any[]) => unknown;
+    scopeForCreate?: (...args: any[]) => unknown;
+    findBy?: (...args: any[]) => unknown;
+    serialize?: (...args: any[]) => unknown;
   } = {};
 
   beforeEach(() => {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -357,7 +357,7 @@ interface SchemaHost {
   _protectedEnvironments?: string[];
   _attributeDefinitions: Map<string, any>;
   _defaultAttributes(): { deepDup(): { toHash(): Record<string, unknown> } };
-  _columnsHash?: Record<string, any>;
+  _columnsHash?: Record<string, unknown>;
   _columns?: any[];
   _attributesBuilder?: any;
   _schemaLoaded?: boolean;
@@ -605,7 +605,7 @@ export function loadSchema(this: SchemaHost): void {
   // work host so subclasses don't fork _columnsHash (which would persist
   // past a later base reflection).
   if (!workHost._columnsHash && workHost._attributeDefinitions.size > 0) {
-    const hash: Record<string, any> = {};
+    const hash: Record<string, unknown> = {};
     const ignored = new Set(workHost._ignoredColumns ?? []);
     for (const [name, def] of workHost._attributeDefinitions) {
       if (ignored.has(name)) continue;
@@ -621,7 +621,7 @@ export function loadSchema(this: SchemaHost): void {
   workHost._schemaLoaded = true;
 }
 
-function getColumnsHash(host: SchemaHost): Record<string, any> {
+function getColumnsHash(host: SchemaHost): Record<string, unknown> {
   if (host._columnsHash != null) return host._columnsHash;
   const ch = (host as any).columnsHash;
   if (typeof ch === "function") return ch.call(host) ?? {};

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -4,7 +4,9 @@
  * Mirrors: ActiveRecord::NoTouching
  */
 
-const _noTouchingDepth = new Map<Function, number>();
+type AnyClass = abstract new (...args: any[]) => any;
+
+const _noTouchingDepth = new Map<AnyClass, number>();
 
 /**
  * Execute a block with touch callbacks suppressed for the given model class.
@@ -12,7 +14,7 @@ const _noTouchingDepth = new Map<Function, number>();
  *
  * Mirrors: ActiveRecord::NoTouching.no_touching
  */
-export async function noTouching<R>(modelClass: Function, fn: () => R | Promise<R>): Promise<R> {
+export async function noTouching<R>(modelClass: AnyClass, fn: () => R | Promise<R>): Promise<R> {
   const depth = _noTouchingDepth.get(modelClass) ?? 0;
   _noTouchingDepth.set(modelClass, depth + 1);
   try {
@@ -32,10 +34,10 @@ export async function noTouching<R>(modelClass: Function, fn: () => R | Promise<
  *
  * Mirrors: ActiveRecord::NoTouching.applied_to?
  */
-export function isAppliedTo(modelClass: Function): boolean {
+export function isAppliedTo(modelClass: AnyClass): boolean {
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    if ((_noTouchingDepth.get(current as Function) ?? 0) > 0) return true;
+    if ((_noTouchingDepth.get(current as AnyClass) ?? 0) > 0) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -36,7 +36,7 @@ import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
 interface PersistenceHost {
   new (attrs?: Record<string, unknown>): any;
-  _instantiate(row: Record<string, unknown>, columnTypes?: Record<string, any>): any;
+  _instantiate(row: Record<string, unknown>, columnTypes?: Record<string, unknown>): any;
   /** @internal */
   discriminateClassForRecord?(attributes: Record<string, unknown>): PersistenceHost;
   primaryKey: string | string[];
@@ -114,7 +114,7 @@ export function build(
 export function instantiate(
   this: PersistenceHost,
   attributes: Record<string, unknown>,
-  columnTypes: Record<string, any> = {},
+  columnTypes: Record<string, unknown> = {},
   block?: (record: any) => void,
 ): any {
   // Rails: klass = discriminate_class_for_record(attributes)
@@ -1326,9 +1326,9 @@ export function _raiseRecordNotTouchedError(): never {
 
 /** @internal */
 function instantiateInstanceOf(
-  klass: { _instantiate(attrs: Record<string, unknown>, colTypes?: Record<string, any>): any },
+  klass: { _instantiate(attrs: Record<string, unknown>, colTypes?: Record<string, unknown>): any },
   attributes: Record<string, unknown>,
-  columnTypes: Record<string, any> = {},
+  columnTypes: Record<string, unknown> = {},
   block?: (r: any) => void,
 ): any {
   const record = klass._instantiate(attributes, columnTypes);

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -707,7 +707,7 @@ export function references<T extends typeof Base>(
 }
 
 /** Mirrors: ActiveRecord::Querying#extending */
-export function extending<T extends typeof Base, M extends Record<string, Function>>(
+export function extending<T extends typeof Base, M extends Record<string, (...args: any[]) => any>>(
   this: T,
   mod: M,
 ): Relation<InstanceType<T>> & M;
@@ -718,9 +718,11 @@ export function extending<T extends typeof Base>(
 export function extending<T extends typeof Base>(this: T): Relation<InstanceType<T>>;
 export function extending<T extends typeof Base>(
   this: T,
-  mod?: Record<string, Function> | ((rel: Relation<InstanceType<T>>) => void),
+  mod?: Record<string, (...args: any[]) => any> | ((rel: Relation<InstanceType<T>>) => void),
 ): Relation<InstanceType<T>> {
-  return mod ? this.all().extending(mod as Record<string, Function>) : this.all().extending();
+  return mod
+    ? this.all().extending(mod as Record<string, (...args: any[]) => any>)
+    : this.all().extending();
 }
 
 /** Mirrors: ActiveRecord::Querying#unscope */

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1704,7 +1704,7 @@ export function addReflection(
 ): void {
   clearReflectionsCache(activeRecord);
   const hasOwn = Object.prototype.hasOwnProperty.call(activeRecord, "_reflections");
-  const inherited: Record<string, any> = (activeRecord as any)._reflections ?? {};
+  const inherited: Record<string, unknown> = (activeRecord as any)._reflections ?? {};
   const reflections = hasOwn ? inherited : { ...inherited };
   reflections[name] = reflection;
   (activeRecord as any)._reflections = reflections;
@@ -1751,9 +1751,10 @@ export function normalizedReflections(
   const cached = _normalizedReflectionsCache.get(modelClass);
   if (cached) return cached;
 
-  const rawReflections: Record<string, any> = (modelClass as any)._reflections ?? {};
-  const result: Record<string, any> = {};
-  for (const [name, ref] of Object.entries(rawReflections)) {
+  const rawReflections: Record<string, unknown> = (modelClass as any)._reflections ?? {};
+  const result: Record<string, unknown> = {};
+  for (const [name, rawRef] of Object.entries(rawReflections)) {
+    const ref = rawRef as any;
     const parent = ref.parentReflection;
     if (parent) {
       result[parent.name] = parent;
@@ -1763,8 +1764,9 @@ export function normalizedReflections(
   }
 
   Object.freeze(result);
-  _normalizedReflectionsCache.set(modelClass, result);
-  return result;
+  const frozen = result as Readonly<Record<string, AssociationReflection | ThroughReflection>>;
+  _normalizedReflectionsCache.set(modelClass, frozen);
+  return frozen;
 }
 
 export function clearReflectionsCache(modelClass: typeof Base): void {
@@ -1794,8 +1796,8 @@ export function _reflectOnAssociation(
   modelClass: typeof Base,
   name: string,
 ): AssociationReflection | ThroughReflection | null {
-  const rawReflections: Record<string, any> = (modelClass as any)._reflections ?? {};
-  return rawReflections[name] ?? null;
+  const rawReflections: Record<string, unknown> = (modelClass as any)._reflections ?? {};
+  return (rawReflections[name] as AssociationReflection | ThroughReflection | undefined) ?? null;
 }
 
 /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -291,7 +291,7 @@ export class Relation<T extends Base> {
   private _referencesValues: string[] = [];
   private _fromClause: FromClause = FromClause.empty();
   private _createWithAttrs: Record<string, unknown> = {};
-  private _extending: Array<Record<string, Function>> = [];
+  private _extending: Array<Record<string, (...args: any[]) => any>> = [];
   private _ctes: Array<{ name: string; sql: string; recursive: boolean }> = [];
   private _skipPreloading = false;
   private _skipQueryCache = false;
@@ -1187,13 +1187,15 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#extending
    */
-  extending<M extends Record<string, Function>>(mod: M): Relation<T> & M;
-  extending<M extends Record<string, Function>>(mod: M | undefined): Relation<T> & Partial<M>;
+  extending<M extends Record<string, (...args: any[]) => any>>(mod: M): Relation<T> & M;
+  extending<M extends Record<string, (...args: any[]) => any>>(
+    mod: M | undefined,
+  ): Relation<T> & Partial<M>;
   extending(fn: (rel: Relation<T>) => void): Relation<T>;
   extending(): Relation<T>;
   extending(
-    mod?: Record<string, Function> | ((rel: Relation<T>) => void),
-  ): Relation<T> | (Relation<T> & Record<string, Function>) {
+    mod?: Record<string, (...args: any[]) => any> | ((rel: Relation<T>) => void),
+  ): Relation<T> | (Relation<T> & Record<string, (...args: any[]) => any>) {
     if (!mod) return this._clone();
     return this._clone().extendingBang(mod);
   }

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -18,7 +18,7 @@ import { Delegation as ASDelegation } from "@blazetrails/activesupport";
  * Mirrors: ActiveRecord::Delegation
  */
 type AnyClass = abstract new (...args: any[]) => any;
-type AnyCallable = (...args: unknown[]) => unknown;
+type AnyCallable = (...args: any[]) => any;
 
 export interface Delegation {
   delegatedClasses: Set<AnyClass>;

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -17,8 +17,11 @@ import { Delegation as ASDelegation } from "@blazetrails/activesupport";
  *
  * Mirrors: ActiveRecord::Delegation
  */
+type AnyClass = abstract new (...args: any[]) => any;
+type AnyCallable = (...args: unknown[]) => unknown;
+
 export interface Delegation {
-  delegatedClasses: Set<Function>;
+  delegatedClasses: Set<AnyClass>;
 }
 
 /**
@@ -38,13 +41,13 @@ export interface ClassSpecificRelation {}
  * Mirrors: ActiveRecord::Delegation::GeneratedRelationMethods
  */
 export class GeneratedRelationMethods {
-  private _methods: Map<string, Function> = new Map();
+  private _methods: Map<string, AnyCallable> = new Map();
 
-  generate(name: string, fn: Function): void {
+  generate(name: string, fn: AnyCallable): void {
     this._methods.set(name, fn);
   }
 
-  get(name: string): Function | undefined {
+  get(name: string): AnyCallable | undefined {
     return this._methods.get(name);
   }
 
@@ -52,7 +55,7 @@ export class GeneratedRelationMethods {
     return this._methods.has(name);
   }
 
-  entries(): IterableIterator<[string, Function]> {
+  entries(): IterableIterator<[string, AnyCallable]> {
     return this._methods.entries();
   }
 }
@@ -65,19 +68,19 @@ export class GeneratedRelationMethods {
  * Mirrors: ActiveRecord::Delegation::DelegateCache
  */
 export class DelegateCache {
-  private _cache: Map<Function, Set<string>> = new Map();
+  private _cache: Map<AnyClass, Set<string>> = new Map();
 
-  initialize(modelClass: Function): void {
+  initialize(modelClass: AnyClass): void {
     if (!this._cache.has(modelClass)) {
       this._cache.set(modelClass, new Set());
     }
   }
 
-  hasDelegated(modelClass: Function, method: string): boolean {
+  hasDelegated(modelClass: AnyClass, method: string): boolean {
     return this._cache.get(modelClass)?.has(method) ?? false;
   }
 
-  register(modelClass: Function, method: string): void {
+  register(modelClass: AnyClass, method: string): void {
     this.initialize(modelClass);
     this._cache.get(modelClass)!.add(method);
   }
@@ -90,11 +93,11 @@ export class DelegateCache {
  * Constrained to `object` because Relation._modelClass is private;
  * internal access uses `any` casts.
  */
-const _delegatedClasses = new Set<Function>();
+const _delegatedClasses = new Set<AnyClass>();
 const _uncacheableMethods = new Set<string>(["to_a", "to_ary", "records", "inspect"]);
 const _delegateCache = new DelegateCache();
 
-export function delegatedClasses(): Set<Function> {
+export function delegatedClasses(): Set<AnyClass> {
   return _delegatedClasses;
 }
 
@@ -102,12 +105,12 @@ export function uncacheableMethods(): Set<string> {
   return _uncacheableMethods;
 }
 
-export function delegateBaseMethods(klass: Function): void {
+export function delegateBaseMethods(klass: AnyClass): void {
   _delegatedClasses.add(klass);
   _delegateCache.initialize(klass);
 }
 
-export function relationDelegateClass(klass: Function): Function {
+export function relationDelegateClass(klass: AnyClass): AnyClass {
   _delegatedClasses.add(klass);
   return klass;
 }
@@ -116,9 +119,9 @@ export function initializeRelationDelegateCache(): void {
   _delegateCache.initialize(Object);
 }
 
-const _generatedMethodsByModel = new WeakMap<Function, GeneratedRelationMethods>();
+const _generatedMethodsByModel = new WeakMap<AnyClass, GeneratedRelationMethods>();
 
-function generatedMethodsFor(modelClass: Function): GeneratedRelationMethods {
+function generatedMethodsFor(modelClass: AnyClass): GeneratedRelationMethods {
   let methods = _generatedMethodsByModel.get(modelClass);
   if (!methods) {
     methods = new GeneratedRelationMethods();
@@ -127,11 +130,11 @@ function generatedMethodsFor(modelClass: Function): GeneratedRelationMethods {
   return methods;
 }
 
-export function generateRelationMethod(modelClass: Function, name: string, fn: Function): void {
+export function generateRelationMethod(modelClass: AnyClass, name: string, fn: AnyCallable): void {
   generatedMethodsFor(modelClass).generate(name, fn);
 }
 
-export function generateMethod(name: string): Function {
+export function generateMethod(name: string): AnyCallable {
   const holder = { model: null } as any;
   ASDelegation.generate(holder, [name], { to: "model", allowNil: true });
   if (typeof holder[name] === "function") return holder[name];
@@ -179,7 +182,7 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
 }
 
 /** @internal */
-function relationClassFor(klass: Function): typeof GeneratedRelationMethods {
+function relationClassFor(klass: AnyClass): typeof GeneratedRelationMethods {
   return GeneratedRelationMethods;
 }
 
@@ -191,6 +194,6 @@ function includeRelationMethods(target: object, methods: GeneratedRelationMethod
 }
 
 /** @internal */
-function generatedRelationMethods(modelClass: Function): GeneratedRelationMethods {
+function generatedRelationMethods(modelClass: AnyClass): GeneratedRelationMethods {
   return _generatedMethodsByModel.get(modelClass) ?? new GeneratedRelationMethods();
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -126,7 +126,7 @@ interface QueryMethodsHost {
   _referencesValues: string[];
   _fromClause: FromClause;
   _createWithAttrs: Record<string, unknown>;
-  _extending: Array<Record<string, Function>>;
+  _extending: Array<Record<string, (...args: any[]) => any>>;
   _ctes: Array<{ name: string; sql: string; recursive: boolean }>;
   _skipPreloading: boolean;
   _skipQueryCache: boolean;
@@ -244,7 +244,7 @@ function upsertCte(
   }
 }
 
-function withBang(this: QueryMethodsHost, ...ctes: Array<Record<string, any>>): any {
+function withBang(this: QueryMethodsHost, ...ctes: Array<Record<string, unknown>>): any {
   for (const cte of ctes) {
     if (!isPlainObject(cte)) {
       const typeName =
@@ -261,7 +261,7 @@ function withBang(this: QueryMethodsHost, ...ctes: Array<Record<string, any>>): 
   return this;
 }
 
-function withRecursiveBang(this: QueryMethodsHost, ...ctes: Array<Record<string, any>>): any {
+function withRecursiveBang(this: QueryMethodsHost, ...ctes: Array<Record<string, unknown>>): any {
   for (const cte of ctes) {
     if (!isPlainObject(cte)) {
       const typeName =
@@ -1031,7 +1031,7 @@ function distinctBang(this: QueryMethodsHost, value = true): any {
 
 function extendingBang(
   this: QueryMethodsHost,
-  ...modules: Array<Record<string, Function> | ((rel: any) => void)>
+  ...modules: Array<Record<string, (...args: any[]) => any> | ((rel: any) => void)>
 ): any {
   for (const mod of modules) {
     if (typeof mod === "function") {

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -17,7 +17,7 @@ export function scope<T extends typeof Base>(
   this: T,
   name: string,
   fn: (rel: Relation<InstanceType<T>>, ...args: any[]) => Relation<any>,
-  extension?: Record<string, Function>,
+  extension?: Record<string, (...args: any[]) => any>,
 ): void {
   const modelClass = this as any;
   if (!Object.prototype.hasOwnProperty.call(modelClass, "_scopes")) {

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -61,7 +61,9 @@ export function registry(): Record<string, true | undefined> {
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
-export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>): Promise<R> {
+type AnyClass = abstract new (...args: any[]) => any;
+
+export async function suppress<R>(modelClass: AnyClass, fn: () => R | Promise<R>): Promise<R> {
   const name = modelClass.name;
   if (!name) {
     // Anonymous classes can't participate in the name-keyed registry
@@ -81,11 +83,11 @@ export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>
  * Check if the given model class (or any ancestor) is currently
  * suppressed in the active scope.
  */
-export function isSuppressed(modelClass: Function): boolean {
+export function isSuppressed(modelClass: AnyClass): boolean {
   const reg = currentRegistry();
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    const klassName = (current as Function).name;
+    const klassName = (current as AnyClass).name;
     if (klassName && reg[klassName]) return true;
     current = Object.getPrototypeOf(current);
   }

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -113,8 +113,15 @@ interface PolymorphicBelongsTo {
 }
 
 function findPolymorphicRef(modelClass: BaseClass, colName: string): PolymorphicBelongsTo | null {
-  const reflections: Record<string, any> = (modelClass as any)._reflections ?? {};
-  const refl = reflections[colName];
+  const reflections: Record<string, unknown> = (modelClass as any)._reflections ?? {};
+  const refl = reflections[colName] as
+    | {
+        macro?: string;
+        isPolymorphic?: () => boolean;
+        foreignType?: string;
+        foreignKey?: string | string[];
+      }
+    | undefined;
   if (!refl || refl.macro !== "belongsTo" || !refl.isPolymorphic?.()) return null;
   // Prefer the reflection's own foreignType/foreignKey to honour custom column overrides.
   const typeColumn: string = refl.foreignType ?? `${colName}_type`;


### PR DESCRIPTION
## Summary

Implements Wave 1a of the activerecord type audit:

- **48 `: Function` sites** replaced with specific callable or constructor signatures across 26 files
  - Callable sites: `(...args: any[]) => unknown` / `(...args: any[]) => any` (any[] required by TypeScript parameter contravariance — callers pass typed functions)
  - Constructor/class sites: `type AnyClass = abstract new (...args: any[]) => any`
  - Module-of-methods (`.extending()`, `_scopeExtensions`, scopes): `Record<string, (...args: any[]) => any>`
- **21 `Record<string, any>` sites** narrowed to `Record<string, unknown>` with explicit casts at read sites (reflection.ts, belongs-to.ts, define-fixtures.ts, connection-handling.ts)
- **`@typescript-eslint/no-unsafe-function-type` enabled** in `eslint.config.mjs` by removing the `"off"` override for activerecord

### Counts (all src files incl. test)
| Pattern | Before | After |
|---|---|---|
| `: Function` | 48 | 0 |
| `Record<string, any>` | 21 | 0 |

### Validation
- `pnpm exec eslint "packages/activerecord/src/**/*.ts"` — clean
- `pnpm exec tsc --build` — clean
- `pnpm test:types` — 6 test files, 83 tests, 0 type errors

## Follow-ups (separate PRs)
- W1b: variadic rest overloads
- W1c: `@ts-expect-error` audit
- Wave 2+: host typing, private-state, reflection refactors