### PR TITLE
fix(activerecord): MariaDB indexes() freshness — restore addIndex ifNotExists test

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -709,24 +709,33 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    const ss = this.schemaStatements();
-    const [idx, algorithmClause, ifNotExists] = ss.addIndexOptions(tableName, columnName, options);
-    if (ifNotExists && (await ss.indexExists(tableName, idx.columns, { name: idx.name }))) {
-      return;
-    }
-    const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
-    await this._execMutation(new MysqlSchemaCreation().accept(createDef));
+    const createIndex = await this.buildCreateIndexDefinition(tableName, columnName, options);
+    if (!createIndex) return;
+    await this._execMutation(this.schemaStatements().schemaCreation.accept(createIndex));
   }
 
-  buildCreateIndexDefinition(
+  /**
+   * Returns a {@link CreateIndexDefinition} or `undefined` when
+   * `ifNotExists: true` and the index already exists. Mirrors Rails'
+   * MySQL `build_create_index_definition`, which is the seam used by
+   * `add_index` so callers can build-without-executing or short-circuit
+   * uniformly. The `IF NOT EXISTS` keyword is intentionally not carried
+   * onto the definition — MySQL doesn't support it; the pre-flight here
+   * is the portable substitute.
+   *
+   * Mirrors: AbstractMysqlAdapter#build_create_index_definition
+   */
+  async buildCreateIndexDefinition(
     tableName: string,
     columnName: string | string[],
     options: Record<string, unknown> = {},
-  ): Record<string, unknown> {
-    void tableName;
-    void columnName;
-    void options;
-    return {};
+  ): Promise<CreateIndexDefinition | undefined> {
+    const ss = this.schemaStatements();
+    const [idx, algorithmClause, ifNotExists] = ss.addIndexOptions(tableName, columnName, options);
+    if (ifNotExists && (await ss.indexExists(tableName, idx.columns, { name: idx.name }))) {
+      return undefined;
+    }
+    return new CreateIndexDefinition(idx, false, algorithmClause);
   }
 
   addSqlComment(sql: string, comment: string): string {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -14,7 +14,8 @@ import {
   NotImplementedError,
   SQLWarning,
 } from "../errors.js";
-import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import { CreateIndexDefinition, ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import type { AddIndexOptions } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
@@ -38,6 +39,34 @@ class MysqlSchemaStatements extends SchemaStatements {
   private _mysqlSchemaCreation?: MysqlSchemaCreation;
   override get schemaCreation(): MysqlSchemaCreation {
     return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation());
+  }
+
+  /**
+   * MySQL/MariaDB don't support `CREATE INDEX IF NOT EXISTS` (MySQL never
+   * has; MariaDB does, but Rails standardizes on the pre-flight approach
+   * for portability). Override `addIndex` to mirror Rails' MySQL
+   * `add_index`: if `ifNotExists: true` and the index is already present,
+   * short-circuit before emitting DDL — otherwise the second call trips
+   * `ER_DUP_KEYNAME` because `MysqlSchemaCreation` (correctly) omits the
+   * `IF NOT EXISTS` keyword.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_index
+   */
+  override async addIndex(
+    tableName: string,
+    columnName: string | string[],
+    options: AddIndexOptions = {},
+  ): Promise<void> {
+    const [idx, algorithmClause, ifNotExists] = this.addIndexOptions(
+      tableName,
+      columnName,
+      options as Record<string, unknown>,
+    );
+    if (ifNotExists && (await this.indexExists(tableName, idx.columns, { name: idx.name }))) {
+      return;
+    }
+    const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
+    await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
   }
 
   override async dropTable(

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -42,15 +42,18 @@ class MysqlSchemaStatements extends SchemaStatements {
   }
 
   /**
-   * MySQL/MariaDB don't support `CREATE INDEX IF NOT EXISTS` (MySQL never
-   * has; MariaDB does, but Rails standardizes on the pre-flight approach
-   * for portability). Override `addIndex` to mirror Rails' MySQL
-   * `add_index`: if `ifNotExists: true` and the index is already present,
-   * short-circuit before emitting DDL — otherwise the second call trips
-   * `ER_DUP_KEYNAME` because `MysqlSchemaCreation` (correctly) omits the
-   * `IF NOT EXISTS` keyword.
+   * `Migration#addIndex` routes through `this.schema.addIndex(...)`, so
+   * we override here. Mirrors Rails' `AbstractMysqlAdapter#add_index` /
+   * `#build_create_index_definition` pair: pre-flight via
+   * `indexExists()` and emit `CREATE INDEX` without `IF NOT EXISTS`
+   * (MySQL doesn't support the keyword; MariaDB does but Rails
+   * standardizes on the pre-flight for portability). Without this, the
+   * second `addIndex(..., { ifNotExists: true })` call trips
+   * `ER_DUP_KEYNAME` on MariaDB because `MysqlSchemaCreation`
+   * correctly omits the keyword.
    *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_index
+   * Mirrors: AbstractMysqlAdapter#add_index +
+   * AbstractMysqlAdapter#build_create_index_definition
    */
   override async addIndex(
     tableName: string,

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -709,11 +709,12 @@ describe("Migration DDL (extended)", () => {
     },
   );
 
-  // BLOCKED: adapter — MySQL/MariaDB implements addIndex(ifNotExists:) via a
-  // pre-flight indexExists() lookup, not an "IF NOT EXISTS" SQL clause, so the
-  // SQL-string assertion below does not hold on the mysql path; pre-flight also
-  // currently fails to detect the just-created index on MariaDB (ER_DUP_KEYNAME).
-  it.skip("addIndex with ifNotExists option", async () => {
+  // PG/SQLite emit `CREATE INDEX IF NOT EXISTS …` for both calls. MySQL/MariaDB
+  // can't (MySQL doesn't support it; MariaDB does but Rails standardizes on the
+  // pre-flight approach) — instead the second call short-circuits via
+  // `indexExists()` in `MysqlSchemaStatements.addIndex`, so only one
+  // `CREATE INDEX` reaches the database.
+  it("addIndex with ifNotExists option", async () => {
     const adapter = freshAdapter();
     const spy = vi.spyOn(adapter, "executeMutation");
     class AddIdxIfNotExists extends Migration {
@@ -728,10 +729,18 @@ describe("Migration DDL (extended)", () => {
     }
     const m = new AddIdxIfNotExists();
     await m.run(adapter, "up");
-    const indexCalls = spy.mock.calls.filter(
-      ([sql]) => typeof sql === "string" && sql.includes("IF NOT EXISTS"),
+    const createIndexCalls = spy.mock.calls.filter(
+      ([sql]) => typeof sql === "string" && /CREATE\s+(UNIQUE\s+)?INDEX/i.test(sql),
     );
-    expect(indexCalls).toHaveLength(2);
+    if (adapterType === "mysql") {
+      expect(createIndexCalls).toHaveLength(1);
+      expect(createIndexCalls[0][0]).not.toMatch(/IF NOT EXISTS/i);
+    } else {
+      expect(createIndexCalls).toHaveLength(2);
+      for (const [sql] of createIndexCalls) {
+        expect(sql as string).toMatch(/IF NOT EXISTS/i);
+      }
+    }
   });
 
   it.skipIf(adapterType === "sqlite")(


### PR DESCRIPTION
## Summary

Restores the skipped `Migration DDL (extended) > addIndex with ifNotExists option` test in `packages/activerecord/src/migration.test.ts`, with the underlying MariaDB failure fixed at its root.

- Adds `addIndex` override on `MysqlSchemaStatements` that pre-flights via `indexExists()` and emits `CREATE INDEX` without `IF NOT EXISTS`, mirroring Rails' `ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_index`.
- Splits the test assertion adapter-aware:
  - PG / SQLite: both calls emit `CREATE INDEX IF NOT EXISTS` (2 mutations).
  - MySQL / MariaDB: exactly one `CREATE INDEX` reaches the database; the second call short-circuits before DDL.

## Root cause

Not a freshness bug. PR #1599 added a `schemaCreation` override on `MysqlSchemaStatements` so it returns `MysqlSchemaCreation`, whose `visitCreateIndexDefinition` correctly omits `IF NOT EXISTS` (MySQL doesn't support it). Before #1599 the base abstract `SchemaCreation` was used, which always emits `IF NOT EXISTS` — MariaDB happens to accept that clause, so the second call was silently a no-op in CI. After #1599 the bare `CREATE INDEX` reaches MariaDB twice and trips `ER_DUP_KEYNAME`.

The Rails-mirror pre-flight already exists on `AbstractMysqlAdapter.addIndex`, but that method is dead code from the migration path: `Migration#addIndex` calls `this.schema.addIndex(...)`, which lands on `SchemaStatements.addIndex`, not the adapter. Moving the pre-flight onto `MysqlSchemaStatements` (a `SchemaStatements` subclass) puts it on the real call path.

Confirmed `SHOW INDEX FROM` returns live results across pool connections on MariaDB via a local mysql2 reproduction, so the post-merge findings doc's "stale `indexes()`" hypothesis was wrong.

## Test plan

- [x] Local MariaDB 11 (Docker): `addIndex with ifNotExists option` passes
- [x] Local SQLite (default): passes
- [x] Full `migration.test.ts` against MariaDB: 168/185 (17 pre-existing skips), no regressions
- [x] Full `mysql2-adapter.test.ts` + `abstract-mysql-adapter.test.ts` against MariaDB: 103/103
- [ ] CI: MariaDB / Postgres / SQLite jobs green