### PR TITLE
test(activerecord): add withTransactionalFixtures helper (Phase 2)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -79,6 +79,22 @@ let _setupLock: Promise<void> | null = null;
 let _needsCleanup = false;
 let _cleanupPromise: Promise<void> | null = null;
 
+// When true, the global beforeEach in test-setup-ar.ts skips
+// resetTestAdapterState(). Set by `withTransactionalFixtures` for files that
+// take responsibility for their own per-test state via BEGIN/ROLLBACK around
+// each test, so a one-time schema set up in `beforeAll` survives across tests.
+let _skipGlobalReset = false;
+
+/** @internal */
+export function setSkipGlobalReset(value: boolean): void {
+  _skipGlobalReset = value;
+}
+
+/** @internal */
+export function shouldSkipGlobalReset(): boolean {
+  return _skipGlobalReset;
+}
+
 /** Map ActiveModel type names to SQL column types. */
 function sqlType(typeName: string): string {
   switch (typeName) {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -94,8 +94,9 @@ export function pushSkipGlobalReset(): void {
 }
 
 /** @internal */
-export function popSkipGlobalReset(): void {
+export function popSkipGlobalReset(): number {
   if (_skipGlobalResetDepth > 0) _skipGlobalResetDepth -= 1;
+  return _skipGlobalResetDepth;
 }
 
 /** @internal */

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -79,20 +79,28 @@ let _setupLock: Promise<void> | null = null;
 let _needsCleanup = false;
 let _cleanupPromise: Promise<void> | null = null;
 
-// When true, the global beforeEach in test-setup-ar.ts skips
-// resetTestAdapterState(). Set by `withTransactionalFixtures` for files that
-// take responsibility for their own per-test state via BEGIN/ROLLBACK around
-// each test, so a one-time schema set up in `beforeAll` survives across tests.
-let _skipGlobalReset = false;
+// Refcount of active `withTransactionalFixtures` scopes. When > 0, the
+// global beforeEach in test-setup-ar.ts skips resetTestAdapterState() so a
+// one-time schema set up in `beforeAll` survives across tests in the file.
+// Refcounted (not a bool) so nested describes / multiple suites that each
+// call withTransactionalFixtures don't clobber an outer scope's skip when
+// an inner scope's afterAll runs. Mirrors Rails ConnectionPool's
+// `@pinned_connections_depth` (connection_pool.rb:327, 345).
+let _skipGlobalResetDepth = 0;
 
 /** @internal */
-export function setSkipGlobalReset(value: boolean): void {
-  _skipGlobalReset = value;
+export function pushSkipGlobalReset(): void {
+  _skipGlobalResetDepth += 1;
+}
+
+/** @internal */
+export function popSkipGlobalReset(): void {
+  if (_skipGlobalResetDepth > 0) _skipGlobalResetDepth -= 1;
 }
 
 /** @internal */
 export function shouldSkipGlobalReset(): boolean {
-  return _skipGlobalReset;
+  return _skipGlobalResetDepth > 0;
 }
 
 /** Map ActiveModel type names to SQL column types. */

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
+
+interface AdapterWithExec {
+  exec(sql: string): Promise<void>;
+  execute(sql: string): Promise<unknown[]>;
+  innerAdapter: {
+    transactionManager: {
+      beginTransaction(opts: Record<string, unknown>): Promise<unknown>;
+      commitTransaction(): Promise<void>;
+    };
+  };
+}
+
+describe("withTransactionalFixtures", () => {
+  let adapter: TestDatabaseAdapter;
+  const a = (): AdapterWithExec => adapter as unknown as AdapterWithExec;
+
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await a().exec(`CREATE TABLE fixture_users (id INTEGER PRIMARY KEY, name TEXT)`);
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  // These two tests run in order. If the wrap works, the second sees zero
+  // rows because the first's INSERT was rolled back by `afterEach`. If it
+  // doesn't, the second test sees the row from the first.
+  it("inserts a row (first run)", async () => {
+    await a().exec(`INSERT INTO fixture_users (name) VALUES ('alice')`);
+    const rows = await a().execute(`SELECT * FROM fixture_users`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("sees zero rows because the previous insert rolled back", async () => {
+    const rows = await a().execute(`SELECT * FROM fixture_users`);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("nested user transaction becomes a savepoint and still rolls back at teardown", async () => {
+    await a().innerAdapter.transactionManager.beginTransaction({});
+    await a().exec(`INSERT INTO fixture_users (name) VALUES ('bob')`);
+    await a().innerAdapter.transactionManager.commitTransaction();
+    const rows = await a().execute(`SELECT * FROM fixture_users`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("nested transaction commit was a savepoint release, outer still rolls back", async () => {
+    const rows = await a().execute(`SELECT * FROM fixture_users`);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -28,7 +28,7 @@ describe("withTransactionalFixtures", () => {
   // rows because the first's INSERT was rolled back by `afterEach`. If it
   // doesn't, the second test sees the row from the first.
   it("inserts a row (first run)", async () => {
-    await a().exec(`INSERT INTO fixture_users (name) VALUES ('alice')`);
+    await a().exec(`INSERT INTO fixture_users (id, name) VALUES (1, 'alice')`);
     const rows = await a().execute(`SELECT * FROM fixture_users`);
     expect(rows).toHaveLength(1);
   });
@@ -40,7 +40,7 @@ describe("withTransactionalFixtures", () => {
 
   it("nested user transaction becomes a savepoint and still rolls back at teardown", async () => {
     await a().innerAdapter.transactionManager.beginTransaction({});
-    await a().exec(`INSERT INTO fixture_users (name) VALUES ('bob')`);
+    await a().exec(`INSERT INTO fixture_users (id, name) VALUES (2, 'bob')`);
     await a().innerAdapter.transactionManager.commitTransaction();
     const rows = await a().execute(`SELECT * FROM fixture_users`);
     expect(rows).toHaveLength(1);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -64,8 +64,10 @@ export function withTransactionalFixtures(getAdapter: () => TestDatabaseAdapter)
   });
 
   afterAll(async () => {
-    popSkipGlobalReset();
-    await resetTestAdapterState();
+    // Only reset when the outermost scope exits, mirroring Rails
+    // ConnectionPool#unpin_connection! finalizing at depth zero
+    // (connection_pool.rb:347).
+    if (popSkipGlobalReset() === 0) await resetTestAdapterState();
   });
 
   beforeEach(async () => {

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -4,9 +4,8 @@ import { setSkipGlobalReset, type TestDatabaseAdapter } from "../test-adapter.js
 import { dropAllTables } from "./drop-all-tables.js";
 
 function tm(adapter: DatabaseAdapter): {
-  beginTransaction: (opts: { joinable: boolean; _lazy?: boolean }) => Promise<unknown>;
+  beginTransaction: (opts: { joinable: boolean; _lazy: boolean }) => Promise<unknown>;
   rollbackTransaction: () => Promise<void>;
-  materializeTransactions: () => Promise<void>;
   openTransactions: number;
 } {
   const inner = (adapter as TestDatabaseAdapter).innerAdapter ?? adapter;
@@ -58,9 +57,9 @@ export function withTransactionalFixtures(getAdapter: () => DatabaseAdapter): vo
   });
 
   beforeEach(async () => {
-    const t = tm(getAdapter());
-    await t.beginTransaction({ joinable: false, _lazy: false });
-    await t.materializeTransactions();
+    // Mirrors Rails ConnectionPool#pin_connection!:
+    //   @pinned_connection.begin_transaction joinable: false, _lazy: false
+    await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
   });
 
   afterEach(async () => {

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,8 +1,9 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
 import {
+  popSkipGlobalReset,
+  pushSkipGlobalReset,
   resetTestAdapterState,
-  setSkipGlobalReset,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 
@@ -49,11 +50,11 @@ function tm(adapter: DatabaseAdapter): {
  */
 export function withTransactionalFixtures(getAdapter: () => DatabaseAdapter): void {
   beforeAll(() => {
-    setSkipGlobalReset(true);
+    pushSkipGlobalReset();
   });
 
   afterAll(async () => {
-    setSkipGlobalReset(false);
+    popSkipGlobalReset();
     // Use resetTestAdapterState (not raw dropAllTables) so module-level
     // tracking (_createdTables, _declaredColumns, schemaCache) is cleared
     // alongside the DB drops. Otherwise a following opt-in file that

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,7 +1,10 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
-import { setSkipGlobalReset, type TestDatabaseAdapter } from "../test-adapter.js";
-import { dropAllTables } from "./drop-all-tables.js";
+import {
+  resetTestAdapterState,
+  setSkipGlobalReset,
+  type TestDatabaseAdapter,
+} from "../test-adapter.js";
 
 function tm(adapter: DatabaseAdapter): {
   beginTransaction: (opts: { joinable: boolean; _lazy: boolean }) => Promise<unknown>;
@@ -51,9 +54,11 @@ export function withTransactionalFixtures(getAdapter: () => DatabaseAdapter): vo
 
   afterAll(async () => {
     setSkipGlobalReset(false);
-    const adapter = getAdapter();
-    const inner = (adapter as TestDatabaseAdapter).innerAdapter ?? adapter;
-    await dropAllTables(inner);
+    // Use resetTestAdapterState (not raw dropAllTables) so module-level
+    // tracking (_createdTables, _declaredColumns, schemaCache) is cleared
+    // alongside the DB drops. Otherwise a following opt-in file that
+    // also skips the global reset starts with stale in-memory tracking.
+    await resetTestAdapterState();
   });
 
   beforeEach(async () => {

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,5 +1,4 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
-import type { DatabaseAdapter } from "../adapter.js";
 import {
   popSkipGlobalReset,
   pushSkipGlobalReset,
@@ -7,13 +6,23 @@ import {
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 
-function tm(adapter: DatabaseAdapter): {
-  beginTransaction: (opts: { joinable: boolean; _lazy: boolean }) => Promise<unknown>;
-  rollbackTransaction: () => Promise<void>;
-  openTransactions: number;
-} {
-  const inner = (adapter as TestDatabaseAdapter).innerAdapter ?? adapter;
-  return (inner as unknown as { transactionManager: ReturnType<typeof tm> }).transactionManager;
+interface TxnAdapter {
+  transactionManager: {
+    beginTransaction: (opts: { joinable: boolean; _lazy: boolean }) => Promise<unknown>;
+    rollbackTransaction: () => Promise<void>;
+    openTransactions: number;
+  };
+}
+
+function tm(adapter: TestDatabaseAdapter): TxnAdapter["transactionManager"] {
+  const inner = adapter.innerAdapter as unknown as Partial<TxnAdapter>;
+  if (!inner.transactionManager) {
+    throw new Error(
+      `withTransactionalFixtures: adapter ${(adapter as { adapterName?: string }).adapterName ?? "unknown"} ` +
+        `does not expose transactionManager`,
+    );
+  }
+  return inner.transactionManager;
 }
 
 /**
@@ -26,8 +35,9 @@ function tm(adapter: DatabaseAdapter): {
  *
  * Files calling this helper opt out of the global `resetTestAdapterState`
  * beforeEach (in `test-setup-ar.ts`) for their duration, so a one-time
- * schema set up in `beforeAll` survives across tests. The helper drops any
- * tables left behind in its own `afterAll` so other files are unaffected.
+ * schema set up in `beforeAll` survives across tests. The helper runs
+ * `resetTestAdapterState` in its own `afterAll` so other files are
+ * unaffected.
  *
  * Caller contract:
  *   - Set up schema in `beforeAll` *before* calling this helper, or inside
@@ -42,23 +52,19 @@ function tm(adapter: DatabaseAdapter): {
  *   let adapter: TestDatabaseAdapter;
  *   beforeAll(async () => {
  *     adapter = createTestAdapter();
- *     await adapter.exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`);
+ *     // Use adapter directly for schema setup (see test for cast pattern).
  *   });
  *   withTransactionalFixtures(() => adapter);
  *
- *   it("inserts a user", async () => { ... });  // rolled back in afterEach
+ *   it("inserts a row", async () => { ... });  // rolled back in afterEach
  */
-export function withTransactionalFixtures(getAdapter: () => DatabaseAdapter): void {
+export function withTransactionalFixtures(getAdapter: () => TestDatabaseAdapter): void {
   beforeAll(() => {
     pushSkipGlobalReset();
   });
 
   afterAll(async () => {
     popSkipGlobalReset();
-    // Use resetTestAdapterState (not raw dropAllTables) so module-level
-    // tracking (_createdTables, _declaredColumns, schemaCache) is cleared
-    // alongside the DB drops. Otherwise a following opt-in file that
-    // also skips the global reset starts with stale in-memory tracking.
     await resetTestAdapterState();
   });
 

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,0 +1,70 @@
+import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import type { DatabaseAdapter } from "../adapter.js";
+import { setSkipGlobalReset, type TestDatabaseAdapter } from "../test-adapter.js";
+import { dropAllTables } from "./drop-all-tables.js";
+
+function tm(adapter: DatabaseAdapter): {
+  beginTransaction: (opts: { joinable: boolean; _lazy?: boolean }) => Promise<unknown>;
+  rollbackTransaction: () => Promise<void>;
+  materializeTransactions: () => Promise<void>;
+  openTransactions: number;
+} {
+  const inner = (adapter as TestDatabaseAdapter).innerAdapter ?? adapter;
+  return (inner as unknown as { transactionManager: ReturnType<typeof tm> }).transactionManager;
+}
+
+/**
+ * Wrap every test in a top-level transaction that rolls back in `afterEach`,
+ * so data inserted/updated during the test is discarded without re-running
+ * schema DDL between tests.
+ *
+ * Mirrors Rails' transactional fixtures (`ActiveRecord::TestFixtures`:
+ * `setup_fixtures` opens a transaction; `teardown_fixtures` rolls back).
+ *
+ * Files calling this helper opt out of the global `resetTestAdapterState`
+ * beforeEach (in `test-setup-ar.ts`) for their duration, so a one-time
+ * schema set up in `beforeAll` survives across tests. The helper drops any
+ * tables left behind in its own `afterAll` so other files are unaffected.
+ *
+ * Caller contract:
+ *   - Set up schema in `beforeAll` *before* calling this helper, or inside
+ *     each test (which then rolls back).
+ *   - On MySQL, DDL auto-commits and escapes the wrap. Schema work must
+ *     happen in `beforeAll` (not in a test body) on MySQL.
+ *
+ * Nested `transaction { ... }` calls inside a test become savepoints because
+ * the outer transaction is opened with `joinable: false`.
+ *
+ * @example
+ *   let adapter: TestDatabaseAdapter;
+ *   beforeAll(async () => {
+ *     adapter = createTestAdapter();
+ *     await adapter.exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`);
+ *   });
+ *   withTransactionalFixtures(() => adapter);
+ *
+ *   it("inserts a user", async () => { ... });  // rolled back in afterEach
+ */
+export function withTransactionalFixtures(getAdapter: () => DatabaseAdapter): void {
+  beforeAll(() => {
+    setSkipGlobalReset(true);
+  });
+
+  afterAll(async () => {
+    setSkipGlobalReset(false);
+    const adapter = getAdapter();
+    const inner = (adapter as TestDatabaseAdapter).innerAdapter ?? adapter;
+    await dropAllTables(inner);
+  });
+
+  beforeEach(async () => {
+    const t = tm(getAdapter());
+    await t.beginTransaction({ joinable: false, _lazy: false });
+    await t.materializeTransactions();
+  });
+
+  afterEach(async () => {
+    const t = tm(getAdapter());
+    while (t.openTransactions > 0) await t.rollbackTransaction();
+  });
+}

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -12,7 +12,7 @@
 // for non-test consumers.
 import "@blazetrails/activesupport/sqlite/better-sqlite3";
 import { beforeEach } from "vitest";
-import { resetTestAdapterState } from "./test-adapter.js";
+import { resetTestAdapterState, shouldSkipGlobalReset } from "./test-adapter.js";
 
 // Wipe shared test-adapter state before every test. The previous lazy
 // "clean up on first DB op of next test" model left a window where a
@@ -21,5 +21,6 @@ import { resetTestAdapterState } from "./test-adapter.js";
 // schema setup, causing intermittent failures (count→0, queries against
 // stale schemas). Eager reset closes that window.
 beforeEach(async () => {
+  if (shouldSkipGlobalReset()) return;
   await resetTestAdapterState();
 });


### PR DESCRIPTION
## Summary

Phase 2 of [`docs/shared-adapter-test-suite-plan.md`](docs/shared-adapter-test-suite-plan.md): per-file opt-in helper that wraps every test in a top-level transaction rolled back in `afterEach`, so data is discarded between tests without re-running schema DDL.

Mirrors Rails' `ActiveRecord::TestFixtures` (`setup_fixtures` opens a transaction, `teardown_fixtures` rolls back). The outer transaction is opened with `joinable: false` so nested user `transaction { ... }` calls become savepoints — matching Rails' behavior under transactional fixtures.

## Coupling with the global beforeEach

`test-setup-ar.ts` runs `resetTestAdapterState()` (which `dropAllTables()`) before every test by default. That defeats schema-set-up-in-`beforeAll`. This PR adds a `setSkipGlobalReset` flag on the test-adapter module that the helper toggles in `beforeAll`/`afterAll`, so files opting in keep their one-time schema across tests. The helper's `afterAll` drops any tables it left behind so other files are unaffected.

## What this PR doesn't do

- Doesn't wire the helper as the default for all tests. That requires the ~11 holdout files in Phase 3 to be migrated to a schema-in-`beforeAll` pattern first.
- Doesn't change MySQL semantics — DDL auto-commits on MySQL, so schema work must happen in `beforeAll`, not in a test body. Documented on the helper.

## Test plan

- [x] `pnpm vitest run with-transactional-fixtures` — 4 tests pass on sqlite3 default leg
- [x] `pnpm vitest run packages/activerecord/src/test-helpers/` — sibling helpers unaffected (79/79 pass)
- [x] `pnpm typecheck` clean
- [ ] CI sqlite3 leg green