### PR TITLE
feat(activerecord): Relation Slot G — PredicateBuilder.registerHandler + schema refs + dot-notation

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -895,7 +895,14 @@ export class Base extends Model {
     return _Core.arelTable.call(this);
   }
 
-  /** @internal */
+  /**
+   * Returns the model's predicate builder, creating it if necessary.
+   * Use this to register custom value handlers:
+   *
+   *   MyModel.predicateBuilder.registerHandler(MyRange, handler)
+   *
+   * Mirrors: ActiveRecord::Base.predicate_builder
+   */
   static get predicateBuilder(): import("./relation/predicate-builder.js").PredicateBuilder {
     return _Core.predicateBuilder.call(this);
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -895,6 +895,11 @@ export class Base extends Model {
     return _Core.arelTable.call(this);
   }
 
+  /** @internal */
+  static get predicateBuilder(): import("./relation/predicate-builder.js").PredicateBuilder {
+    return _Core.predicateBuilder.call(this);
+  }
+
   /**
    * Create the database table for this model from its attribute definitions.
    * Drops the table first if it already exists to handle schema changes

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -5,6 +5,7 @@ import { Substitute } from "../statement-cache.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { TableMetadata } from "../table-metadata.js";
 import { Base, registerModel, modelRegistry } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
 
 describe("PredicateBuilderTest", () => {
   // Rails setup: Topic.predicate_builder.register_handler(Regexp, proc { |col, val| col ~ val.source })
@@ -25,10 +26,12 @@ describe("PredicateBuilderTest", () => {
       call: (attr, val: RegexFilter) =>
         new Nodes.InfixOperation("~", attr, new Nodes.Quoted(val.source)),
     });
-    const sql = PbTopic.where({ title: new RegexFilter("rails") }).toSql();
-    expect(sql).toMatch(/"topics"."title" ~ 'rails'/i);
-    // Reset so next test isn't affected
-    (PbTopic as any)._predicateBuilder = null;
+    try {
+      const sql = PbTopic.where({ title: new RegexFilter("rails") }).toSql();
+      expect(sql).toMatch(/"topics"."title" ~ 'rails'/i);
+    } finally {
+      (PbTopic as any)._predicateBuilder = null;
+    }
   });
 
   it("registering new handlers for association", () => {
@@ -54,12 +57,15 @@ describe("PredicateBuilderTest", () => {
       call: (attr, val: RegexFilter2) =>
         new Nodes.InfixOperation("~", attr, new Nodes.Quoted(val.source)),
     });
-    const sql = PbReply2.where({ pbTopic2: { title: new RegexFilter2("rails") } }).toSql();
-    // Handler propagates to associated table — column uses association-resolved table name.
-    expect(sql).toMatch(/"pbTopic2"."title" ~ 'rails'/i);
-    modelRegistry.delete("PbTopic2");
-    modelRegistry.delete("PbReply2");
-    (PbTopic2 as any)._predicateBuilder = null;
+    try {
+      const sql = PbReply2.where({ pbTopic2: { title: new RegexFilter2("rails") } }).toSql();
+      // Handler propagates to associated table — column uses association-resolved table name.
+      expect(sql).toMatch(/"pbTopic2"."title" ~ 'rails'/i);
+    } finally {
+      modelRegistry.delete("PbTopic2");
+      modelRegistry.delete("PbReply2");
+      (PbTopic2 as any)._predicateBuilder = null;
+    }
   });
 
   it.skip("registering new handlers for joins", () => {
@@ -76,13 +82,27 @@ describe("PredicateBuilderTest", () => {
 
   it("build from hash with schema", () => {
     // Rails: predicate_builder.build_from_hash("schema.table.column" => "value").first.to_sql
-    // Mirrors convert_dot_notation_to_hash: "schema.table.column" → {schema.table: {column: value}}
-    // which then expands to "schema"."table"."column" = 'value'
-    const table = new Table("topics");
-    const builder = new PredicateBuilder(table);
-    const [node] = builder.buildFromHash({ "schema.table.column": "value" });
+    // convert_dot_notation_to_hash splits on rindex("."):
+    //   "schema.table.column" → { "schema.table" => { "column" => "value" } }
+    // TableMetadata.associated_table("schema.table") falls back to a bare Arel::Table("schema.table"),
+    // so expand_from_hash produces: "schema.table"."column" = 'value'
+    class PbSchemaModel extends Base {
+      static {
+        this.tableName = "topics";
+        this.attribute("title", "string");
+        this.adapter = createTestAdapter();
+      }
+    }
+    // Use TableMetadata-backed PB to enable associated_table fallback expansion,
+    // matching Rails' Topic.predicate_builder which is always backed by TableMetadata.
+    const [node] = new TableMetadata(
+      PbSchemaModel as any,
+      PbSchemaModel.arelTable,
+    ).predicateBuilder.buildFromHash({ "schema.table.column": "value" });
     const sql = new Visitors.ToSql().compile(node);
-    expect(sql).toMatch(/schema.*table.*column/i);
+    // Arel resolves "schema.table" as schema.table identifier, producing:
+    // "schema"."table"."column" = 'value'
+    expect(sql).toMatch(/"schema"\."table"\."column"/);
     expect(sql).toContain("value");
   });
 

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -7,35 +7,97 @@ import { TableMetadata } from "../table-metadata.js";
 import { Base, registerModel, modelRegistry } from "../index.js";
 
 describe("PredicateBuilderTest", () => {
-  it.skip("registering new handlers", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+  // Rails setup: Topic.predicate_builder.register_handler(Regexp, proc { |col, val| col ~ val.source })
+  // Teardown: Topic.class_eval { @predicate_builder = nil }
+  // We use a local custom class instead of Regexp to keep the test self-contained.
+
+  it("registering new handlers", () => {
+    class PbTopic extends Base {
+      static {
+        this.tableName = "topics";
+        this.attribute("title", "string");
+      }
+    }
+    class RegexFilter {
+      constructor(public source: string) {}
+    }
+    PbTopic.predicateBuilder.registerHandler(RegexFilter, {
+      call: (attr, val: RegexFilter) =>
+        new Nodes.InfixOperation("~", attr, new Nodes.Quoted(val.source)),
+    });
+    const sql = PbTopic.where({ title: new RegexFilter("rails") }).toSql();
+    expect(sql).toMatch(/"topics"."title" ~ 'rails'/i);
+    // Reset so next test isn't affected
+    (PbTopic as any)._predicateBuilder = null;
   });
-  it.skip("registering new handlers for association", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+
+  it("registering new handlers for association", () => {
+    class PbTopic2 extends Base {
+      static {
+        this.tableName = "topics";
+        this.attribute("title", "string");
+      }
+    }
+    class PbReply2 extends Base {
+      static {
+        this.tableName = "replies";
+        this.attribute("parent_id", "integer");
+        this.belongsTo("pbTopic2");
+      }
+    }
+    registerModel("PbTopic2", PbTopic2);
+    registerModel("PbReply2", PbReply2);
+    class RegexFilter2 {
+      constructor(public source: string) {}
+    }
+    PbTopic2.predicateBuilder.registerHandler(RegexFilter2, {
+      call: (attr, val: RegexFilter2) =>
+        new Nodes.InfixOperation("~", attr, new Nodes.Quoted(val.source)),
+    });
+    const sql = PbReply2.where({ pbTopic2: { title: new RegexFilter2("rails") } }).toSql();
+    // Handler propagates to associated table — column uses association-resolved table name.
+    expect(sql).toMatch(/"pbTopic2"."title" ~ 'rails'/i);
+    modelRegistry.delete("PbTopic2");
+    modelRegistry.delete("PbReply2");
+    (PbTopic2 as any)._predicateBuilder = null;
   });
+
   it.skip("registering new handlers for joins", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+    // BLOCKED: relation — requires scoped belongs_to (lambda scope) evaluated against association's
+    // predicate builder; our scoped-association where-clause expansion doesn't yet propagate
+    // the custom handlers registered on the target model into the scope lambda context.
   });
-  it.skip("references with schema", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+
+  it("references with schema", () => {
+    // Rails: PredicateBuilder.references(%w{schema.table.column}) => ["schema.table"]
+    const refs = PredicateBuilder.references(["schema.table.column"]);
+    expect(refs.map((r) => r.value)).toEqual(["schema.table"]);
   });
-  it.skip("build from hash with schema", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+
+  it("build from hash with schema", () => {
+    // Rails: predicate_builder.build_from_hash("schema.table.column" => "value").first.to_sql
+    // Mirrors convert_dot_notation_to_hash: "schema.table.column" → {schema.table: {column: value}}
+    // which then expands to "schema"."table"."column" = 'value'
+    const table = new Table("topics");
+    const builder = new PredicateBuilder(table);
+    const [node] = builder.buildFromHash({ "schema.table.column": "value" });
+    const sql = new Visitors.ToSql().compile(node);
+    expect(sql).toMatch(/schema.*table.*column/i);
+    expect(sql).toContain("value");
   });
-  it.skip("does not mutate", () => {
-    // BLOCKED: relation — Relation API gap in predicate-builder
-    // ROOT-CAUSE: relation/predicate-builder.ts or relation.ts missing Rails parity for this query feature
-    // SCOPE: ~30–100 LOC fix in relation/; affects ~10–39 tests in predicate-builder.test.ts
+
+  it("does not mutate", () => {
+    class PbTopic3 extends Base {
+      static {
+        this.tableName = "topics";
+        this.attribute("title", "string");
+        this.attribute("approved", "boolean");
+      }
+    }
+    const defaults: Record<string, unknown> = { title: "rails", approved: true };
+    const original = { ...defaults };
+    PbTopic3.where(defaults).toSql();
+    expect(defaults).toEqual(original);
   });
 
   describe("buildFromHash", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -61,11 +61,11 @@ export class PredicateBuilder {
   }
 
   buildFromHash(conditions: Record<string, unknown>): Nodes.Node[] {
-    return this.buildFromHashInternal(conditions, false);
+    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), false);
   }
 
   buildNegatedFromHash(conditions: Record<string, unknown>): Nodes.Node[] {
-    return this.buildFromHashInternal(conditions, true);
+    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), true);
   }
 
   private buildFromHashInternal(
@@ -402,7 +402,7 @@ export class PredicateBuilder {
     ) {
       throw new TypeError("registerHandler requires a constructor function as the first argument");
     }
-    this.handlers.push([klass, handler]);
+    this.handlers.unshift([klass, handler]);
   }
 
   buildBindAttribute(columnName: string, value: unknown): QueryAttribute {
@@ -462,9 +462,14 @@ export class PredicateBuilder {
     return null;
   }
 
-  static references(conditions: Record<string, unknown>): Nodes.SqlLiteral[] {
+  static references(conditions: string[] | Record<string, unknown>): Nodes.SqlLiteral[] {
     const refs: Nodes.SqlLiteral[] = [];
-    for (const [key, value] of Object.entries(conditions)) {
+    // Support array form: references(["schema.table.column"]) → ["schema.table"]
+    // Rails iterates attributes with each_with_object; for array input the "key" is each element.
+    const entries: Array<[string, unknown]> = Array.isArray(conditions)
+      ? conditions.map((k) => [k, undefined] as [string, unknown])
+      : Object.entries(conditions);
+    for (const [key, value] of entries) {
       if (isPlainObject(value)) {
         refs.push(arelSql(key));
       } else {


### PR DESCRIPTION
## Summary

- Wire `convertDotNotationToHash` into `buildFromHash`/`buildNegatedFromHash` so dot-notation keys (`"schema.table.column"`) are expanded before predicate building (matching Rails' `convert_dot_notation_to_hash` call in `build_from_hash`)
- Fix `registerHandler` to unshift (prepend) so later registrations take priority, matching Rails' `@handlers.unshift` pattern
- Expose `Base.predicateBuilder` as a static getter (delegates to `core.ts`) so per-model handler registration works from model classes (`Topic.predicateBuilder.registerHandler(...)`)
- Fix `PredicateBuilder.references` to accept `string[]` in addition to `Record<string, unknown>`, matching Rails' `test_references_with_schema` call form
- Un-skip 5 of 6 Rails-mirrored tests in `predicate-builder.test.ts`: `registering new handlers`, `registering new handlers for association`, `references with schema`, `build from hash with schema`, `does not mutate`

## Follow-ups

- **"registering new handlers for joins"** stays skipped — requires scoped `belongsTo` lambda evaluation against the target model's predicate builder, which our scoped-association where-clause expansion doesn't yet support
- Calculations skips (`should group by summed association`, `should calculate grouped association with foreign key option`, `pluck with serialization`) remain — all require fixture/DB data
- Field-ordered-values fixture tests (`in order of`, `in order of expression`, `in order of with associations`, `in order of with filter false`) remain — require actual DB rows