### PR TITLE
feat(test-compare): --cached + --incomplete flags, add globalid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
       - name: Extract Ruby API
         run: cd scripts/api-compare && RAILS_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rails) ruby extract-ruby-api.rb
       - name: Extract Ruby tests
-        run: cd scripts/test-compare && RAILS_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rails) RACK_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rack) ruby extract-ruby-tests.rb
+        run: cd scripts/test-compare && RAILS_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rails) RACK_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rack) GLOBALID_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths globalid) ruby extract-ruby-tests.rb
       - name: API comparison
         run: pnpm exec tsx scripts/api-compare/extract-ts-api.ts && pnpm exec tsx scripts/api-compare/compare.ts
       - name: API comparison (privates)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
     "lint:deps": "pnpm vendor:fetch --source rails && RAILS_DIR=$(pnpm -s vendor:fetch --print-paths rails) ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
-    "test:compare": "pnpm vendor:fetch && RAILS_DIR=$(pnpm -s vendor:fetch --print-paths rails) RACK_DIR=$(pnpm -s vendor:fetch --print-paths rack) ruby scripts/test-compare/extract-ruby-tests.rb && pnpm tsx scripts/test-compare/extract-ts-tests.ts && pnpm tsx scripts/test-compare/test-compare.ts",
+    "test:compare": "bash scripts/test-compare/run.sh",
     "test:stubs": "pnpm test:compare -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",
     "stats:sync": "pnpm tsx scripts/sync-stats/sync.ts",
     "parity:validate": "ajv compile -s scripts/parity/canonical/schema.schema.json -s scripts/parity/canonical/query.schema.json --spec=draft2020",

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -23,6 +23,10 @@ RACK_DIR = ENV.fetch("RACK_DIR") do
   abort "extract-ruby-tests.rb: RACK_DIR env var not set. Caller must export " \
         "it via `RACK_DIR=$(pnpm -s vendor:fetch --print-paths rack)`."
 end
+GLOBALID_DIR = ENV.fetch("GLOBALID_DIR") do
+  abort "extract-ruby-tests.rb: GLOBALID_DIR env var not set. Caller must export " \
+        "it via `GLOBALID_DIR=$(pnpm -s vendor:fetch --print-paths globalid)`."
+end
 OUTPUT_DIR = File.join(SCRIPT_DIR, "output")
 
 # Map packages to their test directories
@@ -36,6 +40,7 @@ PACKAGE_TEST_DIRS = {
   "actioncontroller" => File.join(RAILS_DIR, "actionpack", "test"),
   "actionview" => File.join(RAILS_DIR, "actionview", "test"),
   "trailties" => File.join(RAILS_DIR, "railties", "test"),
+  "globalid" => File.join(GLOBALID_DIR, "test", "cases"),
 }
 
 # Files/directories to skip (infrastructure, not actual tests)
@@ -526,6 +531,9 @@ def run
   end
   unless File.directory?(RACK_DIR)
     abort "Rack source not found at #{RACK_DIR}. Run `pnpm vendor:fetch` first."
+  end
+  unless File.directory?(GLOBALID_DIR)
+    abort "GlobalID source not found at #{GLOBALID_DIR}. Run `pnpm vendor:fetch` first."
   end
 
   Dir.mkdir(OUTPUT_DIR) unless File.directory?(OUTPUT_DIR)

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -17,6 +17,7 @@ function getPackageTestFiles(): Record<string, string[]> {
     "rack",
     "actionview",
     "trailties",
+    "globalid",
   ];
   const packageAliases: Record<string, string> = {};
   const result: Record<string, string[]> = {};

--- a/scripts/test-compare/run.sh
+++ b/scripts/test-compare/run.sh
@@ -34,12 +34,13 @@ if [[ "$USE_CACHE" -eq 1 ]]; then
 fi
 
 if [[ "$CACHE_HIT" -eq 0 ]]; then
-  pnpm tsx "$ROOT/vendor/fetch.ts" --source rails
-  pnpm tsx "$ROOT/vendor/fetch.ts" --source rack
-  pnpm tsx "$ROOT/vendor/fetch.ts" --source globalid
-  RAILS_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths rails)" \
-    RACK_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths rack)" \
-    GLOBALID_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths globalid)" \
+  # Single tsx invocation fetches every source registered in vendor/sources.ts.
+  pnpm -s vendor:fetch
+  # Vendored sources always land at $ROOT/vendor/<name> — no need to shell
+  # out to tsx three times just to print the same paths.
+  RAILS_DIR="$ROOT/vendor/rails" \
+    RACK_DIR="$ROOT/vendor/rack" \
+    GLOBALID_DIR="$ROOT/vendor/globalid" \
     ruby "$DIR/extract-ruby-tests.rb"
   pnpm tsx "$DIR/extract-ts-tests.ts"
 fi

--- a/scripts/test-compare/run.sh
+++ b/scripts/test-compare/run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Driver for `pnpm test:compare`. Forwards extra args ("$@") to
+# test-compare.ts so flags like `--package`, `--missing`, `--json`,
+# `--incomplete` reach the comparison step.
+#
+# Special flag handled here (not forwarded to test-compare.ts):
+#   --cached   Skip the fetch + Ruby/TS extract steps if the cached
+#              output/rails-tests.json and output/ts-tests.json already
+#              exist. Falls back to a full run if either is missing.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+OUT_DIR="$DIR/output"
+
+USE_CACHE=0
+FORWARD_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--cached" ]]; then
+    USE_CACHE=1
+  else
+    FORWARD_ARGS+=("$arg")
+  fi
+done
+
+CACHE_HIT=0
+if [[ "$USE_CACHE" -eq 1 ]]; then
+  if [[ -f "$OUT_DIR/rails-tests.json" && -f "$OUT_DIR/ts-tests.json" ]]; then
+    CACHE_HIT=1
+    echo "==> Using cached rails-tests.json + ts-tests.json (--cached)"
+  else
+    echo "==> --cached requested but cache missing; running full extract" >&2
+  fi
+fi
+
+if [[ "$CACHE_HIT" -eq 0 ]]; then
+  pnpm tsx "$ROOT/vendor/fetch.ts" --source rails
+  pnpm tsx "$ROOT/vendor/fetch.ts" --source rack
+  pnpm tsx "$ROOT/vendor/fetch.ts" --source globalid
+  RAILS_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths rails)" \
+    RACK_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths rack)" \
+    GLOBALID_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths globalid)" \
+    ruby "$DIR/extract-ruby-tests.rb"
+  pnpm tsx "$DIR/extract-ts-tests.ts"
+fi
+
+pnpm tsx "$DIR/test-compare.ts" "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -25,8 +25,10 @@
  *     [--incomplete] [--package activesupport]
  *
  *   --incomplete  In the per-file table, hide files that are fully complete
- *                 (every Ruby test matched, none skipped, no wrong-describe,
- *                 no misplaced). Mirrors `api:compare --incomplete`.
+ *                 (every Ruby test matched in the convention TS file, no
+ *                 wrong-describe). Misplaced tests are not in this file's
+ *                 match count, so a file with misplaced > 0 is always
+ *                 incomplete and never hidden. Mirrors `api:compare --incomplete`.
  */
 
 import * as fs from "fs";

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -628,12 +628,8 @@ function main() {
       for (const f of pkg.files) {
         const fileImplemented = f.matched - f.matchedSkipped;
         const pct = f.rubyTestCount > 0 ? Math.round((fileImplemented / f.rubyTestCount) * 100) : 0;
-        const isComplete =
-          fileImplemented === f.rubyTestCount &&
-          f.wrongDescribe === 0 &&
-          f.misplaced === 0 &&
-          f.tsFileExists;
-        if (showIncomplete && isComplete) continue;
+        const isComplete = fileImplemented === f.rubyTestCount && f.wrongDescribe === 0;
+        if (showIncomplete && isComplete && f.tsFileExists) continue;
         const marker = !f.tsFileExists ? " ✗" : isComplete ? " ✓" : "";
         console.log(
           `  ${f.rubyFile.padEnd(45)} ${f.conventionTsFile.padEnd(45)} ${String(fileImplemented).padStart(4)} ${String(f.matchedSkipped).padStart(4)} ${String(f.wrongDescribe).padStart(4)} ${String(f.misplaced).padStart(4)} ${String(f.missing).padStart(4)} ${String(f.rubyTestCount).padStart(4)}${marker}`,

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -21,7 +21,12 @@
  * activesupport, rack, trailties). Using --package overrides this and always shows detail.
  *
  * Usage:
- *   npx tsx scripts/test-compare/test-compare.ts [--missing] [--json] [--package activesupport]
+ *   npx tsx scripts/test-compare/test-compare.ts [--missing] [--json]
+ *     [--incomplete] [--package activesupport]
+ *
+ *   --incomplete  In the per-file table, hide files that are fully complete
+ *                 (every Ruby test matched, none skipped, no wrong-describe,
+ *                 no misplaced). Mirrors `api:compare --incomplete`.
  */
 
 import * as fs from "fs";
@@ -40,6 +45,7 @@ const DETAIL_PACKAGES = new Set([
   "rack",
   "actionview",
   "trailties",
+  "globalid",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -170,6 +176,7 @@ function main() {
   const filterPkg = args.includes("--package") ? args[args.indexOf("--package") + 1] : null;
   const showMissing = args.includes("--missing");
   const jsonOutput = args.includes("--json");
+  const showIncomplete = args.includes("--incomplete");
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-tests.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-tests.json");
@@ -621,7 +628,12 @@ function main() {
       for (const f of pkg.files) {
         const fileImplemented = f.matched - f.matchedSkipped;
         const pct = f.rubyTestCount > 0 ? Math.round((fileImplemented / f.rubyTestCount) * 100) : 0;
-        const isComplete = fileImplemented === f.rubyTestCount && f.wrongDescribe === 0;
+        const isComplete =
+          fileImplemented === f.rubyTestCount &&
+          f.wrongDescribe === 0 &&
+          f.misplaced === 0 &&
+          f.tsFileExists;
+        if (showIncomplete && isComplete) continue;
         const marker = !f.tsFileExists ? " ✗" : isComplete ? " ✓" : "";
         console.log(
           `  ${f.rubyFile.padEnd(45)} ${f.conventionTsFile.padEnd(45)} ${String(fileImplemented).padStart(4)} ${String(f.matchedSkipped).padStart(4)} ${String(f.wrongDescribe).padStart(4)} ${String(f.misplaced).padStart(4)} ${String(f.missing).padStart(4)} ${String(f.rubyTestCount).padStart(4)}${marker}`,
@@ -663,6 +675,7 @@ function extractRelativeTsPath(fullPath: string, pkg: string): string {
     actioncontroller: "packages/actionpack/src/actioncontroller/",
     actionview: "packages/actionview/src/",
     trailties: "packages/trailties/src/",
+    globalid: "packages/globalid/src/",
   };
 
   const prefix = pkgDirs[pkg];


### PR DESCRIPTION
## Summary

- New `scripts/test-compare/run.sh` driver (mirrors `api:compare`'s `run.sh`). `pnpm test:compare` now goes through it.
- `--cached` skips fetch + Ruby/TS extract when `output/rails-tests.json` and `output/ts-tests.json` already exist. Useful when iterating on `test-compare.ts` itself.
- `--incomplete` hides per-file rows that are fully complete (every Ruby test matched, none skipped, no wrong-describe, no misplaced, TS file present). Mirrors `api:compare --incomplete`.
- Wires `globalid` into the comparison: `vendor/globalid/test/cases/` ↔ `packages/globalid/src/`. Currently surfaces 0/158 (7 of 8 test files don't exist on the TS side yet).

## Test plan

- [x] `pnpm test:compare --package arel --incomplete` — only shows files with gaps
- [x] `pnpm test:compare --cached --package arel` — skips fetch/extract on second run
- [x] `pnpm test:compare --package globalid` — picks up vendor/globalid tests