### PR TITLE
feat(activerecord): associations-reflection Slot E — namespace resolution + sourceType-as-class guard

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -188,13 +188,16 @@ export function resolveModel(name: string): typeof Base {
  */
 export function resolveAssocClass(record: Base, assocName: string, className: string): typeof Base {
   const ctor = record.constructor as typeof Base & {
-    _reflectOnAssociation?: (name: string) => { klass?: typeof Base } | null;
+    _reflectOnAssociation?: (
+      name: string,
+    ) => { klass?: typeof Base; isPolymorphic?: () => boolean } | null;
   };
-  try {
-    const richKlass = ctor._reflectOnAssociation?.(assocName)?.klass;
+  const refl = ctor._reflectOnAssociation?.(assocName);
+  // Skip .klass for polymorphic associations — it throws by design.
+  // All other errors (e.g. not-an-AR-subclass) must propagate.
+  if (refl && !refl.isPolymorphic?.()) {
+    const richKlass = refl.klass;
     if (richKlass) return richKlass;
-  } catch {
-    // polymorphic associations throw on .klass — fall through to flat lookup
   }
   return resolveModel(className);
 }
@@ -625,7 +628,7 @@ export async function loadBelongsTo(
       // Resolve target class from instance if available, otherwise from options.
       const targetModel =
         (cached?.constructor as typeof Base | undefined) ??
-        resolveModel(options.className ?? camelize(assocName));
+        resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
     if (options.inverseOf && cached) {
@@ -639,7 +642,7 @@ export async function loadBelongsTo(
     if (options.inverseOf && !options.polymorphic) {
       const targetModel =
         (preloaded?.constructor as typeof Base | undefined) ??
-        resolveModel(options.className ?? camelize(assocName));
+        resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
     if (options.inverseOf && preloaded) {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1234,7 +1234,7 @@ export async function loadHasManyThrough(
 
   // Resolve the target model
   const className = options.className ?? camelize(singularize(assocName));
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
 
   // The source defaults to the singularized association name
   const sourceName = options.source ?? singularize(assocName);
@@ -1243,7 +1243,7 @@ export async function loadHasManyThrough(
   // push sourceType filtering into the through query
   const throughClassName =
     throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-  const throughModel = resolveModel(throughClassName);
+  const throughModel = resolveAssocClass(record, throughAssoc.name, throughClassName);
   const throughModelAssocs: AssociationDefinition[] = throughModel._associations ?? [];
   const sourceAssoc =
     throughModelAssocs.find((a) => a.name === sourceName) ??
@@ -1709,7 +1709,7 @@ export function buildThroughAssociation(
   // Build intermediate record with owner FK
   const throughClassName =
     throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-  const throughModel = resolveModel(throughClassName);
+  const throughModel = resolveAssocClass(record, throughAssoc.name, throughClassName);
   const ownerFk = ownerFkOption as string;
   const ownerPk = ownerPkOption as string;
   const throughAttrs: Record<string, unknown> = {};

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -180,10 +180,11 @@ export function resolveModel(name: string): typeof Base {
 }
 
 /**
- * Resolve the target model for an association, using the rich reflection's
+ * Resolve the target model for an association using the rich reflection's
  * namespace-aware klass when available, falling back to flat resolveModel.
- * Safe for polymorphic associations — accessing klass on a polymorphic
- * reflection throws, so we catch and fall back.
+ * Skips `.klass` for polymorphic associations (checked via `isPolymorphic()`)
+ * because polymorphic reflections intentionally throw on `.klass` access.
+ * Non-polymorphic errors (e.g. not-an-AR-subclass) propagate unchanged.
  * @internal
  */
 export function resolveAssocClass(record: Base, assocName: string, className: string): typeof Base {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -180,6 +180,26 @@ export function resolveModel(name: string): typeof Base {
 }
 
 /**
+ * Resolve the target model for an association, using the rich reflection's
+ * namespace-aware klass when available, falling back to flat resolveModel.
+ * Safe for polymorphic associations — accessing klass on a polymorphic
+ * reflection throws, so we catch and fall back.
+ * @internal
+ */
+export function resolveAssocClass(record: Base, assocName: string, className: string): typeof Base {
+  const ctor = record.constructor as typeof Base & {
+    _reflectOnAssociation?: (name: string) => { klass?: typeof Base } | null;
+  };
+  try {
+    const richKlass = ctor._reflectOnAssociation?.(assocName)?.klass;
+    if (richKlass) return richKlass;
+  } catch {
+    // polymorphic associations throw on .klass — fall through to flat lookup
+  }
+  return resolveModel(className);
+}
+
+/**
  * Validate that an inverse_of association exists on the target model.
  * Throws InverseOfAssociationNotFoundError if not found.
  */
@@ -648,7 +668,7 @@ export async function loadBelongsTo(
     className = options.className ?? camelize(assocName);
   }
 
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
 
   if (options.inverseOf && !options.polymorphic) {
     validateInverseOf(targetModel, assocName, options.inverseOf);
@@ -771,7 +791,7 @@ export async function loadHasOne(
   const className = options.className ?? camelize(assocName);
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
 
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
 
   if (options.inverseOf) {
     validateInverseOf(targetModel, assocName, options.inverseOf);
@@ -970,7 +990,7 @@ export async function loadHasMany(
   const className = options.className ?? camelize(singularize(assocName));
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
 
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
 
   if (options.inverseOf) {
     validateInverseOf(targetModel, assocName, options.inverseOf);
@@ -1153,7 +1173,7 @@ export function buildHasManyRelation(
   const conditions = computeHasManyWhere(record, assocName, options);
   if (conditions === null) return null;
   const className = options.className ?? camelize(singularize(assocName));
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
   let rel = targetModel.all().where(conditions);
   if (options.scope) rel = options.scope(rel);
   return rel;

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -247,6 +247,13 @@ export class Association {
    * this to look at the polymorphic_type field on the owner.
    */
   get klass(): typeof Base {
+    // Use the rich reflection's klass getter when available — it does
+    // namespace-relative resolution, matching Rails' compute_type walk.
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
+    };
+    const richKlass = ctor._reflectOnAssociation?.(this.reflection.name)?.klass;
+    if (richKlass) return richKlass;
     const className =
       this.reflection.options.className ?? camelize(singularize(this.reflection.name));
     return resolveModel(className);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -35,6 +35,7 @@ import { getInheritanceColumn, findStiClass } from "../inheritance.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   resolveModel,
+  resolveAssocClass,
   fireAssocCallbacks,
   buildHasManyRelation,
   loadHasMany,
@@ -999,7 +1000,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const throughModel = resolveModel(throughClassName);
+    const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
     if (Array.isArray(ownerFk)) {
       throw new Error(
@@ -1150,7 +1151,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const throughModel = resolveModel(throughClassName);
+    const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
     const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
     const pkValue = this._record._readAttribute(primaryKey as string);
@@ -1186,7 +1187,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const throughModel = resolveModel(throughClassName);
+    const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
     if (Array.isArray(primaryKey)) {
       throw new Error(
@@ -1724,7 +1725,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const throughModel = resolveModel(throughClassName);
+    const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const throughModelAssocs: AssociationDefinition[] = (throughModel as any)._associations ?? [];
     const sourceAssoc =
       throughModelAssocs.find((a) => a.name === sourceName) ??

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -638,7 +638,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   private _buildRaw(attrs: Record<string, unknown> = {}): Base {
     const ctor = this._record.constructor as typeof Base;
-    const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
     const primaryKey = this._assocDef.options.primaryKey ?? ctor.primaryKey;
 
     // Polymorphic "as" option
@@ -668,7 +667,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   private _buildThrough(attrs: Record<string, unknown> = {}): Base {
-    const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
     let targetModel = this.model as typeof Base;
 
     const inheritanceCol = getInheritanceColumn(targetModel);
@@ -1412,7 +1410,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         const entries = Object.entries(conditions as Record<string, unknown>);
         return records.some((r) => entries.every(([k, v]) => r.readAttribute(k) === v));
       }
-      const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
       const targetModel = this.model as typeof Base;
       const pk = targetModel.primaryKey;
       if (Array.isArray(pk)) {
@@ -1596,7 +1593,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#ids=
    */
   async setIds(ids: (number | string)[]): Promise<void> {
-    const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
     const targetModel = this.model as typeof Base;
     const cleanIds = ids.filter((id) => id !== null && id !== undefined && id !== "");
     const records = (await Promise.all(cleanIds.map((id) => targetModel.find(Number(id))))) as T[];
@@ -1677,7 +1673,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const rel = buildHasManyRelation(this._record, this._assocName, this._assocDef.options);
     if (rel === null) {
-      const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
       const targetModel = this.model as typeof Base;
       let emptyRel = (targetModel as any).all();
       if (this._assocDef.options.scope) {
@@ -1724,7 +1719,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       );
     }
 
-    const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
     const targetModel = this.model as typeof Base;
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -330,7 +330,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           `Through association "${assocDef.options.through}" not found on ${ctor.name}`,
         );
       }
-      resolveModel(className); // throws if the target model isn't registered
       // No try/catch: if `_buildThroughScope()` throws, the caller
       // sees the real error (composite-PK mismatch, join resolution
       // failure, etc.) instead of a silently `none`-coerced proxy.
@@ -656,7 +655,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       buildAttrs[`${underscore(asName)}_type`] = ctor.name;
     }
 
-    let targetModel = resolveModel(className);
+    let targetModel = this.model as typeof Base;
 
     // STI: if a type attribute is provided, resolve to the correct subclass
     const inheritanceCol = getInheritanceColumn(targetModel);
@@ -670,7 +669,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   private _buildThrough(attrs: Record<string, unknown> = {}): Base {
     const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-    let targetModel = resolveModel(className);
+    let targetModel = this.model as typeof Base;
 
     const inheritanceCol = getInheritanceColumn(targetModel);
     if (inheritanceCol && attrs[inheritanceCol]) {
@@ -1414,7 +1413,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         return records.some((r) => entries.every(([k, v]) => r.readAttribute(k) === v));
       }
       const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-      const targetModel = resolveModel(className);
+      const targetModel = this.model as typeof Base;
       const pk = targetModel.primaryKey;
       if (Array.isArray(pk)) {
         throw new Error(
@@ -1598,7 +1597,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   async setIds(ids: (number | string)[]): Promise<void> {
     const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-    const targetModel = resolveModel(className);
+    const targetModel = this.model as typeof Base;
     const cleanIds = ids.filter((id) => id !== null && id !== undefined && id !== "");
     const records = (await Promise.all(cleanIds.map((id) => targetModel.find(Number(id))))) as T[];
     await this.replace(records);
@@ -1679,7 +1678,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const rel = buildHasManyRelation(this._record, this._assocName, this._assocDef.options);
     if (rel === null) {
       const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-      const targetModel = resolveModel(className);
+      const targetModel = this.model as typeof Base;
       let emptyRel = (targetModel as any).all();
       if (this._assocDef.options.scope) {
         emptyRel = this._assocDef.options.scope(emptyRel);
@@ -1726,7 +1725,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
 
     const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-    const targetModel = resolveModel(className);
+    const targetModel = this.model as typeof Base;
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
 
     const throughClassName =

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -283,7 +283,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   constructor(record: Base, assocName: string, assocDef: AssociationDefinition) {
     const className = assocDef.options.className ?? camelize(singularize(assocName));
-    const targetModel = resolveModel(className) as typeof Base;
+    // Prefer the rich reflection's klass so namespace-relative resolution applies.
+    const ownerCtor = record.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
+    };
+    const richKlass = ownerCtor._reflectOnAssociation?.(assocName)?.klass;
+    const targetModel = richKlass ?? (resolveModel(className) as typeof Base);
     super(targetModel, targetModel.arelTable);
     this._record = record;
     this._assocName = assocName;

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1744,7 +1744,7 @@ describe("ReflectionTest", () => {
     const ref = reflectOnAssociation(Orphan, "ghosts");
     expect(ref).not.toBeNull();
     // "Ghost" is not registered, so accessing klass should throw
-    expect(() => ref!.klass).toThrow(/Could not find model 'Ghost'/);
+    expect(() => ref!.klass).toThrow(/not found in registry/);
   });
 
   it("reflection klass not found with pointer to non existent class name", () => {
@@ -1757,7 +1757,7 @@ describe("ReflectionTest", () => {
     Associations.hasMany.call(Orphan2, "items", { className: "NonExistentModel" });
     const ref = reflectOnAssociation(Orphan2, "items");
     expect(ref).not.toBeNull();
-    expect(() => ref!.klass).toThrow(/Could not find model 'NonExistentModel'/);
+    expect(() => ref!.klass).toThrow(/not found in registry/);
   });
 
   it("reflection klass requires ar subclass", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -20,6 +20,7 @@ import {
   AggregateReflection,
   AssociationReflection,
   registerModel,
+  modelRegistry,
   composedOf,
 } from "./index.js";
 import { Associations } from "./associations.js";
@@ -1778,6 +1779,15 @@ describe("ReflectionTest", () => {
     expect(ref).not.toBeNull();
     // klass should return a class that extends Base
     expect(ref!.klass).toBe(Child);
+
+    // Non-AR subclass registered under a different name raises ArgumentError
+    class NotAModel {}
+    modelRegistry.set("NotAModel", NotAModel as unknown as typeof Base);
+    Associations.hasMany.call(Parent, "notModels", { className: "NotAModel" });
+    const badRef = reflectOnAssociation(Parent, "notModels");
+    expect(() => badRef!.klass).toThrow(ArgumentError);
+    expect(() => badRef!.klass).toThrow(/not an ActiveRecord::Base subclass/);
+    modelRegistry.delete("NotAModel");
   });
 
   it("reflection klass with same demodularized name", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1203,7 +1203,7 @@ describe("ReflectionTest", () => {
     expect(ref!.name).toBe("books");
   });
   it.skip("reflect on missing source assocation raise exception", () => {
-    // UNPORTED: relies on Ruby Hotel/Chef fixture models — Slot C.
+    // BLOCKED: Hotel/Chef fixture models + check_validity! not yet ported — Slot C.
   });
   it.skip("name error from incidental code is not converted to name error for association", () => {
     // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
@@ -1903,6 +1903,13 @@ describe("ReflectionTest", () => {
     });
     const nestedRef = reflectOnAssociation(NsBillingAccount, "nestedUnqualifiedBillingFirm");
     expect(nestedRef!.klass).toBe(NsBillingNestedFirm);
+
+    // Absolute reference with leading "::" bypasses namespace walk
+    Associations.belongsTo.call(NsBillingAccount, "absoluteFirm", {
+      className: "::MyApplication::Business::Firm",
+    });
+    const absRef = reflectOnAssociation(NsBillingAccount, "absoluteFirm");
+    expect(absRef!.klass).toBe(NsBizFirm);
   });
 
   it("has and belongs to many reflection", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1783,11 +1783,14 @@ describe("ReflectionTest", () => {
     // Non-AR subclass registered under a different name raises ArgumentError
     class NotAModel {}
     modelRegistry.set("NotAModel", NotAModel as unknown as typeof Base);
-    Associations.hasMany.call(Parent, "notModels", { className: "NotAModel" });
-    const badRef = reflectOnAssociation(Parent, "notModels");
-    expect(() => badRef!.klass).toThrow(ArgumentError);
-    expect(() => badRef!.klass).toThrow(/not an ActiveRecord::Base subclass/);
-    modelRegistry.delete("NotAModel");
+    try {
+      Associations.hasMany.call(Parent, "notModels", { className: "NotAModel" });
+      const badRef = reflectOnAssociation(Parent, "notModels");
+      expect(() => badRef!.klass).toThrow(ArgumentError);
+      expect(() => badRef!.klass).toThrow(/not an ActiveRecord::Base subclass/);
+    } finally {
+      modelRegistry.delete("NotAModel");
+    }
   });
 
   it("reflection klass with same demodularized name", () => {
@@ -1809,6 +1812,36 @@ describe("ReflectionTest", () => {
     Associations.hasMany.call(Project, "tasks", {});
     const ref = reflectOnAssociation(Project, "tasks");
     expect(ref!.klass).toBe(Task);
+  });
+
+  it("reflection klass demodulize top-level-first resolution", () => {
+    // Rails _klass: when demodulize(activeRecord.name) == className,
+    // top-level ::ClassName is tried before namespace-relative lookup.
+    const adp = freshAdapter();
+    class TopUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    class NsAdminUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    // Top-level "User" and namespaced "Admin::User" are both in the registry.
+    registerModel("User", TopUser);
+    registerModel("Admin::User", NsAdminUser);
+    // NsAdminUser.demodulize("Admin::User") == "User" == className("user")
+    // → _klass tries ::User first → resolves to top-level TopUser
+    Associations.hasOne.call(NsAdminUser, "user", {});
+    const ref = reflectOnAssociation(NsAdminUser, "user");
+    expect(ref!.klass).toBe(TopUser);
+    // When className is explicitly qualified it bypasses the demodulize path
+    Associations.hasOne.call(NsAdminUser, "adminUser", { className: "Admin::User" });
+    const nsRef = reflectOnAssociation(NsAdminUser, "adminUser");
+    expect(nsRef!.klass).toBe(NsAdminUser);
   });
 
   it("aggregation reflection", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -28,6 +28,7 @@ import { Table } from "@blazetrails/arel";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { UnknownPrimaryKey } from "./errors.js";
+import { ArgumentError } from "@blazetrails/activemodel";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -1040,9 +1041,7 @@ describe("ReflectionTest", () => {
     expect(ref.validate).toBe(false);
   });
   it.skip("symbol for class name", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+    // UNPORTED: Ruby Symbol type for className has no JS equivalent.
   });
   it("class for class name", () => {
     class Firm extends Base {
@@ -1066,10 +1065,29 @@ describe("ReflectionTest", () => {
       }),
     ).toThrow(/expecting a string/);
   });
-  it.skip("class for source type", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+  it("class for source type", () => {
+    class NsTag extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class NsPost extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("NsTag", NsTag);
+    registerModel("NsPost", NsPost);
+    expect(() =>
+      Associations.hasMany.call(NsTag, "taggedPosts", {
+        through: "taggings",
+        source: "taggable",
+        // @ts-expect-error sourceType must be a string, not a class
+        sourceType: NsPost,
+      }),
+    ).toThrow(ArgumentError);
   });
   it("join table with common prefix", () => {
     class CatalogCategory extends Base {
@@ -1184,24 +1202,16 @@ describe("ReflectionTest", () => {
     expect(ref!.name).toBe("books");
   });
   it.skip("reflect on missing source assocation raise exception", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+    // UNPORTED: relies on Ruby Hotel/Chef fixture models — Slot C.
   });
   it.skip("name error from incidental code is not converted to name error for association", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+    // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
   });
   it.skip("automatic inverse suppresses name error for association", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+    // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
   });
   it.skip("automatic inverse does not suppress name error from incidental code", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
+    // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
   });
 
   it("has one and belongs to should find inverse automatically", () => {
@@ -1819,11 +1829,70 @@ describe("ReflectionTest", () => {
     expect(addr.city).toBe("Springfield");
   });
 
-  it.skip("association reflection in modules", () => {
-    // BLOCKED: associations — reflection feature gap (macros / options inspection)
-    // ROOT-CAUSE: reflection.ts#AggregateReflection or ThroughReflection missing Rails parity
-    // SCOPE: ~50 LOC in reflection.ts; affects ~31 tests in reflection.test.ts
-    // Requires module/namespace support
+  it("association reflection in modules", () => {
+    const adp = freshAdapter();
+    class NsBizFirm extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    class NsBizClient extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("firm_id", "integer");
+        this.adapter = adp;
+      }
+    }
+    class NsBillingAccount extends Base {
+      static {
+        this.attribute("firm_id", "integer");
+        this.adapter = adp;
+      }
+    }
+    class NsBillingFirm extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    class NsBillingNestedFirm extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    registerModel("MyApplication::Business::Firm", NsBizFirm);
+    registerModel("MyApplication::Business::Client", NsBizClient);
+    registerModel("MyApplication::Billing::Account", NsBillingAccount);
+    registerModel("MyApplication::Billing::Firm", NsBillingFirm);
+    registerModel("MyApplication::Billing::Nested::Firm", NsBillingNestedFirm);
+
+    // Unqualified "Client" resolves namespace-relative from MyApplication::Business::Firm
+    Associations.hasMany.call(NsBizFirm, "clientsOfFirm", { className: "Client" });
+    const firmRef = reflectOnAssociation(NsBizFirm, "clientsOfFirm");
+    expect(firmRef!.klass).toBe(NsBizClient);
+    expect(firmRef!.className).toBe("Client");
+
+    // Fully qualified class_name resolves absolutely
+    Associations.belongsTo.call(NsBillingAccount, "firm", {
+      className: "MyApplication::Business::Firm",
+    });
+    const acctFirmRef = reflectOnAssociation(NsBillingAccount, "firm");
+    expect(acctFirmRef!.klass).toBe(NsBizFirm);
+    expect(acctFirmRef!.className).toBe("MyApplication::Business::Firm");
+
+    // Unqualified "Firm" resolves namespace-relative from MyApplication::Billing::Account
+    Associations.belongsTo.call(NsBillingAccount, "unqualifiedBillingFirm", { className: "Firm" });
+    const unqualRef = reflectOnAssociation(NsBillingAccount, "unqualifiedBillingFirm");
+    expect(unqualRef!.klass).toBe(NsBillingFirm);
+
+    // Partially qualified "Nested::Firm" resolves namespace-relative
+    Associations.belongsTo.call(NsBillingAccount, "nestedUnqualifiedBillingFirm", {
+      className: "Nested::Firm",
+    });
+    const nestedRef = reflectOnAssociation(NsBillingAccount, "nestedUnqualifiedBillingFirm");
+    expect(nestedRef!.klass).toBe(NsBillingNestedFirm);
   });
 
   it("has and belongs to many reflection", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -21,6 +21,7 @@ import {
   AssociationReflection,
   registerModel,
   modelRegistry,
+  association,
   composedOf,
 } from "./index.js";
 import { Associations, resolveAssocClass } from "./associations.js";
@@ -1948,6 +1949,14 @@ describe("ReflectionTest", () => {
     // resolution — verifies the actual loading path, not only ref.klass
     const firmInstance = NsBizFirm.new({ name: "Acme" });
     expect(resolveAssocClass(firmInstance, "clientsOfFirm", "Client")).toBe(NsBizClient);
+
+    // CollectionProxy build path: proxy.model and proxy.build() use the
+    // namespace-aware resolved class, catching regressions where ref.klass
+    // resolves but the build/load path hits the wrong target.
+    const proxy = association<InstanceType<typeof NsBizClient>>(firmInstance, "clientsOfFirm");
+    expect((proxy as any).model).toBe(NsBizClient);
+    const built = proxy.build({ name: "Acme Client" });
+    expect(built).toBeInstanceOf(NsBizClient);
   });
 
   it("has and belongs to many reflection", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -23,7 +23,7 @@ import {
   modelRegistry,
   composedOf,
 } from "./index.js";
-import { Associations } from "./associations.js";
+import { Associations, resolveAssocClass } from "./associations.js";
 import { Table } from "@blazetrails/arel";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -1943,6 +1943,11 @@ describe("ReflectionTest", () => {
     });
     const absRef = reflectOnAssociation(NsBillingAccount, "absoluteFirm");
     expect(absRef!.klass).toBe(NsBizFirm);
+
+    // Runtime: resolveAssocClass uses the reflection layer for namespace-aware
+    // resolution — verifies the actual loading path, not only ref.klass
+    const firmInstance = NsBizFirm.new({ name: "Acme" });
+    expect(resolveAssocClass(firmInstance, "clientsOfFirm", "Client")).toBe(NsBizClient);
   });
 
   it("has and belongs to many reflection", () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -392,7 +392,7 @@ export class MacroReflection extends AbstractReflection {
     const resolved = modelRegistry.get(lookupName);
     if (!resolved) {
       throw new Error(
-        `Could not find model '${lookupName}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
+        `Model '${lookupName}' not found in registry (for '${this.name}' on ${this.activeRecord.name})`,
       );
     }
     return resolved;
@@ -658,7 +658,11 @@ export class AssociationReflection extends MacroReflection {
     } catch (e: unknown) {
       // Rails: rescue NameError => error; raise unless error.name.to_s == class_name
       // Only swallow model-not-found errors from computeClass, re-raise anything else
-      if (e instanceof Error && e.message.startsWith("Could not find model")) {
+      if (
+        e instanceof Error &&
+        e.message.startsWith("Model ") &&
+        e.message.includes("not found in registry")
+      ) {
         reflection = false;
       } else {
         throw e;
@@ -943,7 +947,7 @@ export class AssociationReflection extends MacroReflection {
     const resolved = modelRegistry.get(simpleName);
     if (!resolved) {
       throw new Error(
-        `Could not find model '${simpleName}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
+        `Model '${simpleName}' not found in registry (for '${this.name}' on ${this.activeRecord.name})`,
       );
     }
     if (!(resolved as any)._isActiveRecordBase) {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -900,13 +900,13 @@ export class AssociationReflection extends MacroReflection {
 
     if (!isAbsolute) {
       // Namespace-relative walk: mirrors Ruby's compute_type candidate list.
-      // For activeRecord registered as "A::B::C", tries "A::B::Name", "A::Name"
-      // before falling through to top-level "Name".
+      // For activeRecord registered as "A::B::C", tries "A::B::C::Name",
+      // "A::B::Name", "A::Name" before falling through to top-level "Name".
       const registryKeys = (this.activeRecord as any)._registryKeys as string[] | undefined;
       const arName = registryKeys?.[0] ?? this.activeRecord.name;
       if (arName.includes("::")) {
         const segments = arName.split("::");
-        for (let i = segments.length - 1; i > 0; i--) {
+        for (let i = segments.length; i > 0; i--) {
           const candidate = [...segments.slice(0, i), simpleName].join("::");
           const resolved = modelRegistry.get(candidate);
           if (resolved) return resolved;
@@ -918,6 +918,11 @@ export class AssociationReflection extends MacroReflection {
     if (!resolved) {
       throw new Error(
         `Could not find model '${simpleName}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
+      );
+    }
+    if (!(resolved as any)._isActiveRecordBase) {
+      throw new ArgumentError(
+        `The ${simpleName} model class for the ${this.activeRecord.name}#${this.name} association is not an ActiveRecord::Base subclass.`,
       );
     }
     return resolved;

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -354,13 +354,19 @@ export class MacroReflection extends AbstractReflection {
   _klass(className: string): typeof Base {
     // Rails: when active_record.name.demodulize == class_name, try ::ClassName
     // (absolute top-level) first, then fall back to namespace-relative lookup.
-    const registryKeys = (this.activeRecord as any)._registryKeys as string[] | undefined;
-    const arName = registryKeys?.[0] ?? this.activeRecord.name;
+    // Use own _registryKeys only — inherited keys belong to a superclass namespace.
+    const ar = this.activeRecord as any;
+    const ownKeys = Object.prototype.hasOwnProperty.call(ar, "_registryKeys")
+      ? (ar._registryKeys as string[])
+      : undefined;
+    const arName = ownKeys?.[0] ?? this.activeRecord.name;
     const lastSegment = arName.includes("::") ? arName.split("::").pop()! : arName;
     if (lastSegment === className) {
       try {
         return this.computeClass(`::${className}`);
-      } catch {
+      } catch (e) {
+        // Rails: rescue NameError only — let ArgumentError (invalid subclass) propagate.
+        if (e instanceof ArgumentError) throw e;
         // fall through to namespace-relative lookup
       }
     }
@@ -902,14 +908,25 @@ export class AssociationReflection extends MacroReflection {
       // Namespace-relative walk: mirrors Ruby's compute_type candidate list.
       // For activeRecord registered as "A::B::C", tries "A::B::C::Name",
       // "A::B::Name", "A::Name" before falling through to top-level "Name".
-      const registryKeys = (this.activeRecord as any)._registryKeys as string[] | undefined;
-      const arName = registryKeys?.[0] ?? this.activeRecord.name;
+      // Use own _registryKeys only — inherited keys belong to a superclass namespace.
+      const ar = this.activeRecord as any;
+      const ownKeys = Object.prototype.hasOwnProperty.call(ar, "_registryKeys")
+        ? (ar._registryKeys as string[])
+        : undefined;
+      const arName = ownKeys?.[0] ?? this.activeRecord.name;
       if (arName.includes("::")) {
         const segments = arName.split("::");
         for (let i = segments.length; i > 0; i--) {
           const candidate = [...segments.slice(0, i), simpleName].join("::");
           const resolved = modelRegistry.get(candidate);
-          if (resolved) return resolved;
+          if (resolved) {
+            if (!(resolved as any)._isActiveRecordBase) {
+              throw new ArgumentError(
+                `The ${candidate} model class for the ${this.activeRecord.name}#${this.name} association is not an ActiveRecord::Base subclass.`,
+              );
+            }
+            return resolved;
+          }
         }
       }
     }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -355,11 +355,17 @@ export class MacroReflection extends AbstractReflection {
   protected activeRecordRegistryName(): string {
     const ar = this.activeRecord as any;
     if (Object.prototype.hasOwnProperty.call(ar, "_registryKeys")) {
-      // Filter to keys that actually point to this class (not inherited superclass aliases).
-      const own = (ar._registryKeys as string[]).filter(
+      // Filter to keys that actually point to this class (not inherited superclass aliases),
+      // then prefer the most deeply namespaced key so that a model registered as both
+      // "Author" and "Admin::Author" resolves associations relative to "Admin::Author".
+      const matching = (ar._registryKeys as string[]).filter(
         (k) => modelRegistry.get(k) === this.activeRecord,
       );
-      if (own.length > 0) return own[0];
+      if (matching.length > 0) {
+        return matching.reduce((best, k) =>
+          (k.match(/::/g) ?? []).length > (best.match(/::/g) ?? []).length ? k : best,
+        );
+      }
     }
     return this.activeRecord.name;
   }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -351,15 +351,23 @@ export class MacroReflection extends AbstractReflection {
     return this._klassCache;
   }
 
+  /** @internal */
+  protected activeRecordRegistryName(): string {
+    const ar = this.activeRecord as any;
+    if (Object.prototype.hasOwnProperty.call(ar, "_registryKeys")) {
+      // Filter to keys that actually point to this class (not inherited superclass aliases).
+      const own = (ar._registryKeys as string[]).filter(
+        (k) => modelRegistry.get(k) === this.activeRecord,
+      );
+      if (own.length > 0) return own[0];
+    }
+    return this.activeRecord.name;
+  }
+
   _klass(className: string): typeof Base {
     // Rails: when active_record.name.demodulize == class_name, try ::ClassName
     // (absolute top-level) first, then fall back to namespace-relative lookup.
-    // Use own _registryKeys only — inherited keys belong to a superclass namespace.
-    const ar = this.activeRecord as any;
-    const ownKeys = Object.prototype.hasOwnProperty.call(ar, "_registryKeys")
-      ? (ar._registryKeys as string[])
-      : undefined;
-    const arName = ownKeys?.[0] ?? this.activeRecord.name;
+    const arName = this.activeRecordRegistryName();
     const lastSegment = arName.includes("::") ? arName.split("::").pop()! : arName;
     if (lastSegment === className) {
       try {
@@ -908,12 +916,7 @@ export class AssociationReflection extends MacroReflection {
       // Namespace-relative walk: mirrors Ruby's compute_type candidate list.
       // For activeRecord registered as "A::B::C", tries "A::B::C::Name",
       // "A::B::Name", "A::Name" before falling through to top-level "Name".
-      // Use own _registryKeys only — inherited keys belong to a superclass namespace.
-      const ar = this.activeRecord as any;
-      const ownKeys = Object.prototype.hasOwnProperty.call(ar, "_registryKeys")
-        ? (ar._registryKeys as string[])
-        : undefined;
-      const arName = ownKeys?.[0] ?? this.activeRecord.name;
+      const arName = this.activeRecordRegistryName();
       if (arName.includes("::")) {
         const segments = arName.split("::");
         for (let i = segments.length; i > 0; i--) {
@@ -1137,10 +1140,7 @@ export class ThroughReflection extends AbstractReflection {
     super();
     this._delegate = delegate;
     const sourceTypeVal = delegate.options.sourceType;
-    if (
-      typeof sourceTypeVal === "function" &&
-      /^class[\s{]/.test(Function.prototype.toString.call(sourceTypeVal))
-    ) {
+    if (typeof sourceTypeVal === "function") {
       throw new ArgumentError("A class was passed to `:sourceType` but we are expecting a string.");
     }
   }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -352,18 +352,27 @@ export class MacroReflection extends AbstractReflection {
   }
 
   _klass(className: string): typeof Base {
-    // Rails uses this for namespace-aware resolution (tries ::ClassName
-    // before Module::ClassName). Our model registry is flat, so this
-    // delegates directly to computeClass. When namespace support is
-    // added, this should try top-level resolution first.
+    // Rails: when active_record.name.demodulize == class_name, try ::ClassName
+    // (absolute top-level) first, then fall back to namespace-relative lookup.
+    const registryKeys = (this.activeRecord as any)._registryKeys as string[] | undefined;
+    const arName = registryKeys?.[0] ?? this.activeRecord.name;
+    const lastSegment = arName.includes("::") ? arName.split("::").pop()! : arName;
+    if (lastSegment === className) {
+      try {
+        return this.computeClass(`::${className}`);
+      } catch {
+        // fall through to namespace-relative lookup
+      }
+    }
     return this.computeClass(className);
   }
 
   computeClass(name: string): typeof Base {
-    const resolved = modelRegistry.get(name);
+    const lookupName = name.startsWith("::") ? name.slice(2) : name;
+    const resolved = modelRegistry.get(lookupName);
     if (!resolved) {
       throw new Error(
-        `Could not find model '${name}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
+        `Could not find model '${lookupName}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
       );
     }
     return resolved;
@@ -883,9 +892,35 @@ export class AssociationReflection extends MacroReflection {
 
   computeClass(name: string): typeof Base {
     if (this.isPolymorphic()) {
-      throw new Error("Polymorphic associations do not support computing the class.");
+      throw new ArgumentError("Polymorphic associations do not support computing the class.");
     }
-    return super.computeClass(name);
+
+    const isAbsolute = name.startsWith("::");
+    const simpleName = isAbsolute ? name.slice(2) : name;
+
+    if (!isAbsolute) {
+      // Namespace-relative walk: mirrors Ruby's compute_type candidate list.
+      // For activeRecord registered as "A::B::C", tries "A::B::Name", "A::Name"
+      // before falling through to top-level "Name".
+      const registryKeys = (this.activeRecord as any)._registryKeys as string[] | undefined;
+      const arName = registryKeys?.[0] ?? this.activeRecord.name;
+      if (arName.includes("::")) {
+        const segments = arName.split("::");
+        for (let i = segments.length - 1; i > 0; i--) {
+          const candidate = [...segments.slice(0, i), simpleName].join("::");
+          const resolved = modelRegistry.get(candidate);
+          if (resolved) return resolved;
+        }
+      }
+    }
+
+    const resolved = modelRegistry.get(simpleName);
+    if (!resolved) {
+      throw new Error(
+        `Could not find model '${simpleName}' in model registry (for '${this.name}' on ${this.activeRecord.name})`,
+      );
+    }
+    return resolved;
   }
 
   get strictLoading(): boolean {
@@ -1079,6 +1114,13 @@ export class ThroughReflection extends AbstractReflection {
   constructor(delegate: AssociationReflection) {
     super();
     this._delegate = delegate;
+    const sourceTypeVal = delegate.options.sourceType;
+    if (
+      typeof sourceTypeVal === "function" &&
+      /^class[\s{]/.test(Function.prototype.toString.call(sourceTypeVal))
+    ) {
+      throw new ArgumentError("A class was passed to `:sourceType` but we are expecting a string.");
+    }
   }
 
   get name(): string {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -222,6 +222,18 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   // --- Permanently not-portable: Ruby Module namespace / constant-path semantics ---
   {
+    testFile: "reflection_test.rb",
+    tests: [
+      "symbol for class name",
+      "name error from incidental code is not converted to name error for association",
+      "automatic inverse suppresses name error for association",
+      "automatic inverse does not suppress name error from incidental code",
+    ],
+    reason:
+      "Ruby Symbol type for class_name and const_missing hook for NameError discrimination " +
+      "have no JavaScript equivalent.",
+  },
+  {
     testFile: "modules_test.rb",
     tests: [
       "module spanning associations",
@@ -317,18 +329,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason:
       "Tests Marshal/YAML binary encoding of AR records. " +
       "Ruby binary serialization formats have no Node.js equivalent.",
-  },
-  {
-    testFile: "reflection_test.rb",
-    tests: [
-      "symbol for class name",
-      "name error from incidental code is not converted to name error for association",
-      "automatic inverse suppresses name error for association",
-      "automatic inverse does not suppress name error from incidental code",
-    ],
-    reason:
-      "Ruby-only language semantics: Symbol type for class_name and const_missing mechanism " +
-      "have no JavaScript equivalent.",
   },
 ];
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -318,6 +318,18 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Tests Marshal/YAML binary encoding of AR records. " +
       "Ruby binary serialization formats have no Node.js equivalent.",
   },
+  {
+    testFile: "reflection_test.rb",
+    tests: [
+      "symbol for class name",
+      "name error from incidental code is not converted to name error for association",
+      "automatic inverse suppresses name error for association",
+      "automatic inverse does not suppress name error from incidental code",
+    ],
+    reason:
+      "Ruby-only language semantics: Symbol type for class_name and const_missing mechanism " +
+      "have no JavaScript equivalent.",
+  },
 ];
 
 export function isSourceUnported(file: string): boolean {


### PR DESCRIPTION
## Summary

- `MacroReflection._klass`: implements Rails' demodulize check — when the last segment of `activeRecord`'s registry name matches `className`, tries absolute top-level lookup first, then falls back to namespace-relative
- `MacroReflection.computeClass`: strips `::` prefix for absolute references
- `AssociationReflection.computeClass`: full namespace-relative candidate walk (mirrors Ruby `compute_type`) — for `"A::B::C"` tries `"A::B::Name"`, `"A::Name"` before top-level `"Name"`, enabling unqualified `className` resolution within a module namespace
- `ThroughReflection.constructor`: raises `ArgumentError` when `sourceType` is passed as a class instead of a string
- Un-skips `"class for source type"` and `"association reflection in modules"` tests with full bodies
- Marks `"symbol for class name"` + 3 `const_missing` tests as UNPORTED (Ruby-only); adds per-test entries to `unported-files.ts`

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/reflection.test.ts` — 123 pass, 19 skip
- [ ] `pnpm run api:compare --package activerecord` — reflection.rb 106/106, overall 99.9%