### PR TITLE
feat(activerecord): associations HABTM Slot A — AssociationTypeMismatch + isInclude fixes (3 un-skips)

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1077,14 +1077,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   private _raiseOnTypeMismatch(records: T[]): void {
     const opts = this._assocDef.options;
+    // Polymorphic associations have no fixed klass — Rails no-ops type checking there.
+    if (opts.polymorphic) return;
     const className =
       (opts.className as string | undefined) ?? camelize(singularize(this._assocName));
-    let klass: typeof Base | null = null;
-    try {
-      klass = resolveAssocClass(this._record, this._assocName, className);
-    } catch {
-      return;
-    }
+    const klass = resolveAssocClass(this._record, this._assocName, className);
     for (const record of records) {
       if (record == null || !(record instanceof klass)) {
         const actual =

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -30,6 +30,7 @@ import {
   HasManyThroughNestedAssociationsAreReadonly,
   HasOneThroughNestedAssociationsAreReadonly,
   HasManyThroughOrderError,
+  AssociationTypeMismatch,
 } from "./errors.js";
 import { getInheritanceColumn, findStiClass } from "../inheritance.js";
 import type { AssociationDefinition } from "../associations.js";
@@ -939,6 +940,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   async push(...records: T[]): Promise<void> {
     this._ensureThroughWritable();
+    this._raiseOnTypeMismatch(records);
     // Through association (including HABTM): create join records
     if (this._assocDef.options.through) {
       await this._pushThrough(records);
@@ -1065,6 +1067,27 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         if (!skipCallbacks) {
           fireAssocCallbacks(this._assocDef.options.afterAdd, this._record, record);
         }
+      }
+    }
+  }
+
+  private _raiseOnTypeMismatch(records: T[]): void {
+    const opts = this._assocDef.options;
+    const className =
+      (opts.className as string | undefined) ?? camelize(singularize(this._assocName));
+    let klass: typeof Base | null = null;
+    try {
+      klass = resolveAssocClass(this._record, this._assocName, className);
+    } catch {
+      return;
+    }
+    for (const record of records) {
+      if (record == null || !(record instanceof klass)) {
+        const actual =
+          record == null
+            ? String(record)
+            : `an instance of ${(record as any)?.constructor?.name ?? "unknown"}`;
+        throw new AssociationTypeMismatch(`${className}`, actual);
       }
     }
   }
@@ -1289,6 +1312,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#include?
    */
   async isInclude(record: T): Promise<boolean> {
+    if (record.isNewRecord()) {
+      return this._target.includes(record);
+    }
+
     if (this._targetLoaded) {
       const targetId = this._identityFor(record);
       if (targetId != null) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -23,14 +23,18 @@ import {
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Nodes } from "@blazetrails/arel";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
-import { StrictLoadingViolationError, RecordNotSaved, ConfigurationError } from "../errors.js";
+import {
+  StrictLoadingViolationError,
+  RecordNotSaved,
+  ConfigurationError,
+  AssociationTypeMismatch,
+} from "../errors.js";
 import { RecordInvalid } from "../validations.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
   HasManyThroughNestedAssociationsAreReadonly,
   HasOneThroughNestedAssociationsAreReadonly,
   HasManyThroughOrderError,
-  AssociationTypeMismatch,
 } from "./errors.js";
 import { getInheritanceColumn, findStiClass } from "../inheritance.js";
 import type { AssociationDefinition } from "../associations.js";

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -6,6 +6,13 @@
  */
 import { ActiveRecordError, ConfigurationError } from "../errors.js";
 
+export class AssociationTypeMismatch extends ActiveRecordError {
+  constructor(expected: string, actual: string) {
+    super(`${expected} expected, got ${actual}`);
+    this.name = "AssociationTypeMismatch";
+  }
+}
+
 export class AssociationNotFoundError extends ConfigurationError {
   readonly record: any;
   readonly associationName: string;

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -6,13 +6,6 @@
  */
 import { ActiveRecordError, ConfigurationError } from "../errors.js";
 
-export class AssociationTypeMismatch extends ActiveRecordError {
-  constructor(expected: string, actual: string) {
-    super(`${expected} expected, got ${actual}`);
-    this.name = "AssociationTypeMismatch";
-  }
-}
-
 export class AssociationNotFoundError extends ConfigurationError {
   readonly record: any;
   readonly associationName: string;

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, registerModel } from "../index.js";
+import { Base, registerModel, AssociationTypeMismatch } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { Associations, loadHasMany, loadHabtm, association } from "../associations.js";
@@ -112,10 +112,12 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(projects.length).toBe(1);
   });
 
-  it.skip("adding type mismatch", () => {
-    // BLOCKED: associations — collection-proxy mutation
-    // ROOT-CAUSE: CollectionProxy#push does not raise AssociationTypeMismatch for wrong model
-    // SCOPE: collection-proxy.ts — type guard on push/append
+  it("adding type mismatch", async () => {
+    const dev = await Developer.create({ name: "TypeMismatch", salary: 80000 });
+    const proxy = association(dev, "projects");
+    await expect(proxy.push(null as any)).rejects.toThrow(AssociationTypeMismatch);
+    await expect(proxy.push(1 as any)).rejects.toThrow(AssociationTypeMismatch);
+    await expect(proxy.push(dev as any)).rejects.toThrow(AssociationTypeMismatch);
   });
 
   it("adding from the project", async () => {
@@ -515,10 +517,15 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(included).toBe(true);
   });
 
-  it.skip("include checks if record exists if target not loaded", () => {
-    // BLOCKED: associations — collection-proxy mutation
-    // ROOT-CAUSE: CollectionProxy#include? (include without prior load) issues a DB EXISTS check — not yet implemented
-    // SCOPE: collection-proxy.ts — include? lazy/db-check path
+  it("include checks if record exists if target not loaded", async () => {
+    const dev = await Developer.create({ name: "IncludeCheck", salary: 80000 });
+    const proj = await Project.create({ name: "IncludeProj" });
+    await DeveloperProject.create({ developer_id: dev.id, project_id: proj.id });
+    const proxy = association<Project>(dev, "projects");
+    expect(proxy.loaded).toBe(false);
+    const result = await proxy.isInclude(proj);
+    expect(result).toBe(true);
+    expect(proxy.loaded).toBe(false);
   });
 
   it("include returns false for non matching record to verify scoping", async () => {
@@ -890,10 +897,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     // SCOPE: collection-proxy.ts — scope_attributes merging for chained where conditions
   });
 
-  it.skip("include method in has and belongs to many association should return true for instance added with build", () => {
-    // BLOCKED: associations — collection-proxy mutation
-    // ROOT-CAUSE: CollectionProxy#include? returns false for a record that was built (not yet persisted) via the proxy
-    // SCOPE: collection-proxy.ts — in-memory include? check for unsaved built records
+  it("include method in has and belongs to many association should return true for instance added with build", async () => {
+    const dev = new Developer({ name: "BuiltDev", salary: 50000 });
+    const proxy = association<Project>(dev, "projects");
+    const proj = proxy.build({ name: "BuiltProj" });
+    expect(await proxy.isInclude(proj)).toBe(true);
   });
 
   it("destruction does not error without primary key", async () => {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -12,6 +12,13 @@ export class SubclassNotFound extends ActiveRecordError {
   }
 }
 
+export class AssociationTypeMismatch extends ActiveRecordError {
+  constructor(expected: string, actual: string) {
+    super(`${expected} expected, got ${actual}`);
+    this.name = "AssociationTypeMismatch";
+  }
+}
+
 export class SerializationTypeMismatch extends ActiveRecordError {
   constructor(message?: string, options?: ErrorOptions) {
     super(message, options);

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -233,6 +233,7 @@ export {
   LockWaitTimeout,
   QueryCanceled,
   RangeError,
+  AssociationTypeMismatch,
 } from "./errors.js";
 export {
   ReadonlyAttributeError,
@@ -241,7 +242,6 @@ export {
 } from "./readonly-attributes.js";
 export { RecordInvalid } from "./validations.js";
 export {
-  AssociationTypeMismatch,
   AssociationNotFoundError,
   InverseOfAssociationNotFoundError,
   InverseOfAssociationRecursiveError,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -241,6 +241,7 @@ export {
 } from "./readonly-attributes.js";
 export { RecordInvalid } from "./validations.js";
 export {
+  AssociationTypeMismatch,
   AssociationNotFoundError,
   InverseOfAssociationNotFoundError,
   InverseOfAssociationRecursiveError,


### PR DESCRIPTION
## Summary

- Add `AssociationTypeMismatch` error class (mirrors `ActiveRecord::AssociationTypeMismatch`)
- Wire type guard into `CollectionProxy#push` — raises when record is null, a primitive, or instance of the wrong model class
- Fix `CollectionProxy#isInclude` to return `true` for new (unsaved) records built via the proxy (Rails `include?` routes `new_record?` through `include_in_memory?`)
- Un-skip 3 tests in `has-and-belongs-to-many-associations.test.ts`: `adding type mismatch`, `include checks if record exists if target not loaded`, `include method in has and belongs to many association should return true for instance added with build`

## Follow-ups (remaining Slot A scope)

- `dynamic find all should respect readonly access` — needs `readonly: true` option marking returned records as `ReadOnlyRecord`
- `association with validate false does not run associated validation callbacks on create/update` — needs `validate: false` option to suppress validation on push/create (Slot D candidate)