### PR TITLE
feat(vendor): wave 7 — generate parity Gemfile from vendor/sources.ts

### DIFF
--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -111,7 +111,7 @@ Plus: MySQL `SchemaDumper.tableCollationCache` is never populated; base `createT
 4. **Slot D** (~270 LOC) — Nested-through preloader + STI + joins/includes.
 5. **Slot E** (~260 LOC) — Nested-through advanced (distinct/repeated table/polymorphic-with-scope/source-reset/autosave-skip).
 
-Note: audit worktree didn't have `.rails-source/` populated → slots sized by test-name-family inference rather than line-by-line Rails read. Workers picking these up should re-validate against `.rails-source` once spawned.
+Note: audit worktree didn't have rails source populated (pre-wave-2b: `scripts/api-compare/.rails-source/`; now `vendor/rails/`) → slots sized by test-name-family inference rather than line-by-line Rails read. Workers picking these up should re-validate against `vendor/rails/` once spawned (run `pnpm vendor:fetch` to populate).
 
 ## Associations-HABTM cluster (~1690 LOC across 9 slots, from audit-associations-habtm)
 

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -27,6 +27,8 @@ import { readdirSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 
+import { buildGemfile } from "./schema/ruby/build-gemfile.js";
+
 const FIXTURES_DIR = "scripts/parity/fixtures";
 const GEMFILE = "scripts/parity/schema/ruby/Gemfile";
 
@@ -246,6 +248,10 @@ function dumpOne(cfg: TypeConfig, label: "rails" | "trails", fixture: string): P
 }
 
 async function runRails(cfg: TypeConfig): Promise<void> {
+  // Regenerate the parity Gemfile from vendor/sources.ts so the activerecord
+  // pin can't drift from the rails ref. Idempotent: writes only on diff.
+  const { changed, path } = buildGemfile();
+  if (changed) console.log(`parity: regenerated ${path} from vendor/sources.ts`);
   rmSync(cfg.outRails, { recursive: true, force: true });
   mkdirSync(cfg.outRails, { recursive: true });
   await runPool(fixtures(cfg), (fixture) => dumpOne(cfg, "rails", fixture));

--- a/scripts/parity/schema/ruby/Gemfile
+++ b/scripts/parity/schema/ruby/Gemfile
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+#
+# GENERATED from vendor/sources.ts by scripts/parity/schema/ruby/build-gemfile.ts.
+# Do not edit by hand — change vendor/sources.ts and the parity-schema runner
+# regenerates this file on its next invocation.
 
 source "https://rubygems.org"
 
-gem "activerecord", "8.0.2"     # D10 — matches rails ref in vendor/sources.ts (wave 7 will generate)
+gem "activerecord", "8.0.2"     # tracks rails ref in vendor/sources.ts
 gem "sqlite3", "~> 2.1"         # matches AR 8.0.2 declared dependency range
 gem "minitest", "~> 5.25"       # canonicalize_test.rb

--- a/scripts/parity/schema/ruby/build-gemfile.test.ts
+++ b/scripts/parity/schema/ruby/build-gemfile.test.ts
@@ -17,4 +17,17 @@ describe("scripts/parity/schema/ruby/build-gemfile.ts", () => {
     expect(content).toContain("sqlite3");
     expect(content).toContain("minitest");
   });
+
+  it("committed Gemfile matches the generated content (drift forcing function)", async () => {
+    // If sources.ts bumped the rails ref but nobody re-ran parity, the
+    // committed Gemfile lags. CI catches it at runRails time, but this test
+    // catches it at PR review time alongside the wave-3 lockfile-sync and
+    // wave-4 pinned-PACKAGES tests.
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const here = dirname(fileURLToPath(import.meta.url));
+    const onDisk = readFileSync(join(here, "Gemfile"), "utf8");
+    expect(onDisk).toBe(buildGemfileContent());
+  });
 });

--- a/scripts/parity/schema/ruby/build-gemfile.test.ts
+++ b/scripts/parity/schema/ruby/build-gemfile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildGemfileContent } from "./build-gemfile.js";
+
+describe("scripts/parity/schema/ruby/build-gemfile.ts", () => {
+  it("derives activerecord version from vendor/sources.ts rails ref", () => {
+    const content = buildGemfileContent();
+    // Rails ref is "v8.0.2" in sources.ts → "8.0.2" gem version (v stripped).
+    expect(content).toContain('gem "activerecord", "8.0.2"');
+  });
+
+  it("includes the GENERATED banner so contributors know not to hand-edit", () => {
+    expect(buildGemfileContent()).toMatch(/GENERATED from vendor\/sources\.ts/);
+  });
+
+  it("preserves sqlite3 and minitest dependencies", () => {
+    const content = buildGemfileContent();
+    expect(content).toContain("sqlite3");
+    expect(content).toContain("minitest");
+  });
+});

--- a/scripts/parity/schema/ruby/build-gemfile.ts
+++ b/scripts/parity/schema/ruby/build-gemfile.ts
@@ -41,7 +41,7 @@ export function buildGemfileContent(): string {
     'source "https://rubygems.org"',
     "",
     `gem "activerecord", "${arVersion}"     # tracks rails ref in vendor/sources.ts`,
-    'gem "sqlite3", "~> 2.1"         # matches AR 8.0.2 declared dependency range',
+    `gem "sqlite3", "~> 2.1"         # matches AR ${arVersion} declared dependency range`,
     'gem "minitest", "~> 5.25"       # canonicalize_test.rb',
     "",
   ].join("\n");

--- a/scripts/parity/schema/ruby/build-gemfile.ts
+++ b/scripts/parity/schema/ruby/build-gemfile.ts
@@ -1,0 +1,62 @@
+// Wave 7: generate scripts/parity/schema/ruby/Gemfile from vendor/sources.ts
+// so the activerecord pin can't drift from the rails ref pinned in the
+// upstream-source registry.
+//
+// The Gemfile stays committed (so contributors can `bundle exec --gemfile`
+// without an extra build step). This script rewrites it only when the
+// generated content differs — same idempotent pattern as vendor/fetch.ts's
+// writeLockfile. Called from scripts/parity/run.ts before any rails-side
+// work; CI will see a non-empty diff if the Gemfile was out of sync at
+// merge time.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SOURCES } from "../../../../vendor/sources.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GEMFILE_PATH = join(HERE, "Gemfile");
+
+function railsVersion(): string {
+  const rails = SOURCES.find((s) => s.name === "rails");
+  if (!rails) throw new Error("vendor/sources.ts: no rails source");
+  // Refs are tags like "v8.0.2" — strip the leading "v" for the gem version.
+  const ref = rails.origin.ref;
+  if (!/^v\d/.test(ref)) {
+    throw new Error(`vendor/sources.ts: rails origin.ref "${ref}" doesn't look like a vN.N.N tag`);
+  }
+  return ref.slice(1);
+}
+
+export function buildGemfileContent(): string {
+  const arVersion = railsVersion();
+  return [
+    "# frozen_string_literal: true",
+    "#",
+    "# GENERATED from vendor/sources.ts by scripts/parity/schema/ruby/build-gemfile.ts.",
+    "# Do not edit by hand — change vendor/sources.ts and the parity-schema runner",
+    "# regenerates this file on its next invocation.",
+    "",
+    'source "https://rubygems.org"',
+    "",
+    `gem "activerecord", "${arVersion}"     # tracks rails ref in vendor/sources.ts`,
+    'gem "sqlite3", "~> 2.1"         # matches AR 8.0.2 declared dependency range',
+    'gem "minitest", "~> 5.25"       # canonicalize_test.rb',
+    "",
+  ].join("\n");
+}
+
+export function buildGemfile(): { changed: boolean; path: string } {
+  const next = buildGemfileContent();
+  if (existsSync(GEMFILE_PATH) && readFileSync(GEMFILE_PATH, "utf8") === next) {
+    return { changed: false, path: GEMFILE_PATH };
+  }
+  writeFileSync(GEMFILE_PATH, next);
+  return { changed: true, path: GEMFILE_PATH };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { changed, path } = buildGemfile();
+  console.log(changed ? `wrote ${path}` : `${path} already up to date`);
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -15,13 +15,13 @@ schema-parity tooling.
 
 ## Status
 
-| Wave | Status  | What landed                                                                        |
-| ---- | ------- | ---------------------------------------------------------------------------------- |
-| 1    | merged  | schema + rails-only `SOURCES` list (#1559)                                         |
-| 2a   | merged  | `fetch.ts` + lockfile + rack entry + parallel fetch (#1561)                        |
-| 2b   | merged  | consumers cut over; old `.rails-source/.rack-source` retired (#1563)               |
-| 3    | this PR | globalid entry (git clone of `rails/globalid`); `scripts/globalid-source/` deleted |
-| 4    | pending | `api-compare` derives `PACKAGES` from `SOURCES`; rack/globalid api-compare wiring  |
-| 5    | pending | `test-compare` reads from `resolvePath`                                            |
-| 6    | pending | globalid quoted test count + final wiring confirmation                             |
-| 7    | pending | doc + memory sweep; generate parity Gemfile from `SOURCES`                         |
+| Wave | Status  | What landed                                                                                 |
+| ---- | ------- | ------------------------------------------------------------------------------------------- |
+| 1    | merged  | schema + rails-only `SOURCES` list (#1559)                                                  |
+| 2a   | merged  | `fetch.ts` + lockfile + rack entry + parallel fetch (#1561)                                 |
+| 2b   | merged  | consumers cut over; old `.rails-source/.rack-source` retired (#1563)                        |
+| 3    | merged  | globalid entry (git clone of `rails/globalid`); `scripts/globalid-source/` deleted (#1578)  |
+| 4    | merged  | `api-compare` derives `PACKAGES` from `SOURCES` (#1579)                                     |
+| 5    | merged  | `test-compare` reads from `vendor/sources.ts` via `--print-test-paths` (#1586)              |
+| 6    | merged  | rack + globalid + abstractcontroller wired into api-compare via `--print-lib-paths` (#1589) |
+| 7    | this PR | parity-schema Gemfile generated from `vendor/sources.ts`; plan complete                     |


### PR DESCRIPTION
**Final wave** of the unified Ruby source-fetcher plan ([docs/ruby-source-fetcher-plan.md](docs/ruby-source-fetcher-plan.md)). The parity-schema Gemfile is now derived from `vendor/sources.ts` (the rails ref) instead of being hand-maintained — closes the last drift risk in the vendor system.

## Summary
- **`scripts/parity/schema/ruby/build-gemfile.ts`** (new): reads rails ref from `SOURCES`, computes activerecord version (strips leading `v`), writes Gemfile only on diff. Idempotent — same pattern as `vendor/fetch.ts`'s `writeLockfile`, so no-op runs don't bump mtime.
- **`scripts/parity/run.ts`**: `runRails()` calls `buildGemfile()` before bundle exec; logs when the file changed.
- **`scripts/parity/schema/ruby/Gemfile`**: regenerated with a `GENERATED from vendor/sources.ts` banner so contributors know not to hand-edit. Content equivalent to before.
- **`scripts/parity/schema/ruby/build-gemfile.test.ts`** (new): 3 unit tests.
- **`vendor/README.md`**: status table updated through wave 7 (plan complete).
- **`docs/activerecord-100-clusters.md:114`**: historical `.rails-source/` reference annotated with the post-wave-2b `vendor/rails/` path so future workers don't trip on the migration.

## Memory
`reference_rails_source_path.md` was already updated in wave 2b — verified still current; no change needed.

## What's *not* in this PR (deferred)
- abstractcontroller 0/82 parity gap surfaced by wave 6 — separate parity workstream, not a vendor-system concern.
- actiondispatch/actioncontroller testPath split — deferred from wave 5; lower priority.

## Plan complete

8 PRs over the wave series:

| Wave | PR | Status |
| --- | --- | --- |
| Plan doc | #1552 | merged |
| 1 (schema + rails entry) | #1559 | merged |
| 2a (fetcher tooling) | #1561 | merged |
| 2b (consumer cutover) | #1563 | merged |
| 3 (globalid) | #1578 | merged |
| 4 (derive PACKAGES + helpers) | #1579 | merged |
| 5 (derive test paths) | #1586 | merged |
| 6 (rack/globalid api wired) | #1589 | merged |
| 7 (parity Gemfile generated) | this PR | ready |

## Stats
- 6 files changed, +104/-12 LOC.
- 44 vendor + parity/schema tests pass (the 5 unrelated parity/query/node failures are a pre-existing `@blazetrails/globalid/dist/` build issue, unrelated to wave 7).

## Test plan
- [x] vendor + parity/schema tests pass.
- [x] Generator is idempotent (second run reports "already up to date").
- [ ] CI green.