### PR TITLE
feat(activerecord): Relation Slot H — small-surface bundle

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2665,6 +2665,8 @@ export class Base extends Model {
         um.where(table.get(lockCol).eq(Number(rawVersion) || 0));
       }
     }
+    const updateDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
+    if (updateDefaultConstraint != null) um.where(updateDefaultConstraint as any);
 
     const umVisitor = ctor.adapter.arelVisitor;
     this._pendingOperation = ctor.adapter
@@ -2705,6 +2707,8 @@ export class Base extends Model {
             dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
           }
         }
+        const destroyDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
+        if (destroyDefaultConstraint != null) dm.where(destroyDefaultConstraint as any);
 
         const affected = await ctor.adapter.execDelete(dm.toSql(), `${ctor.name} Destroy`);
         if (ctor.lockingEnabled && affected === 0) {

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -741,12 +741,54 @@ describe("EachTest", () => {
     // ROOT-CAUSE fixed: findEach no longer throws on CPK; table alias needs Relation.create test infra
   });
 
-  it.skip(".in_batches should start from the start option when using composite primary key", () => {
-    // ROOT-CAUSE fixed: inBatches start option works with composite PKs
+  it(".in_batches should start from the start option when using composite primary key", async () => {
+    const adp = freshAdapter();
+    class Order extends Base {
+      static {
+        this.primaryKey = ["shopId", "id"];
+        this.attribute("shopId", "integer");
+        this.attribute("id", "integer");
+        this.adapter = adp;
+      }
+    }
+    await Order.create({ shopId: 1, id: 1 });
+    await Order.create({ shopId: 1, id: 2 });
+    await Order.create({ shopId: 1, id: 3 });
+    const second = (await Order.all().toArray())[1];
+    const startId = [second.readAttribute("shopId"), second.readAttribute("id")];
+    let firstBatch: any = null;
+    for await (const rel of Order.inBatches({ batchSize: 1, start: startId })) {
+      firstBatch = rel;
+      break;
+    }
+    expect(firstBatch).not.toBeNull();
+    const record = (await firstBatch.toArray())[0];
+    expect(record.readAttribute("id")).toBe(second.readAttribute("id"));
   });
 
-  it.skip(".in_batches should end at the finish option when using composite primary key", () => {
-    // ROOT-CAUSE fixed: inBatches finish option works with composite PKs
+  it(".in_batches should end at the finish option when using composite primary key", async () => {
+    const adp = freshAdapter();
+    class Order extends Base {
+      static {
+        this.primaryKey = ["shopId", "id"];
+        this.attribute("shopId", "integer");
+        this.attribute("id", "integer");
+        this.adapter = adp;
+      }
+    }
+    await Order.create({ shopId: 1, id: 1 });
+    await Order.create({ shopId: 1, id: 2 });
+    await Order.create({ shopId: 1, id: 3 });
+    const allOrders = await Order.all().toArray();
+    const secondToLast = allOrders[allOrders.length - 2];
+    const finishId = [secondToLast.readAttribute("shopId"), secondToLast.readAttribute("id")];
+    const batches: any[] = [];
+    for await (const rel of Order.inBatches({ batchSize: 1, finish: finishId })) {
+      batches.push(rel);
+    }
+    const lastBatch = batches[batches.length - 1];
+    const records = await lastBatch.toArray();
+    expect(records[records.length - 1].readAttribute("id")).toBe(secondToLast.readAttribute("id"));
   });
 });
 

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -733,8 +733,20 @@ describe("EachTest", () => {
     // ROOT-CAUSE fixed: cursor option supported; needs Subscriber test fixture
   });
 
-  it.skip("in_batches should return no records if the limit is 0 and load is ", () => {
-    // ROOT-CAUSE fixed: inBatches now supports composite PK and limit option
+  it("in_batches should return no records if the limit is 0 and load is ", async () => {
+    const adp = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    for (let i = 0; i < 3; i++) await Post.create({ title: `post-${i}` });
+    let total = 0;
+    for await (const batch of Post.limit(0).inBatches({ batchSize: 1 })) {
+      total += (await batch.count()) as number;
+    }
+    expect(total).toBe(0);
   });
 
   it.skip(".find_each respects table alias", () => {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -243,6 +243,9 @@ export async function _updateRecord(
     um.where(table.get(col).eq(val));
   }
 
+  const defaultConstraint = buildDefaultConstraint.call(this as any);
+  if (defaultConstraint != null) um.where(defaultConstraint as any);
+
   const adapter = (this as any).adapter;
   if (typeof adapter.update === "function") {
     return adapter.update(um);
@@ -267,6 +270,9 @@ export async function _deleteRecord(
   for (const [col, val] of Object.entries(constraints)) {
     dm.where(table.get(col).eq(val));
   }
+
+  const defaultConstraint = buildDefaultConstraint.call(this as any);
+  if (defaultConstraint != null) dm.where(defaultConstraint as any);
 
   const adapter = (this as any).adapter;
   if (typeof adapter.delete === "function") {
@@ -1379,14 +1385,14 @@ function discriminateClassForRecord<T>(klass: T, _record: Record<string, unknown
 }
 
 /** @internal */
-function buildDefaultConstraint(this: {
+export function buildDefaultConstraint(this: {
   defaultScopes?: { allQueries: boolean; scope: (rel: any) => any }[];
   defaultScoped(
     scope?: any,
     options?: { allQueries?: boolean | null },
-  ): { whereClause: { isEmpty(): boolean; ast: unknown } };
+  ): { _whereClause: { isEmpty(): boolean; ast: unknown } };
 }): unknown {
   if (!this.defaultScopes?.some((s) => s.allQueries)) return undefined;
-  const defaultWhereClause = this.defaultScoped(undefined, { allQueries: true }).whereClause;
+  const defaultWhereClause = this.defaultScoped(undefined, { allQueries: true })._whereClause;
   return defaultWhereClause.isEmpty() ? undefined : defaultWhereClause.ast;
 }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3221,6 +3221,35 @@ export class Relation<T extends Base> {
 
     const batchOrders = _buildBatchOrders(cursorArr, order as any);
 
+    let remaining: number | null = null;
+    let effectiveBatchSize = batchSize;
+    if (this._limitValue !== null) {
+      remaining = this._limitValue;
+      if (remaining < effectiveBatchSize) effectiveBatchSize = remaining;
+    }
+
+    if (this._loaded) {
+      const loadedBatches = _batchOnLoadedRelation({
+        relation: this,
+        start,
+        finish,
+        cursor: cursorArr,
+        order: (order ?? "asc") as any,
+        batchLimit: effectiveBatchSize,
+      });
+      return new BatchEnumerator(async function* () {
+        for (const batchRows of loadedBatches) {
+          const batchRel = self._clone();
+          batchRel._orderClauses = batchOrders.map(
+            ([col, dir]) => [col, dir] as [string, "asc" | "desc"],
+          );
+          (batchRel as any)._records = batchRows;
+          (batchRel as any)._loaded = true;
+          yield stripThenable(batchRel) as LoadedRelation<Relation<T>>;
+        }
+      }, effectiveBatchSize);
+    }
+
     return new BatchEnumerator(
       async function* () {
         const rel = self._clone();
@@ -3232,10 +3261,14 @@ export class Relation<T extends Base> {
           finish,
           cursor: cursorArr,
           order: (order ?? "asc") as any,
-          batchLimit: batchSize,
+          batchLimit: effectiveBatchSize,
           load,
+          remaining,
         })) {
           const batchRel = self._clone();
+          batchRel._orderClauses = batchOrders.map(
+            ([col, dir]) => [col, dir] as [string, "asc" | "desc"],
+          );
           const tuples = (batchRows as any[]).map((r) =>
             cursorArr.map((c) => (r as any).readAttribute(c)),
           );
@@ -3255,7 +3288,7 @@ export class Relation<T extends Base> {
           yield stripThenable(batchRel);
         }
       } as () => AsyncGenerator<LoadedRelation<Relation<T>>>,
-      batchSize,
+      effectiveBatchSize,
     );
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3225,6 +3225,9 @@ export class Relation<T extends Base> {
     let effectiveBatchSize = batchSize;
     if (this._limitValue !== null) {
       remaining = this._limitValue;
+      if (remaining === 0) {
+        return new BatchEnumerator(async function* () {}, batchSize);
+      }
       if (remaining < effectiveBatchSize) effectiveBatchSize = remaining;
     }
 

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -140,11 +140,24 @@ export function batchOnLoadedRelation(opts: {
 }): any[] {
   const { relation, cursor, batchLimit } = opts;
   // relation.records() is async in this codebase; loaded records live on _records.
-  const records: any[] = Array.isArray((relation as any)._records)
-    ? (relation as any)._records
-    : [];
+  let records: any[] = Array.isArray((relation as any)._records) ? (relation as any)._records : [];
   const batchOrders = buildBatchOrders(cursor, opts.order as any);
   const orderDirs = batchOrders.map(([, dir]) => dir);
+
+  if (opts.start != null || opts.finish != null) {
+    const startArr =
+      opts.start != null ? (Array.isArray(opts.start) ? opts.start : [opts.start]) : null;
+    const finishArr =
+      opts.finish != null ? (Array.isArray(opts.finish) ? opts.finish : [opts.finish]) : null;
+    records = records.filter((record) => {
+      const values = recordCursorValues(record, cursor);
+      if (startArr != null && compareValuesForOrder(values, startArr, orderDirs) < 0) return false;
+      if (finishArr != null && compareValuesForOrder(values, finishArr, orderDirs) > 0)
+        return false;
+      return true;
+    });
+  }
+
   const sorted = [...records].sort((a, b) => {
     const v1 = recordCursorValues(a, cursor);
     const v2 = recordCursorValues(b, cursor);

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -188,13 +188,16 @@ export async function* batchOnUnloadedRelation(opts: {
   order: "asc" | "desc" | ("asc" | "desc")[];
   batchLimit: number;
   load?: boolean;
+  remaining?: number | null;
 }): AsyncGenerator<any[]> {
-  const { relation, cursor, batchLimit } = opts;
+  const { relation, cursor } = opts;
+  let { batchLimit } = opts;
+  let remaining: number | null | undefined = opts.remaining;
   const batchOrders = buildBatchOrders(cursor, opts.order as any);
   // Apply start/finish limits once on the base relation; advance cursor per
   // iteration — matching Rails' batch_condition(relation, ...) pattern where
   // `relation` is always the original scoped relation, not the previous batch.
-  const baseRelation = applyLimits(relation, cursor, opts.start, opts.finish, batchOrders).limit(
+  let baseRelation = applyLimits(relation, cursor, opts.start, opts.finish, batchOrders).limit(
     batchLimit,
   );
   const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
@@ -213,6 +216,14 @@ export async function* batchOnUnloadedRelation(opts: {
     if (rows.length === 0) break;
     yield rows;
     if (rows.length < batchLimit) break;
+    if (remaining != null) {
+      remaining -= rows.length;
+      if (remaining === 0) break;
+      if (remaining < batchLimit) {
+        batchLimit = remaining;
+        baseRelation = baseRelation.limit(batchLimit);
+      }
+    }
     lastValues = recordCursorValues(rows[rows.length - 1], cursor);
   }
 }

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1978,9 +1978,7 @@ describe("DefaultScopingTest", () => {
     expect(allQueriesSql).toContain("blog_id");
   });
 
-  it("default_scope_with_all_queries_runs_on_update", () => {
-    // Verify buildDefaultConstraint wires the allQueries scope into the
-    // UpdateManager's WHERE clause by inspecting the generated SQL directly.
+  it("default_scope_with_all_queries_runs_on_update", async () => {
     class Dev extends Base {
       static {
         this.attribute("name", "string");
@@ -1989,12 +1987,20 @@ describe("DefaultScopingTest", () => {
         this.defaultScope((rel: any) => rel.where({ mentor_id: 1 }), { allQueries: true });
       }
     }
-    // The allQueries scope should appear in defaultScoped({allQueries:true})
-    const scoped = (Dev as any).defaultScoped(undefined, { allQueries: true });
-    const sql = scoped.toSql();
-    expect(sql).toContain("mentor_id");
-    // Confirm it's applied via buildDefaultConstraint (non-empty whereClause ast)
-    expect(scoped._whereClause.isEmpty()).toBe(false);
+    const dev = await Dev.create({ name: "Eileen", mentor_id: 1 });
+    const sqls: string[] = [];
+    const origExecuteMutation = (adapter as any).executeMutation.bind(adapter);
+    (adapter as any).executeMutation = (sql: string, ...args: unknown[]) => {
+      sqls.push(sql);
+      return origExecuteMutation(sql, ...args);
+    };
+    try {
+      await dev.update({ name: "Not Eileen" });
+    } finally {
+      (adapter as any).executeMutation = origExecuteMutation;
+    }
+    const updateSql = sqls.find((s) => /UPDATE/i.test(s));
+    expect(updateSql).toMatch(/mentor_id/);
   });
 
   it("default_scope_with_all_queries_runs_on_destroy", async () => {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1989,9 +1989,13 @@ describe("DefaultScopingTest", () => {
     }
     const dev = await Dev.create({ name: "Eileen", mentor_id: 1 });
     const spy = vi.spyOn(adapter as any, "executeMutation");
-    await dev.update({ name: "Not Eileen" });
-    const updateSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /UPDATE/i.test(s));
-    spy.mockRestore();
+    let updateSql: string | undefined;
+    try {
+      await dev.update({ name: "Not Eileen" });
+      updateSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /UPDATE/i.test(s));
+    } finally {
+      spy.mockRestore();
+    }
     expect(updateSql).toMatch(/mentor_id/);
   });
 
@@ -2006,9 +2010,13 @@ describe("DefaultScopingTest", () => {
     }
     const dev = await Dev2.create({ name: "Eileen", mentor_id: 1 });
     const spy = vi.spyOn(adapter as any, "executeMutation");
-    await dev.destroy();
-    const deleteSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /DELETE/i.test(s));
-    spy.mockRestore();
+    let deleteSql: string | undefined;
+    try {
+      await dev.destroy();
+      deleteSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /DELETE/i.test(s));
+    } finally {
+      spy.mockRestore();
+    }
     expect(deleteSql).toMatch(/mentor_id/);
   });
 });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
@@ -1989,15 +1989,16 @@ describe("DefaultScopingTest", () => {
     }
     const dev = await Dev.create({ name: "Eileen", mentor_id: 1 });
     const sqls: string[] = [];
-    const origExecuteMutation = (adapter as any).executeMutation.bind(adapter);
-    (adapter as any).executeMutation = (sql: string, ...args: unknown[]) => {
-      sqls.push(sql);
-      return origExecuteMutation(sql, ...args);
-    };
+    const spy = vi
+      .spyOn(adapter as any, "executeMutation")
+      .mockImplementation((...args: unknown[]) => {
+        sqls.push(args[0] as string);
+        return (adapter as any).inner.executeMutation(...args);
+      });
     try {
       await dev.update({ name: "Not Eileen" });
     } finally {
-      (adapter as any).executeMutation = origExecuteMutation;
+      spy.mockRestore();
     }
     const updateSql = sqls.find((s) => /UPDATE/i.test(s));
     expect(updateSql).toMatch(/mentor_id/);
@@ -2014,15 +2015,16 @@ describe("DefaultScopingTest", () => {
     }
     const dev = await Dev2.create({ name: "Eileen", mentor_id: 1 });
     const sqls: string[] = [];
-    const origExecuteMutation = (adapter as any).executeMutation.bind(adapter);
-    (adapter as any).executeMutation = (sql: string, ...args: unknown[]) => {
-      sqls.push(sql);
-      return origExecuteMutation(sql, ...args);
-    };
+    const spy = vi
+      .spyOn(adapter as any, "executeMutation")
+      .mockImplementation((...args: unknown[]) => {
+        sqls.push(args[0] as string);
+        return (adapter as any).inner.executeMutation(...args);
+      });
     try {
       await dev.destroy();
     } finally {
-      (adapter as any).executeMutation = origExecuteMutation;
+      spy.mockRestore();
     }
     const deleteSql = sqls.find((s) => /DELETE/i.test(s));
     expect(deleteSql).toMatch(/mentor_id/);

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1977,4 +1977,48 @@ describe("DefaultScopingTest", () => {
     expect(allQueriesSql).not.toContain("visible");
     expect(allQueriesSql).toContain("blog_id");
   });
+
+  it("default_scope_with_all_queries_runs_on_update", () => {
+    // Verify buildDefaultConstraint wires the allQueries scope into the
+    // UpdateManager's WHERE clause by inspecting the generated SQL directly.
+    class Dev extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("mentor_id", "integer");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ mentor_id: 1 }), { allQueries: true });
+      }
+    }
+    // The allQueries scope should appear in defaultScoped({allQueries:true})
+    const scoped = (Dev as any).defaultScoped(undefined, { allQueries: true });
+    const sql = scoped.toSql();
+    expect(sql).toContain("mentor_id");
+    // Confirm it's applied via buildDefaultConstraint (non-empty whereClause ast)
+    expect(scoped._whereClause.isEmpty()).toBe(false);
+  });
+
+  it("default_scope_with_all_queries_runs_on_destroy", async () => {
+    class Dev2 extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("mentor_id", "integer");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ mentor_id: 1 }), { allQueries: true });
+      }
+    }
+    const dev = await Dev2.create({ name: "Eileen", mentor_id: 1 });
+    const sqls: string[] = [];
+    const origExecuteMutation = (adapter as any).executeMutation.bind(adapter);
+    (adapter as any).executeMutation = (sql: string, ...args: unknown[]) => {
+      sqls.push(sql);
+      return origExecuteMutation(sql, ...args);
+    };
+    try {
+      await dev.destroy();
+    } finally {
+      (adapter as any).executeMutation = origExecuteMutation;
+    }
+    const deleteSql = sqls.find((s) => /DELETE/i.test(s));
+    expect(deleteSql).toMatch(/mentor_id/);
+  });
 });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1988,19 +1988,10 @@ describe("DefaultScopingTest", () => {
       }
     }
     const dev = await Dev.create({ name: "Eileen", mentor_id: 1 });
-    const sqls: string[] = [];
-    const spy = vi
-      .spyOn(adapter as any, "executeMutation")
-      .mockImplementation((...args: unknown[]) => {
-        sqls.push(args[0] as string);
-        return (adapter as any).inner.executeMutation(...args);
-      });
-    try {
-      await dev.update({ name: "Not Eileen" });
-    } finally {
-      spy.mockRestore();
-    }
-    const updateSql = sqls.find((s) => /UPDATE/i.test(s));
+    const spy = vi.spyOn(adapter as any, "executeMutation");
+    await dev.update({ name: "Not Eileen" });
+    const updateSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /UPDATE/i.test(s));
+    spy.mockRestore();
     expect(updateSql).toMatch(/mentor_id/);
   });
 
@@ -2014,19 +2005,10 @@ describe("DefaultScopingTest", () => {
       }
     }
     const dev = await Dev2.create({ name: "Eileen", mentor_id: 1 });
-    const sqls: string[] = [];
-    const spy = vi
-      .spyOn(adapter as any, "executeMutation")
-      .mockImplementation((...args: unknown[]) => {
-        sqls.push(args[0] as string);
-        return (adapter as any).inner.executeMutation(...args);
-      });
-    try {
-      await dev.destroy();
-    } finally {
-      spy.mockRestore();
-    }
-    const deleteSql = sqls.find((s) => /DELETE/i.test(s));
+    const spy = vi.spyOn(adapter as any, "executeMutation");
+    await dev.destroy();
+    const deleteSql = spy.mock.calls.map((c) => c[0] as string).find((s) => /DELETE/i.test(s));
+    spy.mockRestore();
     expect(deleteSql).toMatch(/mentor_id/);
   });
 });


### PR DESCRIPTION
## Summary

- **inBatches loaded branch**: when `_loaded`, delegates to `_batchOnLoadedRelation` (no DB queries) — un-skips 1 test
- **inBatches remaining cap**: passes `limitValue` as `remaining` to `batchOnUnloadedRelation`; each iteration decrements and caps the limit — un-skips limit tests
- **inBatches batch order**: sets `batchOrders` on yielded `batchRel` in all code paths (loaded + unloaded) so relations carry consistent ordering metadata
- **CPK start/finish**: implements test bodies for `.in_batches(start:)` and `.in_batches(finish:)` with composite primary keys — un-skips 2 tests
- **buildDefaultConstraint wiring**: exports `buildDefaultConstraint` from `persistence.ts` and wires it into `_performUpdate` and `_destroyRow` in `base.ts` so `allQueries: true` default scopes add WHERE predicates to UPDATE and DELETE — un-skips 2 default-scoping tests

## Test plan

- [ ] `pnpm vitest run packages/activerecord/src/batches.test.ts`
- [ ] `pnpm vitest run packages/activerecord/src/persistence.test.ts`
- [ ] `pnpm vitest run packages/activerecord/src/scoping/default-scoping.test.ts`
- [ ] CI full suite