### PR TITLE
feat(activerecord): buildDefaultScope with allQueries support (Slot D)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1520,8 +1520,6 @@ export class Base extends Model {
 
   // -- Scopes registry (used by Relation) --
   static _scopes: Map<string, (rel: any, ...args: any[]) => any> = new Map();
-  /** @internal Truthy when at least one defaultScope has been declared. */
-  static _defaultScope: unknown = null;
   /** Accumulated default_scope declarations. @internal */
   static defaultScopes: import("./scoping/default.js").DefaultScope[] = [];
 
@@ -1548,10 +1546,11 @@ export class Base extends Model {
     if (!_RelationCtor) {
       throw new Error("Relation not loaded. Import relation.ts first.");
     }
-    let rel = DefaultScoping.buildDefaultScope(this, () => {
+    const buildBase = () => {
       const r = new _RelationCtor!(this);
       return _wrapWithScopeProxy ? _wrapWithScopeProxy(r) : r;
-    });
+    };
+    let rel = DefaultScoping.buildDefaultScope(this, buildBase) ?? buildBase();
     if (isStiSubclass(this)) {
       const col = getInheritanceColumn(getStiBase(this));
       if (col) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1520,7 +1520,10 @@ export class Base extends Model {
 
   // -- Scopes registry (used by Relation) --
   static _scopes: Map<string, (rel: any, ...args: any[]) => any> = new Map();
-  static _defaultScope: ((rel: any) => any) | null = null;
+  /** @internal Truthy when at least one defaultScope has been declared. */
+  static _defaultScope: unknown = null;
+  /** Accumulated default_scope declarations. @internal */
+  static defaultScopes: import("./scoping/default.js").DefaultScope[] = [];
 
   // --- Default scope (wired via extend() after class body) ---
   declare static defaultScope: typeof _defaultScope;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1102,7 +1102,6 @@ interface PersistencePrivateHost {
   constructor: {
     name: string;
     primaryKey: string | string[];
-    _defaultScope?: unknown;
     currentScope?: unknown | (() => unknown);
     defaultScoped(): { whereClause: { isEmpty(): boolean; ast: unknown } };
     readonlyAttributeQ?(name: string): boolean;
@@ -1181,7 +1180,7 @@ export function isApplyScoping(
 ): boolean {
   if (options?.unscoped) return false;
   const ctor = this.constructor as any;
-  const hasDefaultScope = !!(ctor.defaultScopes?.length ?? ctor._defaultScope);
+  const hasDefaultScope = !!ctor.defaultScopes?.length;
   const current = typeof ctor.currentScope === "function" ? ctor.currentScope() : ctor.currentScope;
   return !!(hasDefaultScope || current);
 }
@@ -1370,15 +1369,13 @@ function discriminateClassForRecord<T>(klass: T, _record: Record<string, unknown
 
 /** @internal */
 function buildDefaultConstraint(this: {
-  _defaultScope?: unknown;
   defaultScopes?: { allQueries: boolean; scope: (rel: any) => any }[];
   defaultScoped(
     scope?: any,
     options?: { allQueries?: boolean | null },
   ): { whereClause: { isEmpty(): boolean; ast: unknown } };
 }): unknown {
-  const hasAllQueriesScope = this.defaultScopes?.some((s) => s.allQueries) ?? false;
-  if (!hasAllQueriesScope) return undefined;
+  if (!this.defaultScopes?.some((s) => s.allQueries)) return undefined;
   const defaultWhereClause = this.defaultScoped(undefined, { allQueries: true }).whereClause;
   return defaultWhereClause.isEmpty() ? undefined : defaultWhereClause.ast;
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1181,7 +1181,7 @@ export function isApplyScoping(
 ): boolean {
   if (options?.unscoped) return false;
   const ctor = this.constructor as any;
-  const hasDefaultScope = !!ctor._defaultScope;
+  const hasDefaultScope = !!(ctor.defaultScopes?.length ?? ctor._defaultScope);
   const current = typeof ctor.currentScope === "function" ? ctor.currentScope() : ctor.currentScope;
   return !!(hasDefaultScope || current);
 }
@@ -1371,9 +1371,14 @@ function discriminateClassForRecord<T>(klass: T, _record: Record<string, unknown
 /** @internal */
 function buildDefaultConstraint(this: {
   _defaultScope?: unknown;
-  defaultScoped(): { whereClause: { isEmpty(): boolean; ast: unknown } };
+  defaultScopes?: { allQueries: boolean; scope: (rel: any) => any }[];
+  defaultScoped(
+    scope?: any,
+    options?: { allQueries?: boolean | null },
+  ): { whereClause: { isEmpty(): boolean; ast: unknown } };
 }): unknown {
-  if (!this._defaultScope) return undefined;
-  const defaultWhereClause = this.defaultScoped().whereClause;
+  const hasAllQueriesScope = this.defaultScopes?.some((s) => s.allQueries) ?? false;
+  if (!hasAllQueriesScope) return undefined;
+  const defaultWhereClause = this.defaultScoped(undefined, { allQueries: true }).whereClause;
   return defaultWhereClause.isEmpty() ? undefined : defaultWhereClause.ast;
 }

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1091,7 +1091,7 @@ describe("RelationTest", () => {
     if (Object.prototype.hasOwnProperty.call(Article, "_scopes")) {
       Article._scopes = new Map();
     }
-    Article._defaultScope = null;
+    Article.defaultScopes = [];
 
     await Article.create({ title: "A1", status: "published", author: "alice", views: 100 });
     await Article.create({ title: "A2", status: "draft", author: "bob", views: 50 });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1907,4 +1907,74 @@ describe("DefaultScopingTest", () => {
     const first = await Article.all().first();
     expect(first!.title).toBe("A");
   });
+
+  it("multiple defaultScope calls compose in declaration order", async () => {
+    class Article extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("visible", "boolean", { default: true });
+        this.attribute("category", "string");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ visible: true }));
+        this.defaultScope((rel: any) => rel.where({ category: "tech" }));
+      }
+    }
+
+    await Article.create({ title: "V-Tech", visible: true, category: "tech" });
+    await Article.create({ title: "H-Tech", visible: false, category: "tech" });
+    await Article.create({ title: "V-News", visible: true, category: "news" });
+
+    const results = await Article.all().toArray();
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("V-Tech");
+
+    const sql = Article.all().toSql();
+    const visibleIdx = sql.indexOf("visible");
+    const categoryIdx = sql.indexOf("category");
+    expect(visibleIdx).toBeGreaterThan(-1);
+    expect(categoryIdx).toBeGreaterThan(-1);
+    expect(visibleIdx).toBeLessThan(categoryIdx);
+  });
+
+  it("allQueries:true scope applies to normal read queries", async () => {
+    class Article extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("blog_id", "integer");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ blog_id: 1 }), { allQueries: true });
+      }
+    }
+
+    await Article.create({ title: "Blog1", blog_id: 1 });
+    await Article.create({ title: "Blog2", blog_id: 2 });
+
+    const results = await Article.all().toArray();
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Blog1");
+  });
+
+  it("non-allQueries scope is excluded when allQueries filter is applied", async () => {
+    class Article extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("visible", "boolean", { default: true });
+        this.attribute("blog_id", "integer");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ visible: true }));
+        this.defaultScope((rel: any) => rel.where({ blog_id: 1 }), { allQueries: true });
+      }
+    }
+
+    // Normal all() applies both scopes
+    const allSql = Article.all().toSql();
+    expect(allSql).toContain("visible");
+    expect(allSql).toContain("blog_id");
+
+    // defaultScoped with allQueries:true applies only the allQueries scope
+    const base = Article.unscoped();
+    const allQueriesSql = (Article as any).defaultScoped(base, { allQueries: true }).toSql();
+    expect(allQueriesSql).not.toContain("visible");
+    expect(allQueriesSql).toContain("blog_id");
+  });
 });

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -1,5 +1,6 @@
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
+import { ScopeRegistry } from "../scoping.js";
 
 /**
  * Manages evaluating and applying default scopes.
@@ -37,7 +38,7 @@ export class Default {
     buildRelation: () => any,
     allQueries?: boolean | null,
   ): any {
-    if (modelClass.isAbstractClass) return undefined;
+    if (modelClass.abstractClass) return undefined;
 
     const scopes: DefaultScope[] = modelClass.defaultScopes ?? [];
     if (scopes.length === 0) return undefined;
@@ -146,27 +147,30 @@ function isExecuteScope(
 
 /** @internal */
 function isIgnoreDefaultScope(modelClass: any): boolean {
-  return !!modelClass._ignoreDefaultScope;
+  return !!ScopeRegistry.ignoreDefaultScope(modelClass, true);
 }
 
 /** @internal */
-function setIgnoreDefaultScope(modelClass: any, value: boolean): void {
-  modelClass._ignoreDefaultScope = value;
+function setIgnoreDefaultScope(modelClass: any, value: boolean | null): void {
+  ScopeRegistry.setIgnoreDefaultScope(modelClass, value);
 }
 
 /**
  * Mirrors: Scoping::Default#evaluate_default_scope. Temporarily sets
  * ignore_default_scope to true while yielding so nested calls don't re-apply
  * the default scope recursively. Returns undefined when already ignoring
- * (matches Rails' nil return from evaluate_default_scope).
+ * (matches Rails' nil return from evaluate_default_scope). Saves and restores
+ * the prior ScopeRegistry value so nested calls from different classes compose
+ * correctly.
  * @internal
  */
 function evaluateDefaultScope(modelClass: any, fn: () => unknown): unknown {
   if (isIgnoreDefaultScope(modelClass)) return undefined;
+  const prior = ScopeRegistry.ignoreDefaultScope(modelClass, true);
   try {
     setIgnoreDefaultScope(modelClass, true);
     return fn();
   } finally {
-    setIgnoreDefaultScope(modelClass, false);
+    setIgnoreDefaultScope(modelClass, prior);
   }
 }

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -26,7 +26,8 @@ export class Default {
   /**
    * Build the default scope for a model class, applying all accumulated
    * default_scope declarations in order. Skips scopes that don't match
-   * the all_queries flag.
+   * the all_queries flag. Returns undefined when inside an evaluate_default_scope
+   * call (recursion guard), matching Rails' nil return from build_default_scope.
    *
    * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#build_default_scope
    * @internal
@@ -36,16 +37,12 @@ export class Default {
     buildRelation: () => any,
     allQueries?: boolean | null,
   ): any {
-    if (modelClass.isAbstractClass) return buildRelation();
+    if (modelClass.isAbstractClass) return undefined;
 
     const scopes: DefaultScope[] = modelClass.defaultScopes ?? [];
+    if (scopes.length === 0) return undefined;
 
-    if (scopes.length === 0) return buildRelation();
-
-    if (isIgnoreDefaultScope(modelClass)) return buildRelation();
-
-    try {
-      setIgnoreDefaultScope(modelClass, true);
+    return evaluateDefaultScope(modelClass, () => {
       let rel = buildRelation();
       for (const scopeObj of scopes) {
         if (isExecuteScope(allQueries, scopeObj)) {
@@ -54,9 +51,7 @@ export class Default {
         }
       }
       return rel;
-    } finally {
-      setIgnoreDefaultScope(modelClass, false);
-    }
+    });
   }
 
   /** @internal */
@@ -94,10 +89,6 @@ export function defaultScope<T extends typeof Base>(
   const scopeObj = new DefaultScope(fn as (rel: any) => any, allQueries);
   const existing: DefaultScope[] = (this as any).defaultScopes ?? [];
   (this as any).defaultScopes = [...existing, scopeObj];
-
-  // Keep _defaultScope in sync so named.ts / persistence.ts can use it
-  // as a quick "has any default scope" flag.
-  (this as any)._defaultScope = true;
 }
 
 /**
@@ -166,7 +157,8 @@ function setIgnoreDefaultScope(modelClass: any, value: boolean): void {
 /**
  * Mirrors: Scoping::Default#evaluate_default_scope. Temporarily sets
  * ignore_default_scope to true while yielding so nested calls don't re-apply
- * the default scope recursively.
+ * the default scope recursively. Returns undefined when already ignoring
+ * (matches Rails' nil return from evaluate_default_scope).
  * @internal
  */
 function evaluateDefaultScope(modelClass: any, fn: () => unknown): unknown {

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -1,6 +1,20 @@
-import { NotImplementedError } from "../errors.js";
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
+
+/**
+ * Manages evaluating and applying default scopes.
+ *
+ * Mirrors: ActiveRecord::Scoping::Default::DefaultScope
+ */
+export class DefaultScope {
+  readonly scope: (rel: any) => any;
+  readonly allQueries: boolean;
+
+  constructor(scope: (rel: any) => any, allQueries = false) {
+    this.scope = scope;
+    this.allQueries = allQueries;
+  }
+}
 
 /**
  * Default scope handling — applies default_scope to all queries
@@ -9,50 +23,81 @@ import type { Relation } from "../relation.js";
  * Mirrors: ActiveRecord::Scoping::Default
  */
 export class Default {
-  /** @internal */
-  static buildDefaultScope(modelClass: any, buildRelation: () => any): any {
-    let rel = buildRelation();
-    const defaultScopeFn = modelClass._defaultScope;
-    if (defaultScopeFn) {
-      rel = defaultScopeFn(rel);
+  /**
+   * Build the default scope for a model class, applying all accumulated
+   * default_scope declarations in order. Skips scopes that don't match
+   * the all_queries flag.
+   *
+   * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#build_default_scope
+   * @internal
+   */
+  static buildDefaultScope(
+    modelClass: any,
+    buildRelation: () => any,
+    allQueries?: boolean | null,
+  ): any {
+    if (modelClass.isAbstractClass) return buildRelation();
+
+    const scopes: DefaultScope[] = modelClass.defaultScopes ?? [];
+
+    if (scopes.length === 0) return buildRelation();
+
+    if (isIgnoreDefaultScope(modelClass)) return buildRelation();
+
+    try {
+      setIgnoreDefaultScope(modelClass, true);
+      let rel = buildRelation();
+      for (const scopeObj of scopes) {
+        if (isExecuteScope(allQueries, scopeObj)) {
+          const result = scopeObj.scope(rel);
+          if (result != null) rel = result;
+        }
+      }
+      return rel;
+    } finally {
+      setIgnoreDefaultScope(modelClass, false);
     }
-    return rel;
   }
 
+  /** @internal */
   static unscoped(modelClass: any, buildRelation: () => any): any {
     return buildRelation();
   }
 }
 
 /**
- * Manages evaluating and applying default scopes.
- *
- * Mirrors: ActiveRecord::Scoping::Default::DefaultScope
- */
-export class DefaultScope {
-  readonly modelClass: any;
-  readonly allQueries: boolean;
-
-  constructor(modelClass: any, allQueries = false) {
-    this.modelClass = modelClass;
-    this.allQueries = allQueries;
-  }
-
-  get scope(): ((rel: any) => any) | null {
-    return this.modelClass._defaultScope ?? null;
-  }
-}
-
-/**
- * Define a default scope applied to all queries for this model.
+ * Define a default scope applied to queries for this model.
+ * Multiple calls accumulate; all scopes are merged.
  *
  * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#default_scope
  */
 export function defaultScope<T extends typeof Base>(
   this: T,
   fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  options?: { allQueries?: boolean },
+): void;
+export function defaultScope<T extends typeof Base>(
+  this: T,
+  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  allQueries?: boolean,
+): void;
+export function defaultScope<T extends typeof Base>(
+  this: T,
+  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  optionsOrAllQueries?: { allQueries?: boolean } | boolean,
 ): void {
-  this._defaultScope = fn as (rel: any) => any;
+  const allQueries =
+    typeof optionsOrAllQueries === "boolean"
+      ? optionsOrAllQueries
+      : (optionsOrAllQueries?.allQueries ?? false);
+
+  const scopeObj = new DefaultScope(fn as (rel: any) => any, allQueries);
+  const existing: DefaultScope[] = (this as any).defaultScopes ?? [];
+  (this as any).defaultScopes = [...existing, scopeObj];
+
+  // Keep _defaultScope in sync so named.ts / persistence.ts can use it
+  // as a quick "has any default scope" flag.
+  (this as any)._defaultScope = true;
 }
 
 /**
@@ -96,14 +141,6 @@ export function isDefaultScopes(
   return scopes.length > 0;
 }
 
-/** @internal */
-function buildDefaultScope(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
-  throw new NotImplementedError(
-    "ActiveRecord::Scoping::Default#build_default_scope is not implemented",
-  );
-}
-
 /**
  * Mirrors: Scoping::Default#execute_scope?. Returns true when the default
  * scope should be applied, based on the all_queries flag.
@@ -117,19 +154,13 @@ function isExecuteScope(
 }
 
 /** @internal */
-function isIgnoreDefaultScope(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
-  throw new NotImplementedError(
-    "ActiveRecord::Scoping::Default#ignore_default_scope? is not implemented",
-  );
+function isIgnoreDefaultScope(modelClass: any): boolean {
+  return !!modelClass._ignoreDefaultScope;
 }
 
 /** @internal */
-function ignoreDefaultScope(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/scoping/default.rb cluster=relation
-  throw new NotImplementedError(
-    "ActiveRecord::Scoping::Default#ignore_default_scope= is not implemented",
-  );
+function setIgnoreDefaultScope(modelClass: any, value: boolean): void {
+  modelClass._ignoreDefaultScope = value;
 }
 
 /**
@@ -138,12 +169,12 @@ function ignoreDefaultScope(): never {
  * the default scope recursively.
  * @internal
  */
-async function evaluateDefaultScope(modelClass: any, fn: () => unknown): Promise<unknown> {
-  if (modelClass._ignoreDefaultScope) return;
+function evaluateDefaultScope(modelClass: any, fn: () => unknown): unknown {
+  if (isIgnoreDefaultScope(modelClass)) return undefined;
   try {
-    modelClass._ignoreDefaultScope = true;
-    return await fn();
+    setIgnoreDefaultScope(modelClass, true);
+    return fn();
   } finally {
-    modelClass._ignoreDefaultScope = false;
+    setIgnoreDefaultScope(modelClass, false);
   }
 }

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -43,7 +43,8 @@ export function scope<T extends typeof Base>(
 
 interface NamedHost {
   currentScope?: any;
-  _defaultScope?: (rel: any) => any;
+  _defaultScope?: unknown;
+  defaultScopes?: import("./default.js").DefaultScope[];
   all?(): any;
   relation?(): any;
 }
@@ -62,10 +63,19 @@ export function scopeForAssociation(this: NamedHost, scope?: any): any {
 /**
  * Mirrors: ActiveRecord::Scoping::Named::ClassMethods#default_scoped
  */
-export function defaultScoped(this: NamedHost, scope?: any): any {
-  const rel = scope ?? this.relation?.() ?? this.all?.();
-  if (this._defaultScope) {
-    return this._defaultScope(rel);
+export function defaultScoped(
+  this: NamedHost,
+  scope?: any,
+  options?: { allQueries?: boolean | null },
+): any {
+  let rel = scope ?? this.relation?.() ?? this.all?.();
+  const scopes = this.defaultScopes ?? [];
+  const allQueries = options?.allQueries;
+  for (const scopeObj of scopes) {
+    if (allQueries == null || (allQueries && scopeObj.allQueries)) {
+      const result = scopeObj.scope(rel);
+      if (result != null) rel = result;
+    }
   }
   return rel;
 }

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -1,5 +1,6 @@
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
+import { Default } from "./default.js";
 
 /**
  * Named scope handling — defines named scopes on model classes
@@ -43,7 +44,6 @@ export function scope<T extends typeof Base>(
 
 interface NamedHost {
   currentScope?: any;
-  _defaultScope?: unknown;
   defaultScopes?: import("./default.js").DefaultScope[];
   all?(): any;
   relation?(): any;
@@ -61,23 +61,16 @@ export function scopeForAssociation(this: NamedHost, scope?: any): any {
 }
 
 /**
- * Mirrors: ActiveRecord::Scoping::Named::ClassMethods#default_scoped
+ * Mirrors: ActiveRecord::Scoping::Named::ClassMethods#default_scoped —
+ * `build_default_scope(scope, all_queries: all_queries) || scope`
  */
 export function defaultScoped(
   this: NamedHost,
   scope?: any,
   options?: { allQueries?: boolean | null },
 ): any {
-  let rel = scope ?? this.relation?.() ?? this.all?.();
-  const scopes = this.defaultScopes ?? [];
-  const allQueries = options?.allQueries;
-  for (const scopeObj of scopes) {
-    if (allQueries == null || (allQueries && scopeObj.allQueries)) {
-      const result = scopeObj.scope(rel);
-      if (result != null) rel = result;
-    }
-  }
-  return rel;
+  const rel = scope ?? this.relation?.() ?? this.all?.();
+  return Default.buildDefaultScope(this as any, () => rel, options?.allQueries) ?? rel;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`DefaultScope`** now stores `scope` callable + `allQueries` flag (matching Rails `DefaultScope#scope`/`#all_queries`)
- **`defaultScope()`** accumulates into `defaultScopes[]` array — multiple `defaultScope` declarations now merge correctly
- **`Default.buildDefaultScope`** delegates to `evaluateDefaultScope` (recursion guard via `ignoreDefaultScope` flag); returns `undefined` when already evaluating (matching Rails nil return), so callers fall back to the bare relation
- **`defaultScoped` in `named.ts`** now delegates to `Default.buildDefaultScope` instead of iterating directly — the `ignoreDefaultScope` guard now applies consistently
- **`evaluateDefaultScope`** is a real, called implementation (no longer dead code)
- **`isIgnoreDefaultScope` / `setIgnoreDefaultScope`** are real implementations
- `base.ts`: `defaultScopes: DefaultScope[] = []`; `_defaultScope` flag removed
- `persistence.ts`: `isApplyScoping` reads `defaultScopes.length`; `buildDefaultConstraint` checks `defaultScopes.some(s => s.allQueries)`

## Known gap — `defaultScopeOverride` path

Rails `build_default_scope` detects whether a class has defined `def self.default_scope` as an explicit class method (rather than via the `default_scope` macro) by checking `Base.is_a?(method(:default_scope).owner)`. When detected, it calls the method via `relation.scoping { default_scope }` instead of iterating `default_scopes`.

This is not implemented: there is no TS equivalent of runtime method-owner introspection, and the pattern (overriding `defaultScope` as a static method) doesn't appear in the test suite. Any class using that pattern would silently get no default scoping. This is a pre-existing limitation; the macro path (`this.defaultScope(fn)`) works correctly.