### PR TITLE
feat(activerecord) Migration Slot B — tableNamePrefix/Suffix + CTAS + InvalidMigrationTimestampError (6 unskips)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -100,6 +100,7 @@ const loadSignedId = async () => {
   }
   return _signedIdModulePromise;
 };
+import { registerMigrationArConfig } from "./migration.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
 import * as LockingPessimistic from "./locking/pessimistic.js";
 import { hookAttributeType as tzHookAttributeType } from "./attribute-methods/time-zone-conversion.js";
@@ -3427,3 +3428,13 @@ _setSuperValidates(Model.validates);
     });
   }
 }
+
+registerMigrationArConfig({
+  get tableNamePrefix() {
+    return Base._tableNamePrefix;
+  },
+  get tableNameSuffix() {
+    return Base._tableNameSuffix;
+  },
+  validateMigrationTimestamps: false,
+});

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3436,5 +3436,4 @@ registerMigrationArConfig({
   get tableNameSuffix() {
     return Base._tableNameSuffix;
   },
-  validateMigrationTimestamps: false,
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -995,7 +995,8 @@ export class TableDefinition {
           parts.push(`CHAR(${col.options.limit ?? 1})`);
           break;
         default:
-          parts.push(col.type.toUpperCase());
+          // Pass arbitrary type strings through verbatim (case matters for PG enums).
+          parts.push(col.type);
           break;
       }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -994,6 +994,9 @@ export class TableDefinition {
         case "char":
           parts.push(`CHAR(${col.options.limit ?? 1})`);
           break;
+        default:
+          parts.push(col.type.toUpperCase());
+          break;
       }
 
       // For types that don't handle PRIMARY KEY internally, append it if requested

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2192,22 +2192,19 @@ describe("MigrationTest", () => {
         expect(new LongV().version).toBe("123456789012345");
       });
 
-      it("migration raises if timestamp is future date", async () => {
+      it("migration raises if timestamp is future date", () => {
         const savedValidate = Migrator.validateMigrationTimestamps;
         try {
           Migrator.validateMigrationTimestamps = true;
-          const { Temporal } = await import("@blazetrails/activesupport/temporal");
-          const futureTs = Temporal.Now.plainDateTimeISO("UTC").add({ months: 1 });
-          const pad = (n: number, w = 2) => String(n).padStart(w, "0");
-          const ts = `${futureTs.year}${pad(futureTs.month)}${pad(futureTs.day)}${pad(futureTs.hour)}${pad(futureTs.minute)}${pad(futureTs.second)}`;
+          // A timestamp far in the future (year 9999) is definitely > tomorrow
+          const ts = "99991231235959";
           class FutureM extends Migration {
             static version = ts;
             async change() {}
           }
-          const adapter = createTestAdapter();
           expect(
             () =>
-              new Migrator(adapter, [
+              new Migrator(createTestAdapter(), [
                 { name: "test_migration", version: ts, migration: () => new FutureM() },
               ]),
           ).toThrow(/Invalid timestamp/);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1583,33 +1583,108 @@ describe("MigrationTest", () => {
     // Requires schema cache implementation
   });
 
-  it.skip("add drop table with prefix and suffix", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    /* needs prefix/suffix auto-applied by MigrationContext.createTable/dropTable */
+  it("add drop table with prefix and suffix", async () => {
+    const adapter = freshAdapter();
+    const savedPrefix = Base.tableNamePrefix;
+    const savedSuffix = Base.tableNameSuffix;
+    Base.tableNamePrefix = "prefix_";
+    Base.tableNameSuffix = "_suffix";
+    try {
+      class WeNeedReminders extends Migration {
+        async up() {
+          await this.createTable("reminders", (t) => {
+            t.text("content");
+          });
+        }
+        async down() {
+          await this.dropTable("reminders");
+        }
+      }
+
+      const checkExists = async () =>
+        adapterType === "sqlite"
+          ? (
+              (await adapter.execute(
+                `SELECT name FROM sqlite_master WHERE type='table' AND name='prefix_reminders_suffix'`,
+              )) as unknown[]
+            ).length
+          : (
+              (await adapter.execute(
+                `SELECT table_name FROM information_schema.tables WHERE table_name='prefix_reminders_suffix'`,
+              )) as unknown[]
+            ).length;
+
+      const m = new WeNeedReminders();
+      await m.run(adapter, "up");
+      expect(await checkExists()).toBe(1);
+      await adapter.executeMutation(
+        `INSERT INTO "prefix_reminders_suffix" ("content") VALUES ('hello')`,
+      );
+      const rows = await adapter.execute(`SELECT * FROM "prefix_reminders_suffix"`);
+      expect(rows).toHaveLength(1);
+
+      await m.run(adapter, "down");
+      expect(await checkExists()).toBe(0);
+    } finally {
+      Base.tableNamePrefix = savedPrefix;
+      Base.tableNameSuffix = savedSuffix;
+    }
   });
 
-  it.skip("create table with query", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires DDL migration runner
+  it.skipIf(adapterType === "mysql")("create table with query", async () => {
+    const adapter = freshAdapter();
+    const ctx = new MigrationContext(adapter);
+    await ctx.createTable("people_src", {}, (t) => {
+      t.integer("person_id");
+    });
+    await adapter.executeMutation(`INSERT INTO "people_src" ("person_id") VALUES (1)`);
+
+    await ctx.createTable("table_from_query_testings", {
+      as: `SELECT person_id FROM people_src WHERE person_id = 1`,
+    });
+    const rows = await adapter.execute(`SELECT * FROM "table_from_query_testings"`);
+    expect(rows).toHaveLength(1);
+
+    await ctx.dropTable("table_from_query_testings");
+    await ctx.dropTable("people_src");
   });
 
-  it.skip("create table with query from relation", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires DDL migration runner
+  it.skipIf(adapterType === "mysql")("create table with query from relation", async () => {
+    const adapter = freshAdapter();
+    const ctx = new MigrationContext(adapter);
+    await ctx.createTable("people_src2", {}, (t) => {
+      t.integer("person_id");
+    });
+    await adapter.executeMutation(`INSERT INTO "people_src2" ("person_id") VALUES (1)`);
+
+    // Build a relation SQL string directly (mirrors Rails `Person.select(:id).where(id: 1).to_sql`)
+    const sql = `SELECT "people_src2"."person_id" FROM "people_src2" WHERE "people_src2"."person_id" = 1`;
+    await ctx.createTable("table_from_query_testings2", { as: sql });
+    const rows = await adapter.execute(`SELECT * FROM "table_from_query_testings2"`);
+    expect(rows).toHaveLength(1);
+
+    await ctx.dropTable("table_from_query_testings2");
+    await ctx.dropTable("people_src2");
   });
 
-  it.skip("allows sqlite3 rollback on invalid column type", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires real database adapter
-  });
+  it.skipIf(adapterType !== "sqlite")(
+    "allows sqlite3 rollback on invalid column type",
+    async () => {
+      const adapter = freshAdapter();
+      const ctx = new MigrationContext(adapter);
+      await ctx.createTable("something", { force: true }, (t) => {
+        t.integer("number");
+        t.string("name");
+        t.column("foo", "bar" as any);
+      });
+      expect(ctx.columnExists("something", "foo")).toBe(true);
+      await ctx.removeColumn("something", "foo");
+      expect(ctx.columnExists("something", "foo")).toBe(false);
+      expect(ctx.columnExists("something", "name")).toBe(true);
+      expect(ctx.columnExists("something", "number")).toBe(true);
+      await ctx.dropTable("something");
+    },
+  );
 
   it.skip("migrator generates valid lock id", () => {
     // BLOCKED: migration — migration runner gap in migration
@@ -1618,11 +1693,13 @@ describe("MigrationTest", () => {
     // Requires migration runner
   });
 
-  it.skip("generate migrator advisory lock id", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
+  it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {
+    const adapter = createTestAdapter();
+    const migrator = new Migrator(adapter, []);
+    const lockId = await migrator.generateMigratorAdvisoryLockId();
+    // Must fit in a signed 63-bit integer
+    expect(lockId).toBeGreaterThanOrEqual(0n);
+    expect(lockId.toString(2).length).toBeLessThanOrEqual(63);
   });
 
   it.skip("migrator one up with unavailable lock", () => {
@@ -2113,11 +2190,28 @@ describe("MigrationTest", () => {
         expect(new LongV().version).toBe("123456789012345");
       });
 
-      it.skip("migration raises if timestamp is future date", () => {
-        // BLOCKED: migration — migration runner gap in migration
-        // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-        // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-        /* timestamp validation not implemented */
+      it("migration raises if timestamp is future date", async () => {
+        const savedValidate = Migrator.validateMigrationTimestamps;
+        try {
+          Migrator.validateMigrationTimestamps = true;
+          const { Temporal } = await import("@blazetrails/activesupport/temporal");
+          const futureTs = Temporal.Now.plainDateTimeISO("UTC").add({ months: 1 });
+          const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+          const ts = `${futureTs.year}${pad(futureTs.month)}${pad(futureTs.day)}${pad(futureTs.hour)}${pad(futureTs.minute)}${pad(futureTs.second)}`;
+          class FutureM extends Migration {
+            static version = ts;
+            async change() {}
+          }
+          const adapter = createTestAdapter();
+          expect(
+            () =>
+              new Migrator(adapter, [
+                { name: "test_migration", version: ts, migration: () => new FutureM() },
+              ]),
+          ).toThrow(/Invalid timestamp/);
+        } finally {
+          Migrator.validateMigrationTimestamps = savedValidate;
+        }
       });
 
       it("migration succeeds if timestamp is less than one day in the future", () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1603,10 +1603,11 @@ describe("MigrationTest", () => {
 
       const m = new WeNeedReminders();
       await m.run(adapter, "up");
-      await adapter.executeMutation(
-        `INSERT INTO "prefix_reminders_suffix" ("content") VALUES ('hello')`,
-      );
-      const rows = await adapter.execute(`SELECT * FROM "prefix_reminders_suffix"`);
+      // Use adapter quoting so MySQL (no ANSI_QUOTES) works alongside PG/SQLite.
+      const qt = adapter.quoteTableName("prefix_reminders_suffix");
+      const qc = adapter.quoteIdentifier("content");
+      await adapter.executeMutation(`INSERT INTO ${qt} (${qc}) VALUES ('hello')`);
+      const rows = await adapter.execute(`SELECT * FROM ${qt}`);
       expect(rows).toHaveLength(1);
 
       await m.run(adapter, "down");

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1612,16 +1612,21 @@ describe("MigrationTest", () => {
       await m.run(adapter, "down");
       expect(await m.tableExists("reminders")).toBe(false);
 
-      // Regression: change()-based reversal must not double-apply prefix/suffix.
+      // Exercises addColumn + renameTable (both args prefixed per Rails method_missing)
+      // and change()-based reversal without double-applying prefix/suffix.
       class ChangeBased extends Migration {
         async change() {
           await this.createTable("widgets", (t) => t.string("name"));
+          await this.addColumn("widgets", "price", "integer");
+          await this.renameTable("widgets", "gadgets");
         }
       }
       const cb = new ChangeBased();
       await cb.run(adapter, "up");
-      expect(await cb.tableExists("widgets")).toBe(true);
+      expect(await cb.tableExists("gadgets")).toBe(true);
+      expect(await cb.columnExists("gadgets", "price")).toBe(true);
       await cb.run(adapter, "down");
+      expect(await cb.tableExists("gadgets")).toBe(false);
       expect(await cb.tableExists("widgets")).toBe(false);
     } finally {
       Base.tableNamePrefix = savedPrefix;

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1601,22 +1601,9 @@ describe("MigrationTest", () => {
         }
       }
 
-      const checkExists = async () =>
-        adapterType === "sqlite"
-          ? (
-              (await adapter.execute(
-                `SELECT name FROM sqlite_master WHERE type='table' AND name='prefix_reminders_suffix'`,
-              )) as unknown[]
-            ).length
-          : (
-              (await adapter.execute(
-                `SELECT table_name FROM information_schema.tables WHERE table_name='prefix_reminders_suffix'`,
-              )) as unknown[]
-            ).length;
-
       const m = new WeNeedReminders();
       await m.run(adapter, "up");
-      expect(await checkExists()).toBe(1);
+      // Direct INSERT proves the actual table name (with prefix/suffix applied) was created.
       await adapter.executeMutation(
         `INSERT INTO "prefix_reminders_suffix" ("content") VALUES ('hello')`,
       );
@@ -1624,7 +1611,8 @@ describe("MigrationTest", () => {
       expect(rows).toHaveLength(1);
 
       await m.run(adapter, "down");
-      expect(await checkExists()).toBe(0);
+      // m.tableExists("reminders") flows through this._pt() so it queries the prefixed name.
+      expect(await m.tableExists("reminders")).toBe(false);
     } finally {
       Base.tableNamePrefix = savedPrefix;
       Base.tableNameSuffix = savedSuffix;
@@ -1694,8 +1682,11 @@ describe("MigrationTest", () => {
   });
 
   it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {
-    const adapter = createTestAdapter();
-    const migrator = new Migrator(adapter, []);
+    // Bypass the SchemaAdapter wrapper — generateMigratorAdvisoryLockId needs
+    // currentDatabase(), which lives on the real adapter (pg/mysql), not the wrapper.
+    const testAdapter = createTestAdapter();
+    const realAdapter = testAdapter.innerAdapter;
+    const migrator = new Migrator(realAdapter, []);
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     // Must fit in a signed 63-bit integer
     expect(lockId).toBeGreaterThanOrEqual(0n);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1603,7 +1603,6 @@ describe("MigrationTest", () => {
 
       const m = new WeNeedReminders();
       await m.run(adapter, "up");
-      // Direct INSERT proves the actual table name (with prefix/suffix applied) was created.
       await adapter.executeMutation(
         `INSERT INTO "prefix_reminders_suffix" ("content") VALUES ('hello')`,
       );
@@ -1611,8 +1610,19 @@ describe("MigrationTest", () => {
       expect(rows).toHaveLength(1);
 
       await m.run(adapter, "down");
-      // m.tableExists("reminders") flows through this._pt() so it queries the prefixed name.
       expect(await m.tableExists("reminders")).toBe(false);
+
+      // Regression: change()-based reversal must not double-apply prefix/suffix.
+      class ChangeBased extends Migration {
+        async change() {
+          await this.createTable("widgets", (t) => t.string("name"));
+        }
+      }
+      const cb = new ChangeBased();
+      await cb.run(adapter, "up");
+      expect(await cb.tableExists("widgets")).toBe(true);
+      await cb.run(adapter, "down");
+      expect(await cb.tableExists("widgets")).toBe(false);
     } finally {
       Base.tableNamePrefix = savedPrefix;
       Base.tableNameSuffix = savedSuffix;
@@ -1632,6 +1642,7 @@ describe("MigrationTest", () => {
     });
     const rows = await adapter.execute(`SELECT * FROM "table_from_query_testings"`);
     expect(rows).toHaveLength(1);
+    expect(ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
 
     await ctx.dropTable("table_from_query_testings");
     await ctx.dropTable("people_src");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1500,11 +1500,12 @@ export class MigrationContext {
   /** @internal Query catalog for column names — used after CTAS where columns derive from the SELECT. */
   private async _introspectColumns(name: string): Promise<string[]> {
     const a = this._adapterName;
+    const e = name.replace(/'/g, "''"); // defense-in-depth for catalog string literals
     const sql =
       a === "sqlite"
         ? `PRAGMA table_info(${this.adapter.quoteTableName(name)})`
         : a === "postgres"
-          ? `SELECT column_name FROM information_schema.columns WHERE table_name = '${name}'`
+          ? `SELECT column_name FROM information_schema.columns WHERE table_name = '${e}'`
           : `SHOW COLUMNS FROM ${this.adapter.quoteTableName(name)}`;
     const rows = await this.adapter.execute(sql);
     return rows.map((r) => {
@@ -1568,9 +1569,12 @@ export class MigrationContext {
     }
     this._tables.add(name);
     const cols = new Set<string>();
-    for (const col of td.columns) {
+    // CTAS ignores td.columns — actual columns come from the SELECT (introspected below).
+    const tdCols = options?.as != null ? [] : td.columns;
+    for (const col of tdCols) {
       cols.add(col.name);
     }
+
     // Store column metadata
     const meta = new Map<
       string,
@@ -1588,7 +1592,7 @@ export class MigrationContext {
       const idType = typeof options?.id === "string" ? options.id : "integer";
       meta.set("id", { type: idType, primaryKey: true });
     }
-    for (const col of td.columns) {
+    for (const col of tdCols) {
       if (col.name === "id" && meta.has("id")) continue;
       meta.set(col.name, {
         type: col.type,
@@ -1600,11 +1604,10 @@ export class MigrationContext {
         scale: col.options.scale,
       });
     }
-    // CTAS columns come from the SELECT list — introspect from the DB.
     if (options?.as != null) {
       for (const c of await this._introspectColumns(name)) {
         cols.add(c);
-        if (!meta.has(c)) meta.set(c, { type: "string" });
+        meta.set(c, { type: "string" });
       }
     }
     this._columns.set(name, cols);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -65,11 +65,12 @@ function _extractNewCommentValue(
 }
 
 // Registry for AR config injected by Base to avoid circular imports.
+// Mirrors Rails' Base.table_name_prefix / table_name_suffix accessors that
+// Migration.table_name_options reads from at runtime.
 /** @internal */
 export interface MigrationArConfig {
   tableNamePrefix: string;
   tableNameSuffix: string;
-  validateMigrationTimestamps: boolean;
 }
 let _arConfig: MigrationArConfig | null = null;
 /** @internal */
@@ -572,6 +573,11 @@ export abstract class Migration {
   // In Rails, these methods live on the connection adapter via
   // ActiveRecord::ConnectionAdapters::SchemaStatements.
 
+  /** @internal Mirrors Rails Migration#method_missing's proper_table_name dispatch. */
+  protected _pt(name: string): string {
+    return Migration.properTableName(name, Migration.tableNameOptions());
+  }
+
   async createTable(
     name: string,
     optionsOrFn?:
@@ -585,7 +591,7 @@ export abstract class Migration {
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    const tname = Migration.properTableName(name, Migration.tableNameOptions());
+    const tname = this._pt(name);
     if (this._recording) {
       this._recorder.record("createTable", [tname, optionsOrFn, fn]);
       return;
@@ -594,7 +600,7 @@ export abstract class Migration {
   }
 
   async dropTable(name: string, options?: { ifExists?: boolean }): Promise<void> {
-    const tname = Migration.properTableName(name, Migration.tableNameOptions());
+    const tname = this._pt(name);
     if (this._recording) {
       this._recorder.record("dropTable", [tname]);
       return;
@@ -612,6 +618,7 @@ export abstract class Migration {
     type: ColumnType,
     options: ColumnOptions & { ifNotExists?: boolean } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addColumn", [tableName, columnName, type, options]);
       return;
@@ -625,6 +632,7 @@ export abstract class Migration {
     typeOrOptions?: ColumnType | { ifExists?: boolean },
     options?: { ifExists?: boolean },
   ): Promise<void> {
+    tableName = this._pt(tableName);
     const type = typeof typeOrOptions === "string" ? typeOrOptions : undefined;
     const opts = typeof typeOrOptions === "object" ? typeOrOptions : (options ?? {});
     if (this._recording) {
@@ -635,6 +643,7 @@ export abstract class Migration {
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("renameColumn", [tableName, oldName, newName]);
       return;
@@ -653,6 +662,7 @@ export abstract class Migration {
       ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addIndex", [tableName, columns, options]);
       return;
@@ -664,6 +674,7 @@ export abstract class Migration {
     tableName: string,
     options: { column?: string | string[]; name?: string } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeIndex", [tableName, options]);
       return;
@@ -677,6 +688,7 @@ export abstract class Migration {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumn", [tableName, columnName, type, options]);
       return;
@@ -685,6 +697,8 @@ export abstract class Migration {
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
+    oldName = this._pt(oldName);
+    newName = this._pt(newName);
     if (this._recording) {
       this._recorder.record("renameTable", [oldName, newName]);
       return;
@@ -693,11 +707,11 @@ export abstract class Migration {
   }
 
   async tableExists(tableName: string): Promise<boolean> {
-    return this.schema.tableExists(tableName);
+    return this.schema.tableExists(this._pt(tableName));
   }
 
   async columnExists(tableName: string, columnName: string): Promise<boolean> {
-    return this.schema.columnExists(tableName, columnName);
+    return this.schema.columnExists(this._pt(tableName), columnName);
   }
 
   async changeColumnDefault(
@@ -705,6 +719,7 @@ export abstract class Migration {
     columnName: string,
     options: { from?: unknown; to: unknown } | unknown,
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumnDefault", [tableName, columnName, options]);
       return;
@@ -718,6 +733,7 @@ export abstract class Migration {
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumnNull", [tableName, columnName, allowNull, defaultValue]);
       return;
@@ -735,6 +751,7 @@ export abstract class Migration {
       index?: boolean;
     } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addReference", [tableName, refName, options]);
       return;
@@ -747,6 +764,7 @@ export abstract class Migration {
     refName: string,
     options: { polymorphic?: boolean } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeReference", [tableName, refName, options]);
       return;
@@ -759,6 +777,7 @@ export abstract class Migration {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
+    fromTable = this._pt(fromTable);
     if (this._recording) {
       this._recorder.record("addForeignKey", [fromTable, toTable, options]);
       return;
@@ -772,6 +791,8 @@ export abstract class Migration {
       | string
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
   ): Promise<void> {
+    fromTable = this._pt(fromTable);
+    if (typeof toTableOrOptions === "string") toTableOrOptions = this._pt(toTableOrOptions);
     if (this._recording) {
       this._recorder.record("removeForeignKey", [fromTable, toTableOrOptions]);
       return;
@@ -784,6 +805,7 @@ export abstract class Migration {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addCheckConstraint", [tableName, expression, options]);
       return;
@@ -795,6 +817,7 @@ export abstract class Migration {
     tableName: string,
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
   ): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeCheckConstraint", [tableName, expressionOrOptions]);
       return;
@@ -938,6 +961,7 @@ export abstract class Migration {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addTimestamps", [tableName, options]);
       return;
@@ -946,6 +970,7 @@ export abstract class Migration {
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeTimestamps", [tableName]);
       return;
@@ -959,6 +984,7 @@ export abstract class Migration {
     options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
+    table1 = this._pt(table1);
     if (this._recording) {
       this._recorder.record("createJoinTable", [table1, table2, options, fn]);
       return;
@@ -971,6 +997,7 @@ export abstract class Migration {
     table2: string,
     options?: { tableName?: string },
   ): Promise<void> {
+    table1 = this._pt(table1);
     if (this._recording) {
       this._recorder.record("dropJoinTable", [table1, table2, options]);
       return;
@@ -986,6 +1013,7 @@ export abstract class Migration {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
+    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("renameIndex", [tableName, oldName, newName]);
       return;
@@ -994,7 +1022,7 @@ export abstract class Migration {
   }
 
   indexName(tableName: string, options: { column?: string | string[] }): string {
-    return this.schema.indexName(tableName, options);
+    return this.schema.indexName(this._pt(tableName), options);
   }
 
   async removeColumns(tableName: string, ...columns: string[]): Promise<void> {
@@ -2755,9 +2783,7 @@ export class Migrator {
   // Rails: MigrationContext#validate_timestamp?
   /** @internal */
   isValidateTimestamp(): boolean {
-    return (
-      (_arConfig?.validateMigrationTimestamps ?? false) || Migrator.validateMigrationTimestamps
-    );
+    return Migrator.validateMigrationTimestamps;
   }
 
   // Rails: MigrationContext#valid_migration_timestamp?

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -64,9 +64,7 @@ function _extractNewCommentValue(
   return v as string | null;
 }
 
-// Registry for AR config injected by Base to avoid circular imports.
-// Mirrors Rails' Base.table_name_prefix / table_name_suffix accessors that
-// Migration.table_name_options reads from at runtime.
+// Registry for AR config injected by Base — breaks the migration ↔ base import cycle.
 /** @internal */
 export interface MigrationArConfig {
   tableNamePrefix: string;
@@ -140,18 +138,14 @@ export class IllegalMigrationNameError extends MigrationError {
 
 export class InvalidMigrationTimestampError extends MigrationError {
   constructor(version?: string | number, name?: string) {
-    const tomorrow = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
-    const pad = (n: number, w = 2) => String(n).padStart(w, "0");
-    const limit = `${tomorrow.year}${pad(tomorrow.month)}${pad(tomorrow.day)}${pad(tomorrow.hour)}${pad(tomorrow.minute)}${pad(tomorrow.second)}`;
-    if (version != null && name != null) {
-      super(
-        `Invalid timestamp ${version} for migration file: ${name}.\nTimestamp must be in form YYYYMMDDHHMMSS, and less than ${limit}.`,
-      );
-    } else {
-      super(
-        `Invalid timestamp for migration.\nTimestamp must be in form YYYYMMDDHHMMSS, and less than ${limit}.`,
-      );
-    }
+    const t = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
+    const p = (n: number) => String(n).padStart(2, "0");
+    const limit = `${t.year}${p(t.month)}${p(t.day)}${p(t.hour)}${p(t.minute)}${p(t.second)}`;
+    const prefix =
+      version != null && name != null
+        ? `Invalid timestamp ${version} for migration file: ${name}.`
+        : "Invalid timestamp for migration.";
+    super(`${prefix}\nTimestamp must be in form YYYYMMDDHHMMSS, and less than ${limit}.`);
     this.name = "InvalidMigrationTimestampError";
   }
 }
@@ -591,20 +585,20 @@ export abstract class Migration {
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    const tname = this._pt(name);
     if (this._recording) {
-      this._recorder.record("createTable", [tname, optionsOrFn, fn]);
+      this._recorder.record("createTable", [name, optionsOrFn, fn]);
       return;
     }
+    const tname = this._pt(name);
     await this.schema.createTable(tname, optionsOrFn, fn);
   }
 
   async dropTable(name: string, options?: { ifExists?: boolean }): Promise<void> {
-    const tname = this._pt(name);
     if (this._recording) {
-      this._recorder.record("dropTable", [tname]);
+      this._recorder.record("dropTable", [name]);
       return;
     }
+    const tname = this._pt(name);
     if (options) {
       await this.schema.dropTable(tname, options);
     } else {
@@ -618,11 +612,11 @@ export abstract class Migration {
     type: ColumnType,
     options: ColumnOptions & { ifNotExists?: boolean } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addColumn", [tableName, columnName, type, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.addColumn(tableName, columnName, type, options);
   }
 
@@ -632,22 +626,22 @@ export abstract class Migration {
     typeOrOptions?: ColumnType | { ifExists?: boolean },
     options?: { ifExists?: boolean },
   ): Promise<void> {
-    tableName = this._pt(tableName);
     const type = typeof typeOrOptions === "string" ? typeOrOptions : undefined;
     const opts = typeof typeOrOptions === "object" ? typeOrOptions : (options ?? {});
     if (this._recording) {
       this._recorder.record("removeColumn", [tableName, columnName, type, opts]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.removeColumn(tableName, columnName, type, opts);
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("renameColumn", [tableName, oldName, newName]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.renameColumn(tableName, oldName, newName);
   }
 
@@ -662,11 +656,11 @@ export abstract class Migration {
       ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addIndex", [tableName, columns, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.addIndex(tableName, columns, options);
   }
 
@@ -674,11 +668,11 @@ export abstract class Migration {
     tableName: string,
     options: { column?: string | string[]; name?: string } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeIndex", [tableName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.removeIndex(tableName, options);
   }
 
@@ -688,21 +682,21 @@ export abstract class Migration {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumn", [tableName, columnName, type, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.changeColumn(tableName, columnName, type, options);
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
-    oldName = this._pt(oldName);
-    newName = this._pt(newName);
     if (this._recording) {
       this._recorder.record("renameTable", [oldName, newName]);
       return;
     }
+    oldName = this._pt(oldName);
+    newName = this._pt(newName);
     await this.schema.renameTable(oldName, newName);
   }
 
@@ -719,11 +713,11 @@ export abstract class Migration {
     columnName: string,
     options: { from?: unknown; to: unknown } | unknown,
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumnDefault", [tableName, columnName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.changeColumnDefault(tableName, columnName, options);
   }
 
@@ -733,11 +727,11 @@ export abstract class Migration {
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("changeColumnNull", [tableName, columnName, allowNull, defaultValue]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.changeColumnNull(tableName, columnName, allowNull, defaultValue);
   }
 
@@ -751,11 +745,11 @@ export abstract class Migration {
       index?: boolean;
     } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addReference", [tableName, refName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.addReference(tableName, refName, options);
   }
 
@@ -764,11 +758,11 @@ export abstract class Migration {
     refName: string,
     options: { polymorphic?: boolean } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeReference", [tableName, refName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.removeReference(tableName, refName, options);
   }
 
@@ -777,11 +771,11 @@ export abstract class Migration {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    fromTable = this._pt(fromTable);
     if (this._recording) {
       this._recorder.record("addForeignKey", [fromTable, toTable, options]);
       return;
     }
+    fromTable = this._pt(fromTable);
     await this.schema.addForeignKey(fromTable, toTable, options);
   }
 
@@ -791,12 +785,12 @@ export abstract class Migration {
       | string
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
   ): Promise<void> {
-    fromTable = this._pt(fromTable);
-    if (typeof toTableOrOptions === "string") toTableOrOptions = this._pt(toTableOrOptions);
     if (this._recording) {
       this._recorder.record("removeForeignKey", [fromTable, toTableOrOptions]);
       return;
     }
+    fromTable = this._pt(fromTable);
+    if (typeof toTableOrOptions === "string") toTableOrOptions = this._pt(toTableOrOptions);
     await this.schema.removeForeignKey(fromTable, toTableOrOptions);
   }
 
@@ -805,11 +799,11 @@ export abstract class Migration {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addCheckConstraint", [tableName, expression, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.addCheckConstraint(tableName, expression, options);
   }
 
@@ -817,18 +811,18 @@ export abstract class Migration {
     tableName: string,
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
   ): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeCheckConstraint", [tableName, expressionOrOptions]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
   }
   async validateCheckConstraint(
     tableName: string,
     nameOrOptions: string | { name: string },
   ): Promise<void> {
-    await (this.connection as any).validateCheckConstraint(tableName, nameOrOptions);
+    await (this.connection as any).validateCheckConstraint(this._pt(tableName), nameOrOptions);
   }
 
   async validateForeignKey(
@@ -838,7 +832,7 @@ export abstract class Migration {
   ): Promise<void> {
     const toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts = typeof toTableOrOptions === "object" ? toTableOrOptions : (options ?? undefined);
-    await (this.connection as any).validateForeignKey(fromTable, toTable, opts);
+    await (this.connection as any).validateForeignKey(this._pt(fromTable), toTable, opts);
   }
 
   async changeColumnComment(
@@ -850,6 +844,7 @@ export abstract class Migration {
       this._recorder.record("changeColumnComment", [tableName, columnName, commentOrChanges]);
       return;
     }
+    tableName = this._pt(tableName);
     const resolved = _extractNewCommentValue(commentOrChanges);
     await (this.connection as any).changeColumnComment(tableName, columnName, resolved);
   }
@@ -862,6 +857,7 @@ export abstract class Migration {
       this._recorder.record("changeTableComment", [tableName, commentOrChanges]);
       return;
     }
+    tableName = this._pt(tableName);
     const resolved = _extractNewCommentValue(commentOrChanges);
     await (this.connection as any).changeTableComment(tableName, resolved);
   }
@@ -933,6 +929,7 @@ export abstract class Migration {
       this._recorder.record("addUniqueConstraint", [tableName, columnName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await (this.connection as any).addUniqueConstraint(tableName, columnName, options);
   }
 
@@ -957,24 +954,25 @@ export abstract class Migration {
       this._recorder.record("removeUniqueConstraint", [tableName, columnName, opts]);
       return;
     }
+    tableName = this._pt(tableName);
     await (this.connection as any).removeUniqueConstraint(tableName, columnName, opts);
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("addTimestamps", [tableName, options]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.addTimestamps(tableName, options);
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("removeTimestamps", [tableName]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.removeTimestamps(tableName);
   }
 
@@ -984,11 +982,11 @@ export abstract class Migration {
     options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    table1 = this._pt(table1);
     if (this._recording) {
       this._recorder.record("createJoinTable", [table1, table2, options, fn]);
       return;
     }
+    table1 = this._pt(table1);
     await this.schema.createJoinTable(table1, table2, options, fn);
   }
 
@@ -997,11 +995,11 @@ export abstract class Migration {
     table2: string,
     options?: { tableName?: string },
   ): Promise<void> {
-    table1 = this._pt(table1);
     if (this._recording) {
       this._recorder.record("dropJoinTable", [table1, table2, options]);
       return;
     }
+    table1 = this._pt(table1);
     await this.schema.dropJoinTable(table1, table2, options);
   }
 
@@ -1013,11 +1011,11 @@ export abstract class Migration {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
-    tableName = this._pt(tableName);
     if (this._recording) {
       this._recorder.record("renameIndex", [tableName, oldName, newName]);
       return;
     }
+    tableName = this._pt(tableName);
     await this.schema.renameIndex(tableName, oldName, newName);
   }
 
@@ -1041,21 +1039,21 @@ export abstract class Migration {
   }
 
   async columns(tableName: string): Promise<import("./connection-adapters/column.js").Column[]> {
-    return this.schema.columns(tableName);
+    return this.schema.columns(this._pt(tableName));
   }
 
   async indexes(
     tableName: string,
   ): Promise<Array<{ name: string; columns: string[]; unique: boolean }>> {
-    return this.schema.indexes(tableName);
+    return this.schema.indexes(this._pt(tableName));
   }
 
   async primaryKey(tableName: string): Promise<string | null> {
-    return this.schema.primaryKey(tableName);
+    return this.schema.primaryKey(this._pt(tableName));
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    return this.schema.foreignKeys(tableName);
+    return this.schema.foreignKeys(this._pt(tableName));
   }
 
   async tables(): Promise<string[]> {
@@ -1175,7 +1173,7 @@ export abstract class Migration {
     columnName: string | string[],
     options?: { unique?: boolean; name?: string },
   ): Promise<boolean> {
-    return this.schema.indexExists(tableName, columnName, options);
+    return this.schema.indexExists(this._pt(tableName), columnName, options);
   }
 
   /**
@@ -1499,6 +1497,22 @@ export class MigrationContext {
     return this.adapter.adapterName;
   }
 
+  /** @internal Query catalog for column names — used after CTAS where columns derive from the SELECT. */
+  private async _introspectColumns(name: string): Promise<string[]> {
+    const a = this._adapterName;
+    const sql =
+      a === "sqlite"
+        ? `PRAGMA table_info(${this.adapter.quoteTableName(name)})`
+        : a === "postgres"
+          ? `SELECT column_name FROM information_schema.columns WHERE table_name = '${name}'`
+          : `SHOW COLUMNS FROM ${this.adapter.quoteTableName(name)}`;
+    const rows = await this.adapter.execute(sql);
+    return rows.map((r) => {
+      const x = r as Record<string, unknown>;
+      return (x.name ?? x.column_name ?? x.Field) as string;
+    });
+  }
+
   async createTable(
     name: string,
     options?: {
@@ -1557,8 +1571,6 @@ export class MigrationContext {
     for (const col of td.columns) {
       cols.add(col.name);
     }
-    this._columns.set(name, cols);
-
     // Store column metadata
     const meta = new Map<
       string,
@@ -1588,6 +1600,14 @@ export class MigrationContext {
         scale: col.options.scale,
       });
     }
+    // CTAS columns come from the SELECT list — introspect from the DB.
+    if (options?.as != null) {
+      for (const c of await this._introspectColumns(name)) {
+        cols.add(c);
+        if (!meta.has(c)) meta.set(c, { type: "string" });
+      }
+    }
+    this._columns.set(name, cols);
     this._columnMeta.set(name, meta);
 
     // Create indexes from table definition

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1500,13 +1500,17 @@ export class MigrationContext {
   /** @internal Query catalog for column names — used after CTAS where columns derive from the SELECT. */
   private async _introspectColumns(name: string): Promise<string[]> {
     const a = this._adapterName;
-    const e = name.replace(/'/g, "''"); // defense-in-depth for catalog string literals
-    const sql =
-      a === "sqlite"
-        ? `PRAGMA table_info(${this.adapter.quoteTableName(name)})`
-        : a === "postgres"
-          ? `SELECT column_name FROM information_schema.columns WHERE table_name = '${e}'`
-          : `SHOW COLUMNS FROM ${this.adapter.quoteTableName(name)}`;
+    const qt = this.adapter.quoteTableName(name);
+    let sql: string;
+    if (a === "sqlite") {
+      sql = `PRAGMA table_info(${qt})`;
+    } else if (a === "postgres") {
+      const [s, t] = name.includes(".") ? name.split(".", 2) : ["public", name];
+      const e = (x: string) => x.replace(/'/g, "''");
+      sql = `SELECT column_name FROM information_schema.columns WHERE table_schema = '${e(s)}' AND table_name = '${e(t)}' ORDER BY ordinal_position`;
+    } else {
+      sql = `SHOW COLUMNS FROM ${qt}`;
+    }
     const rows = await this.adapter.execute(sql);
     return rows.map((r) => {
       const x = r as Record<string, unknown>;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -64,6 +64,19 @@ function _extractNewCommentValue(
   return v as string | null;
 }
 
+// Registry for AR config injected by Base to avoid circular imports.
+/** @internal */
+export interface MigrationArConfig {
+  tableNamePrefix: string;
+  tableNameSuffix: string;
+  validateMigrationTimestamps: boolean;
+}
+let _arConfig: MigrationArConfig | null = null;
+/** @internal */
+export function registerMigrationArConfig(config: MigrationArConfig): void {
+  _arConfig = config;
+}
+
 // Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial) operating on UTF-8 bytes.
 function _crc32(str: string): number {
   const bytes = new TextEncoder().encode(str);
@@ -125,8 +138,19 @@ export class IllegalMigrationNameError extends MigrationError {
 }
 
 export class InvalidMigrationTimestampError extends MigrationError {
-  constructor(version: string | number) {
-    super(`Invalid timestamp ${version} in migration file name.`);
+  constructor(version?: string | number, name?: string) {
+    const tomorrow = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
+    const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+    const limit = `${tomorrow.year}${pad(tomorrow.month)}${pad(tomorrow.day)}${pad(tomorrow.hour)}${pad(tomorrow.minute)}${pad(tomorrow.second)}`;
+    if (version != null && name != null) {
+      super(
+        `Invalid timestamp ${version} for migration file: ${name}.\nTimestamp must be in form YYYYMMDDHHMMSS, and less than ${limit}.`,
+      );
+    } else {
+      super(
+        `Invalid timestamp for migration.\nTimestamp must be in form YYYYMMDDHHMMSS, and less than ${limit}.`,
+      );
+    }
     this.name = "InvalidMigrationTimestampError";
   }
 }
@@ -556,26 +580,29 @@ export abstract class Migration {
           force?: boolean | "cascade";
           ifNotExists?: boolean;
           default?: unknown;
+          as?: string;
         }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
+    const tname = Migration.properTableName(name, Migration.tableNameOptions());
     if (this._recording) {
-      this._recorder.record("createTable", [name, optionsOrFn, fn]);
+      this._recorder.record("createTable", [tname, optionsOrFn, fn]);
       return;
     }
-    await this.schema.createTable(name, optionsOrFn, fn);
+    await this.schema.createTable(tname, optionsOrFn, fn);
   }
 
   async dropTable(name: string, options?: { ifExists?: boolean }): Promise<void> {
+    const tname = Migration.properTableName(name, Migration.tableNameOptions());
     if (this._recording) {
-      this._recorder.record("dropTable", [name]);
+      this._recorder.record("dropTable", [tname]);
       return;
     }
     if (options) {
-      await this.schema.dropTable(name, options);
+      await this.schema.dropTable(tname, options);
     } else {
-      await this.schema.dropTable(name);
+      await this.schema.dropTable(tname);
     }
   }
 
@@ -1266,7 +1293,10 @@ export abstract class Migration {
   }
 
   static tableNameOptions(): { tableNamePrefix: string; tableNameSuffix: string } {
-    return { tableNamePrefix: "", tableNameSuffix: "" };
+    return {
+      tableNamePrefix: _arConfig?.tableNamePrefix ?? "",
+      tableNameSuffix: _arConfig?.tableNameSuffix ?? "",
+    };
   }
 
   static async copy(
@@ -1451,6 +1481,7 @@ export class MigrationContext {
       default?: unknown;
       options?: string;
       comment?: string;
+      as?: string;
     },
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
@@ -1469,10 +1500,11 @@ export class MigrationContext {
       return;
     }
     const td = new TableDefinition(name, {
-      id: options?.id,
+      id: options?.as != null ? false : options?.id,
       default: options?.default,
       options: options?.options,
       comment: options?.comment,
+      as: options?.as,
       adapterName: this._adapterName,
       adapter: this.adapter,
     });
@@ -1512,7 +1544,7 @@ export class MigrationContext {
         scale?: number | null;
       }
     >();
-    if (options?.id !== false) {
+    if (options?.id !== false && options?.as == null) {
       const idType = typeof options?.id === "string" ? options.id : "integer";
       meta.set("id", { type: idType, primaryKey: true });
     }
@@ -1907,6 +1939,8 @@ export interface MigrationProxy {
 }
 
 export class Migrator {
+  static validateMigrationTimestamps = false;
+
   private _adapter: DatabaseAdapter;
   private _migrations: MigrationProxy[];
   private _schemaMigration: SchemaMigration;
@@ -2356,12 +2390,16 @@ export class Migrator {
   private validate(migrations: MigrationProxy[]): void {
     const versions = new Set<string>();
     const names = new Set<string>();
+    const validateTs = this.isValidateTimestamp();
 
     for (const m of migrations) {
       if (!m.version || !/^\d+$/.test(m.version)) {
         throw new MigrationError(
           `Invalid migration version: ${m.version}. Version must be a numeric string.`,
         );
+      }
+      if (validateTs && !this.isValidMigrationTimestamp(m.version)) {
+        throw new InvalidMigrationTimestampError(m.version, m.name);
       }
       const normalized = String(BigInt(m.version));
       if (versions.has(normalized)) {
@@ -2717,9 +2755,9 @@ export class Migrator {
   // Rails: MigrationContext#validate_timestamp?
   /** @internal */
   isValidateTimestamp(): boolean {
-    // Rails: ActiveRecord.timestamped_migrations (default true) && ActiveRecord.validate_migration_timestamps (default false)
-    // true && false = false, so false is the correct default until these config flags are wired.
-    return false;
+    return (
+      (_arConfig?.validateMigrationTimestamps ?? false) || Migrator.validateMigrationTimestamps
+    );
   }
 
   // Rails: MigrationContext#valid_migration_timestamp?


### PR DESCRIPTION
## Summary

Migration cluster Slot B from `docs/activerecord-100-clusters.md`. Wires up three gaps + un-skips 6 tests.

- **tableNamePrefix / tableNameSuffix on Migration**: every `Migration` schema method (`createTable`, `dropTable`, `addColumn`, `removeColumn`, `renameColumn`, `addIndex`, `removeIndex`, `changeColumn`, `renameTable`, `addReference`, `removeReference`, `addForeignKey`, `removeForeignKey`, `addCheckConstraint`, `removeCheckConstraint`, `changeColumn{Default,Null}`, `addTimestamps`, `removeTimestamps`, `renameIndex`, `indexName`, `tableExists`, `columnExists`, `createJoinTable`, `dropJoinTable`) now flows its table-name argument through `this._pt(name)`. Mirrors Rails' `Migration#method_missing` dispatch exactly: arg[0] always prefixed, plus arg[1] for `rename_table` and string-form `remove_foreign_key`. `Migration.tableNameOptions()` reads from `Base.tableNamePrefix`/`tableNameSuffix` via a registry (`registerMigrationArConfig`) wired in `base.ts` to break the migration → base circular import.
- **CTAS support**: `MigrationContext.createTable` accepts an `as: string` option that creates `CREATE TABLE … AS SELECT …`. `TableDefinition.toSql()` already supported `as`; this plumbs the option through and forces `id: false` when `as` is set.
- **InvalidMigrationTimestampError**: constructor matches Rails' two-arg form `(version, name)` with the multi-line message format. Raised in `Migrator.validate` when `Migrator.validateMigrationTimestamps` is enabled and a version is malformed or further than one day in the future.
- **Bonus**: `TableDefinition.toSql()` column-type switch gets a `default` case that passes unknown types through as-is — Rails accepts arbitrary type strings (`t.column :foo, :bar`).

## Un-skips (6)

- `add drop table with prefix and suffix`
- `create table with query`
- `create table with query from relation`
- `allows sqlite3 rollback on invalid column type`
- `migration raises if timestamp is future date`
- `generate migrator advisory lock id`

## Test plan

- [x] `pnpm test packages/activerecord/src/migration.test.ts` — 162 passed, 23 skipped (down from 29)
- [x] `pnpm api:compare --package activerecord` — `migration.rb` 92/94 (98%), overall AR 99.8%
- [x] LOC: 209 additions / 47 deletions (256 total, under 300 ceiling)