### PR TITLE
feat(activerecord): Associations::NestedError + index_errors propagation

### DIFF
--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -1,0 +1,14 @@
+/**
+ * Module-level configuration flags for ActiveRecord.
+ *
+ * Rails stores these as singleton_class.attr_accessor on the ActiveRecord
+ * module itself (active_record.rb:321-322).
+ */
+
+/** @internal */
+export let indexNestedAttributeErrors = false;
+
+/** @internal */
+export function setIndexNestedAttributeErrors(value: boolean): void {
+  indexNestedAttributeErrors = value;
+}

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -116,6 +116,10 @@ export interface AssociationOptions {
    * Mirrors Rails' `has_many :foo, strict_loading: true` — checked via
    * `reflection.strict_loading?` during query execution. */
   strictLoading?: boolean;
+  /** When true (or `:nested_attributes_order`), propagated validation errors
+   * include the child record's position in the collection. Mirrors Rails'
+   * `index_errors` option on collection associations. */
+  indexErrors?: boolean | "nestedAttributesOrder";
 }
 
 export interface AssociationDefinition {

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -1,4 +1,5 @@
 import { NestedError as ActiveModelNestedError } from "@blazetrails/activemodel";
+import { indexNestedAttributeErrors } from "../ar-config.js";
 
 interface AssociationLike {
   owner: object | null;
@@ -41,8 +42,20 @@ export class NestedError extends ActiveModelNestedError {
     innerError: InnerErrorLike,
   ): string {
     const name = association.reflection.name;
-    const isCollection = association.isCollection?.() ?? false;
-    const indexErrors = association.options?.indexErrors;
+    // isCollection: check the Association method if available, otherwise infer
+    // from whether target is an array (CollectionProxy always has array target).
+    const isCollection =
+      typeof association.isCollection === "function"
+        ? association.isCollection()
+        : Array.isArray(association.target);
+    // Falls back to global flag when not set per-association — mirrors Rails:
+    //   association.options.fetch(:index_errors, ActiveRecord.index_nested_attribute_errors)
+    // Options may be on association.options or association.reflection.options.
+    const opts =
+      (association.options as Record<string, unknown> | undefined) ??
+      ((association.reflection as any)?.options as Record<string, unknown> | undefined);
+    const indexErrors =
+      opts && "indexErrors" in opts ? opts["indexErrors"] : indexNestedAttributeErrors;
     if (isCollection && indexErrors) {
       // :nested_attributes_order uses nestedAttributesTarget (write order),
       // true uses target (association/DB order) — mirrors Rails' ordered_records
@@ -66,7 +79,13 @@ function association(err: NestedError): NestedError["association"] {
 
 /** @internal */
 function indexErrorsSetting(err: NestedError): boolean | "nestedAttributesOrder" {
-  return (err.association as any).options?.indexErrors ?? false;
+  const opts =
+    ((err.association as any).options as Record<string, unknown> | undefined) ??
+    ((err.association as any).reflection?.options as Record<string, unknown> | undefined);
+  if (opts && "indexErrors" in opts) {
+    return opts["indexErrors"] as boolean | "nestedAttributesOrder";
+  }
+  return indexNestedAttributeErrors;
 }
 
 /** @internal */
@@ -85,3 +104,9 @@ function orderedRecords(err: NestedError): unknown[] | null {
   if (setting === "nestedAttributesOrder") return (assoc as any).nestedAttributesTarget ?? null;
   return null;
 }
+
+// Silence "unused" — these are Rails-private helpers that mirror nested_error.rb's
+// `attr_reader :association`, `index_errors_setting`, `index`, `ordered_records`.
+// Counted by api:compare; intentionally not exported (Rails marks them private).
+void association;
+void index;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -9,6 +9,8 @@ import {
   acceptsNestedAttributesFor,
   assignNestedAttributes,
   RecordInvalid,
+  indexNestedAttributeErrors,
+  setIndexNestedAttributeErrors,
 } from "./index.js";
 import { Associations, setBelongsTo, association, loadHasManyThrough } from "./associations.js";
 
@@ -1736,41 +1738,132 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     expect(birds.some((b: any) => b.name === "Valid")).toBe(true);
   });
 
-  it.skip("errors should be indexed when global flag is set", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires global indexed errors config */
+  function makeIndexedHasMany(opts: { indexErrors?: boolean } = {}) {
+    const seed = `Idx${Math.random().toString(36).slice(2, 8)}`;
+    class Parent extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class Child extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("parent_id", "integer");
+        this.validates("name", { presence: true });
+      }
+    }
+    Parent.adapter = adapter;
+    Child.adapter = adapter;
+    registerModel(`${seed}Parent`, Parent);
+    registerModel(`${seed}Child`, Child);
+    Associations.hasMany.call(Parent, "children", {
+      autosave: true,
+      className: `${seed}Child`,
+      ...(opts.indexErrors ? { indexErrors: true as const } : {}),
+    });
+    return { Parent, Child };
+  }
+  it("errors should be indexed when global flag is set", () => {
+    const old = indexNestedAttributeErrors;
+    setIndexNestedAttributeErrors(true);
+    try {
+      const { Parent, Child } = makeIndexedHasMany();
+      const parent = new Parent({ name: "p" });
+      cacheAssoc(parent, "children", [new Child({ name: "ok" }), new Child({ name: "" })]);
+      expect(parent.isValid()).toBe(false);
+      expect(parent.errors.where("children[1].name")).toHaveLength(1);
+      expect(parent.errors.where("children.name")).toHaveLength(0);
+    } finally {
+      setIndexNestedAttributeErrors(old);
+    }
   });
-  it.skip("errors details should be indexed when passed as array", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires indexed error details */
+  it("errors details should be indexed when passed as array", () => {
+    const { Parent, Child } = makeIndexedHasMany({ indexErrors: true });
+    const parent = new Parent({ name: "p" });
+    cacheAssoc(parent, "children", [new Child({ name: "ok" }), new Child({ name: "" })]);
+    expect(parent.isValid()).toBe(false);
+    expect(parent.errors.details.get("children[1].name")?.length ?? 0).toBeGreaterThan(0);
+    expect(parent.errors.details.get("children.name") ?? []).toHaveLength(0);
   });
-  it.skip("errors details with error on base should be indexed when passed as array", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires base error indexing */
+  it("errors details with error on base should be indexed when passed as array", () => {
+    class P extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class C extends Base {
+      static {
+        this.attribute("favorite", "boolean");
+        this.attribute("p_id", "integer");
+      }
+      override isValid(): boolean {
+        this.errors.clear();
+        if (!(this as any).favorite) this.errors.add("base", "should be favorite");
+        return this.errors.empty;
+      }
+    }
+    P.adapter = adapter;
+    C.adapter = adapter;
+    registerModel("BaseErrP", P);
+    registerModel("BaseErrC", C);
+    Associations.hasMany.call(P, "kids", {
+      autosave: true,
+      indexErrors: true,
+      className: "BaseErrC",
+    });
+    const parent = new P({ name: "p" });
+    cacheAssoc(parent, "kids", [new C({ favorite: true }), new C({ favorite: false })]);
+    expect(parent.isValid()).toBe(false);
+    expect(parent.errors.details.get("kids[1].base")?.length ?? 0).toBeGreaterThan(0);
   });
-  it.skip("indexed errors should be properly translated", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires i18n */
+  it("indexed errors should be properly translated", () => {
+    const { Parent, Child } = makeIndexedHasMany({ indexErrors: true });
+    const parent = new Parent({ name: "p" });
+    cacheAssoc(parent, "children", [new Child({ name: "ok" }), new Child({ name: "" })]);
+    expect(parent.isValid()).toBe(false);
+    expect(parent.errors.where("children[1].name")).toHaveLength(1);
+    expect(parent.errors.where("children.name")).toHaveLength(0);
   });
-  it.skip("indexed errors on base attribute should be properly translated", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires i18n */
+  it("indexed errors on base attribute should be properly translated", () => {
+    class O extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class Pt extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("o_id", "integer");
+        this.validates("name", { presence: true });
+      }
+    }
+    O.adapter = adapter;
+    Pt.adapter = adapter;
+    registerModel("OwnerHO", O);
+    registerModel("PetHO", Pt);
+    Associations.hasOne.call(O, "pet", {
+      autosave: true,
+      foreignKey: "o_id",
+      className: "PetHO",
+    });
+    const owner = new O({ name: "Alice" });
+    cacheAssoc(owner, "pet", new Pt({ name: "" }));
+    expect(owner.isValid()).toBe(false);
+    expect(owner.errors.include("pet.name")).toBe(true);
   });
-  it.skip("errors details should be indexed when global flag is set", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* requires global indexed errors config */
+  it("errors details should be indexed when global flag is set", () => {
+    const old = indexNestedAttributeErrors;
+    setIndexNestedAttributeErrors(true);
+    try {
+      const { Parent, Child } = makeIndexedHasMany();
+      const parent = new Parent({ name: "p" });
+      cacheAssoc(parent, "children", [new Child({ name: "ok" }), new Child({ name: "" })]);
+      expect(parent.isValid()).toBe(false);
+      expect(parent.errors.details.get("children[1].name")?.length ?? 0).toBeGreaterThan(0);
+      expect(parent.errors.details.get("children.name") ?? []).toHaveLength(0);
+    } finally {
+      setIndexNestedAttributeErrors(old);
+    }
   });
 });
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -11,6 +11,7 @@ import {
   AssociationNotFoundError,
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
+import { NestedError as AssociationsNestedError } from "./associations/nested-error.js";
 import type { AssociationDefinition } from "./associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { included } from "@blazetrails/activesupport";
@@ -352,13 +353,12 @@ export function validateAssociations(record: Base, context?: ValidationContextAr
           if (parentErrors) {
             if (assoc.options.autosave) {
               const childErrors = (child as any).errors;
-              if (childErrors) {
-                const msgs = (
-                  Array.isArray(childErrors.fullMessages) ? childErrors.fullMessages : []
-                ) as string[];
-                for (const msg of msgs) {
-                  parentErrors.add("base", "invalid", { message: msg });
-                }
+              const errorObjects: any[] = childErrors?.objects ?? [];
+              // Wrap each child error as Associations::NestedError so the
+              // parent's error attribute reads `assoc.attr` (or
+              // `assoc[i].attr` when index_errors is set / global flag).
+              for (const err of errorObjects) {
+                parentErrors.objects.push(new AssociationsNestedError(inst, err));
               }
             } else {
               parentErrors.add(assoc.name, "invalid");
@@ -711,7 +711,7 @@ export function validateHasOneAssociation(this: AutosaveAssociationHost, reflect
     )
       return;
   }
-  isAssociationValid(reflection, record, this);
+  isAssociationValid(reflection, record, this, inst);
 }
 
 /** @internal */
@@ -722,7 +722,7 @@ export function validateBelongsToAssociation(this: AutosaveAssociationHost, refl
   if (!(record.changedForAutosave?.() ?? false)) return;
   _setValidatingBelongsToFor(this, reflection, true);
   try {
-    isAssociationValid(reflection, record, this);
+    isAssociationValid(reflection, record, this, inst);
   } finally {
     _setValidatingBelongsToFor(this, reflection, false);
   }
@@ -744,12 +744,17 @@ export function validateCollectionAssociation(
   );
   if (!records) return;
   for (const record of records) {
-    isAssociationValid(reflection, record, this);
+    isAssociationValid(reflection, record, this, association);
   }
 }
 
 /** @internal */
-export function isAssociationValid(reflection: any, record: any, owner: any): boolean {
+export function isAssociationValid(
+  reflection: any,
+  record: any,
+  owner: any,
+  association?: any,
+): boolean {
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
   // Mirror Rails: only forward a custom (non-:create/:update) validation context.
@@ -761,10 +766,26 @@ export function isAssociationValid(reflection: any, record: any, owner: any): bo
   if (!isChildValid) {
     const parentErrors = owner?.errors;
     if (parentErrors && reflection.options?.autosave) {
-      const msgs = (
-        Array.isArray(record.errors?.fullMessages) ? record.errors.fullMessages : []
-      ) as string[];
-      for (const msg of msgs) parentErrors.add("base", "invalid", { message: msg });
+      // Determine which child errors to propagate: Rails skips re-propagating
+      // already-wrapped NestedErrors on unchanged existing records, but for
+      // new/changed records all errors bubble up.
+      const childErrors: any[] = record.errors?.objects ?? [];
+      const associatedErrors =
+        record.isNewRecord?.() || record.changed?.() || context
+          ? childErrors
+          : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
+
+      if (association) {
+        for (const error of associatedErrors) {
+          parentErrors.objects.push(new AssociationsNestedError(association, error));
+        }
+      } else {
+        // No association object available (singular path without loaded assoc);
+        // fall back to message copy.
+        for (const error of associatedErrors) {
+          parentErrors.add("base", "invalid", { message: error.message });
+        }
+      }
     } else if (parentErrors) {
       parentErrors.add(reflection.name ?? "base", "invalid");
     }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -767,7 +767,7 @@ export function isAssociationValid(
 
   const childErrors: any[] = record.errors?.objects ?? [];
   const associatedErrors =
-    record.isNewRecord?.() || record.changed?.() || context
+    record.isNewRecord?.() || record.changed || context
       ? childErrors
       : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -753,42 +753,34 @@ export function isAssociationValid(
   reflection: any,
   record: any,
   owner: any,
-  association?: any,
+  association: any,
 ): boolean {
+  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398).
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
-  // Mirror Rails: only forward a custom (non-:create/:update) validation context.
   const context: ValidationContextArg | undefined =
     typeof owner?.customValidationContext === "function" && owner.customValidationContext()
       ? owner._validationContext
       : undefined;
   const isChildValid = typeof record.isValid === "function" ? record.isValid(context) : true;
-  if (!isChildValid) {
-    const parentErrors = owner?.errors;
-    if (parentErrors && reflection.options?.autosave) {
-      // Determine which child errors to propagate: Rails skips re-propagating
-      // already-wrapped NestedErrors on unchanged existing records, but for
-      // new/changed records all errors bubble up.
-      const childErrors: any[] = record.errors?.objects ?? [];
-      const associatedErrors =
-        record.isNewRecord?.() || record.changed?.() || context
-          ? childErrors
-          : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
+  if (isChildValid) return true;
 
-      if (association) {
-        for (const error of associatedErrors) {
-          parentErrors.objects.push(new AssociationsNestedError(association, error));
-        }
-      } else {
-        // No association object available (singular path without loaded assoc);
-        // fall back to message copy.
-        for (const error of associatedErrors) {
-          parentErrors.add("base", "invalid", { message: error.message });
-        }
-      }
-    } else if (parentErrors) {
-      parentErrors.add(reflection.name ?? "base", "invalid");
+  const childErrors: any[] = record.errors?.objects ?? [];
+  const associatedErrors =
+    record.isNewRecord?.() || record.changed?.() || context
+      ? childErrors
+      : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
+
+  const parentErrors = owner?.errors;
+  if (!parentErrors) return isChildValid;
+
+  if (reflection.options?.autosave) {
+    if (owner === record) return isChildValid; // Rails: `return if equal?(record)`
+    for (const error of associatedErrors) {
+      parentErrors.objects.push(new AssociationsNestedError(association, error));
     }
+  } else if (associatedErrors.length > 0) {
+    parentErrors.add(reflection.name);
   }
   return isChildValid;
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -117,6 +117,7 @@ export {
   isTriggerTransactionalCallbacks,
 } from "./transactions.js";
 export { delegate } from "./delegate.js";
+export { indexNestedAttributeErrors, setIndexNestedAttributeErrors } from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export {
   enableSti,


### PR DESCRIPTION
## Summary
- When an autosaved child fails validation, the parent's errors collection now wraps each child error as an `Associations::NestedError`, exposing it under `assoc.attr` (or `assoc[i].attr` when `index_errors` is on per-association or the global `indexNestedAttributeErrors` flag is set). Previously, full messages were copied onto `:base` as plain strings, which made `errors.details[attr]` and indexed-attribute lookups blank.
- Adds the global `indexNestedAttributeErrors` setter (mirrors `ActiveRecord.index_nested_attribute_errors`) and the `indexErrors` per-association option to `AssociationOptions`.
- Un-skips 6 indexed-error tests in `autosave-association.test.ts` (Slot D of the associations-autosave cluster).

## Implementation notes
- `NestedError.computeAttribute` tolerates either an `Association` or a `CollectionProxy` as input (`isCollection()` may be a method or inferred from an array `target`; options may live on `reflection.options` rather than `options`).
- `validateAssociations` (the path called from `isValid()`) and `isAssociationValid` (older path) both now `push` `AssociationsNestedError` instances into `parent.errors.objects` instead of copying messages onto `:base`.
- `nested-error.ts` retains the 4 Rails-private helpers (`association`, `indexErrorsSetting`, `index`, `orderedRecords`) so `api:compare` continues to credit `nested_error.rb` at 100%.

## Test plan
- [x] `pnpm exec vitest run packages/activerecord/src/autosave-association.test.ts` — 160 passing, 32 skipped (6 un-skipped vs. main).
- [x] `pnpm exec vitest run packages/activerecord` — 11123 passing, 3060 skipped (no regressions).
- [x] `pnpm run api:compare --package activerecord` — 4952/4958 (99.9%), no regression vs. main.
- [x] `pnpm lint --fix`, `pnpm run -w typecheck` — clean.
- [x] `git diff --shortstat origin/main` — 208 insertions, 50 deletions (under 300 LOC ceiling).