### PR TITLE
refactor(activerecord): move autosaveBelongsTo into before_save chain

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -189,7 +189,6 @@ Small Rails-fidelity polish from PR reviews. Subsections group items by topic.
 
 ### Callbacks convergence aftermath (#1492–#1526)
 
-- **~30 LOC** — Move `autosaveBelongsTo` inside the `around_save` chain rather than running it as an explicit pre-save check. Rails-fidelity improvement (current ordering diverges when autosave fails); behavior risk for `after_save` firing. (#1526)
 - **~20 LOC** — Targeted test for a model with only `beforeCommit` callbacks to pin the `hasTransactionalCallbacks` path. PR 7 simplified this to check only `commit`/`rollback` chains (before_commit entries live in the `commit` chain as "before"-kind callbacks); prevent future regression. (#1526)
 
 ### Callbacks PR 1+2 aftermath (#1492 / #1497)

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -9,7 +9,7 @@ import {
   afterDestroy,
 } from "../../callbacks.js";
 import { resolveModel, modelRegistry } from "../../associations.js";
-import { saveBelongsToAssociation } from "../../autosave-association.js";
+import { saveBelongsToAssociation, defineNonCyclicMethod } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 
 /**
@@ -64,13 +64,20 @@ export class BelongsTo extends SingularAssociation {
   }
 
   static addAutosaveCallbacks(model: any, reflection: any): void {
-    // Runtime: resolved false halts the chain (activesupport callbacks asyncHalted check).
+    // Mirrors add_autosave_association_callbacks belongs_to branch:
+    //   define_non_cyclic_method(save_method) { throw(:abort) if save_belongs_to_association == false }
+    //   before_save save_method
+    const saveMethod = `autosaveAssociatedRecordsFor_${reflection.name}`;
+    defineNonCyclicMethod(model, saveMethod, function (this: any) {
+      return saveBelongsToAssociation.call(this, reflection);
+    });
+    // Runtime: resolved false halts the chain (activesupport asyncHalted check).
     // Type cast needed because beforeSave's fn type doesn't expose Promise<false>.
-    const cb = (record: any): Promise<void> =>
-      saveBelongsToAssociation.call(record, reflection).then((ok) => {
-        if (!ok) return false as unknown as void;
-      });
-    beforeSave(model, cb);
+    beforeSave(
+      model,
+      (record: any): Promise<void> =>
+        record[saveMethod]().then((ok: boolean) => (ok ? undefined : (false as unknown as void))),
+    );
   }
 
   static addCounterCacheCallbacks(model: any, reflection: any): void {

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,8 +1,15 @@
 import { underscore, pluralize, camelize } from "@blazetrails/activesupport";
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
-import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
+import {
+  beforeValidation,
+  beforeSave,
+  afterCreate,
+  afterUpdate,
+  afterDestroy,
+} from "../../callbacks.js";
 import { resolveModel, modelRegistry } from "../../associations.js";
+import { saveBelongsToAssociation } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 
 /**
@@ -51,6 +58,19 @@ export class BelongsTo extends SingularAssociation {
     if (options.default != null) {
       this.addDefaultCallbacks(model, reflection);
     }
+    if (options.autosave) {
+      this.addAutosaveCallbacks(model, reflection);
+    }
+  }
+
+  static addAutosaveCallbacks(model: any, reflection: any): void {
+    // Runtime: resolved false halts the chain (activesupport callbacks asyncHalted check).
+    // Type cast needed because beforeSave's fn type doesn't expose Promise<false>.
+    const cb = (record: any): Promise<void> =>
+      saveBelongsToAssociation.call(record, reflection).then((ok) => {
+        if (!ok) return false as unknown as void;
+      });
+    beforeSave(model, cb);
   }
 
   static addCounterCacheCallbacks(model: any, reflection: any): void {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -899,7 +899,7 @@ export function _ensureNoDuplicateErrors(this: AutosaveAssociationHost): void {
 }
 
 /** @internal */
-function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any): void {
+export function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any): void {
   if (typeof klass.prototype?.[name] === "function") return;
   if (klass.prototype) {
     klass.prototype[name] = function (this: any) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -52,7 +52,6 @@ import {
 } from "./errors.js";
 import {
   AutosaveAssociation,
-  autosaveBelongsTo,
   autosaveChildren,
   flushPendingReplaces,
   computePrimaryKey as _computePrimaryKey,
@@ -2461,14 +2460,6 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
     let saved = false;
     let wasNewRecord = false;
-
-    // autosaveBelongsTo is an explicit pre-save check (not a registered callback); keep it
-    // outside the save block so that after_save does not fire when it fails.
-    const belongsToOk = await autosaveBelongsTo(this);
-    if (!belongsToOk) {
-      this._skipTouch = false;
-      return false;
-    }
 
     // Rails: Callbacks#create_or_update wraps super in run_callbacks(:save) { ... }.
     // Around_save callbacks correctly wrap the _createRecord/_updateRecord calls which


### PR DESCRIPTION
## Summary

- Move `autosaveBelongsTo` from an explicit pre-save guard in `_createOrUpdate` into a registered `before_save` callback, matching Rails' `add_autosave_association_callbacks` (autosave_association.rb:212–213).
- `BelongsTo.defineCallbacks` now calls `addAutosaveCallbacks(model, reflection)` when `options.autosave` is true, registering one `before_save` per reflection.
- Remove the pre-chain `autosaveBelongsTo(this)` call from `base.ts#_createOrUpdate`.
- Drop the closed item from `docs/activerecord-100-plan.md`.

## Behavior change

Previously, `aroundSave` callbacks did not wrap belongs-to autosave — it ran outside the chain entirely. Now it participates correctly:

- `aroundSave` wraps it
- When autosave fails (returns false), `after_save` does NOT fire (chain-halt semantics)
- When autosave succeeds, `after_save` fires once as before

## Test plan

- [x] `pnpm vitest run --project activerecord src/autosave-association.test.ts src/callbacks.test.ts` — 243 passed, 40 skipped
- [x] `pnpm run api:compare --package activerecord` — 4952/4958 (99.9%), no regression
- [x] `tsc --build` — clean