### PR TITLE
feat(activerecord): MySQL active-schema Slot D — bulk change-table + timestamps

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -127,11 +127,7 @@ describeIfMysql("Mysql2Adapter", () => {
 
       const sqls = await captureSql(() =>
         adapter.schemaStatements().changeTable("people", { bulk: true }, (t) => {
-          return t.index("last_name", {
-            length: 10 as unknown as Record<string, number>,
-            using: "btree",
-            algorithm: "copy",
-          });
+          return t.index("last_name", { length: 10, using: "btree", algorithm: "copy" });
         }),
       );
       expect(sqls[0]).toBe(
@@ -191,18 +187,18 @@ describeIfMysql("Mysql2Adapter", () => {
 
     it("add timestamps", async () => {
       const ss = adapter.schemaStatements();
-      await ss.createTable("delete_me", { id: false });
+      await ss.createTable("delete_me", { force: true });
       try {
         await ss.addTimestamps("delete_me", { null: true });
         expect(await ss.columnExists("delete_me", "updated_at")).toBe(true);
         expect(await ss.columnExists("delete_me", "created_at")).toBe(true);
       } finally {
-        await ss.dropTable("delete_me").catch(() => {});
+        await ss.dropTable("delete_me", { ifExists: true });
       }
     });
     it("remove timestamps", async () => {
       const ss = adapter.schemaStatements();
-      await ss.createTable("delete_me", { id: false }, (t) => {
+      await ss.createTable("delete_me", { force: true }, (t) => {
         return t.timestamps({ null: true });
       });
       try {
@@ -210,7 +206,7 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(await ss.columnExists("delete_me", "updated_at")).toBe(false);
         expect(await ss.columnExists("delete_me", "created_at")).toBe(false);
       } finally {
-        await ss.dropTable("delete_me").catch(() => {});
+        await ss.dropTable("delete_me", { ifExists: true });
       }
     });
     it("indexes in create", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -187,8 +187,8 @@ describeIfMysql("Mysql2Adapter", () => {
 
     it("add timestamps", async () => {
       const ss = adapter.schemaStatements();
-      await ss.createTable("delete_me", { force: true });
       try {
+        await ss.createTable("delete_me", { force: true });
         await ss.addTimestamps("delete_me", { null: true });
         expect(await ss.columnExists("delete_me", "updated_at")).toBe(true);
         expect(await ss.columnExists("delete_me", "created_at")).toBe(true);
@@ -198,10 +198,10 @@ describeIfMysql("Mysql2Adapter", () => {
     });
     it("remove timestamps", async () => {
       const ss = adapter.schemaStatements();
-      await ss.createTable("delete_me", { force: true }, (t) => {
-        return t.timestamps({ null: true });
-      });
       try {
+        await ss.createTable("delete_me", { force: true }, (t) => {
+          return t.timestamps({ null: true });
+        });
         await ss.removeTimestamps("delete_me");
         expect(await ss.columnExists("delete_me", "updated_at")).toBe(false);
         expect(await ss.columnExists("delete_me", "created_at")).toBe(false);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -113,10 +113,30 @@ describeIfMysql("Mysql2Adapter", () => {
         /^CREATE TABLE `people` \(INDEX `index_people_on_last_name` USING btree \(`last_name`\(10\)\)\)/,
       );
     });
-    it.skip("index in bulk change", () => {
-      // BLOCKED: adapter-mysql — changeTable bulk-mode not implemented for MySQL
-      // ROOT-CAUSE: AbstractMysqlAdapter bulk change_table path missing
-      // SCOPE: Slot D (bulk change-table ALTER coalescing)
+    it("index in bulk change", async () => {
+      for (const type of ["SPATIAL", "FULLTEXT", "UNIQUE"]) {
+        const sqls = await captureSql(() =>
+          adapter.schemaStatements().changeTable("people", { bulk: true }, (t) => {
+            return t.index("last_name", { type });
+          }),
+        );
+        expect(sqls[0]).toBe(
+          `ALTER TABLE \`people\` ADD ${type} INDEX \`index_people_on_last_name\` (\`last_name\`)`,
+        );
+      }
+
+      const sqls = await captureSql(() =>
+        adapter.schemaStatements().changeTable("people", { bulk: true }, (t) => {
+          return t.index("last_name", {
+            length: 10 as unknown as Record<string, number>,
+            using: "btree",
+            algorithm: "copy",
+          });
+        }),
+      );
+      expect(sqls[0]).toBe(
+        "ALTER TABLE `people` ADD INDEX `index_people_on_last_name` USING btree (`last_name`(10)), ALGORITHM = COPY",
+      );
     });
 
     it("drop table", async () => {
@@ -169,15 +189,29 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(sqls[0]).toBe("DROP TABLE `otherdb`.`people`, `otherdb`.`sobrinho`");
     });
 
-    it.skip("add timestamps", () => {
-      // BLOCKED: adapter-mysql — requires a real MySQL connection (with_real_execute scope)
-      // ROOT-CAUSE: addTimestamps needs a live table to add columns to; captureSql-only harness insufficient
-      // SCOPE: Slot D (live-table tests)
+    it("add timestamps", async () => {
+      const ss = adapter.schemaStatements();
+      await ss.createTable("delete_me", { id: false });
+      try {
+        await ss.addTimestamps("delete_me", { null: true });
+        expect(await ss.columnExists("delete_me", "updated_at")).toBe(true);
+        expect(await ss.columnExists("delete_me", "created_at")).toBe(true);
+      } finally {
+        await ss.dropTable("delete_me").catch(() => {});
+      }
     });
-    it.skip("remove timestamps", () => {
-      // BLOCKED: adapter-mysql — requires a real MySQL connection (with_real_execute scope)
-      // ROOT-CAUSE: removeTimestamps needs a live table; captureSql-only harness insufficient
-      // SCOPE: Slot D (live-table tests)
+    it("remove timestamps", async () => {
+      const ss = adapter.schemaStatements();
+      await ss.createTable("delete_me", { id: false }, (t) => {
+        return t.timestamps({ null: true });
+      });
+      try {
+        await ss.removeTimestamps("delete_me");
+        expect(await ss.columnExists("delete_me", "updated_at")).toBe(false);
+        expect(await ss.columnExists("delete_me", "created_at")).toBe(false);
+      } finally {
+        await ss.dropTable("delete_me").catch(() => {});
+      }
     });
     it("indexes in create", async () => {
       const sqls = await captureSql(() =>

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -280,7 +280,11 @@ export interface AbstractAdapter {
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
   dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;
-  changeTable(tableName: string, fn?: (t: Table) => void | Promise<void>): Promise<void>;
+  changeTable(
+    tableName: string,
+    fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },
+    fn?: (t: Table) => void | Promise<void>,
+  ): Promise<void>;
   tableAliasFor(tableName: string): string;
   dataSources(): Promise<string[]>;
   isDataSourceExists(name: string): Promise<boolean>;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1495,11 +1495,26 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /** @internal */
   removeIndexForAlter(
     tableName: string,
-    columnName?: string | string[],
+    columnNameOrOptions?: string | string[] | Record<string, unknown>,
     options: Record<string, unknown> = {},
   ): string {
+    // Accept both the Rails-style (columnName, options) and the bulk-recorder
+    // options-object form (options) where the second arg carries {column?, name?}.
+    let columnName: string | string[] | undefined;
+    let opts: Record<string, unknown>;
+    if (
+      columnNameOrOptions != null &&
+      typeof columnNameOrOptions === "object" &&
+      !Array.isArray(columnNameOrOptions)
+    ) {
+      opts = columnNameOrOptions;
+      columnName = opts.column as string | string[] | undefined;
+    } else {
+      columnName = columnNameOrOptions as string | string[] | undefined;
+      opts = options;
+    }
     const indexName =
-      (options.name as string | undefined) ??
+      (opts.name as string | undefined) ??
       (columnName
         ? `index_${tableName}_on_${Array.isArray(columnName) ? columnName.join("_and_") : columnName}`
         : undefined);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -240,7 +240,7 @@ export interface AddIndexOptions {
   type?: string;
   comment?: string;
   ifNotExists?: boolean;
-  length?: Record<string, number>;
+  length?: number | Record<string, number>;
   opclass?: Record<string, string>;
   include?: string[];
   nullsNotDistinct?: boolean;
@@ -285,7 +285,7 @@ export class IndexDefinition {
     options: {
       where?: string;
       orders?: Record<string, string>;
-      lengths?: Record<string, number>;
+      lengths?: number | Record<string, number>;
       opclasses?: Record<string, string>;
       type?: string;
       using?: string;
@@ -303,7 +303,10 @@ export class IndexDefinition {
     this.columns = columns;
     this.where = options.where;
     this.orders = this.conciseOptions(options.orders ?? {});
-    this.lengths = this.conciseOptions(options.lengths ?? {});
+    this.lengths =
+      typeof options.lengths === "number"
+        ? options.lengths
+        : this.conciseOptions((options.lengths ?? {}) as Record<string, number>);
     this.opclasses = this.conciseOptions(options.opclasses ?? {});
     this.type = options.type;
     this.using = options.using;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -240,7 +240,7 @@ export interface AddIndexOptions {
   type?: string;
   comment?: string;
   ifNotExists?: boolean;
-  length?: number | Record<string, number>;
+  length?: number | null | Record<string, number>;
   opclass?: Record<string, string>;
   include?: string[];
   nullsNotDistinct?: boolean;
@@ -285,7 +285,7 @@ export class IndexDefinition {
     options: {
       where?: string;
       orders?: Record<string, string>;
-      lengths?: number | Record<string, number>;
+      lengths?: number | null | Record<string, number>;
       opclasses?: Record<string, string>;
       type?: string;
       using?: string;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2043,18 +2043,6 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  removeIndexForAlter(
-    tableName: string,
-    options: { column?: string | string[]; name?: string } = {},
-  ): string {
-    const name =
-      options.name ??
-      (options.column ? this.indexName(tableName, { column: options.column }) : undefined);
-    if (!name) throw new Error("removeIndexForAlter: must specify :name or :column");
-    return `DROP INDEX ${this.adapter.quoteIdentifier(name)}`;
-  }
-
-  /** @internal */
   addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): string[] {
     const opts: ColumnOptions = { ...options };
     if (opts.null == null) opts.null = false;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -676,11 +676,11 @@ export class SchemaStatements {
         isCheckConstraintExists: (t, opts) => this.isCheckConstraintExists(t, opts as any),
         primaryKey: (t) => this.primaryKey(t),
       };
-      const bulkTable = new Table(tableName, recorder as any);
+      const bulkTable = this.updateTableDefinition(tableName, recorder as any);
       if (callback) await callback(bulkTable);
       await this.bulkChangeTable(tableName, ops);
     } else {
-      const table = new Table(tableName, this);
+      const table = this.updateTableDefinition(tableName, this);
       if (callback) await callback(table);
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -671,10 +671,16 @@ export class SchemaStatements {
         removeTimestamps: rec("removeTimestamps"),
         addReference: rec("addReference"),
         removeReference: rec("removeReference"),
-        // Read-only predicates pass through to the real SchemaStatements so conditional
-        // patterns (t.isColumnExists, t.isIndexExists) work inside bulk blocks.
+        addForeignKey: rec("addForeignKey"),
+        removeForeignKey: rec("removeForeignKey"),
+        addCheckConstraint: rec("addCheckConstraint"),
+        removeCheckConstraint: rec("removeCheckConstraint"),
+        // Read-only predicates pass through to the real SchemaStatements.
         columnExists: (t, col) => this.columnExists(t, col),
         indexExists: (t, col, opts) => this.indexExists(t, col, opts as any),
+        foreignKeyExists: (t, opts) => this.foreignKeyExists(t, opts as any),
+        isCheckConstraintExists: (t, opts) => this.isCheckConstraintExists(t, opts as any),
+        primaryKey: (t) => this.primaryKey(t),
       };
       const bulkTable = new Table(tableName, recorder as any);
       if (callback) await callback(bulkTable);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -671,6 +671,10 @@ export class SchemaStatements {
         removeTimestamps: rec("removeTimestamps"),
         addReference: rec("addReference"),
         removeReference: rec("removeReference"),
+        // Read-only predicates pass through to the real SchemaStatements so conditional
+        // patterns (t.isColumnExists, t.isIndexExists) work inside bulk blocks.
+        columnExists: (t, col) => this.columnExists(t, col),
+        indexExists: (t, col, opts) => this.indexExists(t, col, opts as any),
       };
       const bulkTable = new Table(tableName, recorder as any);
       if (callback) await callback(bulkTable);
@@ -1497,7 +1501,7 @@ export class SchemaStatements {
             : null;
       const forAlterMethod = forAlterTarget ? forAlterTarget[`${command}ForAlter`] : null;
       if (typeof forAlterMethod === "function") {
-        const result = forAlterMethod.call(forAlterTarget, table, ...arguments_);
+        const result = await forAlterMethod.call(forAlterTarget, table, ...arguments_);
         const results = Array.isArray(result) ? result : [result];
         for (const r of results) {
           if (typeof r === "string") {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -645,36 +645,32 @@ export class SchemaStatements {
 
     if (options.bulk && supportsBulk) {
       const ops: Array<[string, string, ...unknown[]]> = [];
-      const unsupported = (name: string) => () =>
-        Promise.reject(new Error(`${name} is not supported in bulk changeTable`));
+      const rec =
+        (cmd: string) =>
+        (...args: unknown[]) => {
+          ops.push([cmd, ...(args as [string, ...unknown[]])]);
+          return Promise.resolve();
+        };
       const recorder: SchemaStatementsLike = {
-        addIndex: (t, cols, opts) => {
-          ops.push(["addIndex", t, cols, opts ?? {}]);
+        addIndex: rec("addIndex"),
+        removeIndex: (t, opts) => {
+          // Rails' CommandRecorder captures removeIndex as [tableName, options]; bulkChangeTable
+          // dispatches to removeIndexForAlter(tableName, column, options). Extract column to match.
+          const { column, ...rest } = (opts ?? {}) as any;
+          ops.push(["removeIndex", t, column, rest]);
           return Promise.resolve();
         },
-        addColumn: (t, name, type, opts) => {
-          ops.push(["addColumn", t, name, type, opts ?? {}]);
-          return Promise.resolve();
-        },
-        removeColumn: (t, name, type, opts) => {
-          ops.push(["removeColumn", t, name, type ?? undefined, opts ?? {}]);
-          return Promise.resolve();
-        },
-        renameColumn: (t, old_, new_) => {
-          ops.push(["renameColumn", t, old_, new_]);
-          return Promise.resolve();
-        },
-        addTimestamps: (t, opts) => {
-          ops.push(["addTimestamps", t, opts ?? {}]);
-          return Promise.resolve();
-        },
-        removeTimestamps: (t) => {
-          ops.push(["removeTimestamps", t]);
-          return Promise.resolve();
-        },
-        removeIndex: unsupported("removeIndex"),
-        addReference: unsupported("addReference"),
-        removeReference: unsupported("removeReference"),
+        addColumn: rec("addColumn"),
+        removeColumn: rec("removeColumn"),
+        renameColumn: rec("renameColumn"),
+        changeColumn: rec("changeColumn"),
+        changeColumnDefault: rec("changeColumnDefault"),
+        changeColumnNull: rec("changeColumnNull"),
+        renameIndex: rec("renameIndex"),
+        addTimestamps: rec("addTimestamps"),
+        removeTimestamps: rec("removeTimestamps"),
+        addReference: rec("addReference"),
+        removeReference: rec("removeReference"),
       };
       const bulkTable = new Table(tableName, recorder as any);
       if (callback) await callback(bulkTable);
@@ -1491,9 +1487,17 @@ export class SchemaStatements {
     const nonCombinable: Array<() => Promise<void>> = [];
 
     for (const [command, table, ...arguments_] of operations) {
-      const forAlterMethod = (this as any)[`${command}ForAlter`];
+      // Check SchemaStatements first, then the adapter — mirrors Rails where bulk_change_table
+      // lives on the adapter and calls adapter-defined *_for_alter methods.
+      const forAlterTarget =
+        typeof (this as any)[`${command}ForAlter`] === "function"
+          ? (this as any)
+          : typeof (this.adapter as any)[`${command}ForAlter`] === "function"
+            ? (this.adapter as any)
+            : null;
+      const forAlterMethod = forAlterTarget ? forAlterTarget[`${command}ForAlter`] : null;
       if (typeof forAlterMethod === "function") {
-        const result = forAlterMethod.call(this, table, ...arguments_);
+        const result = forAlterMethod.call(forAlterTarget, table, ...arguments_);
         const results = Array.isArray(result) ? result : [result];
         for (const r of results) {
           if (typeof r === "string") {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -653,13 +653,7 @@ export class SchemaStatements {
         };
       const recorder: SchemaStatementsLike = {
         addIndex: rec("addIndex"),
-        removeIndex: (t, opts) => {
-          // Rails' CommandRecorder captures removeIndex as [tableName, options]; bulkChangeTable
-          // dispatches to removeIndexForAlter(tableName, column, options). Extract column to match.
-          const { column, ...rest } = (opts ?? {}) as any;
-          ops.push(["removeIndex", t, column, rest]);
-          return Promise.resolve();
-        },
+        removeIndex: rec("removeIndex"),
         addColumn: rec("addColumn"),
         removeColumn: rec("removeColumn"),
         renameColumn: rec("renameColumn"),
@@ -1497,13 +1491,13 @@ export class SchemaStatements {
     const nonCombinable: Array<() => Promise<void>> = [];
 
     for (const [command, table, ...arguments_] of operations) {
-      // Check SchemaStatements first, then the adapter — mirrors Rails where bulk_change_table
-      // lives on the adapter and calls adapter-defined *_for_alter methods.
+      // Prefer adapter-specific *ForAlter over the generic SchemaStatements one — mirrors Rails
+      // where bulk_change_table and all *_for_alter methods live on the same adapter object.
       const forAlterTarget =
-        typeof (this as any)[`${command}ForAlter`] === "function"
-          ? (this as any)
-          : typeof (this.adapter as any)[`${command}ForAlter`] === "function"
-            ? (this.adapter as any)
+        typeof (this.adapter as any)[`${command}ForAlter`] === "function"
+          ? (this.adapter as any)
+          : typeof (this as any)[`${command}ForAlter`] === "function"
+            ? (this as any)
             : null;
       const forAlterMethod = forAlterTarget ? forAlterTarget[`${command}ForAlter`] : null;
       if (typeof forAlterMethod === "function") {
@@ -2046,6 +2040,18 @@ export class SchemaStatements {
     _options: Record<string, unknown> = {},
   ): string[] {
     return columnNames.map((col) => this.removeColumnForAlter(tableName, col));
+  }
+
+  /** @internal */
+  removeIndexForAlter(
+    tableName: string,
+    options: { column?: string | string[]; name?: string } = {},
+  ): string {
+    const name =
+      options.name ??
+      (options.column ? this.indexName(tableName, { column: options.column }) : undefined);
+    if (!name) throw new Error("removeIndexForAlter: must specify :name or :column");
+    return `DROP INDEX ${this.adapter.quoteIdentifier(name)}`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -645,37 +645,30 @@ export class SchemaStatements {
 
     if (options.bulk && supportsBulk) {
       const ops: Array<[string, string, ...unknown[]]> = [];
-      const rec =
-        (cmd: string) =>
-        (...args: unknown[]) => {
-          ops.push([cmd, ...(args as [string, ...unknown[]])]);
-          return Promise.resolve();
-        };
-      const recorder: SchemaStatementsLike = {
-        addIndex: rec("addIndex"),
-        removeIndex: rec("removeIndex"),
-        addColumn: rec("addColumn"),
-        removeColumn: rec("removeColumn"),
-        renameColumn: rec("renameColumn"),
-        changeColumn: rec("changeColumn"),
-        changeColumnDefault: rec("changeColumnDefault"),
-        changeColumnNull: rec("changeColumnNull"),
-        renameIndex: rec("renameIndex"),
-        addTimestamps: rec("addTimestamps"),
-        removeTimestamps: rec("removeTimestamps"),
-        addReference: rec("addReference"),
-        removeReference: rec("removeReference"),
-        addForeignKey: rec("addForeignKey"),
-        removeForeignKey: rec("removeForeignKey"),
-        addCheckConstraint: rec("addCheckConstraint"),
-        removeCheckConstraint: rec("removeCheckConstraint"),
-        // Read-only predicates pass through to the real SchemaStatements.
-        columnExists: (t, col) => this.columnExists(t, col),
-        indexExists: (t, col, opts) => this.indexExists(t, col, opts as any),
-        foreignKeyExists: (t, opts) => this.foreignKeyExists(t, opts as any),
-        isCheckConstraintExists: (t, opts) => this.isCheckConstraintExists(t, opts as any),
-        primaryKey: (t) => this.primaryKey(t),
-      };
+      // Mirrors Rails' CommandRecorder#method_missing: records any DDL method call into ops
+      // so bulkChangeTable can coalesce or fall back. Read-only predicates delegate to the
+      // real SchemaStatements so Table#isColumnExists / isIndexExists etc. work in bulk blocks.
+      // Using a Proxy handles adapter-specific methods (e.g. PgTable#addUniqueConstraint)
+      // without enumerating them statically.
+      const predicates = new Set([
+        "columnExists",
+        "indexExists",
+        "foreignKeyExists",
+        "isCheckConstraintExists",
+        "primaryKey",
+      ]);
+      const ss = this;
+      const recorder = new Proxy({} as SchemaStatementsLike, {
+        get(_target, prop: string) {
+          if (predicates.has(prop)) {
+            return (ss as any)[prop].bind(ss);
+          }
+          return (...args: unknown[]) => {
+            ops.push([prop, ...(args as [string, ...unknown[]])]);
+            return Promise.resolve();
+          };
+        },
+      });
       const bulkTable = this.updateTableDefinition(tableName, recorder as any);
       if (callback) await callback(bulkTable);
       await this.bulkChangeTable(tableName, ops);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -28,6 +28,7 @@ import {
   type ColumnType,
   type ColumnOptions,
   type IdHashOptions,
+  type SchemaStatementsLike,
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { quote } from "./quoting.js";
@@ -630,9 +631,58 @@ export class SchemaStatements {
     await this.dropTable(tableName);
   }
 
-  async changeTable(tableName: string, fn?: (t: Table) => void | Promise<void>): Promise<void> {
-    const table = new Table(tableName, this);
-    if (fn) await fn(table);
+  async changeTable(
+    tableName: string,
+    fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },
+    fn?: (t: Table) => void | Promise<void>,
+  ): Promise<void> {
+    const options = typeof fnOrOptions === "function" ? {} : (fnOrOptions ?? {});
+    const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
+
+    const supportsBulk =
+      typeof (this.adapter as any).supportsBulkAlter === "function" &&
+      (this.adapter as any).supportsBulkAlter() === true;
+
+    if (options.bulk && supportsBulk) {
+      const ops: Array<[string, string, ...unknown[]]> = [];
+      const unsupported = (name: string) => () =>
+        Promise.reject(new Error(`${name} is not supported in bulk changeTable`));
+      const recorder: SchemaStatementsLike = {
+        addIndex: (t, cols, opts) => {
+          ops.push(["addIndex", t, cols, opts ?? {}]);
+          return Promise.resolve();
+        },
+        addColumn: (t, name, type, opts) => {
+          ops.push(["addColumn", t, name, type, opts ?? {}]);
+          return Promise.resolve();
+        },
+        removeColumn: (t, name, type, opts) => {
+          ops.push(["removeColumn", t, name, type ?? undefined, opts ?? {}]);
+          return Promise.resolve();
+        },
+        renameColumn: (t, old_, new_) => {
+          ops.push(["renameColumn", t, old_, new_]);
+          return Promise.resolve();
+        },
+        addTimestamps: (t, opts) => {
+          ops.push(["addTimestamps", t, opts ?? {}]);
+          return Promise.resolve();
+        },
+        removeTimestamps: (t) => {
+          ops.push(["removeTimestamps", t]);
+          return Promise.resolve();
+        },
+        removeIndex: unsupported("removeIndex"),
+        addReference: unsupported("addReference"),
+        removeReference: unsupported("removeReference"),
+      };
+      const bulkTable = new Table(tableName, recorder as any);
+      if (callback) await callback(bulkTable);
+      await this.bulkChangeTable(tableName, ops);
+    } else {
+      const table = new Table(tableName, this);
+      if (callback) await callback(table);
+    }
   }
 
   async renameIndex(_tableName: string, oldName: string, newName: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds `bulk: true` support to `changeTable` in `SchemaStatements` — when the adapter supports bulk alter, operations are recorded then coalesced into a single `ALTER TABLE` statement via `bulkChangeTable`
- Un-skips `"index in bulk change"` test in `active-schema.test.ts` — the existing `addIndexForAlter` (line 1450 of `abstract-mysql-adapter.ts`) already had the correct SQL generation; the missing piece was the `changeTable` bulk dispatch path
- Un-skips `"add timestamps"` and `"remove timestamps"` — rewritten as live-table tests using `createTable`/`addTimestamps`/`removeTimestamps`/`columnExists` directly (no `captureSql`)

## Test plan

- [ ] All 3 un-skipped tests pass in CI MySQL job
- [ ] Existing `active-schema.test.ts` tests remain green
- [ ] TypeScript build passes (pre-commit hook confirmed)