### PR TITLE
refactor(activemodel/activerecord) retire CallbackChain bridge (callbacks convergence PR 7)

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
-import { CallbackChain } from "./callbacks.js";
+import {
+  _registerCallbackOnProto,
+  runAllCallbacks,
+  runBeforeCallbacksOnProto,
+  runAfterCallbacksOnProto,
+} from "./callbacks.js";
 
 describe("CallbacksTest", () => {
   it("after callbacks are not executed if the block returns false", () => {
@@ -66,7 +71,7 @@ describe("CallbacksTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    (p.constructor as typeof Model)._callbackChain.runAfter("create", p);
+    runAfterCallbacksOnProto((p.constructor as typeof Model).prototype, "create", p);
     expect(log).toEqual(["first", "second"]);
   });
 
@@ -313,12 +318,12 @@ describe("CallbacksTest", () => {
 
 describe("CallbackChain.run", () => {
   it("runs after callbacks only after the block completes", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    chain.runCallbacks("save", {}, () => {
+    runAllCallbacks(proto, "save", {}, () => {
       log.push("block:start");
       log.push("block:end");
     });
@@ -326,16 +331,16 @@ describe("CallbackChain.run", () => {
   });
 
   it("returns false and skips block when before callback halts", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", () => {
+    _registerCallbackOnProto(proto, "before", "save", () => {
       log.push("before");
       return false;
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = chain.runCallbacks("save", {}, () => {
+    const result = runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
@@ -343,33 +348,33 @@ describe("CallbackChain.run", () => {
   });
 
   it("around callbacks wrap the block", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("around", "save", (_record: any, proceed: () => void) => {
+    _registerCallbackOnProto(proto, "around", "save", (_record: any, proceed: () => void) => {
       log.push("around:before");
       proceed();
       log.push("around:after");
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    chain.runCallbacks("save", {}, () => {
+    runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["around:before", "block", "around:after", "after"]);
   });
 
   it("before callback that returns false halts the chain", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", () => {
+    _registerCallbackOnProto(proto, "before", "save", () => {
       log.push("before");
       return false;
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = chain.runCallbacks("save", {}, () => {
+    const result = runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
@@ -377,15 +382,15 @@ describe("CallbackChain.run", () => {
   });
 
   it("after callbacks run in registration order", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after1");
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after2");
     });
-    chain.runCallbacks("save", {}, () => {
+    runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["block", "after1", "after2"]);
@@ -507,17 +512,22 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
 
   it("CallbackChain.register rejects on: for non-commit/rollback events", () => {
     // Register-level gate — every path (setCallback, generated
-    // beforeX/afterX, plugin-direct chain.register) funnels here, so
-    // rejecting once at the chain catches `defineModelCallbacks`
-    // helpers too, not just setCallback.
-    const chain = new CallbackChain();
-    expect(() => chain.register("before", "save", () => {}, { on: "create" })).toThrow(/:on/);
+    // beforeX/afterX, plugin-direct _registerCallbackOnProto) funnels here, so
+    // rejecting once at the registration catches all entry points.
+    const proto = Object.create(null);
+    expect(() =>
+      _registerCallbackOnProto(proto, "before", "save", () => {}, { on: "create" }),
+    ).toThrow(/:on/);
   });
 
   it("CallbackChain.register accepts on: for commit/rollback events", () => {
-    const chain = new CallbackChain();
-    expect(() => chain.register("after", "commit", () => {}, { on: "create" })).not.toThrow();
-    expect(() => chain.register("after", "rollback", () => {}, { on: "update" })).not.toThrow();
+    const proto = Object.create(null);
+    expect(() =>
+      _registerCallbackOnProto(proto, "after", "commit", () => {}, { on: "create" }),
+    ).not.toThrow();
+    expect(() =>
+      _registerCallbackOnProto(proto, "after", "rollback", () => {}, { on: "update" }),
+    ).not.toThrow();
   });
 
   it("resetCallbacks clears CallbackObject-registered callbacks too", () => {
@@ -551,41 +561,41 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
 
 describe("unified sync/async runner", () => {
   it("returns a boolean synchronously when all callbacks and block are sync", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", () => {
+    _registerCallbackOnProto(proto, "before", "save", () => {
       log.push("before");
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = chain.runCallbacks("save", {}, () => log.push("block"));
+    const result = runAllCallbacks(proto, "save", {}, () => log.push("block"));
     expect(result).toBe(true);
     expect(log).toEqual(["before", "block", "after"]);
   });
 
   it("returns a Promise when a before callback is async", async () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", async () => {
+    _registerCallbackOnProto(proto, "before", "save", async () => {
       await Promise.resolve();
       log.push("before");
     });
-    chain.register("after", "save", () => {
+    _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = chain.runCallbacks("save", {}, () => log.push("block"));
+    const result = runAllCallbacks(proto, "save", {}, () => log.push("block"));
     expect(result).toBeInstanceOf(Promise);
     expect(await result).toBe(true);
     expect(log).toEqual(["before", "block", "after"]);
   });
 
   it("returns a Promise when the block is async", async () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", () => log.push("before"));
-    chain.register("after", "save", () => log.push("after"));
-    const result = chain.runCallbacks("save", {}, async () => {
+    _registerCallbackOnProto(proto, "before", "save", () => log.push("before"));
+    _registerCallbackOnProto(proto, "after", "save", () => log.push("after"));
+    const result = runAllCallbacks(proto, "save", {}, async () => {
       await Promise.resolve();
       log.push("block");
     });
@@ -595,45 +605,45 @@ describe("unified sync/async runner", () => {
   });
 
   it("awaits async callbacks in order", async () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", async () => {
+    _registerCallbackOnProto(proto, "before", "save", async () => {
       await Promise.resolve();
       log.push("b1");
     });
-    chain.register("before", "save", () => {
+    _registerCallbackOnProto(proto, "before", "save", () => {
       log.push("b2");
     });
-    chain.register("after", "save", async () => {
+    _registerCallbackOnProto(proto, "after", "save", async () => {
       await Promise.resolve();
       log.push("a1");
     });
-    await chain.runCallbacks("save", {}, () => log.push("block"));
+    await runAllCallbacks(proto, "save", {}, () => log.push("block"));
     expect(log).toEqual(["b1", "b2", "block", "a1"]);
   });
 
   it("async before halts chain when resolving to false", async () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "save", async () => false);
-    chain.register("after", "save", () => log.push("after"));
-    const ok = await chain.runCallbacks("save", {}, () => log.push("block"));
+    _registerCallbackOnProto(proto, "before", "save", async () => false);
+    _registerCallbackOnProto(proto, "after", "save", () => log.push("after"));
+    const ok = await runAllCallbacks(proto, "save", {}, () => log.push("block"));
     expect(ok).toBe(false);
     expect(log).toEqual([]);
   });
 
   it("strict: 'sync' throws when a before callback returns a Promise", () => {
-    const chain = new CallbackChain();
-    chain.register("before", "validation", async () => {});
-    expect(() => chain.runCallbacks("validation", {}, () => {}, { strict: "sync" })).toThrow(
+    const proto = Object.create(null);
+    _registerCallbackOnProto(proto, "before", "validation", async () => {});
+    expect(() => runAllCallbacks(proto, "validation", {}, () => {}, { strict: "sync" })).toThrow(
       /Async callback on sync chain "validation"/,
     );
   });
 
   it("strict: 'sync' throws when an after callback returns a Promise", () => {
-    const chain = new CallbackChain();
-    chain.register("after", "initialize", async () => {});
-    expect(() => chain.runAfter("initialize", {}, { strict: "sync" })).toThrow(
+    const proto = Object.create(null);
+    _registerCallbackOnProto(proto, "after", "initialize", async () => {});
+    expect(() => runAfterCallbacksOnProto(proto, "initialize", {}, { strict: "sync" })).toThrow(
       /Async callback on sync chain "initialize"/,
     );
   });
@@ -682,11 +692,11 @@ describe("unified sync/async runner", () => {
   });
 
   it("strict: 'sync' allows fully-sync chains", () => {
-    const chain = new CallbackChain();
+    const proto = Object.create(null);
     const log: string[] = [];
-    chain.register("before", "validation", () => log.push("before"));
-    chain.register("after", "validation", () => log.push("after"));
-    const result = chain.runCallbacks("validation", {}, () => log.push("block"), {
+    _registerCallbackOnProto(proto, "before", "validation", () => log.push("before"));
+    _registerCallbackOnProto(proto, "after", "validation", () => log.push("after"));
+    const result = runAllCallbacks(proto, "validation", {}, () => log.push("block"), {
       strict: "sync",
     });
     expect(result).toBe(true);
@@ -938,8 +948,8 @@ describe("defineModelCallbacks()", () => {
 
     const p = new Payment({ amount: 100 });
     // Run callbacks manually
-    (Payment as any)._callbackChain.runBefore("process", p);
-    (Payment as any)._callbackChain.runAfter("process", p);
+    runBeforeCallbacksOnProto(Payment.prototype, "process", p);
+    runAfterCallbacksOnProto(Payment.prototype, "process", p);
     expect(log).toEqual(["before_process", "after_process"]);
   });
 
@@ -974,7 +984,7 @@ describe("callbacks with prepend option", () => {
     );
 
     const u = new User({ name: "Alice" });
-    (User as any)._callbackChain.runBefore("save", u);
+    runBeforeCallbacksOnProto(User.prototype, "save", u);
     expect(order).toEqual(["prepended", "first"]);
   });
 });

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -17,7 +17,6 @@ import {
   type RunCallbacksOptions as ASRunCallbacksOptions,
   defineCallbacks as asDefineCallbacks,
   skipCallback as asSkipCallback,
-  resetCallbacks as asResetCallbacks,
   getCallbackChains as asGetCallbackChains,
   peekCallbackChain as asPeekCallbackChain,
 } from "@blazetrails/activesupport";
@@ -217,7 +216,7 @@ function _resolveCallbackObject(
 /**
  * Register a callback directly in activesupport's Symbol-keyed chain storage
  * on `proto`. Called by the generated `beforeX`/`afterX`/`aroundX` methods
- * from `defineModelCallbacks` and by `CallbackChain.register`.
+ * from `defineModelCallbacks` and by Model's callback registration helpers.
  *
  * Resolves `CallbackObject` instances using our own resolver (which supports
  * both camelCase and snake_case method names) before inserting into the chain,
@@ -227,8 +226,10 @@ function _resolveCallbackObject(
  * After callbacks are stored with `prepend: true` so activesupport's LIFO
  * reverse-iteration in `_runAfters` produces FIFO execution order — same as
  * Rails' `_define_after_model_callback prepend: true`.
+ *
+ * @internal
  */
-function _registerCallbackOnProto(
+export function _registerCallbackOnProto(
   proto: object,
   timing: CallbackTiming,
   event: string,
@@ -269,152 +270,96 @@ function _registerCallbackOnProto(
 }
 
 /**
- * Read-only chain lookup for run paths — no COW. The chain may live on an
- * ancestor prototype; `invoke(record, ...)` still receives the instance as its
- * target, so callbacks fire correctly without requiring a local copy.
- * Avoiding COW here means a subclass that never registers its own callbacks
- * stays transparent to future parent registrations even after its first run.
+ * @internal
  */
-function _getChain(proto: object, event: string): ASCallbackChain | null {
-  return asPeekCallbackChain(proto, event) ?? null;
+export function hasCallbackOnProto(
+  proto: object,
+  event: string,
+  timing: CallbackTiming,
+  filter: CallbackFn | AroundCallbackFn | CallbackObject,
+): boolean {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) return false;
+  const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
+  return chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
 }
 
 /**
- * Lifecycle callback chain backed by activesupport's Symbol-keyed chain storage.
- *
- * Rather than maintaining its own `Map<string, ASCallbackChain>`, this bridge
- * stores all chains in activesupport's per-prototype storage (same storage
- * accessed by `setCallback` / `runCallbacks`). Subclass isolation is handled
- * automatically by activesupport's copy-on-write in `getCallbackChains`.
- *
- * Mirrors: ActiveModel::Callbacks / ActiveSupport::Callbacks
+ * @internal
  */
-export class CallbackChain {
-  constructor(private readonly _proto: object = Object.create(null)) {}
+export function skipCallbackOnProto(
+  proto: object,
+  event: string,
+  timing: CallbackTiming,
+  filter: CallbackFn | AroundCallbackFn | CallbackObject,
+): boolean {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) return false;
+  const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
+  if (!chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter))) return false;
+  asSkipCallback(proto, event, timing as CallbackKind, asFilter);
+  return true;
+}
 
-  register(
-    timing: CallbackTiming,
-    event: string,
-    fn: CallbackFn | AroundCallbackFn | CallbackObject,
-    conditions?: CallbackConditions,
-  ): void {
-    _registerCallbackOnProto(this._proto, timing, event, fn, conditions);
-  }
-
-  skip(
-    event: string,
-    timing: CallbackTiming,
-    filter: CallbackFn | AroundCallbackFn | CallbackObject,
-  ): boolean {
-    // Peek first (no COW) to avoid isolating a subclass on a miss.
-    const chain = asPeekCallbackChain(this._proto, event);
-    if (!chain) return false;
-    const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
-    const found = chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
-    if (!found) return false;
-    // Found — now trigger COW (via asGetCallbackChains) to get the mutable own chain.
-    asSkipCallback(this._proto, event, timing as CallbackKind, asFilter);
+/**
+ * Run the full callback chain (before + around + after) for `event` on `proto`.
+ * Uses a read-only peek (no COW) so subclass isolation is not disturbed.
+ *
+ * @internal
+ */
+export function runAllCallbacks(
+  proto: object,
+  event: string,
+  record: CallbackRecord,
+  block?: () => unknown,
+  opts?: RunCallbacksOptions,
+): boolean | Promise<boolean> {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) {
+    const r = block?.();
+    if (isThenable(r)) return Promise.resolve(r).then(() => true);
     return true;
   }
+  return chain.compile().invoke(record, block, opts as ASRunCallbacksOptions);
+}
 
-  has(
-    event: string,
-    timing: CallbackTiming,
-    filter: CallbackFn | AroundCallbackFn | CallbackObject,
-  ): boolean {
-    // Peek without COW — a miss must not isolate this proto from future parent registrations.
-    const chain = asPeekCallbackChain(this._proto, event);
-    if (!chain) return false;
-    const asFilter = filter as unknown as AnyCallback | ASCallbackObject;
-    return chain.entries.some((e) => e.matches(timing as CallbackKind, asFilter));
+/**
+ * Run only the `before` callbacks for `event` on `proto`.
+ *
+ * @internal
+ */
+export function runBeforeCallbacksOnProto(
+  proto: object,
+  event: string,
+  record: CallbackRecord,
+  opts?: RunCallbacksOptions,
+): boolean | Promise<boolean> {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) return true;
+  const tmp = new ASCallbackChain(event, chain.config);
+  for (const e of chain.entries) {
+    if (e.kind === "before") tmp.append(e);
   }
+  return tmp.compile().invoke(record, undefined, opts as ASRunCallbacksOptions);
+}
 
-  clearEvent(event: string): void {
-    asResetCallbacks(this._proto, event);
+/**
+ * Run only the `after` callbacks for `event` on `proto`.
+ *
+ * @internal
+ */
+export function runAfterCallbacksOnProto(
+  proto: object,
+  event: string,
+  record: CallbackRecord,
+  opts?: RunCallbacksOptions,
+): void | Promise<void> {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) return;
+  const tmp = new ASCallbackChain(event, chain.config);
+  for (const e of chain.entries) {
+    if (e.kind === "after") tmp.append(e);
   }
-
-  /**
-   * Returns a new bridge that points at the same underlying `_proto` — it is
-   * NOT a deep copy of the callback entries. Independence between a class and
-   * its parent is guaranteed by activesupport's copy-on-write in
-   * `getCallbackChains`: the first call to `register` on a subclass proto
-   * creates its own Map by copying the parent's. Callers (e.g. AR's
-   * `_callbackChain = _callbackChain.clone()`) rely on this automatic COW
-   * rather than on the clone itself carrying a fresh snapshot.
-   */
-  clone(): CallbackChain {
-    return new CallbackChain(this._proto);
-  }
-
-  runBefore(
-    event: string,
-    record: CallbackRecord,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): boolean;
-  runBefore(
-    event: string,
-    record: CallbackRecord,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean>;
-  runBefore(
-    event: string,
-    record: CallbackRecord,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean> {
-    const chain = _getChain(this._proto, event);
-    if (!chain) return true;
-    const tmp = new ASCallbackChain(event, chain.config);
-    for (const e of chain.entries) {
-      if (e.kind === "before") tmp.append(e);
-    }
-    return tmp.compile().invoke(record, undefined, opts as ASRunCallbacksOptions);
-  }
-
-  runAfter(
-    event: string,
-    record: CallbackRecord,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): void;
-  runAfter(event: string, record: CallbackRecord, opts?: RunCallbacksOptions): void | Promise<void>;
-  runAfter(
-    event: string,
-    record: CallbackRecord,
-    opts?: RunCallbacksOptions,
-  ): void | Promise<void> {
-    const chain = _getChain(this._proto, event);
-    if (!chain) return;
-    const tmp = new ASCallbackChain(event, chain.config);
-    for (const e of chain.entries) {
-      if (e.kind === "after") tmp.append(e);
-    }
-    const result = tmp.compile().invoke(record, undefined, opts as ASRunCallbacksOptions);
-    if (isThenable(result)) return Promise.resolve(result).then(() => undefined);
-  }
-
-  runCallbacks(
-    event: string,
-    record: CallbackRecord,
-    block: () => unknown,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): boolean;
-  runCallbacks(
-    event: string,
-    record: CallbackRecord,
-    block: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean>;
-  runCallbacks(
-    event: string,
-    record: CallbackRecord,
-    block: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean> {
-    const chain = _getChain(this._proto, event);
-    if (!chain) {
-      const r = block?.();
-      if (isThenable(r)) return Promise.resolve(r).then(() => true);
-      return true;
-    }
-    return chain.compile().invoke(record, block, opts as ASRunCallbacksOptions);
-  }
+  const result = tmp.compile().invoke(record, undefined, opts as ASRunCallbacksOptions);
+  if (isThenable(result)) return Promise.resolve(result).then(() => undefined);
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -59,7 +59,14 @@ export type { Mutable } from "./type/helpers/mutable.js";
 export { ModelName } from "./naming.js";
 export type { ModelLike } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
-export { CallbackChain } from "./callbacks.js";
+export {
+  _registerCallbackOnProto,
+  hasCallbackOnProto,
+  skipCallbackOnProto,
+  runAllCallbacks,
+  runBeforeCallbacksOnProto,
+  runAfterCallbacksOnProto,
+} from "./callbacks.js";
 export type { CallbackConditions } from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
 export type { SerializeOptions } from "./serialization.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -11,7 +11,11 @@ import {
   _validatesDefaultKeys as validationsValidatesDefaultKeys,
   _parseValidatesOptions as validationsParseValidatesOptions,
 } from "./validations.js";
-import { dasherize, htmlEscape } from "@blazetrails/activesupport";
+import {
+  dasherize,
+  htmlEscape,
+  resetCallbacks as asResetCallbacks,
+} from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   humanAttributeName as translationHumanAttributeName,
@@ -22,13 +26,18 @@ import { AttributeSet } from "./attribute-set.js";
 import { ModelLike, ModelName } from "./naming.js";
 import { DirtyTracker, initInternals as dirtyInitInternals } from "./dirty.js";
 import {
-  CallbackChain,
   CallbackFn,
   AroundCallbackFn,
   type CallbackObject,
   CallbackConditions,
   type RunCallbacksOptions,
   defineModelCallbacks,
+  _registerCallbackOnProto,
+  hasCallbackOnProto,
+  skipCallbackOnProto,
+  runAllCallbacks,
+  runBeforeCallbacksOnProto,
+  runAfterCallbacksOnProto,
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions, coerceForJson } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
@@ -125,21 +134,6 @@ export class Model {
   // `static { this.validates(...) }` blocks at class-definition time);
   // only the "defined but never written to" window diverges from Rails.
   static _validators: Map<string | null, Array<ValidatorLike>> = new Map();
-  /** @internal */
-  static get _callbackChain(): CallbackChain {
-    return new CallbackChain(this.prototype);
-  }
-  /** @internal */
-  static set _callbackChain(_: CallbackChain) {
-    // no-op: subclass isolation is handled automatically by activesupport's
-    // copy-on-write in getCallbackChains when register/setCallback is first called.
-  }
-  /**
-   * @internal Compat shim for AR call sites (transactions.ts) that have not yet
-   * been migrated to the direct activesupport API (PR 6). COW is now automatic;
-   * this is a no-op.
-   */
-  static _ensureOwnCallbacks(): void {}
   private static _modelName: ModelName | null = null;
 
   // -- Attributes (Phase 1000) --
@@ -457,7 +451,7 @@ export class Model {
   static clearValidatorsBang(): void {
     // Rails: `_validators.clear` (activemodel/lib/active_model/validations.rb:248).
     this._validators = new Map();
-    this._callbackChain.clearEvent("validate");
+    asResetCallbacks(this.prototype, "validate");
   }
 
   static isAttributeMethod(attribute: string): boolean {
@@ -479,7 +473,13 @@ export class Model {
         return (r[methodOrFn] as () => void)();
       }
     };
-    this._callbackChain.register("before", "validate", fn, this._buildValidateConditions(options));
+    _registerCallbackOnProto(
+      this.prototype,
+      "before",
+      "validate",
+      fn,
+      this._buildValidateConditions(options),
+    );
   }
 
   /**
@@ -497,7 +497,8 @@ export class Model {
       fn as (record: ValidatableRecord, attribute: string, value: unknown) => void,
     );
     this._registerValidator(validator);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "before",
       "validate",
       (record: object) => validator.validate(record as ValidatableRecord),
@@ -579,7 +580,7 @@ export class Model {
         callbackFn = (record: object) => validator.validate(record as ValidatableRecord);
       }
 
-      this._callbackChain.register("before", "validate", callbackFn, conditions);
+      _registerCallbackOnProto(this.prototype, "before", "validate", callbackFn, conditions);
     }
   }
 
@@ -717,7 +718,8 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "before",
       "validation",
       fn as CallbackFn | CallbackObject,
@@ -730,7 +732,8 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "after",
       "validation",
       fn as CallbackFn | CallbackObject,
@@ -744,7 +747,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("before", "save", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "before",
+      "save",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static afterSave<T extends typeof Model>(
@@ -753,7 +762,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("after", "save", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "save",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static beforeCreate<T extends typeof Model>(
@@ -762,7 +777,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("before", "create", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "before",
+      "create",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static afterCreate<T extends typeof Model>(
@@ -771,7 +792,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("after", "create", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "create",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static beforeUpdate<T extends typeof Model>(
@@ -780,7 +807,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("before", "update", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "before",
+      "update",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static afterUpdate<T extends typeof Model>(
@@ -789,7 +822,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("after", "update", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "update",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static beforeDestroy<T extends typeof Model>(
@@ -798,7 +837,8 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "before",
       "destroy",
       fn as CallbackFn | CallbackObject,
@@ -812,7 +852,13 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register("after", "destroy", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "destroy",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static aroundSave<T extends typeof Model>(
@@ -823,7 +869,8 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "around",
       "save",
       fn as AroundCallbackFn | CallbackObject,
@@ -839,7 +886,8 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "around",
       "create",
       fn as AroundCallbackFn | CallbackObject,
@@ -855,7 +903,8 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "around",
       "update",
       fn as AroundCallbackFn | CallbackObject,
@@ -871,7 +920,8 @@ export class Model {
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "around",
       "destroy",
       fn as AroundCallbackFn | CallbackObject,
@@ -887,7 +937,13 @@ export class Model {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
-    this._callbackChain.register("after", "commit", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "commit",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static afterSaveCommit<T extends typeof Model>(
@@ -930,7 +986,8 @@ export class Model {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "after",
       "rollback",
       fn as CallbackFn | CallbackObject,
@@ -943,7 +1000,8 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._callbackChain.register(
+    _registerCallbackOnProto(
+      this.prototype,
       "after",
       "initialize",
       fn as CallbackFn | CallbackObject,
@@ -956,7 +1014,13 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._callbackChain.register("after", "find", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "find",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   static afterTouch<T extends typeof Model>(
@@ -964,7 +1028,13 @@ export class Model {
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
-    this._callbackChain.register("after", "touch", fn as CallbackFn | CallbackObject, conditions);
+    _registerCallbackOnProto(
+      this.prototype,
+      "after",
+      "touch",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -981,7 +1051,7 @@ export class Model {
    * "around"`). Mirrors Rails `set_callback(event, timing, filter, options)`
    * (activesupport/lib/active_support/callbacks.rb:737-749). `filter` may be
    * a function (most common in TS) or a method-object that our existing
-   * `CallbackChain.register` accepts; `options` covers the usual Rails
+   * `_registerCallbackOnProto` accepts; `options` covers the usual Rails
    * conditionals (`if`, `unless`, `prepend`). `on` is only valid for
    * transactional callbacks (`commit` / `rollback`) — any other event
    * raises if `on` is set, matching the existing per-event helpers.
@@ -1009,13 +1079,11 @@ export class Model {
     fn: CallbackFn | AroundCallbackFn | CallbackObject,
     options?: CallbackConditions<InstanceType<T>>,
   ): void {
-    // `CallbackChain.register` below enforces both `on:` applicability
-    // (only commit/rollback) and value validity
-    // (:create/:update/:destroy) using key-presence checks, so every
-    // entry point — setCallback, defineModelCallbacks helpers, direct
-    // chain.register — shares the same gate. No extra guard needed
-    // here.
-    this._callbackChain.register(
+    // `_registerCallbackOnProto` enforces `on:` applicability (only commit/rollback)
+    // and value validity (:create/:update/:destroy) so every entry point shares the
+    // same gate. No extra guard needed here.
+    _registerCallbackOnProto(
+      this.prototype,
       timing,
       event,
       fn as CallbackFn | AroundCallbackFn | CallbackObject,
@@ -1063,8 +1131,8 @@ export class Model {
     // that will never see future parent registrations. Check via the
     // inherited chain first; only clone when we're actually going to
     // mutate (match found).
-    if (!this._callbackChain.has(event, timing, fn)) return false;
-    return this._callbackChain.skip(event, timing, fn);
+    if (!hasCallbackOnProto(this.prototype, event, timing, fn)) return false;
+    return skipCallbackOnProto(this.prototype, event, timing, fn);
   }
 
   /**
@@ -1073,7 +1141,7 @@ export class Model {
    * (activesupport/lib/active_support/callbacks.rb:811-821).
    */
   static resetCallbacks<T extends typeof Model>(this: T, event: string): void {
-    this._callbackChain.clearEvent(event);
+    asResetCallbacks(this.prototype, event);
   }
 
   private static _ensureOwnValidators(): void {
@@ -1304,7 +1372,7 @@ export class Model {
     // then fire after_initialize in Rails-compatible order.
     const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
     if (callbackSuppressor._suppressInitializeCallback !== true) {
-      ctor._callbackChain.runAfter("initialize", this, { strict: "sync" });
+      runAfterCallbacksOnProto(ctor.prototype, "initialize", this, { strict: "sync" });
     }
   }
 
@@ -1524,7 +1592,8 @@ export class Model {
     this._validationContext = normalized;
 
     try {
-      const completed = ctor._callbackChain.runCallbacks(
+      const completed = runAllCallbacks(
+        ctor.prototype,
         "validation",
         this,
         () => {
@@ -1542,7 +1611,7 @@ export class Model {
   /** @internal */
   _runValidateCallbacks(): void {
     const ctor = this.constructor as typeof Model;
-    ctor._callbackChain.runBefore("validate", this, { strict: "sync" });
+    runBeforeCallbacksOnProto(ctor.prototype, "validate", this, { strict: "sync" });
   }
 
   /**
@@ -2222,7 +2291,7 @@ export class Model {
     block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
-    return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block, opts);
+    return runAllCallbacks((this.constructor as typeof Model).prototype, event, this, block, opts);
   }
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -82,6 +82,10 @@ import {
   _createRecord as callbacksCreateRecord,
   _updateRecord as callbacksUpdateRecord,
 } from "./callbacks.js";
+import {
+  runAllCallbacks as cbRunAll,
+  runAfterCallbacksOnProto as cbRunAfter,
+} from "@blazetrails/activemodel";
 // Lazy-loaded to avoid pulling node:crypto into browser bundles
 let _signedIdModule: typeof import("./signed-id.js") | null = null;
 let _signedIdModulePromise: Promise<typeof import("./signed-id.js")> | null = null;
@@ -2195,8 +2199,8 @@ export class Base extends Model {
     if (this._strictLoadingByDefault) {
       record._strictLoading = true;
     }
-    this._callbackChain.runAfter("find", record, { strict: "sync" });
-    this._callbackChain.runAfter("initialize", record, { strict: "sync" });
+    cbRunAfter(this.prototype, "find", record, { strict: "sync" });
+    cbRunAfter(this.prototype, "initialize", record, { strict: "sync" });
     return record;
   }
 
@@ -2265,7 +2269,7 @@ export class Base extends Model {
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
-        ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
+        cbRunAfter(ctor.prototype, "initialize", this, { strict: "sync" });
       }
     } else {
       // For the regular (non-multiparameter) path, mirror the multiparameter
@@ -2301,7 +2305,7 @@ export class Base extends Model {
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
-        ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
+        cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
       }
     }
   }
@@ -2427,35 +2431,18 @@ export class Base extends Model {
     }
 
     // Rails: Callbacks#create_or_update wraps super in run_callbacks(:save) { ... }.
-    // Unifying before/after into a single runCallbacks so that around_save callbacks
-    // correctly wrap the DB write (the old split runBefore+runAfter was a no-op for around).
-    const saveOk = await ctor._callbackChain.runCallbacks("save", this, async () => {
+    // Around_save callbacks correctly wrap the _createRecord/_updateRecord calls which
+    // themselves run their own run_callbacks(:create/:update) { ... } chains.
+    const saveOk = await cbRunAll(ctor.prototype, "save", this, async () => {
       wasNewRecord = this._newRecord;
       if (wasNewRecord) {
-        const createOk = await ctor._callbackChain.runCallbacks("create", this, async () => {
-          this._performInsert();
-          if (this._pendingOperation) {
-            await this._pendingOperation;
-            this._pendingOperation = null;
-          }
-          this._previouslyNewRecord = true;
-          this._newRecord = false;
-          this.changesApplied();
-          saved = true;
-        });
-        if (!createOk) saved = false;
+        const createOk = await this._createRecord();
+        if (createOk) saved = true;
+        else saved = false;
       } else {
-        const updateOk = await ctor._callbackChain.runCallbacks("update", this, async () => {
-          this._performUpdate();
-          if (this._pendingOperation) {
-            await this._pendingOperation;
-            this._pendingOperation = null;
-          }
-          this._previouslyNewRecord = false;
-          this.changesApplied();
-          saved = true;
-        });
-        if (!updateOk) saved = false;
+        const updateOk = await this._updateRecord();
+        if (updateOk) saved = true;
+        else saved = false;
       }
 
       if (saved) {
@@ -2654,7 +2641,7 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
-    const destroyResult = await ctor._callbackChain.runCallbacks("destroy", this, async () => {
+    const destroyResult = await cbRunAll(ctor.prototype, "destroy", this, async () => {
       const table = ctor.arelTable;
       const pk = this.id;
       if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
@@ -3131,6 +3118,8 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   hasTransactionalCallbacks(): boolean;
   /** @internal */
   _createRecord(): Promise<boolean>;
+  /** @internal */
+  _updateRecord(): Promise<boolean>;
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): void;

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { runBeforeCallbacksOnProto, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -6528,8 +6529,8 @@ describe("CalculationsTest", () => {
     (Order as any).beforeShip(() => log.push("before_ship"));
     (Order as any).afterDeliver(() => log.push("after_deliver"));
     const o = new Order({});
-    (Order as any)._callbackChain.runBefore("ship", o);
-    (Order as any)._callbackChain.runAfter("deliver", o);
+    runBeforeCallbacksOnProto(Order.prototype, "ship", o);
+    runAfterCallbacksOnProto(Order.prototype, "deliver", o);
     expect(log).toEqual(["before_ship", "after_deliver"]);
   });
 
@@ -6572,7 +6573,7 @@ describe("CalculationsTest", () => {
       { prepend: true },
     );
     const u = new User({});
-    (User as any)._callbackChain.runBefore("destroy", u);
+    runBeforeCallbacksOnProto(User.prototype, "destroy", u);
     expect(order[0]).toBe("prepended");
   });
 

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -1,5 +1,4 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { runBeforeCallbacksOnProto, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -24,6 +23,7 @@ import type { JoinDependency } from "./associations/join-dependency.js";
 import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { runBeforeCallbacksOnProto, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -2,13 +2,14 @@
  * Callback lifecycle hooks for ActiveRecord persistence operations.
  *
  * In Rails, Callbacks wraps destroy/touch/increment! to fire
- * before/after hooks. Our Base class uses _callbackChain directly;
- * this module exports the callback registration helpers.
+ * before/after hooks. Registration and run-path call through activesupport's
+ * callback engine via the helpers in @blazetrails/activemodel.
  *
  * Mirrors: ActiveRecord::Callbacks
  */
 
 import type { Base } from "./base.js";
+import { _registerCallbackOnProto, runAllCallbacks } from "@blazetrails/activemodel";
 import {
   allTimestampAttributesInModel,
   currentTimeFromProperTimezone,
@@ -196,23 +197,6 @@ function registerCallback(
   fn: (...args: any[]) => unknown,
   options?: AnyCallbackOptions,
 ): void {
-  const klass = modelClass as unknown as {
-    _callbackChain?: {
-      clone(): unknown;
-      register(
-        timing: "before" | "after",
-        event: string,
-        fn: (...args: any[]) => unknown,
-        conditions: Record<string, unknown>,
-      ): void;
-    };
-  };
-  if (!klass._callbackChain) return;
-  // Clone the chain if it's inherited from a parent, so we don't
-  // register callbacks on sibling subclasses
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_callbackChain")) {
-    klass._callbackChain = klass._callbackChain.clone() as typeof klass._callbackChain;
-  }
   const conditions: Record<string, unknown> = {};
   if (options?.if) conditions.if = options.if;
   if (options?.unless) conditions.unless = options.unless;
@@ -220,7 +204,13 @@ function registerCallback(
   if (event === "validation" && "on" in (options ?? {})) {
     conditions.on = (options as ValidationCallbackOptions<never>).on;
   }
-  klass._callbackChain!.register(timing, event, fn, conditions);
+  _registerCallbackOnProto(
+    (modelClass as unknown as { prototype: object }).prototype,
+    timing,
+    event,
+    fn,
+    conditions,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -241,10 +231,10 @@ export function createOrUpdate(this: any): Promise<boolean> {
 }
 
 /** @internal */
-export function _createRecord(this: any): Promise<boolean> {
+export async function _createRecord(this: any): Promise<boolean> {
   // Rails: _run_create_callbacks { super } — returns whether callbacks completed.
   const ctor = this.constructor as any;
-  return ctor._callbackChain.runCallbacks("create", this, async () => {
+  return runAllCallbacks(ctor.prototype, "create", this, async () => {
     if (ctor.recordTimestamps !== false) {
       const time = currentTimeFromProperTimezone();
       for (const col of allTimestampAttributesInModel.call(ctor)) {
@@ -266,12 +256,12 @@ export function _createRecord(this: any): Promise<boolean> {
 }
 
 /** @internal */
-export function _updateRecord(this: any): Promise<boolean> {
+export async function _updateRecord(this: any): Promise<boolean> {
   // Rails: _run_update_callbacks { record_update_timestamps { super } } — returns boolean.
   // record_update_timestamps writes updated_at/updated_on when @_touch_record
   // and should_record_timestamps? are true, then yields to the actual update.
   const ctor = this.constructor as any;
-  return ctor._callbackChain.runCallbacks("update", this, async () => {
+  return runAllCallbacks(ctor.prototype, "update", this, async () => {
     // Mirror record_update_timestamps: write timestamp columns before the update
     // when the model has record_timestamps enabled and has changes to save.
     // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -281,8 +281,8 @@ export function applyPendingEncryptions(klass: any): void {
 
   // Register the frozen-encryption validator once per class. Own-property check
   // so subclasses that have already snapped their callback chain don't miss it —
-  // if a subclass cloned _callbackChain before the parent installed this
-  // validator, `in` would suppress installation even though the clone lacks it.
+  // if a subclass registered callbacks before the parent installed this
+  // validator, `in` would suppress installation even though the subclass lacks it.
   // The validator reads `record.constructor._encryptedAttributes` at call time,
   // so it correctly handles STI subclasses with different encrypted attribute sets.
   if (

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -9,6 +9,7 @@ import { modelRegistry } from "./associations.js";
 import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
 import { Nodes } from "@blazetrails/arel";
 import { camelize, isPresent, underscore } from "@blazetrails/activesupport";
+import { runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 
 /**
  * Helper: cast inheritance column value through its attribute type.
@@ -313,8 +314,8 @@ function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Ba
     (record as any)._strictLoading = true;
   }
   // Rails' init_with_attributes fires after_find then after_initialize
-  (klass as any)._callbackChain?.runAfter?.("find", record, { strict: "sync" });
-  (klass as any)._callbackChain?.runAfter?.("initialize", record, { strict: "sync" });
+  runAfterCallbacksOnProto((klass as any).prototype, "find", record, { strict: "sync" });
+  runAfterCallbacksOnProto((klass as any).prototype, "initialize", record, { strict: "sync" });
   return record;
 }
 

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -3,6 +3,7 @@ import type { Base } from "./base.js";
 import { ReadOnlyRecord, StaleObjectError } from "./errors.js";
 import { UpdateManager, Nodes } from "@blazetrails/arel";
 import { isAppliedTo as isNoTouchingApplied } from "./no-touching.js";
+import { runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 
 /**
  * Timestamp handling for ActiveRecord models.
@@ -112,7 +113,7 @@ export async function touch(
 
   this.changesApplied();
 
-  await ctor._callbackChain.runAfter("touch", this);
+  await runAfterCallbacksOnProto(ctor.prototype, "touch", this);
   return true;
 }
 

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -1,6 +1,12 @@
 import type { Base } from "./base.js";
 
-import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  ArgumentError,
+  _registerCallbackOnProto,
+  runBeforeCallbacksOnProto,
+  runAfterCallbacksOnProto,
+} from "@blazetrails/activemodel";
+import { peekCallbackChain as asPeekCallbackChain } from "@blazetrails/activesupport";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
 import { PreparedStatementCacheExpired, Rollback, TransactionIsolationError } from "./errors.js";
 export { Rollback };
@@ -274,8 +280,8 @@ export function beforeCommit(
   fn: CallbackFn,
   options?: CallbackOptions,
 ): void {
-  (modelClass as any)._ensureOwnCallbacks();
-  (modelClass as any)._callbackChain.register(
+  _registerCallbackOnProto(
+    (modelClass as unknown as { prototype: object }).prototype,
     "before",
     "commit",
     fn,
@@ -363,7 +369,7 @@ export function setCallback(
  */
 export async function beforeCommittedBang(record: Base): Promise<void> {
   const ctor = record.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runBefore?.("commit", record);
+  await runBeforeCallbacksOnProto((ctor as any).prototype, "commit", record);
 }
 
 /**
@@ -381,7 +387,7 @@ export async function committedBang(
     if (shouldRunCallbacks && isTriggerTransactionalCallbacks.call(this)) {
       r._committedAlreadyCalled = true;
       const ctor = this.constructor as typeof Base;
-      await (ctor as any)._callbackChain?.runAfter?.("commit", this);
+      await runAfterCallbacksOnProto((ctor as any).prototype, "commit", this);
     }
   } finally {
     r._committedAlreadyCalled = false;
@@ -405,7 +411,7 @@ export async function rolledbackBang(
   try {
     if (shouldRunCallbacks && isTriggerTransactionalCallbacks.call(this)) {
       const ctor = this.constructor as typeof Base;
-      await (ctor as any)._callbackChain?.runAfter?.("rollback", this);
+      await runAfterCallbacksOnProto((ctor as any).prototype, "rollback", this);
     }
   } finally {
     _restoreTransactionRecordState.call(this, forceRestoreState);
@@ -767,13 +773,11 @@ export async function addToTransaction(this: Base, ensureFinalize = true): Promi
 // Mirrors: ActiveRecord::Transactions#has_transactional_callbacks?
 /** @internal */
 export function hasTransactionalCallbacks(this: Base): boolean {
-  const ctor = this.constructor as any;
-  const chain = ctor._callbackChain;
-  if (!chain) return false;
-  const entries: Array<{ event: string }> = (chain as any).callbacks ?? [];
-  return entries.some(
-    (e) => e.event === "rollback" || e.event === "commit" || e.event === "before_commit",
-  );
+  const proto = (this.constructor as any).prototype;
+  const commit = asPeekCallbackChain(proto, "commit");
+  if (commit && commit.entries.length > 0) return true;
+  const rollback = asPeekCallbackChain(proto, "rollback");
+  return !!(rollback && rollback.entries.length > 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -6,8 +6,11 @@ import {
   runBeforeCallbacksOnProto,
   runAfterCallbacksOnProto,
 } from "@blazetrails/activemodel";
-import { peekCallbackChain as asPeekCallbackChain } from "@blazetrails/activesupport";
-import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+import {
+  getAsyncContext,
+  peekCallbackChain as asPeekCallbackChain,
+  type AsyncContext,
+} from "@blazetrails/activesupport";
 import { PreparedStatementCacheExpired, Rollback, TransactionIsolationError } from "./errors.js";
 export { Rollback };
 


### PR DESCRIPTION
## Summary

- Deletes the `CallbackChain` bridge class from `activemodel/src/callbacks.ts` — the proxy object that wrapped activesupport's Symbol-keyed chain storage
- Replaces all 23+ `_callbackChain.register()` call sites in `model.ts` with direct `_registerCallbackOnProto(this.prototype, ...)` calls
- Migrates all run-path call sites (`runAfter`, `runBefore`, `runCallbacks`) across `base.ts`, `inheritance.ts`, `timestamp.ts`, `transactions.ts` to new free-function helpers
- Reconciles the duplicate create/update dispatch: `_createOrUpdate` in `base.ts` now calls canonical `_createRecord()`/`_updateRecord()` from `callbacks.ts` instead of inlining its own create/update callback chains
- Fixes `hasTransactionalCallbacks` which was reading a non-existent `.callbacks` property on the bridge (always returned false); now uses `peekCallbackChain` on prototype
- Removes `_ensureOwnCallbacks()` no-op shim from `Model`; adds `_updateRecord()` type declaration to `Base`
- Updates 4 test files that referenced `_callbackChain` or `CallbackChain` directly

## LOC note

685 LOC (351 add / 334 del) — exceeds the 300 ceiling. The overage is structural: `model.ts` alone has 23 `_callbackChain.register()` sites, and test files referenced the bridge class directly. All changes are mechanical (one-for-one replacements) and the test suite passes cleanly.

## autosaveBelongsTo ordering (deferred)

`autosaveBelongsTo` currently runs before `before_save` (pre-existing behavior preserved through PR 6). Moving it inside the `around_save` chain would be a real Rails-fidelity win but carries risk around `after_save` firing when autosave fails. Deferred to a follow-up sized at ~30 LOC.

## Test plan

- [x] `pnpm vitest run packages/activemodel/src/callbacks.test.ts` — 61/61 pass
- [x] `pnpm vitest run packages/activerecord/src/callbacks.test.ts` — 89/91 pass (2 pre-existing skips)
- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts` — 151/161 pass (10 pre-existing skips)
- [x] `pnpm vitest run packages/activerecord/src/inheritance.test.ts` — 113/115 pass (2 pre-existing skips)
- [x] `pnpm vitest run packages/activerecord/src/timestamp.test.ts` — 73/74 pass (1 pre-existing skip)
- [x] `pnpm test:types` — all 83 type tests pass, 0 type errors