### PR TITLE
feat(activerecord) MySQL tableOptions parsing + dumper wiring (Slot A)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Column } from "./mysql/column.js";
 import { ChangeColumnDefinition } from "./abstract/schema-definitions.js";
+import { parseTableOptions } from "./abstract-mysql-adapter.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
   return new Column("id", null, { sqlType: "bigint" }, false, {
@@ -297,5 +298,69 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
     for (const s of ["it's", "back\\slash", "\0null\nbyte\rreturn\x1aeof", "'; DROP TABLE t; --"]) {
       expect(adapter.quote(s)).toBe(standaloneQuote(s));
     }
+  });
+});
+
+// Minimal SHOW CREATE TABLE wrapper for parseTableOptions tests.
+function showCreate(tableName: string, options: string): string {
+  return `CREATE TABLE \`${tableName}\` (\n  \`id\` bigint NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (\`id\`)\n) ${options}`;
+}
+
+describe("parseTableOptions", () => {
+  it("returns empty object for ENGINE=InnoDB only (default — not emitted)", () => {
+    expect(parseTableOptions(showCreate("t", "ENGINE=InnoDB"), null)).toEqual({});
+  });
+
+  it("extracts charset without collation", () => {
+    const opts = parseTableOptions(showCreate("t", "ENGINE=InnoDB DEFAULT CHARSET=latin1"), null);
+    expect(opts).toEqual({ charset: "latin1" });
+  });
+
+  it("extracts charset and collation together", () => {
+    const opts = parseTableOptions(
+      showCreate("t", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"),
+      null,
+    );
+    expect(opts).toEqual({ charset: "utf8mb4", collation: "utf8mb4_bin" });
+  });
+
+  it("strips AUTO_INCREMENT from ENGINE clause", () => {
+    const opts = parseTableOptions(
+      showCreate("t", "ENGINE=MyISAM AUTO_INCREMENT=42 DEFAULT CHARSET=utf8mb4"),
+      null,
+    );
+    expect(opts).toEqual({ charset: "utf8mb4", options: "ENGINE=MyISAM" });
+  });
+
+  it("includes non-InnoDB engine in options", () => {
+    const opts = parseTableOptions(showCreate("t", "ENGINE=MyISAM DEFAULT CHARSET=utf8mb4"), null);
+    expect(opts).toEqual({ charset: "utf8mb4", options: "ENGINE=MyISAM" });
+  });
+
+  it("includes row format in options", () => {
+    const opts = parseTableOptions(
+      showCreate("t", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=REDUNDANT"),
+      null,
+    );
+    expect(opts).toEqual({ charset: "utf8mb4", options: "ENGINE=InnoDB ROW_FORMAT=REDUNDANT" });
+  });
+
+  it("extracts comment via pre-fetched value", () => {
+    const opts = parseTableOptions(
+      showCreate("t", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='hello world'"),
+      "hello world",
+    );
+    expect(opts).toEqual({ charset: "utf8mb4", comment: "hello world" });
+  });
+
+  it("returns empty object when createInfo has no options (NO_TABLE_OPTIONS mode)", () => {
+    expect(parseTableOptions(showCreate("t", ""), null)).toEqual({});
+  });
+
+  it("strips partition hint from options", () => {
+    const createInfo =
+      "CREATE TABLE `t` (\n  `id` bigint NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4\n/*!50100 PARTITION BY HASH (`id`)\nPARTITIONS 4 */\n";
+    const opts = parseTableOptions(createInfo, null);
+    expect(opts).toEqual({ charset: "utf8mb4" });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -447,8 +447,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async tableComment(tableName: string): Promise<string | null> {
-    void tableName;
-    return null;
+    const rows = await this.schemaQuery(
+      `SELECT table_comment FROM information_schema.tables` +
+        ` WHERE table_schema = database() AND table_name = ${this.quote(tableName)}`,
+    );
+    const val = rows[0]?.["table_comment"] as string | null | undefined;
+    return val || null;
   }
 
   async changeTableComment(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -694,8 +694,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async tableOptions(tableName: string): Promise<Record<string, string>> {
     const createInfo = await this.createTableInfo(tableName);
     if (!createInfo) return {};
-    const hasComment = /COMMENT='/.test(createInfo);
-    const comment = hasComment ? await this.tableComment(tableName) : null;
+    // Check only the options tail (after column defs) so per-column COMMENT clauses
+    // don't trigger an extra tableComment() round-trip.
+    const tail = createInfo.replace(/[\s\S]*\n\) ?/, "");
+    const comment = /COMMENT='/.test(tail) ? await this.tableComment(tableName) : null;
     return parseTableOptions(createInfo, comment);
   }
 
@@ -1427,9 +1429,10 @@ export function parseTableOptions(
 ): Record<string, string> {
   // Strip column definitions — everything up to and including the closing `)`.
   // Also strip MySQL partition hints (`/*!50100 ... */` appended after options).
+  // Mirrors Rails: .sub(/\A.*\n\) ?/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
   let raw = createInfo
-    .replace(/^[\s\S]*\n\) ?/m, "")
-    .replace(/\n\/\*![\s\S]*\*\/\n?$/m, "")
+    .replace(/[\s\S]*\n\) ?/, "")
+    .replace(/\n\/\*![\s\S]*\*\/\n?$/, "")
     .trim();
   if (!raw) return {};
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -692,8 +692,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async tableOptions(tableName: string): Promise<Record<string, string>> {
-    void tableName;
-    return {};
+    const createInfo = await this.createTableInfo(tableName);
+    if (!createInfo) return {};
+    const hasComment = /COMMENT='/.test(createInfo);
+    const comment = hasComment ? await this.tableComment(tableName) : null;
+    return parseTableOptions(createInfo, comment);
   }
 
   /**
@@ -1408,6 +1411,49 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
     return parsed;
   }
+}
+
+/**
+ * Parse the trailing table-options string from `SHOW CREATE TABLE` output.
+ * Exported for unit testing. Mirrors Rails AbstractMysqlAdapter#table_options.
+ *
+ * @param createInfo - Raw output of `SHOW CREATE TABLE`
+ * @param tableComment - Pre-fetched table comment (pass null if no COMMENT= in createInfo)
+ * @internal
+ */
+export function parseTableOptions(
+  createInfo: string,
+  tableComment: string | null,
+): Record<string, string> {
+  // Strip column definitions — everything up to and including the closing `)`.
+  // Also strip MySQL partition hints (`/*!50100 ... */` appended after options).
+  let raw = createInfo
+    .replace(/^[\s\S]*\n\) ?/m, "")
+    .replace(/\n\/\*![\s\S]*\*\/\n?$/m, "")
+    .trim();
+  if (!raw) return {};
+
+  const opts: Record<string, string> = {};
+
+  // Extract DEFAULT CHARSET and optional COLLATE, then remove from raw.
+  const charsetMatch = / DEFAULT CHARSET=(?<charset>\w+)(?: COLLATE=(?<collation>\w+))?/.exec(raw);
+  if (charsetMatch) {
+    raw = raw.slice(0, charsetMatch.index) + raw.slice(charsetMatch.index + charsetMatch[0].length);
+    opts["charset"] = charsetMatch.groups!["charset"]!;
+    if (charsetMatch.groups!["collation"]) opts["collation"] = charsetMatch.groups!["collation"]!;
+  }
+
+  // Strip AUTO_INCREMENT — mirrors Rails: sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
+  raw = raw.replace(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, "$1");
+
+  // Strip COMMENT= and use the pre-fetched comment value for accuracy.
+  if (/ COMMENT='/.test(raw)) {
+    raw = raw.replace(/ COMMENT='.+'/, "");
+    if (tableComment != null) opts["comment"] = tableComment;
+  }
+
+  if (raw !== "ENGINE=InnoDB") opts["options"] = raw;
+  return opts;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -184,4 +184,27 @@ describe("MySQL::SchemaDumper", () => {
       '"e"',
     );
   });
+
+  describe("fetchTableOptions", () => {
+    it("populates tableCollationCache when collation is present", async () => {
+      const d = make();
+      d.connection = {
+        tableOptions: async () => ({ charset: "utf8mb4", collation: "utf8mb4_bin" }),
+      };
+      await (d as any).fetchTableOptions("users");
+      expect(d.tableCollationCache["users"]).toBe("utf8mb4_bin");
+    });
+
+    it("does not populate tableCollationCache when no collation in options", async () => {
+      const d = make();
+      d.connection = { tableOptions: async () => ({ charset: "utf8mb4" }) };
+      await (d as any).fetchTableOptions("users");
+      expect(Object.hasOwn(d.tableCollationCache, "users")).toBe(false);
+    });
+
+    it("returns empty object when connection is absent", async () => {
+      const d = make();
+      expect(await (d as any).fetchTableOptions("users")).toEqual({});
+    });
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -52,13 +52,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
     if (!this.connection) return {};
     const opts = await this.connection.tableOptions(tableName);
-    // Populate tableCollationCache from the parsed collation so schemaCollation
-    // can suppress column-level collation when it matches the table default.
+    // Populate tableCollationCache when the table has an explicit COLLATE clause so
+    // schemaCollation can suppress per-column collation that matches the table default.
     if (Object.hasOwn(opts, "collation")) {
       this.tableCollationCache[tableName] = opts["collation"];
-    } else if (Object.hasOwn(opts, "charset")) {
-      // No COLLATE clause — mark table as having no explicit collation override.
-      this.tableCollationCache[tableName] = undefined;
     }
     return opts;
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -32,9 +32,13 @@ interface MysqlColumn extends ColumnInfo {
   extra?: string | null;
 }
 
+interface MysqlAdapterLike {
+  tableOptions(tableName: string): Promise<Record<string, string>>;
+}
+
 export class SchemaDumper extends AbstractSchemaDumper {
   /** Injected adapter; presence signals that caches have been (or will be) populated. */
-  connection?: object;
+  connection?: MysqlAdapterLike;
   /** table → table-default collation. Populated by adapter before column iteration. */
   tableCollationCache: Record<string, string | undefined> = Object.create(null);
   /**
@@ -43,6 +47,21 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * Populated by adapter before column iteration via `information_schema` query.
    */
   virtualExpressionCache: Record<string, Record<string, string> | undefined> = Object.create(null);
+
+  /** @internal */
+  protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
+    if (!this.connection) return {};
+    const opts = await this.connection.tableOptions(tableName);
+    // Populate tableCollationCache from the parsed collation so schemaCollation
+    // can suppress column-level collation when it matches the table default.
+    if (Object.hasOwn(opts, "collation")) {
+      this.tableCollationCache[tableName] = opts["collation"];
+    } else if (Object.hasOwn(opts, "charset")) {
+      // No COLLATE clause — mark table as having no explicit collation override.
+      this.tableCollationCache[tableName] = undefined;
+    }
+    return opts;
+  }
 
   defaultPrimaryKeyType(): string {
     return "bigint";


### PR DESCRIPTION
## Summary

- Implements `AbstractMysqlAdapter#tableOptions` — parses `SHOW CREATE TABLE` output for `charset`, `collation`, `comment`, and residual `options:` string, mirroring Rails `abstract_mysql_adapter.rb` line 549
- Extracts `parseTableOptions` as a pure exported helper (unit-testable without a live DB); adds 9 unit tests covering all parsing branches
- Adds `MysqlSchemaDumper#fetchTableOptions` override that calls `tableOptions` and populates `tableCollationCache` from the parsed collation, so `schemaCollation` can suppress per-column collation when it matches the table default

## What this is NOT (Slot B)

The base `emitTable` already threads `adapterTableOpts.options` and `.comment` into the `create_table` call. The Rails-style `charset:` / `collation:` / `options:` emission shape (needed for the 9 integration tests in `table-options.test.ts`) follows in Slot B, which will:
- Add `charset` and `collation` keys to `emitTable`'s `tableOpts` object
- Add `fetchTableOptions` override on the MySQL schema-dumper for the `SHOW TABLE STATUS` collation path (or reuse the already-parsed value)

## Follow-ups (Slot B)

- Emit `charset:` and `collation:` in `SchemaDumper#emitTable` from `adapterTableOpts`
- Unskip the 9 integration tests in `src/adapters/abstract-mysql-adapter/table-options.test.ts`

## Test plan

- [x] `parseTableOptions` unit tests: 9/9 passing
- [x] `MySQL::SchemaDumper` unit tests: 29/29 passing  
- [x] TypeScript build: clean
- [ ] MariaDB CI integration tests (Slot B unblocks full unskip)