### PR TITLE
feat(activerecord,arel): Schema cluster Slot H-b — Thing1..5 + SchemaThing AR fixtures + 6 un-skips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema-ar-models.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-ar-models.ts
@@ -42,7 +42,7 @@ export async function makeThingModels(
   return { Thing1, Thing2, Thing3, Thing4 };
 }
 
-export async function makeThing5Model(adapter: PostgreSQLAdapter): Promise<ModelCtor> {
+export function makeThing5Model(adapter: PostgreSQLAdapter): ModelCtor {
   class Thing5 extends Base {
     static {
       this.tableName = "things";

--- a/packages/activerecord/src/adapters/postgresql/schema-ar-models.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-ar-models.ts
@@ -1,0 +1,63 @@
+/**
+ * AR model fixtures for schema.test.ts and schema-authorization.test.ts.
+ * Each factory builds fresh subclasses so tests are isolated from each other
+ * and from the global model registry.
+ */
+import { Base } from "../../index.js";
+import type { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
+
+type ModelCtor = typeof Base;
+
+const SCHEMA_NAME = "test_schema";
+const SCHEMA2_NAME = "test_schema2";
+
+export async function makeThingModels(
+  adapter: PostgreSQLAdapter,
+): Promise<{ Thing1: ModelCtor; Thing2: ModelCtor; Thing3: ModelCtor; Thing4: ModelCtor }> {
+  class Thing1 extends Base {
+    static {
+      this.tableName = `${SCHEMA_NAME}.things`;
+      this.adapter = adapter as any;
+    }
+  }
+  class Thing2 extends Base {
+    static {
+      this.tableName = `${SCHEMA2_NAME}.things`;
+      this.adapter = adapter as any;
+    }
+  }
+  class Thing3 extends Base {
+    static {
+      this.tableName = `${SCHEMA_NAME}."things.table"`;
+      this.adapter = adapter as any;
+    }
+  }
+  class Thing4 extends Base {
+    static {
+      this.tableName = `${SCHEMA_NAME}."Things"`;
+      this.adapter = adapter as any;
+    }
+  }
+  await Promise.all([Thing1, Thing2, Thing3, Thing4].map((M) => M.loadSchema()));
+  return { Thing1, Thing2, Thing3, Thing4 };
+}
+
+export async function makeThing5Model(adapter: PostgreSQLAdapter): Promise<ModelCtor> {
+  class Thing5 extends Base {
+    static {
+      this.tableName = "things";
+      this.adapter = adapter as any;
+    }
+  }
+  return Thing5 as unknown as ModelCtor;
+}
+
+export function makeSchemaThingModel(adapter: PostgreSQLAdapter): ModelCtor {
+  class SchemaThing extends Base {
+    static {
+      this.tableName = "schema_things";
+      this.adapter = adapter as any;
+    }
+  }
+  return SchemaThing as unknown as ModelCtor;
+}

--- a/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { StatementInvalid } from "../../errors.js";
+import { makeSchemaThingModel } from "./schema-ar-models.js";
 
 const TABLE_NAME = "schema_things";
 const COLUMNS = "id serial primary key, name character varying(50)";
@@ -78,10 +79,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it.skip("sequence schema caching", () => {
-      // BLOCKED: needs-ar-model — SchemaThing AR model (schema_things table) requires full AR model layer
-      // ROOT-CAUSE: test exercises SchemaThing.new/save! through the model layer; no AR model infrastructure in adapter tests
-      // SCOPE: needs AR model setup similar to packages/activerecord/src/adapters/postgresql/active-schema.test.ts pattern
+    it("sequence schema caching", async () => {
+      const SchemaThing = makeSchemaThingModel(adapter);
+      // Load schema once via user1's session (where schema_things is visible)
+      await adapter.sessionAuth(USERS[0]);
+      await SchemaThing.loadSchema();
+      await adapter.sessionAuth("default");
+      for (const u of USERS) {
+        await adapter.sessionAuth(u);
+        const st1 = await (SchemaThing as any).create({ name: "TEST1" });
+        expect(st1.id).toBeDefined();
+        const st2 = new (SchemaThing as any)({ id: 5, name: "TEST2" });
+        await st2.save();
+        expect(st2.id).toBe(5);
+        await adapter.sessionAuth("default");
+      }
     });
 
     it("tables in current schemas", async () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -477,15 +477,20 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("prepared statements with multiple schemas", async () => {
-      const Thing5 = await makeThing5Model(adapter);
+      const Thing5 = makeThing5Model(adapter);
       // Load schema within a transaction to pin all queries to one connection.
       // Without this, the pool may route `columns("things")` to a fresh
       // connection without the search path set, returning 0 columns and causing
       // DEFAULT VALUES inserts that silently drop all attributes.
-      await adapter.beginTransaction();
-      await adapter.setSchemaSearchPath(SCHEMA_NAME);
-      await (Thing5 as any).loadSchema();
-      await adapter.commitTransaction();
+      try {
+        await adapter.beginTransaction();
+        await adapter.setSchemaSearchPath(SCHEMA_NAME);
+        await (Thing5 as any).loadSchema();
+        await adapter.commitTransaction();
+      } catch (e) {
+        await adapter.rollbackTransaction();
+        throw e;
+      }
       for (const schema of [SCHEMA_NAME, SCHEMA2_NAME]) {
         await adapter.setSchemaSearchPath(schema);
         await (Thing5 as any).create({

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { StatementInvalid } from "../../errors.js";
+import { makeThingModels, makeThing5Model } from "./schema-ar-models.js";
 
 const SCHEMA_NAME = "test_schema";
 const SCHEMA2_NAME = "test_schema2";
@@ -193,9 +194,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("habtm table name with schema", () => {
-      // BLOCKED: needs-ar-model — Song/Album HABTM models with schema-qualified table names
-      // ROOT-CAUSE: test requires AR model layer (Song.create, album.songs, Song.includes) + music schema setup
-      // SCOPE: needs full HABTM + AR model infrastructure beyond adapter-only tests
+      // BLOCKED: needs-includes-references — Song/Album HABTM with schema-qualified table names
+      // ROOT-CAUSE: includes(:albums).where("albums.id": id) requires auto-promotion to eager_load
+      // (references mechanism); joins(:albums).pluck also needs HABTM join SQL wired for music schema
+      // SCOPE: needs includes→eager_load auto-promotion + HABTM joins infrastructure
     });
 
     it("drop schema with nonexisting schema", async () => {
@@ -285,20 +287,44 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
     });
 
-    it.skip("where with qualified schema name", () => {
-      // BLOCKED: needs-ar-model — Thing1.where("test_schema.things.name": "thing1")
-      // ROOT-CAUSE: test requires AR model (Thing1, tableName="test_schema.things") + relation where() path
-      // SCOPE: needs full AR model layer + where() with qualified column predicate
+    it("where with qualified schema name", async () => {
+      const { Thing1 } = await makeThingModels(adapter);
+      await (Thing1 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      const names = (
+        await (Thing1 as any).where({ "test_schema.things.name": "thing1" }).toArray()
+      ).map((r: any) => r.name);
+      expect(names).toEqual(["thing1"]);
     });
-    it.skip("pluck with qualified schema name", () => {
-      // BLOCKED: needs-ar-model — Thing1.pluck(:"test_schema.things.name")
-      // ROOT-CAUSE: test requires AR model (Thing1) + relation pluck() with qualified column
-      // SCOPE: needs full AR model layer
+    it("pluck with qualified schema name", async () => {
+      const { Thing1 } = await makeThingModels(adapter);
+      await (Thing1 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      const names = await (Thing1 as any).pluck("test_schema.things.name");
+      expect(names).toEqual(["thing1"]);
     });
-    it.skip("classes with qualified schema name", () => {
-      // BLOCKED: needs-ar-model — Thing1/Thing2/Thing3/Thing4 models with schema-qualified table names
-      // ROOT-CAUSE: test requires 4 AR models with different qualified table_name settings + count/create
-      // SCOPE: needs full AR model layer
+    it("classes with qualified schema name", async () => {
+      const { Thing1, Thing2, Thing3, Thing4 } = await makeThingModels(adapter);
+      expect(await (Thing1 as any).count()).toBe(0);
+      expect(await (Thing2 as any).count()).toBe(0);
+      expect(await (Thing3 as any).count()).toBe(0);
+      expect(await (Thing4 as any).count()).toBe(0);
+      await (Thing1 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      expect(await (Thing1 as any).count()).toBe(1);
+      expect(await (Thing2 as any).count()).toBe(0);
+      expect(await (Thing3 as any).count()).toBe(0);
+      expect(await (Thing4 as any).count()).toBe(0);
+      await (Thing2 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      expect(await (Thing1 as any).count()).toBe(1);
+      expect(await (Thing2 as any).count()).toBe(1);
+      expect(await (Thing3 as any).count()).toBe(0);
+      expect(await (Thing4 as any).count()).toBe(0);
+      await (Thing3 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      expect(await (Thing3 as any).count()).toBe(1);
+      expect(await (Thing4 as any).count()).toBe(0);
+      await (Thing4 as any).create({ id: 1, name: "thing1", email: "thing1@localhost" });
+      expect(await (Thing1 as any).count()).toBe(1);
+      expect(await (Thing2 as any).count()).toBe(1);
+      expect(await (Thing3 as any).count()).toBe(1);
+      expect(await (Thing4 as any).count()).toBe(1);
     });
     it("raise on unquoted schema name", async () => {
       // $user without surrounding single quotes is invalid in SET search_path TO (PG
@@ -450,11 +476,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.currentSchema()).toBe("public");
     });
 
-    it.skip("prepared statements with multiple schemas", () => {
-      // BLOCKED: needs-ar-model — Thing5.create + Thing5.count with schema_search_path swapped between schemas
-      // ROOT-CAUSE: test requires AR model (Thing5, tableName="things") with search_path toggled between
-      // SCHEMA_NAME and SCHEMA2_NAME; needs full AR model layer + connection.schema_search_path= setter
-      // SCOPE: needs AR model layer + schema_search_path scoped to AR Base connection
+    it("prepared statements with multiple schemas", async () => {
+      const Thing5 = await makeThing5Model(adapter);
+      for (const schema of [SCHEMA_NAME, SCHEMA2_NAME]) {
+        await adapter.setSchemaSearchPath(schema);
+        await (Thing5 as any).create({
+          id: 1,
+          name: `thing inside ${schema}`,
+          email: "thing1@localhost",
+        });
+      }
+      for (const schema of [SCHEMA_NAME, SCHEMA2_NAME]) {
+        await adapter.setSchemaSearchPath(schema);
+        expect(await (Thing5 as any).count()).toBe(1);
+      }
+      await adapter.setSchemaSearchPath("'$user', public");
     });
 
     it("schema exists?", async () => {
@@ -742,10 +778,22 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(tbls).toContain("articles");
     });
 
-    it.skip("Active Record basics", () => {
-      // BLOCKED: needs-ar-model — requires AR model with tableName in "my.schema" (dot-containing schema name)
-      // ROOT-CAUSE: test exercises AR model CRUD (create/find/update) against a table in a schema named "my.schema"
-      // SCOPE: needs AR model layer + special quoting for dot-in-schema-name table references
+    it("Active Record basics", async () => {
+      await adapter.setSchemaSearchPath('"my.schema"');
+      await adapter.createTable("articles", async (t) => {
+        t.string("title");
+      });
+      const { Base } = await import("../../index.js");
+      class Article extends Base {
+        static {
+          this.tableName = '"my.schema".articles';
+          this.adapter = adapter as any;
+        }
+      }
+      await Article.loadSchema();
+      await (Article as any).create({ title: "zOMG, welcome to my blorgh!" });
+      const welcome = await (Article as any).last();
+      expect(welcome.title).toBe("zOMG, welcome to my blorgh!");
     });
   });
 

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -478,6 +478,14 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("prepared statements with multiple schemas", async () => {
       const Thing5 = await makeThing5Model(adapter);
+      // Load schema within a transaction to pin all queries to one connection.
+      // Without this, the pool may route `columns("things")` to a fresh
+      // connection without the search path set, returning 0 columns and causing
+      // DEFAULT VALUES inserts that silently drop all attributes.
+      await adapter.beginTransaction();
+      await adapter.setSchemaSearchPath(SCHEMA_NAME);
+      await (Thing5 as any).loadSchema();
+      await adapter.commitTransaction();
       for (const schema of [SCHEMA_NAME, SCHEMA2_NAME]) {
         await adapter.setSchemaSearchPath(schema);
         await (Thing5 as any).create({
@@ -489,6 +497,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       for (const schema of [SCHEMA_NAME, SCHEMA2_NAME]) {
         await adapter.setSchemaSearchPath(schema);
         expect(await (Thing5 as any).count()).toBe(1);
+        const row = await (Thing5 as any).where({ id: 1 }).first();
+        expect(row?.name).toBe(`thing inside ${schema}`);
       }
       await adapter.setSchemaSearchPath("'$user', public");
     });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2544,7 +2544,7 @@ export class Base extends Model {
     let sql: string;
     if (columns.length === 0) {
       const emptyValue = ctor.adapter.emptyInsertStatementValue();
-      sql = `INSERT INTO "${table.name}" ${emptyValue}`;
+      sql = `INSERT INTO ${ctor.adapter.quoteTableName(table.name)} ${emptyValue}`;
     } else {
       const im = new InsertManager(table);
       const insertValues: [InstanceType<typeof Nodes.Node>, unknown][] = columns.map((c, i) => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -18,6 +18,7 @@ import { ValueType } from "@blazetrails/activemodel";
 import { Data as BitData } from "./oid/bit.js";
 import { MultiRange, Range } from "./oid/range.js";
 import { Data as XmlData } from "./oid/xml.js";
+import { Visitors as ArelVisitors } from "@blazetrails/arel";
 
 // Rails inherits from StandardError — use plain Error in TS for
 // parity. JS's `RangeError` is a built-in that extends Error; it
@@ -86,42 +87,7 @@ export function quoteIdentifier(name: string): string {
 }
 
 export function quoteTableName(name: string): string {
-  return splitSchemaQualifiedName(name)
-    .map((part) => {
-      const unquoted =
-        part.startsWith('"') && part.endsWith('"') && part.length >= 2
-          ? part.slice(1, -1).replace(/""/g, '"')
-          : part;
-      return `"${unquoted.replace(/"/g, '""')}"`;
-    })
-    .join(".");
-}
-
-function splitSchemaQualifiedName(name: string): string[] {
-  const parts: string[] = [];
-  let current = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < name.length; i++) {
-    const ch = name[i];
-    if (ch === '"') {
-      current += ch;
-      if (inQuotes && i + 1 < name.length && name[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (ch === "." && !inQuotes) {
-      parts.push(current);
-      current = "";
-    } else {
-      current += ch;
-    }
-  }
-
-  parts.push(current);
-  return parts;
+  return ArelVisitors.quoteSchemaQualifiedName(name);
 }
 
 export function quoteColumnName(name: string): string {

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -176,6 +176,20 @@ describe("TableTest", () => {
     expect(users.star.value).toBe('"users".*');
   });
 
+  it("star splits schema-qualified name", () => {
+    expect(new Table("test_schema.things").star.value).toBe('"test_schema"."things".*');
+  });
+
+  it("star preserves quoted table name with dot", () => {
+    expect(new Table('test_schema."things.table"').star.value).toBe(
+      '"test_schema"."things.table".*',
+    );
+  });
+
+  it("star preserves quoted schema name with dot", () => {
+    expect(new Table('"my.schema".articles').star.value).toBe('"my.schema"."articles".*');
+  });
+
   it("alias references use the alias in SQL", () => {
     const u = new Table("users", { as: "u" });
     const result = u.project(u.get("name")).toSql();

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -6,6 +6,7 @@ import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import type { Join } from "./nodes/binary.js";
 import { TableAlias } from "./nodes/table-alias.js";
+import { quoteSchemaQualifiedName } from "./visitors/split-schema-qualified-name.js";
 
 /** Structural duck-type for Rails' `@klass.attribute_aliases`.
  *  Kept minimal so arel does not import activerecord. */
@@ -90,7 +91,7 @@ export class Table extends Node {
   }
 
   get star(): SqlLiteral {
-    return new SqlLiteral(`"${this.name}".*`);
+    return new SqlLiteral(`${quoteSchemaQualifiedName(this.name)}.*`);
   }
 
   /**

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -1,4 +1,5 @@
 import type { ArelConnection } from "./connection.js";
+import { quoteSchemaQualifiedName } from "./split-schema-qualified-name.js";
 
 function quoteScalar(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
@@ -66,10 +67,7 @@ export const mysqlDefaultQuoter: ArelConnection = {
  */
 export const defaultQuoter: ArelConnection = {
   quoteTableName(name: string): string {
-    return String(name)
-      .split(".")
-      .map((p) => `"${p.replace(/"/g, '""')}"`)
-      .join(".");
+    return quoteSchemaQualifiedName(String(name));
   },
 
   quoteColumnName(name: string): string {

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,5 +1,9 @@
 export { ToSql, type ArelConnection, type ArelQuoter } from "./to-sql.js";
 export { defaultQuoter, mysqlDefaultQuoter } from "./default-quoter.js";
+export {
+  splitSchemaQualifiedName,
+  quoteSchemaQualifiedName,
+} from "./split-schema-qualified-name.js";
 export { UnsupportedVisitError, NotImplementedError } from "../errors.js";
 export { MySQL } from "./mysql.js";
 export { PostgreSQL, PostgreSQLWithBinds } from "./postgresql.js";

--- a/packages/arel/src/visitors/split-schema-qualified-name.ts
+++ b/packages/arel/src/visitors/split-schema-qualified-name.ts
@@ -2,10 +2,7 @@
  * Split a schema-qualified table name on unquoted dots, preserving
  * double-quoted segments (which may themselves contain dots).
  *
- * Examples:
- *   "schema.table"          → ["schema", "table"]
- *   'schema."table.name"'   → ["schema", '"table.name"']
- *   '"my.schema".table'     → ['"my.schema"', "table"]
+ * @internal
  */
 export function splitSchemaQualifiedName(name: string): string[] {
   const parts: string[] = [];
@@ -36,10 +33,7 @@ export function splitSchemaQualifiedName(name: string): string[] {
  * Quote each part of a schema-qualified name with ANSI double-quotes,
  * stripping any existing outer quotes before re-quoting.
  *
- * Examples:
- *   "schema.table"          → '"schema"."table"'
- *   'schema."table.name"'   → '"schema"."table.name"'
- *   '"my.schema".table'     → '"my.schema"."table"'
+ * @internal
  */
 export function quoteSchemaQualifiedName(name: string): string {
   return splitSchemaQualifiedName(name)

--- a/packages/arel/src/visitors/split-schema-qualified-name.ts
+++ b/packages/arel/src/visitors/split-schema-qualified-name.ts
@@ -1,0 +1,54 @@
+/**
+ * Split a schema-qualified table name on unquoted dots, preserving
+ * double-quoted segments (which may themselves contain dots).
+ *
+ * Examples:
+ *   "schema.table"          → ["schema", "table"]
+ *   'schema."table.name"'   → ["schema", '"table.name"']
+ *   '"my.schema".table'     → ['"my.schema"', "table"]
+ */
+export function splitSchemaQualifiedName(name: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < name.length; i++) {
+    const ch = name[i];
+    if (ch === '"') {
+      current += ch;
+      if (inQuotes && i + 1 < name.length && name[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "." && !inQuotes) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+/**
+ * Quote each part of a schema-qualified name with ANSI double-quotes,
+ * stripping any existing outer quotes before re-quoting.
+ *
+ * Examples:
+ *   "schema.table"          → '"schema"."table"'
+ *   'schema."table.name"'   → '"schema"."table.name"'
+ *   '"my.schema".table'     → '"my.schema"."table"'
+ */
+export function quoteSchemaQualifiedName(name: string): string {
+  return splitSchemaQualifiedName(name)
+    .map((part) => {
+      const unquoted =
+        part.startsWith('"') && part.endsWith('"') && part.length >= 2
+          ? part.slice(1, -1).replace(/""/g, '"')
+          : part;
+      return `"${unquoted.replace(/"/g, '""')}"`;
+    })
+    .join(".");
+}

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1785,6 +1785,20 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
     expect(sql).toContain('"users"."id"');
   });
 
+  it("default quoter: schema-qualified name is split and each part double-quoted", () => {
+    const t = new Table("test_schema.things");
+    const sql = new Visitors.ToSql().compile(t.project(t.star).ast);
+    expect(sql).toContain('"test_schema"."things".*');
+    expect(sql).toContain('FROM "test_schema"."things"');
+  });
+
+  it("default quoter: quoted table name with dot is preserved as single identifier", () => {
+    const t = new Table('test_schema."things.table"');
+    const sql = new Visitors.ToSql().compile(t.project(t.star).ast);
+    expect(sql).toContain('"test_schema"."things.table".*');
+    expect(sql).toContain('FROM "test_schema"."things.table"');
+  });
+
   it("stub quoter: quoteTableName output appears in compiled SQL", () => {
     const stubQuoter: Visitors.ArelQuoter = {
       quoteTableName: (name) => `<<${name}>>`,


### PR DESCRIPTION
## Summary

- **`schema-ar-models.ts`** — new fixture file with `makeThingModels` (Thing1-4 with schema-qualified `tableName`), `makeThing5Model`, `makeSchemaThingModel`; each factory returns fresh subclasses so tests are isolated
- **6 tests un-skipped** in `schema.test.ts` and `schema-authorization.test.ts` via the AR model layer
- **3 arel/base bug fixes** uncovered while implementing — each blocking the tests

### Tests un-skipped (6)

| Test | File |
|---|---|
| `where with qualified schema name` | `schema.test.ts` |
| `pluck with qualified schema name` | `schema.test.ts` |
| `classes with qualified schema name` | `schema.test.ts` |
| `prepared statements with multiple schemas` | `schema.test.ts` |
| `Active Record basics` (dot-in-schema-name) | `schema.test.ts` |
| `sequence schema caching` | `schema-authorization.test.ts` |

### Bug fixes

1. **`Table#star`** (`arel/src/table.ts`) — was generating `"schema.table".*` (dot inside single quotes) instead of `"schema"."table".*`. Broke `SELECT *` for schema-qualified models.

2. **`defaultQuoter.quoteTableName`** (`arel/src/visitors/default-quoter.ts`) — naive `split(".")` broke quoted table names like `schema."things.table"`. The `COUNT(*)` path in `performCount` goes through the default visitor, not the adapter's visitor, so this caused `cross-database references` errors for Thing3.

3. **Empty-insert path in `Base._executeInsert`** (`base.ts`) — `INSERT INTO "${table.name}"` did not go through `quoteTableName`, generating `"music.songs"` (single identifier) instead of `"music"."songs"`. Fixed to use `ctor.adapter.quoteTableName(table.name)`.

### Still skipped (deferred to Slot H-c)

- `habtm table name with schema` — needs `includes→eager_load` auto-promotion (references mechanism) + HABTM joins SQL for schema-qualified join tables
- `schema change with prepared stmt` — needs prepared_statements mode wired in test setup

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapters/postgresql/schema.test.ts packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts` → 79 passed, 2 skipped
- [x] TypeScript build (`tsc --build`) passes
- [x] Lint passes