### PR TITLE
feat(activerecord): mysql2-adapter Slot A — databaseExists + exec_query(prepare) + fake_connection

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -67,6 +67,9 @@ export interface MysqlAdapterOptions extends TrailsAdapterOptions {
   waitTimeout?: number | string;
   // Mirrors: database.yml `variables:` — SET SESSION key = value on each new connection.
   variables?: Record<string, string | number | boolean | null | ":default" | "default">;
+  // Test-only sentinel: skips pool creation so the adapter can be instantiated without a live DB.
+  // @internal
+  _fakeConnection?: boolean;
 }
 
 /**

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -126,6 +126,11 @@ describeIfMysql("Mysql2Adapter", () => {
       const exists = await Mysql2Adapter.databaseExists(url.toString());
       expect(exists).toBe(false);
     });
+    it("database exists returns true when the database exists", async () => {
+      // Mirrors: test_database_exists_returns_true_when_the_database_exists
+      const exists = await Mysql2Adapter.databaseExists(MYSQL_TEST_URL);
+      expect(exists).toBe(true);
+    });
 
     // FK type-mismatch fixture tables — created/dropped around each test so
     // the FK tests are self-contained. beforeEach/afterEach live directly in

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -14,6 +14,7 @@ import {
   RecordNotUnique,
   ValueTooLong,
 } from "../../errors.js";
+import { Result } from "../../result.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -91,25 +92,39 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("Mysql2AdapterTest", () => {
-    it.skip("mysql2 default prepared statements", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("mysql2 default prepared statements", () => {
+      // Mirrors: test_mysql2_default_prepared_statements
+      // Instantiate with _fakeConnection:true to skip pool creation — mirrors
+      // Rails' fake_connection constructor path.
+      const fakeAdapter = new Mysql2Adapter({ _fakeConnection: true } as any);
+      expect(fakeAdapter.preparedStatements).toBe(false);
     });
-    it.skip("exec query with prepared statements", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("exec query with prepared statements", async () => {
+      // Mirrors: test_exec_query_with_prepared_statements
+      const result = await adapter.execQuery("SELECT 1", "SQL", [], { prepare: true });
+      expect(result).toBeInstanceOf(Result);
+      expect(result.toArray()).toEqual([{ "1": 1 }]);
     });
-    it.skip("exec query nothing raises with no result queries", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("exec query nothing raises with no result queries", async () => {
+      // Mirrors: test_exec_query_nothing_raises_with_no_result_queries
+      await adapter.executeMutation("CREATE TABLE IF NOT EXISTS `ex` (`number` INT) ENGINE=InnoDB");
+      try {
+        await expect(
+          adapter.execQuery("INSERT INTO `ex` (number) VALUES (1)"),
+        ).resolves.toBeInstanceOf(Result);
+        await expect(
+          adapter.execQuery("DELETE FROM `ex` WHERE number = 1"),
+        ).resolves.toBeInstanceOf(Result);
+      } finally {
+        await adapter.executeMutation("DROP TABLE IF EXISTS `ex`");
+      }
     });
-    it.skip("database exists returns false if database does not exist", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("database exists returns false if database does not exist", async () => {
+      // Mirrors: test_database_exists_returns_false_if_database_does_not_exist
+      const url = new URL(MYSQL_TEST_URL);
+      url.pathname = "/inexistent_activerecord_unittest";
+      const exists = await Mysql2Adapter.databaseExists(url.toString());
+      expect(exists).toBe(false);
     });
 
     // FK type-mismatch fixture tables — created/dropped around each test so

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -96,7 +96,7 @@ describeIfMysql("Mysql2Adapter", () => {
       // Mirrors: test_mysql2_default_prepared_statements
       // Instantiate with _fakeConnection:true to skip pool creation — mirrors
       // Rails' fake_connection constructor path.
-      const fakeAdapter = new Mysql2Adapter({ _fakeConnection: true } as any);
+      const fakeAdapter = new Mysql2Adapter({ _fakeConnection: true });
       expect(fakeAdapter.preparedStatements).toBe(false);
     });
     it("exec query with prepared statements", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -409,7 +409,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const driverBinds = this.mysqlBinds(binds ?? []);
     const payload: Record<string, unknown> = {
       sql: driverSql,
-      name,
+      name: name ?? "SQL",
       binds: driverBinds,
       type_casted_binds: typeCastedBinds(driverBinds),
       connection: this,
@@ -441,7 +441,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           payload.exception_object = e;
           throw e;
         }
-        if (!conn) throw e;
         const { error: translated, connReleased } = await this._translateAndEnrich(
           e,
           driverSql,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -400,13 +400,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   override async execQuery(
     sql: string,
-    name: string = "SQL",
-    binds: unknown[] = [],
-    options: { prepare?: boolean } = {},
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
   ): Promise<Result> {
     await this.materializeTransactions();
     const driverSql = this.mysqlQuote(sql);
-    const driverBinds = this.mysqlBinds(binds);
+    const driverBinds = this.mysqlBinds(binds ?? []);
     const payload: Record<string, unknown> = {
       sql: driverSql,
       name,
@@ -419,7 +419,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       let conn: mysql.PoolConnection | undefined;
       try {
         conn = await this.getConn();
-        const prepare = options.prepare ?? this._shouldPrepare(conn, binds);
+        const prepare = options?.prepare ?? this._shouldPrepare(conn, binds ?? []);
         if (prepare) this._trackPrepared(conn, driverSql);
         const [rawResult] = prepare
           ? await conn.execute(driverSql, driverBinds as any[])

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -292,8 +292,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const adapter = new Mysql2Adapter(config);
     try {
       // Any query that requires a real database will trigger ER_BAD_DB_ERROR
-      // if the DB doesn't exist — getConn() already translates it to NoDatabaseError.
-      const conn = await (adapter as any)._checkoutConn();
+      // if the DB doesn't exist — _checkoutConn() already translates it to NoDatabaseError.
+      const conn = await adapter._checkoutConn();
       conn.release();
       return true;
     } catch (e) {
@@ -399,6 +399,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     binds: unknown[] = [],
     options: { prepare?: boolean } = {},
   ): Promise<Result> {
+    await this.materializeTransactions();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds);
     let conn: mysql.PoolConnection | undefined;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -188,6 +188,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // Set by close() to distinguish permanent teardown from disconnectBang(),
   // which is reconnectable. _checkoutConn() refuses to lazy-reconnect after close().
   private _permanentlyClosed = false;
+  // Set by the _fakeConnection constructor path — prevents _checkoutConn() from
+  // lazily creating a real pool when _driverPool is null.
+  private _isFakeConnection = false;
   // Normalized config passed to newClient — stored for reconnect.
   private _poolConfig: mysql.PoolOptions & MysqlAdapterOptions;
   private _conn: mysql.PoolConnection | null = null;
@@ -379,7 +382,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // _fakeConnection: true skips pool creation — used in unit tests that need
     // an Mysql2Adapter instance without a live DB (mirrors Rails' fake_connection
     // constructor path: `new Mysql2Adapter(fake_conn, logger, nil, config)`).
-    if (!fake) {
+    if (fake) {
+      this._isFakeConnection = true;
+    } else {
       this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
     }
   }
@@ -402,33 +407,55 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     await this.materializeTransactions();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds);
-    let conn: mysql.PoolConnection | undefined;
-    try {
-      conn = await this.getConn();
-      const prepare = options.prepare ?? this._shouldPrepare(conn, binds);
-      if (prepare) this._trackPrepared(conn, driverSql);
-      const [rawResult] = prepare
-        ? await conn.execute(driverSql, driverBinds as any[])
-        : await conn.query(driverSql, driverBinds);
-      // DML results in a ResultSetHeader (no rows array); SELECT results
-      // in an array of row objects. Return empty Result for DML to avoid
-      // throwing on INSERT/UPDATE/DELETE passed to execQuery.
-      if (!Array.isArray(rawResult)) return new Result([], []);
-      await this._handleWarningsOn(conn, driverSql);
-      return Result.fromRowHashes(rawResult as Record<string, unknown>[]);
-    } catch (e) {
-      if (!conn) throw e;
-      const { error: translated, connReleased } = await this._translateAndEnrich(
-        e,
-        driverSql,
-        driverBinds,
-        conn,
-      );
-      if (connReleased) conn = undefined;
-      throw translated;
-    } finally {
-      if (conn) this.releaseConn(conn);
-    }
+    const payload: Record<string, unknown> = {
+      sql: driverSql,
+      name,
+      binds: driverBinds,
+      type_casted_binds: typeCastedBinds(driverBinds),
+      connection: this,
+      row_count: 0,
+    };
+    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      let conn: mysql.PoolConnection | undefined;
+      try {
+        conn = await this.getConn();
+        const prepare = options.prepare ?? this._shouldPrepare(conn, binds);
+        if (prepare) this._trackPrepared(conn, driverSql);
+        const [rawResult] = prepare
+          ? await conn.execute(driverSql, driverBinds as any[])
+          : await conn.query(driverSql, driverBinds);
+        // DML results in a ResultSetHeader (no rows array); SELECT results
+        // in an array of row objects. Return empty Result for DML to avoid
+        // throwing on INSERT/UPDATE/DELETE passed to execQuery.
+        if (!Array.isArray(rawResult)) {
+          this.dirtyCurrentTransaction();
+          await this._handleWarningsOn(conn, driverSql);
+          return new Result([], []);
+        }
+        payload.row_count = rawResult.length;
+        await this._handleWarningsOn(conn, driverSql);
+        return Result.fromRowHashes(rawResult as Record<string, unknown>[]);
+      } catch (e: any) {
+        if (e instanceof SQLWarning) {
+          payload.exception = e;
+          payload.exception_object = e;
+          throw e;
+        }
+        if (!conn) throw e;
+        const { error: translated, connReleased } = await this._translateAndEnrich(
+          e,
+          driverSql,
+          driverBinds,
+          conn,
+        );
+        if (connReleased) conn = undefined;
+        payload.exception = translated;
+        payload.exception_object = translated;
+        throw translated;
+      } finally {
+        if (conn) this.releaseConn(conn);
+      }
+    });
   }
 
   /** Returns true for raw mysql2 errors that indicate the database doesn't exist (ER_BAD_DB_ERROR). */
@@ -443,8 +470,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Lazy reconnect after disconnectBang() — mirrors Rails' reconnect on next
     // execute after disconnect! (abstract_adapter.rb #with_raw_connection).
     // close() sets _permanentlyClosed so we don't silently reopen after teardown.
+    // _isFakeConnection skips reconnect — fake adapters have no pool by design.
     if (!this._driverPool) {
       if (this._permanentlyClosed) throw new Error("Mysql2Adapter: connection is closed");
+      if (this._isFakeConnection) throw new Error("Mysql2Adapter: fake connection has no pool");
       this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
       this._activeState = true;
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -14,6 +14,7 @@ import {
   NotImplementedError,
   SQLWarning,
 } from "../errors.js";
+import { Result } from "../result.js";
 import { CreateIndexDefinition, ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import type { AddIndexOptions } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
@@ -182,7 +183,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return this._driverPool != null;
   }
 
-  private _driverPool: mysql.Pool | null;
+  private _driverPool: mysql.Pool | null = null;
   private _endingPool: Promise<void> | null = null;
   // Set by close() to distinguish permanent teardown from disconnectBang(),
   // which is reconnectable. _checkoutConn() refuses to lazy-reconnect after close().
@@ -280,6 +281,29 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _fullVersionString: string | null = null;
   private _database: string | undefined;
 
+  /**
+   * Returns true when the database named in `config` is reachable; false when
+   * the server responds with ER_BAD_DB_ERROR (1049). Mirrors Rails'
+   * `AbstractAdapter.database_exists?(config)` → `new(config).database_exists?`.
+   */
+  static async databaseExists(
+    config: string | (mysql.PoolOptions & MysqlAdapterOptions),
+  ): Promise<boolean> {
+    const adapter = new Mysql2Adapter(config);
+    try {
+      // Any query that requires a real database will trigger ER_BAD_DB_ERROR
+      // if the DB doesn't exist — getConn() already translates it to NoDatabaseError.
+      const conn = await (adapter as any)._checkoutConn();
+      conn.release();
+      return true;
+    } catch (e) {
+      if (e instanceof NoDatabaseError) return false;
+      throw e;
+    } finally {
+      await adapter.close();
+    }
+  }
+
   constructor(config: string | (mysql.PoolOptions & MysqlAdapterOptions)) {
     super();
     if (typeof config === "string") {
@@ -311,8 +335,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // hash. Validate & apply the adapter-level keys FIRST so an
     // invalid value fails before `mysql.createPool` runs — otherwise
     // a throw would leave a live pool with no cleanup path.
-    const { statementLimit, preparedStatements, strict, waitTimeout, variables, ...mysqlConfig } =
-      config;
+    const {
+      statementLimit,
+      preparedStatements,
+      strict,
+      waitTimeout,
+      variables,
+      _fakeConnection: fake,
+      ...mysqlConfig
+    } = config as mysql.PoolOptions & MysqlAdapterOptions & { _fakeConnection?: boolean };
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     this._database =
@@ -345,7 +376,58 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       waitTimeout,
       variables,
     };
-    this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
+    // _fakeConnection: true skips pool creation — used in unit tests that need
+    // an Mysql2Adapter instance without a live DB (mirrors Rails' fake_connection
+    // constructor path: `new Mysql2Adapter(fake_conn, logger, nil, config)`).
+    if (!fake) {
+      this._driverPool = Mysql2Adapter.newClient(this._poolConfig, this._buildInitSql());
+    }
+  }
+
+  /**
+   * Execute a query and return an ActiveRecord::Result. Accepts a `prepare`
+   * option that, when true, forces server-side prepared-statement execution
+   * on this query even if `preparedStatements` is globally off. DML statements
+   * (INSERT/UPDATE/DELETE) are tolerated — they return an empty Result.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#perform_query
+   * (the `prepare:` keyword routing) + Rails' exec_query tolerating no-result DML.
+   */
+  override async execQuery(
+    sql: string,
+    name: string = "SQL",
+    binds: unknown[] = [],
+    options: { prepare?: boolean } = {},
+  ): Promise<Result> {
+    const driverSql = this.mysqlQuote(sql);
+    const driverBinds = this.mysqlBinds(binds);
+    let conn: mysql.PoolConnection | undefined;
+    try {
+      conn = await this.getConn();
+      const prepare = options.prepare ?? this._shouldPrepare(conn, binds);
+      if (prepare) this._trackPrepared(conn, driverSql);
+      const [rawResult] = prepare
+        ? await conn.execute(driverSql, driverBinds as any[])
+        : await conn.query(driverSql, driverBinds);
+      // DML results in a ResultSetHeader (no rows array); SELECT results
+      // in an array of row objects. Return empty Result for DML to avoid
+      // throwing on INSERT/UPDATE/DELETE passed to execQuery.
+      if (!Array.isArray(rawResult)) return new Result([], []);
+      await this._handleWarningsOn(conn, driverSql);
+      return Result.fromRowHashes(rawResult as Record<string, unknown>[]);
+    } catch (e) {
+      if (!conn) throw e;
+      const { error: translated, connReleased } = await this._translateAndEnrich(
+        e,
+        driverSql,
+        driverBinds,
+        conn,
+      );
+      if (connReleased) conn = undefined;
+      throw translated;
+    } finally {
+      if (conn) this.releaseConn(conn);
+    }
   }
 
   /** Returns true for raw mysql2 errors that indicate the database doesn't exist (ER_BAD_DB_ERROR). */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -346,7 +346,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       variables,
       _fakeConnection: fake,
       ...mysqlConfig
-    } = config as mysql.PoolOptions & MysqlAdapterOptions & { _fakeConnection?: boolean };
+    } = config as mysql.PoolOptions & MysqlAdapterOptions;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     this._database =
@@ -429,6 +429,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // throwing on INSERT/UPDATE/DELETE passed to execQuery.
         if (!Array.isArray(rawResult)) {
           this.dirtyCurrentTransaction();
+          payload.row_count = (rawResult as mysql.ResultSetHeader).affectedRows ?? 0;
           await this._handleWarningsOn(conn, driverSql);
           return new Result([], []);
         }


### PR DESCRIPTION
## Summary

- `Mysql2Adapter.databaseExists(config)` — static method that connects and returns false on `NoDatabaseError` (ER_BAD_DB_ERROR). Mirrors `AbstractAdapter.database_exists?`.
- `execQuery(sql, name, binds, { prepare })` override — routes through `conn.execute()` when `prepare: true`; tolerates DML (INSERT/DELETE) by returning empty `Result` instead of throwing.
- `_fakeConnection: true` constructor sentinel — skips `mysql.createPool()` so tests can instantiate `Mysql2Adapter` without a live driver. Mirrors Rails' `new Mysql2Adapter(fake_conn, ...)` constructor path.
- Un-skip 4 tests in `adapters/mysql2/mysql2-adapter.test.ts`.

## Follow-ups (Slots B + C)

- Slot B (~200 LOC): `read_timeout` → `AdapterTimeout`, `ER_FILSORT_ABORT`/`ER_QUERY_TIMEOUT` → `StatementTimeout`
- Slot C (~280 LOC): `query_options[:database_timezone]` plumbing + `with_db_warnings_action`

## Test plan

- [ ] MySQL CI job runs `adapters/mysql2/mysql2-adapter.test.ts` — 4 new tests pass
- [ ] No regressions in existing translate_exception + FK tests