### PR TITLE
feat(activerecord) Migration Slot C — advisory-lock seams + Slot B followups (3+ unskips)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -86,6 +86,20 @@ describe("ReferenceDefinition helpers", () => {
   });
 });
 
+describe("TableDefinition#toSql blank type guard", () => {
+  it("throws a descriptive error for an empty custom type", () => {
+    const td = new TableDefinition("t", { id: false });
+    td.column("bad", "" as any);
+    expect(() => td.toSql()).toThrow(/Column "bad" has an empty or blank type/);
+  });
+
+  it("throws a descriptive error for a whitespace-only custom type", () => {
+    const td = new TableDefinition("t", { id: false });
+    td.column("bad", "   " as any);
+    expect(() => td.toSql()).toThrow(/Column "bad" has an empty or blank type/);
+  });
+});
+
 describe("TableDefinition#raise_on_duplicate_column", () => {
   it("raises when adding a duplicate non-pk column", () => {
     const td = new TableDefinition("t", { id: false });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -995,6 +995,11 @@ export class TableDefinition {
           parts.push(`CHAR(${col.options.limit ?? 1})`);
           break;
         default:
+          if (!col.type || !col.type.trim()) {
+            throw new Error(
+              `Column ${JSON.stringify(col.name)} has an empty or blank type — specify a valid SQL type`,
+            );
+          }
           // Pass arbitrary type strings through verbatim (case matters for PG enums).
           parts.push(col.type);
           break;

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterAll, afterEach, vi } from "vites
 import { Base, MigrationContext, MigrationRunner, Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
+import { ConcurrentMigrationError } from "./migration.js";
 import { createTestAdapter, adapterType } from "./test-adapter.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1691,51 +1692,105 @@ describe("MigrationTest", () => {
     },
   );
 
-  it.skip("migrator generates valid lock id", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
-  });
-
-  it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {
-    // Bypass the SchemaAdapter wrapper — generateMigratorAdvisoryLockId needs
-    // currentDatabase(), which lives on the real adapter (pg/mysql), not the wrapper.
+  it.skipIf(adapterType === "sqlite")("migrator generates valid lock id", async () => {
     const testAdapter = createTestAdapter();
     const realAdapter = testAdapter.innerAdapter;
     const migrator = new Migrator(realAdapter, []);
+    const lockId = await migrator.generateMigratorAdvisoryLockId();
+    expect(await (realAdapter as any).getAdvisoryLock(lockId)).toBe(true);
+    expect(await (realAdapter as any).releaseAdvisoryLock(lockId)).toBe(true);
+  });
+
+  it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {
+    const testAdapter = createTestAdapter();
+    const migrator = new Migrator(testAdapter, []);
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     // Must fit in a signed 63-bit integer
     expect(lockId).toBeGreaterThanOrEqual(0n);
     expect(lockId.toString(2).length).toBeLessThanOrEqual(63);
   });
 
-  it.skip("migrator one up with unavailable lock", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
+  it("migrator one up with unavailable lock", async () => {
+    const ran: string[] = [];
+    const proxy: MigrationProxy = {
+      version: "100",
+      name: "Broken",
+      migration: () => ({
+        up: async () => {
+          ran.push("ran");
+        },
+        down: async () => {},
+      }),
+    };
+    // Adapter that reports advisory lock support but always fails to acquire
+    const lockAdapter = {
+      adapterName: "sqlite" as const,
+      supportsAdvisoryLocks: () => true,
+      getAdvisoryLock: async (_id: unknown) => false,
+      releaseAdvisoryLock: async (_id: unknown) => true,
+      currentDatabase: async () => "test_db",
+      isNoDatabaseError: () => false,
+    } as unknown as DatabaseAdapter;
+    const migrator = new Migrator(lockAdapter, [proxy]);
+    await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
+    expect(ran).toEqual([]);
   });
 
-  it.skip("migrator one up with unavailable lock using run", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
+  it("migrator one up with unavailable lock using run", async () => {
+    const ran: string[] = [];
+    const proxy: MigrationProxy = {
+      version: "100",
+      name: "Broken",
+      migration: () => ({
+        up: async () => {
+          ran.push("ran");
+        },
+        down: async () => {},
+      }),
+    };
+    const lockAdapter = {
+      adapterName: "sqlite" as const,
+      supportsAdvisoryLocks: () => true,
+      getAdvisoryLock: async (_id: unknown) => false,
+      releaseAdvisoryLock: async (_id: unknown) => true,
+      currentDatabase: async () => "test_db",
+      isNoDatabaseError: () => false,
+    } as unknown as DatabaseAdapter;
+    const migrator = new Migrator(lockAdapter, [proxy]);
+    await expect(migrator.run("up", 100)).rejects.toThrow(ConcurrentMigrationError);
+    expect(ran).toEqual([]);
   });
 
-  it.skip("with advisory lock closes connection", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
+  it.skipIf(adapterType !== "postgres")("with advisory lock closes connection", async () => {
+    // PG-specific: verify the advisory lock query does not linger in pg_stat_activity.
+    // In JS there is no persistent lock connection to close, so we verify the lock
+    // is acquired and released around a no-op migration without leaving idle queries.
+    const testAdapter = createTestAdapter();
+    const proxy: MigrationProxy = {
+      version: "200",
+      name: "NoOp",
+      migration: () => ({ up: async () => {}, down: async () => {} }),
+    };
+    const migrator = new Migrator(testAdapter, [proxy]);
+    // Should complete without error — the advisory lock was acquired and released
+    await migrator.migrate();
+    expect(await migrator.getAllVersions()).toContain("200");
   });
 
-  it.skip("with advisory lock raises the right error when it fails to release lock", () => {
-    // BLOCKED: migration — migration runner gap in migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-    // Requires migration runner
+  it("with advisory lock raises the right error when it fails to release lock", async () => {
+    // Adapter that acquires the lock but refuses to release it (simulates stale lock)
+    const lockAdapter = {
+      adapterName: "sqlite" as const,
+      supportsAdvisoryLocks: () => true,
+      getAdvisoryLock: async (_id: unknown) => true,
+      releaseAdvisoryLock: async (_id: unknown) => false,
+      currentDatabase: async () => "test_db",
+      isNoDatabaseError: () => false,
+    } as unknown as DatabaseAdapter;
+    const migrator = new Migrator(lockAdapter, []);
+    const error = await migrator.withAdvisoryLock(async () => {}).catch((e) => e);
+    expect(error).toBeInstanceOf(ConcurrentMigrationError);
+    expect(error.message).toMatch(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);
   });
 
   it("out of range text limit should raise", () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1761,9 +1761,11 @@ describe("MigrationTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("with advisory lock closes connection", async () => {
-    // PG-specific: verify the advisory lock is acquired and released around the migration.
-    // Rails checks pg_stat_activity for lingering lock queries; in JS we verify the
-    // lock calls happen symmetrically via spies on the real adapter.
+    // PG-specific: mirrors Rails test_with_advisory_lock_closes_connection.
+    // Rails queries pg_stat_activity for lingering lock queries; in JS we check:
+    //   (1) acquire/release are called symmetrically, and
+    //   (2) _advisoryLockClient is null after migration — the pinned pool client
+    //       was actually returned (not just nulled without release).
     const testAdapter = createTestAdapter();
     const inner = testAdapter.innerAdapter as any;
     const getSpy = vi.spyOn(inner, "getAdvisoryLock");
@@ -1778,6 +1780,10 @@ describe("MigrationTest", () => {
       await migrator.migrate();
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(releaseSpy).toHaveBeenCalledWith(getSpy.mock.calls[0][0]);
+      // The pinned advisory-lock client must be released back to the pool.
+      // A null _advisoryLockClient after migration means the pool client was
+      // not leaked — the connection was closed as Rails expects.
+      expect(inner._advisoryLockClient).toBeNull();
       expect(await migrator.getAllVersions()).toContain("200");
     } finally {
       getSpy.mockRestore();

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -22,6 +22,19 @@ function freshContext(): { adapter: DatabaseAdapter; ctx: MigrationContext } {
   return { adapter, ctx };
 }
 
+/** Build a minimal mock adapter that participates in advisory lock negotiation. */
+function makeLockAdapter(opts: { acquires?: boolean; releases?: boolean } = {}): DatabaseAdapter {
+  const { acquires = true, releases = true } = opts;
+  return {
+    adapterName: "sqlite" as const,
+    supportsAdvisoryLocks: () => true,
+    getAdvisoryLock: async (_id: number | bigint | string) => acquires,
+    releaseAdvisoryLock: async (_id: number | bigint | string) => releases,
+    currentDatabase: async () => "test_db",
+    isNoDatabaseError: () => false,
+  } as unknown as DatabaseAdapter;
+}
+
 // ==========================================================================
 // MigrationTest
 // ==========================================================================
@@ -1702,6 +1715,7 @@ describe("MigrationTest", () => {
   });
 
   it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {
+    // SchemaAdapter now forwards currentDatabase() — no need to bypass the wrapper
     const testAdapter = createTestAdapter();
     const migrator = new Migrator(testAdapter, []);
     const lockId = await migrator.generateMigratorAdvisoryLockId();
@@ -1722,15 +1736,7 @@ describe("MigrationTest", () => {
         down: async () => {},
       }),
     };
-    // Adapter that reports advisory lock support but always fails to acquire
-    const lockAdapter = {
-      adapterName: "sqlite" as const,
-      supportsAdvisoryLocks: () => true,
-      getAdvisoryLock: async (_id: unknown) => false,
-      releaseAdvisoryLock: async (_id: unknown) => true,
-      currentDatabase: async () => "test_db",
-      isNoDatabaseError: () => false,
-    } as unknown as DatabaseAdapter;
+    const lockAdapter = makeLockAdapter({ acquires: false });
     const migrator = new Migrator(lockAdapter, [proxy]);
     await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
     expect(ran).toEqual([]);
@@ -1748,45 +1754,44 @@ describe("MigrationTest", () => {
         down: async () => {},
       }),
     };
-    const lockAdapter = {
-      adapterName: "sqlite" as const,
-      supportsAdvisoryLocks: () => true,
-      getAdvisoryLock: async (_id: unknown) => false,
-      releaseAdvisoryLock: async (_id: unknown) => true,
-      currentDatabase: async () => "test_db",
-      isNoDatabaseError: () => false,
-    } as unknown as DatabaseAdapter;
+    const lockAdapter = makeLockAdapter({ acquires: false });
     const migrator = new Migrator(lockAdapter, [proxy]);
     await expect(migrator.run("up", 100)).rejects.toThrow(ConcurrentMigrationError);
     expect(ran).toEqual([]);
   });
 
   it.skipIf(adapterType !== "postgres")("with advisory lock closes connection", async () => {
-    // PG-specific: verify the advisory lock query does not linger in pg_stat_activity.
-    // In JS there is no persistent lock connection to close, so we verify the lock
-    // is acquired and released around a no-op migration without leaving idle queries.
+    // PG-specific: verify the advisory lock is acquired and released around the migration.
+    // Rails checks pg_stat_activity for lingering lock queries; in JS we verify the
+    // lock calls happen symmetrically via spies on the real adapter.
     const testAdapter = createTestAdapter();
+    const inner = testAdapter.innerAdapter as any;
+    const acquired: bigint[] = [];
+    const released: bigint[] = [];
+    const origGet = inner.getAdvisoryLock.bind(inner);
+    const origRelease = inner.releaseAdvisoryLock.bind(inner);
+    inner.getAdvisoryLock = async (id: bigint) => {
+      acquired.push(id);
+      return origGet(id);
+    };
+    inner.releaseAdvisoryLock = async (id: bigint) => {
+      released.push(id);
+      return origRelease(id);
+    };
     const proxy: MigrationProxy = {
       version: "200",
       name: "NoOp",
       migration: () => ({ up: async () => {}, down: async () => {} }),
     };
     const migrator = new Migrator(testAdapter, [proxy]);
-    // Should complete without error — the advisory lock was acquired and released
     await migrator.migrate();
+    expect(acquired).toHaveLength(1);
+    expect(released).toEqual(acquired);
     expect(await migrator.getAllVersions()).toContain("200");
   });
 
   it("with advisory lock raises the right error when it fails to release lock", async () => {
-    // Adapter that acquires the lock but refuses to release it (simulates stale lock)
-    const lockAdapter = {
-      adapterName: "sqlite" as const,
-      supportsAdvisoryLocks: () => true,
-      getAdvisoryLock: async (_id: unknown) => true,
-      releaseAdvisoryLock: async (_id: unknown) => false,
-      currentDatabase: async () => "test_db",
-      isNoDatabaseError: () => false,
-    } as unknown as DatabaseAdapter;
+    const lockAdapter = makeLockAdapter({ acquires: true, releases: false });
     const migrator = new Migrator(lockAdapter, []);
     const error = await migrator.withAdvisoryLock(async () => {}).catch((e) => e);
     expect(error).toBeInstanceOf(ConcurrentMigrationError);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1766,28 +1766,23 @@ describe("MigrationTest", () => {
     // lock calls happen symmetrically via spies on the real adapter.
     const testAdapter = createTestAdapter();
     const inner = testAdapter.innerAdapter as any;
-    const acquired: bigint[] = [];
-    const released: bigint[] = [];
-    const origGet = inner.getAdvisoryLock.bind(inner);
-    const origRelease = inner.releaseAdvisoryLock.bind(inner);
-    inner.getAdvisoryLock = async (id: bigint) => {
-      acquired.push(id);
-      return origGet(id);
-    };
-    inner.releaseAdvisoryLock = async (id: bigint) => {
-      released.push(id);
-      return origRelease(id);
-    };
-    const proxy: MigrationProxy = {
-      version: "200",
-      name: "NoOp",
-      migration: () => ({ up: async () => {}, down: async () => {} }),
-    };
-    const migrator = new Migrator(testAdapter, [proxy]);
-    await migrator.migrate();
-    expect(acquired).toHaveLength(1);
-    expect(released).toEqual(acquired);
-    expect(await migrator.getAllVersions()).toContain("200");
+    const getSpy = vi.spyOn(inner, "getAdvisoryLock");
+    const releaseSpy = vi.spyOn(inner, "releaseAdvisoryLock");
+    try {
+      const proxy: MigrationProxy = {
+        version: "200",
+        name: "NoOp",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      };
+      const migrator = new Migrator(testAdapter, [proxy]);
+      await migrator.migrate();
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(releaseSpy).toHaveBeenCalledWith(getSpy.mock.calls[0][0]);
+      expect(await migrator.getAllVersions()).toContain("200");
+    } finally {
+      getSpy.mockRestore();
+      releaseSpy.mockRestore();
+    }
   });
 
   it("with advisory lock raises the right error when it fails to release lock", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1710,8 +1710,15 @@ describe("MigrationTest", () => {
     const realAdapter = testAdapter.innerAdapter;
     const migrator = new Migrator(realAdapter, []);
     const lockId = await migrator.generateMigratorAdvisoryLockId();
-    expect(await (realAdapter as any).getAdvisoryLock(lockId)).toBe(true);
-    expect(await (realAdapter as any).releaseAdvisoryLock(lockId)).toBe(true);
+    const acquired = await (realAdapter as any).getAdvisoryLock(lockId);
+    try {
+      expect(acquired).toBe(true);
+    } finally {
+      if (acquired) {
+        const released = await (realAdapter as any).releaseAdvisoryLock(lockId);
+        expect(released).toBe(true);
+      }
+    }
   });
 
   it.skipIf(adapterType === "sqlite")("generate migrator advisory lock id", async () => {

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -847,11 +847,16 @@ describe("Migrator advisory lock wrapping", () => {
   });
 
   it("throws when adapter supports advisory locks but lacks currentDatabase()", async () => {
-    const adapter = createTestAdapter();
-    adapter.supportsAdvisoryLocks = () => true;
-    adapter.getAdvisoryLock = async () => true;
-    adapter.releaseAdvisoryLock = async () => true;
-    const migrator = new Migrator(adapter, []);
+    // Use a raw mock (not SchemaAdapter) that omits currentDatabase()
+    const rawAdapter = {
+      adapterName: "sqlite" as const,
+      supportsAdvisoryLocks: () => true,
+      getAdvisoryLock: async (_id: unknown) => true,
+      releaseAdvisoryLock: async (_id: unknown) => true,
+      isNoDatabaseError: () => false,
+      // currentDatabase intentionally absent
+    } as unknown as import("./adapter.js").DatabaseAdapter;
+    const migrator = new Migrator(rawAdapter, []);
     await expect(migrator.migrate()).rejects.toThrow("must implement currentDatabase()");
   });
 });

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1063,6 +1063,32 @@ class SchemaAdapter implements DatabaseAdapter {
     return (this.inner as any).lookupCastTypeFromColumn?.(column);
   }
 
+  async currentDatabase(): Promise<string> {
+    const inner = this.inner as { currentDatabase?: () => Promise<string> };
+    if (typeof inner.currentDatabase === "function") return inner.currentDatabase();
+    return "";
+  }
+
+  supportsAdvisoryLocks(): boolean {
+    return (
+      (this.inner as { supportsAdvisoryLocks?: () => boolean }).supportsAdvisoryLocks?.() ?? false
+    );
+  }
+
+  async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
+    const inner = this.inner as {
+      getAdvisoryLock?: (id: number | bigint | string) => Promise<boolean>;
+    };
+    return inner.getAdvisoryLock?.(lockId) ?? false;
+  }
+
+  async releaseAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
+    const inner = this.inner as {
+      releaseAdvisoryLock?: (id: number | bigint | string) => Promise<boolean>;
+    };
+    return inner.releaseAdvisoryLock?.(lockId) ?? false;
+  }
+
   async cleanup(): Promise<void> {
     await dropTrackedTables(this.inner);
   }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1066,7 +1066,9 @@ class SchemaAdapter implements DatabaseAdapter {
   async currentDatabase(): Promise<string> {
     const inner = this.inner as { currentDatabase?: () => Promise<string> };
     if (typeof inner.currentDatabase === "function") return inner.currentDatabase();
-    return "";
+    throw new Error(
+      `${this.inner.adapterName} adapter must implement currentDatabase() to support advisory-locked migrations`,
+    );
   }
 
   supportsAdvisoryLocks(): boolean {


### PR DESCRIPTION
## Summary

- **SchemaAdapter advisory-lock forwarding** (`test-adapter.ts`): `currentDatabase()`, `supportsAdvisoryLocks()`, `getAdvisoryLock()`, and `releaseAdvisoryLock()` now delegate to the inner adapter so the SchemaAdapter wrapper fully participates in advisory-locked migrations. `currentDatabase()` throws when the inner adapter lacks it, preserving the "must implement currentDatabase()" behavior.
- **3 unskips on sqlite** (5–6 on pg/mysql): `migrator one up with unavailable lock`, `migrator one up with unavailable lock using run`, `with advisory lock raises the right error when it fails to release lock`
- **3 blanket skips converted to conditional skips:**
  - `migrator generates valid lock id` → `skipIf(sqlite)` — runs on pg + mysql (Rails: guarded by `supports_advisory_locks?`)
  - `generate migrator advisory lock id` → `skipIf(sqlite)` — runs on pg + mysql (same guard)
  - `with advisory lock closes connection` → `skipIf(adapterType !== "postgres")` — runs on pg only (Rails: guarded by `if current_adapter?(:PostgreSQLAdapter)`)
- **`TableDefinition#toSql` empty-type guard** (`schema-definitions.ts`): rejects empty/blank type in the default branch with a descriptive error; covered by 2 new tests in `schema-definitions.test.ts`
- **`migrator.test.ts` fix**: "lacks currentDatabase()" test updated to use a raw mock adapter

## LOC
141 insertions / 34 deletions = 175 gross LOC (under 300 ceiling)

## Test plan
- [x] `npx vitest run packages/activerecord/src/migration.test.ts packages/activerecord/src/migrator.test.ts packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts` — 246 passed, 25 skipped
- [x] `pnpm test:types` — 83 passed, no type errors
- [x] `pnpm run api:compare --package activerecord` — 4949/4958 (99.8%), no regression
- [x] `tsc --build` passes (via pre-commit hook)

## Follow-up items (Slot C remainder, deferred)
- CTAS `_introspectColumns`: store real SQL types in `_columnMeta` instead of `"string"` placeholder (~30 LOC)
- `MigrationContext.tableNamePrefix`/`Suffix` fallback to `_arConfig` registry (~20 LOC)