### PR TITLE
feat(activerecord) NIE annotations + ESLint guardrail

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import vitest from "@vitest/eslint-plugin";
 import noNodeBuiltins from "./eslint/no-node-builtins.mjs";
 import noProcessBypass from "./eslint/no-process-bypass.mjs";
 import railsPrivateJsdoc from "./eslint/rails-private-jsdoc.mjs";
+import nieRequiresAnnotation from "./eslint/nie-requires-annotation.mjs";
 import noNativeDate from "./eslint/no-native-date.mjs";
 import sqliteDriverAwait from "./eslint/sqlite-driver-await.mjs";
 
@@ -105,6 +106,7 @@ export default defineConfig(
           "rails-private-jsdoc": railsPrivateJsdoc,
           "no-native-date": noNativeDate,
           "sqlite-driver-await": sqliteDriverAwait,
+          "nie-requires-annotation": nieRequiresAnnotation,
         },
       },
     },
@@ -176,6 +178,17 @@ export default defineConfig(
     ignores: ["**/*.test.ts"],
     rules: {
       "blazetrails/rails-private-jsdoc": "error",
+    },
+  },
+
+  // ── nie-requires-annotation: every `throw new NotImplementedError` must
+  // carry a `// @nie disposition=…` comment. Tracks the elimination
+  // initiative (docs/activerecord-100-clusters.md).
+  {
+    files: ["packages/activerecord/src/**/*.ts"],
+    ignores: ["**/*.test.ts"],
+    rules: {
+      "blazetrails/nie-requires-annotation": "error",
     },
   },
 

--- a/eslint/nie-requires-annotation.mjs
+++ b/eslint/nie-requires-annotation.mjs
@@ -1,0 +1,101 @@
+/**
+ * ESLint rule: nie-requires-annotation
+ *
+ * Every `throw new NotImplementedError(...)` must carry an `@nie` annotation
+ * comment on the immediately preceding line, specifying the disposition under
+ * the `NotImplementedError` elimination initiative
+ * (docs/activerecord-100-clusters.md).
+ *
+ * Allowed dispositions:
+ *   port-real | keep-as-strategy-hook | remove-from-class |
+ *   empty-default | delete-stub | TODO
+ *
+ * Format:
+ *   // @nie disposition=<one-of-above> [rails=path[:line]] [cluster=<slug>]
+ */
+
+const ALLOWED = new Set([
+  "port-real",
+  "keep-as-strategy-hook",
+  "remove-from-class",
+  "empty-default",
+  "delete-stub",
+  "TODO",
+]);
+
+const ANNOTATION_RE = /@nie\s+disposition=([\w-]+)/;
+
+function isNotImplementedThrow(node) {
+  if (node.type !== "ThrowStatement") return false;
+  const arg = node.argument;
+  if (!arg || arg.type !== "NewExpression") return false;
+  const callee = arg.callee;
+  if (!callee) return false;
+  if (callee.type === "Identifier" && callee.name === "NotImplementedError") return true;
+  if (
+    callee.type === "MemberExpression" &&
+    callee.property &&
+    callee.property.type === "Identifier" &&
+    callee.property.name === "NotImplementedError"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function precedingAnnotation(node, sourceCode) {
+  const comments = sourceCode.getCommentsBefore(node);
+  if (!comments.length) return null;
+  const last = comments[comments.length - 1];
+  if (!last.loc || !node.loc) return null;
+  if (last.loc.end.line !== node.loc.start.line - 1) return null;
+  return last;
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require `@nie` disposition annotation on every `throw new NotImplementedError(...)`.",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      missing:
+        "`throw new NotImplementedError` requires a preceding `// @nie disposition=…` annotation. See docs/activerecord-100-clusters.md.",
+      invalid:
+        "Invalid `@nie disposition=` value `{{value}}`. Allowed: port-real, keep-as-strategy-hook, remove-from-class, empty-default, delete-stub, TODO.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    return {
+      ThrowStatement(node) {
+        if (!isNotImplementedThrow(node)) return;
+        const comment = precedingAnnotation(node, sourceCode);
+        const match = comment && comment.value.match(ANNOTATION_RE);
+        if (!match) {
+          context.report({
+            node,
+            messageId: "missing",
+            fix(fixer) {
+              const lineText = sourceCode.lines[node.loc.start.line - 1] ?? "";
+              const indent = (lineText.match(/^(\s*)/) || ["", ""])[1];
+              return fixer.insertTextBeforeRange(
+                node.range,
+                `// @nie disposition=TODO\n${indent}`,
+              );
+            },
+          });
+          return;
+        }
+        if (!ALLOWED.has(match[1])) {
+          context.report({ node: comment, messageId: "invalid", data: { value: match[1] } });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/nie-requires-annotation.mjs
+++ b/eslint/nie-requires-annotation.mjs
@@ -82,10 +82,7 @@ const rule = {
             fix(fixer) {
               const lineText = sourceCode.lines[node.loc.start.line - 1] ?? "";
               const indent = (lineText.match(/^(\s*)/) || ["", ""])[1];
-              return fixer.insertTextBeforeRange(
-                node.range,
-                `// @nie disposition=TODO\n${indent}`,
-              );
+              return fixer.insertTextBeforeRange(node.range, `// @nie disposition=TODO\n${indent}`);
             },
           });
           return;

--- a/eslint/nie-requires-annotation.test.mjs
+++ b/eslint/nie-requires-annotation.test.mjs
@@ -1,0 +1,40 @@
+import { RuleTester } from "eslint";
+import rule from "./nie-requires-annotation.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parser: (await import("typescript-eslint")).parser,
+  },
+});
+
+tester.run("nie-requires-annotation", rule, {
+  valid: [
+    {
+      code: `function f() {\n  // @nie disposition=port-real rails=foo.rb:1 cluster=bar\n  throw new NotImplementedError("x");\n}\n`,
+    },
+    {
+      code: `function f() {\n  // @nie disposition=keep-as-strategy-hook\n  throw new NotImplementedError("x");\n}\n`,
+    },
+    {
+      code: `function f() {\n  throw new TypeError("not the target rule");\n}\n`,
+    },
+  ],
+  invalid: [
+    {
+      code: `function f() {\n  throw new NotImplementedError("x");\n}\n`,
+      errors: [{ messageId: "missing" }],
+      output: `function f() {\n  // @nie disposition=TODO\n  throw new NotImplementedError("x");\n}\n`,
+    },
+    {
+      code: `function f() {\n  // unrelated comment\n  throw new NotImplementedError("x");\n}\n`,
+      errors: [{ messageId: "missing" }],
+      output: `function f() {\n  // unrelated comment\n  // @nie disposition=TODO\n  throw new NotImplementedError("x");\n}\n`,
+    },
+    {
+      code: `function f() {\n  // @nie disposition=bogus\n  throw new NotImplementedError("x");\n}\n`,
+      errors: [{ messageId: "invalid", data: { value: "bogus" } }],
+    },
+  ],
+});

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -640,7 +640,7 @@ export class Base extends Model {
 
   static _requireConcreteClass(): void {
     if (this.abstractClass && !this._suppressAbstractCheck) {
-      // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/core.rb
+      // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/inheritance.rb:58
       throw new NotImplementedError(
         `${this.name} is an abstract class and cannot be instantiated.`,
       );

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -640,6 +640,7 @@ export class Base extends Model {
 
   static _requireConcreteClass(): void {
     if (this.abstractClass && !this._suppressAbstractCheck) {
+      // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/core.rb
       throw new NotImplementedError(
         `${this.name} is an abstract class and cannot be instantiated.`,
       );

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -109,6 +109,7 @@ export class ColumnSerializer {
 
 /** @internal */
 function checkArityOfConstructor(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/coders/column_serializer.rb
   throw new NotImplementedError(
     "ActiveRecord::Coders::ColumnSerializer#check_arity_of_constructor is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -118,19 +118,23 @@ export function defaultPrimaryKey(): string {
 }
 
 function name(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
   throw new NotImplementedError("ActiveRecord::ConnectionAdapters#name is not implemented");
 }
 
 function isValidate(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
   throw new NotImplementedError("ActiveRecord::ConnectionAdapters#validate? is not implemented");
 }
 
 function isExportNameOnSchemaDump(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters#export_name_on_schema_dump? is not implemented",
   );
 }
 
 function isDefinedFor(toTable?: any, validate?: any, options?: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
   throw new NotImplementedError("ActiveRecord::ConnectionAdapters#defined_for? is not implemented");
 }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1534,7 +1534,7 @@ export function rawExecute(
   materializeTransactions?: any,
   batch?: any,
 ): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:552
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1534,6 +1534,7 @@ export function rawExecute(
   materializeTransactions?: any,
   batch?: any,
 ): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute is not implemented",
   );
@@ -1553,6 +1554,7 @@ export function performQuery(
   _typeCastedBinds: unknown[],
   _options?: { prepare?: boolean; notificationPayload?: unknown; batch?: boolean },
 ): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#perform_query is not implemented",
   );
@@ -1560,6 +1562,7 @@ export function performQuery(
 
 /** @internal */
 function castResult(rawResult: any): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#cast_result is not implemented",
   );
@@ -1567,6 +1570,7 @@ function castResult(rawResult: any): never {
 
 /** @internal */
 function affectedRows(rawResult: any): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#affected_rows is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -501,7 +501,7 @@ function typeCastedBinds(
 
 /** @internal */
 function lookupCastType(sqlType: any): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:234
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -501,6 +501,7 @@ function typeCastedBinds(
 
 /** @internal */
 function lookupCastType(sqlType: any): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1991,6 +1991,7 @@ export class SchemaStatements {
 
   /** @internal */
   dataSourceSql(_name?: string, _options?: { type?: string }): string {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#data_source_sql is not implemented",
     );
@@ -1998,6 +1999,7 @@ export class SchemaStatements {
 
   /** @internal */
   quotedScope(_name?: string, _options?: { type?: string }): Record<string, string> {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#quoted_scope is not implemented",
     );

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1055,7 +1055,7 @@ export class TransactionManager {
 
 /** @internal */
 function appendCallbacks(callbacks: any): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/transaction.rb cluster=transactions
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:331 cluster=transactions
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Transaction#append_callbacks is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1055,6 +1055,7 @@ export class TransactionManager {
 
 /** @internal */
 function appendCallbacks(callbacks: any): never {
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/transaction.rb cluster=transactions
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Transaction#append_callbacks is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -200,6 +200,7 @@ export class Table extends AbstractTable {
 
 /** @internal */
 function validColumnDefinitionOptions(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb cluster=mysql-charset-collation
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#valid_column_definition_options is not implemented",
   );
@@ -207,6 +208,7 @@ function validColumnDefinitionOptions(): never {
 
 /** @internal */
 function aliasedTypes(name: any, fallback: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb cluster=mysql-charset-collation
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#aliased_types is not implemented",
   );
@@ -214,6 +216,7 @@ function aliasedTypes(name: any, fallback: any): never {
 
 /** @internal */
 function integerLikePrimaryKeyType(type: any, options: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb cluster=mysql-charset-collation
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1558,6 +1558,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
 /** @internal */
 function reconnect(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#reconnect is not implemented",
   );
@@ -1565,6 +1566,7 @@ function reconnect(): never {
 
 /** @internal */
 function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#translate_exception is not implemented",
   );
@@ -1572,6 +1574,7 @@ function translateException(exception: any, message?: any, sql?: any, binds?: an
 
 /** @internal */
 function initializeTypeMap(m: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -72,6 +72,7 @@ export async function executeBatch(
 
 /** @internal */
 function lastInsertedId(result: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -616,6 +616,7 @@ export class AlterTable extends AbstractAlterTable {
 
 /** @internal */
 function validColumnDefinitionOptions(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#valid_column_definition_options is not implemented",
   );
@@ -623,6 +624,7 @@ function validColumnDefinitionOptions(): never {
 
 /** @internal */
 function aliasedTypes(name: any, fallback: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#aliased_types is not implemented",
   );
@@ -630,6 +632,7 @@ function aliasedTypes(name: any, fallback: any): never {
 
 /** @internal */
 function integerLikePrimaryKeyType(type: any, options: any): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2315,7 +2315,7 @@ function translateException(
 
 /** @internal */
 function arelVisitor(): never {
-  // @nie disposition=remove-from-class rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:798
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#arel_visitor is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2315,6 +2315,7 @@ function translateException(
 
 /** @internal */
 function arelVisitor(): never {
+  // @nie disposition=remove-from-class rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#arel_visitor is not implemented",
   );
@@ -2322,6 +2323,7 @@ function arelVisitor(): never {
 
 /** @internal */
 function reconnect(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#reconnect is not implemented",
   );

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -59,6 +59,7 @@ export function connectsTo(
   },
 ): ConnectionPool[] {
   if (!isBaseClass(this) && !this.abstractClass) {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
     throw new NotImplementedError(
       "`connects_to` can only be called on ActiveRecord::Base or abstract classes",
     );
@@ -104,12 +105,14 @@ export function connectedTo<T>(
   fn: () => T,
 ): T {
   if (!isBaseClass(this) && !this.abstractClass) {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
     throw new NotImplementedError(
       "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes.",
     );
   }
 
   if (!this.connectionClassQ() && !isPrimaryClass.call(this)) {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
     throw new NotImplementedError(
       "calling `connected_to` is only allowed on the abstract class that established the connection.",
     );
@@ -159,10 +162,12 @@ export function connectedToMany<T>(this: typeof Base, ...args: unknown[]): T {
   }
 
   if (!isBaseClass(this)) {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
     throw new NotImplementedError("connected_to_many can only be called on ActiveRecord::Base.");
   }
 
   if (normalized.some((klass) => isBaseClass(klass))) {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
     throw new NotImplementedError("connected_to_many cannot include ActiveRecord::Base.");
   }
 

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -98,6 +98,7 @@ export function isDefaultScopes(
 
 /** @internal */
 function buildDefaultScope(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
   throw new NotImplementedError(
     "ActiveRecord::Scoping::Default#build_default_scope is not implemented",
   );
@@ -117,6 +118,7 @@ function isExecuteScope(
 
 /** @internal */
 function isIgnoreDefaultScope(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
   throw new NotImplementedError(
     "ActiveRecord::Scoping::Default#ignore_default_scope? is not implemented",
   );
@@ -124,6 +126,7 @@ function isIgnoreDefaultScope(): never {
 
 /** @internal */
 function ignoreDefaultScope(): never {
+  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
   throw new NotImplementedError(
     "ActiveRecord::Scoping::Default#ignore_default_scope= is not implemented",
   );


### PR DESCRIPTION
## Summary

Convert the one-time `NotImplementedError` audit (2026-05-11, `docs/activerecord-100-clusters.md`) into a permanent tracker:

1. Annotate every `throw new NotImplementedError(...)` in `packages/activerecord/src/` with a `// @nie disposition=...` comment.
2. Add ESLint rule `blazetrails/nie-requires-annotation` enforcing the annotation on future throws (autofix inserts `// @nie disposition=TODO`).

Each disposition was cross-checked against `scripts/api-compare/.rails-source/`. ~190 LOC; no behavior changes.

## Disposition tally (34 sites, 14 files)

| Disposition | Count |
| --- | --- |
| `port-real` | 23 |
| `keep-as-strategy-hook` | 11 |
| `remove-from-class` | 0 |
| `empty-default` | 0 |
| `delete-stub` | 0 |

(Audit said 38; current src has 34 — 4 sites closed since 2026-05-11. Audit's port-real/keep-as-strategy-hook split also shifted: Rails has real implementations for `rawExecute`, `appendCallbacks`, `lookupCastType`, and SQLite3's `arelVisitor` — all now classified port-real.)

## Cluster overlap

| Cluster | Sites |
| --- | --- |
| `mysql-mysql2-adapter` | `mysql2-adapter.ts` ×3, `mysql2/database-statements.ts` ×1 |
| `mysql-charset-collation` | `mysql/schema-definitions.ts` ×3 |
| `pg-long-tail` | `postgresql/schema-definitions.ts` ×3 |
| `relation` | `scoping/default.ts` ×3 |
| `transactions` | `abstract/transaction.ts` ×1 |
| `connection-pool` | `connection-handling.ts` ×5 |
| (no cluster scheduled) | `abstract/{database-statements,schema-statements,quoting}.ts`, `base.ts`, `connection-adapters.ts`, `sqlite3-adapter.ts`, `coders/column-serializer.ts` |

## Annotation format

```ts
// @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb:145 cluster=relation
throw new NotImplementedError("...");
```

Required: `disposition=`. Optional: `rails=path[:line]`, `cluster=<slug>`.

Allowed dispositions: `port-real`, `keep-as-strategy-hook`, `remove-from-class`, `empty-default`, `delete-stub`, `TODO` (escape hatch for new throws pre-classification).

## ESLint rule

- Fires on `ThrowStatement` whose throw is `new NotImplementedError(...)`.
- Requires the immediately preceding comment to match `/@nie\s+disposition=([\w-]+)/`.
- Reports `invalid` for disposition values outside the allowlist.
- Autofix inserts `// @nie disposition=TODO` so the rule is approachable for new code; reviewers then promote to a real disposition.
- Wired for `packages/activerecord/src/**/*.ts` (excludes `*.test.ts`).

## Test plan

- [x] `node --test eslint/nie-requires-annotation.test.mjs` green (3 valid + 3 invalid cases including autofix output)
- [x] `pnpm lint` green — no false positives on the annotations
- [x] All 34 dispositions verified against `scripts/api-compare/.rails-source/`
- [ ] CI green