### PR TITLE
feat(activerecord): PG virtual-column Slot B — live-PG DSL round-trip + 5 un-skips

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -72,6 +72,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await t.virtual("lower_name", { type: "string", as: "LOWER(name)", stored: true });
       });
       adapter.schemaCache?.clear();
+      VirtualColumn.resetColumnInformation();
       await VirtualColumn.loadSchema();
       const column = await findColumn("lower_name");
       expect(column!.isVirtual()).toBe(true);

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -72,7 +72,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await t.virtual("lower_name", { type: "string", as: "LOWER(name)", stored: true });
       });
       adapter.schemaCache?.clear();
-      await VirtualColumn.resetColumnInformation();
+      await VirtualColumn.loadSchema();
       const column = await findColumn("lower_name");
       expect(column!.isVirtual()).toBe(true);
       const row = await VirtualColumn.take();

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -5,18 +5,6 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { FixtureSet } from "../../test-helpers/fixture-set.js";
 
-const CREATE_TABLE_SQL = `
-  CREATE TABLE virtual_columns (
-    id bigserial PRIMARY KEY,
-    name character varying,
-    upper_name character varying GENERATED ALWAYS AS (UPPER(name)) STORED,
-    name_length integer GENERATED ALWAYS AS (LENGTH(name)) STORED,
-    name_octet_length integer GENERATED ALWAYS AS (OCTET_LENGTH(name)) STORED,
-    column1 integer,
-    column2 integer GENERATED ALWAYS AS (column1 + 1) STORED
-  )
-`;
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let VirtualColumn: any;
@@ -24,7 +12,14 @@ describeIfPg("PostgreSQLAdapter", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS virtual_columns`);
-    await adapter.exec(CREATE_TABLE_SQL);
+    await adapter.createTable("virtual_columns", (t) => {
+      t.string("name");
+      t.virtual("upper_name", { type: "string", as: "UPPER(name)", stored: true });
+      t.virtual("name_length", { type: "integer", as: "LENGTH(name)", stored: true });
+      t.virtual("name_octet_length", { type: "integer", as: "OCTET_LENGTH(name)", stored: true });
+      t.integer("column1");
+      t.virtual("column2", { type: "integer", as: "column1 + 1", stored: true });
+    });
     const { Base } = await import("../../index.js");
     class VirtualColumnCls extends Base {
       static tableName = "virtual_columns";
@@ -73,26 +68,23 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("change table", async () => {
-      await adapter.exec(
-        `ALTER TABLE virtual_columns ADD COLUMN lower_name character varying GENERATED ALWAYS AS (LOWER(name)) STORED`,
-      );
+      await adapter.changeTable("virtual_columns", async (t) => {
+        await t.virtual("lower_name", { type: "string", as: "LOWER(name)", stored: true });
+      });
       adapter.schemaCache?.clear();
+      await VirtualColumn.resetColumnInformation();
       const column = await findColumn("lower_name");
       expect(column!.isVirtual()).toBe(true);
-      const rows = await adapter.execute(`SELECT lower_name FROM virtual_columns LIMIT 1`);
-      expect(rows[0].lower_name).toBe("rails");
+      const row = await VirtualColumn.take();
+      expect(row.lower_name).toBe("rails");
     });
 
-    it("non persisted column", () => {
-      // Rails routes change_table → schema-creation → addColumnOptionsBang. Our
-      // adapter's high-level addColumn path doesn't reach addColumnOptionsBang
-      // for generated columns, so we exercise the visitor directly — same fixture
-      // shape that connection-adapters/postgresql/schema-creation.test.ts uses.
-      const sc: any = adapter.schemaCreation;
-      const col = { name: "invalid_definition" };
-      expect(() =>
-        sc.addColumnOptionsBang("n", { as: "LOWER(name)", stored: false, column: col }),
-      ).toThrow(/does not support VIRTUAL.*Specify 'stored: true'/s);
+    it("non persisted column", async () => {
+      await expect(
+        adapter.changeTable("virtual_columns", async (t) => {
+          await t.virtual("invalid_definition", { type: "string", as: "LOWER(name)" });
+        }),
+      ).rejects.toThrow(/does not support VIRTUAL.*Specify 'stored: true'/s);
     });
 
     it.skip("schema dumping", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -288,6 +288,13 @@ export class SchemaCreation {
         else if (this.adapterName === "mysql") sql = "BIGINT AUTO_INCREMENT PRIMARY KEY";
         else sql = "INTEGER PRIMARY KEY AUTOINCREMENT";
         break;
+      case "virtual": {
+        // Resolve to the real column type declared via options.type (Rails pattern:
+        // newColumnDefinition maps :virtual → options[:type] before SQL generation).
+        const realType =
+          ((options as Record<string, unknown>)["type"] as ColumnType | undefined) ?? "string";
+        return this.typeToSql(realType, options);
+      }
       default:
         // Pass-through for adapter-specific type strings (e.g.
         // "timestamptz", "inet", "hstore", custom PG enum names).

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -99,7 +99,7 @@ export class SchemaCreation {
     const sqlType = o.sqlType ?? this.typeToSql(o.type, o.options);
     let sql = `${this.adapter.quoteIdentifier(o.name)} ${sqlType}`;
     if (o.type !== "primary_key") {
-      sql = this.addColumnOptions(sql, o.options);
+      sql = this.addColumnOptionsBang(sql, o.options);
     }
     return sql;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -386,6 +386,10 @@ export interface ColumnMethods {
   timestamp(name: string, options?: ColumnOptions): unknown;
   binary(name: string, options?: ColumnOptions): unknown;
   json(name: string, options?: ColumnOptions): unknown;
+  virtual(
+    name: string,
+    options?: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean },
+  ): unknown;
 }
 
 /**
@@ -908,6 +912,13 @@ export class TableDefinition {
     return this.column(name, "json", options);
   }
 
+  virtual(
+    name: string,
+    options: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean } = {},
+  ): this {
+    return this.column(name, "virtual" as ColumnType, options);
+  }
+
   jsonb(name: string, options: ColumnOptions = {}): this {
     return this.column(name, "jsonb", options);
   }
@@ -1234,6 +1245,12 @@ export class Table {
   }
   async char(name: string, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, "char", options);
+  }
+  async virtual(
+    name: string,
+    options: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean } = {},
+  ): Promise<void> {
+    await this.column(name, "virtual" as ColumnType, options);
   }
   async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, type, { ...options, array: true });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3061,7 +3061,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<void> {
     const opts = typeof options === "function" ? {} : options;
     const callback = typeof options === "function" ? options : fn;
-    const table = new SimpleTableBuilder();
+    const table = new SimpleTableBuilder(this);
     if (opts.id !== false) {
       if (typeof opts.id === "string" && opts.id === "uuid") {
         table.column("id", "uuid default gen_random_uuid() primary key");
@@ -5180,6 +5180,8 @@ export type IndexDefinition = PgIndexDefinition;
 class SimpleTableBuilder {
   private _columns: { name: string; type: string }[] = [];
 
+  constructor(private _adapter: PostgreSQLAdapter) {}
+
   column(name: string, type: string): void {
     this._columns.push({ name, type });
   }
@@ -5238,17 +5240,11 @@ class SimpleTableBuilder {
   }
 
   virtual(name: string, options: { type?: string; as?: string; stored?: boolean } = {}): void {
-    const pgTypes: Record<string, string> = {
-      string: "character varying",
-      text: "text",
-      integer: "integer",
-      bigint: "bigint",
-      float: "double precision",
-      boolean: "boolean",
-      date: "date",
-      datetime: "timestamp without time zone",
-    };
-    const pgType = pgTypes[options.type ?? "string"] ?? options.type ?? "character varying";
+    // Delegate type resolution to the adapter so precision/scale/limit and custom aliases
+    // stay consistent with the addColumn virtual branch (single source of truth).
+    const pgType = this._adapter.typeToSql(options.type ?? "string", {});
+    // Rails: if options[:as] is absent, no GENERATED clause is added (plain column).
+    // add_column_options_bang wraps the whole block in `if as = options[:as]`.
     if (!options.as) {
       this._columns.push({ name, type: pgType });
       return;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -102,7 +102,10 @@ import {
   type ReferentialAction,
 } from "./abstract/schema-definitions.js";
 import { joinTableName as deriveJoinTableName } from "../migration/join-table.js";
-import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
+import {
+  SchemaCreation as PgSchemaCreation,
+  _pgGeneratedClause,
+} from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
@@ -3093,44 +3096,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteIdentifier(columnName);
 
-    // Virtual (generated) columns: resolve the real type and append GENERATED ALWAYS AS.
-    // Mirrors Rails PG add_column → new_column_definition resolves :virtual → options[:type].
+    // Mirrors Rails PG `new_column_definition`: when `type == :virtual`,
+    // resolve the real type from `options[:type]` and pass `as`/`stored`
+    // through to `add_column_options!`. All other options (`null`,
+    // `default`, `comment`) flow through the standard pipeline.
+    let effectiveType = type;
+    let generatedClause = "";
     if (type === "virtual") {
       const opts = options as Record<string, unknown>;
-      const realType = (opts["type"] as string | undefined) ?? "string";
-      const as = opts["as"] as string | undefined;
-      const stored = opts["stored"] as boolean | undefined;
-      const pgType = this.typeToSql(realType, {
-        limit: options.limit ?? undefined,
-        precision: options.precision ?? undefined,
-        scale: options.scale ?? undefined,
-      });
-      let colSql = `${quotedCol} ${pgType}`;
-      if (as) {
-        colSql += ` GENERATED ALWAYS AS (${as})`;
-        if (stored) {
-          colSql += " STORED";
-        } else {
-          throw new Error(
-            `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
-              `Specify 'stored: true' option for '${columnName}'`,
-          );
-        }
-      }
-      const ifNotExists = options.ifNotExists ? " IF NOT EXISTS" : "";
-      await this.exec(`ALTER TABLE ${quotedTable} ADD COLUMN${ifNotExists} ${colSql}`);
-      return;
+      effectiveType = (opts["type"] as string | undefined) ?? "string";
+      generatedClause = _pgGeneratedClause(
+        columnName,
+        opts["as"] as string | undefined,
+        opts["stored"] as boolean | undefined,
+      );
     }
 
     const resolvedPrecision =
-      type === "datetime" && options.precision === undefined ? 6 : (options.precision ?? undefined);
-    const pgType = this.typeToSql(type, {
+      effectiveType === "datetime" && options.precision === undefined
+        ? 6
+        : (options.precision ?? undefined);
+    const pgType = this.typeToSql(effectiveType, {
       ...options,
       precision: resolvedPrecision,
       limit: options.limit ?? undefined,
       scale: options.scale ?? undefined,
     });
-    let colSql = `${quotedCol} ${pgType}`;
+    let colSql = `${quotedCol} ${pgType}${generatedClause}`;
     if (options.default !== undefined) {
       const defaultClause = pgQuoteDefaultExpression(
         options.default,
@@ -5240,22 +5232,12 @@ class SimpleTableBuilder {
   }
 
   virtual(name: string, options: { type?: string; as?: string; stored?: boolean } = {}): void {
-    // Delegate type resolution to the adapter so precision/scale/limit and custom aliases
-    // stay consistent with the addColumn virtual branch (single source of truth).
+    // Mirrors Rails PG `new_column_definition`: resolve `:virtual` → real type,
+    // append the GENERATED clause via the shared helper. When `as` is absent
+    // the helper returns "" (Rails: a plain column).
     const pgType = this._adapter.typeToSql(options.type ?? "string", {});
-    // Rails: if options[:as] is absent, no GENERATED clause is added (plain column).
-    // add_column_options_bang wraps the whole block in `if as = options[:as]`.
-    if (!options.as) {
-      this._columns.push({ name, type: pgType });
-      return;
-    }
-    if (!options.stored) {
-      throw new Error(
-        `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
-          `Specify 'stored: true' option for '${name}'`,
-      );
-    }
-    this._columns.push({ name, type: `${pgType} GENERATED ALWAYS AS (${options.as}) STORED` });
+    const generatedClause = _pgGeneratedClause(name, options.as, options.stored);
+    this._columns.push({ name, type: `${pgType}${generatedClause}` });
   }
 
   getColumns(): { name: string; type: string }[] {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -5207,6 +5207,31 @@ class SimpleTableBuilder {
     this._columns.push({ name, type });
   }
 
+  virtual(name: string, options: { type?: string; as?: string; stored?: boolean } = {}): void {
+    const pgTypes: Record<string, string> = {
+      string: "character varying",
+      text: "text",
+      integer: "integer",
+      bigint: "bigint",
+      float: "double precision",
+      boolean: "boolean",
+      date: "date",
+      datetime: "timestamp without time zone",
+    };
+    const pgType = pgTypes[options.type ?? "string"] ?? options.type ?? "character varying";
+    if (!options.as) {
+      this._columns.push({ name, type: pgType });
+      return;
+    }
+    if (!options.stored) {
+      throw new Error(
+        `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
+          `Specify 'stored: true' option for '${name}'`,
+      );
+    }
+    this._columns.push({ name, type: `${pgType} GENERATED ALWAYS AS (${options.as}) STORED` });
+  }
+
   getColumns(): { name: string; type: string }[] {
     return this._columns;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3092,6 +3092,36 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<void> {
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteIdentifier(columnName);
+
+    // Virtual (generated) columns: resolve the real type and append GENERATED ALWAYS AS.
+    // Mirrors Rails PG add_column → new_column_definition resolves :virtual → options[:type].
+    if (type === "virtual") {
+      const opts = options as Record<string, unknown>;
+      const realType = (opts["type"] as string | undefined) ?? "string";
+      const as = opts["as"] as string | undefined;
+      const stored = opts["stored"] as boolean | undefined;
+      const pgType = this.typeToSql(realType, {
+        limit: options.limit ?? undefined,
+        precision: options.precision ?? undefined,
+        scale: options.scale ?? undefined,
+      });
+      let colSql = `${quotedCol} ${pgType}`;
+      if (as) {
+        colSql += ` GENERATED ALWAYS AS (${as})`;
+        if (stored) {
+          colSql += " STORED";
+        } else {
+          throw new Error(
+            `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
+              `Specify 'stored: true' option for '${columnName}'`,
+          );
+        }
+      }
+      const ifNotExists = options.ifNotExists ? " IF NOT EXISTS" : "";
+      await this.exec(`ALTER TABLE ${quotedTable} ADD COLUMN${ifNotExists} ${colSql}`);
+      return;
+    }
+
     const resolvedPrecision =
       type === "datetime" && options.precision === undefined ? 6 : (options.precision ?? undefined);
     const pgType = this.typeToSql(type, {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -21,6 +21,32 @@ import type {
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { Utils } from "./utils.js";
 
+/**
+ * Build the `GENERATED ALWAYS AS (...) STORED` suffix for a PostgreSQL
+ * column. Returns `""` when no `as` expression is provided. Throws the
+ * Rails VIRTUAL-unsupported error when `stored` is falsy.
+ *
+ * Mirrors the `as` / `stored` branch of `PostgreSQL::SchemaCreation#add_column_options!`.
+ * Single source of truth shared by the visitor, `PostgreSQLAdapter#addColumn`,
+ * and `SimpleTableBuilder#virtual`.
+ *
+ * @internal
+ */
+export function _pgGeneratedClause(
+  columnName: string,
+  as: string | undefined,
+  stored: boolean | undefined,
+): string {
+  if (!as) return "";
+  if (!stored) {
+    throw new Error(
+      `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
+        `Specify 'stored: true' option for '${columnName}'`,
+    );
+  }
+  return ` GENERATED ALWAYS AS (${as}) STORED`;
+}
+
 export class SchemaCreation extends AbstractSchemaCreation {
   constructor(adapter?: SchemaQuoter) {
     super("postgres", adapter);
@@ -212,18 +238,12 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (opts["collation"]) {
       sql += ` COLLATE ${this.adapter.quoteIdentifier(String(opts["collation"]))}`;
     }
-    if (opts["as"]) {
-      sql += ` GENERATED ALWAYS AS (${opts["as"]})`;
-      if (opts["stored"]) {
-        sql += " STORED";
-      } else {
-        const colName = opts["column"] ? (opts["column"] as any).name : "unknown";
-        throw new Error(
-          `PostgreSQL currently does not support VIRTUAL (not persisted) generated columns.\n` +
-            `Specify 'stored: true' option for '${colName}'`,
-        );
-      }
-    }
+    const colName = opts["column"] ? ((opts["column"] as any).name as string) : "unknown";
+    sql += _pgGeneratedClause(
+      colName,
+      opts["as"] as string | undefined,
+      opts["stored"] as boolean | undefined,
+    );
     return super.addColumnOptionsBang(sql, options);
   }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -544,6 +544,7 @@ export function resetColumnInformation(this: SchemaHost): void {
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
   (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) return;
   for (const [name, def] of Array.from(this._attributeDefinitions)) {
     if ((def.userProvided ?? true) === false || def.source === "schema") {

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -281,9 +281,9 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
   // Filter generated (virtual) columns from fixture rows — PG rejects INSERT on those columns.
   // Mirrors Rails: build_fixture_sql rejects schema_cache.columns_hash entries where column.virtual?
   if ((adapter as any).supportsVirtualColumns?.()) {
-    const cols: { name: string; isVirtual(): boolean }[] = await (adapter as any)
-      .columns(tableName)
-      .catch(() => []);
+    const cols: { name: string; isVirtual(): boolean }[] = await (adapter as any).columns(
+      tableName,
+    );
     const virtualNames = new Set(cols.filter((c) => c.isVirtual()).map((c) => c.name));
     if (virtualNames.size > 0) {
       for (const row of rows) {

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -280,7 +280,9 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
 
   // Filter generated (virtual) columns from fixture rows — PG rejects INSERT on those columns.
   // Mirrors Rails: build_fixture_sql rejects schema_cache.columns_hash entries where column.virtual?
-  if ((adapter as any).supportsVirtualColumns?.()) {
+  // Avoid supportsVirtualColumns() — it requires databaseVersion to be pre-initialized.
+  // isVirtual() returns false for non-virtual adapters, so calling columns() is always safe.
+  if (typeof (adapter as any).columns === "function") {
     const cols: { name: string; isVirtual(): boolean }[] = await (adapter as any).columns(
       tableName,
     );

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -278,6 +278,20 @@ export async function defineFixtures<T extends BaseClass, K extends string>(
     rows.push(row);
   }
 
+  // Filter generated (virtual) columns from fixture rows — PG rejects INSERT on those columns.
+  // Mirrors Rails: build_fixture_sql rejects schema_cache.columns_hash entries where column.virtual?
+  if ((adapter as any).supportsVirtualColumns?.()) {
+    const cols: { name: string; isVirtual(): boolean }[] = await (adapter as any)
+      .columns(tableName)
+      .catch(() => []);
+    const virtualNames = new Set(cols.filter((c) => c.isVirtual()).map((c) => c.name));
+    if (virtualNames.size > 0) {
+      for (const row of rows) {
+        for (const name of virtualNames) delete row[name];
+      }
+    }
+  }
+
   // Mirrors Rails: pass tableName as tablesToDelete so rows are replaced, not appended.
   await insertFixturesSet.call(adapter as unknown as InsertHost, { [tableName]: rows }, [
     tableName,


### PR DESCRIPTION
## Summary

- Adds `t.virtual(name, opts)` to `ColumnMethods` interface, `TableDefinition`, and `Table` — wiring the `createTable` and `changeTable` DSL paths for virtual/generated columns
- Adds `SimpleTableBuilder.virtual()` so `PostgreSQLAdapter.createTable` callback supports virtual columns; generates `<pgType> GENERATED ALWAYS AS (...) STORED` DDL
- Fixes `SchemaCreation.typeToSql("virtual", opts)` to recursively resolve via `opts.type`, unblocking the `addColumn`/`changeTable` path (which bypasses `newColumnDefinition`)
- Adds virtual-column filter in `define-fixtures.ts`: strips generated columns from fixture rows before INSERT when `adapter.supportsVirtualColumns()` is true, mirroring Rails `build_fixture_sql`
- Updates `virtual-column.test.ts`: replaces raw-SQL table setup with `adapter.createTable(t => t.virtual(...))`, replaces raw ALTER TABLE with `adapter.changeTable(t => t.virtual(...))`, and routes non-persisted-column error through `changeTable` to exercise the full error path (5 un-skips)

## Follow-ups

- `schema dumping` test remains skipped — schema-dumper.ts `emitTable` bypasses PG `prepareColumnOptions` for virtual columns (tracked in schema cluster Slot E)

## Test plan

- [ ] PG live tests: `virtual column with full inserts`, `virtual column`, `stored column`, `change table`, `non persisted column`, `build fixture sql` all pass when `PG_TEST_URL` is set
- [ ] `api:compare --package activerecord` stays at 100%
- [ ] Lint passes (`eslint --fix` applied by pre-commit hook)