### PR TITLE
feat(activerecord): delegatedType primaryKey option + UUID FK accessors + entryableTypes

### DIFF
--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -149,12 +149,50 @@ describe("DelegatedTypeTest", () => {
 
   it("association id", () => {
     const { Entry } = makeModels();
-    const e = new Entry({ entryable_type: "Message", entryable_id: 99 });
-    expect(e.entryable_id).toBe(99);
+    const eMsg = new Entry({ entryable_type: "Message", entryable_id: 99 });
+    expect(eMsg.entryable_id).toBe(99);
+    expect((eMsg as any).message_id).toBe(99);
+    expect((eMsg as any).comment_id).toBeNull();
+
+    const eCmt = new Entry({ entryable_type: "Comment", entryable_id: 42 });
+    expect((eCmt as any).comment_id).toBe(42);
+    expect((eCmt as any).message_id).toBeNull();
   });
 
-  it.skip("association uuid", () => {
-    // BLOCKED: uuid-pk — delegated type uses a UUID primary key; no STI routing gap
+  it("association uuid", () => {
+    // Mirrors Rails PostgreSQLDelegatedTypeTest#test_association_uuid.
+    // UUID PK accessor naming: delegatedType with primaryKey: "uuid" and
+    // foreignKey: "entryable_uuid" generates `uuid_message_uuid` / `uuid_comment_uuid`
+    // accessors (${singular}_${primaryKey}) instead of the default `_id` suffix.
+    class UuidEntry extends Base {
+      static {
+        this.attribute("entryable_uuid", "string");
+        this.attribute("entryable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    delegatedType(UuidEntry, "entryable", {
+      types: ["UuidMessage", "UuidComment"],
+      primaryKey: "uuid",
+      foreignKey: "entryable_uuid",
+    });
+
+    const uuid1 = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    const uuid2 = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+    const entryWithMessage = new UuidEntry({
+      entryable_type: "UuidMessage",
+      entryable_uuid: uuid1,
+    });
+    expect((entryWithMessage as any).uuid_message_uuid).toBe(uuid1);
+    expect((entryWithMessage as any).uuid_comment_uuid).toBeNull();
+
+    const entryWithComment = new UuidEntry({
+      entryable_type: "UuidComment",
+      entryable_uuid: uuid2,
+    });
+    expect((entryWithComment as any).uuid_comment_uuid).toBe(uuid2);
+    expect((entryWithComment as any).uuid_message_uuid).toBeNull();
   });
 
   it.skip("touch account", () => {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -161,8 +161,8 @@ describe("DelegatedTypeTest", () => {
   it("association uuid", () => {
     // Mirrors Rails PostgreSQLDelegatedTypeTest#test_association_uuid.
     // UUID PK accessor naming: delegatedType with primaryKey: "uuid" and
-    // foreignKey: "entryable_uuid" generates `uuid_message_uuid` / `uuid_comment_uuid`
-    // accessors (${singular}_${primaryKey}) instead of the default `_id` suffix.
+    // foreignKey: "entryable_uuid" generates `uuidMessageUuid` / `uuidCommentUuid`
+    // accessors (camelCase of ${singular}_${primaryKey}) instead of the default `Id` suffix.
     class UuidEntry extends Base {
       static {
         this.attribute("entryable_uuid", "string");

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -150,12 +150,12 @@ describe("DelegatedTypeTest", () => {
     const { Entry } = makeModels();
     const eMsg = new Entry({ entryable_type: "Message", entryable_id: 99 });
     expect(eMsg.entryable_id).toBe(99);
-    expect((eMsg as any).message_id).toBe(99);
-    expect((eMsg as any).comment_id).toBeNull();
+    expect((eMsg as any).messageId).toBe(99);
+    expect((eMsg as any).commentId).toBeNull();
 
     const eCmt = new Entry({ entryable_type: "Comment", entryable_id: 42 });
-    expect((eCmt as any).comment_id).toBe(42);
-    expect((eCmt as any).message_id).toBeNull();
+    expect((eCmt as any).commentId).toBe(42);
+    expect((eCmt as any).messageId).toBeNull();
   });
 
   it("association uuid", () => {
@@ -183,15 +183,15 @@ describe("DelegatedTypeTest", () => {
       entryable_type: "UuidMessage",
       entryable_uuid: uuid1,
     });
-    expect((entryWithMessage as any).uuid_message_uuid).toBe(uuid1);
-    expect((entryWithMessage as any).uuid_comment_uuid).toBeNull();
+    expect((entryWithMessage as any).uuidMessageUuid).toBe(uuid1);
+    expect((entryWithMessage as any).uuidCommentUuid).toBeNull();
 
     const entryWithComment = new UuidEntry({
       entryable_type: "UuidComment",
       entryable_uuid: uuid2,
     });
-    expect((entryWithComment as any).uuid_comment_uuid).toBe(uuid2);
-    expect((entryWithComment as any).uuid_message_uuid).toBeNull();
+    expect((entryWithComment as any).uuidCommentUuid).toBe(uuid2);
+    expect((entryWithComment as any).uuidMessageUuid).toBeNull();
   });
 
   it.skip("touch account", () => {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -52,8 +52,7 @@ describe("DelegatedTypeTest", () => {
 
   it("delegated types", () => {
     const { Entry } = makeModels();
-    const e = new Entry({ title: "hi", entryable_type: "Message", entryable_id: 1 });
-    expect(e.entryable_type).toBe("Message");
+    expect((Entry as any).entryableTypes).toEqual(["Message", "Comment"]);
   });
 
   it("delegated class", () => {

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -8,6 +8,15 @@ export interface DelegatedTypeOptions {
   types: string[];
   foreignKey?: string;
   foreignType?: string;
+  /**
+   * Primary key column on the delegated-type target models.
+   * Defaults to "id". Set to "uuid" (or another column name) when the
+   * target models use a non-integer primary key — e.g.
+   * `delegatedType(Entry, "entryable", { types: [...], primaryKey: "uuid", foreignKey: "entryable_uuid" })`.
+   * Mirrors Rails' `:primary_key` option, which controls the name of the
+   * generated `${singular}_${primaryKey}` accessor on each type.
+   */
+  primaryKey?: string;
 }
 
 /**
@@ -45,6 +54,7 @@ export function delegatedType(
 ): void {
   const foreignKey = options.foreignKey ?? `${role}_id`;
   const foreignType = options.foreignType ?? `${role}_type`;
+  const primaryKey = options.primaryKey ?? "id";
   const config = { ...options, foreignKey, foreignType };
 
   // Rails: belongs_to role, **options.merge(polymorphic: true)
@@ -113,8 +123,18 @@ export function delegatedType(
       configurable: true,
     });
 
-    // Accessor: entry.message → returns the record if type matches
+    // Accessor: entry.message → returns the FK value if type matches
     Object.defineProperty(modelClass.prototype, snakeName, {
+      get(this: Base) {
+        if (this.readAttribute(foreignType) !== typeName) return null;
+        return this.readAttribute(foreignKey);
+      },
+      configurable: true,
+    });
+
+    // FK accessor: entry.message_id (or entry.message_uuid for UUID PKs) → returns FK if type matches
+    // Mirrors Rails' define_method("#{singular}_#{primary_key}") { public_send(role_id) if public_send(query) }
+    Object.defineProperty(modelClass.prototype, `${snakeName}_${primaryKey}`, {
       get(this: Base) {
         if (this.readAttribute(foreignType) !== typeName) return null;
         return this.readAttribute(foreignKey);

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -55,7 +55,7 @@ export function delegatedType(
   const foreignKey = options.foreignKey ?? `${role}_id`;
   const foreignType = options.foreignType ?? `${role}_type`;
   const primaryKey = options.primaryKey ?? "id";
-  const config = { ...options, foreignKey, foreignType };
+  const config = { ...options, foreignKey, foreignType, primaryKey };
 
   // Rails: belongs_to role, **options.merge(polymorphic: true)
   // (Rails also accepts an optional scope proc; we omit it as there's no proc equivalent)

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -78,6 +78,15 @@ export function delegatedType(
   }
   (modelClass as any)._delegatedTypes.set(role, config);
 
+  // Class method: Entry.entryableTypes → ["Message", "Comment"]
+  // Mirrors Rails' define_singleton_method("#{role}_types") { types.map(&:to_s) }
+  Object.defineProperty(modelClass, `${role}Types`, {
+    get() {
+      return options.types.map(String);
+    },
+    configurable: true,
+  });
+
   // Add instance method: delegatedClass (e.g. entryableClass)
   Object.defineProperty(modelClass.prototype, `${role}Class`, {
     get(this: Base) {

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -144,7 +144,7 @@ export function delegatedType(
     // FK accessor: entry.messageId (or entry.uuidMessageUuid for UUID PKs) → returns FK if type matches
     // Mirrors Rails' define_method("#{singular}_#{primary_key}") { public_send(role_id) if public_send(query) }
     // Name is camelCase of `${snakeName}_${primaryKey}` (e.g. "message_id" → "messageId").
-    const fkAccessorName = camelize(`${snakeName}_${primaryKey}`, false);
+    const fkAccessorName = camelize(`${snakeName.replace(/\//g, "_")}_${primaryKey}`, false);
     Object.defineProperty(modelClass.prototype, fkAccessorName, {
       get(this: Base) {
         if (this.readAttribute(foreignType) !== typeName) return null;

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { underscore } from "@blazetrails/activesupport";
+import { camelize, underscore } from "@blazetrails/activesupport";
 
 /**
  * Configuration for a delegated type.
@@ -141,9 +141,11 @@ export function delegatedType(
       configurable: true,
     });
 
-    // FK accessor: entry.message_id (or entry.message_uuid for UUID PKs) → returns FK if type matches
+    // FK accessor: entry.messageId (or entry.uuidMessageUuid for UUID PKs) → returns FK if type matches
     // Mirrors Rails' define_method("#{singular}_#{primary_key}") { public_send(role_id) if public_send(query) }
-    Object.defineProperty(modelClass.prototype, `${snakeName}_${primaryKey}`, {
+    // Name is camelCase of `${snakeName}_${primaryKey}` (e.g. "message_id" → "messageId").
+    const fkAccessorName = camelize(`${snakeName}_${primaryKey}`, false);
+    Object.defineProperty(modelClass.prototype, fkAccessorName, {
       get(this: Base) {
         if (this.readAttribute(foreignType) !== typeName) return null;
         return this.readAttribute(foreignKey);


### PR DESCRIPTION
## Summary

- Adds `primaryKey` option to `DelegatedTypeOptions` (defaults to `"id"`); stored normalized alongside `foreignKey`/`foreignType` in the config registry
- Emits a camelCase `${singular}${PrimaryKey}` FK accessor per type — e.g. `messageId` (default), `uuidMessageUuid` (when `primaryKey: "uuid"`). Mirrors Rails `define_method("#{singular}_#{primary_key}")`. Namespaced type names (e.g. `Admin::Message`) have `/` flattened to `_` before camelizing so they produce `adminMessageId` rather than `admin::MessageId`
- Adds `${role}Types` class getter (e.g. `Entry.entryableTypes → ["Message", "Comment"]`) — mirrors Rails `define_singleton_method("#{role}_types")`
- Fixes "delegated types" test body: now asserts `Entry.entryableTypes` as Rails does
- Fixes "association id" test body: now asserts `messageId` / `commentId` as Rails does
- Un-skips "association uuid": verifies `uuidMessageUuid` / `uuidCommentUuid` accessor naming with `primaryKey: "uuid"`

## Test plan

- `pnpm vitest run packages/activerecord/src/delegated-type.test.ts` — 13 pass, 1 skipped
- `pnpm run test:compare` — delegated_type_test.rb 12 matched, 1 skipped (was 10/3 on main)
- `pnpm run api:compare --package activerecord` — 4955/4958 (99.9%), no regression
- `pnpm test:types` — 83/83 pass

## Remaining skipped

- `touch account` — BLOCKED: polymorphic-touch propagation through delegated_type; separate effort