### PR TITLE
feat(activerecord) PG long-tail Slot C — ltree + tsvector + bit-string

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/bit-string.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bit-string.test.ts
@@ -1,63 +1,107 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/bit_string_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_bit_strings`);
+    await adapter.exec(`
+      CREATE TABLE postgresql_bit_strings (
+        id serial primary key,
+        a_bit bit(8) DEFAULT B'00000011',
+        a_bit_varying bit varying(4) DEFAULT B'0011',
+        another_bit bit,
+        another_bit_varying bit varying
+      )
+    `);
   });
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS postgresql_bit_strings`);
     await adapter.close();
   });
 
   describe("PostgresqlBitStringTest", () => {
-    it.skip("bit string", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+    it("bit string", async () => {
+      // Roundtrip: write and read back bit strings.
+      await adapter.exec(
+        `INSERT INTO postgresql_bit_strings (a_bit, a_bit_varying) VALUES (B'00001010', B'0101')`,
+      );
+      const rows = await adapter.execute(`SELECT a_bit, a_bit_varying FROM postgresql_bit_strings`);
+      expect(rows[0].a_bit).toBe("00001010");
+      expect(rows[0].a_bit_varying).toBe("0101");
     });
-    it.skip("bit string default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("bit string default", async () => {
+      const cols = await adapter.columns("postgresql_bit_strings");
+      const aBit = cols.find((c) => c.name === "a_bit")!;
+      expect(aBit.default).toBe("00000011");
+      const aBitVarying = cols.find((c) => c.name === "a_bit_varying")!;
+      expect(aBitVarying.default).toBe("0011");
     });
-    it.skip("bit string type cast", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("bit string type cast", async () => {
+      const { Bit } = await import("../../connection-adapters/postgresql/oid/bit.js");
+      const type = new Bit();
+      expect(type.cast("0101")).toBe("0101");
+      expect(type.cast("0xFF")).toBe("11111111");
+      expect(type.cast(null)).toBeNull();
     });
-    it.skip("bit string invalid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("bit string invalid", async () => {
+      // Inserting a value that doesn't fit the bit length constraint should fail.
+      await expect(
+        adapter.exec(`INSERT INTO postgresql_bit_strings (a_bit) VALUES (B'0000000011')`),
+      ).rejects.toThrow();
     });
-    it.skip("varbit string", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("varbit string", async () => {
+      await adapter.exec(
+        `INSERT INTO postgresql_bit_strings (a_bit, a_bit_varying) VALUES (B'11111111', B'1111')`,
+      );
+      const rows = await adapter.execute(`SELECT a_bit, a_bit_varying FROM postgresql_bit_strings`);
+      expect(rows[0].a_bit).toBe("11111111");
+      expect(rows[0].a_bit_varying).toBe("1111");
     });
-    it.skip("varbit string default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("varbit string default", async () => {
+      const cols = await adapter.columns("postgresql_bit_strings");
+      const col = cols.find((c) => c.name === "a_bit_varying")!;
+      expect(col).toBeDefined();
+      expect(col.type).toBe("bit_varying");
+      expect(col.default).toBe("0011");
     });
-    it.skip("bit string column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("bit string column", async () => {
+      const cols = await adapter.columns("postgresql_bit_strings");
+      const col = cols.find((c) => c.name === "a_bit")!;
+      expect(col).toBeDefined();
+      expect(col.type).toBe("bit");
+      expect(col.sqlType).toBe("bit(8)");
+      expect((col as any).isArray()).toBe(false);
+      expect(col.type).not.toBe("binary");
     });
-    it.skip("bit string varying column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("bit string varying column", async () => {
+      const cols = await adapter.columns("postgresql_bit_strings");
+      const col = cols.find((c) => c.name === "a_bit_varying")!;
+      expect(col).toBeDefined();
+      expect(col.type).toBe("bit_varying");
+      expect(col.sqlType).toBe("bit varying(4)");
+      expect((col as any).isArray()).toBe(false);
+      expect(col.type).not.toBe("binary");
     });
-    it.skip("assigning invalid hex string raises exception", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in bit-string
-      // ROOT-CAUSE: connection-adapters/postgresql/bit-string.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/bit-string.ts; affects ~10–47 tests in bit-string.test.ts
+
+    it("assigning invalid hex string raises exception", async () => {
+      await expect(
+        adapter.exec(`INSERT INTO postgresql_bit_strings (a_bit) VALUES ('FF')`),
+      ).rejects.toThrow();
+      await expect(
+        adapter.exec(`INSERT INTO postgresql_bit_strings (a_bit_varying) VALUES ('F')`),
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/bit-string.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bit-string.test.ts
@@ -26,13 +26,12 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgresqlBitStringTest", () => {
     it("bit string", async () => {
-      // Roundtrip: write and read back bit strings.
-      await adapter.exec(
-        `INSERT INTO postgresql_bit_strings (a_bit, a_bit_varying) VALUES (B'00001010', B'0101')`,
+      const { SchemaDumper } = await import("../../schema-dumper.js");
+      const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_bit_strings");
+      expect(output).toMatch(/t\.bit\("a_bit",\s*\{[^}]*default:\s*"00000011"[^}]*limit:\s*8/);
+      expect(output).toMatch(
+        /t\.bitVarying\("a_bit_varying",\s*\{[^}]*default:\s*"0011"[^}]*limit:\s*4/,
       );
-      const rows = await adapter.execute(`SELECT a_bit, a_bit_varying FROM postgresql_bit_strings`);
-      expect(rows[0].a_bit).toBe("00001010");
-      expect(rows[0].a_bit_varying).toBe("0101");
     });
 
     it("bit string default", async () => {
@@ -52,7 +51,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("bit string invalid", async () => {
-      // Inserting a value that doesn't fit the bit length constraint should fail.
       await expect(
         adapter.exec(`INSERT INTO postgresql_bit_strings (a_bit) VALUES (B'0000000011')`),
       ).rejects.toThrow();

--- a/packages/activerecord/src/adapters/postgresql/full-text.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/full-text.test.ts
@@ -1,38 +1,54 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/full_text_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS tsvectors`);
+    await adapter.exec(`CREATE TABLE tsvectors (id serial primary key, text_vector tsvector)`);
   });
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS tsvectors`);
     await adapter.close();
   });
 
   describe("PostgresqlFullTextTest", () => {
-    it.skip("tsvector column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in full-text
-      // ROOT-CAUSE: connection-adapters/postgresql/full-text.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/full-text.ts; affects ~10–47 tests in full-text.test.ts
+    it("tsvector column", async () => {
+      const cols = await adapter.columns("tsvectors");
+      const col = cols.find((c) => c.name === "text_vector")!;
+      expect(col).toBeDefined();
+      expect(col.type).toBe("tsvector");
+      expect(col.sqlType).toBe("tsvector");
+      expect((col as any).isArray()).toBe(false);
+      expect(col.type).not.toBe("binary");
     });
+
     it.skip("tsquery column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in full-text
-      // ROOT-CAUSE: connection-adapters/postgresql/full-text.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/full-text.ts; affects ~10–47 tests in full-text.test.ts
+      // tsquery is not a registered OID type in Rails (no corresponding Rails test).
     });
-    it.skip("full text search", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in full-text
-      // ROOT-CAUSE: connection-adapters/postgresql/full-text.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/full-text.ts; affects ~10–47 tests in full-text.test.ts
+
+    it("full text search", async () => {
+      await adapter.exec(`INSERT INTO tsvectors (text_vector) VALUES ('cat'::tsvector)`);
+      const rows = await adapter.execute(
+        `SELECT text_vector FROM tsvectors WHERE text_vector @@ to_tsquery('cat')`,
+      );
+      expect(rows).toHaveLength(1);
     });
-    it.skip("update tsvector", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in full-text
-      // ROOT-CAUSE: connection-adapters/postgresql/full-text.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/full-text.ts; affects ~10–47 tests in full-text.test.ts
+
+    it("update tsvector", async () => {
+      await adapter.exec(
+        `INSERT INTO tsvectors (text_vector) VALUES ($$'text' 'vector'$$::tsvector)`,
+      );
+      const rows = await adapter.execute(`SELECT text_vector FROM tsvectors`);
+      expect(String(rows[0].text_vector)).toBe("'text' 'vector'");
+
+      await adapter.exec(`UPDATE tsvectors SET text_vector = $$'new' 'text' 'vector'$$::tsvector`);
+      const updated = await adapter.execute(`SELECT text_vector FROM tsvectors`);
+      expect(String(updated[0].text_vector)).toBe("'new' 'text' 'vector'");
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/ltree.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/ltree.test.ts
@@ -1,43 +1,57 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/ltree_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS ltrees`);
+    await adapter.exec(`CREATE EXTENSION IF NOT EXISTS ltree`);
+    await adapter.exec(`CREATE TABLE ltrees (id serial primary key, path ltree)`);
+    await adapter.loadAdditionalTypes();
   });
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS ltrees`);
     await adapter.close();
   });
 
   describe("PostgresqlLtreeTest", () => {
-    it.skip("column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in ltree
-      // ROOT-CAUSE: connection-adapters/postgresql/ltree.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/ltree.ts; affects ~10–47 tests in ltree.test.ts
+    it("column", async () => {
+      const cols = await adapter.columns("ltrees");
+      const col = cols.find((c) => c.name === "path")!;
+      expect(col).toBeDefined();
+      expect(col.type).toBe("ltree");
+      expect(col.sqlType).toBe("ltree");
+      expect((col as any).isArray()).toBe(false);
+      expect(col.type).not.toBe("binary");
     });
-    it.skip("default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in ltree
-      // ROOT-CAUSE: connection-adapters/postgresql/ltree.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/ltree.ts; affects ~10–47 tests in ltree.test.ts
+
+    it("default", async () => {
+      const cols = await adapter.columns("ltrees");
+      const col = cols.find((c) => c.name === "path")!;
+      expect(col).toBeDefined();
+      expect(col.default).toBeNull();
     });
-    it.skip("ltree query", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in ltree
-      // ROOT-CAUSE: connection-adapters/postgresql/ltree.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/ltree.ts; affects ~10–47 tests in ltree.test.ts
+
+    it("ltree query", async () => {
+      await adapter.exec(`INSERT INTO ltrees (path) VALUES ('1.2.3')`);
+      const rows = await adapter.execute(`SELECT path FROM ltrees`);
+      expect(String(rows[0].path)).toBe("1.2.3");
     });
-    it.skip("ltree schema dump", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in ltree
-      // ROOT-CAUSE: connection-adapters/postgresql/ltree.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/ltree.ts; affects ~10–47 tests in ltree.test.ts
+
+    it("ltree schema dump", async () => {
+      const output = await SchemaDumper.dumpTableSchema(adapter, "ltrees");
+      expect(output).toMatch(/t\.ltree\("path"\)/);
     });
-    it.skip("write", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in ltree
-      // ROOT-CAUSE: connection-adapters/postgresql/ltree.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/ltree.ts; affects ~10–47 tests in ltree.test.ts
+
+    it("write", async () => {
+      await adapter.exec(`INSERT INTO ltrees (path) VALUES ('1.2.3.4')`);
+      const rows = await adapter.execute(`SELECT path FROM ltrees`);
+      expect(String(rows[0].path)).toBe("1.2.3.4");
     });
   });
 });

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -296,7 +296,9 @@ export function cleanDefault(raw: unknown): unknown {
 
   if (str === "true") return true;
   if (str === "false") return false;
-  if (/^-?\d+(\.\d+)?$/.test(str)) return Number(str);
+  // Only coerce to number when there are no leading zeros — leading zeros mean
+  // the string is a bit-string pattern ("00000011") or similar, not a decimal.
+  if (/^-?\d+(\.\d+)?$/.test(str) && !/^-?0\d/.test(str)) return Number(str);
 
   return raw;
 }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -136,9 +136,11 @@ const SQL_TYPE_MAP: Record<string, DslMapping> = {
   circle: { dslType: "circle" },
   interval: { dslType: "interval" },
   bit: { dslType: "bit" },
-  "bit varying": { dslType: "bit" },
+  "bit varying": { dslType: "bitVarying" },
+  varbit: { dslType: "bitVarying" },
   citext: { dslType: "citext" },
   ltree: { dslType: "ltree" },
+  tsvector: { dslType: "tsvector" },
   oid: { dslType: "oid" },
   int4range: { dslType: "int4range" },
   int8range: { dslType: "int8range" },
@@ -195,6 +197,10 @@ const DSL_HELPER_METHODS = new Set([
   "json",
   "jsonb",
   "citext",
+  "ltree",
+  "tsvector",
+  "bit",
+  "bitVarying",
   "money",
   "int4range",
   "int8range",
@@ -244,6 +250,10 @@ function sqlTypeToDsl(sqlType: string): DslMapping {
             : { dslType: "datetime" };
       } else if (timeMatch) {
         result = { dslType: "time" };
+      } else if (/^bit\(\d+\)$/.test(baseType)) {
+        result = { dslType: "bit" };
+      } else if (/^(?:bit varying|varbit)\(\d+\)$/.test(baseType)) {
+        result = { dslType: "bitVarying" };
       } else if (KNOWN_DSL_TYPES.has(baseType)) {
         result = { dslType: baseType };
       } else {


### PR DESCRIPTION
## Summary

- Implements test bodies for `ltree`, `tsvector`/full-text, and `bit-string` PG adapter tests (un-skips 17 tests from 3 files)
- Fixes schema-dumper DSL dispatch for `bit(N)`, `bit varying(N)`, and `bitVarying` / `ltree` / `tsvector` column types:
  - `bit(8)` → `t.bit(...)`, `bit varying(4)` → `t.bitVarying(...)`, `ltree` → `t.ltree(...)`, `tsvector` → `t.tsvector(...)`
  - Adds `"bit"`, `"bitVarying"`, `"ltree"`, `"tsvector"` to `DSL_HELPER_METHODS`
  - Fixes incorrect `"bit varying": { dslType: "bit" }` → `{ dslType: "bitVarying" }`

## Notes

- **tsquery** has no Rails OID file, no Rails test, and is not registered in `postgresql_adapter.rb`. The `tsquery column` test remains skipped (fabricated name with no Rails counterpart).
- `bit-string` tests use raw SQL (not ORM layer) since `Base` auto-schema creates tables without the `ltree`/type columns.
- All 17 new tests verified passing in full `pnpm run test:db` run.

## LOC

261 additions + deletions (within 300 ceiling).

## Test plan

- [x] `pnpm run test:db` — all 3 test files pass (ltree 5/5, bit-string 9/9, full-text 3/4 + 1 skip)
- [x] `pnpm run api:compare --package activerecord` — 4949/4958 (no regression)
- [x] `pnpm run test:types` — 83/83
- [x] `pnpm run lint` — no errors