### PR TITLE
refactor(activerecord): remove eager pg import from temporal-type-parsers (BC-3)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -67,8 +67,9 @@ import {
   temporalToBindString,
   extractTableRefFromInsertSql,
 } from "./abstract/database-statements.js";
-import { getTypeParser as getTemporalTypeParser } from "./postgresql/temporal-type-parsers.js";
+import { makeGetTypeParser } from "./postgresql/temporal-type-parsers.js";
 
+const getTemporalTypeParser = makeGetTypeParser(pg.types);
 const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
 const OID_INTERVAL = 1186;
 import {

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
@@ -9,7 +9,9 @@ import { describe, expect, it } from "vitest";
 import pg from "pg";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
-import { getTypeParser } from "./temporal-type-parsers.js";
+import { makeGetTypeParser } from "./temporal-type-parsers.js";
+
+const getTypeParser = makeGetTypeParser(pg.types);
 
 const OID_DATE = 1082;
 const OID_TIME = 1083;

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -11,8 +11,6 @@
  * etc. Per-connection tables, not global mutation.
  */
 
-// Not imported by the top-level activerecord barrel; only pulled in when the PostgreSQL adapter is loaded.
-import pg from "pg";
 import {
   parsePostgresInstant,
   parsePostgresTimestampAsInstant,
@@ -40,20 +38,28 @@ const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser
 ]);
 
 /**
- * Drop-in replacement for `pg.types.getTypeParser`.
- * Pass as `{ types: { getTypeParser } }` in the pg.Pool / pg.Client config.
+ * Returns a drop-in replacement for `pg.types.getTypeParser`.
+ * Pass the returned function as `{ types: { getTypeParser } }` in the pg.Pool / pg.Client config.
  *
  * Intercepts text-format for the five temporal OIDs and returns our Temporal
- * wire parsers. All other OIDs delegate to `pg.types.getTypeParser` so the
+ * wire parsers. All other OIDs delegate to `pgTypes.getTypeParser` so the
  * built-in parsers (int, bool, numeric, etc.) remain active. Returning `null`
  * is NOT correct — pg stores the return value directly in its `_parsers` array
  * and calls it; a non-function crashes query processing.
+ *
+ * Accepts `pgTypes` rather than importing `pg` directly so this module carries
+ * no eager native-package import — keeping it loadable in browser bundles even
+ * though PostgreSQL itself is server-only.
  */
-export function getTypeParser(oid: number, format?: string): PgParser {
-  const fmt = format || "text";
-  if (fmt === "text") {
-    const parser = TEMPORAL_PARSERS.get(oid);
-    if (parser) return parser;
-  }
-  return pg.types.getTypeParser(oid, fmt as "text" | "binary") as PgParser;
+export function makeGetTypeParser(pgTypes: {
+  getTypeParser: (oid: number, format: "text" | "binary") => unknown;
+}): (oid: number, format?: string) => PgParser {
+  return function getTypeParser(oid: number, format?: string): PgParser {
+    const fmt = format || "text";
+    if (fmt === "text") {
+      const parser = TEMPORAL_PARSERS.get(oid);
+      if (parser) return parser;
+    }
+    return pgTypes.getTypeParser(oid, fmt as "text" | "binary") as PgParser;
+  };
 }


### PR DESCRIPTION
## Summary

- `temporal-type-parsers.ts` had a top-level `import pg from "pg"` to delegate unknown OIDs to `pg.types.getTypeParser`. This created the last eager native-package import reachable from non-subpath-entry files (tracked in `docs/browser-compat-plan.md` § BC-3).
- Replace the function with a factory `makeGetTypeParser(pgTypes)` that accepts the pg types object from the caller.
- `postgresql-adapter.ts` (the PG subpath entry, which already has `import pg from "pg"`) calls `makeGetTypeParser(pg.types)` at module load — zero behavior change.
- `temporal-type-parsers.ts` now has no native-package imports and is safe for browser bundles.

## Test plan

- [ ] `temporal-type-parsers.test.ts` — 17 tests pass (verified locally)
- [ ] Build + typecheck pass (lint hook ran clean on commit)
- [ ] No new TS errors in changed files
- [ ] `pnpm run api:compare --package activerecord` — no regression expected (no public API surface changed)