### PR TITLE
refactor(activerecord): TM unification Phase 1 — SchemaAdapter delegation

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -901,6 +901,25 @@ class SchemaAdapter implements DatabaseAdapter {
     return m[1] || m[2] || null;
   }
 
+  async withinNewTransaction<T>(
+    opts: { isolation?: string | null; joinable?: boolean },
+    fn: (tx?: unknown) => Promise<T> | T,
+  ): Promise<T> {
+    return (this.inner as any).withinNewTransaction(opts, fn);
+  }
+
+  currentTransaction() {
+    return (this.inner as any).currentTransaction?.();
+  }
+
+  addTransactionRecord(record: unknown, ensureFinalize?: boolean) {
+    return (this.inner as any).addTransactionRecord?.(record, ensureFinalize);
+  }
+
+  materializeTransactions() {
+    return (this.inner as any).materializeTransactions?.();
+  }
+
   async beginTransaction(): Promise<void> {
     // Run pending DDL before beginning the transaction because MySQL DDL
     // causes implicit commits which destroy savepoints and break nesting.

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -982,6 +982,13 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   currentTransaction() {
+    // Async-chain-aware: a foreign concurrent caller must NOT see another
+    // chain's TM frame as joinable. database-statements.transaction() checks
+    // currentTransaction() before falling through to withinNewTransaction;
+    // if we exposed a foreign frame here it would "join" and bypass the
+    // outer mutex entirely (Copilot review #3 / #4). Return null when our
+    // own chain has no transaction open.
+    if (_txLockStorage().getStore() !== true) return null;
     return (this.inner as any).currentTransaction?.();
   }
 
@@ -1018,10 +1025,16 @@ class SchemaAdapter implements DatabaseAdapter {
     this.inner.clearCacheBang?.();
   }
   get inTransaction(): boolean {
+    // Async-chain-aware (see currentTransaction comment). transactions.ts:142
+    // uses adapter.inTransaction in the duck-type check; if we returned true
+    // for foreign chains, that caller would route to _transactionFallback and
+    // bypass the outer mutex (Copilot review #4).
+    if (_txLockStorage().getStore() !== true) return false;
     return this.inner.inTransaction;
   }
 
   get openTransactions(): number {
+    if (_txLockStorage().getStore() !== true) return 0;
     return this.inner.openTransactions ?? 0;
   }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1033,18 +1033,17 @@ class SchemaAdapter implements DatabaseAdapter {
     this._manualTxDepth++;
   }
   async commit(): Promise<void> {
-    try {
-      await this.inner.commit();
-    } finally {
-      if (this._manualTxDepth > 0) this._manualTxDepth--;
-    }
+    // Only decrement on success — failed COMMIT can leave PG/MySQL in an
+    // unresolved transaction (driver clears `inTransaction` only when COMMIT
+    // succeeds). If we decremented in finally, SchemaAdapter would report
+    // no tx while inner is still mid-transaction, sending the next
+    // transaction() call down the wrong path.
+    await this.inner.commit();
+    if (this._manualTxDepth > 0) this._manualTxDepth--;
   }
   async rollback(): Promise<void> {
-    try {
-      await this.inner.rollback();
-    } finally {
-      if (this._manualTxDepth > 0) this._manualTxDepth--;
-    }
+    await this.inner.rollback();
+    if (this._manualTxDepth > 0) this._manualTxDepth--;
   }
   async createSavepoint(name: string): Promise<void> {
     return this.inner.createSavepoint(name);

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -16,6 +16,8 @@
  * creation from model definitions — not SQL guessing.
  */
 
+import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+
 import { inspectExplainOption } from "./adapter.js";
 import type { AdapterName, DatabaseAdapter, ExplainOption } from "./adapter.js";
 import type { SchemaCache } from "./connection-adapters/schema-cache.js";
@@ -77,11 +79,25 @@ let _setupLock: Promise<void> | null = null;
 
 // Per-inner-adapter mutex for outermost withinNewTransaction calls. Rails uses
 // `connection.lock.synchronize` to serialize concurrent transactions on a
-// shared connection; the deleted _transactionFallback had the equivalent via
-// `_adapterLocks`. Routing through TM (Phase 1) loses that serialization, so
-// concurrent `Promise.all([Model.create, Model.create])` callers corrupt the
-// TM stack on the shared inner adapter. This mutex restores serialization.
+// shared connection; the `_transactionFallback` path in `transactions.ts` has
+// the equivalent via `_adapterLocks` (Phase 2 will delete that fallback).
+// SchemaAdapter no longer takes the fallback path after Phase 1, so it loses
+// the fallback's serialization. Concurrent `Promise.all([Model.create, ...])`
+// callers would otherwise corrupt the TM stack on the shared inner adapter.
+// This mutex restores serialization for that case.
+//
+// Reentrancy: AsyncLocalStorage marks "we already hold the lock in THIS async
+// chain." Nested transaction() calls within the same chain (including those
+// fired by after_commit/after_rollback callbacks before
+// inner.withinNewTransaction returns) skip lock acquisition, avoiding deadlock.
+// A concurrent call from a DIFFERENT async chain sees an empty store and
+// correctly blocks on the mutex.
 const _withinNewTxLocks = new WeakMap<object, Promise<void>>();
+let _txLockHeld: AsyncContext<true> | null = null;
+function _txLockStorage(): AsyncContext<true> {
+  if (!_txLockHeld) _txLockHeld = getAsyncContext().create<true>();
+  return _txLockHeld;
+}
 
 async function _acquireWithinNewTxLock(adapter: object): Promise<() => void> {
   while (_withinNewTxLocks.has(adapter)) {
@@ -718,6 +734,12 @@ class SchemaAdapter implements DatabaseAdapter {
       const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
       // Force TM materialization (BEGIN on the wire) before SAVEPOINT — TM uses
       // lazy materialization so openTransactions>0 alone doesn't mean BEGIN was sent.
+      // Known limitation: TM.materializeTransactions() returns immediately when
+      // another caller is already materializing, so concurrent statements
+      // inside the same lazy transaction can still race SAVEPOINT-before-BEGIN.
+      // The proper fix lives in TransactionManager (Phase 8 of the plan doc).
+      // The outer mutex in withinNewTransaction prevents the cross-transaction
+      // race that hits MariaDB CI; this case requires deeper TM changes.
       if (useSp) await this.materializeTransactions();
       const sp = useSp ? `_sr_${attempt}` : "";
       try {
@@ -938,13 +960,14 @@ class SchemaAdapter implements DatabaseAdapter {
     fn: (tx?: unknown) => Promise<T> | T,
   ): Promise<T> {
     const inner = this.inner as any;
-    const nested = (inner.openTransactions ?? 0) > 0 || inner.inTransaction;
-    // Only run setup() and acquire the per-adapter mutex on the OUTERMOST
-    // transaction. For nested (requiresNew) calls, running setup() would
-    // drain pending schema work mid-transaction — on MySQL, DDL implicitly
-    // commits the outer transaction so the outer rollback can no longer
-    // undo prior writes.
-    if (nested) return inner.withinNewTransaction(opts, fn);
+    // Detect "nested in our OWN async chain" via AsyncLocalStorage — not via
+    // shared adapter state. An unrelated concurrent transaction on the same
+    // inner adapter must NOT cause us to bypass the mutex (would race the TM
+    // stack); conversely, callbacks fired from within our own transaction
+    // (after_commit, etc.) must skip the lock to avoid self-deadlock.
+    const storage = _txLockStorage();
+    const inOurOwnTx = storage.getStore() === true;
+    if (inOurOwnTx) return inner.withinNewTransaction(opts, fn);
 
     const release = await _acquireWithinNewTxLock(inner);
     try {
@@ -952,7 +975,7 @@ class SchemaAdapter implements DatabaseAdapter {
       // existing invariant): MySQL DDL implicit-commits an open tx; PG would
       // try SAVEPOINT before BEGIN was sent.
       await this.setup();
-      return await inner.withinNewTransaction(opts, fn);
+      return await storage.run(true, () => inner.withinNewTransaction(opts, fn));
     } finally {
       release();
     }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -607,9 +607,24 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   private inner: DatabaseAdapter;
+  // Counts manual beginTransaction()/commit()/rollback() pairs on this
+  // wrapper instance. Direct callers (migrations, fixtures, query-cache
+  // tests) don't go through withinNewTransaction so they don't set the
+  // AsyncLocalStorage flag — without this counter the chain-aware
+  // delegations would hide the transaction state from them.
+  private _manualTxDepth = 0;
 
   constructor(inner: DatabaseAdapter) {
     this.inner = inner;
+  }
+
+  /**
+   * True when this caller should see the inner adapter's transaction state.
+   * Either we entered through withinNewTransaction (storage set) or the
+   * caller manually opened a transaction on this wrapper instance.
+   */
+  private _txVisible(): boolean {
+    return _txLockStorage().getStore() === true || this._manualTxDepth > 0;
   }
 
   get schemaCache(): SchemaCache | undefined {
@@ -988,7 +1003,7 @@ class SchemaAdapter implements DatabaseAdapter {
     // if we exposed a foreign frame here it would "join" and bypass the
     // outer mutex entirely (Copilot review #3 / #4). Return null when our
     // own chain has no transaction open.
-    if (_txLockStorage().getStore() !== true) return null;
+    if (!this._txVisible()) return null;
     return (this.inner as any).currentTransaction?.();
   }
 
@@ -1004,13 +1019,22 @@ class SchemaAdapter implements DatabaseAdapter {
     // Run pending DDL before beginning the transaction because MySQL DDL
     // causes implicit commits which destroy savepoints and break nesting.
     await this.setup();
-    return this.inner.beginTransaction();
+    await this.inner.beginTransaction();
+    this._manualTxDepth++;
   }
   async commit(): Promise<void> {
-    return this.inner.commit();
+    try {
+      await this.inner.commit();
+    } finally {
+      if (this._manualTxDepth > 0) this._manualTxDepth--;
+    }
   }
   async rollback(): Promise<void> {
-    return this.inner.rollback();
+    try {
+      await this.inner.rollback();
+    } finally {
+      if (this._manualTxDepth > 0) this._manualTxDepth--;
+    }
   }
   async createSavepoint(name: string): Promise<void> {
     return this.inner.createSavepoint(name);
@@ -1029,12 +1053,12 @@ class SchemaAdapter implements DatabaseAdapter {
     // uses adapter.inTransaction in the duck-type check; if we returned true
     // for foreign chains, that caller would route to _transactionFallback and
     // bypass the outer mutex (Copilot review #4).
-    if (_txLockStorage().getStore() !== true) return false;
+    if (!this._txVisible()) return false;
     return this.inner.inTransaction;
   }
 
   get openTransactions(): number {
-    if (_txLockStorage().getStore() !== true) return 0;
+    if (!this._txVisible()) return 0;
     return this.inner.openTransactions ?? 0;
   }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -104,8 +104,17 @@ let _setupLock: Promise<void> | null = null;
 //      per-instance). Phase 7 deletes SchemaAdapter so this becomes moot.
 const _withinNewTxLocks = new WeakMap<object, Promise<void>>();
 let _txLockHeld: AsyncContext<true> | null = null;
+let _txLockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
 function _txLockStorage(): AsyncContext<true> {
-  if (!_txLockHeld) _txLockHeld = getAsyncContext().create<true>();
+  // Recreate storage if ActiveSupport.asyncContextAdapter is swapped at
+  // runtime (matches the pattern in transactions.ts / core.ts /
+  // explain-registry.ts). Caching the first adapter forever would leak
+  // visibility state across browser-compat / DI swaps.
+  const asyncContext = getAsyncContext();
+  if (!_txLockHeld || _txLockHeldAdapter !== asyncContext) {
+    _txLockHeld = asyncContext.create<true>();
+    _txLockHeldAdapter = asyncContext;
+  }
   return _txLockHeld;
 }
 
@@ -1011,8 +1020,9 @@ class SchemaAdapter implements DatabaseAdapter {
     // chain's TM frame as joinable. database-statements.transaction() checks
     // currentTransaction() before falling through to withinNewTransaction;
     // if we exposed a foreign frame here it would "join" and bypass the
-    // outer mutex entirely (Copilot review #3 / #4). Return null when our
-    // own chain has no transaction open.
+    // outer mutex entirely (failure mode: Promise.all top-level transactions
+    // observing each other's frame as joinable, breaking serialization).
+    // Return null when our own chain has no transaction open.
     if (!this._txVisible()) return null;
     return (this.inner as any).currentTransaction?.();
   }
@@ -1060,8 +1070,9 @@ class SchemaAdapter implements DatabaseAdapter {
   get inTransaction(): boolean {
     // Async-chain-aware (see currentTransaction comment). transactions.ts:142
     // uses adapter.inTransaction in the duck-type check; if we returned true
-    // for foreign chains, that caller would route to _transactionFallback and
-    // bypass the outer mutex (Copilot review #4).
+    // for foreign chains, that caller would route to _transactionFallback,
+    // bypass the outer mutex, and run as a nested savepoint inside the
+    // unrelated chain's transaction.
     if (!this._txVisible()) return false;
     return this.inner.inTransaction;
   }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -92,6 +92,16 @@ let _setupLock: Promise<void> | null = null;
 // inner.withinNewTransaction returns) skip lock acquisition, avoiding deadlock.
 // A concurrent call from a DIFFERENT async chain sees an empty store and
 // correctly blocks on the mutex.
+//
+// Known limitations (both fixed by Phase 8 — push lock into TM itself):
+//   1. `Promise.all([transaction(M, …, requiresNew), transaction(M, …,
+//      requiresNew)])` started from inside a transaction body shares the
+//      parent's storage flag. Both child branches see "in our own chain"
+//      and skip the mutex, then race the TM stack at await points. Exotic
+//      pattern; the common Promise.all(top-level) case IS serialized.
+//   2. Cross-wrapper manual transactions on the same inner adapter aren't
+//      visible to other wrappers in the same chain (_manualTxDepth is
+//      per-instance). Phase 7 deletes SchemaAdapter so this becomes moot.
 const _withinNewTxLocks = new WeakMap<object, Promise<void>>();
 let _txLockHeld: AsyncContext<true> | null = null;
 function _txLockStorage(): AsyncContext<true> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -75,6 +75,29 @@ const _registeredModelClasses = new Set<any>();
 // Module-level lock to serialize setup() across all SchemaAdapter instances.
 let _setupLock: Promise<void> | null = null;
 
+// Per-inner-adapter mutex for outermost withinNewTransaction calls. Rails uses
+// `connection.lock.synchronize` to serialize concurrent transactions on a
+// shared connection; the deleted _transactionFallback had the equivalent via
+// `_adapterLocks`. Routing through TM (Phase 1) loses that serialization, so
+// concurrent `Promise.all([Model.create, Model.create])` callers corrupt the
+// TM stack on the shared inner adapter. This mutex restores serialization.
+const _withinNewTxLocks = new WeakMap<object, Promise<void>>();
+
+async function _acquireWithinNewTxLock(adapter: object): Promise<() => void> {
+  while (_withinNewTxLocks.has(adapter)) {
+    await _withinNewTxLocks.get(adapter);
+  }
+  let release!: () => void;
+  const lock = new Promise<void>((resolve) => {
+    release = () => {
+      _withinNewTxLocks.delete(adapter);
+      resolve();
+    };
+  });
+  _withinNewTxLocks.set(adapter, lock);
+  return release;
+}
+
 // Set true when createTestAdapter() is called; cleared after data cleanup.
 let _needsCleanup = false;
 let _cleanupPromise: Promise<void> | null = null;
@@ -914,12 +937,25 @@ class SchemaAdapter implements DatabaseAdapter {
     opts: { isolation?: string | null; joinable?: boolean },
     fn: (tx?: unknown) => Promise<T> | T,
   ): Promise<T> {
-    // Run setup() before entering TM — same invariant as beginTransaction().
-    // Without this, pending cleanup/DDL could run while TM already has an open
-    // frame: on PG execDdlWithSavepoint would issue SAVEPOINT before BEGIN;
-    // on MySQL, DDL inside a transaction causes an implicit commit.
-    await this.setup();
-    return (this.inner as any).withinNewTransaction(opts, fn);
+    const inner = this.inner as any;
+    const nested = (inner.openTransactions ?? 0) > 0 || inner.inTransaction;
+    // Only run setup() and acquire the per-adapter mutex on the OUTERMOST
+    // transaction. For nested (requiresNew) calls, running setup() would
+    // drain pending schema work mid-transaction — on MySQL, DDL implicitly
+    // commits the outer transaction so the outer rollback can no longer
+    // undo prior writes.
+    if (nested) return inner.withinNewTransaction(opts, fn);
+
+    const release = await _acquireWithinNewTxLock(inner);
+    try {
+      // setup() runs before TM enters its frame (mirrors beginTransaction()'s
+      // existing invariant): MySQL DDL implicit-commits an open tx; PG would
+      // try SAVEPOINT before BEGIN was sent.
+      await this.setup();
+      return await inner.withinNewTransaction(opts, fn);
+    } finally {
+      release();
+    }
   }
 
   currentTransaction() {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -345,6 +345,11 @@ let _ddlSpCounter = 0;
  */
 async function execDdlWithSavepoint(inner: any, sql: string): Promise<void> {
   const useSp = isPg() && ((inner.openTransactions ?? 0) > 0 || inner.inTransaction);
+  // TM uses lazy materialization: openTransactions>0 doesn't mean BEGIN was
+  // sent. If we issue SAVEPOINT now PG errors with "SAVEPOINT can only be
+  // used in transaction blocks". Force materialization so the BEGIN is on
+  // the wire before SAVEPOINT.
+  if (useSp) await inner.materializeTransactions?.();
   const sp = useSp ? `_ddl_sp_${++_ddlSpCounter}` : "";
   try {
     if (useSp) await inner.createSavepoint(sp);
@@ -688,6 +693,9 @@ class SchemaAdapter implements DatabaseAdapter {
       // can rollback the failed statement and retry after auto-creating the
       // missing table/column.
       const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
+      // Force TM materialization (BEGIN on the wire) before SAVEPOINT — TM uses
+      // lazy materialization so openTransactions>0 alone doesn't mean BEGIN was sent.
+      if (useSp) await this.materializeTransactions();
       const sp = useSp ? `_sr_${attempt}` : "";
       try {
         if (useSp) await this.inner.createSavepoint(sp);
@@ -733,6 +741,7 @@ class SchemaAdapter implements DatabaseAdapter {
     let lastError: unknown;
     for (let attempt = 0; attempt < 5; attempt++) {
       const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
+      if (useSp) await this.materializeTransactions();
       const sp = useSp ? `_sr_m_${attempt}` : "";
       try {
         if (useSp) await this.inner.createSavepoint(sp);
@@ -905,6 +914,11 @@ class SchemaAdapter implements DatabaseAdapter {
     opts: { isolation?: string | null; joinable?: boolean },
     fn: (tx?: unknown) => Promise<T> | T,
   ): Promise<T> {
+    // Run setup() before entering TM — same invariant as beginTransaction().
+    // Without this, pending cleanup/DDL could run while TM already has an open
+    // frame: on PG execDdlWithSavepoint would issue SAVEPOINT before BEGIN;
+    // on MySQL, DDL inside a transaction causes an implicit commit.
+    await this.setup();
     return (this.inner as any).withinNewTransaction(opts, fn);
   }
 

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2346,18 +2346,26 @@ describe("SchemaAdapter TM delegation", () => {
     // Force a defineSchema-like priming so concurrent creates don't race on DDL.
     await Item.create({ name: "prime" });
 
-    const observed: Array<{ before: unknown; inside: unknown }> = [];
+    const observed: Array<{ inside: unknown }> = [];
+    // Track concurrent execution: increment on entry, decrement on exit.
+    // The mutex should keep this at 1 for the entire run.
+    let active = 0;
+    let maxActive = 0;
     await Promise.all(
       Array.from({ length: 6 }, (_v, i) =>
         transaction(Item, async () => {
-          // Each chain must see its own frame inside, and null outside (verified
-          // post-Promise.all). Capture frame identity from the async-chain-aware
-          // currentTransaction() — if foreign chains were leaking, two concurrent
-          // callers would observe the SAME frame here.
-          const before = (testAdapter as any).currentTransaction?.();
-          await Item.create({ name: `concurrent-${i}` });
-          const inside = (testAdapter as any).currentTransaction?.();
-          observed.push({ before, inside });
+          active++;
+          if (active > maxActive) maxActive = active;
+          try {
+            // Each chain must see its own frame inside. If foreign chains
+            // were leaking, two concurrent callers would observe the SAME
+            // frame here.
+            await Item.create({ name: `concurrent-${i}` });
+            const inside = (testAdapter as any).currentTransaction?.();
+            observed.push({ inside });
+          } finally {
+            active--;
+          }
         }),
       ),
     );
@@ -2365,6 +2373,8 @@ describe("SchemaAdapter TM delegation", () => {
     // After all transactions complete, the adapter's chain-aware view sees
     // no current transaction (storage cleared).
     expect((testAdapter as any).currentTransaction?.()).toBeFalsy();
+    // Mutex must have fully serialized — no two bodies ever overlapped.
+    expect(maxActive).toBe(1);
     // Every chain must have seen a frame (no nulls/undefined) AND each frame
     // must be distinct — if the mutex degenerated to "join", or if a chain
     // saw the empty NULL_TRANSACTION, this would fail.
@@ -2376,5 +2386,43 @@ describe("SchemaAdapter TM delegation", () => {
     const distinctFrames = new Set(observed.map((o) => o.inside)).size;
     expect(distinctFrames).toBe(observed.length);
     expect(await Item.count()).toBe(7);
+  });
+
+  it("manual beginTransaction/commit pair exposes inner state via _manualTxDepth", async () => {
+    // Direct adapter.beginTransaction() callers (query-cache tests,
+    // migrations, fixtures) don't enter withinNewTransaction so they don't
+    // set the AsyncLocalStorage flag. _manualTxDepth tracks them per
+    // wrapper so the chain-aware delegations expose inner state.
+    const testAdapter = createTestAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = testAdapter;
+      }
+    }
+    // Prime the schema before beginTransaction so MySQL DDL doesn't
+    // implicit-commit the manual transaction.
+    await Item.create({ name: "prime" });
+
+    // Before any manual tx: state hidden.
+    expect((testAdapter as any).inTransaction).toBe(false);
+    expect((testAdapter as any).openTransactions).toBe(0);
+    expect((testAdapter as any).currentTransaction?.()).toBeNull();
+
+    await testAdapter.beginTransaction();
+    // After manual BEGIN: inner state visible to this wrapper.
+    expect((testAdapter as any).inTransaction).toBe(true);
+    expect((testAdapter as any).openTransactions).toBeGreaterThan(0);
+
+    await testAdapter.commit();
+    // After commit: state hidden again.
+    expect((testAdapter as any).inTransaction).toBe(false);
+    expect((testAdapter as any).openTransactions).toBe(0);
+
+    // Rollback path also clears.
+    await testAdapter.beginTransaction();
+    expect((testAdapter as any).inTransaction).toBe(true);
+    await testAdapter.rollback();
+    expect((testAdapter as any).inTransaction).toBe(false);
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2328,4 +2328,45 @@ describe("SchemaAdapter TM delegation", () => {
     expect(outerType).toBe(RealTransaction.name);
     expect(innerType).toBe(SavepointTransaction.name);
   });
+
+  it("concurrent Promise.all top-level transactions are serialized (no shared TM frame)", async () => {
+    // Regression: before the per-inner-adapter mutex + async-chain-aware
+    // delegations, two concurrent top-level transactions would race the
+    // shared TM stack and corrupt instrumenter state (the failure that
+    // hit MariaDB CI).
+    const testAdapter = createTestAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = testAdapter;
+      }
+    }
+    // Force a defineSchema-like priming so concurrent creates don't race on DDL.
+    await Item.create({ name: "prime" });
+
+    const observed: Array<{ before: unknown; inside: unknown }> = [];
+    await Promise.all(
+      Array.from({ length: 6 }, (_v, i) =>
+        transaction(Item, async () => {
+          // Each chain must see its own frame inside, and null outside (verified
+          // post-Promise.all). Capture frame identity from the async-chain-aware
+          // currentTransaction() — if foreign chains were leaking, two concurrent
+          // callers would observe the SAME frame here.
+          const before = (testAdapter as any).currentTransaction?.();
+          await Item.create({ name: `concurrent-${i}` });
+          const inside = (testAdapter as any).currentTransaction?.();
+          observed.push({ before, inside });
+        }),
+      ),
+    );
+
+    // After all transactions complete, the adapter's chain-aware view sees
+    // no current transaction (storage cleared).
+    expect((testAdapter as any).currentTransaction?.()).toBeFalsy();
+    // Every chain saw its own frame, and they aren't all the same object —
+    // if the mutex degenerated to "join", every observed.inside would be ===.
+    const distinctFrames = new Set(observed.map((o) => o.inside)).size;
+    expect(distinctFrames).toBeGreaterThan(1);
+    expect(await Item.count()).toBe(7);
+  });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2256,6 +2256,12 @@ describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () =>
 // SchemaAdapter TM delegation regression test (Phase 1)
 // ==========================================================================
 describe("SchemaAdapter TM delegation", () => {
+  // createTestAdapter wraps a shared inner adapter; without local restore,
+  // spies leak into the next test in this file.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // SchemaAdapter.setup() calls execDdlWithSavepoint which issues
   // this.inner.createSavepoint directly — bypassing TM intentionally.
   // After Phase 1, TM may have an open frame when setup() fires inside a

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2093,10 +2093,12 @@ describe("TransactionTest", () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
-    // The tests above exercise the fallback path (test-adapter has no
-    // withinNewTransaction). The TransactionManager path is reached
-    // when an adapter defines withinNewTransaction — cover that branch
-    // explicitly so it can't regress without a failing test.
+    // The "after_failure_actions" tests above run on a SchemaAdapter, which
+    // (after Phase 1) takes the TM path. They cover the SchemaAdapter→TM
+    // delegation by spying on inner.clearCacheBang. The test below covers
+    // the pure-TM path directly, against a hand-rolled TransactionManager
+    // with no SchemaAdapter wrapper — guards against TM-internal regressions
+    // independently of the wrapper.
     it("calls clearCacheBang via TransactionManager.withinNewTransaction", async () => {
       const { PreparedStatementCacheExpired } = await import("./errors.js");
       const { TransactionManager } = await import("./connection-adapters/abstract/transaction.js");
@@ -2363,10 +2365,16 @@ describe("SchemaAdapter TM delegation", () => {
     // After all transactions complete, the adapter's chain-aware view sees
     // no current transaction (storage cleared).
     expect((testAdapter as any).currentTransaction?.()).toBeFalsy();
-    // Every chain saw its own frame, and they aren't all the same object —
-    // if the mutex degenerated to "join", every observed.inside would be ===.
+    // Every chain must have seen a frame (no nulls/undefined) AND each frame
+    // must be distinct — if the mutex degenerated to "join", or if a chain
+    // saw the empty NULL_TRANSACTION, this would fail.
+    expect(observed).toHaveLength(6);
+    for (const o of observed) {
+      expect(o.inside).toBeDefined();
+      expect(o.inside).not.toBeNull();
+    }
     const distinctFrames = new Set(observed.map((o) => o.inside)).size;
-    expect(distinctFrames).toBeGreaterThan(1);
+    expect(distinctFrames).toBe(observed.length);
     expect(await Item.count()).toBe(7);
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2069,7 +2069,11 @@ describe("TransactionTest", () => {
 
     it("calls clearCacheBang and re-raises when the body throws the expired error", async () => {
       const { PreparedStatementCacheExpired } = await import("./errors.js");
-      const spy = vi.spyOn(adapter as Required<DatabaseAdapter>, "clearCacheBang");
+      // TM routes through this.inner (the real connection), so spy on innerAdapter.
+      // SchemaAdapter.clearCacheBang delegates to inner, and TM calls clearCacheBang
+      // on _connection (= inner) directly — spying on the wrapper would miss it.
+      const innerAdapter = (adapter as any).innerAdapter ?? adapter;
+      const spy = vi.spyOn(innerAdapter as Required<DatabaseAdapter>, "clearCacheBang");
       await expect(
         transaction(Account, async () => {
           throw new PreparedStatementCacheExpired("cached plan expired");
@@ -2244,5 +2248,64 @@ describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () =>
 
     expect((topic as any)._dirty.changed).toBe(false);
     expect((topic as any)._dirty.mutationsFromDatabase).toEqual({});
+  });
+});
+
+// ==========================================================================
+// SchemaAdapter TM delegation regression test (Phase 1)
+// ==========================================================================
+describe("SchemaAdapter TM delegation", () => {
+  // SchemaAdapter.setup() calls execDdlWithSavepoint which issues
+  // this.inner.createSavepoint directly — bypassing TM intentionally.
+  // After Phase 1, TM may have an open frame when setup() fires inside a
+  // test transaction. This test confirms that:
+  //   1. SchemaAdapter satisfies the withinNewTransaction duck-type check,
+  //      so transaction() takes the TM path (not _transactionFallback).
+  //   2. setup() triggered inside a transaction (via DDL recovery) doesn't
+  //      interfere with the enclosing SavepointTransaction: TM's commit()
+  //      releases the SavepointTransaction's own savepoint name, not the
+  //      already-released DDL savepoints.
+  //
+  // DDL savepoints are released eagerly (releaseSavepoint right after exec);
+  // TM does not track them and never tries to release them again.
+  it("SchemaAdapter exposes withinNewTransaction, routing transaction() through TM", async () => {
+    const adapter = createTestAdapter();
+    expect(typeof (adapter as any).withinNewTransaction).toBe("function");
+  });
+
+  it("setup() inside a TM transaction does not corrupt the SavepointTransaction lifecycle", async () => {
+    // SchemaAdapter.setup() calls execDdlWithSavepoint (direct createSavepoint on inner,
+    // bypassing TM). After Phase 1, TM may have an open frame when setup fires inside a
+    // test transaction. This test confirms TM's commit() on the SavepointTransaction
+    // releases its own name without interfering with the already-released DDL savepoints.
+    //
+    // DDL savepoints are released eagerly; TM never tracks them.
+    const testAdapter = createTestAdapter();
+    // withinNewTransaction delegates to inner (SQLite has AbstractAdapter TM)
+    // and a nested transaction (requiresNew: true) creates a SavepointTransaction.
+    // Verify the outer and inner transactions both complete without error.
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = testAdapter;
+      }
+    }
+
+    let outerCommitted = false;
+    let innerCommitted = false;
+
+    await transaction(Item, async () => {
+      outerCommitted = true;
+      await transaction(
+        Item,
+        async () => {
+          innerCommitted = true;
+        },
+        { requiresNew: true },
+      );
+    });
+
+    expect(outerCommitted).toBe(true);
+    expect(innerCommitted).toBe(true);
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2269,20 +2269,26 @@ describe("SchemaAdapter TM delegation", () => {
   //
   // DDL savepoints are released eagerly (releaseSavepoint right after exec);
   // TM does not track them and never tries to release them again.
-  it("SchemaAdapter exposes withinNewTransaction, routing transaction() through TM", async () => {
-    const adapter = createTestAdapter();
-    expect(typeof (adapter as any).withinNewTransaction).toBe("function");
+  it("transaction() routes SchemaAdapter through TM (spy on inner.withinNewTransaction)", async () => {
+    const testAdapter = createTestAdapter();
+    const inner = (testAdapter as any).innerAdapter;
+    const spy = vi.spyOn(inner, "withinNewTransaction");
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = testAdapter;
+      }
+    }
+    await transaction(Item, async () => {
+      await Item.create({ name: "tm-path" });
+    });
+    expect(spy).toHaveBeenCalled();
   });
 
-  it("setup() inside a TM transaction does not corrupt the SavepointTransaction lifecycle", async () => {
-    // SchemaAdapter.setup() calls execDdlWithSavepoint (direct createSavepoint on inner,
-    // bypassing TM intentionally — DDL savepoints are released eagerly and TM never
-    // tracks them). After Phase 1, setup() runs inside withinNewTransaction, so TM
-    // already has an open frame when DDL savepoints are issued. This test confirms:
-    //   - setup() fires inside the outer transaction (via the first Item.create() call)
-    //   - requiresNew:true creates a real SavepointTransaction on top of the outer frame
-    //   - TM's commit() releases its own savepoint name without touching the already-
-    //     released DDL savepoints; no error escapes.
+  it("requiresNew nested transaction uses SavepointTransaction on top of outer RealTransaction", async () => {
+    const { Transaction: TxBase } = await import("./connection-adapters/abstract/transaction.js");
+    const { SavepointTransaction, RealTransaction } =
+      await import("./connection-adapters/abstract/transaction.js");
     const testAdapter = createTestAdapter();
     class Item extends Base {
       static {
@@ -2291,25 +2297,29 @@ describe("SchemaAdapter TM delegation", () => {
       }
     }
 
-    let outerCount = 0;
-    let innerCount = 0;
+    let outerType: string | undefined;
+    let innerType: string | undefined;
 
     await transaction(Item, async () => {
-      // This create triggers setup() → DDL CREATE TABLE inside the outer TM frame.
       await Item.create({ name: "outer" });
-      outerCount = (await Item.count()) as number;
+      const cur = (testAdapter as any).currentTransaction?.();
+      outerType = cur instanceof TxBase ? cur.constructor.name : String(cur);
 
       await transaction(
         Item,
         async () => {
           await Item.create({ name: "inner" });
-          innerCount = (await Item.count()) as number;
+          const curIn = (testAdapter as any).currentTransaction?.();
+          innerType = curIn instanceof TxBase ? curIn.constructor.name : String(curIn);
         },
         { requiresNew: true },
       );
     });
 
-    expect(outerCount).toBeGreaterThanOrEqual(1);
-    expect(innerCount).toBeGreaterThanOrEqual(2);
+    // Outer must be a real DB transaction frame; inner must be a Savepoint
+    // (NOT RestartParent or NullTransaction). This guards against TM joining
+    // the parent instead of opening a savepoint.
+    expect(outerType).toBe(RealTransaction.name);
+    expect(innerType).toBe(SavepointTransaction.name);
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2083,7 +2083,8 @@ describe("TransactionTest", () => {
     });
 
     it("does not call clearCacheBang for unrelated errors", async () => {
-      const spy = vi.spyOn(adapter as Required<DatabaseAdapter>, "clearCacheBang");
+      const innerAdapter = (adapter as any).innerAdapter ?? adapter;
+      const spy = vi.spyOn(innerAdapter as Required<DatabaseAdapter>, "clearCacheBang");
       await expect(
         transaction(Account, async () => {
           throw new Error("unrelated");
@@ -2275,15 +2276,14 @@ describe("SchemaAdapter TM delegation", () => {
 
   it("setup() inside a TM transaction does not corrupt the SavepointTransaction lifecycle", async () => {
     // SchemaAdapter.setup() calls execDdlWithSavepoint (direct createSavepoint on inner,
-    // bypassing TM). After Phase 1, TM may have an open frame when setup fires inside a
-    // test transaction. This test confirms TM's commit() on the SavepointTransaction
-    // releases its own name without interfering with the already-released DDL savepoints.
-    //
-    // DDL savepoints are released eagerly; TM never tracks them.
+    // bypassing TM intentionally — DDL savepoints are released eagerly and TM never
+    // tracks them). After Phase 1, setup() runs inside withinNewTransaction, so TM
+    // already has an open frame when DDL savepoints are issued. This test confirms:
+    //   - setup() fires inside the outer transaction (via the first Item.create() call)
+    //   - requiresNew:true creates a real SavepointTransaction on top of the outer frame
+    //   - TM's commit() releases its own savepoint name without touching the already-
+    //     released DDL savepoints; no error escapes.
     const testAdapter = createTestAdapter();
-    // withinNewTransaction delegates to inner (SQLite has AbstractAdapter TM)
-    // and a nested transaction (requiresNew: true) creates a SavepointTransaction.
-    // Verify the outer and inner transactions both complete without error.
     class Item extends Base {
       static {
         this.attribute("name", "string");
@@ -2291,21 +2291,25 @@ describe("SchemaAdapter TM delegation", () => {
       }
     }
 
-    let outerCommitted = false;
-    let innerCommitted = false;
+    let outerCount = 0;
+    let innerCount = 0;
 
     await transaction(Item, async () => {
-      outerCommitted = true;
+      // This create triggers setup() → DDL CREATE TABLE inside the outer TM frame.
+      await Item.create({ name: "outer" });
+      outerCount = (await Item.count()) as number;
+
       await transaction(
         Item,
         async () => {
-          innerCommitted = true;
+          await Item.create({ name: "inner" });
+          innerCount = (await Item.count()) as number;
         },
         { requiresNew: true },
       );
     });
 
-    expect(outerCommitted).toBe(true);
-    expect(innerCommitted).toBe(true);
+    expect(outerCount).toBeGreaterThanOrEqual(1);
+    expect(innerCount).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `withinNewTransaction`, `currentTransaction`, `addTransactionRecord`, and `materializeTransactions` delegation methods to `SchemaAdapter` so it satisfies the duck-type check at `transactions.ts:142` and routes test transactions through `TransactionManager` instead of `_transactionFallback`.
- Adds a per-inner-adapter mutex (`_withinNewTxLocks`) for outermost `withinNewTransaction` calls, restoring the serialization that `_transactionFallback`'s `_adapterLocks` provided (Rails parity with `connection.lock.synchronize`).
- Makes `currentTransaction` / `inTransaction` / `openTransactions` delegations async-chain-aware via `AsyncContext`, with a per-instance `_manualTxDepth` counter for direct `beginTransaction()` callers (migrations, query-cache tests, fixtures). Foreign concurrent chains see empty state and correctly route through the TM-path mutex.
- Forces TM materialization before issuing SAVEPOINTs in `execute` / `executeMutation` / `execDdlWithSavepoint` so PG doesn't see "SAVEPOINT can only be used in transaction blocks" when TM has a lazy frame.
- Regression tests: TM-path routing (spy on `inner.withinNewTransaction`), nested `requiresNew` opens a `SavepointTransaction` on a `RealTransaction`, 6-way concurrent `Promise.all` top-level transactions are fully serialized (`maxActive === 1`, distinct frame identities), and the manual `beginTransaction` / `commit` / `rollback` path correctly toggles the chain-aware delegations.

## What's NOT in this PR

- `_transactionFallback` removal — Phase 2 (per plan doc, requires Phase 3 landing together).
- HABTM workaround removal — Phase 4.
- Universal `defineSchema` adoption — Phase 5 (separate PR).
- TM-level lock + materialization barrier — Phase 8.

## Known limitations (deferred to plan-doc phases)

Documented inline in code and accepted as out-of-scope for Phase 1. Multiple Copilot review cycles raised these; the proper fixes live in `TransactionManager` itself or in deleting `SchemaAdapter` outright.

1. **Intra-transaction materialize race.** `TM.materializeTransactions()` returns immediately when another caller is already materializing, so two concurrent statements inside the same lazy transaction can race SAVEPOINT-before-BEGIN. The outer mutex covers cross-transaction races (which is what hit MariaDB CI); intra-transaction concurrency needs TM to await in-flight materialization. **→ Phase 8.**
2. **Promise.all concurrent `requiresNew` inside a transaction.** Both child branches inherit the parent's `AsyncContext` flag, both see "in our own chain", both skip the mutex, and they can interleave at await points on the shared TM stack. Common Promise.all (top-level) IS serialized; only the in-body concurrent-requiresNew pattern is exposed. The fix needs lock-ownership identity (not just an inherited boolean) — Rails-style `Monitor` semantics. **→ Phase 8.**
3. **After-commit callbacks that outlive the TM frame.** Storage stays set after the TM stack pops; a callback that opens a new transaction skips both setup() and the mutex. Same root cause as #2 — fix is a real lock-ownership check. **→ Phase 8.**
4. **Cross-wrapper manual transactions in the same chain.** `_manualTxDepth` is per-`SchemaAdapter` instance, so a manual BEGIN issued on one wrapper isn't visible to a sibling wrapper around the same inner connection in the same chain. Per-inner-adapter depth would fix it but would reintroduce cross-chain bypass for concurrent tests. **→ Phase 7 deletes `SchemaAdapter` entirely.**
5. **Lost fallback-path test coverage.** Pre-Phase-1, the `PreparedStatementCacheExpired` tests exercised `_transactionFallback`; they now take the TM path. The pure-TM `clearCacheBang` test in this PR covers the actual production path. Intentionally not adding fixture coverage for soon-to-be-deleted code. **→ Phase 2 deletes the fallback.**

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts` — pass
- [x] `pnpm vitest run packages/activerecord/src/transaction-instrumentation.test.ts` — pass
- [x] `pnpm vitest run packages/activerecord/src/query-cache.test.ts` — pass (regression coverage for direct `beginTransaction` callers)
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts` — pass
- [x] PostgreSQL CI — pass (was the SAVEPOINT-before-BEGIN failure that triggered the materialize fix)
- [x] MariaDB CI — pass (was the `InstrumentationNotStartedError` failure that triggered the mutex)
- [x] SQLite CI — pass (was the `payload with open transaction` failure that triggered `_manualTxDepth`)
- [x] TypeScript build — pass