### PR TITLE
feat(tooling): extra-surface audit — TS classes exceeding Rails counterparts

### DIFF
--- a/docs/ts-extras/README.md
+++ b/docs/ts-extras/README.md
@@ -1,0 +1,98 @@
+# TS Extras — surface that exceeds Rails
+
+This directory captures findings from `pnpm api:extra` — the inverse of
+`pnpm api:compare`. Where `api:compare` answers _"which Rails methods are
+missing in TS?"_, `api:extra` answers _"which TS methods have no Rails
+counterpart in the matched file?"_
+
+The audit exists to identify drift to prune toward Rails-faithful shape.
+It is read-only; nothing here modifies source.
+
+- See [patterns.md](patterns.md) for the recurring shapes (Ruby-private →
+  TS-public promotion, `method_missing` → explicit dispatch, barrel
+  re-exports, etc.).
+- See [top-files.md](top-files.md) for a drill-down on the highest-value
+  targets — what's there, why, and whether the noise is signal.
+
+## Running
+
+```bash
+pnpm api:compare       # generates manifests if stale
+pnpm api:extra         # default report — top 50 by novel count
+pnpm api:extra --novel-only --max-detail 80 --top 20 --package activerecord
+pnpm api:extra --json > out.json
+```
+
+Useful flags (full list in `--help`):
+
+| Flag                         | Effect                                                    |
+| ---------------------------- | --------------------------------------------------------- |
+| `--package <name>`           | Restrict to one Rails-mirroring package.                  |
+| `--top <N>`                  | Number of files in the ranked top-N section (default 50). |
+| `--novel-only`               | Drop "moved" extras entirely. Filters barrel-file noise.  |
+| `--exclude-glob <substring>` | Repeatable. Skip TS files whose path contains substring.  |
+| `--max-detail <N>`           | Cap per-file name listing (default 40, 0 = unlimited).    |
+| `--json`                     | Machine-readable output.                                  |
+| `FORCE_COLOR=0/1` env        | Override TTY detection for ANSI output.                   |
+
+## What counts as an "extra"
+
+For each Rails-mirroring package, for each `.rb` file with a matched `.ts`
+counterpart (resolved by `conventions.rubyFileToTs`):
+
+1. Collect public Ruby methods declared in or `include`d into the entities
+   in that file.
+2. Convert each Ruby name to its TS-candidate set via
+   `conventions.rubyMethodToTs` (snake → camel, `?` → `is*`, `!` →
+   `*Bang`, etc.). Skip `OPERATORS` and `SKIP` entries.
+3. Walk mixins with namespace-scoped resolution (same as compare.ts's
+   `flattenIncludedMethodInfos`): only `mod.instanceMethods` cross via
+   `include`/`extend`, not the module's own `classMethods`. The
+   `ActiveSupport::Concern` `ClassMethods` submodule is pre-folded into
+   its parent's `classMethods` so ASC class methods still land as the
+   parent's own entity-level surface.
+4. Union all of the above into `allowed`.
+5. Collect TS public method/getter/setter/function names in the matched
+   `.ts` file (each class/module's _own_ methods, plus top-level
+   `fileFunctions`). Filter out:
+   - `internal: true` — Ruby/TS `private`/`protected`, TS `#`-fields,
+     `@internal` JSDoc;
+   - `_`-prefixed names — repo-wide Rails-private convention;
+   - the `TS_ALWAYS_ALLOWED` set — TS overrides of Ruby methods on the
+     `SKIP` list (`dup`, `clone`, `freeze`, `inspect`, `equals`, `eql`,
+     `toH`, `toHash`, `toArray`, `valueOf`, `initializeDup`,
+     `initializeCopy`, `klasses`, `[Symbol.for("nodejs.util.inspect.custom")]`).
+     These ARE Rails-faithful (e.g. AR `Base#freeze` exists in
+     `core.rb`); they only vanish from `allowed` because `rubyMethodToTs`
+     returns null for them.
+6. `extras = tsNames \ allowed`.
+7. Each extra is classified:
+   - **novel** — the candidate name appears _nowhere_ in any Rails file.
+     High-signal: TS-only helpers, accidental public surface, Ruby-private
+     methods promoted to TS-public.
+   - **moved** — Rails defines the same name in some _other_ `.rb`. Often
+     barrel-file re-exports, occasionally real misplacement.
+
+## Ranking
+
+Files are ranked by **novel count first**, then total. Barrel aggregators
+(`connection-adapters.ts`: 150 novel / 438 moved) drop below smaller
+novel-heavy files (`relation/finder-methods.ts`: 44 novel / 0 moved)
+even though their raw totals are an order of magnitude smaller.
+
+## Limits & known noise
+
+- The novel-vs-moved distinction is per-name (camelized candidate), not
+  per-method-signature. A TS method that takes different arguments than
+  the Ruby one but shares a name will appear as "matched", not novel.
+- The script ignores inheritance: a TS class extending a base picks up
+  the base's surface, but we measure each file's _own_ declarations. If
+  a parent is itself Rails-faithful and the child legitimately overrides
+  one of its names, the override IS counted as the child's surface and
+  diffed against the child's Rails counterpart.
+- `barrel`-style `.ts` files re-export public surface from sibling files;
+  their moved counts will always be high. Filter with
+  `--exclude-glob connection-adapters.ts` for cleaner signal.
+- TS-only language features (`[Symbol.iterator]`, `valueOf`,
+  `[Symbol.toPrimitive]`) appear as novel when no SKIP-list entry maps
+  to them. They're rarely accidental; eyeball each one.

--- a/docs/ts-extras/patterns.md
+++ b/docs/ts-extras/patterns.md
@@ -1,0 +1,165 @@
+# Patterns in the extras
+
+Run on 2026-05-15 against `main`. Total novel extras across all
+Rails-mirroring packages: **2,135**. The clusters below explain ~70% of
+that volume.
+
+## 1. Ruby-private methods promoted to TS-public surface
+
+By far the dominant pattern. Rails marks lots of internal helpers as
+`private` in Ruby; trails frequently exports them as ordinary functions
+or methods because:
+
+- TS has no `private` _file-level_ — to share between sibling files,
+  you must `export`;
+- `protected` doesn't reach across files either;
+- The Rails-private convention in this repo is the leading `_`-prefix,
+  which only some authors apply.
+
+The audit filters `internal: true` on the Ruby side (private/protected)
+so these never enter `allowed`, then filters `_`-prefix on the TS side
+so the convention-following exports are exempt. What's left in `novel`
+is genuine: TS public surface that mirrors a Rails private API.
+
+**Examples**
+
+| TS file                                   | Promoted symbol                                                                           | Rails counterpart                                               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `relation/finder-methods.ts`              | `findOne`, `findSome`, `findNth*`, `findTake*`                                            | `Relation::FinderMethods#find_one` etc., all `private` in Rails |
+| `relation/calculations.ts`                | `executeGroupedCalculation`, `executeSimpleCalculation`, `performCount`, `performMaximum` | `Relation::Calculations`, all `private`                         |
+| `autosave-association.ts`                 | `validateBelongsToAssociation`, `saveCollectionAssociation`, `autosaveBelongsTo`          | `AutosaveAssociation`, all `private`                            |
+| `connection-adapters/abstract-adapter.ts` | `arelVisitor`, `buildStatementPool`, `configureConnection`                                | `AbstractAdapter`, all `private`                                |
+
+**Recommendation:** wrap with `_`-prefix or move into nested scope when
+practical. Where TS modular splits make `export` necessary, add the
+`@internal` JSDoc tag — the audit filters that already, and the
+`blazetrails/rails-private-jsdoc` ESLint rule keeps it from leaking into
+public types.
+
+Total cluster size: ~120 across `perform*` (44), `findNth*` (10),
+`validate*`/`autosave*` (21), `cast*`/`typeCast*` (16), `raise*` (6), etc.
+
+## 2. `method_missing` / dynamic dispatch → explicit TS methods
+
+Where Rails uses Ruby's `method_missing` or dynamic `define_method` to
+materialize a family of methods on demand, trails has to enumerate each
+one statically because TS lacks the introspection surface and the type
+system needs concrete signatures.
+
+**Example: `migration/command-recorder.ts`** — Rails' `CommandRecorder`
+uses `method_missing` to forward any call to a recorded array and then
+generates an `invert_<verb>` mirror at playback time. trails enumerates
+all 36 verbs explicitly:
+
+```
+invertAddCheckConstraint        invertAddColumn        invertAddColumns
+invertAddExclusionConstraint    invertAddForeignKey    invertAddIndex
+invertAddReference              invertAddTimestamps    invertAddUniqueConstraint
+invertChangeColumn              invertChangeColumnDefault invertChangeColumnNull
+invertChangeTable               invertCreateEnum       invertCreateJoinTable
+invertCreateTable               invertDisableExtension invertDropEnum
+invertDropJoinTable             invertDropTable        invertDropVirtualTable
+invertEnableExtension           invertRemoveCheckConstraint  …
+```
+
+This is genuine architectural divergence, not bugs. It IS extra surface,
+but pruning it doesn't make sense — the Rails-private `inverse_of` lookup
+isn't expressible as a single helper in TS without giving up type safety.
+
+**Recommendation:** treat this cluster as intentional. Either add
+`@internal` JSDoc and let the audit filter it, or accept the noise and
+exclude with `--exclude-glob migration/command-recorder.ts`.
+
+## 3. Schema/connection helpers exposed for testability
+
+Files like `connection-adapters/abstract-adapter.ts`,
+`connection-adapters/postgresql-adapter.ts`, and
+`connection-adapters/abstract/schema-statements.ts` expose `addColumnForAlter`,
+`addIndexForAlter`, `addTimestampsForAlter`, `buildCreateIndexDefinition`,
+`buildTruncateStatement`, etc. — Rails has these but marks them `private`
+in the adapter. trails exposes them because the test suite (and parity
+infrastructure) needs to drive them directly.
+
+This overlaps with cluster 1 but warrants its own bucket because the
+fix isn't always "make it private" — sometimes the test-only access
+is load-bearing.
+
+**Recommendation:** audit each one; for the ones genuinely test-only,
+prefer a `@internal` tag. For ones that need to remain public, document
+why (a comment naming the call site is enough).
+
+## 4. `arel*` accessor helpers
+
+`relation/calculations.ts`, `relation/query-methods.ts`, and similar
+expose `arelColumn`, `arelColumnsFromHash`, `arelColumnWithTable`,
+`arelFromRelation`. Rails has equivalent private methods that build Arel
+nodes inline; trails extracted them as named helpers so the Arel
+construction logic is reusable across relation methods.
+
+Often legitimate. The `arel*` naming makes the cluster easy to grep,
+and the methods are typically narrow and well-named.
+
+## 5. TS language idioms
+
+Symbol-keyed properties have no Ruby analog:
+
+- `[Symbol.iterator]`, `[Symbol.asyncIterator]` — make a class iterable
+  (CollectionProxy, Relation, etc.).
+- `[Symbol.toPrimitive]` — the TS analog of Ruby `to_s` coercion (e.g.
+  `globalid/signed-global-id.ts`).
+- `[Symbol.for("nodejs.util.inspect.custom")]` — V8 inspection hook;
+  the TS analog of Ruby `inspect`. Filtered via `TS_ALWAYS_ALLOWED`.
+- `[ADDITIONAL_VALUE_BRAND]`, `[ATTRIBUTE_BRAND]` — branded-type
+  discriminants for nominal typing.
+
+**Recommendation:** leave alone. These are necessary TS idioms.
+
+## 6. Barrel re-exports
+
+`connection-adapters.ts` (438 moved), `base.ts` (223 moved), and
+`associations.ts` (79 moved) lead the **moved** column because they
+re-export classes/values from sibling files. Each re-exported public
+method appears in `tsMethodsByFile[barrel]` from the extractor's
+viewpoint even though the actual definition lives elsewhere.
+
+Mostly noise for prune-toward-Rails work. Filter with `--exclude-glob
+connection-adapters.ts --exclude-glob base.ts` (or use `--novel-only`).
+
+## 7. Snake-case typos (real bugs)
+
+Found via the audit:
+
+- `autosave-association.ts:897` exports `is_recordChanged` (snake-case,
+  should be `isRecordChanged`). Three of these total. Worth a separate
+  fix-up PR.
+
+## 8. Predicate-form ambiguity
+
+`activeConnectionsQ`, `applicationRecordClassQ` and similar `Q`-suffix
+names — trails-internal convention for predicates that already have
+non-predicate sibling methods (`activeConnections` returns a count,
+`activeConnectionsQ` returns boolean). Rails uses the `?` suffix which
+our convention maps to `is*`/camel forms; `Q` is a third trails-only
+form not generated by `rubyMethodToTs`.
+
+**Recommendation:** decide whether to widen `rubyMethodToTs` to also
+emit a `Q`-suffix candidate, or rename the trails-side to the canonical
+`is*`. A single-PR sweep would close ~15 of these. Out of scope here.
+
+## Filter recipes
+
+```bash
+# Highest-signal prune candidates (Ruby-private promotions, no barrel noise)
+pnpm api:extra --novel-only \
+  --exclude-glob connection-adapters.ts \
+  --exclude-glob base.ts \
+  --exclude-glob inheritance.ts \
+  --exclude-glob model.ts
+
+# One package, novel only
+pnpm api:extra --package activerecord --novel-only --top 30
+
+# Audit a specific subdir
+pnpm api:extra --json --top 1000 \
+  | jq '.topN[] | select(.tsFile | startswith("relation/"))'
+```

--- a/docs/ts-extras/top-files.md
+++ b/docs/ts-extras/top-files.md
@@ -1,0 +1,69 @@
+# Top-25 drill-down
+
+Per-file assessment for the highest-novel files in the audit (snapshot:
+2026-05-15, against `main`). Counts are `novel / moved`. Verdicts:
+
+- **PRUNE** — extras are mostly genuine drift; worth a follow-up PR to
+  `@internal`-tag or `_`-prefix.
+- **ARCH** — extras are an intentional architectural divergence (often
+  `method_missing` → explicit dispatch). Document & leave.
+- **NOISE** — extras are dominated by barrel re-exports or
+  language-idiom Symbols; filter from future runs.
+- **MIXED** — needs per-symbol triage.
+
+| #   | Novel / Moved | Package       | TS file                                                | Verdict | Notes                                                                                                                                                                                                                                                                                |
+| --- | ------------: | ------------- | ------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   |     145 / 438 | activerecord  | `connection-adapters.ts`                               | NOISE   | Barrel of every adapter symbol — re-exports inflate both columns. Filter with `--exclude-glob`.                                                                                                                                                                                      |
+| 2   |     133 / 223 | activerecord  | `base.ts`                                              | NOISE   | Same as #1 — barrel that re-exports core, scoping, associations, etc.                                                                                                                                                                                                                |
+| 3   |      67 / 122 | activerecord  | `connection-adapters/postgresql-adapter.ts`            | MIXED   | `addPgDecoders/addPgEncoders` (PG-specific, legit), `addIndexOpclass` (PG-only Rails-private — could `_`-prefix), `NATIVE_DATABASE_TYPES` (intentional public const).                                                                                                                |
+| 4   |       67 / 19 | activerecord  | `connection-adapters/abstract-adapter.ts`              | PRUNE   | `arelVisitor`, `buildStatementPool`, `affectedRows`, `attemptConfigureConnection` — most are Rails-private. Good candidate for an `@internal`/`_`-prefix sweep.                                                                                                                      |
+| 5   |        47 / 1 | activerecord  | `relation/query-methods.ts`                            | PRUNE   | `arelColumn*` family (8 names) — Arel-helpers extracted from inline. Either keep+document or hide.                                                                                                                                                                                   |
+| 6   |       44 / 16 | activerecord  | `migration/command-recorder.ts`                        | ARCH    | `invert*` enumeration explained in [patterns.md §2](patterns.md). `method_missing` divergence — intentional.                                                                                                                                                                         |
+| 7   |        44 / 0 | activerecord  | `relation/finder-methods.ts`                           | PRUNE   | Pure novel: `findOne`, `findSome`, `findNth*`, `findTake*`, `perform*` — all Rails-private finders promoted. Strongest single prune target.                                                                                                                                          |
+| 8   |        43 / 1 | activerecord  | `connection-adapters/abstract/schema-statements.ts`    | PRUNE   | `addColumnForAlter`, `addIndexForAlter`, `addTimestampsForAlter` etc. — bulk-alter primitives Rails keeps private.                                                                                                                                                                   |
+| 9   |       40 / 79 | activerecord  | `associations.ts`                                      | NOISE   | Barrel of every association class + a few `_`-promotions.                                                                                                                                                                                                                            |
+| 10  |       40 / 28 | activerecord  | `connection-adapters/abstract-mysql-adapter.ts`        | ARCH    | `ER_*` MySQL error-code constants (24 of them). Rails uses `Mysql2::Error::ER_*` constants directly; trails re-exposes for portable error handling. Intentional.                                                                                                                     |
+| 11  |       39 / 57 | activerecord  | `migration.ts`                                         | MIXED   | `RELEASE_LOCK_FAILED_MESSAGE`, `VERSION` (constants, OK); `buildWatcher`, `checkProtectedEnvironments` (Rails-private — prune).                                                                                                                                                      |
+| 12  |       37 / 72 | activemodel   | `model.ts`                                             | ARCH    | `afterCreate`, `afterDestroy`, `afterFind` etc. — Rails generates these via `define_callbacks`; trails declares them as explicit class methods so the type system sees them. Same divergence as #6.                                                                                  |
+| 13  |       31 / 82 | activerecord  | `inheritance.ts`                                       | NOISE   | Most extras live on `Base` / barrels; misattributed by the manifest because `Base` includes `Inheritance`.                                                                                                                                                                           |
+| 14  |       31 / 17 | activerecord  | `relation.ts`                                          | MIXED   | `[Symbol.asyncIterator]` (legit TS idiom); `arelColumn*` cluster again; `defineProcedures` (private?).                                                                                                                                                                               |
+| 15  |        30 / 8 | activerecord  | `connection-adapters/postgresql/schema-statements.ts`  | PRUNE   | Same pattern as #8 (`addColumnForAlter`, PG-flavor).                                                                                                                                                                                                                                 |
+| 16  |       28 / 16 | activerecord  | `connection-adapters/postgresql/schema-definitions.ts` | ARCH    | `bigserial`, `bit`, `bitVarying`, `box`, `cidr`, `inet`, `interval`, `jsonb`, etc. — PG-specific column-type DSL methods. Rails generates these via metaprogramming; trails enumerates. Intentional.                                                                                 |
+| 17  |       24 / 16 | activesupport | `time-with-zone.ts`                                    | ARCH    | `compareTo`, `day`, `getTime`, `hour`, `isFriday` etc. — Temporal/Date API surface that has no Ruby `TimeWithZone` equivalent (Ruby uses `<=>`, day-of-week predicates, etc.). Intentional JS-idiomatic API.                                                                         |
+| 18  |        24 / 4 | activerecord  | `tasks/database-tasks.ts`                              | PRUNE   | `classForAdapter`, `clearRegisteredTasks`, `databaseAdapterFor`, `dumpSchemaAfterMigration` — Rails-private rake-task helpers. Prune.                                                                                                                                                |
+| 19  |        24 / 0 | activerecord  | `autosave-association.ts`                              | PRUNE   | Pure novel — `autosave*` and `validate*` cluster. Also contains the **`is_recordChanged`** snake-case bug (line 897). High-priority cleanup.                                                                                                                                         |
+| 20  |       23 / 10 | activerecord  | `connection-adapters/abstract/database-statements.ts`  | PRUNE   | Same pattern as #4 — Rails-private adapter helpers exposed.                                                                                                                                                                                                                          |
+| 21  |       21 / 11 | arel          | `attributes/attribute.ts`                              | ARCH    | `[ATTRIBUTE_BRAND]` (nominal type discriminant), `abs`, `bitwiseAnd`, `bitwiseNot`, `bitwiseOr` — Arel predicate/factory methods. Mixed: bitwise\* are real Rails methods (`bitwise_and`) that the audit didn't match because of a missing predication mixin wiring; abs is genuine. |
+| 22  |        21 / 0 | activerecord  | `relation/calculations.ts`                             | PRUNE   | Pure novel — `executeGroupedCalculation`, `executeSimpleCalculation`, `performCount`, `performMaximum`, etc. Mirror of #7's pattern.                                                                                                                                                 |
+| 23  |       19 / 18 | activesupport | `logger.ts`                                            | ARCH    | `DEBUG`, `ERROR`, `FATAL`, `INFO`, `UNKNOWN`, `WARN` constants — Ruby `Logger` exposes these as integer constants (`Logger::DEBUG`); trails re-exports for compat. Intentional.                                                                                                      |
+| 24  |        19 / 8 | activerecord  | `schema-dumper.ts`                                     | MIXED   | Constants (`DEFAULT_DATETIME_PRECISION`) OK; `checkParts`, `cleanDefault`, `cleanRawPgExpression` are Rails-private.                                                                                                                                                                 |
+| 25  |       18 / 53 | activerecord  | `connection-adapters/sqlite3-adapter.ts`               | PRUNE   | `arelVisitor`, `buildStatementPool`, `configureConnection` again — same Rails-private adapter pattern as #4.                                                                                                                                                                         |
+
+## Suggested follow-up PRs
+
+Ranked by signal-to-noise (prune candidates only):
+
+1. **Adapter Rails-private sweep** (#4, #15, #20, #25): `@internal`-tag
+   the adapter helpers Rails marks `private`. One sweep across abstract +
+   PG + sqlite3 + abstract-mysql adapters covers ~150 names.
+2. **Relation finder/calculation privates** (#7, #22, #5): `findNth*`,
+   `findOne`, `findSome`, `performCount`, `executeGroupedCalculation`,
+   `arelColumn*` — most are Rails-private and have no test-only public
+   reason. ~80 names.
+3. **Autosave-association cleanup** (#19): one focused PR including
+   the `is_recordChanged` snake-case fix and `_`-prefix on the
+   `validate*`/`autosave*` family.
+4. **Migration tasks/protected-env** (#11, #18): `buildWatcher`,
+   `classForAdapter`, `dumpSchemaAfterMigration`. ~10 names.
+
+## Architecture-divergence notes (no fix needed)
+
+- `migration/command-recorder.ts` (#6) — explicit `invert*` enumeration.
+- `model.ts` (#12) — explicit `afterCreate`/`afterUpdate`/... methods.
+- `postgresql/schema-definitions.ts` (#16) — explicit PG column-type DSL.
+- `connection-adapters/abstract-mysql-adapter.ts` (#10) — re-exported
+  `ER_*` MySQL error-code constants.
+- `time-with-zone.ts` (#17) — JS-idiomatic Temporal/Date API.
+- `logger.ts` (#23) — re-exported severity constants.
+- All Symbol-keyed properties everywhere (`[Symbol.iterator]`,
+  `[Symbol.asyncIterator]`, brand symbols).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "api:compare": "bash scripts/api-compare/run.sh",
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
+    "api:extra": "pnpm tsx scripts/api-compare/extra-surface.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
     "test:stubs": "pnpm test:compare -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
+import { buildGlobalRubyCandidates, buildReport, parseArgs } from "./extra-surface.js";
+
+function method(name: string, internal = false): MethodInfo {
+  return { name, visibility: internal ? "private" : "public", params: [], internal };
+}
+
+function rubyClass(opts: {
+  name: string;
+  file: string;
+  instance?: MethodInfo[];
+  klass?: MethodInfo[];
+  includes?: string[];
+}): ClassInfo {
+  return {
+    name: opts.name,
+    file: opts.file,
+    includes: opts.includes ?? [],
+    extends: [],
+    instanceMethods: opts.instance ?? [],
+    classMethods: opts.klass ?? [],
+  };
+}
+
+describe("parseArgs", () => {
+  it("defaults topN=50, maxDetail=40, no novelOnly", () => {
+    const a = parseArgs([]);
+    expect(a).toEqual({
+      filterPkg: null,
+      topN: 50,
+      json: false,
+      excludeGlobs: [],
+      novelOnly: false,
+      maxDetail: 40,
+    });
+  });
+
+  it("parses all flags", () => {
+    const a = parseArgs([
+      "--package",
+      "activerecord",
+      "--top",
+      "10",
+      "--json",
+      "--novel-only",
+      "--max-detail",
+      "0",
+      "--exclude-glob",
+      "dx-tests/",
+      "--exclude-glob",
+      "barrel.ts",
+    ]);
+    expect(a.filterPkg).toBe("activerecord");
+    expect(a.topN).toBe(10);
+    expect(a.json).toBe(true);
+    expect(a.novelOnly).toBe(true);
+    expect(a.maxDetail).toBe(0);
+    expect(a.excludeGlobs).toEqual(["dx-tests/", "barrel.ts"]);
+  });
+});
+
+describe("buildGlobalRubyCandidates", () => {
+  it("unions public Ruby method TS-candidates across all packages, skipping internal", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Foo": rubyClass({
+              name: "Foo",
+              file: "foo.rb",
+              instance: [method("public_one"), method("private_one", true)],
+            }),
+          },
+          modules: {},
+        },
+        activerecord: {
+          classes: {},
+          modules: {
+            "ActiveRecord::Mod": rubyClass({
+              name: "Mod",
+              file: "mod.rb",
+              instance: [method("save_bang!")],
+            }),
+          },
+        },
+      },
+    };
+    const set = buildGlobalRubyCandidates(ruby);
+    expect(set.has("publicOne")).toBe(true);
+    expect(set.has("saveBangBang")).toBe(true);
+    expect(set.has("privateOne")).toBe(false);
+  });
+});
+
+describe("buildReport — novel vs moved classification", () => {
+  function makeManifests(): { ruby: ApiManifest; ts: ApiManifest } {
+    // Rails: foo.rb defines `bar`; baz.rb defines `quux`.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Foo": rubyClass({
+              name: "Foo",
+              file: "foo.rb",
+              instance: [method("bar")],
+            }),
+            "ActiveModel::Baz": rubyClass({
+              name: "Baz",
+              file: "baz.rb",
+              instance: [method("quux")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    // TS: foo.ts defines `bar` (matched), `quux` (moved from baz.rb),
+    //     and `tsOnlyHelper` (novel — nowhere in Rails).
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("bar"), method("quux"), method("tsOnlyHelper")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    return { ruby, ts };
+  }
+
+  it("classifies extras as novel when no Rails method maps to the name, moved otherwise", () => {
+    const { ruby, ts } = makeManifests();
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages).toHaveLength(1);
+    const pkg = report.packages[0];
+    expect(pkg.totalNovel).toBe(1);
+    expect(pkg.totalMoved).toBe(1);
+    expect(pkg.extraFiles).toHaveLength(1);
+    const f = pkg.extraFiles[0];
+    expect(f.tsFile).toBe("foo.ts");
+    expect(f.extras.map((e) => [e.name, e.kind])).toEqual([
+      ["tsOnlyHelper", "novel"],
+      ["quux", "moved"],
+    ]);
+  });
+
+  it("--novel-only drops moved extras from output and totals", () => {
+    const { ruby, ts } = makeManifests();
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: true,
+      topN: 50,
+    });
+    const pkg = report.packages[0];
+    expect(pkg.totalNovel).toBe(1);
+    expect(pkg.totalMoved).toBe(0);
+    expect(pkg.extraFiles[0].extras.map((e) => e.name)).toEqual(["tsOnlyHelper"]);
+  });
+
+  it("skips _-prefixed and internal TS members, doesn't flag them as extras", () => {
+    const { ruby } = makeManifests();
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [
+                method("bar"),
+                method("_railsPrivate"),
+                method("internalThing", true),
+              ],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    // baz.rb still maps to baz.ts which doesn't exist → no entry. foo.ts
+    // has only `bar` (matched) plus filtered names → no drift entry at all.
+    expect(report.packages[0].extraFiles).toHaveLength(0);
+  });
+
+  it("--exclude-glob skips matching TS file paths", () => {
+    const { ruby, ts } = makeManifests();
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: ["foo.ts"],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0].extraFiles).toHaveLength(0);
+  });
+
+  it("ranks files by novel count, not raw extra count", () => {
+    // bigBarrel.ts: 0 novel, 5 moved.  smallNovel.ts: 2 novel, 0 moved.
+    // smallNovel should outrank bigBarrel even though bigBarrel has more total.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        p: {
+          classes: {
+            "P::Barrel": rubyClass({ name: "Barrel", file: "big_barrel.rb" }),
+            "P::Small": rubyClass({ name: "Small", file: "small_novel.rb" }),
+            "P::Origins": rubyClass({
+              name: "Origins",
+              file: "origins.rb",
+              instance: [method("a"), method("b"), method("c"), method("d"), method("e")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        p: {
+          classes: {
+            Barrel: {
+              name: "Barrel",
+              file: "big-barrel.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("a"), method("b"), method("c"), method("d"), method("e")],
+              classMethods: [],
+            },
+            Small: {
+              name: "Small",
+              file: "small-novel.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("novelOne"), method("novelTwo")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.topN.map((f) => f.tsFile)).toEqual(["small-novel.ts", "big-barrel.ts"]);
+    expect(report.topN[0].novelCount).toBe(2);
+    expect(report.topN[1].novelCount).toBe(0);
+    expect(report.topN[1].movedCount).toBe(5);
+  });
+});

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -225,6 +225,91 @@ describe("buildReport — novel vs moved classification", () => {
     expect(report.packages[0].extraFiles).toHaveLength(0);
   });
 
+  it("resolves include names with namespace scope (no flat short-name pollution)", () => {
+    // Two unrelated `Quoting` modules: AbstractAdapter::Quoting and
+    // PostgreSQL::Quoting. AbstractAdapter `include "Quoting"` must resolve
+    // ONLY to AbstractAdapter::Quoting; PG's `pgOnlyMethod` must NOT count
+    // as allowed surface for abstract-adapter.ts.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            "ConnectionAdapters::AbstractAdapter": {
+              ...rubyClass({ name: "AbstractAdapter", file: "abstract_adapter.rb" }),
+              includes: ["Quoting"],
+            },
+          },
+          modules: {
+            "ConnectionAdapters::Quoting": rubyClass({
+              name: "Quoting",
+              file: "abstract/quoting.rb",
+              instance: [method("quote")],
+            }),
+            "ConnectionAdapters::PostgreSQL::Quoting": rubyClass({
+              name: "Quoting",
+              file: "postgresql/quoting.rb",
+              instance: [method("pg_only_method")],
+            }),
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            AbstractAdapter: {
+              name: "AbstractAdapter",
+              file: "abstract-adapter.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("quote"), method("pgOnlyMethod")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "abstract-adapter.ts");
+    // pgOnlyMethod must be flagged — namespace-scoped resolution prevents
+    // PG's Quoting from contributing to AbstractAdapter's allowed set.
+    expect(f).toBeDefined();
+    expect(f!.extras.map((e) => e.name)).toContain("pgOnlyMethod");
+  });
+
+  it("rejects non-integer --top and --max-detail", () => {
+    const proc = process as unknown as { exit: (n: number) => never };
+    const origExit = proc.exit;
+    const origErr = console.error;
+    let exited = false;
+    proc.exit = ((n: number) => {
+      exited = true;
+      throw new Error(`exit:${n}`);
+    }) as never;
+    console.error = () => {};
+    try {
+      expect(() => parseArgs(["--top", "3.7"])).toThrow(/exit:1/);
+      expect(exited).toBe(true);
+      exited = false;
+      expect(() => parseArgs(["--max-detail", "1.5"])).toThrow(/exit:1/);
+      expect(exited).toBe(true);
+    } finally {
+      proc.exit = origExit;
+      console.error = origErr;
+    }
+  });
+
   it("ranks files by novel count, not raw extra count", () => {
     // bigBarrel.ts: 0 novel, 5 moved.  smallNovel.ts: 2 novel, 0 moved.
     // smallNovel should outrank bigBarrel even though bigBarrel has more total.

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -288,6 +288,179 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras.map((e) => e.name)).toContain("pgOnlyMethod");
   });
 
+  it("skips nested classes sharing a file with a shorter-named parent (matches compare.ts)", () => {
+    // Nested Preloader::Association::LoaderQuery in association.rb is an
+    // impl detail; its `nestedHelper` must NOT count as allowed for the
+    // matched TS file. Per compare.ts:738-755.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            "Preloader::Association": rubyClass({
+              name: "Association",
+              file: "preloader/association.rb",
+              instance: [method("primary_method")],
+            }),
+            "Preloader::Association::LoaderQuery": rubyClass({
+              name: "LoaderQuery",
+              file: "preloader/association.rb",
+              instance: [method("nested_helper")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            Association: {
+              name: "Association",
+              file: "preloader/association.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("primaryMethod"), method("nestedHelper")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "preloader/association.ts");
+    expect(f).toBeDefined();
+    // primaryMethod allowed; nestedHelper flagged (nested class is skipped).
+    expect(f!.extras.map((e) => e.name)).toEqual(["nestedHelper"]);
+  });
+
+  it("folds ASC ::ClassMethods submodules into parent's classMethods", () => {
+    // host `include Foo` — Rails runtime gives Host the methods on
+    // Foo::ClassMethods. The fold puts ascHelper on Foo.classMethods so
+    // it counts as Foo's own surface (compare.ts:759-773).
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            "P::Host": {
+              ...rubyClass({ name: "Host", file: "host.rb" }),
+              includes: ["Foo"],
+            },
+          },
+          modules: {
+            "P::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
+            "P::Foo::ClassMethods": rubyClass({
+              name: "ClassMethods",
+              file: "foo.rb",
+              instance: [method("asc_helper")],
+            }),
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {},
+          modules: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              // After fold, ascHelper is on Foo's own classMethods, so it
+              // counts as Foo's matched surface (not extra).
+              classMethods: [method("ascHelper")],
+            },
+          },
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    // foo.ts has only ascHelper, which matches (post-fold) → no drift entry.
+    const fooDrift = report.packages[0].extraFiles.find((x) => x.tsFile === "foo.ts");
+    expect(fooDrift).toBeUndefined();
+  });
+
+  it("does NOT propagate module classMethods through include (Ruby semantics)", () => {
+    // Module Bar defines a class method `bareClassMethod` directly (not via
+    // ASC's ClassMethods submodule). Host `include Bar` must NOT give Host
+    // that name as allowed — Ruby's include only crosses instance methods.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            "P::Host": {
+              ...rubyClass({ name: "Host", file: "host.rb" }),
+              includes: ["Bar"],
+            },
+          },
+          modules: {
+            "P::Bar": rubyClass({
+              name: "Bar",
+              file: "bar.rb",
+              klass: [method("bare_class_method")],
+            }),
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        ar: {
+          classes: {
+            Host: {
+              name: "Host",
+              file: "host.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("bareClassMethod")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "host.ts");
+    // bareClassMethod IS extra on host.ts — module class methods don't
+    // propagate through include. (It will be classified `moved` because
+    // it exists on Bar globally.)
+    expect(f).toBeDefined();
+    expect(f!.extras.map((e) => e.name)).toEqual(["bareClassMethod"]);
+    expect(f!.extras[0].kind).toBe("moved");
+  });
+
   it("rejects non-integer --top and --max-detail", () => {
     const proc = process as unknown as { exit: (n: number) => never };
     const origExit = proc.exit;

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { buildGlobalRubyCandidates, buildReport, parseArgs } from "./extra-surface.js";
 
@@ -461,26 +461,21 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras[0].kind).toBe("moved");
   });
 
-  it("rejects non-integer --top and --max-detail", () => {
-    const proc = process as unknown as { exit: (n: number) => never };
-    const origExit = proc.exit;
-    const origErr = console.error;
-    let exited = false;
-    proc.exit = ((n: number) => {
-      exited = true;
-      throw new Error(`exit:${n}`);
-    }) as never;
-    console.error = () => {};
-    try {
+  describe("integer-only flag validation", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("rejects non-integer --top and --max-detail", () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+        throw new Error(`exit:${code}`);
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
       expect(() => parseArgs(["--top", "3.7"])).toThrow(/exit:1/);
-      expect(exited).toBe(true);
-      exited = false;
       expect(() => parseArgs(["--max-detail", "1.5"])).toThrow(/exit:1/);
-      expect(exited).toBe(true);
-    } finally {
-      proc.exit = origExit;
-      console.error = origErr;
-    }
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
   });
 
   it("ranks files by novel count, not raw extra count", () => {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S npx tsx
 /**
  * Surface TypeScript files whose public API has drifted *beyond* their Rails
  * counterpart — the inverse of `api:compare`.
@@ -564,12 +564,12 @@ function pickPalette(): { palette: Palette; colored: boolean } {
 }
 
 /**
- * Right-pad a colored cell to a target visible width. `colorCount` either
- * returns plain `String(n)` (no color) or wraps it in ANSI escapes that
- * vary in length — small novel counts (<5) get no color and large ones
- * get red+bold+reset (13 invisible chars). Padding off the colored string
- * with a fixed boost misaligns the table for low-count rows. Compute the
- * gap from `String(n).length` so every row matches.
+ * Left-pad a colored numeric cell to a target visible width. `colorCount`
+ * either returns plain `String(n)` (no color) or wraps it in ANSI escapes
+ * that vary in length — small novel counts (<5) get no color and large
+ * ones get red+bold+reset (13 invisible chars). Padding off the colored
+ * string with a fixed boost misaligns the table for low-count rows.
+ * Compute the gap from `String(n).length` so every row right-aligns.
  */
 function padNumCell(n: number, colored: string, width: number): string {
   const visible = String(n).length;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -490,29 +490,56 @@ function buildPackageReport(
   return result;
 }
 
-const RED = "\x1b[31m";
-const YELLOW = "\x1b[33m";
-const DIM = "\x1b[2m";
-const BOLD = "\x1b[1m";
-const RESET = "\x1b[0m";
+interface Palette {
+  red: string;
+  yellow: string;
+  dim: string;
+  bold: string;
+  reset: string;
+}
+const COLOR_ON: Palette = {
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  reset: "\x1b[0m",
+};
+const COLOR_OFF: Palette = { red: "", yellow: "", dim: "", bold: "", reset: "" };
 
-function colorCount(n: number, useColor: boolean): string {
-  if (!useColor) return String(n);
-  if (n >= 20) return `${RED}${BOLD}${n}${RESET}`;
-  if (n >= 10) return `${RED}${n}${RESET}`;
-  if (n >= 5) return `${YELLOW}${n}${RESET}`;
+function colorCount(n: number, p: Palette): string {
+  if (n >= 20) return `${p.red}${p.bold}${n}${p.reset}`;
+  if (n >= 10) return `${p.red}${n}${p.reset}`;
+  if (n >= 5) return `${p.yellow}${n}${p.reset}`;
   return String(n);
 }
 
-function printHumanReport(report: Report, topN: number, maxDetail: number): void {
-  const useColor = process.stdout.isTTY === true;
+/**
+ * `useColor` defaults to TTY but is forceable via env so CI logs and pipes
+ * don't get raw escape codes. Padding widens by the per-cell escape-sequence
+ * length when color is on so the columns still align.
+ */
+function pickPalette(): { palette: Palette; colored: boolean } {
+  const env = process.env["FORCE_COLOR"];
+  if (env === "0" || env === "false") return { palette: COLOR_OFF, colored: false };
+  if (env && env !== "") return { palette: COLOR_ON, colored: true };
+  return process.stdout.isTTY === true
+    ? { palette: COLOR_ON, colored: true }
+    : { palette: COLOR_OFF, colored: false };
+}
 
-  console.log(`\n${BOLD}Extra TS surface vs Rails${RESET}  (the inverse of api:compare)`);
+function printHumanReport(report: Report, topN: number, maxDetail: number): void {
+  const { palette: p, colored } = pickPalette();
+  // colorCount adds invisible escape characters; widen padding by the
+  // max envelope length so the columns still align when color is on.
+  // Worst case is red+bold+reset = 13 chars (\x1b[31m\x1b[1m...\x1b[0m).
+  const padBoost = colored ? 13 : 0;
+
+  console.log(`\n${p.bold}Extra TS surface vs Rails${p.reset}  (the inverse of api:compare)`);
   console.log(
-    `${DIM}Generated ${report.generatedAt}  |  novel = name not found anywhere in Rails;  moved = found, just in a different .rb${RESET}\n`,
+    `${p.dim}Generated ${report.generatedAt}  |  novel = name not found anywhere in Rails;  moved = found, just in a different .rb${p.reset}\n`,
   );
 
-  console.log(`${BOLD}Per-package totals${RESET}`);
+  console.log(`${p.bold}Per-package totals${p.reset}`);
   console.log(
     `  ${"Package".padEnd(20)} ${"Files".padStart(7)} ${"Novel".padStart(7)} ${"Moved".padStart(7)} ${"Total".padStart(7)}`,
   );
@@ -520,15 +547,14 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
     `  ${"-".repeat(20)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)}`,
   );
   for (const pkg of report.packages) {
-    const novel = colorCount(pkg.totalNovel, useColor);
-    const pad = useColor ? 16 : 7;
+    const novel = colorCount(pkg.totalNovel, p);
     console.log(
-      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel.padStart(pad)} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)}`,
+      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel.padStart(7 + padBoost)} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)}`,
     );
   }
 
   console.log(
-    `\n${BOLD}Top ${Math.min(topN, report.topN.length)} most-divergent files${RESET}  ${DIM}(ranked by novel count, then total)${RESET}`,
+    `\n${p.bold}Top ${Math.min(topN, report.topN.length)} most-divergent files${p.reset}  ${p.dim}(ranked by novel count, then total)${p.reset}`,
   );
   console.log(
     `  ${"#".padStart(3)}  ${"Novel".padStart(5)}  ${"Moved".padStart(5)}  ${"Package".padEnd(16)} ${"TS file".padEnd(60)}`,
@@ -538,35 +564,31 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
   );
   for (let i = 0; i < Math.min(topN, report.topN.length); i++) {
     const f = report.topN[i];
-    const c = colorCount(f.novelCount, useColor);
-    const pad = useColor ? 14 : 5;
+    const c = colorCount(f.novelCount, p);
     console.log(
-      `  ${String(i + 1).padStart(3)}  ${c.padStart(pad)}  ${String(f.movedCount).padStart(5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
+      `  ${String(i + 1).padStart(3)}  ${c.padStart(5 + padBoost)}  ${String(f.movedCount).padStart(5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
     );
   }
 
   console.log(
-    `\n${BOLD}Per-file detail${RESET}  ${DIM}(novel-first; moved names dimmed; +N more elided when over --max-detail)${RESET}\n`,
+    `\n${p.bold}Per-file detail${p.reset}  ${p.dim}(novel-first; moved names dimmed; +N more elided when over --max-detail)${p.reset}\n`,
   );
   for (const pkg of report.packages) {
     if (pkg.extraFiles.length === 0) continue;
-    console.log(`${BOLD}${pkg.package}${RESET}`);
+    console.log(`${p.bold}${pkg.package}${p.reset}`);
     for (const f of pkg.extraFiles) {
-      const novelTag = useColor
-        ? colorCount(f.novelCount, useColor) + " novel"
-        : `${f.novelCount} novel`;
-      console.log(`  ${f.tsFile} — ${novelTag}, ${f.movedCount} moved`);
+      console.log(`  ${f.tsFile} — ${colorCount(f.novelCount, p)} novel, ${f.movedCount} moved`);
       const shown = maxDetail > 0 ? f.extras.slice(0, maxDetail) : f.extras;
       const cols = 4;
       for (let i = 0; i < shown.length; i += cols) {
         const row = shown.slice(i, i + cols).map((e) => {
           const label = e.name.padEnd(24);
-          return useColor && e.kind === "moved" ? `${DIM}${label}${RESET}` : label;
+          return e.kind === "moved" ? `${p.dim}${label}${p.reset}` : label;
         });
         console.log(`    ${row.join(" ")}`);
       }
       const elided = f.extras.length - shown.length;
-      if (elided > 0) console.log(`    ${DIM}… +${elided} more${RESET}`);
+      if (elided > 0) console.log(`    ${p.dim}… +${elided} more${p.reset}`);
     }
     console.log();
   }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env npx tsx
+/**
+ * Surface TypeScript files whose public API has drifted *beyond* their Rails
+ * counterpart — the inverse of `api:compare`.
+ *
+ * `api:compare` reports Rails methods missing in TS. This script reports TS
+ * public methods/functions/getters/setters that don't correspond to any
+ * Ruby method in the matched Rails file. It's a fact-finding audit so we
+ * can prune toward Rails-faithful shape; it never modifies source.
+ *
+ * Algorithm, per Rails-mirroring package:
+ *   1. For each Ruby file, resolve its expected TS file via `rubyFileToTs`.
+ *   2. Collect Ruby public methods declared in (or `include`d into) the
+ *      entities in that Ruby file. Map each to its TS-candidate name set
+ *      via `rubyMethodToTs`. Union = the "allowed" TS name set.
+ *   3. Collect public TS names declared in the matching TS file — each
+ *      class/module's *own* methods (skipping inherited surface so the
+ *      diff measures this file's drift, not its ancestor's) plus top-level
+ *      `fileFunctions`. Filter out `internal: true` (covers `_`-prefixed,
+ *      `@internal` JSDoc, `private`/`protected`, `#`-prefixed fields).
+ *   4. Extra = TS names \ allowed names. Emit per-file, per-package, and
+ *      top-N reports.
+ *
+ * Manifests are produced by `pnpm api:compare`; if they're missing the
+ * script bails with a hint (same convention as `api:moves`).
+ *
+ * Usage:
+ *   pnpm tsx scripts/api-compare/extra-surface.ts \
+ *     [--package <name>] [--top <N>] [--json] [--exclude-glob <glob>]...
+ *
+ * Flags:
+ *   --package <name>      Restrict to one package (e.g. activerecord).
+ *   --top <N>             Top-N most-divergent files (default 50).
+ *   --json                Emit machine-readable JSON to stdout instead of
+ *                         the human report.
+ *   --exclude-glob <g>    Skip TS files matching <g> (substring match
+ *                         against the TS file path). Repeatable. Useful
+ *                         for known-intentional extensions like
+ *                         `dx-tests/` or `defineSchema`-only modules.
+ *   --help                Print this message.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
+import { OUTPUT_DIR } from "./config.js";
+import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+
+interface ExtraFile {
+  package: string;
+  tsFile: string;
+  rubyFile: string;
+  extraCount: number;
+  extras: string[];
+}
+
+interface PackageTotals {
+  package: string;
+  filesWithDrift: number;
+  totalExtras: number;
+  extraFiles: ExtraFile[];
+}
+
+interface Report {
+  generatedAt: string;
+  packages: PackageTotals[];
+  topN: ExtraFile[];
+}
+
+const HELP = `extra-surface — TS files with public API exceeding their Rails counterpart
+
+Usage:
+  pnpm tsx scripts/api-compare/extra-surface.ts [options]
+
+Options:
+  --package <name>     Restrict to one package (e.g. activerecord)
+  --top <N>            Top-N most-divergent files (default 50)
+  --json               Emit JSON to stdout instead of the human report
+  --exclude-glob <g>   Skip TS files containing substring <g> (repeatable)
+  --help               This message
+
+Requires: pnpm api:compare must have run first to produce
+  scripts/api-compare/output/{rails-api.json,ts-api.json}.
+`;
+
+interface CliArgs {
+  filterPkg: string | null;
+  topN: number;
+  json: boolean;
+  excludeGlobs: string[];
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  let filterPkg: string | null = null;
+  let topN = 50;
+  let json = false;
+  const excludeGlobs: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") {
+      console.log(HELP);
+      process.exit(0);
+    } else if (a === "--package") {
+      const v = argv[++i];
+      if (!v || v.startsWith("--")) {
+        console.error("--package requires a value");
+        process.exit(1);
+      }
+      filterPkg = v;
+    } else if (a === "--top") {
+      const v = argv[++i];
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) {
+        console.error("--top requires a positive integer");
+        process.exit(1);
+      }
+      topN = Math.floor(n);
+    } else if (a === "--json") {
+      json = true;
+    } else if (a === "--exclude-glob") {
+      const v = argv[++i];
+      if (!v || v.startsWith("--")) {
+        console.error("--exclude-glob requires a value");
+        process.exit(1);
+      }
+      excludeGlobs.push(v);
+    } else {
+      console.error(`Unknown flag: ${a}`);
+      console.error(HELP);
+      process.exit(1);
+    }
+  }
+  return { filterPkg, topN, json, excludeGlobs };
+}
+
+/**
+ * Collect public TS names declared *in this file's own entities* — no
+ * inherited surface. Inherited names that the parent already defines are
+ * not "drift" relative to Rails; they're the parent's problem (and Rails
+ * inherits them too).
+ */
+function collectTsFileNames(
+  file: string,
+  classes: ClassInfo[],
+  modules: ClassInfo[],
+  fileFunctions: MethodInfo[] | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  const push = (m: MethodInfo): void => {
+    if (m.internal === true) return;
+    if (m.name.startsWith("_")) return;
+    out.add(m.name);
+  };
+  for (const c of classes) {
+    if (c.file !== file) continue;
+    for (const m of c.instanceMethods) push(m);
+    for (const m of c.classMethods) push(m);
+  }
+  for (const m of modules) {
+    if (m.file !== file) continue;
+    for (const im of m.instanceMethods) push(im);
+    for (const cm of m.classMethods) push(cm);
+  }
+  for (const fn of fileFunctions ?? []) push(fn);
+  return out;
+}
+
+/**
+ * For a set of Ruby entities (one Ruby file), compute the union of all TS
+ * candidate names produced by `rubyMethodToTs`. Walks `include`s and
+ * `extend`s shallowly so methods reached via mixin still count as expected.
+ *
+ * Cross-package or stdlib mixins are silently skipped — same convention
+ * as compare.ts's `flattenIncludedMethodInfos`.
+ */
+function collectAllowedNames(
+  entities: ClassInfo[],
+  rubyModules: Record<string, ClassInfo>,
+  moduleFqnByShort: Map<string, string[]>,
+): Set<string> {
+  const allowed = new Set<string>();
+  const visited = new Set<string>();
+
+  const addMethods = (methods: MethodInfo[]): void => {
+    for (const m of methods) {
+      if (m.internal === true) continue;
+      const candidates = rubyMethodToTs(m.name);
+      if (!candidates) continue;
+      for (const c of candidates) allowed.add(c);
+    }
+  };
+
+  const walkMixin = (name: string): void => {
+    const fqns = name.includes("::") ? [name] : (moduleFqnByShort.get(name) ?? []);
+    for (const fqn of fqns) {
+      if (visited.has(fqn)) continue;
+      visited.add(fqn);
+      const mod = rubyModules[fqn];
+      if (!mod) continue;
+      addMethods(mod.instanceMethods);
+      addMethods(mod.classMethods);
+      for (const inc of mod.includes ?? []) walkMixin(inc);
+      for (const ext of mod.extends ?? []) walkMixin(ext);
+    }
+  };
+
+  for (const e of entities) {
+    addMethods(e.instanceMethods);
+    addMethods(e.classMethods);
+    for (const inc of e.includes ?? []) walkMixin(inc);
+    for (const ext of e.extends ?? []) walkMixin(ext);
+  }
+  return allowed;
+}
+
+function buildPackageReport(
+  pkg: string,
+  ruby: ApiManifest,
+  ts: ApiManifest,
+  excludeGlobs: string[],
+): PackageTotals {
+  const rubyPkg = ruby.packages[pkg];
+  const tsPkg = ts.packages[pkg];
+  const result: PackageTotals = {
+    package: pkg,
+    filesWithDrift: 0,
+    totalExtras: 0,
+    extraFiles: [],
+  };
+  if (!rubyPkg || !tsPkg) return result;
+
+  const moduleFqnByShort = new Map<string, string[]>();
+  for (const fqn of Object.keys(rubyPkg.modules)) {
+    const short = fqn.split("::").pop();
+    if (!short) continue;
+    const list = moduleFqnByShort.get(short) ?? [];
+    list.push(fqn);
+    moduleFqnByShort.set(short, list);
+  }
+
+  const rubyFiles = new Map<string, ClassInfo[]>();
+  for (const entity of [
+    ...Object.values(rubyPkg.classes),
+    ...Object.values(rubyPkg.modules),
+  ] as ClassInfo[]) {
+    if (!entity.file) continue;
+    const list = rubyFiles.get(entity.file) ?? [];
+    list.push(entity);
+    rubyFiles.set(entity.file, list);
+  }
+
+  const tsClassesByFile = new Map<string, ClassInfo[]>();
+  const tsModulesByFile = new Map<string, ClassInfo[]>();
+  for (const c of Object.values(tsPkg.classes) as ClassInfo[]) {
+    if (!c.file) continue;
+    (tsClassesByFile.get(c.file) ?? tsClassesByFile.set(c.file, []).get(c.file)!).push(c);
+  }
+  for (const m of Object.values(tsPkg.modules) as ClassInfo[]) {
+    if (!m.file) continue;
+    (tsModulesByFile.get(m.file) ?? tsModulesByFile.set(m.file, []).get(m.file)!).push(m);
+  }
+  const tsFileFunctions = tsPkg.fileFunctions ?? {};
+
+  for (const [rubyFile, entities] of rubyFiles) {
+    const expectedTs = rubyFileToTs(rubyFile, pkg);
+    if (excludeGlobs.some((g) => expectedTs.includes(g))) continue;
+
+    const classes = tsClassesByFile.get(expectedTs) ?? [];
+    const modules = tsModulesByFile.get(expectedTs) ?? [];
+    const fileFns = tsFileFunctions[expectedTs];
+    if (classes.length === 0 && modules.length === 0 && !fileFns) continue;
+
+    const tsNames = collectTsFileNames(expectedTs, classes, modules, fileFns);
+    if (tsNames.size === 0) continue;
+
+    const allowed = collectAllowedNames(
+      entities,
+      rubyPkg.modules as Record<string, ClassInfo>,
+      moduleFqnByShort,
+    );
+
+    const extras: string[] = [];
+    for (const name of tsNames) {
+      if (!allowed.has(name)) extras.push(name);
+    }
+    if (extras.length === 0) continue;
+
+    extras.sort();
+    result.extraFiles.push({
+      package: pkg,
+      tsFile: expectedTs,
+      rubyFile,
+      extraCount: extras.length,
+      extras,
+    });
+    result.filesWithDrift++;
+    result.totalExtras += extras.length;
+  }
+
+  result.extraFiles.sort((a, b) => b.extraCount - a.extraCount || a.tsFile.localeCompare(b.tsFile));
+  return result;
+}
+
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+function colorCount(n: number, useColor: boolean): string {
+  if (!useColor) return String(n);
+  if (n >= 20) return `${RED}${BOLD}${n}${RESET}`;
+  if (n >= 10) return `${RED}${n}${RESET}`;
+  if (n >= 5) return `${YELLOW}${n}${RESET}`;
+  return String(n);
+}
+
+function printHumanReport(report: Report, topN: number): void {
+  const useColor = process.stdout.isTTY === true;
+
+  console.log(`\n${BOLD}Extra TS surface vs Rails${RESET}  (the inverse of api:compare)`);
+  console.log(`${DIM}Generated ${report.generatedAt}${RESET}\n`);
+
+  console.log(`${BOLD}Per-package totals${RESET}`);
+  console.log(
+    `  ${"Package".padEnd(20)} ${"Files w/ drift".padStart(15)} ${"Extra names".padStart(13)}`,
+  );
+  console.log(`  ${"-".repeat(20)} ${"-".repeat(15)} ${"-".repeat(13)}`);
+  for (const pkg of report.packages) {
+    console.log(
+      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(15)} ${colorCount(pkg.totalExtras, useColor).padStart(useColor ? 22 : 13)}`,
+    );
+  }
+
+  console.log(`\n${BOLD}Top ${Math.min(topN, report.topN.length)} most-divergent files${RESET}`);
+  console.log(
+    `  ${"#".padStart(3)}  ${"Extra".padStart(5)}  ${"Package".padEnd(16)} ${"TS file".padEnd(60)}`,
+  );
+  console.log(`  ${"-".repeat(3)}  ${"-".repeat(5)}  ${"-".repeat(16)} ${"-".repeat(60)}`);
+  for (let i = 0; i < Math.min(topN, report.topN.length); i++) {
+    const f = report.topN[i];
+    const c = colorCount(f.extraCount, useColor);
+    console.log(
+      `  ${String(i + 1).padStart(3)}  ${c.padStart(useColor ? 14 : 5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
+    );
+  }
+
+  console.log(
+    `\n${BOLD}Per-file detail${RESET} (only files with drift; sorted by extra count desc)\n`,
+  );
+  for (const pkg of report.packages) {
+    if (pkg.extraFiles.length === 0) continue;
+    console.log(`${BOLD}${pkg.package}${RESET}`);
+    for (const f of pkg.extraFiles) {
+      console.log(`  ${f.tsFile} — +${f.extraCount} over Rails`);
+      const cols = 4;
+      for (let i = 0; i < f.extras.length; i += cols) {
+        const row = f.extras.slice(i, i + cols).map((n) => n.padEnd(24));
+        console.log(`    ${row.join(" ")}`);
+      }
+    }
+    console.log();
+  }
+}
+
+export function main(argv = process.argv.slice(2)): void {
+  const { filterPkg, topN, json, excludeGlobs } = parseArgs(argv);
+
+  const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
+  const tsPath = path.join(OUTPUT_DIR, "ts-api.json");
+  if (!fs.existsSync(rubyPath) || !fs.existsSync(tsPath)) {
+    console.error(
+      `Missing ${path.basename(fs.existsSync(rubyPath) ? tsPath : rubyPath)}. Run \`pnpm api:compare\` first to generate the manifests.`,
+    );
+    process.exit(1);
+  }
+  const ruby: ApiManifest = JSON.parse(fs.readFileSync(rubyPath, "utf-8"));
+  const ts: ApiManifest = JSON.parse(fs.readFileSync(tsPath, "utf-8"));
+
+  const packages: PackageTotals[] = [];
+  for (const pkg of Object.keys(ruby.packages)) {
+    if (filterPkg && pkg !== filterPkg) continue;
+    if (!ts.packages[pkg]) continue;
+    packages.push(buildPackageReport(pkg, ruby, ts, excludeGlobs));
+  }
+  packages.sort((a, b) => b.totalExtras - a.totalExtras);
+
+  const allExtras: ExtraFile[] = packages.flatMap((p) => p.extraFiles);
+  allExtras.sort((a, b) => b.extraCount - a.extraCount || a.tsFile.localeCompare(b.tsFile));
+
+  const report: Report = {
+    generatedAt: new Date().toISOString(),
+    packages,
+    topN: allExtras.slice(0, topN),
+  };
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  printHumanReport(report, topN);
+}
+
+const invokedAsScript =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  typeof process.argv[1] === "string" &&
+  process.argv[1].endsWith("extra-surface.ts");
+if (invokedAsScript) main();

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -53,6 +53,25 @@ import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import { resolveModuleName } from "./compare.js";
+
+/**
+ * Track the FQN alongside the entity so namespace-scoped include resolution
+ * (`resolveModuleName(short, fqn, …)`) picks the *enclosing* module —
+ * e.g. `AbstractAdapter` including `"Quoting"` resolves to
+ * `ConnectionAdapters::Quoting`, not the adapter-specific siblings.
+ */
+interface RubyEntity {
+  fqn: string;
+  info: ClassInfo;
+}
+
+/** Get-or-init helper: replaces the `(get() ?? set([]).get()!).push(v)` idiom. */
+function pushTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const list = map.get(key);
+  if (list) list.push(value);
+  else map.set(key, [value]);
+}
 
 /**
  * An extra TS name is **moved** if a Ruby method somewhere in Rails-land
@@ -149,18 +168,18 @@ export function parseArgs(argv: string[]): CliArgs {
       filterPkg = requireValue("--package", argv[++i]);
     } else if (a === "--top") {
       const n = Number(requireValue("--top", argv[++i]));
-      if (!Number.isFinite(n) || n <= 0) {
+      if (!Number.isInteger(n) || n <= 0) {
         console.error("--top requires a positive integer");
         process.exit(1);
       }
-      topN = Math.floor(n);
+      topN = n;
     } else if (a === "--max-detail") {
       const n = Number(requireValue("--max-detail", argv[++i]));
-      if (!Number.isFinite(n) || n < 0) {
+      if (!Number.isInteger(n) || n < 0) {
         console.error("--max-detail requires a non-negative integer");
         process.exit(1);
       }
-      maxDetail = Math.floor(n);
+      maxDetail = n;
     } else if (a === "--json") {
       json = true;
     } else if (a === "--novel-only") {
@@ -209,15 +228,32 @@ function collectTsFileNames(
 }
 
 /**
- * For a set of Ruby entities (one Ruby file), compute the union of all TS
- * candidate names produced by `rubyMethodToTs`. Walks `include`s and
- * `extend`s shallowly so methods reached via mixin still count as expected.
+ * For one Ruby file's entities, compute the union of all TS candidate names
+ * produced by `rubyMethodToTs`. Mirrors `compare.flattenIncludedMethodInfos`
+ * mixin routing:
  *
- * Cross-package or stdlib mixins are silently skipped — same convention
- * as compare.ts's `flattenIncludedMethodInfos`.
+ *   - `include M`: M's instance methods land on the host as instance methods.
+ *     A nested `include N` inside M chains through (instance methods only).
+ *     M's own `extend` chain does NOT propagate to the host — Ruby `extend`
+ *     affects only the receiver's singleton class.
+ *   - `extend M` (at host level): M's instance methods land as class methods.
+ *
+ *   - Module `classMethods` are kept here because the api-compare extractor
+ *     folds nested `ClassMethods` submodules (the `ActiveSupport::Concern`
+ *     idiom) into their parent module's `classMethods` before we see them.
+ *     Excluding them would drop the most common Rails mixin pattern from
+ *     the allowed-name set and inflate false-positive extras.
+ *
+ * `include` names are resolved via compare.ts's `resolveModuleName`, which
+ * walks namespace prefixes — `AbstractAdapter` including `"Quoting"` maps
+ * only to `ConnectionAdapters::Quoting`, never to PG/MySQL siblings of the
+ * same short name. The flat-by-short-name lookup we used before pulled in
+ * unrelated modules and silently inflated `allowed`.
+ *
+ * Cross-package or stdlib mixins are silently skipped — same as compare.ts.
  */
 function collectAllowedNames(
-  entities: ClassInfo[],
+  entities: RubyEntity[],
   rubyModules: Record<string, ClassInfo>,
   moduleFqnByShort: Map<string, string[]>,
 ): Set<string> {
@@ -233,8 +269,8 @@ function collectAllowedNames(
     }
   };
 
-  const walkMixin = (name: string): void => {
-    const fqns = name.includes("::") ? [name] : (moduleFqnByShort.get(name) ?? []);
+  const walkMixin = (incName: string, contextFqn: string): void => {
+    const fqns = resolveModuleName(incName, contextFqn, moduleFqnByShort);
     for (const fqn of fqns) {
       if (visited.has(fqn)) continue;
       visited.add(fqn);
@@ -242,16 +278,17 @@ function collectAllowedNames(
       if (!mod) continue;
       addMethods(mod.instanceMethods);
       addMethods(mod.classMethods);
-      for (const inc of mod.includes ?? []) walkMixin(inc);
-      for (const ext of mod.extends ?? []) walkMixin(ext);
+      // Only chain `include`s — a module's own `extend` doesn't propagate
+      // to the host (Ruby singleton-class semantics).
+      for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
     }
   };
 
-  for (const e of entities) {
-    addMethods(e.instanceMethods);
-    addMethods(e.classMethods);
-    for (const inc of e.includes ?? []) walkMixin(inc);
-    for (const ext of e.extends ?? []) walkMixin(ext);
+  for (const { fqn, info } of entities) {
+    addMethods(info.instanceMethods);
+    addMethods(info.classMethods);
+    for (const inc of info.includes ?? []) walkMixin(inc, fqn);
+    for (const ext of info.extends ?? []) walkMixin(ext, fqn);
   }
   return allowed;
 }
@@ -306,26 +343,24 @@ function buildPackageReport(
     moduleFqnByShort.set(short, list);
   }
 
-  const rubyFiles = new Map<string, ClassInfo[]>();
-  for (const entity of [
-    ...Object.values(rubyPkg.classes),
-    ...Object.values(rubyPkg.modules),
-  ] as ClassInfo[]) {
-    if (!entity.file) continue;
-    const list = rubyFiles.get(entity.file) ?? [];
-    list.push(entity);
-    rubyFiles.set(entity.file, list);
+  const rubyFiles = new Map<string, RubyEntity[]>();
+  for (const [fqn, info] of [
+    ...Object.entries(rubyPkg.classes),
+    ...Object.entries(rubyPkg.modules),
+  ] as [string, ClassInfo][]) {
+    if (!info.file) continue;
+    pushTo(rubyFiles, info.file, { fqn, info });
   }
 
   const tsClassesByFile = new Map<string, ClassInfo[]>();
   const tsModulesByFile = new Map<string, ClassInfo[]>();
   for (const c of Object.values(tsPkg.classes) as ClassInfo[]) {
     if (!c.file) continue;
-    (tsClassesByFile.get(c.file) ?? tsClassesByFile.set(c.file, []).get(c.file)!).push(c);
+    pushTo(tsClassesByFile, c.file, c);
   }
   for (const m of Object.values(tsPkg.modules) as ClassInfo[]) {
     if (!m.file) continue;
-    (tsModulesByFile.get(m.file) ?? tsModulesByFile.set(m.file, []).get(m.file)!).push(m);
+    pushTo(tsModulesByFile, m.file, m);
   }
   const tsFileFunctions = tsPkg.fileFunctions ?? {};
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -69,6 +69,41 @@ interface RubyEntity {
   info: ClassInfo;
 }
 
+/**
+ * TS-side method names that mirror Ruby methods on `conventions.SKIP`.
+ * `rubyMethodToTs` returns null for SKIP entries (they have no clean TS
+ * mapping at scoring time), so they never enter `allowed` even when the
+ * Ruby method exists in the matched file — but a TS override of e.g.
+ * `freeze`/`inspect` IS Rails-faithful (Rails AR `Base#freeze` lives in
+ * core.rb, AM `model#inspect` in attribute_methods.rb). Filtering these
+ * from the TS-side name set prevents them from showing up as "novel
+ * drift" when in fact they're carrying-the-pattern through.
+ */
+const TS_ALWAYS_ALLOWED = new Set([
+  "dup",
+  "clone",
+  "freeze",
+  "inspect",
+  "prettyPrint",
+  "tap",
+  "then",
+  "eql",
+  "equals",
+  "initializeDup",
+  "initializeClone",
+  "initializeCopy",
+  "encodeWith",
+  "initWith",
+  "toArray",
+  "toH",
+  "toHash",
+  "valueOf",
+  "klasses",
+  // Node.js / V8 inspection hook — the canonical TS analog of Ruby
+  // `inspect`. Pure language-level convention; never has a Rails counterpart.
+  '[Symbol.for("nodejs.util.inspect.custom")]',
+]);
+
 /** Get-or-init helper: replaces the `(get() ?? set([]).get()!).push(v)` idiom. */
 function pushTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   const list = map.get(key);
@@ -219,6 +254,7 @@ function collectTsFileNames(
   const push = (m: MethodInfo): void => {
     if (m.internal === true) return;
     if (m.name.startsWith("_")) return;
+    if (TS_ALWAYS_ALLOWED.has(m.name)) return;
     out.add(m.name);
   };
   for (const c of classes) {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -527,12 +527,22 @@ function pickPalette(): { palette: Palette; colored: boolean } {
     : { palette: COLOR_OFF, colored: false };
 }
 
+/**
+ * Right-pad a colored cell to a target visible width. `colorCount` either
+ * returns plain `String(n)` (no color) or wraps it in ANSI escapes that
+ * vary in length — small novel counts (<5) get no color and large ones
+ * get red+bold+reset (13 invisible chars). Padding off the colored string
+ * with a fixed boost misaligns the table for low-count rows. Compute the
+ * gap from `String(n).length` so every row matches.
+ */
+function padNumCell(n: number, colored: string, width: number): string {
+  const visible = String(n).length;
+  const gap = Math.max(0, width - visible);
+  return " ".repeat(gap) + colored;
+}
+
 function printHumanReport(report: Report, topN: number, maxDetail: number): void {
-  const { palette: p, colored } = pickPalette();
-  // colorCount adds invisible escape characters; widen padding by the
-  // max envelope length so the columns still align when color is on.
-  // Worst case is red+bold+reset = 13 chars (\x1b[31m\x1b[1m...\x1b[0m).
-  const padBoost = colored ? 13 : 0;
+  const { palette: p } = pickPalette();
 
   console.log(`\n${p.bold}Extra TS surface vs Rails${p.reset}  (the inverse of api:compare)`);
   console.log(
@@ -547,9 +557,9 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
     `  ${"-".repeat(20)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)}`,
   );
   for (const pkg of report.packages) {
-    const novel = colorCount(pkg.totalNovel, p);
+    const novel = padNumCell(pkg.totalNovel, colorCount(pkg.totalNovel, p), 7);
     console.log(
-      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel.padStart(7 + padBoost)} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)}`,
+      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)}`,
     );
   }
 
@@ -564,9 +574,9 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
   );
   for (let i = 0; i < Math.min(topN, report.topN.length); i++) {
     const f = report.topN[i];
-    const c = colorCount(f.novelCount, p);
+    const c = padNumCell(f.novelCount, colorCount(f.novelCount, p), 5);
     console.log(
-      `  ${String(i + 1).padStart(3)}  ${c.padStart(5 + padBoost)}  ${String(f.movedCount).padStart(5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
+      `  ${String(i + 1).padStart(3)}  ${c}  ${String(f.movedCount).padStart(5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
     );
   }
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -28,6 +28,12 @@
  *   pnpm tsx scripts/api-compare/extra-surface.ts \
  *     [--package <name>] [--top <N>] [--json] [--exclude-glob <glob>]...
  *
+ * Each extra is classified as **novel** (the candidate name appears nowhere
+ * in Rails-land) or **moved** (Rails defines it, just in a different `.rb`).
+ * Files are ranked by novel count primarily — barrel-style aggregators
+ * (`connection-adapters.ts`) drop below smaller novel-heavy files like
+ * `relation/finder-methods.ts`. `--novel-only` drops moved extras entirely.
+ *
  * Flags:
  *   --package <name>      Restrict to one package (e.g. activerecord).
  *   --top <N>             Top-N most-divergent files (default 50).
@@ -37,6 +43,8 @@
  *                         against the TS file path). Repeatable. Useful
  *                         for known-intentional extensions like
  *                         `dx-tests/` or `defineSchema`-only modules.
+ *   --novel-only          Drop moved-not-novel extras (filters barrel noise).
+ *   --max-detail <N>      Cap names per file in detail listing (default 40).
  *   --help                Print this message.
  */
 
@@ -46,18 +54,37 @@ import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 
+/**
+ * An extra TS name is **moved** if a Ruby method somewhere in Rails-land
+ * camelizes to it (just not in the matched file). It's **novel** when no
+ * Ruby method anywhere produces it — that's the high-signal class:
+ * helpers, accidental public surface, TS-only ergonomics. Barrel files
+ * like `connection-adapters.ts` are mostly `moved`; small focused files'
+ * extras are mostly `novel`.
+ */
+export type ExtraKind = "novel" | "moved";
+
+export interface ExtraName {
+  name: string;
+  kind: ExtraKind;
+}
+
 interface ExtraFile {
   package: string;
   tsFile: string;
   rubyFile: string;
   extraCount: number;
-  extras: string[];
+  novelCount: number;
+  movedCount: number;
+  extras: ExtraName[];
 }
 
 interface PackageTotals {
   package: string;
   filesWithDrift: number;
   totalExtras: number;
+  totalNovel: number;
+  totalMoved: number;
   extraFiles: ExtraFile[];
 }
 
@@ -77,24 +104,41 @@ Options:
   --top <N>            Top-N most-divergent files (default 50)
   --json               Emit JSON to stdout instead of the human report
   --exclude-glob <g>   Skip TS files containing substring <g> (repeatable)
+  --novel-only         Only count/show extras that don't appear ANYWHERE
+                       in the Rails source (filters out moved-not-novel
+                       drift; rank order also flips to novel-first)
+  --max-detail <N>     Per-file detail listing cap (default 40 names;
+                       0 = unlimited)
   --help               This message
 
 Requires: pnpm api:compare must have run first to produce
   scripts/api-compare/output/{rails-api.json,ts-api.json}.
 `;
 
-interface CliArgs {
+export interface CliArgs {
   filterPkg: string | null;
   topN: number;
   json: boolean;
   excludeGlobs: string[];
+  novelOnly: boolean;
+  maxDetail: number;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
   let filterPkg: string | null = null;
   let topN = 50;
   let json = false;
+  let novelOnly = false;
+  let maxDetail = 40;
   const excludeGlobs: string[] = [];
+
+  const requireValue = (flag: string, v: string | undefined): string => {
+    if (!v || v.startsWith("--")) {
+      console.error(`${flag} requires a value`);
+      process.exit(1);
+    }
+    return v;
+  };
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -102,36 +146,34 @@ export function parseArgs(argv: string[]): CliArgs {
       console.log(HELP);
       process.exit(0);
     } else if (a === "--package") {
-      const v = argv[++i];
-      if (!v || v.startsWith("--")) {
-        console.error("--package requires a value");
-        process.exit(1);
-      }
-      filterPkg = v;
+      filterPkg = requireValue("--package", argv[++i]);
     } else if (a === "--top") {
-      const v = argv[++i];
-      const n = Number(v);
+      const n = Number(requireValue("--top", argv[++i]));
       if (!Number.isFinite(n) || n <= 0) {
         console.error("--top requires a positive integer");
         process.exit(1);
       }
       topN = Math.floor(n);
-    } else if (a === "--json") {
-      json = true;
-    } else if (a === "--exclude-glob") {
-      const v = argv[++i];
-      if (!v || v.startsWith("--")) {
-        console.error("--exclude-glob requires a value");
+    } else if (a === "--max-detail") {
+      const n = Number(requireValue("--max-detail", argv[++i]));
+      if (!Number.isFinite(n) || n < 0) {
+        console.error("--max-detail requires a non-negative integer");
         process.exit(1);
       }
-      excludeGlobs.push(v);
+      maxDetail = Math.floor(n);
+    } else if (a === "--json") {
+      json = true;
+    } else if (a === "--novel-only") {
+      novelOnly = true;
+    } else if (a === "--exclude-glob") {
+      excludeGlobs.push(requireValue("--exclude-glob", argv[++i]));
     } else {
       console.error(`Unknown flag: ${a}`);
       console.error(HELP);
       process.exit(1);
     }
   }
-  return { filterPkg, topN, json, excludeGlobs };
+  return { filterPkg, topN, json, excludeGlobs, novelOnly, maxDetail };
 }
 
 /**
@@ -214,11 +256,34 @@ function collectAllowedNames(
   return allowed;
 }
 
+/**
+ * Build the global "all Ruby method candidate names anywhere in Rails-land"
+ * set, used to classify each extra as novel (nowhere in Rails) vs moved
+ * (somewhere in Rails, just not in the matched file).
+ */
+export function buildGlobalRubyCandidates(ruby: ApiManifest): Set<string> {
+  const all = new Set<string>();
+  for (const pkg of Object.values(ruby.packages)) {
+    const entities = [...Object.values(pkg.classes), ...Object.values(pkg.modules)] as ClassInfo[];
+    for (const e of entities) {
+      for (const m of [...e.instanceMethods, ...e.classMethods]) {
+        if (m.internal === true) continue;
+        const candidates = rubyMethodToTs(m.name);
+        if (!candidates) continue;
+        for (const c of candidates) all.add(c);
+      }
+    }
+  }
+  return all;
+}
+
 function buildPackageReport(
   pkg: string,
   ruby: ApiManifest,
   ts: ApiManifest,
   excludeGlobs: string[],
+  globalRubyCandidates: Set<string>,
+  novelOnly: boolean,
 ): PackageTotals {
   const rubyPkg = ruby.packages[pkg];
   const tsPkg = ts.packages[pkg];
@@ -226,6 +291,8 @@ function buildPackageReport(
     package: pkg,
     filesWithDrift: 0,
     totalExtras: 0,
+    totalNovel: 0,
+    totalMoved: 0,
     extraFiles: [],
   };
   if (!rubyPkg || !tsPkg) return result;
@@ -280,25 +347,48 @@ function buildPackageReport(
       moduleFqnByShort,
     );
 
-    const extras: string[] = [];
+    const extras: ExtraName[] = [];
+    let novelCount = 0;
+    let movedCount = 0;
     for (const name of tsNames) {
-      if (!allowed.has(name)) extras.push(name);
+      if (allowed.has(name)) continue;
+      const kind: ExtraKind = globalRubyCandidates.has(name) ? "moved" : "novel";
+      if (novelOnly && kind !== "novel") continue;
+      extras.push({ name, kind });
+      if (kind === "novel") novelCount++;
+      else movedCount++;
     }
     if (extras.length === 0) continue;
 
-    extras.sort();
+    // Sort novel before moved, then alphabetical — novel is the higher-signal
+    // tier and surfaces first in per-file detail dumps.
+    extras.sort((a, b) =>
+      a.kind === b.kind ? a.name.localeCompare(b.name) : a.kind === "novel" ? -1 : 1,
+    );
     result.extraFiles.push({
       package: pkg,
       tsFile: expectedTs,
       rubyFile,
       extraCount: extras.length,
+      novelCount,
+      movedCount,
       extras,
     });
     result.filesWithDrift++;
     result.totalExtras += extras.length;
+    result.totalNovel += novelCount;
+    result.totalMoved += movedCount;
   }
 
-  result.extraFiles.sort((a, b) => b.extraCount - a.extraCount || a.tsFile.localeCompare(b.tsFile));
+  // Rank order: novel-first when --novel-only is on (only novel exists),
+  // and otherwise rank by novel count (high-signal) then total. Pure-moved
+  // barrel files (588 extras, 0 novel) drop below smaller novel-heavy files.
+  result.extraFiles.sort(
+    (a, b) =>
+      b.novelCount - a.novelCount ||
+      b.extraCount - a.extraCount ||
+      a.tsFile.localeCompare(b.tsFile),
+  );
   return result;
 }
 
@@ -316,56 +406,113 @@ function colorCount(n: number, useColor: boolean): string {
   return String(n);
 }
 
-function printHumanReport(report: Report, topN: number): void {
+function printHumanReport(report: Report, topN: number, maxDetail: number): void {
   const useColor = process.stdout.isTTY === true;
 
   console.log(`\n${BOLD}Extra TS surface vs Rails${RESET}  (the inverse of api:compare)`);
-  console.log(`${DIM}Generated ${report.generatedAt}${RESET}\n`);
+  console.log(
+    `${DIM}Generated ${report.generatedAt}  |  novel = name not found anywhere in Rails;  moved = found, just in a different .rb${RESET}\n`,
+  );
 
   console.log(`${BOLD}Per-package totals${RESET}`);
   console.log(
-    `  ${"Package".padEnd(20)} ${"Files w/ drift".padStart(15)} ${"Extra names".padStart(13)}`,
+    `  ${"Package".padEnd(20)} ${"Files".padStart(7)} ${"Novel".padStart(7)} ${"Moved".padStart(7)} ${"Total".padStart(7)}`,
   );
-  console.log(`  ${"-".repeat(20)} ${"-".repeat(15)} ${"-".repeat(13)}`);
+  console.log(
+    `  ${"-".repeat(20)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)}`,
+  );
   for (const pkg of report.packages) {
+    const novel = colorCount(pkg.totalNovel, useColor);
+    const pad = useColor ? 16 : 7;
     console.log(
-      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(15)} ${colorCount(pkg.totalExtras, useColor).padStart(useColor ? 22 : 13)}`,
+      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel.padStart(pad)} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)}`,
     );
   }
 
-  console.log(`\n${BOLD}Top ${Math.min(topN, report.topN.length)} most-divergent files${RESET}`);
   console.log(
-    `  ${"#".padStart(3)}  ${"Extra".padStart(5)}  ${"Package".padEnd(16)} ${"TS file".padEnd(60)}`,
+    `\n${BOLD}Top ${Math.min(topN, report.topN.length)} most-divergent files${RESET}  ${DIM}(ranked by novel count, then total)${RESET}`,
   );
-  console.log(`  ${"-".repeat(3)}  ${"-".repeat(5)}  ${"-".repeat(16)} ${"-".repeat(60)}`);
+  console.log(
+    `  ${"#".padStart(3)}  ${"Novel".padStart(5)}  ${"Moved".padStart(5)}  ${"Package".padEnd(16)} ${"TS file".padEnd(60)}`,
+  );
+  console.log(
+    `  ${"-".repeat(3)}  ${"-".repeat(5)}  ${"-".repeat(5)}  ${"-".repeat(16)} ${"-".repeat(60)}`,
+  );
   for (let i = 0; i < Math.min(topN, report.topN.length); i++) {
     const f = report.topN[i];
-    const c = colorCount(f.extraCount, useColor);
+    const c = colorCount(f.novelCount, useColor);
+    const pad = useColor ? 14 : 5;
     console.log(
-      `  ${String(i + 1).padStart(3)}  ${c.padStart(useColor ? 14 : 5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
+      `  ${String(i + 1).padStart(3)}  ${c.padStart(pad)}  ${String(f.movedCount).padStart(5)}  ${f.package.padEnd(16)} ${f.tsFile.padEnd(60)}`,
     );
   }
 
   console.log(
-    `\n${BOLD}Per-file detail${RESET} (only files with drift; sorted by extra count desc)\n`,
+    `\n${BOLD}Per-file detail${RESET}  ${DIM}(novel-first; moved names dimmed; +N more elided when over --max-detail)${RESET}\n`,
   );
   for (const pkg of report.packages) {
     if (pkg.extraFiles.length === 0) continue;
     console.log(`${BOLD}${pkg.package}${RESET}`);
     for (const f of pkg.extraFiles) {
-      console.log(`  ${f.tsFile} — +${f.extraCount} over Rails`);
+      const novelTag = useColor
+        ? colorCount(f.novelCount, useColor) + " novel"
+        : `${f.novelCount} novel`;
+      console.log(`  ${f.tsFile} — ${novelTag}, ${f.movedCount} moved`);
+      const shown = maxDetail > 0 ? f.extras.slice(0, maxDetail) : f.extras;
       const cols = 4;
-      for (let i = 0; i < f.extras.length; i += cols) {
-        const row = f.extras.slice(i, i + cols).map((n) => n.padEnd(24));
+      for (let i = 0; i < shown.length; i += cols) {
+        const row = shown.slice(i, i + cols).map((e) => {
+          const label = e.name.padEnd(24);
+          return useColor && e.kind === "moved" ? `${DIM}${label}${RESET}` : label;
+        });
         console.log(`    ${row.join(" ")}`);
       }
+      const elided = f.extras.length - shown.length;
+      if (elided > 0) console.log(`    ${DIM}… +${elided} more${RESET}`);
     }
     console.log();
   }
 }
 
+export function buildReport(
+  ruby: ApiManifest,
+  ts: ApiManifest,
+  opts: {
+    filterPkg: string | null;
+    excludeGlobs: string[];
+    novelOnly: boolean;
+    topN: number;
+  },
+): Report {
+  const globalRubyCandidates = buildGlobalRubyCandidates(ruby);
+
+  const packages: PackageTotals[] = [];
+  for (const pkg of Object.keys(ruby.packages)) {
+    if (opts.filterPkg && pkg !== opts.filterPkg) continue;
+    if (!ts.packages[pkg]) continue;
+    packages.push(
+      buildPackageReport(pkg, ruby, ts, opts.excludeGlobs, globalRubyCandidates, opts.novelOnly),
+    );
+  }
+  packages.sort((a, b) => b.totalNovel - a.totalNovel || b.totalExtras - a.totalExtras);
+
+  const allExtras: ExtraFile[] = packages.flatMap((p) => p.extraFiles);
+  allExtras.sort(
+    (a, b) =>
+      b.novelCount - a.novelCount ||
+      b.extraCount - a.extraCount ||
+      a.tsFile.localeCompare(b.tsFile),
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    packages,
+    topN: allExtras.slice(0, opts.topN),
+  };
+}
+
 export function main(argv = process.argv.slice(2)): void {
-  const { filterPkg, topN, json, excludeGlobs } = parseArgs(argv);
+  const args = parseArgs(argv);
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-api.json");
@@ -378,28 +525,18 @@ export function main(argv = process.argv.slice(2)): void {
   const ruby: ApiManifest = JSON.parse(fs.readFileSync(rubyPath, "utf-8"));
   const ts: ApiManifest = JSON.parse(fs.readFileSync(tsPath, "utf-8"));
 
-  const packages: PackageTotals[] = [];
-  for (const pkg of Object.keys(ruby.packages)) {
-    if (filterPkg && pkg !== filterPkg) continue;
-    if (!ts.packages[pkg]) continue;
-    packages.push(buildPackageReport(pkg, ruby, ts, excludeGlobs));
-  }
-  packages.sort((a, b) => b.totalExtras - a.totalExtras);
+  const report = buildReport(ruby, ts, {
+    filterPkg: args.filterPkg,
+    excludeGlobs: args.excludeGlobs,
+    novelOnly: args.novelOnly,
+    topN: args.topN,
+  });
 
-  const allExtras: ExtraFile[] = packages.flatMap((p) => p.extraFiles);
-  allExtras.sort((a, b) => b.extraCount - a.extraCount || a.tsFile.localeCompare(b.tsFile));
-
-  const report: Report = {
-    generatedAt: new Date().toISOString(),
-    packages,
-    topN: allExtras.slice(0, topN),
-  };
-
-  if (json) {
+  if (args.json) {
     console.log(JSON.stringify(report, null, 2));
     return;
   }
-  printHumanReport(report, topN);
+  printHumanReport(report, args.topN, args.maxDetail);
 }
 
 const invokedAsScript =

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -16,8 +16,11 @@
  *   3. Collect public TS names declared in the matching TS file — each
  *      class/module's *own* methods (skipping inherited surface so the
  *      diff measures this file's drift, not its ancestor's) plus top-level
- *      `fileFunctions`. Filter out `internal: true` (covers `_`-prefixed,
- *      `@internal` JSDoc, `private`/`protected`, `#`-prefixed fields).
+ *      `fileFunctions`. Filter out `internal: true` (Ruby private/protected,
+ *      TS private/protected, TS `#`-prefixed fields, `@internal` JSDoc) and
+ *      separately filter `_`-prefixed names — the extractor keeps those as
+ *      public exports; the Rails-private convention in this repo means they
+ *      should not count toward extra surface.
  *   4. Extra = TS names \ allowed names. Emit per-file, per-package, and
  *      top-N reports.
  *
@@ -200,6 +203,11 @@ export function parseArgs(argv: string[]): CliArgs {
  * inherited surface. Inherited names that the parent already defines are
  * not "drift" relative to Rails; they're the parent's problem (and Rails
  * inherits them too).
+ *
+ * The extractor keeps `_`-prefixed exports as public (only Ruby
+ * `private`/`protected`, TS `private`/`protected`, `#`-prefixed fields,
+ * and `@internal` JSDoc set `internal: true`). The Rails-private
+ * convention in this repo means we filter `_`-prefix here too.
  */
 function collectTsFileNames(
   file: string,
@@ -228,29 +236,59 @@ function collectTsFileNames(
 }
 
 /**
+ * Pre-fold `Foo::ClassMethods` submodules (the `ActiveSupport::Concern`
+ * idiom) into `Foo.classMethods`, mirroring compare.ts's pre-pass. This
+ * pre-fold lives in compare.ts at the consumer level (not in the Ruby
+ * extractor), so we replicate it here for the same semantics: when a host
+ * `include Foo`, the host gains `Foo::ClassMethods`'s instanceMethods as
+ * class methods even though only `Foo` is named in the include list.
+ *
+ * Returns the set of FQNs that were merged-and-skip-listed so the caller
+ * doesn't double-count them when iterating modules.
+ */
+function foldClassMethodsModules(modules: Record<string, ClassInfo>): Set<string> {
+  const folded = new Set<string>();
+  for (const [fqn, info] of Object.entries(modules)) {
+    if (!fqn.endsWith("::ClassMethods")) continue;
+    const parentFqn = fqn.replace(/::ClassMethods$/, "");
+    const parent = modules[parentFqn];
+    if (!parent) continue;
+    for (const m of info.instanceMethods) {
+      if (!parent.classMethods.some((pm) => pm.name === m.name)) {
+        parent.classMethods.push(m);
+      }
+    }
+    folded.add(fqn);
+  }
+  return folded;
+}
+
+/**
  * For one Ruby file's entities, compute the union of all TS candidate names
  * produced by `rubyMethodToTs`. Mirrors `compare.flattenIncludedMethodInfos`
- * mixin routing:
+ * mixin routing exactly:
  *
  *   - `include M`: M's instance methods land on the host as instance methods.
  *     A nested `include N` inside M chains through (instance methods only).
  *     M's own `extend` chain does NOT propagate to the host — Ruby `extend`
  *     affects only the receiver's singleton class.
  *   - `extend M` (at host level): M's instance methods land as class methods.
+ *   - Module `classMethods` are NOT propagated through include/extend (Ruby
+ *     semantics; `flattenIncludedMethodInfos` only pushes `instanceMethods`).
+ *     The `ActiveSupport::Concern` "class methods via include" pattern is
+ *     handled by `foldClassMethodsModules` above, which moves the nested
+ *     `ClassMethods` submodule's instanceMethods into the parent's own
+ *     `classMethods` — flattening still only reads `instanceMethods`, so
+ *     ASC class methods become entity-level surface, not propagated mixins.
  *
- *   - Module `classMethods` are kept here because the api-compare extractor
- *     folds nested `ClassMethods` submodules (the `ActiveSupport::Concern`
- *     idiom) into their parent module's `classMethods` before we see them.
- *     Excluding them would drop the most common Rails mixin pattern from
- *     the allowed-name set and inflate false-positive extras.
+ * Since `allowed` is a flat name set (instance vs class collapsed on the TS
+ * side anyway), we simply union both `instanceMethods` and `classMethods`
+ * for the *host* entity, but ONLY `instanceMethods` for walked-into mixins.
  *
  * `include` names are resolved via compare.ts's `resolveModuleName`, which
  * walks namespace prefixes — `AbstractAdapter` including `"Quoting"` maps
  * only to `ConnectionAdapters::Quoting`, never to PG/MySQL siblings of the
- * same short name. The flat-by-short-name lookup we used before pulled in
- * unrelated modules and silently inflated `allowed`.
- *
- * Cross-package or stdlib mixins are silently skipped — same as compare.ts.
+ * same short name. Cross-package / stdlib mixins are silently skipped.
  */
 function collectAllowedNames(
   entities: RubyEntity[],
@@ -276,10 +314,12 @@ function collectAllowedNames(
       visited.add(fqn);
       const mod = rubyModules[fqn];
       if (!mod) continue;
+      // Only the module's instance methods cross into the host. Class
+      // methods on the module itself stay on the module (Ruby `include`
+      // semantics; matches compare.flattenIncludedMethodInfos).
       addMethods(mod.instanceMethods);
-      addMethods(mod.classMethods);
-      // Only chain `include`s — a module's own `extend` doesn't propagate
-      // to the host (Ruby singleton-class semantics).
+      // Chain `include`s only — a module's own `extend` doesn't propagate
+      // (Ruby singleton-class semantics).
       for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
     }
   };
@@ -334,8 +374,13 @@ function buildPackageReport(
   };
   if (!rubyPkg || !tsPkg) return result;
 
+  // Pre-fold ASC's `::ClassMethods` submodules into their parent's
+  // classMethods (mirrors compare.ts:759-773). Mutates rubyPkg.modules.
+  const foldedFqns = foldClassMethodsModules(rubyPkg.modules as Record<string, ClassInfo>);
+
   const moduleFqnByShort = new Map<string, string[]>();
   for (const fqn of Object.keys(rubyPkg.modules)) {
+    if (foldedFqns.has(fqn)) continue;
     const short = fqn.split("::").pop();
     if (!short) continue;
     const list = moduleFqnByShort.get(short) ?? [];
@@ -343,12 +388,30 @@ function buildPackageReport(
     moduleFqnByShort.set(short, list);
   }
 
-  const rubyFiles = new Map<string, RubyEntity[]>();
-  for (const [fqn, info] of [
-    ...Object.entries(rubyPkg.classes),
-    ...Object.entries(rubyPkg.modules),
-  ] as [string, ClassInfo][]) {
+  // Match compare.ts's nested-class filter: for each file, keep only the
+  // shortest-named class as the "primary" and skip nested classes that
+  // share the same file (e.g. `Preloader::Association::LoaderQuery` in
+  // `preloader/association.rb` is an implementation detail — its methods
+  // shouldn't inflate the parent file's allowed-name set).
+  const primaryClassPerFile = new Map<string, string>();
+  for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
+    const existing = primaryClassPerFile.get(info.file);
+    if (!existing || fqn.split("::").length < existing.split("::").length) {
+      primaryClassPerFile.set(info.file, fqn);
+    }
+  }
+
+  const rubyFiles = new Map<string, RubyEntity[]>();
+  for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
+    if (!info.file) continue;
+    const primary = primaryClassPerFile.get(info.file);
+    if (primary && primary !== fqn && fqn.startsWith(primary + "::")) continue;
+    pushTo(rubyFiles, info.file, { fqn, info });
+  }
+  for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
+    if (!info.file) continue;
+    if (foldedFqns.has(fqn)) continue;
     pushTo(rubyFiles, info.file, { fqn, info });
   }
 


### PR DESCRIPTION
## Summary

Inverse of `pnpm api:compare`: surfaces TS public methods/functions/getters/setters that **don't** map back to a Ruby method in the matched Rails file, so we can prune toward Rails-faithful shape.

- New script: `scripts/api-compare/extra-surface.ts` (wired as `pnpm api:extra`)
- Co-located tests: `scripts/api-compare/extra-surface.test.ts` (8 tests, all passing)
- Reuses `conventions.rubyFileToTs` / `rubyMethodToTs` and consumes the same `rails-api.json` / `ts-api.json` manifests as `api:compare` — no duplicate parsers
- Read-only audit, no source modifications
- Filters `_`-prefixed, `internal` (Ruby/TS private/protected, `#`-fields, `@internal` JSDoc), and inherited surface — each file's own declarations only

### Novel vs moved classification

Every extra is tagged:

- **novel** — the candidate name appears *nowhere* in Rails-land (high-signal: TS-only helpers, accidental public surface, Ruby-private→TS-public promotions)
- **moved** — Rails defines a same-camelized method, just in a different `.rb` (mostly barrel-file re-exports)

Files are ranked by novel count first, so barrel aggregators stop dominating the top. Example: `connection-adapters.ts` has 588 total extras but only 150 novel; `relation/finder-methods.ts` has 44 — but **0 moved**, so it's pure TS drift and ranks high despite the smaller total.

### Flags

- `--package <name>` · `--top <N>` (default 50) · `--json`
- `--exclude-glob <substring>` (repeatable; for known-intentional extensions like `dx-tests/`)
- `--novel-only` — drop moved extras entirely
- `--max-detail <N>` — cap per-file detail listing (default 40; 0 = unlimited)
- `--help`

## Sample output

### Per-package totals

```
  Package                Files   Novel   Moved   Total
  -------------------- ------- ------- ------- -------
  activerecord             232    1623    1961    3584
  activemodel               51     196     169     365
  activesupport             44     169     139     308
  arel                      60     110     147     257
  actioncontroller          38      78      82     160
  rack                      11      49      47      96
  actionview                 3      16       4      20
  actiondispatch             5      10       9      19
  trailties                  1       4       2       6
  globalid                   1       1       3       4
  abstractcontroller         0       0       0       0
```

### Top 20 most-divergent files (ranked by novel)

```
    #  Novel  Moved  Package          TS file
  ---  -----  -----  ---------------- ------------------------------------------------------------
    1    150    438  activerecord     connection-adapters.ts
    2    139    217  activerecord     base.ts
    3     67    120  activerecord     connection-adapters/postgresql-adapter.ts
    4     67     17  activerecord     connection-adapters/abstract-adapter.ts
    5     47      1  activerecord     relation/query-methods.ts
    6     46     79  activerecord     associations.ts
    7     44     16  activerecord     migration/command-recorder.ts
    8     44      0  activerecord     relation/finder-methods.ts
    9     43      1  activerecord     connection-adapters/abstract/schema-statements.ts
   10     40     28  activerecord     connection-adapters/abstract-mysql-adapter.ts
   11     39     57  activerecord     migration.ts
   12     38     67  activemodel      model.ts
   13     37     82  activerecord     inheritance.ts
   14     35     17  activerecord     relation.ts
   15     30      8  activerecord     connection-adapters/postgresql/schema-statements.ts
   16     28     16  activerecord     connection-adapters/postgresql/schema-definitions.ts
   17     28     16  activesupport    time-with-zone.ts
   18     24      4  activerecord     tasks/database-tasks.ts
   19     24      0  activerecord     autosave-association.ts
   20     23     10  activerecord     connection-adapters/abstract/database-statements.ts
```

Notice rows 8 and 19 — pure-novel files (0 moved) — surface alongside barrel files even when their absolute totals are an order of magnitude smaller. That's the rank tweak doing real work.

### Signal-vs-noise notes

- Barrel files (`connection-adapters.ts`, `base.ts`) re-export public surface from sibling files; their high moved counts are expected. Filter with `--exclude-glob connection-adapters.ts --exclude-glob base.ts` when surveying genuine novel additions, or just `--novel-only`.
- Many "novel" names in finder-methods (`findOne`, `findSome`, `findNth*`) are Ruby-private methods promoted to TS-public surface — that's correctly real drift worth auditing.
- Tooling does no intentionality categorization (per spec); the human filters via `--exclude-glob`.

## Test plan

- [x] `pnpm vitest run scripts/api-compare/extra-surface.test.ts` — 8/8 passing (parseArgs, global candidates, novel/moved classification, `--novel-only`, `--exclude-glob`, ranking)
- [x] `pnpm api:extra` runs end-to-end and produces the report above
- [x] `pnpm api:extra --package globalid --json` emits parseable JSON
- [x] `pnpm api:extra --novel-only --exclude-glob connection-adapters.ts --top 5` filters and re-ranks
- [x] `pnpm typecheck` clean
- [x] Prettier + lint clean