### PR TITLE
feat(activerecord): pg/cidr IpAddr value + prefix-aware changed?

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -2,8 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/cidr_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { Cidr } from "../../connection-adapters/postgresql/oid/cidr.js";
-import { IpAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
+import { Cidr, IpAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {

--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/cidr_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { Cidr, IpAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
+import { Cidr, IPAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -27,8 +27,8 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("type casting IPAddr for database", async () => {
       const type = new Cidr();
-      const ip = new IpAddr("255.0.0.0", 8);
-      const ip2 = new IpAddr("127.0.0.1", 32);
+      const ip = new IPAddr("255.0.0.0", 8);
+      const ip2 = new IPAddr("127.0.0.1", 32);
 
       expect(type.serialize(ip)).toBe("255.0.0.0/8");
       expect(type.serialize(ip2)).toBe("127.0.0.1/32");
@@ -47,16 +47,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(type.isChanged("192.168.0.0/24", null, "")).toBe(true);
       expect(type.isChanged(null, "192.168.0.0/24", "")).toBe(true);
       expect(type.isChanged("192.168.0.0/24", "192.168.0.0/25", "")).toBe(true);
-      expect(type.isChanged(new IpAddr("192.168.0.0", 24), null, "")).toBe(true);
-      expect(type.isChanged(null, new IpAddr("192.168.0.0", 24), "")).toBe(true);
-      expect(type.isChanged(new IpAddr("192.168.0.0", 24), new IpAddr("192.168.0.0", 25), "")).toBe(
+      expect(type.isChanged(new IPAddr("192.168.0.0", 24), null, "")).toBe(true);
+      expect(type.isChanged(null, new IPAddr("192.168.0.0", 24), "")).toBe(true);
+      expect(type.isChanged(new IPAddr("192.168.0.0", 24), new IPAddr("192.168.0.0", 25), "")).toBe(
         true,
       );
 
-      expect(type.isChanged(new IpAddr("0.0.0.0", 32), null, "")).toBe(true);
-      expect(type.isChanged(null, new IpAddr("0.0.0.0", 32), "")).toBe(true);
-      expect(type.isChanged(new IpAddr("::", 128), null, "")).toBe(true);
-      expect(type.isChanged(null, new IpAddr("::", 128), "")).toBe(true);
+      expect(type.isChanged(new IPAddr("0.0.0.0", 32), null, "")).toBe(true);
+      expect(type.isChanged(null, new IPAddr("0.0.0.0", 32), "")).toBe(true);
+      expect(type.isChanged(new IPAddr("::", 128), null, "")).toBe(true);
+      expect(type.isChanged(null, new IPAddr("::", 128), "")).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -1,7 +1,9 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/cidr_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Cidr } from "../../connection-adapters/postgresql/oid/cidr.js";
+import { IpAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -15,34 +17,47 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("CidrTest", () => {
     it.skip("cidr column", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+      // BLOCKED: adapter-pg — requires live schema with cidr column
     });
     it.skip("cidr type cast", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+      // BLOCKED: adapter-pg — requires live DB round-trip
     });
     it.skip("cidr invalid", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+      // BLOCKED: adapter-pg — requires live DB
     });
-    it.skip("type casting IPAddr for database", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+
+    it("type casting IPAddr for database", async () => {
+      const type = new Cidr();
+      const ip = new IpAddr("255.0.0.0", 8);
+      const ip2 = new IpAddr("127.0.0.1", 32);
+
+      expect(type.serialize(ip)).toBe("255.0.0.0/8");
+      expect(type.serialize(ip2)).toBe("127.0.0.1/32");
     });
-    it.skip("casting does nothing with non-IPAddr objects", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+
+    it("casting does nothing with non-IPAddr objects", async () => {
+      const type = new Cidr();
+
+      expect(type.serialize("foo")).toBe("foo");
     });
-    it.skip("changed? with nil values", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in cidr
-      // ROOT-CAUSE: connection-adapters/postgresql/cidr.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/cidr.ts; affects ~10–47 tests in cidr.test.ts
+
+    it("changed? with nil values", async () => {
+      const type = new Cidr();
+
+      expect(type.isChanged(null, null, "")).toBe(false);
+      expect(type.isChanged("192.168.0.0/24", null, "")).toBe(true);
+      expect(type.isChanged(null, "192.168.0.0/24", "")).toBe(true);
+      expect(type.isChanged("192.168.0.0/24", "192.168.0.0/25", "")).toBe(true);
+      expect(type.isChanged(new IpAddr("192.168.0.0", 24), null, "")).toBe(true);
+      expect(type.isChanged(null, new IpAddr("192.168.0.0", 24), "")).toBe(true);
+      expect(type.isChanged(new IpAddr("192.168.0.0", 24), new IpAddr("192.168.0.0", 25), "")).toBe(
+        true,
+      );
+
+      expect(type.isChanged(new IpAddr("0.0.0.0", 32), null, "")).toBe(true);
+      expect(type.isChanged(null, new IpAddr("0.0.0.0", 32), "")).toBe(true);
+      expect(type.isChanged(new IpAddr("::", 128), null, "")).toBe(true);
+      expect(type.isChanged(null, new IpAddr("::", 128), "")).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -160,14 +160,14 @@ describe("PostgresqlNetworkTest", () => {
 
   it("invalid network address", () => {
     // Rails: test_invalid_network_address — IPAddr.new raises on garbage,
-    // so Cidr#cast_value returns nil. cast returns IpAddr on valid input.
+    // so Cidr#cast_value returns nil. cast returns IPAddr on valid input.
     const type = new Cidr();
     expect(type.cast("invalid addr")).toBeNull();
     expect(type.cast("not-an-ip")).toBeNull();
     expect(type.cast(42)).toBeNull();
     // Out-of-range prefixes are rejected too.
     expect(type.cast("192.168.1.0/999")).toBeNull();
-    // Valid inputs produce IpAddr with correct address + prefixLength.
+    // Valid inputs produce IPAddr with correct address + prefixLength.
     expect(type.cast("192.168.1.1")).toMatchObject({ address: "192.168.1.1", prefixLength: 32 });
     expect(type.cast("192.168.1.0/24")).toMatchObject({ address: "192.168.1.0", prefixLength: 24 });
     expect(type.cast("::1")).toMatchObject({ address: "::1", prefixLength: 128 });

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -160,19 +160,22 @@ describe("PostgresqlNetworkTest", () => {
 
   it("invalid network address", () => {
     // Rails: test_invalid_network_address — IPAddr.new raises on garbage,
-    // so Cidr#cast_value returns nil. Mirror that in TS.
+    // so Cidr#cast_value returns nil. cast returns IpAddr on valid input.
     const type = new Cidr();
     expect(type.cast("invalid addr")).toBeNull();
     expect(type.cast("not-an-ip")).toBeNull();
     expect(type.cast(42)).toBeNull();
     // Out-of-range prefixes are rejected too.
     expect(type.cast("192.168.1.0/999")).toBeNull();
-    // Valid IPv4 / IPv6 / prefixed forms pass through.
-    expect(type.cast("192.168.1.1")).toBe("192.168.1.1");
-    expect(type.cast("192.168.1.0/24")).toBe("192.168.1.0/24");
-    expect(type.cast("::1")).toBe("::1");
-    expect(type.cast("2001:db8::/32")).toBe("2001:db8::/32");
+    // Valid inputs produce IpAddr with correct address + prefixLength.
+    expect(type.cast("192.168.1.1")).toMatchObject({ address: "192.168.1.1", prefixLength: 32 });
+    expect(type.cast("192.168.1.0/24")).toMatchObject({ address: "192.168.1.0", prefixLength: 24 });
+    expect(type.cast("::1")).toMatchObject({ address: "::1", prefixLength: 128 });
+    expect(type.cast("2001:db8::/32")).toMatchObject({ address: "2001:db8::", prefixLength: 32 });
     // IPv4-embedded IPv6 is valid (e.g. IPv4-mapped addresses).
-    expect(type.cast("::ffff:192.168.0.1")).toBe("::ffff:192.168.0.1");
+    expect(type.cast("::ffff:192.168.0.1")).toMatchObject({
+      address: "::ffff:192.168.0.1",
+      prefixLength: 128,
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { Cidr, IpAddr } from "./cidr.js";
+import { Cidr, IPAddr } from "./cidr.js";
 
 describe("PostgreSQL::OID::Cidr", () => {
   it("type_cast_for_schema quotes the address, eliding /32 and /128", () => {
@@ -8,18 +8,18 @@ describe("PostgreSQL::OID::Cidr", () => {
     // "#{value}" calls IPAddr#to_s which returns just the address.
     // Rails only checks prefix == 32 (not 128); /128 IPv6 keeps its suffix.
     const type = new Cidr();
-    expect(type.typeCastForSchema(new IpAddr("192.168.1.0", 24))).toBe('"192.168.1.0/24"');
-    expect(type.typeCastForSchema(new IpAddr("192.168.1.1", 32))).toBe('"192.168.1.1"');
-    expect(type.typeCastForSchema(new IpAddr("::1", 128))).toBe('"::1/128"');
+    expect(type.typeCastForSchema(new IPAddr("192.168.1.0", 24))).toBe('"192.168.1.0/24"');
+    expect(type.typeCastForSchema(new IPAddr("192.168.1.1", 32))).toBe('"192.168.1.1"');
+    expect(type.typeCastForSchema(new IPAddr("::1", 128))).toBe('"::1/128"');
     // Rails checks prefix == 32 for any IP version, so IPv6 /32 is also elided.
-    expect(type.typeCastForSchema(new IpAddr("2001:db8::", 32))).toBe('"2001:db8::"');
+    expect(type.typeCastForSchema(new IPAddr("2001:db8::", 32))).toBe('"2001:db8::"');
   });
 
   it("castValue is the public Rails-named hook", () => {
     // Rails cast_value returns an IPAddr object (or nil on ArgumentError).
     const type = new Cidr();
     const result = type.castValue("192.168.1.1");
-    expect(result).toBeInstanceOf(IpAddr);
+    expect(result).toBeInstanceOf(IPAddr);
     expect(result?.address).toBe("192.168.1.1");
     expect(result?.prefixLength).toBe(32);
 
@@ -30,8 +30,8 @@ describe("PostgreSQL::OID::Cidr", () => {
     expect(type.castValue("not-an-ip")).toBeNull();
     expect(type.castValue(null)).toBeNull();
 
-    // Pass-through for existing IpAddr (Rails: `else value`).
-    const ip = new IpAddr("10.0.0.1", 32);
+    // Pass-through for existing IPAddr (Rails: `else value`).
+    const ip = new IPAddr("10.0.0.1", 32);
     expect(type.castValue(ip)).toBe(ip);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
@@ -11,7 +11,7 @@ describe("PostgreSQL::OID::Cidr", () => {
     expect(type.typeCastForSchema(new IpAddr("192.168.1.0", 24))).toBe('"192.168.1.0/24"');
     expect(type.typeCastForSchema(new IpAddr("192.168.1.1", 32))).toBe('"192.168.1.1"');
     expect(type.typeCastForSchema(new IpAddr("::1", 128))).toBe('"::1/128"');
-    // Non-host prefixes are preserved.
+    // Rails checks prefix == 32 for any IP version, so IPv6 /32 is also elided.
     expect(type.typeCastForSchema(new IpAddr("2001:db8::", 32))).toBe('"2001:db8::"');
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
@@ -1,25 +1,37 @@
 import { describe, expect, it } from "vitest";
 
-import { Cidr } from "./cidr.js";
+import { Cidr, IpAddr } from "./cidr.js";
 
 describe("PostgreSQL::OID::Cidr", () => {
   it("type_cast_for_schema quotes the address, eliding /32 and /128", () => {
-    // Rails branches on `value.prefix == 32` (or /128 for IPv6) to
-    // omit the host-prefix. We carry the prefix inline on the string,
-    // so strip it before quoting to match Rails' schema output.
+    // Rails: if value.prefix == 32 then "\"#{value}\"" else "\"#{value}/#{value.prefix}\""
+    // "#{value}" calls IPAddr#to_s which returns just the address.
+    // Rails only checks prefix == 32 (not 128); /128 IPv6 keeps its suffix.
     const type = new Cidr();
-    expect(type.typeCastForSchema("192.168.1.0/24")).toBe('"192.168.1.0/24"');
-    expect(type.typeCastForSchema("192.168.1.1")).toBe('"192.168.1.1"');
-    expect(type.typeCastForSchema("192.168.1.1/32")).toBe('"192.168.1.1"');
-    expect(type.typeCastForSchema("::1")).toBe('"::1"');
-    expect(type.typeCastForSchema("::1/128")).toBe('"::1"');
+    expect(type.typeCastForSchema(new IpAddr("192.168.1.0", 24))).toBe('"192.168.1.0/24"');
+    expect(type.typeCastForSchema(new IpAddr("192.168.1.1", 32))).toBe('"192.168.1.1"');
+    expect(type.typeCastForSchema(new IpAddr("::1", 128))).toBe('"::1/128"');
     // Non-host prefixes are preserved.
-    expect(type.typeCastForSchema("2001:db8::/32")).toBe('"2001:db8::/32"');
+    expect(type.typeCastForSchema(new IpAddr("2001:db8::", 32))).toBe('"2001:db8::"');
   });
 
   it("castValue is the public Rails-named hook", () => {
+    // Rails cast_value returns an IPAddr object (or nil on ArgumentError).
     const type = new Cidr();
-    expect(type.castValue("192.168.1.1")).toBe("192.168.1.1");
+    const result = type.castValue("192.168.1.1");
+    expect(result).toBeInstanceOf(IpAddr);
+    expect(result?.address).toBe("192.168.1.1");
+    expect(result?.prefixLength).toBe(32);
+
+    const cidr = type.castValue("192.168.1.0/24");
+    expect(cidr?.address).toBe("192.168.1.0");
+    expect(cidr?.prefixLength).toBe(24);
+
     expect(type.castValue("not-an-ip")).toBeNull();
+    expect(type.castValue(null)).toBeNull();
+
+    // Pass-through for existing IpAddr (Rails: `else value`).
+    const ip = new IpAddr("10.0.0.1", 32);
+    expect(type.castValue(ip)).toBe(ip);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -5,7 +5,7 @@
  *
  * Rails: `class Cidr < Type::Value`. cast_value parses a String into an
  * IPAddr; serialize renders it back as "addr/prefix". TypeScript has no
- * stdlib IPAddr, so we provide IpAddr as a lightweight equivalent.
+ * stdlib IPAddr, so we provide IPAddr as a lightweight equivalent.
  */
 
 import { ValueType } from "@blazetrails/activemodel";
@@ -14,7 +14,7 @@ import { ValueType } from "@blazetrails/activemodel";
  * Lightweight equivalent of Ruby's IPAddr, carrying address + prefix length.
  * Mirrors the Rails IPAddr shape used by Cidr#serialize and Cidr#changed?.
  */
-export class IpAddr {
+export class IPAddr {
   constructor(
     readonly address: string,
     readonly prefixLength: number,
@@ -31,18 +31,18 @@ export class IpAddr {
   }
 }
 
-export class Cidr extends ValueType<IpAddr> {
+export class Cidr extends ValueType<IPAddr> {
   readonly name: string = "cidr";
 
   override type(): string {
     return "cidr";
   }
 
-  cast(value: unknown): IpAddr | null {
+  cast(value: unknown): IPAddr | null {
     return this.castValue(value);
   }
 
-  override deserialize(value: unknown): IpAddr | null {
+  override deserialize(value: unknown): IPAddr | null {
     return this.castValue(value);
   }
 
@@ -50,11 +50,11 @@ export class Cidr extends ValueType<IpAddr> {
    * Rails Cidr#serialize:
    *   if IPAddr === value then "#{value}/#{value.prefix}" else value
    * "#{value}" calls IPAddr#to_s (address only); we mirror that via toString().
-   * Non-IpAddr values are coerced to string via String() (Rails returns them
+   * Non-IPAddr values are coerced to string via String() (Rails returns them
    * as-is, but our return type is string | null so coercion is required).
    */
   override serialize(value: unknown): string | null {
-    if (value instanceof IpAddr) return `${value}/${value.prefixLength}`;
+    if (value instanceof IPAddr) return `${value}/${value.prefixLength}`;
     if (value == null) return null;
     return String(value);
   }
@@ -66,7 +66,7 @@ export class Cidr extends ValueType<IpAddr> {
    * Ruby's IPAddr#eql? compares only the address bits (not the prefix), hence
    * the explicit prefix guard. We normalise both sides to { address, prefix }
    * so the comparison is always prefix-aware regardless of whether the caller
-   * supplies strings or IpAddr instances.
+   * supplies strings or IPAddr instances.
    */
   override isChanged(
     oldValue: unknown,
@@ -86,9 +86,9 @@ export class Cidr extends ValueType<IpAddr> {
    *   String → IPAddr.new(value) or nil on ArgumentError
    *   else → value (pass-through for existing IPAddr instances)
    */
-  castValue(value: unknown): IpAddr | null {
+  castValue(value: unknown): IPAddr | null {
     if (value == null) return null;
-    if (value instanceof IpAddr) return value;
+    if (value instanceof IPAddr) return value;
     if (typeof value !== "string") return null;
     return parseIpAddr(value);
   }
@@ -97,12 +97,12 @@ export class Cidr extends ValueType<IpAddr> {
    * Rails Cidr#type_cast_for_schema:
    *   if value.prefix == 32 then "\"#{value}\"" else "\"#{value}/#{value.prefix}\""
    *
-   * Rails omits the prefix for any IpAddr with prefix == 32, regardless of
+   * Rails omits the prefix for any IPAddr with prefix == 32, regardless of
    * IP version (this means IPv6 /32 is also elided — Rails does not special-case it).
    * "#{value}" calls IPAddr#to_s which returns just the address string.
    */
   override typeCastForSchema(value: unknown): string {
-    if (value instanceof IpAddr) {
+    if (value instanceof IPAddr) {
       if (value.prefixLength === 32) return JSON.stringify(value.address);
       return JSON.stringify(`${value.address}/${value.prefixLength}`);
     }
@@ -112,7 +112,7 @@ export class Cidr extends ValueType<IpAddr> {
 
 function toComparable(value: unknown): { address: string; prefix: number } | null {
   if (value === null || value === undefined) return null;
-  if (value instanceof IpAddr) return { address: value.address, prefix: value.prefixLength };
+  if (value instanceof IPAddr) return { address: value.address, prefix: value.prefixLength };
   if (typeof value === "string") {
     const ip = parseIpAddr(value);
     if (ip === null) return null;
@@ -122,25 +122,25 @@ function toComparable(value: unknown): { address: string; prefix: number } | nul
 }
 
 /**
- * Parses a CIDR/inet string into an IpAddr. Mirrors IPAddr.new(str): returns
+ * Parses a CIDR/inet string into an IPAddr. Mirrors IPAddr.new(str): returns
  * null for invalid input (Rails raises ArgumentError, which cast_value rescues).
  * Defaults to /32 for IPv4 and /128 for IPv6 when no prefix is specified.
  */
-function parseIpAddr(value: string): IpAddr | null {
+function parseIpAddr(value: string): IPAddr | null {
   if (value === "") return null;
   const slash = value.indexOf("/");
   const address = slash === -1 ? value : value.slice(0, slash);
   const prefixStr = slash === -1 ? null : value.slice(slash + 1);
 
   if (isIpv4(address)) {
-    if (prefixStr == null) return new IpAddr(address, 32);
+    if (prefixStr == null) return new IPAddr(address, 32);
     if (!isValidPrefix(prefixStr, 32)) return null;
-    return new IpAddr(address, Number(prefixStr));
+    return new IPAddr(address, Number(prefixStr));
   }
   if (isIpv6(address)) {
-    if (prefixStr == null) return new IpAddr(address, 128);
+    if (prefixStr == null) return new IPAddr(address, 128);
     if (!isValidPrefix(prefixStr, 128)) return null;
-    return new IpAddr(address, Number(prefixStr));
+    return new IPAddr(address, Number(prefixStr));
   }
   return null;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -113,9 +113,9 @@ function toComparable(value: unknown): { address: string; prefix: number } | nul
   if (value === null || value === undefined) return null;
   if (value instanceof IpAddr) return { address: value.address, prefix: value.prefixLength };
   if (typeof value === "string") {
-    const slash = value.indexOf("/");
-    if (slash === -1) return { address: value, prefix: isIpv6(value) ? 128 : 32 };
-    return { address: value.slice(0, slash), prefix: Number(value.slice(slash + 1)) };
+    const ip = parseIpAddr(value);
+    if (ip === null) return null;
+    return { address: ip.address, prefix: ip.prefixLength };
   }
   return null;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -49,8 +49,9 @@ export class Cidr extends ValueType<IpAddr> {
   /**
    * Rails Cidr#serialize:
    *   if IPAddr === value then "#{value}/#{value.prefix}" else value
-   * Accepts IpAddr instances and emits canonical "addr/prefix" form;
-   * passes non-IpAddr values (e.g. raw strings) through unchanged.
+   * Accepts IpAddr instances and emits canonical "addr/prefix" form.
+   * Non-IpAddr values are coerced to string via String() (Rails returns them
+   * as-is, but our return type is string | null so coercion is required).
    */
   override serialize(value: unknown): string | null {
     if (value instanceof IpAddr) return `${value.address}/${value.prefixLength}`;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -20,6 +20,11 @@ export class IpAddr {
     readonly prefixLength: number,
   ) {}
 
+  /** Alias for prefixLength — matches Ruby IPAddr#prefix. */
+  get prefix(): number {
+    return this.prefixLength;
+  }
+
   /** Returns just the address portion, like Ruby IPAddr#to_s. */
   toString(): string {
     return this.address;
@@ -91,7 +96,8 @@ export class Cidr extends ValueType<IpAddr> {
    * Rails Cidr#type_cast_for_schema:
    *   if value.prefix == 32 then "\"#{value}\"" else "\"#{value}/#{value.prefix}\""
    *
-   * Rails checks only prefix == 32 (IPv4 host) and omits the suffix.
+   * Rails omits the prefix for any IpAddr with prefix == 32, regardless of
+   * IP version (this means IPv6 /32 is also elided — Rails does not special-case it).
    * "#{value}" calls IPAddr#to_s which returns just the address string.
    */
   override typeCastForSchema(value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -49,12 +49,12 @@ export class Cidr extends ValueType<IpAddr> {
   /**
    * Rails Cidr#serialize:
    *   if IPAddr === value then "#{value}/#{value.prefix}" else value
-   * Accepts IpAddr instances and emits canonical "addr/prefix" form.
+   * "#{value}" calls IPAddr#to_s (address only); we mirror that via toString().
    * Non-IpAddr values are coerced to string via String() (Rails returns them
    * as-is, but our return type is string | null so coercion is required).
    */
   override serialize(value: unknown): string | null {
-    if (value instanceof IpAddr) return `${value.address}/${value.prefixLength}`;
+    if (value instanceof IpAddr) return `${value}/${value.prefixLength}`;
     if (value == null) return null;
     return String(value);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -5,113 +5,146 @@
  *
  * Rails: `class Cidr < Type::Value`. cast_value parses a String into an
  * IPAddr; serialize renders it back as "addr/prefix". TypeScript has no
- * IPAddr primitive, so we pass the string through and leave parsing to
- * the consumer.
+ * stdlib IPAddr, so we provide IpAddr as a lightweight equivalent.
  */
 
 import { ValueType } from "@blazetrails/activemodel";
 
-export class Cidr extends ValueType<string> {
+/**
+ * Lightweight equivalent of Ruby's IPAddr, carrying address + prefix length.
+ * Mirrors the Rails IPAddr shape used by Cidr#serialize and Cidr#changed?.
+ */
+export class IpAddr {
+  constructor(
+    readonly address: string,
+    readonly prefixLength: number,
+  ) {}
+
+  /** Returns just the address portion, like Ruby IPAddr#to_s. */
+  toString(): string {
+    return this.address;
+  }
+}
+
+export class Cidr extends ValueType<IpAddr> {
   readonly name: string = "cidr";
 
   override type(): string {
     return "cidr";
   }
 
-  cast(value: unknown): string | null {
+  cast(value: unknown): IpAddr | null {
     return this.castValue(value);
   }
 
-  override deserialize(value: unknown): string | null {
+  override deserialize(value: unknown): IpAddr | null {
     return this.castValue(value);
   }
 
+  /**
+   * Rails Cidr#serialize:
+   *   if IPAddr === value then "#{value}/#{value.prefix}" else value
+   * Accepts IpAddr instances and emits canonical "addr/prefix" form;
+   * passes non-IpAddr values (e.g. raw strings) through unchanged.
+   */
   override serialize(value: unknown): string | null {
+    if (value instanceof IpAddr) return `${value.address}/${value.prefixLength}`;
     if (value == null) return null;
     return String(value);
   }
 
   /**
    * Rails Cidr#changed?:
-   *   !old.eql?(new) || (!old.nil? && old.prefix != new.prefix)
+   *   !old_value.eql?(new_value) || !old_value.nil? && old_value.prefix != new_value.prefix
    *
-   * Without an IPAddr type we fall back to string equality, which is a
-   * faithful subset — the prefix comparison is implicit in the string.
+   * Ruby's IPAddr#eql? compares only the address bits (not the prefix), hence
+   * the explicit prefix guard. We normalise both sides to { address, prefix }
+   * so the comparison is always prefix-aware regardless of whether the caller
+   * supplies strings or IpAddr instances.
    */
   override isChanged(
     oldValue: unknown,
     newValue: unknown,
     _newValueBeforeTypeCast?: unknown,
   ): boolean {
-    return oldValue !== newValue;
+    const oldC = toComparable(oldValue);
+    const newC = toComparable(newValue);
+    if (oldC === null && newC === null) return false;
+    if (oldC === null || newC === null) return true;
+    return oldC.address !== newC.address || oldC.prefix !== newC.prefix;
   }
 
   /**
-   * Rails' cast_value uses `IPAddr.new(value)` and returns nil on
-   * ArgumentError. Without an IPAddr primitive in TS, validate syntax
-   * ourselves and return null for anything that isn't a plausible
-   * CIDR-shaped string (Rails' behavior for non-String input is a
-   * pass-through, but our TS return type is `string | null`, so we
-   * return null rather than lie about the type).
+   * Rails Cidr#cast_value:
+   *   nil → nil
+   *   String → IPAddr.new(value) or nil on ArgumentError
+   *   else → value (pass-through for existing IPAddr instances)
    */
-  castValue(value: unknown): string | null {
+  castValue(value: unknown): IpAddr | null {
     if (value == null) return null;
+    if (value instanceof IpAddr) return value;
     if (typeof value !== "string") return null;
-    if (value === "") return null;
-    return isCidrShaped(value) ? value : null;
+    return parseIpAddr(value);
   }
 
   /**
-   * Rails' type_cast_for_schema:
-   *   if value.prefix == 32
-   *     "\"#{value}\""
-   *   else
-   *     "\"#{value}/#{value.prefix}\""
-   *   end
+   * Rails Cidr#type_cast_for_schema:
+   *   if value.prefix == 32 then "\"#{value}\"" else "\"#{value}/#{value.prefix}\""
    *
-   * Rails elides a host prefix (/32 for IPv4, /128 for IPv6) since
-   * that's implicit. Our string-based cidr carries the prefix inline,
-   * so strip /32 / /128 before quoting to match Rails' schema output.
-   * Use JSON.stringify so embedded quotes/backslashes escape properly.
-   * Non-string inputs defer to Type#typeCastForSchema.
+   * Rails checks only prefix == 32 (IPv4 host) and omits the suffix.
+   * "#{value}" calls IPAddr#to_s which returns just the address string.
    */
   override typeCastForSchema(value: unknown): string {
-    if (typeof value === "string") return JSON.stringify(elideHostPrefix(value));
+    if (value instanceof IpAddr) {
+      if (value.prefixLength === 32) return JSON.stringify(value.address);
+      return JSON.stringify(`${value.address}/${value.prefixLength}`);
+    }
     return super.typeCastForSchema(value);
   }
 }
 
-function elideHostPrefix(value: string): string {
-  const slash = value.indexOf("/");
-  if (slash === -1) return value;
-  const address = value.slice(0, slash);
-  const prefix = value.slice(slash + 1);
-  if (prefix === "32" && isIpv4(address)) return address;
-  if (prefix === "128" && isIpv6(address)) return address;
-  return value;
+function toComparable(value: unknown): { address: string; prefix: number } | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof IpAddr) return { address: value.address, prefix: value.prefixLength };
+  if (typeof value === "string") {
+    const slash = value.indexOf("/");
+    if (slash === -1) return { address: value, prefix: isIpv6(value) ? 128 : 32 };
+    return { address: value.slice(0, slash), prefix: Number(value.slice(slash + 1)) };
+  }
+  return null;
 }
 
 /**
- * Lightweight IP syntax validator. Rails uses IPAddr.new (which rescues
- * ArgumentError); we inline a parser here rather than pulling in
+ * Parses a CIDR/inet string into an IpAddr. Mirrors IPAddr.new(str): returns
+ * null for invalid input (Rails raises ArgumentError, which cast_value rescues).
+ * Defaults to /32 for IPv4 and /128 for IPv6 when no prefix is specified.
+ */
+function parseIpAddr(value: string): IpAddr | null {
+  if (value === "") return null;
+  const slash = value.indexOf("/");
+  const address = slash === -1 ? value : value.slice(0, slash);
+  const prefixStr = slash === -1 ? null : value.slice(slash + 1);
+
+  if (isIpv4(address)) {
+    if (prefixStr == null) return new IpAddr(address, 32);
+    if (!isValidPrefix(prefixStr, 32)) return null;
+    return new IpAddr(address, Number(prefixStr));
+  }
+  if (isIpv6(address)) {
+    if (prefixStr == null) return new IpAddr(address, 128);
+    if (!isValidPrefix(prefixStr, 128)) return null;
+    return new IpAddr(address, Number(prefixStr));
+  }
+  return null;
+}
+
+/**
+ * Lightweight IP syntax validators. Rails uses IPAddr.new (which rescues
+ * ArgumentError); we inline parsers here rather than pulling in
  * `node:net.isIP` (blocked by a repo-wide no-Node-builtins lint rule
  * for browser compat). Accepts IPv4, IPv6, and IPv4-embedded IPv6
  * (e.g. ::ffff:192.168.0.1) — enough to match PG's input syntax.
  */
-function isCidrShaped(value: string): boolean {
-  const slash = value.indexOf("/");
-  const address = slash === -1 ? value : value.slice(0, slash);
-  const prefix = slash === -1 ? null : value.slice(slash + 1);
-
-  if (isIpv4(address)) {
-    return prefix == null || isValidPrefix(prefix, 32);
-  }
-  if (isIpv6(address)) {
-    return prefix == null || isValidPrefix(prefix, 128);
-  }
-  return false;
-}
-
 const IPV4_OCTET = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
 
 function isIpv4(value: string): boolean {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -15,6 +15,7 @@ export {
   MultiRange,
   MultiRangeType,
 } from "./connection-adapters/postgresql/oid/range.js";
+export { IPAddr } from "./connection-adapters/postgresql/oid/cidr.js";
 export type { LoadedRelation } from "./relation.js";
 export { QueryAttribute } from "./relation/query-attribute.js";
 export { InsertAll, Builder as InsertAllBuilder } from "./insert-all.js";

--- a/packages/activerecord/src/type-virtualization/type-registry.ts
+++ b/packages/activerecord/src/type-virtualization/type-registry.ts
@@ -26,14 +26,15 @@
 // synthesize.ts).
 
 const T = `import("@blazetrails/activesupport/temporal").Temporal`;
+const IPADDR = `import("@blazetrails/activerecord").IPAddr`;
 
 export const ATTRIBUTE_TYPE_MAP: Record<string, string> = {
   string: "string",
   text: "string",
   immutable_string: "string",
   uuid: "string",
-  inet: "string",
-  cidr: "string",
+  inet: IPADDR,
+  cidr: IPADDR,
   citext: "string",
   integer: "number",
   big_integer: "bigint",


### PR DESCRIPTION
## Summary

- Adds `IpAddr` class to `cidr.ts` as a lightweight Rails `IPAddr` equivalent with `address` + `prefixLength` fields
- `Cidr#serialize` now emits canonical `"addr/prefix"` when given an `IpAddr` instance (Rails parity: `"#{value}/#{value.prefix}"`)
- `Cidr#isChanged` normalises both sides (string or `IpAddr`) to `{ address, prefix }` before comparing, so a prefix change always marks the attribute dirty (Rails TODO: `IPAddr#==` doesn't compare `#prefix`, hence the explicit check)
- Un-skips 3 `CidrTest` cases: *type casting IPAddr for database*, *casting does nothing with non-IPAddr objects*, *changed? with nil values*

## Test plan

- [ ] `pnpm vitest run --project=activerecord packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts` — 2 pass
- [ ] `pnpm vitest run --project=activerecord packages/activerecord/src/adapters/postgresql/network.test.ts` — no regressions
- [ ] `pnpm run api:compare --package activerecord` — 4952/4958 (99.9%), no regression
- [ ] PG CI — 3 newly un-skipped CidrTest cases run against a live database