### PR TITLE
refactor(activerecord) Relation Calculations to method-syntax (CP PR B)

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -190,8 +190,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   // reads; with CP now extending Relation, chained AR methods need the
   // same gate.
 
-  // @ts-expect-error — Relation defines `count` as a property; override
-  //   as a method so we can gate strict-loading before dispatching.
   async count(column?: string): Promise<number | Record<string, number>> {
     this._checkStrictLoading();
     return (
@@ -201,9 +199,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     ).count.call(this, column);
   }
 
-  // @ts-expect-error — sum/average/minimum/maximum are also property-
-  //   assigned on Relation (from the Calculations mixin); override as
-  //   methods to gate strict-loading before each SQL entry point.
   async sum(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     return (
@@ -213,7 +208,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     ).sum.call(this, column);
   }
 
-  // @ts-expect-error — see `sum`.
   async average(column: string): Promise<number | null | Record<string, number>> {
     this._checkStrictLoading();
     return (
@@ -223,7 +217,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     ).average.call(this, column);
   }
 
-  // @ts-expect-error — see `sum`.
   async minimum(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     return (
@@ -233,7 +226,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     ).minimum.call(this, column);
   }
 
-  // @ts-expect-error — see `sum`.
   async maximum(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     return (

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -756,10 +756,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Count associated records.
    */
-  // @ts-expect-error Relation defines `count` as a property (from the
-  //   calculations mixin); CP declares it as a method with association
-  //   semantics (loaded-target fast path). PR B will delete CP's count
-  //   and let Relation's win.
   async count(): Promise<number> {
     // Rails' CollectionAssociation#count: if the target is already
     // loaded, count the loaded array (no query). Otherwise issue a
@@ -849,8 +845,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // treatment as pluck/pick/count. Without overriding, cp.sum('x') /
   // cp.whereBang({...}); cp.average('y') would both bypass the gate
   // and drop in-place mutations.
-  // @ts-expect-error sum is a property on Relation (Calculations mixin);
-  //   method override is intentional to gate + honor divergence.
   async sum(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     const fn = (
@@ -867,7 +861,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     ).sum(column);
   }
 
-  // @ts-expect-error see `sum`.
   async average(column: string): Promise<number | null | Record<string, number>> {
     this._checkStrictLoading();
     const fn = (
@@ -882,7 +875,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     ).average(column);
   }
 
-  // @ts-expect-error see `sum`.
   async minimum(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     const fn = (
@@ -899,7 +891,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     ).minimum(column);
   }
 
-  // @ts-expect-error see `sum`.
   async maximum(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     const fn = (

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -391,9 +391,6 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * loading) — except we skip the materialization since count
    * doesn't need it. Net: same result, fewer rows hydrated.
    */
-  // @ts-expect-error Relation defines `count` as a property (from
-  //   the calculations mixin); DJAR overrides as an async method
-  //   that runs the deferred chain walk before counting.
   async count(column?: string): Promise<number | Record<string, number>> {
     if (this._chainWalker) {
       const { relation } = await this._walkOnce();

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -66,6 +66,7 @@ import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { include, type Included } from "@blazetrails/activesupport";
 import {
   Calculations,
+  type CalculationMethods,
   groupColumnToArel,
   aggregateColumn as _aggregateColumn,
   isAllAttributes as _isAllAttributes,
@@ -5067,11 +5068,14 @@ export interface Relation<T extends Base> {
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 
-// QueryMethodBangs and Calculations don't involve T — Included<> works fine.
+// QueryMethodBangs doesn't involve T — Included<> works fine.
+// Calculations uses the explicit CalculationMethods interface (method-syntax)
+// so subclasses (CollectionProxy, AssociationRelation, DJAR) can override
+// count/sum/etc. with narrower signatures.
 // FinderMethods and SpawnMethods return T-typed values — explicit signatures needed.
 
 export interface Relation<T extends Base>
-  extends Included<typeof QueryMethodBangs>, Included<typeof Calculations> {
+  extends Included<typeof QueryMethodBangs>, CalculationMethods {
   find(ids: unknown[]): Promise<T[]>;
   find(id: unknown): Promise<T>;
   find(...ids: unknown[]): Promise<T | T[]>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -420,9 +420,15 @@ export async function performMaximum(
 }
 
 /**
- * Interface for the calculation methods mixed into Relation.
- * Used with interface merging so the methods appear as proper
- * method signatures in .d.ts output.
+ * Interface for the calculation methods mixed into Relation. Declared as
+ * **method-syntax** (not property-syntax) so subclasses — CollectionProxy,
+ * AssociationRelation, DisableJoinsAssociationRelation — can override
+ * `count` / `sum` / `average` / `minimum` / `maximum` with narrower
+ * signatures and added behavior (loaded-target fast path, strict-loading
+ * gating, DJAR chain-walker). Do NOT replace this with
+ * `Included<typeof Calculations>` on the `Relation` interface:
+ * `Included<>` emits property-syntax members, and TS's strict variance
+ * rules then reject every subclass override.
  */
 export interface CalculationMethods {
   count(column?: string): Promise<number | Record<string, number>>;


### PR DESCRIPTION
## Summary

Switches `Relation`'s Calculations interface declaration from `Included<typeof Calculations>` (property-syntax) to the explicit `CalculationMethods` interface (method-syntax), unblocking subclass overrides of `count` / `sum` / `average` / `minimum` / `maximum`.

## Root cause

`Included<>` produces a mapped type with **property-syntax** members (`count: (...args) => Promise<...>`). TS's variance rules treat a method-syntax override (`async count() {}`) as incompatible with a property-syntax parent member — even when the override is a legitimate subtype. That's what every "Relation defines `count` as a property" `@ts-expect-error` comment was describing.

`CalculationMethods` already existed in `relation/calculations.ts` with matching method-syntax declarations. Wiring it into the `Relation` interface lets CP / AssociationRelation / DJAR override these methods normally.

## Changes

- `relation.ts`: `extends Included<typeof Calculations>` → `extends CalculationMethods`. Import `CalculationMethods` as a type. Updated adjacent comment.
- Deleted 11 `@ts-expect-error` directives:
  - `associations/collection-proxy.ts`: 5 (count, sum, average, minimum, maximum)
  - `association-relation.ts`: 5 (count, sum, average, minimum, maximum)
  - `disable-joins-association-relation.ts`: 1 (count)

The 2 remaining directives in CP that are still nominally about Calculations (`pluck`, `calculate`) — actually they aren't; checked the file, those 2 are about signature divergence on `delete` / `destroy` / `isNone` / `destroyAll` / `deleteAll` / `calculate` / `load`, which are orthogonal and remain.

## Behavior preservation

Runtime is unchanged. `include(Relation, Calculations)` at the bottom of `relation.ts` still assigns the calc functions to the prototype. CP's `count` still has its loaded-target fast path + through-association DJAR routing. AR's strict-loading gates still run. DJAR's chain-walker still drives `count`.

## Size

`+6 / -22` LOC across 4 files. No public API changes; no fixture/snapshot updates.

## Test plan

- [x] `tsc --build packages/activerecord` clean
- [x] `pnpm test:types` clean (83 passed, 0 type errors)
- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1309 passed, 334 skipped (no new failures)
- [x] `collection-proxy.test.ts`, `association-relation.test.ts` green