### PR TITLE
feat(vendor): wave 6 — wire rack + globalid + abstractcontroller into api-compare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
       - name: Fetch upstream Ruby sources
         run: pnpm vendor:fetch
       - name: Extract Ruby API
-        run: cd scripts/api-compare && RAILS_DIR=$(pnpm -s -C ../.. vendor:fetch --print-paths rails) ruby extract-ruby-api.rb
+        run: cd scripts/api-compare && LIB_PATHS_JSON=$(pnpm -s -C ../.. vendor:fetch --print-lib-paths) LOCKFILE_PATH=$GITHUB_WORKSPACE/vendor/sources.lock.json ruby extract-ruby-api.rb
       - name: Extract Ruby tests
         run: cd scripts/test-compare && TEST_PATHS_JSON=$(pnpm -s -C ../.. vendor:fetch --print-test-paths) ruby extract-ruby-tests.rb
       - name: API comparison

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "api:compare": "bash scripts/api-compare/run.sh",
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
-    "lint:deps": "pnpm vendor:fetch --source rails && RAILS_DIR=$(pnpm -s vendor:fetch --print-paths rails) ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
+    "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
     "test:stubs": "pnpm test:compare -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",
     "stats:sync": "pnpm tsx scripts/sync-stats/sync.ts",

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -35,18 +35,21 @@ PACKAGE_DIRS =
           "If you set it manually, re-run via `LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths)`."
   end
 
-# Cache gate: vendor/sources.lock.json's mtime tracks every fetched source —
-# a re-fetch updates it, an unchanged fetch leaves it alone. Skip the ~8s
-# Ripper pass when the output is newer than the lockfile. Honours
-# `API_COMPARE_FORCE=1` for the rare case where the extractor itself was
-# modified and you want a fresh manifest.
+# Cache gate: invalidate on either (a) a re-fetch (lockfile mtime bumped) or
+# (b) a registry edit (sources.ts mtime bumped — covers compareApi flips,
+# libPath edits, source add/remove). The output is current only when it's
+# newer than BOTH signals. Honours `API_COMPARE_FORCE=1` for the rare case
+# where the extractor itself was modified and you want a fresh manifest.
 output_path = File.join(OUTPUT_DIR, "rails-api.json")
 lockfile_path = ENV.fetch("LOCKFILE_PATH") do
   abort "extract-ruby-api.rb: LOCKFILE_PATH env var not set. Caller must export " \
         "it (e.g. LOCKFILE_PATH=\"$ROOT/vendor/sources.lock.json\")."
 end
+sources_ts_path = File.join(File.dirname(lockfile_path), "sources.ts")
 if ENV["API_COMPARE_FORCE"] != "1" && File.exist?(output_path) &&
-   File.exist?(lockfile_path) && File.mtime(output_path) >= File.mtime(lockfile_path)
+   File.exist?(lockfile_path) && File.exist?(sources_ts_path) &&
+   File.mtime(output_path) >= File.mtime(lockfile_path) &&
+   File.mtime(output_path) >= File.mtime(sources_ts_path)
   puts "Rails manifest #{output_path} is up to date (set API_COMPARE_FORCE=1 to regenerate)"
   exit 0
 end

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -11,37 +11,45 @@ require "time"
 require "set"
 
 SCRIPT_DIR = File.dirname(__FILE__)
-RAILS_DIR = ENV.fetch("RAILS_DIR") do
-  abort "extract-ruby-api.rb: RAILS_DIR env var not set. Caller must export " \
-        "it via `RAILS_DIR=$(pnpm -s vendor:fetch --print-paths rails)`."
-end
 OUTPUT_DIR = File.join(SCRIPT_DIR, "output")
 
-# Cache gate: Rails source is pinned to a tag by vendor/sources.ts and
-# doesn't change between runs. Skip the ~8s Ripper pass when the
-# output already exists and the Rails source hasn't moved since it
-# was last written. Honours `API_COMPARE_FORCE=1` for the rare case
-# where the extractor itself was modified and you want a fresh
-# manifest.
+# PACKAGE_DIRS is fed by the caller via LIB_PATHS_JSON (a JSON map of
+# {package_name: absolute_lib_dir}) — built from vendor/sources.ts by
+# `vendor/fetch.ts --print-lib-paths`. This Ruby script no longer carries
+# a parallel package table that drifts from the registry; adding a source
+# with compareApi !== false in vendor/sources.ts feeds through automatically.
+LIB_PATHS_JSON = ENV.fetch("LIB_PATHS_JSON") do
+  abort "extract-ruby-api.rb: LIB_PATHS_JSON env var not set. Caller must export " \
+        "it via `LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths)`."
+end
+PACKAGE_DIRS =
+  begin
+    parsed = JSON.parse(LIB_PATHS_JSON)
+    unless parsed.is_a?(Hash) && parsed.values.all? { |v| v.is_a?(String) }
+      abort "extract-ruby-api.rb: LIB_PATHS_JSON must be a JSON object of " \
+            "{string: string}; got #{parsed.class}. Re-run vendor:fetch --print-lib-paths."
+    end
+    parsed
+  rescue JSON::ParserError => e
+    abort "extract-ruby-api.rb: LIB_PATHS_JSON is not valid JSON (#{e.message}). " \
+          "If you set it manually, re-run via `LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths)`."
+  end
+
+# Cache gate: vendor/sources.lock.json's mtime tracks every fetched source —
+# a re-fetch updates it, an unchanged fetch leaves it alone. Skip the ~8s
+# Ripper pass when the output is newer than the lockfile. Honours
+# `API_COMPARE_FORCE=1` for the rare case where the extractor itself was
+# modified and you want a fresh manifest.
 output_path = File.join(OUTPUT_DIR, "rails-api.json")
-rails_head = File.join(RAILS_DIR, ".git", "HEAD")
+lockfile_path = ENV.fetch("LOCKFILE_PATH") do
+  abort "extract-ruby-api.rb: LOCKFILE_PATH env var not set. Caller must export " \
+        "it (e.g. LOCKFILE_PATH=\"$ROOT/vendor/sources.lock.json\")."
+end
 if ENV["API_COMPARE_FORCE"] != "1" && File.exist?(output_path) &&
-   File.exist?(rails_head) && File.mtime(output_path) >= File.mtime(rails_head)
+   File.exist?(lockfile_path) && File.mtime(output_path) >= File.mtime(lockfile_path)
   puts "Rails manifest #{output_path} is up to date (set API_COMPARE_FORCE=1 to regenerate)"
   exit 0
 end
-
-# Map of source directories to package names
-PACKAGE_DIRS = {
-  "arel" => File.join(RAILS_DIR, "activerecord", "lib", "arel"),
-  "activemodel" => File.join(RAILS_DIR, "activemodel", "lib", "active_model"),
-  "activerecord" => File.join(RAILS_DIR, "activerecord", "lib", "active_record"),
-  "activesupport" => File.join(RAILS_DIR, "activesupport", "lib", "active_support"),
-  "actiondispatch" => File.join(RAILS_DIR, "actionpack", "lib", "action_dispatch"),
-  "actioncontroller" => File.join(RAILS_DIR, "actionpack", "lib", "action_controller"),
-  "actionview" => File.join(RAILS_DIR, "actionview", "lib", "action_view"),
-  "trailties" => File.join(RAILS_DIR, "railties", "lib", "rails"),
-}
 
 # ---- Param extraction from Ripper AST ----
 
@@ -928,8 +936,11 @@ end
 # ---- Main ----
 
 def run
-  unless File.directory?(RAILS_DIR)
-    abort "Rails source not found at #{RAILS_DIR}. Run `pnpm vendor:fetch --source rails` first."
+  # Validate per-package paths (the JSON manifest may include paths the user
+  # hasn't fetched yet, e.g. a fresh checkout that skipped pnpm vendor:fetch).
+  PACKAGE_DIRS.each do |pkg, dir|
+    next if File.directory?(dir)
+    abort "Lib directory for #{pkg} not found at #{dir}. Run `pnpm vendor:fetch` first."
   end
 
   Dir.mkdir(OUTPUT_DIR) unless File.directory?(OUTPUT_DIR)

--- a/scripts/api-compare/run.sh
+++ b/scripts/api-compare/run.sh
@@ -9,8 +9,14 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/../.." && pwd)"
 
-pnpm tsx "$ROOT/vendor/fetch.ts" --source rails
-RAILS_DIR="$(pnpm tsx "$ROOT/vendor/fetch.ts" --print-paths rails)" ruby "$DIR/extract-ruby-api.rb"
+# Fetch every source the registry knows about (rails, rack, globalid, …).
+# extract-ruby-api.rb iterates whichever packages are in LIB_PATHS_JSON; the
+# old per-source --source rails was a wave-2b vestige that pre-dated rack
+# and globalid being api-compared.
+pnpm -s tsx "$ROOT/vendor/fetch.ts"
+LIB_PATHS_JSON="$(pnpm -s tsx "$ROOT/vendor/fetch.ts" --print-lib-paths)" \
+  LOCKFILE_PATH="$ROOT/vendor/sources.lock.json" \
+  ruby "$DIR/extract-ruby-api.rb"
 pnpm tsx "$DIR/extract-ts-api.ts"
 pnpm tsx "$DIR/compare.ts" "$@"
 pnpm tsx "$ROOT/scripts/build-rails-privates-manifest.ts"

--- a/vendor/fetch.test.ts
+++ b/vendor/fetch.test.ts
@@ -66,6 +66,20 @@ describe("vendor/fetch.ts parseArgs", () => {
     expect(JSON.parse(out)).toEqual(testPathsManifest());
   });
 
+  it("--print-lib-paths emits valid JSON matching libPathsManifest()", async () => {
+    // Mirror of the --print-test-paths integration test for wave-6's
+    // LIB_PATHS_JSON pipeline (extract-ruby-api.rb).
+    const { execFileSync } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const here = dirname(fileURLToPath(import.meta.url));
+    const out = execFileSync("pnpm", ["-s", "tsx", join(here, "fetch.ts"), "--print-lib-paths"], {
+      encoding: "utf8",
+    });
+    const { libPathsManifest } = await import("./sources.js");
+    expect(JSON.parse(out)).toEqual(libPathsManifest());
+  });
+
   it("rejects unknown flags", () => {
     expect(() => parseArgs(["--bogus"])).toThrow(/unknown flag: --bogus/);
   });

--- a/vendor/fetch.test.ts
+++ b/vendor/fetch.test.ts
@@ -8,6 +8,7 @@ describe("vendor/fetch.ts parseArgs", () => {
       migrate: false,
       printPaths: { active: false },
       printTestPaths: false,
+      printLibPaths: false,
     });
   });
 
@@ -42,6 +43,10 @@ describe("vendor/fetch.ts parseArgs", () => {
 
   it("--print-test-paths sets the flag", () => {
     expect(parseArgs(["--print-test-paths"]).printTestPaths).toBe(true);
+  });
+
+  it("--print-lib-paths sets the flag", () => {
+    expect(parseArgs(["--print-lib-paths"]).printLibPaths).toBe(true);
   });
 
   it("--print-test-paths emits valid JSON matching testPathsManifest()", async () => {

--- a/vendor/fetch.ts
+++ b/vendor/fetch.ts
@@ -18,6 +18,9 @@
 //                         for every package with a testPath and
 //                         compareTests !== false. Used by extract-ruby-tests.rb
 //                         via the TEST_PATHS_JSON env var.
+//   --print-lib-paths:    no fetch; print JSON map {package: absolute_lib_dir}
+//                         for every package with compareApi !== false. Used by
+//                         extract-ruby-api.rb via the LIB_PATHS_JSON env var.
 
 import { execFile, execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -27,7 +30,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-import { SOURCES, testPathsManifest, type UpstreamSource } from "./sources.js";
+import { libPathsManifest, SOURCES, testPathsManifest, type UpstreamSource } from "./sources.js";
 
 const VENDOR_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(VENDOR_DIR, "..");
@@ -197,12 +200,17 @@ function printTestPaths(): void {
   process.stdout.write(JSON.stringify(testPathsManifest()) + "\n");
 }
 
+function printLibPaths(): void {
+  process.stdout.write(JSON.stringify(libPathsManifest()) + "\n");
+}
+
 export interface ParsedArgs {
   sourceFilter?: string;
   refresh: boolean;
   migrate: boolean;
   printPaths: { active: boolean; name?: string };
   printTestPaths: boolean;
+  printLibPaths: boolean;
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -211,6 +219,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     migrate: false,
     printPaths: { active: false },
     printTestPaths: false,
+    printLibPaths: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -218,6 +227,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     else if (a === "--refresh") out.refresh = true;
     else if (a === "--migrate") out.migrate = true;
     else if (a === "--print-test-paths") out.printTestPaths = true;
+    else if (a === "--print-lib-paths") out.printLibPaths = true;
     else if (a === "--print-paths") {
       const next = argv[i + 1];
       out.printPaths = {
@@ -238,6 +248,10 @@ async function main(argv: string[]): Promise<void> {
   }
   if (args.printTestPaths) {
     printTestPaths();
+    return;
+  }
+  if (args.printLibPaths) {
+    printLibPaths();
     return;
   }
 

--- a/vendor/fetch.ts
+++ b/vendor/fetch.ts
@@ -61,7 +61,12 @@ function writeLockfile(lock: Lockfile): void {
   for (const name of Object.keys(lock.sources).sort()) {
     sorted.sources[name] = lock.sources[name];
   }
-  writeFileSync(LOCKFILE_PATH, JSON.stringify(sorted, null, 2) + "\n");
+  const next = JSON.stringify(sorted, null, 2) + "\n";
+  // Only write when content actually changed. Otherwise every no-op fetch
+  // would bump the lockfile mtime and defeat extract-ruby-api.rb's cache
+  // gate (which compares output_path mtime to LOCKFILE_PATH mtime).
+  if (existsSync(LOCKFILE_PATH) && readFileSync(LOCKFILE_PATH, "utf8") === next) return;
+  writeFileSync(LOCKFILE_PATH, next);
 }
 
 async function git(args: string[], cwd: string): Promise<string> {

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   apiComparePackages,
+  libPathsManifest,
   resolvePath,
   SOURCES,
   testPathsManifest,
@@ -42,9 +43,7 @@ describe("vendor/sources.ts", () => {
     const rack = SOURCES.find((s) => s.name === "rack");
     expect(rack).toBeDefined();
     expect(rack!.origin.ref).toBe("v3.1.14");
-    expect(rack!.packages).toEqual([
-      { name: "rack", libPath: "lib", testPath: "test", compareApi: false },
-    ]);
+    expect(rack!.packages).toEqual([{ name: "rack", libPath: "lib/rack", testPath: "test" }]);
   });
 
   it("declares the globalid source (wave 3)", () => {
@@ -56,7 +55,7 @@ describe("vendor/sources.ts", () => {
       ref: "v1.3.0",
     });
     expect(gid!.packages).toEqual([
-      { name: "globalid", libPath: "lib", testPath: "test/cases", compareApi: false },
+      { name: "globalid", libPath: "lib/global_id", testPath: "test/cases" },
     ]);
   });
 
@@ -142,20 +141,20 @@ describe("vendor/sources.ts", () => {
     expect(() => vendoredRoot("nope")).toThrow(/no source named "nope"/);
   });
 
-  it("apiComparePackages excludes compareApi:false entries (rack, globalid)", () => {
+  it("apiComparePackages includes rack and globalid (wave 6: compareApi flipped on)", () => {
     const pkgs = apiComparePackages();
-    expect(pkgs).not.toContain("rack");
-    expect(pkgs).not.toContain("globalid");
+    expect(pkgs).toContain("rack");
+    expect(pkgs).toContain("globalid");
     expect(pkgs).toContain("activerecord");
     expect(pkgs).toContain("abstractcontroller");
   });
 
-  it("apiComparePackages returns exactly the historic 9-entry api-compare set", () => {
-    // Bulletproofs against a future PR that accidentally toggles compareApi on
-    // an api-compared package, or adds/drops a Rails subgem from SOURCES
-    // without updating extract-ruby-api.rb. If extract-ruby-api.rb's PACKAGE_DIRS
-    // gets derived from SOURCES (a future wave), this assertion needs to grow
-    // with it — that's the intended forcing function.
+  it("apiComparePackages returns exactly the wave-6 11-entry api-compare set", () => {
+    // Bulletproofs against a future PR that accidentally toggles compareApi
+    // on a package, or adds/drops a source from SOURCES without updating
+    // extract-ruby-api.rb. extract-ruby-api.rb's PACKAGE_DIRS is now derived
+    // from libPathsManifest() — same SOURCES list — so this assertion stays
+    // in lockstep with the Ruby script automatically.
     expect(apiComparePackages().sort()).toEqual(
       [
         "abstractcontroller",
@@ -166,9 +165,22 @@ describe("vendor/sources.ts", () => {
         "activerecord",
         "activesupport",
         "arel",
+        "globalid",
+        "rack",
         "trailties",
       ].sort(),
     );
+  });
+
+  it("libPathsManifest returns absolute lib dirs for every api-compared package", () => {
+    const m = libPathsManifest();
+    expect(Object.keys(m).sort()).toEqual(apiComparePackages().sort());
+    expect(m["activerecord"].endsWith("vendor/rails/activerecord/lib/active_record")).toBe(true);
+    expect(
+      m["abstractcontroller"].endsWith("vendor/rails/actionpack/lib/abstract_controller"),
+    ).toBe(true);
+    expect(m["rack"].endsWith("vendor/rack/lib/rack")).toBe(true);
+    expect(m["globalid"].endsWith("vendor/globalid/lib/global_id")).toBe(true);
   });
 
   it("testPathsManifest returns absolute test dirs for the wave-5 set", () => {

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -127,7 +127,10 @@ export const SOURCES: readonly UpstreamSource[] = [
       url: "https://github.com/rack/rack.git",
       ref: "v3.1.14",
     },
-    packages: [{ name: "rack", libPath: "lib", testPath: "test", compareApi: false }],
+    // libPath points at `lib/rack/` (the Rack module root) for symmetry with
+    // how Rails subgems are mapped — see e.g. activerecord/lib/active_record.
+    // Bare `lib` would also scan lib/rack.rb (the entrypoint shim).
+    packages: [{ name: "rack", libPath: "lib/rack", testPath: "test" }],
   },
   {
     name: "globalid",
@@ -139,12 +142,13 @@ export const SOURCES: readonly UpstreamSource[] = [
     packages: [
       {
         name: "globalid",
-        libPath: "lib",
+        // Globalid's lib root is `lib/global_id/` (Ruby module GlobalID maps
+        // to global_id). Pointing at `lib` directly would scan global_id.rb +
+        // global_id/*.rb together; pointing at `lib/global_id` matches the
+        // pattern used for activerecord (lib/active_record/).
+        libPath: "lib/global_id",
         // Globalid puts *_test.rb under test/cases/ (not test/ directly).
         testPath: "test/cases",
-        compareApi: false,
-        // compareTests defaults to true; globalid tests are already in
-        // extract-ruby-tests.rb's PACKAGE_TEST_DIRS (predates this PR).
       },
     ],
   },
@@ -226,6 +230,23 @@ export function vendoredRoot(sourceName: string): string {
   const found = SOURCES.find((s) => s.name === sourceName);
   if (!found) throw new Error(`vendor/sources.ts: no source named "${sourceName}"`);
   return join(VENDOR_DIR, sourceName);
+}
+
+/**
+ * Map of package name → absolute lib directory for every package with
+ * `compareApi !== false`. Wave 6: feeds extract-ruby-api.rb via
+ * `LIB_PATHS_JSON` env var so the Ruby script's PACKAGE_DIRS isn't a
+ * hand-maintained map that drifts from SOURCES.
+ */
+export function libPathsManifest(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const source of SOURCES) {
+    for (const pkg of source.packages) {
+      if (pkg.compareApi === false) continue;
+      out[pkg.name] = resolve(VENDOR_DIR, source.name, pkg.libPath);
+    }
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
Wave 6 of the unified Ruby source-fetcher plan ([docs/ruby-source-fetcher-plan.md](docs/ruby-source-fetcher-plan.md)). Closes the parallel-package-list drift between `vendor/sources.ts` and `extract-ruby-api.rb`. PACKAGE_DIRS is now derived from sources.ts via a new `--print-lib-paths` JSON flag — symmetric with wave 5's `--print-test-paths`.

## Summary

- **`vendor/sources.ts`**:
  - `libPathsManifest()` returns `{pkg: absolute_lib_dir}` for every `compareApi`-eligible package.
  - Flips `compareApi: false → true` on rack and globalid (now api-compared).
  - Sharpens libPaths: `rack` "lib" → "lib/rack", `globalid` "lib" → "lib/global_id" (matches `activerecord/lib/active_record` style — module root, not entrypoint shim).
- **`vendor/fetch.ts`**: `--print-lib-paths` flag; CLI synopsis updated.
- **`scripts/api-compare/extract-ruby-api.rb`**:
  - `PACKAGE_DIRS = JSON.parse(ENV["LIB_PATHS_JSON"])`. `RAILS_DIR` consumption deleted.
  - Cache gate switched from `<RAILS_DIR>/.git/HEAD` mtime to `vendor/sources.lock.json` mtime (single signal for all sources; no privileged "rails" source). Reads lockfile path from `LOCKFILE_PATH`.
  - Per-package dir validation in `run()` replaces the single-RAILS_DIR check.
- **`scripts/api-compare/run.sh` + `package.json` `lint:deps` + `.github/workflows/ci.yml`**: collapsed `RAILS_DIR` / `--source rails` plumbing into `LIB_PATHS_JSON` + `LOCKFILE_PATH`. Single env-var pattern, mirrors wave 5.
- **`vendor/sources.test.ts`**: pin updated 9 → 11 entries; new `libPathsManifest` test asserts manifest matches `apiComparePackages` set.
- **`vendor/fetch.test.ts`**: `--print-lib-paths` parse coverage + defaults.

## Visible side effects (newly correct, not regressions)

| package | before | after |
| --- | --- | --- |
| activemodel | 621/621 (100%) | **621/621 (100%)** unchanged |
| rack | hidden (no PACKAGE_DIRS entry) | **289/550 (52.5%)** newly visible |
| globalid | hidden (no PACKAGE_DIRS entry) | **8/59 (13.6%)** newly visible |
| abstractcontroller | 0/0 (PACKAGE_DIRS gap from before wave 6) | **0/82 (0%)** gap now visible |

abstractcontroller's 0/82 was the pre-existing gap called out in wave-4 post-merge findings — `PACKAGES` had it, `PACKAGE_DIRS` didn't. Now both derive from the same source so the gap surfaces. Future parity work can address it.

## Globalid test count
**8** `*_test.rb` files at v1.3.0 in `test/cases/` (per PR #1578 follow-up).

## What's deferred to wave 7
- Doc + memory sweep.
- Generate `scripts/parity/schema/ruby/Gemfile` from `vendor/sources.ts`.
- Optional: refactor `extract-ruby-tests.rb` to use per-subdir `actiondispatch`/`actioncontroller` testPaths and remove the in-extractor split filter.

## Stats
- Net **+69 LOC** (118 add / 49 del). Within wave 6 budget.
- 27 → 29 vendor tests.

## Test plan
- [x] 29 vendor tests pass.
- [x] `pnpm api:compare` smoke for activemodel / rack / globalid / abstractcontroller — numbers match expectations.
- [ ] CI green.