### PR TITLE
feat(vendor): wave 1 — sources.ts schema + rails entry

### DIFF
--- a/docs/ruby-source-fetcher-plan.md
+++ b/docs/ruby-source-fetcher-plan.md
@@ -103,7 +103,9 @@ Pro: one origin = one fetch = one cache invalidation. Versioning is monorepo-awa
 
 **Decision**: Shape B, **git-only**. Rubygems origins were considered and rejected: gem tarballs ship `lib/` only (gemspecs typically exclude `test/`), so test-compare integration silently breaks for bundler-fetched sources. globalid 1.3.0 ships from `rails/globalid` with a `v1.3.0` tag; rack from `rack/rack`. Going git-only also drops the bundlerFetcher, the ephemeral Gemfile, the lib/test symlink dance, and the runtime ruby/bundler dependency for fetching. If a future gem isn't on GitHub or isn't tagged, we'll add a bundler origin then.
 
-### 2.2 Concrete list (initial migration target)
+### 2.2 Concrete list (end-state)
+
+This is the _final_ list after all waves ship. Wave 1 lands the rails entry only; wave 2 adds rack alongside its fetcher; wave 3 adds globalid. The live `vendor/sources.ts` reflects the current wave's subset.
 
 ```ts
 export const SOURCES: UpstreamSource[] = [

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,8 @@
+# Vendored sources are fetched on demand by the unified fetcher (wave 2).
+# Everything under vendor/ is gitignored except the registry, this file,
+# the README, and the lockfile (added in wave 2).
+*
+!.gitignore
+!README.md
+!sources.ts
+!sources.lock.json

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -6,3 +6,4 @@
 !README.md
 !sources.ts
 !sources.lock.json
+!*.test.ts

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,26 @@
+# vendor/
+
+Upstream Ruby source mirrors used by `api-compare`, `test-compare`, and
+schema-parity tooling.
+
+- `sources.ts` — declarative registry. Single source of truth for which
+  gems we mirror and at what version. See
+  [`docs/ruby-source-fetcher-plan.md`](../docs/ruby-source-fetcher-plan.md)
+  for the full design.
+- Per-source subdirs (`rails/`, `rack/`, `globalid/`, …) are gitignored
+  shallow clones of the upstream repo at the pinned tag. They land here
+  via the unified fetcher (wave 2).
+- `sources.lock.json` (committed, wave 2) records resolved git SHAs for
+  reproducibility.
+
+## Status
+
+| Wave | Status  | What landed                                                                       |
+| ---- | ------- | --------------------------------------------------------------------------------- |
+| 1    | this PR | schema + rails-only `SOURCES` list                                                |
+| 2    | pending | `fetch.ts`, `sources.lock.json`, rack entry, migrate `.rails-source/.rack-source` |
+| 3    | pending | globalid entry (git clone of `rails/globalid`)                                    |
+| 4    | pending | `api-compare` reads from `resolvePath`; derive `PACKAGES`                         |
+| 5    | pending | `test-compare` reads from `resolvePath`                                           |
+| 6    | pending | globalid wired through both compares                                              |
+| 7    | pending | doc + memory sweep; generate parity Gemfile from `SOURCES`                        |

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { SOURCES, type UpstreamSource, validateSources } from "./sources.js";
+
+describe("vendor/sources.ts", () => {
+  it("loads without throwing (wave 1 invariant holds)", () => {
+    expect(SOURCES).toBeDefined();
+    expect(SOURCES.length).toBeGreaterThan(0);
+  });
+
+  it("declares the rails source with all 9 wave-1 packages", () => {
+    const rails = SOURCES.find((s) => s.name === "rails");
+    expect(rails).toBeDefined();
+    expect(rails!.origin).toEqual({
+      type: "git",
+      url: "https://github.com/rails/rails.git",
+      ref: "v8.0.2",
+    });
+    expect(rails!.packages.map((p) => p.name).sort()).toEqual(
+      [
+        "abstractcontroller",
+        "actioncontroller",
+        "actiondispatch",
+        "actionview",
+        "activemodel",
+        "activerecord",
+        "activesupport",
+        "arel",
+        "trailties",
+      ].sort(),
+    );
+  });
+
+  it("matches scripts/api-compare/config.ts PACKAGES keys (parity with wave 4 derivation)", async () => {
+    const { PACKAGES } = await import("../scripts/api-compare/config.js");
+    const sourcePackageNames = SOURCES.flatMap((s) => s.packages.map((p) => p.name)).sort();
+    expect(sourcePackageNames).toEqual([...PACKAGES].sort());
+  });
+
+  it("validateSources rejects duplicate source names", () => {
+    const bad: UpstreamSource[] = [
+      { name: "x", origin: { type: "git", url: "u", ref: "r" }, packages: [] },
+      { name: "x", origin: { type: "git", url: "u", ref: "r" }, packages: [] },
+    ];
+    expect(() => validateSources(bad)).toThrow(/duplicate source name "x"/);
+  });
+
+  it("validateSources rejects duplicate package names across sources", () => {
+    const bad: UpstreamSource[] = [
+      {
+        name: "a",
+        origin: { type: "git", url: "u", ref: "r" },
+        packages: [{ name: "shared", libPath: "lib" }],
+      },
+      {
+        name: "b",
+        origin: { type: "git", url: "u", ref: "r" },
+        packages: [{ name: "shared", libPath: "lib" }],
+      },
+    ];
+    expect(() => validateSources(bad)).toThrow(/duplicate package name "shared"/);
+  });
+
+  it("validateSources rejects missing libPath", () => {
+    const bad: UpstreamSource[] = [
+      {
+        name: "x",
+        origin: { type: "git", url: "u", ref: "r" },
+        // @ts-expect-error — intentional bad shape for the test
+        packages: [{ name: "p" }],
+      },
+    ];
+    expect(() => validateSources(bad)).toThrow(/missing libPath/);
+  });
+});

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -1,0 +1,131 @@
+// Upstream Ruby source registry.
+//
+// Single source of truth for which upstream gems we mirror, where to fetch
+// them from, and where each one's lib/test directories live on disk after
+// fetching. Designed in docs/ruby-source-fetcher-plan.md.
+//
+// Each entry corresponds to one vendored root at `vendor/<source-name>/`.
+// `libPath` / `testPath` on each package are relative paths *inside* that
+// root — for monorepo origins they reach into the gem subdir
+// (e.g. `vendor/rails/actionpack/lib/action_dispatch`).
+
+export interface GitOrigin {
+  type: "git";
+  url: string;
+  ref: string;
+}
+
+export interface PackageEntry {
+  /** Logical package key; surfaces in api-compare's PACKAGES. */
+  name: string;
+  /** Path relative to the source's vendored root. */
+  libPath: string;
+  /** Path relative to the source's vendored root; omitted = test-compare ignores. */
+  testPath?: string;
+}
+
+export interface UpstreamSource {
+  /** Source name; used as `vendor/<name>/` directory. */
+  name: string;
+  origin: GitOrigin;
+  packages: PackageEntry[];
+}
+
+/**
+ * Wave-1 state: rails only. Rack lands in wave 2, globalid in wave 3.
+ * The end-state list (all three sources) is enumerated in
+ * docs/ruby-source-fetcher-plan.md §2.2.
+ *
+ * Package names mirror scripts/api-compare/config.ts PACKAGES exactly,
+ * including the trails-side rename `trailties` (← railties) and the
+ * actionpack split into `actiondispatch` / `actioncontroller` /
+ * `abstractcontroller` — each pointing at a distinct lib subdir so
+ * derived PACKAGES doesn't need an alias table.
+ */
+export const SOURCES: readonly UpstreamSource[] = [
+  {
+    name: "rails",
+    origin: {
+      type: "git",
+      url: "https://github.com/rails/rails.git",
+      ref: "v8.0.2",
+    },
+    packages: [
+      {
+        name: "arel",
+        libPath: "activerecord/lib/arel",
+        testPath: "activerecord/test/cases/arel",
+      },
+      {
+        name: "activerecord",
+        libPath: "activerecord/lib/active_record",
+        testPath: "activerecord/test/cases",
+      },
+      {
+        name: "activemodel",
+        libPath: "activemodel/lib/active_model",
+        testPath: "activemodel/test/cases",
+      },
+      {
+        name: "activesupport",
+        libPath: "activesupport/lib/active_support",
+        testPath: "activesupport/test",
+      },
+      {
+        name: "actiondispatch",
+        libPath: "actionpack/lib/action_dispatch",
+        testPath: "actionpack/test/dispatch",
+      },
+      {
+        name: "actioncontroller",
+        libPath: "actionpack/lib/action_controller",
+        testPath: "actionpack/test/controller",
+      },
+      {
+        name: "abstractcontroller",
+        libPath: "actionpack/lib/abstract_controller",
+      },
+      {
+        name: "actionview",
+        libPath: "actionview/lib/action_view",
+        testPath: "actionview/test",
+      },
+      {
+        name: "trailties",
+        libPath: "railties/lib/rails",
+        testPath: "railties/test",
+      },
+    ],
+  },
+];
+
+/**
+ * Validate SOURCES at load time. Catches schema mistakes (duplicate names,
+ * missing fields) before any consumer reads from the list. Throws on
+ * violation. Called from the module's top level so wave-1 contributors
+ * get errors at import, not at fetch time.
+ */
+function validate(sources: readonly UpstreamSource[]): void {
+  const sourceNames = new Set<string>();
+  const packageNames = new Set<string>();
+  for (const source of sources) {
+    if (sourceNames.has(source.name)) {
+      throw new Error(`vendor/sources.ts: duplicate source name "${source.name}"`);
+    }
+    sourceNames.add(source.name);
+    if (!source.origin.url || !source.origin.ref) {
+      throw new Error(`vendor/sources.ts: source "${source.name}" missing origin url/ref`);
+    }
+    for (const pkg of source.packages) {
+      if (packageNames.has(pkg.name)) {
+        throw new Error(`vendor/sources.ts: duplicate package name "${pkg.name}" across sources`);
+      }
+      packageNames.add(pkg.name);
+      if (!pkg.libPath) {
+        throw new Error(`vendor/sources.ts: package "${pkg.name}" missing libPath`);
+      }
+    }
+  }
+}
+
+validate(SOURCES);

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -100,12 +100,13 @@ export const SOURCES: readonly UpstreamSource[] = [
 ];
 
 /**
- * Validate SOURCES at load time. Catches schema mistakes (duplicate names,
+ * Validate a SOURCES-shaped list. Catches schema mistakes (duplicate names,
  * missing fields) before any consumer reads from the list. Throws on
- * violation. Called from the module's top level so wave-1 contributors
- * get errors at import, not at fetch time.
+ * violation. Called from the module's top level so contributors get errors
+ * at import, not at fetch time. Exported so wave 2's lockfile/fetcher
+ * tooling can reuse the same invariant when reading a manifest.
  */
-function validate(sources: readonly UpstreamSource[]): void {
+export function validateSources(sources: readonly UpstreamSource[]): void {
   const sourceNames = new Set<string>();
   const packageNames = new Set<string>();
   for (const source of sources) {
@@ -128,4 +129,4 @@ function validate(sources: readonly UpstreamSource[]): void {
   }
 }
 
-validate(SOURCES);
+validateSources(SOURCES);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -133,6 +133,7 @@ export default defineConfig({
             "scripts/guides-typecheck/*.test.ts",
             "scripts/api-compare/*.test.ts",
             "scripts/parity/**/*.test.ts",
+            "vendor/*.test.ts",
           ],
           exclude: ["packages/activerecord/**", ...SHARED_EXCLUDE],
           setupFiles: ["./packages/activerecord/src/test-setup.ts"],


### PR DESCRIPTION
First wave of the unified Ruby source-fetcher plan ([docs/ruby-source-fetcher-plan.md](docs/ruby-source-fetcher-plan.md), merged in #1552).

## Summary
- `vendor/sources.ts` — `UpstreamSource`/`PackageEntry`/`GitOrigin` interfaces plus the rails entry. Package names match `scripts/api-compare/config.ts` `PACKAGES` exactly (arel, activerecord, activemodel, activesupport, actiondispatch, actioncontroller, abstractcontroller, actionview, trailties) so wave 4's derive-PACKAGES step is a one-liner.
- `validate(SOURCES)` runs at import: catches duplicate source/package names and missing fields before any consumer reads from the list.
- `vendor/.gitignore` — gitignores everything under `vendor/` except the registry, README, and (future) `sources.lock.json`.
- `vendor/README.md` — per-wave status table.
- Doc tweak: §2.2 of the plan reframed as the *end-state* list with a note that the live `vendor/sources.ts` reflects the current wave's subset (post-merge finding from #1552).

## What's NOT in this PR
- No fetcher — that's wave 2.
- No `resolvePath` helper — that's wave 4 when consumers actually read from it.
- No rack/globalid entries — waves 2 and 3.
- No CI changes.

## Test plan
- [x] `pnpm tsx vendor/sources.ts` loads without throwing (validate passes).
- [ ] CI green.
- [ ] Diff against plan §2.2 — wave-1 subset (rails only) matches.

168 LOC additions per `git diff --shortstat`.