### PR TITLE
refactor(activerecord): Slot C — WhereChain associated/missing merge+scope + predicate-builder parity

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -16,13 +16,28 @@
 export interface AssocTableMeta {
   joinForeignKey: string | string[];
   joinPrimaryKey: string | string[] | null;
+  joinPrimaryType?: string | null;
+  polymorphicNameAssociation?: string | null;
 }
 
 export class AssociationQueryValue {
-  constructor(
-    private associatedTable: AssocTableMeta,
-    private value: unknown,
-  ) {}
+  private readonly _associatedTable: AssocTableMeta;
+  private readonly _value: unknown;
+
+  constructor(associatedTable: AssocTableMeta, value: unknown) {
+    this._associatedTable = associatedTable;
+    this._value = value;
+  }
+
+  /** @internal */
+  private get associatedTable() {
+    return this._associatedTable;
+  }
+
+  /** @internal */
+  private get value() {
+    return this._value;
+  }
 
   queries(): Record<string, unknown>[] {
     const fk = this.associatedTable.joinForeignKey;
@@ -70,10 +85,14 @@ export class AssociationQueryValue {
     const value = this.value;
     if (this.isRelation(value)) {
       const pk = this.primaryKey();
-      if (!Array.isArray(pk) && this.isSelectClause(value)) {
-        return (value as any).select(pk);
+      let relation = value as any;
+      if (!Array.isArray(pk) && this.isSelectClause(relation)) {
+        relation = relation.select(pk);
       }
-      return value;
+      if (this.isPolymorphicClause(relation)) {
+        relation = relation.where({ [this.primaryType()!]: this.polymorphicName() });
+      }
+      return relation;
     }
     if (Array.isArray(value)) {
       return value.map((v) => this.convertToId(v));
@@ -81,8 +100,27 @@ export class AssociationQueryValue {
     return [this.convertToId(value)];
   }
 
+  /** @internal */
   private primaryKey(): string | string[] {
     return this.associatedTable.joinPrimaryKey ?? "id";
+  }
+
+  /** @internal */
+  private primaryType(): string | null {
+    return this.associatedTable.joinPrimaryType ?? null;
+  }
+
+  /** @internal */
+  private polymorphicName(): string | null {
+    return this.associatedTable.polymorphicNameAssociation ?? null;
+  }
+
+  /** @internal */
+  private isPolymorphicClause(relation: unknown): boolean {
+    const type = this.primaryType();
+    if (!type) return false;
+    const hash = (relation as any).whereValuesHash?.();
+    return !(hash && type in hash);
   }
 
   private isSelectClause(relation: unknown): boolean {

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -10,14 +10,34 @@
  *        OR (commentable_type = 'Image' AND commentable_id = 2)
  */
 export class PolymorphicArrayValue {
+  private readonly _associatedTable: {
+    joinForeignKey: string;
+    joinForeignType: string;
+    joinPrimaryKey(klass?: unknown): string;
+  };
+  private readonly _values: unknown[];
+
   constructor(
-    private readonly associatedTable: {
+    associatedTable: {
       joinForeignKey: string;
       joinForeignType: string;
       joinPrimaryKey(klass?: unknown): string;
     },
-    private readonly values: unknown[],
-  ) {}
+    values: unknown[],
+  ) {
+    this._associatedTable = associatedTable;
+    this._values = values;
+  }
+
+  /** @internal */
+  private get associatedTable() {
+    return this._associatedTable;
+  }
+
+  /** @internal */
+  private get values() {
+    return this._values;
+  }
 
   queries(): Record<string, unknown>[] {
     if (this.values.length === 0) {

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -290,15 +290,6 @@ describe("WhereChainTest", () => {
 
   it("missing unscoped merged with scope on association", () => {
     const sql = Post.all()
-      .unscope("where")
-      .whereMissing("author")
-      .merge(Author.where({ id: 1 }))
-      .toSql();
-    expect(sql).toMatch(/LEFT.*JOIN/);
-    expect(sql).not.toMatch(/IS NULL/);
-  });
-  it("missing unscoped merged with scope on association", () => {
-    const sql = Post.all()
       .joins("author")
       .unscope("where")
       .whereMissing("author")
@@ -338,33 +329,26 @@ describe("WhereChainTest", () => {
     expect(sql).not.toMatch(/IS NULL/);
     expect(sql).toContain("ORDER BY");
   });
-  it("missing ordered merged joined with scope on association", () => {
-    const sql = Post.all()
-      .order({ title: "asc" })
-      .whereMissing("author")
-      .merge(Author.where({ id: 1 }))
-      .toSql();
-    expect(sql).toMatch(/LEFT.*JOIN/);
-    expect(sql).not.toMatch(/IS NULL/);
-  });
   it("missing unscoped merged joined extended early with scope on association", () => {
     const sql = Post.all()
       .extending({ noop: () => 1 })
+      .joins("author")
       .unscope("where")
       .whereMissing("author")
       .merge(Author.where({ id: 1 }))
       .toSql();
-    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).toContain("JOIN");
     expect(sql).not.toMatch(/IS NULL/);
   });
   it("missing unscoped merged joined extended late with scope on association", () => {
     const sql = Post.all()
+      .joins("author")
       .unscope("where")
       .whereMissing("author")
       .merge(Author.where({ id: 1 }))
       .extending({ noop: () => 1 })
       .toSql();
-    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).toContain("JOIN");
     expect(sql).not.toMatch(/IS NULL/);
   });
   it.skip("missing with enum", () => {

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -38,49 +38,78 @@ describe("WhereChainTest", () => {
     expect(sql).toContain("author_id");
     expect(sql).toMatch(/!=\s*NULL|IS NOT NULL/);
   });
-  it.skip("associated merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs cross-model merge with automatic JOIN */
+  it("associated merged with scope on association", () => {
+    const sql = Post.all()
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
+    expect(sql).toContain('"authors"');
   });
 
-  it.skip("associated unscoped merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs unscope support */
+  it("associated unscoped merged with scope on association", () => {
+    const sql = Post.all()
+      .unscope("where")
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
   });
-  it.skip("associated unscoped merged joined with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs unscope support */
+  it("associated unscoped merged joined with scope on association", () => {
+    const sql = Post.all()
+      .joins("author")
+      .unscope("where")
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
   });
-  it.skip("associated unscoped merged joined extended early with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs extending support */
+  it("associated unscoped merged joined extended early with scope on association", () => {
+    const sql = Post.all()
+      .extending({ noop: () => 1 })
+      .joins("author")
+      .unscope("where")
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
   });
-  it.skip("associated unscoped merged joined extended late with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs extending support */
+  it("associated unscoped merged joined extended late with scope on association", () => {
+    const sql = Post.all()
+      .joins("author")
+      .unscope("where")
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .extending({ noop: () => 1 })
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
   });
 
-  it.skip("associated ordered merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs cross-model merge with automatic JOIN */
+  it("associated ordered merged with scope on association", () => {
+    const sql = Post.all()
+      .order({ author_id: "desc" })
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
+    expect(sql).toContain("ORDER BY");
   });
-  it.skip("associated ordered merged joined with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs cross-model merge with automatic JOIN */
+  it("associated ordered merged joined with scope on association", () => {
+    const sql = Post.all()
+      .joins("author")
+      .order({ author_id: "desc" })
+      .whereAssociated("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).not.toMatch(/IS NOT NULL/);
+    expect(sql).toContain("ORDER BY");
   });
   it.skip("associated with enum", () => {
     // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
@@ -249,61 +278,94 @@ describe("WhereChainTest", () => {
     expect(sql).toContain("author_id");
     expect(sql).toContain("IS NULL");
   });
-  it.skip("missing merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs cross-model merge with automatic JOIN */
+  it("missing merged with scope on association", () => {
+    const sql = Post.all()
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
+    expect(sql).toContain('"authors"');
   });
 
-  it.skip("missing unscoped merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing unscoped merged with scope on association", () => {
+    const sql = Post.all()
+      .unscope("where")
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
   });
-  it.skip("missing unscoped merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing unscoped merged with scope on association", () => {
+    const sql = Post.all()
+      .joins("author")
+      .unscope("where")
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("JOIN");
+    expect(sql).not.toMatch(/IS NULL/);
   });
-  it.skip("missing unscoped merged joined with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing unscoped merged joined with scope on association", () => {
+    const sql = Post.all()
+      .unscope("where")
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
   });
-  it.skip("missing ordered merged with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs cross-model merge with automatic JOIN */
+  it("missing ordered merged with scope on association", () => {
+    const sql = Post.all()
+      .order({ author_id: "desc" })
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
+    expect(sql).toContain("ORDER BY");
   });
 
-  it.skip("missing ordered merged joined with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing ordered merged joined with scope on association", () => {
+    const sql = Post.all()
+      .joins("author")
+      .order({ author_id: "desc" })
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toContain("JOIN");
+    expect(sql).not.toMatch(/IS NULL/);
+    expect(sql).toContain("ORDER BY");
   });
-  it.skip("missing ordered merged joined with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing ordered merged joined with scope on association", () => {
+    const sql = Post.all()
+      .order({ title: "asc" })
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
   });
-  it.skip("missing unscoped merged joined extended early with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing unscoped merged joined extended early with scope on association", () => {
+    const sql = Post.all()
+      .extending({ noop: () => 1 })
+      .unscope("where")
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
   });
-  it.skip("missing unscoped merged joined extended late with scope on association", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* fixture-dependent */
+  it("missing unscoped merged joined extended late with scope on association", () => {
+    const sql = Post.all()
+      .unscope("where")
+      .whereMissing("author")
+      .merge(Author.where({ id: 1 }))
+      .extending({ noop: () => 1 })
+      .toSql();
+    expect(sql).toMatch(/LEFT.*JOIN/);
+    expect(sql).not.toMatch(/IS NULL/);
   });
   it.skip("missing with enum", () => {
     // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -227,7 +227,7 @@ function exceptPredicates(
       // Also register as qualified "table.column" so cross-model merges work
       // even when two Table instances for the same table have different klass/
       // typeCaster (and thus different stableSerialize outputs, breaking eql).
-      colStrings.add(`${(c as any).relation.name}.${(c as any).name}`);
+      colStrings.add(`${c.relation.name}.${c.name}`);
     }
   }
   return predicates.filter((node) => {

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -222,7 +222,13 @@ function exceptPredicates(
   const colStrings = new Set<string>();
   for (const c of columns) {
     if (typeof c === "string") colStrings.add(c);
-    else if (c instanceof Nodes.Attribute) attrNodes.push(c);
+    else if (c instanceof Nodes.Attribute) {
+      attrNodes.push(c);
+      // Also register as qualified "table.column" so cross-model merges work
+      // even when two Table instances for the same table have different klass/
+      // typeCaster (and thus different stableSerialize outputs, breaking eql).
+      colStrings.add(`${(c as any).relation.name}.${(c as any).name}`);
+    }
   }
   return predicates.filter((node) => {
     const attr = fetchAttributeNode(node);


### PR DESCRIPTION
## Summary

- **Un-skip 16 `where-chain.test.ts` tests** for `whereAssociated`/`whereMissing` with merged scopes (merged, unscoped, joined, ordered, extended-early/late). Tests verify SQL shape: INNER/LEFT JOIN present, IS NOT NULL/IS NULL removed after merge.
- **Fix `WhereClause.merge` cross-model predicate filtering**: `exceptPredicates` now also registers qualified `"table.column"` strings from `Attribute` nodes. Two `Table` instances for the same table can differ in `klass`/`typeCaster`, causing `stableSerialize`-based `eql` to return false; the qualified string match handles this case.
- **`association-query-value.ts` → 100%** (was 55%): add `primaryType`, `polymorphicName`, `isPolymorphicClause` privates for polymorphic Relation values in `ids()`; expose `associatedTable`/`value` as `@internal` getters mirroring Ruby `private attr_reader`.
- **`polymorphic-array-value.ts` → 100%** (was 75%): expose `associatedTable`/`values` as `@internal` getters.

## Remaining skips (13)

Still skipped — require infrastructure not in scope for this PR:
- `associated/missing with enum` (×5 each) — scoped/enum associations
- `associated/missing with composite primary key` — CPK support in `whereAssociated`/`whereMissing`
- `rewhere with polymorphic association` — polymorphic association setup

## Test plan

- [x] `pnpm vitest run --project activerecord packages/activerecord/src/relation/where-chain.test.ts` — 44 passed, 13 skipped (was 28/29)
- [x] `pnpm vitest run --project activerecord` — all 337 test files pass
- [x] `pnpm run api:compare --package activerecord` — no public regression; `association-query-value.ts` 55%→100%, `polymorphic-array-value.ts` 75%→100%
- [x] Pre-commit hooks (build + typecheck) pass