### PR TITLE
feat(activerecord): PG-adapter Slot E — prepared-statements introspection

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -373,17 +373,45 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.disableExtension("citext", { force: "cascade" });
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
-    it.skip("prepared statements", async () => {
-      // BLOCKED: Verifying pg_prepared_statements state not yet implemented.
+    it("prepared statements", async () => {
+      adapter.preparedStatements = true;
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::integer AS n", [1]);
+        const rows = await adapter.execute("SELECT name FROM pg_prepared_statements");
+        expect(rows.length).toBeGreaterThan(0);
+      } finally {
+        await adapter.rollback();
+      }
     });
-    it.skip("prepared statements with multiple binds", async () => {
-      // BLOCKED: Same as "prepared statements" — pg_prepared_statements verification.
+    it("prepared statements with multiple binds", async () => {
+      adapter.preparedStatements = true;
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::integer + $2::integer AS n", [1, 2]);
+        const rows = await adapter.execute("SELECT name FROM pg_prepared_statements");
+        expect(rows.length).toBeGreaterThan(0);
+      } finally {
+        await adapter.rollback();
+      }
     });
-    it.skip("prepared statements disabled", async () => {
-      // BLOCKED: See adapters/postgresql/prepared-statements-disabled.test.ts.
+    it("prepared statements disabled", async () => {
+      const a = new PostgreSQLAdapter({ connectionString: PG_TEST_URL, preparedStatements: false });
+      try {
+        expect(a.preparedStatements).toBe(false);
+        const result = await a.execute("SELECT 1 AS n");
+        expect(result[0]["n"]).toBe(1);
+      } finally {
+        await a.close();
+      }
     });
-    it.skip("default prepared statements", async () => {
-      // BLOCKED: preparedStatements defaults to true but not yet tested standalone.
+    it("default prepared statements", async () => {
+      const a = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        expect(a.preparedStatements).toBe(true);
+      } finally {
+        await a.close();
+      }
     });
 
     // ── Bind parameter rewriting + type round-trip ──────────────────────

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -1,28 +1,28 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
-    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL, preparedStatements: false });
   });
   afterEach(async () => {
     await adapter.close();
   });
 
   describe("PreparedStatementsDisabledTest", () => {
-    it.skip("prepared statements disabled", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in prepared-statements-disabled
-      // ROOT-CAUSE: connection-adapters/postgresql/prepared-statements-disabled.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/prepared-statements-disabled.ts; affects ~10–47 tests in prepared-statements-disabled.test.ts
+    it("prepared statements disabled", async () => {
+      expect(adapter.preparedStatements).toBe(false);
     });
-    it.skip("select query works even when prepared statements are disabled", async () => {
-      // BLOCKED: adapter-pg — PostgreSQL-specific adapter gap in prepared-statements-disabled
-      // ROOT-CAUSE: connection-adapters/postgresql/prepared-statements-disabled.ts missing or incomplete Rails parity
-      // SCOPE: ~50–200 LOC fix in connection-adapters/postgresql/prepared-statements-disabled.ts; affects ~10–47 tests in prepared-statements-disabled.test.ts
+    it("select query works even when prepared statements are disabled", async () => {
+      expect(adapter.preparedStatements).toBe(false);
+      const withBinds = await adapter.execute("SELECT $1::integer AS n", [42]);
+      expect(withBinds[0]["n"]).toBe(42);
+      const withoutBinds = await adapter.execute("SELECT 1 AS n");
+      expect(withoutBinds[0]["n"]).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Un-skip 3 test groups (6 tests) in the PG-adapter prepared-statements cluster
- `prepared-statements-disabled.test.ts`: implement both `PreparedStatementsDisabledTest` tests — create adapter with `preparedStatements: false`, verify the flag is `false` and that queries (with and without binds) execute correctly
- `postgresql-adapter.test.ts`: implement "prepared statements" and "prepared statements with multiple binds" (query `pg_prepared_statements` system view inside a txn to verify server-side PREPARE); "prepared statements disabled" (standalone no-prepared adapter); "default prepared statements" (verify default is `true`)

## Test plan

- [ ] Postgres available: `pnpm vitest run packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts`
- [ ] CI runs full suite on push