### PR TITLE
fix(eslint): rails-file-structure-method-order — ancestor-walk eligibility for ClassBody

### DIFF
--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -272,21 +272,28 @@ const rule = {
 
     return {
       ClassBody(node) {
-        // Only consider classes at the top level of the file. Classes
-        // nested inside a function body (e.g. the `class NumericType
-        // extends Base` inside `applyNumericMixin()`) are
-        // implementation detail of the surrounding function — if we
-        // also reorder a containing top-level FunctionDeclaration, the
-        // two fix ranges overlap and ESLint throws.
-        const klass = node.parent; // ClassDeclaration | ClassExpression
-        const klassParent = klass?.parent;
-        const topLevel =
-          klassParent?.type === "Program" ||
-          (klassParent?.type === "ExportNamedDeclaration" &&
-            klassParent.parent?.type === "Program") ||
-          (klassParent?.type === "ExportDefaultDeclaration" &&
-            klassParent.parent?.type === "Program");
-        if (!topLevel) return;
+        // Eligible iff no function-like scope sits between the class
+        // and the Program root. Rejects classes nested inside a
+        // function body (whose members would otherwise emit fixes
+        // overlapping with a reordered enclosing FunctionDeclaration);
+        // accepts top-level ClassDeclaration, default/named export,
+        // and `const Foo = class { … }` / variable-declarator forms.
+        let ancestor = node.parent?.parent;
+        let nested = false;
+        while (ancestor && ancestor.type !== "Program") {
+          if (
+            ancestor.type === "FunctionDeclaration" ||
+            ancestor.type === "FunctionExpression" ||
+            ancestor.type === "ArrowFunctionExpression" ||
+            ancestor.type === "MethodDefinition" ||
+            ancestor.type === "TSDeclareFunction"
+          ) {
+            nested = true;
+            break;
+          }
+          ancestor = ancestor.parent;
+        }
+        if (nested) return;
         const orderable = node.body.filter(isOrderableClassMember);
         if (orderable.length < 2) return;
         containers.push({ container: node, members: orderable });

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -281,12 +281,14 @@ const rule = {
         let ancestor = node.parent?.parent;
         let nested = false;
         while (ancestor && ancestor.type !== "Program") {
+          // TSDeclareFunction (signature-only `function foo(...): T;`)
+          // intentionally omitted — it has no body, so it cannot
+          // contain a ClassBody and would never appear in this chain.
           if (
             ancestor.type === "FunctionDeclaration" ||
             ancestor.type === "FunctionExpression" ||
             ancestor.type === "ArrowFunctionExpression" ||
-            ancestor.type === "MethodDefinition" ||
-            ancestor.type === "TSDeclareFunction"
+            ancestor.type === "MethodDefinition"
           ) {
             nested = true;
             break;

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -104,6 +104,28 @@ try {
           `  };\n` +
           `}\n`,
       },
+      // Class nested inside an arrow function — also rejected. The
+      // ancestor walk catches ArrowFunctionExpression too.
+      {
+        filename: classFile,
+        code: `const mk = () => class {\n  third() {}\n  first() {}\n  second() {}\n};\n`,
+      },
+      // Class nested inside another class's method — also rejected.
+      // The ancestor walk catches MethodDefinition before reaching
+      // Program.
+      {
+        filename: classFile,
+        code:
+          `class Outer {\n` +
+          `  build() {\n` +
+          `    return class {\n` +
+          `      third() {}\n` +
+          `      first() {}\n` +
+          `      second() {}\n` +
+          `    };\n` +
+          `  }\n` +
+          `}\n`,
+      },
       // Hoisting-scope safety: ClassDeclaration and `const`/`let` are NOT
       // orderable. A file with only those declarations (no
       // MethodDefinition or FunctionDeclaration) emits no diagnostic,

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -111,8 +111,9 @@ try {
         code: `const mk = () => class {\n  third() {}\n  first() {}\n  second() {}\n};\n`,
       },
       // Class nested inside another class's method — also rejected.
-      // The ancestor walk catches MethodDefinition before reaching
-      // Program.
+      // The first function-like ancestor encountered is the method's
+      // FunctionExpression (the inner ClassBody's grandparent), which
+      // short-circuits the walk before MethodDefinition.
       {
         filename: classFile,
         code:

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -144,6 +144,17 @@ try {
         errors: [{ messageId: "outOfOrder" }],
         output: `class X {\n  first() {}\n  second() {}\n  third() {}\n}\n`,
       },
+      // `const X = class { … }` — class expression bound to a
+      // top-level variable. Reachable from Program through
+      // VariableDeclarator / VariableDeclaration with no function-like
+      // ancestor between, so it's still file-level structure and gets
+      // reordered.
+      {
+        filename: classFile,
+        code: `const X = class {\n  third() {}\n  first() {}\n  second() {}\n};\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output: `const X = class {\n  first() {}\n  second() {}\n  third() {}\n};\n`,
+      },
       // Method-level @rails-structure-skip JSDoc must NOT suppress the
       // whole file — even though the marker is present, it sits inside
       // the class body (after the first non-comment token), so the rule

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -111,9 +111,9 @@ try {
         code: `const mk = () => class {\n  third() {}\n  first() {}\n  second() {}\n};\n`,
       },
       // Class nested inside another class's method — also rejected.
-      // The first function-like ancestor encountered is the method's
-      // FunctionExpression (the inner ClassBody's grandparent), which
-      // short-circuits the walk before MethodDefinition.
+      // The ancestor walk hits a function-like node (the method's
+      // FunctionExpression, then MethodDefinition) on the way up to
+      // Program and short-circuits.
       {
         filename: classFile,
         code:


### PR DESCRIPTION
## Summary

Follow-up to PR #1626 (Copilot review #1 — the fix didn't make it into the merge). Replaces the strict parent-shape check on `ClassBody` with an ancestor walk.

The previous check accepted only `ClassDeclaration` whose immediate parent was `Program` / `ExportNamedDeclaration` / `ExportDefaultDeclaration`. That silently skipped top-level class expressions bound via `const Foo = class { … }` — their members would never be reordered.

New behaviour: a class is eligible iff no function-like scope (`FunctionDeclaration`, `FunctionExpression`, `ArrowFunctionExpression`, `MethodDefinition`, `TSDeclareFunction`) sits between it and the `Program` root. Same rejection for the nested-class-inside-function case that motivated the original check, but now accepts `const Foo = class { … }` and similar variable-declarator forms.

Pre-requisite for the upcoming activerecord rollout, where the const-class pattern is more common.

## Test plan

- [x] New RuleTester case asserts `const X = class { … }` with out-of-order members gets reordered
- [x] Existing nested-class test (class inside function body) still passes — nested class is still left alone
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] No autofix churn in arel/activemodel (no current const-class patterns)