### PR TITLE
feat(activerecord): migration Slot F — bulk-alter recorder round-trip + change-column test reorg

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1179,8 +1179,12 @@ export class Table {
   async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, type, { ...options, array: true });
   }
-  async remove(name: string): Promise<void> {
-    await this._schema.removeColumn(this._tableName, name);
+  async remove(
+    name: string,
+    options: { type?: string } & Record<string, unknown> = {},
+  ): Promise<void> {
+    const { type, ...rest } = options;
+    await this._schema.removeColumn(this._tableName, name, type as any, rest);
   }
   async rename(oldName: string, newName: string): Promise<void> {
     await this._schema.renameColumn(this._tableName, oldName, newName);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1179,12 +1179,9 @@ export class Table {
   async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, type, { ...options, array: true });
   }
-  async remove(
-    name: string,
-    options: { type?: string } & Record<string, unknown> = {},
-  ): Promise<void> {
+  async remove(name: string, options: { type?: string; ifExists?: boolean } = {}): Promise<void> {
     const { type, ...rest } = options;
-    await this._schema.removeColumn(this._tableName, name, type as any, rest);
+    await this._schema.removeColumn(this._tableName, name, type as ColumnType | undefined, rest);
   }
   async rename(oldName: string, newName: string): Promise<void> {
     await this._schema.renameColumn(this._tableName, oldName, newName);

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -421,10 +421,41 @@ describe("InvertibleMigrationTest", () => {
     /* check constraints not implemented */
   });
 
-  it.skip("migrate revert change table", () => {
-    // BLOCKED: migration — migration runner gap in invertible-migration
-    // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-    // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in invertible-migration.test.ts
+  it("migrate revert change table", async () => {
+    // Create horses table with remind_at column
+    class CreateHorses extends Migration {
+      async change() {
+        await this.createTable("horses", (t) => {
+          t.string("content");
+          t.datetime("remind_at");
+        });
+      }
+    }
+
+    class ChangeHorsesTable extends Migration {
+      async change() {
+        await this.changeTable("horses", async (t) => {
+          await t.string("name");
+          await t.remove("remind_at", { type: "datetime" });
+        });
+      }
+    }
+
+    async function hasColumn(tbl: string, col: string): Promise<boolean> {
+      const rows = await adapter.execute(`PRAGMA table_info("${tbl}")`);
+      return rows.some((r: any) => r.name === col);
+    }
+
+    await makeMigration(new CreateHorses()).up();
+    expect(await hasColumn("horses", "remind_at")).toBe(true);
+
+    const cm = makeMigration(new ChangeHorsesTable());
+    await cm.up();
+    expect(await hasColumn("horses", "remind_at")).toBe(false);
+    expect(await hasColumn("horses", "name")).toBe(true);
+
+    await cm.down();
+    expect(await hasColumn("horses", "remind_at")).toBe(true);
   });
 });
 

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -422,7 +422,6 @@ describe("InvertibleMigrationTest", () => {
   });
 
   it("migrate revert change table", async () => {
-    // Create horses table with remind_at column
     class CreateHorses extends Migration {
       async change() {
         await this.createTable("horses", (t) => {
@@ -441,21 +440,19 @@ describe("InvertibleMigrationTest", () => {
       }
     }
 
-    async function hasColumn(tbl: string, col: string): Promise<boolean> {
-      const rows = await adapter.execute(`PRAGMA table_info("${tbl}")`);
-      return rows.some((r: any) => r.name === col);
-    }
+    const schemaOf = (m: Migration) => (m as any).schema;
 
-    await makeMigration(new CreateHorses()).up();
-    expect(await hasColumn("horses", "remind_at")).toBe(true);
+    const create = makeMigration(new CreateHorses());
+    await create.up();
+    expect(await schemaOf(create).columnExists("horses", "remind_at")).toBe(true);
 
     const cm = makeMigration(new ChangeHorsesTable());
     await cm.up();
-    expect(await hasColumn("horses", "remind_at")).toBe(false);
-    expect(await hasColumn("horses", "name")).toBe(true);
+    expect(await schemaOf(cm).columnExists("horses", "remind_at")).toBe(false);
+    expect(await schemaOf(cm).columnExists("horses", "name")).toBe(true);
 
     await cm.down();
-    expect(await hasColumn("horses", "remind_at")).toBe(true);
+    expect(await schemaOf(cm).columnExists("horses", "remind_at")).toBe(true);
   });
 });
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2193,38 +2193,47 @@ describe("MigrationTest", () => {
     });
 
     it.skip("changing columns", () => {
-      // BLOCKED: migration — migration runner gap in migration
-      // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-      // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-      /* ALTER COLUMN TYPE not supported in SQLite */
+      // BLOCKED: adapter — changeColumn requires ALTER COLUMN TYPE not supported by SQLite
     });
 
     it.skip("changing column null with default", () => {
-      // BLOCKED: migration — migration runner gap in migration
-      // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-      // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-      /* ALTER COLUMN not supported */
+      // BLOCKED: adapter — changeColumnNull requires ALTER COLUMN ... SET NOT NULL not supported by SQLite
     });
 
     it.skip("default functions on columns", () => {
-      // BLOCKED: migration — migration runner gap in migration
-      // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-      // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-      /* not supported */
+      // BLOCKED: adapter — gen_random_uuid() / UUID() requires PostgreSQL or MySQL
     });
 
     it.skip("updating auto increment", () => {
-      // BLOCKED: migration — migration runner gap in migration
-      // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-      // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-      /* not supported */
+      // BLOCKED: adapter — auto_increment is MySQL-only (Mysql2Adapter / TrilogyAdapter)
     });
 
-    it.skip("changing index", () => {
-      // BLOCKED: migration — migration runner gap in migration
-      // ROOT-CAUSE: migration.ts#Migrator or MigrationContext not fully implementing Rails migration semantics
-      // SCOPE: ~50–150 LOC fix in migration.ts; affects ~4–30 tests in migration.test.ts
-      /* ALTER INDEX not supported */
+    it("changing index", async () => {
+      // Create table with a non-unique index, then swap to a unique index
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk_idx", (t) => {
+              t.string("username");
+            });
+            await this.addIndex("bk_idx", "username", { name: "username_index" });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.removeIndex("bk_idx", { name: "username_index" });
+            await this.addIndex("bk_idx", "username", { name: "username_index", unique: true });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await bulkAdapter.executeMutation(`INSERT INTO "bk_idx" ("username") VALUES ('alice')`);
+      await expect(
+        bulkAdapter.executeMutation(`INSERT INTO "bk_idx" ("username") VALUES ('alice')`),
+      ).rejects.toThrow();
     });
   }); // BulkAlterTableMigrationsTest
 

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CommandRecorder } from "./command-recorder.js";
+import { CommandRecorder, RecorderTableProxy } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
 
 describe("CommandRecorder", () => {
@@ -389,6 +389,74 @@ describe("CommandRecorder", () => {
       expect(new CommandRecorder().findJoinTableName("cats", "dogs", { tableName: "pets" })).toBe(
         "pets",
       );
+    });
+  });
+
+  describe("invert change column", () => {
+    it("throws IrreversibleMigration", () => {
+      const recorder = new CommandRecorder();
+      expect(() => recorder.inverseOf("changeColumn", ["table", "column", "string", {}])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+  });
+
+  describe("invert change table (non-bulk)", () => {
+    it("reverts string + rename inside change_table block", async () => {
+      const recorder = new CommandRecorder();
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", {}, async (t) => {
+          t.string("name");
+          t.rename("kind", "cultivar");
+        });
+      });
+      // Reversed order and inverted: renameColumn first, then removeColumn
+      expect(recorder.commands).toHaveLength(2);
+      const [first, second] = recorder.commands;
+      expect(first.cmd).toBe("renameColumn");
+      expect(first.args).toEqual(["fruits", "cultivar", "kind"]);
+      expect(second.cmd).toBe("removeColumn");
+      expect(second.args[0]).toBe("fruits");
+      expect(second.args[1]).toBe("name");
+    });
+
+    it("raises IrreversibleMigration when remove lacks type", async () => {
+      const recorder = new CommandRecorder();
+      await expect(
+        recorder.revert(async () => {
+          await recorder.changeTable("fruits", {}, async (t) => {
+            t.remove("kind"); // no type → not reversible
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+  });
+
+  describe("bulk invert change table", () => {
+    it("records two changeTable commands from revert + revert-of-revert", async () => {
+      const delegate = { supportsBulkAlter: () => true };
+      const recorder = new CommandRecorder(delegate);
+
+      const block = async (t: RecorderTableProxy) => {
+        t.string("name");
+        t.rename("kind", "cultivar");
+      };
+
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", { bulk: true }, block);
+      });
+
+      await recorder.revert(async () => {
+        await recorder.revert(async () => {
+          await recorder.changeTable("fruits", { bulk: true }, block);
+        });
+      });
+
+      expect(recorder.commands).toHaveLength(2);
+      expect(recorder.commands[0].cmd).toBe("changeTable");
+      expect(recorder.commands[0].args[0]).toBe("fruits");
+      expect(recorder.commands[1].cmd).toBe("changeTable");
+      expect(recorder.commands[1].args[0]).toBe("fruits");
     });
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { CommandRecorder, RecorderTableProxy } from "./command-recorder.js";
+import { CommandRecorder } from "./command-recorder.js";
+import type { RecorderTableProxy } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
 
 describe("CommandRecorder", () => {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -419,13 +419,16 @@ describe("CommandRecorder", () => {
       expect(recorder.commands[0].cmd).toBe("addColumn");
     });
 
-    it("remove with multiple columns records removeColumns", async () => {
+    it("remove with multiple columns records individual removeColumn per name", async () => {
       const recorder = new CommandRecorder();
       await recorder.changeTable("fruits", async (t) => {
         t.remove("name", "kind", { type: "string" });
       });
-      expect(recorder.commands[0].cmd).toBe("removeColumns");
-      expect(recorder.commands[0].args[0]).toBe("fruits");
+      expect(recorder.commands).toHaveLength(2);
+      expect(recorder.commands[0].cmd).toBe("removeColumn");
+      expect(recorder.commands[0].args).toEqual(["fruits", "name", "string"]);
+      expect(recorder.commands[1].cmd).toBe("removeColumn");
+      expect(recorder.commands[1].args).toEqual(["fruits", "kind", "string"]);
     });
 
     it("reverts string + rename inside change_table block", async () => {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -402,10 +402,26 @@ describe("CommandRecorder", () => {
     });
   });
 
+  describe("invertAddColumns", () => {
+    it("returns removeColumns", () => {
+      const [cmd] = new CommandRecorder().invertAddColumns(["users", "name", "age"]);
+      expect(cmd).toBe("removeColumns");
+    });
+  });
+
   describe("invert change table (non-bulk)", () => {
+    it("accepts (tableName, fn) without explicit options", async () => {
+      const recorder = new CommandRecorder();
+      // short form: no options argument
+      await recorder.changeTable("fruits", async (t) => {
+        t.string("name");
+      });
+      expect(recorder.commands[0].cmd).toBe("addColumn");
+    });
+
     it("remove with multiple columns records removeColumns", async () => {
       const recorder = new CommandRecorder();
-      await recorder.changeTable("fruits", {}, async (t) => {
+      await recorder.changeTable("fruits", async (t) => {
         t.remove("name", "kind", { type: "string" });
       });
       expect(recorder.commands[0].cmd).toBe("removeColumns");
@@ -415,7 +431,7 @@ describe("CommandRecorder", () => {
     it("reverts string + rename inside change_table block", async () => {
       const recorder = new CommandRecorder();
       await recorder.revert(async () => {
-        await recorder.changeTable("fruits", {}, async (t) => {
+        await recorder.changeTable("fruits", async (t) => {
           t.string("name");
           t.rename("kind", "cultivar");
         });
@@ -434,7 +450,7 @@ describe("CommandRecorder", () => {
       const recorder = new CommandRecorder();
       await expect(
         recorder.revert(async () => {
-          await recorder.changeTable("fruits", {}, async (t) => {
+          await recorder.changeTable("fruits", async (t) => {
             t.remove("kind"); // no type → not reversible
           });
         }),

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -402,6 +402,15 @@ describe("CommandRecorder", () => {
   });
 
   describe("invert change table (non-bulk)", () => {
+    it("remove with multiple columns records removeColumns", async () => {
+      const recorder = new CommandRecorder();
+      await recorder.changeTable("fruits", {}, async (t) => {
+        t.remove("name", "kind", { type: "string" });
+      });
+      expect(recorder.commands[0].cmd).toBe("removeColumns");
+      expect(recorder.commands[0].args[0]).toBe("fruits");
+    });
+
     it("reverts string + rename inside change_table block", async () => {
       const recorder = new CommandRecorder();
       await recorder.revert(async () => {

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -103,7 +103,6 @@ export class CommandRecorder {
       // Bulk path: sub-recorder captures commands, parent stores a single
       // changeTable entry that invertChangeTable knows how to flip.
       const sub = new CommandRecorder(this._delegate);
-      sub.reverting = this._reverting;
       const proxy = new RecorderTableProxy(tableName, sub);
       await callback(proxy);
       this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
@@ -122,7 +121,16 @@ export class CommandRecorder {
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
     for (const { cmd, args } of this._commands) {
-      if (typeof migration[cmd] === "function") {
+      // Bulk changeTable stores [tableName, subCommands[]]. Replay each
+      // sub-command individually rather than forwarding the array as an arg.
+      if (cmd === "changeTable" && Array.isArray(args[1])) {
+        const subCmds = args[1] as Array<{ cmd: string; args: unknown[] }>;
+        for (const { cmd: sub, args: subArgs } of subCmds) {
+          if (typeof migration[sub] === "function") {
+            await migration[sub](...subArgs);
+          }
+        }
+      } else if (typeof migration[cmd] === "function") {
         await migration[cmd](...args);
       }
     }
@@ -682,6 +690,11 @@ export class RecorderTableProxy {
         colArgs.push(options["type"]);
         const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
         if (Object.keys(rest).length > 0) colArgs.push(rest);
+      } else if (Object.keys(options).length > 0) {
+        // Forward options (e.g. ifExists) even without type so replay semantics
+        // are preserved. Inversion will still raise IrreversibleMigration since
+        // args.length <= 2 (table + col, no type positional arg).
+        colArgs.push(options);
       }
       this._recorder.record("removeColumn", colArgs);
     }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -27,6 +27,10 @@ export class CommandRecorder {
     return this._reverting;
   }
 
+  set reverting(value: boolean) {
+    this._reverting = value;
+  }
+
   get commands(): Array<{ cmd: string; args: unknown[] }> {
     return [...this._commands];
   }
@@ -76,12 +80,41 @@ export class CommandRecorder {
   }
 
   /**
-   * Record a change_table block.
+   * Record a change_table block. When a callback is given, operations inside
+   * the block are individually recorded so they can be inverted.  With
+   * `bulk: true` the operations are captured into a sub-recorder and stored as
+   * a single batched command (mirrors the Rails bulk alter path).
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#change_table
    */
-  changeTable(tableName: string, options: Record<string, unknown> = {}): void {
-    this.record("changeTable", [tableName, options]);
+  async changeTable(
+    tableName: string,
+    options: Record<string, unknown> = {},
+    fn?: (t: RecorderTableProxy) => Promise<void> | void,
+  ): Promise<void> {
+    if (!fn) {
+      this.record("changeTable", [tableName, options]);
+      return;
+    }
+
+    const supportsBulk =
+      typeof (this._delegate as any)?.supportsBulkAlter === "function" &&
+      (this._delegate as any).supportsBulkAlter() === true;
+
+    if (options["bulk"] && supportsBulk) {
+      // Bulk path: sub-recorder captures commands, parent stores a single
+      // changeTable entry that invertChangeTable knows how to flip.
+      const sub = new CommandRecorder(this._delegate);
+      sub.reverting = this._reverting;
+      const proxy = new RecorderTableProxy(tableName, sub);
+      await fn(proxy);
+      this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
+    } else {
+      // Non-bulk: route operations directly through this recorder so the
+      // enclosing revert() block can invert them individually.
+      const proxy = new RecorderTableProxy(tableName, this);
+      await fn(proxy);
+    }
   }
 
   /**
@@ -363,6 +396,23 @@ export class CommandRecorder {
   }
 
   /** @internal */
+  invertChangeColumn(_args: unknown[]): [string, unknown[]] {
+    throw new IrreversibleMigration(
+      "change_column is not reversible. Use change_column_default or change_column_null instead.",
+    );
+  }
+
+  /** @internal */
+  invertChangeTable(args: unknown[]): [string, unknown[]] {
+    const [tableName, subCommands] = args as [string, Array<{ cmd: string; args: unknown[] }>];
+    const inverted = [...subCommands].reverse().map(({ cmd, args: subArgs }) => {
+      const [iCmd, iArgs] = this._dispatchInvert(cmd, subArgs);
+      return { cmd: iCmd, args: iArgs };
+    });
+    return ["changeTable", [tableName, inverted]];
+  }
+
+  /** @internal */
   invertTransaction(args: unknown[]): [string, unknown[]] {
     throw new IrreversibleMigration(
       "This migration uses transaction, which is not automatically reversible.",
@@ -555,5 +605,96 @@ export class CommandRecorder {
       return (method as (args: unknown[]) => [string, unknown[]]).call(this, args);
     }
     throw new IrreversibleMigration(`${cmd} is not reversible`);
+  }
+}
+
+/**
+ * Table proxy used inside CommandRecorder#changeTable blocks. Routes each
+ * Table-style method call to recorder.record() so the parent recorder (or
+ * revert block) can capture and optionally invert the individual operations.
+ *
+ * Mirrors: the Table object yielded by CommandRecorder#change_table in Rails
+ * (non-bulk path: `yield delegate.update_table_definition(table_name, self)`).
+ */
+export class RecorderTableProxy {
+  constructor(
+    private _tableName: string,
+    private _recorder: CommandRecorder,
+  ) {}
+
+  private _col(name: string, type: string, options: Record<string, unknown>): void {
+    this._recorder.record("addColumn", [this._tableName, name, type, options]);
+  }
+
+  string(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "string", options);
+  }
+  text(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "text", options);
+  }
+  integer(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "integer", options);
+  }
+  float(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "float", options);
+  }
+  decimal(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "decimal", options);
+  }
+  boolean(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "boolean", options);
+  }
+  date(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "date", options);
+  }
+  datetime(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "datetime", options);
+  }
+  bigint(name: string, options: Record<string, unknown> = {}): void {
+    this._col(name, "bigint", options);
+  }
+
+  rename(oldName: string, newName: string): void {
+    this._recorder.record("renameColumn", [this._tableName, oldName, newName]);
+  }
+
+  remove(name: string, options: Record<string, unknown> = {}): void {
+    const args: unknown[] = [this._tableName, name];
+    if (options["type"]) {
+      args.push(options["type"]);
+      const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
+      if (Object.keys(rest).length > 0) args.push(rest);
+    }
+    this._recorder.record("removeColumn", args);
+  }
+
+  change(name: string, type: string, options: Record<string, unknown> = {}): void {
+    this._recorder.record("changeColumn", [this._tableName, name, type, options]);
+  }
+
+  changeDefault(name: string, value: unknown): void {
+    this._recorder.record("changeColumnDefault", [this._tableName, name, value]);
+  }
+
+  changeNull(name: string, nullable: boolean, defaultValue?: unknown): void {
+    const args: unknown[] = [this._tableName, name, nullable];
+    if (defaultValue !== undefined) args.push(defaultValue);
+    this._recorder.record("changeColumnNull", args);
+  }
+
+  index(columns: string | string[], options: Record<string, unknown> = {}): void {
+    this._recorder.record("addIndex", [this._tableName, columns, options]);
+  }
+
+  removeIndex(options: Record<string, unknown> = {}): void {
+    this._recorder.record("removeIndex", [this._tableName, options]);
+  }
+
+  timestamps(options: Record<string, unknown> = {}): void {
+    this._recorder.record("addTimestamps", [this._tableName, options]);
+  }
+
+  removeTimestamps(options: Record<string, unknown> = {}): void {
+    this._recorder.record("removeTimestamps", [this._tableName, options]);
   }
 }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -214,7 +214,7 @@ export class CommandRecorder {
 
   /** @internal */
   invertRemoveColumn(args: unknown[]): [string, unknown[]] {
-    if (args.length <= 2) {
+    if (typeof args[2] !== "string") {
       throw new IrreversibleMigration("remove_column is only reversible if given a type.");
     }
     return ["addColumn", args];

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -93,8 +93,12 @@ export class CommandRecorder {
     fn?: (t: RecorderTableProxy) => Promise<void> | void,
   ): Promise<void> {
     const options: Record<string, unknown> = typeof fnOrOptions === "function" ? {} : fnOrOptions;
-    const callback: (t: RecorderTableProxy) => Promise<void> | void =
-      typeof fnOrOptions === "function" ? fnOrOptions : fn!;
+    const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
+    if (!callback) {
+      throw new TypeError(
+        "changeTable requires a callback. Rails change_table always takes a block.",
+      );
+    }
     const supportsBulk =
       typeof (this._delegate as any)?.supportsBulkAlter === "function" &&
       (this._delegate as any).supportsBulkAlter() === true;

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -90,13 +90,8 @@ export class CommandRecorder {
   async changeTable(
     tableName: string,
     options: Record<string, unknown> = {},
-    fn?: (t: RecorderTableProxy) => Promise<void> | void,
+    fn: (t: RecorderTableProxy) => Promise<void> | void,
   ): Promise<void> {
-    if (!fn) {
-      this.record("changeTable", [tableName, options]);
-      return;
-    }
-
     const supportsBulk =
       typeof (this._delegate as any)?.supportsBulkAlter === "function" &&
       (this._delegate as any).supportsBulkAlter() === true;
@@ -658,14 +653,23 @@ export class RecorderTableProxy {
     this._recorder.record("renameColumn", [this._tableName, oldName, newName]);
   }
 
-  remove(name: string, options: Record<string, unknown> = {}): void {
-    const args: unknown[] = [this._tableName, name];
-    if (options["type"]) {
-      args.push(options["type"]);
-      const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
-      if (Object.keys(rest).length > 0) args.push(rest);
+  remove(...args: [...string[], Record<string, unknown>] | string[]): void {
+    const last = args[args.length - 1];
+    const hasOpts = typeof last === "object" && last !== null;
+    const options = hasOpts ? (args.pop() as Record<string, unknown>) : {};
+    const names = args as string[];
+    if (names.length > 1) {
+      // Multi-column: mirrors Rails Table#remove -> remove_columns (plural)
+      this._recorder.record("removeColumns", [this._tableName, ...names, options]);
+    } else {
+      const colArgs: unknown[] = [this._tableName, names[0]];
+      if (options["type"]) {
+        colArgs.push(options["type"]);
+        const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
+        if (Object.keys(rest).length > 0) colArgs.push(rest);
+      }
+      this._recorder.record("removeColumn", colArgs);
     }
-    this._recorder.record("removeColumn", args);
   }
 
   change(name: string, type: string, options: Record<string, unknown> = {}): void {

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -89,9 +89,12 @@ export class CommandRecorder {
    */
   async changeTable(
     tableName: string,
-    options: Record<string, unknown> = {},
-    fn: (t: RecorderTableProxy) => Promise<void> | void,
+    fnOrOptions: ((t: RecorderTableProxy) => Promise<void> | void) | Record<string, unknown>,
+    fn?: (t: RecorderTableProxy) => Promise<void> | void,
   ): Promise<void> {
+    const options: Record<string, unknown> = typeof fnOrOptions === "function" ? {} : fnOrOptions;
+    const callback: (t: RecorderTableProxy) => Promise<void> | void =
+      typeof fnOrOptions === "function" ? fnOrOptions : fn!;
     const supportsBulk =
       typeof (this._delegate as any)?.supportsBulkAlter === "function" &&
       (this._delegate as any).supportsBulkAlter() === true;
@@ -102,13 +105,13 @@ export class CommandRecorder {
       const sub = new CommandRecorder(this._delegate);
       sub.reverting = this._reverting;
       const proxy = new RecorderTableProxy(tableName, sub);
-      await fn(proxy);
+      await callback(proxy);
       this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
     } else {
       // Non-bulk: route operations directly through this recorder so the
       // enclosing revert() block can invert them individually.
       const proxy = new RecorderTableProxy(tableName, this);
-      await fn(proxy);
+      await callback(proxy);
     }
   }
 
@@ -430,6 +433,11 @@ export class CommandRecorder {
       throw new IrreversibleMigration("remove_columns is only reversible if given a type.");
     }
     return ["addColumns", args];
+  }
+
+  /** @internal */
+  invertAddColumns(args: unknown[]): [string, unknown[]] {
+    return ["removeColumns", args];
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -685,19 +685,18 @@ export class RecorderTableProxy {
     const hasOpts = typeof last === "object" && last !== null;
     const options = hasOpts ? (args.pop() as Record<string, unknown>) : {};
     const names = args as string[];
-    if (names.length > 1) {
-      // Multi-column: mirrors Rails Table#remove -> remove_columns (plural)
-      this._recorder.record("removeColumns", [this._tableName, ...names, options]);
-    } else {
-      const colArgs: unknown[] = [this._tableName, names[0]];
+    // Emit one removeColumn per name (mirrors Rails Table#remove -> remove_columns
+    // iterating remove_column). This avoids the removeColumns arg-shape mismatch
+    // with Migration.removeColumns (strings only, no trailing options).
+    for (const name of names) {
+      const colArgs: unknown[] = [this._tableName, name];
       if (options["type"]) {
         colArgs.push(options["type"]);
         const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
         if (Object.keys(rest).length > 0) colArgs.push(rest);
       } else if (Object.keys(options).length > 0) {
         // Forward options (e.g. ifExists) even without type so replay semantics
-        // are preserved. Inversion will still raise IrreversibleMigration since
-        // args.length <= 2 (table + col, no type positional arg).
+        // are preserved. Inversion still raises IrreversibleMigration (no type).
         colArgs.push(options);
       }
       this._recorder.record("removeColumn", colArgs);

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -399,11 +399,18 @@ export class CommandRecorder {
 
   /** @internal */
   invertChangeTable(args: unknown[]): [string, unknown[]] {
-    const [tableName, subCommands] = args as [string, Array<{ cmd: string; args: unknown[] }>];
-    const inverted = [...subCommands].reverse().map(({ cmd, args: subArgs }) => {
-      const [iCmd, iArgs] = this._dispatchInvert(cmd, subArgs);
-      return { cmd: iCmd, args: iArgs };
-    });
+    const [tableName, subCommands] = args as [string, unknown];
+    if (!Array.isArray(subCommands)) {
+      throw new IrreversibleMigration(
+        "change_table is not reversible without captured sub-commands.",
+      );
+    }
+    const inverted = ([...subCommands] as Array<{ cmd: string; args: unknown[] }>)
+      .reverse()
+      .map(({ cmd, args: subArgs }) => {
+        const [iCmd, iArgs] = this._dispatchInvert(cmd, subArgs);
+        return { cmd: iCmd, args: iArgs };
+      });
     return ["changeTable", [tableName, inverted]];
   }
 


### PR DESCRIPTION
## Summary

- **`CommandRecorder.changeTable`** now accepts an async callback, implementing both non-bulk and bulk change-table paths mirroring Rails' `CommandRecorder#change_table`
- **`RecorderTableProxy`** — new class that bridges Table-style API (`string/rename/remove/change/index/…`) to `recorder.record()` calls, matching Rails' `update_table_definition` pattern
- **`invertChangeTable`** — inverts captured bulk sub-commands so double-revert round-trips work
- **`invertChangeColumn`** — explicit throw with Rails-matching message (was previously caught by generic fallback)
- **`Table.remove(name, {type?})`** — extended to pass `type` through to `removeColumn` for reversible `changeTable` blocks
- **2 tests un-skipped**: "migrate revert change table" (invertible-migration) + "changing index" (BulkAlterTableMigrationsTest)
- **4 BulkAlterTableMigrationsTest skips re-annotated** from stale "migration runner gap" to accurate adapter blockers

## Test plan

- [x] All 58 command-recorder tests pass (new: `invert change column`, `invert change table (non-bulk)`, `bulk invert change table`)
- [x] invertible-migration "migrate revert change table" now passes
- [x] migration BulkAlterTableMigrationsTest "changing index" now passes
- [x] `api:compare` for `migration/command_recorder` stays at 38/38 (100%)
- [x] Lint clean, TypeScript build passes
- [x] 293 LOC (under 300 ceiling)

## Follow-ups

The remaining 4 `BulkAlterTableMigrationsTest` skips require PG or MySQL adapters:

- **"changing columns"** — `changeColumn` needs `ALTER COLUMN TYPE` (PG/MySQL only); move to PG change-schema suite
- **"changing column null with default"** — `changeColumnNull` uses `ALTER COLUMN … SET NOT NULL` (PG/MySQL only)
- **"default functions on columns"** — `gen_random_uuid()` / `UUID()` requires PG or MySQL
- **"updating auto increment"** — `auto_increment` is MySQL-only (MySQL Cluster Slot D)