### PR TITLE
feat(activerecord): MySQL active-schema Slot C — addIndex output + inline t.index

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -504,6 +504,12 @@ export interface DatabaseAdapter {
   supportsCommentsInCreate?(): boolean;
 
   /**
+   * Whether the adapter supports inline INDEX clauses inside CREATE TABLE.
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#supports_indexes_in_create?
+   */
+  supportsIndexesInCreate?(): boolean;
+
+  /**
    * Set or clear the comment on a table after it has been created.
    * Called by SchemaStatements#createTable when supportsComments() is true but
    * supportsCommentsInCreate() is false. The second parameter is `string | null`

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -90,10 +90,28 @@ describeIfMysql("Mysql2Adapter", () => {
       );
     });
 
-    it.skip("index in create", () => {
-      // BLOCKED: adapter-mysql — createTable callback form needed + index-in-create emission
-      // ROOT-CAUSE: MySQL createTable does not wire up inline INDEX clauses from TableDefinition.index()
-      // SCOPE: Slot C (mysql DDL parity)
+    it("index in create", async () => {
+      for (const type of ["SPATIAL", "FULLTEXT", "UNIQUE"]) {
+        const sqls = await captureSql(() =>
+          adapter.schemaStatements().createTable("people", { id: false }, (t) => {
+            t.index(["last_name"], { type });
+          }),
+        );
+        expect(sqls[0]).toMatch(
+          new RegExp(
+            `^CREATE TABLE \`people\` \\(${type} INDEX \`index_people_on_last_name\` \\(\`last_name\`\\)\\)`,
+          ),
+        );
+      }
+
+      const sqls = await captureSql(() =>
+        adapter.schemaStatements().createTable("people", { id: false }, (t) => {
+          t.index(["last_name"], { length: { last_name: 10 }, using: "btree" });
+        }),
+      );
+      expect(sqls[0]).toMatch(
+        /^CREATE TABLE `people` \(INDEX `index_people_on_last_name` USING btree \(`last_name`\(10\)\)\)/,
+      );
     });
     it.skip("index in bulk change", () => {
       // BLOCKED: adapter-mysql — changeTable bulk-mode not implemented for MySQL
@@ -161,10 +179,21 @@ describeIfMysql("Mysql2Adapter", () => {
       // ROOT-CAUSE: removeTimestamps needs a live table; captureSql-only harness insufficient
       // SCOPE: Slot D (live-table tests)
     });
-    it.skip("indexes in create", () => {
-      // BLOCKED: adapter-mysql — createTable TEMPORARY + AS SELECT not implemented
-      // ROOT-CAUSE: createTable options.temporary and options.as not wired in MysqlSchemaCreation
-      // SCOPE: Slot C (mysql DDL parity)
+    it("indexes in create", async () => {
+      const sqls = await captureSql(() =>
+        adapter
+          .schemaStatements()
+          .createTable(
+            "temp",
+            { temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query" },
+            (t) => {
+              t.index(["zip"]);
+            },
+          ),
+      );
+      expect(sqls[0]).toMatch(
+        /^CREATE TEMPORARY TABLE `temp` \(INDEX `index_temp_on_zip` \(`zip`\)\) AS SELECT id, name, zip FROM a_really_complicated_query/,
+      );
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -967,6 +967,26 @@ export class TableDefinition {
     return this;
   }
 
+  /** @internal Builds MySQL inline INDEX clause for use inside CREATE TABLE (...). */
+  private _mysqlInlineIndexSql(idx: IndexDefinition): string {
+    const indexType = idx.type?.toUpperCase() ?? (idx.unique ? "UNIQUE" : undefined);
+    const parts: string[] = [];
+    if (indexType) parts.push(indexType);
+    parts.push("INDEX");
+    parts.push(this._adapter.quoteIdentifier(idx.name));
+    if (idx.using) parts.push(`USING ${idx.using}`);
+    const cols = Array.isArray(idx.columns) ? idx.columns : [idx.columns];
+    const quotedCols = cols.map((c) => {
+      let q = this._adapter.quoteIdentifier(c);
+      const lengths = idx.lengths as Record<string, number> | number | undefined;
+      const len = typeof lengths === "number" ? lengths : (lengths as Record<string, number>)?.[c];
+      if (len != null) q += `(${len})`;
+      return q;
+    });
+    parts.push(`(${quotedCols.join(", ")})`);
+    return parts.join(" ");
+  }
+
   /**
    * Generate CREATE TABLE SQL.
    */
@@ -1124,7 +1144,12 @@ export class TableDefinition {
     sql += ` ${this._adapter.quoteTableName(this.tableName)}`;
 
     if (this.as) {
-      sql += ` AS ${this.as}`;
+      if (this._adapterName === "mysql" && this.indexes.length > 0) {
+        const inlineIdxSql = this.indexes.map((idx) => this._mysqlInlineIndexSql(idx));
+        sql += ` (${inlineIdxSql.join(", ")}) AS ${this.as}`;
+      } else {
+        sql += ` AS ${this.as}`;
+      }
     } else {
       const tableElements = [...columnDefs];
       for (const chk of this.checkConstraints) {
@@ -1162,6 +1187,11 @@ export class TableDefinition {
           .map((k) => this._adapter.quoteIdentifier(k))
           .join(", ");
         tableElements.push(`PRIMARY KEY (${quotedCols})`);
+      }
+      if (this._adapterName === "mysql") {
+        for (const idx of this.indexes) {
+          tableElements.push(this._mysqlInlineIndexSql(idx));
+        }
       }
       sql += ` (${tableElements.join(", ")})`;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -984,7 +984,9 @@ export class TableDefinition {
       return q;
     });
     parts.push(`(${quotedCols.join(", ")})`);
-    return parts.join(" ");
+    let sql = parts.join(" ");
+    if (idx.comment) sql += ` COMMENT '${idx.comment.replace(/'/g, "''")}'`;
+    return sql;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -985,7 +985,7 @@ export class TableDefinition {
     });
     parts.push(`(${quotedCols.join(", ")})`);
     let sql = parts.join(" ");
-    if (idx.comment) sql += ` COMMENT '${idx.comment.replace(/'/g, "''")}'`;
+    if (idx.comment) sql += ` COMMENT '${idx.comment.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
     return sql;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -167,22 +167,24 @@ export class SchemaStatements {
       await this.adapter.changeTableComment(name, options.comment);
     }
 
-    for (const idx of td.indexes) {
-      await this.addIndex(name, idx.columns, {
-        unique: idx.unique,
-        name: idx.name,
-        where: idx.where,
-        order: expandIndexOption(idx.orders, idx.columns) as Record<string, string>,
-        using: idx.using,
-        type: idx.type,
-        comment: idx.comment,
-        length: expandIndexOption(idx.lengths, idx.columns) as Record<string, number>,
-        opclass: expandIndexOption(idx.opclasses, idx.columns) as Record<string, string>,
-        include: idx.include,
-        nullsNotDistinct: idx.nullsNotDistinct,
-        algorithm: idx.algorithm,
-        ifNotExists: idx.ifNotExists,
-      });
+    if (this.adapter.adapterName !== "mysql") {
+      for (const idx of td.indexes) {
+        await this.addIndex(name, idx.columns, {
+          unique: idx.unique,
+          name: idx.name,
+          where: idx.where,
+          order: expandIndexOption(idx.orders, idx.columns) as Record<string, string>,
+          using: idx.using,
+          type: idx.type,
+          comment: idx.comment,
+          length: expandIndexOption(idx.lengths, idx.columns) as Record<string, number>,
+          opclass: expandIndexOption(idx.opclasses, idx.columns) as Record<string, string>,
+          include: idx.include,
+          nullsNotDistinct: idx.nullsNotDistinct,
+          algorithm: idx.algorithm,
+          ifNotExists: idx.ifNotExists,
+        });
+      }
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -167,7 +167,7 @@ export class SchemaStatements {
       await this.adapter.changeTableComment(name, options.comment);
     }
 
-    if (this.adapter.adapterName !== "mysql") {
+    if (!this.adapter.supportsIndexesInCreate?.()) {
       for (const idx of td.indexes) {
         await this.addIndex(name, idx.columns, {
           unique: idx.unique,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -64,20 +64,30 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   override typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     const limit = options.limit as number | null | undefined;
+    const unsigned = (options as Record<string, unknown>).unsigned;
+    let sql: string;
     switch (type) {
       case "float":
-        return `float(${limit ?? 24})`;
+        sql = `float(${limit ?? 24})`;
+        break;
       case "integer":
-        return integerToSql(limit);
+        sql = integerToSql(limit);
+        break;
       case "text":
-        return typeWithSizeToSql("text", limitToSize(limit ?? null, "text"));
+        sql = typeWithSizeToSql("text", limitToSize(limit ?? null, "text"));
+        break;
       case "blob":
-        return typeWithSizeToSql("blob", limitToSize(limit ?? null, "blob"));
+        sql = typeWithSizeToSql("blob", limitToSize(limit ?? null, "blob"));
+        break;
       case "binary":
-        if (limit != null && limit >= 0 && limit <= 0xfff) return `varbinary(${limit})`;
-        return typeWithSizeToSql("blob", limitToSize(limit ?? null, "binary"));
+        sql =
+          limit != null && limit >= 0 && limit <= 0xfff
+            ? `varbinary(${limit})`
+            : typeWithSizeToSql("blob", limitToSize(limit ?? null, "binary"));
+        break;
       case "string":
-        return `varchar(${limit ?? 255})`;
+        sql = `varchar(${limit ?? 255})`;
+        break;
       case "datetime":
       case "timestamp": {
         const base = type === "timestamp" ? "timestamp" : "datetime";
@@ -86,7 +96,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
           throw new ArgumentError(
             `No ${base} type has precision of ${p}. The allowed range of precision is from 0 to 6`,
           );
-        return p != null ? `${base}(${p})` : base;
+        sql = p != null ? `${base}(${p})` : base;
+        break;
       }
       case "time": {
         const p = options.precision;
@@ -94,30 +105,43 @@ export class SchemaCreation extends AbstractSchemaCreation {
           throw new ArgumentError(
             `No time type has precision of ${p}. The allowed range of precision is from 0 to 6`,
           );
-        return p != null ? `time(${p})` : "time";
+        sql = p != null ? `time(${p})` : "time";
+        break;
       }
       case "date":
-        return "date";
+        sql = "date";
+        break;
       case "bigint":
-        return "bigint";
+        sql = "bigint";
+        break;
       case "decimal": {
         const p = options.precision;
         const s = options.scale;
-        if (p != null && s != null) return `decimal(${p},${s})`;
-        if (p != null) return `decimal(${p})`;
-        if (s != null)
+        if (p != null && s != null) {
+          sql = `decimal(${p},${s})`;
+        } else if (p != null) {
+          sql = `decimal(${p})`;
+        } else if (s != null) {
           throw new ArgumentError(
             "Error adding decimal column: precision cannot be empty if scale is specified",
           );
-        return "decimal";
+        } else {
+          sql = "decimal";
+        }
+        break;
       }
       case "boolean":
-        return "tinyint(1)";
+        sql = "tinyint(1)";
+        break;
       case "json":
-        return "json";
+        sql = "json";
+        break;
       default:
-        return super.typeToSql(type, options);
+        sql = super.typeToSql(type, options);
+        break;
     }
+    if (unsigned && type !== "primary_key") sql += " unsigned";
+    return sql;
   }
 
   visitAddForeignKey(fromTable: string, toTable: string, options: Record<string, unknown>): string {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -64,7 +64,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   override typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     const limit = options.limit as number | null | undefined;
-    const unsigned = (options as Record<string, unknown>).unsigned;
+    const unsigned = options.unsigned;
     let sql: string;
     switch (type) {
       case "float":

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1630,7 +1630,16 @@ export class MigrationContext {
     this._columns.set(name, cols);
     this._columnMeta.set(name, meta);
 
-    // Create indexes from table definition
+    // Create indexes from table definition — skip for adapters that emit them inline in CREATE TABLE
+    const adapterWithIndexInCreate = this.adapter as { supportsIndexesInCreate?: () => boolean };
+    if (adapterWithIndexInCreate.supportsIndexesInCreate?.()) {
+      for (const idx of td.indexes) {
+        const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
+        if (!this._indexes.has(name)) this._indexes.set(name, []);
+        this._indexes.get(name)!.push({ ...idx, name: indexName, orders: {} });
+      }
+      return;
+    }
     for (const idx of td.indexes) {
       const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
       const ordersMap: Record<string, string> =

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1075,6 +1075,13 @@ class SchemaAdapter implements DatabaseAdapter {
     );
   }
 
+  supportsIndexesInCreate(): boolean {
+    return (
+      (this.inner as { supportsIndexesInCreate?: () => boolean }).supportsIndexesInCreate?.() ??
+      false
+    );
+  }
+
   supportsAdvisoryLocks(): boolean {
     return (
       (this.inner as { supportsAdvisoryLocks?: () => boolean }).supportsAdvisoryLocks?.() ?? false


### PR DESCRIPTION
## Summary

- `TableDefinition.toSql()`: for MySQL, emit inline `INDEX ...` clauses inside `CREATE TABLE (...)` rather than as post-creation `addIndex` calls
- `TEMPORARY + AS SELECT` with inline index: produces `CREATE TEMPORARY TABLE \`t\` (INDEX ...) AS SELECT ...`
- `createTable` skips the post-creation addIndex loop for MySQL (indexes are inline, matching `supportsIndexesInCreate? => true`)
- `typeToSql`: append `" unsigned"` suffix when `options.unsigned && type !== "primary_key"` (Slot B followup)
- Un-skip `"index in create"` and `"indexes in create"` tests with bodies

## Test plan

- [ ] `"index in create"`: SPATIAL/FULLTEXT/UNIQUE inline index + btree+length combo verified via `captureSql` pattern match
- [ ] `"indexes in create"`: TEMPORARY + AS SELECT with inline index produces correct SQL
- [ ] Existing `"add index"` test (14 assertions) unaffected
- [ ] `schema-statements.test.ts` (31 tests) still pass
- [ ] TypeScript build clean