### PR TITLE
feat(vendor): wave 4 — derive PACKAGES + add resolvePath helper

### DIFF
--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -1,20 +1,18 @@
 import * as path from "path";
 
+import { apiComparePackages } from "../../vendor/sources.js";
+
 export const SCRIPT_DIR = __dirname;
 export const ROOT_DIR = path.resolve(SCRIPT_DIR, "../..");
 export const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
 
-export const PACKAGES = [
-  "arel",
-  "activemodel",
-  "activerecord",
-  "activesupport",
-  "actiondispatch",
-  "actioncontroller",
-  "abstractcontroller",
-  "actionview",
-  "trailties",
-];
+/**
+ * Derived from vendor/sources.ts (single source of truth). Package entries
+ * with `compareApi: false` (rack, globalid today) are filtered out — they're
+ * vendored for test-compare but not yet wired into extract-ruby-api.rb.
+ * A future wave wires them in and the filter naturally goes away.
+ */
+export const PACKAGES = apiComparePackages();
 
 /** Override package → directory mapping when they differ */
 export const PACKAGE_DIR_OVERRIDES: Record<string, string> = {

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { SOURCES, type UpstreamSource, validateSources } from "./sources.js";
+import {
+  apiComparePackages,
+  resolvePath,
+  SOURCES,
+  type UpstreamSource,
+  validateSources,
+  vendoredRoot,
+} from "./sources.js";
 
 describe("vendor/sources.ts", () => {
   it("loads without throwing (wave 1 invariant holds)", () => {
@@ -34,7 +41,9 @@ describe("vendor/sources.ts", () => {
     const rack = SOURCES.find((s) => s.name === "rack");
     expect(rack).toBeDefined();
     expect(rack!.origin.ref).toBe("v3.1.14");
-    expect(rack!.packages).toEqual([{ name: "rack", libPath: "lib", testPath: "test" }]);
+    expect(rack!.packages).toEqual([
+      { name: "rack", libPath: "lib", testPath: "test", compareApi: false },
+    ]);
   });
 
   it("declares the globalid source (wave 3)", () => {
@@ -45,7 +54,9 @@ describe("vendor/sources.ts", () => {
       url: "https://github.com/rails/globalid.git",
       ref: "v1.3.0",
     });
-    expect(gid!.packages).toEqual([{ name: "globalid", libPath: "lib", testPath: "test" }]);
+    expect(gid!.packages).toEqual([
+      { name: "globalid", libPath: "lib", testPath: "test", compareApi: false },
+    ]);
   });
 
   it("vendor/sources.lock.json has an entry for every source (commit invariant)", async () => {
@@ -102,6 +113,40 @@ describe("vendor/sources.ts", () => {
       },
     ];
     expect(() => validateSources(bad)).toThrow(/duplicate package name "shared"/);
+  });
+
+  it("resolvePath returns absolute lib path for a known package", () => {
+    const p = resolvePath("activerecord");
+    expect(p.endsWith("vendor/rails/activerecord/lib/active_record")).toBe(true);
+  });
+
+  it("resolvePath('test') returns absolute test path", () => {
+    const p = resolvePath("activerecord", "test");
+    expect(p.endsWith("vendor/rails/activerecord/test/cases")).toBe(true);
+  });
+
+  it("resolvePath throws for unknown package", () => {
+    expect(() => resolvePath("nope")).toThrow(/no package named "nope"/);
+  });
+
+  it("resolvePath throws when test requested for package without testPath", () => {
+    expect(() => resolvePath("abstractcontroller", "test")).toThrow(/no testPath/);
+  });
+
+  it("vendoredRoot returns absolute source root", () => {
+    expect(vendoredRoot("rails").endsWith("vendor/rails")).toBe(true);
+  });
+
+  it("vendoredRoot throws for unknown source", () => {
+    expect(() => vendoredRoot("nope")).toThrow(/no source named "nope"/);
+  });
+
+  it("apiComparePackages excludes compareApi:false entries (rack, globalid)", () => {
+    const pkgs = apiComparePackages();
+    expect(pkgs).not.toContain("rack");
+    expect(pkgs).not.toContain("globalid");
+    expect(pkgs).toContain("activerecord");
+    expect(pkgs).toContain("abstractcontroller");
   });
 
   it("validateSources rejects missing libPath", () => {

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -149,6 +149,27 @@ describe("vendor/sources.ts", () => {
     expect(pkgs).toContain("abstractcontroller");
   });
 
+  it("apiComparePackages returns exactly the historic 9-entry api-compare set", () => {
+    // Bulletproofs against a future PR that accidentally toggles compareApi on
+    // an api-compared package, or adds/drops a Rails subgem from SOURCES
+    // without updating extract-ruby-api.rb. If extract-ruby-api.rb's PACKAGE_DIRS
+    // gets derived from SOURCES (a future wave), this assertion needs to grow
+    // with it — that's the intended forcing function.
+    expect(apiComparePackages().sort()).toEqual(
+      [
+        "abstractcontroller",
+        "actioncontroller",
+        "actiondispatch",
+        "actionview",
+        "activemodel",
+        "activerecord",
+        "activesupport",
+        "arel",
+        "trailties",
+      ].sort(),
+    );
+  });
+
   it("validateSources rejects missing libPath", () => {
     const bad: UpstreamSource[] = [
       {

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -1,3 +1,6 @@
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 // Upstream Ruby source registry.
 //
 // Single source of truth for which upstream gems we mirror, where to fetch
@@ -16,12 +19,21 @@ export interface GitOrigin {
 }
 
 export interface PackageEntry {
-  /** Logical package key; surfaces in api-compare's PACKAGES. */
+  /** Logical package key; surfaces in api-compare's PACKAGES when compareApi !== false. */
   name: string;
   /** Path relative to the source's vendored root. */
   libPath: string;
   /** Path relative to the source's vendored root; omitted = test-compare ignores. */
   testPath?: string;
+  /**
+   * Default true. Set to false to vendor the source (so test-compare or other
+   * tooling can read it) without including it in the api-compare PACKAGES
+   * derivation. rack and globalid are vendored today but not yet api-compared
+   * — extract-ruby-api.rb's PACKAGE_DIRS doesn't have entries for them. A
+   * future wave wires them in and removes this flag (see post-merge findings
+   * on PRs #1561 / #1578).
+   */
+  compareApi?: boolean;
 }
 
 export interface UpstreamSource {
@@ -104,7 +116,7 @@ export const SOURCES: readonly UpstreamSource[] = [
       url: "https://github.com/rack/rack.git",
       ref: "v3.1.14",
     },
-    packages: [{ name: "rack", libPath: "lib", testPath: "test" }],
+    packages: [{ name: "rack", libPath: "lib", testPath: "test", compareApi: false }],
   },
   {
     name: "globalid",
@@ -113,7 +125,7 @@ export const SOURCES: readonly UpstreamSource[] = [
       url: "https://github.com/rails/globalid.git",
       ref: "v1.3.0",
     },
-    packages: [{ name: "globalid", libPath: "lib", testPath: "test" }],
+    packages: [{ name: "globalid", libPath: "lib", testPath: "test", compareApi: false }],
   },
 ];
 
@@ -148,3 +160,49 @@ export function validateSources(sources: readonly UpstreamSource[]): void {
 }
 
 validateSources(SOURCES);
+
+const VENDOR_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Absolute path to a vendored package's `lib` (default) or `test` dir, e.g.
+ * `resolvePath("activerecord")` → `/.../vendor/rails/activerecord/lib/active_record`.
+ * Throws if the package isn't in SOURCES, or if `kind` is "test" but the
+ * package has no `testPath`.
+ */
+export function resolvePath(packageName: string, kind: "lib" | "test" = "lib"): string {
+  for (const source of SOURCES) {
+    for (const pkg of source.packages) {
+      if (pkg.name !== packageName) continue;
+      if (kind === "test") {
+        if (!pkg.testPath) {
+          throw new Error(`vendor/sources.ts: package "${packageName}" has no testPath`);
+        }
+        return resolve(VENDOR_DIR, source.name, pkg.testPath);
+      }
+      return resolve(VENDOR_DIR, source.name, pkg.libPath);
+    }
+  }
+  throw new Error(`vendor/sources.ts: no package named "${packageName}"`);
+}
+
+/**
+ * Names of packages eligible for api-compare's PACKAGES list — every package
+ * across all sources whose compareApi flag isn't explicitly set to false.
+ * Wave 4: feeds scripts/api-compare/config.ts so PACKAGES becomes derived
+ * instead of a hand-maintained literal that drifts from SOURCES.
+ */
+export function apiComparePackages(): string[] {
+  return SOURCES.flatMap((s) => s.packages)
+    .filter((p) => p.compareApi !== false)
+    .map((p) => p.name);
+}
+
+/**
+ * Absolute path to a vendored source's clone root, e.g.
+ * `vendoredRoot("rails")` → `/.../vendor/rails`. Throws on unknown name.
+ */
+export function vendoredRoot(sourceName: string): string {
+  const found = SOURCES.find((s) => s.name === sourceName);
+  if (!found) throw new Error(`vendor/sources.ts: no source named "${sourceName}"`);
+  return join(VENDOR_DIR, sourceName);
+}


### PR DESCRIPTION
Wave 4 of the unified Ruby source-fetcher plan ([docs/ruby-source-fetcher-plan.md](docs/ruby-source-fetcher-plan.md)). Foundation step that makes `vendor/sources.ts` the single source of truth for `api-compare`'s PACKAGES list and exposes path-resolution helpers for downstream consumers.

## Summary

- **`vendor/sources.ts`**:
  - `PackageEntry` gains optional `compareApi` flag (default `true`). rack and globalid set `compareApi: false` — they're vendored for test-compare but not yet wired into `extract-ruby-api.rb`'s `PACKAGE_DIRS`. A future wave wires them in and the flags go away (per post-merge findings on #1561 / #1578).
  - **New helpers**: `resolvePath(name, kind?)`, `apiComparePackages()`, `vendoredRoot(name)`.
- **`scripts/api-compare/config.ts`**: `PACKAGES = apiComparePackages()`. Derivation produces exactly the same 9 entries as the prior literal — just no longer drift-prone.
- **`vendor/sources.test.ts`**: 7 new tests (resolvePath happy/error paths, vendoredRoot, apiComparePackages excludes `compareApi:false`). 16 → 23 tests.

## Smoke test
- `pnpm api:compare --package activemodel`: **621/621 (100%)**, no regression.

## What's deferred
- **`extract-ruby-api.rb`'s `PACKAGE_DIRS` stays hardcoded** in this PR. A future wave (4b or 6) replaces it with derivation when rack+globalid PACKAGE_DIRS entries land. Keeping the Ruby side untouched here makes the wave bounded.
- **Wave 5**: `test-compare` adopts `resolvePath()`.
- **Wave 6**: rack + globalid wired into `extract-ruby-api.rb`; `compareApi: false` flags removed from sources.ts.

## Stats
- Net **+101 LOC** (118 add / 17 del). Within the ~150 LOC budget for wave 4.

## Test plan
- [x] 23 vendor tests pass.
- [x] api:compare smoke green.
- [ ] CI green.