### PR TITLE
fix(scripts): repair 5 pre-existing failures in extract-ts-api.test.ts

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1210,7 +1210,6 @@ export function extractClass(
 
   for (const member of node.members) {
     const memberName = getMemberName(member);
-
     const visibility = memberVisibility(member);
     const internal = visibility !== "public";
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -738,7 +738,8 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
         const sym =
           sym0 && sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
 
-        // (b): const object literal → harvest directly.
+        // (b): const object literal → harvest directly, then fall through to
+        // also push the name onto extends for compare.ts resolution.
         const valDecl = sym?.valueDeclaration ?? sym?.declarations?.[0];
         if (valDecl && ts.isVariableDeclaration(valDecl) && valDecl.initializer) {
           // Strip `as const` / other type assertions to reach the raw literal.
@@ -748,7 +749,6 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           }
           if (ts.isObjectLiteralExpression(init)) {
             pushMethods(harvestObjectLiteralMethods(init, checker, hostInfo.file ?? ""));
-            return;
           }
         }
 
@@ -869,7 +869,6 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           }
           if (ts.isObjectLiteralExpression(init)) {
             pushMethods(harvestObjectLiteralMethods(init, checker, hostInfo.file ?? ""));
-            return;
           }
         }
 
@@ -1211,10 +1210,6 @@ export function extractClass(
 
   for (const member of node.members) {
     const memberName = getMemberName(member);
-    // Skip #-prefixed private fields (TS private identifiers / backing fields).
-    // _-prefixed members are kept — Rails uses _snake_case for private helpers
-    // (e.g. _query_by_sql, _load_from_sql) and we mirror that convention.
-    if (memberName && ts.isPrivateIdentifier((member as ts.NamedDeclaration).name!)) continue;
 
     const visibility = memberVisibility(member);
     const internal = visibility !== "public";


### PR DESCRIPTION
## Summary

- `extractClass` was skipping all `#`-prefixed (private identifier) members before the visibility-tagging code ran. Removed the early `continue`; `memberVisibility()` already returns `"private"` for private-identifier names, so they now land in `instanceMethods` with `internal: true`.
- In the bare-identifier branch of both the include- and extend-detection passes, when the mod resolved to a `const` object literal the handler called `pushMethods()` then `return`ed — the mod name was never pushed onto `host.extends`. Removed the early `return` so control falls through to the existing `if (!hostInfo.extends.includes(modName))` dedup guard. This fixes the "pushes bare-identifier", "follows import aliases", "dedupes", and "const-cast host" tests simultaneously.

## Before / after

```
api:compare Overall: 7307/14593 (50.1%) — unchanged
```

All 38 tests in `scripts/api-compare/extract-ts-api.test.ts` now pass (was 33/38).