### PR TITLE
feat(globalid): GID-5 — Identification mixin + locateSigned (+ GID-4 followups)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3,6 +3,7 @@ import {
   getApp as _getGlobalIdApp,
   buildGid as _buildGid,
   Locator as _Locator,
+  GlobalID as _GlobalIDCtor,
 } from "@blazetrails/globalid";
 import type {
   GlobalIDModel,
@@ -2870,6 +2871,23 @@ export class Base extends Model {
     return (await this.toSgid(options)).toParam();
   }
 
+  /** Mirrors: Identification#to_global_id — returns a GlobalID instance. */
+  toGlobalId(
+    options?: import("@blazetrails/globalid").GlobalIDOptions,
+  ): import("@blazetrails/globalid").GlobalID {
+    return _GlobalIDCtor.create(this as unknown as GlobalIDModel, options);
+  }
+
+  /** Mirrors: Identification#to_gid_param — base64url-encoded GID. */
+  toGidParam(options?: import("@blazetrails/globalid").GlobalIDOptions): string {
+    return this.toGlobalId(options).toParam();
+  }
+
+  /** Mirrors: Identification#to_signed_global_id — alias of toSgid. */
+  async toSignedGlobalId(options?: Parameters<Base["toSgid"]>[0]): Promise<SignedGlobalIDType> {
+    return this.toSgid(options);
+  }
+
   /**
    * Find a record by its GlobalID URI string (or GlobalID instance).
    * Returns null if the GID is invalid, the model class isn't registered, or
@@ -2883,6 +2901,26 @@ export class Base extends Model {
     options?: import("@blazetrails/globalid").LocateOptions,
   ): Promise<unknown | null> {
     return _Locator.locate(input, options);
+  }
+
+  /** Mirrors: ActiveRecord::Base.find_signed_global_id — uses signedIdVerifier(this). */
+  static async findSignedGlobalId(
+    input: string,
+    options?: { for?: string; only?: import("@blazetrails/globalid").LocateOptions["only"] },
+  ): Promise<unknown | null> {
+    const SignedIdModule = await loadSignedId();
+    const verifier = SignedIdModule.signedIdVerifier(this);
+    return _Locator.locateSigned(input, { ...options, verifier });
+  }
+
+  /** Mirrors: ActiveRecord::Base.find_signed_global_id! — throws on miss. */
+  static async findSignedGlobalIdBang(
+    input: string,
+    options?: { for?: string; only?: import("@blazetrails/globalid").LocateOptions["only"] },
+  ): Promise<unknown> {
+    const found = await this.findSignedGlobalId(input, options);
+    if (found == null) throw new RecordNotFound("Couldn't find SignedGlobalID");
+    return found;
   }
 
   // valuesAt / assignAttributes extracted to persistence.ts.
@@ -3582,5 +3620,11 @@ _setGlobalIdModelFinder((name: string) => {
   if (fromBase) return fromBase as unknown as _LocatorModel;
   const fromAssoc = _gidModelRegistry.get(name);
   if (fromAssoc) return fromAssoc as unknown as _LocatorModel;
+  // STI subclasses inherit their parent's adapter, so they don't trigger the
+  // adapter setter that populates _modelsByName. They're tracked via
+  // Base.descendants when registerSubclass() has been called on them.
+  for (const klass of Base.descendants) {
+    if (klass.name === name) return klass as unknown as _LocatorModel;
+  }
   return undefined;
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -5,6 +5,24 @@ import {
   Locator as _Locator,
   GlobalID as _GlobalIDCtor,
 } from "@blazetrails/globalid";
+import type { SignedGlobalID as _SignedGlobalIDType } from "@blazetrails/globalid/signed-global-id";
+
+/**
+ * Options accepted by {@link Base.toSgid} / {@link Base.toSignedGlobalId} /
+ * {@link Base.toSgidParam}. Mirrors SignedGlobalIDOptions minus `verifier`
+ * (AR supplies the verifier via signedIdVerifier(this)). The index signature
+ * carries arbitrary keys through as GID URI params, matching Rails.
+ */
+interface ToSgidOptions {
+  app?: string;
+  /** Rails-canonical purpose option. */
+  for?: string;
+  /** Alias of `for` kept for backward compatibility. */
+  purpose?: string;
+  expiresIn?: number;
+  expiresAt?: Temporal.Instant;
+  [key: string]: unknown;
+}
 import type {
   GlobalIDModel,
   SignedGlobalID as SignedGlobalIDType,
@@ -2846,9 +2864,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#to_sgid
    */
-  async toSgid(
-    options?: Omit<import("@blazetrails/globalid").SignedGlobalIDOptions, "verifier">,
-  ): Promise<SignedGlobalIDType> {
+  async toSgid(options?: ToSgidOptions): Promise<SignedGlobalIDType> {
     const [SgidMod, SignedIdModule] = await Promise.all([loadSgid(), loadSignedId()]);
     const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
     return SgidMod.SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier });
@@ -2897,7 +2913,7 @@ export class Base extends Model {
 
   /** Mirrors: ActiveRecord::Base.find_signed_global_id — uses signedIdVerifier(this). */
   static async findSignedGlobalId(
-    input: string,
+    input: string | _SignedGlobalIDType,
     options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
   ): Promise<unknown | null> {
     const SignedIdModule = await loadSignedId();
@@ -2907,7 +2923,7 @@ export class Base extends Model {
 
   /** Mirrors: ActiveRecord::Base.find_signed_global_id! — throws on miss. */
   static async findSignedGlobalIdBang(
-    input: string,
+    input: string | _SignedGlobalIDType,
     options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
   ): Promise<unknown> {
     const found = await this.findSignedGlobalId(input, options);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2906,7 +2906,7 @@ export class Base extends Model {
   /** Mirrors: ActiveRecord::Base.find_signed_global_id — uses signedIdVerifier(this). */
   static async findSignedGlobalId(
     input: string,
-    options?: { for?: string; only?: import("@blazetrails/globalid").LocateOptions["only"] },
+    options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
   ): Promise<unknown | null> {
     const SignedIdModule = await loadSignedId();
     const verifier = SignedIdModule.signedIdVerifier(this);
@@ -2916,7 +2916,7 @@ export class Base extends Model {
   /** Mirrors: ActiveRecord::Base.find_signed_global_id! — throws on miss. */
   static async findSignedGlobalIdBang(
     input: string,
-    options?: { for?: string; only?: import("@blazetrails/globalid").LocateOptions["only"] },
+    options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
   ): Promise<unknown> {
     const found = await this.findSignedGlobalId(input, options);
     if (found == null) throw new RecordNotFound("Couldn't find SignedGlobalID");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2846,12 +2846,9 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#to_sgid
    */
-  async toSgid(options?: {
-    app?: string;
-    purpose?: string;
-    expiresIn?: number;
-    expiresAt?: Temporal.Instant;
-  }): Promise<SignedGlobalIDType> {
+  async toSgid(
+    options?: Omit<import("@blazetrails/globalid").SignedGlobalIDOptions, "verifier">,
+  ): Promise<SignedGlobalIDType> {
     const [SgidMod, SignedIdModule] = await Promise.all([loadSgid(), loadSignedId()]);
     const verifier = SignedIdModule.signedIdVerifier(this.constructor as typeof Base);
     return SgidMod.SignedGlobalID.create(this as GlobalIDModel, { ...options, verifier });
@@ -2862,12 +2859,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#to_sgid_param
    */
-  async toSgidParam(options?: {
-    app?: string;
-    purpose?: string;
-    expiresIn?: number;
-    expiresAt?: Temporal.Instant;
-  }): Promise<string> {
+  async toSgidParam(options?: Parameters<Base["toSgid"]>[0]): Promise<string> {
     return (await this.toSgid(options)).toParam();
   }
 
@@ -3621,10 +3613,13 @@ _setGlobalIdModelFinder((name: string) => {
   const fromAssoc = _gidModelRegistry.get(name);
   if (fromAssoc) return fromAssoc as unknown as _LocatorModel;
   // STI subclasses inherit their parent's adapter, so they don't trigger the
-  // adapter setter that populates _modelsByName. They're tracked via
-  // Base.descendants when registerSubclass() has been called on them.
+  // adapter setter that populates _modelsByName. Walk Base.descendants once
+  // and cache the match into _modelsByName so subsequent lookups are O(1).
   for (const klass of Base.descendants) {
-    if (klass.name === name) return klass as unknown as _LocatorModel;
+    if (klass.name === name) {
+      Base._modelsByName.set(name, klass as typeof Base);
+      return klass as unknown as _LocatorModel;
+    }
   }
   return undefined;
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3613,12 +3613,15 @@ _setGlobalIdModelFinder((name: string) => {
   const fromAssoc = _gidModelRegistry.get(name);
   if (fromAssoc) return fromAssoc as unknown as _LocatorModel;
   // STI subclasses inherit their parent's adapter, so they don't trigger the
-  // adapter setter that populates _modelsByName. Walk Base.descendants once
-  // and cache the match into _modelsByName so subsequent lookups are O(1).
-  for (const klass of Base.descendants) {
-    if (klass.name === name) {
-      Base._modelsByName.set(name, klass as typeof Base);
-      return klass as unknown as _LocatorModel;
+  // adapter setter. registerSubclass(klass) attaches them to their direct
+  // parent's _subclasses, not to Base — so we walk descendants of every
+  // model in _modelsByName, not just Base.descendants. Cache for O(1) repeat.
+  for (const root of Base._modelsByName.values()) {
+    for (const klass of root.descendants) {
+      if (klass.name === name) {
+        Base._modelsByName.set(name, klass as typeof Base);
+        return klass as unknown as _LocatorModel;
+      }
     }
   }
   return undefined;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4,8 +4,12 @@ import {
   buildGid as _buildGid,
   Locator as _Locator,
   GlobalID as _GlobalIDCtor,
+  SignedGlobalID as _SignedGlobalIDType,
 } from "@blazetrails/globalid";
-import type { SignedGlobalID as _SignedGlobalIDType } from "@blazetrails/globalid/signed-global-id";
+// _SignedGlobalIDType is imported from the barrel so Locator.locateSigned's
+// parameter type stays nominally identical. Going through the
+// `/signed-global-id` subpath produces a distinct SignedGlobalID class under
+// src/ vs dist/ resolution (private fields are nominal in TS).
 
 /**
  * Options accepted by {@link Base.toSgid} / {@link Base.toSignedGlobalId} /

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -333,6 +333,28 @@ describe("Base.findGlobalId", () => {
   });
 });
 
+describe("Base.toGlobalId / toGidParam", () => {
+  afterEach(() => _resetApp());
+
+  it("toGlobalId returns a GlobalID instance; toGidParam round-trips through findGlobalId", async () => {
+    setApp("MyApp");
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Pat" });
+    const gid = u.toGlobalId();
+    expect(gid.uri).toBe(`gid://MyApp/User/${u.id}`);
+    expect(gid.modelName).toBe("User");
+    const found = (await Base.findGlobalId(u.toGidParam())) as User;
+    expect(found.id).toBe(u.id);
+  });
+});
+
 describe("Base.findSignedGlobalId", () => {
   beforeEach(() => setSignedIdVerifierSecret("blazetrails-test-secret"));
   afterEach(() => _resetApp());

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -380,6 +380,23 @@ describe("Base.findSignedGlobalId", () => {
     setApp("MyApp");
     await expect(Base.findSignedGlobalIdBang("invalid-token")).rejects.toThrow(RecordNotFound);
   });
+
+  it("toSignedGlobalId is an alias of toSgid (same URI + purpose)", async () => {
+    setApp("MyApp");
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ id: 7 });
+    const a = await u.toSignedGlobalId({ for: "login" });
+    const b = await u.toSgid({ for: "login" });
+    expect(a.uri).toBe(b.uri);
+    expect(a.purpose).toBe(b.purpose);
+    expect(a.purpose).toBe("login");
+  });
 });
 
 describe("signedId / findSigned / findSignedBang", () => {

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -333,6 +333,33 @@ describe("Base.findGlobalId", () => {
   });
 });
 
+describe("Base.findSignedGlobalId", () => {
+  beforeEach(() => setSignedIdVerifierSecret("blazetrails-test-secret"));
+  afterEach(() => _resetApp());
+
+  it("locates a record by SignedGlobalID token", async () => {
+    setApp("MyApp");
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Bob" });
+    const sgid = await u.toSgid();
+    const found = (await Base.findSignedGlobalId(sgid.toString())) as User;
+    expect(found).toBeInstanceOf(User);
+    expect(found.id).toBe(u.id);
+  });
+
+  it("findSignedGlobalIdBang throws RecordNotFound for invalid token", async () => {
+    setApp("MyApp");
+    await expect(Base.findSignedGlobalIdBang("invalid-token")).rejects.toThrow(RecordNotFound);
+  });
+});
+
 describe("signedId / findSigned / findSignedBang", () => {
   it("generates a signed ID for a persisted record", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Base, RecordNotFound } from "./index.js";
+import { Base, RecordNotFound, registerSubclass } from "./index.js";
 import { setSignedIdVerifierSecret, signedIdVerifier } from "./signed-id.js";
 import { SignedGlobalID, setApp, _resetApp } from "@blazetrails/globalid";
 
@@ -330,6 +330,28 @@ describe("Base.findGlobalId", () => {
     setApp("MyApp");
     const found = await Base.findGlobalId("gid://MyApp/NoSuchModel/1");
     expect(found).toBeNull();
+  });
+
+  it("resolves an inherited-adapter STI subclass via the descendants fallback", async () => {
+    setApp("MyApp");
+    const adapter = freshAdapter();
+    class Animal extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Dog extends Animal {
+      static {
+        // STI subclass registers with its parent; does NOT set its own adapter.
+        registerSubclass(this);
+      }
+    }
+    const d = await Dog.create({ name: "Rex" });
+    const found = (await Base.findGlobalId(d.toGid())) as Dog;
+    expect(found).toBeInstanceOf(Dog);
+    expect(found.id).toBe(d.id);
   });
 });
 

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -381,6 +381,26 @@ describe("Base.findSignedGlobalId", () => {
     await expect(Base.findSignedGlobalIdBang("invalid-token")).rejects.toThrow(RecordNotFound);
   });
 
+  it("findSignedGlobalId honors for: purpose scoping", async () => {
+    setApp("MyApp");
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ id: 3 });
+    const sgid = await u.toSgid({ for: "share" });
+    const token = sgid.toString();
+    // Matching for: locates the record.
+    const found = (await Base.findSignedGlobalId(token, { for: "share" })) as User;
+    expect(found.id).toBe(3);
+    // Mismatching for: returns null (purpose-scoped tokens are the SGID
+    // security boundary).
+    expect(await Base.findSignedGlobalId(token, { for: "other" })).toBeNull();
+  });
+
   it("toSignedGlobalId is an alias of toSgid (same URI + purpose)", async () => {
     setApp("MyApp");
     const adapter = freshAdapter();

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -3,7 +3,7 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { setApp, _resetApp } from "./config.js";
 import { GlobalID } from "./global-id.js";
 import { SignedGlobalID } from "./signed-global-id.js";
-import { toGlobalId, toGid, toSignedGlobalId, toSgid, toSgidParam } from "./identification.js";
+import { toGlobalId, toGid, toGidParam, toSignedGlobalId, toSgid } from "./identification.js";
 import { Locator, setModelFinder, _resetModelFinder, type LocatorModel } from "./locator.js";
 
 function makeVerifier(): MessageVerifier {
@@ -57,15 +57,26 @@ describe("GlobalIdentificationTest", () => {
 
   it("creates a signed Global ID with purpose", () => {
     const verifier = makeVerifier();
-    const a = toSignedGlobalId.call(new Person("1"), { verifier, purpose: "login" });
+    const a = toSignedGlobalId.call(new Person("1"), { verifier, for: "login" });
     expect(a.purpose).toBe("login");
+    // Round-trip verifies the purpose only when caller passes matching for:.
+    const token = a.toString();
+    expect(SignedGlobalID.parse(token, { verifier, for: "login" })).not.toBeNull();
+    expect(SignedGlobalID.parse(token, { verifier, for: "other" })).toBeNull();
   });
 
   it("creates a signed Global ID with custom params", () => {
     const verifier = makeVerifier();
-    const token = toSgidParam.call(new Person("1"), { verifier });
-    const parsed = SignedGlobalID.parse(token, { verifier });
-    expect(parsed!.uri).toBe("gid://bcx/Person/1");
+    const sgid = toSignedGlobalId.call(new Person("1"), { verifier, db: "primary" });
+    expect(sgid.uri).toContain("?db=primary");
+    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
+    expect(parsed!.uri).toContain("?db=primary");
+  });
+
+  it("toGidParam round-trips through GlobalID.parse", () => {
+    const p = new Person("5");
+    const parsed = GlobalID.parse(toGidParam.call(p));
+    expect(parsed!.modelId).toBe("5");
   });
 });
 
@@ -85,6 +96,17 @@ describe("Locator.locateSigned + locateManySigned", () => {
     const found = (await Locator.locateSigned(sgid.toString(), { verifier })) as Person;
     expect(found).toBeInstanceOf(Person);
     expect(found.id).toBe("7");
+  });
+
+  it("locate_signed finds a record by purpose-scoped SGID when for: matches", async () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(new Person("9"), { verifier, for: "login" });
+    const found = (await Locator.locateSigned(sgid.toString(), {
+      verifier,
+      for: "login",
+    })) as Person;
+    expect(found).toBeInstanceOf(Person);
+    expect(found.id).toBe("9");
   });
 
   it("locate_signed returns null for invalid signature or purpose mismatch", async () => {

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { setApp, _resetApp } from "./config.js";
+import { GlobalID } from "./global-id.js";
+import { SignedGlobalID } from "./signed-global-id.js";
+import { toGlobalId, toGid, toSignedGlobalId, toSgid, toSgidParam } from "./identification.js";
+import { Locator, setModelFinder, _resetModelFinder, type LocatorModel } from "./locator.js";
+
+function makeVerifier(): MessageVerifier {
+  return new MessageVerifier("test-secret", { digest: "sha256", url_safe: true });
+}
+
+class Person {
+  static name = "Person";
+  static primaryKey = "id";
+  id: string;
+  constructor(id: string) {
+    this.id = id;
+  }
+  static async find(id: unknown): Promise<Person | Person[]> {
+    if (Array.isArray(id)) return id.map((i) => new Person(String(i)));
+    return new Person(String(id));
+  }
+}
+
+describe("GlobalIdentificationTest", () => {
+  beforeEach(() => {
+    setApp("bcx");
+    setModelFinder((name) => (name === "Person" ? (Person as unknown as LocatorModel) : undefined));
+  });
+  afterEach(() => {
+    _resetApp();
+    _resetModelFinder();
+  });
+
+  it("creates a Global ID from self", () => {
+    const p = new Person("1");
+    expect(toGlobalId.call(p).uri).toBe(GlobalID.create(p).uri);
+    expect(toGid.call(p).uri).toBe(GlobalID.create(p).uri);
+    expect(toGlobalId.call(p)).toBeInstanceOf(GlobalID);
+  });
+
+  it("creates a Global ID with custom params", () => {
+    const p = new Person("1");
+    const a = toGlobalId.call(p, { some: "param" });
+    expect(a.params).toEqual({ some: "param" });
+  });
+
+  it("creates a signed Global ID from self", () => {
+    const verifier = makeVerifier();
+    const a = toSignedGlobalId.call(new Person("1"), { verifier });
+    const b = toSgid.call(new Person("1"), { verifier });
+    expect(a).toBeInstanceOf(SignedGlobalID);
+    expect(a.uri).toBe("gid://bcx/Person/1");
+    expect(b.uri).toBe(a.uri);
+  });
+
+  it("creates a signed Global ID with purpose", () => {
+    const verifier = makeVerifier();
+    const a = toSignedGlobalId.call(new Person("1"), { verifier, purpose: "login" });
+    expect(a.purpose).toBe("login");
+  });
+
+  it("creates a signed Global ID with custom params", () => {
+    const verifier = makeVerifier();
+    const token = toSgidParam.call(new Person("1"), { verifier });
+    const parsed = SignedGlobalID.parse(token, { verifier });
+    expect(parsed!.uri).toBe("gid://bcx/Person/1");
+  });
+});
+
+describe("Locator.locateSigned + locateManySigned", () => {
+  beforeEach(() => {
+    setApp("bcx");
+    setModelFinder((name) => (name === "Person" ? (Person as unknown as LocatorModel) : undefined));
+  });
+  afterEach(() => {
+    _resetApp();
+    _resetModelFinder();
+  });
+
+  it("locate_signed finds a record by valid SGID", async () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(new Person("7"), { verifier });
+    const found = (await Locator.locateSigned(sgid.toString(), { verifier })) as Person;
+    expect(found).toBeInstanceOf(Person);
+    expect(found.id).toBe("7");
+  });
+
+  it("locate_signed returns null for invalid signature or purpose mismatch", async () => {
+    const v1 = makeVerifier();
+    const v2 = new MessageVerifier("other", { digest: "sha256", url_safe: true });
+    const sgid = SignedGlobalID.create(new Person("7"), { verifier: v1, purpose: "login" });
+    expect(await Locator.locateSigned(sgid.toString(), { verifier: v2 })).toBeNull();
+    expect(await Locator.locateSigned(sgid.toString(), { verifier: v1, for: "signup" })).toBeNull();
+  });
+
+  it("locate_many_signed locates the valid subset", async () => {
+    const verifier = makeVerifier();
+    const wrongVerifier = new MessageVerifier("other", { digest: "sha256", url_safe: true });
+    const validSgid = SignedGlobalID.create(new Person("1"), { verifier });
+    const invalidSgid = SignedGlobalID.create(new Person("2"), { verifier: wrongVerifier });
+    const validSgid2 = SignedGlobalID.create(new Person("3"), { verifier });
+
+    const found = await Locator.locateManySigned(
+      [validSgid.toString(), invalidSgid.toString(), validSgid2.toString()],
+      { verifier },
+    );
+    expect(found).toHaveLength(2);
+    expect((found[0] as Person).id).toBe("1");
+    expect((found[1] as Person).id).toBe("3");
+  });
+});

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -145,6 +145,20 @@ describe("Locator.locateSigned + locateManySigned", () => {
     expect((found[0] as Person).id).toBe("1");
   });
 
+  it("accepts SignedGlobalID instances directly (no toString needed)", async () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(new Person("4"), { verifier });
+    const sgid2 = SignedGlobalID.create(new Person("5"), { verifier });
+    // locateSigned with a SignedGlobalID instance, not a string.
+    const found = (await Locator.locateSigned(sgid, { verifier })) as Person;
+    expect(found.id).toBe("4");
+    // locateManySigned with an array of SignedGlobalID instances.
+    const many = await Locator.locateManySigned([sgid, sgid2], { verifier });
+    expect(many).toHaveLength(2);
+    expect((many[0] as Person).id).toBe("4");
+    expect((many[1] as Person).id).toBe("5");
+  });
+
   it("locate_many_signed locates the valid subset", async () => {
     const verifier = makeVerifier();
     const wrongVerifier = new MessageVerifier("other", { digest: "sha256", url_safe: true });

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -3,7 +3,14 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { setApp, _resetApp } from "./config.js";
 import { GlobalID } from "./global-id.js";
 import { SignedGlobalID } from "./signed-global-id.js";
-import { toGlobalId, toGid, toGidParam, toSignedGlobalId, toSgid } from "./identification.js";
+import {
+  toGlobalId,
+  toGid,
+  toGidParam,
+  toSignedGlobalId,
+  toSgid,
+  toSgidParam,
+} from "./identification.js";
 import { Locator, setModelFinder, _resetModelFinder, type LocatorModel } from "./locator.js";
 
 function makeVerifier(): MessageVerifier {
@@ -78,6 +85,15 @@ describe("GlobalIdentificationTest", () => {
     const parsed = GlobalID.parse(toGidParam.call(p));
     expect(parsed!.modelId).toBe("5");
   });
+
+  it("toSgidParam returns a verifiable token", () => {
+    const verifier = makeVerifier();
+    const token = toSgidParam.call(new Person("2"), { verifier });
+    expect(typeof token).toBe("string");
+    const parsed = SignedGlobalID.parse(token, { verifier });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.uri).toBe("gid://bcx/Person/2");
+  });
 });
 
 describe("Locator.locateSigned + locateManySigned", () => {
@@ -115,6 +131,18 @@ describe("Locator.locateSigned + locateManySigned", () => {
     const sgid = SignedGlobalID.create(new Person("7"), { verifier: v1, purpose: "login" });
     expect(await Locator.locateSigned(sgid.toString(), { verifier: v2 })).toBeNull();
     expect(await Locator.locateSigned(sgid.toString(), { verifier: v1, for: "signup" })).toBeNull();
+  });
+
+  it("locate_many_signed filters by for: purpose", async () => {
+    const verifier = makeVerifier();
+    const matching = SignedGlobalID.create(new Person("1"), { verifier, for: "login" });
+    const mismatched = SignedGlobalID.create(new Person("2"), { verifier, for: "signup" });
+    const found = await Locator.locateManySigned([matching.toString(), mismatched.toString()], {
+      verifier,
+      for: "login",
+    });
+    expect(found).toHaveLength(1);
+    expect((found[0] as Person).id).toBe("1");
   });
 
   it("locate_many_signed locates the valid subset", async () => {

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -185,6 +185,43 @@ describe("locateMany with custom primaryKey and slash-containing composite ids",
   });
 });
 
+describe("locateMany ignoreMissing without toArray on the relation", () => {
+  class BadWhereModel {
+    static name = "BadWhereModel";
+    static primaryKey = "id";
+    id: string;
+    constructor(id: string) {
+      this.id = id;
+    }
+    static async find(id: unknown): Promise<BadWhereModel | BadWhereModel[]> {
+      if (Array.isArray(id)) return id.map((i) => new BadWhereModel(String(i)));
+      return new BadWhereModel(String(id));
+    }
+    // Returns a relation object missing .toArray — should trigger the
+    // explicit throw rather than silently returning [].
+    static where(): { someOtherMethod?: () => void } {
+      return {};
+    }
+  }
+
+  beforeEach(() => {
+    setApp("bcx");
+    setModelFinder((name) =>
+      name === "BadWhereModel" ? (BadWhereModel as unknown as LocatorModel) : undefined,
+    );
+  });
+  afterEach(() => {
+    _resetApp();
+    _resetModelFinder();
+  });
+
+  it("throws a clear error instead of silently returning []", async () => {
+    await expect(
+      Locator.locateMany(["gid://bcx/BadWhereModel/1"], { ignoreMissing: true }),
+    ).rejects.toThrow(/toArray/);
+  });
+});
+
 describe("Locator without model finder", () => {
   beforeEach(() => {
     setApp("bcx");

--- a/packages/globalid/src/identification.ts
+++ b/packages/globalid/src/identification.ts
@@ -1,0 +1,39 @@
+import { GlobalID, type GlobalIDModel, type GlobalIDOptions } from "./global-id.js";
+import { SignedGlobalID, type SignedGlobalIDOptions } from "./signed-global-id.js";
+
+/**
+ * Mirrors: GlobalID::Identification module — methods are mixed onto any
+ * model class with a `find(id)` class method (Active Record in our case).
+ *
+ * These are `this`-typed functions so the host class assigns them to its
+ * prototype; see CLAUDE.md for the mixin pattern.
+ */
+
+/** Mirrors: Identification#to_global_id */
+export function toGlobalId(this: GlobalIDModel, options: GlobalIDOptions = {}): GlobalID {
+  return GlobalID.create(this, options);
+}
+
+/** Alias of toGlobalId. Mirrors: Identification#to_gid */
+export const toGid = toGlobalId;
+
+/** Mirrors: Identification#to_gid_param */
+export function toGidParam(this: GlobalIDModel, options: GlobalIDOptions = {}): string {
+  return GlobalID.create(this, options).toParam();
+}
+
+/** Mirrors: Identification#to_signed_global_id */
+export function toSignedGlobalId(
+  this: GlobalIDModel,
+  options: SignedGlobalIDOptions,
+): SignedGlobalID {
+  return SignedGlobalID.create(this, options);
+}
+
+/** Alias of toSignedGlobalId. Mirrors: Identification#to_sgid */
+export const toSgid = toSignedGlobalId;
+
+/** Mirrors: Identification#to_sgid_param */
+export function toSgidParam(this: GlobalIDModel, options: SignedGlobalIDOptions): string {
+  return SignedGlobalID.create(this, options).toParam();
+}

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -16,4 +16,12 @@ export type { GidComponents } from "./uri/gid.js";
 export { Locator, setModelFinder } from "./locator.js";
 /** @internal */
 export { _resetModelFinder } from "./locator.js";
-export type { LocatorModel, LocateOptions, ModelFinder } from "./locator.js";
+export type { LocatorModel, LocateOptions, LocateSignedOptions, ModelFinder } from "./locator.js";
+export {
+  toGlobalId,
+  toGid,
+  toGidParam,
+  toSignedGlobalId,
+  toSgid,
+  toSgidParam,
+} from "./identification.js";

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -27,6 +27,8 @@ export interface LocateOptions {
 export interface LocateSignedOptions extends LocateOptions {
   /** Purpose to verify against (Rails: `for:`). */
   for?: string;
+  /** Alias of `for` kept consistent with SignedGlobalIDOptions/ParseOptions. */
+  purpose?: string;
   /** Verifier to validate the SGID signature. */
   verifier: MessageVerifier;
 }
@@ -117,31 +119,34 @@ export class Locator {
   }
 
   /**
-   * Mirrors: Locator.locate_signed(sgid, options).
-   * Parses the SGID with the supplied verifier; returns null on invalid
-   * signature, expired token, purpose mismatch, or unknown model class.
+   * Mirrors: Locator.locate_signed(sgid, options). Accepts a token string or
+   * a SignedGlobalID instance (parity with `locate` which accepts string |
+   * GlobalID). Returns null on invalid signature, expired token, purpose
+   * mismatch, or unknown model class.
    */
-  static async locateSigned(sgid: string, options: LocateSignedOptions): Promise<unknown | null> {
-    const parsed = SignedGlobalID.parse(sgid, {
-      for: options.for,
-      verifier: options.verifier,
-    });
+  static async locateSigned(
+    sgid: string | SignedGlobalID,
+    options: LocateSignedOptions,
+  ): Promise<unknown | null> {
+    const purpose = options.for ?? options.purpose;
+    const parsed = SignedGlobalID.parse(String(sgid), { for: purpose, verifier: options.verifier });
     if (!parsed) return null;
     return Locator.locate(parsed.uri, options);
   }
 
   /**
-   * Mirrors: Locator.locate_many_signed(sgids, options).
-   * Filters out invalid/expired SGIDs and locates the rest. Empty array if
-   * none verify.
+   * Mirrors: Locator.locate_many_signed(sgids, options). Accepts strings or
+   * SignedGlobalID instances. Filters out invalid/expired SGIDs and locates
+   * the rest. Empty array if none verify.
    */
-  static async locateManySigned(sgids: string[], options: LocateSignedOptions): Promise<unknown[]> {
+  static async locateManySigned(
+    sgids: Array<string | SignedGlobalID>,
+    options: LocateSignedOptions,
+  ): Promise<unknown[]> {
+    const purpose = options.for ?? options.purpose;
     const uris: string[] = [];
     for (const s of sgids) {
-      const parsed = SignedGlobalID.parse(s, {
-        purpose: options.for,
-        verifier: options.verifier,
-      });
+      const parsed = SignedGlobalID.parse(String(s), { for: purpose, verifier: options.verifier });
       if (parsed) uris.push(parsed.uri);
     }
     return Locator.locateMany(uris, options);

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -123,7 +123,7 @@ export class Locator {
    */
   static async locateSigned(sgid: string, options: LocateSignedOptions): Promise<unknown | null> {
     const parsed = SignedGlobalID.parse(sgid, {
-      purpose: options.for,
+      for: options.for,
       verifier: options.verifier,
     });
     if (!parsed) return null;

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -1,4 +1,6 @@
 import { GlobalID } from "./global-id.js";
+import { SignedGlobalID } from "./signed-global-id.js";
+import type { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
 /** Duck-typed model interface; globalid stays AR-agnostic. */
 export interface LocatorModel {
@@ -20,6 +22,13 @@ export interface LocateOptions {
    * this option, a missing record causes `find` to throw.
    */
   ignoreMissing?: boolean;
+}
+
+export interface LocateSignedOptions extends LocateOptions {
+  /** Purpose to verify against (Rails: `for:`). */
+  for?: string;
+  /** Verifier to validate the SGID signature. */
+  verifier: MessageVerifier;
 }
 
 /** Lookup function: given a model name, return the class (or undefined). */
@@ -106,6 +115,37 @@ export class Locator {
     }
     return result;
   }
+
+  /**
+   * Mirrors: Locator.locate_signed(sgid, options).
+   * Parses the SGID with the supplied verifier; returns null on invalid
+   * signature, expired token, purpose mismatch, or unknown model class.
+   */
+  static async locateSigned(sgid: string, options: LocateSignedOptions): Promise<unknown | null> {
+    const parsed = SignedGlobalID.parse(sgid, {
+      purpose: options.for,
+      verifier: options.verifier,
+    });
+    if (!parsed) return null;
+    return Locator.locate(parsed.uri, options);
+  }
+
+  /**
+   * Mirrors: Locator.locate_many_signed(sgids, options).
+   * Filters out invalid/expired SGIDs and locates the rest. Empty array if
+   * none verify.
+   */
+  static async locateManySigned(sgids: string[], options: LocateSignedOptions): Promise<unknown[]> {
+    const uris: string[] = [];
+    for (const s of sgids) {
+      const parsed = SignedGlobalID.parse(s, {
+        purpose: options.for,
+        verifier: options.verifier,
+      });
+      if (parsed) uris.push(parsed.uri);
+    }
+    return Locator.locateMany(uris, options);
+  }
 }
 
 function lookupClass(name: string): LocatorModel | undefined {
@@ -129,12 +169,18 @@ async function findRecords(
   ids: unknown[],
   options: LocateOptions,
 ): Promise<unknown[]> {
-  // Composite primary keys don't have a single column to filter by, so fall
-  // through to the batch find path even with ignoreMissing.
+  // Composite primary keys would need where(cols, tuples) — Rails relation
+  // form not yet supported by our AR layer. Fall through to find(ids), which
+  // raises on missing; CPK + ignoreMissing is a known limitation.
   if (options.ignoreMissing && klass.where && !Array.isArray(klass.primaryKey)) {
     const pkKey = klass.primaryKey ?? "id";
     const rel = klass.where({ [pkKey]: ids });
-    const records = await (rel.toArray ? rel.toArray() : []);
+    if (!rel.toArray) {
+      throw new Error(
+        "LocatorModel.where() returned a relation without .toArray() — required for ignoreMissing.",
+      );
+    }
+    const records = await rel.toArray();
     return Array.isArray(records) ? records : [];
   }
   // Rails: model_class.find(ids) — single batch call returning an array.

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -10,13 +10,21 @@ const DEFAULT_PURPOSE = "default";
 
 export interface SignedGlobalIDOptions {
   app?: string;
+  /** Rails-canonical purpose option. */
+  for?: string;
+  /** Alias of `for` kept for backward compatibility. */
   purpose?: string;
   expiresIn?: number;
   expiresAt?: Temporal.Instant;
   verifier: MessageVerifier;
+  /** Custom GID query params (any extra keys become URI params). */
+  [key: string]: unknown;
 }
 
 export interface ParseOptions {
+  /** Rails-canonical purpose option. */
+  for?: string;
+  /** Alias of `for` kept for backward compatibility. */
   purpose?: string;
   verifier: MessageVerifier;
 }
@@ -62,9 +70,20 @@ export class SignedGlobalID {
       );
     }
     const modelName = model.constructor.name;
-    const uri = buildGid(app, modelName, model.id);
+    // Rails: arbitrary options beyond the known SGID keys become GID URI params.
+    const KNOWN = new Set(["app", "for", "purpose", "expiresIn", "expiresAt", "verifier"]);
+    const filteredParams: Record<string, string> = {};
+    for (const [k, v] of Object.entries(options)) {
+      if (!KNOWN.has(k) && v != null) filteredParams[k] = String(v);
+    }
+    const uri = buildGid(
+      app,
+      modelName,
+      model.id,
+      Object.keys(filteredParams).length ? filteredParams : null,
+    );
 
-    const purpose = options.purpose ?? DEFAULT_PURPOSE;
+    const purpose = options.for ?? options.purpose ?? DEFAULT_PURPOSE;
     const expiresAt = pickExpiration(options);
 
     return new SignedGlobalID(uri, purpose, expiresAt, options.verifier);
@@ -77,7 +96,7 @@ export class SignedGlobalID {
    * Mirrors: SignedGlobalID.parse (verify_with_verifier_validated_metadata path)
    */
   static parse(sgid: string, options: ParseOptions): SignedGlobalID | null {
-    const purpose = options.purpose ?? DEFAULT_PURPOSE;
+    const purpose = options.for ?? options.purpose ?? DEFAULT_PURPOSE;
     const result = verifyToken(sgid, purpose, options.verifier);
     if (result === null) return null;
     const { uri, expiresAt } = result;

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -8,6 +8,9 @@ export type { GlobalIDModel };
 
 const DEFAULT_PURPOSE = "default";
 
+/** Option keys that are NOT forwarded as GID URI params. @internal */
+const KNOWN_SGID_KEYS = new Set(["app", "for", "purpose", "expiresIn", "expiresAt", "verifier"]);
+
 export interface SignedGlobalIDOptions {
   app?: string;
   /** Rails-canonical purpose option. */
@@ -71,10 +74,9 @@ export class SignedGlobalID {
     }
     const modelName = model.constructor.name;
     // Rails: arbitrary options beyond the known SGID keys become GID URI params.
-    const KNOWN = new Set(["app", "for", "purpose", "expiresIn", "expiresAt", "verifier"]);
     const filteredParams: Record<string, string> = {};
     for (const [k, v] of Object.entries(options)) {
-      if (!KNOWN.has(k) && v != null) filteredParams[k] = String(v);
+      if (!KNOWN_SGID_KEYS.has(k) && v != null) filteredParams[k] = String(v);
     }
     const uri = buildGid(
       app,


### PR DESCRIPTION
## Summary

### GID-5 (primary scope)

- **`identification.ts`** — new file with the `Identification` module mirror: `toGlobalId`, `toGid` (alias), `toGidParam`, `toSignedGlobalId`, `toSgid` (alias), `toSgidParam`. `this`-typed functions per the CLAUDE.md mixin pattern. `api:compare identification.rb` jumps from 0% → **100% (4/4)**.
- **`locator.ts`** — `Locator.locateSigned(sgid, options)` and `Locator.locateManySigned(sgids, options)`. New `LocateSignedOptions` carries the verifier + `for:` (purpose). `api:compare locator.rb` 19% → **31%**.
- **`base.ts`** — instance methods `toGlobalId`, `toGidParam`, `toSignedGlobalId` (Rails-faithful forms; `toGid()` keeps its existing string return). Static `findSignedGlobalId` and `findSignedGlobalIdBang` using `signedIdVerifier(this)`.
- **`global-identification.test.ts`** — 5/6 of `global_identification_test.rb` Ruby tests match by name. Locator-signed smoke tests included.

### GID-4 review-#3 follow-ups (bundled in this PR)

- `Locator.locate` model finder now walks `Base.descendants` as a third fallback (after `_modelsByName` and `modelRegistry`) so STI subclasses calling `registerSubclass()` are findable.
- CPK + `ignoreMissing` documented as a known limitation (Rails' composite `where(cols, tuples)` not yet supported by our AR layer; falls through to `find(ids)` which raises).
- `findRecords` throws a clear error when `LocatorModel.where()` returns a relation without `.toArray()` (was silently returning `[]`).

## api:compare delta

| File | Before | After |
|------|--------|-------|
| `identification.ts` | 0% | **100%** |
| `locator.ts` | 19% | 31% |
| **Overall** | 22% | **32.2%** |

## test:compare delta

5/158 → **10/158** (3/8 files have ≥1 named-match).

## Test plan

- [x] `pnpm vitest run packages/globalid/src/` — 36 tests pass
- [x] `pnpm vitest run packages/activerecord/src/signed-id.test.ts` — 32 pass, 9 skipped
- [x] `pnpm api:compare --package globalid` — 32.2% (from 22%)
- [x] `pnpm test:compare --package globalid` — 10/158 (from 5/158)
- [x] Build + typecheck pass via pre-commit hook