### PR TITLE
feat(activerecord): migration Slot D — multi-DB MigrationContext factory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,8 @@ export default defineConfig(
       "packages/activerecord/src/connection-handling.ts",
       // MigrationProxy uses createRequire for synchronous file loading — Node-only
       "packages/activerecord/src/deprecator.ts",
+      // Migrator.fromDir scans filesystem and uses pathToFileURL for ESM import — Node-only
+      "packages/activerecord/src/migration.ts",
     ],
     rules: {
       "blazetrails/no-node-builtins": "error",

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath, Logger, getEnv } from "@blazetrails/activesupport";
+import { getFs, getPath, Logger, getEnv, camelize } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { FsDirent } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -2019,6 +2019,8 @@ export interface MigrationProxy {
   version: string;
   name: string;
   filename?: string;
+  /** Mirrors: ActiveRecord::MigrationProxy#scope — engine name for copied engine migrations */
+  scope?: string;
   migration: () => MigrationLike | Promise<MigrationLike>;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#basename */
   basename?(): string;
@@ -2462,6 +2464,38 @@ export class Migrator {
     _paths?: string[],
   ): Migrator {
     return new Migrator(adapter, migrations);
+  }
+
+  /**
+   * Build a Migrator by scanning `dir` for migration files, mirroring
+   * Rails' `MigrationContext.new(dir, schema_migration, internal_metadata)`.
+   *
+   * Each discovered file becomes a `MigrationProxy` whose `migration` factory
+   * dynamically imports the file (ESM `import()`).
+   *
+   * Mirrors: ActiveRecord::MigrationContext#migrations (the discovery half)
+   */
+  static fromDir(dir: string, adapter: DatabaseAdapter): Migrator {
+    const helper = new Migrator(adapter, []);
+    const files = helper.migrationFiles([dir]);
+    const proxies: MigrationProxy[] = [];
+    for (const file of files) {
+      const parsed = helper.parseMigrationFilename(file);
+      if (!parsed) continue;
+      const [version, rawName, scope] = parsed;
+      const name = camelize(rawName);
+      proxies.push({
+        version,
+        name,
+        filename: file,
+        scope: scope || undefined,
+        migration: async () => {
+          const mod = await import(file);
+          return (mod.default ?? mod[name]) as MigrationLike;
+        },
+      });
+    }
+    return new Migrator(adapter, proxies);
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2490,7 +2490,8 @@ export class Migrator {
         filename: file,
         scope: scope || undefined,
         migration: async () => {
-          const mod = await import(file);
+          const { pathToFileURL } = await import("node:url");
+          const mod = await import(pathToFileURL(file).href);
           return (mod.default ?? mod[name]) as MigrationLike;
         },
       });

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -1,39 +1,255 @@
-import { describe, it } from "vitest";
+/**
+ * Multi-DB migrator tests: two separate database connections run migrations independently.
+ * Mirrors: activerecord/test/cases/multi_db_migrator_test.rb
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Migrator } from "./index.js";
+import { SchemaMigration } from "./schema-migration.js";
+import type { MigrationProxy } from "./migration.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+async function makeSqliteAdapter(): Promise<DatabaseAdapter> {
+  const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+  return new SQLite3Adapter(":memory:");
+}
+
+function sensor(
+  version: string,
+  name: string,
+): MigrationProxy & { wentUp: boolean; wentDown: boolean } {
+  const proxy = {
+    version,
+    name,
+    wentUp: false,
+    wentDown: false,
+    migration: () => ({
+      up: async () => {
+        proxy.wentUp = true;
+      },
+      down: async () => {
+        proxy.wentDown = true;
+      },
+    }),
+  };
+  return proxy;
+}
 
 describe("MultiDbMigratorTest", () => {
-  it.skip("schema migration is different for different connections", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+  let adapterA: DatabaseAdapter;
+  let adapterB: DatabaseAdapter;
+  let smA: SchemaMigration;
+  let smB: SchemaMigration;
+  let migrationsA: MigrationProxy[];
+  let migrationsB: MigrationProxy[];
+
+  beforeEach(async () => {
+    adapterA = await makeSqliteAdapter();
+    adapterB = await makeSqliteAdapter();
+    smA = new SchemaMigration(adapterA);
+    smB = new SchemaMigration(adapterB);
+    await smA.createTable();
+    await smB.createTable();
+    await smA.deleteAllVersions();
+    await smB.deleteAllVersions();
+
+    migrationsA = [
+      {
+        version: "1",
+        name: "ValidPeopleHaveLastNames",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+      {
+        version: "2",
+        name: "WeNeedReminders",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+      {
+        version: "3",
+        name: "InnocentJointable",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+    ];
+    migrationsB = [
+      {
+        version: "1",
+        name: "PeopleHaveHobbies",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+      {
+        version: "2",
+        name: "PeopleHaveDescriptions",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+    ];
   });
-  it.skip("finds migrations", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("schema migration is different for different connections", async () => {
+    const migratorA = new Migrator(adapterA, migrationsA);
+    const migratorB = new Migrator(adapterB, migrationsB);
+
+    await migratorA.up();
+    const versionsA = await migratorA.getAllVersions();
+    const versionsB = await migratorB.getAllVersions();
+
+    expect(versionsA).toEqual(["1", "2", "3"]);
+    expect(versionsB).toEqual([]);
   });
-  it.skip("migrations status", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("finds migrations", () => {
+    const migratorA = new Migrator(adapterA, migrationsA);
+    const migratorB = new Migrator(adapterB, migrationsB);
+
+    const listA = [
+      [1, "ValidPeopleHaveLastNames"],
+      [2, "WeNeedReminders"],
+      [3, "InnocentJointable"],
+    ];
+    const listB = [
+      [1, "PeopleHaveHobbies"],
+      [2, "PeopleHaveDescriptions"],
+    ];
+
+    listA.forEach(([version, name], i) => {
+      expect(Number(migratorA.migrations[i]!.version)).toBe(version);
+      expect(migratorA.migrations[i]!.name).toBe(name);
+    });
+    listB.forEach(([version, name], i) => {
+      expect(Number(migratorB.migrations[i]!.version)).toBe(version);
+      expect(migratorB.migrations[i]!.name).toBe(name);
+    });
   });
-  it.skip("get all versions", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("migrations status", async () => {
+    await smA.createVersion("2");
+    await smA.createVersion("10");
+
+    const migratorA = new Migrator(adapterA, migrationsA);
+    const statusA = await migratorA.migrationsStatus();
+    expect(statusA).toEqual([
+      { status: "down", version: "1", name: "ValidPeopleHaveLastNames" },
+      { status: "up", version: "2", name: "WeNeedReminders" },
+      { status: "down", version: "3", name: "InnocentJointable" },
+    ]);
+
+    await smB.createVersion("4");
+    const migratorB = new Migrator(adapterB, migrationsB);
+    const statusB = await migratorB.migrationsStatus();
+    expect(statusB).toEqual([
+      { status: "down", version: "1", name: "PeopleHaveHobbies" },
+      { status: "down", version: "2", name: "PeopleHaveDescriptions" },
+    ]);
   });
-  it.skip("finds pending migrations", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("get all versions", async () => {
+    const sensorsA = [sensor("1", "S1"), sensor("2", "S2"), sensor("3", "S3")];
+    const migratorA = new Migrator(adapterA, sensorsA);
+
+    await migratorA.up();
+    expect(await migratorA.getAllVersions()).toEqual(["1", "2", "3"]);
+
+    await migratorA.rollback();
+    expect(await migratorA.getAllVersions()).toEqual(["1", "2"]);
+
+    await migratorA.rollback();
+    expect(await migratorA.getAllVersions()).toEqual(["1"]);
+
+    await migratorA.rollback();
+    expect(await migratorA.getAllVersions()).toEqual([]);
+
+    const sensorsB = [sensor("1", "S1"), sensor("2", "S2")];
+    const migratorB = new Migrator(adapterB, sensorsB);
+
+    await migratorB.up();
+    expect(await migratorB.getAllVersions()).toEqual(["1", "2"]);
+
+    await migratorB.rollback();
+    expect(await migratorB.getAllVersions()).toEqual(["1"]);
+
+    await migratorB.rollback();
+    expect(await migratorB.getAllVersions()).toEqual([]);
   });
-  it.skip("migrator db has no schema migrations table", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("finds pending migrations", async () => {
+    await smA.createVersion("1");
+    const listA = [
+      {
+        version: "1",
+        name: "Foo",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+      {
+        version: "3",
+        name: "Bar",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+    ];
+    const migratorA = new Migrator(adapterA, listA);
+    const pendingA = await migratorA.pendingMigrations();
+    expect(pendingA.length).toBe(1);
+    expect(pendingA[0]!.name).toBe("Bar");
+
+    await smB.createVersion("1");
+    const listB = [
+      {
+        version: "1",
+        name: "Foo",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+      {
+        version: "3",
+        name: "Bar",
+        migration: () => ({ up: async () => {}, down: async () => {} }),
+      },
+    ];
+    const migratorB = new Migrator(adapterB, listB);
+    const pendingB = await migratorB.pendingMigrations();
+    expect(pendingB.length).toBe(1);
+    expect(pendingB[0]!.name).toBe("Bar");
   });
-  it.skip("migrator forward", () => {
-    // BLOCKED: migration — multi-DB migrator / primary-class gap
-    // ROOT-CAUSE: migration.ts#MigrationContext or connection-adapters/abstract/connection-handler.ts#primaryClassQ not fully implemented
-    // SCOPE: ~50 LOC fix in migration.ts; affects ~7 tests in multi-db-migrator.test.ts
+
+  it("migrator db has no schema migrations table", async () => {
+    const sensorsA = [sensor("1", "S1"), sensor("2", "S2"), sensor("3", "S3")];
+    const migratorA = new Migrator(adapterA, sensorsA);
+
+    await smA.dropTable();
+    expect(await smA.tableExists()).toBe(false);
+    await migratorA.up(1);
+    expect(await smA.tableExists()).toBe(true);
+    await migratorA.rollback();
+
+    const sensorsB = [sensor("1", "S1"), sensor("2", "S2"), sensor("3", "S3")];
+    const migratorB = new Migrator(adapterB, sensorsB);
+
+    await smB.dropTable();
+    expect(await smB.tableExists()).toBe(false);
+    await migratorB.up(1);
+    expect(await smB.tableExists()).toBe(true);
+    await migratorB.rollback();
+  });
+
+  it("migrator forward", async () => {
+    const sensorsA = [sensor("1", "S1"), sensor("2", "S2"), sensor("3", "S3")];
+    const migratorA = new Migrator(adapterA, sensorsA);
+
+    await migratorA.up(1);
+    expect(await migratorA.currentVersion()).toBe(1);
+
+    await migratorA.forward(2);
+    expect(await migratorA.currentVersion()).toBe(3);
+
+    await migratorA.forward();
+    expect(await migratorA.currentVersion()).toBe(3);
+
+    const sensorsB = [sensor("1", "S1"), sensor("2", "S2"), sensor("3", "S3")];
+    const migratorB = new Migrator(adapterB, sensorsB);
+
+    await migratorB.up(1);
+    expect(await migratorB.currentVersion()).toBe(1);
+
+    await migratorB.forward(2);
+    expect(await migratorB.currentVersion()).toBe(3);
+
+    await migratorB.forward();
+    expect(await migratorB.currentVersion()).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `scope?: string` field to `MigrationProxy` interface (mirrors Rails `MigrationProxy = Struct.new(:name, :version, :filename, :scope)`)
- Adds `Migrator.fromDir(dir, adapter)` static factory that scans a directory for migration files, parses filenames via `migrationFiles` + `parseMigrationFilename` + `camelize`, and builds `MigrationProxy[]` with dynamic ESM `import()` (mirrors Rails `MigrationContext#migrations`)
- Implements all 7 skipped tests in `multi-db-migrator.test.ts`: two independent SQLite in-memory adapters run migrations and track versions in isolation

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/multi-db-migrator.test.ts` — 7/7 pass
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts` — no regressions (170 pass, 15 skip)
- [x] Build + typecheck pass (pre-commit hook)