### PR TITLE
feat(activerecord) primaryClassQ + applicationRecordClassQ — un-skip PrimaryClassTest

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -678,8 +678,9 @@ export class Base extends Model {
   }
 
   /**
-   * Returns true when this class's connection class resolves to Base —
-   * i.e. no ancestor between this class and Base has connectionClass set.
+   * Returns true if this class is `Base` itself or the designated
+   * application-record class (set via `primaryAbstractClass()` or implicitly
+   * via a `globalThis.ApplicationRecord` constant).
    *
    * Mirrors: ActiveRecord::Base.primary_class?
    */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -29,6 +29,7 @@ import {
   descendants as inheritanceDescendants,
   isFinderNeedsTypeCondition,
   primaryAbstractClass,
+  applicationRecordClassQ as _applicationRecordClassQ,
   stiClassFor,
   polymorphicClassFor,
   initializeInternalsCallback as inheritanceInitializeInternalsCallback,
@@ -683,7 +684,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.primary_class?
    */
   static primaryClassQ(): boolean {
-    return this.connectionClassForSelf() === Base;
+    return this === Base || this.applicationRecordClassQ();
   }
 
   static currentPreventingWrites(): boolean {
@@ -1122,6 +1123,14 @@ export class Base extends Model {
 
   static primaryAbstractClass(): void {
     primaryAbstractClass(this);
+  }
+
+  /**
+   * @internal
+   * Mirrors: ActiveRecord::Core::ClassMethods#application_record_class?
+   */
+  static applicationRecordClassQ(): boolean {
+    return _applicationRecordClassQ(this);
   }
 
   static stiClassFor(typeName: string): typeof Base {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Core
  */
 
+import { getApplicationRecordClass } from "./inheritance.js";
 import { RecordNotFound } from "./errors.js";
 import { WRITING_ROLE } from "./roles.js";
 import { Notifications, getAsyncContext, ParameterFilter } from "@blazetrails/activesupport";
@@ -286,6 +287,8 @@ export function configurations(this: CoreHost, config?: any): any {
 }
 
 export function isApplicationRecordClass(this: CoreHost): boolean {
+  const explicit = getApplicationRecordClass();
+  if (explicit) return (this as unknown) === explicit;
   return this.name === "ApplicationRecord";
 }
 

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -289,7 +289,7 @@ export function configurations(this: CoreHost, config?: any): any {
 export function isApplicationRecordClass(this: CoreHost): boolean {
   const explicit = getApplicationRecordClass();
   if (explicit) return (this as unknown) === explicit;
-  return this.name === "ApplicationRecord";
+  return (this as unknown) === (globalThis as Record<string, unknown>)["ApplicationRecord"];
 }
 
 // Rails uses ActiveSupport::IsolatedExecutionState for per-fiber/thread

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -359,6 +359,11 @@ export function __resetPrimaryAbstractClass(): void {
   _applicationRecordClass = null;
 }
 
+/** @internal */
+export function getApplicationRecordClass(): typeof Base | null {
+  return _applicationRecordClass;
+}
+
 /**
  * Returns true if this class is the designated application-record base class.
  * When a primary abstract class has been explicitly set via `primaryAbstractClass`,

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -360,6 +360,22 @@ export function __resetPrimaryAbstractClass(): void {
 }
 
 /**
+ * Returns true if this class is the designated application-record base class.
+ * When a primary abstract class has been explicitly set via `primaryAbstractClass`,
+ * this compares against that class. Otherwise it falls back to checking whether
+ * the class is registered on `globalThis` as `"ApplicationRecord"`.
+ *
+ * @internal
+ * Mirrors: ActiveRecord::Core::ClassMethods#application_record_class?
+ */
+export function applicationRecordClassQ(modelClass: typeof Base): boolean {
+  if (_applicationRecordClass) {
+    return modelClass === _applicationRecordClass;
+  }
+  return modelClass === (globalThis as Record<string, unknown>)["ApplicationRecord"];
+}
+
+/**
  * Declare this class as the top-level application record base class and mark
  * it abstract.  Only one class per application may be designated as the
  * primary abstract class.

--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -22,6 +22,7 @@ describe("PrimaryClassTest", () => {
   it("application record is used if no primary class is set", () => {
     (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
 
+    expect(ApplicationRecord.primaryClassQ()).toBe(true);
     expect(ApplicationRecord.applicationRecordClassQ()).toBe(true);
     expect(ApplicationRecord.abstractClass).toBe(true);
   });
@@ -52,7 +53,11 @@ describe("PrimaryClassTest", () => {
     PrimaryAppRecord.primaryAbstractClass();
     (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
 
+    expect(PrimaryAppRecord.primaryClassQ()).toBe(true);
     expect(PrimaryAppRecord.applicationRecordClassQ()).toBe(true);
+    expect(PrimaryAppRecord.abstractClass).toBe(true);
+
+    expect(ApplicationRecord.primaryClassQ()).toBe(false);
     expect(ApplicationRecord.applicationRecordClassQ()).toBe(false);
     expect(ApplicationRecord.abstractClass).toBe(true);
 
@@ -64,11 +69,17 @@ describe("PrimaryClassTest", () => {
   it("setting primary abstract class explicitly wins over application record set implicitly", () => {
     (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
 
+    expect(ApplicationRecord.primaryClassQ()).toBe(true);
     expect(ApplicationRecord.applicationRecordClassQ()).toBe(true);
+    expect(ApplicationRecord.abstractClass).toBe(true);
 
     PrimaryAppRecord.primaryAbstractClass();
 
+    expect(PrimaryAppRecord.primaryClassQ()).toBe(true);
     expect(PrimaryAppRecord.applicationRecordClassQ()).toBe(true);
+    expect(PrimaryAppRecord.abstractClass).toBe(true);
+
+    expect(ApplicationRecord.primaryClassQ()).toBe(false);
     expect(ApplicationRecord.applicationRecordClassQ()).toBe(false);
     expect(ApplicationRecord.abstractClass).toBe(true);
   });

--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -1,39 +1,83 @@
-import { describe, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { Base } from "./base.js";
+import { __resetPrimaryAbstractClass } from "./inheritance.js";
+
+class PrimaryAppRecord extends Base {}
+PrimaryAppRecord.abstractClass = true;
+
+class AnotherAppRecord extends PrimaryAppRecord {
+  static override _abstractClass = true;
+}
+
+class ApplicationRecord extends Base {
+  static override _abstractClass = true;
+}
 
 describe("PrimaryClassTest", () => {
-  it.skip("application record is used if no primary class is set", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+  afterEach(() => {
+    __resetPrimaryAbstractClass();
+    delete (globalThis as Record<string, unknown>)["ApplicationRecord"];
   });
-  it.skip("primary class and primary abstract class behavior", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+
+  it("application record is used if no primary class is set", () => {
+    (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
+
+    expect(ApplicationRecord.applicationRecordClassQ()).toBe(true);
+    expect(ApplicationRecord.abstractClass).toBe(true);
   });
-  it.skip("primary abstract class cannot be reset", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+
+  it("primary class and primary abstract class behavior", () => {
+    PrimaryAppRecord.primaryAbstractClass();
+
+    expect(PrimaryAppRecord.primaryClassQ()).toBe(true);
+    expect(PrimaryAppRecord.applicationRecordClassQ()).toBe(true);
+    expect(PrimaryAppRecord.abstractClass).toBe(true);
+
+    expect(AnotherAppRecord.primaryClassQ()).toBe(false);
+    expect(AnotherAppRecord.applicationRecordClassQ()).toBe(false);
+    expect(AnotherAppRecord.abstractClass).toBe(true);
+
+    expect(Base.primaryClassQ()).toBe(true);
+    expect(Base.applicationRecordClassQ()).toBe(false);
+    expect(Base.abstractClass).toBe(false);
   });
-  it.skip("primary abstract class is used over application record if set", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+
+  it("primary abstract class cannot be reset", () => {
+    PrimaryAppRecord.primaryAbstractClass();
+
+    expect(() => AnotherAppRecord.primaryAbstractClass()).toThrow();
   });
-  it.skip("setting primary abstract class explicitly wins over application record set implicitly", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+
+  it("primary abstract class is used over application record if set", () => {
+    PrimaryAppRecord.primaryAbstractClass();
+    (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
+
+    expect(PrimaryAppRecord.applicationRecordClassQ()).toBe(true);
+    expect(ApplicationRecord.applicationRecordClassQ()).toBe(false);
+    expect(ApplicationRecord.abstractClass).toBe(true);
+
+    expect(Base.primaryClassQ()).toBe(true);
+    expect(Base.applicationRecordClassQ()).toBe(false);
+    expect(Base.abstractClass).toBe(false);
   });
+
+  it("setting primary abstract class explicitly wins over application record set implicitly", () => {
+    (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
+
+    expect(ApplicationRecord.applicationRecordClassQ()).toBe(true);
+
+    PrimaryAppRecord.primaryAbstractClass();
+
+    expect(PrimaryAppRecord.applicationRecordClassQ()).toBe(true);
+    expect(ApplicationRecord.applicationRecordClassQ()).toBe(false);
+    expect(ApplicationRecord.abstractClass).toBe(true);
+  });
+
   it.skip("application record shares a connection with active record by default", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+    // Requires multi-DB named config (arunit) — not available in in-memory test env
   });
+
   it.skip("application record shares a connection with the primary abstract class if set", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in primary-class.test.ts
+    // Requires multi-DB named config (arunit) — not available in in-memory test env
   });
 });


### PR DESCRIPTION
## Summary

- **Fix `primaryClassQ`**: Rails defines it as `self == Base || application_record_class?`, not `connection_class_for_self === Base`. The old impl incorrectly returned `true` for all non-connection-class subclasses.
- **Add `applicationRecordClassQ`**: checks the `_applicationRecordClass` singleton (set via `primaryAbstractClass`) first, then falls back to `globalThis["ApplicationRecord"]` for Rails' implicit `ApplicationRecord` constant pattern.
- **Un-skip 5 of 7 `PrimaryClassTest` tests**. The remaining 2 (`shares a connection with...`) need multi-DB named configs (`arunit`) not available in the in-memory test environment.

## Follow-ups

- Tests 6–7 of `PrimaryClassTest` (`application record shares a connection`) require `connects_to` with named DB configs (`arunit`/`arunit2`) — needs multi-DB test infrastructure.
- `MultiDbMigratorTest` (7 tests) remains fully blocked — needs a second connection pool (`ARUnit2Model`) equivalent.