### PR TITLE
chore(activerecord) type audit W2d+W2e — model-schema SchemaHost + builder AssociationInstanceHost

### DIFF
--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -8,6 +8,29 @@
 import * as Reflection from "../../reflection.js";
 import { beforeDestroy } from "../../callbacks.js";
 
+/**
+ * Minimal instance shape for model instances that host association accessors.
+ * @internal
+ */
+export interface AssociationInstanceHost {
+  association(name: string): AssociationProxyLike;
+}
+
+/** @internal */
+export interface AssociationProxyLike {
+  reader: unknown;
+  writer(value: unknown): void;
+  idsReader(): unknown;
+  idsWriter(ids: unknown): void;
+  forceReloadReader(): unknown;
+  reset(): unknown;
+  build(...args: unknown[]): unknown;
+  create(...args: unknown[]): unknown;
+  createBang(...args: unknown[]): unknown;
+  isTargetChanged(): boolean;
+  isTargetPreviouslyChanged(): boolean;
+}
+
 type ExtensionModule = {
   validOptions?: () => string[];
   build?: (model: any, reflection: any) => void;
@@ -140,7 +163,7 @@ export class Association {
       // Rails: proc { instance_exec(&scope) }
       // When scopeFor calls scope.call(relation, owner), `this` is the relation.
       // 0-arity scopes ignore the owner arg and execute with relation as context.
-      return function (this: any) {
+      return function (this: unknown) {
         return orig.call(this);
       };
     }
@@ -200,7 +223,7 @@ export class Association {
     const existing = Object.getOwnPropertyDescriptor(mixin, name);
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, name, {
-      get(this: any) {
+      get(this: AssociationInstanceHost) {
         return this.association(name).reader;
       },
       set: existing?.set,
@@ -214,7 +237,7 @@ export class Association {
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, name, {
       get: existing?.get,
-      set(this: any, value: any) {
+      set(this: AssociationInstanceHost, value: unknown) {
         this.association(name).writer(value);
       },
       configurable: true,

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,4 +1,5 @@
 import { underscore, pluralize, camelize } from "@blazetrails/activesupport";
+import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
 import { resolveModel, modelRegistry } from "../../associations.js";
@@ -333,13 +334,13 @@ export class BelongsTo extends SingularAssociation {
     for (const [methodName, impl] of [
       [
         `${name}Changed`,
-        function (this: any) {
+        function (this: AssociationInstanceHost) {
           return this.association(name).isTargetChanged();
         },
       ],
       [
         `${name}PreviouslyChanged`,
-        function (this: any) {
+        function (this: AssociationInstanceHost) {
           return this.association(name).isTargetPreviouslyChanged();
         },
       ],

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -1,5 +1,6 @@
 import { singularize } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
+import type { AssociationInstanceHost } from "./association.js";
 import { association } from "../../associations.js";
 
 const CALLBACKS = ["beforeAdd", "afterAdd", "beforeRemove", "afterRemove"] as const;
@@ -114,7 +115,7 @@ export class CollectionAssociation extends Association {
     const idsName = `${singularize(name)}Ids`;
     if (!(idsName in mixin)) {
       Object.defineProperty(mixin, idsName, {
-        get(this: any) {
+        get(this: AssociationInstanceHost) {
           return this.association(name).idsReader();
         },
         configurable: true,
@@ -130,7 +131,7 @@ export class CollectionAssociation extends Association {
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, idsName, {
       get: existing?.get,
-      set(this: any, ids: any) {
+      set(this: AssociationInstanceHost, ids: unknown) {
         this.association(name).idsWriter(ids);
       },
       configurable: true,

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -1,6 +1,5 @@
 import { singularize } from "@blazetrails/activesupport";
-import { Association } from "./association.js";
-import type { AssociationInstanceHost } from "./association.js";
+import { Association, type AssociationInstanceHost } from "./association.js";
 import { association } from "../../associations.js";
 
 const CALLBACKS = ["beforeAdd", "afterAdd", "beforeRemove", "afterRemove"] as const;

--- a/packages/activerecord/src/associations/builder/singular-association.ts
+++ b/packages/activerecord/src/associations/builder/singular-association.ts
@@ -1,4 +1,5 @@
 import { Association } from "./association.js";
+import type { AssociationInstanceHost } from "./association.js";
 
 function defineMethod(mixin: any, methodName: string, fn: (...args: any[]) => any): void {
   if (!mixin || typeof mixin !== "object") return;
@@ -31,24 +32,36 @@ export class SingularAssociation extends Association {
       this.defineConstructors(mixin, name);
     }
 
-    defineMethod(mixin, `reload${cap}`, function (this: any) {
+    defineMethod(mixin, `reload${cap}`, function (this: AssociationInstanceHost) {
       return this.association(name).forceReloadReader();
     });
-    defineMethod(mixin, `reset${cap}`, function (this: any) {
+    defineMethod(mixin, `reset${cap}`, function (this: AssociationInstanceHost) {
       return this.association(name).reset();
     });
   }
 
   static defineConstructors(mixin: any, name: string): void {
     const cap = name.charAt(0).toUpperCase() + name.slice(1);
-    defineMethod(mixin, `build${cap}`, function (this: any, ...args: any[]) {
-      return this.association(name).build(...args);
-    });
-    defineMethod(mixin, `create${cap}`, function (this: any, ...args: any[]) {
-      return this.association(name).create(...args);
-    });
-    defineMethod(mixin, `create${cap}Bang`, function (this: any, ...args: any[]) {
-      return this.association(name).createBang(...args);
-    });
+    defineMethod(
+      mixin,
+      `build${cap}`,
+      function (this: AssociationInstanceHost, ...args: unknown[]) {
+        return this.association(name).build(...args);
+      },
+    );
+    defineMethod(
+      mixin,
+      `create${cap}`,
+      function (this: AssociationInstanceHost, ...args: unknown[]) {
+        return this.association(name).create(...args);
+      },
+    );
+    defineMethod(
+      mixin,
+      `create${cap}Bang`,
+      function (this: AssociationInstanceHost, ...args: unknown[]) {
+        return this.association(name).createBang(...args);
+      },
+    );
   }
 }

--- a/packages/activerecord/src/associations/builder/singular-association.ts
+++ b/packages/activerecord/src/associations/builder/singular-association.ts
@@ -1,5 +1,4 @@
-import { Association } from "./association.js";
-import type { AssociationInstanceHost } from "./association.js";
+import { Association, type AssociationInstanceHost } from "./association.js";
 
 function defineMethod(mixin: any, methodName: string, fn: (...args: any[]) => any): void {
   if (!mixin || typeof mixin !== "object") return;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -199,7 +199,7 @@ export function getInheritanceColumn(modelClass: typeof Base): string | null {
 /**
  * Check if a model class is an STI subclass (not the base STI class).
  */
-export function isStiSubclass(modelClass: typeof Base): boolean {
+export function isStiSubclass(modelClass: object): boolean {
   // Walk up the prototype chain to find if any parent has _inheritanceColumn
   let current = Object.getPrototypeOf(modelClass);
   while (current && current !== Function.prototype) {
@@ -251,9 +251,9 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 /**
  * Get the STI base class for a model.
  */
-export function getStiBase(modelClass: typeof Base): typeof Base {
-  let current = modelClass;
-  let base = modelClass;
+export function getStiBase(modelClass: object): typeof Base {
+  let current = modelClass as typeof Base;
+  let base = current;
   while (current && current !== Function.prototype) {
     if ((current as any)._inheritanceColumn) {
       base = current;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -141,7 +141,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   if (this.abstractClass) {
     throw new Error(`Cannot call columnsHash on abstract class ${this.name}`);
   }
-  loadSchema.call(this as unknown as SchemaHost);
+  loadSchema.call(this as SchemaHost);
 
   // STI-aware adapter + table resolution: adapter may live on the base
   // OR the concrete subclass. Use the same candidate-list logic the
@@ -153,13 +153,13 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   let adapter: DatabaseAdapterLike | null = null;
   for (const cand of candidates) {
     try {
-      adapter = (cand as typeof Base).adapter as unknown as DatabaseAdapterLike;
+      adapter = cand.adapter as DatabaseAdapterLike;
     } catch {
       adapter = null;
     }
     if (adapter) break;
   }
-  const cache = (adapter as unknown as { schemaCache?: unknown } | null)?.schemaCache as
+  const cache = adapter?.schemaCache as
     | {
         isCached?: (t: string) => boolean;
         getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined;
@@ -362,7 +362,7 @@ interface SchemaHost {
   _attributesBuilder?: any;
   _schemaLoaded?: boolean;
   adapter: any;
-  prototype: any;
+  prototype: Record<string, unknown>;
   superclass?: SchemaHost;
   hookAttributeType?(name: string, type: Type): Type;
 }
@@ -451,20 +451,15 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
 
   // STI: write cache to the base so subclasses inherit via prototype
   // chain, and a base reset propagates automatically.
-  const cacheHost = isStiSubclass(this as unknown as typeof Base)
-    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
-    : this;
+  const cacheHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
   cacheHost._attributesBuilder = new AttributeSetBuilder(types, defaults);
   // If we are an STI subclass, resetDefaultAttributes() may have placed an
   // own-property shadow of `undefined` on `this` to block stale inheritance.
   // Now that cacheHost has a fresh builder, remove the shadow so subsequent
   // calls on this STI subclass find cacheHost's builder via prototype chain
   // instead of rebuilding on every access.
-  if (
-    cacheHost !== (this as unknown) &&
-    Object.prototype.hasOwnProperty.call(this, "_attributesBuilder")
-  ) {
-    delete (this as unknown as Record<string, unknown>)._attributesBuilder;
+  if (cacheHost !== this && Object.prototype.hasOwnProperty.call(this, "_attributesBuilder")) {
+    delete this._attributesBuilder;
   }
   return cacheHost._attributesBuilder;
 }
@@ -476,9 +471,7 @@ export function columns(this: SchemaHost): any[] {
   if (this._columns) return this._columns;
   loadSchema.call(this);
   const hash = getColumnsHash(this);
-  const cacheHost = isStiSubclass(this as unknown as typeof Base)
-    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
-    : this;
+  const cacheHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
   cacheHost._columns = Object.values(hash);
   return cacheHost._columns!;
 }
@@ -516,12 +509,10 @@ export function resetColumnInformation(this: SchemaHost): void {
   // STI subclasses share the base's defs. Redirect the reset to the base
   // so schema-sourced defs and accessors are actually cleared; clear the
   // subclass-local caches too so any forked metadata is dropped.
-  if (isStiSubclass(this as unknown as typeof Base)) {
-    const subCaches = this as SchemaHost & { _cachedDefaultAttributes?: unknown };
+  if (isStiSubclass(this)) {
     // Delete own properties rather than assigning undefined/false, so
     // the subclass inherits the base's freshly-rebuilt caches via the
     // prototype chain instead of shadowing them.
-    const sub = subCaches as unknown as Record<string, unknown>;
     for (const key of [
       "_columnsHash",
       "_columns",
@@ -529,7 +520,7 @@ export function resetColumnInformation(this: SchemaHost): void {
       "_schemaLoaded",
       "_cachedDefaultAttributes",
     ]) {
-      if (Object.prototype.hasOwnProperty.call(sub, key)) delete sub[key];
+      if (Object.prototype.hasOwnProperty.call(this, key)) Reflect.deleteProperty(this, key);
     }
     // Scrub schema-sourced entries from any subclass-forked
     // _attributeDefinitions too (from a prior attribute() /
@@ -539,16 +530,13 @@ export function resetColumnInformation(this: SchemaHost): void {
       for (const [name, def] of Array.from(this._attributeDefinitions)) {
         if ((def.userProvided ?? true) === false || def.source === "schema") {
           this._attributeDefinitions.delete(name);
-          const proto = (this as unknown as { prototype: object }).prototype;
-          if (Object.prototype.hasOwnProperty.call(proto, name)) {
-            delete (proto as Record<string, unknown>)[name];
+          if (Object.prototype.hasOwnProperty.call(this.prototype, name)) {
+            delete this.prototype[name];
           }
         }
       }
     }
-    resetColumnInformation.call(
-      getStiBase(this as unknown as typeof Base) as unknown as SchemaHost,
-    );
+    resetColumnInformation.call(getStiBase(this) as SchemaHost);
     return;
   }
   this._columnsHash = undefined;
@@ -560,9 +548,8 @@ export function resetColumnInformation(this: SchemaHost): void {
   for (const [name, def] of Array.from(this._attributeDefinitions)) {
     if ((def.userProvided ?? true) === false || def.source === "schema") {
       this._attributeDefinitions.delete(name);
-      const proto = (this as unknown as { prototype: object }).prototype;
-      if (Object.prototype.hasOwnProperty.call(proto, name)) {
-        delete (proto as Record<string, unknown>)[name];
+      if (Object.prototype.hasOwnProperty.call(this.prototype, name)) {
+        delete this.prototype[name];
       }
     }
   }
@@ -588,11 +575,9 @@ export function loadSchema(this: SchemaHost): void {
   // so subclasses inherit the flag via the prototype chain. Assigning
   // on the subclass would shadow the base flag and prevent re-reflection
   // when the base is reset. Delete any stale own-flag on the subclass.
-  const workHost = isStiSubclass(this as unknown as typeof Base)
-    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
-    : this;
+  const workHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
   if (workHost !== this && Object.prototype.hasOwnProperty.call(this, "_schemaLoaded")) {
-    delete (this as unknown as Record<string, unknown>)._schemaLoaded;
+    delete this._schemaLoaded;
   }
 
   const reflected = loadSchemaFromCacheSync(this);
@@ -669,17 +654,15 @@ function applyColumnsHash(
       // respects the ignore. Only drop the attribute def when it's
       // schema-sourced — user-declared defs survive `ignoredColumns`
       // per base.test.ts semantics.
-      const proto = (host as unknown as { prototype: object }).prototype;
-      if (Object.prototype.hasOwnProperty.call(proto, name)) {
-        delete (proto as Record<string, unknown>)[name];
+      if (Object.prototype.hasOwnProperty.call(host.prototype, name)) {
+        delete host.prototype[name];
       }
       // STI: also strip a subclass-owned accessor if the originating
       // host declared the attribute on itself, or `"col" in record` on
       // the subclass would still return true.
       if (originatingHost && originatingHost !== host) {
-        const subProto = (originatingHost as unknown as { prototype: object }).prototype;
-        if (Object.prototype.hasOwnProperty.call(subProto, name)) {
-          delete (subProto as Record<string, unknown>)[name];
+        if (Object.prototype.hasOwnProperty.call(originatingHost.prototype, name)) {
+          delete originatingHost.prototype[name];
         }
       }
       const existing = host._attributeDefinitions.get(name);
@@ -721,13 +704,12 @@ function applyColumnsHash(
     });
 
     if (name === "id") {
-      const proto = (host as unknown as { prototype: object }).prototype;
-      if (Object.prototype.hasOwnProperty.call(proto, "id")) {
-        delete (proto as Record<string, unknown>).id;
+      if (Object.prototype.hasOwnProperty.call(host.prototype, "id")) {
+        delete host.prototype.id;
       }
       continue;
     }
-    const proto = (host as unknown as { prototype: object }).prototype;
+    const proto = host.prototype;
     // Skip if this class or any parent prototype already has a custom accessor —
     // prevents schema reflection from overwriting an ignore_case (or other)
     // override that was installed on a parent class.
@@ -753,7 +735,6 @@ function applyColumnsHash(
     _columns?: unknown;
   };
   const invalidate = (h: SchemaHost, { deleteOwn }: { deleteOwn: boolean }) => {
-    const c = h as unknown as Record<string, unknown>;
     if (deleteOwn) {
       // Delete own properties so `h` inherits freshly-rebuilt caches
       // from its prototype chain (used for the STI subclass case).
@@ -763,11 +744,11 @@ function applyColumnsHash(
         "_columnsHash",
         "_columns",
       ]) {
-        if (Object.prototype.hasOwnProperty.call(c, key)) delete c[key];
+        if (Object.prototype.hasOwnProperty.call(h, key)) Reflect.deleteProperty(h, key);
       }
       return;
     }
-    const bag = c as CacheBag;
+    const bag = h as CacheBag;
     bag._attributesBuilder = undefined;
     bag._cachedDefaultAttributes = null;
     bag._columnsHash = undefined;
@@ -826,8 +807,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // STI base without forking. Use whichever class has the adapter
   // configured (base in normal Rails setup, but tolerate subclass-only
   // configuration).
-  const klass = this as unknown as typeof Base;
-  const schemaHost = isStiSubclass(klass) ? (getStiBase(klass) as unknown as SchemaHost) : this;
+  const schemaHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
 
   let startingAdapter: SchemaHost["adapter"] | undefined;
   let adapterOwner: SchemaHost | undefined;
@@ -846,7 +826,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (!startingAdapter || !adapterOwner) return;
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
-  const table = (schemaHost as unknown as typeof Base).tableName;
+  const table = schemaHost.tableName;
   const pool = startingAdapter.pool ?? startingAdapter;
 
   if (typeof cache.dataSourceExists === "function") {
@@ -887,9 +867,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   // STI subclasses share the base's table and attribute defs. Reflecting
   // on a subclass would fork _attributeDefinitions; instead, apply
   // reflection to the STI base so subclasses inherit it.
-  const schemaHost = isStiSubclass(host as unknown as typeof Base)
-    ? (getStiBase(host as unknown as typeof Base) as unknown as SchemaHost)
-    : host;
+  const schemaHost = isStiSubclass(host) ? (getStiBase(host) as SchemaHost) : host;
   // Adapter may be configured on the base OR on the subclass. Try base
   // first (Rails-normal), fall back to the originating host. Access can
   // throw when no pool is configured; treat as "no adapter".
@@ -906,7 +884,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (!adapter) return false;
   const cache = adapter.schemaCache;
   if (!cache || typeof cache.isCached !== "function") return false;
-  const table = (schemaHost as unknown as typeof Base).tableName;
+  const table = schemaHost.tableName;
   if (!cache.isCached(table)) return false;
   const hash =
     typeof cache.getCachedColumnsHash === "function"


### PR DESCRIPTION
## Summary

Type audit Wave 2 — W2d and W2e bundled (~137 LOC).

### W2d — \`model-schema.ts\` (31 \`as unknown\` eliminated)

**Root cause**: \`isStiSubclass\`/\`getStiBase\` required \`typeof Base\`, forcing double-cast via \`unknown\` throughout \`model-schema.ts\`.

**Fixes**:
- Widen \`isStiSubclass\`/\`getStiBase\` params from \`typeof Base\` → \`object\` in \`inheritance.ts\` — both functions only call \`Object.getPrototypeOf\`, the narrower constraint was unnecessary.
- Change \`SchemaHost.prototype: any\` → \`Record<string, unknown>\` so \`host.prototype\` access is direct (no cast needed).
- Use \`Reflect.deleteProperty(obj, key)\` for own-property deletion in STI cache invalidation — eliminates the \`as unknown as Record<string,unknown>\` escape hatch.
- Remove three trivially unnecessary casts: \`(schemaHost as unknown as typeof Base).tableName\` (SchemaHost already has \`tableName\`), \`cacheHost !== (this as unknown)\` (same-type comparison), and \`(adapter as unknown as {schemaCache?}).schemaCache\` (redundant re-cast).

### W2e — \`associations/builder/*.ts\` (12 \`this: any\` replaced)

- Declare \`AssociationInstanceHost\` + \`AssociationProxyLike\` (\`@internal\`) in \`association.ts\`.
- Replace \`this: any\` with \`this: AssociationInstanceHost\` in \`defineReaders\`, \`defineWriters\`, \`defineChangeTrackingMethods\`, and \`defineConstructors\`.
- One site retained (\`this: any\` in \`CollectionAssociation.defineReaders\` main getter): it passes \`this\` to the standalone \`association(record: Base, name)\` function which requires a \`Base\`-typed receiver. Wiring \`Base\` here would be circular; that site is a legitimate W3-era fix when \`Base\`-typed helpers get a narrower interface.

## Audit deltas

Measured on this branch vs \`main\` (which has W2a + W2b merged):

| signal | main | this branch | delta |
|---|---|---|---|
| \`as unknown\` | 270 | 239 | **−31** |
| \`this: any\` | 82 | 64 (pre-change) → 52 | **−12** (W2e) |

The \`as unknown\` reduction of 31 exceeds the 28 target because the \`isStiSubclass\`/\`getStiBase\` widening also eliminated a few cross-file casts that existed in the branch base alongside the model-schema.ts work.

## Validation

- \`pnpm --filter @blazetrails/activerecord test\` ✅
- \`pnpm test:types\` — 83/83 passed, no type errors ✅
- \`git diff --shortstat origin/main...HEAD ':!pnpm-lock.yaml'\` → 6 files, 90+/74− = 164 LOC ✅ (< 300)