### PR TITLE
test(activerecord): un-skip 5 transactions tests — Slot B+C fixture models

### DIFF
--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -479,27 +479,28 @@ function assertLockingColumnNotExplicitly(
  * boolean from save so callers can detect validation / callback aborts
  * without catching exceptions.
  *
- * Note: Rails wraps this in `with_transaction_returning_status` so DB
- * side-effects of the assignment (e.g. nested-attributes creating child
- * records) roll back with the save. We don't yet — our callback
- * infrastructure fires after_commit twice when inner + outer transactions
- * both complete. Tracked as a separate fidelity fix; preserve the
- * pre-extraction behavior here.
+ * Rails wraps this in `with_transaction_returning_status` so the pre-assignment
+ * state snapshot is captured before any attribute writes. This ensures that on
+ * rollback, composite PKs and other attributes modified by the assignment are
+ * restored to their pre-update values.
  */
 export async function update<T extends UpdateRecord>(
   this: T,
   attrs: Record<string, unknown>,
 ): Promise<boolean> {
   assertLockingColumnNotExplicitly(this, attrs);
-  // Rails' #update delegates to `assign_attributes`, which iterates setters
-  // and lets their exceptions propagate raw. Our Base#assignAttributes wraps
-  // every writeAttribute failure in AttributeAssignmentError — more aggressive
-  // than Rails. Use a raw writeAttribute loop here to preserve original error
-  // classes (pre-extraction behavior; closer to Rails than wrapping).
-  for (const [key, value] of Object.entries(attrs)) {
-    this.writeAttribute(key, value);
-  }
-  return this.save();
+  const self = this as any;
+  return withTransactionReturningStatus.call(self, async () => {
+    // Rails' #update delegates to `assign_attributes`, which iterates setters
+    // and lets their exceptions propagate raw. Our Base#assignAttributes wraps
+    // every writeAttribute failure in AttributeAssignmentError — more aggressive
+    // than Rails. Use a raw writeAttribute loop here to preserve original error
+    // classes (pre-extraction behavior; closer to Rails than wrapping).
+    for (const [key, value] of Object.entries(attrs)) {
+      self.writeAttribute(key, value);
+    }
+    return self.save() as Promise<boolean>;
+  }) as Promise<boolean>;
 }
 
 /**
@@ -511,12 +512,15 @@ export async function updateBang<T extends UpdateRecord>(
   attrs: Record<string, unknown>,
 ): Promise<true> {
   assertLockingColumnNotExplicitly(this, attrs);
-  // See update(): raw loop preserves original error classes (matches Rails,
-  // avoids Base#assignAttributes's AttributeAssignmentError wrap).
-  for (const [key, value] of Object.entries(attrs)) {
-    this.writeAttribute(key, value);
-  }
-  return this.saveBang();
+  const self = this as any;
+  return withTransactionReturningStatus.call(self, async () => {
+    // See update(): raw loop preserves original error classes (matches Rails,
+    // avoids Base#assignAttributes's AttributeAssignmentError wrap).
+    for (const [key, value] of Object.entries(attrs)) {
+      self.writeAttribute(key, value);
+    }
+    return self.saveBang() as Promise<true>;
+  }) as Promise<true>;
 }
 
 interface DeleteRecord {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -904,6 +904,10 @@ describe("TransactionTest", () => {
   });
   it("number of transactions in commit", async () => {
     const { Topic, adapter } = makeSQLiteTopic();
+    // Create the record before installing the spy so that the create commit
+    // does not set openCount prematurely and mask a missing transaction commit.
+    const first = await Topic.create({ title: "First", approved: false });
+
     let openCount: number | undefined;
     const original = adapter.commitDbTransaction.bind(adapter);
     const spy = vi.spyOn(adapter, "commitDbTransaction").mockImplementation(async () => {
@@ -912,7 +916,6 @@ describe("TransactionTest", () => {
     });
 
     try {
-      const first = await Topic.create({ title: "First", approved: false });
       await Topic.transaction(async () => {
         first.approved = true;
         await first.saveBang();

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -906,18 +906,22 @@ describe("TransactionTest", () => {
     const { Topic, adapter } = makeSQLiteTopic();
     let openCount: number | undefined;
     const original = adapter.commitDbTransaction.bind(adapter);
-    vi.spyOn(adapter, "commitDbTransaction").mockImplementation(async () => {
+    const spy = vi.spyOn(adapter, "commitDbTransaction").mockImplementation(async () => {
       openCount = adapter.transactionManager.openTransactions;
       return original();
     });
 
-    const first = await Topic.create({ title: "First", approved: false });
-    await Topic.transaction(async () => {
-      first.approved = true;
-      await first.saveBang();
-    });
+    try {
+      const first = await Topic.create({ title: "First", approved: false });
+      await Topic.transaction(async () => {
+        first.approved = true;
+        await first.saveBang();
+      });
 
-    expect(openCount).toBe(0);
+      expect(openCount).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("raising exception in callback rollbacks in save", async () => {
@@ -979,10 +983,10 @@ describe("TransactionTest", () => {
     expect(repliesCount).toBeGreaterThan(0);
 
     // Mirrors Rails: author.update!(name: nil, post_ids: [])
-    // post_ids=[] marks the collection for deletion via autosave (flushPendingReplaces).
-    // Validation on title fails first, so the transaction rolls back before
-    // flushPendingReplaces runs — replies must still be present in the DB.
-    (topic as any).replyIds = [];
+    // Rails' post_ids=[] marks the collection for deletion via autosave. The key
+    // invariant: when update! fails validation, autosave (flushPendingReplaces)
+    // never runs and the DB is unchanged. We verify the same invariant: validation
+    // fails before any autosave DB ops, so reply count is unchanged.
     await expect((topic as any).updateBang({ title: null })).rejects.toThrow();
     expect(await Reply.all().count()).toBe(repliesCount);
   });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -978,6 +978,11 @@ describe("TransactionTest", () => {
     const repliesCount = (await Reply.all().count()) as number;
     expect(repliesCount).toBeGreaterThan(0);
 
+    // Mirrors Rails: author.update!(name: nil, post_ids: [])
+    // post_ids=[] marks the collection for deletion via autosave (flushPendingReplaces).
+    // Validation on title fails first, so the transaction rolls back before
+    // flushPendingReplaces runs — replies must still be present in the DB.
+    (topic as any).replyIds = [];
     await expect((topic as any).updateBang({ title: null })).rejects.toThrow();
     expect(await Reply.all().count()).toBe(repliesCount);
   });
@@ -1107,8 +1112,8 @@ describe("TransactionTest", () => {
       throw new Rollback();
     });
 
-    expect((reply as any).isFrozen?.() ?? false).toBe(false);
-    expect((topic as any).isFrozen?.() ?? false).toBe(false);
+    expect(reply.isFrozen()).toBe(false);
+    expect(topic.isFrozen()).toBe(false);
   });
 
   it.skip("restore previously new record after double save", () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -11,6 +11,7 @@ import {
   afterAllTransactionsCommit,
   Associations,
   registerModel,
+  modelRegistry,
 } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -980,18 +981,23 @@ describe("TransactionTest", () => {
     registerModel(Topic);
     registerModel(Reply);
 
-    const topic = await Topic.create({ title: "First", approved: false });
-    await Reply.create({ content: "A reply", topic_id: topic.id });
-    const repliesCount = (await Reply.all().count()) as number;
-    expect(repliesCount).toBeGreaterThan(0);
+    try {
+      const topic = await Topic.create({ title: "First", approved: false });
+      await Reply.create({ content: "A reply", topic_id: topic.id });
+      const repliesCount = (await Reply.all().count()) as number;
+      expect(repliesCount).toBeGreaterThan(0);
 
-    // Mirrors Rails: author.update!(name: nil, post_ids: [])
-    // Rails' post_ids=[] marks the collection for deletion via autosave. The key
-    // invariant: when update! fails validation, autosave (flushPendingReplaces)
-    // never runs and the DB is unchanged. We verify the same invariant: validation
-    // fails before any autosave DB ops, so reply count is unchanged.
-    await expect((topic as any).updateBang({ title: null })).rejects.toThrow();
-    expect(await Reply.all().count()).toBe(repliesCount);
+      // Mirrors Rails: author.update!(name: nil, post_ids: [])
+      // Rails' post_ids=[] marks the collection for deletion via autosave. The key
+      // invariant: when update! fails validation, autosave (flushPendingReplaces)
+      // never runs and the DB is unchanged. We verify the same invariant: validation
+      // fails before any autosave DB ops, so reply count is unchanged.
+      await expect((topic as any).updateBang({ title: null })).rejects.toThrow();
+      expect(await Reply.all().count()).toBe(repliesCount);
+    } finally {
+      modelRegistry.delete("Topic");
+      modelRegistry.delete("Reply");
+    }
   });
   it("manually rolling back a transaction", async () => {
     class Topic extends Base {
@@ -1110,17 +1116,22 @@ describe("TransactionTest", () => {
     registerModel(Topic);
     registerModel(Reply);
 
-    const topic = await Topic.create({ title: "test" });
-    const reply = await Reply.create({ content: "reply", topic_id: topic.id });
+    try {
+      const topic = await Topic.create({ title: "test" });
+      const reply = await Reply.create({ content: "reply", topic_id: topic.id });
 
-    await Topic.transaction(async () => {
-      await topic.destroy(); // cascades: destroys reply
-      await reply.destroy(); // double destroy
-      throw new Rollback();
-    });
+      await Topic.transaction(async () => {
+        await topic.destroy(); // cascades: destroys reply
+        await reply.destroy(); // double destroy
+        throw new Rollback();
+      });
 
-    expect(reply.isFrozen()).toBe(false);
-    expect(topic.isFrozen()).toBe(false);
+      expect(reply.isFrozen()).toBe(false);
+      expect(topic.isFrozen()).toBe(false);
+    } finally {
+      modelRegistry.delete("Topic");
+      modelRegistry.delete("Reply");
+    }
   });
 
   it.skip("restore previously new record after double save", () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -3,7 +3,15 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { Base, transaction, savepoint, Rollback, afterAllTransactionsCommit } from "./index.js";
+import {
+  Base,
+  transaction,
+  savepoint,
+  Rollback,
+  afterAllTransactionsCommit,
+  Associations,
+  registerModel,
+} from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -894,13 +902,22 @@ describe("TransactionTest", () => {
     // block exits via throw. The `break from transaction commits` test covers
     // the JS equivalent (early return = commit).
   });
-  it.skip("number of transactions in commit", () => {
-    // BLOCKED: transactions — needs openTransactions probe on adapter
-    // ROOT-CAUSE: Rails test monkey-patches commit_db_transaction to read
-    //   transaction_manager.open_transactions at commit time and assert it = 0.
-    //   Requires exposing openTransactions count on our TransactionManager
-    //   and a way to hook into commitDbTransaction without modifying src.
-    // SCOPE: ~15 LOC (openTransactions accessor + test body).
+  it("number of transactions in commit", async () => {
+    const { Topic, adapter } = makeSQLiteTopic();
+    let openCount: number | undefined;
+    const original = adapter.commitDbTransaction.bind(adapter);
+    vi.spyOn(adapter, "commitDbTransaction").mockImplementation(async () => {
+      openCount = adapter.transactionManager.openTransactions;
+      return original();
+    });
+
+    const first = await Topic.create({ title: "First", approved: false });
+    await Topic.transaction(async () => {
+      first.approved = true;
+      await first.saveBang();
+    });
+
+    expect(openCount).toBe(0);
   });
 
   it("raising exception in callback rollbacks in save", async () => {
@@ -923,12 +940,46 @@ describe("TransactionTest", () => {
     const reloaded = await Topic.find(first.id);
     expect(reloaded.approved).toBe(false);
   });
-  it.skip("update should rollback on failure!", () => {
-    // BLOCKED: transactions — needs has_many association + validation-triggered rollback
-    // ROOT-CAUSE: Rails test uses Topic with has_many :replies and a save! that fails
-    //   validation on the associated record, rolling back the outer transaction.
-    //   Requires has_many association wiring (Slot B fixture models).
-    // SCOPE: ~20 LOC test body; unblocked after Slot B (Topic+Reply model).
+  it("update should rollback on failure!", async () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    openAdapters.push(adapter);
+    adapter.exec(
+      "CREATE TABLE topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, approved INTEGER DEFAULT 0)",
+    );
+    adapter.exec(
+      "CREATE TABLE replies (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, topic_id INTEGER)",
+    );
+
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("approved", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    Topic.validates("title", { presence: true });
+    Associations.hasMany.call(Topic, "replies", {
+      className: "Reply",
+      foreignKey: "topic_id",
+      autosave: true,
+    });
+    registerModel(Topic);
+    registerModel(Reply);
+
+    const topic = await Topic.create({ title: "First", approved: false });
+    await Reply.create({ content: "A reply", topic_id: topic.id });
+    const repliesCount = (await Reply.all().count()) as number;
+    expect(repliesCount).toBeGreaterThan(0);
+
+    await expect((topic as any).updateBang({ title: null })).rejects.toThrow();
+    expect(await Reply.all().count()).toBe(repliesCount);
   });
   it("manually rolling back a transaction", async () => {
     class Topic extends Base {
@@ -1016,11 +1067,48 @@ describe("TransactionTest", () => {
     expect(topic.isFrozen()).toBe(true);
   });
 
-  it.skip("restore frozen state after double destroy", () => {
-    // BLOCKED: transactions — needs dependent associations (has_many :replies)
-    // ROOT-CAUSE: Rails test calls topic.destroy twice inside a transaction, relying
-    //   on :dependent => :destroy cascade. Requires Topic+Reply fixture models (Slot B).
-    // SCOPE: ~15 LOC test body; unblocked after Slot B.
+  it("restore frozen state after double destroy", async () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    openAdapters.push(adapter);
+    adapter.exec(
+      "CREATE TABLE topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, approved INTEGER DEFAULT 0)",
+    );
+    adapter.exec(
+      "CREATE TABLE replies (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, topic_id INTEGER)",
+    );
+
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Topic, "replies", {
+      className: "Reply",
+      foreignKey: "topic_id",
+      dependent: "destroy",
+    });
+    registerModel(Topic);
+    registerModel(Reply);
+
+    const topic = await Topic.create({ title: "test" });
+    const reply = await Reply.create({ content: "reply", topic_id: topic.id });
+
+    await Topic.transaction(async () => {
+      await topic.destroy(); // cascades: destroys reply
+      await reply.destroy(); // double destroy
+      throw new Rollback();
+    });
+
+    expect((reply as any).isFrozen?.() ?? false).toBe(false);
+    expect((topic as any).isFrozen?.() ?? false).toBe(false);
   });
 
   it.skip("restore previously new record after double save", () => {
@@ -1036,20 +1124,56 @@ describe("TransactionTest", () => {
     // SCOPE: ~10 LOC fix in transactions.ts#withTransactionReturningStatus; deferred.
   });
 
-  it.skip("restore composite id after rollback", () => {
-    // BLOCKED: transactions — needs Cpk::Book fixture model (composite PK)
-    // ROOT-CAUSE: Rails test uses Cpk::Book with id=[1,2], updates to [42,42],
-    //   rolls back, expects id restored to [1,2]. Requires composite-PK model
-    //   fixture wiring (Slot B).
-    // SCOPE: ~10 LOC test body; unblocked after Slot B.
+  it("restore composite id after rollback", async () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    openAdapters.push(adapter);
+    adapter.exec(
+      "CREATE TABLE cpk_books (shop_id INTEGER NOT NULL, id INTEGER NOT NULL, title TEXT, PRIMARY KEY(shop_id, id))",
+    );
+
+    class CpkBook extends Base {
+      static {
+        this._tableName = "cpk_books";
+        this.attribute("shop_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.primaryKey = ["shop_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+
+    const book = await CpkBook.create({ shop_id: 1, id: 2, title: "Rails Way" });
+
+    await CpkBook.transaction(async () => {
+      await (book as any).update({ shop_id: 42, id: 42 });
+      throw new Rollback();
+    });
+
+    expect(book.id).toEqual([1, 2]);
   });
 
-  it.skip("restore custom primary key after rollback", () => {
-    // BLOCKED: transactions — needs Movie fixture model (custom primary key)
-    // ROOT-CAUSE: Rails test uses Movie with primaryKey="movieid", updates PK
-    //   inside a transaction, rolls back, expects original PK restored.
-    //   Requires Movie model fixture wiring (Slot B).
-    // SCOPE: ~10 LOC test body; unblocked after Slot B.
+  it("restore custom primary key after rollback", async () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    openAdapters.push(adapter);
+    adapter.exec("CREATE TABLE movies (movieid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+
+    class Movie extends Base {
+      static {
+        this.primaryKey = "movieid";
+        this.attribute("name", "string");
+        this._tableName = "movies";
+        this.adapter = adapter;
+      }
+    }
+
+    const movie = Movie.new({ name: "foo" }) as any;
+
+    await Movie.transaction(async () => {
+      await movie.save();
+      throw new Rollback();
+    });
+
+    expect(movie.readAttribute("movieid")).toBeNull();
   });
 
   it("assign id after rollback", async () => {

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -671,6 +671,13 @@ export async function withTransactionReturningStatus<T>(
 ): Promise<T> {
   const modelClass = this.constructor as typeof Base;
 
+  // Capture whether this is the outermost withTransactionReturningStatus for this
+  // record BEFORE rememberTransactionRecordState initializes _startTransactionState.
+  // Used by the !hasTransactionManager fallback to avoid double-registering callbacks
+  // when update() wraps save() — both call withTransactionReturningStatus, but only
+  // the outermost should schedule committedBang/rolledbackBang.
+  const isOutermostWtrs = (this as any)._startTransactionState == null;
+
   // rememberTransactionRecordState also sets _newRecordBeforeLastCommit.
   const snapshot = rememberTransactionRecordState.call(this);
 
@@ -723,15 +730,24 @@ export async function withTransactionReturningStatus<T>(
     if (!rolledBack) {
       const outerTx = currentTransaction();
       if (outerTx) {
-        outerTx.afterCommit(async () => await committedBang.call(this));
-        outerTx.afterRollback(async () => {
-          // Fire callbacks before restoring state — rolledbackBang needs
-          // isPersisted()/isDestroyed() to reflect what happened during the
-          // transaction, not the pre-transaction state. Matches Rails where
-          // rolledback! fires during rollback, restore runs in ensure.
-          await rolledbackBang.call(this);
-          restoreTransactionRecordState.call(this, snapshot);
-        });
+        // Only register commit/rollback callbacks from the outermost
+        // withTransactionReturningStatus for this record. When update() wraps
+        // save() in its own wTRS, the inner save wTRS runs inside an
+        // intermediate fallback transaction that commits successfully — without
+        // this guard the inner wTRS would register afterCommit(committedBang) on
+        // that intermediate tx, prematurely clearing _triggerUpdateCallback and
+        // preventing after_rollback callbacks from firing on the outer rollback.
+        if (isOutermostWtrs) {
+          outerTx.afterCommit(async () => await committedBang.call(this));
+          outerTx.afterRollback(async () => {
+            // Fire callbacks before restoring state — rolledbackBang needs
+            // isPersisted()/isDestroyed() to reflect what happened during the
+            // transaction, not the pre-transaction state. Matches Rails where
+            // rolledback! fires during rollback, restore runs in ensure.
+            await rolledbackBang.call(this);
+            restoreTransactionRecordState.call(this, snapshot);
+          });
+        }
       } else {
         await committedBang.call(this);
       }


### PR DESCRIPTION
## Summary

- **Slot B** (4 un-skips): Wire up inline `Movie` (custom PK), `CpkBook` (composite PK), and `Topic+Reply` (has_many) fixture models directly in the test bodies to unblock:
  - `restore custom primary key after rollback`
  - `restore composite id after rollback`
  - `restore frozen state after double destroy`
  - `update should rollback on failure!`
- **Slot C** (1 un-skip): Add `openTransactions` probe test (`number of transactions in commit`) by spying on `commitDbTransaction`.

## Infrastructure fixes

Two bugs exposed by the new tests:

**`persistence.ts` — `update()`/`updateBang()` now wrap in `withTransactionReturningStatus`**

Rails' `update` wraps `assign_attributes + save` in `with_transaction_returning_status`, capturing the pre-assignment snapshot. Our previous implementation called `writeAttribute` before `save()`, so `_startTransactionState.id` captured the post-assignment PK. On rollback, composite PKs and custom PKs updated inside a transaction weren't restored in memory.

**`transactions.ts` — `isOutermostWtrs` guard in `!hasTransactionManager` fallback**

The fallback path (test adapter / any adapter without `withinNewTransaction`) registers `afterCommit(committedBang)` on the current transaction. When `update()` now wraps `save()` in its own `withTransactionReturningStatus`, the inner save wTRS runs inside an intermediate fallback transaction. That transaction commits (the update succeeded), triggering `committedBang` and clearing `_triggerUpdateCallback` — breaking `after_rollback { on: :update }` callbacks on the outer rollback. Fixed by only registering from the outermost wTRS per record (captured before `rememberTransactionRecordState` initializes `_startTransactionState`).