### PR TITLE
test(activerecord): un-skip 6 composite-FK association tests — Slot B

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -16,6 +16,7 @@ import {
   reflectOnAllAssociations,
   registerModel,
   DeleteRestrictionError,
+  ConfigurationError,
   touchBelongsToParents,
 } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
@@ -2422,17 +2423,71 @@ describe("AssociationsTest", () => {
     expect(posts).toHaveLength(2);
     expect(posts.map((p) => p.title).sort()).toEqual(["Post1", "Post2"]);
   });
-  it.skip("has many association from a model with query constraints different from the association", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs composite key / query constraints support */
+  it("has many association from a model with query constraints different from the association", async () => {
+    const adapter = freshAdapter();
+    class DqcBlogPost extends Base {
+      static {
+        this._tableName = "dqc_blog_posts";
+        this.attribute("blog_id", "integer");
+        this.attribute("revision", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        // 3-column query_constraints, but association provides explicit FK/PK
+        (this as any)._queryConstraintsList = ["blog_id", "revision", "id"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    class DqcComment extends Base {
+      static {
+        this._tableName = "dqc_comments";
+        this.attribute("blog_id", "integer");
+        this.attribute("blog_post_id", "integer");
+        this.attribute("body", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("DqcBlogPost", DqcBlogPost);
+    registerModel("DqcComment", DqcComment);
+    Associations.hasMany.call(DqcBlogPost, "dqcComments", {
+      className: "DqcComment",
+      primaryKey: ["blog_id", "id"],
+      foreignKey: ["blog_id", "blog_post_id"],
+    });
+    const post = await DqcBlogPost.create({ blog_id: 1, revision: 0, title: "Post" });
+    await DqcComment.create({ blog_id: 1, blog_post_id: post.id, body: "A" });
+    await DqcComment.create({ blog_id: 1, blog_post_id: post.id, body: "B" });
+    await DqcComment.create({ blog_id: 2, blog_post_id: post.id, body: "Other" });
+    const comments = await loadHasMany(post, "dqcComments", {
+      className: "DqcComment",
+      primaryKey: ["blog_id", "id"],
+      foreignKey: ["blog_id", "blog_post_id"],
+    });
+    expect(comments).toHaveLength(2);
+    expect(comments.map((c) => c.body).sort()).toEqual(["A", "B"]);
   });
-  it.skip("query constraints over three without defining explicit foreign key query constraints raises", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs composite key / query constraints support */
+  it("query constraints over three without defining explicit foreign key query constraints raises", () => {
+    const adapter = freshAdapter();
+    class QcThreeBlogPost extends Base {
+      static {
+        this.attribute("blog_id", "integer");
+        this.attribute("revision", "integer");
+        this.adapter = adapter;
+        (this as any)._queryConstraintsList = ["blog_id", "revision", "id"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    class QcThreeComment extends Base {
+      static {
+        this.attribute("blog_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("QcThreeBlogPost", QcThreeBlogPost);
+    registerModel("QcThreeComment", QcThreeComment);
+    Associations.hasMany.call(QcThreeBlogPost, "qcThreeComments", { className: "QcThreeComment" });
+    const refl = reflectOnAssociation(QcThreeBlogPost, "qcThreeComments")!;
+    expect(() => refl.foreignKey).toThrow(ConfigurationError);
+    expect(() => refl.foreignKey).toThrow("more than 2 attributes");
   });
   it("model with composite query constraints has many association sql", async () => {
     const adapter = freshAdapter();
@@ -2467,11 +2522,52 @@ describe("AssociationsTest", () => {
     });
     expect(posts).toHaveLength(1);
   });
-  it.skip("belongs to association does not use parent query constraints if not configured to", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs single FK to CPK parent resolution */
+  it("belongs to association does not use parent query constraints if not configured to", async () => {
+    // Rails: test_belongs_to_association_does_not_use_parent_query_constraints_if_not_configured_to
+    // When belongs_to has explicit single FK/PK, it bypasses query_constraints derivation.
+    const adapter = freshAdapter();
+    class BtNqcBlogPost extends Base {
+      static {
+        this.attribute("blog_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    class BtNqcComment extends Base {
+      static {
+        this.attribute("blog_id", "integer");
+        this.attribute("blog_post_id", "integer");
+        this.attribute("body", "string");
+        this.adapter = adapter;
+        // Comment has query_constraints, but the belongs_to uses explicit single FK/PK
+        (this as any)._queryConstraintsList = ["blog_id", "id"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    registerModel("BtNqcBlogPost", BtNqcBlogPost);
+    registerModel("BtNqcComment", BtNqcComment);
+    Associations.belongsTo.call(BtNqcComment, "btNqcBlogPostById", {
+      foreignKey: "blog_post_id",
+      primaryKey: "id",
+      className: "BtNqcBlogPost",
+    });
+    const post = await BtNqcBlogPost.create({ blog_id: 1, title: "Following best practices" });
+    const comment = await BtNqcComment.create({ blog_id: 1, body: "Hello" });
+    setBelongsTo(comment, "btNqcBlogPostById", post, {
+      foreignKey: "blog_post_id",
+      primaryKey: "id",
+      className: "BtNqcBlogPost",
+    });
+    // Only blog_post_id is set to post's scalar id; blog_id is unchanged
+    expect(comment.blog_post_id).toBe(post.id);
+    await comment.save();
+    const loaded = await loadBelongsTo(comment, "btNqcBlogPostById", {
+      foreignKey: "blog_post_id",
+      primaryKey: "id",
+      className: "BtNqcBlogPost",
+    });
+    expect(loaded).not.toBeNull();
+    expect(loaded!.title).toBe("Following best practices");
   });
   it.skip("polymorphic belongs to uses parent query constraints", () => {
     // BLOCKED: associations — collection/singular feature gap
@@ -2714,17 +2810,58 @@ describe("AssociationsTest", () => {
     expect(child.inf_parent2_id).toBeNull();
   });
 
-  it.skip("query constraints that dont include the primary key raise with a single column", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs composite key / query constraints support */
+  it("query constraints that dont include the primary key raise with a single column", () => {
+    const adapter = freshAdapter();
+    class QcSingleBlogPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        (this as any)._queryConstraintsList = ["title"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    class QcSingleComment extends Base {
+      static {
+        this.attribute("blog_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("QcSingleBlogPost", QcSingleBlogPost);
+    registerModel("QcSingleComment", QcSingleComment);
+    Associations.hasMany.call(QcSingleBlogPost, "qcSingleComments", {
+      className: "QcSingleComment",
+      primaryKey: ["blog_id", "id"],
+    });
+    const refl = reflectOnAssociation(QcSingleBlogPost, "qcSingleComments")!;
+    expect(() => refl.foreignKey).toThrow(ConfigurationError);
+    expect(() => refl.foreignKey).toThrow("not include the primary key");
   });
-  it.skip("query constraints that dont include the primary key raise with multiple columns", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs composite key / query constraints support */
+  it("query constraints that dont include the primary key raise with multiple columns", () => {
+    const adapter = freshAdapter();
+    class QcMultiBlogPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("revision", "integer");
+        this.adapter = adapter;
+        (this as any)._queryConstraintsList = ["title", "revision"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    class QcMultiComment extends Base {
+      static {
+        this.attribute("blog_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("QcMultiBlogPost", QcMultiBlogPost);
+    registerModel("QcMultiComment", QcMultiComment);
+    Associations.hasMany.call(QcMultiBlogPost, "qcMultiComments", {
+      className: "QcMultiComment",
+      primaryKey: ["blog_id", "id"],
+    });
+    const refl = reflectOnAssociation(QcMultiBlogPost, "qcMultiComments")!;
+    expect(() => refl.foreignKey).toThrow(ConfigurationError);
+    expect(() => refl.foreignKey).toThrow("not include the primary key");
   });
   it("assign belongs to cpk model by id attribute", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2834,7 +2834,7 @@ describe("AssociationsTest", () => {
     });
     const refl = reflectOnAssociation(QcSingleBlogPost, "qcSingleComments")!;
     expect(() => refl.foreignKey).toThrow(ConfigurationError);
-    expect(() => refl.foreignKey).toThrow("not include the primary key");
+    expect(() => refl.foreignKey).toThrow("does not include the primary key");
   });
   it("query constraints that dont include the primary key raise with multiple columns", () => {
     const adapter = freshAdapter();
@@ -2861,7 +2861,7 @@ describe("AssociationsTest", () => {
     });
     const refl = reflectOnAssociation(QcMultiBlogPost, "qcMultiComments")!;
     expect(() => refl.foreignKey).toThrow(ConfigurationError);
-    expect(() => refl.foreignKey).toThrow("not include the primary key");
+    expect(() => refl.foreignKey).toThrow("does not include the primary key");
   });
   it("assign belongs to cpk model by id attribute", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1484,11 +1484,44 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     expect(saved).toBe(true);
   });
 
-  it.skip("composite primary key autosave", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* cpk not fully supported */
+  it("composite primary key autosave", async () => {
+    // Rails: test "composite primary key autosave" — creating a has_one child
+    // via autosave propagates composite FK columns from parent to child.
+    class CpkOrder2 extends Base {
+      static {
+        this.attribute("shop_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("status", "string");
+        this.primaryKey = ["shop_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkBook2 extends Base {
+      static {
+        this.attribute("shop_id", "integer");
+        this.attribute("order_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("CpkOrder2", CpkOrder2);
+    registerModel("CpkBook2", CpkBook2);
+    Associations.hasOne.call(CpkOrder2, "cpkBook2", {
+      className: "CpkBook2",
+      autosave: true,
+      foreignKey: ["shop_id", "order_id"],
+    });
+    // Provide explicit composite PK values (Rails: Order.create!(id: [1, 2], ...))
+    const order = new CpkOrder2({ shop_id: 1, id: 2, status: "pending" });
+    const book = new CpkBook2({ title: "Composite Key Book" });
+    cacheAssoc(order, "cpkBook2", book);
+    const saved = await order.save();
+    expect(saved).toBe(true);
+    expect(order.isNewRecord()).toBe(false);
+    expect(book.isNewRecord()).toBe(false);
+    // autosave should have propagated composite FK from order PK to book
+    expect(book.shop_id).toBe(1);
+    expect(book.order_id).toBe(2);
   });
 
   it("should not load the associated model", async () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -534,7 +534,7 @@ export class AssociationReflection extends MacroReflection {
 
     if (ownerPkStr && !primaryQueryConstraints.includes(ownerPkStr)) {
       throw new ConfigurationError(
-        `The query constraints on the \`${this.activeRecord.name}\` model do not include the primary ` +
+        `The query constraints on the \`${this.activeRecord.name}\` model does not include the primary ` +
           `key so Active Record is unable to derive the foreign key constraints for ` +
           `the association. You need to explicitly define the query constraints for this ` +
           `association.`,


### PR DESCRIPTION
## Summary

Un-skip 6 placeholder tests from the Associations-core Slot B cluster (composite-FK association runtime). All tests are self-contained (no fixture dependencies).

**associations.test.ts** — 5 tests un-skipped:
- `query constraints over three without defining explicit foreign key query constraints raises` — verifies `ConfigurationError` when `query_constraints_list.length > 2` with no explicit FK
- `query constraints that dont include the primary key raise with a single column` — verifies `ConfigurationError` when query_constraints doesn't include PK (single column)
- `query constraints that dont include the primary key raise with multiple columns` — same for 2-column non-PK constraints
- `has many association from a model with query constraints different from the association` — verifies that explicit `primaryKey`/`foreignKey` on has_many bypasses query_constraints derivation
- `belongs to association does not use parent query constraints if not configured to` — verifies explicit single FK/PK belongs_to ignores owner's query_constraints

**autosave-association.test.ts** — 1 test un-skipped:
- `composite primary key autosave` — verifies that saving a composite-PK owner with a cached has_one child propagates both FK columns correctly

**reflection.ts** — 1-line production fix:
- `deriveFkQueryConstraints` error message: "do not include" → "does not include" to match Rails source exactly. Rails uses this phrasing (grammatically awkward but canonical): `scripts/api-compare/.rails-source/activerecord/lib/active_record/reflection.rb` says `"does not include the primary"`.

## Follow-ups (deferred)

- `querying by whole/single associated records using query constraints` — requires `AssociationQueryValue.convertToId` to handle array primary keys for record values (CPK path)
- `polymorphic belongs to uses parent query_constraints` — requires polymorphic belongs_to to apply owner's query_constraints when loading
- `preloads model with query_constraints by explicitly configured fk and pk` — preloader investigation needed
- Fixture-dependent autosave/has-many-through CPK tests

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts` — 358 pass, 39 skip
- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 155 pass, 37 skip
- [x] Full suite — 750 test files pass, no regressions
- [x] `pnpm run api:compare --package activerecord` — 99.9%, no regression
- [x] `pnpm test:types` — no errors
- [x] LOC: 232 additions+deletions (under 300 ceiling)