### PR TITLE
feat(activerecord): mysql changeColumn{Default,Null,Comment} + buildChangeColumnDefaultDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -616,9 +616,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // { from:, to: } change-descriptor hash. Both keys are required for
     // the unwrap branch — `{ to: "x" }` alone falls through as-is in
     // Rails too, so the type explicitly requires both.
-    commentOrChanges: string | null | { from: unknown; to: unknown },
+    commentOrChanges: string | null | { from: unknown; to: string | null },
   ): Promise<void> {
-    const comment = this.schemaStatements().extractNewCommentValue(commentOrChanges);
+    const extracted = this.schemaStatements().extractNewCommentValue(commentOrChanges);
+    // Normalize JS-only `undefined` → `null` so changeColumn doesn't
+    // misinterpret an explicit clear (`{from, to: undefined}` shape) as
+    // "no comment key present" and silently keep the existing comment.
+    // Rails has no nil/undefined split — defensive normalization, no
+    // Rails analogue.
+    const comment = extracted === undefined ? null : extracted;
     await this.changeColumn(tableName, columnName, "", { comment });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -500,47 +500,97 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     await exec.call(this, sql);
   }
 
+  /**
+   * Mirrors AbstractMysqlAdapter#change_column_default.
+   * Emits `ALTER TABLE ... ALTER COLUMN col SET DEFAULT val` (or DROP DEFAULT).
+   * MySQL's ALTER COLUMN syntax accepts a default change without re-stating
+   * the column type, unlike CHANGE COLUMN which requires a full redefinition.
+   */
   async changeColumnDefault(
     tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
-    void tableName;
-    void columnName;
-    void defaultOrChanges;
+    const newDefault = (
+      this as unknown as {
+        extractNewDefaultValue(v: unknown): unknown;
+      }
+    ).extractNewDefaultValue(defaultOrChanges);
+    const colId = this.quoteIdentifier(columnName);
+    const tbl = this.quoteTableName(tableName);
+    const sql =
+      newDefault == null
+        ? `ALTER TABLE ${tbl} ALTER COLUMN ${colId} DROP DEFAULT`
+        : `ALTER TABLE ${tbl} ALTER COLUMN ${colId} SET DEFAULT ${this.quote(newDefault)}`;
+    await this._execMutation(sql);
   }
 
-  buildChangeColumnDefaultDefinition(
+  /**
+   * Mirrors AbstractMysqlAdapter#build_change_column_default_definition.
+   * Returns a ChangeColumnDefaultDefinition the schema-creation visitor
+   * can render. Returns null when the column does not exist (matches Rails
+   * `return unless column`).
+   */
+  async buildChangeColumnDefaultDefinition(
     tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
-  ): Record<string, unknown> {
-    void tableName;
-    void columnName;
-    void defaultOrChanges;
-    return {};
+  ): Promise<{ column: unknown; default: unknown } | null> {
+    let column;
+    try {
+      column = await this.columnFor(tableName, columnName);
+    } catch {
+      return null;
+    }
+    const newDefault = (
+      this as unknown as {
+        extractNewDefaultValue(v: unknown): unknown;
+      }
+    ).extractNewDefaultValue(defaultOrChanges);
+    return { column, default: newDefault };
   }
 
+  /**
+   * Mirrors AbstractMysqlAdapter#change_column_null.
+   * Validates `null_`, backfills NULLs from `default_` when flipping to
+   * NOT NULL, then routes through change_column with `null:` set.
+   */
   async changeColumnNull(
     tableName: string,
     columnName: string,
     null_: boolean,
     default_?: unknown,
   ): Promise<void> {
-    void tableName;
-    void columnName;
-    void null_;
-    void default_;
+    (
+      this as unknown as {
+        validateChangeColumnNullArgumentBang(v: unknown): void;
+      }
+    ).validateChangeColumnNullArgumentBang(null_);
+    if (!null_ && default_ != null) {
+      const colId = this.quoteIdentifier(columnName);
+      await this._execMutation(
+        `UPDATE ${this.quoteTableName(tableName)} SET ${colId}=${this.quote(default_)} WHERE ${colId} IS NULL`,
+      );
+    }
+    await this.changeColumn(tableName, columnName, "", { null: null_ });
   }
 
+  /**
+   * Mirrors AbstractMysqlAdapter#change_column_comment.
+   * MySQL has no dedicated ALTER COMMENT syntax; mirrors Rails by routing
+   * through change_column with the resolved comment.
+   */
   async changeColumnComment(
     tableName: string,
     columnName: string,
     commentOrChanges: string | Record<string, string | null>,
   ): Promise<void> {
-    void tableName;
-    void columnName;
-    void commentOrChanges;
+    const comment = (
+      this as unknown as {
+        extractNewCommentValue(v: unknown): unknown;
+      }
+    ).extractNewCommentValue(commentOrChanges);
+    await this.changeColumn(tableName, columnName, "", { comment });
   }
 
   async changeColumn(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -47,6 +47,7 @@ import {
 } from "./mysql/quoting.js";
 import {
   ChangeColumnDefinition,
+  ChangeColumnDefaultDefinition,
   ColumnDefinition,
   CreateIndexDefinition,
   ForeignKeyDefinition,
@@ -501,53 +502,82 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Mirrors AbstractMysqlAdapter#change_column_default.
-   * Emits `ALTER TABLE ... ALTER COLUMN col SET DEFAULT val` (or DROP DEFAULT).
-   * MySQL's ALTER COLUMN syntax accepts a default change without re-stating
-   * the column type, unlike CHANGE COLUMN which requires a full redefinition.
+   * Mirrors: AbstractMysqlAdapter#change_column_default
+   *   execute "ALTER TABLE #{quote_table_name(table_name)}
+   *            #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
    */
   async changeColumnDefault(
     tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
-    const newDefault = (
-      this as unknown as {
-        extractNewDefaultValue(v: unknown): unknown;
-      }
-    ).extractNewDefaultValue(defaultOrChanges);
-    const colId = this.quoteIdentifier(columnName);
-    const tbl = this.quoteTableName(tableName);
-    const sql =
-      newDefault == null
-        ? `ALTER TABLE ${tbl} ALTER COLUMN ${colId} DROP DEFAULT`
-        : `ALTER TABLE ${tbl} ALTER COLUMN ${colId} SET DEFAULT ${this.quote(newDefault)}`;
-    await this._execMutation(sql);
+    const fragment = await this.changeColumnDefaultForAlter(
+      tableName,
+      columnName,
+      defaultOrChanges,
+    );
+    await this._execMutation(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
   }
 
   /**
-   * Mirrors AbstractMysqlAdapter#build_change_column_default_definition.
-   * Returns a ChangeColumnDefaultDefinition the schema-creation visitor
-   * can render. Returns null when the column does not exist (matches Rails
-   * `return unless column`).
+   * MySQL routes the abstract base's `change_column_default_for_alter` through
+   * `build_change_column_default_definition` + schema_creation, so the
+   * dumper-friendly visitor handles `DROP DEFAULT` vs `SET DEFAULT <expr>`.
+   *
+   *   def change_column_default_for_alter(table_name, column_name, default_or_changes)
+   *     cd = build_change_column_default_definition(table_name, column_name, default_or_changes)
+   *     schema_creation.accept(cd)
+   *   end
+   *
+   * @internal
+   */
+  async changeColumnDefaultForAlter(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): Promise<string> {
+    const cd = await this.buildChangeColumnDefaultDefinition(
+      tableName,
+      columnName,
+      defaultOrChanges,
+    );
+    return new MysqlSchemaCreation().accept(cd);
+  }
+
+  /**
+   * Mirrors: AbstractMysqlAdapter#build_change_column_default_definition.
+   *
+   *   column = column_for(table_name, column_name)
+   *   return unless column
+   *   default = extract_new_default_value(default_or_changes)
+   *   ChangeColumnDefaultDefinition.new(column, default)
+   *
+   * Rails' `column_for` itself raises ActiveRecordError when the column is
+   * missing (the `return unless column` guard is defensive against an
+   * unreachable nil branch), so we let columnFor's throw propagate the
+   * same way rather than silently returning null.
    */
   async buildChangeColumnDefaultDefinition(
     tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
-  ): Promise<{ column: unknown; default: unknown } | null> {
-    let column;
-    try {
-      column = await this.columnFor(tableName, columnName);
-    } catch {
-      return null;
-    }
+  ): Promise<ChangeColumnDefaultDefinition> {
+    const column = await this.columnFor(tableName, columnName);
     const newDefault = (
-      this as unknown as {
-        extractNewDefaultValue(v: unknown): unknown;
-      }
+      this as unknown as { extractNewDefaultValue(v: unknown): unknown }
     ).extractNewDefaultValue(defaultOrChanges);
-    return { column, default: newDefault };
+    // ChangeColumnDefaultDefinition takes a ColumnDefinition; lift the
+    // queried Column up via the same TableDefinition channel
+    // buildChangeColumnDefinition uses for column-rebuild round-trips.
+    const td = new MysqlTableDefinition(tableName, { id: false });
+    const colDef = td.newColumnDefinition(
+      column.name,
+      (column.sqlType ?? "") as never,
+      {
+        null: column.null,
+      } as never,
+    );
+    return new ChangeColumnDefaultDefinition(colDef, newDefault);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -563,7 +563,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     defaultOrChanges: unknown,
   ): Promise<ChangeColumnDefaultDefinition> {
     const column = await this.columnFor(tableName, columnName);
-    const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
+    const extracted = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
+    // Normalize JS-only `undefined` → `null` so the schema-creation
+    // visitor's SET branch produces `SET DEFAULT NULL` rather than the
+    // bare `SET` that quoteDefaultExpression(undefined) → "" would emit.
+    // Rails has no nil/undefined split, so this is TS-specific defense.
+    const newDefault = extracted === undefined ? null : extracted;
     // Match the PG adapter's shape: build ColumnDefinition with the
     // semantic type and set sqlType separately so dumper/visitor paths
     // see both. visitChangeColumnDefaultDefinition reads name +
@@ -608,7 +613,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async changeColumnComment(
     tableName: string,
     columnName: string,
-    commentOrChanges: string | Record<string, string | null>,
+    commentOrChanges: string | null | { from?: unknown; to?: unknown },
   ): Promise<void> {
     const comment = this.schemaStatements().extractNewCommentValue(commentOrChanges);
     await this.changeColumn(tableName, columnName, "", { comment });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -53,6 +53,7 @@ import {
   ForeignKeyDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
+import type { ColumnType, ColumnOptions } from "./abstract/schema-definitions.js";
 import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
 import { TypeMap } from "../type/type-map.js";
 import {
@@ -575,10 +576,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // options.null, but preserve type metadata for any downstream visitor.
     const colDef = new ColumnDefinition(
       column.name,
-      (column.type ?? "string") as never,
-      {
-        null: column.null,
-      } as never,
+      (column.type ?? "string") as ColumnType,
+      { null: column.null } as ColumnOptions,
     );
     colDef.sqlType = column.sqlType ?? undefined;
     return new ChangeColumnDefaultDefinition(colDef, newDefault);
@@ -613,7 +612,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async changeColumnComment(
     tableName: string,
     columnName: string,
-    commentOrChanges: string | null | { from?: unknown; to?: unknown },
+    // Mirrors Rails: comment is either a plain value (string|nil) or the
+    // { from:, to: } change-descriptor hash. Both keys are required for
+    // the unwrap branch — `{ to: "x" }` alone falls through as-is in
+    // Rails too, so the type explicitly requires both.
+    commentOrChanges: string | null | { from: unknown; to: unknown },
   ): Promise<void> {
     const comment = this.schemaStatements().extractNewCommentValue(commentOrChanges);
     await this.changeColumn(tableName, columnName, "", { comment });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -563,20 +563,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     defaultOrChanges: unknown,
   ): Promise<ChangeColumnDefaultDefinition> {
     const column = await this.columnFor(tableName, columnName);
-    const newDefault = (
-      this as unknown as { extractNewDefaultValue(v: unknown): unknown }
-    ).extractNewDefaultValue(defaultOrChanges);
-    // ChangeColumnDefaultDefinition takes a ColumnDefinition; lift the
-    // queried Column up via the same TableDefinition channel
-    // buildChangeColumnDefinition uses for column-rebuild round-trips.
-    const td = new MysqlTableDefinition(tableName, { id: false });
-    const colDef = td.newColumnDefinition(
+    const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
+    // Match the PG adapter's shape: build ColumnDefinition with the
+    // semantic type and set sqlType separately so dumper/visitor paths
+    // see both. visitChangeColumnDefaultDefinition reads name +
+    // options.null, but preserve type metadata for any downstream visitor.
+    const colDef = new ColumnDefinition(
       column.name,
-      (column.sqlType ?? "") as never,
+      (column.type ?? "string") as never,
       {
         null: column.null,
       } as never,
     );
+    colDef.sqlType = column.sqlType ?? undefined;
     return new ChangeColumnDefaultDefinition(colDef, newDefault);
   }
 
@@ -591,11 +590,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     null_: boolean,
     default_?: unknown,
   ): Promise<void> {
-    (
-      this as unknown as {
-        validateChangeColumnNullArgumentBang(v: unknown): void;
-      }
-    ).validateChangeColumnNullArgumentBang(null_);
+    this.schemaStatements().validateChangeColumnNullArgumentBang(null_);
     if (!null_ && default_ != null) {
       const colId = this.quoteIdentifier(columnName);
       await this._execMutation(
@@ -615,11 +610,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string,
     commentOrChanges: string | Record<string, string | null>,
   ): Promise<void> {
-    const comment = (
-      this as unknown as {
-        extractNewCommentValue(v: unknown): unknown;
-      }
-    ).extractNewCommentValue(commentOrChanges);
+    const comment = this.schemaStatements().extractNewCommentValue(commentOrChanges);
     await this.changeColumn(tableName, columnName, "", { comment });
   }
 


### PR DESCRIPTION
## Summary

Replaces four empty stubs in `AbstractMysqlAdapter` with Rails-faithful implementations. Part of the MySQL charset-collation cluster Slot B-followups (adjacent DDL stubs).

- **`changeColumnDefault`** — routes through `changeColumnDefaultForAlter` → `buildChangeColumnDefaultDefinition` → `MysqlSchemaCreation.accept(cd)`, mirroring Rails' `execute "ALTER TABLE … #{change_column_default_for_alter(…)}"` chain so dumper/visitor paths stay coherent.
- **`changeColumnDefaultForAlter`** (new helper) — MySQL-specific override of the abstract base, mirroring `def change_column_default_for_alter(t, c, d) cd = build_change_column_default_definition(...); schema_creation.accept(cd); end`.
- **`buildChangeColumnDefaultDefinition`** — calls `columnFor` (which **raises** `ActiveRecordError` on a missing column, mirroring Rails — the `return unless column` in Rails source is dead defensive code), then constructs a real `ChangeColumnDefaultDefinition` with the column's semantic type + sqlType (matching the PG adapter's pattern).
- **`changeColumnNull`** — validates the null arg via `schemaStatements().validateChangeColumnNullArgumentBang`, backfills NULLs from `default_` when flipping to NOT NULL using Rails' literal `quote()` (NOT `quoteDefaultExpression` — Rails uses `quote(default)` here too), then dispatches through `changeColumn` with `null:` set.
- **`changeColumnComment`** — resolves the new comment via `schemaStatements().extractNewCommentValue`, accepts `string | null | { from, to }` (Rails accepts nil to clear).

### Defensive normalization

`extractNewDefaultValue` can return `undefined` from a JS hash like `{from:'a', to:undefined}` — Rails' Ruby has no undefined/nil split. Normalize undefined → null in `buildChangeColumnDefaultDefinition` so the schema-creation visitor emits `SET DEFAULT NULL` rather than the bare `SET` that `quoteDefaultExpression(undefined) → ""` would produce.

## Follow-ups deferred

- **MySQL charset-collation Slot A** (`createTable id: { type, collation }` hash form + `ColumnOptions.charset` + "add column with charset and collation" un-skip) — needs MySQL TableDefinition / SchemaCreation type plumbing, sized for its own PR.
- **MySQL schema Slot C fixtures** (`posts`/`key_tests`/`lessons_students`/`topics`/`students` defineFixtures + qualified-table subclassing) — fixtures-loader work, separate PR.
- **MySQL schema-definitions stubs** (`validColumnDefinitionOptions`, `aliasedTypes`, `integerLikePrimaryKeyType`) — `@nie` annotated; carry no test impact today, fold with charset-collation Slot A.
- **Targeted SQL-fragment unit tests** for the new methods — would require mocking `columnFor` since the existing abstract-mysql test suite is live-DB-only. Defer with the charset-collation tests.

## Test plan

- [x] `pnpm build` passes
- [x] All CI suites green on previous round (SQLite/PG/MariaDB/Unit/Lint)
- [x] `pnpm api:compare --package activerecord` — `abstract_mysql_adapter.rb` 92/92 (100%)