### PR TITLE
feat(activerecord) PG long-tail Slot B — money column metadata + serialize

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -84,9 +84,16 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("money schema dump", async () => {
       const { SchemaDumper } = await import("../../connection-adapters/abstract/schema-dumper.js");
       const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_moneys");
-      expect(output).toMatch(/t\.column\("wealth", "money"/);
-      expect(output).toMatch(/t\.column\("depth", "money"/);
+      expect(output).toMatch(/t\.money\("wealth"/);
+      expect(output).toMatch(/t\.money\("depth"/);
       expect(output).toContain("scale: 2");
+    });
+
+    it("schema dumping", async () => {
+      const { SchemaDumper } = await import("../../connection-adapters/abstract/schema-dumper.js");
+      const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_moneys");
+      expect(output).toMatch(/t\.money\("wealth",\s*\{[^}]*scale:\s*2/);
+      expect(output).toMatch(/t\.money\("depth",\s*\{[^}]*default:\s*150\.55[^}]*scale:\s*2/);
     });
 
     it("money where", async () => {
@@ -158,25 +165,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number(negative[0].wealth)).toBeCloseTo(-567.89, 2);
     });
 
-    // Needs ActiveRecord type system
-    it.skip("money regex backtracking", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in money
-      // ROOT-CAUSE: connection-adapters/postgresql/money.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/money.ts; affects ~10–47 tests in money.test.ts
+    it("money regex backtracking", async () => {
+      // Rails: test_money_regex_backtracking — verifies no catastrophic backtracking (ReDoS)
+      // on long repeated-separator inputs by running within a Timeout.timeout(0.1).
+      // JS fix: replaced \D* with [^0-9,.] in castValue regex (money.ts).
+      const type = new Money();
+      const commas = ",".repeat(100000);
+      const dots = ".".repeat(100000);
+      expect(Number(type.cast("$" + commas + ".11!") ?? 0)).toBeCloseTo(0, 2);
+      expect(Number(type.cast("$" + dots + ",11!") ?? 0)).toBeCloseTo(0, 2);
     });
 
-    // Needs ORM layer (sum with expressions)
+    // Needs ORM layer (Relation#sum with type cast)
     it.skip("sum with type cast", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in money
-      // ROOT-CAUSE: connection-adapters/postgresql/money.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/money.ts; affects ~10–47 tests in money.test.ts
+      // BLOCKED: relation
+      // ROOT-CAUSE: Relation#sum — no type-cast applied to SQL expressions (e.g. PostgresqlMoney.sum("id * wealth"))
+      // SCOPE: ~100 LOC in relation/calculations.ts; affects ~2 tests in money.test.ts
     });
 
-    // Needs ORM layer (pluck)
+    // Needs ORM layer (Relation#pluck with type cast)
     it.skip("pluck with type cast", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in money
-      // ROOT-CAUSE: connection-adapters/postgresql/money.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/money.ts; affects ~10–47 tests in money.test.ts
+      // BLOCKED: relation
+      // ROOT-CAUSE: Relation#pluck — no type-cast applied to Arel.sql expressions (e.g. PostgresqlMoney.pluck(Arel.sql("id * wealth")))
+      // SCOPE: ~100 LOC in relation/calculations.ts; affects ~2 tests in money.test.ts
     });
 
     it("create and update money", async () => {
@@ -211,11 +222,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number(rows[0].wealth)).toBeCloseTo(987.65, 2);
     });
 
-    // Needs ORM layer (BigDecimal handling)
+    // Needs ORM layer (Relation#update_all with BigDecimal cast)
     it.skip("update all with money big decimal", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in money
-      // ROOT-CAUSE: connection-adapters/postgresql/money.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/money.ts; affects ~10–47 tests in money.test.ts
+      // BLOCKED: relation
+      // ROOT-CAUSE: Relation#update_all — BigDecimal values not serialized via Money#serialize before SQL binding
+      // SCOPE: ~50 LOC in relation.ts or relation/query-methods.ts; affects ~1 test in money.test.ts
     });
 
     it("update all with money numeric", async () => {

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -165,17 +165,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number(negative[0].wealth)).toBeCloseTo(-567.89, 2);
     });
 
-    it("money regex backtracking", async () => {
-      // Rails: test_money_regex_backtracking — verifies no catastrophic backtracking (ReDoS)
-      // on long repeated-separator inputs by running within a Timeout.timeout(0.1).
-      // JS fix: replaced \D* with [^0-9,.] in castValue regex (money.ts).
-      const type = new Money();
-      const commas = ",".repeat(100000);
-      const dots = ".".repeat(100000);
-      expect(Number(type.cast("$" + commas + ".11!") ?? 0)).toBeCloseTo(0, 2);
-      expect(Number(type.cast("$" + dots + ",11!") ?? 0)).toBeCloseTo(0, 2);
-    });
-
     // Needs ORM layer (Relation#sum with type cast)
     it.skip("sum with type cast", async () => {
       // BLOCKED: relation
@@ -245,6 +234,14 @@ describeIfPg("PostgreSQLAdapter", () => {
 // Unit-level tests that don't need a live PG connection — Rails test
 // names so api:compare matches.
 describe("PostgresqlMoneyTest", () => {
+  it("money regex backtracking", () => {
+    // Ruby uses possessive quantifiers (\D*+) to prevent ReDoS; JS has none.
+    // [^0-9,.] in the prefix avoids overlap with [\d,]+ / [\d.]+ so no O(n²) path.
+    const type = new Money();
+    expect(Number(type.cast("$" + ",".repeat(100000) + ".11!"))).toBeCloseTo(0, 2);
+    expect(Number(type.cast("$" + ".".repeat(100000) + ",11!"))).toBeCloseTo(0, 2);
+  });
+
   it("money type cast", () => {
     const type = new Money();
     for (const [str, num] of [

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
@@ -57,10 +57,14 @@ export class Money extends DecimalType {
     // (4) (2.55) → -2.55
     let str = value.replace(/^\((.+)\)$/, "-$1");
 
-    if (/^-?\D*[\d,]+\.\d{2}$/.test(str)) {
+    // Use [^0-9,.] for the currency-symbol prefix instead of \D* to prevent
+    // catastrophic backtracking (ReDoS) — \D* overlaps with [\d,]+ and [\d.]+
+    // causing O(n²) backtracking on long repeated-separator inputs. Ruby avoids
+    // this with possessive quantifiers (\D*+); JS has no possessive quantifiers.
+    if (/^-?[^0-9,.]*[\d,]+\.\d{2}$/.test(str)) {
       // (1) US format: keep digits/minus/dot, drop everything else.
       str = str.replace(/[^\-0-9.]/g, "");
-    } else if (/^-?\D*[\d.]+,\d{2}$/.test(str)) {
+    } else if (/^-?[^0-9,.]*[\d.]+,\d{2}$/.test(str)) {
       // (2) EU format: drop non-digit/minus/comma, then comma → dot.
       str = str.replace(/[^\-0-9,]/g, "").replace(/,/g, ".");
     }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -195,6 +195,7 @@ const DSL_HELPER_METHODS = new Set([
   "json",
   "jsonb",
   "citext",
+  "money",
   "int4range",
   "int8range",
   "numrange",


### PR DESCRIPTION
## Summary

- **ReDoS fix** in `OID::Money#castValue`: replaced `\D*` with `[^0-9,.]` in both format-detection regexes. The original regex caused O(n²) backtracking on long repeated-separator inputs (e.g. `"$" + "." * 100000 + ",11!"`) because `\D*` and `[\d.]+` overlap on `.`. Ruby sidesteps this with possessive quantifiers (`\D*+`); JS has none. Unblocks "money regex backtracking" (un-skipped).
- **Schema dumper** now emits `t.money(...)` instead of `t.column(..., "money")`: added `"money"` to `DSL_HELPER_METHODS`. SQL_TYPE_MAP already had the right mapping; the DSL gate was the only missing piece. Added a "schema dumping" test to match Rails' `test_schema_dumping`.
- **BLOCKED annotation sharpening**: retagged "sum with type cast", "pluck with type cast", and "update all with money big decimal" from the stale `adapter-pg` template to `BLOCKED: relation` with specific ROOT-CAUSE and SCOPE lines.

## Follow-ups (out of scope)

- "sum with type cast", "pluck with type cast": `BLOCKED: relation` — `Relation#sum` / `Relation#pluck` need type-cast on SQL expressions.
- "update all with money big decimal": `BLOCKED: relation` — `Relation#update_all` needs BigDecimal→money serialization.