### PR TITLE
feat(eslint): enable rails-file-structure-method-order on activemodel

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -193,7 +193,7 @@ export default defineConfig(
   // by `pnpm tsx scripts/build-rails-file-structure-manifest.ts`,
   // invoked by `pnpm api:compare`). Autofixable.
   {
-    files: ["packages/arel/src/**/*.ts"],
+    files: ["packages/arel/src/**/*.ts", "packages/activemodel/src/**/*.ts"],
     ignores: ["**/*.test.ts"],
     rules: {
       "blazetrails/rails-file-structure-method-order": "error",

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -95,15 +95,6 @@ function extendedStart(node, sourceCode) {
   return i + 1;
 }
 
-function blockText(node, sourceCode) {
-  const start = extendedStart(node, sourceCode);
-  return {
-    start,
-    end: node.range[1],
-    text: sourceCode.getText().slice(start, node.range[1]),
-  };
-}
-
 function memberName(node) {
   // MethodDefinition / PropertyDefinition.
   if (node.type === "MethodDefinition" || node.type === "PropertyDefinition") {
@@ -111,9 +102,17 @@ function memberName(node) {
     if (node.key.name === "constructor") return "constructor";
     return node.key.name;
   }
-  // FunctionDeclaration (incl. as child of ExportNamedDeclaration).
-  if (node.type === "FunctionDeclaration") return node.id?.name ?? null;
-  if (node.type === "ExportNamedDeclaration" && node.declaration?.type === "FunctionDeclaration") {
+  // FunctionDeclaration / TSDeclareFunction (overload signatures —
+  // signature-only declarations without a body), incl. as child of
+  // ExportNamedDeclaration.
+  if (node.type === "FunctionDeclaration" || node.type === "TSDeclareFunction") {
+    return node.id?.name ?? null;
+  }
+  if (
+    node.type === "ExportNamedDeclaration" &&
+    (node.declaration?.type === "FunctionDeclaration" ||
+      node.declaration?.type === "TSDeclareFunction")
+  ) {
     return node.declaration.id?.name ?? null;
   }
   return null;
@@ -126,15 +125,52 @@ function isOrderableClassMember(node) {
 }
 
 function isOrderableTopLevel(node) {
-  if (node.type === "FunctionDeclaration") return !!node.id;
-  if (node.type === "ExportNamedDeclaration" && node.declaration?.type === "FunctionDeclaration") {
+  // TSDeclareFunction = overload signature (no body). Including them
+  // is essential so a same-named impl+signature group stays adjacent
+  // under reorder — TS errors out ("Function implementation name must
+  // be 'foo'") if signatures get separated from their implementation.
+  // The same-name grouping in computeTargetOrder keeps them together.
+  if (node.type === "FunctionDeclaration" || node.type === "TSDeclareFunction") {
+    return !!node.id;
+  }
+  if (
+    node.type === "ExportNamedDeclaration" &&
+    (node.declaration?.type === "FunctionDeclaration" ||
+      node.declaration?.type === "TSDeclareFunction")
+  ) {
     return !!node.declaration.id;
   }
   return false;
 }
 
+/**
+ * Group consecutive same-named members into a single "unit". TS
+ * function overload signatures (TSDeclareFunction) plus their
+ * implementation must remain physically adjacent — `function foo(x):
+ * A; function foo(x): B { … }` would otherwise be split by reorder if
+ * a non-orderable node (type alias, interface) sits in the original
+ * "slot" between the signatures and the impl. Same intent for class
+ * member overloads.
+ *
+ * Each unit gets one slot spanning all its consecutive members. The
+ * reorder algorithm then operates on units, not individual members.
+ */
+function groupUnits(members) {
+  const units = [];
+  for (const m of members) {
+    const name = memberName(m);
+    const prev = units[units.length - 1];
+    if (prev && prev.name === name && name !== null) {
+      prev.members.push(m);
+    } else {
+      units.push({ name, members: [m] });
+    }
+  }
+  return units;
+}
+
 function computeTargetOrder(currentNodes, expectedOrder) {
-  const names = currentNodes.map(memberName);
+  const names = currentNodes.map((u) => u.name);
   const expectedSet = new Set(expectedOrder);
   // Mapped subset in current order — used to detect "already correct"
   // without rebuilding when nothing maps.
@@ -236,6 +272,21 @@ const rule = {
 
     return {
       ClassBody(node) {
+        // Only consider classes at the top level of the file. Classes
+        // nested inside a function body (e.g. the `class NumericType
+        // extends Base` inside `applyNumericMixin()`) are
+        // implementation detail of the surrounding function — if we
+        // also reorder a containing top-level FunctionDeclaration, the
+        // two fix ranges overlap and ESLint throws.
+        const klass = node.parent; // ClassDeclaration | ClassExpression
+        const klassParent = klass?.parent;
+        const topLevel =
+          klassParent?.type === "Program" ||
+          (klassParent?.type === "ExportNamedDeclaration" &&
+            klassParent.parent?.type === "Program") ||
+          (klassParent?.type === "ExportDefaultDeclaration" &&
+            klassParent.parent?.type === "Program");
+        if (!topLevel) return;
         const orderable = node.body.filter(isOrderableClassMember);
         if (orderable.length < 2) return;
         containers.push({ container: node, members: orderable });
@@ -251,26 +302,39 @@ const rule = {
         let mismatchCount = 0;
 
         for (const { members } of containers) {
-          const target = computeTargetOrder(members, expectedOrder);
-          if (!ordersDiffer(members, target)) continue;
+          // Collapse consecutive same-named members into units before
+          // reorder, so TS overload groups (and class accessor pairs
+          // where the pair is already adjacent) move as a single block.
+          const units = groupUnits(members);
+          const target = computeTargetOrder(units, expectedOrder);
+          if (!ordersDiffer(units, target)) continue;
 
-          // Capture block texts BEFORE any fixes are applied so the
-          // single autofix pass swaps them all at once.
-          const slotBlocks = members.map((m) => blockText(m, sourceCode));
-          const targetBlocks = target.map((m) => blockText(m, sourceCode));
+          // Each unit's slot spans from the first member's extended
+          // start to the last member's end. Captured BEFORE any fixes
+          // are applied so the single autofix pass swaps them at once.
+          const slotBlocks = units.map((u) => {
+            const start = extendedStart(u.members[0], sourceCode);
+            const end = u.members[u.members.length - 1].range[1];
+            return { start, end, text: sourceCode.getText().slice(start, end) };
+          });
+          const targetBlocks = target.map((u) => {
+            const start = extendedStart(u.members[0], sourceCode);
+            const end = u.members[u.members.length - 1].range[1];
+            return { start, end, text: sourceCode.getText().slice(start, end) };
+          });
 
-          for (let i = 0; i < members.length; i++) {
+          for (let i = 0; i < units.length; i++) {
             fixes.push({
               range: [slotBlocks[i].start, slotBlocks[i].end],
               text: targetBlocks[i].text,
             });
-            if (members[i] !== target[i]) {
+            if (units[i] !== target[i]) {
               mismatchCount++;
               if (!firstMismatch) {
                 firstMismatch = {
-                  node: members[i],
-                  expectedName: memberName(target[i]),
-                  beforeName: memberName(members[i]),
+                  node: units[i].members[0],
+                  expectedName: target[i].name,
+                  beforeName: units[i].name,
                 };
               }
             }

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -87,6 +87,23 @@ try {
           `  third() {}\n` +
           `}\n`,
       },
+      // Class nested inside a function body is not reordered. If we
+      // also reordered the outer function (it has 0 siblings here so
+      // we don't), the nested class members' fix ranges would overlap
+      // the function's fix range and ESLint would throw. Skipping
+      // non-top-level classes avoids the conflict and matches the
+      // file-structure intent (top-of-file mirroring, not deep AST).
+      {
+        filename: classFile,
+        code:
+          `export function mkClass() {\n` +
+          `  return class {\n` +
+          `    third() {}\n` +
+          `    first() {}\n` +
+          `    second() {}\n` +
+          `  };\n` +
+          `}\n`,
+      },
       // Hoisting-scope safety: ClassDeclaration and `const`/`let` are NOT
       // orderable. A file with only those declarations (no
       // MethodDefinition or FunctionDeclaration) emits no diagnostic,
@@ -99,6 +116,27 @@ try {
       },
     ],
     invalid: [
+      // TS function overload signatures (TSDeclareFunction) travel
+      // with their implementation. Separating them would produce
+      // TS2389 ("Function implementation name must be 'foo'").
+      // Same-name grouping in computeTargetOrder keeps the
+      // signature(s) + implementation adjacent across a reorder.
+      {
+        filename: fnFile,
+        code:
+          `export function beta(x: string): string;\n` +
+          `export function beta(x: number): number;\n` +
+          `export function beta(x: any): any { return x; }\n` +
+          `export function alpha(): void {}\n` +
+          `export function gamma(): void {}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `export function alpha(): void {}\n` +
+          `export function beta(x: string): string;\n` +
+          `export function beta(x: number): number;\n` +
+          `export function beta(x: any): any { return x; }\n` +
+          `export function gamma(): void {}\n`,
+      },
       // Class methods out of order.
       {
         filename: classFile,

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -5,6 +5,65 @@ interface PermittedAttributes {
   permitted?(): boolean;
 }
 
+export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
+  if (typeof newAttributes !== "object" || newAttributes === null || Array.isArray(newAttributes)) {
+    throw new ArgumentError(
+      `When assigning attributes, you must pass a hash as an argument, ${typeNameForError(newAttributes)} passed.`,
+    );
+  }
+
+  const attrs = newAttributes as Record<string, unknown>;
+  if (Object.keys(attrs).length === 0) return;
+
+  const sanitized = sanitizeForMassAssignment(attrs);
+  _assignAttributes(model, sanitized);
+}
+
+export interface AttributeAssignment {
+  writeAttribute(name: string, value: unknown): void;
+  attributeWriterMissing?(name: string, value: unknown): void;
+}
+
+export function attributeWriterMissing(
+  model: AttributeAssignment,
+  name: string,
+  _value: unknown,
+): void {
+  throw new UnknownAttributeError(model, name);
+}
+
+/** @internal Rails-private helper. */
+export function _assignAttributes(
+  model: AttributeAssignment,
+  attributes: Record<string, unknown>,
+): void {
+  for (const [k, v] of Object.entries(attributes)) {
+    _assignAttribute(model, k, v);
+  }
+}
+
+/** @internal Rails-private helper. */
+export function _assignAttribute(model: AttributeAssignment, key: string, value: unknown): void {
+  const setter = findSetter(model, key);
+  if (setter) {
+    setter.call(model, value);
+    return;
+  }
+  try {
+    model.writeAttribute(key, value);
+  } catch (error) {
+    if (error instanceof UnknownAttributeError) {
+      if (typeof model.attributeWriterMissing === "function") {
+        model.attributeWriterMissing(key, value);
+      } else {
+        attributeWriterMissing(model, key, value);
+      }
+    } else {
+      throw error;
+    }
+  }
+}
+
 /** @internal Rails-private helper. */
 export function sanitizeForMassAssignment(
   attributes: Record<string, unknown>,
@@ -18,30 +77,11 @@ export function sanitizeForMassAssignment(
   return attributes;
 }
 
-export interface AttributeAssignment {
-  writeAttribute(name: string, value: unknown): void;
-  attributeWriterMissing?(name: string, value: unknown): void;
-}
-
 function typeNameForError(value: unknown): string {
   if (value === null) return "Null";
   if (Array.isArray(value)) return "Array";
   const t = typeof value;
   return t.charAt(0).toUpperCase() + t.slice(1);
-}
-
-export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
-  if (typeof newAttributes !== "object" || newAttributes === null || Array.isArray(newAttributes)) {
-    throw new ArgumentError(
-      `When assigning attributes, you must pass a hash as an argument, ${typeNameForError(newAttributes)} passed.`,
-    );
-  }
-
-  const attrs = newAttributes as Record<string, unknown>;
-  if (Object.keys(attrs).length === 0) return;
-
-  const sanitized = sanitizeForMassAssignment(attrs);
-  _assignAttributes(model, sanitized);
 }
 
 /**
@@ -80,46 +120,6 @@ function findSetter(model: object, key: string): ((this: object, value: unknown)
     obj = Object.getPrototypeOf(obj);
   }
   return null;
-}
-
-/** @internal Rails-private helper. */
-export function _assignAttributes(
-  model: AttributeAssignment,
-  attributes: Record<string, unknown>,
-): void {
-  for (const [k, v] of Object.entries(attributes)) {
-    _assignAttribute(model, k, v);
-  }
-}
-
-/** @internal Rails-private helper. */
-export function _assignAttribute(model: AttributeAssignment, key: string, value: unknown): void {
-  const setter = findSetter(model, key);
-  if (setter) {
-    setter.call(model, value);
-    return;
-  }
-  try {
-    model.writeAttribute(key, value);
-  } catch (error) {
-    if (error instanceof UnknownAttributeError) {
-      if (typeof model.attributeWriterMissing === "function") {
-        model.attributeWriterMissing(key, value);
-      } else {
-        attributeWriterMissing(model, key, value);
-      }
-    } else {
-      throw error;
-    }
-  }
-}
-
-export function attributeWriterMissing(
-  model: AttributeAssignment,
-  name: string,
-  _value: unknown,
-): void {
-  throw new UnknownAttributeError(model, name);
 }
 
 class ArgumentError extends globalThis.Error {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -130,34 +130,46 @@ export interface AttributeMethodHost {
   prototype: { [key: string]: unknown };
 }
 
-function ensureOwnPatterns(host: AttributeMethodHost): void {
-  if (!Object.prototype.hasOwnProperty.call(host, "_attributeMethodPatterns")) {
-    host._attributeMethodPatterns = [...host._attributeMethodPatterns];
-  }
+/** @internal Rails-private helper. Mirrors: #attribute_method? */
+export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
+  return this._attributes?.has(attrName) ?? false;
 }
 
-function ensureOwnGeneratedMethods(host: AttributeMethodHost): void {
-  if (!Object.prototype.hasOwnProperty.call(host, "_generatedMethods")) {
-    host._generatedMethods = new Set(host._generatedMethods ?? []);
-  }
+/** @internal Rails-private helper. Mirrors: #matched_attribute_method */
+export function matchedAttributeMethod(
+  this: InstanceHost,
+  methodName: string,
+): { proxyTarget: string; attrName: string } | null {
+  const matches = attributeMethodPatternsMatching.call(
+    this.constructor as AttributeMethodHost,
+    methodName,
+  );
+  return matches.find((m) => isAttributeMethod.call(this, m.attrName)) ?? null;
 }
 
-function ensureOwnAliases(host: AttributeMethodHost): void {
-  if (!Object.prototype.hasOwnProperty.call(host, "_attributeAliases")) {
-    host._attributeAliases = { ...host._attributeAliases };
-  }
+/** @internal Rails-private helper. Mirrors: #missing_attribute */
+export function missingAttribute(this: InstanceHost, attrName: string): never {
+  throw new MissingAttributeError(
+    `missing attribute '${attrName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+  );
 }
 
-export function aliasesByAttributeName(host: AttributeMethodHost): Map<string, string[]> {
-  if (!Object.prototype.hasOwnProperty.call(host, "_aliasesByAttributeName")) {
-    const parent = host._aliasesByAttributeName;
-    const copy = new Map<string, string[]>();
-    if (parent) {
-      for (const [k, v] of parent) copy.set(k, [...v]);
-    }
-    host._aliasesByAttributeName = copy;
+/**
+ * @internal Rails-private helper. Mirrors: #_read_attribute
+ * Bypasses alias resolution and reads directly from the attribute store,
+ * matching Rails AR _read_attribute (fetch_value without alias lookup).
+ */
+export function _readAttribute(
+  this: InstanceHost & {
+    _attributes?: { fetchValue(name: string): unknown };
+    _readAttribute?(name: string): unknown;
+  },
+  attr: string,
+): unknown {
+  if (typeof this._readAttribute === "function" && this._readAttribute !== _readAttribute) {
+    return this._readAttribute(attr);
   }
-  return host._aliasesByAttributeName;
+  return this._attributes?.fetchValue(attr) ?? null;
 }
 
 // -- Public ClassMethods (use `this`, assigned to Model directly) -----------
@@ -223,27 +235,55 @@ export function aliasAttribute(this: AttributeMethodHost, newName: string, oldNa
   defineDirtyAttributeMethods(this.prototype, newName);
 }
 
-export function undefineAttributeMethods(this: AttributeMethodHost): void {
-  if (!this._generatedMethods) return;
-  for (const methodName of this._generatedMethods) {
-    const desc = Object.getOwnPropertyDescriptor(this.prototype, methodName);
-    if (!desc) continue;
-    // Only delete if the method is still the generated one (has our marker)
-    const fn = desc.value ?? desc.get;
-    if (fn && (fn as TaggedFn).__generatedAttributeMethod) {
-      delete this.prototype[methodName];
+export function eagerlyGenerateAliasAttributeMethods(
+  host: AttributeMethodHost,
+  newName: string,
+  oldName: string,
+): void {
+  generateAliasAttributeMethods(host, newName, oldName);
+}
+
+export function generateAliasAttributeMethods(
+  host: AttributeMethodHost,
+  newName: string,
+  oldName: string,
+): void {
+  for (const pattern of host._attributeMethodPatterns) {
+    aliasAttributeMethodDefinition(host, pattern, newName, oldName);
+  }
+}
+
+export function aliasAttributeMethodDefinition(
+  host: AttributeMethodHost,
+  pattern: AttributeMethodPattern,
+  newName: string,
+  oldName: string,
+): void {
+  const methodName = pattern.methodName(newName);
+  const targetName = pattern.methodName(oldName);
+  ensureOwnGeneratedMethods(host);
+  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
+    const target = this[targetName];
+    if (typeof target === "function") {
+      return (target as (...a: unknown[]) => unknown).apply(this, args);
     }
-  }
-  this._generatedMethods.clear();
-  // Clear the pattern-match cache so stale entries don't survive after patterns change.
-  // Mirrors: Rails attribute_method_patterns_cache.clear in undefine_attribute_methods.
-  // Only clear an own-property cache; don't reach up and clear a parent's cache
-  // via inherited prototype-chain lookup.
-  if (Object.prototype.hasOwnProperty.call(this, "_attributeMethodPatternsCache")) {
-    (
-      this as AttributeMethodHost & { _attributeMethodPatternsCache: Map<unknown, unknown> }
-    )._attributeMethodPatternsCache.clear();
-  }
+    return this.readAttribute(oldName);
+  };
+  fn.__generatedAttributeMethod = true;
+  Object.defineProperty(host.prototype, methodName, {
+    value: fn,
+    writable: true,
+    configurable: true,
+  });
+  host._generatedMethods.add(methodName);
+}
+
+export function isAttributeAlias(host: AttributeMethodHost, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(host._attributeAliases, name);
+}
+
+export function attributeAlias(host: AttributeMethodHost, name: string): string | undefined {
+  return host._attributeAliases[name];
 }
 
 export function defineAttributeMethods(this: AttributeMethodHost, ...attrNames: string[]): void {
@@ -288,47 +328,169 @@ export function defineAttributeMethodPattern(
   host._generatedMethods.add(methodName);
 }
 
-export function eagerlyGenerateAliasAttributeMethods(
-  host: AttributeMethodHost,
-  newName: string,
-  oldName: string,
-): void {
-  generateAliasAttributeMethods(host, newName, oldName);
-}
-
-export function generateAliasAttributeMethods(
-  host: AttributeMethodHost,
-  newName: string,
-  oldName: string,
-): void {
-  for (const pattern of host._attributeMethodPatterns) {
-    aliasAttributeMethodDefinition(host, pattern, newName, oldName);
+export function undefineAttributeMethods(this: AttributeMethodHost): void {
+  if (!this._generatedMethods) return;
+  for (const methodName of this._generatedMethods) {
+    const desc = Object.getOwnPropertyDescriptor(this.prototype, methodName);
+    if (!desc) continue;
+    // Only delete if the method is still the generated one (has our marker)
+    const fn = desc.value ?? desc.get;
+    if (fn && (fn as TaggedFn).__generatedAttributeMethod) {
+      delete this.prototype[methodName];
+    }
+  }
+  this._generatedMethods.clear();
+  // Clear the pattern-match cache so stale entries don't survive after patterns change.
+  // Mirrors: Rails attribute_method_patterns_cache.clear in undefine_attribute_methods.
+  // Only clear an own-property cache; don't reach up and clear a parent's cache
+  // via inherited prototype-chain lookup.
+  if (Object.prototype.hasOwnProperty.call(this, "_attributeMethodPatternsCache")) {
+    (
+      this as AttributeMethodHost & { _attributeMethodPatternsCache: Map<unknown, unknown> }
+    )._attributeMethodPatternsCache.clear();
   }
 }
 
-export function aliasAttributeMethodDefinition(
-  host: AttributeMethodHost,
-  pattern: AttributeMethodPattern,
-  newName: string,
-  oldName: string,
-): void {
-  const methodName = pattern.methodName(newName);
-  const targetName = pattern.methodName(oldName);
-  ensureOwnGeneratedMethods(host);
-  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
-    const target = this[targetName];
-    if (typeof target === "function") {
-      return (target as (...a: unknown[]) => unknown).apply(this, args);
+export function aliasesByAttributeName(host: AttributeMethodHost): Map<string, string[]> {
+  if (!Object.prototype.hasOwnProperty.call(host, "_aliasesByAttributeName")) {
+    const parent = host._aliasesByAttributeName;
+    const copy = new Map<string, string[]>();
+    if (parent) {
+      for (const [k, v] of parent) copy.set(k, [...v]);
     }
-    return this.readAttribute(oldName);
+    host._aliasesByAttributeName = copy;
+  }
+  return host._aliasesByAttributeName;
+}
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */
+export function resolveAttributeName(this: AttributeMethodHost, name: string): string {
+  return this._attributeAliases?.[name] ?? name;
+}
+
+// ---------------------------------------------------------------------------
+// Class-level Rails privates (attribute_methods.rb)
+// ---------------------------------------------------------------------------
+
+const NAME_COMPILABLE_REGEXP = /^[a-zA-Z_]\w*[!?=]?$/;
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#generated_attribute_methods */
+export function generatedAttributeMethods(this: AttributeMethodHost): Set<string> {
+  return this._generatedMethods;
+}
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#instance_method_already_implemented? */
+export function isInstanceMethodAlreadyImplemented(
+  this: AttributeMethodHost,
+  methodName: string,
+): boolean {
+  return this._generatedMethods?.has(methodName) ?? false;
+}
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_cache */
+export function attributeMethodPatternsCache(
+  this: AttributeMethodHost,
+): Map<string, Array<{ proxyTarget: string; attrName: string }>> {
+  const h = this as AttributeMethodHost & {
+    _attributeMethodPatternsCache?: Map<string, Array<{ proxyTarget: string; attrName: string }>>;
+  };
+  if (!Object.prototype.hasOwnProperty.call(h, "_attributeMethodPatternsCache")) {
+    h._attributeMethodPatternsCache = new Map();
+  }
+  return h._attributeMethodPatternsCache!;
+}
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_matching */
+export function attributeMethodPatternsMatching(
+  this: AttributeMethodHost,
+  methodName: string,
+): Array<{ proxyTarget: string; attrName: string }> {
+  const cache = attributeMethodPatternsCache.call(this);
+  if (cache.has(methodName)) return cache.get(methodName)!;
+  const matches = this._attributeMethodPatterns.flatMap((pattern) => {
+    const m = pattern.match(methodName);
+    return m ? [{ proxyTarget: pattern.proxyTarget, attrName: m.attr }] : [];
+  });
+  cache.set(methodName, matches);
+  return matches;
+}
+
+/** @internal Rails-private helper. Mirrors: ClassMethods#define_proxy_call */
+export function defineProxyCall(
+  this: AttributeMethodHost,
+  name: string,
+  proxyTarget: string,
+  _parameters: string | null,
+  attrName: string,
+): void {
+  ensureOwnGeneratedMethods(this);
+  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
+    const handler = this[proxyTarget];
+    if (typeof handler !== "function") {
+      throw new MissingAttributeError(
+        `attribute_missing dispatch failed: ${proxyTarget} not defined`,
+      );
+    }
+    return (handler as (...a: unknown[]) => unknown).call(this, attrName, ...args);
   };
   fn.__generatedAttributeMethod = true;
-  Object.defineProperty(host.prototype, methodName, {
-    value: fn,
-    writable: true,
-    configurable: true,
-  });
-  host._generatedMethods.add(methodName);
+  Object.defineProperty(this.prototype, name, { value: fn, writable: true, configurable: true });
+  this._generatedMethods.add(name);
+}
+
+/**
+ * @internal Rails-private helper. Mirrors: ClassMethods#build_mangled_name
+ * Returns a compilable temp name for attributes with non-identifier characters.
+ */
+export function buildMangledName(this: AttributeMethodHost, name: string): string {
+  if (NAME_COMPILABLE_REGEXP.test(name)) return name;
+  const hex = Array.from(name)
+    .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+    .join("");
+  return `__temp__${hex}`;
+}
+
+/**
+ * @internal Rails-private helper. Mirrors: ClassMethods#define_call
+ * Trails has no eval/code generation, so delegates to defineProxyCall.
+ */
+export function defineCall(
+  this: AttributeMethodHost,
+  name: string,
+  targetName: string,
+  _mangledName: string,
+  _parameters: string | null,
+  attrName: string,
+): void {
+  defineProxyCall.call(this, name, targetName, _parameters, attrName);
+}
+
+function ensureOwnPatterns(host: AttributeMethodHost): void {
+  if (!Object.prototype.hasOwnProperty.call(host, "_attributeMethodPatterns")) {
+    host._attributeMethodPatterns = [...host._attributeMethodPatterns];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instance-level Rails privates (attribute_methods.rb)
+// ---------------------------------------------------------------------------
+
+export type InstanceHost = {
+  _attributes?: { has(name: string): boolean };
+  _attributeMethodPatterns?: AttributeMethodPattern[];
+  constructor: AttributeMethodHost;
+};
+
+function ensureOwnGeneratedMethods(host: AttributeMethodHost): void {
+  if (!Object.prototype.hasOwnProperty.call(host, "_generatedMethods")) {
+    host._generatedMethods = new Set(host._generatedMethods ?? []);
+  }
+}
+
+function ensureOwnAliases(host: AttributeMethodHost): void {
+  if (!Object.prototype.hasOwnProperty.call(host, "_attributeAliases")) {
+    host._attributeAliases = { ...host._attributeAliases };
+  }
 }
 
 /**
@@ -390,14 +552,6 @@ export function defineDirtyAttributeMethods(prototype: object, attrName: string)
   }
 }
 
-export function isAttributeAlias(host: AttributeMethodHost, name: string): boolean {
-  return Object.prototype.hasOwnProperty.call(host._attributeAliases, name);
-}
-
-export function attributeAlias(host: AttributeMethodHost, name: string): string | undefined {
-  return host._attributeAliases[name];
-}
-
 /**
  * Resolve `name` to its canonical attribute name, following one alias
  * hop. Mirrors Rails `ActiveModel::AttributeMethods#read_attribute`'s
@@ -408,158 +562,4 @@ export function attributeAlias(host: AttributeMethodHost, name: string): string 
 export function resolveAliasName(host: AttributeMethodHost, name: string): string {
   const aliased = host._attributeAliases?.[name];
   return aliased ?? name;
-}
-
-// ---------------------------------------------------------------------------
-// Class-level Rails privates (attribute_methods.rb)
-// ---------------------------------------------------------------------------
-
-const NAME_COMPILABLE_REGEXP = /^[a-zA-Z_]\w*[!?=]?$/;
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */
-export function resolveAttributeName(this: AttributeMethodHost, name: string): string {
-  return this._attributeAliases?.[name] ?? name;
-}
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#generated_attribute_methods */
-export function generatedAttributeMethods(this: AttributeMethodHost): Set<string> {
-  return this._generatedMethods;
-}
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#instance_method_already_implemented? */
-export function isInstanceMethodAlreadyImplemented(
-  this: AttributeMethodHost,
-  methodName: string,
-): boolean {
-  return this._generatedMethods?.has(methodName) ?? false;
-}
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_cache */
-export function attributeMethodPatternsCache(
-  this: AttributeMethodHost,
-): Map<string, Array<{ proxyTarget: string; attrName: string }>> {
-  const h = this as AttributeMethodHost & {
-    _attributeMethodPatternsCache?: Map<string, Array<{ proxyTarget: string; attrName: string }>>;
-  };
-  if (!Object.prototype.hasOwnProperty.call(h, "_attributeMethodPatternsCache")) {
-    h._attributeMethodPatternsCache = new Map();
-  }
-  return h._attributeMethodPatternsCache!;
-}
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_matching */
-export function attributeMethodPatternsMatching(
-  this: AttributeMethodHost,
-  methodName: string,
-): Array<{ proxyTarget: string; attrName: string }> {
-  const cache = attributeMethodPatternsCache.call(this);
-  if (cache.has(methodName)) return cache.get(methodName)!;
-  const matches = this._attributeMethodPatterns.flatMap((pattern) => {
-    const m = pattern.match(methodName);
-    return m ? [{ proxyTarget: pattern.proxyTarget, attrName: m.attr }] : [];
-  });
-  cache.set(methodName, matches);
-  return matches;
-}
-
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#build_mangled_name
- * Returns a compilable temp name for attributes with non-identifier characters.
- */
-export function buildMangledName(this: AttributeMethodHost, name: string): string {
-  if (NAME_COMPILABLE_REGEXP.test(name)) return name;
-  const hex = Array.from(name)
-    .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-    .join("");
-  return `__temp__${hex}`;
-}
-
-/** @internal Rails-private helper. Mirrors: ClassMethods#define_proxy_call */
-export function defineProxyCall(
-  this: AttributeMethodHost,
-  name: string,
-  proxyTarget: string,
-  _parameters: string | null,
-  attrName: string,
-): void {
-  ensureOwnGeneratedMethods(this);
-  const fn: TaggedFn = function (this: ReadWriteHost, ...args: unknown[]) {
-    const handler = this[proxyTarget];
-    if (typeof handler !== "function") {
-      throw new MissingAttributeError(
-        `attribute_missing dispatch failed: ${proxyTarget} not defined`,
-      );
-    }
-    return (handler as (...a: unknown[]) => unknown).call(this, attrName, ...args);
-  };
-  fn.__generatedAttributeMethod = true;
-  Object.defineProperty(this.prototype, name, { value: fn, writable: true, configurable: true });
-  this._generatedMethods.add(name);
-}
-
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#define_call
- * Trails has no eval/code generation, so delegates to defineProxyCall.
- */
-export function defineCall(
-  this: AttributeMethodHost,
-  name: string,
-  targetName: string,
-  _mangledName: string,
-  _parameters: string | null,
-  attrName: string,
-): void {
-  defineProxyCall.call(this, name, targetName, _parameters, attrName);
-}
-
-// ---------------------------------------------------------------------------
-// Instance-level Rails privates (attribute_methods.rb)
-// ---------------------------------------------------------------------------
-
-export type InstanceHost = {
-  _attributes?: { has(name: string): boolean };
-  _attributeMethodPatterns?: AttributeMethodPattern[];
-  constructor: AttributeMethodHost;
-};
-
-/** @internal Rails-private helper. Mirrors: #attribute_method? */
-export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
-  return this._attributes?.has(attrName) ?? false;
-}
-
-/** @internal Rails-private helper. Mirrors: #matched_attribute_method */
-export function matchedAttributeMethod(
-  this: InstanceHost,
-  methodName: string,
-): { proxyTarget: string; attrName: string } | null {
-  const matches = attributeMethodPatternsMatching.call(
-    this.constructor as AttributeMethodHost,
-    methodName,
-  );
-  return matches.find((m) => isAttributeMethod.call(this, m.attrName)) ?? null;
-}
-
-/** @internal Rails-private helper. Mirrors: #missing_attribute */
-export function missingAttribute(this: InstanceHost, attrName: string): never {
-  throw new MissingAttributeError(
-    `missing attribute '${attrName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
-  );
-}
-
-/**
- * @internal Rails-private helper. Mirrors: #_read_attribute
- * Bypasses alias resolution and reads directly from the attribute store,
- * matching Rails AR _read_attribute (fetch_value without alias lookup).
- */
-export function _readAttribute(
-  this: InstanceHost & {
-    _attributes?: { fetchValue(name: string): unknown };
-    _readAttribute?(name: string): unknown;
-  },
-  attr: string,
-): unknown {
-  if (typeof this._readAttribute === "function" && this._readAttribute !== _readAttribute) {
-    return this._readAttribute(attr);
-  }
-  return this._attributes?.fetchValue(attr) ?? null;
 }

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -121,14 +121,14 @@ export class AttributeMutationTracker {
     this.forcedChanges.set(name, this.fetchValue(name));
   }
 
-  protected attributeChanged(name: string): boolean {
-    return this.forcedChanges.has(name) || this.attributes.getAttribute(name).isChanged();
-  }
-
   protected attrNames(): string[] {
     const keys = new Set(this.attributes.keys());
     for (const name of this.forcedChanges.keys()) keys.add(name);
     return [...keys];
+  }
+
+  protected attributeChanged(name: string): boolean {
+    return this.forcedChanges.has(name) || this.attributes.getAttribute(name).isChanged();
   }
 
   /** @internal */
@@ -150,18 +150,6 @@ export class AttributeMutationTracker {
 export class ForcedMutationTracker extends AttributeMutationTracker {
   private finalizedChanges: Record<string, [unknown, unknown]> | null = null;
 
-  protected override attributeChanged(name: string): boolean {
-    return this.forcedChanges.has(name);
-  }
-
-  protected override attrNames(): string[] {
-    return Array.from(this.forcedChanges.keys());
-  }
-
-  changedInPlace(_name: string): boolean {
-    return false;
-  }
-
   changeToAttribute(name: string): [unknown, unknown] | null {
     if (
       this.finalizedChanges &&
@@ -170,6 +158,10 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
       return [...this.finalizedChanges[name]];
     }
     return super.changeToAttribute(name);
+  }
+
+  changedInPlace(_name: string): boolean {
+    return false;
   }
 
   forgetChange(name: string): void {
@@ -189,13 +181,21 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
     this.forcedChanges.set(name, cloneValue(value));
   }
 
-  finalizeChanges(): void {
-    this.finalizedChanges = this.changes();
+  protected override attrNames(): string[] {
+    return Array.from(this.forcedChanges.keys());
+  }
+
+  protected override attributeChanged(name: string): boolean {
+    return this.forcedChanges.has(name);
   }
 
   /** @internal */
   protected override typeCast(_name: string, value: unknown): unknown {
     return value;
+  }
+
+  finalizeChanges(): void {
+    this.finalizedChanges = this.changes();
   }
 }
 
@@ -233,11 +233,11 @@ export class NullMutationTracker {
     return false;
   }
 
+  forgetChange(_name: string): void {}
+
   originalValue(_name: string): unknown {
     return undefined;
   }
-
   forceChange(_name: string): void {}
-  forgetChange(_name: string): void {}
   finalizeChanges(): void {}
 }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -117,125 +117,6 @@ export class PendingDecorator implements PendingModification {
  */
 type HostAsClass = new (...args: unknown[]) => unknown;
 
-export function registerWithSuperclass(cls: AttributeHostInternals): void {
-  const superclass = Object.getPrototypeOf(cls) as AttributeHostInternals;
-  if (!superclass || (superclass as unknown) === Function.prototype) return;
-  // Only register if the superclass participates in the attribute system.
-  if (!("_attributeDefinitions" in superclass)) return;
-  DescendantsTracker.registerSubclass(
-    superclass as unknown as HostAsClass,
-    cls as unknown as HostAsClass,
-  );
-}
-
-/**
- * Clear the cached default AttributeSet on this class and all known
- * subclasses, so the next call to _defaultAttributes() recomputes.
- *
- * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#reset_default_attributes
- * which calls reset_default_attributes! then recurses via subclasses.each.
- *
- * @internal
- */
-export function resetDefaultAttributes(cls: AttributeHostInternals): void {
-  resetDefaultAttributesBang.call(cls);
-  for (const sub of DescendantsTracker.subclasses(cls as unknown as HostAsClass)) {
-    resetDefaultAttributes(sub as unknown as AttributeHostInternals);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function collectPendingModifications(cls: AttributeHostInternals): PendingModification[] {
-  if (!cls || (cls as unknown) === Function.prototype || !cls._pendingAttributeModifications)
-    return [];
-  const superMods = collectPendingModifications(Object.getPrototypeOf(cls));
-  const own = Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")
-    ? (cls._pendingAttributeModifications as PendingModification[])
-    : [];
-  return [...superMods, ...own];
-}
-
-/**
- * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#apply_pending_attribute_modifications
- *
- * @internal
- */
-export function applyPendingAttributeModifications(
-  cls: AttributeHostInternals,
-  attributeSet: AttributeSet,
-): void {
-  for (const mod of collectPendingModifications(cls)) {
-    mod.applyTo(attributeSet);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Exported functions
-// ---------------------------------------------------------------------------
-
-/**
- * Push a type declaration onto the pending-modification queue.
- * Called internally by attribute() implementations.
- *
- * Mirrors: the PendingType push inside ActiveModel::AttributeRegistration#attribute
- */
-export function pushPendingType(cls: AttributeHostInternals, name: string, type: Type): void {
-  pendingAttributeModifications.call(cls).push(new PendingType(name, type));
-}
-
-/**
- * Push a default declaration onto the pending-modification queue.
- * Called internally by attribute() implementations.
- *
- * Mirrors: the PendingDefault push inside ActiveModel::AttributeRegistration#attribute
- */
-export function pushPendingDefault(
-  cls: AttributeHostInternals,
-  name: string,
-  value: unknown,
-): void {
-  pendingAttributeModifications.call(cls).push(new PendingDefault(name, value));
-}
-
-/**
- * Push a decorator onto the pending-modification queue.
- * Called by decorateAttributes and AR's applyPendingEncryptions.
- *
- * Mirrors: the PendingDecorator push inside ActiveModel::AttributeRegistration#decorate_attributes
- */
-export function pushPendingDecorator(
-  cls: AttributeHostInternals,
-  names: string[] | null,
-  decorator: (name: string, type: Type) => Type,
-): void {
-  pendingAttributeModifications.call(cls).push(new PendingDecorator(names, decorator));
-}
-
-/**
- * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#_default_attributes
- *
- * Seeds an empty AttributeSet and replays all pending attribute modifications
- * from the class hierarchy. The result is cached.
- *
- * AR overrides this to seed from columnsHash first, then replay.
- */
-export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
-  if (!this._cachedDefaultAttributes) {
-    // Register with our superclass so resetDefaultAttributes() cascades to us
-    // when the superclass gains new attribute declarations. Mirrors the
-    // ActiveSupport::DescendantsTracker registration that Rails does via
-    // the `inherited` hook; we do it lazily here instead.
-    registerWithSuperclass(this);
-    const attributeSet = new AttributeSet(new Map<string, Attribute>());
-    applyPendingAttributeModifications(this, attributeSet);
-    this._cachedDefaultAttributes = attributeSet;
-  }
-  return this._cachedDefaultAttributes;
-}
-
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#decorate_attributes
  *
@@ -270,6 +151,28 @@ export function decorateAttributes(
   }
 
   resetDefaultAttributes(this);
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#_default_attributes
+ *
+ * Seeds an empty AttributeSet and replays all pending attribute modifications
+ * from the class hierarchy. The result is cached.
+ *
+ * AR overrides this to seed from columnsHash first, then replay.
+ */
+export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
+  if (!this._cachedDefaultAttributes) {
+    // Register with our superclass so resetDefaultAttributes() cascades to us
+    // when the superclass gains new attribute declarations. Mirrors the
+    // ActiveSupport::DescendantsTracker registration that Rails does via
+    // the `inherited` hook; we do it lazily here instead.
+    registerWithSuperclass(this);
+    const attributeSet = new AttributeSet(new Map<string, Attribute>());
+    applyPendingAttributeModifications(this, attributeSet);
+    this._cachedDefaultAttributes = attributeSet;
+  }
+  return this._cachedDefaultAttributes;
 }
 
 /**
@@ -315,6 +218,36 @@ export function pendingAttributeModifications(this: AttributeHostInternals): Pen
     this._pendingAttributeModifications = [];
   }
   return this._pendingAttributeModifications as PendingModification[];
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#apply_pending_attribute_modifications
+ *
+ * @internal
+ */
+export function applyPendingAttributeModifications(
+  cls: AttributeHostInternals,
+  attributeSet: AttributeSet,
+): void {
+  for (const mod of collectPendingModifications(cls)) {
+    mod.applyTo(attributeSet);
+  }
+}
+
+/**
+ * Clear the cached default AttributeSet on this class and all known
+ * subclasses, so the next call to _defaultAttributes() recomputes.
+ *
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#reset_default_attributes
+ * which calls reset_default_attributes! then recurses via subclasses.each.
+ *
+ * @internal
+ */
+export function resetDefaultAttributes(cls: AttributeHostInternals): void {
+  resetDefaultAttributesBang.call(cls);
+  for (const sub of DescendantsTracker.subclasses(cls as unknown as HostAsClass)) {
+    resetDefaultAttributes(sub as unknown as AttributeHostInternals);
+  }
 }
 
 /**
@@ -375,4 +308,71 @@ export function hookAttributeType(
   type: Type,
 ): Type {
   return type;
+}
+
+export function registerWithSuperclass(cls: AttributeHostInternals): void {
+  const superclass = Object.getPrototypeOf(cls) as AttributeHostInternals;
+  if (!superclass || (superclass as unknown) === Function.prototype) return;
+  // Only register if the superclass participates in the attribute system.
+  if (!("_attributeDefinitions" in superclass)) return;
+  DescendantsTracker.registerSubclass(
+    superclass as unknown as HostAsClass,
+    cls as unknown as HostAsClass,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function collectPendingModifications(cls: AttributeHostInternals): PendingModification[] {
+  if (!cls || (cls as unknown) === Function.prototype || !cls._pendingAttributeModifications)
+    return [];
+  const superMods = collectPendingModifications(Object.getPrototypeOf(cls));
+  const own = Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")
+    ? (cls._pendingAttributeModifications as PendingModification[])
+    : [];
+  return [...superMods, ...own];
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Push a type declaration onto the pending-modification queue.
+ * Called internally by attribute() implementations.
+ *
+ * Mirrors: the PendingType push inside ActiveModel::AttributeRegistration#attribute
+ */
+export function pushPendingType(cls: AttributeHostInternals, name: string, type: Type): void {
+  pendingAttributeModifications.call(cls).push(new PendingType(name, type));
+}
+
+/**
+ * Push a default declaration onto the pending-modification queue.
+ * Called internally by attribute() implementations.
+ *
+ * Mirrors: the PendingDefault push inside ActiveModel::AttributeRegistration#attribute
+ */
+export function pushPendingDefault(
+  cls: AttributeHostInternals,
+  name: string,
+  value: unknown,
+): void {
+  pendingAttributeModifications.call(cls).push(new PendingDefault(name, value));
+}
+
+/**
+ * Push a decorator onto the pending-modification queue.
+ * Called by decorateAttributes and AR's applyPendingEncryptions.
+ *
+ * Mirrors: the PendingDecorator push inside ActiveModel::AttributeRegistration#decorate_attributes
+ */
+export function pushPendingDecorator(
+  cls: AttributeHostInternals,
+  names: string[] | null,
+  decorator: (name: string, type: Type) => Type,
+): void {
+  pendingAttributeModifications.call(cls).push(new PendingDecorator(names, decorator));
 }

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -16,6 +16,132 @@ export class AttributeSet {
     this.attributes = attributes;
   }
 
+  castTypes(): Record<string, import("./type/value.js").Type> {
+    const result: Record<string, import("./type/value.js").Type> = {};
+    for (const [name, attr] of this.attributes) {
+      result[name] = attr.type;
+    }
+    return result;
+  }
+
+  valuesBeforeTypeCast(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [name, attr] of this.attributes) {
+      if (attr.isInitialized()) {
+        result[name] = attr.valueBeforeTypeCast;
+      }
+    }
+    return result;
+  }
+
+  valuesForDatabase(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [name, attr] of this.attributes) {
+      if (attr.isInitialized()) {
+        result[name] = attr.valueForDatabase;
+      }
+    }
+    return result;
+  }
+
+  isKey(name: string): boolean {
+    const attr = this.attributes.get(name);
+    return attr !== undefined && attr.isInitialized();
+  }
+
+  keys(): string[] {
+    const result: string[] = [];
+    for (const [name, attr] of this.attributes) {
+      if (attr.isInitialized()) result.push(name);
+    }
+    return result;
+  }
+
+  fetchValue(name: string): unknown {
+    return this.getAttribute(name).value;
+  }
+
+  writeFromDatabase(name: string, value: unknown): void {
+    this.assertNotFrozen();
+    const existing = this.attributes.get(name);
+    if (existing) {
+      this.attributes.set(name, existing.withValueFromDatabase(value));
+    } else {
+      this.attributes.set(name, Attribute.fromDatabase(name, value, typeRegistry.lookup("value")));
+    }
+  }
+
+  writeFromUser(name: string, value: unknown): unknown {
+    this.assertNotFrozen();
+    const existing = this.attributes.get(name);
+    if (existing) {
+      this.attributes.set(name, existing.withValueFromUser(value));
+    } else {
+      // New attribute not previously declared — create a FromUser with default type
+      this.attributes.set(name, Attribute.fromUser(name, value, typeRegistry.lookup("value")));
+    }
+    return value;
+  }
+
+  writeCastValue(name: string, value: unknown): void {
+    this.assertNotFrozen();
+    const attr = this.attributes.get(name);
+    if (attr) {
+      attr.overrideCastValue(value);
+    } else {
+      this.attributes.set(name, Attribute.withCastValue(name, value, typeRegistry.lookup("value")));
+    }
+  }
+
+  deepDup(): AttributeSet {
+    const newAttrs = new Map<string, Attribute>();
+    const cache = new Map<Attribute, Attribute>();
+
+    for (const [name, attr] of this.attributes) {
+      newAttrs.set(name, this.cloneAttribute(attr, cache));
+    }
+
+    return new AttributeSet(newAttrs);
+  }
+
+  reset(name: string): void {
+    if (this.has(name)) {
+      this.writeFromDatabase(name, null);
+    }
+  }
+
+  accessed(): string[] {
+    const result: string[] = [];
+    for (const [name, attr] of this.attributes) {
+      if (attr.hasBeenRead()) result.push(name);
+    }
+    return result;
+  }
+
+  map(fn: (attr: Attribute) => Attribute): AttributeSet {
+    const newAttrs = new Map<string, Attribute>();
+    for (const [name, attr] of this.attributes) {
+      newAttrs.set(name, fn(attr));
+    }
+    return new AttributeSet(newAttrs);
+  }
+
+  reverseMergeBang(target: AttributeSet): this {
+    this.assertNotFrozen();
+    const cache = new Map<Attribute, Attribute>();
+    target.forEach((attr, name) => {
+      if (!this.isKey(name)) {
+        this.attributes.set(name, this.cloneAttribute(attr, cache));
+      }
+    });
+    return this;
+  }
+
+  /** @internal */
+  protected defaultAttribute(name: string): Attribute {
+    return Attribute.null(name);
+  }
+
   /**
    * Freeze this set in place so subsequent mutations throw.
    * Matches Ruby's `Hash#freeze` semantic used by `ActiveRecord::Core#freeze`.
@@ -54,11 +180,6 @@ export class AttributeSet {
     return attr.value;
   }
 
-  /** @internal */
-  protected defaultAttribute(name: string): Attribute {
-    return Attribute.null(name);
-  }
-
   set(name: string, attrOrValue: Attribute | unknown): void {
     this.assertNotFrozen();
     if (attrOrValue instanceof Attribute) {
@@ -75,50 +196,6 @@ export class AttributeSet {
     return attr !== undefined && attr.isInitialized();
   }
 
-  keys(): string[] {
-    const result: string[] = [];
-    for (const [name, attr] of this.attributes) {
-      if (attr.isInitialized()) result.push(name);
-    }
-    return result;
-  }
-
-  fetchValue(name: string): unknown {
-    return this.getAttribute(name).value;
-  }
-
-  writeFromUser(name: string, value: unknown): unknown {
-    this.assertNotFrozen();
-    const existing = this.attributes.get(name);
-    if (existing) {
-      this.attributes.set(name, existing.withValueFromUser(value));
-    } else {
-      // New attribute not previously declared — create a FromUser with default type
-      this.attributes.set(name, Attribute.fromUser(name, value, typeRegistry.lookup("value")));
-    }
-    return value;
-  }
-
-  writeFromDatabase(name: string, value: unknown): void {
-    this.assertNotFrozen();
-    const existing = this.attributes.get(name);
-    if (existing) {
-      this.attributes.set(name, existing.withValueFromDatabase(value));
-    } else {
-      this.attributes.set(name, Attribute.fromDatabase(name, value, typeRegistry.lookup("value")));
-    }
-  }
-
-  writeCastValue(name: string, value: unknown): void {
-    this.assertNotFrozen();
-    const attr = this.attributes.get(name);
-    if (attr) {
-      attr.overrideCastValue(value);
-    } else {
-      this.attributes.set(name, Attribute.withCastValue(name, value, typeRegistry.lookup("value")));
-    }
-  }
-
   toHash(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const name of this.keys()) {
@@ -127,14 +204,14 @@ export class AttributeSet {
     return result;
   }
 
-  valuesBeforeTypeCast(): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const [name, attr] of this.attributes) {
-      if (attr.isInitialized()) {
-        result[name] = attr.valueBeforeTypeCast;
-      }
+  /**
+   * Make AttributeSet iterable — yields [name, value] pairs for compatibility
+   * with code that iterates `for (const [k, v] of _attributes)`.
+   */
+  *[Symbol.iterator](): IterableIterator<[string, unknown]> {
+    for (const name of this.keys()) {
+      yield [name, this.fetchValue(name)];
     }
-    return result;
   }
 
   /**
@@ -170,25 +247,9 @@ export class AttributeSet {
     return value;
   }
 
-  valuesForDatabase(): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const [name, attr] of this.attributes) {
-      if (attr.isInitialized()) {
-        result[name] = attr.valueForDatabase;
-      }
-    }
-    return result;
-  }
-
   delete(name: string): boolean {
     this.assertNotFrozen();
     return this.attributes.delete(name);
-  }
-
-  reset(name: string): void {
-    if (this.has(name)) {
-      this.writeFromDatabase(name, null);
-    }
   }
 
   protected cloneAttribute(attr: Attribute, cache: Map<Attribute, Attribute>): Attribute {
@@ -213,30 +274,9 @@ export class AttributeSet {
     return cloned;
   }
 
-  deepDup(): AttributeSet {
-    const newAttrs = new Map<string, Attribute>();
-    const cache = new Map<Attribute, Attribute>();
-
-    for (const [name, attr] of this.attributes) {
-      newAttrs.set(name, this.cloneAttribute(attr, cache));
-    }
-
-    return new AttributeSet(newAttrs);
-  }
-
   forEach(fn: (attr: Attribute, name: string) => void): void {
     for (const [name, attr] of this.attributes) {
       fn(attr, name);
-    }
-  }
-
-  /**
-   * Make AttributeSet iterable — yields [name, value] pairs for compatibility
-   * with code that iterates `for (const [k, v] of _attributes)`.
-   */
-  *[Symbol.iterator](): IterableIterator<[string, unknown]> {
-    for (const name of this.keys()) {
-      yield [name, this.fetchValue(name)];
     }
   }
 
@@ -244,38 +284,9 @@ export class AttributeSet {
     return this[Symbol.iterator]();
   }
 
-  castTypes(): Record<string, import("./type/value.js").Type> {
-    const result: Record<string, import("./type/value.js").Type> = {};
-    for (const [name, attr] of this.attributes) {
-      result[name] = attr.type;
-    }
-    return result;
-  }
-
-  isKey(name: string): boolean {
-    const attr = this.attributes.get(name);
-    return attr !== undefined && attr.isInitialized();
-  }
-
   /** Whether `name` is present in the internal map (initialized or not). */
   protected hasAttribute(name: string): boolean {
     return this.attributes.has(name);
-  }
-
-  accessed(): string[] {
-    const result: string[] = [];
-    for (const [name, attr] of this.attributes) {
-      if (attr.hasBeenRead()) result.push(name);
-    }
-    return result;
-  }
-
-  map(fn: (attr: Attribute) => Attribute): AttributeSet {
-    const newAttrs = new Map<string, Attribute>();
-    for (const [name, attr] of this.attributes) {
-      newAttrs.set(name, fn(attr));
-    }
-    return new AttributeSet(newAttrs);
   }
 
   /**
@@ -293,16 +304,5 @@ export class AttributeSet {
       const next = attr.forgettingAssignment();
       if (next !== attr) this.attributes.set(name, next);
     }
-  }
-
-  reverseMergeBang(target: AttributeSet): this {
-    this.assertNotFrozen();
-    const cache = new Map<Attribute, Attribute>();
-    target.forEach((attr, name) => {
-      if (!this.isKey(name)) {
-        this.attributes.set(name, this.cloneAttribute(attr, cache));
-      }
-    });
-    return this;
   }
 }

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -69,6 +69,13 @@ export class LazyAttributeSet extends AttributeSet {
     return this._additionalTypes;
   }
 
+  override deepDup(): LazyAttributeSet {
+    const cache = new Map<Attribute, Attribute>();
+    const newAttrs = new Map<string, Attribute>();
+    this.forEach((attr, name) => newAttrs.set(name, this.cloneAttribute(attr, cache)));
+    return new LazyAttributeSet(newAttrs, new Map(this._additionalTypes));
+  }
+
   /**
    * @internal Rails-private helper. Mirrors: LazyAttributeSet#materialize (protected)
    * Materializes the lazy set by resolving all keys into the attribute map.
@@ -83,13 +90,6 @@ export class LazyAttributeSet extends AttributeSet {
     const result = new Map<string, Attribute>();
     this.forEach((attr, name) => result.set(name, attr));
     return result;
-  }
-
-  override deepDup(): LazyAttributeSet {
-    const cache = new Map<Attribute, Attribute>();
-    const newAttrs = new Map<string, Attribute>();
-    this.forEach((attr, name) => newAttrs.set(name, this.cloneAttribute(attr, cache)));
-    return new LazyAttributeSet(newAttrs, new Map(this._additionalTypes));
   }
 
   override map(fn: (attr: Attribute) => Attribute): LazyAttributeSet {
@@ -125,21 +125,8 @@ export class LazyAttributeHash {
     this.delegate = delegateHash;
   }
 
-  get(name: string): Attribute {
-    if (this.delegate.has(name)) return this.delegate.get(name)!;
-    return this.assignDefault(name);
-  }
-
-  set(name: string, attr: Attribute): void {
-    this.delegate.set(name, attr);
-  }
-
-  has(name: string): boolean {
-    return (
-      this.delegate.has(name) ||
-      Object.prototype.hasOwnProperty.call(this.values, name) ||
-      this.types.has(name)
-    );
+  isKey(key: string): boolean {
+    return this.has(key);
   }
 
   keys(): string[] {
@@ -163,22 +150,6 @@ export class LazyAttributeHash {
       copy.delegate.set(name, LazyAttributeHash.cloneAttr(attr, cache));
     }
     return copy;
-  }
-
-  private static cloneAttr(attr: Attribute, cache: Map<Attribute, Attribute>): Attribute {
-    const existing = cache.get(attr);
-    if (existing) return existing;
-    const cloned = Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
-    cache.set(attr, cloned);
-    const orig = attr.getOriginalAttribute();
-    if (orig) {
-      cloned.setOriginalAttribute(LazyAttributeHash.cloneAttr(orig, cache));
-    }
-    return cloned;
-  }
-
-  isKey(key: string): boolean {
-    return this.has(key);
   }
 
   eachKey(fn: (key: string) => void): void {
@@ -223,6 +194,35 @@ export class LazyAttributeHash {
    */
   assignDefaultValue(name: string): Attribute {
     return this.assignDefault(name);
+  }
+
+  get(name: string): Attribute {
+    if (this.delegate.has(name)) return this.delegate.get(name)!;
+    return this.assignDefault(name);
+  }
+
+  set(name: string, attr: Attribute): void {
+    this.delegate.set(name, attr);
+  }
+
+  has(name: string): boolean {
+    return (
+      this.delegate.has(name) ||
+      Object.prototype.hasOwnProperty.call(this.values, name) ||
+      this.types.has(name)
+    );
+  }
+
+  private static cloneAttr(attr: Attribute, cache: Map<Attribute, Attribute>): Attribute {
+    const existing = cache.get(attr);
+    if (existing) return existing;
+    const cloned = Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
+    cache.set(attr, cloned);
+    const orig = attr.getOriginalAttribute();
+    if (orig) {
+      cloned.setOriginalAttribute(LazyAttributeHash.cloneAttr(orig, cache));
+    }
+    return cloned;
   }
 
   private assignDefault(name: string): Attribute {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -86,9 +86,8 @@ export abstract class Attribute {
     return this._cachedValueForDatabase;
   }
 
-  /** @internal */
-  protected _valueForDatabase(): unknown {
-    return this.type.serialize(this.value);
+  isSerializable(): boolean {
+    return this.type.isSerializable(this.value);
   }
 
   isChanged(): boolean {
@@ -99,6 +98,10 @@ export abstract class Attribute {
     return (
       this.hasBeenRead() && this.type.isChangedInPlace(this.originalValueForDatabase(), this.value)
     );
+  }
+
+  forgettingAssignment(): Attribute {
+    return this.withValueFromDatabase(this.valueForDatabase);
   }
 
   withValueFromUser(value: unknown): Attribute {
@@ -112,6 +115,10 @@ export abstract class Attribute {
 
   withCastValue(value: unknown): Attribute {
     return new WithCastValue(this.name, value, this.type);
+  }
+
+  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
+    return new WithCastValue(name, value, type);
   }
 
   withType(type: Type): Attribute {
@@ -139,8 +146,54 @@ export abstract class Attribute {
     return this._hasValue;
   }
 
-  forgettingAssignment(): Attribute {
-    return this.withValueFromDatabase(this.valueForDatabase);
+  originalValueForDatabase(): unknown {
+    if (this.originalAttribute !== null) {
+      return this.originalAttribute.originalValueForDatabase();
+    }
+    return this._originalValueForDatabase();
+  }
+
+  private changedFromAssignment(): boolean {
+    if (!this.isAssigned()) return false;
+    return this.type.isChanged(this.originalValue, this.value, this.valueBeforeTypeCast);
+  }
+
+  abstract typeCast(value: unknown): unknown;
+
+  /** @internal */
+  protected _valueForDatabase(): unknown {
+    return this.type.serialize(this.value);
+  }
+
+  /** @internal */
+  protected _originalValueForDatabase(): unknown {
+    return this.type.serialize(this.originalValue);
+  }
+
+  // --- Factory methods ---
+
+  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
+    if (arguments.length >= 4) {
+      return new FromDatabase(name, value, type, null, castValue);
+    }
+    return new FromDatabase(name, value, type, null);
+  }
+
+  static fromUser(
+    name: string,
+    value: unknown,
+    type: Type,
+    originalAttribute: Attribute | null = null,
+  ): FromUser {
+    return new FromUser(name, value, type, originalAttribute);
+  }
+
+  static null(name: string): Null {
+    return new Null(name);
+  }
+
+  static uninitialized(name: string, type: Type): Uninitialized {
+    return new Uninitialized(name, type);
   }
 
   /**
@@ -155,11 +208,6 @@ export abstract class Attribute {
     this._hasValueForDatabase = false;
   }
 
-  /** @internal */
-  protected _originalValueForDatabase(): unknown {
-    return this.type.serialize(this.originalValue);
-  }
-
   equals(other: Attribute): boolean {
     const typeEqual = this.type === other.type || this.type.constructor === other.type.constructor;
     return (
@@ -168,19 +216,6 @@ export abstract class Attribute {
       this.valueBeforeTypeCast === other.valueBeforeTypeCast &&
       typeEqual
     );
-  }
-
-  abstract typeCast(value: unknown): unknown;
-
-  isSerializable(): boolean {
-    return this.type.isSerializable(this.value);
-  }
-
-  originalValueForDatabase(): unknown {
-    if (this.originalAttribute !== null) {
-      return this.originalAttribute.originalValueForDatabase();
-    }
-    return this._originalValueForDatabase();
   }
 
   withUserDefault(value: unknown): Attribute {
@@ -212,41 +247,6 @@ export abstract class Attribute {
     return this.originalAttribute !== null;
   }
 
-  private changedFromAssignment(): boolean {
-    if (!this.isAssigned()) return false;
-    return this.type.isChanged(this.originalValue, this.value, this.valueBeforeTypeCast);
-  }
-
-  // --- Factory methods ---
-
-  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
-    if (arguments.length >= 4) {
-      return new FromDatabase(name, value, type, null, castValue);
-    }
-    return new FromDatabase(name, value, type, null);
-  }
-
-  static fromUser(
-    name: string,
-    value: unknown,
-    type: Type,
-    originalAttribute: Attribute | null = null,
-  ): FromUser {
-    return new FromUser(name, value, type, originalAttribute);
-  }
-
-  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
-    return new WithCastValue(name, value, type);
-  }
-
-  static null(name: string): Null {
-    return new Null(name);
-  }
-
-  static uninitialized(name: string, type: Type): Uninitialized {
-    return new Uninitialized(name, type);
-  }
-
   /**
    * Create an attribute where we already have both the raw and cast values.
    * Used in the Model constructor after applying normalization/nullify.
@@ -262,15 +262,6 @@ export abstract class Attribute {
 }
 
 export class FromDatabase extends Attribute {
-  typeCast(value: unknown): unknown {
-    return this.type.deserialize(value);
-  }
-
-  /** @internal */
-  protected override _originalValueForDatabase(): unknown {
-    return this.valueBeforeTypeCast;
-  }
-
   override forgettingAssignment(): Attribute {
     // Rails condition: `!defined?(@value_for_database) && !changed_in_place?`
     // → fast-path creates a new FromDatabase using the existing value_before_type_cast.
@@ -280,6 +271,15 @@ export class FromDatabase extends Attribute {
     // a new FromDatabase, resetting the baseline to the post-mutation state.
     if (!this.changedInPlace()) return this;
     return super.forgettingAssignment();
+  }
+
+  typeCast(value: unknown): unknown {
+    return this.type.deserialize(value);
+  }
+
+  /** @internal */
+  protected override _originalValueForDatabase(): unknown {
+    return this.valueBeforeTypeCast;
   }
 }
 
@@ -303,12 +303,12 @@ export class FromUser extends Attribute {
 }
 
 export class WithCastValue extends Attribute {
-  typeCast(value: unknown): unknown {
-    return value;
-  }
-
   changedInPlace(): boolean {
     return false;
+  }
+
+  typeCast(value: unknown): unknown {
+    return value;
   }
 }
 
@@ -317,20 +317,20 @@ export class Null extends Attribute {
     super(name, null, typeRegistry.lookup("value"));
   }
 
-  typeCast(): unknown {
-    return null;
+  withValueFromUser(_value: unknown): Attribute {
+    throw new MissingAttributeError(`can't write unknown attribute \`${this.name}\``);
   }
 
   withValueFromDatabase(_value: unknown): Attribute {
     throw new MissingAttributeError(`can't write unknown attribute \`${this.name}\``);
   }
 
-  withValueFromUser(_value: unknown): Attribute {
-    throw new MissingAttributeError(`can't write unknown attribute \`${this.name}\``);
-  }
-
   override withType(type: Type): Attribute {
     return Attribute.withCastValue(this.name, null, type);
+  }
+
+  typeCast(): unknown {
+    return null;
   }
 }
 
@@ -351,10 +351,6 @@ export class Uninitialized extends Attribute {
     return undefined;
   }
 
-  isInitialized(): boolean {
-    return false;
-  }
-
   forgettingAssignment(): Attribute {
     return new Uninitialized(this.name, this.type);
   }
@@ -365,5 +361,9 @@ export class Uninitialized extends Attribute {
 
   typeCast(): unknown {
     return undefined;
+  }
+
+  isInitialized(): boolean {
+    return false;
   }
 }

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -42,22 +42,6 @@ export class UserProvidedDefault extends FromUser {
     return this.userProvidedValue;
   }
 
-  /**
-   * Create a fresh instance from the original function/value so function
-   * defaults re-evaluate — called by AttributeSet.deepDup.
-   */
-  dupForDeepClone(): UserProvidedDefault {
-    // Functions re-evaluate on each construction. Non-function objects need
-    // cloning to prevent cross-instance mutation (JS has no Ruby-style dup
-    // that copies value semantics for built-in types).
-    const val = this.userProvidedValue;
-    const clonedVal =
-      typeof val === "function" || val === null || typeof val !== "object"
-        ? val
-        : structuredClone(val);
-    return new UserProvidedDefault(this.name, clonedVal, this.type, this.getOriginalAttribute());
-  }
-
   override withType(type: Type): Attribute {
     return new UserProvidedDefault(
       this.name,
@@ -73,6 +57,22 @@ export class UserProvidedDefault extends FromUser {
 
   static marshalLoad(data: [string, unknown, Type, Attribute | null]): UserProvidedDefault {
     return new UserProvidedDefault(data[0], data[1], data[2], data[3]);
+  }
+
+  /**
+   * Create a fresh instance from the original function/value so function
+   * defaults re-evaluate — called by AttributeSet.deepDup.
+   */
+  dupForDeepClone(): UserProvidedDefault {
+    // Functions re-evaluate on each construction. Non-function objects need
+    // cloning to prevent cross-instance mutation (JS has no Ruby-style dup
+    // that copies value semantics for built-in types).
+    const val = this.userProvidedValue;
+    const clonedVal =
+      typeof val === "function" || val === null || typeof val !== "object"
+        ? val
+        : structuredClone(val);
+    return new UserProvidedDefault(this.name, clonedVal, this.type, this.getOriginalAttribute());
   }
 }
 

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -42,6 +42,31 @@ export interface AttributeDefinition {
   source?: "user" | "schema";
 }
 
+/**
+ * Return all attributes as a plain hash.
+ *
+ * Mirrors: ActiveModel::Attributes#attributes
+ */
+export function attributes(attrs: AttributeSet): Record<string, unknown> {
+  return attrs.toHash();
+}
+
+/**
+ * Mirrors: ActiveModel::Attributes#_write_attribute
+ *
+ * Writes a value into the attribute store via the user-write path (casts
+ * through the type's `cast` method before storing).
+ *
+ * @internal Rails-private helper.
+ */
+export function _writeAttribute(
+  this: AttributeInstanceHost,
+  attrName: string,
+  value: unknown,
+): void {
+  this._attributes.writeFromUser(attrName, value);
+}
+
 // ---------------------------------------------------------------------------
 // Class methods — Mirrors: ActiveModel::Attributes::ClassMethods
 // ---------------------------------------------------------------------------
@@ -136,46 +161,6 @@ export function attribute(
   defineDirtyAttributeMethods(this.prototype, name);
 }
 
-// ---------------------------------------------------------------------------
-// Instance methods — Mirrors: ActiveModel::Attributes instance methods
-// ---------------------------------------------------------------------------
-
-/**
- * Build default AttributeSet from class definitions.
- *
- * Mirrors: ActiveModel::AttributeRegistration._default_attributes
- */
-export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
-  const attrMap = new Map<string, Attribute>();
-  for (const [name, def] of defs) {
-    const userProvided = def.userProvided ?? true;
-    if (def.defaultValue != null) {
-      if (userProvided) {
-        // Rails: user_provided_default: true → wraps the default so it is
-        // cast through the user-type (and procs re-evaluate per instance).
-        const base = Attribute.withCastValue(name, null, def.type);
-        attrMap.set(name, base.withUserDefault(def.defaultValue));
-      } else {
-        // Rails: user_provided_default: false → column default comes from
-        // the database; use fromDatabase so deserialize is applied.
-        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
-      }
-    } else {
-      attrMap.set(name, Attribute.withCastValue(name, null, def.type));
-    }
-  }
-  return new AttributeSet(attrMap);
-}
-
-/**
- * Return all attributes as a plain hash.
- *
- * Mirrors: ActiveModel::Attributes#attributes
- */
-export function attributes(attrs: AttributeSet): Record<string, unknown> {
-  return attrs.toHash();
-}
-
 /**
  * Concrete mixin host for `ActiveModel::Attributes`. Rails ships
  * `Attributes` as a module included into a model; in TS this class is
@@ -229,55 +214,6 @@ export class Attributes {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Rails privates surfaced by attributes.rb
-// ---------------------------------------------------------------------------
-
-/** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
-export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
-  return _isAttributeMethod.call(this, attrName);
-}
-
-/** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
-export function matchedAttributeMethod(
-  this: InstanceHost,
-  methodName: string,
-): { proxyTarget: string; attrName: string } | null {
-  return _matchedAttributeMethod.call(this, methodName);
-}
-
-/** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
-export function missingAttribute(this: InstanceHost, attrName: string): never {
-  return _missingAttribute.call(this, attrName);
-}
-
-/** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
-export function _readAttribute(this: InstanceHost, attr: string): unknown {
-  type ReadAttributeThis = InstanceHost & {
-    _attributes?: { fetchValue(name: string): unknown };
-    _readAttribute?(name: string): unknown;
-  };
-  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
-}
-
-type AttributeInstanceHost = { _attributes: AttributeSet };
-
-/**
- * Mirrors: ActiveModel::Attributes#_write_attribute
- *
- * Writes a value into the attribute store via the user-write path (casts
- * through the type's `cast` method before storing).
- *
- * @internal Rails-private helper.
- */
-export function _writeAttribute(
-  this: AttributeInstanceHost,
-  attrName: string,
-  value: unknown,
-): void {
-  this._attributes.writeFromUser(attrName, value);
-}
-
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods#define_method_attribute=
  *
@@ -298,4 +234,68 @@ export function defineMethodAttribute(
   // that inspect the name (e.g. alias generation paths).
   const { methodName } = AttrNames.defineAttributeAccessorMethod(canonicalName, true);
   void methodName;
+}
+
+// ---------------------------------------------------------------------------
+// Instance methods — Mirrors: ActiveModel::Attributes instance methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Build default AttributeSet from class definitions.
+ *
+ * Mirrors: ActiveModel::AttributeRegistration._default_attributes
+ */
+export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
+  const attrMap = new Map<string, Attribute>();
+  for (const [name, def] of defs) {
+    const userProvided = def.userProvided ?? true;
+    if (def.defaultValue != null) {
+      if (userProvided) {
+        // Rails: user_provided_default: true → wraps the default so it is
+        // cast through the user-type (and procs re-evaluate per instance).
+        const base = Attribute.withCastValue(name, null, def.type);
+        attrMap.set(name, base.withUserDefault(def.defaultValue));
+      } else {
+        // Rails: user_provided_default: false → column default comes from
+        // the database; use fromDatabase so deserialize is applied.
+        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
+      }
+    } else {
+      attrMap.set(name, Attribute.withCastValue(name, null, def.type));
+    }
+  }
+  return new AttributeSet(attrMap);
+}
+
+// ---------------------------------------------------------------------------
+// Rails privates surfaced by attributes.rb
+// ---------------------------------------------------------------------------
+
+/** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
+export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
+  return _isAttributeMethod.call(this, attrName);
+}
+
+/** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
+export function matchedAttributeMethod(
+  this: InstanceHost,
+  methodName: string,
+): { proxyTarget: string; attrName: string } | null {
+  return _matchedAttributeMethod.call(this, methodName);
+}
+
+type AttributeInstanceHost = { _attributes: AttributeSet };
+
+/** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
+export function missingAttribute(this: InstanceHost, attrName: string): never {
+  return _missingAttribute.call(this, attrName);
+}
+
+/** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
+export function _readAttribute(this: InstanceHost, attr: string): unknown {
+  type ReadAttributeThis = InstanceHost & {
+    _attributes?: { fetchValue(name: string): unknown };
+    _readAttribute?(name: string): unknown;
+  };
+  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
 }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -23,53 +23,6 @@ import {
 
 type AnyCallback = BeforeCallback | AfterCallback | AroundCallback;
 
-function isThenable(v: unknown): v is PromiseLike<unknown> {
-  return (
-    v !== null &&
-    (typeof v === "object" || typeof v === "function") &&
-    typeof (v as { then?: unknown }).then === "function"
-  );
-}
-
-/** Minimum shape required of a record object threaded through a callback chain. */
-export type CallbackRecord = object;
-
-export interface DefineModelCallbacksOptions {
-  only?: CallbackTiming[];
-}
-
-export interface CallbacksClassMethods {
-  defineModelCallbacks(
-    ...args: [string, ...string[]] | [string, ...string[], DefineModelCallbacksOptions]
-  ): void;
-}
-
-export type Callbacks = CallbacksClassMethods;
-
-export type CallbackTiming = CallbackKind;
-export type CallbackFn = (record: CallbackRecord) => void | boolean | Promise<void | boolean>;
-export type AroundCallbackFn = (
-  record: CallbackRecord,
-  proceed: () => void | Promise<void>,
-) => void | Promise<void>;
-/** Rails supports passing an object with callback-named methods. */
-export type CallbackObject = object;
-export interface RunCallbacksOptions {
-  strict?: "sync";
-}
-export interface CallbackConditions<TRecord = CallbackRecord> {
-  if?(record: TRecord): boolean;
-  unless?(record: TRecord): boolean;
-  prepend?: boolean;
-}
-
-/** Extends CallbackConditions with the `on:` option available on commit/rollback callbacks. */
-export interface TransactionalCallbackConditions<
-  TRecord = CallbackRecord,
-> extends CallbackConditions<TRecord> {
-  on?: string | string[];
-}
-
 /**
  * Core implementation of define_model_callbacks.
  * Creates beforeX(), afterX(), and/or aroundX() class methods for each event
@@ -145,7 +98,44 @@ export function defineModelCallbacks(this: object, ...args: unknown[]): void {
   }
 }
 
-type CallbackHost = object;
+/** Minimum shape required of a record object threaded through a callback chain. */
+export type CallbackRecord = object;
+
+export interface DefineModelCallbacksOptions {
+  only?: CallbackTiming[];
+}
+
+export interface CallbacksClassMethods {
+  defineModelCallbacks(
+    ...args: [string, ...string[]] | [string, ...string[], DefineModelCallbacksOptions]
+  ): void;
+}
+
+export type Callbacks = CallbacksClassMethods;
+
+export type CallbackTiming = CallbackKind;
+export type CallbackFn = (record: CallbackRecord) => void | boolean | Promise<void | boolean>;
+export type AroundCallbackFn = (
+  record: CallbackRecord,
+  proceed: () => void | Promise<void>,
+) => void | Promise<void>;
+/** Rails supports passing an object with callback-named methods. */
+export type CallbackObject = object;
+export interface RunCallbacksOptions {
+  strict?: "sync";
+}
+export interface CallbackConditions<TRecord = CallbackRecord> {
+  if?(record: TRecord): boolean;
+  unless?(record: TRecord): boolean;
+  prepend?: boolean;
+}
+
+/** Extends CallbackConditions with the `on:` option available on commit/rollback callbacks. */
+export interface TransactionalCallbackConditions<
+  TRecord = CallbackRecord,
+> extends CallbackConditions<TRecord> {
+  on?: string | string[];
+}
 
 /**
  * Mirrors: ActiveModel::Callbacks#_define_before_model_callback
@@ -161,6 +151,8 @@ export function _defineBeforeModelCallback(klass: CallbackHost, event: string): 
     configurable: true,
   });
 }
+
+type CallbackHost = object;
 
 /**
  * Mirrors: ActiveModel::Callbacks#_define_around_model_callback
@@ -193,6 +185,14 @@ export function _defineAfterModelCallback(klass: CallbackHost, event: string): v
     writable: true,
     configurable: true,
   });
+}
+
+function isThenable(v: unknown): v is PromiseLike<unknown> {
+  return (
+    v !== null &&
+    (typeof v === "object" || typeof v === "function") &&
+    typeof (v as { then?: unknown }).then === "function"
+  );
 }
 
 function _resolveCallbackObject(

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -38,10 +38,6 @@ export interface Dirty {
   clearAttributeChange(name: string): void;
 }
 
-function resolveValue(value: unknown): unknown {
-  return AttributeSet.resolveSnapshotValue(value);
-}
-
 /**
  * Per-instance reset hook for dirty-tracking state. Mirrors Rails
  * `ActiveModel::Dirty#init_internals`
@@ -64,6 +60,20 @@ export function initInternals(this: DirtyInternalsHost): void {
 }
 
 /**
+ * Mirrors: ActiveModel::Dirty#attribute_previous_change
+ *
+ * Dispatch target for `*_previous_change` per-attribute methods.
+ *
+ * @internal Rails-private helper.
+ */
+export function attributePreviousChange(
+  this: DirtyDispatchHost,
+  attrName: string,
+): [unknown, unknown] | undefined {
+  return this._dirty.previousChanges[attrName];
+}
+
+/**
  * Host shape consumed by `initInternals`.
  */
 export interface DirtyInternalsHost {
@@ -82,6 +92,171 @@ export class DirtyTracker {
   private _previousChanges: Map<string, [unknown, unknown]> = new Map();
   /** Names explicitly force-dirtied via attribute_will_change!. @internal */
   private _forcedNames: Set<string> = new Set();
+
+  initAttributes(
+    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+  ): void {
+    this.snapshot(attributes);
+  }
+
+  asJson(): Record<string, [unknown, unknown]> {
+    return this.changes;
+  }
+
+  changesApplied(
+    currentAttributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+  ): void {
+    this._previousChanges = new Map(this._changedAttributes);
+    if (currentAttributes instanceof Map) {
+      this._originalAttributes = new Map(currentAttributes);
+      this._originalHas = new Set(currentAttributes.keys());
+    } else {
+      this._originalAttributes = currentAttributes.snapshotValues();
+      this._originalHas = new Set(this._originalAttributes.keys());
+    }
+    this._clearChanges();
+  }
+
+  get changed(): boolean {
+    return this._changedAttributes.size > 0;
+  }
+
+  attributeChanged(name: string): boolean {
+    return this._changedAttributes.has(name);
+  }
+
+  attributeWas(name: string): unknown {
+    const change = this._changedAttributes.get(name);
+    return change ? change[0] : resolveValue(this._originalAttributes.get(name));
+  }
+
+  clearChangesInformation(): void {
+    this._clearChanges();
+    this._previousChanges.clear();
+  }
+
+  clearAttributeChanges(attributes: string[]): void {
+    for (const attr of attributes) {
+      this._deleteChange(attr);
+    }
+  }
+
+  get changedAttributes(): string[] {
+    return Array.from(this._changedAttributes.keys());
+  }
+
+  get changes(): Record<string, [unknown, unknown]> {
+    const result: Record<string, [unknown, unknown]> = {};
+    for (const [k, v] of this._changedAttributes) {
+      result[k] = v;
+    }
+    return result;
+  }
+
+  get previousChanges(): Record<string, [unknown, unknown]> {
+    const result: Record<string, [unknown, unknown]> = {};
+    for (const [k, v] of this._previousChanges) {
+      result[k] = v;
+    }
+    return result;
+  }
+
+  /**
+   * Drop a single attribute's pending change and rebind its baseline to
+   * the current value, so a later write reports `[current, next]` instead
+   * of `[originalFromFirstSnapshot, next]`.
+   *
+   * Mirrors: ActiveModel::Dirty#clear_attribute_change
+   * -> `mutation_tracker.forget_change(name)`.
+   *
+   * @internal
+   */
+  clearAttributeChange(
+    attributes:
+      | Map<string, unknown>
+      | { has(name: string): boolean; fetchValue(name: string): unknown }
+      | { snapshotValues(): Map<string, unknown> },
+    name: string,
+  ): void {
+    this._deleteChange(name);
+    // Fast path: avoid snapshotting every attribute when only one baseline
+    // needs rebinding. AttributeSet exposes has/fetchValue per-attribute;
+    // fall back to the full snapshot for plain Maps / other shapes.
+    let has: boolean;
+    let value: unknown;
+    const perAttr = attributes as { has?: unknown; fetchValue?: unknown };
+    if (typeof perAttr.has === "function" && typeof perAttr.fetchValue === "function") {
+      const src = attributes as { has(n: string): boolean; fetchValue(n: string): unknown };
+      has = src.has(name);
+      value = has ? src.fetchValue(name) : undefined;
+    } else {
+      const snap =
+        attributes instanceof Map
+          ? attributes
+          : (attributes as { snapshotValues(): Map<string, unknown> }).snapshotValues();
+      has = snap.has(name);
+      value = snap.get(name);
+    }
+    if (has) {
+      this._originalAttributes.set(name, value);
+      this._originalHas.add(name);
+    } else {
+      this._originalAttributes.delete(name);
+      this._originalHas.delete(name);
+    }
+  }
+
+  /**
+   * Pending changes diff against the values loaded from the database —
+   * what will be written on the next save. Cleared by `changesApplied()`.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_from_database
+   * (activemodel/lib/active_model/dirty.rb + attribute_mutation_tracker.rb).
+   *
+   * @internal
+   */
+  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
+    return this.changes;
+  }
+
+  /**
+   * Drop all pending assignment tracking and reset the baseline to the
+   * current in-memory values. Subsequent writes diff from the new baseline.
+   *
+   * Rails' `forget_attribute_assignments` replaces `@attributes` with
+   * `@attributes.map(&:forgotten_change)`, which rebinds each Attribute's
+   * `@original_attribute` to its current cast value. Mirror that by
+   * re-snapshotting (while preserving `_previousChanges` from the last save).
+   *
+   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
+   *
+   * @internal
+   */
+  forgetAttributeAssignments(
+    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+  ): void {
+    // Same shape as snapshot(): reset baseline + clear pending changes.
+    // `snapshot` also clears `_changedAttributes`, so the single call
+    // covers both sides of Rails' `forget_attribute_assignments`.
+    this.snapshot(attributes);
+  }
+
+  /**
+   * Snapshot of `mutations_from_database` at the moment of the last save.
+   * Lives until the next save.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_before_last_save
+   *
+   * @internal
+   */
+  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
+    return this.previousChanges;
+  }
+
+  /** @internal */
+  attributeChange(name: string): [unknown, unknown] | null {
+    return this._changedAttributes.get(name) ?? null;
+  }
 
   /** @internal Delete a single change entry and its forced-dirty marker together. */
   private _deleteChange(name: string): void {
@@ -169,63 +344,6 @@ export class DirtyTracker {
     }
   }
 
-  get changed(): boolean {
-    return this._changedAttributes.size > 0;
-  }
-
-  get changedAttributes(): string[] {
-    return Array.from(this._changedAttributes.keys());
-  }
-
-  get changes(): Record<string, [unknown, unknown]> {
-    const result: Record<string, [unknown, unknown]> = {};
-    for (const [k, v] of this._changedAttributes) {
-      result[k] = v;
-    }
-    return result;
-  }
-
-  attributeChanged(name: string): boolean {
-    return this._changedAttributes.has(name);
-  }
-
-  attributeWas(name: string): unknown {
-    const change = this._changedAttributes.get(name);
-    return change ? change[0] : resolveValue(this._originalAttributes.get(name));
-  }
-
-  /** @internal */
-  attributeChange(name: string): [unknown, unknown] | null {
-    return this._changedAttributes.get(name) ?? null;
-  }
-
-  changesApplied(
-    currentAttributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
-  ): void {
-    this._previousChanges = new Map(this._changedAttributes);
-    if (currentAttributes instanceof Map) {
-      this._originalAttributes = new Map(currentAttributes);
-      this._originalHas = new Set(currentAttributes.keys());
-    } else {
-      this._originalAttributes = currentAttributes.snapshotValues();
-      this._originalHas = new Set(this._originalAttributes.keys());
-    }
-    this._clearChanges();
-  }
-
-  get previousChanges(): Record<string, [unknown, unknown]> {
-    const result: Record<string, [unknown, unknown]> = {};
-    for (const [k, v] of this._previousChanges) {
-      result[k] = v;
-    }
-    return result;
-  }
-
-  clearChangesInformation(): void {
-    this._clearChanges();
-    this._previousChanges.clear();
-  }
-
   /**
    * Walk `currentAttributes` (post-TX) and populate `_changedAttributes` for
    * any attribute whose current value differs from the pre-TX baseline already
@@ -258,114 +376,6 @@ export class DirtyTracker {
         }
       }
     }
-  }
-
-  clearAttributeChanges(attributes: string[]): void {
-    for (const attr of attributes) {
-      this._deleteChange(attr);
-    }
-  }
-
-  /**
-   * Pending changes diff against the values loaded from the database —
-   * what will be written on the next save. Cleared by `changesApplied()`.
-   *
-   * Mirrors: ActiveModel::Dirty#mutations_from_database
-   * (activemodel/lib/active_model/dirty.rb + attribute_mutation_tracker.rb).
-   *
-   * @internal
-   */
-  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
-    return this.changes;
-  }
-
-  /**
-   * Snapshot of `mutations_from_database` at the moment of the last save.
-   * Lives until the next save.
-   *
-   * Mirrors: ActiveModel::Dirty#mutations_before_last_save
-   *
-   * @internal
-   */
-  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
-    return this.previousChanges;
-  }
-
-  /**
-   * Drop all pending assignment tracking and reset the baseline to the
-   * current in-memory values. Subsequent writes diff from the new baseline.
-   *
-   * Rails' `forget_attribute_assignments` replaces `@attributes` with
-   * `@attributes.map(&:forgotten_change)`, which rebinds each Attribute's
-   * `@original_attribute` to its current cast value. Mirror that by
-   * re-snapshotting (while preserving `_previousChanges` from the last save).
-   *
-   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
-   *
-   * @internal
-   */
-  forgetAttributeAssignments(
-    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
-  ): void {
-    // Same shape as snapshot(): reset baseline + clear pending changes.
-    // `snapshot` also clears `_changedAttributes`, so the single call
-    // covers both sides of Rails' `forget_attribute_assignments`.
-    this.snapshot(attributes);
-  }
-
-  /**
-   * Drop a single attribute's pending change and rebind its baseline to
-   * the current value, so a later write reports `[current, next]` instead
-   * of `[originalFromFirstSnapshot, next]`.
-   *
-   * Mirrors: ActiveModel::Dirty#clear_attribute_change
-   * -> `mutation_tracker.forget_change(name)`.
-   *
-   * @internal
-   */
-  clearAttributeChange(
-    attributes:
-      | Map<string, unknown>
-      | { has(name: string): boolean; fetchValue(name: string): unknown }
-      | { snapshotValues(): Map<string, unknown> },
-    name: string,
-  ): void {
-    this._deleteChange(name);
-    // Fast path: avoid snapshotting every attribute when only one baseline
-    // needs rebinding. AttributeSet exposes has/fetchValue per-attribute;
-    // fall back to the full snapshot for plain Maps / other shapes.
-    let has: boolean;
-    let value: unknown;
-    const perAttr = attributes as { has?: unknown; fetchValue?: unknown };
-    if (typeof perAttr.has === "function" && typeof perAttr.fetchValue === "function") {
-      const src = attributes as { has(n: string): boolean; fetchValue(n: string): unknown };
-      has = src.has(name);
-      value = has ? src.fetchValue(name) : undefined;
-    } else {
-      const snap =
-        attributes instanceof Map
-          ? attributes
-          : (attributes as { snapshotValues(): Map<string, unknown> }).snapshotValues();
-      has = snap.has(name);
-      value = snap.get(name);
-    }
-    if (has) {
-      this._originalAttributes.set(name, value);
-      this._originalHas.add(name);
-    } else {
-      this._originalAttributes.delete(name);
-      this._originalHas.delete(name);
-    }
-  }
-
-  initAttributes(
-    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
-  ): void {
-    this.snapshot(attributes);
-  }
-
-  asJson(): Record<string, [unknown, unknown]> {
-    return this.changes;
   }
 
   restore(attributes: {
@@ -417,60 +427,6 @@ export class DirtyTracker {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Rails privates surfaced by dirty.rb
-// ---------------------------------------------------------------------------
-
-/** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
-export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
-  return _isAttributeMethod.call(this, attrName);
-}
-
-/** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
-export function matchedAttributeMethod(
-  this: InstanceHost,
-  methodName: string,
-): { proxyTarget: string; attrName: string } | null {
-  return _matchedAttributeMethod.call(this, methodName);
-}
-
-/** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
-export function missingAttribute(this: InstanceHost, attrName: string): never {
-  return _missingAttribute.call(this, attrName);
-}
-
-/** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
-export function _readAttribute(this: InstanceHost, attr: string): unknown {
-  type ReadAttributeThis = InstanceHost & {
-    _attributes?: { fetchValue(name: string): unknown };
-    _readAttribute?(name: string): unknown;
-  };
-  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
-}
-
-type DirtyDispatchHost = {
-  _dirty: DirtyTracker;
-  _attributes: AttributeSet;
-  restoreAttribute?(name: string): void;
-  attributeWas?(name: string): unknown;
-  writeAttribute?(name: string, value: unknown): void;
-  clearAttributeChange?(name: string): void;
-};
-
-/**
- * Mirrors: ActiveModel::Dirty#attribute_previous_change
- *
- * Dispatch target for `*_previous_change` per-attribute methods.
- *
- * @internal Rails-private helper.
- */
-export function attributePreviousChange(
-  this: DirtyDispatchHost,
-  attrName: string,
-): [unknown, unknown] | undefined {
-  return this._dirty.previousChanges[attrName];
-}
-
 /**
  * Mirrors: ActiveModel::Dirty#attribute_will_change!
  *
@@ -494,4 +450,48 @@ export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: strin
  */
 export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string): void {
   this._dirty.restoreAttribute(this._attributes, attrName);
+}
+
+function resolveValue(value: unknown): unknown {
+  return AttributeSet.resolveSnapshotValue(value);
+}
+
+// ---------------------------------------------------------------------------
+// Rails privates surfaced by dirty.rb
+// ---------------------------------------------------------------------------
+
+/** @internal Rails-private helper. Mirrors: #attribute_method? (via AttributeMethods include) */
+export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
+  return _isAttributeMethod.call(this, attrName);
+}
+
+type DirtyDispatchHost = {
+  _dirty: DirtyTracker;
+  _attributes: AttributeSet;
+  restoreAttribute?(name: string): void;
+  attributeWas?(name: string): unknown;
+  writeAttribute?(name: string, value: unknown): void;
+  clearAttributeChange?(name: string): void;
+};
+
+/** @internal Rails-private helper. Mirrors: #matched_attribute_method (via AttributeMethods include) */
+export function matchedAttributeMethod(
+  this: InstanceHost,
+  methodName: string,
+): { proxyTarget: string; attrName: string } | null {
+  return _matchedAttributeMethod.call(this, methodName);
+}
+
+/** @internal Rails-private helper. Mirrors: #missing_attribute (via AttributeMethods include) */
+export function missingAttribute(this: InstanceHost, attrName: string): never {
+  return _missingAttribute.call(this, attrName);
+}
+
+/** @internal Rails-private helper. Mirrors: #_read_attribute (via AttributeMethods include) */
+export function _readAttribute(this: InstanceHost, attr: string): unknown {
+  type ReadAttributeThis = InstanceHost & {
+    _attributes?: { fetchValue(name: string): unknown };
+    _readAttribute?(name: string): unknown;
+  };
+  return __readAttribute.call(this as unknown as ReadAttributeThis, attr);
 }

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -103,19 +103,6 @@ export class Error {
     this.options = options;
   }
 
-  /**
-   * Return a deep-duped copy of this error, optionally rebinding `base` to a
-   * new model instance. Mirrors Rails' usage in
-   * `ActiveModel::Errors#copy!` where each error is `deep_dup`ed and then
-   * its `@base` is reset to the receiver
-   * (activemodel/lib/active_model/errors.rb:138-143). Preserves a split
-   * between `type` and `rawType` when a NestedError-style override was in
-   * play.
-   */
-  dupWithBase(newBase: ModelBase): Error {
-    return new Error(newBase, this.attribute, this.type, deepDup(this.options), this.rawType);
-  }
-
   get message(): string {
     // Rails error.rb:136-141: dispatch on raw_type shape — Symbol → generate_message, else → literal.
     // TS has no Symbol type; identifier-shaped strings (no spaces/punctuation) are the equivalent.
@@ -155,88 +142,6 @@ export class Error {
 
   get fullMessage(): string {
     return Error.fullMessage(this.attribute, this.message, this.base);
-  }
-
-  /**
-   * See if this error matches `attribute`, `type`, and `options`. Mirrors
-   * Rails `Error#match?` (activemodel/lib/active_model/error.rb:166-174):
-   * subset match — every key in `options` must equal (Ruby `==`, i.e.
-   * structural for Array/Hash, value-equal for primitives) the
-   * corresponding value in `this.options`; extra keys on the error are
-   * ignored. Not Ruby's case-equality (`===`), which would imply
-   * RegExp/Range-style matching — Rails' `match?` uses `!=`.
-   */
-  match(attribute: string, type?: string, options?: Record<string, unknown>): boolean {
-    if (this.attribute !== attribute) return false;
-    if (type !== undefined && this.type !== type) return false;
-    if (options) {
-      for (const [key, value] of Object.entries(options)) {
-        if (!optionsEqual(this.options[key], value)) return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Strict match — Rails `Error#strict_match?`
-   * (activemodel/lib/active_model/error.rb:184-188): attribute/type must
-   * match and `options` must equal the error's `@options` with
-   * `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` stripped.
-   */
-  strictMatch(attribute: string, type: string, options?: Record<string, unknown>): boolean {
-    if (!this.match(attribute, type)) return false;
-    const expected = options ?? {};
-    const own: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(this.options)) {
-      if (!CALLBACKS_OPTIONS.has(k) && !MESSAGE_OPTIONS.has(k)) own[k] = v;
-    }
-    const expectedKeys = Object.keys(expected);
-    const ownKeys = Object.keys(own);
-    if (expectedKeys.length !== ownKeys.length) return false;
-    for (const k of expectedKeys) {
-      if (!Object.prototype.hasOwnProperty.call(own, k) || !optionsEqual(own[k], expected[k]))
-        return false;
-    }
-    return true;
-  }
-
-  equals(other: Error): boolean {
-    if (!(other instanceof Error)) return false;
-    const a = this.attributesForHash();
-    const b = other.attributesForHash();
-    if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) return false;
-    return optionsEqual(a[3], b[3]);
-  }
-
-  /**
-   * Identity tuple used by `==` and `hash`. Mirrors Rails
-   * `attributes_for_hash` (activemodel/lib/active_model/error.rb:204-206):
-   * `[@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]`.
-   *
-   * @internal Rails-private helper.
-   */
-  protected attributesForHash(): [ModelBase, string, string, Record<string, unknown>] {
-    const own: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(this.options)) {
-      if (!CALLBACKS_OPTIONS.has(k)) own[k] = v;
-    }
-    return [this.base, this.attribute, this.rawType, own];
-  }
-
-  inspect(): string {
-    let optionsStr: string;
-    try {
-      optionsStr = JSON.stringify(this.options);
-    } catch {
-      optionsStr = "{...}";
-    }
-    return `#<ActiveModel::Error attribute=${this.attribute}, type=${this.type}, options=${optionsStr}>`;
-  }
-
-  static interpolate(msg: string, options: Record<string, unknown>): string {
-    return msg.replace(/%\{(\w+)\}/g, (_, key) => {
-      return options[key] !== undefined ? String(options[key]) : `%{${key}}`;
-    });
   }
 
   static fullMessage(attribute: string, message: string, base: ModelBase): string {
@@ -290,6 +195,64 @@ export class Error {
     }
 
     return format;
+  }
+
+  /**
+   * See if this error matches `attribute`, `type`, and `options`. Mirrors
+   * Rails `Error#match?` (activemodel/lib/active_model/error.rb:166-174):
+   * subset match — every key in `options` must equal (Ruby `==`, i.e.
+   * structural for Array/Hash, value-equal for primitives) the
+   * corresponding value in `this.options`; extra keys on the error are
+   * ignored. Not Ruby's case-equality (`===`), which would imply
+   * RegExp/Range-style matching — Rails' `match?` uses `!=`.
+   */
+  match(attribute: string, type?: string, options?: Record<string, unknown>): boolean {
+    if (this.attribute !== attribute) return false;
+    if (type !== undefined && this.type !== type) return false;
+    if (options) {
+      for (const [key, value] of Object.entries(options)) {
+        if (!optionsEqual(this.options[key], value)) return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Strict match — Rails `Error#strict_match?`
+   * (activemodel/lib/active_model/error.rb:184-188): attribute/type must
+   * match and `options` must equal the error's `@options` with
+   * `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` stripped.
+   */
+  strictMatch(attribute: string, type: string, options?: Record<string, unknown>): boolean {
+    if (!this.match(attribute, type)) return false;
+    const expected = options ?? {};
+    const own: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.options)) {
+      if (!CALLBACKS_OPTIONS.has(k) && !MESSAGE_OPTIONS.has(k)) own[k] = v;
+    }
+    const expectedKeys = Object.keys(expected);
+    const ownKeys = Object.keys(own);
+    if (expectedKeys.length !== ownKeys.length) return false;
+    for (const k of expectedKeys) {
+      if (!Object.prototype.hasOwnProperty.call(own, k) || !optionsEqual(own[k], expected[k]))
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * Identity tuple used by `==` and `hash`. Mirrors Rails
+   * `attributes_for_hash` (activemodel/lib/active_model/error.rb:204-206):
+   * `[@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected attributesForHash(): [ModelBase, string, string, Record<string, unknown>] {
+    const own: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.options)) {
+      if (!CALLBACKS_OPTIONS.has(k)) own[k] = v;
+    }
+    return [this.base, this.attribute, this.rawType, own];
   }
 
   /**
@@ -369,6 +332,43 @@ export class Error {
       ...i18nOptions,
       defaults: defaults.slice(1),
       defaultValue: type,
+    });
+  }
+
+  /**
+   * Return a deep-duped copy of this error, optionally rebinding `base` to a
+   * new model instance. Mirrors Rails' usage in
+   * `ActiveModel::Errors#copy!` where each error is `deep_dup`ed and then
+   * its `@base` is reset to the receiver
+   * (activemodel/lib/active_model/errors.rb:138-143). Preserves a split
+   * between `type` and `rawType` when a NestedError-style override was in
+   * play.
+   */
+  dupWithBase(newBase: ModelBase): Error {
+    return new Error(newBase, this.attribute, this.type, deepDup(this.options), this.rawType);
+  }
+
+  equals(other: Error): boolean {
+    if (!(other instanceof Error)) return false;
+    const a = this.attributesForHash();
+    const b = other.attributesForHash();
+    if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) return false;
+    return optionsEqual(a[3], b[3]);
+  }
+
+  inspect(): string {
+    let optionsStr: string;
+    try {
+      optionsStr = JSON.stringify(this.options);
+    } catch {
+      optionsStr = "{...}";
+    }
+    return `#<ActiveModel::Error attribute=${this.attribute}, type=${this.type}, options=${optionsStr}>`;
+  }
+
+  static interpolate(msg: string, options: Record<string, unknown>): string {
+    return msg.replace(/%\{(\w+)\}/g, (_, key) => {
+      return options[key] !== undefined ? String(options[key]) : `%{${key}}`;
     });
   }
 }

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -27,12 +27,168 @@ export class Errors<TBase extends object = object> {
     this._base = base;
   }
 
-  get base(): TBase | null {
-    return this._base;
-  }
-
   get errors(): this {
     return this;
+  }
+
+  /**
+   * Replace this collection's errors with a deep-duped copy of `other`'s,
+   * rebinding each error's `base` to this collection's base. Mirrors
+   * Rails' `ActiveModel::Errors#copy!`
+   * (activemodel/lib/active_model/errors.rb:138-143):
+   *
+   *   def copy!(other)
+   *     @errors = other.errors.deep_dup
+   *     @errors.each { |error| error.instance_variable_set(:@base, @base) }
+   *   end
+   */
+  copyBang<U extends object>(other: Errors<U>): void {
+    this._errors = other._errors.map((e) => e.dupWithBase(this._base));
+  }
+
+  /**
+   * Import a single error, wrapping it as a `NestedError` so the original
+   * error object + its options stay reachable. Mirrors Rails'
+   * `ActiveModel::Errors#import`
+   * (activemodel/lib/active_model/errors.rb:154-161):
+   *
+   *   def import(error, override_options = {})
+   *     ...
+   *     @errors.append(NestedError.new(@base, error, override_options))
+   *   end
+   */
+  import(error: ActiveModelError, options?: { attribute?: string; type?: string }): void {
+    this._errors.push(new NestedError(this._base, error, options));
+  }
+
+  /**
+   * Merge errors from `other`, wrapping each as a `NestedError` so the
+   * original error + its options remain accessible. Mirrors Rails'
+   * `ActiveModel::Errors#merge!`
+   * (activemodel/lib/active_model/errors.rb:174-180):
+   *
+   *   def merge!(other)
+   *     return errors if equal?(other)
+   *     other.errors.each { |error| import(error) }
+   *   end
+   */
+  mergeBang<U extends object>(other: Errors<U>): void {
+    if (Object.is(other, this)) return;
+    for (const error of other._errors) {
+      this.import(error);
+    }
+  }
+
+  /**
+   * Search errors matching `attribute`, `type`, or `options`. Mirrors
+   * Rails `errors.rb:189-194` — delegates to `Error#match?` (subset
+   * match on options).
+   */
+  where(
+    attribute: string,
+    type?: string | ((record: TBase | null, options: Record<string, unknown>) => string),
+    options?: Record<string, unknown>,
+  ): ActiveModelError[] {
+    if (type === undefined) {
+      return this._errors.filter((e) => e.match(attribute));
+    }
+    const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
+    return this._errors.filter((e) => e.match(normAttr, normType, normOpts));
+  }
+
+  include(attribute: string): boolean {
+    return this._errors.some((e) => e.attribute === attribute);
+  }
+
+  /**
+   * Remove and return errors matching `attribute`/`type`/`options`.
+   * Returns the removed errors when non-empty, or `null` when nothing was
+   * removed. Mirrors Rails `errors.rb:215-222` — `matches.map(&:message).presence`
+   * returns `nil` for an empty array.
+   */
+  delete(
+    attribute: string,
+    type?: string,
+    options?: Record<string, unknown>,
+  ): ActiveModelError[] | null {
+    const matches = this.where(attribute, type, options);
+    if (matches.length === 0) return null;
+    const toRemove = new Set(matches);
+    this._errors = this._errors.filter((e) => !toRemove.has(e));
+    return matches;
+  }
+
+  get attributeNames(): string[] {
+    return [...new Set(this._errors.map((e) => e.attribute))];
+  }
+
+  asJson(_options?: Record<string, unknown>): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    for (const [attr, msgs] of this.toHash(false)) {
+      result[attr] = msgs;
+    }
+    return result;
+  }
+
+  /**
+   * Returns a Map of attributes to their short message arrays. Missing-key
+   * `.get()` returns the singleton frozen `[]`. Mirrors Rails `errors.rb:268-273`.
+   */
+  get messages(): Map<string, readonly string[]> {
+    const base = this.toHash(false);
+    // Proxy: missing key returns EMPTY_ARRAY (Rails hash.default = EMPTY_ARRAY).
+    return new Proxy(base, {
+      get(target, prop, receiver) {
+        if (prop === "get") {
+          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
+        }
+        const val = Reflect.get(target, prop, target);
+        return typeof val === "function" ? val.bind(target) : val;
+      },
+    });
+  }
+
+  /**
+   * Returns a Map of attributes to arrays of per-error detail hashes.
+   * Each entry is `{ error: type, ...filteredOptions }` (reserved option keys
+   * stripped). Missing-key `.get()` returns the singleton frozen `[]`.
+   * Mirrors Rails `errors.rb:276-284` + `Error#details` (error.rb:154-157).
+   */
+  get details(): Map<string, ReadonlyArray<ErrorDetailHash>> {
+    const grouped = this.groupByAttribute();
+    const map = new Map<string, ReadonlyArray<ErrorDetailHash>>();
+    for (const [attr, errors] of Object.entries(grouped)) {
+      map.set(
+        attr,
+        errors.map((e) => e.details as ErrorDetailHash),
+      );
+    }
+    // Proxy: override only `get` so missing keys return EMPTY_ARRAY (Rails
+    // hash.default = EMPTY_ARRAY). All other Map methods bound to target so
+    // native Map internals (`size`, `forEach`, etc.) keep the correct receiver.
+    return new Proxy(map, {
+      get(target, prop, receiver) {
+        if (prop === "get") {
+          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
+        }
+        const val = Reflect.get(target, prop, target);
+        return typeof val === "function" ? val.bind(target) : val;
+      },
+    });
+  }
+
+  /**
+   * @internal Rails-private helper.
+   */
+  groupByAttribute(): Record<string, ActiveModelError[]> {
+    const result: Record<string, ActiveModelError[]> = {};
+    for (const error of this._errors) {
+      if (!result[error.attribute]) {
+        result[error.attribute] = [];
+      }
+      result[error.attribute].push(error);
+    }
+    return result;
   }
 
   /**
@@ -75,6 +231,64 @@ export class Errors<TBase extends object = object> {
   }
 
   /**
+   * Returns `true` if an error with this exact attribute/type/options has
+   * been added. Mirrors Rails `Errors#added?`
+   * (activemodel/lib/active_model/errors.rb:372-388) Symbol-vs-String dispatch:
+   * if `type` looks like an i18n key (no spaces → Symbol-like), use strict match;
+   * otherwise treat it as a full message string and check `messagesFor`.
+   */
+  added(attribute: string, type: string = "invalid", options?: Record<string, unknown>): boolean {
+    if (!type.includes(" ")) {
+      // Symbol-like branch: strict attribute/type/options match.
+      return this._errors.some((e) => e.strictMatch(attribute, type, options));
+    }
+    // String branch: full-message lookup (Rails else clause in added?).
+    return this.messagesFor(attribute).includes(type);
+  }
+
+  /**
+   * Returns `true` if an error of the given type exists on `attribute`.
+   * Mirrors Rails `errors.rb:395-403` Symbol-vs-String dispatch:
+   * if `type` looks like an i18n key (no spaces → Symbol-like), use `where`;
+   * otherwise treat it as a full message string and check `messagesFor`.
+   */
+  ofKind(attribute: string, type?: string): boolean {
+    if (type === undefined) {
+      return this._errors.some((e) => e.attribute === attribute);
+    }
+    if (!type.includes(" ")) {
+      // Symbol-like: check for errors of this exact type.
+      return this.where(attribute, type).length > 0;
+    }
+    // String branch: full-message lookup (Rails else clause).
+    return this.messagesFor(attribute).includes(type);
+  }
+
+  get fullMessages(): string[] {
+    return this._errors.map((e) => e.fullMessage);
+  }
+
+  fullMessagesFor(attribute: string): string[] {
+    return this._errors.filter((e) => e.attribute === attribute).map((e) => e.fullMessage);
+  }
+
+  messagesFor(attribute: string): string[] {
+    return this.get(attribute);
+  }
+
+  fullMessage(attribute: string, message: string): string {
+    return ActiveModelError.fullMessage(attribute, message, this._base);
+  }
+
+  generateMessage(
+    attribute: string,
+    type: string = "invalid",
+    options?: Record<string, unknown>,
+  ): string {
+    return ActiveModelError.generateMessage(attribute, type, this._base, options);
+  }
+
+  /**
    * Coerce the arguments to `add` / `where` into a normalized triple.
    * Mirrors Rails `normalize_arguments`
    * (activemodel/lib/active_model/errors.rb:490-497): if `type` is
@@ -93,33 +307,28 @@ export class Errors<TBase extends object = object> {
     return [attribute, resolvedType, opts];
   }
 
+  get base(): TBase | null {
+    return this._base;
+  }
+
   get(attribute: string): string[] {
     return this._errors.filter((e) => e.attribute === attribute).map((e) => e.message);
   }
 
+  /**
+   * Makes `Errors` iterable so `for (const e of errors)`, `[...errors]`,
+   * and `Array.from(errors)` all work. Mirrors Rails' `include Enumerable`
+   * on the Errors class (activemodel/lib/active_model/errors.rb:62) and
+   * its `def_delegators :@errors, :each, :clear, :empty?, :size, :uniq!`
+   * (errors.rb:103) — `each` powers the Enumerable surface in Ruby; the
+   * TS analog is the iterator protocol.
+   */
+  [Symbol.iterator](): IterableIterator<ActiveModelError> {
+    return this._errors[Symbol.iterator]();
+  }
+
   on(attribute: string): string[] {
     return this.get(attribute);
-  }
-
-  /**
-   * Search errors matching `attribute`, `type`, or `options`. Mirrors
-   * Rails `errors.rb:189-194` — delegates to `Error#match?` (subset
-   * match on options).
-   */
-  where(
-    attribute: string,
-    type?: string | ((record: TBase | null, options: Record<string, unknown>) => string),
-    options?: Record<string, unknown>,
-  ): ActiveModelError[] {
-    if (type === undefined) {
-      return this._errors.filter((e) => e.match(attribute));
-    }
-    const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
-    return this._errors.filter((e) => e.match(normAttr, normType, normOpts));
-  }
-
-  get fullMessages(): string[] {
-    return this._errors.map((e) => e.fullMessage);
   }
 
   get count(): number {
@@ -169,153 +378,15 @@ export class Errors<TBase extends object = object> {
     this._errors = out;
   }
 
-  /**
-   * Returns a Map of attributes to arrays of per-error detail hashes.
-   * Each entry is `{ error: type, ...filteredOptions }` (reserved option keys
-   * stripped). Missing-key `.get()` returns the singleton frozen `[]`.
-   * Mirrors Rails `errors.rb:276-284` + `Error#details` (error.rb:154-157).
-   */
-  get details(): Map<string, ReadonlyArray<ErrorDetailHash>> {
-    const grouped = this.groupByAttribute();
-    const map = new Map<string, ReadonlyArray<ErrorDetailHash>>();
-    for (const [attr, errors] of Object.entries(grouped)) {
-      map.set(
-        attr,
-        errors.map((e) => e.details as ErrorDetailHash),
-      );
-    }
-    // Proxy: override only `get` so missing keys return EMPTY_ARRAY (Rails
-    // hash.default = EMPTY_ARRAY). All other Map methods bound to target so
-    // native Map internals (`size`, `forEach`, etc.) keep the correct receiver.
-    return new Proxy(map, {
-      get(target, prop, receiver) {
-        if (prop === "get") {
-          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
-        }
-        const val = Reflect.get(target, prop, target);
-        return typeof val === "function" ? val.bind(target) : val;
-      },
-    });
-  }
-
-  get attributeNames(): string[] {
-    return [...new Set(this._errors.map((e) => e.attribute))];
-  }
-
-  fullMessagesFor(attribute: string): string[] {
-    return this._errors.filter((e) => e.attribute === attribute).map((e) => e.fullMessage);
-  }
-
-  fullMessage(attribute: string, message: string): string {
-    return ActiveModelError.fullMessage(attribute, message, this._base);
-  }
-
-  /**
-   * Returns `true` if an error of the given type exists on `attribute`.
-   * Mirrors Rails `errors.rb:395-403` Symbol-vs-String dispatch:
-   * if `type` looks like an i18n key (no spaces → Symbol-like), use `where`;
-   * otherwise treat it as a full message string and check `messagesFor`.
-   */
-  ofKind(attribute: string, type?: string): boolean {
-    if (type === undefined) {
-      return this._errors.some((e) => e.attribute === attribute);
-    }
-    if (!type.includes(" ")) {
-      // Symbol-like: check for errors of this exact type.
-      return this.where(attribute, type).length > 0;
-    }
-    // String branch: full-message lookup (Rails else clause).
-    return this.messagesFor(attribute).includes(type);
-  }
-
-  /**
-   * Returns `true` if an error with this exact attribute/type/options has
-   * been added. Mirrors Rails `Errors#added?`
-   * (activemodel/lib/active_model/errors.rb:372-388) Symbol-vs-String dispatch:
-   * if `type` looks like an i18n key (no spaces → Symbol-like), use strict match;
-   * otherwise treat it as a full message string and check `messagesFor`.
-   */
-  added(attribute: string, type: string = "invalid", options?: Record<string, unknown>): boolean {
-    if (!type.includes(" ")) {
-      // Symbol-like branch: strict attribute/type/options match.
-      return this._errors.some((e) => e.strictMatch(attribute, type, options));
-    }
-    // String branch: full-message lookup (Rails else clause in added?).
-    return this.messagesFor(attribute).includes(type);
-  }
-
-  /**
-   * Remove and return errors matching `attribute`/`type`/`options`.
-   * Returns the removed errors when non-empty, or `null` when nothing was
-   * removed. Mirrors Rails `errors.rb:215-222` — `matches.map(&:message).presence`
-   * returns `nil` for an empty array.
-   */
-  delete(
-    attribute: string,
-    type?: string,
-    options?: Record<string, unknown>,
-  ): ActiveModelError[] | null {
-    const matches = this.where(attribute, type, options);
-    if (matches.length === 0) return null;
-    const toRemove = new Set(matches);
-    this._errors = this._errors.filter((e) => !toRemove.has(e));
-    return matches;
-  }
-
   each(fn: (error: ActiveModelError) => void): void {
     for (const error of this._errors) {
       fn(error);
     }
   }
 
-  /**
-   * Makes `Errors` iterable so `for (const e of errors)`, `[...errors]`,
-   * and `Array.from(errors)` all work. Mirrors Rails' `include Enumerable`
-   * on the Errors class (activemodel/lib/active_model/errors.rb:62) and
-   * its `def_delegators :@errors, :each, :clear, :empty?, :size, :uniq!`
-   * (errors.rb:103) — `each` powers the Enumerable surface in Ruby; the
-   * TS analog is the iterator protocol.
-   */
-  [Symbol.iterator](): IterableIterator<ActiveModelError> {
-    return this._errors[Symbol.iterator]();
-  }
-
-  /**
-   * Replace this collection's errors with a deep-duped copy of `other`'s,
-   * rebinding each error's `base` to this collection's base. Mirrors
-   * Rails' `ActiveModel::Errors#copy!`
-   * (activemodel/lib/active_model/errors.rb:138-143):
-   *
-   *   def copy!(other)
-   *     @errors = other.errors.deep_dup
-   *     @errors.each { |error| error.instance_variable_set(:@base, @base) }
-   *   end
-   */
-  copyBang<U extends object>(other: Errors<U>): void {
-    this._errors = other._errors.map((e) => e.dupWithBase(this._base));
-  }
-
   /** Alias for `copyBang` — Rails ships only `copy!`. */
   copy<U extends object>(other: Errors<U>): void {
     this.copyBang(other);
-  }
-
-  /**
-   * Merge errors from `other`, wrapping each as a `NestedError` so the
-   * original error + its options remain accessible. Mirrors Rails'
-   * `ActiveModel::Errors#merge!`
-   * (activemodel/lib/active_model/errors.rb:174-180):
-   *
-   *   def merge!(other)
-   *     return errors if equal?(other)
-   *     other.errors.each { |error| import(error) }
-   *   end
-   */
-  mergeBang<U extends object>(other: Errors<U>): void {
-    if (Object.is(other, this)) return;
-    for (const error of other._errors) {
-      this.import(error);
-    }
   }
 
   /** Alias for `mergeBang` — Rails ships only `merge!`. */
@@ -342,79 +413,8 @@ export class Errors<TBase extends object = object> {
     return map;
   }
 
-  include(attribute: string): boolean {
-    return this._errors.some((e) => e.attribute === attribute);
-  }
-
   toArray(): string[] {
     return this.fullMessages;
-  }
-
-  /**
-   * Returns a Map of attributes to their short message arrays. Missing-key
-   * `.get()` returns the singleton frozen `[]`. Mirrors Rails `errors.rb:268-273`.
-   */
-  get messages(): Map<string, readonly string[]> {
-    const base = this.toHash(false);
-    // Proxy: missing key returns EMPTY_ARRAY (Rails hash.default = EMPTY_ARRAY).
-    return new Proxy(base, {
-      get(target, prop, receiver) {
-        if (prop === "get") {
-          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
-        }
-        const val = Reflect.get(target, prop, target);
-        return typeof val === "function" ? val.bind(target) : val;
-      },
-    });
-  }
-
-  generateMessage(
-    attribute: string,
-    type: string = "invalid",
-    options?: Record<string, unknown>,
-  ): string {
-    return ActiveModelError.generateMessage(attribute, type, this._base, options);
-  }
-
-  /**
-   * Import a single error, wrapping it as a `NestedError` so the original
-   * error object + its options stay reachable. Mirrors Rails'
-   * `ActiveModel::Errors#import`
-   * (activemodel/lib/active_model/errors.rb:154-161):
-   *
-   *   def import(error, override_options = {})
-   *     ...
-   *     @errors.append(NestedError.new(@base, error, override_options))
-   *   end
-   */
-  import(error: ActiveModelError, options?: { attribute?: string; type?: string }): void {
-    this._errors.push(new NestedError(this._base, error, options));
-  }
-
-  asJson(_options?: Record<string, unknown>): Record<string, string[]> {
-    const result: Record<string, string[]> = {};
-    for (const [attr, msgs] of this.toHash(false)) {
-      result[attr] = msgs;
-    }
-    return result;
-  }
-
-  /**
-   * @internal Rails-private helper.
-   */
-  groupByAttribute(): Record<string, ActiveModelError[]> {
-    const result: Record<string, ActiveModelError[]> = {};
-    for (const error of this._errors) {
-      if (!result[error.attribute]) {
-        result[error.attribute] = [];
-      }
-      result[error.attribute].push(error);
-    }
-    return result;
-  }
-
-  messagesFor(attribute: string): string[] {
-    return this.get(attribute);
   }
 
   inspect(): string {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -100,27 +100,6 @@ export class ModelName {
   private _humanFallback: string;
   private _klass: ModelLike | null;
 
-  // Uncountable lookup delegates to `@blazetrails/activesupport`'s
-  // `Inflections.instance("en")` — the same store Rails models go
-  // through via `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
-  // (activesupport/lib/active_support/inflections.rb). Previously we
-  // maintained a local 6-word set that ignored user-added inflections
-  // and diverged from activesupport's own pluralize() which uses the
-  // shared store.
-  private static get _uncountables(): Set<string> {
-    return Inflections.instance("en").uncountables;
-  }
-
-  /**
-   * Register an uncountable word. Mirrors Rails
-   * `ActiveSupport::Inflector.inflections.uncountable(word)` — writes
-   * through to the shared inflector store so `pluralize("sheep")`,
-   * `ModelName`, and every other inflection consumer see it.
-   */
-  static addUncountable(word: string): void {
-    Inflections.instance("en").uncountable(word);
-  }
-
   /**
    * Construct a ModelName.
    *
@@ -241,6 +220,85 @@ export class ModelName {
     return this.collection;
   }
 
+  get human(): string {
+    if (!this._klass) return this._humanFallback;
+
+    const i18nKeys = this.i18nKeys();
+    const i18nScope = this._i18nScope();
+    if (i18nKeys.length === 0 || i18nScope.length === 0) return this._humanFallback;
+
+    const [primaryKey, ...restKeys] = i18nKeys;
+    const scopePrefix = i18nScope.join(".");
+    const fullKey = `${scopePrefix}.${primaryKey}`;
+
+    const defaults: Array<{ key: string } | { message: string }> = restKeys.map((k) => ({
+      key: `${scopePrefix}.${k}`,
+    }));
+    defaults.push({ message: this._humanFallback });
+
+    return I18n.t(fullKey, { defaults });
+  }
+
+  /**
+   * Flatten a class name into the singular `_`-joined form. Mirrors
+   * Rails `_singularize` (activemodel/lib/active_model/naming.rb:216-218):
+   * `ActiveSupport::Inflector.underscore(string).tr("/", "_")`.
+   *
+   * @internal Rails-private helper.
+   */
+  _singularize(string: string): string {
+    return underscore(string).replace(/\//g, "_");
+  }
+
+  /**
+   * Lazy list of i18n lookup keys for this model and its ancestors.
+   * Mirrors Rails `i18n_keys` (activemodel/lib/active_model/naming.rb:220-226).
+   *
+   * @internal Rails-private helper.
+   */
+  i18nKeys(): string[] {
+    if (this._cachedI18nKeys) return this._cachedI18nKeys;
+    let keys: string[];
+    if (!this._klass) {
+      keys = [];
+    } else if (typeof this._klass.lookupAncestors === "function") {
+      keys = this._klass.lookupAncestors().map((k) => {
+        if (k.modelName) return k.modelName.i18nKey;
+        return underscore(k.name);
+      });
+    } else {
+      keys = [this.i18nKey];
+    }
+    this._cachedI18nKeys = keys;
+    return keys;
+  }
+
+  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
+  [Symbol.toPrimitive](_hint: string): string {
+    return this.name;
+  }
+
+  // Uncountable lookup delegates to `@blazetrails/activesupport`'s
+  // `Inflections.instance("en")` — the same store Rails models go
+  // through via `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
+  // (activesupport/lib/active_support/inflections.rb). Previously we
+  // maintained a local 6-word set that ignored user-added inflections
+  // and diverged from activesupport's own pluralize() which uses the
+  // shared store.
+  private static get _uncountables(): Set<string> {
+    return Inflections.instance("en").uncountables;
+  }
+
+  /**
+   * Register an uncountable word. Mirrors Rails
+   * `ActiveSupport::Inflector.inflections.uncountable(word)` — writes
+   * through to the shared inflector store so `pluralize("sheep")`,
+   * `ModelName`, and every other inflection consumer see it.
+   */
+  static addUncountable(word: string): void {
+    Inflections.instance("en").uncountable(word);
+  }
+
   // ---------------------------------------------------------------------------
   // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
   //   include Comparable
@@ -268,11 +326,6 @@ export class ModelName {
    * directly.
    */
   toString(): string {
-    return this.name;
-  }
-
-  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
-  [Symbol.toPrimitive](_hint: string): string {
     return this.name;
   }
 
@@ -354,64 +407,11 @@ export class ModelName {
     return this.name;
   }
 
+  private _cachedI18nKeys?: string[];
+
   /** JSON.stringify hook — delegates to `asJson`. */
   toJSON(): string {
     return this.asJson();
-  }
-
-  get human(): string {
-    if (!this._klass) return this._humanFallback;
-
-    const i18nKeys = this.i18nKeys();
-    const i18nScope = this._i18nScope();
-    if (i18nKeys.length === 0 || i18nScope.length === 0) return this._humanFallback;
-
-    const [primaryKey, ...restKeys] = i18nKeys;
-    const scopePrefix = i18nScope.join(".");
-    const fullKey = `${scopePrefix}.${primaryKey}`;
-
-    const defaults: Array<{ key: string } | { message: string }> = restKeys.map((k) => ({
-      key: `${scopePrefix}.${k}`,
-    }));
-    defaults.push({ message: this._humanFallback });
-
-    return I18n.t(fullKey, { defaults });
-  }
-
-  /**
-   * Lazy list of i18n lookup keys for this model and its ancestors.
-   * Mirrors Rails `i18n_keys` (activemodel/lib/active_model/naming.rb:220-226).
-   *
-   * @internal Rails-private helper.
-   */
-  i18nKeys(): string[] {
-    if (this._cachedI18nKeys) return this._cachedI18nKeys;
-    let keys: string[];
-    if (!this._klass) {
-      keys = [];
-    } else if (typeof this._klass.lookupAncestors === "function") {
-      keys = this._klass.lookupAncestors().map((k) => {
-        if (k.modelName) return k.modelName.i18nKey;
-        return underscore(k.name);
-      });
-    } else {
-      keys = [this.i18nKey];
-    }
-    this._cachedI18nKeys = keys;
-    return keys;
-  }
-
-  private _cachedI18nKeys?: string[];
-
-  /**
-   * Flatten a class name into the singular `_`-joined form. Mirrors
-   * Rails `_singularize` (activemodel/lib/active_model/naming.rb:216-218):
-   * `ActiveSupport::Inflector.underscore(string).tr("/", "_")`.
-   *
-   * @internal Rails-private helper.
-   */
-  _singularize(string: string): string {
-    return underscore(string).replace(/\//g, "_");
   }
 
   private _i18nScope(): string[] {

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -20,27 +20,6 @@ export namespace SecurePassword {
   }
 }
 
-function setPassword(
-  instance: Model,
-  value: unknown,
-  attribute: string,
-  digestAttr: string,
-  passwordCache: WeakMap<object, string | null>,
-) {
-  if (value === null || value === undefined) {
-    passwordCache.set(instance, null);
-    instance.writeAttribute(digestAttr, null);
-    return;
-  }
-  const str = String(value);
-  if (str === "") {
-    return;
-  }
-  passwordCache.set(instance, str);
-  const cost = SecurePassword.minCost ? MIN_COST : DEFAULT_COST;
-  instance.writeAttribute(digestAttr, bcrypt.hashSync(str, cost));
-}
-
 export function hasSecurePassword(
   modelClass: typeof Model,
   attribute: string = "password",
@@ -166,6 +145,27 @@ export function hasSecurePassword(
       }
     });
   }
+}
+
+function setPassword(
+  instance: Model,
+  value: unknown,
+  attribute: string,
+  digestAttr: string,
+  passwordCache: WeakMap<object, string | null>,
+) {
+  if (value === null || value === undefined) {
+    passwordCache.set(instance, null);
+    instance.writeAttribute(digestAttr, null);
+    return;
+  }
+  const str = String(value);
+  if (str === "") {
+    return;
+  }
+  passwordCache.set(instance, str);
+  const cost = SecurePassword.minCost ? MIN_COST : DEFAULT_COST;
+  instance.writeAttribute(digestAttr, bcrypt.hashSync(str, cost));
 }
 
 /**

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -12,48 +12,6 @@ export interface SerializationRecord {
 }
 
 /**
- * Set `key` on `target` as an own data property, even when `key` is
- * `__proto__` (or another magic name that has accessors on
- * `Object.prototype`). A plain assignment would invoke the inherited
- * setter and mutate the target's prototype chain. Used everywhere the
- * key may originate from user input — attribute names, include keys,
- * association names from a JSON-decoded options bag.
- */
-function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
-  Object.defineProperty(target, key, {
-    value,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Serialization mixin contract — provides serializable_hash.
- *
- * Mirrors: ActiveModel::Serialization
- */
-export interface Serialization {
-  serializableHash(options?: SerializeOptions): Record<string, unknown>;
-}
-
-/**
- * Serialization options.
- */
-export interface SerializeOptions {
-  only?: string[];
-  except?: string[];
-  methods?: string[];
-  // Mirrors Rails `:include` polymorphism: a single name, an array of
-  // names, a hash of name → opts, or — like `include: [:posts, { comments: {} }]`
-  // — an array mixing names and hashes.
-  include?:
-    | Record<string, SerializeOptions>
-    | Array<string | Record<string, SerializeOptions>>
-    | string;
-}
-
-/**
  * Serialize a model's attributes to a plain object.
  *
  * Mirrors: ActiveModel::Serialization#serializable_hash
@@ -119,26 +77,29 @@ export function serializableHash(
 }
 
 /**
- * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
- * (serialization.rb:158-160)
+ * Serialization mixin contract — provides serializable_hash.
  *
- *   def attribute_names_for_serialization
- *     attributes.keys
- *   end
- *
- * Models can override this hook to scope which attributes appear.
- * Trails has multiple attribute storage shapes (AttributeSet via
- * `_attributes`, Map, plain object) so the fallback walks them in
- * order. Virtual attributes (acceptance/confirmation) are filtered
- * out — they aren't real attributes and shouldn't surface in JSON.
- *
- * @internal Rails-private helper.
+ * Mirrors: ActiveModel::Serialization
  */
-type AttributeStore =
-  | { keys(): string[]; fetchValue(key: string): unknown }
-  | Map<string, unknown>
-  | null
-  | undefined;
+export interface Serialization {
+  serializableHash(options?: SerializeOptions): Record<string, unknown>;
+}
+
+/**
+ * Serialization options.
+ */
+export interface SerializeOptions {
+  only?: string[];
+  except?: string[];
+  methods?: string[];
+  // Mirrors Rails `:include` polymorphism: a single name, an array of
+  // names, a hash of name → opts, or — like `include: [:posts, { comments: {} }]`
+  // — an array mixing names and hashes.
+  include?:
+    | Record<string, SerializeOptions>
+    | Array<string | Record<string, SerializeOptions>>
+    | string;
+}
 
 /** @internal */
 export function attributeNamesForSerialization(record: SerializationRecord): string[] {
@@ -166,6 +127,28 @@ export function attributeNamesForSerialization(record: SerializationRecord): str
   }
   return keys;
 }
+
+/**
+ * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
+ * (serialization.rb:158-160)
+ *
+ *   def attribute_names_for_serialization
+ *     attributes.keys
+ *   end
+ *
+ * Models can override this hook to scope which attributes appear.
+ * Trails has multiple attribute storage shapes (AttributeSet via
+ * `_attributes`, Map, plain object) so the fallback walks them in
+ * order. Virtual attributes (acceptance/confirmation) are filtered
+ * out — they aren't real attributes and shouldn't surface in JSON.
+ *
+ * @internal Rails-private helper.
+ */
+type AttributeStore =
+  | { keys(): string[]; fetchValue(key: string): unknown }
+  | Map<string, unknown>
+  | null
+  | undefined;
 
 /**
  * Mirrors: ActiveModel::Serialization#serializable_attributes
@@ -258,6 +241,23 @@ export function serializableAddIncludes(
       callback(assocName, cached, assocOpts);
     }
   }
+}
+
+/**
+ * Set `key` on `target` as an own data property, even when `key` is
+ * `__proto__` (or another magic name that has accessors on
+ * `Object.prototype`). A plain assignment would invoke the inherited
+ * setter and mutate the target's prototype chain. Used everywhere the
+ * key may originate from user input — attribute names, include keys,
+ * association names from a JSON-decoded options bag.
+ */
+function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -54,60 +54,6 @@ export class JSON {
   /** Plain attribute store for lightweight adopters; subclasses override with their storage shape. */
   declare attributes: Record<string, unknown>;
 
-  // Rails: included do; extend ActiveModel::Naming; end — surfaces
-  // model_name on the host class. Subclasses override to customize.
-  static get modelName(): ModelName {
-    if (!this._modelName || this._modelName.name !== this.name) {
-      this._modelName = new ModelName(this.name, { klass: this });
-    }
-    return this._modelName;
-  }
-
-  /**
-   * Mirrors: ActiveModel::Serialization#serializable_hash
-   * (serialization.rb), included into JSON via `include
-   * ActiveModel::Serialization`. Delegates to the canonical
-   * implementation in `serialization.ts` so a subclass that mixes in
-   * the JSON host gets the same Rails semantics for `:only`, `:except`,
-   * `:methods`, `:include`.
-   */
-  serializableHash(options?: SerializeOptions): Record<string, unknown> {
-    return serializableHash(this as unknown as SerializationRecord, options);
-  }
-
-  /**
-   * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
-   * (serialization.rb:158-160), inherited via `include Serialization`.
-   *
-   * @internal Rails-private helper.
-   */
-  protected attributeNamesForSerialization(): string[] {
-    return attributeNamesForSerialization(this as unknown as SerializationRecord);
-  }
-
-  /**
-   * Mirrors: ActiveModel::Serialization#serializable_attributes
-   * (serialization.rb:162-164), inherited via `include Serialization`.
-   *
-   * @internal Rails-private helper.
-   */
-  protected serializableAttributes(attributeNames: readonly string[]): Record<string, unknown> {
-    return serializableAttributes(this as unknown as SerializationRecord, attributeNames);
-  }
-
-  /**
-   * Mirrors: ActiveModel::Serialization#serializable_add_includes
-   * (serialization.rb:171-183), inherited via `include Serialization`.
-   *
-   * @internal Rails-private helper.
-   */
-  protected serializableAddIncludes(
-    options: SerializeOptions = {},
-    callback: (association: string, records: unknown, opts: SerializeOptions) => void = () => {},
-  ): void {
-    serializableAddIncludes(this as unknown as SerializationRecord, options, callback);
-  }
-
   /**
    * Mirrors: json.rb:96-108
    *   def as_json(options = nil)
@@ -174,6 +120,60 @@ export class JSON {
     }
     this.attributes = hash as Record<string, unknown>;
     return this;
+  }
+
+  // Rails: included do; extend ActiveModel::Naming; end — surfaces
+  // model_name on the host class. Subclasses override to customize.
+  static get modelName(): ModelName {
+    if (!this._modelName || this._modelName.name !== this.name) {
+      this._modelName = new ModelName(this.name, { klass: this });
+    }
+    return this._modelName;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_hash
+   * (serialization.rb), included into JSON via `include
+   * ActiveModel::Serialization`. Delegates to the canonical
+   * implementation in `serialization.ts` so a subclass that mixes in
+   * the JSON host gets the same Rails semantics for `:only`, `:except`,
+   * `:methods`, `:include`.
+   */
+  serializableHash(options?: SerializeOptions): Record<string, unknown> {
+    return serializableHash(this as unknown as SerializationRecord, options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
+   * (serialization.rb:158-160), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected attributeNamesForSerialization(): string[] {
+    return attributeNamesForSerialization(this as unknown as SerializationRecord);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_attributes
+   * (serialization.rb:162-164), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected serializableAttributes(attributeNames: readonly string[]): Record<string, unknown> {
+    return serializableAttributes(this as unknown as SerializationRecord, attributeNames);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_add_includes
+   * (serialization.rb:171-183), inherited via `include Serialization`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected serializableAddIncludes(
+    options: SerializeOptions = {},
+    callback: (association: string, records: unknown, opts: SerializeOptions) => void = () => {},
+  ): void {
+    serializableAddIncludes(this as unknown as SerializationRecord, options, callback);
   }
 
   /**

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -44,6 +44,18 @@ export function raiseOnMissingTranslations(value?: boolean): boolean {
 }
 
 /**
+ * Walk the class prototype chain collecting constructors that expose a
+ * modelName static (i.e. those that include ActiveModel::Naming in Rails).
+ *
+ * @internal Mirrors ActiveModel::Translation#lookup_ancestors
+ */
+export function lookupAncestors(
+  this: object,
+): Array<{ new (...args: never[]): unknown; modelName: ModelName }> {
+  return _walkAncestors(this);
+}
+
+/**
  * Transforms attribute names into a more human format, such as "First name"
  * instead of "first_name".
  *
@@ -117,18 +129,6 @@ function _appendUserDefaults(
   for (const item of items) {
     defaults.push({ message: item });
   }
-}
-
-/**
- * Walk the class prototype chain collecting constructors that expose a
- * modelName static (i.e. those that include ActiveModel::Naming in Rails).
- *
- * @internal Mirrors ActiveModel::Translation#lookup_ancestors
- */
-export function lookupAncestors(
-  this: object,
-): Array<{ new (...args: never[]): unknown; modelName: ModelName }> {
-  return _walkAncestors(this);
 }
 
 function _walkAncestors(

--- a/packages/activemodel/src/type/big-integer.ts
+++ b/packages/activemodel/src/type/big-integer.ts
@@ -3,6 +3,17 @@ import { IntegerType } from "./integer.js";
 export class BigIntegerType extends IntegerType {
   readonly name: string = "big_integer";
 
+  serializeCastValue(value: number | null): number | null {
+    return value;
+  }
+
+  /**
+   * @internal Rails-private helper. Returns Infinity to bypass Integer's range check.
+   */
+  protected maxValue(): number {
+    return Number.POSITIVE_INFINITY;
+  }
+
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): number | null {
     if (typeof value === "bigint") return value as unknown as number;
@@ -27,16 +38,5 @@ export class BigIntegerType extends IntegerType {
   serialize(value: unknown): unknown {
     // No range check — maxValue is Infinity. Return cast value as-is (matches Rails).
     return this.cast(value);
-  }
-
-  serializeCastValue(value: number | null): number | null {
-    return value;
-  }
-
-  /**
-   * @internal Rails-private helper. Returns Infinity to bypass Integer's range check.
-   */
-  protected maxValue(): number {
-    return Number.POSITIVE_INFINITY;
   }
 }

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -6,6 +6,14 @@ const textDecoder = new TextDecoder();
 export class BinaryType extends ValueType<Uint8Array> {
   readonly name = "binary";
 
+  type(): string {
+    return this.name;
+  }
+
+  isBinary(): boolean {
+    return true;
+  }
+
   cast(value: unknown): Uint8Array | null {
     if (value === null || value === undefined) return null;
     if (value instanceof Data) return value.bytes;
@@ -15,19 +23,6 @@ export class BinaryType extends ValueType<Uint8Array> {
 
   serialize(value: unknown): Uint8Array | null {
     return this.cast(value);
-  }
-
-  deserialize(value: unknown): Uint8Array | null {
-    if (value instanceof Data) return value.bytes;
-    return this.cast(value);
-  }
-
-  type(): string {
-    return this.name;
-  }
-
-  isBinary(): boolean {
-    return true;
   }
 
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
@@ -40,6 +35,11 @@ export class BinaryType extends ValueType<Uint8Array> {
       if (old[i] !== (cur as Uint8Array)[i]) return true;
     }
     return false;
+  }
+
+  deserialize(value: unknown): Uint8Array | null {
+    if (value instanceof Data) return value.bytes;
+    return this.cast(value);
   }
 }
 
@@ -54,13 +54,13 @@ export class Data {
     return textDecoder.decode(this.bytes);
   }
 
-  byteSize(): number {
-    return this.bytes.length;
-  }
-
   hex(): string {
     return Array.from(this.bytes)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
+  }
+
+  byteSize(): number {
+    return this.bytes.length;
   }
 }

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -20,6 +20,18 @@ export class BooleanType extends ValueType<boolean> {
     "OFF",
   ]);
 
+  type(): string {
+    return this.name;
+  }
+
+  serialize(value: unknown): boolean | null {
+    return this.cast(value);
+  }
+
+  serializeCastValue(value: boolean | null): boolean | null {
+    return value;
+  }
+
   /**
    * Mirrors Rails `cast_value` (type/boolean.rb:40-45):
    *
@@ -39,17 +51,5 @@ export class BooleanType extends ValueType<boolean> {
   protected castValue(value: unknown): boolean | null {
     if (value === "") return null;
     return !BooleanType.FALSE_VALUES.has(value);
-  }
-
-  serialize(value: unknown): boolean | null {
-    return this.cast(value);
-  }
-
-  type(): string {
-    return this.name;
-  }
-
-  serializeCastValue(value: boolean | null): boolean | null {
-    return value;
   }
 }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -18,6 +18,10 @@ export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegat
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
 
+  type(): string {
+    return this.name;
+  }
+
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): DateTimeCastResult | null {
     if (value === DateInfinity) return DateInfinity;
@@ -27,6 +31,85 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     const str = String(value).trim();
     if (str === "") return null;
     return this.parseString(str);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#microseconds (date_time.rb:62-64).
+   *
+   *   # '0.123456' -> 123456
+   *   # '1.123456' -> 123456
+   *   def microseconds(time)
+   *     time[:sec_fraction] ? (time[:sec_fraction] * 1_000_000).to_i : 0
+   *   end
+   *
+   * Rails parses sub-second precision out of `Date._parse` results as
+   * a `Rational` (e.g. `123456/1000000`); multiplying by 1_000_000
+   * normalizes it to an integer microsecond count.
+   *
+   * @internal Rails-private helper.
+   */
+  protected microseconds(time: { sec_fraction?: number | null }): number {
+    return time.sec_fraction ? Math.trunc(time.sec_fraction * 1_000_000) : 0;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#fallback_string_to_time
+   * (date_time.rb:66-75).
+   *
+   *   def fallback_string_to_time(string)
+   *     time_hash = begin
+   *       ::Date._parse(string)
+   *     rescue ArgumentError
+   *     end
+   *     return unless time_hash
+   *     time_hash[:sec_fraction] = microseconds(time_hash)
+   *     new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
+   *   end
+   *
+   * Trails has no `Date._parse` equivalent; reuse Temporal's
+   * permissive parser plus the configured-zone resolution that
+   * `parseString` already implements. Returns null on parse failure.
+   *
+   * @internal Rails-private helper.
+   */
+  protected fallbackStringToTime(s: string): Temporal.Instant | null {
+    const result = this.parseString(s.trim());
+    return result instanceof Temporal.Instant ? result : null;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#value_from_multiparameter_assignment
+   * (date_time.rb:77-83).
+   *
+   *   def value_from_multiparameter_assignment(values_hash)
+   *     missing_parameters = [1, 2, 3].delete_if { |key| values_hash.key?(key) }
+   *     unless missing_parameters.empty?
+   *       raise ArgumentError, "Provided hash #{values_hash} doesn't contain necessary keys: #{missing_parameters}"
+   *     end
+   *     super
+   *   end
+   *
+   * Validates that year/mon/mday (multiparameter keys 1, 2, 3) are
+   * present, then defers to the multiparameter wrapper. Trails routes
+   * the actual reconstruction through `AcceptsMultiparameterTime`
+   * (`helpers/accepts-multiparameter-time.ts`); this helper exists for
+   * Rails parity and as the entry point for callers that want the
+   * key-presence check.
+   *
+   * @internal Rails-private helper.
+   */
+  protected valueFromMultiparameterAssignment(
+    values: Record<string | number, unknown>,
+  ): DateTimeCastResult | null {
+    const missing = [1, 2, 3].filter((k) => !Object.hasOwn(values, k));
+    if (missing.length > 0) {
+      throw new ArgumentError(
+        `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
+      );
+    }
+    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(
+      values,
+    ) as DateTimeCastResult | null;
   }
 
   private _applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {
@@ -123,88 +206,5 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   serializeCastValue(value: DateTimeCastResult | null): string | null {
     return this.serialize(value);
-  }
-
-  type(): string {
-    return this.name;
-  }
-
-  /**
-   * Mirrors: ActiveModel::Type::DateTime#microseconds (date_time.rb:62-64).
-   *
-   *   # '0.123456' -> 123456
-   *   # '1.123456' -> 123456
-   *   def microseconds(time)
-   *     time[:sec_fraction] ? (time[:sec_fraction] * 1_000_000).to_i : 0
-   *   end
-   *
-   * Rails parses sub-second precision out of `Date._parse` results as
-   * a `Rational` (e.g. `123456/1000000`); multiplying by 1_000_000
-   * normalizes it to an integer microsecond count.
-   *
-   * @internal Rails-private helper.
-   */
-  protected microseconds(time: { sec_fraction?: number | null }): number {
-    return time.sec_fraction ? Math.trunc(time.sec_fraction * 1_000_000) : 0;
-  }
-
-  /**
-   * Mirrors: ActiveModel::Type::DateTime#fallback_string_to_time
-   * (date_time.rb:66-75).
-   *
-   *   def fallback_string_to_time(string)
-   *     time_hash = begin
-   *       ::Date._parse(string)
-   *     rescue ArgumentError
-   *     end
-   *     return unless time_hash
-   *     time_hash[:sec_fraction] = microseconds(time_hash)
-   *     new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
-   *   end
-   *
-   * Trails has no `Date._parse` equivalent; reuse Temporal's
-   * permissive parser plus the configured-zone resolution that
-   * `parseString` already implements. Returns null on parse failure.
-   *
-   * @internal Rails-private helper.
-   */
-  protected fallbackStringToTime(s: string): Temporal.Instant | null {
-    const result = this.parseString(s.trim());
-    return result instanceof Temporal.Instant ? result : null;
-  }
-
-  /**
-   * Mirrors: ActiveModel::Type::DateTime#value_from_multiparameter_assignment
-   * (date_time.rb:77-83).
-   *
-   *   def value_from_multiparameter_assignment(values_hash)
-   *     missing_parameters = [1, 2, 3].delete_if { |key| values_hash.key?(key) }
-   *     unless missing_parameters.empty?
-   *       raise ArgumentError, "Provided hash #{values_hash} doesn't contain necessary keys: #{missing_parameters}"
-   *     end
-   *     super
-   *   end
-   *
-   * Validates that year/mon/mday (multiparameter keys 1, 2, 3) are
-   * present, then defers to the multiparameter wrapper. Trails routes
-   * the actual reconstruction through `AcceptsMultiparameterTime`
-   * (`helpers/accepts-multiparameter-time.ts`); this helper exists for
-   * Rails parity and as the entry point for callers that want the
-   * key-presence check.
-   *
-   * @internal Rails-private helper.
-   */
-  protected valueFromMultiparameterAssignment(
-    values: Record<string | number, unknown>,
-  ): DateTimeCastResult | null {
-    const missing = [1, 2, 3].filter((k) => !Object.hasOwn(values, k));
-    if (missing.length > 0) {
-      throw new ArgumentError(
-        `Provided hash ${JSON.stringify(values)} doesn't contain necessary keys: ${JSON.stringify(missing)}`,
-      );
-    }
-    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(
-      values,
-    ) as DateTimeCastResult | null;
   }
 }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -16,6 +16,16 @@ export type DateCastResult = Temporal.PlainDate | DateInfinityType | DateNegativ
 export class DateType extends ValueType<DateCastResult> {
   readonly name: string = "date";
 
+  type(): string {
+    return this.name;
+  }
+
+  typeCastForSchema(value: unknown): string {
+    const cast = this.cast(value);
+    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return "null";
+    return JSON.stringify(cast.toString());
+  }
+
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): DateCastResult | null {
     if (value === DateInfinity) return DateInfinity;
@@ -36,28 +46,6 @@ export class DateType extends ValueType<DateCastResult> {
     const str = String(value).trim();
     if (str === "") return null;
     return this.fastStringToDate(str) ?? this.fallbackStringToDate(str);
-  }
-
-  serialize(value: unknown): string | null {
-    const cast = this.cast(value);
-    // Sentinels are Postgres-specific; base type returns null. The Postgres
-    // OID::Date subclass overrides serialize() to emit 'infinity'/'-infinity'.
-    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
-    return cast.toString();
-  }
-
-  serializeCastValue(value: DateCastResult | null): string | null {
-    return this.serialize(value);
-  }
-
-  type(): string {
-    return this.name;
-  }
-
-  typeCastForSchema(value: unknown): string {
-    const cast = this.cast(value);
-    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return "null";
-    return JSON.stringify(cast.toString());
   }
 
   /**
@@ -158,6 +146,18 @@ export class DateType extends ValueType<DateCastResult> {
     values: Record<number, number | null | undefined>,
   ): Temporal.PlainDate | null {
     return this.newDate(values[1], values[2], values[3]);
+  }
+
+  serialize(value: unknown): string | null {
+    const cast = this.cast(value);
+    // Sentinels are Postgres-specific; base type returns null. The Postgres
+    // OID::Date subclass overrides serialize() to emit 'infinity'/'-infinity'.
+    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
+    return cast.toString();
+  }
+
+  serializeCastValue(value: DateCastResult | null): string | null {
+    return this.serialize(value);
   }
 }
 

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -6,6 +6,14 @@ const NumericValueType = applyNumericMixin(ValueType<string>);
 export class DecimalType extends NumericValueType {
   readonly name: string = "decimal";
 
+  type(): string {
+    return this.name;
+  }
+
+  typeCastForSchema(value: unknown): string {
+    return JSON.stringify(value) ?? String(value);
+  }
+
   // JS has no BigDecimal, so we represent decimals as strings to avoid
   // losing precision through IEEE-754 floats. Rails' `cast_value`:
   //   - Numeric  -> BigDecimal(value)
@@ -17,50 +25,6 @@ export class DecimalType extends NumericValueType {
   protected castValue(value: unknown): string | null {
     const casted = this._castWithoutScale(value);
     return this.applyScale(casted);
-  }
-
-  /**
-   * Apply Rails' `scale:` option to a decimal string, rounding to the
-   * configured number of fractional digits using Ruby's default
-   * `BigDecimal#round` mode (`ROUND_HALF_UP` — half away from zero).
-   *
-   * Mirrors: ActiveModel::Type::Decimal#apply_scale
-   * (activemodel/lib/active_model/type/decimal.rb).
-   */
-  protected applyScale(value: string | null): string | null {
-    if (value === null) return null;
-    if (this.scale === undefined) return value;
-    // Ruby `BigDecimal#round(n)` only accepts an Integer argument; a
-    // non-integer or negative TS `scale:` option would just misfire our
-    // slice/charCodeAt math, so leave the value untouched rather than
-    // invent new semantics.
-    if (!Number.isInteger(this.scale) || this.scale < 0) return value;
-    return roundHalfUpToScale(value, this.scale);
-  }
-
-  private _castWithoutScale(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
-    if (typeof value === "bigint") return value.toString();
-    if (typeof value === "number") {
-      if (!Number.isFinite(value)) return null;
-      // Rails dispatches Float through `convert_float_to_big_decimal`
-      // (decimal.rb:75-81). Route every JS number through the same hook
-      // so a configured `precision:` applies the same significant-digit
-      // rounding per Rails; integer-valued inputs may still change when
-      // the value has more digits than `floatPrecision()` preserves.
-      return this.convertFloatToBigDecimal(value);
-    }
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed === "") return null;
-      // Rails' `String#to_d` parses a leading numeric prefix and
-      // silently drops everything after, returning `BigDecimal(0)` if
-      // no leading number is present. Tests assert, e.g.,
-      // `"1ignore" -> BigDecimal("1")`, `"bad" -> BigDecimal("0")`.
-      const match = trimmed.match(/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?/);
-      return match ? match[0] : "0";
-    }
-    return null;
   }
 
   /**
@@ -121,12 +85,48 @@ export class DecimalType extends NumericValueType {
     return p > 16 ? 16 : p;
   }
 
-  type(): string {
-    return this.name;
+  /**
+   * Apply Rails' `scale:` option to a decimal string, rounding to the
+   * configured number of fractional digits using Ruby's default
+   * `BigDecimal#round` mode (`ROUND_HALF_UP` — half away from zero).
+   *
+   * Mirrors: ActiveModel::Type::Decimal#apply_scale
+   * (activemodel/lib/active_model/type/decimal.rb).
+   */
+  protected applyScale(value: string | null): string | null {
+    if (value === null) return null;
+    if (this.scale === undefined) return value;
+    // Ruby `BigDecimal#round(n)` only accepts an Integer argument; a
+    // non-integer or negative TS `scale:` option would just misfire our
+    // slice/charCodeAt math, so leave the value untouched rather than
+    // invent new semantics.
+    if (!Number.isInteger(this.scale) || this.scale < 0) return value;
+    return roundHalfUpToScale(value, this.scale);
   }
 
-  typeCastForSchema(value: unknown): string {
-    return JSON.stringify(value) ?? String(value);
+  private _castWithoutScale(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "bigint") return value.toString();
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) return null;
+      // Rails dispatches Float through `convert_float_to_big_decimal`
+      // (decimal.rb:75-81). Route every JS number through the same hook
+      // so a configured `precision:` applies the same significant-digit
+      // rounding per Rails; integer-valued inputs may still change when
+      // the value has more digits than `floatPrecision()` preserves.
+      return this.convertFloatToBigDecimal(value);
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") return null;
+      // Rails' `String#to_d` parses a leading numeric prefix and
+      // silently drops everything after, returning `BigDecimal(0)` if
+      // no leading number is present. Tests assert, e.g.,
+      // `"1ignore" -> BigDecimal("1")`, `"bad" -> BigDecimal("0")`.
+      const match = trimmed.match(/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?/);
+      return match ? match[0] : "0";
+    }
+    return null;
   }
 }
 

--- a/packages/activemodel/src/type/float.ts
+++ b/packages/activemodel/src/type/float.ts
@@ -6,17 +6,6 @@ const NumericValueType = applyNumericMixin(ValueType<number>);
 export class FloatType extends NumericValueType {
   readonly name = "float";
 
-  /** @internal Rails-private helper. */
-  protected castValue(value: unknown): number | null {
-    if (typeof value === "number") return value;
-    // Case-sensitive exact match mirrors Rails float.rb:53-60; "nan"/"infinity" are not valid.
-    if (value === "Infinity") return Number.POSITIVE_INFINITY;
-    if (value === "-Infinity") return Number.NEGATIVE_INFINITY;
-    if (value === "NaN") return Number.NaN;
-    const parsed = parseFloat(String(value));
-    return isNaN(parsed) ? null : parsed;
-  }
-
   type(): string {
     return this.name;
   }
@@ -28,5 +17,16 @@ export class FloatType extends NumericValueType {
       if (value === -Infinity) return '"-Infinity"';
     }
     return JSON.stringify(value) ?? String(value);
+  }
+
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): number | null {
+    if (typeof value === "number") return value;
+    // Case-sensitive exact match mirrors Rails float.rb:53-60; "nan"/"infinity" are not valid.
+    if (value === "Infinity") return Number.POSITIVE_INFINITY;
+    if (value === "-Infinity") return Number.NEGATIVE_INFINITY;
+    if (value === "NaN") return Number.NaN;
+    const parsed = parseFloat(String(value));
+    return isNaN(parsed) ? null : parsed;
   }
 }

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -29,13 +29,6 @@ export class AcceptsMultiparameterTime {
     this.defaults = defaults;
   }
 
-  cast(value: unknown): unknown {
-    if (this.isMultiparameterHash(value)) {
-      return this.castFromMultiparameter(value as Record<string, unknown>);
-    }
-    return this.type.cast(value);
-  }
-
   serialize(value: unknown): unknown {
     return this.type.serialize(value);
   }
@@ -50,6 +43,13 @@ export class AcceptsMultiparameterTime {
       ).serializeCastValue(value);
     }
     return this.type.serialize(value);
+  }
+
+  cast(value: unknown): unknown {
+    if (this.isMultiparameterHash(value)) {
+      return this.castFromMultiparameter(value as Record<string, unknown>);
+    }
+    return this.type.cast(value);
   }
 
   assertValidValue(value: unknown): void {

--- a/packages/activemodel/src/type/helpers/numeric.ts
+++ b/packages/activemodel/src/type/helpers/numeric.ts
@@ -9,12 +9,20 @@ import { ValueType } from "../value.js";
 const NUMERIC_REGEX = /^\s*[+-]?\d/;
 
 /**
- * Mirrors: ActiveModel::Type::Helpers::Numeric#non_numeric_string?
+ * Mirrors: ActiveModel::Type::Helpers::Numeric#equal_nan?
+ *
+ * Trails has no BigDecimal class, so the constructor-equality check
+ * collapses to "both are JS numbers and both are NaN".
  *
  * @internal Rails-private helper.
  */
-export function isNonNumericString(value: unknown): boolean {
-  return !NUMERIC_REGEX.test(String(value));
+export function isEqualNan(oldValue: unknown, newValue: unknown): boolean {
+  return (
+    typeof oldValue === "number" &&
+    Number.isNaN(oldValue) &&
+    typeof newValue === "number" &&
+    Number.isNaN(newValue)
+  );
 }
 
 /**
@@ -31,20 +39,12 @@ export function isNumberToNonNumber(oldValue: unknown, newValueBeforeTypeCast: u
 }
 
 /**
- * Mirrors: ActiveModel::Type::Helpers::Numeric#equal_nan?
- *
- * Trails has no BigDecimal class, so the constructor-equality check
- * collapses to "both are JS numbers and both are NaN".
+ * Mirrors: ActiveModel::Type::Helpers::Numeric#non_numeric_string?
  *
  * @internal Rails-private helper.
  */
-export function isEqualNan(oldValue: unknown, newValue: unknown): boolean {
-  return (
-    typeof oldValue === "number" &&
-    Number.isNaN(oldValue) &&
-    typeof newValue === "number" &&
-    Number.isNaN(newValue)
-  );
+export function isNonNumericString(value: unknown): boolean {
+  return !NUMERIC_REGEX.test(String(value));
 }
 
 // Constructor rest args must be `any[]` — idiomatic in TypeScript mixin

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -86,20 +86,6 @@ export function applySecondsPrecision<T>(this: { precision?: number }, value: T)
   return (roundable as Roundable<T>).round(opts);
 }
 
-export function serializeTimeValue(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (
-    value instanceof Temporal.Instant ||
-    value instanceof Temporal.PlainDateTime ||
-    value instanceof Temporal.PlainDate ||
-    value instanceof Temporal.PlainTime ||
-    value instanceof Temporal.ZonedDateTime
-  ) {
-    return value.toJSON();
-  }
-  return String(value);
-}
-
 export function userInputInTimeZone(
   value: unknown,
   zone: string = "UTC",
@@ -232,4 +218,18 @@ export function fastStringToTime(s: string): Temporal.Instant | null {
   } catch {
     return null;
   }
+}
+
+export function serializeTimeValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime ||
+    value instanceof Temporal.ZonedDateTime
+  ) {
+    return value.toJSON();
+  }
+  return String(value);
 }

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -19,6 +19,18 @@ export class ImmutableStringType extends ValueType<string> {
     this.falseString = options?.falseString ?? "f";
   }
 
+  type(): string {
+    return "string";
+  }
+
+  serialize(value: unknown): unknown {
+    return this.cast(value);
+  }
+
+  serializeCastValue(value: string | null): string | null {
+    return value;
+  }
+
   /**
    * Mirrors: ActiveModel::Type::ImmutableString#cast_value
    * (immutable_string.rb):
@@ -36,17 +48,5 @@ export class ImmutableStringType extends ValueType<string> {
     if (value === false) return Object.freeze(this.falseString) as string;
     const str = String(value);
     return Object.freeze(str) as string;
-  }
-
-  serialize(value: unknown): unknown {
-    return this.cast(value);
-  }
-
-  type(): string {
-    return "string";
-  }
-
-  serializeCastValue(value: string | null): string | null {
-    return value;
   }
 }

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -15,15 +15,8 @@ export class IntegerType extends NumericValueType {
     super(options);
   }
 
-  /** @internal Rails-private helper. */
-  protected castValue(value: unknown): number | null {
-    if (typeof value === "number") {
-      if (isNaN(value)) return null;
-      return Math.trunc(value);
-    }
-    if (typeof value === "bigint") return Number(value);
-    const parsed = parseInt(String(value), 10);
-    return isNaN(parsed) ? null : parsed;
+  type(): string {
+    return this.name;
   }
 
   /**
@@ -48,10 +41,6 @@ export class IntegerType extends NumericValueType {
 
   serialize(value: unknown): unknown {
     return this.ensureInRange(this.cast(value));
-  }
-
-  type(): string {
-    return this.name;
   }
 
   serializeCastValue(value: number | null): number | null {
@@ -100,6 +89,17 @@ export class IntegerType extends NumericValueType {
     if (value == null) return true;
     const [min, max] = this.range;
     return value >= min && value <= max;
+  }
+
+  /** @internal Rails-private helper. */
+  protected castValue(value: unknown): number | null {
+    if (typeof value === "number") {
+      if (isNaN(value)) return null;
+      return Math.trunc(value);
+    }
+    if (typeof value === "bigint") return Number(value);
+    const parsed = parseInt(String(value), 10);
+    return isNaN(parsed) ? null : parsed;
   }
 
   /**

--- a/packages/activemodel/src/type/registry.ts
+++ b/packages/activemodel/src/type/registry.ts
@@ -22,17 +22,6 @@ export class TypeRegistry {
    */
   protected registrationsMap = new Map<string, () => Type>();
 
-  /**
-   * Mirrors: ActiveModel::Type::Registry#registrations (registry.rb:30,
-   * `attr_reader :registrations`). Private in Rails; protected here so
-   * subclasses can read or replace the registry.
-   *
-   * @internal Rails-private helper.
-   */
-  protected get registrations(): Map<string, () => Type> {
-    return this.registrationsMap;
-  }
-
   constructor() {
     this.register("string", () => new StringType());
     this.register("integer", () => new IntegerType());
@@ -56,6 +45,17 @@ export class TypeRegistry {
     const factory = this.registrations.get(name);
     if (!factory) throw new Error(`Unknown type: ${name}`);
     return factory();
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::Registry#registrations (registry.rb:30,
+   * `attr_reader :registrations`). Private in Rails; protected here so
+   * subclasses can read or replace the registry.
+   *
+   * @internal Rails-private helper.
+   */
+  protected get registrations(): Map<string, () => Type> {
+    return this.registrationsMap;
   }
 }
 

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -3,6 +3,22 @@ import { ImmutableStringType } from "./immutable-string.js";
 export class StringType extends ImmutableStringType {
   readonly name: string = "string";
 
+  isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+    if (typeof newValue !== "string") return false;
+    if (rawOldValue === null || rawOldValue === undefined) return true;
+    return rawOldValue !== newValue;
+  }
+
+  toImmutableString(): ImmutableStringType {
+    return new ImmutableStringType({
+      precision: this.precision,
+      scale: this.scale,
+      limit: this.limit,
+      trueString: this.trueString,
+      falseString: this.falseString,
+    });
+  }
+
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): string | null {
     // Rails type/string.rb subclasses immutable_string.rb, so the
@@ -18,21 +34,5 @@ export class StringType extends ImmutableStringType {
   // output type the way Rails' loosely-typed `serialize` does.
   serialize(value: unknown): unknown {
     return this.cast(value);
-  }
-
-  isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
-    if (typeof newValue !== "string") return false;
-    if (rawOldValue === null || rawOldValue === undefined) return true;
-    return rawOldValue !== newValue;
-  }
-
-  toImmutableString(): ImmutableStringType {
-    return new ImmutableStringType({
-      precision: this.precision,
-      scale: this.scale,
-      limit: this.limit,
-      trueString: this.trueString,
-      falseString: this.falseString,
-    });
   }
 }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -9,26 +9,33 @@ import { ValueType } from "./value.js";
 export class TimeType extends ValueType<Temporal.PlainTime> {
   readonly name = "time";
 
-  private _applySecondsPrecision(value: Temporal.PlainTime): Temporal.PlainTime {
-    if (
-      this.precision == null ||
-      !Number.isInteger(this.precision) ||
-      this.precision < 0 ||
-      this.precision > 9
-    )
-      return value;
-    const nsec = value.millisecond * 1_000_000 + value.microsecond * 1_000 + value.nanosecond;
-    const mod = 10 ** (9 - this.precision);
-    const roundedOff = nsec % mod;
-    if (roundedOff === 0) return value;
-    // Rebuild from truncated sub-second components to avoid PlainTime.subtract()
-    // wrapping across the midnight boundary (00:00:00.000000001 - 1ns = 23:59:59...).
-    const truncated = nsec - roundedOff;
-    return value.with({
-      millisecond: Math.floor(truncated / 1_000_000),
-      microsecond: Math.floor((truncated % 1_000_000) / 1_000),
-      nanosecond: truncated % 1_000,
-    });
+  type(): string {
+    return this.name;
+  }
+
+  userInputInTimeZone(value: unknown, zone: string = "UTC"): Temporal.ZonedDateTime | null {
+    if (value === null || value === undefined) return null;
+    if (value instanceof Temporal.ZonedDateTime) return value;
+    // Full ZonedDateTime string (has timezone bracket)
+    const str = String(value).trim();
+    if (str === "") return null;
+    if (str.includes("[")) {
+      try {
+        return Temporal.ZonedDateTime.from(str);
+      } catch {
+        return null;
+      }
+    }
+    // Otherwise cast to PlainTime and attach the given zone
+    const plain = this.cast(value);
+    if (!plain) return null;
+    // Use a fixed reference date (Rails convention: 2000-01-01) so the result
+    // is stable across DST transitions and independent of the current date.
+    try {
+      return Temporal.PlainDate.from("2000-01-01").toPlainDateTime(plain).toZonedDateTime(zone);
+    } catch {
+      return null;
+    }
   }
 
   /** @internal Rails-private helper. */
@@ -58,6 +65,28 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
     }
   }
 
+  private _applySecondsPrecision(value: Temporal.PlainTime): Temporal.PlainTime {
+    if (
+      this.precision == null ||
+      !Number.isInteger(this.precision) ||
+      this.precision < 0 ||
+      this.precision > 9
+    )
+      return value;
+    const nsec = value.millisecond * 1_000_000 + value.microsecond * 1_000 + value.nanosecond;
+    const mod = 10 ** (9 - this.precision);
+    const roundedOff = nsec % mod;
+    if (roundedOff === 0) return value;
+    // Rebuild from truncated sub-second components to avoid PlainTime.subtract()
+    // wrapping across the midnight boundary (00:00:00.000000001 - 1ns = 23:59:59...).
+    const truncated = nsec - roundedOff;
+    return value.with({
+      millisecond: Math.floor(truncated / 1_000_000),
+      microsecond: Math.floor((truncated % 1_000_000) / 1_000),
+      nanosecond: truncated % 1_000,
+    });
+  }
+
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
     if (cast === null) return null;
@@ -80,10 +109,6 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
     return this.serialize(value);
   }
 
-  type(): string {
-    return this.name;
-  }
-
   /**
    * Mirrors: ActiveModel::Type::Time includes AcceptsMultiparameterTime.new(defaults: { 1 => 2000, 2 => 1, 3 => 1, 4 => 0, 5 => 0 }).
    * Rails' base date 2000-01-01 lets hour-only form inputs (e.g. { "4": 15 }) produce a valid Time.
@@ -100,30 +125,5 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
       "4": 0,
       "5": 0,
     }).cast(values) as Temporal.PlainTime | null;
-  }
-
-  userInputInTimeZone(value: unknown, zone: string = "UTC"): Temporal.ZonedDateTime | null {
-    if (value === null || value === undefined) return null;
-    if (value instanceof Temporal.ZonedDateTime) return value;
-    // Full ZonedDateTime string (has timezone bracket)
-    const str = String(value).trim();
-    if (str === "") return null;
-    if (str.includes("[")) {
-      try {
-        return Temporal.ZonedDateTime.from(str);
-      } catch {
-        return null;
-      }
-    }
-    // Otherwise cast to PlainTime and attach the given zone
-    const plain = this.cast(value);
-    if (!plain) return null;
-    // Use a fixed reference date (Rails convention: 2000-01-01) so the result
-    // is stable across DST transitions and independent of the current date.
-    try {
-      return Temporal.PlainDate.from("2000-01-01").toPlainDateTime(plain).toZonedDateTime(zone);
-    } catch {
-      return null;
-    }
   }
 }

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -19,6 +19,18 @@ export abstract class Type<T = unknown> {
     return this._scale;
   }
 
+  isSerializable(_value: unknown): boolean {
+    return true;
+  }
+
+  type(): string {
+    return this.name;
+  }
+
+  deserialize(value: unknown): T | null {
+    return this.cast(value);
+  }
+
   /**
    * Mirrors: ActiveModel::Type::Value#cast (value.rb:53-55)
    *
@@ -37,6 +49,52 @@ export abstract class Type<T = unknown> {
     return this.castValue(value);
   }
 
+  serialize(value: unknown): unknown {
+    return value;
+  }
+
+  typeCastForSchema(value: unknown): string {
+    return JSON.stringify(value) ?? String(value);
+  }
+
+  isBinary(): boolean {
+    return false;
+  }
+
+  isChanged(oldValue: unknown, newValue: unknown, _newValueBeforeTypeCast?: unknown): boolean {
+    return oldValue !== newValue;
+  }
+
+  isChangedInPlace(_rawOldValue: unknown, _newValue: unknown): boolean {
+    return false;
+  }
+
+  isValueConstructedByMassAssignment(_value: unknown): boolean {
+    return false;
+  }
+
+  isForceEquality(_value: unknown): boolean {
+    return false;
+  }
+
+  map(value: T | null): T | null {
+    return value;
+  }
+
+  assertValidValue(_value: unknown): void {}
+
+  isSerialized(): boolean {
+    return false;
+  }
+
+  isMutable(): boolean {
+    return false;
+  }
+
+  asJson(): never {
+    throw new Error("Unimplemented");
+  }
+
   /**
    * Mirrors: ActiveModel::Type::Value#cast_value (value.rb:155-157)
    *
@@ -52,18 +110,6 @@ export abstract class Type<T = unknown> {
    */
   protected castValue(value: unknown): T | null {
     return value as T | null;
-  }
-
-  type(): string {
-    return this.name;
-  }
-
-  deserialize(value: unknown): T | null {
-    return this.cast(value);
-  }
-
-  serialize(value: unknown): unknown {
-    return value;
   }
 
   serializeCastValue(value: T | null): unknown {
@@ -137,52 +183,6 @@ export abstract class Type<T = unknown> {
       configurable: true,
     });
     return result;
-  }
-
-  isSerializable(_value: unknown): boolean {
-    return true;
-  }
-
-  typeCastForSchema(value: unknown): string {
-    return JSON.stringify(value) ?? String(value);
-  }
-
-  isBinary(): boolean {
-    return false;
-  }
-
-  isChanged(oldValue: unknown, newValue: unknown, _newValueBeforeTypeCast?: unknown): boolean {
-    return oldValue !== newValue;
-  }
-
-  isChangedInPlace(_rawOldValue: unknown, _newValue: unknown): boolean {
-    return false;
-  }
-
-  isValueConstructedByMassAssignment(_value: unknown): boolean {
-    return false;
-  }
-
-  isForceEquality(_value: unknown): boolean {
-    return false;
-  }
-
-  map(value: T | null): T | null {
-    return value;
-  }
-
-  assertValidValue(_value: unknown): void {}
-
-  isSerialized(): boolean {
-    return false;
-  }
-
-  isMutable(): boolean {
-    return false;
-  }
-
-  asJson(): never {
-    throw new Error("Unimplemented");
   }
 }
 

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -32,6 +32,51 @@ export const _defineAroundModelCallback = _defineAroundModelCallbackImpl;
 export const _defineAfterModelCallback = _defineAfterModelCallbackImpl;
 
 /**
+ * Lazy per-instance accessor for the active `ValidationContext`.
+ * Mirrors Rails
+ * `def context_for_validation; @context_for_validation ||= ValidationContext.new; end`
+ * (activemodel/lib/active_model/validations.rb:463-465). Trails stores
+ * the active context as `_validationContext: string | string[] | null`
+ * directly; this helper returns a `ValidationContext` whose
+ * `.context` property is a live view of that field, so Rails' pattern
+ * `context_for_validation.context = ctx` still works.
+ *
+ * @internal Rails-private helper.
+ */
+export function contextForValidation(this: ContextForValidationHost): ValidationContext {
+  if (this._contextForValidation) return this._contextForValidation;
+  // Construct via the real constructor so any future
+  // ValidationContext initialization runs, then replace the
+  // `context` and underlying `_context` slot with a live view of
+  // `_validationContext`. Both must be aliased so `vc.name` /
+  // `vc.toString()` stay consistent with the live field.
+  const vc = new ValidationContext();
+  const accessor: PropertyDescriptor = {
+    get: (): string | string[] | null => this._validationContext,
+    set: (value: string | string[] | null): void => {
+      this._validationContext = value;
+    },
+    configurable: true,
+    enumerable: false,
+  };
+  Object.defineProperty(vc, "context", accessor);
+  Object.defineProperty(vc, "_context", accessor);
+  this._contextForValidation = vc;
+  return vc;
+}
+
+/**
+ * Host shape consumed by `initInternals`. Kept loose so any class with
+ * the validation-related fields satisfies it without circular imports
+ * back to `Model`.
+ */
+export interface ValidationsInternalsHost<TBase extends object = object> {
+  errors: Errors<TBase>;
+  _validationContext: string | string[] | null;
+  _contextForValidation?: ValidationContext;
+}
+
+/**
  * Per-instance reset hook for validation state. Mirrors Rails
  * `ActiveModel::Validations#init_internals`
  * (activemodel/lib/active_model/validations.rb:467-471):
@@ -52,26 +97,6 @@ export function initInternals<TBase extends object>(this: ValidationsInternalsHo
   this.errors = new Errors(this as unknown as TBase);
   this._validationContext = null;
   this._contextForValidation = undefined;
-}
-
-/**
- * Host shape consumed by `initInternals`. Kept loose so any class with
- * the validation-related fields satisfies it without circular imports
- * back to `Model`.
- */
-export interface ValidationsInternalsHost<TBase extends object = object> {
-  errors: Errors<TBase>;
-  _validationContext: string | string[] | null;
-  _contextForValidation?: ValidationContext;
-}
-
-/**
- * Rails: ActiveModel::Validations extends Translation (validations.rb:43),
- * so the singleton accessor surfaces on Validations directly. Mirror that
- * here so callers can read/write via `Validations.raiseOnMissingTranslations(...)`.
- */
-export function raiseOnMissingTranslations(value?: boolean): boolean {
-  return translationRaise(value);
 }
 
 /**
@@ -230,6 +255,47 @@ const _predicatesForValidationContexts = new Map<
 >();
 
 /**
+ * Run the `:validate` callbacks and report whether the model has no
+ * errors. Mirrors Rails
+ * `def run_validations!; _run_validate_callbacks; errors.empty?; end`
+ * (activemodel/lib/active_model/validations.rb:473-476).
+ *
+ * @internal Rails-private helper.
+ */
+export function runValidationsBang(this: RunValidationsHost): boolean {
+  this._runValidateCallbacks();
+  return this.errors.empty;
+}
+
+/**
+ * Host shape consumed by `predicateForValidationContext`.
+ */
+export interface ValidationsContextHost {
+  readonly validationContext: string | string[] | null;
+}
+
+/**
+ * Throw `ValidationError` for the current model. Mirrors Rails
+ * `def raise_validation_error; raise(ValidationError.new(self)); end`
+ * (activemodel/lib/active_model/validations.rb:478-480).
+ *
+ * @internal Rails-private helper.
+ */
+export function raiseValidationError<TBase extends object = object>(this: {
+  errors: Errors<TBase>;
+}): never {
+  throw new ValidationError(this);
+}
+
+/**
+ * Host shape consumed by `contextForValidation`.
+ */
+export interface ContextForValidationHost {
+  _validationContext: string | string[] | null;
+  _contextForValidation?: ValidationContext;
+}
+
+/**
  * Build a predicate that returns whether a model's
  * `validationContext` matches one of the supplied contexts. Used by
  * `validates(..., on: :create)` to gate a validator on the active
@@ -259,68 +325,6 @@ export function predicateForValidationContext(
 }
 
 /**
- * Host shape consumed by `predicateForValidationContext`.
- */
-export interface ValidationsContextHost {
-  readonly validationContext: string | string[] | null;
-}
-
-/**
- * Lazy per-instance accessor for the active `ValidationContext`.
- * Mirrors Rails
- * `def context_for_validation; @context_for_validation ||= ValidationContext.new; end`
- * (activemodel/lib/active_model/validations.rb:463-465). Trails stores
- * the active context as `_validationContext: string | string[] | null`
- * directly; this helper returns a `ValidationContext` whose
- * `.context` property is a live view of that field, so Rails' pattern
- * `context_for_validation.context = ctx` still works.
- *
- * @internal Rails-private helper.
- */
-export function contextForValidation(this: ContextForValidationHost): ValidationContext {
-  if (this._contextForValidation) return this._contextForValidation;
-  // Construct via the real constructor so any future
-  // ValidationContext initialization runs, then replace the
-  // `context` and underlying `_context` slot with a live view of
-  // `_validationContext`. Both must be aliased so `vc.name` /
-  // `vc.toString()` stay consistent with the live field.
-  const vc = new ValidationContext();
-  const accessor: PropertyDescriptor = {
-    get: (): string | string[] | null => this._validationContext,
-    set: (value: string | string[] | null): void => {
-      this._validationContext = value;
-    },
-    configurable: true,
-    enumerable: false,
-  };
-  Object.defineProperty(vc, "context", accessor);
-  Object.defineProperty(vc, "_context", accessor);
-  this._contextForValidation = vc;
-  return vc;
-}
-
-/**
- * Host shape consumed by `contextForValidation`.
- */
-export interface ContextForValidationHost {
-  _validationContext: string | string[] | null;
-  _contextForValidation?: ValidationContext;
-}
-
-/**
- * Run the `:validate` callbacks and report whether the model has no
- * errors. Mirrors Rails
- * `def run_validations!; _run_validate_callbacks; errors.empty?; end`
- * (activemodel/lib/active_model/validations.rb:473-476).
- *
- * @internal Rails-private helper.
- */
-export function runValidationsBang(this: RunValidationsHost): boolean {
-  this._runValidateCallbacks();
-  return this.errors.empty;
-}
-
-/**
  * Host shape consumed by `runValidationsBang`.
  */
 export interface RunValidationsHost<TBase extends object = object> {
@@ -329,16 +333,12 @@ export interface RunValidationsHost<TBase extends object = object> {
 }
 
 /**
- * Throw `ValidationError` for the current model. Mirrors Rails
- * `def raise_validation_error; raise(ValidationError.new(self)); end`
- * (activemodel/lib/active_model/validations.rb:478-480).
- *
- * @internal Rails-private helper.
+ * Rails: ActiveModel::Validations extends Translation (validations.rb:43),
+ * so the singleton accessor surfaces on Validations directly. Mirror that
+ * here so callers can read/write via `Validations.raiseOnMissingTranslations(...)`.
  */
-export function raiseValidationError<TBase extends object = object>(this: {
-  errors: Errors<TBase>;
-}): never {
-  throw new ValidationError(this);
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  return translationRaise(value);
 }
 
 /**

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -16,56 +16,18 @@ export class LazilyDefineAttributes {
     this.attributes = Object.freeze([...attributes]);
   }
 
-  include(attribute: string): boolean {
-    return this.attributes.includes(attribute);
-  }
-
   matches(method: string): string | null {
     return this.include(method) ? method : null;
+  }
+
+  include(attribute: string): boolean {
+    return this.attributes.includes(attribute);
   }
 
   define(attribute: string): LazilyDefineAttributes {
     if (this.include(attribute)) return this;
     return new LazilyDefineAttributes([...this.attributes, attribute]);
   }
-}
-
-/**
- * Ruby `Array()` coerces any object with `to_a`/`to_ary` (Set, Enumerator,
- * Hash, etc.) into an array, but leaves strings wrapped as `[str]`. Match
- * that: if the value is iterable but not a string, spread it.
- */
-function isNonStringIterable(value: unknown): value is Iterable<unknown> {
-  if (typeof value !== "object" || value === null) return false;
-  // Boxed strings (`new String("yes")`) are iterable by char; Ruby's
-  // `Array("yes")` still wraps as `["yes"]`, so treat them as scalars.
-  if (value instanceof String) return false;
-  return typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function";
-}
-
-export class AcceptanceValidator extends EachValidator {
-  static readonly lazilyDefineAttributes = new LazilyDefineAttributes([]);
-
-  /** @internal Rails-private helper. */
-  declare setupBang: typeof setupBang;
-  /** @internal Rails-private helper. */
-  declare isAcceptableOption: typeof isAcceptableOption;
-
-  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
-    const allowNil = this.options.allowNil ?? true;
-    if (allowNil && (value === null || value === undefined)) return;
-    if (!this.isAcceptableOption(value)) {
-      record.errors.add(attribute, "accepted", this.filteredErrorOptions(["accept", "allowNil"]));
-    }
-  }
-
-  static setup(attributes: string[]): LazilyDefineAttributes {
-    return new LazilyDefineAttributes(attributes);
-  }
-}
-
-interface AcceptanceHost {
-  attributes: readonly string[];
 }
 
 /**
@@ -111,6 +73,31 @@ export function setupBang(this: AcceptanceHost, klass: unknown): void {
   }
 }
 
+export class AcceptanceValidator extends EachValidator {
+  static readonly lazilyDefineAttributes = new LazilyDefineAttributes([]);
+
+  /** @internal Rails-private helper. */
+  declare setupBang: typeof setupBang;
+  /** @internal Rails-private helper. */
+  declare isAcceptableOption: typeof isAcceptableOption;
+
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
+    const allowNil = this.options.allowNil ?? true;
+    if (allowNil && (value === null || value === undefined)) return;
+    if (!this.isAcceptableOption(value)) {
+      record.errors.add(attribute, "accepted", this.filteredErrorOptions(["accept", "allowNil"]));
+    }
+  }
+
+  static setup(attributes: string[]): LazilyDefineAttributes {
+    return new LazilyDefineAttributes(attributes);
+  }
+}
+
+interface AcceptanceHost {
+  attributes: readonly string[];
+}
+
 /**
  * Mirrors: acceptance.rb:24-26
  *   def acceptable_option?(value)
@@ -140,6 +127,19 @@ export function isAcceptableOption(
     else accepted = [rawAccept];
   }
   return accepted.includes(value);
+}
+
+/**
+ * Ruby `Array()` coerces any object with `to_a`/`to_ary` (Set, Enumerator,
+ * Hash, etc.) into an array, but leaves strings wrapped as `[str]`. Match
+ * that: if the value is iterable but not a string, spread it.
+ */
+function isNonStringIterable(value: unknown): value is Iterable<unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  // Boxed strings (`new String("yes")`) are iterable by char; Ruby's
+  // `Array("yes")` still wraps as `["yes"]`, so treat them as scalars.
+  if (value instanceof String) return false;
+  return typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function";
 }
 
 AcceptanceValidator.prototype.setupBang = setupBang;

--- a/packages/activemodel/src/validations/callbacks.ts
+++ b/packages/activemodel/src/validations/callbacks.ts
@@ -34,6 +34,35 @@ interface CallbackHostRecord {
 }
 
 /**
+ * Mirrors: callbacks.rb:113-115
+ *   def run_validations!
+ *     _run_validation_callbacks { super }
+ *   end
+ *
+ * The interface declaration above adds `runValidationsBang()` to the
+ * Callbacks contract — host classes that want before/after validation
+ * dispatch implement the method to wrap their underlying validation
+ * pass in the callback chain. This export documents the Rails surface
+ * and gives downstream hosts a typed reference for that
+ * callback-wrapping behavior.
+ *
+ * @internal Rails-private helper.
+ */
+export function runValidationsBang(this: {
+  _runValidationCallbacks?: (block: () => boolean) => boolean;
+  runValidations?: () => boolean;
+}): boolean {
+  const block = (): boolean => {
+    if (typeof this.runValidations === "function") return this.runValidations();
+    return true;
+  };
+  if (typeof this._runValidationCallbacks === "function") {
+    return this._runValidationCallbacks(block);
+  }
+  return block();
+}
+
+/**
  * Mirrors: callbacks.rb:99-110
  *   def set_options_for_callback(options)
  *     if options.key?(:on)
@@ -68,33 +97,4 @@ export function setOptionsForCallback(options: CallbackOptions): void {
   const existingArr =
     existingIf == null ? [] : Array.isArray(existingIf) ? existingIf : [existingIf];
   options.if = [contextGuard, ...existingArr];
-}
-
-/**
- * Mirrors: callbacks.rb:113-115
- *   def run_validations!
- *     _run_validation_callbacks { super }
- *   end
- *
- * The interface declaration above adds `runValidationsBang()` to the
- * Callbacks contract — host classes that want before/after validation
- * dispatch implement the method to wrap their underlying validation
- * pass in the callback chain. This export documents the Rails surface
- * and gives downstream hosts a typed reference for that
- * callback-wrapping behavior.
- *
- * @internal Rails-private helper.
- */
-export function runValidationsBang(this: {
-  _runValidationCallbacks?: (block: () => boolean) => boolean;
-  runValidations?: () => boolean;
-}): boolean {
-  const block = (): boolean => {
-    if (typeof this.runValidations === "function") return this.runValidations();
-    return true;
-  };
-  if (typeof this._runValidationCallbacks === "function") {
-    return this._runValidationCallbacks(block);
-  }
-  return block();
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -45,6 +45,82 @@ interface ClusivityHost {
 }
 
 /**
+ * Mirrors: clusivity.rb:14-18
+ *   def check_validity!
+ *     unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
+ *       raise ArgumentError, ERROR_MESSAGE
+ *     end
+ *   end
+ *
+ * TS analogues for the three Ruby duck checks:
+ * - `respond_to?(:include?)` ↔ array / iterable / Set
+ * - `respond_to?(:call)` ↔ function
+ * - `respond_to?(:to_sym)` ↔ string (resolved via resolveValue at call time)
+ */
+export function checkValidityBang(this: ClusivityHost): void {
+  const d = this.delimiter();
+  if (d === undefined || d === null) {
+    throw new Error(ERROR_MESSAGE);
+  }
+  // Symmetric with isMemberOf — anything membership accepts must also
+  // pass validity. Maps Ruby duck checks to TS analogues:
+  //   respond_to?(:include?) ↔ string (substring), Array, Set, iterable,
+  //                            custom .includes / .has
+  //   respond_to?(:call)     ↔ function
+  //   respond_to?(:to_sym)   ↔ string (resolved via resolveValue at call time)
+  const isString = typeof d === "string";
+  const hasIncludeMethod =
+    typeof d === "object" &&
+    d !== null &&
+    (typeof (d as { includes?: unknown }).includes === "function" ||
+      typeof (d as { has?: unknown }).has === "function");
+  const isIterable =
+    Array.isArray(d) ||
+    d instanceof Set ||
+    d instanceof Map ||
+    (typeof d === "object" &&
+      d !== null &&
+      typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
+  const isCallable = typeof d === "function";
+  if (!isString && !hasIncludeMethod && !isIterable && !isCallable) {
+    throw new Error(ERROR_MESSAGE);
+  }
+}
+
+/**
+ * Mirrors: clusivity.rb:21-29
+ *   def include?(record, value)
+ *     members = resolve_value(record, delimiter)
+ *     if value.is_a?(Array)
+ *       value.all? { |v| members.public_send(inclusion_method(members), v) }
+ *     else
+ *       members.public_send(inclusion_method(members), value)
+ *     end
+ *   end
+ *
+ * `resolve_value` resolves Procs and Symbol-method references; a string
+ * option treated as a method name only if the record responds to it
+ * (resolve-value.ts).
+ *
+ * @internal
+ */
+export function isInclude(this: ClusivityHost, record: unknown, value: unknown): boolean {
+  // Route through `this.delimiter()` / `this.inclusionMethod(...)` so
+  // a subclass that overrides either gets the same dispatch Rails'
+  // Ruby method lookup would give it. Direct calls to the free
+  // functions would bypass overrides.
+  const members = this.resolveValue(record, this.delimiter());
+  // Rails: `members.public_send(inclusion_method(members), v)`. The
+  // cover-vs-include branch slots in via inclusionMethod when a Range
+  // type lands without reworking the call path.
+  const method = this.inclusionMethod(members);
+  if (Array.isArray(value)) {
+    return value.every((v) => testMembership(members, v, method));
+  }
+  return testMembership(members, value, method);
+}
+
+/**
  * Mirrors: clusivity.rb:31-33
  *   def delimiter
  *     @delimiter ||= options[:in] || options[:within]
@@ -99,39 +175,6 @@ export function delimiter(this: ClusivityHost): unknown {
  */
 export function inclusionMethod(_enumerable: unknown): "include?" | "cover?" {
   return "include?";
-}
-
-/**
- * Mirrors: clusivity.rb:21-29
- *   def include?(record, value)
- *     members = resolve_value(record, delimiter)
- *     if value.is_a?(Array)
- *       value.all? { |v| members.public_send(inclusion_method(members), v) }
- *     else
- *       members.public_send(inclusion_method(members), value)
- *     end
- *   end
- *
- * `resolve_value` resolves Procs and Symbol-method references; a string
- * option treated as a method name only if the record responds to it
- * (resolve-value.ts).
- *
- * @internal
- */
-export function isInclude(this: ClusivityHost, record: unknown, value: unknown): boolean {
-  // Route through `this.delimiter()` / `this.inclusionMethod(...)` so
-  // a subclass that overrides either gets the same dispatch Rails'
-  // Ruby method lookup would give it. Direct calls to the free
-  // functions would bypass overrides.
-  const members = this.resolveValue(record, this.delimiter());
-  // Rails: `members.public_send(inclusion_method(members), v)`. The
-  // cover-vs-include branch slots in via inclusionMethod when a Range
-  // type lands without reworking the call path.
-  const method = this.inclusionMethod(members);
-  if (Array.isArray(value)) {
-    return value.every((v) => testMembership(members, v, method));
-  }
-  return testMembership(members, value, method);
 }
 
 function testMembership(members: unknown, value: unknown, method: "include?" | "cover?"): boolean {
@@ -193,47 +236,4 @@ export function exceptInWithinMergeValue(
   }
   rest.value = value;
   return rest;
-}
-
-/**
- * Mirrors: clusivity.rb:14-18
- *   def check_validity!
- *     unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
- *       raise ArgumentError, ERROR_MESSAGE
- *     end
- *   end
- *
- * TS analogues for the three Ruby duck checks:
- * - `respond_to?(:include?)` ↔ array / iterable / Set
- * - `respond_to?(:call)` ↔ function
- * - `respond_to?(:to_sym)` ↔ string (resolved via resolveValue at call time)
- */
-export function checkValidityBang(this: ClusivityHost): void {
-  const d = this.delimiter();
-  if (d === undefined || d === null) {
-    throw new Error(ERROR_MESSAGE);
-  }
-  // Symmetric with isMemberOf — anything membership accepts must also
-  // pass validity. Maps Ruby duck checks to TS analogues:
-  //   respond_to?(:include?) ↔ string (substring), Array, Set, iterable,
-  //                            custom .includes / .has
-  //   respond_to?(:call)     ↔ function
-  //   respond_to?(:to_sym)   ↔ string (resolved via resolveValue at call time)
-  const isString = typeof d === "string";
-  const hasIncludeMethod =
-    typeof d === "object" &&
-    d !== null &&
-    (typeof (d as { includes?: unknown }).includes === "function" ||
-      typeof (d as { has?: unknown }).has === "function");
-  const isIterable =
-    Array.isArray(d) ||
-    d instanceof Set ||
-    d instanceof Map ||
-    (typeof d === "object" &&
-      d !== null &&
-      typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
-  const isCallable = typeof d === "function";
-  if (!isString && !hasIncludeMethod && !isIterable && !isCallable) {
-    throw new Error(ERROR_MESSAGE);
-  }
 }

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -29,6 +29,34 @@ export class ComparisonValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
 
+  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
+    for (const optKey of COMPARE_CHECKS) {
+      const raw = (this.options as Record<string, unknown>)[optKey];
+      if (raw === undefined) continue;
+      const optionValue = this.resolveValue(record, raw);
+
+      if (value === null || value === undefined || (typeof value === "string" && isBlank(value))) {
+        record.errors.add(attribute, "blank", this.errorOptions(value, optionValue));
+        return;
+      }
+
+      try {
+        const cmp = this.compare(value, optionValue);
+        if (!COMPARE_OPS[optKey](cmp)) {
+          record.errors.add(
+            attribute,
+            COMPARE_KEYS_TO_RAILS[optKey],
+            this.errorOptions(value, optionValue),
+          );
+        }
+      } catch (e) {
+        // Rails comparison.rb:30 — uses the ArgumentError message as the
+        // error key/message and continues to the next compare option.
+        record.errors.add(attribute, (e as Error).message);
+      }
+    }
+  }
+
   private compare(a: unknown, b: unknown): number {
     if (a instanceof Temporal.Instant && b instanceof Temporal.Instant)
       return Temporal.Instant.compare(a, b);
@@ -60,34 +88,6 @@ export class ComparisonValidator extends EachValidator {
       throw new Error(
         "One of :greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to, :equal_to, or :other_than must be supplied",
       );
-    }
-  }
-
-  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
-    for (const optKey of COMPARE_CHECKS) {
-      const raw = (this.options as Record<string, unknown>)[optKey];
-      if (raw === undefined) continue;
-      const optionValue = this.resolveValue(record, raw);
-
-      if (value === null || value === undefined || (typeof value === "string" && isBlank(value))) {
-        record.errors.add(attribute, "blank", this.errorOptions(value, optionValue));
-        return;
-      }
-
-      try {
-        const cmp = this.compare(value, optionValue);
-        if (!COMPARE_OPS[optKey](cmp)) {
-          record.errors.add(
-            attribute,
-            COMPARE_KEYS_TO_RAILS[optKey],
-            this.errorOptions(value, optionValue),
-          );
-        }
-      } catch (e) {
-        // Rails comparison.rb:30 — uses the ArgumentError message as the
-        // error key/message and continues to the next compare option.
-        record.errors.add(attribute, (e as Error).message);
-      }
     }
   }
 }

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -39,14 +39,14 @@ export class ExclusionValidator extends EachValidator {
   /** @internal */
   declare isInclude: typeof isInclude;
 
-  override checkValidity(): void {
-    checkValidityBang.call(this);
-  }
-
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (this.isInclude(record, value)) {
       record.errors.add(attribute, "exclusion", exceptInWithinMergeValue(this.options, value));
     }
+  }
+
+  override checkValidity(): void {
+    checkValidityBang.call(this);
   }
 }
 

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -33,19 +33,6 @@ export class FormatValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare regexpUsingMultilineAnchors: typeof regexpUsingMultilineAnchors;
 
-  override checkValidity(): void {
-    // Rails: `unless options.include?(:with) ^ options.include?(:without)`
-    // — Hash#include? checks own keys only; use Object.hasOwn to avoid
-    // prototype-chain surprises (the `in` operator would include inherited).
-    const hasWith = Object.hasOwn(this.options, "with");
-    const hasWithout = Object.hasOwn(this.options, "without");
-    if (hasWith === hasWithout) {
-      throw new Error("Either :with or :without must be supplied (but not both)");
-    }
-    this.checkOptionsValidity("with");
-    this.checkOptionsValidity("without");
-  }
-
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     // Rails uses Ruby truthiness on options[:with] / options[:without] —
     // nil/false skip the branch entirely. Mirror that so an explicit
@@ -63,6 +50,19 @@ export class FormatValidator extends EachValidator {
         this.recordError(record, attribute, "without", value);
       }
     }
+  }
+
+  override checkValidity(): void {
+    // Rails: `unless options.include?(:with) ^ options.include?(:without)`
+    // — Hash#include? checks own keys only; use Object.hasOwn to avoid
+    // prototype-chain surprises (the `in` operator would include inherited).
+    const hasWith = Object.hasOwn(this.options, "with");
+    const hasWithout = Object.hasOwn(this.options, "without");
+    if (hasWith === hasWithout) {
+      throw new Error("Either :with or :without must be supplied (but not both)");
+    }
+    this.checkOptionsValidity("with");
+    this.checkOptionsValidity("without");
   }
 }
 

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -40,14 +40,14 @@ export class InclusionValidator extends EachValidator {
   /** @internal */
   declare isInclude: typeof isInclude;
 
-  override checkValidity(): void {
-    checkValidityBang.call(this);
-  }
-
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (!this.isInclude(record, value)) {
       record.errors.add(attribute, "inclusion", exceptInWithinMergeValue(this.options, value));
     }
+  }
+
+  override checkValidity(): void {
+    checkValidityBang.call(this);
   }
 }
 

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -88,35 +88,6 @@ export class LengthValidator extends EachValidator {
     super(options);
   }
 
-  override checkValidity(): void {
-    const hasCheck =
-      this.options.minimum !== undefined ||
-      this.options.maximum !== undefined ||
-      this.options.is !== undefined;
-
-    if (!hasCheck) {
-      throw new Error(
-        "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.",
-      );
-    }
-
-    for (const key of ["minimum", "maximum", "is"] as const) {
-      const value = this.options[key];
-      if (value === undefined) continue;
-      if (
-        (Number.isInteger(value as number) && (value as number) >= 0) ||
-        value === Infinity ||
-        typeof value === "function" ||
-        typeof value === "string"
-      ) {
-        continue;
-      }
-      throw new Error(
-        `:${key} must be a non-negative Integer, Infinity, string (method name), or Proc`,
-      );
-    }
-  }
-
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     // Rails length.rb:50 — `value.respond_to?(:length) ? value.length : value.to_s.length`.
     // For nil → 0 (nil.to_s.length); for non-nil values without a .length
@@ -177,21 +148,35 @@ export class LengthValidator extends EachValidator {
       }
     }
   }
-}
 
-/**
- * @internal Resolves a length option through this.resolveValue (so a
- * Proc / method-name reference is honored per Rails length.rb:55) and
- * narrows the result to a number.
- */
-function resolveLengthOpt(
-  this: { resolveValue(record: unknown, value: unknown): unknown },
-  record: ValidatableRecord,
-  raw: unknown,
-): number | undefined {
-  if (raw === undefined || raw === null) return undefined;
-  const resolved = this.resolveValue(record, raw);
-  return typeof resolved === "number" ? resolved : undefined;
+  override checkValidity(): void {
+    const hasCheck =
+      this.options.minimum !== undefined ||
+      this.options.maximum !== undefined ||
+      this.options.is !== undefined;
+
+    if (!hasCheck) {
+      throw new Error(
+        "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.",
+      );
+    }
+
+    for (const key of ["minimum", "maximum", "is"] as const) {
+      const value = this.options[key];
+      if (value === undefined) continue;
+      if (
+        (Number.isInteger(value as number) && (value as number) >= 0) ||
+        value === Infinity ||
+        typeof value === "function" ||
+        typeof value === "string"
+      ) {
+        continue;
+      }
+      throw new Error(
+        `:${key} must be a non-negative Integer, Infinity, string (method name), or Proc`,
+      );
+    }
+  }
 }
 
 /**
@@ -216,6 +201,21 @@ export function skipNilCheck(
     this.options.allowNil === undefined &&
     this.options.allowBlank === undefined
   );
+}
+
+/**
+ * @internal Resolves a length option through this.resolveValue (so a
+ * Proc / method-name reference is honored per Rails length.rb:55) and
+ * narrows the result to a number.
+ */
+function resolveLengthOpt(
+  this: { resolveValue(record: unknown, value: unknown): unknown },
+  record: ValidatableRecord,
+  raw: unknown,
+): number | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const resolved = this.resolveValue(record, raw);
+  return typeof resolved === "number" ? resolved : undefined;
 }
 
 LengthValidator.prototype.resolveValue = resolveValue;

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -46,65 +46,6 @@ export class NumericalityValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isRecordAttributeChangedInPlace: typeof isRecordAttributeChangedInPlace;
 
-  private resolveNumeric(
-    val: NumericValue | undefined,
-    record: ValidatableRecord,
-    precision: number,
-    scale?: number,
-  ): number | undefined {
-    if (val === undefined) return undefined;
-    return this.optionAsNumber(record, val, precision, scale);
-  }
-
-  override checkValidity(): void {
-    const compareKeys = [
-      "greaterThan",
-      "greaterThanOrEqualTo",
-      "lessThan",
-      "lessThanOrEqualTo",
-      "equalTo",
-      "otherThan",
-    ] as const;
-    for (const key of compareKeys) {
-      const val = this.options[key];
-      if (
-        val !== undefined &&
-        typeof val !== "number" &&
-        typeof val !== "function" &&
-        typeof val !== "string"
-      ) {
-        throw new Error(`:${key} must be a number, a symbol or a proc`);
-      }
-    }
-    if (this.options.in !== undefined && !Array.isArray(this.options.in)) {
-      throw new Error(":in must be a range");
-    }
-  }
-
-  // Rails: validate_each(record, attr_name, value, precision: Float::DIG, scale: nil)
-  /**
-   * Override EachValidator.validate so prepareValueForValidation runs
-   * BEFORE the allow_nil short-circuit. Rails' EachValidator
-   * normally would skip nil values when allow_nil: true, but
-   * Numericality wants to validate what the user actually typed —
-   * an integer column casting "abc" to null mustn't bypass the check
-   * (numericality.rb's validate_each operates on raw input).
-   */
-  override validate(record: ValidatableRecord): void {
-    for (const attribute of this.attributes) {
-      // Reuses EachValidator.readAttributeForValidation so the lookup
-      // chain stays in one place. The flow then runs through
-      // prepareValueForValidation BEFORE the allowNil/allowBlank
-      // short-circuits so raw user input ('abc' → cast null) still
-      // gets validated.
-      const cast = this.readAttributeForValidation(record, attribute);
-      const value = this.prepareValueForValidation(cast, record, attribute);
-      if (value == null && this.options.allowNil === true) continue;
-      if (isBlank(value) && this.options.allowBlank === true) continue;
-      this.validateEach(record, attribute, value);
-    }
-  }
-
   validateEach(
     record: ValidatableRecord,
     attribute: string,
@@ -210,6 +151,65 @@ export class NumericalityValidator extends EachValidator {
       record.errors.add(attribute, "even", this.filteredOptions(value));
     }
   }
+
+  private resolveNumeric(
+    val: NumericValue | undefined,
+    record: ValidatableRecord,
+    precision: number,
+    scale?: number,
+  ): number | undefined {
+    if (val === undefined) return undefined;
+    return this.optionAsNumber(record, val, precision, scale);
+  }
+
+  override checkValidity(): void {
+    const compareKeys = [
+      "greaterThan",
+      "greaterThanOrEqualTo",
+      "lessThan",
+      "lessThanOrEqualTo",
+      "equalTo",
+      "otherThan",
+    ] as const;
+    for (const key of compareKeys) {
+      const val = this.options[key];
+      if (
+        val !== undefined &&
+        typeof val !== "number" &&
+        typeof val !== "function" &&
+        typeof val !== "string"
+      ) {
+        throw new Error(`:${key} must be a number, a symbol or a proc`);
+      }
+    }
+    if (this.options.in !== undefined && !Array.isArray(this.options.in)) {
+      throw new Error(":in must be a range");
+    }
+  }
+
+  // Rails: validate_each(record, attr_name, value, precision: Float::DIG, scale: nil)
+  /**
+   * Override EachValidator.validate so prepareValueForValidation runs
+   * BEFORE the allow_nil short-circuit. Rails' EachValidator
+   * normally would skip nil values when allow_nil: true, but
+   * Numericality wants to validate what the user actually typed —
+   * an integer column casting "abc" to null mustn't bypass the check
+   * (numericality.rb's validate_each operates on raw input).
+   */
+  override validate(record: ValidatableRecord): void {
+    for (const attribute of this.attributes) {
+      // Reuses EachValidator.readAttributeForValidation so the lookup
+      // chain stays in one place. The flow then runs through
+      // prepareValueForValidation BEFORE the allowNil/allowBlank
+      // short-circuits so raw user input ('abc' → cast null) still
+      // gets validated.
+      const cast = this.readAttributeForValidation(record, attribute);
+      const value = this.prepareValueForValidation(cast, record, attribute);
+      if (value == null && this.options.allowNil === true) continue;
+      if (isBlank(value) && this.options.allowBlank === true) continue;
+      this.validateEach(record, attribute, value);
+    }
+  }
 }
 
 // Rails: /\A[+-]?\d+\z/ — use a true end-of-string check rather than
@@ -247,6 +247,65 @@ const RESERVED_OPTIONS = [
 ] as const;
 
 /**
+ * Mirrors: numericality.rb:67-69
+ *   def option_as_number(record, option_value, precision, scale)
+ *     parse_as_number(resolve_value(record, option_value), precision, scale)
+ *   end
+ *
+ * The single Rails call site that consumes `resolve_value` for compare
+ * options (numericality.rb:60). With this private in place, validateEach
+ * routes every numeric option through `this.optionAsNumber(...)` rather
+ * than the previous inline resolve+coerce.
+ *
+ * @internal Rails-private helper.
+ */
+export function optionAsNumber(
+  this: {
+    resolveValue(record: unknown, value: unknown): unknown;
+  },
+  record: ValidatableRecord,
+  optionValue: unknown,
+  precision: number,
+  scale?: number,
+): number | undefined {
+  const resolved = this.resolveValue(record, optionValue);
+  if (resolved === undefined || resolved === null) return undefined;
+  // Rails option_as_number → parse_as_number → Kernel.Float would raise
+  // TypeError on non-Numeric/non-String input (Date, boolean, object).
+  // Throw the consistent validator error rather than silently accepting
+  // values that JS Number() happens to coerce (true → 1, Date → epoch).
+  if (typeof resolved !== "number" && typeof resolved !== "string") {
+    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  }
+  if (typeof resolved === "string") {
+    if (resolved.trim() === "") {
+      // Rails Kernel.Float raises ArgumentError on blank strings, so
+      // option_as_number propagates the error.
+      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+    }
+    // Rails parse_as_number's elsif chain only falls through for hex
+    // literals when the ANCHORED regex matches (HEXADECIMAL_REGEX uses
+    // \A so leading whitespace doesn't qualify). "  0x10" doesn't
+    // match, falls through to Kernel.Float, and raises — so we should
+    // raise too rather than silently skipping.
+    if (HEXADECIMAL_REGEX.test(resolved)) return undefined;
+    const trimmed = resolved.trimStart();
+    // Anything non-decimal that survives — leading-whitespace hex,
+    // 0b… / 0o… — is rejected by Rails Kernel.Float. JS Number() would
+    // silently coerce 0b/0o, so the explicit guard is load-bearing
+    // on the trails side.
+    if (HEXADECIMAL_REGEX.test(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
+      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+    }
+  }
+  const numeric = typeof resolved === "number" ? resolved : Number(resolved);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
+  }
+  return parseAsNumber(numeric, precision, scale);
+}
+
+/**
  * Rails: parse_as_number → branches by Ruby type (Float / BigDecimal /
  * Numeric / integer-string / non-hex string). In TS we just narrow to
  * number and route through round + parseFloat per Rails:
@@ -271,22 +330,6 @@ const RESERVED_OPTIONS = [
 export function parseAsNumber(num: number, precision: number, scale?: number): number | undefined {
   if (!Number.isFinite(num)) return undefined;
   return parseFloatRails(num, precision, scale);
-}
-
-/**
- * Mirrors: numericality.rb:86-88
- *   def parse_float(raw_value, precision, scale)
- *     round(raw_value, scale).to_d(precision)
- *   end
- *
- * Rounds to `scale` decimal places, then rounds to `precision`
- * significant digits — matches Ruby's `BigDecimal(float.round(scale), precision)`.
- * (Number.prototype.toPrecision performs rounding, not truncation.)
- *
- * @internal Rails-private helper.
- */
-export function parseFloatRails(num: number, precision: number, scale?: number): number {
-  return +round(num, scale).toPrecision(precision);
 }
 
 /**
@@ -386,65 +429,6 @@ export function isHexadecimalLiteral(rawValue: unknown): boolean {
 }
 
 /**
- * Mirrors: numericality.rb:67-69
- *   def option_as_number(record, option_value, precision, scale)
- *     parse_as_number(resolve_value(record, option_value), precision, scale)
- *   end
- *
- * The single Rails call site that consumes `resolve_value` for compare
- * options (numericality.rb:60). With this private in place, validateEach
- * routes every numeric option through `this.optionAsNumber(...)` rather
- * than the previous inline resolve+coerce.
- *
- * @internal Rails-private helper.
- */
-export function optionAsNumber(
-  this: {
-    resolveValue(record: unknown, value: unknown): unknown;
-  },
-  record: ValidatableRecord,
-  optionValue: unknown,
-  precision: number,
-  scale?: number,
-): number | undefined {
-  const resolved = this.resolveValue(record, optionValue);
-  if (resolved === undefined || resolved === null) return undefined;
-  // Rails option_as_number → parse_as_number → Kernel.Float would raise
-  // TypeError on non-Numeric/non-String input (Date, boolean, object).
-  // Throw the consistent validator error rather than silently accepting
-  // values that JS Number() happens to coerce (true → 1, Date → epoch).
-  if (typeof resolved !== "number" && typeof resolved !== "string") {
-    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-  }
-  if (typeof resolved === "string") {
-    if (resolved.trim() === "") {
-      // Rails Kernel.Float raises ArgumentError on blank strings, so
-      // option_as_number propagates the error.
-      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-    }
-    // Rails parse_as_number's elsif chain only falls through for hex
-    // literals when the ANCHORED regex matches (HEXADECIMAL_REGEX uses
-    // \A so leading whitespace doesn't qualify). "  0x10" doesn't
-    // match, falls through to Kernel.Float, and raises — so we should
-    // raise too rather than silently skipping.
-    if (HEXADECIMAL_REGEX.test(resolved)) return undefined;
-    const trimmed = resolved.trimStart();
-    // Anything non-decimal that survives — leading-whitespace hex,
-    // 0b… / 0o… — is rejected by Rails Kernel.Float. JS Number() would
-    // silently coerce 0b/0o, so the explicit guard is load-bearing
-    // on the trails side.
-    if (HEXADECIMAL_REGEX.test(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) {
-      throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-    }
-  }
-  const numeric = typeof resolved === "number" ? resolved : Number(resolved);
-  if (!Number.isFinite(numeric)) {
-    throw new Error(`Resolved numericality option must be numeric: ${String(resolved)}`);
-  }
-  return parseAsNumber(numeric, precision, scale);
-}
-
-/**
  * Mirrors: numericality.rb:110-114
  *   def filtered_options(value)
  *     filtered = options.except(*RESERVED_OPTIONS)
@@ -496,14 +480,6 @@ export function isAllowOnlyInteger(
   // clusivity.ts:delimiter, comparison.ts).
   const resolved = this.resolveValue(record, this.options.onlyInteger);
   return resolved !== undefined && resolved !== null && resolved !== false;
-}
-
-interface RecordWithRawAttribute {
-  attributeChangedInPlace?: (name: string) => boolean;
-  cameFromUser?: (name: string) => boolean;
-  readAttribute?: (name: string) => unknown;
-  readAttributeBeforeTypeCast?: (name: string) => unknown;
-  [key: string]: unknown;
 }
 
 /**
@@ -580,6 +556,14 @@ export function prepareValueForValidation(
   return rawValue !== undefined && rawValue !== null && rawValue !== false ? rawValue : value;
 }
 
+interface RecordWithRawAttribute {
+  attributeChangedInPlace?: (name: string) => boolean;
+  cameFromUser?: (name: string) => boolean;
+  readAttribute?: (name: string) => unknown;
+  readAttributeBeforeTypeCast?: (name: string) => unknown;
+  [key: string]: unknown;
+}
+
 /**
  * Mirrors: numericality.rb:140-143
  *   def record_attribute_changed_in_place?(record, attr_name)
@@ -595,6 +579,22 @@ export function isRecordAttributeChangedInPlace(
 ): boolean {
   const r = record as unknown as RecordWithRawAttribute;
   return typeof r.attributeChangedInPlace === "function" && r.attributeChangedInPlace(attrName);
+}
+
+/**
+ * Mirrors: numericality.rb:86-88
+ *   def parse_float(raw_value, precision, scale)
+ *     round(raw_value, scale).to_d(precision)
+ *   end
+ *
+ * Rounds to `scale` decimal places, then rounds to `precision`
+ * significant digits — matches Ruby's `BigDecimal(float.round(scale), precision)`.
+ * (Number.prototype.toPrecision performs rounding, not truncation.)
+ *
+ * @internal Rails-private helper.
+ */
+export function parseFloatRails(num: number, precision: number, scale?: number): number {
+  return +round(num, scale).toPrecision(precision);
 }
 
 NumericalityValidator.prototype.optionAsNumber = optionAsNumber;

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -2,16 +2,6 @@ import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
 
 export class WithValidator extends EachValidator {
-  override checkValidity(): void {
-    super.checkValidity();
-    const methodName = this.options.with;
-    if (typeof methodName !== "string" || methodName.trim().length === 0) {
-      throw new globalThis.Error(
-        "WithValidator requires the :with option to be a non-blank string",
-      );
-    }
-  }
-
   validateEach(record: ValidatableRecord, attribute: string, _value: unknown): void {
     const methodName = this.options.with as string;
     const method = (record as unknown as Record<string, unknown>)[methodName];
@@ -28,6 +18,16 @@ export class WithValidator extends EachValidator {
       method.call(record);
     } else {
       method.call(record, attribute);
+    }
+  }
+
+  override checkValidity(): void {
+    super.checkValidity();
+    const methodName = this.options.with;
+    if (typeof methodName !== "string" || methodName.trim().length === 0) {
+      throw new globalThis.Error(
+        "WithValidator requires the :with option to be a non-blank string",
+      );
     }
   }
 }

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -114,6 +114,40 @@ export class EachValidator<TBase extends object = object> extends Validator<TBas
     this.checkValidity();
   }
 
+  validate(record: ValidatableRecord<TBase>): void {
+    for (const attribute of this.attributes) {
+      let value = this.readAttributeForValidation(record, attribute);
+      if (value == null && this.options.allowNil === true) continue;
+      if (isBlank(value) && this.options.allowBlank === true) continue;
+      value = this.prepareValueForValidation(value, record, attribute);
+      this.validateEach(record, attribute, value);
+    }
+  }
+
+  validateEach(_record: ValidatableRecord<TBase>, _attribute: string, _value: unknown): void {
+    throw new Error("Subclasses must implement validateEach(record, attribute, value)");
+  }
+
+  checkValidityBang(): void {
+    this.checkValidity();
+  }
+
+  /**
+   * Mirrors: ActiveModel::EachValidator#prepare_value_for_validation
+   * (validator.rb:170-172). Identity by default; subclasses (e.g.
+   * NumericalityValidator) override to coerce the value before
+   * validation. Wired through `validate` so subclass overrides fire.
+   *
+   * @internal Rails-private hook.
+   */
+  protected prepareValueForValidation(
+    value: unknown,
+    _record: ValidatableRecord<TBase>,
+    _attribute: string,
+  ): unknown {
+    return value;
+  }
+
   /**
    * Mirrors: ActiveModel::Validations#read_attribute_for_validation.
    * Defaults to `send(attr)` (record[attr]); ActiveRecord overrides to
@@ -133,36 +167,6 @@ export class EachValidator<TBase extends object = object> extends Validator<TBas
       return (rec.readAttribute as (a: string) => unknown)(attribute);
     }
     return rec[attribute];
-  }
-
-  validate(record: ValidatableRecord<TBase>): void {
-    for (const attribute of this.attributes) {
-      let value = this.readAttributeForValidation(record, attribute);
-      if (value == null && this.options.allowNil === true) continue;
-      if (isBlank(value) && this.options.allowBlank === true) continue;
-      value = this.prepareValueForValidation(value, record, attribute);
-      this.validateEach(record, attribute, value);
-    }
-  }
-
-  /**
-   * Mirrors: ActiveModel::EachValidator#prepare_value_for_validation
-   * (validator.rb:170-172). Identity by default; subclasses (e.g.
-   * NumericalityValidator) override to coerce the value before
-   * validation. Wired through `validate` so subclass overrides fire.
-   *
-   * @internal Rails-private hook.
-   */
-  protected prepareValueForValidation(
-    value: unknown,
-    _record: ValidatableRecord<TBase>,
-    _attribute: string,
-  ): unknown {
-    return value;
-  }
-
-  validateEach(_record: ValidatableRecord<TBase>, _attribute: string, _value: unknown): void {
-    throw new Error("Subclasses must implement validateEach(record, attribute, value)");
   }
 
   /**
@@ -186,10 +190,6 @@ export class EachValidator<TBase extends object = object> extends Validator<TBas
 
   checkValidity(): void {
     // Override in subclasses to validate options
-  }
-
-  checkValidityBang(): void {
-    this.checkValidity();
   }
 }
 


### PR DESCRIPTION
## Summary

Second wave of the [rails-file-structure rule family](../blob/main/docs/rails-file-structure-mirror-plan.md) rollout (after PR #1602 landed arel). Enables `blazetrails/rails-file-structure-method-order` on `packages/activemodel/src/**/*.ts` with autofix applied across 46 files. All 1911 activemodel tests pass.

## Rule changes driven by activemodel

Two real bugs surfaced and are fixed in this PR (with tests):

1. **Nested classes are not reordered.** `packages/activemodel/src/type/helpers/numeric.ts` has `class NumericType extends Base { ... }` inside `applyNumericMixin()`. The rule previously matched the nested ClassBody AND the outer FunctionDeclaration, emitting overlapping fix ranges; ESLint threw `Fix objects must not be overlapped in a report`. Now only top-level `ClassDeclaration`/`ClassExpression` bodies are reordered. Nested classes are implementation detail of their surrounding function.

2. **TS function overload signatures travel with their implementation.** `TSDeclareFunction` was previously not orderable, so signature-only declarations stayed put while the implementation moved — producing TS2389 (`Function implementation name must be 'foo'`). Now: (a) TSDeclareFunction is orderable, (b) consecutive same-named members group into a single unit, so signatures + impl move as one block even when non-orderable nodes (type aliases, interfaces) sit between the original positions. Confirmed on `callbacks.ts:defineModelCallbacks` (3 declarations: 2 sigs + impl).

## Test plan

- [x] `pnpm vitest run packages/activemodel` — 1911 tests passing
- [x] `pnpm vitest run packages/arel` — 1404 tests passing (no regression from rule rework)
- [x] `pnpm --filter @blazetrails/activemodel exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean

## Spot-check verification

Compared autofixed activemodel files against their Rails counterparts:

- **`validator.ts` vs `validator.rb`** — 3 classes (Validator, EachValidator, BlockValidator) in both files. Mapped methods in Rails order in each TS class. TS-only `filteredErrorOptions` + `checkValidity` trail the mapped block.
- **`validations/with.ts` vs `validations/with.rb`** — Rails has one def (`validate_each`); TS has `validateEach` first, then TS-only `checkValidity` override. ✓
- **`type/integer.ts` vs `type/integer.rb`** — 12 Rails defs all in TS in source order (`constructor → type → deserialize → serialize → serializeCastValue → isSerializable → range → isInRange → castValue → ensureInRange → maxValue → minValue → _limit`).
- **`callbacks.ts` `defineModelCallbacks`** — 3 declarations (2 signatures + impl) now physically adjacent after autofix, where the prior rule version would have separated them and produced TS2389.
- **`type/helpers/numeric.ts`** — nested `class NumericType` inside `applyNumericMixin` is left alone; top-level helpers (`isNonNumericString`/`isNumberToNonNumber`/`isEqualNan`) reordered into Rails source order (which puts `equal_nan?` first under the `private` section).