### PR TITLE
refactor(activemodel) callbacks engine → activesupport Symbol storage (PR 5)

### DIFF
--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -16,6 +16,10 @@ import {
   type CallbackObject as ASCallbackObject,
   type RunCallbacksOptions as ASRunCallbacksOptions,
   defineCallbacks as asDefineCallbacks,
+  skipCallback as asSkipCallback,
+  resetCallbacks as asResetCallbacks,
+  getCallbackChains as asGetCallbackChains,
+  peekCallbackChain as asPeekCallbackChain,
 } from "@blazetrails/activesupport";
 
 type AnyCallback = BeforeCallback | AfterCallback | AroundCallback;
@@ -143,10 +147,7 @@ export function _defineBeforeModelCallback(klass: CallbackHost, event: string): 
   const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   Object.defineProperty(klass, `before${capitalizedEvent}`, {
     value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
-      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-        this._callbackChain = this._callbackChain.clone();
-      }
-      this._callbackChain.register("before", event, fnOrObject, conditions);
+      _registerCallbackOnProto(this.prototype, "before", event, fnOrObject, conditions);
     },
     writable: true,
     configurable: true,
@@ -164,10 +165,7 @@ export function _defineAroundModelCallback(klass: CallbackHost, event: string): 
       fnOrObject: AroundCallbackFn | CallbackObject,
       conditions?: CallbackConditions,
     ) {
-      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-        this._callbackChain = this._callbackChain.clone();
-      }
-      this._callbackChain.register("around", event, fnOrObject, conditions);
+      _registerCallbackOnProto(this.prototype, "around", event, fnOrObject, conditions);
     },
     writable: true,
     configurable: true,
@@ -182,10 +180,7 @@ export function _defineAfterModelCallback(klass: CallbackHost, event: string): v
   const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   Object.defineProperty(klass, `after${capitalizedEvent}`, {
     value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
-      if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-        this._callbackChain = this._callbackChain.clone();
-      }
-      this._callbackChain.register("after", event, fnOrObject, conditions);
+      _registerCallbackOnProto(this.prototype, "after", event, fnOrObject, conditions);
     },
     writable: true,
     configurable: true,
@@ -217,22 +212,85 @@ function _resolveCallbackObject(
 }
 
 /**
- * Lifecycle callback chain backed by activesupport's Callback engine.
+ * Register a callback directly in activesupport's Symbol-keyed chain storage
+ * on `proto`. Called by the generated `beforeX`/`afterX`/`aroundX` methods
+ * from `defineModelCallbacks` and by `CallbackChain.register`.
+ *
+ * Resolves `CallbackObject` instances using our own resolver (which supports
+ * both camelCase and snake_case method names) before inserting into the chain,
+ * while still storing the original object as `originalObject` so
+ * `skip`-by-reference works.
+ *
+ * After callbacks are stored with `prepend: true` so activesupport's LIFO
+ * reverse-iteration in `_runAfters` produces FIFO execution order — same as
+ * Rails' `_define_after_model_callback prepend: true`.
+ */
+function _registerCallbackOnProto(
+  proto: object,
+  timing: CallbackTiming,
+  event: string,
+  fn: CallbackFn | AroundCallbackFn | CallbackObject,
+  conditions?: CallbackConditions,
+): void {
+  if (conditions && "on" in conditions) {
+    if (event !== "commit" && event !== "rollback") {
+      throw new ArgumentError(
+        `Unknown key: :on. The :on option is only supported for :commit and :rollback callbacks (got :${event})`,
+      );
+    }
+  }
+  asDefineCallbacks(proto, event, { skipAfterCallbacksIfTerminated: true });
+  const chains = asGetCallbackChains(proto);
+  const chain = chains.get(event)!;
+  const isObj = typeof fn === "object" && fn !== null;
+  const resolved: AnyCallback = isObj
+    ? _resolveCallbackObject(fn as unknown as ASCallbackObject, timing, event)
+    : (fn as AnyCallback);
+  const entry = new Callback(
+    event,
+    resolved,
+    timing as CallbackKind,
+    {
+      if: conditions?.if as ((t: object) => boolean) | undefined,
+      unless: conditions?.unless as ((t: object) => boolean) | undefined,
+    },
+    chain.config,
+    isObj ? (fn as unknown as ASCallbackObject) : undefined,
+  );
+  const prepend = !!conditions?.prepend || timing === "after";
+  if (prepend) chain.prepend(entry);
+  else chain.append(entry);
+}
+
+/**
+ * Get the activesupport chain for `event` on `proto`. Triggers COW via
+ * `asGetCallbackChains` (acceptable for prototype-level lookups; COW happens
+ * once per class, never per instance). Used in the run paths.
+ */
+function _getChain(proto: object, event: string): ASCallbackChain | null {
+  return asGetCallbackChains(proto).get(event) ?? null;
+}
+
+/**
+ * Read-only lookup — no COW. Used by `has()` so a skipCallback miss never
+ * isolates a subclass from future parent registrations.
+ */
+function _peekChain(proto: object, event: string): ASCallbackChain | undefined {
+  return asPeekCallbackChain(proto, event);
+}
+
+/**
+ * Lifecycle callback chain backed by activesupport's Symbol-keyed chain storage.
+ *
+ * Rather than maintaining its own `Map<string, ASCallbackChain>`, this bridge
+ * stores all chains in activesupport's per-prototype storage (same storage
+ * accessed by `setCallback` / `runCallbacks`). Subclass isolation is handled
+ * automatically by activesupport's copy-on-write in `getCallbackChains`.
  *
  * Mirrors: ActiveModel::Callbacks / ActiveSupport::Callbacks
  */
 export class CallbackChain {
-  /** Map from event name to an activesupport CallbackChain for that event. */
-  private readonly _chains = new Map<string, ASCallbackChain>();
-
-  private _chain(event: string): ASCallbackChain {
-    let chain = this._chains.get(event);
-    if (!chain) {
-      chain = new ASCallbackChain(event, { skipAfterCallbacksIfTerminated: true });
-      this._chains.set(event, chain);
-    }
-    return chain;
-  }
+  constructor(private readonly _proto: object = Object.create(null)) {}
 
   register(
     timing: CallbackTiming,
@@ -240,38 +298,7 @@ export class CallbackChain {
     fn: CallbackFn | AroundCallbackFn | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
-    // `on:` is synthesized into `if:` by the AR layer (transactions.ts)
-    // before reaching this chain. Reject it here for non-commit/rollback events.
-    if (conditions && "on" in conditions) {
-      if (event !== "commit" && event !== "rollback") {
-        throw new ArgumentError(
-          `Unknown key: :on. The :on option is only supported for :commit and :rollback callbacks (got :${event})`,
-        );
-      }
-    }
-    const chain = this._chain(event);
-    const isObj = typeof fn === "object" && fn !== null;
-    const asObj = isObj ? (fn as unknown as ASCallbackObject) : undefined;
-    const resolved: AnyCallback = isObj
-      ? _resolveCallbackObject(asObj!, timing, event)
-      : (fn as AnyCallback);
-    const entry = new Callback(
-      event,
-      resolved,
-      timing as CallbackKind,
-      { if: conditions?.if, unless: conditions?.unless } as {
-        if?: (t: object) => boolean;
-        unless?: (t: object) => boolean;
-      },
-      chain.config,
-      asObj,
-    );
-    // After callbacks are stored with prepend so that activesupport's reverse
-    // iteration in _runAfters (LIFO) produces FIFO execution order — the same
-    // as Rails' _define_after_model_callback which passes prepend: true.
-    const usePrepend = conditions?.prepend || timing === "after";
-    if (usePrepend) chain.prepend(entry);
-    else chain.append(entry);
+    _registerCallbackOnProto(this._proto, timing, event, fn, conditions);
   }
 
   skip(
@@ -279,12 +306,14 @@ export class CallbackChain {
     timing: CallbackTiming,
     filter: CallbackFn | AroundCallbackFn | CallbackObject,
   ): boolean {
-    const chain = this._chains.get(event);
+    // Peek first (no COW) to avoid isolating a subclass on a miss.
+    const chain = _peekChain(this._proto, event);
     if (!chain) return false;
     const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
-    const entry = chain.entries.find((e) => e.matches(timing as CallbackKind, asFilter));
-    if (!entry) return false;
-    chain.delete(entry);
+    const found = chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
+    if (!found) return false;
+    // Found — now trigger COW (via asGetCallbackChains) to get the mutable own chain.
+    asSkipCallback(this._proto, event, timing as CallbackKind, asFilter as AnyCallback);
     return true;
   }
 
@@ -293,36 +322,22 @@ export class CallbackChain {
     timing: CallbackTiming,
     filter: CallbackFn | AroundCallbackFn | CallbackObject,
   ): boolean {
+    // Peek without COW — a miss must not isolate this proto from future parent registrations.
+    const chain = _peekChain(this._proto, event);
+    if (!chain) return false;
     const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
-    return (
-      this._chains.get(event)?.entries.some((e) => e.matches(timing as CallbackKind, asFilter)) ??
-      false
-    );
+    return chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
   }
 
   clearEvent(event: string): void {
-    this._chains.delete(event);
+    asResetCallbacks(this._proto, event);
   }
 
+  /** COW is automatic via activesupport's `getCallbackChains`. Returns a new
+   * bridge pointing to the same proto; callers that assign the clone trigger
+   * the automatic COW on their own proto when they first register. */
   clone(): CallbackChain {
-    const copy = new CallbackChain();
-    for (const [ev, ch] of this._chains) {
-      const dup = new ASCallbackChain(ch.name, ch.config);
-      for (const e of ch.entries) {
-        dup.append(
-          new Callback(
-            e.name,
-            e.filter as AnyCallback,
-            e.kind,
-            e.options,
-            ch.config,
-            e.originalObject,
-          ),
-        );
-      }
-      copy._chains.set(ev, dup);
-    }
-    return copy;
+    return new CallbackChain(this._proto);
   }
 
   runBefore(
@@ -340,7 +355,7 @@ export class CallbackChain {
     record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
-    const chain = this._chains.get(event);
+    const chain = _getChain(this._proto, event);
     if (!chain) return true;
     const tmp = new ASCallbackChain(event, chain.config);
     for (const e of chain.entries) {
@@ -360,7 +375,7 @@ export class CallbackChain {
     record: CallbackRecord,
     opts?: RunCallbacksOptions,
   ): void | Promise<void> {
-    const chain = this._chains.get(event);
+    const chain = _getChain(this._proto, event);
     if (!chain) return;
     const tmp = new ASCallbackChain(event, chain.config);
     for (const e of chain.entries) {
@@ -388,7 +403,7 @@ export class CallbackChain {
     block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
-    const chain = this._chains.get(event);
+    const chain = _getChain(this._proto, event);
     if (!chain) {
       const r = block?.();
       if (isThenable(r)) return Promise.resolve(r).then(() => true);

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -333,9 +333,15 @@ export class CallbackChain {
     asResetCallbacks(this._proto, event);
   }
 
-  /** COW is automatic via activesupport's `getCallbackChains`. Returns a new
-   * bridge pointing to the same proto; callers that assign the clone trigger
-   * the automatic COW on their own proto when they first register. */
+  /**
+   * Returns a new bridge that points at the same underlying `_proto` — it is
+   * NOT a deep copy of the callback entries. Independence between a class and
+   * its parent is guaranteed by activesupport's copy-on-write in
+   * `getCallbackChains`: the first call to `register` on a subclass proto
+   * creates its own Map by copying the parent's. Callers (e.g. AR's
+   * `_callbackChain = _callbackChain.clone()`) rely on this automatic COW
+   * rather than on the clone itself carrying a fresh snapshot.
+   */
   clone(): CallbackChain {
     return new CallbackChain(this._proto);
   }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -128,9 +128,12 @@ export function defineModelCallbacks(this: object, ...args: unknown[]): void {
   // `Model.skipCallback(event, timing, originalObject)` for entries registered
   // through the generated `beforeX`/`afterX`/`aroundX` helpers.
   for (const event of eventNames) {
-    // Register the chain on the prototype for activesupport API surface parity.
+    // Register the chain on the prototype with the same config used by
+    // _registerCallbackOnProto so skipAfterCallbacksIfTerminated is consistent
+    // regardless of which call runs first.
     // Mirrors: ActiveModel::Callbacks → define_callbacks (activesupport)
-    if (klass.prototype) asDefineCallbacks(klass.prototype, event);
+    if (klass.prototype)
+      asDefineCallbacks(klass.prototype, event, { skipAfterCallbacksIfTerminated: true });
     if (timings.includes("before")) _defineBeforeModelCallback(this, event);
     if (timings.includes("after")) _defineAfterModelCallback(this, event);
     if (timings.includes("around")) _defineAroundModelCallback(this, event);
@@ -265,9 +268,15 @@ function _registerCallbackOnProto(
   else chain.append(entry);
 }
 
-/** Triggers COW on `proto` (once per class, never per instance). Used in run paths. */
+/**
+ * Read-only chain lookup for run paths — no COW. The chain may live on an
+ * ancestor prototype; `invoke(record, ...)` still receives the instance as its
+ * target, so callbacks fire correctly without requiring a local copy.
+ * Avoiding COW here means a subclass that never registers its own callbacks
+ * stays transparent to future parent registrations even after its first run.
+ */
 function _getChain(proto: object, event: string): ASCallbackChain | null {
-  return asGetCallbackChains(proto).get(event) ?? null;
+  return asPeekCallbackChain(proto, event) ?? null;
 }
 
 /**

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -239,6 +239,9 @@ function _registerCallbackOnProto(
       );
     }
   }
+  // Two-step: defineCallbacks creates the chain with the right config (COW if
+  // needed); getCallbackChains re-reads the now-own Map (cheap: hasOwnProperty
+  // true on second call).
   asDefineCallbacks(proto, event, { skipAfterCallbacksIfTerminated: true });
   const chains = asGetCallbackChains(proto);
   const chain = chains.get(event)!;
@@ -262,21 +265,9 @@ function _registerCallbackOnProto(
   else chain.append(entry);
 }
 
-/**
- * Get the activesupport chain for `event` on `proto`. Triggers COW via
- * `asGetCallbackChains` (acceptable for prototype-level lookups; COW happens
- * once per class, never per instance). Used in the run paths.
- */
+/** Triggers COW on `proto` (once per class, never per instance). Used in run paths. */
 function _getChain(proto: object, event: string): ASCallbackChain | null {
   return asGetCallbackChains(proto).get(event) ?? null;
-}
-
-/**
- * Read-only lookup — no COW. Used by `has()` so a skipCallback miss never
- * isolates a subclass from future parent registrations.
- */
-function _peekChain(proto: object, event: string): ASCallbackChain | undefined {
-  return asPeekCallbackChain(proto, event);
 }
 
 /**
@@ -307,7 +298,7 @@ export class CallbackChain {
     filter: CallbackFn | AroundCallbackFn | CallbackObject,
   ): boolean {
     // Peek first (no COW) to avoid isolating a subclass on a miss.
-    const chain = _peekChain(this._proto, event);
+    const chain = asPeekCallbackChain(this._proto, event);
     if (!chain) return false;
     const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
     const found = chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
@@ -323,7 +314,7 @@ export class CallbackChain {
     filter: CallbackFn | AroundCallbackFn | CallbackObject,
   ): boolean {
     // Peek without COW — a miss must not isolate this proto from future parent registrations.
-    const chain = _peekChain(this._proto, event);
+    const chain = asPeekCallbackChain(this._proto, event);
     if (!chain) return false;
     const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
     return chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -313,7 +313,7 @@ export class CallbackChain {
     const found = chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
     if (!found) return false;
     // Found — now trigger COW (via asGetCallbackChains) to get the mutable own chain.
-    asSkipCallback(this._proto, event, timing as CallbackKind, asFilter as AnyCallback);
+    asSkipCallback(this._proto, event, timing as CallbackKind, asFilter);
     return true;
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -125,7 +125,15 @@ export class Model {
   // `static { this.validates(...) }` blocks at class-definition time);
   // only the "defined but never written to" window diverges from Rails.
   static _validators: Map<string | null, Array<ValidatorLike>> = new Map();
-  static _callbackChain: CallbackChain = new CallbackChain();
+  /** @internal */
+  static get _callbackChain(): CallbackChain {
+    return new CallbackChain(this.prototype);
+  }
+  /** @internal */
+  static set _callbackChain(_: CallbackChain) {
+    // no-op: subclass isolation is handled automatically by activesupport's
+    // copy-on-write in getCallbackChains when register/setCallback is first called.
+  }
   private static _modelName: ModelName | null = null;
 
   // -- Attributes (Phase 1000) --
@@ -443,7 +451,6 @@ export class Model {
   static clearValidatorsBang(): void {
     // Rails: `_validators.clear` (activemodel/lib/active_model/validations.rb:248).
     this._validators = new Map();
-    this._ensureOwnCallbacks();
     this._callbackChain.clearEvent("validate");
   }
 
@@ -466,7 +473,6 @@ export class Model {
         return (r[methodOrFn] as () => void)();
       }
     };
-    this._ensureOwnCallbacks();
     this._callbackChain.register("before", "validate", fn, this._buildValidateConditions(options));
   }
 
@@ -485,7 +491,6 @@ export class Model {
       fn as (record: ValidatableRecord, attribute: string, value: unknown) => void,
     );
     this._registerValidator(validator);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "before",
       "validate",
@@ -568,7 +573,6 @@ export class Model {
         callbackFn = (record: object) => validator.validate(record as ValidatableRecord);
       }
 
-      this._ensureOwnCallbacks();
       this._callbackChain.register("before", "validate", callbackFn, conditions);
     }
   }
@@ -707,7 +711,6 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "before",
       "validation",
@@ -721,7 +724,6 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "after",
       "validation",
@@ -736,7 +738,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("before", "save", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -746,7 +747,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "save", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -756,7 +756,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("before", "create", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -766,7 +765,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "create", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -776,7 +774,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("before", "update", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -786,7 +783,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "update", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -796,7 +792,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "before",
       "destroy",
@@ -811,7 +806,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "destroy", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -823,7 +817,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "around",
       "save",
@@ -840,7 +833,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "around",
       "create",
@@ -857,7 +849,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "around",
       "update",
@@ -874,7 +865,6 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "around",
       "destroy",
@@ -891,7 +881,6 @@ export class Model {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "commit", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -935,7 +924,6 @@ export class Model {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "after",
       "rollback",
@@ -949,7 +937,6 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       "after",
       "initialize",
@@ -963,7 +950,6 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "find", fn as CallbackFn | CallbackObject, conditions);
   }
 
@@ -972,14 +958,7 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.register("after", "touch", fn as CallbackFn | CallbackObject, conditions);
-  }
-
-  private static _ensureOwnCallbacks(): void {
-    if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-      this._callbackChain = this._callbackChain.clone();
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -1030,7 +1009,6 @@ export class Model {
     // entry point — setCallback, defineModelCallbacks helpers, direct
     // chain.register — shares the same gate. No extra guard needed
     // here.
-    this._ensureOwnCallbacks();
     this._callbackChain.register(
       timing,
       event,
@@ -1080,7 +1058,6 @@ export class Model {
     // inherited chain first; only clone when we're actually going to
     // mutate (match found).
     if (!this._callbackChain.has(event, timing, fn)) return false;
-    this._ensureOwnCallbacks();
     return this._callbackChain.skip(event, timing, fn);
   }
 
@@ -1090,7 +1067,6 @@ export class Model {
    * (activesupport/lib/active_support/callbacks.rb:811-821).
    */
   static resetCallbacks<T extends typeof Model>(this: T, event: string): void {
-    this._ensureOwnCallbacks();
     this._callbackChain.clearEvent(event);
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -134,6 +134,12 @@ export class Model {
     // no-op: subclass isolation is handled automatically by activesupport's
     // copy-on-write in getCallbackChains when register/setCallback is first called.
   }
+  /**
+   * @internal Compat shim for AR call sites (transactions.ts) that have not yet
+   * been migrated to the direct activesupport API (PR 6). COW is now automatic;
+   * this is a no-op.
+   */
+  static _ensureOwnCallbacks(): void {}
   private static _modelName: ModelName | null = null;
 
   // -- Attributes (Phase 1000) --

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -1061,7 +1061,26 @@ export interface ClassMethods<T extends object = object> {
 
 const CALLBACKS = Symbol("callbacks");
 
-function getCallbackChains(target: object): Map<string, CallbackChain> {
+/**
+ * Read-only lookup of a single CallbackChain for `name` on `target` (or its
+ * prototype chain). Does NOT trigger copy-on-write — returns `undefined` if
+ * no chain is found rather than allocating a new Map on `target`.
+ *
+ * @internal
+ */
+export function peekCallbackChain(target: object, name: string): CallbackChain | undefined {
+  let t: object | null = target;
+  while (t !== null) {
+    if (Object.prototype.hasOwnProperty.call(t, CALLBACKS)) {
+      return (t as Record<symbol, Map<string, CallbackChain>>)[CALLBACKS].get(name);
+    }
+    t = Object.getPrototypeOf(t);
+  }
+  return undefined;
+}
+
+/** @internal */
+export function getCallbackChains(target: object): Map<string, CallbackChain> {
   const t = target as Record<symbol, unknown>;
   if (!Object.prototype.hasOwnProperty.call(target, CALLBACKS)) {
     const parent = t[CALLBACKS] as Map<string, CallbackChain> | undefined;

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -1062,9 +1062,14 @@ export interface ClassMethods<T extends object = object> {
 const CALLBACKS = Symbol("callbacks");
 
 /**
- * Read-only lookup of a single CallbackChain for `name` on `target` (or its
- * prototype chain). Does NOT trigger copy-on-write — returns `undefined` if
- * no chain is found rather than allocating a new Map on `target`.
+ * Read-only lookup of a single CallbackChain for `name`. Walks the prototype
+ * chain of `target` looking for the **first** object that owns a CALLBACKS
+ * map, then returns `map.get(name)` — which may be `undefined` if that map
+ * does not contain `name`. The walk stops at the first own CALLBACKS map; it
+ * does not continue up to find `name` in a higher ancestor. This is
+ * intentional COW semantics: once a class owns its CALLBACKS map (because it
+ * registered at least one callback), all chains it knows about are inside that
+ * map. Does NOT trigger copy-on-write.
  *
  * @internal
  */

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -265,6 +265,8 @@ export {
   skipCallback,
   resetCallbacks,
   runCallbacks,
+  getCallbackChains,
+  peekCallbackChain,
   CallbacksMixin,
 } from "./callbacks.js";
 export type {


### PR DESCRIPTION
## Summary

- Replaces the bridge `CallbackChain`'s internal `Map<string, ASCallbackChain>` with activesupport's Symbol-keyed `getCallbackChains` storage, unifying both storage paths: `_callbackChain.register(...)` and `setCallback(this.prototype, ...)` now write to the same per-prototype chain map
- `Model._callbackChain` becomes a static getter returning `new CallbackChain(this.prototype)`; the setter is a no-op since activesupport's `getCallbackChains` handles copy-on-write automatically
- Removes `_ensureOwnCallbacks()` and all 26 call sites — subclass isolation is now fully automatic
- Exports `getCallbackChains` (COW-triggering lookup) and `peekCallbackChain` (read-only prototype-chain walk, no COW) from activesupport; `peekCallbackChain` is used by `has()` so a `skipCallback` miss never isolates a subclass from future parent registrations
- AR call sites continue to work unchanged via the getter + bridge API (PRs 6–7 handle AR migration)

## Key design decision

The bridge now stores chains in the same Symbol-keyed Map as activesupport's module API. Chain lookup in `runBefore`/`runAfter`/`runCallbacks` uses `this._proto` (the registered prototype), NOT `Object.getPrototypeOf(record)`, so:
- Standalone `CallbackChain` usage (tests, direct instantiation) works without a class
- Class-based usage (AR/AM) works because `ctor._callbackChain` (getter) binds `_proto = ctor.prototype`, and records are instances of `ctor`

## Test plan

- [x] `pnpm exec vitest run packages/activemodel` — 1910/1910 pass
- [x] `pnpm exec vitest run packages/activerecord` — passes (flaky timeout failures in CLI tests are pre-existing, reproduce on baseline)
- [x] `pnpm test:types` — 83/83 pass
- [x] `pnpm run api:compare --package activemodel` — 621/621 (100%)
- [x] ESLint clean
- [x] 254 LOC (additions + deletions, within 300 ceiling)

## Follow-ups (PR 6–7)

- PR 6: Migrate AR's `base.ts` and `callbacks.ts` direct `_callbackChain.runBefore/runAfter/runCallbacks` calls to use activesupport's `runCallbacks` directly
- PR 7: Migrate AR's `transactions.ts` and remaining `_callbackChain.register(...)` sites; retire the bridge class