### PR TITLE
feat(activerecord): pg interval verbose format + AVG dispatch + execInsert pk=false (cluster sweep α)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -408,7 +408,7 @@ export interface DatabaseAdapter {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    pk?: string | null,
+    pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number>;

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -100,22 +100,26 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(i.legacy_term).toBe("P1DT1H");
     });
 
-    it.skip("average interval type", async () => {
-      // BLOCKED: calculations — AVG(interval) aggregate not type-cast through Interval OID
-      // ROOT-CAUSE: calculations.ts average() does not consult the column's cast type
-      //   for aggregate results; AVG of interval returns a raw string instead of Duration.
-      // SCOPE: ~30 LOC — wire typeForAttribute through aggregate result coercion in calculations.ts.
-      // Rails behavior: assert_equal 3.years + 2.months, IntervalDataType.average(:maximum_term)
+    it("average interval type", async () => {
+      await IntervalDataType.createBang({ maximum_term: "P2Y" });
+      await IntervalDataType.createBang({ maximum_term: "P4Y" });
+      const avg = await IntervalDataType.average("maximum_term");
+      // PG averages "2 years" and "4 years" → "3 years". The verbose result
+      // round-trips through Interval.castValue → Duration.
+      expect(avg).toBeInstanceOf(Duration);
+      // 3 years ≈ 3 × 365.25 × 86400 = 94 672 800 seconds.
+      const seconds = (avg as Duration).inSeconds();
+      expect(Math.abs(seconds - 3 * 365.25 * 86400)).toBeLessThan(86400);
     });
 
-    it.skip("schema dump with default value", async () => {
-      // BLOCKED: schema-dumper renders interval default as numeric seconds (e.g. 94670856)
-      //   instead of the ISO8601 string "P3Y".
-      // ROOT-CAUSE: postgresql/schema-statements.ts extractValueFromDefault does not handle
-      //   interval typed defaults; schema-dumper then prints the raw default through Number
-      //   inspection rather than calling Interval.typeCastForSchema.
-      // SCOPE: ~20 LOC — route interval defaults through the OID type's typeCastForSchema
-      //   in extract_value_from_default + schema-dumper column-default rendering.
+    it("schema dump with default value", async () => {
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "interval_data_types");
+      const dumped = lines.join("\n");
+      // default_term column carries DEFAULT 'P3Y' which PG normalizes to
+      // "3 years" in pg_get_expr; the OID type re-serializes it back to
+      // ISO8601 for the schema dump.
+      expect(dumped).toMatch(/default_term.*default:\s*"P3Y"/);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -109,6 +109,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await IntervalDataType.createBang({ maximum_term: "P4M" });
       const avg = await IntervalDataType.average("maximum_term");
       expect(avg).toBeInstanceOf(Duration);
+      // PG averages 6 years + 4 months → "3 years 2 mons" → "P3Y2M".
+      // Assert the actual averaged value rather than just the type to
+      // catch regressions where AVG falls through to wrong deserialization.
+      expect((avg as Duration).iso8601()).toBe("P3Y2M");
     });
 
     it.skip("schema dump with default value", async () => {

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -111,14 +111,19 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(avg).toBeInstanceOf(Duration);
     });
 
-    it("schema dump with default value", async () => {
-      const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "interval_data_types");
-      const dumped = lines.join("\n");
-      // default_term column carries DEFAULT 'P3Y' which PG normalizes to
-      // "3 years" in pg_get_expr; the OID type re-serializes it back to
-      // ISO8601 for the schema dump.
-      expect(dumped).toMatch(/default_term.*default:\s*"P3Y"/);
+    it.skip("schema dump with default value", async () => {
+      // BLOCKED: pg_get_expr returns the interval default as a bare numeric
+      //   (e.g. "94670856") even with `intervalstyle = iso_8601` set on the
+      //   session — the SET only affects SELECT/aggregate output, not the
+      //   pg_attrdef-stored expression text reconstructed by pg_get_expr.
+      // ROOT-CAUSE: splitPgDefault matches the bare numeric branch and
+      //   passes "94670856" to Interval.deserialize, which Duration.parse
+      //   rejects (not ISO 8601). The Column ends up with literal=null but
+      //   the dumper falls back to the raw value and emits `default: 94670856`.
+      // SCOPE: needs a coordinated fix in splitPgDefault (cast-aware
+      //   numeric→Duration conversion for interval columns) plus matching
+      //   adjustments in Interval.castValue/serialize so the seconds form
+      //   round-trips. ~50 LOC, deferred to a focused follow-up.
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -101,15 +101,14 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("average interval type", async () => {
-      await IntervalDataType.createBang({ maximum_term: "P2Y" });
-      await IntervalDataType.createBang({ maximum_term: "P4Y" });
+      // Mirrors Rails test_average_interval_type. Averages 6.years and
+      // 4.months → 3.years + 2.months. PG sets `intervalstyle = iso_8601`
+      // per session (configureConnection), so AVG(interval) returns an
+      // ISO 8601 string that the Interval OID parses cleanly.
+      await IntervalDataType.createBang({ maximum_term: "P6Y" });
+      await IntervalDataType.createBang({ maximum_term: "P4M" });
       const avg = await IntervalDataType.average("maximum_term");
-      // PG averages "2 years" and "4 years" → "3 years". The verbose result
-      // round-trips through Interval.castValue → Duration.
       expect(avg).toBeInstanceOf(Duration);
-      // 3 years ≈ 3 × 365.25 × 86400 = 94 672 800 seconds.
-      const seconds = (avg as Duration).inSeconds();
-      expect(Math.abs(seconds - 3 * 365.25 * 86400)).toBeLessThan(86400);
     });
 
     it("schema dump with default value", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -735,13 +735,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("exec insert with pk=false opt-out skips RETURNING and currval fallback", async () => {
-      // Mirrors Rails: `if use_insert_returning? || pk == false then super`.
-      // With pk === false the PG override delegates to the abstract
-      // execInsert (DatabaseStatements default), which runs the INSERT via
-      // executeMutation and returns the row count — no SELECT currval(...)
-      // sequence fallback runs (which would require a non-null sequenceName)
-      // and no pk-derived RETURNING is appended.
+      // Mirrors Rails: `if use_insert_returning? || pk == false`. With
+      // pk === false PG must NOT auto-append `RETURNING id` (the path
+      // executeMutation would otherwise take). Advance the SERIAL sequence
+      // so the inserted id (101) can't be confused with a row-count of 1
+      // — if the opt-out leaked, the result would be the id 101.
       await adapter.exec(`CREATE TABLE "ex_insert_pkfalse" ("id" SERIAL PRIMARY KEY, "n" INT)`);
+      await adapter.exec(`SELECT setval(pg_get_serial_sequence('ex_insert_pkfalse', 'id'), 100)`);
       try {
         const result = await adapter.execInsert(
           `INSERT INTO "ex_insert_pkfalse" ("n") VALUES (42)`,
@@ -749,11 +749,12 @@ describeIfPg("PostgreSQLAdapter", () => {
           [],
           false,
         );
-        // Abstract execInsert returns the row count (number), proving the
-        // PG-specific currval/RETURNING path was bypassed entirely.
-        expect(typeof result).toBe("number");
-        expect(result).toBe(1);
-        const rows = await adapter.execute(`SELECT n FROM "ex_insert_pkfalse"`);
+        // execQuery returns a Result whose toArray() is empty when no
+        // RETURNING is present (no rows projected back). If RETURNING
+        // had leaked, the Result's first row first column would be 101.
+        expect((result as { toArray(): unknown[] }).toArray?.()).toEqual([]);
+        const rows = await adapter.execute(`SELECT id, n FROM "ex_insert_pkfalse"`);
+        expect(rows[0].id).toBe(101);
         expect(rows[0].n).toBe(42);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS "ex_insert_pkfalse"`);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -734,6 +734,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    it("exec insert with pk=false opt-out skips RETURNING and currval fallback", async () => {
+      // Mirrors Rails: `if use_insert_returning? || pk == false then super`.
+      // pk === false routes to the abstract path which, with sqlForInsert's
+      // pk-false branch, does NOT auto-resolve a RETURNING column or run
+      // SELECT currval(...). Result is the INSERT's bare row count.
+      await adapter.exec(`CREATE TABLE "ex_insert_pkfalse" ("id" SERIAL PRIMARY KEY, "n" INT)`);
+      try {
+        const result = await adapter.execInsert(
+          `INSERT INTO "ex_insert_pkfalse" ("n") VALUES (42)`,
+          null,
+          [],
+          false,
+        );
+        // Abstract execInsert returns a Result without RETURNING — its
+        // toArray() should be empty (no rows projected back).
+        expect((result as any).rows ?? (result as any).toArray?.()).toEqual([]);
+        const rows = await adapter.execute(`SELECT n FROM "ex_insert_pkfalse"`);
+        expect(rows[0].n).toBe(42);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS "ex_insert_pkfalse"`);
+      }
+    });
+
     it("serial sequence", async () => {
       await adapter.exec(`CREATE TABLE "ex_serial_seq" ("id" SERIAL PRIMARY KEY)`);
       const result = await adapter.pkAndSequenceFor("ex_serial_seq");

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -736,9 +736,11 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("exec insert with pk=false opt-out skips RETURNING and currval fallback", async () => {
       // Mirrors Rails: `if use_insert_returning? || pk == false then super`.
-      // pk === false routes to the abstract path which, with sqlForInsert's
-      // pk-false branch, does NOT auto-resolve a RETURNING column or run
-      // SELECT currval(...). Result is the INSERT's bare row count.
+      // With pk === false the PG override delegates to the abstract
+      // execInsert (DatabaseStatements default), which runs the INSERT via
+      // executeMutation and returns the row count — no SELECT currval(...)
+      // sequence fallback runs (which would require a non-null sequenceName)
+      // and no pk-derived RETURNING is appended.
       await adapter.exec(`CREATE TABLE "ex_insert_pkfalse" ("id" SERIAL PRIMARY KEY, "n" INT)`);
       try {
         const result = await adapter.execInsert(
@@ -747,9 +749,10 @@ describeIfPg("PostgreSQLAdapter", () => {
           [],
           false,
         );
-        // Abstract execInsert returns a Result without RETURNING — its
-        // toArray() should be empty (no rows projected back).
-        expect((result as any).rows ?? (result as any).toArray?.()).toEqual([]);
+        // Abstract execInsert returns the row count (number), proving the
+        // PG-specific currval/RETURNING path was bypassed entirely.
+        expect(typeof result).toBe("number");
+        expect(result).toBe(1);
         const rows = await adapter.execute(`SELECT n FROM "ex_insert_pkfalse"`);
         expect(rows[0].n).toBe(42);
       } finally {

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -208,11 +208,11 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     ).sum.call(this, column);
   }
 
-  async average(column: string): Promise<number | null | Record<string, number>> {
+  async average(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     return (
       Relation.prototype as unknown as {
-        average: (col: string) => Promise<number | null | Record<string, number>>;
+        average: (col: string) => Promise<unknown | null | Record<string, unknown>>;
       }
     ).average.call(this, column);
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -862,17 +862,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     ).sum(column);
   }
 
-  async average(column: string): Promise<number | null | Record<string, number>> {
+  async average(column: string): Promise<unknown | null | Record<string, unknown>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        average: (col: string) => Promise<number | null | Record<string, number>>;
+        average: (col: string) => Promise<unknown | null | Record<string, unknown>>;
       }
     ).average;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
-      s as unknown as { average: (col: string) => Promise<number | null | Record<string, number>> }
+      s as unknown as {
+        average: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
     ).average(column);
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1970,7 +1970,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async calculate(
     operation: "average",
     column: string,
-  ): Promise<number | null | Record<string, number>>;
+  ): Promise<unknown | null | Record<string, unknown>>;
   async calculate(
     operation: "minimum" | "maximum",
     column: string,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -299,7 +299,7 @@ export interface AbstractAdapter {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    pk?: string | null,
+    pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number>;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -502,6 +502,36 @@ describe("sqlForInsert", () => {
     );
     expect(sql).toContain('RETURNING "id", "created_at"');
   });
+
+  it("does NOT append pk-derived RETURNING when pk is false (Rails opt-out)", () => {
+    // Mirrors Rails sql_for_insert: pk=false signals the caller does not
+    // want any pk-derived RETURNING column. extractTableRefFromInsertSql /
+    // primaryKey lookup must be skipped too.
+    const host: DatabaseStatementsHost = {
+      supportsInsertReturning: () => true,
+      quoteColumnName: (c) => `"${c}"`,
+      primaryKey: () => {
+        throw new Error("primaryKey() must not be called when pk=false");
+      },
+    };
+    const [sql] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", false, [], null);
+    expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
+  });
+
+  it("still honours explicit returning list when pk=false", () => {
+    const host: DatabaseStatementsHost = {
+      supportsInsertReturning: () => true,
+      quoteColumnName: (c) => `"${c}"`,
+    };
+    const [sql] = sqlForInsert.call(
+      host,
+      "INSERT INTO t (x) VALUES (1)",
+      false,
+      [],
+      ["created_at"],
+    );
+    expect(sql).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "created_at"`);
+  });
 });
 
 describe("arelFromRelation", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -392,7 +392,7 @@ export function execInsert(
   sql: string,
   name?: string | null,
   binds: unknown[] = [],
-  pk?: string | null,
+  pk?: string | false | null,
   _sequenceName?: string | null,
   returning?: string[] | null,
 ): Promise<Result> {
@@ -1377,7 +1377,7 @@ export const DatabaseStatements = {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    _pk?: string | null,
+    _pk?: string | false | null,
     _sequenceName?: string | null,
   ): Promise<number> {
     return this.executeMutation(sql, binds, name ?? "SQL");
@@ -1789,13 +1789,16 @@ export async function select(
 export function sqlForInsert(
   this: DatabaseStatementsHost,
   sql: string,
-  pk: string | null | undefined,
+  pk: string | false | null | undefined,
   binds: unknown[],
   returning: string[] | null | undefined,
 ): [string, unknown[]] {
   if (this.supportsInsertReturning?.()) {
-    let resolvedPk = pk;
-    if (resolvedPk == null) {
+    // Mirrors Rails: `pk == false` is the explicit caller opt-out — skip
+    // any pk-derived RETURNING column (caller may still pass `returning:`
+    // for an alternate column list).
+    let resolvedPk: string | null | undefined = pk === false ? null : pk;
+    if (pk !== false && resolvedPk == null) {
       const tableRef = extractTableRefFromInsertSql.call(this, sql);
       if (tableRef) resolvedPk = this.primaryKey?.(tableRef) ?? null;
     }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -19,7 +19,12 @@ export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
-  execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;
+  execInsert(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    pk?: string | false | null,
+  ): Promise<unknown>;
   explain(arel: unknown, binds?: unknown[], options?: ExplainOption[]): Promise<string>;
   lastInsertedId(result: unknown): number;
   highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1757,12 +1757,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sql: string,
     name?: string | null,
     binds: unknown[] = [],
-    pk?: string | null,
+    pk?: string | boolean | null,
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {
-    if (this._useInsertReturning) {
-      return super.execInsert(sql, name, binds, pk as string | null, sequenceName, returning);
+    // Mirrors Rails: `if use_insert_returning? || pk == false`. `pk === false`
+    // is the explicit caller opt-out for "this table has no PK / don't fetch
+    // the inserted id" (Rails passes false from InsertAll for skip-rows).
+    if (this._useInsertReturning || pk === false) {
+      return super.execInsert(
+        sql,
+        name,
+        binds,
+        pk === false ? null : ((pk as string | null | undefined) ?? null),
+        sequenceName,
+        returning,
+      );
     }
     // Resolve sequence name before acquiring the INSERT client so the
     // metadata queries (primaryKey, defaultSequenceName) don't consume
@@ -1771,7 +1781,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const tableRef = extractTableRefFromInsertSql.call(this as never, sql);
       if (tableRef) {
         if (pk == null) pk = (await this.primaryKey(tableRef)) as string | null;
-        const resolvedPk = suppressCompositePrimaryKey(pk ?? undefined);
+        const pkStr = typeof pk === "string" ? pk : null;
+        const resolvedPk = suppressCompositePrimaryKey(pkStr ?? undefined);
         sequenceName = resolvedPk ? await this.defaultSequenceName(tableRef, resolvedPk) : null;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1761,13 +1761,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {
-    // Mirrors Rails: `if use_insert_returning? || pk == false`. `pk === false`
-    // is the explicit caller opt-out for "this table has no PK / don't fetch
-    // the inserted id" (Rails passes false from InsertAll for skip-rows).
-    // Pass `false` (not null) through to super so the abstract sqlForInsert
-    // takes the false-opt-out branch and does NOT auto-resolve a RETURNING
-    // column from the table's primary key.
-    if (this._useInsertReturning || pk === false) {
+    // Mirrors Rails: `if use_insert_returning? || pk == false`.
+    if (pk === false) {
+      // Explicit caller opt-out: skip the pk-derived RETURNING column.
+      // Cannot delegate to super here — our mixed-in DatabaseStatements
+      // default routes through executeMutation, which auto-appends
+      // `RETURNING id` for bare INSERTs when use_insert_returning is on
+      // (postgresql-adapter.ts:1238-1243). That would defeat the opt-out.
+      // Instead: honour an explicit `returning:` arg ourselves, then
+      // run via execQuery which executes the SQL as-is.
+      if (returning && returning.length > 0) {
+        const cols = returning.map((c) => this.quoteColumnName(c)).join(", ");
+        sql = `${sql} RETURNING ${cols}`;
+      }
+      return this.execQuery(sql, name, binds);
+    }
+    if (this._useInsertReturning) {
       return super.execInsert(sql, name, binds, pk, sequenceName, returning);
     }
     // Resolve sequence name before acquiring the INSERT client so the

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1757,22 +1757,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sql: string,
     name?: string | null,
     binds: unknown[] = [],
-    pk?: string | boolean | null,
+    pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {
     // Mirrors Rails: `if use_insert_returning? || pk == false`. `pk === false`
     // is the explicit caller opt-out for "this table has no PK / don't fetch
     // the inserted id" (Rails passes false from InsertAll for skip-rows).
+    // Pass `false` (not null) through to super so the abstract sqlForInsert
+    // takes the false-opt-out branch and does NOT auto-resolve a RETURNING
+    // column from the table's primary key.
     if (this._useInsertReturning || pk === false) {
-      return super.execInsert(
-        sql,
-        name,
-        binds,
-        pk === false ? null : ((pk as string | null | undefined) ?? null),
-        sequenceName,
-        returning,
-      );
+      return super.execInsert(sql, name, binds, pk, sequenceName, returning);
     }
     // Resolve sequence name before acquiring the INSERT client so the
     // metadata queries (primaryKey, defaultSequenceName) don't consume

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1768,13 +1768,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // default routes through executeMutation, which auto-appends
       // `RETURNING id` for bare INSERTs when use_insert_returning is on
       // (postgresql-adapter.ts:1238-1243). That would defeat the opt-out.
-      // Instead: honour an explicit `returning:` arg ourselves, then
-      // run via execQuery which executes the SQL as-is.
+      // Cannot use execQuery either — it intentionally skips
+      // materializeTransactions / dirtyCurrentTransaction (read-path
+      // optimisation), so an INSERT inside a lazy transaction would
+      // escape rollback. Use the same write-path scaffolding the
+      // pk-non-false branch below uses, just without the currval probe.
       if (returning && returning.length > 0) {
         const cols = returning.map((c) => this.quoteColumnName(c)).join(", ");
         sql = `${sql} RETURNING ${cols}`;
       }
-      return this.execQuery(sql, name, binds);
+      this.checkIfWriteQuery(sql);
+      await this.materializeTransactions();
+      return this.withClient(async (client) => {
+        this.dirtyCurrentTransaction();
+        return this._instrumentedQueryOnClient(client, sql, name ?? "SQL", binds);
+      });
     }
     if (this._useInsertReturning) {
       return super.execInsert(sql, name, binds, pk, sequenceName, returning);

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -32,7 +32,7 @@ export interface DatabaseStatements {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    pk?: string,
+    pk?: string | false | null,
     sequenceName?: string,
   ): Promise<unknown>;
   // Mirrors: database_statements.rb:7

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -36,7 +36,11 @@ export class Interval extends ValueType<Duration> {
       try {
         return Duration.parse(value);
       } catch {
-        return null;
+        // PG round-trips intervals in its verbose form ("3 years 2 mons",
+        // "00:01:00.123456", "-1 year") rather than the ISO8601 input
+        // string. Duration.parse only accepts ISO8601, so fall back to a
+        // PG-format parser for AVG(interval) and pg_get_expr defaults.
+        return parsePgInterval(value);
       }
     }
     if (typeof value === "number") {
@@ -70,4 +74,38 @@ export class Interval extends ValueType<Duration> {
     // Rails: `serialize(value).inspect` — quote the string for schema dump.
     return `"${serialized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
+}
+
+const PG_FIELD_RE =
+  /(-?\d+)\s+(year|years|mon|mons|month|months|day|days|hour|hours|minute|minutes|second|seconds)/g;
+const PG_TIME_RE = /(-)?(\d+):(\d+):(\d+)(?:\.(\d+))?/;
+
+function parsePgInterval(raw: string): Duration | null {
+  const value = raw.trim();
+  if (value === "") return null;
+  let totalSeconds = 0;
+  let matched = false;
+  for (const [, num, unit] of value.matchAll(PG_FIELD_RE)) {
+    const n = Number(num);
+    if (Number.isNaN(n)) continue;
+    matched = true;
+    if (unit.startsWith("year")) totalSeconds += n * 365.25 * 24 * 3600;
+    else if (unit.startsWith("mon")) totalSeconds += n * 30 * 24 * 3600;
+    else if (unit.startsWith("day")) totalSeconds += n * 24 * 3600;
+    else if (unit.startsWith("hour")) totalSeconds += n * 3600;
+    else if (unit.startsWith("minute")) totalSeconds += n * 60;
+    else if (unit.startsWith("second")) totalSeconds += n;
+  }
+  const tm = PG_TIME_RE.exec(value);
+  if (tm) {
+    matched = true;
+    const sign = tm[1] === "-" ? -1 : 1;
+    const h = Number(tm[2]);
+    const m = Number(tm[3]);
+    const s = Number(tm[4]);
+    const frac = tm[5] ? Number(`0.${tm[5]}`) : 0;
+    totalSeconds += sign * (h * 3600 + m * 60 + s + frac);
+  }
+  if (!matched) return null;
+  return Duration.build(totalSeconds);
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -37,8 +37,11 @@ export class Interval extends ValueType<Duration> {
         return Duration.parse(value);
       } catch {
         // Mirrors Rails: rescue ISO8601Parser::ParsingError → nil. Our
-        // PG adapter sets `intervalstyle = iso_8601` per session so all
-        // SELECT/AVG/pg_get_expr interval results arrive in ISO 8601 form.
+        // PG adapter sets `intervalstyle = iso_8601` per session so AVG
+        // and SELECT interval results arrive in ISO 8601 form. (Note:
+        // pg_get_expr does NOT honour intervalstyle for interval defaults
+        // — that path needs separate handling, see the deferred
+        // "schema dump with default value" test in interval.test.ts.)
         return null;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -36,11 +36,10 @@ export class Interval extends ValueType<Duration> {
       try {
         return Duration.parse(value);
       } catch {
-        // PG round-trips intervals in its verbose form ("3 years 2 mons",
-        // "00:01:00.123456", "-1 year") rather than the ISO8601 input
-        // string. Duration.parse only accepts ISO8601, so fall back to a
-        // PG-format parser for AVG(interval) and pg_get_expr defaults.
-        return parsePgInterval(value);
+        // Mirrors Rails: rescue ISO8601Parser::ParsingError → nil. Our
+        // PG adapter sets `intervalstyle = iso_8601` per session so all
+        // SELECT/AVG/pg_get_expr interval results arrive in ISO 8601 form.
+        return null;
       }
     }
     if (typeof value === "number") {
@@ -74,38 +73,4 @@ export class Interval extends ValueType<Duration> {
     // Rails: `serialize(value).inspect` — quote the string for schema dump.
     return `"${serialized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
-}
-
-const PG_FIELD_RE =
-  /(-?\d+)\s+(year|years|mon|mons|month|months|day|days|hour|hours|minute|minutes|second|seconds)/g;
-const PG_TIME_RE = /(-)?(\d+):(\d+):(\d+)(?:\.(\d+))?/;
-
-function parsePgInterval(raw: string): Duration | null {
-  const value = raw.trim();
-  if (value === "") return null;
-  let totalSeconds = 0;
-  let matched = false;
-  for (const [, num, unit] of value.matchAll(PG_FIELD_RE)) {
-    const n = Number(num);
-    if (Number.isNaN(n)) continue;
-    matched = true;
-    if (unit.startsWith("year")) totalSeconds += n * 365.25 * 24 * 3600;
-    else if (unit.startsWith("mon")) totalSeconds += n * 30 * 24 * 3600;
-    else if (unit.startsWith("day")) totalSeconds += n * 24 * 3600;
-    else if (unit.startsWith("hour")) totalSeconds += n * 3600;
-    else if (unit.startsWith("minute")) totalSeconds += n * 60;
-    else if (unit.startsWith("second")) totalSeconds += n;
-  }
-  const tm = PG_TIME_RE.exec(value);
-  if (tm) {
-    matched = true;
-    const sign = tm[1] === "-" ? -1 : 1;
-    const h = Number(tm[2]);
-    const m = Number(tm[3]);
-    const s = Number(tm[4]);
-    const frac = tm[5] ? Number(`0.${tm[5]}`) : 0;
-    totalSeconds += sign * (h * 3600 + m * 60 + s + frac);
-  }
-  if (!matched) return null;
-  return Duration.build(totalSeconds);
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -28,7 +28,12 @@ export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
-  execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;
+  execInsert(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    pk?: string | false | null,
+  ): Promise<unknown>;
   explain(sql: string, binds?: unknown[]): Promise<string>;
   lastInsertedId(result: unknown): number;
 }

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -510,7 +510,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    pk?: string | null,
+    pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2602,7 +2602,7 @@ export class Relation<T extends Base> {
   async calculate(
     operation: "average",
     column: string,
-  ): Promise<number | null | Record<string, number>>;
+  ): Promise<unknown | null | Record<string, unknown>>;
   async calculate(
     operation: "minimum" | "maximum",
     column: string,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -105,8 +105,29 @@ function castAggValue(val: unknown, fn: AggFn, colType: unknown, coerceNumeric: 
     return Number(val ?? 0);
   }
 
-  // count / average: always a JS number.
+  // For average over non-numeric column types (e.g. PG interval), route the
+  // raw aggregate value through the column type's deserialize so callers
+  // get a domain object (Duration) rather than a stringified driver value.
+  if (fn === "average" && colType != null && !isNumericLikeType(colType)) {
+    const ct = colType as { deserialize?(v: unknown): unknown };
+    if (typeof ct.deserialize === "function") return ct.deserialize(val);
+  }
+  // count / average over numeric columns: JS number.
   return Number(val);
+}
+
+function isNumericLikeType(colType: unknown): boolean {
+  if (colType == null || typeof colType !== "object") return true;
+  const name = (colType as { type?(): string }).type?.();
+  if (!name) return true;
+  return (
+    name === "integer" ||
+    name === "bigint" ||
+    name === "float" ||
+    name === "decimal" ||
+    name === "numeric" ||
+    name === "boolean"
+  );
 }
 
 function buildAggNode(table: any, fn: AggFn, column: string, distinct: boolean): any {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -421,12 +421,18 @@ export async function performSum(
 export async function performAverage(
   this: CalculationRelation,
   column: string,
-): Promise<number | null | Record<string, number>> {
+): Promise<unknown | null | Record<string, unknown>> {
+  // Returns `unknown` (not just number) because non-numeric column types
+  // — interval (Duration), money, time — route through the column type's
+  // deserialize and yield a domain object. Rails' AVG return type is
+  // similarly polymorphic (BigDecimal for integer/decimal, Duration for
+  // interval, etc.). Numeric averages still narrow to JS number at the
+  // call site.
   if (this._isNone) return this._groupColumns.length > 0 ? {} : null;
   if (this._groupColumns.length > 0) {
-    return groupedAggregate(this, "average", column, true) as Promise<Record<string, number>>;
+    return groupedAggregate(this, "average", column, true);
   }
-  return singleAggregate(this, "average", column, true) as Promise<number | null>;
+  return singleAggregate(this, "average", column, true);
 }
 
 export async function performMinimum(
@@ -465,7 +471,7 @@ export async function performMaximum(
 export interface CalculationMethods {
   count(column?: string): Promise<number | Record<string, number>>;
   sum(column?: string): Promise<number | bigint | Record<string, number | bigint>>;
-  average(column: string): Promise<number | null | Record<string, number>>;
+  average(column: string): Promise<unknown | null | Record<string, unknown>>;
   minimum(column: string): Promise<unknown | null | Record<string, unknown>>;
   maximum(column: string): Promise<unknown | null | Record<string, unknown>>;
 }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -105,27 +105,38 @@ function castAggValue(val: unknown, fn: AggFn, colType: unknown, coerceNumeric: 
     return Number(val ?? 0);
   }
 
-  // For average over non-numeric column types (e.g. PG interval), route the
-  // raw aggregate value through the column type's deserialize so callers
-  // get a domain object (Duration) rather than a stringified driver value.
-  if (fn === "average" && colType != null && !isNumericLikeType(colType)) {
-    const ct = colType as { deserialize?(v: unknown): unknown };
-    if (typeof ct.deserialize === "function") return ct.deserialize(val);
+  // Mirrors Rails ActiveRecord::Calculations#type_cast_calculated_value:
+  //   when "average"
+  //     case type.type
+  //     when :integer, :decimal then value&.to_d   # Rails: BigDecimal
+  //     else                          type.deserialize(value)
+  //     end
+  // We coerce integer/decimal averages to a JS number (documented Rails-→JS
+  // limitation). For other types — interval, time, money — route through
+  // the column type's deserialize so callers get a domain object (Duration,
+  // Time, …) rather than the raw driver string.
+  if (fn === "average" && colType != null) {
+    const typeName = (colType as { type?(): string }).type?.();
+    if (!isCoerceNumericTypeName(typeName)) {
+      const ct = colType as { deserialize?(v: unknown): unknown };
+      if (typeof ct.deserialize === "function") return ct.deserialize(val);
+    }
   }
   // count / average over numeric columns: JS number.
   return Number(val);
 }
 
-function isNumericLikeType(colType: unknown): boolean {
-  if (colType == null || typeof colType !== "object") return true;
-  const name = (colType as { type?(): string }).type?.();
+function isCoerceNumericTypeName(name: string | undefined): boolean {
   if (!name) return true;
+  // Rails maps :integer + :decimal to value&.to_d. BigInteger inherits
+  // Integer.type → :integer in Rails; our BigIntegerType.name === "big_integer"
+  // so list it explicitly. UnsignedInteger / Float are also numeric-coerce.
   return (
     name === "integer" ||
-    name === "bigint" ||
-    name === "float" ||
+    name === "big_integer" ||
     name === "decimal" ||
-    name === "numeric" ||
+    name === "float" ||
+    name === "unsigned_integer" ||
     name === "boolean"
   );
 }


### PR DESCRIPTION
## Summary

Bundles two near-done cluster closures into a single ~140 LOC PR.

- **PG interval Slot B (partial)** — `castAggValue` routes the `average` aggregate through the column type's `deserialize` for non-numeric types (interval, time, money, …), mirroring Rails' `type_cast_calculated_value` dispatch:

  ```ruby
  case type.type
  when :integer, :decimal then value&.to_d   # → JS number for us
  else                          type.deserialize(value)
  end
  ```

  Includes \`big_integer\` / \`unsigned_integer\` / \`float\` / \`boolean\` in the numeric-coerce set (BigInteger.type returns :integer in Rails; our class exposes "big_integer", so the list is explicit).

  `Interval.castValue` matches Rails exactly: `Duration.parse` + nil on failure. PG already sets `intervalstyle = iso_8601` per session in `_maybeConfigureConnection` (postgresql-adapter.ts:454), so AVG/SELECT interval results arrive in ISO 8601 form. **No verbose-format fallback parser** — Rails has none either.

  Un-skips: `average interval type`. Asserts the actual `"P3Y2M"` value.

- **PG-adapter Slot A followup (pk = false)** — widens `execInsert`'s `pk` parameter to `string | false | null` across the abstract interface, free function, default method, and `sqlForInsert`. Mirrors Rails' `if use_insert_returning? || pk == false` opt-out: when `pk === false`, skip the pk-derived RETURNING column. Callers using the shared `DatabaseAdapter` interface can now pass `false` (Copilot review #1 caught that the change was originally only effective when typed as `PostgreSQLAdapter`).

## Re-skipped (root cause documented inline)

- `schema dump with default value` (interval) — live PG CI revealed `pg_get_expr` returns interval defaults as a bare numeric (`94670856`) regardless of `intervalstyle`. The `SET` only affects SELECT/aggregate output, not pg_attrdef expression text. Real fix needs a coordinated `splitPgDefault` + `Interval.castValue` numeric→Duration round-trip (~50 LOC); deferred to a focused follow-up.

## Follow-ups deferred from the sweep prompt

- `setSchemaSearchPath` unquoted-`$user` rejection — needs PG-version validation before locking in a regex.
- 5 fixture-model gaps (`Thing1..5`, `Song`/`Album` habtm) — fixture-loader work, separate PR.
- PG-adapter Slot E (prepared-statements introspection) — its own PR per the sweep instructions.
- `_instrumentedQueryOnClient` rename/dedupe with `execQuery` — cosmetic, fold with the next PG-adapter touch.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm api:compare --package activerecord` — no regression (4952/4958, identical to main)
- [x] CI: SQLite / PG / MariaDB / Unit / Lint all green on the previous round
- [ ] Re-verify CI after the `sqlForInsert` widening