### PR TITLE
feat(globalid): GID-2 — SignedGlobalID in the new package

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -22,7 +22,8 @@
         "../../activesupport/src/testing/temporal-helpers.ts"
       ],
       "@blazetrails/globalid": ["../../globalid/src/index.ts"],
-      "@blazetrails/globalid/wire": ["../../globalid/src/wire.ts"]
+      "@blazetrails/globalid/wire": ["../../globalid/src/wire.ts"],
+      "@blazetrails/globalid/signed-global-id": ["../../globalid/src/signed-global-id.ts"]
     }
   },
   "include": ["."]

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { getApp as _getGlobalIdApp } from "@blazetrails/globalid";
+import { getApp as _getGlobalIdApp, SignedGlobalID } from "@blazetrails/globalid";
 import {
   Model,
   type Type,
@@ -2782,6 +2782,29 @@ export class Base extends Model {
       return `gid://${app}/${ctor.name}/${this.id}`;
     }
     return `gid://${ctor.name}/${this.id}`;
+  }
+
+  /**
+   * Return a cryptographically signed GlobalID for this record.
+   * Uses the model's `signedIdVerifier` (same secret as signed IDs).
+   *
+   * Mirrors: ActiveRecord::Base#to_sgid
+   */
+  async toSgid(options?: {
+    app?: string;
+    purpose?: string;
+    expiresIn?: number;
+    expiresAt?: Temporal.Instant;
+  }): Promise<string> {
+    const SignedIdModule = await loadSignedId();
+    const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
+    return SignedGlobalID.create(
+      this as unknown as { id: unknown; constructor: { name: string } },
+      {
+        ...options,
+        verifier,
+      },
+    ).toString();
   }
 
   // valuesAt / assignAttributes extracted to persistence.ts.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2789,7 +2789,7 @@ export class Base extends Model {
   }
 
   /**
-   * Return a cryptographically signed GlobalID for this record.
+   * Return a SignedGlobalID for this record.
    * Uses the model's `signedIdVerifier` (same secret as signed IDs).
    *
    * Mirrors: ActiveRecord::Base#to_sgid
@@ -2799,10 +2799,24 @@ export class Base extends Model {
     purpose?: string;
     expiresIn?: number;
     expiresAt?: Temporal.Instant;
-  }): Promise<string> {
+  }): Promise<SignedGlobalID> {
     const SignedIdModule = await loadSignedId();
     const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
-    return SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier }).toString();
+    return SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier });
+  }
+
+  /**
+   * Return the signed GlobalID token string for this record.
+   *
+   * Mirrors: ActiveRecord::Base#to_sgid_param
+   */
+  async toSgidParam(options?: {
+    app?: string;
+    purpose?: string;
+    expiresIn?: number;
+    expiresAt?: Temporal.Instant;
+  }): Promise<string> {
+    return (await this.toSgid(options)).toParam();
   }
 
   // valuesAt / assignAttributes extracted to persistence.ts.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,5 +1,9 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { getApp as _getGlobalIdApp, SignedGlobalID } from "@blazetrails/globalid";
+import {
+  getApp as _getGlobalIdApp,
+  SignedGlobalID,
+  type GlobalIDModel,
+} from "@blazetrails/globalid";
 import {
   Model,
   type Type,
@@ -2798,13 +2802,7 @@ export class Base extends Model {
   }): Promise<string> {
     const SignedIdModule = await loadSignedId();
     const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
-    return SignedGlobalID.create(
-      this as unknown as { id: unknown; constructor: { name: string } },
-      {
-        ...options,
-        verifier,
-      },
-    ).toString();
+    return SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier }).toString();
   }
 
   // valuesAt / assignAttributes extracted to persistence.ts.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,9 +1,9 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import {
-  getApp as _getGlobalIdApp,
-  SignedGlobalID,
-  type GlobalIDModel,
-} from "@blazetrails/globalid";
+import { getApp as _getGlobalIdApp } from "@blazetrails/globalid";
+import type {
+  GlobalIDModel,
+  SignedGlobalID as SignedGlobalIDType,
+} from "@blazetrails/globalid/signed-global-id";
 import {
   Model,
   type Type,
@@ -93,6 +93,24 @@ import {
   runAfterCallbacksOnProto as cbRunAfter,
 } from "@blazetrails/activemodel";
 // Lazy-loaded to avoid pulling node:crypto into browser bundles
+let _sgidModule: typeof import("@blazetrails/globalid/signed-global-id") | null = null;
+let _sgidModulePromise: Promise<typeof import("@blazetrails/globalid/signed-global-id")> | null =
+  null;
+const loadSgid = async () => {
+  if (_sgidModule) return _sgidModule;
+  if (!_sgidModulePromise) {
+    _sgidModulePromise = import("@blazetrails/globalid/signed-global-id")
+      .then((mod) => {
+        _sgidModule = mod;
+        return mod;
+      })
+      .catch((error) => {
+        _sgidModulePromise = null;
+        throw error;
+      });
+  }
+  return _sgidModulePromise;
+};
 let _signedIdModule: typeof import("./signed-id.js") | null = null;
 let _signedIdModulePromise: Promise<typeof import("./signed-id.js")> | null = null;
 const loadSignedId = async () => {
@@ -2799,10 +2817,10 @@ export class Base extends Model {
     purpose?: string;
     expiresIn?: number;
     expiresAt?: Temporal.Instant;
-  }): Promise<SignedGlobalID> {
-    const SignedIdModule = await loadSignedId();
+  }): Promise<SignedGlobalIDType> {
+    const [SgidMod, SignedIdModule] = await Promise.all([loadSgid(), loadSignedId()]);
     const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
-    return SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier });
+    return SgidMod.SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier });
   }
 
   /**

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -5,7 +5,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base, RecordNotFound } from "./index.js";
-import { setSignedIdVerifierSecret } from "./signed-id.js";
+import { setSignedIdVerifierSecret, signedIdVerifier } from "./signed-id.js";
+import { SignedGlobalID } from "@blazetrails/globalid/signed-global-id";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -390,9 +391,13 @@ describe("signedId / findSigned / findSignedBang", () => {
     const sgid = await u.toSgid({ purpose: "test" });
     expect(sgid.purpose).toBe("test");
     expect(sgid.uri).toContain(`/${u.id}`);
-    const token = sgid.toParam();
-    expect(typeof token).toBe("string");
-    expect(token.length).toBeGreaterThan(0);
+    const parsed = SignedGlobalID.parse(sgid.toParam(), {
+      purpose: "test",
+      verifier: signedIdVerifier(User),
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.uri).toBe(sgid.uri);
+    expect(parsed!.purpose).toBe(sgid.purpose);
   });
 
   it("toSgidParam returns a string token identical to toSgid().toParam()", async () => {

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -377,4 +377,35 @@ describe("signedId / findSigned / findSignedBang", () => {
     }
     await expect(User.findSignedBang("invalid")).rejects.toThrow();
   });
+
+  it("toSgid returns SignedGlobalID whose toParam round-trips to same instance", async () => {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Dave" });
+    const sgid = await u.toSgid({ purpose: "test" });
+    expect(sgid.purpose).toBe("test");
+    expect(sgid.uri).toContain(`/${u.id}`);
+    const token = sgid.toParam();
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it("toSgidParam returns a string token identical to toSgid().toParam()", async () => {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Eve" });
+    const token = await u.toSgidParam();
+    expect(typeof token).toBe("string");
+    expect(token).toBe((await u.toSgid()).toParam());
+  });
 });

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -12,7 +12,8 @@
       "@blazetrails/activesupport/message-verifier": [
         "../../activesupport/src/message-verifier.ts"
       ],
-      "@blazetrails/activesupport/process-adapter": ["../../activesupport/src/process-adapter.ts"]
+      "@blazetrails/activesupport/process-adapter": ["../../activesupport/src/process-adapter.ts"],
+      "@blazetrails/globalid/signed-global-id": ["../../globalid/src/signed-global-id.ts"]
     }
   },
   "include": ["."]

--- a/packages/globalid/package.json
+++ b/packages/globalid/package.json
@@ -13,6 +13,10 @@
     "./wire": {
       "types": "./dist/wire.d.ts",
       "default": "./dist/wire.js"
+    },
+    "./signed-global-id": {
+      "types": "./dist/signed-global-id.d.ts",
+      "default": "./dist/signed-global-id.js"
     }
   },
   "scripts": {

--- a/packages/globalid/src/config.ts
+++ b/packages/globalid/src/config.ts
@@ -12,3 +12,8 @@ export function setApp(name: string): void {
 export function getApp(): string | undefined {
   return _app;
 }
+
+/** @internal — test use only */
+export function _resetApp(): void {
+  _app = undefined;
+}

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -1,1 +1,3 @@
 export { getApp, setApp } from "./config.js";
+export { SignedGlobalID } from "./signed-global-id.js";
+export type { SignedGlobalIDOptions, ParseOptions, GlobalIDModel } from "./signed-global-id.js";

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { SignedGlobalID } from "./signed-global-id.js";
+
+function makeVerifier(secret = "test-secret"): MessageVerifier {
+  return new MessageVerifier(secret, { digest: "sha256", url_safe: true });
+}
+
+const fakeModel = { id: 42, constructor: { name: "User" } };
+
+describe("SignedGlobalID", () => {
+  it("round-trips create → parse", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    const token = sgid.toString();
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
+
+    const parsed = SignedGlobalID.parse(token, { verifier });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.uri).toContain("User/42");
+    expect(parsed!.purpose).toBe("default");
+  });
+
+  it("toParam equals toString", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    expect(sgid.toParam()).toBe(sgid.toString());
+  });
+
+  it("caches the signed token", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    expect(sgid.toString()).toBe(sgid.toString());
+  });
+
+  it("returns null for tampered token", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    const token = sgid.toString();
+    const tampered = token.slice(0, -4) + "xxxx";
+    expect(SignedGlobalID.parse(tampered, { verifier })).toBeNull();
+  });
+
+  it("returns null for wrong verifier", () => {
+    const v1 = makeVerifier("secret-1");
+    const v2 = makeVerifier("secret-2");
+    const sgid = SignedGlobalID.create(fakeModel, { verifier: v1 });
+    const token = sgid.toString();
+    expect(SignedGlobalID.parse(token, { verifier: v2 })).toBeNull();
+  });
+
+  it("returns null for purpose mismatch", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, purpose: "login" });
+    const token = sgid.toString();
+    expect(SignedGlobalID.parse(token, { verifier, purpose: "default" })).toBeNull();
+    expect(SignedGlobalID.parse(token, { verifier, purpose: "login" })).not.toBeNull();
+  });
+
+  it("returns null for expired token (expiresIn)", () => {
+    const verifier = makeVerifier();
+    const past = Temporal.Now.instant().add({ milliseconds: -1000 });
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: past });
+    const token = sgid.toString();
+    expect(SignedGlobalID.parse(token, { verifier })).toBeNull();
+  });
+
+  it("encodes expiresAt in the token", () => {
+    const verifier = makeVerifier();
+    const future = Temporal.Now.instant().add({ seconds: 3600 });
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: future });
+    expect(sgid.expiresAt).toBeDefined();
+    const token = sgid.toString();
+    const parsed = SignedGlobalID.parse(token, { verifier });
+    expect(parsed).not.toBeNull();
+  });
+
+  it("respects expiresIn (seconds)", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresIn: 3600 });
+    expect(sgid.expiresAt).toBeDefined();
+    const token = sgid.toString();
+    expect(SignedGlobalID.parse(token, { verifier })).not.toBeNull();
+  });
+
+  it("includes app in URI when provided", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, app: "MyApp" });
+    expect(sgid.uri).toBe("gid://MyApp/User/42");
+  });
+
+  it("uses getApp() when no app option", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    // no app configured — fallback URI
+    expect(sgid.uri).toContain("User/42");
+  });
+});

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { SignedGlobalID } from "./signed-global-id.js";
+import { setApp } from "./config.js";
 
 function makeVerifier(secret = "test-secret"): MessageVerifier {
   return new MessageVerifier(secret, { digest: "sha256", url_safe: true });
@@ -98,9 +99,14 @@ describe("SignedGlobalID", () => {
     expect(sgid.uri).toBe("gid://MyApp/User/42");
   });
 
-  it("uses getApp() when no app option", () => {
-    const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier });
-    expect(sgid.uri).toContain("User/42");
+  describe("getApp() integration", () => {
+    afterEach(() => setApp("placeholder"));
+
+    it("uses getApp() when no app option", () => {
+      setApp("ConfiguredApp");
+      const verifier = makeVerifier();
+      const sgid = SignedGlobalID.create(fakeModel, { verifier });
+      expect(sgid.uri).toBe("gid://ConfiguredApp/User/42");
+    });
   });
 });

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -67,14 +67,15 @@ describe("SignedGlobalID", () => {
     expect(SignedGlobalID.parse(token, { verifier })).toBeNull();
   });
 
-  it("encodes expiresAt in the token", () => {
+  it("encodes expiresAt in the token and round-trips it", () => {
     const verifier = makeVerifier();
     const future = Temporal.Now.instant().add({ seconds: 3600 });
     const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: future });
     expect(sgid.expiresAt).toBeDefined();
-    const token = sgid.toString();
-    const parsed = SignedGlobalID.parse(token, { verifier });
+    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
     expect(parsed).not.toBeNull();
+    expect(parsed!.expiresAt).toBeDefined();
+    expect(Temporal.Instant.compare(parsed!.expiresAt!, Temporal.Now.instant())).toBeGreaterThan(0);
   });
 
   it("respects expiresIn (seconds)", () => {
@@ -94,7 +95,6 @@ describe("SignedGlobalID", () => {
   it("uses getApp() when no app option", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(fakeModel, { verifier });
-    // no app configured — fallback URI
     expect(sgid.uri).toContain("User/42");
   });
 });

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { SignedGlobalID } from "./signed-global-id.js";
-import { setApp } from "./config.js";
+import { setApp, _resetApp } from "./config.js";
 
 function makeVerifier(secret = "test-secret"): MessageVerifier {
   return new MessageVerifier(secret, { digest: "sha256", url_safe: true });
@@ -100,7 +100,7 @@ describe("SignedGlobalID", () => {
   });
 
   describe("getApp() integration", () => {
-    afterEach(() => setApp("placeholder"));
+    afterEach(() => _resetApp());
 
     it("uses getApp() when no app option", () => {
       setApp("ConfiguredApp");

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -59,12 +59,18 @@ describe("SignedGlobalID", () => {
     expect(SignedGlobalID.parse(token, { verifier, purpose: "login" })).not.toBeNull();
   });
 
-  it("returns null for expired token (expiresIn)", () => {
+  it("returns null for expired token (expiresAt in the past)", () => {
     const verifier = makeVerifier();
     const past = Temporal.Now.instant().add({ milliseconds: -1000 });
     const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: past });
-    const token = sgid.toString();
-    expect(SignedGlobalID.parse(token, { verifier })).toBeNull();
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+  });
+
+  it("returns null for token expired via expiresIn", () => {
+    const verifier = makeVerifier();
+    // expiresIn of 0 seconds resolves to now, which is immediately expired
+    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresIn: 0 });
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
   });
 
   it("encodes expiresAt in the token and round-trips it", () => {

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -1,0 +1,140 @@
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { getApp } from "./config.js";
+
+const DEFAULT_PURPOSE = "default";
+
+export interface SignedGlobalIDOptions {
+  app?: string;
+  purpose?: string;
+  expiresIn?: number;
+  expiresAt?: Temporal.Instant;
+  verifier: MessageVerifier;
+}
+
+export interface ParseOptions {
+  purpose?: string;
+  verifier: MessageVerifier;
+}
+
+export interface GlobalIDModel {
+  id: unknown;
+  constructor: { name: string };
+}
+
+/** @internal */
+interface SgidPayload {
+  gid: string;
+  purpose: string;
+  expires_at: string | null;
+}
+
+export class SignedGlobalID {
+  /** The raw GID URI string, e.g. `gid://MyApp/User/1` */
+  readonly uri: string;
+  readonly purpose: string;
+  readonly expiresAt: Temporal.Instant | undefined;
+
+  /** @internal */
+  private readonly verifier: MessageVerifier;
+  /** @internal */
+  private _cached: string | undefined;
+
+  private constructor(
+    uri: string,
+    purpose: string,
+    expiresAt: Temporal.Instant | undefined,
+    verifier: MessageVerifier,
+  ) {
+    this.uri = uri;
+    this.purpose = purpose;
+    this.expiresAt = expiresAt;
+    this.verifier = verifier;
+  }
+
+  /**
+   * Create a SignedGlobalID for a model instance.
+   *
+   * Mirrors: SignedGlobalID.new
+   */
+  static create(model: GlobalIDModel, options: SignedGlobalIDOptions): SignedGlobalID {
+    const app = options.app ?? getApp();
+    const modelName = model.constructor.name;
+    const uri = app ? `gid://${app}/${modelName}/${model.id}` : `gid://${modelName}/${model.id}`;
+
+    const purpose = options.purpose ?? DEFAULT_PURPOSE;
+    const expiresAt = pickExpiration(options);
+
+    return new SignedGlobalID(uri, purpose, expiresAt, options.verifier);
+  }
+
+  /**
+   * Parse a signed SGID token. Returns null on invalid signature, expiration,
+   * or purpose mismatch.
+   *
+   * Mirrors: SignedGlobalID.parse (verify_with_verifier_validated_metadata path)
+   */
+  static parse(sgid: string, options: ParseOptions): SignedGlobalID | null {
+    const purpose = options.purpose ?? DEFAULT_PURPOSE;
+    const result = verifyToken(sgid, purpose, options.verifier);
+    if (result === null) return null;
+    const { uri, expiresAt } = result;
+    return new SignedGlobalID(uri, purpose, expiresAt, options.verifier);
+  }
+
+  toString(): string {
+    if (this._cached) return this._cached;
+    const payload: SgidPayload = {
+      gid: this.uri,
+      purpose: this.purpose,
+      expires_at: this.expiresAt ? this.expiresAt.toString({ smallestUnit: "millisecond" }) : null,
+    };
+    this._cached = this.verifier.generate(payload, {
+      purpose: this.purpose,
+      expiresAt: this.expiresAt,
+    });
+    return this._cached;
+  }
+
+  toParam(): string {
+    return this.toString();
+  }
+
+  /** @internal */
+  [Symbol.toPrimitive](): string {
+    return this.toString();
+  }
+}
+
+/** @internal */
+function verifyToken(
+  sgid: string,
+  purpose: string,
+  verifier: MessageVerifier,
+): { uri: string; expiresAt: Temporal.Instant | undefined } | null {
+  try {
+    const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
+    if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
+    if (raw.purpose !== purpose) return null;
+    let expiresAt: Temporal.Instant | undefined;
+    if (raw.expires_at) {
+      expiresAt = Temporal.Instant.from(raw.expires_at);
+      if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) <= 0) return null;
+    }
+    return { uri: raw.gid, expiresAt };
+  } catch {
+    return null;
+  }
+}
+
+/** @internal */
+function pickExpiration(
+  options: Pick<SignedGlobalIDOptions, "expiresAt" | "expiresIn">,
+): Temporal.Instant | undefined {
+  if (options.expiresAt !== undefined) return options.expiresAt;
+  if (options.expiresIn !== undefined) {
+    const ms = Math.round(options.expiresIn * 1000);
+    return Temporal.Now.instant().add({ milliseconds: ms });
+  }
+  return undefined;
+}

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -113,6 +113,7 @@ function verifyToken(
   try {
     const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
     if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
+    if (!raw.gid.startsWith("gid://")) return null;
     if (raw.purpose !== purpose) return null;
     let expiresAt: Temporal.Instant | undefined;
     if (raw.expires_at) {

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -35,9 +35,7 @@ export class SignedGlobalID {
   readonly purpose: string;
   readonly expiresAt: Temporal.Instant | undefined;
 
-  /** @internal */
   private readonly verifier: MessageVerifier;
-  /** @internal */
   private _cached: string | undefined;
 
   private constructor(
@@ -101,7 +99,7 @@ export class SignedGlobalID {
   }
 
   /** @internal */
-  [Symbol.toPrimitive](): string {
+  [Symbol.toPrimitive](_hint: string): string {
     return this.toString();
   }
 }

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
       pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),
+      pkgAlias("@blazetrails/globalid/signed-global-id", "../globalid/src/signed-global-id.ts"),
       pkgAlias("@blazetrails/globalid", "../globalid/src/index.ts"),
     ],
   },

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
       pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),
+      pkgAlias("@blazetrails/globalid/signed-global-id", "../globalid/src/signed-global-id.ts"),
       pkgAlias("@blazetrails/globalid", "../globalid/src/index.ts"),
     ],
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,10 @@ const alias = {
   "@blazetrails/actionview": path.resolve(__dirname, "packages/actionview/src/index.ts"),
   "@blazetrails/actionpack": path.resolve(__dirname, "packages/actionpack/src/index.ts"),
   "@blazetrails/globalid/wire": path.resolve(__dirname, "packages/globalid/src/wire.ts"),
+  "@blazetrails/globalid/signed-global-id": path.resolve(
+    __dirname,
+    "packages/globalid/src/signed-global-id.ts",
+  ),
   "@blazetrails/globalid": path.resolve(__dirname, "packages/globalid/src/index.ts"),
 };
 


### PR DESCRIPTION
## Summary

- Adds `SignedGlobalID` to `packages/globalid/src/signed-global-id.ts` (mirrors `globalid-1.3.0/lib/global_id/signed_global_id.rb`)
- Implements `SignedGlobalID.create(model, { verifier, purpose?, expiresIn?, expiresAt?, app? })` and `SignedGlobalID.parse(sgid, { verifier, purpose? })`
- Payload shape: `{ gid, purpose, expires_at }` signed via `MessageVerifier` — distinguishable from `signedId` tokens by value shape
- Wires `Base#toSgid()` back in AR (was deleted in GID-1), delegating to `SignedGlobalID.create` via the model's `signedIdVerifier`
- Only implements `verify_with_verifier_validated_metadata` path (no legacy self-validated metadata — no Trails legacy SGIDs exist)
- 11 tests: round-trip, expiry (expiresAt/expiresIn), purpose mismatch, tamper detection, wrong verifier, app in URI

## Test plan

- [x] `pnpm test:types` — 83 tests pass
- [x] `npx vitest run --project other packages/globalid/src/signed-global-id.test.ts` — 11/11 pass
- [x] Build + typecheck pass (pre-commit hook)

## Follow-ups (not this PR)

- GID-3: `URI::GID` parser + `GlobalID` class
- GID-4: `GlobalID::Locator` + `findGlobalId`/`findSignedGlobalId` on AR Base
- Note from GID-1: `toGid` fallback URI is non-parseable when no app configured — GID-3 will fix