### PR TITLE
chore(actionpack): wave 2b — delete dispatch/ re-export stubs, update test imports

### DIFF
--- a/packages/actionpack/src/actiondispatch/dispatch/header.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/header.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Headers } from "./header.js";
+import { Headers } from "../http/headers.js";
 
 function makeHeaders(hash: Record<string, unknown>): Headers {
   return new Headers(hash);

--- a/packages/actionpack/src/actiondispatch/dispatch/header.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/header.ts
@@ -1,1 +1,0 @@
-export { Headers } from "../http/headers.js";

--- a/packages/actionpack/src/actiondispatch/dispatch/request/session.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/request/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Session, type SessionStore } from "./session.js";
+import { Session, type SessionStore } from "../../request/session.js";
 
 function makeStore(opts: { exists?: boolean; data?: Record<string, unknown> } = {}): SessionStore {
   const exists = opts.exists ?? true;

--- a/packages/actionpack/src/actiondispatch/dispatch/request/session.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/request/session.ts
@@ -1,1 +1,0 @@
-export { Session, type SessionStore } from "../../request/session.js";


### PR DESCRIPTION
## Summary

- Deletes `dispatch/header.ts` and `dispatch/request/session.ts` — backward-compat re-export stubs created in Wave 2 to keep dispatch/ tests green after the source files moved
- Updates the two test files that imported from those stubs to point directly at the canonical source locations (`http/headers.ts`, `request/session.ts`)
- Leaves `dispatch/` as test-only, matching Rails' `actionpack/test/dispatch/` layout

**Note:** The dispatch/ test files are correctly placed per `test:compare` convention (`dispatch/*_test.rb` → `dispatch/*.test.ts`). No file moves were needed — only the stub deletion.

## Metrics

- `test:compare`: actiondispatch 535/1622 (33%) — unchanged ✓
- `api:compare`: no regression ✓
- 6 LOC diff