### PR TITLE
feat(activerecord): connection-pool Slot C — shard-selector wiring + prohibitShardSwapping

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -183,6 +183,11 @@ export interface DatabaseAdapter {
   isNoDatabaseError(error: unknown): boolean;
 
   /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#preventing_writes?
+   */
+  isPreventingWrites(): boolean;
+
+  /**
    * Execute a SQL query and return rows.
    */
   execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]>;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1081,6 +1081,7 @@ export class Base extends Model {
   declare static clearCacheBang: typeof ConnectionHandling.clearCacheBang;
   declare static shardKeys: typeof ConnectionHandling.shardKeys;
   declare static isSharded: typeof ConnectionHandling.isSharded;
+  declare static defaultShard: typeof ConnectionHandling.defaultShard;
   /** @internal */
   declare static withRoleAndShard: typeof ConnectionHandling.withRoleAndShard;
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -712,10 +712,19 @@ export class AbstractAdapter implements Quoting {
     if (pool?.preventWrites === true) return true;
     if (pool?.dbConfig?.preventWrites === true) return true;
     if (this._config.preventWrites === true) return true;
-    // Mirror Rails: connection_descriptor.current_preventing_writes — read from stack
+    // Mirrors Rails: connection_descriptor.current_preventing_writes
+    // Filter by the pool's owner class name so an unrelated abstract-class
+    // connected_to block doesn't affect this adapter's connection scope.
+    const ownerName: string | undefined = pool?.poolConfig?.connectionDescriptor?.name;
     const stack = connectedToStack();
     for (let i = stack.length - 1; i >= 0; i--) {
-      if (stack[i].preventWrites !== undefined) return stack[i].preventWrites!;
+      const entry = stack[i];
+      if (entry.preventWrites === undefined) continue;
+      for (const k of entry.klasses) {
+        if (typeof k === "function" && (k.name === ownerName || k.name === "Base")) {
+          return entry.preventWrites;
+        }
+      }
     }
     return false;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -91,6 +91,7 @@ import {
   BinaryType,
   DecimalType,
 } from "@blazetrails/activemodel";
+import { connectedToStack } from "../core.js";
 import { Text as TextType } from "../type/text.js";
 import { Date as DateType } from "../type/date.js";
 import { Time as TimeType } from "../type/time.js";
@@ -711,6 +712,11 @@ export class AbstractAdapter implements Quoting {
     if (pool?.preventWrites === true) return true;
     if (pool?.dbConfig?.preventWrites === true) return true;
     if (this._config.preventWrites === true) return true;
+    // Mirror Rails: connection_descriptor.current_preventing_writes — read from stack
+    const stack = connectedToStack();
+    for (let i = stack.length - 1; i >= 0; i--) {
+      if (stack[i].preventWrites !== undefined) return stack[i].preventWrites!;
+    }
     return false;
   }
 

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
@@ -57,13 +57,59 @@ describe("ConnectionHandlersMultiDbTest", () => {
     // SCOPE: permanent skip-list.ts candidate
   });
   it.skip("loading relations with multi db connections", () => {
-    // BLOCKED: connection-pool — needs connects_to with in-memory SQLite + DDL + insert; Slot C
+    // BLOCKED: connection-pool — needs AR model + lazy Relation loading across roles; Slot C-b
   });
-  it.skip("establish connection using 3 levels config", () => {
-    // BLOCKED: connection-pool — pool.dbConfig.database assertion requires file-backed DB; Slot C
+
+  it("establish connection using 3 levels config", () => {
+    withBaseConfigs(
+      {
+        default_env: {
+          readonly: { adapter: "sqlite3", database: ":memory:", replica: true },
+          default: { adapter: "sqlite3", database: ":memory:" },
+        },
+      },
+      () => {
+        Base.connectsTo({ database: { writing: "default", reading: "readonly" } });
+
+        const writingPool = Base.connectionHandler.retrieveConnectionPool("Base");
+        expect(writingPool).not.toBeNull();
+        expect(writingPool!.dbConfig.name).toBe("default");
+
+        const readingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "reading",
+        });
+        expect(readingPool).not.toBeNull();
+        expect(readingPool!.dbConfig.name).toBe("readonly");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
-  it.skip("establish connection using 3 levels config with non default handlers", () => {
-    // BLOCKED: connection-pool — pool.dbConfig.database assertion requires file-backed DB; Slot C
+
+  it("establish connection using 3 levels config with non default handlers", () => {
+    withBaseConfigs(
+      {
+        default_env: {
+          readonly: { adapter: "sqlite3", database: ":memory:" },
+          primary: { adapter: "sqlite3", database: ":memory:" },
+        },
+      },
+      () => {
+        Base.connectsTo({ database: { default: "primary", readonly: "readonly" } });
+
+        const defaultPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "default",
+        });
+        expect(defaultPool).not.toBeNull();
+        expect(defaultPool!.dbConfig.name).toBe("primary");
+
+        const readonlyPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "readonly",
+        });
+        expect(readonlyPool).not.toBeNull();
+        expect(readonlyPool!.dbConfig.name).toBe("readonly");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
 
   it("switching connections with database url", () => {

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -97,6 +97,10 @@ describe("ConnectionHandlersShardingDbTest", () => {
   });
 
   it("retrieve connection pool with invalid shard", () => {
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "Base", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: "Base" },
+    );
     expect(Base.connectionHandler.retrieveConnectionPool("Base")).not.toBeUndefined();
     expect(Base.connectionHandler.retrieveConnectionPool("Base", { shard: "foo" })).toBeUndefined();
   });

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -1,99 +1,184 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { Base } from "../base.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
+import { currentRole } from "../core.js";
 
 describe("ConnectionHandlersShardingDbTest", () => {
+  afterEach(() => {
+    Base.connectionHandler.clearAllConnectionsBang();
+    (Base as any)._shardKeys = undefined;
+    (Base as any)._defaultShard = undefined;
+    (Base as any).connectionClass = undefined;
+  });
+
   it.skip("establishing a connection in connected to block uses current role and shard", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — needs file-backed DB; establish_connection inside connected_to
   });
   it.skip("establish connection using 3 levels config", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — shard config lookup + pool name assertions; Slot C-b
   });
   it.skip("establish connection using 3 levels config with shards and replica", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — shard config lookup + pool name assertions; Slot C-b
   });
-  it.skip("switching connections via handler", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("switching connections via handler", () => {
+    const makePool = (name: string, role: string, shard: string, replica = false) =>
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", name, {
+          adapter: "sqlite3",
+          database: ":memory:",
+          ...(replica ? { replica: true } : {}),
+        }),
+        { owner: "Base", role, shard, adapterFactory: () => new SQLite3Adapter() },
+      );
+
+    try {
+      makePool("primary", "writing", "default");
+      makePool("primary_replica", "reading", "default", true);
+      makePool("primary_shard_one", "writing", "shard_one");
+      makePool("primary_shard_one_replica", "reading", "shard_one", true);
+      (Base as any)._shardKeys = ["default", "shard_one"];
+
+      Base.connectedTo({ role: "reading", shard: "default" }, () => {
+        expect(currentRole.call(Base as any)).toBe("reading");
+        expect(Base.connectedToQ({ role: "reading", shard: "default" })).toBe(true);
+        expect(Base.connectedToQ({ role: "writing", shard: "default" })).toBe(false);
+        expect(Base.connectedToQ({ role: "reading", shard: "shard_one" })).toBe(false);
+        expect(Base.leaseConnection().isPreventingWrites()).toBe(true);
+      });
+
+      Base.connectedTo({ role: "writing", shard: "default" }, () => {
+        expect(currentRole.call(Base as any)).toBe("writing");
+        expect(Base.connectedToQ({ role: "writing", shard: "default" })).toBe(true);
+        expect(Base.connectedToQ({ role: "reading", shard: "default" })).toBe(false);
+        expect(Base.connectedToQ({ role: "writing", shard: "shard_one" })).toBe(false);
+        expect(Base.leaseConnection().isPreventingWrites()).toBe(false);
+      });
+
+      Base.connectedTo({ role: "reading", shard: "shard_one" }, () => {
+        expect(currentRole.call(Base as any)).toBe("reading");
+        expect(Base.connectedToQ({ role: "reading", shard: "shard_one" })).toBe(true);
+        expect(Base.connectedToQ({ role: "writing", shard: "shard_one" })).toBe(false);
+        expect(Base.connectedToQ({ role: "reading", shard: "default" })).toBe(false);
+        expect(Base.leaseConnection().isPreventingWrites()).toBe(true);
+      });
+
+      Base.connectedTo({ role: "writing", shard: "shard_one" }, () => {
+        expect(currentRole.call(Base as any)).toBe("writing");
+        expect(Base.connectedToQ({ role: "writing", shard: "shard_one" })).toBe(true);
+        expect(Base.connectedToQ({ role: "reading", shard: "shard_one" })).toBe(false);
+        expect(Base.connectedToQ({ role: "writing", shard: "default" })).toBe(false);
+        expect(Base.leaseConnection().isPreventingWrites()).toBe(false);
+      });
+    } finally {
+      Base.connectionHandler.clearAllConnectionsBang();
+      (Base as any)._shardKeys = undefined;
+    }
   });
+
   it.skip("retrieves proper connection with nested connected to", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — nested shard switching; Slot C-b
   });
-  it.skip("connected to raises without a shard or role", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("connected to raises without a shard or role", () => {
+    expect(() => Base.connectedTo({} as any, () => {})).toThrow(
+      /must provide a `shard` and\/or `role`/,
+    );
   });
-  it.skip("connects to raises with a shard and database key", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("connects to raises with a shard and database key", () => {
+    expect(() =>
+      Base.connectsTo({
+        database: { writing: "arunit" },
+        shards: { s: { writing: "arunit" } },
+      } as any),
+    ).toThrow(/can only accept a `database` or `shards` argument/);
   });
-  it.skip("retrieve connection pool with invalid shard", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("retrieve connection pool with invalid shard", () => {
+    expect(Base.connectionHandler.retrieveConnectionPool("Base")).not.toBeUndefined();
+    expect(Base.connectionHandler.retrieveConnectionPool("Base", { shard: "foo" })).toBeUndefined();
   });
+
   it.skip("calling connected to on a non existent shard raises", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — Slot C-b
   });
   it.skip("calling connected to on a non existent role for shard raises", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — Slot C-b
   });
   it.skip("calling connected to on a default role for non existent shard raises", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — Slot C-b
   });
-  it.skip("cannot swap shards while prohibited", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("cannot swap shards while prohibited", () => {
+    const makePool = (shard: string) =>
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", shard, { adapter: "sqlite3", database: ":memory:" }),
+        { owner: "Base", role: "writing", shard },
+      );
+    try {
+      makePool("default");
+      makePool("shard_one");
+      expect(() => {
+        Base.prohibitShardSwapping(() => {
+          Base.connectedTo({ role: "reading", shard: "default" }, () => {});
+        });
+      }).toThrow(/cannot swap `shard` while shard swapping is prohibited/);
+    } finally {
+      Base.connectionHandler.clearAllConnectionsBang();
+    }
   });
-  it.skip("can swap roles while shard swapping is prohibited", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("can swap roles while shard swapping is prohibited", () => {
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "Base", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: "Base", role: "reading", shard: "default" },
+    );
+    expect(() => {
+      Base.prohibitShardSwapping(() => {
+        Base.connectedTo({ role: "reading" }, () => {});
+      });
+    }).not.toThrow();
   });
-  it.skip("default shard is chosen by first key or default", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("default shard is chosen by first key or default", () => {
+    class SecondaryBase extends Base {
+      static override abstractClass = true;
+    }
+    class SomeOtherBase extends Base {
+      static override abstractClass = true;
+    }
+    try {
+      SecondaryBase.connectsTo({
+        shards: { not_default: { writing: { database: ":memory:", adapter: "sqlite3" } } },
+      });
+      SomeOtherBase.connectsTo({
+        database: { writing: { database: ":memory:", adapter: "sqlite3" } },
+      });
+      expect(SecondaryBase.defaultShard()).toBe("not_default");
+      expect(SomeOtherBase.defaultShard()).toBe("default");
+    } finally {
+      Base.connectionHandler.clearAllConnectionsBang();
+    }
   });
+
   it.skip("same shards across clusters", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — multi-cluster shard isolation with real DB; Slot C-b
   });
   it.skip("sharding separation", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+    // BLOCKED: connection-pool — per-shard DB isolation with real DDL/DML; Slot C-b
   });
   it.skip("swapping shards globally in a multi threaded environment", () => {
     // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
     // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
   });
   it.skip("swapping shards and roles in a multi threaded environment", () => {
     // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
     // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
   });
   it.skip("swapping granular shards and roles in a multi threaded environment", () => {
     // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // ROOT-CAUSE: Node.js has no Thread.new / GVL; concurrent connection tests cannot translate
     // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
   });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -78,6 +78,8 @@ export function connectsTo(
   // Mirrors: @shard_keys = shards.keys (before injecting :default for database: usage)
   (this as any)._shardKeys = Object.keys(shards);
   const shardEntries = Object.keys(shards).length > 0 ? shards : { default: database };
+  // Mirrors: self.default_shard = shards.keys.first
+  (this as any)._defaultShard = Object.keys(shardEntries)[0] ?? "default";
   (this as any).connectionClass = true;
 
   const rawConfigs = (this as any).configurations;
@@ -399,6 +401,11 @@ export function isSharded(this: typeof Base): boolean {
   return shardKeys.call(this).length > 0;
 }
 
+export function defaultShard(this: typeof Base): string {
+  const connClass = this.connectionClassForSelf();
+  return (connClass as any)._defaultShard ?? "default";
+}
+
 // --- Private helpers ---
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
@@ -493,13 +500,7 @@ export function appendToConnectedToStack(entry: {
   klasses: Set<any>;
 }): void {
   if (isShardSwappingProhibited() && entry.shard) {
-    // Check if the shard would actually change
-    for (const klass of entry.klasses) {
-      const current = coreCurrentShard.call(klass);
-      if (current !== entry.shard) {
-        throw new ArgumentError("cannot swap `shard` while shard swapping is prohibited.");
-      }
-    }
+    throw new ArgumentError("cannot swap `shard` while shard swapping is prohibited.");
   }
   connectedToStack().push(entry);
 }
@@ -820,6 +821,7 @@ export const ClassMethods = {
   clearCacheBang,
   shardKeys,
   isSharded,
+  defaultShard,
   withRoleAndShard,
   appendToConnectedToStack,
 };

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -363,7 +363,8 @@ export function currentShard(this: CoreHost): string {
       return entry.shard;
     }
   }
-  return "default";
+  // Mirrors Rails: default_shard (class_attribute, set by connects_to)
+  return (connClass as any)._defaultShard ?? "default";
 }
 
 export function currentPreventingWrites(this: CoreHost): boolean {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -155,6 +155,10 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return this.inner.isNoDatabaseError(error);
   }
 
+  isPreventingWrites(): boolean {
+    return this.inner.isPreventingWrites();
+  }
+
   readonly inner: DatabaseAdapter;
   readonly cache: QueryCacheStore;
   private _queryCount = 0;

--- a/packages/activerecord/src/shard-selector.test.ts
+++ b/packages/activerecord/src/shard-selector.test.ts
@@ -1,24 +1,70 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { Base } from "./base.js";
+import { ShardSelector } from "./middleware/shard-selector.js";
+import { createTestAdapter } from "./test-adapter.js";
+import { HashConfig } from "./database-configurations/hash-config.js";
 
 describe("ShardSelectorTest", () => {
-  it.skip("middleware locks to shard by default", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+  afterEach(() => {
+    Base.connectionHandler.clearAllConnectionsBang();
   });
-  it.skip("middleware can turn off lock option", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  function setupShards() {
+    const dbConfig = new HashConfig("test", "Base", { adapter: "sqlite3", database: ":memory:" });
+    Base.connectionHandler.establishConnection(dbConfig, {
+      owner: "Base",
+      role: "writing",
+      shard: "shard_one",
+      adapterFactory: createTestAdapter,
+    });
+  }
+
+  it("middleware locks to shard by default", async () => {
+    const middleware = new ShardSelector(
+      async () => {
+        expect(Base.isShardSwappingProhibited()).toBe(true);
+        return [200, {}, ["body"]];
+      },
+      () => "shard_one",
+    );
+    setupShards();
+    expect(await middleware.call({ method: "GET" })).toEqual([200, {}, ["body"]]);
   });
-  it.skip("middleware can change shards", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("middleware can turn off lock option", async () => {
+    const middleware = new ShardSelector(
+      async () => {
+        expect(Base.isShardSwappingProhibited()).toBe(false);
+        return [200, {}, ["body"]];
+      },
+      () => "shard_one",
+      { lock: false },
+    );
+    setupShards();
+    expect(await middleware.call({ method: "GET" })).toEqual([200, {}, ["body"]]);
   });
-  it.skip("middleware can handle string shards", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("middleware can change shards", async () => {
+    setupShards();
+    const middleware = new ShardSelector(
+      async () => {
+        expect(Base.connectedToQ({ role: "writing", shard: "shard_one" })).toBe(true);
+        return [200, {}, ["body"]];
+      },
+      () => "shard_one",
+    );
+    expect(await middleware.call({ method: "GET" })).toEqual([200, {}, ["body"]]);
+  });
+
+  it("middleware can handle string shards", async () => {
+    setupShards();
+    const middleware = new ShardSelector(
+      async () => {
+        expect(Base.connectedToQ({ role: "writing", shard: "shard_one" })).toBe(true);
+        return [200, {}, ["body"]];
+      },
+      () => "shard_one",
+    );
+    expect(await middleware.call({ method: "GET" })).toEqual([200, {}, ["body"]]);
   });
 });

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -558,6 +558,10 @@ class SchemaAdapter implements DatabaseAdapter {
     return this.inner.isNoDatabaseError(error);
   }
 
+  isPreventingWrites(): boolean {
+    return this.inner.isPreventingWrites();
+  }
+
   private inner: DatabaseAdapter;
 
   constructor(inner: DatabaseAdapter) {


### PR DESCRIPTION
## Summary

- `defaultShard()` on Base: set by `connectsTo` to first shard key, or `"default"` for `database:` usage — mirrors `self.default_shard = shards.keys.first` in Rails
- `isPreventingWrites()` reads from the connected-to stack (mirrors Rails `connection_descriptor.current_preventing_writes`); added to `DatabaseAdapter` interface; wired in `QueryCacheAdapter` and `SchemaAdapter`
- `appendToConnectedToStack`: throw on ANY shard entry while swapping is prohibited — was only throwing when the shard would change; Rails throws unconditionally (`entry[:shard].present?`)
- 13 tests un-skipped across 3 files; 12 sharding tests remain for Slot C-b

## Tests un-skipped

| File | Tests |
|------|-------|
| `shard-selector.test.ts` | middleware locks by default, can turn off lock, can change shards, can handle string shards (4) |
| `connection-handlers-sharding-db.test.ts` | switching connections via handler, cannot swap shards while prohibited, can swap roles while prohibited, connected_to raises without shard/role, connects_to raises with shard+database, invalid shard pool, default shard chosen by first key (7) |
| `connection-handlers-multi-db.test.ts` | establish connection using 3 levels config, establish connection using 3 levels config with non-default handlers (2) |

## Slot C-b follow-ups (sized ~200 LOC)

- `sharding separation` — per-shard DB isolation with real DDL/DML
- `same shards across clusters` — multi-cluster shard isolation
- `retrieves proper connection with nested connected to` — nested shard switching
- `establish connection using 3 levels config` (sharding file, shards: form)
- `establish connection using 3 levels config with shards and replica`
- `calling connected to on a non-existent shard raises` (3 variants)
- `loading relations with multi db connections` (needs AR model + lazy Relation loading)

## LOC note

375 LOC (additions + deletions), slightly over the 300 ceiling. The overage is 88 deletions from replacing old verbose stub comments with shorter ones across 12 sharding test stubs — not new implementation lines.

## Test plan
- [ ] `pnpm test packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts` — 7 pass, 12 skip
- [ ] `pnpm test packages/activerecord/src/shard-selector.test.ts` — 4 pass
- [ ] `pnpm test packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts` — 15 pass, 2 skip
- [ ] `pnpm test packages/activerecord/src/connection-adapters/` — 1137 pass, 264 skip