### PR TITLE
refactor(activerecord) schema-dumper: slot D — constraint method renames + cleanDefault split

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/geometric.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/geometric.test.ts
@@ -442,17 +442,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].a_circle).toBeTruthy();
     });
 
-    it.skip("geometric where", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in geometric
-      // ROOT-CAUSE: connection-adapters/postgresql/geometric.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/geometric.ts; affects ~10–47 tests in geometric.test.ts
-    });
-    it.skip("geometric invalid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in geometric
-      // ROOT-CAUSE: connection-adapters/postgresql/geometric.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/geometric.ts; affects ~10–47 tests in geometric.test.ts
-    });
-
     it("geometric nil", async () => {
       await adapter.exec(`DROP TABLE IF EXISTS test_geometric_types`);
       await adapter.exec(`

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -280,7 +280,7 @@ describe("PostgreSQL::SchemaDumper", () => {
     });
   });
 
-  describe("_emitExclusionConstraints", () => {
+  describe("exclusionConstraintsInCreate", () => {
     it("emits sorted ctx.addExclusionConstraint lines with options", async () => {
       const { ExclusionConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
@@ -295,7 +295,7 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper._emitExclusionConstraints("rooms", lines);
+      await dumper.exclusionConstraintsInCreate("rooms", lines);
       expect(lines[0]).toContain(`await ctx.addExclusionConstraint("rooms", "price WITH ="`);
       expect(lines[0]).toContain(`where: "(price > 0)"`);
       expect(lines[0]).toContain(`using: "gist"`);
@@ -303,7 +303,7 @@ describe("PostgreSQL::SchemaDumper", () => {
     });
   });
 
-  describe("_emitUniqueConstraints", () => {
+  describe("uniqueConstraintsInCreate", () => {
     it("emits sorted ctx.addUniqueConstraint lines with options", async () => {
       const { UniqueConstraintDefinition } = await import("./schema-definitions.js");
       const adapter = {
@@ -317,7 +317,7 @@ describe("PostgreSQL::SchemaDumper", () => {
       };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper._emitUniqueConstraints("users", lines);
+      await dumper.uniqueConstraintsInCreate("users", lines);
       expect(lines[0]).toContain(`await ctx.addUniqueConstraint("users", ["email"]`);
       expect(lines[0]).toContain(`nullsNotDistinct: true`);
       expect(lines[0]).toContain(`name: "uniq_users_email"`);
@@ -327,7 +327,7 @@ describe("PostgreSQL::SchemaDumper", () => {
       const adapter = { ...emptySource, uniqueConstraints: async () => [] };
       const dumper = new (SchemaDumper as any)(adapter) as any;
       const lines: string[] = [];
-      await dumper._emitUniqueConstraints("users", lines);
+      await dumper.uniqueConstraintsInCreate("users", lines);
       expect(lines).toHaveLength(0);
     });
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -14,7 +14,7 @@ import type { IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   // Per-table constraint cache populated by filterIndexesForDump and consumed
-  // by _emitExclusionConstraints / _emitUniqueConstraints to avoid
+  // by exclusionConstraintsInCreate / uniqueConstraintsInCreate to avoid
   // fetching the same constraint lists twice per table.
   private _cachedExclConstraints: ExclusionConstraintDefinition[] | undefined;
   private _cachedUniqConstraints: UniqueConstraintDefinition[] | undefined;
@@ -154,13 +154,13 @@ export class SchemaDumper extends AbstractSchemaDumper {
     await super.table(tableName, lines);
     // Remove the trailing blank pushed by super.table so constraints land before it.
     if (lines[lines.length - 1] === "") lines.pop();
-    await this._emitExclusionConstraints(tableName, lines);
-    await this._emitUniqueConstraints(tableName, lines);
+    await this.exclusionConstraintsInCreate(tableName, lines);
+    await this.uniqueConstraintsInCreate(tableName, lines);
     lines.push("");
   }
 
   /** @internal */
-  private async _emitExclusionConstraints(tableName: string, lines: string[]): Promise<void> {
+  protected async exclusionConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
     const adapter = this.pgAdapter();
     const constraints: ExclusionConstraintDefinition[] =
       this._cachedExclConstraints ??
@@ -181,7 +181,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  private async _emitUniqueConstraints(tableName: string, lines: string[]): Promise<void> {
+  protected async uniqueConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
     const adapter = this.pgAdapter();
     const constraints: UniqueConstraintDefinition[] =
       this._cachedUniqConstraints ??

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
+import { cleanDefault, cleanRawPgExpression } from "./schema-dumper.js";
 import { createTestAdapter, adapterType } from "./test-adapter.js";
 import type { TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -890,5 +891,58 @@ describe("SchemaDumper async header ordering", () => {
     const typesIdx = result.indexOf("TYPES");
     expect(schemasIdx).toBeLessThan(extensionsIdx);
     expect(extensionsIdx).toBeLessThan(typesIdx);
+  });
+});
+
+describe("cleanRawPgExpression", () => {
+  it("strips string type casts", () => {
+    expect(cleanRawPgExpression("'happy'::mood")).toBe("happy");
+    expect(cleanRawPgExpression("'192.168.1.1'::inet")).toBe("192.168.1.1");
+    expect(cleanRawPgExpression("'(12.2,13.3)'::point")).toBe("(12.2,13.3)");
+  });
+
+  it("unescapes doubled single-quotes", () => {
+    expect(cleanRawPgExpression("'it''s'::text")).toBe("it's");
+  });
+
+  it("strips numeric type casts", () => {
+    expect(cleanRawPgExpression("150.55::numeric")).toBe(150.55);
+    expect(cleanRawPgExpression("(150.55)::numeric")).toBe(150.55);
+  });
+
+  it("preserves expression defaults like nextval", () => {
+    const val = "nextval('seq_id_seq'::regclass)";
+    expect(cleanRawPgExpression(val)).toBe(val);
+  });
+
+  it("returns unrecognised strings unchanged", () => {
+    expect(cleanRawPgExpression("hello")).toBe("hello");
+  });
+});
+
+describe("cleanDefault", () => {
+  it("delegates raw PG cast expressions to cleanRawPgExpression", () => {
+    expect(cleanDefault("'happy'::mood")).toBe("happy");
+    expect(cleanDefault("'(12.2,13.3)'::point")).toBe("(12.2,13.3)");
+  });
+
+  it("coerces scalar booleans", () => {
+    expect(cleanDefault("true")).toBe(true);
+    expect(cleanDefault("false")).toBe(false);
+  });
+
+  it("coerces plain numeric strings", () => {
+    expect(cleanDefault("42")).toBe(42);
+    expect(cleanDefault("3.14")).toBe(3.14);
+  });
+
+  it("preserves bit-string patterns with leading zeros", () => {
+    expect(cleanDefault("00000011")).toBe("00000011");
+    expect(cleanDefault("0011")).toBe("0011");
+  });
+
+  it("returns null/undefined unchanged", () => {
+    expect(cleanDefault(null)).toBeNull();
+    expect(cleanDefault(undefined)).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -278,38 +278,51 @@ function sqlTypeToDsl(sqlType: string): DslMapping {
 }
 
 /**
- * Clean up a PG default expression to a human-readable literal value.
- * E.g. "'happy'::mood" -> "happy", "'192.168.1.1'::inet" -> "192.168.1.1"
+ * Strip a raw PG catalog default expression to a plain value.
+ * E.g. `'happy'::mood` → `"happy"`, `'192.168.1.1'::inet` → `"192.168.1.1"`,
+ * `nextval(...)` → kept as-is (expression default).
  *
- * Two distinct inputs flow through here:
- *  1. Raw PG catalog expressions (e.g. `'happy'::mood`, `'(12.2,13.3)'::point`)
- *     — SQL strings from `column_default` in information_schema/pg_attrdef.
- *     The cast-stripping branches and the expression-default branch (parens
- *     not starting with `'`) handle this path.
- *  2. Already-deserialized scalar literals — plain strings like `"00000011"`
- *     (bit-string), `"true"`, or `"42"` that reach the trailing
- *     boolean/numeric branches. The `/^-?0\d/` guard added in #1515 lives
- *     here to prevent bit-string patterns from being coerced to `Number`.
+ * Only call this with raw SQL strings from `column_default` /
+ * `pg_attrdef.adbin`. For already-deserialized ORM values (e.g. bit-strings
+ * like `"00000011"`) use `cleanDefault` instead.
  */
-export function cleanDefault(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return raw;
-  const str = String(raw);
-
-  // Strip type casts (supports chained casts like 'value'::type::type2)
-  const castMatch = str.match(/^'((?:[^']|'')*)'(::[\w\s."[\](),]+)+$/);
+export function cleanRawPgExpression(raw: string): unknown {
+  const castMatch = raw.match(/^'((?:[^']|'')*)'(::[\w\s."[\](),]+)+$/);
   if (castMatch) {
     return castMatch[1].replace(/''/g, "'");
   }
 
-  // Numeric defaults: 150.55::type, (150.55)::type, with chained casts
-  const numericCastMatch = str.match(/^\(?(-?\d+(?:\.\d+)?)\)?(::[\w\s."[\](),]+)+$/);
+  const numericCastMatch = raw.match(/^\(?(-?\d+(?:\.\d+)?)\)?(::[\w\s."[\](),]+)+$/);
   if (numericCastMatch) {
     return Number(numericCastMatch[1]);
   }
 
   // Expression defaults like nextval(...) — keep as-is
-  if (str.includes("(") && !str.startsWith("'")) {
-    return str;
+  if (raw.includes("(") && !raw.startsWith("'")) {
+    return raw;
+  }
+
+  return raw;
+}
+
+/**
+ * Clean up a default value — either a raw PG catalog expression or an
+ * already-deserialized ORM scalar — to the JS literal used in schema dumps.
+ *
+ * Two distinct inputs flow through here:
+ *  1. Raw PG catalog expressions (e.g. `'happy'::mood`, `'(12.2,13.3)'::point`)
+ *     — dispatched to `cleanRawPgExpression`.
+ *  2. Already-deserialized scalar literals — plain strings like `"00000011"`
+ *     (bit-string), `"true"`, or `"42"`. The `/^-?0\d/` guard prevents
+ *     bit-string patterns from being coerced to `Number`.
+ */
+export function cleanDefault(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return raw;
+  const str = String(raw);
+
+  // Delegate raw PG expressions (contain a type cast or are expression defaults)
+  if (str.includes("::") || (str.includes("(") && !str.startsWith("'"))) {
+    return cleanRawPgExpression(str);
   }
 
   if (str === "true") return true;
@@ -757,6 +770,15 @@ export class SchemaDumper {
    * @internal
    */
   protected async gatherInlineConstraints(tableName: string, lines: string[]): Promise<void> {
+    await this.checkConstraintsInCreate(tableName, lines);
+  }
+
+  /**
+   * Emit inline check-constraint `t.checkConstraint(...)` lines inside the
+   * createTable block. Mirrors Rails' `SchemaDumper#check_constraints_in_create`.
+   * @internal
+   */
+  protected async checkConstraintsInCreate(tableName: string, lines: string[]): Promise<void> {
     const host = this._hookHost("checkConstraints");
     if (!host) return;
     const fn = (host as { checkConstraints: (t: string) => Promise<unknown[]> }).checkConstraints;


### PR DESCRIPTION
## Summary

- **Slot C followup B**: Extract `cleanRawPgExpression` from `cleanDefault` in `schema-dumper.ts`. Raw PG catalog expressions (containing `::`) route to the new helper; already-deserialized scalar defaults take the bool/number coercion path. The leading-zero guard stays in the scalar path where it's semantically correct.
- **api:compare gaps** (schema-dumper files):
  - Rename `_emitExclusionConstraints` → `exclusionConstraintsInCreate` and `_emitUniqueConstraints` → `uniqueConstraintsInCreate` on PG `SchemaDumper` — matches Rails `schema_dumper.rb` method names. Brings `connection_adapters/postgresql/schema_dumper.rb` from 82% → 100%.
  - Extract `checkConstraintsInCreate` from `gatherInlineConstraints` on the base `SchemaDumper`; `gatherInlineConstraints` delegates to it. Closes the one remaining gap in `schema_dumper.rb` (96% → 100%).
- **Slot C followup A**: Already shipped in #1515 (`"schema dump with shorthand"` test exists in `full-text.test.ts`).
- Remove two fabricated `it.skip` stubs ("geometric where" / "geometric invalid") from `geometric.test.ts` — neither exists in Rails' `geometric_test.rb`.

**Note on geometric OIDs**: Rails' box, circle, line, lseg, path, polygon types are all `SpecializedString` — no separate OID files exist in Rails source (`scripts/api-compare/.rails-source/.../oid/` has no box.rb, circle.rb, etc.). The geometric pass-through helpers in `geometric.ts` already cover the full surface; all tests pass.

## api:compare before → after

| File | Before | After |
|------|--------|-------|
| `connection_adapters/postgresql/schema_dumper.rb` | 82% | 100% ✓ |
| `schema_dumper.rb` | 96% | 100% ✓ |

## Test plan

- [ ] `pnpm vitest run --project activerecord` — 3 pre-existing timeout flakes in `trails-tsc` tests; all other tests pass
- [ ] `pnpm test:types` — 83/83 pass, no type errors
- [ ] `pnpm run api:compare --package activerecord` — both schema-dumper files at 100%