### PR TITLE
feat(activerecord) PG-schema Slot A — indexes() opclass + nulls order

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -529,33 +529,89 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("SchemaIndexOpclassTest", () => {
-    it.skip("string opclass is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("string opclass is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, name varchar(50), description text)`,
+        );
+        await adapter.exec(
+          `CREATE INDEX trains_name_and_description ON trains USING btree(name text_pattern_ops, description text_pattern_ops)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toContain(`opclass: "text_pattern_ops"`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
-    it.skip("non default opclass is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("non default opclass is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, name varchar(50), description text)`,
+        );
+        await adapter.exec(
+          `CREATE INDEX trains_name_and_description ON trains USING btree(name, description text_pattern_ops)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toContain(`opclass: { description: "text_pattern_ops" }`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
-    it.skip("opclass class parsing on non reserved and cannot be function or type keyword", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("opclass class parsing on non reserved and cannot be function or type keyword", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, name varchar(50), position varchar(50))`,
+        );
+        await adapter.exec(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+        await adapter.exec(
+          `CREATE INDEX trains_position ON trains USING gin(position gin_trgm_ops)`,
+        );
+        await adapter.exec(
+          `CREATE INDEX trains_name_and_position ON trains USING btree(name, position text_pattern_ops)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        const output = lines.join("\n");
+        expect(output).toContain(`opclass: "gin_trgm_ops"`);
+        expect(output).toContain(`opclass: { position: "text_pattern_ops" }`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
   });
 
   describe("SchemaIndexNullsOrderTest", () => {
-    it.skip("nulls order is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("nulls order is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, name varchar(50), description text)`,
+        );
+        await adapter.exec(
+          `CREATE INDEX trains_name_and_description ON trains USING btree(name NULLS FIRST, description)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toContain(`order: { name: "NULLS FIRST" }`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
-    it.skip("non default order with nulls is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("non default order with nulls is dumped", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, name varchar(50), description text)`,
+        );
+        await adapter.exec(
+          `CREATE INDEX trains_name_and_desc ON trains USING btree(name DESC NULLS LAST, description)`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toContain(`order: { name: "DESC NULLS LAST" }`);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1461,6 +1461,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQL::DatabaseStatements#execute_batch (database_statements.rb)
+  /** @internal */
   executeBatch = pgExecuteBatch;
 
   // Mirrors: DatabaseStatements#high_precision_current_timestamp (database_statements.rb:92)
@@ -2509,41 +2510,58 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const columns = row.columns as string[];
       const def = row.definition as string;
 
-      let orders: Record<string, string> | string | undefined;
-      const descMatch = def.match(/\(([^)]+)\)/);
-      if (descMatch) {
-        const colDefs = descMatch[1].split(",").map((s) => s.trim());
-        const orderMap: Record<string, string> = {};
-        let hasOrder = false;
-        for (let ci = 0; ci < columns.length; ci++) {
-          const colDef = colDefs[ci] || "";
-          const descFlag = colDef.match(/\bDESC\b/i);
-          const nullsFlag = colDef.match(/\bNULLS\s+(FIRST|LAST)\b/i);
-          if (descFlag || nullsFlag) {
-            let order = descFlag ? "desc" : "asc";
-            if (nullsFlag) order += ` NULLS ${nullsFlag[1].toUpperCase()}`;
-            orderMap[columns[ci]] = order;
-            hasOrder = true;
-          }
-        }
-        if (hasOrder) {
-          if (columns.length === 1) {
-            orders = orderMap[columns[0]];
-          } else {
-            orders = orderMap;
-          }
+      // Extract the expressions, INCLUDE, NULLS NOT DISTINCT, and WHERE clauses.
+      // Mirrors Rails' regex: / USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m
+      const defMatch = def.match(
+        / USING \w+? \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?$/s,
+      );
+      const expressions = defMatch?.[1] ?? "";
+      const includeStr = defMatch?.[2];
+      const nullsNotDistinctStr = defMatch?.[3];
+      const whereStr = defMatch?.[4];
+
+      const include = includeStr
+        ? includeStr.split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
+        : undefined;
+      const where = whereStr?.trim();
+      const nullsNotDistinct = nullsNotDistinctStr ? true : undefined;
+
+      // Parse opclasses and orders from the expressions string.
+      // Mirrors Rails regex: /(?<column>\w+)"?\s?(?<opclass>\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/
+      const opclassesMap: Record<string, string> = {};
+      const ordersMap: Record<string, string> = {};
+      const COL_RE = /(\w+)"?\s?(\w+_ops(?:_\w+)?)?\s?(DESC)?\s?(NULLS (?:FIRST|LAST))?/g;
+      for (const [, column, opclass, desc, nulls] of expressions.matchAll(COL_RE)) {
+        if (opclass) opclassesMap[column] = opclass;
+        if (nulls) {
+          ordersMap[column] = [desc, nulls].filter(Boolean).join(" ");
+        } else if (desc) {
+          ordersMap[column] = "desc";
         }
       }
 
-      // Parse INCLUDE (...) for covering indexes.
-      const includeMatch = def.match(/\bINCLUDE\s*\(([^)]+)\)/i);
-      const include = includeMatch
-        ? includeMatch[1].split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
-        : undefined;
+      // concise_options: collapse to a single scalar when all key columns share the same value.
+      const keyColumns = include ? columns.filter((c) => !include.includes(c)) : columns;
 
-      const whereMatch = def.match(/\bWHERE\s+(.+)$/i);
-      const where = whereMatch ? whereMatch[1].trim() : undefined;
-      const nullsNotDistinct = /\bNULLS NOT DISTINCT\b/i.test(def) ? true : undefined;
+      let opclasses: Record<string, string> | string | undefined;
+      const opclassVals = Object.values(opclassesMap);
+      if (opclassVals.length > 0) {
+        if (keyColumns.length === opclassVals.length && new Set(opclassVals).size === 1) {
+          opclasses = opclassVals[0];
+        } else {
+          opclasses = opclassesMap;
+        }
+      }
+
+      let orders: Record<string, string> | string | undefined;
+      const orderVals = Object.values(ordersMap);
+      if (orderVals.length > 0) {
+        if (keyColumns.length === orderVals.length && new Set(orderVals).size === 1) {
+          orders = orderVals[0];
+        } else {
+          orders = ordersMap;
+        }
+      }
 
       return {
         table: row.table_name as string,
@@ -2552,6 +2570,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         columns,
         using: row.using as string,
         orders,
+        opclasses,
         include,
         where,
         nullsNotDistinct,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -22,6 +22,8 @@ export interface PgIndexDefinition {
   columns: string[];
   using: string;
   orders?: Record<string, string> | string;
+  opclasses?: Record<string, string> | string;
+  include?: string[];
   where?: string;
   nullsNotDistinct?: boolean;
 }


### PR DESCRIPTION
## Summary

- Extends `PgIndexDefinition` with `opclasses` and `include` fields (were missing from the interface, so schema dumper received `undefined`).
- Rewrites `indexes()` expression parsing to use the same regex strategy as Rails: extract the `expressions` substring from `pg_get_indexdef`, then scan per-column captures for opclass / DESC / NULLS order.
- Applies Rails' `concise_options` logic: when all key columns share the same opclass, emit a single scalar string instead of a per-column hash.
- Fixes orders format: previously emitted `"desc"` / `"asc NULLS FIRST"` — now matches Rails: `"desc"` / `"NULLS FIRST"` / `"DESC NULLS LAST"`.
- Implements 5 previously-skipped tests: `SchemaIndexOpclassTest` (3) and `SchemaIndexNullsOrderTest` (2).

## Test plan

- [ ] `pnpm test:types` — passes (83/83)
- [ ] `pnpm api:compare --package activerecord` — 4949/4958, no regression
- [ ] Schema-dumper unit tests — 79 passed, no regression
- [ ] CI runs PG integration tests for the 5 unskipped tests