### PR TITLE
refactor(activemodel): callbacks epic tail-cleanup bundle

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 import {
   _registerCallbackOnProto,
+  skipCallbackOnProto,
   runAllCallbacks,
   runBeforeCallbacksOnProto,
   runAfterCallbacksOnProto,
@@ -256,10 +257,11 @@ describe("CallbacksTest", () => {
   });
 
   it("class-based callback object with snake_case method", () => {
+    // camelCase only — method name is beforeValidation (not before_validation)
     const log: string[] = [];
     const auditor = {
-      before_validation(record: any) {
-        log.push("snake_case called");
+      beforeValidation(record: any) {
+        log.push("camelCase called");
       },
     };
     class Person extends Model {
@@ -269,7 +271,7 @@ describe("CallbacksTest", () => {
       }
     }
     new Person({ name: "test" }).isValid();
-    expect(log).toContain("snake_case called");
+    expect(log).toContain("camelCase called");
   });
 
   it("class-based around callback object with proceed", () => {
@@ -1010,5 +1012,22 @@ describe("withOptions()", () => {
     expect(user.isValid("create")).toBe(false);
     expect(user.errors.on("name")).toContain("can't be blank");
     expect(user.errors.on("email")).toContain("can't be blank");
+  });
+});
+
+describe("skipCallbackOnProto with CallbackObject (mixin-level)", () => {
+  it("removes a CallbackObject from the chain by reference", () => {
+    const log: string[] = [];
+    const proto = Object.create(null);
+    const obj = {
+      beforeSave() {
+        log.push("obj");
+      },
+    };
+    _registerCallbackOnProto(proto, "before", "save", obj);
+    _registerCallbackOnProto(proto, "before", "save", () => log.push("fn"));
+    expect(skipCallbackOnProto(proto, "save", "before", obj)).toBe(true);
+    runBeforeCallbacksOnProto(proto, "save", {});
+    expect(log).toEqual(["fn"]);
   });
 });

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -218,14 +218,16 @@ function _resolveCallbackObject(
     (method as (r: CallbackRecord) => unknown).call(obj, record)) as AnyCallback;
 }
 
+const VALID_ON_VALUES = new Set(["create", "update", "destroy"]);
+
 /**
  * Register a callback directly in activesupport's Symbol-keyed chain storage
  * on `proto`. Called by the generated `beforeX`/`afterX`/`aroundX` methods
  * from `defineModelCallbacks` and by Model's callback registration helpers.
  *
- * Resolves `CallbackObject` instances using our own resolver (which supports
- * both camelCase and snake_case method names) before inserting into the chain,
- * while still storing the original object as `originalObject` so
+ * Resolves `CallbackObject` instances using our own resolver (which looks up
+ * the camelCase method name, e.g. `beforeSave`) before inserting into the
+ * chain, while still storing the original object as `originalObject` so
  * `skip`-by-reference works.
  *
  * After callbacks are stored with `prepend: true` so activesupport's LIFO
@@ -234,9 +236,6 @@ function _resolveCallbackObject(
  *
  * @internal
  */
-
-const VALID_ON_VALUES = new Set(["create", "update", "destroy"]);
-
 export function _registerCallbackOnProto(
   proto: object,
   timing: CallbackTiming,

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -61,6 +61,12 @@ export interface CallbackConditions<TRecord = CallbackRecord> {
   if?(record: TRecord): boolean;
   unless?(record: TRecord): boolean;
   prepend?: boolean;
+}
+
+/** Extends CallbackConditions with the `on:` option available on commit/rollback callbacks. */
+export interface TransactionalCallbackConditions<
+  TRecord = CallbackRecord,
+> extends CallbackConditions<TRecord> {
   on?: string | string[];
 }
 
@@ -196,10 +202,9 @@ function _resolveCallbackObject(
 ): AnyCallback {
   const rec = obj as Record<string, unknown>;
   const camelMethod = `${timing}${event.charAt(0).toUpperCase()}${event.slice(1)}`;
-  const snakeMethod = `${timing}_${event}`;
-  const method = rec[camelMethod] ?? rec[snakeMethod];
+  const method = rec[camelMethod];
   if (typeof method !== "function") {
-    throw new ArgumentError(`Callback object must implement ${camelMethod} or ${snakeMethod}`);
+    throw new ArgumentError(`Callback object must implement ${camelMethod}`);
   }
   if (timing === "around") {
     return ((record: CallbackRecord, proceed: () => void | Promise<void>) =>
@@ -229,18 +234,31 @@ function _resolveCallbackObject(
  *
  * @internal
  */
+
+const VALID_ON_VALUES = new Set(["create", "update", "destroy"]);
+
 export function _registerCallbackOnProto(
   proto: object,
   timing: CallbackTiming,
   event: string,
   fn: CallbackFn | AroundCallbackFn | CallbackObject,
-  conditions?: CallbackConditions,
+  conditions?: CallbackConditions | TransactionalCallbackConditions,
 ): void {
   if (conditions && "on" in conditions) {
     if (event !== "commit" && event !== "rollback") {
       throw new ArgumentError(
         `Unknown key: :on. The :on option is only supported for :commit and :rollback callbacks (got :${event})`,
       );
+    }
+    const onValue = (conditions as TransactionalCallbackConditions).on;
+    if (onValue !== undefined) {
+      const values = Array.isArray(onValue) ? onValue : [onValue];
+      const invalid = values.filter((v) => !VALID_ON_VALUES.has(v));
+      if (invalid.length > 0) {
+        throw new ArgumentError(
+          `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
+        );
+      }
     }
   }
   // Two-step: defineCallbacks creates the chain with the right config (COW if

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -67,7 +67,7 @@ export {
   runBeforeCallbacksOnProto,
   runAfterCallbacksOnProto,
 } from "./callbacks.js";
-export type { CallbackConditions } from "./callbacks.js";
+export type { CallbackConditions, TransactionalCallbackConditions } from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
 export type { SerializeOptions } from "./serialization.js";
 // Aliased to avoid clobbering the global `JSON` namespace; consumers

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -30,6 +30,7 @@ import {
   AroundCallbackFn,
   type CallbackObject,
   CallbackConditions,
+  TransactionalCallbackConditions,
   type RunCallbacksOptions,
   defineModelCallbacks,
   _registerCallbackOnProto,
@@ -932,7 +933,7 @@ export class Model {
   static afterCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions<InstanceType<T>>,
+    conditions?: TransactionalCallbackConditions<InstanceType<T>>,
   ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
@@ -981,7 +982,7 @@ export class Model {
   static afterRollback<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions<InstanceType<T>>,
+    conditions?: TransactionalCallbackConditions<InstanceType<T>>,
   ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4,7 +4,7 @@ import {
   type Type,
   typeRegistry,
   pushPendingDecorator,
-  type CallbackConditions,
+  type TransactionalCallbackConditions,
 } from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
 import {
@@ -2985,11 +2985,11 @@ export class Base extends Model {
   static override afterCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
-    conditions?: CallbackConditions<InstanceType<T>>,
+    conditions?: TransactionalCallbackConditions<InstanceType<T>>,
   ): void {
     super.afterCommit(
       fn,
-      _synthOnCondition(conditions as Record<string, unknown>) as CallbackConditions<
+      _synthOnCondition(conditions as Record<string, unknown>) as TransactionalCallbackConditions<
         InstanceType<T>
       >,
     );
@@ -3003,11 +3003,11 @@ export class Base extends Model {
   static override afterRollback<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | object,
-    conditions?: CallbackConditions<InstanceType<T>>,
+    conditions?: TransactionalCallbackConditions<InstanceType<T>>,
   ): void {
     super.afterRollback(
       fn,
-      _synthOnCondition(conditions as Record<string, unknown>) as CallbackConditions<
+      _synthOnCondition(conditions as Record<string, unknown>) as TransactionalCallbackConditions<
         InstanceType<T>
       >,
     );

--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -3,7 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect } from "vitest";
-import { Base, transaction } from "./index.js";
+import { Base, transaction, beforeCommit } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1075,4 +1075,19 @@ describe("TransactionCallbacksTest", () => {
       expect(log).toContain("before_save");
     });
   }); // SetCallbackTest
+}); // TransactionCallbacksTest
+
+describe("hasTransactionalCallbacks regression", () => {
+  it("returns true for a model with only beforeCommit callbacks", () => {
+    const adp = createTestAdapter();
+    class Widget extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    beforeCommit(Widget, () => {});
+    const w = new Widget({});
+    expect(w.hasTransactionalCallbacks()).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Bundles five tail-cleanup items from the callbacks convergence aftermath.

## Items

| # | Item | Status |
|---|------|--------|
| 1 | Drop snake_case branch from `_resolveCallbackObject` | done |
| 2 | Remove `on?` from `CallbackConditions`; add `TransactionalCallbackConditions` | done |
| 3 | Validate `on:` value (create/update/destroy) in `_registerCallbackOnProto` | done |
| 4 | Mixin-level `skipCallbackOnProto(CallbackObject)` direct test | done |
| 5 | `hasTransactionalCallbacks` regression test for `beforeCommit`-only model | done |
| 6 | Move `autosaveBelongsTo` inside `around_save` chain | deferred-to-followup (behavior risk) |

## Details

**Item 1**: `_resolveCallbackObject` now only looks up `beforeSave`/`afterSave` etc. (camelCase). The test "class-based callback object with snake_case method" keeps its name but its fixture now uses camelCase.

**Item 2**: `CallbackConditions` no longer has `on?`. A new `TransactionalCallbackConditions extends CallbackConditions { on? }` is used for `Model.afterCommit`, `Model.afterRollback`, `Base.afterCommit`, and `Base.afterRollback`.

**Item 3**: `_registerCallbackOnProto` now throws `ArgumentError` if `on:` is present with a value not in `{create, update, destroy}`, in addition to the existing check that `on:` is only allowed for commit/rollback events.

**Item 4**: New `describe("skipCallbackOnProto with CallbackObject (mixin-level)")` in `callbacks.test.ts` — calls the raw function directly, bypassing `Model`.

**Item 5**: New `describe("hasTransactionalCallbacks regression")` in `transaction-callbacks.test.ts` — pins that a model with *only* `beforeCommit` (no afterCommit/afterRollback) returns `true` from `hasTransactionalCallbacks()`.

**Item 6 (deferred)**: Moving `autosaveBelongsTo` inside `around_save` requires careful test coverage of `after_save` ordering when autosave fails. Opening as a separate PR.

## Test plan

- [x] `pnpm --filter @blazetrails/activemodel test` — 62 passed
- [x] `pnpm --filter @blazetrails/activerecord test` (AR project) — 11088 passed, 3089 skipped
- [x] `tsc --build` — clean