### PR TITLE
feat(activerecord): Associations-core Slot C — instance-dependent scopes

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7314,23 +7314,182 @@ describe("PreloaderTest", () => {
       "rails",
     ]);
   });
-  it.skip("preload with instance dependent scope", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs instance-dependent scopes */
+  it("preload with instance dependent scope", async () => {
+    const adapter = freshAdapter();
+    class PIDSAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PIDSPost extends Base {
+      static {
+        this.attribute("pids_author_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("PIDSAuthor", PIDSAuthor);
+    registerModel("PIDSPost", PIDSPost);
+    Associations.hasMany.call(PIDSAuthor, "pidsPostsMentioning", {
+      className: "PIDSPost",
+      foreignKey: "pids_author_id",
+      scope: (_rel: any, owner: any) => _rel.where({ mention: owner.name.toLowerCase() }),
+    });
+
+    const david = await PIDSAuthor.create({ name: "David" });
+    const david2 = await PIDSAuthor.create({ name: "David" });
+    const bob = await PIDSAuthor.create({ name: "Bob" });
+    const post1 = await PIDSPost.create({ pids_author_id: david.id, mention: "david" });
+    const post2 = await PIDSPost.create({ pids_author_id: david.id, mention: "david" });
+
+    await new Preloader({
+      records: [david, david2, bob],
+      associations: ["pidsPostsMentioning"],
+    }).call();
+
+    const davidPosts = (david as any)._preloadedAssociations.get("pidsPostsMentioning") as any[];
+    const david2Posts = (david2 as any)._preloadedAssociations.get("pidsPostsMentioning") as any[];
+    const bobPosts = (bob as any)._preloadedAssociations.get("pidsPostsMentioning") as any[];
+
+    expect(davidPosts.map((p: any) => p.id).sort()).toEqual([post1.id, post2.id].sort());
+    expect(david2Posts).toEqual([]);
+    expect(bobPosts).toEqual([]);
   });
-  it.skip("preload with instance dependent through scope", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs instance-dependent scopes */
+  it("preload with instance dependent through scope", async () => {
+    const adapter = freshAdapter();
+    class PWITSAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PWITSPost extends Base {
+      static {
+        this.attribute("pwits_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class PWITSComment extends Base {
+      static {
+        this.attribute("pwits_post_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("PWITSAuthor", PWITSAuthor);
+    registerModel("PWITSPost", PWITSPost);
+    registerModel("PWITSComment", PWITSComment);
+    Associations.hasMany.call(PWITSAuthor, "pwitsAuthorPosts", {
+      className: "PWITSPost",
+      foreignKey: "pwits_author_id",
+    });
+    Associations.hasMany.call(PWITSPost, "pwitsPostComments", {
+      className: "PWITSComment",
+      foreignKey: "pwits_post_id",
+    });
+    // Instance-dependent scope on through association: filter comments by mention == owner.name
+    Associations.hasMany.call(PWITSAuthor, "pwitsCommentsMentioning", {
+      className: "PWITSComment",
+      through: "pwitsAuthorPosts",
+      source: "pwitsPostComments",
+      scope: (_rel: any, owner: any) => _rel.where({ mention: owner.name.toLowerCase() }),
+    });
+
+    const david = await PWITSAuthor.create({ name: "David" });
+    const david2 = await PWITSAuthor.create({ name: "David" });
+    const bob = await PWITSAuthor.create({ name: "Bob" });
+    const davidPost = await PWITSPost.create({ pwits_author_id: david.id });
+    const comment1 = await PWITSComment.create({ pwits_post_id: davidPost.id, mention: "david" });
+    await PWITSComment.create({ pwits_post_id: davidPost.id, mention: "other" });
+
+    await new Preloader({
+      records: [david, david2, bob],
+      associations: ["pwitsCommentsMentioning"],
+    }).call();
+
+    const davidComments = (david as any)._preloadedAssociations.get(
+      "pwitsCommentsMentioning",
+    ) as any[];
+    const david2Comments = (david2 as any)._preloadedAssociations.get(
+      "pwitsCommentsMentioning",
+    ) as any[];
+    const bobComments = (bob as any)._preloadedAssociations.get("pwitsCommentsMentioning") as any[];
+
+    expect(davidComments.map((c: any) => c.id)).toEqual([comment1.id]);
+    expect(david2Comments).toEqual([]);
+    expect(bobComments).toEqual([]);
   });
-  it.skip("preload with through instance dependent scope", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs instance-dependent scopes */
+  it("preload with through instance dependent scope", async () => {
+    const adapter = freshAdapter();
+    class PWTISSAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PWTISSPost extends Base {
+      static {
+        this.attribute("pwtiss_author_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PWTISSComment extends Base {
+      static {
+        this.attribute("pwtiss_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("PWTISSAuthor", PWTISSAuthor);
+    registerModel("PWTISSPost", PWTISSPost);
+    registerModel("PWTISSComment", PWTISSComment);
+    // posts_mentioning_author: instance-dependent — filter posts where mention == owner.name
+    Associations.hasMany.call(PWTISSAuthor, "pwtissPostsMentioning", {
+      className: "PWTISSPost",
+      foreignKey: "pwtiss_author_id",
+      scope: (_rel: any, owner: any) => _rel.where({ mention: owner.name.toLowerCase() }),
+    });
+    Associations.hasMany.call(PWTISSPost, "pwtissPostComments", {
+      className: "PWTISSComment",
+      foreignKey: "pwtiss_post_id",
+    });
+    // through the instance-dependent pwtissPostsMentioning
+    Associations.hasMany.call(PWTISSAuthor, "pwtissCommentsOnPostsMentioning", {
+      className: "PWTISSComment",
+      through: "pwtissPostsMentioning",
+      source: "pwtissPostComments",
+    });
+
+    const david = await PWTISSAuthor.create({ name: "David" });
+    const david2 = await PWTISSAuthor.create({ name: "David" });
+    const bob = await PWTISSAuthor.create({ name: "Bob" });
+    const davidPost = await PWTISSPost.create({ pwtiss_author_id: david.id, mention: "david" });
+    const bobPost = await PWTISSPost.create({ pwtiss_author_id: bob.id, mention: "bob" });
+    // Non-mentioning post by david — should NOT be in through since filtered
+    await PWTISSPost.create({ pwtiss_author_id: david.id, mention: "other" });
+    const comment1 = await PWTISSComment.create({ pwtiss_post_id: davidPost.id });
+    const comment2 = await PWTISSComment.create({ pwtiss_post_id: davidPost.id });
+    const comment3 = await PWTISSComment.create({ pwtiss_post_id: bobPost.id });
+
+    await new Preloader({
+      records: [david, david2, bob],
+      associations: ["pwtissCommentsOnPostsMentioning"],
+    }).call();
+
+    const davidComments = (david as any)._preloadedAssociations.get(
+      "pwtissCommentsOnPostsMentioning",
+    ) as any[];
+    const david2Comments = (david2 as any)._preloadedAssociations.get(
+      "pwtissCommentsOnPostsMentioning",
+    ) as any[];
+    const bobComments = (bob as any)._preloadedAssociations.get(
+      "pwtissCommentsOnPostsMentioning",
+    ) as any[];
+
+    expect(davidComments.map((c: any) => c.id).sort()).toEqual([comment1.id, comment2.id].sort());
+    expect(david2Comments).toEqual([]);
+    expect(bobComments.map((c: any) => c.id)).toEqual([comment3.id]);
   });
 
   it("some already loaded associations", async () => {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -90,7 +90,7 @@ export interface AssociationOptions {
   counterCache?: boolean | string;
   touch?: boolean | string | string[];
   autosave?: boolean;
-  scope?: (rel: any) => any;
+  scope?: (rel: any, owner?: any) => any;
   validate?: boolean;
   required?: boolean;
   optional?: boolean;

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -4152,25 +4152,113 @@ describe("EagerAssociationTest", () => {
     // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
   });
-  it.skip("preloading of instance dependent associations is supported", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+  it("preloading of instance dependent associations is supported", async () => {
+    class PIDASAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PIDASPost extends Base {
+      static {
+        this.attribute("pidas_author_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("PIDASAuthor", PIDASAuthor);
+    registerModel("PIDASPost", PIDASPost);
+    Associations.hasMany.call(PIDASAuthor, "pidasPostsWithSignature", {
+      className: "PIDASPost",
+      foreignKey: "pidas_author_id",
+      scope: (_rel: any, owner: any) => _rel.where({ mention: owner.name.toLowerCase() }),
+    });
+    const author1 = await PIDASAuthor.create({ name: "Alice" });
+    await PIDASPost.create({ pidas_author_id: author1.id, mention: "alice" });
+    const authors = await (PIDASAuthor as any).preload("pidasPostsWithSignature").toArray();
+    expect(authors).not.toHaveLength(0);
+    for (const author of authors) {
+      expect((author as any)._preloadedAssociations?.has("pidasPostsWithSignature")).toBe(true);
+    }
   });
-  it.skip("eager loading of instance dependent associations is not supported", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+  it("eager loading of instance dependent associations is not supported", async () => {
+    class ELIDASAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class ELIDASPost extends Base {
+      static {
+        this.attribute("elidas_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("ELIDASAuthor", ELIDASAuthor);
+    registerModel("ELIDASPost", ELIDASPost);
+    Associations.hasMany.call(ELIDASAuthor, "elidasPostsWithSignature", {
+      className: "ELIDASPost",
+      foreignKey: "elidas_author_id",
+      scope: (_rel: any, owner: any) => _rel.where({ mention: (owner as any).name }),
+    });
+    await expect(
+      (ELIDASAuthor as any).eagerLoad("elidasPostsWithSignature").toArray(),
+    ).rejects.toThrow("association scope 'elidasPostsWithSignature' is instance dependent");
   });
-  it.skip("preloading of optional instance dependent associations is supported", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+  it("preloading of optional instance dependent associations is supported", async () => {
+    class POIDASAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class POIDASPost extends Base {
+      static {
+        this.attribute("poidas_author_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("POIDASAuthor", POIDASAuthor);
+    registerModel("POIDASPost", POIDASPost);
+    Associations.hasMany.call(POIDASAuthor, "poidasPostsMentioning", {
+      className: "POIDASPost",
+      foreignKey: "poidas_author_id",
+      scope: (_rel: any, owner?: any) =>
+        owner ? _rel.where({ mention: owner.name.toLowerCase() }) : _rel,
+    });
+    const author1 = await POIDASAuthor.create({ name: "Bob" });
+    await POIDASPost.create({ poidas_author_id: author1.id, mention: "bob" });
+    const authors = await (POIDASAuthor as any).includes("poidasPostsMentioning").toArray();
+    expect(authors).not.toHaveLength(0);
+    for (const author of authors) {
+      expect((author as any)._preloadedAssociations?.has("poidasPostsMentioning")).toBe(true);
+    }
   });
-  it.skip("eager loading of optional instance dependent associations is not supported", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+  it("eager loading of optional instance dependent associations is not supported", async () => {
+    class EOIDASAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class EOIDASPost extends Base {
+      static {
+        this.attribute("eoidas_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("EOIDASAuthor", EOIDASAuthor);
+    registerModel("EOIDASPost", EOIDASPost);
+    Associations.hasMany.call(EOIDASAuthor, "eoidasPostsMentioning", {
+      className: "EOIDASPost",
+      foreignKey: "eoidas_author_id",
+      scope: (_rel: any, owner?: any) =>
+        owner ? _rel.where({ mention: (owner as any).name }) : _rel,
+    });
+    await expect(
+      (EOIDASAuthor as any).eagerLoad("eoidasPostsMentioning").toArray(),
+    ).rejects.toThrow("association scope 'eoidasPostsMentioning' is instance dependent");
   });
   it("preload with invalid argument", async () => {
     class PiaWidget extends Base {
@@ -4186,14 +4274,11 @@ describe("EagerAssociationTest", () => {
     expect(widgets).toHaveLength(1);
   });
   it.skip("associations with extensions are not instance dependent", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+    // extensions (do...end block) do NOT make a scope instance-dependent;
+    // only a scope lambda with arity>1 does. Deferred to follow-up sweep.
   });
   it.skip("including associations with extensions and an instance dependent scope is supported", () => {
-    // BLOCKED: associations — eager-loading feature gap
-    // ROOT-CAUSE: associations/eager.ts or preloader.ts missing eager-loading semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in eager.test.ts
+    // Deferred — same infra as "preloading of instance dependent"; follow-up sweep.
   });
   it("preloading readonly association", async () => {
     class PraAuthor extends Base {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -144,6 +144,12 @@ export class JoinDependency {
     const assocDef = associations.find((a: any) => a.name === assocName);
     if (!assocDef) return null;
 
+    const reflection = reflectOnAssociation(modelClass, assocName);
+    if (reflection) {
+      // Mirrors: ActiveRecord::Associations::JoinDependency#build (join_dependency.rb:232)
+      (reflection as any).checkEagerLoadableBang?.();
+    }
+
     const sourceAlias = options?.fromAlias ?? this._baseAlias;
     const sourcePk = modelClass.primaryKey ?? "id";
     if (Array.isArray(sourcePk)) return null;

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -18,7 +18,8 @@ export class Association {
   /** @internal */
   readonly reflection: AssociationLikeReflection;
   private _preloadScope: any;
-  private _reflectionScope: any;
+  /** @internal */
+  protected _reflectionScope: any;
   private _associate: boolean;
   private _model: typeof Base | null;
   private _run: boolean;

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -17,7 +17,8 @@ export class Association {
   readonly owners: Base[];
   /** @internal */
   readonly reflection: AssociationLikeReflection;
-  private _preloadScope: any;
+  /** @internal */
+  protected _preloadScope: any;
   /** @internal */
   protected _reflectionScope: any;
   private _associate: boolean;

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -167,10 +167,14 @@ export class ThroughAssociation extends Association {
       return [];
     }
 
+    // Mirrors: Rails ThroughAssociation#source_preloaders passes reflection_scope
+    // so instance-dependent scopes on the through association are applied to
+    // the source (final target) query.
+    const sourceScope = this._reflectionScope ?? this.scope;
     const preloader = new Preloader({
       records: middleRecords,
       associations: [sourceRefl.name],
-      scope: this.scope,
+      scope: sourceScope,
       associateByDefault: false,
     });
     this._sourcePreloaders = preloader.loaders;

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -167,10 +167,16 @@ export class ThroughAssociation extends Association {
       return [];
     }
 
-    // Mirrors: Rails ThroughAssociation#source_preloaders passes reflection_scope
-    // so instance-dependent scopes on the through association are applied to
-    // the source (final target) query.
-    const sourceScope = this._reflectionScope ?? this.scope;
+    // Apply the per-owner reflection scope to source record loading so
+    // instance-dependent scopes filter the final target (e.g. only comments
+    // mentioning the owner). Merge the user-supplied preload scope on top so
+    // it is not silently dropped when _reflectionScope is set.
+    let sourceScope = this._reflectionScope ?? null;
+    if (sourceScope != null && this._preloadScope != null) {
+      sourceScope = (sourceScope as any).merge(this._preloadScope);
+    } else if (sourceScope == null) {
+      sourceScope = this._preloadScope;
+    }
     const preloader = new Preloader({
       records: middleRecords,
       associations: [sourceRefl.name],

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1227,6 +1227,10 @@ export class ThroughReflection extends AbstractReflection {
     return this.sourceReflection?.joinForeignKey ?? this._delegate.joinForeignKey;
   }
 
+  scopeFor(relation: any, owner?: any): any {
+    return this.delegateReflection.scopeFor(relation, owner);
+  }
+
   joinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
     const sourceScopes =
       this.sourceReflection?.joinScopes(table, predicateBuilder, klass, record) ?? [];


### PR DESCRIPTION
## Summary

- **`ThroughReflection.scopeFor`** added: without it, `AbstractReflection.joinScopes` fell through to `this.scope(rel)` with no owner argument, passing `undefined` as owner to instance-dependent lambdas
- **`JoinDependency.addAssociation`** now calls `reflection.checkEagerLoadableBang()` — mirrors Rails' `join_dependency.rb:232` — so `eager_load` raises `ArgumentError` for instance-dependent scopes
- **`ThroughAssociation._getSourcePreloaders`** propagates `_reflectionScope` (the per-owner WHERE) as the scope for source record loading

## Rails tests un-skipped (7)

**associations.test.ts** (`PreloaderTest`):
- preload with instance dependent scope
- preload with instance dependent through scope
- preload with through instance dependent scope

**eager.test.ts** (`EagerAssociationTest`):
- preloading of instance dependent associations is supported
- eager loading of instance dependent associations is not supported
- preloading of optional instance dependent associations is supported
- eager loading of optional instance dependent associations is not supported

## Known divergence from Rails (follow-up)

For `has_many :through` + instance-dependent scope, Rails applies the scope's WHERE clause to the **through** records query (inside `through_scope`, lines 104-144 of `through_association.rb`) with `includes!(source_reflection.name)` so the JOIN exists. Source preloaders then load all source records for the through records that passed the filter.

Our `_getSourcePreloaders` applies `_reflectionScope` directly to the **source** preloader instead. This gives more selective filtering (only matching source records returned) but differs from Rails' "gate on through records, load all source" behavior. The behavioral difference only manifests when some source records match the scope and others don't (e.g., a post with 5 comments where 1 matches — Rails returns all 5, ours returns 1). The `_buildThroughScope` approach matching Rails exactly is a follow-up.

## Skipped follow-ups
- "associations with extensions are not instance dependent"
- "including associations with extensions and an instance dependent scope is supported"