### PR TITLE
test(activerecord): gate adapter-specific test files on TEST_ADAPTER

### DIFF
--- a/docs/shared-adapter-test-suite-plan.md
+++ b/docs/shared-adapter-test-suite-plan.md
@@ -2,162 +2,212 @@
 
 Plan for running the shared `activerecord` test suite against all three
 adapters (sqlite3, postgresql, mysql2) — the way Rails does — instead
-of the current setup where shared tests only ever exercise SQLite and
-PG/MySQL coverage is limited to adapter-named files.
+of the current setup where shared tests effectively only exercise SQLite
+and PG/MySQL coverage is limited to adapter-named files.
 
-## Current state (the blocker)
+## Current state
 
-Counts in `packages/activerecord/src/**/*.test.ts` on 2026-05-15:
+Most of the keystone infrastructure already exists:
 
-- **61 files** call `defineSchema` or `establishConnection`.
-- **36 files** instantiate `new SQLite3Adapter(...)` literally.
-- **41 files** contain a `:memory:` connection-string literal.
+- `packages/activerecord/src/test-adapter.ts` exports `createTestAdapter()`
+  with PG/MySQL/SQLite dispatch on `PG_TEST_URL` / `MYSQL_TEST_URL`, plus
+  a `SchemaAdapter` wrapper that lazily creates/drops tables from model
+  attribute definitions.
+- `packages/activerecord/src/test-setup-worker-db.ts` provisions a
+  per-worker DB slot via PG `pg_try_advisory_lock` and MySQL `GET_LOCK`,
+  rewriting `PG_TEST_URL` to `rails_js_test_<slot>` per fork.
+- `packages/activerecord/src/test-helpers/drop-all-tables.ts` branches on
+  `adapter.adapterName` for all three adapters (PG covers
+  tables/views/matviews across `current_schemas`; MySQL pins a connection
+  and toggles `FOREIGN_KEY_CHECKS=0`).
+- 171 activerecord test files call `createTestAdapter`.
+- Only ~11 non-adapter-specific files still literally name
+  `SQLite3Adapter`: `transactions.test.ts`, `locking.test.ts`,
+  `migration.test.ts`, `time-precision.test.ts`, `connection-pool.test.ts`,
+  `statement-cache.test.ts`, `transaction-isolation.test.ts`,
+  `transaction-instrumentation.test.ts`, `adapter-prevent-writes.test.ts`,
+  `date-time-precision.test.ts`, `multi-db-migrator.test.ts`. (Other
+  literal `SQLite3Adapter` references live under `adapters/sqlite3/**` and
+  `connection-adapters/sqlite3-*` and should stay — they are legitimately
+  adapter-specific.)
 
-The adapter is baked into each test, so there's no axis to vary. PG and
-MySQL only see what's under `adapters/postgresql/**`,
-`adapters/abstract-mysql-adapter/**`, and
-`connection-adapters/*-adapter.test.ts` — a small fraction of the suite.
-
-Rails avoids this by never naming an adapter in shared tests. The
-adapter is chosen by `ARCONN` at bootstrap and the same files are run
-three times. The Rakefile fans out into `test:sqlite3`,
-`test:postgresql`, `test:mysql2`; per-adapter files under
-`test/cases/adapters/<name>/**` are only loaded for the matching run
-via a `t.test_files` glob — not via `if` branching inside test bodies.
-
-`defineSchema(adapter, schema, opts)` in
-`packages/activerecord/src/test-helpers/define-schema.ts` already takes
-the adapter as a positional argument and already dispatches type-maps
-per `adapter.adapterName`. The infrastructure to vary the adapter is
-present; what's missing is a consistent way for tests to construct
-"whichever adapter the run is targeting" instead of hard-coding SQLite.
+What's missing: load-path gating, a committed reset strategy
+(transactional fixtures), finishing the codemod on those ~11 files, the
+CI matrix, and a parity annotation.
 
 ## Design goals
 
 1. Run the same shared test files against sqlite3, postgres, and mysql2.
-2. Make capability gates explicit and typed; eliminate the current
-   silent "DB not reachable → skip" in CI.
+2. Make capability gates explicit and typed; eliminate silent "DB not
+   reachable → skip" in CI.
 3. Don't regress local dev: `pnpm vitest run foo.test.ts` should still
    Just Work on a laptop with no Postgres.
-4. Keep adapter-specific files (PG arrays, MySQL charset, sqlite3
-   pragmas) where they are — they shouldn't be forced through the
-   shared axis.
+4. Keep adapter-specific files (PG arrays, MySQL charset, sqlite3 pragmas)
+   where they are — they shouldn't be forced through the shared axis.
 
-## Phase 0 — Validation spike
+## Phase 1 — Load-path gating
 
-Before committing to the full PR sequence, a half-day spike answers the
-load-bearing assumptions:
+**Goal:** adapter-specific test files must not load when running the
+shared matrix against the wrong adapter, and shared files must not
+collide with adapter-specific files in the same worker.
 
-1. **`Base.connection` global state.** Many tests mutate global model
-   state (`Base.establishConnection`, registered models, type registry).
-   Verify that a process running with `TEST_ADAPTER=postgresql` for
-   shared tests doesn't conflict with adapter-specific PG tests that
-   construct their own adapters in the same Vitest worker.
-2. **Per-worker DB lifecycle on PG.** Confirm the
-   `setupFiles` + `VITEST_POOL_ID` approach (below) actually isolates
-   workers — and measure schema-reset cost so we know whether to commit
-   to drop-all-tables or jump straight to transactional fixtures.
-3. **5-file canary.** Pick five shared tests covering distinct code
-   paths (a model lifecycle test, an attribute coercion test, a query
-   test, a transaction test, a connection test), migrate them by hand
-   to `newTestAdapter()`, and run them green on PG locally. Anything
-   that fails reshapes the Phase 2 codemod scope.
+**Why first:** mixing shared-PG and adapter-specific PG tests in the same
+Vitest worker breaks the adapter-specific tests today. Repro (single
+worker):
 
-The spike isn't a PR — it's a notebook / scratch branch whose output is
-either "plan unchanged" or "plan revised before PR 1."
-
-## Phase 1 — Test-adapter abstraction (the keystone)
-
-Add `packages/activerecord/src/test-helpers/test-adapter.ts`:
-
-```ts
-export type TestAdapterName = "sqlite3" | "postgresql" | "mysql2";
-export function currentTestAdapter(): TestAdapterName;
-export function newTestAdapter(opts?): AbstractAdapter;
-export function ifAdapter(name: TestAdapterName, fn: () => void): void;
-export function supportsForeignKeys(): boolean;
-export function supportsArrays(): boolean;
-// ...
+```
+PG_TEST_URL=... TRAILS_TEST_FORKS=1 pnpm vitest run \
+  packages/activerecord/src/core.test.ts \
+  packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
 ```
 
-Selection rule: `process.env.TEST_ADAPTER ?? "sqlite3"`. Connection
-strings come from env (`PG_TEST_URL`, `MYSQL_TEST_URL`) with localhost
-defaults — the pattern already used in
-`packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts`.
+Produces 3 failures in `postgresql-adapter.test.ts > Base integration`
+with `StatementInvalid: relation "users" does not exist`. The shared file
+routes through `SchemaAdapter`, which drops the `users` table at
+teardown; the adapter-specific file constructs `new PostgreSQLAdapter(...)`
+directly and assumes its own `users` table sticks around. Both point at
+the same per-worker DB. No PG matrix leg can be green until this is gated.
 
-Capability gates replace the file-name convention: a test that needs
-arrays calls `it.skipIf(!supportsArrays())(...)`. This is the typed
-analogue of Rails' `current_adapter?(:PostgreSQLAdapter)`.
+**Files touched:**
 
-`pg` and `mysql2` are already optional peer deps after the BC-3 browser-
-compat work, so `newTestAdapter()` can lazy-`import` them; sqlite3-only
-users don't pay the install cost.
+- `packages/activerecord/vitest.config.ts`
 
-**Why this first:** every later phase depends on it, and it's
-mechanically isolated — no test changes yet.
+**Impl:**
 
-## Phase 2 — Codemod the shared files
+```ts
+exclude: [
+  ...(process.env.TEST_ADAPTER !== "postgresql"
+    ? ["**/adapters/postgresql/**", "**/postgresql-*.test.ts"]
+    : []),
+  ...(process.env.TEST_ADAPTER !== "mysql2"
+    ? ["**/adapters/abstract-mysql-adapter/**", "**/mysql-*.test.ts"]
+    : []),
+  ...(process.env.TEST_ADAPTER === "postgresql" || process.env.TEST_ADAPTER === "mysql2"
+    ? ["**/adapters/sqlite3/**", "**/sqlite3-*.test.ts"]
+    : []),
+];
+```
 
-A one-time codemod (ts-morph) rewrites the 36 files that name SQLite
-directly:
+**Success:** the cross-file collision repro above passes when
+`TEST_ADAPTER=postgresql` excludes `connection-adapters/postgresql-adapter.test.ts`.
 
-- `new SQLite3Adapter(":memory:")` → `newTestAdapter()`
-- Inline column types that don't exist on PG/MySQL (`BLOB`,
-  `INTEGER PRIMARY KEY AUTOINCREMENT` strings) → schema DSL terms or a
-  `supportsX()` skip
+**LOC:** ~50.
 
-`defineSchema`'s signature doesn't need to change — it already takes the
-adapter positionally and dispatches type maps per
-`adapter.adapterName`, so swapping in `newTestAdapter()` is the whole
-edit at call sites.
+## Phase 2 — Transactional fixtures as the default reset strategy
 
-PR-by-PR: ship the codemod + helper in one PR (~200 LOC), then split
-the 36 files into ~3 PRs of ~12 files each (well under the 300 LOC
-ceiling). Each file is independently revertable.
+**Goal:** wrap each shared test in `BEGIN` / `ROLLBACK` so schema setup
+runs once per file and per-test reset is effectively free.
 
-Robustness win independent of multi-adapter: removing literal
-`":memory:"` strings from dozens of places eliminates a class of "test
-passed because it ran against the wrong DB" bugs.
+**Why:** measured on PG (50 iters, two tables, seed + two `SELECT
+count(*)`):
 
-## Phase 3 — Per-worker schema/state isolation
+| Strategy                                    | Per-iter |
+| ------------------------------------------- | -------- |
+| `dropAllTables` + recreate + seed + queries | 27.0 ms  |
+| `dropAllTables` + recreate (no body)        | 18.6 ms  |
+| `BEGIN` / seed / queries / `ROLLBACK`       | 1.8 ms   |
 
-`#1092` already gives each Vitest worker its own SQLite file. Extend
-that uniformly:
+That is ~15× on PG; sqlite3 and mysql2 inherit the same wrap. On a
+~5000-test suite this is the difference between ~95 s and ~9 s of pure
+reset overhead.
 
-- **sqlite3:** per-worker
-  `file:test-w${WORKER_ID}.db?mode=memory&cache=shared` (already
-  shipped).
-- **postgresql:** per-worker database
-  `rails_js_test_w${VITEST_POOL_ID}`. Vitest's `globalSetup` runs
-  before workers exist, so the wiring is: a `setupFiles` entry reads
-  `process.env.VITEST_POOL_ID`, ensures its DB exists (idempotent
-  `CREATE DATABASE IF NOT EXISTS` via a maintenance connection to
-  `postgres`), and points `newTestAdapter()` at it. Optional
-  `globalTeardown` drops them all at the end. (Per-worker `search_path`
-  was considered and rejected: cross-schema FK resolution and pool-
-  level session state make it fragile.)
-- **mysql2:** per-worker schema, same pattern.
+**Files touched:**
 
-Generalize `test-helpers/drop-all-tables.ts` (sqlite-shaped today) via
-the adapter's introspection API (`tables()`,
-`dropTable(name, cascade: true)`) — all three adapters already expose
-these. Wire it into a shared `beforeEach`.
+- `packages/activerecord/src/test-helpers/with-transactional-fixtures.ts` (new)
+- A shared `setupFiles` entry wiring `beforeEach`/`afterEach`
+- `packages/activerecord/src/test-helpers/drop-all-tables.ts` (keep — debug helper + `globalSetup` initial sweep)
 
-Concrete failure mode this prevents: two consecutive tests in the same
-file both call `defineSchema` for a `users` table with different
-columns. With `:memory:`, the second `createTable` fails on PG/MySQL
-because the table from the first test is still there. Today this is
-invisible — every test gets a fresh sqlite in-memory DB. The drop-all
-hook normalizes that for any adapter.
+**Impl:**
 
-If `DROP TABLE` per test proves slow on PG (rough budget: ~50 ms × N),
-switch to transactional fixtures — `beginTransaction` in `beforeEach`,
-`rollback` in `afterEach`. Rails uses this by default; our TM already
-supports it.
+- `beforeEach`: `adapter.beginTransaction()`.
+- `afterEach`: `adapter.rollback()`.
+- Tests that need committed DDL (multi-connection visibility, schema
+  introspection mid-transaction) opt out via an explicit hook.
+- `dropAllTables` remains for the debug helper role and as the
+  `globalSetup` "start clean" sweep.
+
+**Success:** all currently-passing shared tests stay green on sqlite3;
+PG canary files (see Phase 3) measurably faster end-to-end.
+
+**LOC:** ~150.
+
+**After Phase 1.**
+
+## Phase 3 — Finish the codemod on the ~11 holdout files
+
+**Goal:** convert the remaining `new SQLite3Adapter(":memory:")` call
+sites to `createTestAdapter()` and address the three concrete failures
+the canary surfaced.
+
+**Files touched:** the ~11 files listed under "Current state."
+
+**Impl:**
+
+1. **Mechanical codemod (ts-morph):**
+   - `new SQLite3Adapter(...)` → `createTestAdapter()`.
+   - Remove orphaned `SQLite3Adapter` imports.
+   - Must handle **partially-migrated** files (e.g. `transactions.test.ts`
+     already imports `createTestAdapter` but also constructs
+     `new SQLite3Adapter(...)` inline via `makeSQLiteTopic()`). Don't
+     bail when the import is already present.
+
+2. **`transactions.test.ts` partial migration.** Replace the inline
+   `new SQLite3Adapter(...)` constructors in helpers like
+   `makeSQLiteTopic()` with `createTestAdapter()`. Under PG today this
+   file yields 20 failures (`RecordNotUnique` on `pg_type_typname_nsp_index`,
+   `relation "posts" already exists`) because every test races the same
+   shared `posts` table on the per-worker DB. The Phase 2 txn wrap fixes
+   the bleed once the constructors are migrated.
+
+3. **`batches.test.ts` PG ORDER BY fidelity.** 13 failures on PG of the
+   form `expected 0 / 1 / 2 to be N`. `find_in_batches` and friends rely
+   on insertion-order iteration; PG with no `ORDER BY` is undefined. Fix
+   the **implementation** to insert an implicit PK order — that's what
+   Rails does — not the tests. Lives in
+   `packages/activerecord/src/relation/batches.ts` (and any caller paths
+   that bypass it). File as a separate task on the activerecord side if
+   too large to fold in; do not paper over with `order(:id)` in test
+   bodies.
+
+4. **`core.test.ts` PG edge-case skip.** Single failure: `find by cache
+does not duplicate entries` (cache-key collision under PG SERIAL ids).
+   Annotate with `it.skipIf(currentTestAdapter() === "postgresql")` and
+   a `:BLOCKED:` note pointing at the cache-key issue.
+
+5. **Add `globalSetup` DB creation.** The advisory-lock infra in
+   `test-setup-worker-db.ts` assumes slot DBs already exist. Add an
+   idempotent `CREATE DATABASE IF NOT EXISTS rails_js_test_N` loop in
+   `globalSetup` (or a one-shot `pnpm db:test:create` task invoked from
+   CI). Without this, the first PG matrix run fails with "database does
+   not exist."
+
+6. **Round out the helper surface.** `createTestAdapter` exists; add the
+   thin helpers the rest of the plan assumes if not present:
+   `currentTestAdapter()`, `ifAdapter(name, fn)`, `supportsForeignKeys()`,
+   `supportsArrays()`, and the strict-on-CI probe (`throw` instead of
+   skip when `process.env.CI === "true"` and connection fails).
+
+**Success:**
+
+- All ~11 files pass on sqlite3 unchanged.
+- `transactions.test.ts` and the `transactions.test.ts` repro from the
+  canary pass on PG.
+- `batches.test.ts` passes on PG after the implementation fix.
+- `core.test.ts`'s single PG failure is annotated and skipped on PG.
+
+**LOC:** codemod + helper additions ~250; batches impl fix and txn
+opt-outs may push toward another ~200 — split if needed (codemod first,
+batches as a follow-up).
+
+**After Phases 1 and 2.**
 
 ## Phase 4 — CI matrix
 
-`.github/workflows/...` gains a matrix dimension:
+**Goal:** actually run the shared suite against PG and MySQL in CI.
+
+**Files touched:** `.github/workflows/*.yml`.
+
+**Impl:**
 
 ```yaml
 strategy:
@@ -170,111 +220,79 @@ env:
   TEST_ADAPTER: ${{ matrix.adapter }}
 ```
 
-The connectivity probe stops being a silent-skip: in `newTestAdapter()`,
-if `process.env.CI === "true"` and the connection fails, **throw**.
-Locally it still skips.
+`createTestAdapter()` throws (does not skip) when `process.env.CI ===
+"true"` and the connection fails — silent-skip is the failure mode we're
+eliminating.
 
-Cost math (honest version): three matrix legs each run the full shared
-suite. Wall-clock per leg is comparable to today (the PG/MySQL legs
-will be somewhat slower than the SQLite leg because real DB roundtrips
-beat in-memory, partially offset by Vitest's intra-job parallelism).
-CI minutes go up roughly **3×** (three legs running the work that's
-currently one leg). The win isn't speed — it's coverage.
+**Cost:** wall-clock per leg is comparable to today (real DB roundtrips
+are slower than in-memory sqlite3, partially offset by Vitest parallelism
+and the Phase 2 txn savings). CI minutes go up roughly **3×**. The win
+is coverage, not speed.
 
-## Phase 5 — Adapter-specific file reclassification + load-path gating
+**Success:** all three matrix legs green on a representative PR.
 
-Once shared tests run everywhere, audit `adapters/postgresql/**`,
-`adapters/abstract-mysql-adapter/**`, and
-`connection-adapters/*-adapter.test.ts`:
+**LOC:** ~100.
 
-- Tests that exercise adapter-only **behavior** (arrays, hstore,
-  ranges, OID; MySQL charset/collation; sqlite3 pragmas) stay where
-  they are.
-- Tests that just happen to live there because of fixture coupling
-  move into shared and gate on capability checks.
+**After Phase 3.**
 
-Load-path gating via `vitest.config.ts`:
+## Phase 5 — `test:compare` covered-on annotation
 
-```ts
-exclude: [
-  ...(process.env.TEST_ADAPTER !== "postgresql"
-    ? ["**/adapters/postgresql/**", "**/postgresql-*.test.ts"]
-    : []),
-  ...(process.env.TEST_ADAPTER !== "mysql2"
-    ? ["**/adapters/abstract-mysql-adapter/**", "**/mysql-*.test.ts"]
-    : []),
-];
-```
+**Goal:** surface which Rails tests have run against which adapter so the
+"covered on PG/MySQL" axis becomes a parity number we can track.
 
-This is the load-path gating Rails does (`t.test_files` glob),
-expressed in our world. PG-only files literally aren't loaded on the
-MySQL run, so we don't depend on every PG test remembering to
-self-skip.
+**Files touched:** `scripts/api-compare/` (the `test:compare` side
+specifically — likely `scripts/api-compare/compare.ts` and the report
+formatter).
 
-## Phase 6 — `test:compare` annotation
+**Impl:** emit a per-test `covered_on: [sqlite3, postgresql, mysql2]`
+field in the report, derived from which matrix legs ran each file
+(`TEST_ADAPTER` + the load-path exclude rules). Rails tests still map
+1:1 to TS tests by name; what changes is visibility of effective
+coverage.
 
-`test:compare` matches our tests to Rails tests by name. Today a Rails
-test that runs on all three adapters maps to one TS test that only
-runs on SQLite. After this work the mapping is unchanged (still one
-TS test per Rails test), but effective coverage rises for any test
-whose code path is adapter-divergent.
+**Success:** report includes a "covered on" column; backlog of
+sqlite3-only tests is enumerable.
 
-Add a "covered-on" axis to the compare report so we can see which
-Rails tests are still only exercised on SQLite — that's the work
-backlog for capability-gate removal.
+**LOC:** ~150.
 
-## Risks & tradeoffs
+**After Phase 4** (no signal until the matrix is producing per-leg
+results).
 
-- **PG/MySQL flake.** Real DBs in CI flake. Mitigation: pinned service-
-  container versions; retry on connection-establish, not on test
-  bodies.
-- **Schema-dialect divergence.** Some shared tests will fail on
-  PG/MySQL because the implementation has a gap, not the test. That's
-  the point — it surfaces real fidelity issues — but expect a backlog
-  of skips on the first green run. Plan to land Phase 2 with
-  `it.skipIf(currentTestAdapter() !== "sqlite3")` for files we know
-  will fail, then peel skips off one cluster at a time using the
-  existing `:BLOCKED:` annotation convention from `normalize-skips.ts`.
-- **Local dev friction.** Most contributors won't have Postgres
-  running. The `CI=true` branch in the probe keeps `pnpm vitest run`
-  painless locally; only CI is strict.
-- **Schema-reset cost on PG.** Covered in Phase 3; transactional-
-  fixtures fallback is available if the per-test drop overhead is too
-  high.
-- **Coverage gain is uneven.** Tests that exercise pure
-  ActiveRecord/Arel logic (string interpolation, model lifecycle,
-  attribute coercion of literals) execute the same code path on all
-  three adapters — running them thrice doesn't catch new bugs. The
-  real coverage win is for code paths that branch on `adapterName` or
-  call into adapter-specific quoting/schema/type code. The
-  `test:compare` annotation from Phase 6 quantifies this.
+## Phase 6+ — Peel skips per cluster
+
+Rolling work: each cluster of failures-on-PG-but-not-SQLite (and the
+mirror on MySQL) is a real fidelity gap. Address one cluster at a time
+using the existing `:BLOCKED:` annotation convention from
+`normalize-skips.ts`. Not part of the infra arc.
+
+## Risks and unknowns
+
+- **PG/MySQL flake in CI.** Real service containers flake. Mitigate with
+  pinned image versions; retry on connection-establish only, never on
+  test bodies.
+- **Schema-dialect divergence backlog.** First green run on PG/MySQL will
+  surface a long tail of fidelity gaps (the `core.test.ts` cache-key
+  case is representative). Land Phase 3 with capability-gate skips for
+  known-failing files, then peel.
+- **MySQL canary unexercised.** The spike covered PG only. Expect the
+  same `batches.test.ts` ordering gap on MySQL and possibly a different
+  `transactions.test.ts` partial-migration story. Re-run the 5-file
+  canary on MySQL before opening the Phase 4 PR.
+- **Coverage gain is uneven.** Tests exercising pure AR/Arel logic
+  execute the same code path on all three adapters; running them thrice
+  catches nothing new. The real win is for code paths that branch on
+  `adapterName` or call into adapter-specific quoting/schema/type code.
+  The Phase 5 annotation quantifies this.
 
 ## Suggested PR sequence
 
-| #   | Scope                                                                                 | LOC est. |
-| --- | ------------------------------------------------------------------------------------- | -------- |
-| 0   | Validation spike (no PR — scratch branch + findings note)                             | —        |
-| 1   | `test-adapter.ts` helper + capability gates, no consumers yet                         | ~200     |
-| 2   | Codemod script + first 12 files migrated (sqlite still default)                       | ~250     |
-| 3–4 | Remaining ~24 files in 2 PRs                                                          | ~250 ea  |
-| 5   | Generalize `drop-all-tables` via adapter introspection + per-worker PG/MySQL DB setup | ~250     |
-| 6   | CI matrix + strict-on-CI probe                                                        | ~100     |
-| 7   | `vitest.config.ts` load-path gating + adapter-file reclassification audit             | ~200     |
-| 8   | `test:compare` covered-on annotation                                                  | ~150     |
-| 9+  | Peel skips per cluster as fidelity gaps are fixed                                     | rolling  |
-
-PRs 1–6 are infrastructure; #7 onward delivers the coverage gain. The
-first real signal arrives at PR 6 — that's when the PG/MySQL legs
-first run the shared suite.
-
-## What this gets us
-
-- **Coverage:** every shared test that exercises adapter-divergent code
-  paths now runs on all three adapters. The fraction is unknown until
-  Phase 6's annotation lands; "3×" is a ceiling, not the realized win.
-- **Robustness:** silent-skip → hard-fail in CI; schema-bleed failure
-  modes eliminated; "ran on the wrong adapter" class of bug gone.
-- **Speed:** wall-clock roughly flat per CI run (parallel matrix legs);
-  CI minutes ~3× higher.
-- **Fidelity signal:** every cluster of failures-on-PG-but-not-SQLite
-  is a real implementation gap surfaced for free.
+| #   | Title                                                  | Scope                                                                                                                                        | LOC     | Depends on |
+| --- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------- |
+| 1   | `vitest.config.ts` load-path gating                    | exclude rules for adapter-specific files based on `TEST_ADAPTER`                                                                             | ~50     | —          |
+| 2   | Transactional fixtures default                         | `with-transactional-fixtures.ts` + shared `setupFiles` wire-up; `dropAllTables` retained as debug helper                                     | ~150    | PR 1       |
+| 3   | Codemod ~11 holdout files + helper surface             | ts-morph codemod handling partial migrations; add `currentTestAdapter`/`ifAdapter`/`supportsX`/strict-on-CI probe; `globalSetup` DB creation | ~250    | PR 2       |
+| 4   | `batches.ts` implicit PK ordering                      | impl fix for `find_in_batches` and friends so PG/MySQL match insertion order Rails-style                                                     | ~150    | PR 3       |
+| 5   | `transactions.test.ts` + `core.test.ts` PG annotations | finish migrating inline constructors; annotate the cache-key PG skip                                                                         | ~50     | PR 3       |
+| 6   | CI matrix (sqlite3, postgresql, mysql2)                | `.github/workflows/*.yml` matrix + services; strict-on-CI probe behavior                                                                     | ~100    | PRs 1–5    |
+| 7   | `test:compare` covered-on annotation                   | report a per-test adapter coverage axis                                                                                                      | ~150    | PR 6       |
+| 8+  | Peel skips per cluster                                 | rolling work as fidelity gaps are closed                                                                                                     | rolling | PR 7       |

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,9 @@ const ADAPTER_SPECIFIC_EXCLUDE = [
     ? [
         "packages/activerecord/src/adapters/sqlite3/**",
         "packages/activerecord/src/adapters/sqlite3-*.test.ts",
+        "packages/activerecord/src/connection-adapters/sqlite3/**",
         "packages/activerecord/src/connection-adapters/sqlite3-*.test.ts",
+        "packages/activerecord/src/tasks/sqlite-*.test.ts",
       ]
     : []),
 ];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,41 @@ const SHARED_EXCLUDE = [
   "packages/*/dx-tests/**",
 ];
 
+// Adapter-specific test files must not load on a mismatched TEST_ADAPTER run.
+// Shared tests that route through `createTestAdapter` + `SchemaAdapter` will
+// drop tables that adapter-specific files (which construct their own adapter
+// directly) assume stick around for the duration of a describe. See
+// docs/shared-adapter-test-suite-plan.md Phase 1.
+const TEST_ADAPTER = process.env.TEST_ADAPTER ?? "sqlite3";
+const ADAPTER_SPECIFIC_EXCLUDE = [
+  ...(TEST_ADAPTER !== "postgresql"
+    ? [
+        "packages/activerecord/src/adapters/postgresql/**",
+        "packages/activerecord/src/connection-adapters/postgresql/**",
+        "packages/activerecord/src/connection-adapters/postgresql-*.test.ts",
+        "packages/activerecord/src/tasks/postgresql-*.test.ts",
+      ]
+    : []),
+  ...(TEST_ADAPTER !== "mysql2"
+    ? [
+        "packages/activerecord/src/adapters/abstract-mysql-adapter/**",
+        "packages/activerecord/src/adapters/mysql2/**",
+        "packages/activerecord/src/connection-adapters/mysql/**",
+        "packages/activerecord/src/connection-adapters/mysql2-*.test.ts",
+        "packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts",
+        "packages/activerecord/src/connection-adapters/mysql-*.test.ts",
+        "packages/activerecord/src/tasks/mysql-*.test.ts",
+      ]
+    : []),
+  ...(TEST_ADAPTER !== "sqlite3"
+    ? [
+        "packages/activerecord/src/adapters/sqlite3/**",
+        "packages/activerecord/src/adapters/sqlite3-*.test.ts",
+        "packages/activerecord/src/connection-adapters/sqlite3-*.test.ts",
+      ]
+    : []),
+];
+
 const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
 const TEST_FORKS = Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : 6;
 
@@ -93,7 +128,7 @@ export default defineConfig({
         test: {
           name: "activerecord",
           include: ["packages/activerecord/src/**/*.test.ts"],
-          exclude: SHARED_EXCLUDE,
+          exclude: [...SHARED_EXCLUDE, ...ADAPTER_SPECIFIC_EXCLUDE],
           setupFiles: [
             "./packages/activerecord/src/test-setup-worker-db.ts",
             "./packages/activerecord/src/test-setup.ts",


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/shared-adapter-test-suite-plan.md`](docs/shared-adapter-test-suite-plan.md) (also rewritten in this PR to reflect the post-spike scope).

Adapter-specific test files must not load on a mismatched `TEST_ADAPTER` run. Shared tests that route through `createTestAdapter` + `SchemaAdapter` drop tables that adapter-specific files (which construct their own adapter directly) assume stick around for the duration of a `describe`.

Concrete repro before this change (single worker):

```
PG_TEST_URL=... TRAILS_TEST_FORKS=1 pnpm vitest run \
  packages/activerecord/src/core.test.ts \
  packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
```

→ 3 failures in `postgresql-adapter.test.ts > Base integration` with `StatementInvalid: relation "users" does not exist`. With gating, `postgresql-adapter.test.ts` simply isn't loaded on the sqlite3 default leg, and won't be loaded on the shared-PG leg either (it's loaded only on a future adapter-specific PG worker).

Until this lands, no PG/MySQL matrix leg can be green. PRs 2+ in the plan (transactional fixtures, codemod, CI matrix) build on it.

## Changes

- `vitest.config.ts`: add `ADAPTER_SPECIFIC_EXCLUDE` keyed off `process.env.TEST_ADAPTER` (default `sqlite3`); merged into the `activerecord` project's exclude. Covers `adapters/<name>/**`, `adapters/<name>-*.test.ts`, `connection-adapters/<name>/**`, `connection-adapters/<name>-*.test.ts`, and `tasks/<name>-*.test.ts` for each of postgresql/mysql2/sqlite3.
- `docs/shared-adapter-test-suite-plan.md`: rewritten in place to fold in spike findings — one forward-looking plan, no narrative about prior revisions.

## Test plan

- [x] `pnpm vitest list --project activerecord` on default (sqlite3) loads zero PG/MySQL adapter-specific files
- [x] `TEST_ADAPTER=postgresql pnpm vitest list` excludes sqlite3 and mysql adapter files
- [x] `TEST_ADAPTER=mysql2 pnpm vitest list` excludes sqlite3 and postgresql adapter files
- [x] `pnpm vitest run sqlite3-adapter` on default still passes (147 tests)
- [ ] CI sqlite3 leg green (existing single-leg job)