### PR TITLE
feat(activerecord): pg execInsert returning-disabled fallback via currval

### DIFF
--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -140,6 +140,7 @@ type AttributeStore =
   | null
   | undefined;
 
+/** @internal */
 export function attributeNamesForSerialization(record: SerializationRecord): string[] {
   const attrStore = record._attributes as AttributeStore;
   let keys: string[];

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -410,7 +410,8 @@ export interface DatabaseAdapter {
     binds?: unknown[],
     pk?: string | null,
     sequenceName?: string | null,
-  ): Promise<number>;
+    returning?: string[] | null,
+  ): Promise<Result | number>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   isWriteQuery(sql: string): boolean;

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -31,7 +31,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     try {
       await adapter.exec(`DROP TABLE IF EXISTS "Items" CASCADE`);
       const tables = await adapter.execute(
-        `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND (tablename LIKE 'ex_%' OR tablename IN ('pk_test', 'no_pk_test', 'exec_test', 'items', 'ex_insert_ret', 'ex_insert_ret2', 'ex_insert_ret3', 'ex_insert_ret4'))`,
+        `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND (tablename LIKE 'ex_%' OR tablename IN ('pk_test', 'no_pk_test', 'exec_test', 'items', 'ex_insert_ret', 'ex_insert_ret2', 'ex_insert_ret3', 'ex_insert_ret4', 'ex_insert_ret5'))`,
       );
       for (const t of tables) {
         await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);
@@ -709,6 +709,24 @@ describeIfPg("PostgreSQLAdapter", () => {
           "id",
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret3"`);
+        const maxId = Number(rows[0]["max_id"]);
+        expect((result as any).rows[0][0]).toBe(maxId);
+      } finally {
+        await noReturn.close();
+      }
+    });
+
+    it("exec insert with returning disabled and no pk or sequence name given", async () => {
+      await adapter.exec(`CREATE TABLE "ex_insert_ret5" ("id" SERIAL PRIMARY KEY, "number" INT)`);
+      const noReturn = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        const result = await noReturn.execInsert(
+          `INSERT INTO "ex_insert_ret5" ("number") VALUES (1)`,
+        );
+        const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret5"`);
         const maxId = Number(rows[0]["max_id"]);
         expect((result as any).rows[0][0]).toBe(maxId);
       } finally {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -31,7 +31,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     try {
       await adapter.exec(`DROP TABLE IF EXISTS "Items" CASCADE`);
       const tables = await adapter.execute(
-        `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND (tablename LIKE 'ex_%' OR tablename IN ('pk_test', 'no_pk_test', 'exec_test', 'items'))`,
+        `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND (tablename LIKE 'ex_%' OR tablename IN ('pk_test', 'no_pk_test', 'exec_test', 'items', 'ex_insert_ret', 'ex_insert_ret2', 'ex_insert_ret3', 'ex_insert_ret4'))`,
       );
       for (const t of tables) {
         await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);
@@ -651,14 +651,69 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(pk).toBe("custom_id");
     });
 
-    it.skip("exec insert with returning disabled and no sequence name given", async () => {
-      // BLOCKED: execInsert() with sequence-name fallback not yet ported to TS.
+    it("exec insert with returning disabled and no sequence name given", async () => {
+      await adapter.exec(`CREATE TABLE "ex_insert_ret" ("id" SERIAL PRIMARY KEY, "number" INT)`);
+      const noReturn = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        const result = await noReturn.execInsert(
+          `INSERT INTO "ex_insert_ret" ("number") VALUES (1)`,
+          null,
+          [],
+          "id",
+        );
+        const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret"`);
+        const maxId = Number(rows[0]["max_id"]);
+        expect((result as any).rows[0][0]).toBe(maxId);
+      } finally {
+        await noReturn.close();
+      }
     });
-    it.skip("exec insert default values with returning disabled and no sequence name given", async () => {
-      // BLOCKED: Same as above.
+    it("exec insert default values with returning disabled and no sequence name given", async () => {
+      await adapter.exec(
+        `CREATE TABLE "ex_insert_ret2" ("id" SERIAL PRIMARY KEY, "number" INT DEFAULT 0)`,
+      );
+      const noReturn = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        const result = await noReturn.execInsert(
+          `INSERT INTO "ex_insert_ret2" DEFAULT VALUES`,
+          null,
+          [],
+          "id",
+        );
+        const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret2"`);
+        const maxId = Number(rows[0]["max_id"]);
+        expect((result as any).rows[0][0]).toBe(maxId);
+      } finally {
+        await noReturn.close();
+      }
     });
-    it.skip("exec insert default values quoted schema with returning disabled and no sequence name given", async () => {
-      // BLOCKED: Same as above; schema-qualified parsing also required.
+    it("exec insert default values quoted schema with returning disabled and no sequence name given", async () => {
+      await adapter.exec(
+        `CREATE TABLE "ex_insert_ret3" ("id" SERIAL PRIMARY KEY, "number" INT DEFAULT 0)`,
+      );
+      const noReturn = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        const result = await noReturn.execInsert(
+          `INSERT INTO "public"."ex_insert_ret3" DEFAULT VALUES`,
+          null,
+          [],
+          "id",
+        );
+        const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret3"`);
+        const maxId = Number(rows[0]["max_id"]);
+        expect((result as any).rows[0][0]).toBe(maxId);
+      } finally {
+        await noReturn.close();
+      }
     });
 
     it("serial sequence", async () => {
@@ -1105,8 +1160,26 @@ describeIfPg("PostgreSQLAdapter", () => {
       const exists = await adapter.databaseExists("nonexistent_db_xyz_12345");
       expect(exists).toBe(false);
     });
-    it.skip("exec insert with returning disabled", () => {
-      // BLOCKED: Same as "exec insert with returning disabled and no sequence name given".
+    it("exec insert with returning disabled", async () => {
+      await adapter.exec(`CREATE TABLE "ex_insert_ret4" ("id" SERIAL PRIMARY KEY, "number" INT)`);
+      const noReturn = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        const result = await noReturn.execInsert(
+          `INSERT INTO "ex_insert_ret4" ("number") VALUES (1)`,
+          null,
+          [],
+          "id",
+          "ex_insert_ret4_id_seq",
+        );
+        const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret4"`);
+        const maxId = Number(rows[0]["max_id"]);
+        expect((result as any).rows[0][0]).toBe(maxId);
+      } finally {
+        await noReturn.close();
+      }
     });
 
     it("pk and sequence for", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -666,7 +666,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret"`);
         const maxId = Number(rows[0]["max_id"]);
-        expect((result as any).rows[0][0]).toBe(maxId);
+        expect(Number((result as any).rows[0][0])).toBe(maxId);
       } finally {
         await noReturn.close();
       }
@@ -688,7 +688,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret2"`);
         const maxId = Number(rows[0]["max_id"]);
-        expect((result as any).rows[0][0]).toBe(maxId);
+        expect(Number((result as any).rows[0][0])).toBe(maxId);
       } finally {
         await noReturn.close();
       }
@@ -710,7 +710,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret3"`);
         const maxId = Number(rows[0]["max_id"]);
-        expect((result as any).rows[0][0]).toBe(maxId);
+        expect(Number((result as any).rows[0][0])).toBe(maxId);
       } finally {
         await noReturn.close();
       }
@@ -728,7 +728,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret5"`);
         const maxId = Number(rows[0]["max_id"]);
-        expect((result as any).rows[0][0]).toBe(maxId);
+        expect(Number((result as any).rows[0][0])).toBe(maxId);
       } finally {
         await noReturn.close();
       }
@@ -1194,7 +1194,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         const rows = await noReturn.execute(`SELECT max(id) AS max_id FROM "ex_insert_ret4"`);
         const maxId = Number(rows[0]["max_id"]);
-        expect((result as any).rows[0][0]).toBe(maxId);
+        expect(Number((result as any).rows[0][0])).toBe(maxId);
       } finally {
         await noReturn.close();
       }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -295,7 +295,14 @@ export interface AbstractAdapter {
     binds?: unknown[],
     options?: { prepare?: boolean },
   ): Promise<Result>;
-  execInsert(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
+  execInsert(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    pk?: string | null,
+    sequenceName?: string | null,
+    returning?: string[] | null,
+  ): Promise<Result | number>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   isWriteQuery(sql: string): boolean;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1071,6 +1071,47 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * (postgresql_adapter.rb:901-906).
    */
   /** @internal Mirrors: PostgreSQL::DatabaseStatements#handle_warnings */
+  /**
+   * Run a single query on an already-acquired client with the same
+   * instrumentation, exception translation, and warning flushing that
+   * execQuery/executeMutation use. Used when two queries must share a
+   * session (e.g. INSERT + SELECT currval in the returning-disabled path).
+   * @internal
+   */
+  private async _instrumentedQueryOnClient(
+    client: pg.PoolClient,
+    sql: string,
+    name: string,
+    binds: unknown[],
+  ): Promise<Result> {
+    const castBinds = typeCastedBinds(binds);
+    const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
+    const rewritten = this.rewriteBinds(sql, bindArray);
+    this._noticeReceiverSqlWarnings = [];
+    const payload: Record<string, unknown> = {
+      sql: rewritten,
+      name,
+      binds,
+      type_casted_binds: bindArray,
+      connection: this,
+      row_count: 0,
+    };
+    const pgResult = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      try {
+        const r = await this._runQuery(client, rewritten, bindArray, { rowMode: "array" });
+        payload.row_count = (r as pg.QueryResult).rowCount ?? 0;
+        return r as pg.QueryResult;
+      } catch (e: any) {
+        const translated = this._translateException(e, rewritten, bindArray);
+        payload.exception = translated;
+        payload.exception_object = translated;
+        throw translated;
+      }
+    });
+    this._flushWarnings(rewritten);
+    return castResult.call(this, pgResult);
+  }
+
   private _flushWarnings(sql?: string): void {
     const actionable = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
     const ctor = this.constructor as typeof PostgreSQLAdapter;
@@ -1738,16 +1779,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // run on the same connection. withClient() pins both to one client.
     return this.withClient(async (client) => {
       this.dirtyCurrentTransaction();
-      const castBinds = typeCastedBinds(binds);
-      const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
-      const rewritten = this.rewriteBinds(sql, bindArray);
-      const insertResult = await this._runQuery(client, rewritten, bindArray, { rowMode: "array" });
-      if (!sequenceName) {
-        return castResult.call(this, insertResult as pg.QueryResult);
-      }
+      const insertResult = await this._instrumentedQueryOnClient(client, sql, name ?? "SQL", binds);
+      if (!sequenceName) return insertResult;
       const currvalSql = `SELECT currval(${this.quote(sequenceName)})`;
-      const pgResult = await this._runQuery(client, currvalSql, [], { rowMode: "array" });
-      return castResult.call(this, pgResult as pg.QueryResult);
+      return this._instrumentedQueryOnClient(client, currvalSql, "SQL", []);
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -74,8 +74,8 @@ const OID_INTERVAL = 1186;
 import {
   READ_QUERY,
   executeBatch as pgExecuteBatch,
-  lastInsertIdResult,
   suppressCompositePrimaryKey,
+  castResult,
 } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 import {
@@ -1721,7 +1721,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (this._useInsertReturning) {
       return super.execInsert(sql, name, binds, pk as string | null, sequenceName, returning);
     }
-    const result = await this.execQuery(sql, name ?? "SQL", binds);
+    // Resolve sequence name before acquiring the INSERT client so the
+    // metadata queries (primaryKey, defaultSequenceName) don't consume
+    // an extra connection while the INSERT client is held.
     if (!sequenceName) {
       const tableRef = extractTableRefFromInsertSql.call(this as never, sql);
       if (tableRef) {
@@ -1729,9 +1731,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         const resolvedPk = suppressCompositePrimaryKey(pk ?? undefined);
         sequenceName = resolvedPk ? await this.defaultSequenceName(tableRef, resolvedPk) : null;
       }
-      if (!sequenceName) return result;
     }
-    return lastInsertIdResult.call(this, sequenceName);
+    // currval() is session-scoped: INSERT and SELECT currval(...) must
+    // run on the same connection. withClient() pins both to one client.
+    return this.withClient(async (client) => {
+      const castBinds = typeCastedBinds(binds);
+      const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
+      const rewritten = this.rewriteBinds(sql, bindArray);
+      const insertResult = await this._runQuery(client, rewritten, bindArray, { rowMode: "array" });
+      if (!sequenceName) {
+        return castResult.call(this, insertResult as pg.QueryResult);
+      }
+      const currvalSql = `SELECT currval(${this.quote(sequenceName)})`;
+      const pgResult = await this._runQuery(client, currvalSql, [], { rowMode: "array" });
+      return castResult.call(this, pgResult as pg.QueryResult);
+    });
   }
 
   /** Returns true for raw pg errors that indicate the database doesn't exist (SQLSTATE 3D000). */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -65,12 +65,18 @@ import {
   transactionIsolationLevels,
   typeCastedBinds,
   temporalToBindString,
+  extractTableRefFromInsertSql,
 } from "./abstract/database-statements.js";
 import { getTypeParser as getTemporalTypeParser } from "./postgresql/temporal-type-parsers.js";
 
 const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
 const OID_INTERVAL = 1186;
-import { READ_QUERY, executeBatch as pgExecuteBatch } from "./postgresql/database-statements.js";
+import {
+  READ_QUERY,
+  executeBatch as pgExecuteBatch,
+  lastInsertIdResult,
+  suppressCompositePrimaryKey,
+} from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 import {
   ExclusionConstraintDefinition,
@@ -1698,6 +1704,34 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Mirrors: PostgreSQLAdapter#use_insert_returning? (postgresql_adapter.rb:630)
   isUseInsertReturning(): boolean {
     return this._useInsertReturning;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#exec_insert
+   * @internal
+   */
+  override async execInsert(
+    sql: string,
+    name?: string | null,
+    binds: unknown[] = [],
+    pk?: string | null,
+    sequenceName?: string | null,
+    returning?: string[] | null,
+  ): Promise<Result | number> {
+    if (this._useInsertReturning) {
+      return super.execInsert(sql, name, binds, pk as string | null, sequenceName, returning);
+    }
+    const result = await this.execQuery(sql, name ?? "SQL", binds);
+    if (!sequenceName) {
+      const tableRef = extractTableRefFromInsertSql.call(this as never, sql);
+      if (tableRef) {
+        if (pk == null) pk = (await this.primaryKey(tableRef)) as string | null;
+        const resolvedPk = suppressCompositePrimaryKey(pk ?? undefined);
+        sequenceName = resolvedPk ? await this.defaultSequenceName(tableRef, resolvedPk) : null;
+      }
+      if (!sequenceName) return result;
+    }
+    return lastInsertIdResult.call(this, sequenceName);
   }
 
   /** Returns true for raw pg errors that indicate the database doesn't exist (SQLSTATE 3D000). */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1732,9 +1732,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         sequenceName = resolvedPk ? await this.defaultSequenceName(tableRef, resolvedPk) : null;
       }
     }
+    this.checkIfWriteQuery(sql);
+    await this.materializeTransactions();
     // currval() is session-scoped: INSERT and SELECT currval(...) must
     // run on the same connection. withClient() pins both to one client.
     return this.withClient(async (client) => {
+      this.dirtyCurrentTransaction();
       const castBinds = typeCastedBinds(binds);
       const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
       const rewritten = this.rewriteBinds(sql, bindArray);

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -506,8 +506,17 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return Result.fromRowHashes(rows);
   }
 
-  async execInsert(sql: string, name?: string | null, binds?: unknown[]): Promise<number> {
-    return this.executeMutation(sql, binds, name ?? undefined);
+  async execInsert(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    pk?: string | null,
+    sequenceName?: string | null,
+    returning?: string[] | null,
+  ): Promise<Result | number> {
+    this._queryCount++;
+    if (this.cache.dirties) this.cache.clear();
+    return this.inner.execInsert(sql, name, binds, pk, sequenceName, returning);
   }
 
   async execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number> {


### PR DESCRIPTION
## Summary

- Adds `execInsert` override on `PostgreSQLAdapter` that implements the Rails `exec_insert` fallback when `use_insert_returning?` is false
- When RETURNING is disabled: runs bare INSERT via `execQuery`, then resolves sequence name (from arg or by extracting table ref + pk → `defaultSequenceName`), and calls `lastInsertIdResult` (`SELECT currval(seq)`)
- Widens `execInsert` return type to `Promise<Result | number>` in both `DatabaseAdapter` and `AbstractAdapter` interfaces to accommodate the PG override returning a `Result`
- Un-skips 4 BLOCKED PG integration tests

## Mirrors

`ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#exec_insert` (database_statements.rb:45–61)

## Test plan

- [ ] CI PG job passes 4 newly un-skipped tests
- [ ] `pnpm run api:compare --package activerecord` — no regression
- [ ] `pnpm vitest run` — all non-PG tests pass