### PR TITLE
test(activerecord): un-skip 8 PG schema-dump tests — Slot E

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -755,11 +755,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
         const lines: string[] = [];
         await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
-        const indexLine = lines
-          .join("\n")
-          .split("\n")
-          .find((l) => l.includes("company_include_index"))
-          ?.trim();
+        const indexLine = lines.find((l) => l.includes("company_include_index"))?.trim();
         expect(indexLine).toBeDefined();
         if (adapter.supportsIndexInclude()) {
           expect(indexLine).toContain(`include: ["name","account_id"]`);

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -738,28 +738,75 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("SchemaIndexIncludeColumnsTest", () => {
-    it.skip("schema dumps index included columns", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("schema dumps index included columns", async () => {
+      try {
+        await adapter.exec(
+          `CREATE TABLE trains (id serial primary key, firm_id integer, type varchar(50), name varchar(50), account_id integer)`,
+        );
+        if (adapter.supportsIndexInclude()) {
+          await adapter.exec(
+            `CREATE INDEX company_include_index ON trains USING btree(firm_id, type) INCLUDE (name, account_id)`,
+          );
+        } else {
+          await adapter.exec(
+            `CREATE INDEX company_include_index ON trains USING btree(firm_id, type)`,
+          );
+        }
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        const indexLine = lines
+          .join("\n")
+          .split("\n")
+          .find((l) => l.includes("company_include_index"))
+          ?.trim();
+        if (adapter.supportsIndexInclude()) {
+          expect(indexLine).toContain(`include: ["name","account_id"]`);
+        } else {
+          expect(indexLine).not.toContain("include:");
+        }
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
   });
 
   describe("SchemaIndexNullsNotDistinctTest", () => {
-    it.skip("nulls not distinct is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("nulls not distinct is dumped", async () => {
+      try {
+        await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
+        if (!adapter.supportsNullsNotDistinct()) return;
+        await adapter.exec(
+          `CREATE INDEX trains_name ON trains USING btree(name) NULLS NOT DISTINCT`,
+        );
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).toContain("nullsNotDistinct: true");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
-    it.skip("nulls distinct is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("nulls distinct is dumped", async () => {
+      try {
+        await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
+        if (!adapter.supportsNullsNotDistinct()) return;
+        await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name) NULLS DISTINCT`);
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).not.toContain("nullsNotDistinct");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
-    it.skip("nulls not set is dumped", () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in schema
-      // ROOT-CAUSE: connection-adapters/postgresql/schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/schema.ts; affects ~10–47 tests in schema.test.ts
+    it("nulls not set is dumped", async () => {
+      try {
+        await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
+        await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name)`);
+        const lines: string[] = [];
+        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        expect(lines.join("\n")).not.toContain("nullsNotDistinct");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      }
     });
   });
 

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -743,6 +743,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(
           `CREATE TABLE trains (id serial primary key, firm_id integer, type varchar(50), name varchar(50), account_id integer)`,
         );
+        await adapter.getDatabaseVersion();
         if (adapter.supportsIndexInclude()) {
           await adapter.exec(
             `CREATE INDEX company_include_index ON trains USING btree(firm_id, type) INCLUDE (name, account_id)`,
@@ -759,6 +760,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           .split("\n")
           .find((l) => l.includes("company_include_index"))
           ?.trim();
+        expect(indexLine).toBeDefined();
         if (adapter.supportsIndexInclude()) {
           expect(indexLine).toContain(`include: ["name","account_id"]`);
         } else {
@@ -774,6 +776,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("nulls not distinct is dumped", async () => {
       try {
         await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
+        await adapter.getDatabaseVersion();
         if (!adapter.supportsNullsNotDistinct()) return;
         await adapter.exec(
           `CREATE INDEX trains_name ON trains USING btree(name) NULLS NOT DISTINCT`,
@@ -788,6 +791,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("nulls distinct is dumped", async () => {
       try {
         await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
+        await adapter.getDatabaseVersion();
         if (!adapter.supportsNullsNotDistinct()) return;
         await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name) NULLS DISTINCT`);
         const lines: string[] = [];


### PR DESCRIPTION
## Summary

- **4 enum schema-dump tests** (enum.test.ts): \`schema dump renamed enum\`, \`schema dump renamed enum with to option\`, \`schema dump added enum value\`, \`schema dump renamed enum value\` — verify \`enumTypes()\` reflects enum mutations and that \`dumpTableSchema\`/\`dumper.types()\` renders the updated enum name/values correctly.
- **4 schema index tests** (schema.test.ts): \`schema dumps index included columns\`, \`nulls not distinct is dumped\`, \`nulls distinct is dumped\`, \`nulls not set is dumped\` — create fresh tables + indexes and verify \`dumpTable\` emits \`include: [...]\` and \`nullsNotDistinct: true\` correctly.
- **Bug fix in \`enumTypes()\`** (postgresql-adapter.ts): \`array_agg(enumlabel)\` returns \`anyarray\` (OID 2277) which pg-node returns as a raw PG literal string \`{sad,ok,happy}\`. Cast \`enumlabel::text\` so \`array_agg\` returns \`text[]\` (OID 1009), which pg-node parses via its built-in \`parseStringArray\`. This fix was surfaced by the new tests.

**api:compare**: \`connection_adapters/postgresql/schema_dumper.rb\` stays at 11/11 100% ✓
**LOC**: ~180 (under 300 ceiling)

## Test plan

- [ ] PG CI passes
- [ ] \`pnpm run api:compare --package activerecord\` — \`postgresql/schema_dumper.rb\` stays 100%
- [ ] \`pnpm tsc --build\` passes