### PR TITLE
chore(activerecord) type audit W3a + W2e cleanup — typed internal fields on Base

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -543,10 +543,7 @@ async function _loadThroughViaDisableJoinsScope(
  * Sync loaded result to the association instance if one exists.
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
-  const instances = record._associationInstances as Map<string, any> | undefined;
-  if (instances?.has(assocName)) {
-    instances.get(assocName)!.setTarget(result);
-  }
+  record._associationInstances.get(assocName)?.setTarget(result as Base | Base[] | null);
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -138,9 +138,9 @@ export function registerModel(nameOrModel: string | typeof Base, model?: typeof 
     if (!model) throw new Error("registerModel(name, model) requires a model class");
     modelRegistry.set(nameOrModel, model);
     // Attach registry key so counter-cache pending-map lookup can match it.
-    const keys: string[] = (model as any)._registryKeys ?? [];
+    const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
-    (model as any)._registryKeys = keys;
+    model._registryKeys = keys;
     flushPendingCounterCacheColumns(model);
   } else {
     modelRegistry.set(nameOrModel.name, nameOrModel);
@@ -164,7 +164,7 @@ export function resolveModel(name: string): typeof Base {
  * Throws InverseOfAssociationNotFoundError if not found.
  */
 function validateInverseOf(targetModel: typeof Base, assocName: string, inverseOf: string): void {
-  const targetAssocs: AssociationDefinition[] = (targetModel as any)._associations ?? [];
+  const targetAssocs: AssociationDefinition[] = targetModel._associations ?? [];
   if (targetAssocs.length === 0) return;
   if (targetAssocs.some((a) => a.name === inverseOf)) return;
 
@@ -212,9 +212,7 @@ export function resolveCounterColumn(
     return `${assoc.name}_count`;
   }
   const childModel = resolveModel(childClassName);
-  const childAssocs = (childModel as any)._associations as
-    | Array<{ type: string; name: string; options: any }>
-    | undefined;
+  const childAssocs = childModel._associations as AssociationDefinition[] | undefined;
   if (childAssocs) {
     // Check against parent name and STI base class name
     const parentNames = new Set([parentModel.name]);
@@ -227,7 +225,7 @@ export function resolveCounterColumn(
       (a) =>
         a.type === "belongsTo" &&
         a.options.counterCache &&
-        (parentNames.has(a.options.className) || parentNames.has(camelize(a.name))),
+        (parentNames.has(a.options.className ?? "") || parentNames.has(camelize(a.name))),
     );
     if (belongsTo) {
       if (typeof belongsTo.options.counterCache === "string") {
@@ -545,7 +543,7 @@ async function _loadThroughViaDisableJoinsScope(
  * Sync loaded result to the association instance if one exists.
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
-  const instances = (record as any)._associationInstances as Map<string, any> | undefined;
+  const instances = record._associationInstances as Map<string, any> | undefined;
   if (instances?.has(assocName)) {
     instances.get(assocName)!.setTarget(result);
   }
@@ -566,8 +564,8 @@ export async function loadBelongsTo(
   // the value is null: an invalid name must throw even when the cached value is
   // null (e.g. preloader stored null for a missing row), consistent with the
   // cache-miss path that validates before the FK/null short-circuit.
-  if ((record as any)._cachedAssociations?.has(assocName)) {
-    const cached = (record as any)._cachedAssociations.get(assocName) as Base | null;
+  if (record._cachedAssociations?.has(assocName)) {
+    const cached = record._cachedAssociations.get(assocName) as Base | null;
     if (options.inverseOf && !options.polymorphic) {
       // Resolve target class from instance if available, otherwise from options.
       const targetModel =
@@ -576,13 +574,13 @@ export async function loadBelongsTo(
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
     if (options.inverseOf && cached) {
-      (cached as any)._cachedAssociations = (cached as any)._cachedAssociations ?? new Map();
-      (cached as any)._cachedAssociations.set(options.inverseOf, record);
+      cached._cachedAssociations = cached._cachedAssociations ?? new Map();
+      cached._cachedAssociations.set(options.inverseOf, record);
     }
     return cached;
   }
-  if ((record as any)._preloadedAssociations?.has(assocName)) {
-    const preloaded = (record as any)._preloadedAssociations.get(assocName) as Base | null;
+  if (record._preloadedAssociations?.has(assocName)) {
+    const preloaded = record._preloadedAssociations.get(assocName) as Base | null;
     if (options.inverseOf && !options.polymorphic) {
       const targetModel =
         (preloaded?.constructor as typeof Base | undefined) ??
@@ -590,14 +588,14 @@ export async function loadBelongsTo(
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
     if (options.inverseOf && preloaded) {
-      (preloaded as any)._cachedAssociations = (preloaded as any)._cachedAssociations ?? new Map();
-      (preloaded as any)._cachedAssociations.set(options.inverseOf, record);
+      preloaded._cachedAssociations = preloaded._cachedAssociations ?? new Map();
+      preloaded._cachedAssociations.set(options.inverseOf, record);
     }
     return preloaded;
   }
 
   // Strict loading check: this is a lazy load
-  if ((record as any)._strictLoading && !(record as any)._strictLoadingBypassCount) {
+  if (record._strictLoading && !record._strictLoadingBypassCount) {
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
@@ -686,8 +684,8 @@ export async function loadBelongsTo(
 
   // Set inverse_of: store reference back to the owner
   if (result && options.inverseOf) {
-    (result as any)._cachedAssociations = (result as any)._cachedAssociations ?? new Map();
-    (result as any)._cachedAssociations.set(options.inverseOf, record);
+    result._cachedAssociations = result._cachedAssociations ?? new Map();
+    result._cachedAssociations.set(options.inverseOf, record);
   }
 
   syncToAssociationInstance(record, assocName, result);
@@ -706,15 +704,15 @@ export async function loadHasOne(
     validateThroughReflection(record.constructor as typeof Base, assocName);
   }
   // Check cached (inverse_of) first, then preloaded
-  if ((record as any)._cachedAssociations?.has(assocName)) {
-    return (record as any)._cachedAssociations.get(assocName) as Base | null;
+  if (record._cachedAssociations?.has(assocName)) {
+    return record._cachedAssociations.get(assocName) as Base | null;
   }
-  if ((record as any)._preloadedAssociations?.has(assocName)) {
-    return (record as any)._preloadedAssociations.get(assocName) as Base | null;
+  if (record._preloadedAssociations?.has(assocName)) {
+    return record._preloadedAssociations.get(assocName) as Base | null;
   }
 
   // Strict loading check
-  if ((record as any)._strictLoading && !(record as any)._strictLoadingBypassCount) {
+  if (record._strictLoading && !record._strictLoadingBypassCount) {
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
@@ -831,8 +829,8 @@ export async function loadHasOne(
 
   // Set inverse_of: store reference back to the owner
   if (result && options.inverseOf) {
-    (result as any)._cachedAssociations = (result as any)._cachedAssociations ?? new Map();
-    (result as any)._cachedAssociations.set(options.inverseOf, record);
+    result._cachedAssociations = result._cachedAssociations ?? new Map();
+    result._cachedAssociations.set(options.inverseOf, record);
   }
 
   syncToAssociationInstance(record, assocName, result);
@@ -910,15 +908,15 @@ export async function loadHasMany(
     validateThroughReflection(record.constructor as typeof Base, assocName);
   }
   // Check cached (inverse_of) first, then preloaded
-  if ((record as any)._cachedAssociations?.has(assocName)) {
-    return (record as any)._cachedAssociations.get(assocName) as Base[];
+  if (record._cachedAssociations?.has(assocName)) {
+    return record._cachedAssociations.get(assocName) as Base[];
   }
-  if ((record as any)._preloadedAssociations?.has(assocName)) {
-    return (record as any)._preloadedAssociations.get(assocName) as Base[];
+  if (record._preloadedAssociations?.has(assocName)) {
+    return record._preloadedAssociations.get(assocName) as Base[];
   }
 
   // Strict loading check
-  if ((record as any)._strictLoading && !(record as any)._strictLoadingBypassCount) {
+  if (record._strictLoading && !record._strictLoadingBypassCount) {
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
@@ -1045,8 +1043,8 @@ export async function loadHasMany(
   // Set inverse_of on each loaded child
   if (options.inverseOf) {
     for (const child of results) {
-      (child as any)._cachedAssociations = (child as any)._cachedAssociations ?? new Map();
-      (child as any)._cachedAssociations.set(options.inverseOf, record);
+      child._cachedAssociations = child._cachedAssociations ?? new Map();
+      child._cachedAssociations.set(options.inverseOf, record);
     }
   }
 
@@ -1148,12 +1146,12 @@ export async function countHasMany(
 ): Promise<number> {
   if (options.through) {
     // Temporarily disable strict loading so through-association loading works
-    (record as any)._strictLoadingBypassCount++;
+    record._strictLoadingBypassCount++;
     try {
       const records = await loadHasManyThrough(record, assocName, options);
       return records.length;
     } finally {
-      (record as any)._strictLoadingBypassCount--;
+      record._strictLoadingBypassCount--;
     }
   }
   const rel = buildHasManyRelation(record, assocName, options);
@@ -1177,7 +1175,7 @@ export async function loadHasManyThrough(
   options: AssociationOptions,
 ): Promise<Base[]> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssoc = associations.find((a) => a.name === options.through);
   if (!throughAssoc) {
     throw new ConfigurationError(
@@ -1197,7 +1195,7 @@ export async function loadHasManyThrough(
   const throughClassName =
     throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
   const throughModel = resolveModel(throughClassName);
-  const throughModelAssocs: AssociationDefinition[] = (throughModel as any)._associations ?? [];
+  const throughModelAssocs: AssociationDefinition[] = throughModel._associations ?? [];
   const sourceAssoc =
     throughModelAssocs.find((a) => a.name === sourceName) ??
     throughModelAssocs.find((a) => a.name === pluralize(sourceName));
@@ -1279,7 +1277,7 @@ export async function loadHasOneThrough(
   options: AssociationOptions,
 ): Promise<Base | null> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssoc = associations.find((a) => a.name === options.through);
   if (!throughAssoc) {
     throw new ConfigurationError(
@@ -1305,7 +1303,7 @@ export async function loadHasOneThrough(
   // Now load the source from the through record
   const sourceName = options.source ?? assocName;
   const throughCtor = throughRecord.constructor as typeof Base;
-  const throughAssociations: AssociationDefinition[] = (throughCtor as any)._associations ?? [];
+  const throughAssociations: AssociationDefinition[] = throughCtor._associations ?? [];
   const sourceAssoc = throughAssociations.find((a) => a.name === sourceName);
 
   if (sourceAssoc) {
@@ -1395,7 +1393,7 @@ function createHabtmJoinModel(
     name: sourceName,
     options: { className: targetClassName, foreignKey: targetFk },
   });
-  (JoinModel as any)._associations = joinAssocs;
+  JoinModel._associations = joinAssocs;
 
   for (const assocDef of joinAssocs) {
     const ref = Reflection.create(
@@ -1451,8 +1449,8 @@ export async function loadHabtm(
   options: AssociationOptions & { joinTable?: string },
 ): Promise<Base[]> {
   // Check preloaded cache first
-  if ((record as any)._preloadedAssociations?.has(assocName)) {
-    return (record as any)._preloadedAssociations.get(assocName) as Base[];
+  if (record._preloadedAssociations?.has(assocName)) {
+    return record._preloadedAssociations.get(assocName) as Base[];
   }
 
   const ctor = record.constructor as typeof Base;
@@ -1488,7 +1486,7 @@ export async function loadHabtm(
  */
 export async function processDependentAssociations(record: Base): Promise<void> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
 
   for (const assoc of associations) {
     // HABTM with through: handled by the middle hasMany's dependent: "delete"
@@ -1607,7 +1605,7 @@ export function buildThroughAssociation(
   attrs: Record<string, unknown> = {},
 ): { target: Base; through: Base } {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
   const assocDef = associations.find((a) => a.name === assocName);
   if (!assocDef || !assocDef.options.through) {
     throw new ConfigurationError(
@@ -1699,12 +1697,12 @@ export async function createThroughAssociation(
   const { target, through } = buildThroughAssociation(record, assocName, attrs);
 
   // Resolve source type before any saves to determine save ordering
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
   const assocDef = associations.find((a) => a.name === assocName)!;
   const sourceName = assocDef.options.source ?? assocName;
 
   const throughCtor = through.constructor as typeof Base;
-  const throughAssociations: AssociationDefinition[] = (throughCtor as any)._associations ?? [];
+  const throughAssociations: AssociationDefinition[] = throughCtor._associations ?? [];
   const sourceAssocDef =
     throughAssociations.find((a) => a.name === sourceName) ??
     throughAssociations.find((a) => a.name === pluralize(sourceName));
@@ -1777,8 +1775,8 @@ export async function createThroughAssociation(
   });
 
   if (success) {
-    (record as any)._cachedAssociations = (record as any)._cachedAssociations ?? new Map();
-    (record as any)._cachedAssociations.set(assocName, target);
+    record._cachedAssociations = record._cachedAssociations ?? new Map();
+    record._cachedAssociations.set(assocName, target);
   } else {
     // Transaction rolled back — reset in-memory persisted state and PKs
     for (const rec of [target, through]) {
@@ -1815,7 +1813,7 @@ export function association<T extends Base = Base>(
   }
 
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
   const assocDef = associations.find((a) => a.name === assocName);
   if (!assocDef) {
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
@@ -1910,7 +1908,7 @@ export async function updateCounterCaches(
   direction: "increment" | "decrement",
 ): Promise<void> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
 
   for (const assoc of associations) {
     if (assoc.type !== "belongsTo" || !assoc.options.counterCache) continue;
@@ -2035,13 +2033,13 @@ export function setBelongsTo(
   }
 
   // Cache the association
-  if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
-  (record as any)._cachedAssociations.set(assocName, target);
+  if (!record._cachedAssociations) record._cachedAssociations = new Map();
+  record._cachedAssociations.set(assocName, target);
 
   // Set inverse on target
   if (target && options.inverseOf) {
-    if (!(target as any)._cachedAssociations) (target as any)._cachedAssociations = new Map();
-    (target as any)._cachedAssociations.set(options.inverseOf, record);
+    if (!target._cachedAssociations) target._cachedAssociations = new Map();
+    target._cachedAssociations.set(options.inverseOf, record);
   }
 }
 
@@ -2087,13 +2085,13 @@ export async function setHasOne(
   }
 
   // Cache
-  if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
-  (record as any)._cachedAssociations.set(assocName, target);
+  if (!record._cachedAssociations) record._cachedAssociations = new Map();
+  record._cachedAssociations.set(assocName, target);
 
   // Set inverse
   if (target && options.inverseOf) {
-    if (!(target as any)._cachedAssociations) (target as any)._cachedAssociations = new Map();
-    (target as any)._cachedAssociations.set(options.inverseOf, record);
+    if (!target._cachedAssociations) target._cachedAssociations = new Map();
+    target._cachedAssociations.set(options.inverseOf, record);
   }
 }
 
@@ -2142,19 +2140,19 @@ export async function setHasMany(
 
     // Set inverse
     if (options.inverseOf) {
-      if (!(t as any)._cachedAssociations) (t as any)._cachedAssociations = new Map();
-      (t as any)._cachedAssociations.set(options.inverseOf, record);
+      if (!t._cachedAssociations) t._cachedAssociations = new Map();
+      t._cachedAssociations.set(options.inverseOf, record);
     }
   }
 
   // Cache the collection
-  if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
-  (record as any)._cachedAssociations.set(assocName, targets);
+  if (!record._cachedAssociations) record._cachedAssociations = new Map();
+  record._cachedAssociations.set(assocName, targets);
 }
 
 export async function touchBelongsToParents(record: Base): Promise<void> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
 
   for (const assoc of associations) {
     if (assoc.type !== "belongsTo" || !assoc.options.touch) continue;

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -1,6 +1,7 @@
 import { singularize } from "@blazetrails/activesupport";
 import { Association, type AssociationInstanceHost } from "./association.js";
 import { association } from "../../associations.js";
+import type { Base } from "../../base.js";
 
 const CALLBACKS = ["beforeAdd", "afterAdd", "beforeRemove", "afterRemove"] as const;
 
@@ -101,7 +102,7 @@ export class CollectionAssociation extends Association {
     const existing = Object.getOwnPropertyDescriptor(mixin, name);
     if (!existing || existing.configurable) {
       Object.defineProperty(mixin, name, {
-        get(this: any) {
+        get(this: Base) {
           return association(this, name);
         },
         set: existing?.set,

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -66,7 +66,7 @@ function assertSingularAssociation(
   name: string,
   expected: "belongsTo" | "hasOne",
 ): AssocDef {
-  const ctor = this.constructor as typeof Base & { _associations?: AssocDef[] };
+  const ctor = this.constructor as typeof Base;
   const assocDef = ctor._associations?.find((a) => a.name === name);
   if (!assocDef) {
     throw new AssociationNotFoundError(this, name);
@@ -111,7 +111,7 @@ export function association(this: Base, name: string): AssociationInstance {
     return existing;
   }
 
-  const ctor = this.constructor as typeof Base & { _associations?: AssocDef[] };
+  const ctor = this.constructor as typeof Base;
   const assocDef = ctor._associations?.find((a) => a.name === name);
   if (!assocDef) {
     throw new AssociationNotFoundError(this, name);

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -18,13 +18,8 @@ import { AssociationNotFoundError } from "./errors.js";
 import {
   loadBelongsTo as _loadBelongsToOnce,
   loadHasOne as _loadHasOneOnce,
+  type AssociationDefinition as AssocDef,
 } from "../associations.js";
-
-interface AssocDef {
-  name: string;
-  type: "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany";
-  options?: Record<string, unknown>;
-}
 
 function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationInstance {
   const opts = (assocDef.options ?? {}) as Record<string, unknown>;
@@ -51,10 +46,9 @@ function syncAssociationInstance(this: Base, name: string, instance: Association
     instance.setTarget(proxy.target as any);
     return;
   }
-  const cached = (this as unknown as { _cachedAssociations?: Map<string, unknown> })
-    ._cachedAssociations;
+  const cached = this._cachedAssociations;
   if (cached && cached.has(name)) {
-    instance.setTarget(cached.get(name) as any);
+    instance.setTarget(cached.get(name) ?? null);
     return;
   }
   // Use `has()` so an eagerly-preloaded "nil association" (the preloader

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -17,7 +17,6 @@ import {
   registerWithSuperclass,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
-import type { Base } from "./base.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup } from "./type.js";
 
@@ -68,8 +67,8 @@ export function defineAttribute(
 ): void {
   // STI subclasses share the base's _attributeDefinitions — route to the
   // base to avoid forking a subclass-local map that drifts from the base.
-  if (isStiSubclass(this as typeof Base)) {
-    const stiBase = getStiBase(this as typeof Base);
+  if (isStiSubclass(this)) {
+    const stiBase = getStiBase(this);
     (stiBase as AnyClass).defineAttribute(name, castType, options);
     return;
   }
@@ -135,9 +134,7 @@ export function defineAttribute(
 export function _defaultAttributes(this: AnyClass): AttributeSet {
   // For STI subclasses, delegate to the STI base so cache invalidation
   // from Base.attribute/defineAttribute (always routed to the base) is coherent.
-  const cacheHost = isStiSubclass(this as typeof Base)
-    ? (getStiBase(this as typeof Base) as AnyClass)
-    : this;
+  const cacheHost = isStiSubclass(this) ? (getStiBase(this) as AnyClass) : this;
 
   if (!cacheHost._cachedDefaultAttributes) {
     // Register cacheHost with its superclass so resetDefaultAttributes()

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -237,6 +237,7 @@ import {
   isAssociationCached as _isAssociationCached,
   associationInstanceGet as _associationInstanceGet,
   associationInstanceSet as _associationInstanceSet,
+  type AssociationDefinition,
 } from "./associations.js";
 import * as _AttributeAssignment from "./attribute-assignment.js";
 import * as _NestedAttributes from "./nested-attributes.js";
@@ -556,6 +557,11 @@ export class Base extends Model {
   static _tableName: string | null = null;
   static _primaryKey: string | string[] = "id";
   static readonly _isActiveRecordBase = true;
+
+  /** @internal */
+  declare static _associations: AssociationDefinition[];
+  /** @internal */
+  static _registryKeys: string[] = [];
 
   /** Mirrors: ActiveRecord.writing_role */
   static writingRole = WRITING_ROLE;
@@ -2208,6 +2214,8 @@ export class Base extends Model {
   _preloadedAssociations: Map<string, unknown> = new Map();
   _collectionProxies: Map<string, unknown> = new Map();
   _associationInstances: Map<string, AssociationInstance> = new Map();
+  /** @internal */
+  _cachedAssociations?: Map<string, Base | Base[] | null>;
 
   constructor(attrs: Record<string, unknown> = {}) {
     (new.target as typeof Base | undefined)?._requireConcreteClass();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -561,7 +561,7 @@ export class Base extends Model {
   /** @internal */
   declare static _associations: AssociationDefinition[];
   /** @internal */
-  static _registryKeys: string[] = [];
+  declare static _registryKeys: string[];
 
   /** Mirrors: ActiveRecord.writing_role */
   static writingRole = WRITING_ROLE;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -604,7 +604,7 @@ export async function save<T extends SaveRecord>(
   }
 
   self._skipTouch = options?.touch === false;
-  const ctor = this.constructor as unknown as Parameters<typeof isStiSubclass>[0];
+  const ctor = this.constructor;
 
   // Auto-set STI type column on new records
   if (this._newRecord && isStiSubclass(ctor)) {


### PR DESCRIPTION
## Summary

- **W3a**: Declare `_associations` (`AssociationDefinition[]`), `_registryKeys` (`string[]`) as typed `@internal` static fields on `Base`, and `_cachedAssociations` (`Map<string, Base | Base[] | null>`) as a typed `@internal` instance field. All three were previously accessed via `(x as any)._field` throughout `associations.ts`.
- **W2e cleanup**: Remove redundant `as typeof Base` casts from `attributes.ts` and simplify the `as unknown as Parameters<typeof isStiSubclass>[0]` ctor cast in `persistence.ts` — both became no-ops when `isStiSubclass`/`getStiBase` were widened to `object` in #1507.
- **W2e `this: any` fix**: Add `import type { Base }` to `collection-association.ts` and type the `defineReaders` getter as `this: Base` instead of `this: any`.
- **Bonus**: Replaced local `AssocDef` interface in `instance-methods.ts` with `AssociationDefinition` from `associations.ts`; removed stale `as unknown as { _cachedAssociations? }` cast from the same file.

## `as any` delta

| File | Before | After |
|------|--------|-------|
| `associations.ts` | 90 | 30 |

## Validation

- `pnpm test` — 747 test files passed (5 pre-existing failures in `extract-ts-api.test.ts` unrelated to this PR)
- `pnpm test:types` — 83 passed
- `pnpm run api:compare --package activerecord` — 4949/4958 (99.8%), no regression
- `pnpm run typecheck` — clean
- LOC: +78 / -80 (well within 300 ceiling)