### PR TITLE
feat(activerecord): connection-pool Slot C-b — shard test bodies + connectingTo defaultShard fix

### DIFF
--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -3,7 +3,7 @@ import { Base } from "../base.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
-import { currentRole } from "../core.js";
+import { currentRole, connectedToStack } from "../core.js";
 
 function withBaseConfigs(
   raw: Record<string, unknown>,
@@ -365,6 +365,27 @@ describe("ConnectionHandlersShardingDbTest", () => {
       expect(SomeOtherBase.defaultShard()).toBe("default");
     } finally {
       Base.connectionHandler.clearAllConnectionsBang();
+    }
+  });
+
+  it("connectingTo uses the class defaultShard when shard is omitted", () => {
+    class ShardedAbstractBase extends Base {
+      static override abstractClass = true;
+    }
+    try {
+      ShardedAbstractBase.connectsTo({
+        shards: { not_default: { writing: { database: ":memory:", adapter: "sqlite3" } } },
+      });
+      expect(ShardedAbstractBase.defaultShard()).toBe("not_default");
+
+      ShardedAbstractBase.connectingTo({ role: "writing" });
+      expect(ShardedAbstractBase.connectedToQ({ role: "writing", shard: "not_default" })).toBe(
+        true,
+      );
+    } finally {
+      Base.connectionHandler.clearAllConnectionsBang();
+      // pop the stack entry added by connectingTo
+      connectedToStack().pop();
     }
   });
 

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -1,8 +1,27 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "../base.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
+import { DatabaseConfigurations } from "../database-configurations.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { currentRole } from "../core.js";
+
+function withBaseConfigs(
+  raw: Record<string, unknown>,
+  fn: () => void,
+  opts: { defaultEnv?: string } = {},
+): void {
+  const prevConfigs = (Base as any).configurations;
+  const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
+  if (opts.defaultEnv) DatabaseConfigurations.defaultEnv = opts.defaultEnv;
+  (Base as any).configurations = raw;
+  try {
+    fn();
+  } finally {
+    (Base as any).configurations = prevConfigs;
+    DatabaseConfigurations.defaultEnv = prevDefaultEnv;
+    Base.connectionHandler.clearAllConnectionsBang();
+  }
+}
 
 describe("ConnectionHandlersShardingDbTest", () => {
   afterEach(() => {
@@ -15,11 +34,93 @@ describe("ConnectionHandlersShardingDbTest", () => {
   it.skip("establishing a connection in connected to block uses current role and shard", () => {
     // BLOCKED: connection-pool — needs file-backed DB; establish_connection inside connected_to
   });
-  it.skip("establish connection using 3 levels config", () => {
-    // BLOCKED: connection-pool — shard config lookup + pool name assertions; Slot C-b
+  it("establish connection using 3 levels config", () => {
+    withBaseConfigs(
+      {
+        default_env: {
+          primary: { adapter: "sqlite3", database: ":memory:" },
+          primary_shard_one: { adapter: "sqlite3", database: ":memory:" },
+        },
+      },
+      () => {
+        Base.connectsTo({
+          shards: {
+            default: { writing: "primary", reading: "primary" },
+            shard_one: { writing: "primary_shard_one", reading: "primary_shard_one" },
+          },
+        });
+
+        const basePool = Base.connectionHandler.retrieveConnectionPool("Base");
+        const defaultPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          shard: "default",
+        });
+
+        expect((Base.connectionHandler as any).getPoolManager("Base")!.shardNames).toEqual([
+          "default",
+          "shard_one",
+        ]);
+        expect(basePool).toBe(defaultPool);
+        expect(defaultPool!.dbConfig.name).toBe("primary");
+
+        const shardOnePool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          shard: "shard_one",
+        });
+        expect(shardOnePool).not.toBeNull();
+        expect(shardOnePool!.dbConfig.name).toBe("primary_shard_one");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
-  it.skip("establish connection using 3 levels config with shards and replica", () => {
-    // BLOCKED: connection-pool — shard config lookup + pool name assertions; Slot C-b
+  it("establish connection using 3 levels config with shards and replica", () => {
+    withBaseConfigs(
+      {
+        default_env: {
+          primary: { adapter: "sqlite3", database: ":memory:" },
+          primary_replica: { adapter: "sqlite3", database: ":memory:", replica: true },
+          primary_shard_one: { adapter: "sqlite3", database: ":memory:" },
+          primary_shard_one_replica: { adapter: "sqlite3", database: ":memory:", replica: true },
+        },
+      },
+      () => {
+        Base.connectsTo({
+          shards: {
+            default: { writing: "primary", reading: "primary_replica" },
+            shard_one: { writing: "primary_shard_one", reading: "primary_shard_one_replica" },
+          },
+        });
+
+        const defaultWritingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          shard: "default",
+        });
+        const baseWritingPool = Base.connectionHandler.retrieveConnectionPool("Base");
+        expect(baseWritingPool).toBe(defaultWritingPool);
+        expect(defaultWritingPool!.dbConfig.name).toBe("primary");
+
+        const defaultReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "reading",
+          shard: "default",
+        });
+        const baseReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "reading",
+        });
+        expect(baseReadingPool).toBe(defaultReadingPool);
+        expect(defaultReadingPool!.dbConfig.name).toBe("primary_replica");
+
+        const shardOneWritingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          shard: "shard_one",
+        });
+        expect(shardOneWritingPool).not.toBeNull();
+        expect(shardOneWritingPool!.dbConfig.name).toBe("primary_shard_one");
+
+        const shardOneReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+          role: "reading",
+          shard: "shard_one",
+        });
+        expect(shardOneReadingPool).not.toBeNull();
+        expect(shardOneReadingPool!.dbConfig.name).toBe("primary_shard_one_replica");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
 
   it("switching connections via handler", () => {
@@ -77,8 +178,40 @@ describe("ConnectionHandlersShardingDbTest", () => {
     }
   });
 
-  it.skip("retrieves proper connection with nested connected to", () => {
-    // BLOCKED: connection-pool — nested shard switching; Slot C-b
+  it("retrieves proper connection with nested connected to", () => {
+    withBaseConfigs(
+      {
+        default_env: {
+          primary: { adapter: "sqlite3", database: ":memory:" },
+          primary_replica: { adapter: "sqlite3", database: ":memory:", replica: true },
+          primary_shard_one: { adapter: "sqlite3", database: ":memory:" },
+          primary_shard_one_replica: { adapter: "sqlite3", database: ":memory:", replica: true },
+        },
+      },
+      () => {
+        Base.connectsTo({
+          shards: {
+            default: { writing: "primary", reading: "primary_replica" },
+            shard_one: { writing: "primary_shard_one", reading: "primary_shard_one_replica" },
+          },
+        });
+
+        Base.connectedTo({ role: "reading", shard: "shard_one" }, () => {
+          expect(Base.connectionPool().dbConfig.name).toBe("primary_shard_one_replica");
+
+          Base.connectedTo({ role: "writing" }, () => {
+            expect(Base.connectionPool().dbConfig.name).toBe("primary_shard_one");
+          });
+
+          Base.connectedTo({ role: "reading", shard: "default" }, () => {
+            expect(Base.connectionPool().dbConfig.name).toBe("primary_replica");
+          });
+
+          expect(Base.connectionPool().dbConfig.name).toBe("primary_shard_one_replica");
+        });
+      },
+      { defaultEnv: "default_env" },
+    );
   });
 
   it("connected to raises without a shard or role", () => {
@@ -105,14 +238,80 @@ describe("ConnectionHandlersShardingDbTest", () => {
     expect(Base.connectionHandler.retrieveConnectionPool("Base", { shard: "foo" })).toBeUndefined();
   });
 
-  it.skip("calling connected to on a non existent shard raises", () => {
-    // BLOCKED: connection-pool — Slot C-b
+  it("calling connected to on a non existent shard raises", () => {
+    withBaseConfigs(
+      { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
+      () => {
+        Base.connectsTo({ shards: { default: { writing: "arunit", reading: "arunit" } } });
+        let error: any;
+        try {
+          Base.connectedTo({ role: "reading", shard: "foo" }, () => {
+            Base.connectionPool();
+          });
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeDefined();
+        expect(error.message).toBe(
+          "No database connection defined for 'foo' shard and 'reading' role.",
+        );
+        expect(error.connectionName).toBe("Base");
+        expect(error.shard).toBe("foo");
+        expect(error.role).toBe("reading");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
-  it.skip("calling connected to on a non existent role for shard raises", () => {
-    // BLOCKED: connection-pool — Slot C-b
+  it("calling connected to on a non existent role for shard raises", () => {
+    withBaseConfigs(
+      { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
+      () => {
+        Base.connectsTo({
+          shards: {
+            default: { writing: "arunit", reading: "arunit" },
+            shard_one: { writing: "arunit", reading: "arunit" },
+          },
+        });
+        let error: any;
+        try {
+          Base.connectedTo({ role: "non_existent", shard: "shard_one" }, () => {
+            Base.connectionPool();
+          });
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeDefined();
+        expect(error.message).toBe(
+          "No database connection defined for 'shard_one' shard and 'non_existent' role.",
+        );
+        expect(error.connectionName).toBe("Base");
+        expect(error.shard).toBe("shard_one");
+        expect(error.role).toBe("non_existent");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
-  it.skip("calling connected to on a default role for non existent shard raises", () => {
-    // BLOCKED: connection-pool — Slot C-b
+  it("calling connected to on a default role for non existent shard raises", () => {
+    withBaseConfigs(
+      { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
+      () => {
+        Base.connectsTo({ shards: { default: { writing: "arunit", reading: "arunit" } } });
+        let error: any;
+        try {
+          Base.connectedTo({ shard: "foo" }, () => {
+            Base.connectionPool();
+          });
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeDefined();
+        expect(error.message).toBe("No database connection defined for 'foo' shard.");
+        expect(error.connectionName).toBe("Base");
+        expect(error.shard).toBe("foo");
+        expect(error.role).toBe("writing");
+      },
+      { defaultEnv: "default_env" },
+    );
   });
 
   it("cannot swap shards while prohibited", () => {

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -12,6 +12,7 @@ function withBaseConfigs(
 ): void {
   const prevConfigs = (Base as any).configurations;
   const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
+  const prevCurrent = (DatabaseConfigurations as any).current;
   if (opts.defaultEnv) DatabaseConfigurations.defaultEnv = opts.defaultEnv;
   (Base as any).configurations = raw;
   try {
@@ -19,6 +20,7 @@ function withBaseConfigs(
   } finally {
     (Base as any).configurations = prevConfigs;
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
+    (DatabaseConfigurations as any).current = prevCurrent;
     Base.connectionHandler.clearAllConnectionsBang();
   }
 }
@@ -65,7 +67,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
         const shardOnePool = Base.connectionHandler.retrieveConnectionPool("Base", {
           shard: "shard_one",
         });
-        expect(shardOnePool).not.toBeNull();
+        expect(shardOnePool).not.toBeUndefined();
         expect(shardOnePool!.dbConfig.name).toBe("primary_shard_one");
       },
       { defaultEnv: "default_env" },
@@ -109,14 +111,14 @@ describe("ConnectionHandlersShardingDbTest", () => {
         const shardOneWritingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
           shard: "shard_one",
         });
-        expect(shardOneWritingPool).not.toBeNull();
+        expect(shardOneWritingPool).not.toBeUndefined();
         expect(shardOneWritingPool!.dbConfig.name).toBe("primary_shard_one");
 
         const shardOneReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
           role: "reading",
           shard: "shard_one",
         });
-        expect(shardOneReadingPool).not.toBeNull();
+        expect(shardOneReadingPool).not.toBeUndefined();
         expect(shardOneReadingPool!.dbConfig.name).toBe("primary_shard_one_replica");
       },
       { defaultEnv: "default_env" },

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -376,14 +376,17 @@ describe("ConnectionHandlersShardingDbTest", () => {
       ShardedAbstractBase.connectsTo({
         shards: { not_default: { writing: { database: ":memory:", adapter: "sqlite3" } } },
       });
-      expect(ShardedAbstractBase.defaultShard()).toBe("not_default");
+    } finally {
+      Base.connectionHandler.clearAllConnectionsBang();
+    }
+    expect(ShardedAbstractBase.defaultShard()).toBe("not_default");
 
-      ShardedAbstractBase.connectingTo({ role: "writing" });
+    ShardedAbstractBase.connectingTo({ role: "writing" });
+    try {
       expect(ShardedAbstractBase.connectedToQ({ role: "writing", shard: "not_default" })).toBe(
         true,
       );
     } finally {
-      Base.connectionHandler.clearAllConnectionsBang();
       // pop the stack entry added by connectingTo
       connectedToStack().pop();
     }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -235,7 +235,7 @@ export function connectingTo(
   this: typeof Base,
   options: { role?: string; shard?: string; preventWrites?: boolean },
 ): void {
-  const { role = WRITING_ROLE, shard = "default" } = options;
+  const { role = WRITING_ROLE, shard = defaultShard.call(this) } = options;
   const preventWrites = role === READING_ROLE || !!options.preventWrites;
   appendToConnectedToStack({
     role,

--- a/packages/activerecord/src/shard-keys.test.ts
+++ b/packages/activerecord/src/shard-keys.test.ts
@@ -1,21 +1,70 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "./base.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
 
 describe("ShardsKeysTest", () => {
-  it.skip("connects to sets shard keys", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+  class UnshardedBase extends Base {
+    static override abstractClass = true;
+  }
+  class UnshardedModel extends UnshardedBase {}
+
+  class ShardedBase extends Base {
+    static override abstractClass = true;
+  }
+  class ShardedModel extends ShardedBase {}
+
+  let prevConfigs: unknown;
+  let prevDefaultEnv: string;
+
+  beforeEach(() => {
+    prevConfigs = (Base as any).configurations;
+    prevDefaultEnv = DatabaseConfigurations.defaultEnv;
+    DatabaseConfigurations.defaultEnv = "default_env";
+    (Base as any).configurations = {
+      default_env: {
+        primary: { adapter: "sqlite3", database: ":memory:" },
+        shard_one: { adapter: "sqlite3", database: ":memory:" },
+        shard_one_reading: { adapter: "sqlite3", database: ":memory:", replica: true },
+        shard_two: { adapter: "sqlite3", database: ":memory:" },
+        shard_two_reading: { adapter: "sqlite3", database: ":memory:", replica: true },
+      },
+    };
+    (Base as any)._shardKeys = undefined;
+
+    UnshardedBase.connectsTo({ database: { writing: "primary" } });
+    ShardedBase.connectsTo({
+      shards: {
+        shard_one: { writing: "shard_one", reading: "shard_one_reading" },
+        shard_two: { writing: "shard_two", reading: "shard_two_reading" },
+      },
+    });
   });
-  it.skip("connects to sets shard keys for descendents", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  afterEach(() => {
+    Base.connectionHandler.clearAllConnectionsBang();
+    (Base as any).configurations = prevConfigs;
+    DatabaseConfigurations.defaultEnv = prevDefaultEnv;
+    (Base as any)._shardKeys = undefined;
   });
-  it.skip("sharded?", () => {
-    // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
-    // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented
-    // SCOPE: ~100 LOC in connection-handling.ts + connection-adapters/abstract/connection-handler.ts; affects ~19–26 tests in sharding files
+
+  it("connects to sets shard keys", () => {
+    expect(Base.shardKeys()).toEqual([]);
+    expect(ShardedBase.shardKeys()).toEqual(["shard_one", "shard_two"]);
   });
+
+  it("connects to sets shard keys for descendents", () => {
+    expect(ShardedModel.shardKeys()).toEqual(ShardedBase.shardKeys());
+  });
+
+  it("sharded?", () => {
+    expect(Base.isSharded()).toBe(false);
+    expect(UnshardedBase.isSharded()).toBe(false);
+    expect(UnshardedModel.isSharded()).toBe(false);
+
+    expect(ShardedBase.isSharded()).toBe(true);
+    expect(ShardedModel.isSharded()).toBe(true);
+  });
+
   it.skip("connected to all shards", () => {
     // BLOCKED: connection-pool — sharding / shard-selector not fully implemented
     // ROOT-CAUSE: connection-handling.ts#connectedTo shard routing + connection-adapters/abstract/connection-handler.ts pool-per-shard not fully implemented

--- a/packages/activerecord/src/shard-keys.test.ts
+++ b/packages/activerecord/src/shard-keys.test.ts
@@ -15,10 +15,12 @@ describe("ShardsKeysTest", () => {
 
   let prevConfigs: unknown;
   let prevDefaultEnv: string;
+  let prevCurrent: unknown;
 
   beforeEach(() => {
     prevConfigs = (Base as any).configurations;
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
+    prevCurrent = (DatabaseConfigurations as any).current;
     DatabaseConfigurations.defaultEnv = "default_env";
     (Base as any).configurations = {
       default_env: {
@@ -44,6 +46,7 @@ describe("ShardsKeysTest", () => {
     Base.connectionHandler.clearAllConnectionsBang();
     (Base as any).configurations = prevConfigs;
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
+    (DatabaseConfigurations as any).current = prevCurrent;
     (Base as any)._shardKeys = undefined;
   });
 


### PR DESCRIPTION
## Summary

- Un-skip 9 tests across `connection-handlers-sharding-db.test.ts` and `shard-keys.test.ts` by writing their bodies (all were BLOCKED: connection-pool Slot C-b)
- Fix `connectingTo()` to use `this.defaultShard()` instead of hardcoded `"default"` so sharded abstract bases with a non-default first shard push the right shard onto the stack

## Tests un-skipped

**`connection-handlers-sharding-db.test.ts`** (5):
- `establish connection using 3 levels config` — `shards:` form + pool-name assertions via `withBaseConfigs`
- `establish connection using 3 levels config with shards and replica` — 4-pool variant (writing + reading per shard)
- `retrieves proper connection with nested connected to` — nested `connectedTo` blocks; inner role-only block inherits outer shard
- `calling connected to on a non existent shard raises` ×3 — `ConnectionNotDefined` message, `connectionName`, `shard`, `role` fields

**`shard-keys.test.ts`** (3):
- `connects to sets shard keys` — `shardKeys()` returns `[]` for unsharded, `["shard_one","shard_two"]` for sharded
- `connects to sets shard keys for descendents` — subclass inherits parent's shard keys
- `sharded?` — `isSharded()` false for unsharded, true for sharded and their subclasses

## Follow-ups (Slot C-c)

- `same shards across clusters` — multi-cluster shard isolation with real DB (DDL/DML)
- `sharding separation` — per-shard DB isolation with DDL/DML
- `connected to all shards` / `connected to all shards can switch each to reading role` / `connected to all shards respects preventing writes` — `connectedToAllShards()` result collection