### PR TITLE
feat(activerecord): MySQL active-schema Slot B — DDL SQL parity + 8 un-skips

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -73,15 +73,9 @@ describeIfMysql("Mysql2Adapter", () => {
         sqls = await captureSql(() =>
           adapter.addIndex("people", "last_name", { length: 10, using: "btree", algorithm }),
         );
-        if (algorithm === "default") {
-          expect(sqls[0]).toBe(
-            "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10))",
-          );
-        } else {
-          expect(sqls[0]).toBe(
-            `CREATE INDEX \`index_people_on_last_name\` USING btree ON \`people\` (\`last_name\`(10)) ALGORITHM = ${algorithm.toUpperCase()}`,
-          );
-        }
+        expect(sqls[0]).toBe(
+          `CREATE INDEX \`index_people_on_last_name\` USING btree ON \`people\` (\`last_name\`(10)) ALGORITHM = ${algorithm.toUpperCase()}`,
+        );
       }
 
       await expect(() =>

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { captureSql } from "../../testing/sql-capture.js";
 
@@ -15,77 +16,161 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("ActiveSchemaTest", () => {
-    it.skip("add index", () => {
-      // BLOCKED: adapter-mysql — addIndex stub in abstract-mysql-adapter.ts does nothing (no-op body)
-      // ROOT-CAUSE: AbstractMysqlAdapter#addIndex at connection-adapters/abstract-mysql-adapter.ts:550 is a void stub;
-      //   needs to build+emit the CREATE INDEX SQL via MysqlSchemaCreation
-      // SCOPE: ~30–60 LOC in abstract-mysql-adapter.ts addIndex; unblocks ~10 addIndex sub-tests
+    it("add index", async () => {
+      let sqls = await captureSql(() => adapter.addIndex("people", "last_name", { length: null }));
+      expect(sqls[0]).toBe("CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`)");
+
+      sqls = await captureSql(() => adapter.addIndex("people", "last_name", { length: 10 }));
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`(10))",
+      );
+
+      sqls = await captureSql(() =>
+        adapter.addIndex("people", ["last_name", "first_name"], { length: 15 }),
+      );
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name_and_first_name` ON `people` (`last_name`(15), `first_name`(15))",
+      );
+
+      sqls = await captureSql(() =>
+        adapter.addIndex("people", ["last_name", "first_name"], { length: { last_name: 15 } }),
+      );
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name_and_first_name` ON `people` (`last_name`(15), `first_name`)",
+      );
+
+      sqls = await captureSql(() =>
+        adapter.addIndex("people", ["last_name", "first_name"], {
+          length: { last_name: 15, first_name: 10 },
+        }),
+      );
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name_and_first_name` ON `people` (`last_name`(15), `first_name`(10))",
+      );
+
+      for (const type of ["SPATIAL", "FULLTEXT", "UNIQUE"]) {
+        sqls = await captureSql(() => adapter.addIndex("people", "last_name", { type }));
+        expect(sqls[0]).toBe(
+          `CREATE ${type} INDEX \`index_people_on_last_name\` ON \`people\` (\`last_name\`)`,
+        );
+      }
+
+      for (const using of ["btree", "hash"]) {
+        sqls = await captureSql(() => adapter.addIndex("people", "last_name", { using }));
+        expect(sqls[0]).toBe(
+          `CREATE INDEX \`index_people_on_last_name\` USING ${using} ON \`people\` (\`last_name\`)`,
+        );
+      }
+
+      sqls = await captureSql(() =>
+        adapter.addIndex("people", "last_name", { length: 10, using: "btree" }),
+      );
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10))",
+      );
+
+      for (const algorithm of ["default", "copy", "inplace", "instant"]) {
+        sqls = await captureSql(() =>
+          adapter.addIndex("people", "last_name", { length: 10, using: "btree", algorithm }),
+        );
+        if (algorithm === "default") {
+          expect(sqls[0]).toBe(
+            "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10))",
+          );
+        } else {
+          expect(sqls[0]).toBe(
+            `CREATE INDEX \`index_people_on_last_name\` USING btree ON \`people\` (\`last_name\`(10)) ALGORITHM = ${algorithm.toUpperCase()}`,
+          );
+        }
+      }
+
+      await expect(() =>
+        adapter.addIndex("people", "last_name", { algorithm: "coyp" }),
+      ).rejects.toThrow(ArgumentError);
+
+      sqls = await captureSql(() =>
+        adapter.addIndex("people", ["last_name", "first_name"], { length: 15, using: "btree" }),
+      );
+      expect(sqls[0]).toBe(
+        "CREATE INDEX `index_people_on_last_name_and_first_name` USING btree ON `people` (`last_name`(15), `first_name`(15))",
+      );
     });
+
     it.skip("index in create", () => {
       // BLOCKED: adapter-mysql — createTable callback form needed + index-in-create emission
       // ROOT-CAUSE: MySQL createTable does not wire up inline INDEX clauses from TableDefinition.index()
-      // SCOPE: Slot B (mysql DDL parity)
+      // SCOPE: Slot C (mysql DDL parity)
     });
     it.skip("index in bulk change", () => {
       // BLOCKED: adapter-mysql — changeTable bulk-mode not implemented for MySQL
       // ROOT-CAUSE: AbstractMysqlAdapter bulk change_table path missing
-      // SCOPE: Slot B (mysql DDL parity)
+      // SCOPE: Slot D (bulk change-table ALTER coalescing)
     });
+
     it("drop table", async () => {
       const sqls = await captureSql(() => adapter.dropTable("people"));
       expect(sqls[0]).toBe("DROP TABLE `people`");
     });
-    it.skip("drop tables", () => {
-      // BLOCKED: adapter-mysql — multi-table DROP TABLE emits N separate statements instead of one
-      // ROOT-CAUSE: abstract/schema-statements.ts#dropTable loops over tableNames calling executeMutation
-      //   once per table; Rails MySQL emits "DROP TABLE `a`, `b`" in a single statement
-      // SCOPE: ~10 LOC override on AbstractMysqlAdapter to join names into one DROP TABLE call
+
+    it("drop tables", async () => {
+      const sqls = await captureSql(() => adapter.dropTable("people", "sobrinho"));
+      expect(sqls[0]).toBe("DROP TABLE `people`, `sobrinho`");
     });
-    it.skip("create mysql database with encoding", () => {
-      // BLOCKED: adapter-mysql — createDatabase not implemented
-      // ROOT-CAUSE: AbstractMysqlAdapter#createDatabase method missing
-      // SCOPE: Slot B (mysql DDL parity)
+
+    it("create mysql database with encoding", async () => {
+      let sqls = await captureSql(() => adapter.createDatabase("aimonetti", { charset: "latin1" }));
+      expect(sqls[0]).toBe("CREATE DATABASE `aimonetti` DEFAULT CHARACTER SET `latin1`");
+
+      sqls = await captureSql(() =>
+        adapter.createDatabase("matt_aimonetti", { collation: "utf8mb4_bin" }),
+      );
+      expect(sqls[0]).toBe("CREATE DATABASE `matt_aimonetti` DEFAULT COLLATE `utf8mb4_bin`");
     });
-    it.skip("recreate mysql database with encoding", () => {
-      // BLOCKED: adapter-mysql — recreateDatabase not implemented
-      // ROOT-CAUSE: AbstractMysqlAdapter#recreateDatabase method missing
-      // SCOPE: Slot B (mysql DDL parity)
+
+    it("recreate mysql database with encoding", async () => {
+      const sqls = await captureSql(() => adapter.recreateDatabase("luca", { charset: "latin1" }));
+      expect(sqls).toContain("DROP DATABASE IF EXISTS `luca`");
+      expect(sqls).toContain("CREATE DATABASE `luca` DEFAULT CHARACTER SET `latin1`");
     });
-    it.skip("add column", () => {
-      // BLOCKED: adapter-mysql — SQL type case mismatch
-      // ROOT-CAUSE: abstract/schema-creation.ts#typeToSql emits uppercase "VARCHAR(255)" but Rails MySQL
-      //   uses lowercase "varchar(255)" from nativeDatabaseTypes
-      // SCOPE: ~10 LOC in MysqlSchemaCreation to override typeToSql using nativeDatabaseTypes; Slot B
+
+    it("add column", async () => {
+      const sqls = await captureSql(() =>
+        adapter.schemaStatements().addColumn("people", "last_name", "string"),
+      );
+      expect(sqls[0]).toBe("ALTER TABLE `people` ADD `last_name` varchar(255)");
     });
-    it.skip("add column with limit", () => {
-      // BLOCKED: adapter-mysql — SQL type case mismatch (same as "add column")
-      // ROOT-CAUSE: typeToSql emits "VARCHAR(32)" not "varchar(32)"
-      // SCOPE: same fix as "add column"; Slot B
+
+    it("add column with limit", async () => {
+      const sqls = await captureSql(() =>
+        adapter.schemaStatements().addColumn("people", "key", "string", { limit: 32 }),
+      );
+      expect(sqls[0]).toBe("ALTER TABLE `people` ADD `key` varchar(32)");
     });
+
     it("drop table with specific database", async () => {
       const sqls = await captureSql(() => adapter.dropTable("otherdb.people"));
       expect(sqls[0]).toBe("DROP TABLE `otherdb`.`people`");
     });
-    it.skip("drop tables with specific database", () => {
-      // BLOCKED: adapter-mysql — multi-table DROP TABLE emits N separate statements (same as "drop tables")
-      // ROOT-CAUSE: same as "drop tables" — needs single-statement override on AbstractMysqlAdapter
-      // SCOPE: same fix as "drop tables"; Slot B
+
+    it("drop tables with specific database", async () => {
+      const sqls = await captureSql(() => adapter.dropTable("otherdb.people", "otherdb.sobrinho"));
+      expect(sqls[0]).toBe("DROP TABLE `otherdb`.`people`, `otherdb`.`sobrinho`");
     });
+
     it.skip("add timestamps", () => {
-      // BLOCKED: adapter-mysql — SQL type case mismatch for datetime column
-      // ROOT-CAUSE: addTimestamps calls addColumn with "datetime" type → typeToSql emits "DATETIME(6)"
-      //   but Rails MySQL emits "datetime"; also requires a real table (with_real_execute scope)
-      // SCOPE: Slot B (mysql DDL parity + typeToSql fix)
+      // BLOCKED: adapter-mysql — requires a real MySQL connection (with_real_execute scope)
+      // ROOT-CAUSE: addTimestamps needs a live table to add columns to; captureSql-only harness insufficient
+      // SCOPE: Slot D (live-table tests)
     });
     it.skip("remove timestamps", () => {
-      // BLOCKED: adapter-mysql — requires a real table (with_real_execute scope) and datetime type fix
-      // ROOT-CAUSE: needs live table for add/remove; also datetime type case gap
-      // SCOPE: Slot B
+      // BLOCKED: adapter-mysql — requires a real MySQL connection (with_real_execute scope)
+      // ROOT-CAUSE: removeTimestamps needs a live table; captureSql-only harness insufficient
+      // SCOPE: Slot D (live-table tests)
     });
     it.skip("indexes in create", () => {
       // BLOCKED: adapter-mysql — createTable TEMPORARY + AS SELECT not implemented
       // ROOT-CAUSE: createTable options.temporary and options.as not wired in MysqlSchemaCreation
-      // SCOPE: Slot B (mysql DDL parity)
+      // SCOPE: Slot C (mysql DDL parity)
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -439,6 +439,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET ${this.quoteTableName(String(options.charset))}`,
       );
     } else if (
+      // "" → Version._parts=[NaN] → NaN comparisons fall through → 0 < 5.7.9 → false,
+      // so an uninitialized _databaseVersion correctly falls through to the error branch.
       isRowFormatDynamicByDefault(this._mariadb, this._databaseVersion?.toString() ?? "")
     ) {
       await this._execMutation(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -55,6 +55,7 @@ import {
 } from "./abstract/schema-definitions.js";
 import type { ColumnType, ColumnOptions } from "./abstract/schema-definitions.js";
 import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
+import { isRowFormatDynamicByDefault } from "./mysql/schema-statements.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -397,6 +398,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       default: "ALGORITHM = DEFAULT",
       copy: "ALGORITHM = COPY",
       inplace: "ALGORITHM = INPLACE",
+      instant: "ALGORITHM = INSTANT",
     };
   }
 
@@ -423,17 +425,34 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async recreateDatabase(name: string, options: Record<string, unknown> = {}): Promise<void> {
-    void name;
-    void options;
+    await this.dropDatabase(name);
+    await this.createDatabase(name, options);
   }
 
   async createDatabase(name: string, options: Record<string, unknown> = {}): Promise<void> {
-    void name;
-    void options;
+    if (options.collation) {
+      await this._execMutation(
+        `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT COLLATE ${this.quoteTableName(String(options.collation))}`,
+      );
+    } else if (options.charset) {
+      await this._execMutation(
+        `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET ${this.quoteTableName(String(options.charset))}`,
+      );
+    } else if (
+      isRowFormatDynamicByDefault(this._mariadb, this._databaseVersion?.toString() ?? "")
+    ) {
+      await this._execMutation(
+        `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET \`utf8mb4\``,
+      );
+    } else {
+      throw new Error(
+        "Configure a supported :charset and ensure innodb_large_prefix is enabled to support indexes on varchar(255) string columns.",
+      );
+    }
   }
 
   async dropDatabase(name: string): Promise<void> {
-    void name;
+    await this._execMutation(`DROP DATABASE IF EXISTS ${this.quoteTableName(name)}`);
   }
 
   async currentDatabase(): Promise<string> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1380,7 +1380,7 @@ export class SchemaStatements {
     const valid = adapterAlgorithms
       ? ["default", ...Object.keys(adapterAlgorithms)]
       : ["default", "concurrently"];
-    throw new Error(
+    throw new ArgumentError(
       `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
     );
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1366,20 +1366,22 @@ export class SchemaStatements {
   indexAlgorithm(algorithm?: string): string | undefined {
     if (!algorithm) return undefined;
     const normalized = algorithm.toLowerCase();
-    if (normalized === "default") return undefined;
 
     const adapterAlgorithms =
       typeof (this.adapter as any).indexAlgorithms === "function"
         ? ((this.adapter as any).indexAlgorithms() as Record<string, string>)
         : null;
 
-    if (adapterAlgorithms && normalized in adapterAlgorithms) {
-      return adapterAlgorithms[normalized];
+    if (adapterAlgorithms) {
+      if (normalized in adapterAlgorithms) {
+        const result = adapterAlgorithms[normalized];
+        return result || undefined;
+      }
+    } else if (normalized === "concurrently") {
+      return "CONCURRENTLY";
     }
 
-    const valid = adapterAlgorithms
-      ? ["default", ...Object.keys(adapterAlgorithms)]
-      : ["default", "concurrently"];
+    const valid = adapterAlgorithms ? Object.keys(adapterAlgorithms) : ["concurrently"];
     throw new ArgumentError(
       `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
     );

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -112,18 +112,18 @@ describe("MySQL::SchemaCreation", () => {
     expect(sql).toMatch(/ADD .+ AUTO_INCREMENT/);
   });
 
-  it("typeToSql emits FLOAT for float without limit", () => {
-    expect(sc.typeToSql("float", {})).toBe("FLOAT");
+  it("typeToSql emits float(24) for float without limit", () => {
+    expect(sc.typeToSql("float", {})).toBe("float(24)");
   });
 
-  it("typeToSql emits FLOAT(N) for float with limit", () => {
-    expect(sc.typeToSql("float", { limit: 5 })).toBe("FLOAT(5)");
-    expect(sc.typeToSql("float", { limit: 53 })).toBe("FLOAT(53)");
+  it("typeToSql emits float(N) for float with limit", () => {
+    expect(sc.typeToSql("float", { limit: 5 })).toBe("float(5)");
+    expect(sc.typeToSql("float", { limit: 53 })).toBe("float(53)");
   });
 
   it("typeToSql delegates non-float types to super", () => {
-    expect(sc.typeToSql("integer", {})).not.toContain("FLOAT");
-    expect(sc.typeToSql("string", {})).toMatch(/VARCHAR/i);
+    expect(sc.typeToSql("integer", {})).not.toContain("float");
+    expect(sc.typeToSql("string", {})).toMatch(/varchar/i);
   });
 
   it("addColumnOptions emits ON UPDATE when onUpdate is set (MySQL-specific)", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -66,7 +66,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const limit = options.limit as number | null | undefined;
     switch (type) {
       case "float":
-        return limit != null ? `FLOAT(${limit})` : "FLOAT";
+        return `float(${limit ?? 24})`;
       case "integer":
         return integerToSql(limit);
       case "text":
@@ -80,12 +80,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
         return `varchar(${limit ?? 255})`;
       case "datetime":
       case "timestamp": {
+        const base = type === "timestamp" ? "timestamp" : "datetime";
         const p = options.precision;
         if (p != null && !(p >= 0 && p <= 6))
           throw new ArgumentError(
-            `No datetime type has precision of ${p}. The allowed range of precision is from 0 to 6`,
+            `No ${base} type has precision of ${p}. The allowed range of precision is from 0 to 6`,
           );
-        return p != null ? `datetime(${p})` : "datetime";
+        return p != null ? `${base}(${p})` : base;
       }
       default:
         return super.typeToSql(type, options);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -88,6 +88,33 @@ export class SchemaCreation extends AbstractSchemaCreation {
           );
         return p != null ? `${base}(${p})` : base;
       }
+      case "time": {
+        const p = options.precision;
+        if (p != null && !(p >= 0 && p <= 6))
+          throw new ArgumentError(
+            `No time type has precision of ${p}. The allowed range of precision is from 0 to 6`,
+          );
+        return p != null ? `time(${p})` : "time";
+      }
+      case "date":
+        return "date";
+      case "bigint":
+        return "bigint";
+      case "decimal": {
+        const p = options.precision;
+        const s = options.scale;
+        if (p != null && s != null) return `decimal(${p},${s})`;
+        if (p != null) return `decimal(${p})`;
+        if (s != null)
+          throw new ArgumentError(
+            "Error adding decimal column: precision cannot be empty if scale is specified",
+          );
+        return "decimal";
+      }
+      case "boolean":
+        return "tinyint(1)";
+      case "json":
+        return "json";
       default:
         return super.typeToSql(type, options);
     }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -5,6 +5,7 @@
  */
 
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
+import { ArgumentError } from "@blazetrails/activemodel";
 import type {
   ReferentialAction,
   ColumnOptions,
@@ -21,7 +22,12 @@ import {
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { quoteIdentifier, quoteTableName, quoteString as mysqlQuoteString } from "./quoting.js";
 import { quoteDefaultExpression } from "../abstract/quoting.js";
-import { addOptionsForIndexColumns } from "./schema-statements.js";
+import {
+  addOptionsForIndexColumns,
+  integerToSql,
+  typeWithSizeToSql,
+  limitToSize,
+} from "./schema-statements.js";
 
 /** MySQL-specific column options — extends the abstract ColumnOptions with `onUpdate`. */
 export type MysqlAddColumnOptions = ColumnOptions & { onUpdate?: string };
@@ -53,6 +59,37 @@ export class SchemaCreation extends AbstractSchemaCreation {
       quoteTableName: quoteTableName,
       quoteDefaultExpression: quoteDefaultExpression,
     });
+  }
+
+  /** @internal */
+  override typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
+    const limit = options.limit as number | null | undefined;
+    switch (type) {
+      case "float":
+        return limit != null ? `FLOAT(${limit})` : "FLOAT";
+      case "integer":
+        return integerToSql(limit);
+      case "text":
+        return typeWithSizeToSql("text", limitToSize(limit ?? null, "text"));
+      case "blob":
+        return typeWithSizeToSql("blob", limitToSize(limit ?? null, "blob"));
+      case "binary":
+        if (limit != null && limit >= 0 && limit <= 0xfff) return `varbinary(${limit})`;
+        return typeWithSizeToSql("blob", limitToSize(limit ?? null, "binary"));
+      case "string":
+        return `varchar(${limit ?? 255})`;
+      case "datetime":
+      case "timestamp": {
+        const p = options.precision;
+        if (p != null && !(p >= 0 && p <= 6))
+          throw new ArgumentError(
+            `No datetime type has precision of ${p}. The allowed range of precision is from 0 to 6`,
+          );
+        return p != null ? `datetime(${p})` : "datetime";
+      }
+      default:
+        return super.typeToSql(type, options);
+    }
   }
 
   visitAddForeignKey(fromTable: string, toTable: string, options: Record<string, unknown>): string {
@@ -121,13 +158,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
       sql += `SET${this.adapter.quoteDefaultExpression(o.default)}`;
     }
     return sql;
-  }
-
-  override typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
-    if (type === "float") {
-      return options.limit != null ? `FLOAT(${options.limit})` : "FLOAT";
-    }
-    return super.typeToSql(type, options);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -23,6 +23,7 @@ import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-c
 import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
+import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 
 /**
  * MySQL-specific SchemaStatements subclass. Extends the base `dropTable` to support
@@ -34,6 +35,11 @@ import { SchemaStatements } from "./abstract/schema-statements.js";
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
  */
 class MysqlSchemaStatements extends SchemaStatements {
+  private _mysqlSchemaCreation?: MysqlSchemaCreation;
+  override get schemaCreation(): MysqlSchemaCreation {
+    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation());
+  }
+
   override async dropTable(
     ...args:
       | [string, ...string[]]


### PR DESCRIPTION
## Summary

- **`MysqlSchemaCreation.typeToSql`**: overrides abstract implementation to emit lowercase MySQL type names (`varchar`, `datetime`, `tinyint`, etc.) matching Rails `NATIVE_DATABASE_TYPES`; absorbs the pre-existing `float` override into the same switch
- **`AbstractMysqlAdapter.createDatabase`**: emits `CREATE DATABASE … DEFAULT CHARACTER SET / COLLATE / utf8mb4` with the same charset/collation/rowFormatDynamic dispatch as Rails
- **`AbstractMysqlAdapter.recreateDatabase`**: `dropDatabase` + `createDatabase` (no TS `reconnect!` needed)
- **`AbstractMysqlAdapter.dropDatabase`**: emits `DROP DATABASE IF EXISTS`
- **`AbstractMysqlAdapter.indexAlgorithms`**: adds `instant → ALGORITHM = INSTANT` (was missing vs. Rails)
- **`SchemaStatements.indexAlgorithm`**: throws `ArgumentError` (not plain `Error`) for invalid algorithm, matching Rails `raise ArgumentError`

Un-skipped in `active-schema.test.ts` (8 tests total, all via `captureSql` without a live MySQL connection):
- `add index` — 10 sub-assertions: length variants, SPATIAL/FULLTEXT/UNIQUE, `using`, algorithms (default/copy/inplace/instant), invalid-algorithm `ArgumentError`
- `drop tables` — single `DROP TABLE \`people\`, \`sobrinho\`` statement
- `create mysql database with encoding` — charset + collation variants
- `recreate mysql database with encoding` — drop + create SQL sequence
- `add column` / `add column with limit` — lowercase `varchar(255)` / `varchar(32)`
- `drop tables with specific database` — `DROP TABLE \`otherdb\`.\`people\`, \`otherdb\`.\`sobrinho\``

## Follow-ups

- **Slot C** (~260 LOC): `index-in-create`, `indexes-in-create` (createTable `TEMPORARY` + `AS SELECT`), `addIndex` output shape
- **Slot D** (~200 LOC): `add timestamps`, `remove timestamps` (require live table in `with_real_execute` scope), bulk change-table ALTER coalescing