### PR TITLE
feat(activerecord): MySQL SchemaDumper Slot B — emit charset/collation + composite PK

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -1,8 +1,13 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SchemaDumper } from "../../schema-dumper.js";
+import type { SchemaSource } from "../../schema-dumper.js";
+import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+
+const dumpTable = (adapter: Mysql2Adapter, tableName: string) =>
+  SchemaDumper.dumpTableSchema(adapter as unknown as SchemaSource, tableName);
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -14,53 +19,119 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("TableOptionsTest", () => {
-    it.skip("table options with ENGINE", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+    afterEach(async () => {
+      await adapter.dropTable("mysql_table_options", { ifExists: true });
     });
-    it.skip("table options with ROW_FORMAT", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("table options with ENGINE", async () => {
+      await adapter.createTable("mysql_table_options", { force: true, options: "ENGINE=MyISAM" });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/options:\s*"ENGINE=MyISAM"/);
+      expect(output).toMatch(/force:\s*"cascade"/);
     });
-    it.skip("table options with CHARSET", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("table options with ROW_FORMAT", async () => {
+      await adapter.createTable("mysql_table_options", {
+        force: true,
+        options: "ROW_FORMAT=REDUNDANT",
+      });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/options:\s*"ENGINE=InnoDB ROW_FORMAT=REDUNDANT"/);
     });
-    it.skip("table options with COLLATE", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("table options with CHARSET", async () => {
+      await adapter.createTable("mysql_table_options", { force: true, options: "CHARSET=latin1" });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"latin1"/);
+      expect(output).not.toMatch(/options:/);
     });
-    it.skip("charset and collation options", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("table options with COLLATE", async () => {
+      await adapter.createTable("mysql_table_options", {
+        force: true,
+        options: "COLLATE=utf8mb4_bin",
+      });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/collation:\s*"utf8mb4_bin"/);
     });
-    it.skip("charset and partitioned table options", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("charset and collation options", async () => {
+      await adapter.createTable("mysql_table_options", {
+        force: true,
+        options: "DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+      });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/collation:\s*"utf8mb4_bin"/);
     });
-    it.skip("schema dump works with NO_TABLE_OPTIONS sql mode", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("charset and partitioned table options", async () => {
+      // Use raw SQL to create composite-PK + partitioned table since our createTable
+      // DSL does not yet support composite primary keys as a table option.
+      await adapter.dropTable("mysql_table_options", { ifExists: true });
+      await adapter.execute(
+        "CREATE TABLE `mysql_table_options` (" +
+          "`id` BIGINT NOT NULL AUTO_INCREMENT, " +
+          "`account_id` BIGINT UNSIGNED NOT NULL, " +
+          "PRIMARY KEY (`id`, `account_id`)" +
+          ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n" +
+          "/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */",
+      );
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/primaryKey:\s*\["id",\s*"account_id"\]/);
+      expect(output).toMatch(/charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/collation:\s*"utf8mb4_bin"/);
+      expect(output).toMatch(/PARTITION BY HASH/);
+    });
+
+    it("schema dump works with NO_TABLE_OPTIONS sql mode", async () => {
+      // As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated and removed in MySQL 8+
+      // Skip on MariaDB and newer MySQL where the mode doesn't exist
+      if (!isMariaDb) {
+        const version = await adapter.showVariable("version");
+        if (!version || version >= "5.7.22") return;
+      } else {
+        return; // MariaDB doesn't support NO_TABLE_OPTIONS
+      }
+
+      const oldMode = await adapter.showVariable("sql_mode");
+      if (!oldMode) return;
+      await adapter.execute(`SET @@SESSION.sql_mode='${oldMode},NO_TABLE_OPTIONS'`);
+      try {
+        await adapter.createTable("mysql_table_options", { force: true });
+        const output = await dumpTable(adapter, "mysql_table_options");
+        expect(output).not.toMatch(/options:/);
+      } finally {
+        await adapter.execute(`SET @@SESSION.sql_mode='${oldMode}'`);
+      }
     });
   });
 
   describe("DefaultEngineOptionTest", () => {
-    it.skip("new migrations do not contain default ENGINE=InnoDB option", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+    afterEach(async () => {
+      await adapter.dropTable("mysql_table_options", { ifExists: true });
     });
-    it.skip("legacy migrations contain default ENGINE=InnoDB option", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in table-options
-      // ROOT-CAUSE: adapters/mysql2/table-options.ts or abstract-mysql-adapter/table-options.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/table-options.ts; affects ~10–26 tests in table-options.test.ts
+
+    it("new migrations do not contain default ENGINE=InnoDB option", async () => {
+      await adapter.createTable("mysql_table_options", { force: true });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).not.toMatch(/ENGINE=InnoDB(?!.*ROW_FORMAT)/);
+    });
+
+    it("legacy migrations contain default ENGINE=InnoDB option", async () => {
+      // Rails 5.1 migration format adds ENGINE=InnoDB explicitly.
+      // We simulate by creating with explicit options string.
+      await adapter.createTable("mysql_table_options", {
+        force: true,
+        options: "ENGINE=InnoDB ROW_FORMAT=COMPACT",
+      });
+      const output = await dumpTable(adapter, "mysql_table_options");
+      expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
+      expect(output).toMatch(/options:\s*"ENGINE=InnoDB ROW_FORMAT=COMPACT"/);
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -70,16 +70,20 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("charset and partitioned table options", async () => {
-      // Use raw SQL to create composite-PK + partitioned table since our createTable
-      // DSL does not yet support composite primary keys as a table option.
-      await adapter.dropTable("mysql_table_options", { ifExists: true });
-      await adapter.execute(
-        "CREATE TABLE `mysql_table_options` (" +
-          "`id` BIGINT NOT NULL AUTO_INCREMENT, " +
-          "`account_id` BIGINT UNSIGNED NOT NULL, " +
-          "PRIMARY KEY (`id`, `account_id`)" +
-          ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n" +
-          "/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */",
+      await adapter.createTable(
+        "mysql_table_options",
+        {
+          force: true,
+          id: false,
+          primaryKey: ["id", "account_id"],
+          charset: "utf8mb4",
+          collation: "utf8mb4_bin",
+          options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */",
+        },
+        (t: any) => {
+          t.bigint("id", { null: false });
+          t.bigint("account_id", { null: false, unsigned: true });
+        },
       );
       const output = await dumpTable(adapter, "mysql_table_options");
       expect(output).toMatch(/primaryKey:\s*\["id",\s*"account_id"\]/);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
@@ -91,8 +92,9 @@ describeIfMysql("Mysql2Adapter", () => {
       // As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated and removed in MySQL 8+
       // Skip on MariaDB and newer MySQL where the mode doesn't exist
       if (!isMariaDb) {
-        const version = await adapter.showVariable("version");
-        if (!version || version >= "5.7.22") return;
+        const versionStr = await adapter.showVariable("version");
+        if (!versionStr) return;
+        if (new Version(versionStr.replace(/-.*$/, "")).gte("5.7.22")) return;
       } else {
         return; // MariaDB doesn't support NO_TABLE_OPTIONS
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -123,15 +123,18 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("legacy migrations contain default ENGINE=InnoDB option", async () => {
-      // Rails 5.1 migration format adds ENGINE=InnoDB explicitly.
-      // We simulate by creating with explicit options string.
+      // Rails 5.1 migrations add ENGINE=InnoDB explicitly to CREATE TABLE.
+      // The schema dump should show charset: but strip bare ENGINE=InnoDB (the default),
+      // matching Rails expected: /charset: "utf8mb4"(..., options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC")?, force: :cascade/
+      // We simulate a legacy migration result by creating a table with explicit ENGINE=InnoDB.
       await adapter.createTable("mysql_table_options", {
         force: true,
-        options: "ENGINE=InnoDB ROW_FORMAT=COMPACT",
+        options: "ENGINE=InnoDB",
       });
       const output = await dumpTable(adapter, "mysql_table_options");
       expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
-      expect(output).toMatch(/options:\s*"ENGINE=InnoDB ROW_FORMAT=COMPACT"/);
+      // Bare ENGINE=InnoDB is stripped by parseTableOptions — it must not appear in options:
+      expect(output).not.toMatch(/options:\s*"ENGINE=InnoDB"(?!\s*ROW_FORMAT)/);
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -167,10 +167,13 @@ export interface AbstractAdapter {
     optionsOrFn?:
       | {
           id?: boolean | "uuid";
+          primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
           options?: string;
           comment?: string;
+          charset?: string;
+          collation?: string;
           temporary?: boolean;
           as?: string;
         }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1432,11 +1432,12 @@ export function parseTableOptions(
   tableComment: string | null,
 ): Record<string, string> {
   // Strip column definitions — everything up to and including the closing `)`.
-  // Also strip MySQL partition hints (`/*!50100 ... */` appended after options).
-  // Mirrors Rails: .sub(/\A.*\n\) ?/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
+  // Strip partition hints only when followed by a trailing newline (mirrors Rails:
+  // .sub(/\n\/\*!.*\*\/\n\z/m, "")). Without trailing \n the hint stays in raw
+  // and ends up in opts["options"], which is what the schema-dump test expects.
   let raw = createInfo
     .replace(/[\s\S]*\n\) ?/, "")
-    .replace(/\n\/\*![\s\S]*\*\/\n?$/, "")
+    .replace(/\n\/\*![\s\S]*\*\/\n$/, "")
     .trim();
   if (!raw) return {};
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -591,7 +591,10 @@ export class TableDefinition {
     };
     // Composite primaryKey implies id: false — Rails requires this and emitting both
     // an auto-id column AND a composite PK constraint is invalid DDL.
-    const hasCompositePk = Array.isArray(tdOptions.primaryKey);
+    const hasCompositePk = Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length > 0;
+    if (Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length === 0) {
+      throw new ArgumentError("primaryKey array must not be empty");
+    }
     this._id = hasCompositePk ? false : (tdOptions.id ?? true);
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1108,8 +1108,17 @@ export class TableDefinition {
     }
 
     if (this._adapterName === "mysql") {
-      if (this.charset) sql += ` DEFAULT CHARSET=${this.charset}`;
-      if (this.collation) sql += ` COLLATE=${this.collation}`;
+      const safeIdentRe = /^[A-Za-z0-9_]+$/;
+      if (this.charset) {
+        if (!safeIdentRe.test(this.charset))
+          throw new ArgumentError(`Invalid MySQL charset: ${JSON.stringify(this.charset)}`);
+        sql += ` DEFAULT CHARSET=${this.charset}`;
+      }
+      if (this.collation) {
+        if (!safeIdentRe.test(this.collation))
+          throw new ArgumentError(`Invalid MySQL collation: ${JSON.stringify(this.collation)}`);
+        sql += ` COLLATE=${this.collation}`;
+      }
     }
     if (this.options) sql += ` ${this.options}`;
     if (this.comment && this._adapterName === "mysql") {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -558,6 +558,9 @@ export class TableDefinition {
   readonly as?: string;
   readonly options?: string;
   readonly comment?: string;
+  readonly charset?: string;
+  readonly collation?: string;
+  readonly compositePrimaryKey?: string[];
   private _id: boolean | PrimaryKeyType;
   private _adapterName: "sqlite" | "postgres" | "mysql";
   protected _adapter: SchemaQuoter;
@@ -566,6 +569,7 @@ export class TableDefinition {
     tableName: string,
     tdOptions: {
       id?: boolean | PrimaryKeyType;
+      primaryKey?: string | string[] | false;
       adapterName?: "sqlite" | "postgres" | "mysql";
       adapter?: SchemaQuoter;
       temporary?: boolean;
@@ -573,6 +577,8 @@ export class TableDefinition {
       as?: string;
       options?: string;
       comment?: string;
+      charset?: string;
+      collation?: string;
       default?: unknown;
     } = {},
   ) {
@@ -589,6 +595,11 @@ export class TableDefinition {
     this.as = tdOptions.as;
     this.options = tdOptions.options;
     this.comment = tdOptions.comment;
+    this.charset = tdOptions.charset;
+    this.collation = tdOptions.collation;
+    if (Array.isArray(tdOptions.primaryKey)) {
+      this.compositePrimaryKey = tdOptions.primaryKey;
+    }
 
     if (this._id !== false) {
       const pkType = (typeof this._id === "string" ? this._id : "primary_key") as ColumnType;
@@ -1081,9 +1092,19 @@ export class TableDefinition {
         }
         tableElements.push(fkSql);
       }
+      if (this.compositePrimaryKey && this.compositePrimaryKey.length > 0) {
+        const quotedCols = this.compositePrimaryKey
+          .map((k) => this._adapter.quoteIdentifier(k))
+          .join(", ");
+        tableElements.push(`PRIMARY KEY (${quotedCols})`);
+      }
       sql += ` (${tableElements.join(", ")})`;
     }
 
+    if (this._adapterName === "mysql") {
+      if (this.charset) sql += ` DEFAULT CHARSET=${this.charset}`;
+      if (this.collation) sql += ` COLLATE=${this.collation}`;
+    }
     if (this.options) sql += ` ${this.options}`;
     if (this.comment && this._adapterName === "mysql") {
       const escaped = this.comment.replace(/'/g, "''");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -589,7 +589,10 @@ export class TableDefinition {
       quoteTableName: abstractQuoteTableName,
       quoteDefaultExpression: abstractQuoteDefaultExpression,
     };
-    this._id = tdOptions.id ?? true;
+    // Composite primaryKey implies id: false — Rails requires this and emitting both
+    // an auto-id column AND a composite PK constraint is invalid DDL.
+    const hasCompositePk = Array.isArray(tdOptions.primaryKey);
+    this._id = hasCompositePk ? false : (tdOptions.id ?? true);
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
     this.as = tdOptions.as;
@@ -597,8 +600,8 @@ export class TableDefinition {
     this.comment = tdOptions.comment;
     this.charset = tdOptions.charset;
     this.collation = tdOptions.collation;
-    if (Array.isArray(tdOptions.primaryKey)) {
-      this.compositePrimaryKey = tdOptions.primaryKey;
+    if (hasCompositePk) {
+      this.compositePrimaryKey = tdOptions.primaryKey as string[];
     }
 
     if (this._id !== false) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -87,11 +87,14 @@ export class SchemaStatements {
     optionsOrFn?:
       | {
           id?: boolean | "uuid";
+          primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
           default?: unknown;
           options?: string;
           comment?: string;
+          charset?: string;
+          collation?: string;
           temporary?: boolean;
           as?: string;
         }
@@ -100,11 +103,14 @@ export class SchemaStatements {
   ): Promise<void> {
     let options: {
       id?: boolean | "uuid";
+      primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
       ifNotExists?: boolean;
       default?: unknown;
       options?: string;
       comment?: string;
+      charset?: string;
+      collation?: string;
       temporary?: boolean;
       as?: string;
     } = {};

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1475,7 +1475,16 @@ export class SchemaStatements {
   }
 
   validTableDefinitionOptions(): string[] {
-    return ["temporary", "ifNotExists", "options", "as", "comment", "charset", "collation"];
+    return [
+      "temporary",
+      "ifNotExists",
+      "options",
+      "as",
+      "comment",
+      "charset",
+      "collation",
+      "primaryKey",
+    ];
   }
 
   validColumnDefinitionOptions(): string[] {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -40,9 +40,6 @@ export interface ColumnMethods {
 }
 
 export class TableDefinition extends AbstractTableDefinition {
-  readonly charset: string | null;
-  readonly collation: string | null;
-
   constructor(
     tableName: string,
     options: {
@@ -53,6 +50,8 @@ export class TableDefinition extends AbstractTableDefinition {
   ) {
     super(tableName, {
       ...options,
+      charset: options.charset ?? undefined,
+      collation: options.collation ?? undefined,
       adapterName: "mysql",
       adapter: {
         quoteIdentifier: quoteIdentifier,
@@ -60,8 +59,6 @@ export class TableDefinition extends AbstractTableDefinition {
         quoteDefaultExpression: quoteDefaultExpression,
       },
     });
-    this.charset = options.charset ?? null;
-    this.collation = options.collation ?? null;
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -577,9 +577,14 @@ export abstract class Migration {
     optionsOrFn?:
       | {
           id?: boolean | "uuid";
+          primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
           default?: unknown;
+          options?: string;
+          comment?: string;
+          charset?: string;
+          collation?: string;
           as?: string;
         }
       | ((t: TableDefinition) => void),
@@ -1521,13 +1526,15 @@ export class MigrationContext {
   async createTable(
     name: string,
     options?: {
-      primaryKey?: string | false;
+      primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
       ifNotExists?: boolean;
       id?: boolean | "uuid";
       default?: unknown;
       options?: string;
       comment?: string;
+      charset?: string;
+      collation?: string;
       as?: string;
     },
     fn?: (t: TableDefinition) => void,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1555,9 +1555,12 @@ export class MigrationContext {
     }
     const td = new TableDefinition(name, {
       id: options?.as != null ? false : options?.id,
+      primaryKey: options?.primaryKey,
       default: options?.default,
       options: options?.options,
       comment: options?.comment,
+      charset: options?.charset,
+      collation: options?.collation,
       as: options?.as,
       adapterName: this._adapterName,
       adapter: this.adapter,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1602,7 +1602,7 @@ export class MigrationContext {
         scale?: number | null;
       }
     >();
-    if (options?.id !== false && options?.as == null) {
+    if (options?.id !== false && !Array.isArray(options?.primaryKey) && options?.as == null) {
       const idType = typeof options?.id === "string" ? options.id : "integer";
       meta.set("id", { type: idType, primaryKey: true });
     }

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -859,6 +859,44 @@ describe("SchemaDumperAdapterTest", () => {
     await (dumper as any).table("users", lines);
     expect(lines.join("\n")).toContain(`comment: "user accounts"`);
   });
+
+  it("emitTable emits charset and collation from adapterTableOpts before force", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const source = {
+      tables: () => ["t"],
+      columns: () => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: () => [],
+    };
+    class MysqlDumper extends TopLevelDumper {
+      protected override fetchTableOptions(_t: string): Record<string, unknown> {
+        return { charset: "utf8mb4", collation: "utf8mb4_bin" };
+      }
+    }
+    const dumper = MysqlDumper.create(source as any);
+    const lines: string[] = [];
+    await (dumper as any).table("t", lines);
+    const header = lines[0];
+    expect(header).toContain(`charset: "utf8mb4"`);
+    expect(header).toContain(`collation: "utf8mb4_bin"`);
+    expect(header.indexOf("charset")).toBeLessThan(header.indexOf("force"));
+  });
+
+  it("emitTable emits primaryKey array for composite primary keys", async () => {
+    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const source = {
+      tables: () => ["t"],
+      columns: () => [
+        { name: "id", type: "integer", primaryKey: true },
+        { name: "account_id", type: "integer", primaryKey: true },
+      ],
+      indexes: () => [],
+    };
+    const dumper = TopLevelDumper.create(source as any);
+    const lines: string[] = [];
+    await (dumper as any).table("t", lines);
+    expect(lines[0]).toContain(`primaryKey: ["id","account_id"]`);
+    expect(lines[0]).not.toContain(`id: false`);
+  });
 });
 
 describe("SchemaDumper async header ordering", () => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -895,7 +895,7 @@ describe("SchemaDumperAdapterTest", () => {
     const lines: string[] = [];
     await (dumper as any).table("t", lines);
     expect(lines[0]).toContain(`primaryKey: ["id","account_id"]`);
-    expect(lines[0]).not.toContain(`id: false`);
+    expect(lines[0]).toContain(`id: false`);
   });
 });
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -853,18 +853,25 @@ export class SchemaDumper {
     adapterTableOpts: Record<string, unknown> = {},
     inlineConstraints: string[] = [],
   ): void {
-    const pkColumn = columns.find((c) => c.primaryKey);
-    const hasId = pkColumn?.name === "id";
+    const pkColumns = columns.filter((c) => c.primaryKey);
+    const hasCompositePk = pkColumns.length > 1;
+    const pkColumn = pkColumns[0];
+    const hasId = !hasCompositePk && pkColumn?.name === "id";
     const stripped = this.removePrefixAndSuffix(tableName);
 
     const tableOpts: Record<string, unknown> = {};
-    if (!hasId) {
+    if (hasCompositePk) {
+      tableOpts.primaryKey = pkColumns.map((c) => c.name);
+    } else if (!hasId) {
       tableOpts.id = false;
     } else if (pkColumn) {
       Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
     }
-    tableOpts.force = "cascade";
+    if (typeof adapterTableOpts.charset === "string") tableOpts.charset = adapterTableOpts.charset;
+    if (typeof adapterTableOpts.collation === "string")
+      tableOpts.collation = adapterTableOpts.collation;
     if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
+    tableOpts.force = "cascade";
     if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.length > 0)
       tableOpts.comment = adapterTableOpts.comment;
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -862,6 +862,7 @@ export class SchemaDumper {
     const tableOpts: Record<string, unknown> = {};
     if (hasCompositePk) {
       tableOpts.primaryKey = pkColumns.map((c) => c.name);
+      tableOpts.id = false;
     } else if (!hasId) {
       tableOpts.id = false;
     } else if (pkColumn) {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -871,9 +871,9 @@ export class SchemaDumper {
     if (typeof adapterTableOpts.collation === "string")
       tableOpts.collation = adapterTableOpts.collation;
     if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
-    tableOpts.force = "cascade";
     if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.length > 0)
       tableOpts.comment = adapterTableOpts.comment;
+    tableOpts.force = "cascade";
     const optStr = `{ ${this.formatOptions(tableOpts)} }`;
 
     lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);


### PR DESCRIPTION
## Summary

- `SchemaDumper#emitTable` emits `charset:` and `collation:` from `adapterTableOpts` before `force: :cascade`, matching Rails' schema.rb key order
- Composite PK: detects multi-column primary keys and emits both `primaryKey: [colA, colB]` AND `id: false` — `id: false` is required so `createTable` doesn't auto-add a conflicting id column
- `parseTableOptions` partition-hint strip regex tightened (require trailing `\n`, mirrors Rails `\n\z`), so partition clauses are preserved in `options:` on MySQL servers that don't append a trailing newline
- 9 integration test bodies ported from Rails `table_options_test.rb` (all in `describeIfMysql` scope, run only against live MySQL)
- 3 unit tests added: charset/collation emit order, composite PK emit

### createTable DSL wiring (added during review)

- `TableDefinition` constructor stores `charset`, `collation`, and `primaryKey: string[]` (as `compositePrimaryKey`); `toSql()` emits `DEFAULT CHARSET=`/`COLLATE=` (MySQL only, validated against `/^[A-Za-z0-9_]+$/`) and `PRIMARY KEY (...)` table constraint — so loading a dumped schema round-trips correctly
- `createTable` type signatures updated in `abstract/schema-statements.ts`, `abstract-adapter.ts`, `Migration`, and `MigrationContext` to accept `charset`, `collation`, and `primaryKey: string | string[] | false`
- `MigrationContext.createTable` forwards new options to `TableDefinition`; `_columnMeta` skips phantom id entry for composite PK tables

## Known gaps (follow-up)

1. **`primaryKey: false` / `primaryKey: "custom_id"` in `TableDefinition`**: Only the array form is wired into `TableDefinition.toSql()`. `primaryKey: false` does not imply `id: false` inside `TableDefinition`; `primaryKey: "custom_id"` (string) does not rename the auto-generated PK column. These are pre-existing gaps (the string form predates this PR); fixing them requires renaming the auto-id column in the constructor and treating `false` as `id: false`.

2. **Composite PK column order**: `emitTable` derives PK column order from `columns.filter(c => c.primaryKey)` (declaration order from `SHOW FULL FIELDS`). Rails uses `@connection.primary_key(table)` which returns `seq_in_index` order. A table whose PK constraint columns appear in a different order than their declaration would dump with the wrong order.

3. **`_columnMeta` composite PK tracking**: Columns listed in a composite `primaryKey: [...]` are not marked `primaryKey: true` in `_columnMeta`. `SchemaDumper` reading from a `MigrationContext` source (no live DB) would miss the composite PK.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/schema-dumper.test.ts` — 62 passed
- [x] `pnpm exec vitest run packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts` — 37 passed
- [x] `pnpm exec vitest run packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts` — 32 passed
- [x] Full activerecord test suite: 338 test files, 11152 tests passed
- [x] TypeScript build: clean
- [ ] MySQL CI integration tests (9 tests in table-options.test.ts require live MySQL)