### PR TITLE
test(activerecord): associations-core Slot D — collection-proxy fidelity

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -6735,11 +6735,53 @@ describe("AssociationProxyTest", () => {
     await proxy.push(comment);
     expect(proxy.loaded).toBe(false);
   });
-  it.skip("push has many through does not load target", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* Rails: david.categories << category; assert_not david.categories.loaded? — needs has_many_through push-without-load */
+  it("push has many through does not load target", async () => {
+    class APTagging extends Base {
+      static {
+        this._tableName = "ap_taggings";
+        this.attribute("ap_tagged_post_id", "integer");
+        this.attribute("ap_category_id", "integer");
+        this.adapter = apAdapter;
+      }
+    }
+    class APCategory extends Base {
+      static {
+        this._tableName = "ap_categories";
+        this.attribute("name", "string");
+        this.adapter = apAdapter;
+      }
+    }
+    class APTaggedPost extends Base {
+      static {
+        this._tableName = "ap_tagged_posts";
+        this.attribute("title", "string");
+        this.adapter = apAdapter;
+      }
+    }
+    Associations.hasMany.call(APTaggedPost, "apTaggings", {
+      className: "APTagging",
+      foreignKey: "ap_tagged_post_id",
+    });
+    Associations.hasMany.call(APTaggedPost, "apCategories", {
+      className: "APCategory",
+      through: "apTaggings",
+      source: "apCategory",
+    });
+    Associations.belongsTo.call(APTagging, "apCategory", {
+      className: "APCategory",
+      foreignKey: "ap_category_id",
+    });
+    registerModel("APTagging", APTagging);
+    registerModel("APCategory", APCategory);
+    registerModel("APTaggedPost", APTaggedPost);
+
+    const post = await APTaggedPost.create({ title: "tagged" });
+    const category = await APCategory.create({ name: "ruby" });
+    const proxy = association(post, "apCategories");
+    expect(proxy.loaded).toBe(false);
+    await proxy.push(category as any);
+    // pushing via through creates the join record but must NOT load the target
+    expect(proxy.loaded).toBe(false);
   });
   it("push followed by save does not load target", async () => {
     const { APPost, APComment } = setupProxyModels();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -6782,6 +6782,9 @@ describe("AssociationProxyTest", () => {
     await proxy.push(category as any);
     // pushing via through creates the join record but must NOT load the target
     expect(proxy.loaded).toBe(false);
+    // the pushed record is discoverable via include? (Rails: assert_includes)
+    expect(await proxy.isInclude(category as any)).toBe(true);
+    expect(proxy.loaded).toBe(false);
   });
   it("push followed by save does not load target", async () => {
     const { APPost, APComment } = setupProxyModels();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1376,7 +1376,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async many(predicate?: (record: T) => boolean): Promise<boolean> {
     if (predicate !== undefined) {
       const records = await this.loadTarget();
-      return records.filter(predicate).length > 1;
+      let matched = 0;
+      for (const r of records) {
+        if (predicate(r) && ++matched > 1) return true;
+      }
+      return false;
     }
     return (await this.count()) > 1;
   }
@@ -1392,7 +1396,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async isNone(predicate?: (record: T) => boolean): Promise<boolean> {
     if (predicate !== undefined) {
       const records = await this.loadTarget();
-      return records.filter(predicate).length === 0;
+      for (const r of records) {
+        if (predicate(r)) return false;
+      }
+      return true;
     }
     return (await this.count()) === 0;
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1373,7 +1373,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#many?
    */
-  async many(): Promise<boolean> {
+  async many(predicate?: (record: T) => boolean): Promise<boolean> {
+    if (predicate !== undefined) {
+      const records = await this.loadTarget();
+      return records.filter(predicate).length > 1;
+    }
     return (await this.count()) > 1;
   }
 
@@ -1385,7 +1389,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // @ts-expect-error Rails Relation#none? fires a query (Enumerable#none?
   //   via each); our Relation#isNone only checks the NullRelation flag.
   //   CP must fire a count query to check actual emptiness. Permanent.
-  async isNone(): Promise<boolean> {
+  async isNone(predicate?: (record: T) => boolean): Promise<boolean> {
+    if (predicate !== undefined) {
+      const records = await this.loadTarget();
+      return records.filter(predicate).length === 0;
+    }
     return (await this.count()) === 0;
   }
 

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
 import {
   SubclassNotFound,
   Base,
@@ -6227,7 +6228,16 @@ describe("HasManyAssociationsTest", () => {
     await proxy.load();
     expect(proxy.loaded).toBe(true);
     // many() on a loaded proxy reads target.length — no extra query
-    expect(await proxy.many()).toBe(true);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.many()).toBe(true);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries).toHaveLength(0);
     expect(proxy.loaded).toBe(true);
   });
   it("subsequent calls to many should use query", async () => {
@@ -6344,7 +6354,16 @@ describe("HasManyAssociationsTest", () => {
     await proxy.load();
     expect(proxy.loaded).toBe(true);
     // loaded → isNone reads target.length, no extra query
-    expect(await proxy.isNone()).toBe(false);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.isNone()).toBe(false);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries).toHaveLength(0);
   });
   it("calling none should defer to collection if using a block", async () => {
     class NoneBlkAuthor extends Base {

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3645,59 +3645,67 @@ describe("HasManyAssociationsTest", () => {
     expect((posts2[0] as any).title).toBe("First");
   });
   it("reload with query cache", async () => {
-    class Author extends Base {
+    class ReloadQcAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class ReloadQcPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    const posts1 = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(ReloadQcAuthor, "reloadQcPosts", {
+      className: "ReloadQcPost",
       foreignKey: "author_id",
     });
-    expect(posts1.length).toBe(1);
-    // Reload should return same results
-    const posts2 = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts2.length).toBe(1);
+    registerModel("ReloadQcAuthor", ReloadQcAuthor);
+    registerModel("ReloadQcPost", ReloadQcPost);
+    const author = await ReloadQcAuthor.create({ name: "Alice" });
+    await ReloadQcPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "reloadQcPosts");
+    await proxy.load();
+    expect(proxy.loaded).toBe(true);
+    expect(proxy.target.length).toBe(1);
+    // Insert a new record behind the proxy's back
+    await ReloadQcPost.create({ author_id: author.id, title: "B" });
+    // reload clears the cache and fetches fresh data
+    await proxy.reload();
+    expect(proxy.loaded).toBe(true);
+    expect(proxy.target.length).toBe(2);
   });
   it("reloading unloaded associations with query cache", async () => {
-    class Author extends Base {
+    class ReloadUlAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class ReloadUlPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    // Load without having previously loaded
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(ReloadUlAuthor, "reloadUlPosts", {
+      className: "ReloadUlPost",
       foreignKey: "author_id",
     });
-    expect(posts.length).toBe(1);
+    registerModel("ReloadUlAuthor", ReloadUlAuthor);
+    registerModel("ReloadUlPost", ReloadUlPost);
+    const author = await ReloadUlAuthor.create({ name: "Alice" });
+    await ReloadUlPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "reloadUlPosts");
+    expect(proxy.loaded).toBe(false);
+    // reload on an unloaded proxy still loads and returns the correct data
+    await proxy.reload();
+    expect(proxy.loaded).toBe(true);
+    expect(proxy.target.length).toBe(1);
+    expect(proxy.target[0].title).toBe("A");
   });
   it("find all with include and conditions", async () => {
     class FICAuthor extends Base {
@@ -5963,16 +5971,18 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(InclAuthor);
-    registerModel(InclPost);
-    const author = await InclAuthor.create({ name: "Alice" });
-    const post = await InclPost.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "incl_posts", {
+    Associations.hasMany.call(InclAuthor, "inclPosts", {
       className: "InclPost",
       foreignKey: "author_id",
     });
-    const found = posts.some((p: any) => p.id === post.id);
-    expect(found).toBe(true);
+    registerModel("InclAuthor", InclAuthor);
+    registerModel("InclPost", InclPost);
+    const author = await InclAuthor.create({ name: "Alice" });
+    const post = await InclPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "inclPosts");
+    // target not loaded — isInclude must query the DB
+    expect(proxy.loaded).toBe(false);
+    expect(await proxy.isInclude(post as any)).toBe(true);
   });
   it("include returns false for non matching record to verify scoping", async () => {
     class InclScopeAuthor extends Base {
@@ -5988,17 +5998,18 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(InclScopeAuthor);
-    registerModel(InclScopePost);
-    const author1 = await InclScopeAuthor.create({ name: "Alice" });
-    const author2 = await InclScopeAuthor.create({ name: "Bob" });
-    const post = await InclScopePost.create({ author_id: author2.id, title: "B" });
-    const posts = await loadHasMany(author1, "incl_scope_posts", {
+    Associations.hasMany.call(InclScopeAuthor, "inclScopePosts", {
       className: "InclScopePost",
       foreignKey: "author_id",
     });
-    const found = posts.some((p: any) => p.id === post.id);
-    expect(found).toBe(false);
+    registerModel("InclScopeAuthor", InclScopeAuthor);
+    registerModel("InclScopePost", InclScopePost);
+    const author1 = await InclScopeAuthor.create({ name: "Alice" });
+    const author2 = await InclScopeAuthor.create({ name: "Bob" });
+    const post = await InclScopePost.create({ author_id: author2.id, title: "B" });
+    const proxy = association(author1, "inclScopePosts");
+    // record belongs to author2, not author1 — scope prevents match
+    expect(await proxy.isInclude(post as any)).toBe(false);
   });
   it("calling first nth or last on association should not load association", async () => {
     class FnlAuthor extends Base {
@@ -6172,17 +6183,20 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(ManyCountAuthor);
-    registerModel(ManyCountPost);
-    const author = await ManyCountAuthor.create({ name: "Alice" });
-    await ManyCountPost.create({ author_id: author.id, title: "A" });
-    await ManyCountPost.create({ author_id: author.id, title: "B" });
-    const posts = await loadHasMany(author, "many_count_posts", {
+    Associations.hasMany.call(ManyCountAuthor, "manyCountPosts", {
       className: "ManyCountPost",
       foreignKey: "author_id",
     });
-    // "many?" means length > 1
-    expect(posts.length > 1).toBe(true);
+    registerModel("ManyCountAuthor", ManyCountAuthor);
+    registerModel("ManyCountPost", ManyCountPost);
+    const author = await ManyCountAuthor.create({ name: "Alice" });
+    await ManyCountPost.create({ author_id: author.id, title: "A" });
+    await ManyCountPost.create({ author_id: author.id, title: "B" });
+    const proxy = association(author, "manyCountPosts");
+    expect(proxy.loaded).toBe(false);
+    expect(await proxy.many()).toBe(true);
+    // many() uses COUNT — must NOT have loaded the target
+    expect(proxy.loaded).toBe(false);
   });
   it("calling many on loaded association should not use query", async () => {
     class ManyLoadAuthor extends Base {
@@ -6198,22 +6212,21 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(ManyLoadAuthor);
-    registerModel(ManyLoadPost);
+    Associations.hasMany.call(ManyLoadAuthor, "manyLoadPosts", {
+      className: "ManyLoadPost",
+      foreignKey: "author_id",
+    });
+    registerModel("ManyLoadAuthor", ManyLoadAuthor);
+    registerModel("ManyLoadPost", ManyLoadPost);
     const author = await ManyLoadAuthor.create({ name: "Alice" });
     await ManyLoadPost.create({ author_id: author.id, title: "A" });
     await ManyLoadPost.create({ author_id: author.id, title: "B" });
-    const posts = await loadHasMany(author, "many_load_posts", {
-      className: "ManyLoadPost",
-      foreignKey: "author_id",
-    });
-    expect(posts.length > 1).toBe(true);
-    // Calling again should return same result
-    const posts2 = await loadHasMany(author, "many_load_posts", {
-      className: "ManyLoadPost",
-      foreignKey: "author_id",
-    });
-    expect(posts2.length > 1).toBe(true);
+    const proxy = association(author, "manyLoadPosts");
+    await proxy.load();
+    expect(proxy.loaded).toBe(true);
+    // many() on a loaded proxy reads target.length — no extra query
+    expect(await proxy.many()).toBe(true);
+    expect(proxy.loaded).toBe(true);
   });
   it("subsequent calls to many should use query", async () => {
     class ManySubAuthor extends Base {
@@ -6229,21 +6242,21 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(ManySubAuthor);
-    registerModel(ManySubPost);
+    Associations.hasMany.call(ManySubAuthor, "manySubPosts", {
+      className: "ManySubPost",
+      foreignKey: "author_id",
+    });
+    registerModel("ManySubAuthor", ManySubAuthor);
+    registerModel("ManySubPost", ManySubPost);
     const author = await ManySubAuthor.create({ name: "Alice" });
     await ManySubPost.create({ author_id: author.id, title: "A" });
-    const posts1 = await loadHasMany(author, "many_sub_posts", {
-      className: "ManySubPost",
-      foreignKey: "author_id",
-    });
-    expect(posts1.length > 1).toBe(false);
+    const proxy = association(author, "manySubPosts");
+    // 1 post → not many
+    expect(await proxy.many()).toBe(false);
+    expect(proxy.loaded).toBe(false);
+    // second call still issues a COUNT (not cached)
     await ManySubPost.create({ author_id: author.id, title: "B" });
-    const posts2 = await loadHasMany(author, "many_sub_posts", {
-      className: "ManySubPost",
-      foreignKey: "author_id",
-    });
-    expect(posts2.length > 1).toBe(true);
+    expect(await proxy.many()).toBe(true);
   });
   it("calling many should defer to collection if using a block", async () => {
     class ManyBlkAuthor extends Base {
@@ -6259,18 +6272,22 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(ManyBlkAuthor);
-    registerModel(ManyBlkPost);
-    const author = await ManyBlkAuthor.create({ name: "Alice" });
-    await ManyBlkPost.create({ author_id: author.id, title: "A" });
-    await ManyBlkPost.create({ author_id: author.id, title: "B" });
-    const posts = await loadHasMany(author, "many_blk_posts", {
+    Associations.hasMany.call(ManyBlkAuthor, "manyBlkPosts", {
       className: "ManyBlkPost",
       foreignKey: "author_id",
     });
-    // Block-style: filter and check many
-    const filtered = posts.filter((p: any) => p.title === "A");
-    expect(filtered.length > 1).toBe(false);
+    registerModel("ManyBlkAuthor", ManyBlkAuthor);
+    registerModel("ManyBlkPost", ManyBlkPost);
+    const author = await ManyBlkAuthor.create({ name: "Alice" });
+    await ManyBlkPost.create({ author_id: author.id, title: "A" });
+    await ManyBlkPost.create({ author_id: author.id, title: "B" });
+    const proxy = association(author, "manyBlkPosts");
+    // predicate form: loads target, filters, checks count > 1
+    expect(await proxy.many((p) => (p as any).title === "A")).toBe(false);
+    // predicate matched all → many
+    expect(await proxy.many((_p) => true)).toBe(true);
+    // loading side-effect: target should now be loaded
+    expect(proxy.loaded).toBe(true);
   });
   it("calling none should count instead of loading association", async () => {
     class NoneCountAuthor extends Base {
@@ -6286,15 +6303,18 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(NoneCountAuthor);
-    registerModel(NoneCountPost);
-    const author = await NoneCountAuthor.create({ name: "Alice" });
-    const posts = await loadHasMany(author, "none_count_posts", {
+    Associations.hasMany.call(NoneCountAuthor, "noneCountPosts", {
       className: "NoneCountPost",
       foreignKey: "author_id",
     });
-    // "none?" means length === 0
-    expect(posts.length === 0).toBe(true);
+    registerModel("NoneCountAuthor", NoneCountAuthor);
+    registerModel("NoneCountPost", NoneCountPost);
+    const author = await NoneCountAuthor.create({ name: "Alice" });
+    const proxy = association(author, "noneCountPosts");
+    expect(proxy.loaded).toBe(false);
+    expect(await proxy.isNone()).toBe(true);
+    // isNone() uses COUNT — must NOT have loaded the target
+    expect(proxy.loaded).toBe(false);
   });
   it("calling none on loaded association should not use query", async () => {
     class NoneLoadAuthor extends Base {
@@ -6310,15 +6330,19 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(NoneLoadAuthor);
-    registerModel(NoneLoadPost);
-    const author = await NoneLoadAuthor.create({ name: "Alice" });
-    await NoneLoadPost.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "none_load_posts", {
+    Associations.hasMany.call(NoneLoadAuthor, "noneLoadPosts", {
       className: "NoneLoadPost",
       foreignKey: "author_id",
     });
-    expect(posts.length === 0).toBe(false);
+    registerModel("NoneLoadAuthor", NoneLoadAuthor);
+    registerModel("NoneLoadPost", NoneLoadPost);
+    const author = await NoneLoadAuthor.create({ name: "Alice" });
+    await NoneLoadPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "noneLoadPosts");
+    await proxy.load();
+    expect(proxy.loaded).toBe(true);
+    // loaded → isNone reads target.length, no extra query
+    expect(await proxy.isNone()).toBe(false);
   });
   it("calling none should defer to collection if using a block", async () => {
     class NoneBlkAuthor extends Base {
@@ -6334,16 +6358,20 @@ describe("HasManyAssociationsTest", () => {
         this.adapter = adapter;
       }
     }
-    registerModel(NoneBlkAuthor);
-    registerModel(NoneBlkPost);
-    const author = await NoneBlkAuthor.create({ name: "Alice" });
-    await NoneBlkPost.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "none_blk_posts", {
+    Associations.hasMany.call(NoneBlkAuthor, "noneBlkPosts", {
       className: "NoneBlkPost",
       foreignKey: "author_id",
     });
-    const filtered = posts.filter((p: any) => p.title === "Z");
-    expect(filtered.length === 0).toBe(true);
+    registerModel("NoneBlkAuthor", NoneBlkAuthor);
+    registerModel("NoneBlkPost", NoneBlkPost);
+    const author = await NoneBlkAuthor.create({ name: "Alice" });
+    await NoneBlkPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "noneBlkPosts");
+    // predicate matches nothing → none
+    expect(await proxy.isNone((p) => (p as any).title === "Z")).toBe(true);
+    // predicate matched some → not none
+    expect(await proxy.isNone((_p) => true)).toBe(false);
+    expect(proxy.loaded).toBe(true);
   });
   it("calling one should count instead of loading association", async () => {
     class OneCountAuthor extends Base {

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -5983,6 +5983,8 @@ describe("HasManyAssociationsTest", () => {
     // target not loaded — isInclude must query the DB
     expect(proxy.loaded).toBe(false);
     expect(await proxy.isInclude(post as any)).toBe(true);
+    // include? via EXISTS does not load the target (Rails: assert_not loaded?)
+    expect(proxy.loaded).toBe(false);
   });
   it("include returns false for non matching record to verify scoping", async () => {
     class InclScopeAuthor extends Base {


### PR DESCRIPTION
## Summary

- **`many(predicate?)` / `isNone(predicate?)`**: add optional predicate argument so the Ruby block-form (`many? { ... }`) tests translate naturally to JS. Without a predicate both still delegate to `count()` (no load). With a predicate they load the target, filter, then check the count.

- **9 test stubs ported in `has-many-associations.test.ts`**: replaced `loadHasMany`-based placeholder bodies with `CollectionProxy`-exercising bodies that mirror what the corresponding Rails tests actually assert:
  - `many?` uses COUNT on unloaded proxy → `loaded === false` after
  - `many?` on loaded proxy reads `target.length` (no extra query)
  - subsequent `many?` calls re-issue COUNT (not cached)
  - `many?(pred)` / `none?(pred)` load target and filter (`loaded` becomes true)
  - `none?` mirrors the same pattern
  - `include?` (→ `isInclude`) queries DB when unloaded; respects FK scope
  - `reload` picks up externally-inserted rows; works on an unloaded proxy

- **Un-skipped `push has many through does not load target`** in `associations.test.ts`: a minimal `APTaggedPost → APTagging → APCategory` fixture confirms that `_pushThrough` creates the join record without setting `_targetLoaded`.

## Test plan

- [ ] `pnpm run test` — all tests pass, 0 failures
- [ ] `has-many-associations.test.ts` 310 tests (1 skipped, unchanged)
- [ ] `associations.test.ts` 397 tests (35 skipped, down from 36)