### PR TITLE
feat(activerecord): MySQL schema Slot C — fixtures + qualified table_name

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -99,7 +99,9 @@ describeIfMysql("Mysql2Adapter", () => {
     it("data source exists?", async () => {
       await defineSchema(adapter, { topics: { title: "string" } });
       try {
-        expect(await adapter.dataSourceExists("topics")).toBe(true);
+        const db = await currentDatabase(adapter);
+        // Rails passes @omgpost.table_name, which is the qualified `db.topics` form.
+        expect(await adapter.dataSourceExists(`${db}.topics`)).toBe(true);
       } finally {
         await adapter.dropTable("topics", { ifExists: true });
       }
@@ -112,18 +114,18 @@ describeIfMysql("Mysql2Adapter", () => {
 
     it("dump indexes", async () => {
       await adapter.dropTable("key_tests", { ifExists: true });
-      await adapter.createTable("key_tests", { force: true }, (t: any) => {
-        t.string("awesome");
-        t.string("pizza");
-        t.string("snack");
-      });
-      await adapter.addIndex("key_tests", ["snack"], { name: "index_key_tests_on_snack" });
-      await adapter.addIndex("key_tests", ["pizza"], { name: "index_key_tests_on_pizza" });
-      await adapter.addIndex("key_tests", ["awesome"], {
-        name: "index_key_tests_on_awesome",
-        type: "fulltext",
-      });
       try {
+        await adapter.createTable("key_tests", { force: true }, (t: any) => {
+          t.string("awesome");
+          t.string("pizza");
+          t.string("snack");
+        });
+        await adapter.addIndex("key_tests", ["snack"], { name: "index_key_tests_on_snack" });
+        await adapter.addIndex("key_tests", ["pizza"], { name: "index_key_tests_on_pizza" });
+        await adapter.addIndex("key_tests", ["awesome"], {
+          name: "index_key_tests_on_awesome",
+          type: "fulltext",
+        });
         const indexes = (await adapter.indexes("key_tests")).sort((a, b) =>
           a.name.localeCompare(b.name),
         );

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -96,16 +96,18 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    it("data source exists", async () => {
+    it("data source exists?", async () => {
       await defineSchema(adapter, { topics: { title: "string" } });
       try {
-        const db = await currentDatabase(adapter);
         expect(await adapter.dataSourceExists("topics")).toBe(true);
-        expect(await adapter.dataSourceExists(`${db}.topics`)).toBe(true);
-        expect(await adapter.dataSourceExists(`${db}.zomg`)).toBe(false);
       } finally {
         await adapter.dropTable("topics", { ifExists: true });
       }
+    });
+
+    it("data source exists wrong schema", async () => {
+      const db = await currentDatabase(adapter);
+      expect(await adapter.dataSourceExists(`${db}.zomg`)).toBe(false);
     });
 
     it("dump indexes", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -3,6 +3,14 @@
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { defineSchema } from "../../test-helpers/define-schema.js";
+import { defineFixtures } from "../../test-helpers/define-fixtures.js";
+
+async function currentDatabase(adapter: Mysql2Adapter): Promise<string> {
+  const rows = (await adapter.execute("SELECT DATABASE() AS db")) as Array<{ db: string }>;
+  return rows[0]!.db;
+}
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -47,22 +55,87 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
-    it.skip("schema", () => {
-      // BLOCKED: slot-c-fixtures — requires posts table (qualified db.table_name)
-      // loaded by Slot C fixture infrastructure; not present in base test DB
+    it("schema", async () => {
+      await defineSchema(adapter, {
+        posts: { title: "string", body: "text", type: "string" },
+      });
+      try {
+        class Post extends Base {
+          static _tableName = "posts";
+        }
+        Post.attribute("id", "integer");
+        Post.attribute("title", "string");
+        Post.attribute("body", "text");
+        Post.adapter = adapter;
+        await defineFixtures(adapter, Post, {
+          welcome: { title: "Welcome to the weblog", body: "Such a lovely day", type: "Post" },
+        });
+
+        const db = await currentDatabase(adapter);
+        class OmgPost extends Base {
+          static _tableName = `${db}.posts`;
+        }
+        OmgPost.inheritanceColumn = "disabled";
+        OmgPost.attribute("id", "integer");
+        OmgPost.attribute("title", "string");
+        OmgPost.adapter = adapter;
+
+        const first = await (OmgPost as any).first();
+        expect(first).toBeTruthy();
+      } finally {
+        await adapter.dropTable("posts", { ifExists: true });
+      }
     });
 
-    it.skip("primary key", () => {
-      // BLOCKED: slot-c-fixtures — requires topics fixture table from Slot C
+    it("primary key", async () => {
+      await defineSchema(adapter, { topics: { title: "string" } });
+      try {
+        expect(await adapter.primaryKey("topics")).toBe("id");
+      } finally {
+        await adapter.dropTable("topics", { ifExists: true });
+      }
     });
 
-    it.skip("data source exists", () => {
-      // BLOCKED: slot-c-fixtures — requires topics fixture table from Slot C
+    it("data source exists", async () => {
+      await defineSchema(adapter, { topics: { title: "string" } });
+      try {
+        const db = await currentDatabase(adapter);
+        expect(await adapter.dataSourceExists("topics")).toBe(true);
+        expect(await adapter.dataSourceExists(`${db}.topics`)).toBe(true);
+        expect(await adapter.dataSourceExists(`${db}.zomg`)).toBe(false);
+      } finally {
+        await adapter.dropTable("topics", { ifExists: true });
+      }
     });
 
-    it.skip("dump indexes", () => {
-      // BLOCKED: slot-c-fixtures — requires key_tests fixture table from Slot C
-      // (index_key_tests_on_snack/pizza = btree, index_key_tests_on_awesome = fulltext)
+    it("dump indexes", async () => {
+      await adapter.dropTable("key_tests", { ifExists: true });
+      await adapter.createTable("key_tests", { force: true }, (t: any) => {
+        t.string("awesome");
+        t.string("pizza");
+        t.string("snack");
+      });
+      await adapter.addIndex("key_tests", ["snack"], { name: "index_key_tests_on_snack" });
+      await adapter.addIndex("key_tests", ["pizza"], { name: "index_key_tests_on_pizza" });
+      await adapter.addIndex("key_tests", ["awesome"], {
+        name: "index_key_tests_on_awesome",
+        type: "fulltext",
+      });
+      try {
+        const indexes = (await adapter.indexes("key_tests")).sort((a, b) =>
+          a.name.localeCompare(b.name),
+        );
+        expect(indexes).toHaveLength(3);
+        const byName = (n: string) => indexes.find((i) => i.name === n)!;
+        expect(byName("index_key_tests_on_snack").using).toBe("btree");
+        expect(byName("index_key_tests_on_snack").type).toBeUndefined();
+        expect(byName("index_key_tests_on_pizza").using).toBe("btree");
+        expect(byName("index_key_tests_on_pizza").type).toBeUndefined();
+        expect(byName("index_key_tests_on_awesome").using).toBeUndefined();
+        expect(byName("index_key_tests_on_awesome").type).toBe("fulltext");
+      } finally {
+        await adapter.dropTable("key_tests", { ifExists: true });
+      }
     });
 
     it("drop temporary table", async () => {


### PR DESCRIPTION
## Summary

Closes the MySQL schema cluster (Slot C from `docs/activerecord-100-clusters.md`).

Unskips 4 tests in `adapters/abstract-mysql-adapter/schema.test.ts` that mirror Rails' `abstract_mysql_adapter/schema_test.rb`:

- **schema** — creates `posts` table via `defineSchema`, inserts a fixture row via `defineFixtures`, then queries through a `Base` subclass whose `table_name` is qualified as `\`db.posts\`` (mirrors Rails' `Class.new(ActiveRecord::Base) { self.table_name = "#{db}.#{table}" }`). Verifies cross-database table reference works through the adapter's `parseMysqlName` + `quoteTableName` path.
- **primary key** — `adapter.primaryKey("topics")` returns `"id"`.
- **data source exists** — covers unqualified, qualified, and wrong-schema cases.
- **dump indexes** — creates `key_tests` with two btree indexes and one fulltext, verifies `using` / `type` discrimination through `adapter.indexes()`.

`lessons_students` / `students` fixtures from the prompt are intentionally omitted — they're only consumed by `MySQLAnsiQuotesTest`, which is still BLOCKED on session-variable test-setup wiring (unrelated to this cluster).

## Test plan

- [ ] CI `mysql2` job: 4 previously-skipped `SchemaTest` tests now pass.
- [ ] CI `mysql2` job: `float limits` (skip-on-MariaDB) and `drop temporary table` still pass.
- [ ] Non-mysql jobs: file remains excluded.