### PR TITLE
feat(globalid): skeleton package + delete fake toSgid from AR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,7 +472,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build dependency packages for trails introspection
-        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
+        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel --filter @blazetrails/globalid build
       - name: Run trails-side dump
         run: pnpm tsx scripts/parity/run.ts --side=trails
       - uses: actions/upload-artifact@v4
@@ -605,6 +605,7 @@ jobs:
           pnpm --filter @blazetrails/activesupport build
           pnpm --filter @blazetrails/activemodel build
           pnpm --filter @blazetrails/arel build
+          pnpm --filter @blazetrails/globalid build
           pnpm --filter @blazetrails/activerecord build
       - name: Run trails-side query dump
         run: pnpm tsx scripts/parity/run.ts --type=query --side=trails

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -20,7 +20,9 @@
       "@blazetrails/activesupport/process-adapter": ["../../activesupport/src/process-adapter.ts"],
       "@blazetrails/activesupport/testing/temporal-helpers": [
         "../../activesupport/src/testing/temporal-helpers.ts"
-      ]
+      ],
+      "@blazetrails/globalid": ["../../globalid/src/index.ts"],
+      "@blazetrails/globalid/wire": ["../../globalid/src/wire.ts"]
     }
   },
   "include": ["."]

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@blazetrails/activesupport": "workspace:*",
     "@blazetrails/arel": "workspace:*",
-    "@blazetrails/activemodel": "workspace:*"
+    "@blazetrails/activemodel": "workspace:*",
+    "@blazetrails/globalid": "workspace:*"
   },
   "peerDependencies": {
     "better-sqlite3": "^12.6.2",

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { getApp as _getGlobalIdApp } from "@blazetrails/globalid";
 import {
   Model,
   type Type,
@@ -2766,27 +2767,17 @@ export class Base extends Model {
   // slice extracted to persistence.ts.
 
   /**
-   * Return a GlobalID-like URI for this record.
+   * Return a GlobalID URI for this record.
    *
-   * Mirrors: ActiveRecord::Base#to_gid (simplified, no app name)
+   * Mirrors: ActiveRecord::Base#to_gid
    */
   toGid(): string {
     const ctor = this.constructor as typeof Base;
-    return `gid://${ctor.name}/${this.id}`;
-  }
-
-  /**
-   * Return a signed GlobalID-like URI for this record.
-   * Uses a simple base64 encoding (not cryptographically signed).
-   *
-   * Mirrors: ActiveRecord::Base#to_sgid (simplified)
-   */
-  toSgid(): string {
-    const gid = this.toGid();
-    if (typeof btoa === "function") {
-      return btoa(gid);
+    const app = _getGlobalIdApp();
+    if (app) {
+      return `gid://${app}/${ctor.name}/${this.id}`;
     }
-    return Buffer.from(gid).toString("base64");
+    return `gid://${ctor.name}/${this.id}`;
   }
 
   // valuesAt / assignAttributes extracted to persistence.ts.
@@ -3461,3 +3452,5 @@ registerMigrationArConfig({
     return Base._tableNameSuffix;
   },
 });
+
+import "@blazetrails/globalid/wire";

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2770,6 +2770,10 @@ export class Base extends Model {
    * Return a GlobalID URI for this record.
    *
    * Mirrors: ActiveRecord::Base#to_gid
+   *
+   * When no app is configured the fallback URI has the form
+   * `gid://ClassName/id` (non-standard; GID-3 will require setApp before
+   * producing a parseable URI::GID).
    */
   toGid(): string {
     const ctor = this.constructor as typeof Base;
@@ -3453,4 +3457,6 @@ registerMigrationArConfig({
   },
 });
 
+// Triggers globalid's registration side-effects (currently a no-op stub;
+// filled in GID-4). Kept at the bottom for readability — ESM hoists it.
 import "@blazetrails/globalid/wire";

--- a/packages/activerecord/src/bin/trails-models-dump.test.ts
+++ b/packages/activerecord/src/bin/trails-models-dump.test.ts
@@ -61,7 +61,7 @@ function applySchema(dbPath: string, sql: string): void {
 // is predictable and still fast when already built (tsc incremental).
 beforeAll(() => {
   const packagesRoot = resolve(REPO_ROOT, "packages");
-  const depsInOrder = ["activesupport", "activemodel", "arel"];
+  const depsInOrder = ["activesupport", "activemodel", "arel", "globalid"];
   const anyMissing = depsInOrder.some(
     (p) => !existsSync(join(packagesRoot, p, "dist", "index.js")),
   );

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6981,23 +6981,6 @@ describe("CalculationsTest", () => {
     expect(u.toGid()).toContain("gid://User/");
   });
 
-  // Rails guide: to_sgid — signed GlobalID
-  it("toSgid returns a base64-encoded GID", async () => {
-    const adapter = createTestAdapter();
-    class User extends Base {
-      static {
-        this._tableName = "users";
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    const u = await User.create({ name: "Alice" });
-    const sgid = u.toSgid();
-    expect(typeof sgid).toBe("string");
-    expect(sgid.length).toBeGreaterThan(0);
-  });
-
   // Rails guide: column_defaults
   it("columnDefaults returns default values", () => {
     const adapter = createTestAdapter();

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -275,7 +275,7 @@ describe("SignedIdTest", () => {
   });
 });
 
-describe("toGid / toSgid", () => {
+describe("toGid", () => {
   it("returns a GlobalID-like URI", async () => {
     const adapter = freshAdapter();
     class User extends Base {
@@ -287,22 +287,6 @@ describe("toGid / toSgid", () => {
     }
     const u = await User.create({ name: "Alice" });
     expect(u.toGid()).toBe(`gid://User/${u.id}`);
-  });
-
-  it("returns a base64-encoded signed GID", async () => {
-    const adapter = freshAdapter();
-    class User extends Base {
-      static {
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    const u = await User.create({ name: "Alice" });
-    const sgid = u.toSgid();
-    // Decode and verify
-    const decoded = Buffer.from(sgid, "base64").toString();
-    expect(decoded).toBe(`gid://User/${u.id}`);
   });
 });
 

--- a/packages/activerecord/tsconfig.json
+++ b/packages/activerecord/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "include": ["src"],
   "exclude": ["src/type-virtualization/fixtures", "src/tsc-wrapper/__fixtures__"],
-  "references": [{ "path": "../arel" }, { "path": "../activemodel" }]
+  "references": [{ "path": "../arel" }, { "path": "../activemodel" }, { "path": "../globalid" }]
 }

--- a/packages/globalid/package.json
+++ b/packages/globalid/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@blazetrails/globalid",
+  "version": "0.1.0",
+  "description": "GlobalID support for Trails, mirroring the globalid gem",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./wire": {
+      "types": "./dist/wire.d.ts",
+      "default": "./dist/wire.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@blazetrails/activesupport": "workspace:*"
+  },
+  "peerDependencies": {
+    "@blazetrails/activerecord": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@blazetrails/activerecord": {
+      "optional": true
+    }
+  }
+}

--- a/packages/globalid/src/config.ts
+++ b/packages/globalid/src/config.ts
@@ -1,0 +1,14 @@
+const APP_NAME_RE = /^[a-zA-Z0-9-]+$/;
+
+let _app: string | undefined;
+
+export function setApp(name: string): void {
+  if (!APP_NAME_RE.test(name)) {
+    throw new Error(`GlobalID app name must match /^[a-zA-Z0-9-]+$/, got: ${JSON.stringify(name)}`);
+  }
+  _app = name;
+}
+
+export function getApp(): string | undefined {
+  return _app;
+}

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -1,0 +1,1 @@
+export { getApp, setApp } from "./config.js";

--- a/packages/globalid/src/wire.ts
+++ b/packages/globalid/src/wire.ts
@@ -1,2 +1,5 @@
-// Side-effect module. GID-2–GID-5 will register the Locator and
-// Identification mixin onto AR Base here.
+// Side-effect module. GID-4 will register the Locator and findGlobalId/
+// findSignedGlobalId class methods onto AR Base here via a registration
+// callback (e.g. registerGlobalId(Base)) — NOT via a direct import of Base,
+// because base.ts already imports this file (static imports are hoisted in
+// ESM, so a cross-package circular import would deadlock module initialisation).

--- a/packages/globalid/src/wire.ts
+++ b/packages/globalid/src/wire.ts
@@ -1,0 +1,2 @@
+// Side-effect module. GID-2–GID-5 will register the Locator and
+// Identification mixin onto AR Base here.

--- a/packages/globalid/tsconfig.json
+++ b/packages/globalid/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../activesupport" }]
+}

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
       pkgAlias("@blazetrails/actionview", "../actionview/src/index.ts"),
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
+      pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),
+      pkgAlias("@blazetrails/globalid", "../globalid/src/index.ts"),
     ],
   },
   build: {

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -53,6 +53,8 @@ export default defineConfig({
       pkgAlias("@blazetrails/actionview", "../actionview/src/index.ts"),
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
+      pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),
+      pkgAlias("@blazetrails/globalid", "../globalid/src/index.ts"),
     ],
   },
   build: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../arel
+      '@blazetrails/globalid':
+        specifier: workspace:*
+        version: link:../globalid
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -156,6 +159,15 @@ importers:
       '@blazetrails/activemodel':
         specifier: workspace:*
         version: link:../activemodel
+      '@blazetrails/activesupport':
+        specifier: workspace:*
+        version: link:../activesupport
+
+  packages/globalid:
+    dependencies:
+      '@blazetrails/activerecord':
+        specifier: workspace:*
+        version: link:../activerecord
       '@blazetrails/activesupport':
         specifier: workspace:*
         version: link:../activesupport

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../../packages/arel
+      '@blazetrails/globalid':
+        specifier: workspace:*
+        version: link:../../packages/globalid
       '@blazetrails/rack':
         specifier: workspace:*
         version: link:../../packages/rack

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -12,6 +12,7 @@
     "@blazetrails/rack": "workspace:*",
     "@blazetrails/actionpack": "workspace:*",
     "@blazetrails/actionview": "workspace:*",
-    "@blazetrails/trailties": "workspace:*"
+    "@blazetrails/trailties": "workspace:*",
+    "@blazetrails/globalid": "workspace:*"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     { "path": "packages/rack" },
     { "path": "packages/actionview" },
     { "path": "packages/actionpack" },
-    { "path": "packages/trailties" }
+    { "path": "packages/trailties" },
+    { "path": "packages/globalid" }
   ],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -72,6 +72,8 @@ const alias = {
   "@blazetrails/rack": path.resolve(__dirname, "packages/rack/src/index.ts"),
   "@blazetrails/actionview": path.resolve(__dirname, "packages/actionview/src/index.ts"),
   "@blazetrails/actionpack": path.resolve(__dirname, "packages/actionpack/src/index.ts"),
+  "@blazetrails/globalid/wire": path.resolve(__dirname, "packages/globalid/src/wire.ts"),
+  "@blazetrails/globalid": path.resolve(__dirname, "packages/globalid/src/index.ts"),
 };
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Adds `packages/globalid/` skeleton: `config.ts` (`setApp`/`getApp`), `wire.ts` stub, `src/index.ts` barrel, `package.json` (peer-dep on AR to avoid cycle), `tsconfig.json`
- Deletes `Base#toSgid` — it was plain `btoa`, not cryptographically signed; removing it prevents downstream misuse
- Updates `Base#toGid` to read the app name from `getApp()`; falls back to `gid://ClassName/id` when unset (keeps existing tests green)
- Adds `@blazetrails/globalid/wire` side-effect import at the bottom of `base.ts` (stub for GID-2+)
- Wires `@blazetrails/globalid` into vitest aliases + AR `dx-tests/tsconfig.json`
- Adds `action_controller/railties/ → actioncontroller/trailties/` dir rewrite to `scripts/api-compare/conventions.ts` (Wave 5 from `docs/actionpack-restructure-audit.md`)

## Follow-ups (separate PRs)

- **GID-2** `SignedGlobalID` class using `MessageVerifier`
- **GID-3** `URI::GID` parser + `GlobalID` class
- **GID-4** `GlobalID::Locator` + `findGlobalId` / `findSignedGlobalId` class methods on AR Base (fills `wire.ts`)
- **GID-5** `Identification` mixin polish + `expiresIn`/purpose

## Validation

- `pnpm test:types` — passes
- `pnpm run api:compare --package activerecord` — 99.7% (no regression)
- `signed-id.test.ts` + `calculations.test.ts` — passes
- 109 additions, 54 deletions (well under 300 LOC ceiling)