### PR TITLE
feat(activerecord): pg change-schema timestamptz default round-trip (PG long-tail Slot H)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -2,7 +2,12 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/change_schema_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import {
+  describeIfPg,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+  withPostgresqlDatetimeType,
+} from "./test-helper.js";
 
 describeIfPg("Migration", () => {
   let adapter: PostgreSQLAdapter;
@@ -94,20 +99,35 @@ describeIfPg("Migration", () => {
       expect(col!.sqlType).toBe("timestamp without time zone");
     });
 
-    it.skip("change type with symbol using timestamp with timestamptz as default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in change-schema
-      // ROOT-CAUSE: connection-adapters/postgresql/change-schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/change-schema.ts; affects ~10–47 tests in change-schema.test.ts
+    it("change type with symbol using timestamp with timestamptz as default", async () => {
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        await adapter.changeColumn("strings", "somedate", "timestamp", {
+          castAs: "timestamp",
+        });
+        const cols = await adapter.columns("strings");
+        const col = cols.find((c) => c.name === "somedate");
+        expect(col!.sqlType).toBe("timestamp without time zone");
+      });
     });
-    it.skip("change type with symbol with timestamptz as default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in change-schema
-      // ROOT-CAUSE: connection-adapters/postgresql/change-schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/change-schema.ts; affects ~10–47 tests in change-schema.test.ts
+    it("change type with symbol with timestamptz as default", async () => {
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        await adapter.changeColumn("strings", "somedate", "timestamptz", {
+          castAs: "timestamptz",
+        });
+        const cols = await adapter.columns("strings");
+        const col = cols.find((c) => c.name === "somedate");
+        expect(col!.sqlType).toBe("timestamp with time zone");
+      });
     });
-    it.skip("change type with symbol using datetime with timestamptz as default", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in change-schema
-      // ROOT-CAUSE: connection-adapters/postgresql/change-schema.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/change-schema.ts; affects ~10–47 tests in change-schema.test.ts
+    it("change type with symbol using datetime with timestamptz as default", async () => {
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        await adapter.changeColumn("strings", "somedate", "datetime", {
+          castAs: "datetime",
+        });
+        const cols = await adapter.columns("strings");
+        const col = cols.find((c) => c.name === "somedate");
+        expect(col!.sqlType).toBe("timestamp with time zone");
+      });
     });
 
     it("change type with array", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4073,7 +4073,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       decimal: "numeric",
       boolean: "boolean",
       date: "date",
-      datetime: "timestamp without time zone",
+      datetime:
+        pgDatetimeConfig.datetimeType === "timestamptz"
+          ? "timestamp with time zone"
+          : "timestamp without time zone",
       timestamp: "timestamp without time zone",
       timestamptz: "timestamp with time zone",
       time: "time without time zone",


### PR DESCRIPTION
## Summary

- Fix `nativeType("datetime")` in `PostgreSQLAdapter` to return `"timestamp with time zone"` when `datetimeType === "timestamptz"`, rather than always returning `"timestamp without time zone"`
- Un-skip 3 PG change-schema tests that exercise `changeColumn` with `datetimeType = "timestamptz"` set as the adapter default

## Tests

3 tests un-skipped in `change-schema.test.ts`:
- `change type with symbol using timestamp with timestamptz as default` — `timestamp` type unaffected by datetimeType setting
- `change type with symbol with timestamptz as default` — explicit `timestamptz` produces `timestamp with time zone`  
- `change type with symbol using datetime with timestamptz as default` — `datetime` maps to `timestamp with time zone` when datetimeType=timestamptz

## Follow-ups

Remaining skips in `change-schema.test.ts` (8 tests: change column, change column with null/default, etc.) need broader Schema cluster Slot F work (~200 LOC).