### PR TITLE
test(activerecord): un-skip 2 connection notification tests (connection-pool Slot D)

### DIFF
--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
 import {
   ConnectionPool,
   withExecutionContext,
@@ -573,18 +574,46 @@ it("anonymous class exception", async () => {
   await expect(Anon.establishConnection()).rejects.toThrow("Anonymous class is not allowed.");
 });
 
-it.skip("connection notification is called", () => {
-  // BLOCKED: connection-pool — connection pool / handler gap in connection-pool
-  // ROOT-CAUSE: connection-adapters/abstract/connection-pool.ts or abstract/connection-handler.ts missing Rails parity for pool lifecycle
-  // SCOPE: ~50–100 LOC fix in connection-adapters/abstract/connection-pool.ts; affects ~10–24 tests in connection-pool.test.ts
-  /* needs instrumentation/notifications */
+it("connection notification is called", () => {
+  const payloads: Record<string, unknown>[] = [];
+  const sub = Notifications.subscribe("!connection.active_record", (event) => {
+    payloads.push(event.payload as Record<string, unknown>);
+  });
+  try {
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: ":memory:",
+    });
+    Base.connectionHandler.establishConnection(dbConfig, { owner: Base });
+    expect(payloads).toHaveLength(1);
+    expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
+    expect(payloads[0].connection_name).toBe("Base");
+    expect(payloads[0].shard).toBe("default");
+    expect(payloads[0].role).toBe("writing");
+  } finally {
+    Notifications.unsubscribe(sub);
+    Base.connectionHandler.clearAllConnectionsBang();
+  }
 });
 
-it.skip("connection notification is called for shard", () => {
-  // BLOCKED: connection-pool — connection pool / handler gap in connection-pool
-  // ROOT-CAUSE: connection-adapters/abstract/connection-pool.ts or abstract/connection-handler.ts missing Rails parity for pool lifecycle
-  // SCOPE: ~50–100 LOC fix in connection-adapters/abstract/connection-pool.ts; affects ~10–24 tests in connection-pool.test.ts
-  /* needs instrumentation/notifications */
+it("connection notification is called for shard", () => {
+  const payloads: Record<string, unknown>[] = [];
+  const sub = Notifications.subscribe("!connection.active_record", (event) => {
+    payloads.push(event.payload as Record<string, unknown>);
+  });
+  try {
+    Base.connectsTo({
+      shards: { default: { writing: { adapter: "sqlite3", database: ":memory:" } } },
+    });
+    expect(payloads).toHaveLength(1);
+    expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
+    expect(payloads[0].connection_name).toBe("Base");
+    expect(payloads[0].shard).toBe("default");
+    expect(payloads[0].role).toBe("writing");
+  } finally {
+    Notifications.unsubscribe(sub);
+    Base.connectionHandler.clearAllConnectionsBang();
+  }
 });
 
 it("sets pool schema reflection", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -574,6 +574,10 @@ it("anonymous class exception", async () => {
   await expect(Anon.establishConnection()).rejects.toThrow("Anonymous class is not allowed.");
 });
 
+class ConnectionTestModel extends Base {
+  static override abstractClass = true;
+}
+
 it("connection notification is called", () => {
   const payloads: Record<string, unknown>[] = [];
   const sub = Notifications.subscribe("!connection.active_record", (event) => {
@@ -584,10 +588,10 @@ it("connection notification is called", () => {
       adapter: "sqlite3",
       database: ":memory:",
     });
-    Base.connectionHandler.establishConnection(dbConfig, { owner: Base });
+    Base.connectionHandler.establishConnection(dbConfig, { owner: ConnectionTestModel });
     expect(payloads).toHaveLength(1);
     expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
-    expect(payloads[0].connection_name).toBe("Base");
+    expect(payloads[0].connection_name).toBe(ConnectionTestModel.name);
     expect(payloads[0].shard).toBe("default");
     expect(payloads[0].role).toBe("writing");
   } finally {
@@ -602,12 +606,12 @@ it("connection notification is called for shard", () => {
     payloads.push(event.payload as Record<string, unknown>);
   });
   try {
-    Base.connectsTo({
+    ConnectionTestModel.connectsTo({
       shards: { default: { writing: { adapter: "sqlite3", database: ":memory:" } } },
     });
     expect(payloads).toHaveLength(1);
     expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
-    expect(payloads[0].connection_name).toBe("Base");
+    expect(payloads[0].connection_name).toBe(ConnectionTestModel.name);
     expect(payloads[0].shard).toBe("default");
     expect(payloads[0].role).toBe("writing");
   } finally {


### PR DESCRIPTION
## Summary

- Un-skips `connection notification is called` and `connection notification is called for shard` in `connection-pool.test.ts`
- The `Notifications.instrument("!connection.active_record", ...)` call was already in `connection-handler.ts`; only the test bodies were missing
- Verifies payload shape `{ config, connection_name, role, shard }`, connection name, shard, and role for both `establishConnection` and `connectsTo` paths

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/connection-pool.test.ts` — 62 pass / 21 skip (was 60 / 23)