### PR TITLE
feat(activerecord) Relation Slot A — WhereClause association predicates (core)

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -129,6 +129,22 @@ export class PredicateBuilder {
           ? assocPb.buildNegatedFromHash(value as Record<string, unknown>)
           : assocPb.buildFromHash(value as Record<string, unknown>);
         nodes.push(...innerNodes);
+      } else if (
+        !isPlainObject(value) &&
+        this._tableContext &&
+        typeof this._tableContext.isAssociatedWith === "function" &&
+        typeof this._tableContext.associatedTable === "function" &&
+        this._tableContext.isAssociatedWith(key) &&
+        !this._tableContext.hasColumn?.(key)
+      ) {
+        const assocNodes = this.buildFromHashAssociation(
+          this._tableContext.associatedTable(key),
+          key,
+          value,
+          negated,
+          conditions,
+        );
+        nodes.push(...assocNodes);
       } else {
         const attr = this.resolveColumn(key);
         nodes.push(negated ? this.buildNegated(attr, value) : this.build(attr, value));
@@ -145,7 +161,73 @@ export class PredicateBuilder {
       const arrayValue = Array.isArray(value) ? value : [value];
       return new PolymorphicArrayValue(assoc.foreignKey, assoc.foreignType, arrayValue).queries();
     }
-    return new AssociationQueryValue(assoc.foreignKey, value).queries();
+    return new AssociationQueryValue(
+      { joinForeignKey: assoc.foreignKey, joinPrimaryKey: "id" },
+      value,
+    ).queries();
+  }
+
+  /** @internal */
+  private buildFromHashAssociation(
+    associatedTable: any,
+    key: string,
+    value: unknown,
+    negated: boolean,
+    attributes: Record<string, unknown>,
+  ): Nodes.Node[] {
+    // Polymorphic — Slot B. Attempting to build on the association name (not a real column)
+    // produces incorrect SQL; throw a clear error instead.
+    if (associatedTable.isPolymorphicAssociation?.()) {
+      throw new Error(
+        `Polymorphic association '${key}' is not yet supported in where() (Slot B). ` +
+          "Use explicit _id and _type conditions instead.",
+      );
+    }
+    // Through: delegate with the associated model's primary key (Rails: through_association? path).
+    // Always build positively — negation is applied once at the group level below (mirrors Rails
+    // expand_from_hash which never recurses with negation).
+    if (associatedTable.isThroughAssociation?.()) {
+      const rawPk = associatedTable.klass?.primaryKey ?? "id";
+      if (Array.isArray(rawPk)) {
+        throw new Error(
+          "Through-association with composite primary key is not yet supported (Slot B). " +
+            "Use explicit FK conditions instead.",
+        );
+      }
+      // Normalize value through AssociationQueryValue so records are coerced to their PKs,
+      // arrays of records become id lists, and Relations become subqueries — matching Rails'
+      // build() which does `value = value.id if value.respond_to?(:id)` before dispatching.
+      const normalizedQueries = new AssociationQueryValue(
+        { joinForeignKey: rawPk, joinPrimaryKey: rawPk },
+        value,
+      ).queries();
+      const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
+      const inner = normalizedQueries.flatMap((q) => assocPb.buildFromHash(q));
+      if (inner.length === 0) return [];
+      const group = inner.length === 1 ? inner[0] : new Nodes.And(inner);
+      return negated ? [new Nodes.Not(new Nodes.Grouping(group))] : [group];
+    }
+    // Core non-polymorphic, non-through path.
+    // Rails expand_from_hash is always positive; negation is applied once at the group level.
+    const queries = new AssociationQueryValue(associatedTable, value).queries();
+    const groups: Nodes.Node[] = [];
+    for (const query of queries) {
+      // Cycle guard: prevents infinite recursion when FK name == association name.
+      if (isSameHash(query, attributes)) {
+        groups.push(this.build(this.resolveColumn(key), value));
+      } else {
+        const inner = this.buildFromHash(query);
+        if (inner.length === 0) continue;
+        groups.push(inner.length === 1 ? inner[0] : new Nodes.And(inner));
+      }
+    }
+    if (groups.length === 0) return [];
+    if (negated) return groups.map((g) => new Nodes.Not(new Nodes.Grouping(g)));
+    if (groups.length === 1) return groups;
+    const combined = groups.reduce((acc, g, i) =>
+      i === 0 ? g : new Nodes.Grouping(new Nodes.Or(acc, g)),
+    );
+    return [combined];
   }
 
   buildNegated(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
@@ -509,4 +591,25 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function isSameHash(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!(k in b) || !isSameValue(a[k], b[k])) return false;
+  }
+  return true;
+}
+
+// Value equality that matches Ruby hash equality: scalars by identity, arrays by element.
+// Needed so the FK-cycle guard catches cases like { author_id: [1] } == { author_id: [1] }
+// where AssociationQueryValue produces a new array each time (different reference, same content).
+function isSameValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => isSameValue(v, b[i]));
+  }
+  return false;
 }

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -1,81 +1,110 @@
 /**
  * Converts association-based where conditions into foreign key queries.
  * When you write `where({ author: authorRecord })`, this extracts
- * the foreign key and converts it to `where({ author_id: authorRecord.id })`.
+ * the foreign key and wraps the id in a single-element array so that
+ * `ArrayHandler`'s single-element path emits `author_id = ?` (not IN).
  *
  * Mirrors: ActiveRecord::PredicateBuilder::AssociationQueryValue
  *
- * Examples:
- *   where({ author: author })  → { author_id: author.id }
- *   where({ author: [a1, a2] }) → { author_id: [a1.id, a2.id] }
+ * Intermediate query hash shapes (before predicate building):
+ *   where({ author: author })         → { author_id: [author.id] }
+ *   where({ author: [a1, a2] })       → { author_id: [a1.id, a2.id] }
+ *   where({ author: Author.where(...) }) → { author_id: <subquery> }
  */
+
+/** Metadata about the associated table needed to build the FK predicate. */
+export interface AssocTableMeta {
+  joinForeignKey: string | string[];
+  joinPrimaryKey: string | string[] | null;
+}
+
 export class AssociationQueryValue {
-  private foreignKey: string;
-  private value: unknown;
-  private _associatedTable: {
-    joinForeignKey: string;
-    joinPrimaryKey?: string;
-    joinPrimaryType?: string;
-    polymorphicNameAssociation?: string;
-  } | null = null;
+  constructor(
+    private associatedTable: AssocTableMeta,
+    private value: unknown,
+  ) {}
 
-  constructor(foreignKey: string, value: unknown) {
-    this.foreignKey = foreignKey;
-    this.value = value;
+  queries(): Record<string, unknown>[] {
+    const fk = this.associatedTable.joinForeignKey;
+    if (Array.isArray(fk)) {
+      // CPK path — Slot B. Rails plucks primary_key from Relations then zips to FK tuples.
+      // Relation subqueries can't be represented as an object key (JS would stringify the array).
+      // Throw a clear error so the caller knows this is not yet supported rather than emitting
+      // a silently malformed hash.
+      const ids = this.ids();
+      if (this.isRelation(ids)) {
+        throw new Error(
+          "Composite foreign key with Relation value is not yet supported (Slot B). " +
+            "Use explicit FK conditions instead.",
+        );
+      }
+      // Rails zips each element of id_list with the FK columns (id_list.map { |ids_set| fk.zip(ids_set).to_h }).
+      // Each ids_set must be an array with the same arity as joinForeignKey. Non-tuple values
+      // (single record, scalar) cannot be safely distributed across multiple FK columns — throw
+      // rather than assigning the same value to every column (silently wrong SQL).
+      const idList = Array.isArray(ids) ? ids : [ids];
+      return idList.map((idsSet: any) => {
+        if (!Array.isArray(idsSet)) {
+          throw new Error(
+            `Composite foreign key association requires tuple values matching [${(fk as string[]).join(", ")}]. ` +
+              "Pass an array of [value1, value2, ...] tuples (Slot B).",
+          );
+        }
+        if (idsSet.length !== (fk as string[]).length) {
+          throw new Error(
+            `Composite FK tuple arity mismatch: expected ${(fk as string[]).length} values ` +
+              `([${(fk as string[]).join(", ")}]) but got ${idsSet.length}.`,
+          );
+        }
+        return (fk as string[]).reduce((acc: Record<string, unknown>, k: string, i: number) => {
+          acc[k] = idsSet[i];
+          return acc;
+        }, {});
+      });
+    }
+    return [{ [fk]: this.ids() }];
   }
 
-  private get associatedTable() {
-    return this._associatedTable;
+  /** @internal */
+  private ids(): unknown {
+    const value = this.value;
+    if (this.isRelation(value)) {
+      const pk = this.primaryKey();
+      if (!Array.isArray(pk) && this.isSelectClause(value)) {
+        return (value as any).select(pk);
+      }
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((v) => this.convertToId(v));
+    }
+    return [this.convertToId(value)];
   }
 
-  private primaryKey(): string {
-    return this._associatedTable?.joinPrimaryKey ?? "id";
+  private primaryKey(): string | string[] {
+    return this.associatedTable.joinPrimaryKey ?? "id";
   }
 
-  private primaryType(): string | null {
-    return this._associatedTable?.joinPrimaryType ?? null;
-  }
-
-  private polymorphicName(): string | null {
-    return this._associatedTable?.polymorphicNameAssociation ?? null;
-  }
-
-  private isSelectClause(): boolean {
-    if (!this.value) return false;
-    const sv = (this.value as any).selectValues;
-    if (typeof sv === "function") return sv.call(this.value).length === 0;
+  private isSelectClause(relation: unknown): boolean {
+    const sv = (relation as any).selectValues;
+    if (typeof sv === "function") return sv.call(relation).length === 0;
     if (Array.isArray(sv)) return sv.length === 0;
     return false;
   }
 
-  private isPolymorphicClause(): boolean {
-    const type = this.primaryType();
-    if (!type) return false;
-    if (this.value && typeof (this.value as any).whereValuesHash === "function") {
-      return !Object.prototype.hasOwnProperty.call((this.value as any).whereValuesHash(), type);
-    }
-    return false;
-  }
-
-  queries(): Record<string, unknown>[] {
-    return [{ [this.foreignKey]: this.ids() }];
-  }
-
-  private ids(): unknown {
-    const value = this.value;
-    if (Array.isArray(value)) {
-      return value.map((v) => this.convertToId(v));
-    }
-    return this.convertToId(value);
-  }
-
   private convertToId(value: unknown): unknown {
-    if (value === null || value === undefined) {
-      return null;
-    }
-    if (typeof value === "object" && value !== null && "id" in value) {
-      return (value as any).id;
+    if (value === null || value === undefined) return null;
+    const pk = this.primaryKey();
+    if (typeof pk === "string" && typeof value === "object" && value !== null) {
+      if (pk in (value as object)) return (value as any)[pk];
+      if ("id" in (value as object)) return (value as any).id;
     }
     return value;
+  }
+
+  private isRelation(value: unknown): boolean {
+    return (
+      typeof value === "object" && value !== null && "_modelClass" in value && "toArel" in value
+    );
   }
 }

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -368,11 +368,34 @@ describe("WhereTest", () => {
     const result = await Post.where({ views: new Range(1, 10, true) }).toArray();
     expect(result).toHaveLength(2);
   });
-  it.skip("where on association with custom primary key", () => {
-    // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)
-    // ROOT-CAUSE: relation/where-clause.ts#whereClauseFor missing association / polymorphic join
-    // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
-    /* needs association-scoped WHERE with automatic JOIN */
+  it("where on association with custom primary key", async () => {
+    class WoaAuthor extends Base {
+      static {
+        this._tableName = "woa_authors";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class WoaEssay extends Base {
+      static {
+        this._tableName = "woa_essays";
+        this.attribute("id", "integer");
+        this.attribute("writer_id", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("WoaAuthor", WoaAuthor);
+    Associations.belongsTo.call(WoaEssay, "writer", {
+      className: "WoaAuthor",
+      foreignKey: "writer_id",
+      primaryKey: "name",
+    });
+    const author = await WoaAuthor.create({ name: "David" });
+    await WoaEssay.create({ writer_id: "David" });
+    const essay = await WoaEssay.where({ writer: author }).first();
+    expect(essay).not.toBeNull();
+    expect(essay!.writer_id).toBe("David");
   });
   it.skip("where with association polymorphic", () => {
     // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)
@@ -392,11 +415,34 @@ describe("WhereTest", () => {
     // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
     /* Arel.star as hash key raises ArgumentError in Rails; behavior not yet validated */
   });
-  it.skip("where on association with relation", () => {
-    // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)
-    // ROOT-CAUSE: relation/where-clause.ts#whereClauseFor missing association / polymorphic join
-    // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
-    /* needs association-scoped subquery */
+  it("where on association with relation", async () => {
+    class WoarAuthor extends Base {
+      static {
+        this._tableName = "woar_authors";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class WoarPost extends Base {
+      static {
+        this._tableName = "woar_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("WoarAuthor", WoarAuthor);
+    Associations.belongsTo.call(WoarPost, "author", {
+      className: "WoarAuthor",
+      foreignKey: "author_id",
+    });
+    const author = await WoarAuthor.create({ name: "Alice" });
+    await WoarPost.create({ author_id: author.id });
+    await WoarPost.create({ author_id: null });
+    const result = await WoarPost.where({ author: WoarAuthor.where({ name: "Alice" }) }).toArray();
+    expect(result).toHaveLength(1);
+    expect(result[0].author_id).toBe(author.id);
   });
   it("where with numeric comparison", () => {
     class Post extends Base {
@@ -851,17 +897,107 @@ describe("WhereTest", () => {
     // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
     /* needs belongs_to with composite primary key — association infrastructure gap */
   });
-  it.skip("belongs to shallow where", () => {
-    // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)
-    // ROOT-CAUSE: relation/where-clause.ts#whereClauseFor missing association / polymorphic join
-    // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
-    /* needs belongs_to association with automatic JOIN */
+  it("belongs to shallow where", () => {
+    class BtsAuthor extends Base {
+      static {
+        this._tableName = "bts_authors";
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class BtsPost extends Base {
+      static {
+        this._tableName = "bts_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("BtsAuthor", BtsAuthor);
+    Associations.belongsTo.call(BtsPost, "author", {
+      className: "BtsAuthor",
+      foreignKey: "author_id",
+    });
+    const author = new BtsAuthor();
+    author.id = 1;
+    expect(BtsPost.where({ author_id: 1 }).toSql()).toEqual(
+      BtsPost.where({ author: author }).toSql(),
+    );
   });
-  it.skip("belongs to nested relation where", () => {
-    // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)
-    // ROOT-CAUSE: relation/where-clause.ts#whereClauseFor missing association / polymorphic join
-    // SCOPE: ~100 LOC in relation/where-clause.ts + associations/; affects ~39 tests in where.test.ts
-    /* needs belongs_to association with automatic JOIN */
+  it("belongs to nil where", () => {
+    class BtnAuthor extends Base {
+      static {
+        this._tableName = "btn_authors";
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class BtnPost extends Base {
+      static {
+        this._tableName = "btn_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("BtnAuthor", BtnAuthor);
+    Associations.belongsTo.call(BtnPost, "author", {
+      className: "BtnAuthor",
+      foreignKey: "author_id",
+    });
+    expect(BtnPost.where({ author_id: null }).toSql()).toEqual(
+      BtnPost.where({ author: null }).toSql(),
+    );
+  });
+  it("belongs to array value where", () => {
+    class BtavAuthor extends Base {
+      static {
+        this._tableName = "btav_authors";
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class BtavPost extends Base {
+      static {
+        this._tableName = "btav_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("BtavAuthor", BtavAuthor);
+    Associations.belongsTo.call(BtavPost, "author", {
+      className: "BtavAuthor",
+      foreignKey: "author_id",
+    });
+    expect(BtavPost.where({ author_id: [1, 2] }).toSql()).toEqual(
+      BtavPost.where({ author: [1, 2] }).toSql(),
+    );
+  });
+  it("belongs to nested relation where", () => {
+    class BtnrAuthor extends Base {
+      static {
+        this._tableName = "btnr_authors";
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class BtnrPost extends Base {
+      static {
+        this._tableName = "btnr_posts";
+        this.attribute("id", "integer");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("BtnrAuthor", BtnrAuthor);
+    Associations.belongsTo.call(BtnrPost, "author", {
+      className: "BtnrAuthor",
+      foreignKey: "author_id",
+    });
+    const expected = BtnrPost.where({ author_id: BtnrAuthor.where({ id: [1, 2] }) }).toSql();
+    const actual = BtnrPost.where({ author: BtnrAuthor.where({ id: [1, 2] }) }).toSql();
+    expect(actual).toEqual(expected);
   });
   it.skip("belongs to nested where", () => {
     // BLOCKED: relation — WHERE clause feature gap (polymorphic / association / composite-PK)


### PR DESCRIPTION
## Summary

- **\`AssociationQueryValue\`** refactored to accept \`AssocTableMeta\` (\`joinForeignKey\` + \`joinPrimaryKey\`) instead of a bare FK string — enables custom primary keys, Relation subselects, and arrays of records.
- **\`PredicateBuilder.buildFromHashInternal\`** gains a new branch that checks \`_tableContext.isAssociatedWith(key)\` for non-Hash values (records, arrays, Relations) and dispatches to \`buildFromHashAssociation\`.
- **\`buildFromHashAssociation\`** always builds FK predicates positively and applies negation once at the group level (matching Rails' \`expand_from_hash\` which never recurses with negation). Fixes a double-negation bug in \`whereNot(assoc: record)\`.
- **\`isSameHash\`** updated to compare array values element-by-element (not reference equality), so the FK-cycle guard correctly detects \`{ author_id: [1] } == { author_id: [1] }\` when association name equals FK column name.
- Unsupported paths (polymorphic, through+CPK, CPK+Relation, CPK non-tuple, CPK arity mismatch) throw clear \`Error\`s instead of emitting silently malformed SQL.
- Unskips 6 tests: \`belongs to shallow where\`, \`belongs to nil where\`, \`belongs to array value where\`, \`belongs to nested relation where\`, \`where on association with custom primary key\`, \`where on association with relation\`.

## Follow-ups (separate PRs)

- **Slot A-b**: custom-PK array/relation variants (\`with relation\`, \`with array of base\`, \`with array of ids\`, \`performs subselect not two queries\`)
- **Slot B**: polymorphic associations + CPK associations
- **Slot C**: \`WhereChain#associated\` / \`#missing\`

## Test plan

- [x] \`npx vitest run packages/activerecord/src/relation/where.test.ts\` → 119 passed | 35 skipped
- [x] \`npx vitest run packages/activerecord/src/relation/\` → all pass
- [x] \`pnpm run api:compare --package activerecord\` → 4944/4958 (99.7%), no regression
- [x] \`pnpm tsc --noEmit\` → clean