### PR TITLE
refactor(activerecord): TM unification Phase 5 — universal defineSchema adoption (partial)

### DIFF
--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, association, registerModel, AssociationRelation } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("AssociationRelation", () => {
@@ -31,8 +32,18 @@ describe("AssociationRelation", () => {
 
   ArBlog.hasMany("arPosts", { className: "ArPost" });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      ar_blogs: { name: "string" },
+      ar_posts: { title: "string", published: "boolean", ar_blog_id: "integer" },
+      ar_validated_blogs: { name: "string" },
+      ar_validated_posts: { title: "string", ar_validated_blog_id: "integer" },
+      ar_strict_blogs: { name: "string" },
+      ar_strict_posts: { title: "string", ar_strict_blog_id: "integer" },
+      ar_inv_blogs: { name: "string" },
+      ar_inv_posts: { title: "string", ar_inv_blog_id: "integer" },
+    });
     ArBlog.adapter = adapter;
     ArPost.adapter = adapter;
     registerModel(ArBlog);

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -15,6 +15,7 @@ import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("Association scope cache", () => {
@@ -38,8 +39,13 @@ describe("Association scope cache", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      cache_authors: { name: "string" },
+      cache_posts: { cache_author_id: "integer", title: "string" },
+      cache_comments: { cache_post_id: "integer", body: "string" },
+    });
     CacheAuthor.adapter = adapter;
     CachePost.adapter = adapter;
     CacheComment.adapter = adapter;

--- a/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
+++ b/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("BidirectionalDestroyDependenciesTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      contents: { title: "string" },
+      content_positions: { content_id: "integer", position: "integer" },
+    });
   });
 
   function makeModels() {

--- a/packages/activerecord/src/associations/collection-proxy-count.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.test.ts
@@ -23,6 +23,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("CollectionProxy#count — non-through fast path", () => {
@@ -42,8 +43,13 @@ describe("CollectionProxy#count — non-through fast path", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      cpc_authors: { name: "string" },
+      cpc_posts: { cpc_author_id: "integer", title: "string" },
+      cpc_comments: { cpc_post_id: "integer", body: "string" },
+    });
     CpcAuthor.adapter = adapter;
     CpcPost.adapter = adapter;
     registerModel("CpcAuthor", CpcAuthor);

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -7,6 +7,7 @@ import { Base, registerModel, loadHabtm } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
@@ -17,8 +18,14 @@ function freshAdapter(): DatabaseAdapter {
 describe("has_and_belongs_to_many", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string" },
+      tags: { name: "string" },
+      developers: { name: "string" },
+      projects: { name: "string" },
+    });
   });
 
   it("loads associated records through a join table", async () => {

--- a/packages/activerecord/src/associations/has-many-through.test.ts
+++ b/packages/activerecord/src/associations/has-many-through.test.ts
@@ -2,16 +2,28 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasManyThrough } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    hmt_tags: { name: "string" },
+    hmt_taggings: { post_id: "integer", tag_id: "integer" },
+    hmt_posts: { title: "string" },
+    tags: { name: "string" },
+    taggings: { post_id: "integer", tag_id: "integer" },
+    posts: { title: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/associations/loader-methods.test.ts
+++ b/packages/activerecord/src/associations/loader-methods.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, AssociationNotFoundError } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("Base#loadBelongsTo / Base#loadHasOne", () => {
@@ -46,8 +47,13 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
   LoAuthor.hasOne("loProfile", { className: "LoProfile" });
   LoPost.belongsTo("loAuthor", { className: "LoAuthor" });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      lo_authors: { name: "string" },
+      lo_posts: { title: "string", lo_author_id: "integer" },
+      lo_profiles: { bio: "string", lo_author_id: "integer" },
+    });
     LoAuthor.adapter = adapter;
     LoPost.adapter = adapter;
     LoProfile.adapter = adapter;

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -2,16 +2,34 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter = createTestAdapter();
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    authors: { name: "string" },
+    books: { title: "string", author_id: "integer" },
+    r_authors: { name: "string" },
+    r_books: { title: "string", author_id: "integer" },
+    r_writers: { name: "string" },
+    r_novels: { title: "string", writer_id: "integer" },
+    r_a_users: { name: "string" },
+    r_a_profiles: { bio: "string", r_a_user_id: "integer" },
+    r_h_users: { name: "string" },
+    r_h_profiles: { bio: "string", r_h_user_id: "integer" },
+    r_m_users: { name: "string" },
+    r_m_profiles: { bio: "string", r_m_user_id: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 describe("RequiredAssociationsTest", () => {

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -20,12 +20,15 @@ beforeEach(async () => {
     r_books: { title: "string", author_id: "integer" },
     r_writers: { name: "string" },
     r_novels: { title: "string", writer_id: "integer" },
-    r_a_users: { name: "string" },
-    r_a_profiles: { bio: "string", r_a_user_id: "integer" },
-    r_h_users: { name: "string" },
-    r_h_profiles: { bio: "string", r_h_user_id: "integer" },
-    r_m_users: { name: "string" },
-    r_m_profiles: { bio: "string", r_m_user_id: "integer" },
+    // RAUser/RAProfile etc. tableize as ra_*, rh_*, rm_* (consecutive-caps
+    // collapse per Rails' String#underscore; see packages/activesupport
+    // inflector). The same key columns map through.
+    ra_users: { name: "string" },
+    ra_profiles: { bio: "string", r_a_user_id: "integer" },
+    rh_users: { name: "string" },
+    rh_profiles: { bio: "string", r_h_user_id: "integer" },
+    rm_users: { name: "string" },
+    rm_profiles: { bio: "string", r_m_user_id: "integer" },
   });
 });
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -2,20 +2,25 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+beforeEach(async () => {
+  adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    topics: { title: "string", author_name: "string" },
+    posts: { title: "string" },
+    users: { name: "string" },
+  });
+});
 
 describe("CloneTest", () => {
   it("persisted", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -32,7 +37,6 @@ describe("CloneTest", () => {
   });
 
   it("shallow", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -47,7 +51,6 @@ describe("CloneTest", () => {
   });
 
   it("stays frozen", async () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -60,7 +63,6 @@ describe("CloneTest", () => {
   });
 
   it("freezing a cloned model does not freeze clone", async () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -77,7 +79,6 @@ describe("CloneTest", () => {
 
 describe("CloneTest", () => {
   it("clone preserves frozen state", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -92,7 +93,6 @@ describe("CloneTest", () => {
   });
 
   it("clone of frozen record is not frozen", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -111,7 +111,6 @@ describe("CloneTest", () => {
 
 describe("Base#clone", () => {
   it("creates a shallow clone preserving id and persisted state", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -127,7 +126,6 @@ describe("Base#clone", () => {
   });
 
   it("clone is independent from original", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("id", "integer");

--- a/packages/activerecord/src/coders/json.test.ts
+++ b/packages/activerecord/src/coders/json.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base, serialize } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+let adapter: DatabaseAdapter;
+
+beforeEach(async () => {
+  adapter = createTestAdapter();
+  await defineSchema(adapter, { topics: { content: "string" } });
+});
 
 describe("JSONTest", () => {
   it("returns nil if empty string given", async () => {
-    const adapter = createTestAdapter();
     class Topic extends Base {
       static {
         this.attribute("content", "string");
@@ -18,7 +26,6 @@ describe("JSONTest", () => {
   });
 
   it("returns nil if nil given", async () => {
-    const adapter = createTestAdapter();
     class Topic extends Base {
       static {
         this.attribute("content", "string");

--- a/packages/activerecord/src/inherited.test.ts
+++ b/packages/activerecord/src/inherited.test.ts
@@ -11,7 +11,10 @@ beforeAll(() => {
   adapter = createTestAdapter();
 });
 beforeEach(async () => {
-  await defineSchema(adapter, { parents: { name: "string" } });
+  await defineSchema(adapter, {
+    parents: { name: "string" },
+    children: { name: "string" },
+  });
 });
 afterAll(async () => {
   await dropAllTables(adapter);

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -6,17 +6,22 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("ModulesTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      accounts: { name: "string" },
+      billing_accounts: { name: "string" },
+      app_billing_accounts: { name: "string" },
+      accounts_archive: { name: "string" },
+      accounts_archive_v2: { name: "string" },
+      vehicles: { type: "string" },
+      posts: { title: "string", author_id: "integer" },
+    });
   });
 
   it.skip("module spanning associations", () => {

--- a/packages/activerecord/src/relation/and.test.ts
+++ b/packages/activerecord/src/relation/and.test.ts
@@ -6,23 +6,22 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+beforeEach(async () => {
+  adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    posts: { title: "string", body: "string", author: "string" },
+    users: { name: "string", role: "string", active: "boolean" },
+  });
+});
 
 // ==========================================================================
 // AndTest — targets relation/and_test.rb
 // ==========================================================================
 describe("AndTest", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   it("and combines two relations", () => {
     class Post extends Base {
       static {
@@ -39,11 +38,6 @@ describe("AndTest", () => {
 });
 
 describe("AndTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   function makeModel() {
     class Post extends Base {
       static {
@@ -80,7 +74,6 @@ describe("AndTest", () => {
 
 describe("and()", () => {
   it("combines two relations with AND", async () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -102,11 +95,6 @@ describe("and()", () => {
 });
 
 describe("Relation And (Rails-guided)", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   it("and merges where conditions", async () => {
     class User extends Base {
       static {

--- a/packages/activerecord/src/relation/annotations.test.ts
+++ b/packages/activerecord/src/relation/annotations.test.ts
@@ -6,11 +6,20 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string" },
+    items: {},
+    users: { name: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 describe("WithAnnotationsTest", () => {

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("Relation#where — composite-key form", () => {
@@ -28,8 +29,18 @@ describe("Relation#where — composite-key form", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      comp_orders: {
+        columns: {
+          shop_id: "integer",
+          order_number: "integer",
+          name: "string",
+        },
+        primaryKey: ["shop_id", "order_number"],
+      },
+    });
     CompOrder.adapter = adapter;
     // No registerModel() — this test only exercises where /
     // whereNot / PredicateBuilder directly; nothing resolves

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+let adapter: DatabaseAdapter;
+
+beforeEach(async () => {
+  adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    arel_posts: { title: "string" },
+    posts: { title: "string" },
+  });
+});
 
 describe("DelegationTest", () => {
   it("not respond to arel method", () => {
-    const adapter = createTestAdapter();
     class ArelPost extends Base {
       static {
         this._tableName = "arel_posts";
@@ -18,7 +29,6 @@ describe("DelegationTest", () => {
 
   describe("QueryingMethodsDelegationTest", () => {
     it("delegate querying methods", async () => {
-      const adapter = createTestAdapter();
       class Post extends Base {
         static {
           this.attribute("title", "string");
@@ -38,7 +48,6 @@ describe("DelegationTest", () => {
 
   describe("DelegationCachingTest", () => {
     it("delegation doesn't override methods defined in other relation subclasses", () => {
-      const adapter = createTestAdapter();
       class Post extends Base {
         static {
           this.attribute("title", "string");

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -15,11 +15,28 @@ import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany, processDependentAssociations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: {
+      title: "string",
+      author: "string",
+      status: "string",
+      updated_at: "datetime",
+      author_id: "integer",
+    },
+    items: { name: "string", status: "string", active: "boolean" },
+    users: { name: "string", active: "boolean" },
+    delete_all_authors: { name: "string" },
+    delete_all_posts: { title: "string", author_id: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -6,11 +6,20 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", author: "string" },
+    items: { name: "string", status: "string" },
+    users: { name: "string", age: "integer", active: "boolean" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 describe("RelationMergingTest", () => {

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -6,17 +6,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("RelationMutationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", author: "string" },
+    });
   });
 
   function makeModel() {

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -6,11 +6,25 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: {
+      title: "string",
+      body: "string",
+      score: "integer",
+      author_id: "integer",
+      published: "boolean",
+    },
+    users: { name: "string", age: "integer", role: "string", score: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -6,11 +6,19 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", score: "integer" },
+    items: { name: "string", price: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -21,6 +21,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("SELECT * column collision in joined relations", () => {
@@ -40,8 +41,12 @@ describe("SELECT * column collision in joined relations", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      ssj_users: { name: "string" },
+      ssj_friendships: { ssj_user_id: "integer", ssj_friend_id: "integer" },
+    });
     SsjUser.adapter = adapter;
     SsjFriendship.adapter = adapter;
     registerModel("SsjUser", SsjUser);

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -6,11 +6,22 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", body: "string", status: "string" },
+    items: { name: "string", status: "string", category: "string" },
+    developers: { name: "string", salary: "integer" },
+    orders: { amount: "integer", customer_id: "integer" },
+    users: { name: "string", email: "string", role: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/structural-compatibility.test.ts
+++ b/packages/activerecord/src/relation/structural-compatibility.test.ts
@@ -6,19 +6,24 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+let adapter: DatabaseAdapter;
+
+beforeEach(async () => {
+  adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    posts: { title: "string", score: "integer" },
+    users: { name: "string" },
+  });
+});
 
 // ==========================================================================
 // StructuralCompatibilityTest — targets relation/structural_compatibility_test.rb
 // ==========================================================================
 describe("StructuralCompatibilityTest", () => {
   it("structurally compatible returns true for same model", () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -32,11 +37,6 @@ describe("StructuralCompatibilityTest", () => {
 });
 
 describe("StructuralCompatibilityTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
   function makeModel() {
     class Post extends Base {
       static {
@@ -78,7 +78,6 @@ describe("StructuralCompatibilityTest", () => {
 
 describe("structurallyCompatible", () => {
   it("returns true for relations of the same model", () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -91,7 +90,6 @@ describe("structurallyCompatible", () => {
   });
 
   it("returns false for relations of different models", () => {
-    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -2,14 +2,20 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { Base, Relation, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("Thenable", () => {
   let adapter: DatabaseAdapter;
   let ThenableUser: typeof Base;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      thenable_users: { name: "string", active: "integer" },
+      thenable_posts: { title: "string" },
+      thenable_comments: { body: "string", thenable_post_id: "integer" },
+    });
     ThenableUser = class ThenableUser extends Base {
       static {
         this.attribute("id", "integer");

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -15,11 +15,18 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", author: "string", views: "integer", updated_at: "datetime" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -7,11 +7,39 @@ import { Base, Range, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter = createTestAdapter();
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  const authorCols = { name: "string" as const };
+  const postCols = {
+    title: "string" as const,
+    author_id: "integer" as const,
+    category_id: "integer" as const,
+    score: "integer" as const,
+  };
+  await defineSchema(_adapter, {
+    posts: postCols,
+    authors: authorCols,
+    articles: postCols,
+    art_authors: authorCols,
+    art_categories: { name: "string" },
+    jb_posts: { title: "string", jb_author_id: "integer" },
+    jb_authors: authorCols,
+    lj_posts: { title: "string", lj_author_id: "integer" },
+    lj_authors: authorCols,
+    lo_posts: { title: "string", lo_author_id: "integer" },
+    lo_authors: authorCols,
+    ma_posts: postCols,
+    ma_authors: authorCols,
+    ma_categories: { name: "string" },
+    rr_posts: postCols,
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 describe("WhereChainTest", () => {

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -6,11 +6,18 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", author: "string", status: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -2,15 +2,27 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: { title: "string", tags_count: "integer" },
+    wj_posts: { title: "string" },
+    wj_comments: { wj_post_id: "integer" },
+    wlj_posts: { title: "string" },
+    wlj_comments: { wlj_post_id: "integer" },
+    ws_posts: { title: "string", tags_count: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -6,11 +6,44 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: {
+      title: "string",
+      published: "boolean",
+      body: "string",
+      status: "string",
+      category: "string",
+      order_val: "integer",
+      postId: "integer",
+      views: "integer",
+      visible: "boolean",
+      blog_id: "integer",
+      mentor_id: "integer",
+      active: "boolean",
+    },
+    animals: { name: "string", type: "string" },
+    dogs: { name: "string", type: "string", active: "boolean" },
+    articles: {
+      title: "string",
+      visible: "boolean",
+      order_val: "integer",
+      blog_id: "integer",
+      published: "boolean",
+      category: "string",
+    },
+    comments: { body: "string" },
+    devs: { name: "string", salary: "integer", mentor_id: "integer" },
+    dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -6,11 +6,31 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, Relation } from "../index.js";
 
 import { createTestAdapter, adapterType } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    posts: {
+      title: "string",
+      published: "boolean",
+      featured: "boolean",
+      status: "string",
+      views: "integer",
+      author_id: "integer",
+      active: "boolean",
+    },
+    animals: { name: "string", type: "string" },
+    dogs: { name: "string", type: "string" },
+    articles: { title: "string", status: "string" },
+    products: { name: "string", price: "integer", active: "boolean" },
+    users: { name: "string", age: "integer", active: "boolean", role: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -6,11 +6,42 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-// -- Helpers --
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  const postCols = {
+    title: "string" as const,
+    published: "boolean" as const,
+    salary: "integer" as const,
+    author: "string" as const,
+  };
+  await defineSchema(_adapter, {
+    developers: { name: "string", salary: "integer" },
+    posts: { title: "string", author: "string", published: "boolean" },
+    ro_posts: postCols,
+    dro_posts: postCols,
+    sf_posts: postCols,
+    sff_posts: postCols,
+    sfl_posts: postCols,
+    sc_posts: postCols,
+    sds_posts: postCols,
+    sfa_posts: postCols,
+    scnt_posts: postCols,
+    sj_posts: postCols,
+    nrs_posts: postCols,
+    ann_posts: postCols,
+    ann_unscoped_posts: postCols,
+    animals: { type: "string", name: "string" },
+    cats: { type: "string", name: "string" },
+    dogs: { type: "string", name: "string" },
+    categories: { name: "string" },
+  });
+});
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return _adapter;
 }
 
 describe("RelationScopingTest", () => {

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -119,6 +119,23 @@ describe("defineSchema", () => {
       expect("id" in rows[0]).toBe(false);
     });
 
+    it("STI columns map with a 'type' column is recognised as the wrapper shape", async () => {
+      // Regression: an earlier discriminator looked for `type` inside the
+      // `columns` value to reject ColumnSpec object shapes, which made STI
+      // wrappers (columns: { type: "string", ... }) misclassify as legacy
+      // and silently drop the primaryKey directive.
+      await defineSchema(adapter, {
+        sti: {
+          columns: { type: "string", name: "string" },
+          primaryKey: false,
+        },
+      });
+      await adapter.executeMutation(`INSERT INTO "sti" ("type","name") VALUES ('Dog','Rex')`);
+      const rows = (await adapter.execute(`SELECT * FROM "sti"`)) as Array<Record<string, unknown>>;
+      expect(rows[0]["type"]).toBe("Dog");
+      expect("id" in rows[0]).toBe(false);
+    });
+
     it("does not mis-classify a legacy column literally named 'columns'", async () => {
       // The discriminator must require `columns` to be an object map (not a
       // ColumnSpec string/object) — otherwise a legacy table with a column

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -136,6 +136,22 @@ describe("defineSchema", () => {
       expect("id" in rows[0]).toBe(false);
     });
 
+    it("legacy single-column table named 'columns' with object ColumnSpec stays legacy", async () => {
+      // Corner case: `{ columns: { type: "string" } }` is structurally
+      // indistinguishable from a wrapper with one column named `type` if
+      // the discriminator only inspects `columns`. Requiring `primaryKey`
+      // on the wrapper means a legacy ColumnSpec-object shape like this
+      // unambiguously stays legacy.
+      await defineSchema(adapter, {
+        reports2: { columns: { type: "string" } },
+      });
+      await adapter.executeMutation(`INSERT INTO "reports2" ("columns") VALUES ('hi')`);
+      const rows = (await adapter.execute(`SELECT * FROM "reports2"`)) as Array<
+        Record<string, unknown>
+      >;
+      expect(rows[0]["columns"]).toBe("hi");
+    });
+
     it("does not mis-classify a legacy column literally named 'columns'", async () => {
       // The discriminator must require `columns` to be an object map (not a
       // ColumnSpec string/object) — otherwise a legacy table with a column

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -106,6 +106,28 @@ describe("defineSchema", () => {
       ).rejects.toThrow();
     });
 
+    it("single-element primaryKey array names a non-id PK column (also NOT NULL)", async () => {
+      // The wrapper's documented form for a single-column non-`id` PK is
+      // `primaryKey: [name]` — cover that path so regressions don't slip
+      // past the composite-key test below.
+      await defineSchema(adapter, {
+        single_pk: { columns: { code: "string", label: "string" }, primaryKey: ["code"] },
+      });
+      await adapter.executeMutation(`INSERT INTO "single_pk" ("code","label") VALUES ('a','x')`);
+      await expect(
+        adapter.executeMutation(`INSERT INTO "single_pk" ("code","label") VALUES ('a','y')`),
+      ).rejects.toThrow();
+      await expect(
+        adapter.executeMutation(`INSERT INTO "single_pk" ("code","label") VALUES (NULL,'z')`),
+      ).rejects.toThrow();
+      const rows = (await adapter.execute(`SELECT * FROM "single_pk"`)) as Array<
+        Record<string, unknown>
+      >;
+      expect(rows).toHaveLength(1);
+      // No auto `id` column when wrapper.primaryKey is set.
+      expect("id" in rows[0]).toBe(false);
+    });
+
     it("composite primary key columns are NOT NULL (matches Rails; SQLite quirk-proof)", async () => {
       await defineSchema(adapter, {
         cpk_nn: {

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -86,6 +86,54 @@ describe("defineSchema", () => {
     ).rejects.toThrow(/circular reference/);
   });
 
+  describe("wrapped { columns, primaryKey } shape", () => {
+    it("composite primary key produces a PRIMARY KEY constraint over the named columns", async () => {
+      await defineSchema(adapter, {
+        comp: {
+          columns: { shop_id: "integer", order_number: "integer", name: "string" },
+          primaryKey: ["shop_id", "order_number"],
+        },
+      });
+      // Both rows differ in (shop_id, order_number) → both insert.
+      await adapter.executeMutation(
+        `INSERT INTO "comp" ("shop_id","order_number","name") VALUES (1,1,'a'),(1,2,'b')`,
+      );
+      // Same composite key → should reject.
+      await expect(
+        adapter.executeMutation(
+          `INSERT INTO "comp" ("shop_id","order_number","name") VALUES (1,1,'dup')`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("primaryKey: false creates a table with no primary key (no auto id column)", async () => {
+      await defineSchema(adapter, {
+        no_pk: { columns: { tag: "string" }, primaryKey: false },
+      });
+      // No "id" column present.
+      await adapter.executeMutation(`INSERT INTO "no_pk" ("tag") VALUES ('x')`);
+      const rows = (await adapter.execute(`SELECT * FROM "no_pk"`)) as Array<
+        Record<string, unknown>
+      >;
+      expect(rows).toHaveLength(1);
+      expect("id" in rows[0]).toBe(false);
+    });
+
+    it("does not mis-classify a legacy column literally named 'columns'", async () => {
+      // The discriminator must require `columns` to be an object map (not a
+      // ColumnSpec string/object) — otherwise a legacy table with a column
+      // called "columns" would be parsed as the wrapper shape.
+      await defineSchema(adapter, {
+        reports: { columns: "string", count: "integer" },
+      });
+      await adapter.executeMutation(`INSERT INTO "reports" ("columns","count") VALUES ('hello',1)`);
+      const rows = (await adapter.execute(`SELECT * FROM "reports"`)) as Array<
+        Record<string, unknown>
+      >;
+      expect(rows[0]["columns"]).toBe("hello");
+    });
+  });
+
   it("dropExisting drops first then creates", async () => {
     await defineSchema(adapter, { items: { name: "string" } });
     await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('old')`);

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -106,6 +106,22 @@ describe("defineSchema", () => {
       ).rejects.toThrow();
     });
 
+    it("composite primary key columns are NOT NULL (matches Rails; SQLite quirk-proof)", async () => {
+      await defineSchema(adapter, {
+        cpk_nn: {
+          columns: { a: "integer", b: "integer", name: "string" },
+          primaryKey: ["a", "b"],
+        },
+      });
+      // SQLite otherwise accepts NULLs in composite-PK columns; we forbid it.
+      await expect(
+        adapter.executeMutation(`INSERT INTO "cpk_nn" ("a","b","name") VALUES (NULL,1,'x')`),
+      ).rejects.toThrow();
+      await expect(
+        adapter.executeMutation(`INSERT INTO "cpk_nn" ("a","b","name") VALUES (1,NULL,'x')`),
+      ).rejects.toThrow();
+    });
+
     it("primaryKey: false creates a table with no primary key (no auto id column)", async () => {
       await defineSchema(adapter, {
         no_pk: { columns: { tag: "string" }, primaryKey: false },

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
-import { defineSchema } from "./define-schema.js";
+import { defineSchema, type ColumnSpec } from "./define-schema.js";
 
 let adapter: DatabaseAdapter;
 
@@ -134,6 +134,26 @@ describe("defineSchema", () => {
       const rows = (await adapter.execute(`SELECT * FROM "sti"`)) as Array<Record<string, unknown>>;
       expect(rows[0]["type"]).toBe("Dog");
       expect("id" in rows[0]).toBe(false);
+    });
+
+    it("legacy table with columns both named 'columns' and 'primaryKey' stays legacy (primaryKey is not wrapper-shaped)", async () => {
+      // primaryKey here is a column name with a ColumnSpec value, not a
+      // string[]/false marker. The discriminator must validate the
+      // primaryKey value's shape before treating the table as a wrapper.
+      await defineSchema(adapter, {
+        legacy_pk_col: {
+          columns: { type: "string" },
+          primaryKey: "string",
+        } as unknown as Record<string, ColumnSpec>,
+      });
+      await adapter.executeMutation(
+        `INSERT INTO "legacy_pk_col" ("columns","primaryKey") VALUES ('a','b')`,
+      );
+      const rows = (await adapter.execute(`SELECT * FROM "legacy_pk_col"`)) as Array<
+        Record<string, unknown>
+      >;
+      expect(rows[0]["columns"]).toBe("a");
+      expect(rows[0]["primaryKey"]).toBe("b");
     });
 
     it("legacy single-column table named 'columns' with object ColumnSpec stays legacy", async () => {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -33,8 +33,14 @@ export interface WrappedTableSchema {
    * suppresses the auto-`id` column. `false` builds the table without a PK.
    * `string` is not supported — use the matching column with `primary: true`
    * via the legacy shape, or pass `[name]` for a single-column composite.
+   *
+   * Required: this is the disambiguator that separates the wrapper shape
+   * from the legacy `Record<colName, ColumnSpec>` shape. Without it, a
+   * legacy single-column table whose column happens to be named `columns`
+   * (with an object ColumnSpec) is structurally indistinguishable from a
+   * wrapper. If you don't need to override the PK, use the legacy shape.
    */
-  primaryKey?: string[] | false;
+  primaryKey: string[] | false;
 }
 export type TableSchema = Record<string, ColumnSpec> | WrappedTableSchema;
 export type Schema = Record<string, TableSchema>;
@@ -49,17 +55,20 @@ const WRAPPER_KEYS = new Set(["columns", "primaryKey"]);
 /** @internal */
 function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
   // The wrapper and the legacy `Record<colName, ColumnSpec>` shape both
-  // permit a key called `columns`, so discrimination has to lean on
-  // structural signals. Rule:
-  //   1. `columns` must be present and an object (not a string ColumnSpec).
-  //   2. Every other top-level key must be a recognised wrapper meta key
-  //      (currently only `primaryKey`). A legacy table almost always has
-  //      additional column names alongside any `columns` column, so this
-  //      cleanly separates the two without inspecting nested values —
-  //      important because the wrapper's columns map can include a column
-  //      named `type` (STI), which collides with the ColumnSpec object
-  //      shape.
+  // permit a key called `columns`, so discrimination needs an unambiguous
+  // signal. We use the presence of `primaryKey` — the wrapper's sole
+  // purpose is to set a table-level PK, so making it required also
+  // collapses the only ambiguity: a legacy single-column table
+  // `{ columns: { type: "string" } }` is structurally identical to a
+  // wrapper with one column named `type`, but it cannot have `primaryKey`,
+  // so it stays unambiguously legacy.
+  //
+  // Rule:
+  //   1. `primaryKey` is present.
+  //   2. `columns` is present and an object map.
+  //   3. No other top-level keys.
   if (!table || typeof table !== "object") return false;
+  if (!("primaryKey" in table)) return false;
   const candidate = (table as { columns?: unknown }).columns;
   if (!candidate || typeof candidate !== "object") return false;
   for (const key of Object.keys(table)) {
@@ -195,7 +204,7 @@ export async function defineSchema(
           if (spec.limit !== undefined) options["limit"] = spec.limit;
           if (spec.null !== undefined) options["null"] = spec.null;
           if (spec.default !== undefined) options["default"] = spec.default;
-          if (spec.primary && !Array.isArray(pk)) {
+          if (spec.primary && pk === undefined) {
             options["primaryKey"] = true;
           }
         }

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -44,15 +44,27 @@ export interface DefineSchemaOpts {
 }
 
 /** @internal */
+const WRAPPER_KEYS = new Set(["columns", "primaryKey"]);
+
+/** @internal */
 function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
-  // Discriminate strictly: only treat as wrapper when `columns` is an object
-  // map — otherwise a legacy column literally named "columns" (with a string
-  // or column-spec value) would be mis-parsed as the wrapper shape.
+  // The wrapper and the legacy `Record<colName, ColumnSpec>` shape both
+  // permit a key called `columns`, so discrimination has to lean on
+  // structural signals. Rule:
+  //   1. `columns` must be present and an object (not a string ColumnSpec).
+  //   2. Every other top-level key must be a recognised wrapper meta key
+  //      (currently only `primaryKey`). A legacy table almost always has
+  //      additional column names alongside any `columns` column, so this
+  //      cleanly separates the two without inspecting nested values —
+  //      important because the wrapper's columns map can include a column
+  //      named `type` (STI), which collides with the ColumnSpec object
+  //      shape.
   if (!table || typeof table !== "object") return false;
   const candidate = (table as { columns?: unknown }).columns;
   if (!candidate || typeof candidate !== "object") return false;
-  // A ColumnSpec object has a `type` key; the wrapper's `columns` map does not.
-  if ("type" in (candidate as object)) return false;
+  for (const key of Object.keys(table)) {
+    if (!WRAPPER_KEYS.has(key)) return false;
+  }
   return true;
 }
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -26,7 +26,9 @@ export type ColumnSpec =
       primary?: boolean;
     };
 
-export type TableSchema = Record<string, ColumnSpec>;
+export type TableSchema =
+  | Record<string, ColumnSpec>
+  | { columns: Record<string, ColumnSpec>; primaryKey?: string | string[] | false };
 export type Schema = Record<string, TableSchema>;
 
 export interface DefineSchemaOpts {
@@ -34,10 +36,27 @@ export interface DefineSchemaOpts {
 }
 
 /** @internal */
+function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
+  if (table && typeof table === "object" && "columns" in table && !("type" in table)) {
+    return (table as { columns: Record<string, ColumnSpec> }).columns;
+  }
+  return table as Record<string, ColumnSpec>;
+}
+
+/** @internal */
+function primaryKeyOf(table: TableSchema): string | string[] | false | undefined {
+  if (table && typeof table === "object" && "columns" in table && !("type" in table)) {
+    return (table as { primaryKey?: string | string[] | false }).primaryKey;
+  }
+  return undefined;
+}
+
+/** @internal */
 function resolveReferences(schema: Schema): string[] {
   const refs = new Map<string, Set<string>>();
-  for (const [table, columns] of Object.entries(schema)) {
+  for (const [table, raw] of Object.entries(schema)) {
     refs.set(table, new Set());
+    const columns = columnsOf(raw);
     for (const spec of Object.values(columns)) {
       if (typeof spec === "object" && spec.references) {
         if (spec.references in schema && spec.references !== table) {
@@ -131,8 +150,19 @@ export async function defineSchema(
   }
 
   for (const table of order) {
-    const columns = schema[table];
-    await ss.createTable(table, (t) => {
+    const raw = schema[table];
+    const columns = columnsOf(raw);
+    const pk = primaryKeyOf(raw);
+    const createOpts: Record<string, unknown> = {};
+    if (pk === false) createOpts["id"] = false;
+    else if (Array.isArray(pk)) {
+      createOpts["primaryKey"] = pk;
+      createOpts["id"] = false;
+    } else if (typeof pk === "string") {
+      createOpts["primaryKey"] = pk;
+      createOpts["id"] = false;
+    }
+    await ss.createTable(table, createOpts, (t) => {
       for (const [colName, spec] of Object.entries(columns)) {
         const primitive: PrimitiveColumnSpec = typeof spec === "string" ? spec : spec.type;
         const arType = typeMap[primitive];
@@ -141,7 +171,9 @@ export async function defineSchema(
           if (spec.limit !== undefined) options["limit"] = spec.limit;
           if (spec.null !== undefined) options["null"] = spec.null;
           if (spec.default !== undefined) options["default"] = spec.default;
-          if (spec.primary) options["primaryKey"] = true;
+          if (spec.primary && !Array.isArray(pk) && typeof pk !== "string") {
+            options["primaryKey"] = true;
+          }
         }
         // MySQL DATETIME without precision = DATETIME(0), which rejects fractional
         // seconds. Default to DATETIME(6) so test schemas accept microseconds.

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -69,6 +69,11 @@ function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
   //   3. No other top-level keys.
   if (!table || typeof table !== "object") return false;
   if (!("primaryKey" in table)) return false;
+  const pk = (table as { primaryKey?: unknown }).primaryKey;
+  // Validate primaryKey is the wrapper-shaped value; otherwise this is a
+  // legacy table that happens to have a column called `primaryKey`.
+  if (pk !== false && !Array.isArray(pk)) return false;
+  if (Array.isArray(pk) && !pk.every((v) => typeof v === "string")) return false;
   const candidate = (table as { columns?: unknown }).columns;
   if (!candidate || typeof candidate !== "object") return false;
   for (const key of Object.keys(table)) {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -194,11 +194,11 @@ export async function defineSchema(
     const raw = schema[table];
     const columns = columnsOf(raw);
     const pk = primaryKeyOf(raw);
-    const createOpts: Record<string, unknown> = {};
-    if (pk === false) createOpts["id"] = false;
+    const createOpts: { id?: boolean; primaryKey?: string[] } = {};
+    if (pk === false) createOpts.id = false;
     else if (Array.isArray(pk)) {
-      createOpts["primaryKey"] = pk;
-      createOpts["id"] = false;
+      createOpts.primaryKey = pk;
+      createOpts.id = false;
     }
     await ss.createTable(table, createOpts, (t) => {
       for (const [colName, spec] of Object.entries(columns)) {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -29,10 +29,12 @@ export type ColumnSpec =
 export interface WrappedTableSchema {
   columns: Record<string, ColumnSpec>;
   /**
-   * Table-level primary key. `string[]` builds a composite PK constraint and
-   * suppresses the auto-`id` column. `false` builds the table without a PK.
-   * `string` is not supported — use the matching column with `primary: true`
-   * via the legacy shape, or pass `[name]` for a single-column composite.
+   * Table-level primary key. `string[]` builds a composite PK constraint
+   * over the listed columns (which are also marked NOT NULL, matching
+   * Rails semantics — SQLite otherwise lets NULLs slip through composite
+   * PKs). `false` builds the table without a PK. A single-string form is
+   * intentionally not supported — pass `[name]` for a single-column
+   * non-`id` primary key.
    *
    * Required: this is the disambiguator that separates the wrapper shape
    * from the legacy `Record<colName, ColumnSpec>` shape. Without it, a
@@ -200,6 +202,7 @@ export async function defineSchema(
       createOpts.primaryKey = pk;
       createOpts.id = false;
     }
+    const compositePkCols = Array.isArray(pk) ? new Set(pk) : null;
     await ss.createTable(table, createOpts, (t) => {
       for (const [colName, spec] of Object.entries(columns)) {
         const primitive: PrimitiveColumnSpec = typeof spec === "string" ? spec : spec.type;
@@ -212,6 +215,13 @@ export async function defineSchema(
           if (spec.primary && pk === undefined) {
             options["primaryKey"] = true;
           }
+        }
+        // Columns participating in a composite PK are NOT NULL, matching
+        // Rails semantics. SQLite otherwise lets NULLs into composite-PK
+        // columns (long-known quirk), which would let invalid fixtures
+        // persist.
+        if (compositePkCols?.has(colName)) {
+          options["null"] = false;
         }
         // MySQL DATETIME without precision = DATETIME(0), which rejects fractional
         // seconds. Default to DATETIME(6) so test schemas accept microseconds.

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -26,9 +26,17 @@ export type ColumnSpec =
       primary?: boolean;
     };
 
-export type TableSchema =
-  | Record<string, ColumnSpec>
-  | { columns: Record<string, ColumnSpec>; primaryKey?: string | string[] | false };
+export interface WrappedTableSchema {
+  columns: Record<string, ColumnSpec>;
+  /**
+   * Table-level primary key. `string[]` builds a composite PK constraint and
+   * suppresses the auto-`id` column. `false` builds the table without a PK.
+   * `string` is not supported — use the matching column with `primary: true`
+   * via the legacy shape, or pass `[name]` for a single-column composite.
+   */
+  primaryKey?: string[] | false;
+}
+export type TableSchema = Record<string, ColumnSpec> | WrappedTableSchema;
 export type Schema = Record<string, TableSchema>;
 
 export interface DefineSchemaOpts {
@@ -36,19 +44,26 @@ export interface DefineSchemaOpts {
 }
 
 /** @internal */
-function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
-  if (table && typeof table === "object" && "columns" in table && !("type" in table)) {
-    return (table as { columns: Record<string, ColumnSpec> }).columns;
-  }
-  return table as Record<string, ColumnSpec>;
+function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
+  // Discriminate strictly: only treat as wrapper when `columns` is an object
+  // map — otherwise a legacy column literally named "columns" (with a string
+  // or column-spec value) would be mis-parsed as the wrapper shape.
+  if (!table || typeof table !== "object") return false;
+  const candidate = (table as { columns?: unknown }).columns;
+  if (!candidate || typeof candidate !== "object") return false;
+  // A ColumnSpec object has a `type` key; the wrapper's `columns` map does not.
+  if ("type" in (candidate as object)) return false;
+  return true;
 }
 
 /** @internal */
-function primaryKeyOf(table: TableSchema): string | string[] | false | undefined {
-  if (table && typeof table === "object" && "columns" in table && !("type" in table)) {
-    return (table as { primaryKey?: string | string[] | false }).primaryKey;
-  }
-  return undefined;
+function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
+  return isWrappedSchema(table) ? table.columns : (table as Record<string, ColumnSpec>);
+}
+
+/** @internal */
+function primaryKeyOf(table: TableSchema): string[] | false | undefined {
+  return isWrappedSchema(table) ? table.primaryKey : undefined;
 }
 
 /** @internal */
@@ -158,9 +173,6 @@ export async function defineSchema(
     else if (Array.isArray(pk)) {
       createOpts["primaryKey"] = pk;
       createOpts["id"] = false;
-    } else if (typeof pk === "string") {
-      createOpts["primaryKey"] = pk;
-      createOpts["id"] = false;
     }
     await ss.createTable(table, createOpts, (t) => {
       for (const [colName, spec] of Object.entries(columns)) {
@@ -171,7 +183,7 @@ export async function defineSchema(
           if (spec.limit !== undefined) options["limit"] = spec.limit;
           if (spec.null !== undefined) options["null"] = spec.null;
           if (spec.default !== undefined) options["default"] = spec.default;
-          if (spec.primary && !Array.isArray(pk) && typeof pk !== "string") {
+          if (spec.primary && !Array.isArray(pk)) {
             options["primaryKey"] = true;
           }
         }

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -22,7 +22,10 @@ const files = execSync(`find ${root} -name '*.test.ts' -type f`, { encoding: "ut
 const offenders: string[] = [];
 for (const f of files) {
   const src = readFileSync(f, "utf8");
-  if (!/class\s+\w+\s+extends\s+Base\b/.test(src)) continue;
+  // Match both named declarations (`class Foo extends Base`) and anonymous
+  // class expressions (`class extends Base` — typically assigned to a const
+  // or returned from a factory, as in encryption/test-helpers.ts).
+  if (!/class(?:\s+\w+)?\s+extends\s+Base\b/.test(src)) continue;
   if (/\bdefineSchema\s*\(/.test(src)) continue;
   offenders.push(f);
 }

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -57,12 +57,14 @@ const files = allTs.filter((f) => {
  * identifier-presence matching.
  */
 function stripCommentsAndStrings(src: string): string {
+  // Strings first — otherwise a `//` inside a URL or other quoted literal
+  // would be mistaken for a line comment and chop off the rest of the line.
   return src
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/.*$/gm, "")
     .replace(/`(?:\\.|[^`\\])*`/g, "``")
     .replace(/'(?:\\.|[^'\\])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""');
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
 }
 
 const offenders: string[] = [];

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -14,24 +14,41 @@ import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 
 const root = "packages/activerecord/src";
-// Scan both *.test.ts files and shared test-helper modules, since helpers
-// like encryption/test-helpers.ts define model factories used by tests
-// under AR_NO_AUTO_SCHEMA=1. Helper files don't call defineSchema
-// themselves (the tests that consume them do), so we only flag a helper
-// when no sibling test file imports it AND ensures schema — but at minimum
-// surfacing them lets the migrator see what factories still need wiring.
-const files = execSync(
-  `find ${root} \\( -name '*.test.ts' -o -name 'test-helpers.ts' -o -path '*/test-helpers/*.ts' \\) -type f`,
-  { encoding: "utf8" },
-)
+// Scan every .ts file under src/. In trails, nothing in production code
+// extends `Base` directly (Base IS the library class), so any file that
+// matches the `extends Base` pattern is by definition test or test-helper
+// infrastructure that participates in the schema lifecycle. The shared
+// helpers (encryption/test-helpers.ts, test-fixtures.ts, adapters/.../
+// schema-ar-models.ts, etc.) get flagged the same way as *.test.ts files.
+//
+// A helper flagged here doesn't necessarily fail under AR_NO_AUTO_SCHEMA=1
+// on its own — it fails when a consuming test runs without setting up
+// schema for the helper's models. The audit is intentionally conservative:
+// it surfaces every place a model class is declared without a sibling
+// defineSchema, leaving wiring decisions to the migrator. The actual
+// Phase 5 completion gate is `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` going
+// green; this script is a best-effort triage aid, not a soundness proof.
+const allTs = execSync(`find ${root} -name '*.ts' -type f`, { encoding: "utf8" })
   .trim()
   .split("\n")
-  .filter(Boolean)
-  // The schema helper itself defines defineSchema and contains literal
-  // mentions; exclude it (and its test) so the audit doesn't flag its own
-  // implementation file.
-  .filter((f) => !f.endsWith("/test-helpers/define-schema.ts"))
-  .filter((f) => !f.endsWith("/test-helpers/drop-all-tables.ts"));
+  .filter(Boolean);
+
+const files = allTs.filter((f) => {
+  // The schema helper and the drop helper legitimately reference these
+  // identifiers in their own implementations — skip them.
+  if (f.endsWith("/test-helpers/define-schema.ts")) return false;
+  if (f.endsWith("/test-helpers/drop-all-tables.ts")) return false;
+  // Static fixture files used as compiler inputs by the type-virtualization
+  // / tsc-wrapper test rigs aren't consumed as live models by Vitest —
+  // they exist to be parsed/emitted, not executed against an adapter.
+  if (/\/__fixtures__\//.test(f)) return false;
+  if (/\/type-virtualization\/fixtures\//.test(f)) return false;
+  // model-codegen.ts emits class strings; its matches are inside templates
+  // that the comment/string stripper handles, but excluding it explicitly
+  // is cheaper and clearer.
+  if (f.endsWith("/model-codegen.ts")) return false;
+  return true;
+});
 
 /**
  * Strip line comments, block comments, and string literals so a commented-
@@ -51,10 +68,13 @@ function stripCommentsAndStrings(src: string): string {
 const offenders: string[] = [];
 for (const f of files) {
   const src = stripCommentsAndStrings(readFileSync(f, "utf8"));
-  // Match both named declarations (`class Foo extends Base`) and anonymous
-  // class expressions (`class extends Base` — typically assigned to a const
-  // or returned from a factory, as in encryption/test-helpers.ts).
-  if (!/class(?:\s+\w+)?\s+extends\s+Base\b/.test(src)) continue;
+  // Match named declarations (`class Foo extends Base`), anonymous class
+  // expressions (`class extends Base` — typically returned from a factory),
+  // and qualified / cast forms (`class Foo extends (FreshBase as typeof
+  // Base)`, `class Contact extends (targets.Base as any)`). The character
+  // class `[^{(]` after the optional `(` keeps us from greedily reaching
+  // into a class body if no Base reference exists.
+  if (!/class(?:\s+\w+)?\s+extends\s+\(?[^{(]*?\bBase\b/.test(src)) continue;
   if (/\bdefineSchema\s*\(/.test(src)) continue;
   offenders.push(f);
 }

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -19,9 +19,24 @@ const files = execSync(`find ${root} -name '*.test.ts' -type f`, { encoding: "ut
   .split("\n")
   .filter(Boolean);
 
+/**
+ * Strip line comments, block comments, and string literals so a commented-
+ * out `defineSchema(...)` or a string mentioning it doesn't make the file
+ * look compliant. Cheap regex pass — not a real parser, but adequate for
+ * identifier-presence matching.
+ */
+function stripCommentsAndStrings(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "")
+    .replace(/`(?:\\.|[^`\\])*`/g, "``")
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""');
+}
+
 const offenders: string[] = [];
 for (const f of files) {
-  const src = readFileSync(f, "utf8");
+  const src = stripCommentsAndStrings(readFileSync(f, "utf8"));
   // Match both named declarations (`class Foo extends Base`) and anonymous
   // class expressions (`class extends Base` — typically assigned to a const
   // or returned from a factory, as in encryption/test-helpers.ts).

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -14,10 +14,24 @@ import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 
 const root = "packages/activerecord/src";
-const files = execSync(`find ${root} -name '*.test.ts' -type f`, { encoding: "utf8" })
+// Scan both *.test.ts files and shared test-helper modules, since helpers
+// like encryption/test-helpers.ts define model factories used by tests
+// under AR_NO_AUTO_SCHEMA=1. Helper files don't call defineSchema
+// themselves (the tests that consume them do), so we only flag a helper
+// when no sibling test file imports it AND ensures schema — but at minimum
+// surfacing them lets the migrator see what factories still need wiring.
+const files = execSync(
+  `find ${root} \\( -name '*.test.ts' -o -name 'test-helpers.ts' -o -path '*/test-helpers/*.ts' \\) -type f`,
+  { encoding: "utf8" },
+)
   .trim()
   .split("\n")
-  .filter(Boolean);
+  .filter(Boolean)
+  // The schema helper itself defines defineSchema and contains literal
+  // mentions; exclude it (and its test) so the audit doesn't flag its own
+  // implementation file.
+  .filter((f) => !f.endsWith("/test-helpers/define-schema.ts"))
+  .filter((f) => !f.endsWith("/test-helpers/drop-all-tables.ts"));
 
 /**
  * Strip line comments, block comments, and string literals so a commented-

--- a/scripts/audit-define-schema.ts
+++ b/scripts/audit-define-schema.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+/**
+ * Phase 5 audit — list activerecord test files that declare models
+ * (via `class X extends Base`) but do not call `defineSchema`. The
+ * absence is a strong indicator the file relies on the auto-derived
+ * schema in `test-adapter.ts` and will not pass under
+ * `AR_NO_AUTO_SCHEMA=1`.
+ *
+ * Usage: `pnpm tsx scripts/audit-define-schema.ts`
+ *
+ * Exits non-zero when offenders exist so CI can gate on completion.
+ */
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const root = "packages/activerecord/src";
+const files = execSync(`find ${root} -name '*.test.ts' -type f`, { encoding: "utf8" })
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+const offenders: string[] = [];
+for (const f of files) {
+  const src = readFileSync(f, "utf8");
+  if (!/class\s+\w+\s+extends\s+Base\b/.test(src)) continue;
+  if (/\bdefineSchema\s*\(/.test(src)) continue;
+  offenders.push(f);
+}
+
+if (offenders.length === 0) {
+  console.log("OK: every activerecord test file with `extends Base` calls defineSchema().");
+  process.exit(0);
+}
+
+console.log(
+  `Phase 5 offenders: ${offenders.length} test file(s) declare models without defineSchema().`,
+);
+for (const f of offenders) console.log(`  ${f}`);
+process.exit(1);


### PR DESCRIPTION
## Summary

Phase 5 of `docs/tm-unification-plan.md` — start of universal `defineSchema(adapter, {...})` adoption so test files no longer rely on the lazy schema-derivation path in `SchemaAdapter`.

**Status: partial.** Parent requested a single mega-PR rather than the doc-recommended per-directory split. This PR migrates 32 test files (the smaller ones and complete `scoping/` cluster); 68 of the original 100 `AR_NO_AUTO_SCHEMA=1` failures remain. See "Remaining work" below.

## What's in this PR

- 32 test files migrated to call `defineSchema()` in `beforeEach` (or use a shared lazy-init pattern when the file declares model classes at describe-scope rather than inside tests). All migrated files pass under `AR_NO_AUTO_SCHEMA=1`.
- `defineSchema` API extended to support composite primary keys via a new wrapped shape `{ columns: {...}, primaryKey: string[] | false }`. `primaryKey` is **required** on the wrapper shape — it is the disambiguator that separates the wrapper from the legacy `Record<colName, ColumnSpec>` shape. `primaryKey: string[]` builds a composite PK constraint; `primaryKey: false` suppresses the auto-`id` column. A single-string `primaryKey` is intentionally **not** supported — use `[name]` for a single-column composite, or the legacy per-column `{ type: "...", primary: true }` shape. If you do not need to override the PK, use the legacy shape; the discriminator validates the `primaryKey` value before classifying, so legacy tables with columns literally named `columns` and/or `primaryKey` round-trip correctly.
- New audit script: `scripts/audit-define-schema.ts` (`pnpm tsx scripts/audit-define-schema.ts`). Reports test files that declare `class X extends Base` without calling `defineSchema`. Currently flags 117 files; the delta over the AR_NO_AUTO_SCHEMA=1 failure list comes from tests that declare models against mock/fake adapters or use MigrationContext directly.

### Files migrated

| Cluster | Files |
| --- | --- |
| root | clone, inherited, modules |
| coders | json |
| relation | and, annotations, composite-where, delegation, delete-all, merging, mutation, or, order, select, select-star-join-collision, structural-compatibility, thenable, update-all, where-chain, where-clause, with |
| scoping | default-scoping, named-scoping, relation-scoping |
| associations | association-relation, association-scope-cache, bidirectional-destroy-dependencies, collection-proxy-count, habtm, has-many-through, loader-methods, required |

### Migration pattern

Two shapes appear in this PR:

1. **Per-test setup** (default):
```ts
let adapter: DatabaseAdapter;
beforeEach(async () => {
  adapter = createTestAdapter();
  await defineSchema(adapter, { posts: { title: "string" } });
});
```

2. **Module-level lazy + cached adapter** for files that declare model classes at describe-scope (so `adapter` must exist at module-load time):
```ts
let _adapter: DatabaseAdapter = createTestAdapter();
beforeEach(async () => {
  _adapter = createTestAdapter();
  await defineSchema(_adapter, { /* ... */ });
});
function freshAdapter(): DatabaseAdapter { return _adapter; }
```

3. **Wrapped shape** for composite PKs (and STI / no-PK tables):
```ts
await defineSchema(adapter, {
  comp_orders: {
    columns: { shop_id: "integer", order_number: "integer", name: "string" },
    primaryKey: ["shop_id", "order_number"],
  },
});
```

## Remaining work (~68 files)

Large files deferred (size + complex schema): `associations/{association-scope,inverse-associations,callbacks,cascaded-eager-loading,extension,collection-proxy,source-type-validation,eager,has-many-associations,has-many-through-associations,has-one-associations,inner-join-association,left-outer-join-association,nested-through-associations,disable-joins-*}.test.ts`, `autosave-association`, `autosave`, `attribute-methods`, `attributes`, the `base.test.ts`-adjacent cluster (`batches`, `cache-key`, `calculations`, `callbacks`, `core`, `counter-cache`, `enum`, `finder`, `insert-all`, `instrumentation`, `invertible-migration`, `locking`, `migration`, `nested-attributes`, `persistence`, `primary-keys`, `query-cache`, `readonly`, `reflection`, `secure-password`, `signed-id`, `strict-loading`, `transaction-callbacks`, `validations`, `validations/uniqueness-validation`), the giant `relation/where.test.ts` (2062 LOC, 45 namespaced tables), and the `encryption/*` cluster which shares model factories in `test-helpers.ts` and is best migrated together by extending the helper rather than per-call-site.

The plan doc itself recommends splitting Phase 5 into per-directory PRs ≤300 LOC each. Recommend following that for the remainder.

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` on each migrated file passes
- [x] `defineSchema` helper has unit coverage for composite PK, `primaryKey: false`, STI columns-map with `type` column, and the columns-named-`columns` corner case
- [ ] CI green across PG / MySQL / SQLite
- [ ] `pnpm tsx scripts/audit-define-schema.ts` reports zero offenders (currently 117 — gating until Phase 5 completes)

## Notes

- Plan doc: `docs/tm-unification-plan.md` Part 2 "Phase 5 — Universal defineSchema adoption".
- No changes to `test-adapter.ts` — recovery-path removal is Phase 7, not part of this PR.
