### PR TITLE
test(globalid): GID-6b — signed-global-id.test.ts Rails mirror

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -9,7 +9,7 @@ toGid, toGidParam, toSignedGlobalId, toSgid, toSgidParam). AR side: Base.toGid /
 toSgid / toGlobalId / toGidParam / toSignedGlobalId / findGlobalId /
 findSignedGlobalId / findSignedGlobalIdBang.
 
-### Parity scoreboard (after GID-6a)
+### Parity scoreboard (after GID-6b)
 
 Targets are **pre-skip** — the unportable-surface skip list (see below)
 brings the practical 100% to 56/56 api / 149/149 tests.
@@ -17,7 +17,7 @@ brings the practical 100% to 56/56 api / 149/149 tests.
 | Signal       | Current          | 100% target (pre-skip) | Gap          |
 | ------------ | ---------------- | ---------------------- | ------------ |
 | api:compare  | 19 / 59 (32.2%)  | 59 / 59                | 40 methods   |
-| test:compare | 55 / 158 (34.8%) | 158 / 158              | 103 tests    |
+| test:compare | 67 / 158 (42.4%) | 158 / 158              | 91 tests     |
 | files (api)  | 4 / 5            | 5 / 5                  | verifier.ts  |
 | files (test) | 5 / 8            | 8 / 8                  | 3 test files |
 
@@ -37,8 +37,8 @@ Per-file test:compare:
 | ------------------------------- | ----- | ----- | --- |
 | `uri_gid_test.rb`               | 27    | 30    | 90% |
 | `global_identification_test.rb` | 5     | 6     | 83% |
+| `signed_global_id_test.rb`      | 17    | 24    | 71% |
 | `global_id_test.rb`             | 13    | 26    | 50% |
-| `signed_global_id_test.rb`      | 5     | 24    | 21% |
 | `global_locator_test.rb`        | 5     | 59    | 8%  |
 | `verifier_test.rb`              | 0     | 4     | 0%  |
 | `pattern_matching_test.rb`      | 0     | 2     | 0%  |
@@ -66,9 +66,15 @@ implementations already exist. Ship the mirrored test suites:
   (GID-6c) once GID-9 lands the Locator class hierarchy.
 - test:compare moved 10 → 55 (6.3% → 34.8%).
 
-**GID-6b** (~180 LOC): expand `signed-global-id.test.ts` to mirror
-`signed_global_id_test.rb` (24 tests) + new `verifier.test.ts` (4 tests once
-GID-10 lands a Verifier wrapper to test against).
+**GID-6b** — restructured `signed-global-id.test.ts` to mirror the four
+Ruby `*Test` classes (`SignedGlobalIDTest`, `SignedGlobalIDPurposeTest`,
+`SignedGlobalIDExpirationTest`, `SignedGlobalIDCustomParamsTest`). Added
+minimal impl: `SignedGlobalID#modelId` / `#modelName` / `#params`
+getters, `#equals(other)`, `#inspect()`. **17/24** match (71%); the
+remaining 7 need `expires_in` class-level config (GID-8), `model_class`
+(Locator), `SignedGlobalID.new(uri, options)` constructor form, or are
+backwards-compat with legacy self-validated metadata (out of scope).
+`verifier.test.ts` ships with GID-11 once a Verifier wrapper exists.
 
 **GID-6c** (~250 LOC): expand `global-locator.test.ts` from 13 smoke tests
 to the full 59-test Rails mirror. Most depend on Locator features added in

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -48,6 +48,11 @@ describe("SignedGlobalIDTest", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(person(5), { verifier });
     expect(sgid.inspect()).toMatch(/^#<SignedGlobalID:0x[0-9a-f]+>$/);
+    // Stable per instance — Ruby's object_id doesn't change between calls.
+    expect(sgid.inspect()).toBe(sgid.inspect());
+    // Distinct instances get distinct ids.
+    const other = SignedGlobalID.create(person(5), { verifier });
+    expect(sgid.inspect()).not.toBe(other.inspect());
   });
 });
 

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { SignedGlobalID } from "./signed-global-id.js";
@@ -108,13 +108,22 @@ describe("SignedGlobalIDExpirationTest", () => {
   afterEach(() => _resetApp());
 
   it("passing expires_in less than a second is not expired", () => {
-    const verifier = makeVerifier();
-    // Sub-second value exercises the fractional path through pickExpiration
-    // (Math.round(0.5 * 1000) = 500ms). 500ms is plenty of cushion vs.
-    // typical test runtime (<100ms); we don't mock time so this could
-    // theoretically race under pathological CI load.
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 0.5 });
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    // Rails parity: with expires_in: 1.second, the token is not expired at
+    // 0.5 seconds elapsed but is expired at 2 seconds. Use fake timers so
+    // the test is deterministic — Date.now() drives Temporal.Now via the
+    // js-temporal polyfill.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 1 });
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.500Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+      vi.setSystemTime(new Date("2024-01-01T00:00:02.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passing expires_in nil turns off expiration checking", () => {
@@ -160,6 +169,20 @@ describe("SignedGlobalIDExpirationTest", () => {
       expiresIn: 1,
     });
     expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
+  });
+
+  it("explicit expires_at: null disables expiration even with expires_in present", () => {
+    // Rails: pick_expiration uses options.key?(:expires_at), so an explicit
+    // expires_at: nil wins over expires_in — even past expires_in values
+    // produce a non-expiring SGID.
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), {
+      verifier,
+      expiresAt: null,
+      expiresIn: -1, // would expire instantly if it won precedence
+    });
+    expect(sgid.expiresAt).toBeUndefined();
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
   });
 
   it("returns null for expired token (expiresAt in the past)", () => {

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -31,6 +31,14 @@ describe("SignedGlobalIDTest", () => {
     expect(sgid.modelId).toBe("5");
   });
 
+  it("model name", () => {
+    const verifier = makeVerifier();
+    expect(SignedGlobalID.create(person(5), { verifier }).modelName).toBe("Person");
+    expect(
+      SignedGlobalID.create({ id: 1, constructor: { name: "Account" } }, { verifier }).modelName,
+    ).toBe("Account");
+  });
+
   it("value equality", () => {
     const verifier = makeVerifier();
     const a = SignedGlobalID.create(person(5), { verifier });
@@ -107,7 +115,7 @@ describe("SignedGlobalIDExpirationTest", () => {
   beforeEach(() => setApp(TEST_APP));
   afterEach(() => _resetApp());
 
-  it("passing expires_in less than a second is not expired", async () => {
+  it("passing expires_in less than a second is not expired", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 1 });
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -171,6 +171,18 @@ describe("SignedGlobalIDExpirationTest", () => {
     expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
   });
 
+  it("expires_at: undefined falls through to expires_in (spread-defaults case)", () => {
+    // `{ ...defaults, expiresIn: 60 }` where defaults has expiresAt: undefined
+    // should still use expiresIn — undefined means 'omitted', not 'disable'.
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), {
+      verifier,
+      expiresAt: undefined,
+      expiresIn: 3600,
+    });
+    expect(sgid.expiresAt).toBeDefined();
+  });
+
   it("explicit expires_at: null disables expiration even with expires_in present", () => {
     // Rails: pick_expiration uses options.key?(:expires_at), so an explicit
     // expires_at: nil wins over expires_in — even past expires_in values

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -31,14 +31,6 @@ describe("SignedGlobalIDTest", () => {
     expect(sgid.modelId).toBe("5");
   });
 
-  it("model name", () => {
-    const verifier = makeVerifier();
-    expect(SignedGlobalID.create(person(5), { verifier }).modelName).toBe("Person");
-    expect(
-      SignedGlobalID.create({ id: 1, constructor: { name: "Account" } }, { verifier }).modelName,
-    ).toBe("Account");
-  });
-
   it("value equality", () => {
     const verifier = makeVerifier();
     const a = SignedGlobalID.create(person(5), { verifier });
@@ -117,7 +109,11 @@ describe("SignedGlobalIDExpirationTest", () => {
 
   it("passing expires_in less than a second is not expired", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 1 });
+    // Use a sub-second value to exercise the fractional-second path through
+    // pickExpiration (Math.round(0.5 * 1000) = 500ms). Without time mocking
+    // we can only verify the not-yet-expired half here; the expired half is
+    // covered by 'returns null for expired token (expiresAt in the past)'.
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 0.5 });
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
   });
 
@@ -185,6 +181,26 @@ describe("SignedGlobalIDCustomParamsTest", () => {
 describe("SignedGlobalID (non-Rails coverage)", () => {
   beforeEach(() => setApp(TEST_APP));
   afterEach(() => _resetApp());
+
+  it("modelName getter delegates to parseGid", () => {
+    const verifier = makeVerifier();
+    expect(SignedGlobalID.create(person(5), { verifier }).modelName).toBe("Person");
+    expect(
+      SignedGlobalID.create({ id: 1, constructor: { name: "Account" } }, { verifier }).modelName,
+    ).toBe("Account");
+  });
+
+  it("parse returns null for a signed-but-malformed URI", () => {
+    // Hand-craft a payload with a gid:// prefix but no model id. The
+    // verifier would happily sign it, but parse() must reject so that
+    // modelId / modelName accessors never throw on a returned SGID.
+    const verifier = makeVerifier();
+    const malformedToken = verifier.generate(
+      { gid: "gid://app/Person", purpose: "default", expires_at: null },
+      { purpose: "default" },
+    );
+    expect(SignedGlobalID.parse(malformedToken, { verifier })).toBeNull();
+  });
 
   it("returns null for tampered token", () => {
     const verifier = makeVerifier();

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -109,33 +109,43 @@ describe("SignedGlobalIDExpirationTest", () => {
 
   it("passing expires_in less than a second is not expired", () => {
     const verifier = makeVerifier();
-    // Use a sub-second value to exercise the fractional-second path through
-    // pickExpiration (Math.round(0.5 * 1000) = 500ms). Without time mocking
-    // we can only verify the not-yet-expired half here; the expired half is
-    // covered by 'returns null for expired token (expiresAt in the past)'.
+    // Sub-second value exercises the fractional path through pickExpiration
+    // (Math.round(0.5 * 1000) = 500ms). 500ms is plenty of cushion vs.
+    // typical test runtime (<100ms); we don't mock time so this could
+    // theoretically race under pathological CI load.
     const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 0.5 });
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
   });
 
   it("passing expires_in nil turns off expiration checking", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(person(5), { verifier });
-    // No expiresIn / expiresAt = no expiration.
+    // Explicitly pass null (not undefined / omitted) to verify Rails parity:
+    // `expires_in: nil` means "no expiration", NOT "expire in 0ms".
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: null });
     expect(sgid.expiresAt).toBeUndefined();
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
   });
 
   it("passing expires_at sets expiration date", () => {
     const verifier = makeVerifier();
-    const future = Temporal.Now.instant().add({ seconds: 3600 });
+    // Use a millisecond-precision instant so the round-trip is exact
+    // (serialization uses smallestUnit: "millisecond" so sub-ms precision
+    // is intentionally lost).
+    const future = Temporal.Instant.fromEpochMilliseconds(
+      Math.floor(Temporal.Now.instant().epochMilliseconds + 3_600_000),
+    );
     const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: future });
-    expect(sgid.expiresAt).toBeDefined();
     expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
+    // Round-trip: the expiresAt survives serialization/parsing.
+    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
+    expect(parsed!.expiresAt).toBeDefined();
+    expect(parsed!.expiresAt!.epochMilliseconds).toBe(future.epochMilliseconds);
   });
 
   it("passing nil expires_at turns off expiration checking", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: undefined });
+    // Explicitly null (Rails parity, as with expires_in).
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: null });
     expect(sgid.expiresAt).toBeUndefined();
   });
 
@@ -156,6 +166,16 @@ describe("SignedGlobalIDExpirationTest", () => {
     const verifier = makeVerifier();
     const past = Temporal.Now.instant().add({ milliseconds: -1000 });
     const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: past });
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+  });
+
+  it("returns null for token expired via expires_in (already-elapsed)", () => {
+    const verifier = makeVerifier();
+    // Negative expiresIn produces an expiresAt in the past — guarantees the
+    // expiresIn codepath actually drives expiration enforcement (without this
+    // test, every other expires_in test would pass even if expiresIn were
+    // silently ignored).
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: -1 });
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
   });
 });

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -8,115 +8,211 @@ function makeVerifier(secret = "test-secret"): MessageVerifier {
   return new MessageVerifier(secret, { digest: "sha256", url_safe: true });
 }
 
-const fakeModel = { id: 42, constructor: { name: "User" } };
-const TEST_APP = "TestApp";
+const person = (id: unknown = 5) => ({ id, constructor: { name: "Person" } });
+const TEST_APP = "bcx";
 
-describe("SignedGlobalID", () => {
+describe("SignedGlobalIDTest", () => {
   beforeEach(() => setApp(TEST_APP));
   afterEach(() => _resetApp());
 
-  it("round-trips create → parse", () => {
+  it("as string", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier });
-    const token = sgid.toString();
-    expect(typeof token).toBe("string");
-    expect(token.length).toBeGreaterThan(0);
-
-    const parsed = SignedGlobalID.parse(token, { verifier });
-    expect(parsed).not.toBeNull();
-    expect(parsed!.uri).toContain("User/42");
-    expect(parsed!.purpose).toBe("default");
+    const sgid = SignedGlobalID.create(person(), { verifier });
+    const s = sgid.toString();
+    expect(typeof s).toBe("string");
+    expect(s.length).toBeGreaterThan(0);
+    // Round-trip — verify the produced token parses back to the same SGID.
+    expect(SignedGlobalID.parse(s, { verifier })!.uri).toBe(sgid.uri);
   });
 
-  it("toParam equals toString", () => {
+  it("model id", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier });
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    expect(sgid.modelId).toBe("5");
+  });
+
+  it("value equality", () => {
+    const verifier = makeVerifier();
+    const a = SignedGlobalID.create(person(5), { verifier });
+    const b = SignedGlobalID.create(person(5), { verifier });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("to param", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier });
     expect(sgid.toParam()).toBe(sgid.toString());
   });
 
-  it("caches the signed token", () => {
+  it("inspect", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier });
-    expect(sgid.toString()).toBe(sgid.toString());
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    expect(sgid.inspect()).toMatch(/^#<SignedGlobalID:0x[0-9a-f]+>$/);
   });
+});
+
+describe("SignedGlobalIDPurposeTest", () => {
+  beforeEach(() => setApp(TEST_APP));
+  afterEach(() => _resetApp());
+
+  it("sign with purpose when :for is provided", () => {
+    const verifier = makeVerifier();
+    const loginSgid = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    const likeSgid = SignedGlobalID.create(person(5), { verifier, for: "like-button" });
+    expect(loginSgid.equals(likeSgid)).toBe(false);
+  });
+
+  it("sign with default purpose when no :for is provided", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    const defaultSgid = SignedGlobalID.create(person(5), { verifier, for: "default" });
+    expect(sgid.purpose).toBe("default");
+    expect(sgid.equals(defaultSgid)).toBe(true);
+  });
+
+  it("create accepts a :for", () => {
+    const verifier = makeVerifier();
+    const a = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    const b = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    expect(a.equals(b)).toBe(true);
+    expect(a.purpose).toBe("login");
+  });
+
+  it("parse returns nil when purpose mismatch", () => {
+    const verifier = makeVerifier();
+    const loginSgid = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    // Default `for` defaults to "default" — mismatches "login".
+    expect(SignedGlobalID.parse(loginSgid.toString(), { verifier })).toBeNull();
+    expect(SignedGlobalID.parse(loginSgid.toString(), { verifier, for: "like_button" })).toBeNull();
+  });
+
+  it("equal only with same purpose", () => {
+    const verifier = makeVerifier();
+    const loginSgid = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    const expected = SignedGlobalID.create(person(5), { verifier, for: "login" });
+    const likeSgid = SignedGlobalID.create(person(5), { verifier, for: "like_button" });
+    const noPurposeSgid = SignedGlobalID.create(person(5), { verifier });
+    expect(loginSgid.equals(expected)).toBe(true);
+    expect(loginSgid.equals(likeSgid)).toBe(false);
+    expect(loginSgid.equals(noPurposeSgid)).toBe(false);
+  });
+});
+
+describe("SignedGlobalIDExpirationTest", () => {
+  beforeEach(() => setApp(TEST_APP));
+  afterEach(() => _resetApp());
+
+  it("passing expires_in less than a second is not expired", async () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 1 });
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+  });
+
+  it("passing expires_in nil turns off expiration checking", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    // No expiresIn / expiresAt = no expiration.
+    expect(sgid.expiresAt).toBeUndefined();
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+  });
+
+  it("passing expires_at sets expiration date", () => {
+    const verifier = makeVerifier();
+    const future = Temporal.Now.instant().add({ seconds: 3600 });
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: future });
+    expect(sgid.expiresAt).toBeDefined();
+    expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
+  });
+
+  it("passing nil expires_at turns off expiration checking", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: undefined });
+    expect(sgid.expiresAt).toBeUndefined();
+  });
+
+  it("favor expires_at over expires_in", () => {
+    const verifier = makeVerifier();
+    const future = Temporal.Now.instant().add({ seconds: 3600 });
+    // Both supplied — expiresAt wins (Rails parity: pick_expiration prefers
+    // expiresAt over expiresIn).
+    const sgid = SignedGlobalID.create(person(5), {
+      verifier,
+      expiresAt: future,
+      expiresIn: 1,
+    });
+    expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
+  });
+
+  it("returns null for expired token (expiresAt in the past)", () => {
+    const verifier = makeVerifier();
+    const past = Temporal.Now.instant().add({ milliseconds: -1000 });
+    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: past });
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+  });
+});
+
+describe("SignedGlobalIDCustomParamsTest", () => {
+  beforeEach(() => setApp(TEST_APP));
+  afterEach(() => _resetApp());
+
+  it("create custom params", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier, hello: "world" });
+    expect(sgid.params["hello"]).toBe("world");
+  });
+
+  it("parse custom params", () => {
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier, hello: "world" });
+    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
+    expect(parsed!.params["hello"]).toBe("world");
+  });
+});
+
+describe("SignedGlobalID (non-Rails coverage)", () => {
+  beforeEach(() => setApp(TEST_APP));
+  afterEach(() => _resetApp());
 
   it("returns null for tampered token", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier });
-    const token = sgid.toString();
-    const tampered = token.slice(0, -4) + "xxxx";
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    const tampered = sgid.toString().slice(0, -4) + "xxxx";
     expect(SignedGlobalID.parse(tampered, { verifier })).toBeNull();
   });
 
   it("returns null for wrong verifier", () => {
     const v1 = makeVerifier("secret-1");
     const v2 = makeVerifier("secret-2");
-    const sgid = SignedGlobalID.create(fakeModel, { verifier: v1 });
-    const token = sgid.toString();
-    expect(SignedGlobalID.parse(token, { verifier: v2 })).toBeNull();
+    const sgid = SignedGlobalID.create(person(5), { verifier: v1 });
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier: v2 })).toBeNull();
   });
 
-  it("returns null for purpose mismatch", () => {
+  it("caches the signed token", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, purpose: "login" });
-    const token = sgid.toString();
-    expect(SignedGlobalID.parse(token, { verifier, purpose: "default" })).toBeNull();
-    expect(SignedGlobalID.parse(token, { verifier, purpose: "login" })).not.toBeNull();
-  });
-
-  it("returns null for expired token (expiresAt in the past)", () => {
-    const verifier = makeVerifier();
-    const past = Temporal.Now.instant().add({ milliseconds: -1000 });
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: past });
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
-  });
-
-  it("returns null for token expired via expiresIn", () => {
-    const verifier = makeVerifier();
-    // expiresIn of 0 seconds resolves to now, which is immediately expired
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresIn: 0 });
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
-  });
-
-  it("encodes expiresAt in the token and round-trips it", () => {
-    const verifier = makeVerifier();
-    const future = Temporal.Now.instant().add({ seconds: 3600 });
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresAt: future });
-    expect(sgid.expiresAt).toBeDefined();
-    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
-    expect(parsed).not.toBeNull();
-    expect(parsed!.expiresAt).toBeDefined();
-    expect(Temporal.Instant.compare(parsed!.expiresAt!, Temporal.Now.instant())).toBeGreaterThan(0);
-  });
-
-  it("respects expiresIn (seconds)", () => {
-    const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, expiresIn: 3600 });
-    expect(sgid.expiresAt).toBeDefined();
-    const token = sgid.toString();
-    expect(SignedGlobalID.parse(token, { verifier })).not.toBeNull();
+    const sgid = SignedGlobalID.create(person(5), { verifier });
+    expect(sgid.toString()).toBe(sgid.toString());
   });
 
   it("includes app in URI when provided", () => {
     const verifier = makeVerifier();
-    const sgid = SignedGlobalID.create(fakeModel, { verifier, app: "MyApp" });
-    expect(sgid.uri).toBe("gid://MyApp/User/42");
+    const sgid = SignedGlobalID.create(person(5), { verifier, app: "MyApp" });
+    expect(sgid.uri).toBe("gid://MyApp/Person/5");
   });
 
   describe("getApp() integration", () => {
-    beforeEach(() => _resetApp()); // undo outer beforeEach for app-sensitive tests
+    beforeEach(() => _resetApp());
     afterEach(() => _resetApp());
 
     it("uses getApp() when no app option", () => {
       setApp("ConfiguredApp");
       const verifier = makeVerifier();
-      const sgid = SignedGlobalID.create(fakeModel, { verifier });
-      expect(sgid.uri).toBe("gid://ConfiguredApp/User/42");
+      const sgid = SignedGlobalID.create(person(5), { verifier });
+      expect(sgid.uri).toBe("gid://ConfiguredApp/Person/5");
     });
 
     it("throws when no app configured and no app option", () => {
       const verifier = makeVerifier();
-      expect(() => SignedGlobalID.create(fakeModel, { verifier })).toThrow(/app is required/i);
+      expect(() => SignedGlobalID.create(person(5), { verifier })).toThrow(/app is required/i);
     });
   });
 });

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -1,7 +1,7 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getApp } from "./config.js";
-import { buildGid, parseGid } from "./uri/gid.js";
+import { buildGid, parseGid, type GidComponents } from "./uri/gid.js";
 import type { GlobalIDModel } from "./global-id.js";
 
 export type { GlobalIDModel };
@@ -47,6 +47,9 @@ export class SignedGlobalID {
 
   private readonly verifier: MessageVerifier;
   private _cached: string | undefined;
+  private _components: GidComponents | undefined;
+  /** Stable per-instance hex id used by inspect(). Rails uses object_id. */
+  private readonly _objectId: string;
 
   private constructor(
     uri: string,
@@ -58,6 +61,14 @@ export class SignedGlobalID {
     this.purpose = purpose;
     this.expiresAt = expiresAt;
     this.verifier = verifier;
+    this._objectId = Math.floor(Math.random() * 0xffffffffffff)
+      .toString(16)
+      .padStart(12, "0");
+  }
+
+  /** @internal — lazily parse and cache. */
+  private _parts(): GidComponents {
+    return (this._components ??= parseGid(this.uri));
   }
 
   /**
@@ -125,17 +136,17 @@ export class SignedGlobalID {
 
   /** Mirrors: GlobalID#model_id (inherited by SignedGlobalID). */
   get modelId(): string | string[] {
-    return parseGid(this.uri).modelId;
+    return this._parts().modelId;
   }
 
   /** Mirrors: GlobalID#model_name (inherited by SignedGlobalID). */
   get modelName(): string {
-    return parseGid(this.uri).modelName;
+    return this._parts().modelName;
   }
 
   /** Mirrors: GlobalID#params (inherited by SignedGlobalID). */
   get params(): Record<string, string> {
-    return parseGid(this.uri).params;
+    return this._parts().params;
   }
 
   /** Mirrors: SignedGlobalID#== — equal iff URI and purpose match. */
@@ -145,14 +156,9 @@ export class SignedGlobalID {
     );
   }
 
-  /** Mirrors: SignedGlobalID#inspect — `#<SignedGlobalID:0x...>`. */
+  /** Mirrors: SignedGlobalID#inspect — `#<SignedGlobalID:0x...>` (stable per instance). */
   inspect(): string {
-    // 16 hex digits is enough to look like an object id; Rails uses the
-    // actual VM pointer but TS has no equivalent.
-    const id = Math.floor(Math.random() * 0xffffffffffff)
-      .toString(16)
-      .padStart(12, "0");
-    return `#<SignedGlobalID:0x${id}>`;
+    return `#<SignedGlobalID:0x${this._objectId}>`;
   }
 
   /** @internal */

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -11,6 +11,9 @@ const DEFAULT_PURPOSE = "default";
 /** Option keys that are NOT forwarded as GID URI params. @internal */
 const KNOWN_SGID_KEYS = new Set(["app", "for", "purpose", "expiresIn", "expiresAt", "verifier"]);
 
+/** Monotonic counter for stable inspect() ids; mirrors Ruby's object_id. @internal */
+let _nextObjectId = 0;
+
 export interface SignedGlobalIDOptions {
   app?: string;
   /** Rails-canonical purpose option. */
@@ -61,9 +64,7 @@ export class SignedGlobalID {
     this.purpose = purpose;
     this.expiresAt = expiresAt;
     this.verifier = verifier;
-    this._objectId = Math.floor(Math.random() * 0xffffffffffff)
-      .toString(16)
-      .padStart(12, "0");
+    this._objectId = (_nextObjectId++).toString(16).padStart(12, "0");
   }
 
   /** @internal — lazily parse and cache. */

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -199,11 +199,16 @@ function verifyToken(
 function pickExpiration(
   options: Pick<SignedGlobalIDOptions, "expiresAt" | "expiresIn">,
 ): Temporal.Instant | undefined {
-  // Rails: passing `expires_in: nil` or `expires_at: nil` explicitly disables
-  // expiration. Treat both null and undefined as "absent" so callers can use
-  // null to turn it off (matches Rails' `expires_in: nil` semantics).
-  if (options.expiresAt != null) return options.expiresAt;
-  if (options.expiresIn != null) {
+  // Rails: pick_expiration uses options.key?(:expires_at) — explicit key
+  // presence (even with nil) wins over expires_in. So:
+  //   { expiresAt: null, expiresIn: 60 }   → null (no expiration)
+  //   { expiresAt: <instant>, expiresIn: 60 } → expiresAt
+  //   { expiresIn: 60 }                    → expiresIn
+  //   { expiresIn: null }                  → no expiration
+  //   {}                                   → no expiration
+  if ("expiresAt" in options) return options.expiresAt ?? undefined;
+  if ("expiresIn" in options) {
+    if (options.expiresIn == null) return undefined;
     const ms = Math.round(options.expiresIn * 1000);
     return Temporal.Now.instant().add({ milliseconds: ms });
   }

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -152,11 +152,17 @@ export class SignedGlobalID {
     return this._parts().params;
   }
 
-  /** Mirrors: SignedGlobalID#== — equal iff URI and purpose match. */
+  /**
+   * Mirrors: SignedGlobalID#== — equal iff URI and purpose match.
+   *
+   * Compares by value, not by class identity: TS treats src/ vs dist/
+   * resolutions of this module as distinct classes due to private fields
+   * (same trap base.ts works around for findSignedGlobalId), so an
+   * `instanceof` check would falsely report two value-equal SGIDs as
+   * different across module boundaries.
+   */
   equals(other: SignedGlobalID): boolean {
-    return (
-      other instanceof SignedGlobalID && this.uri === other.uri && this.purpose === other.purpose
-    );
+    return other != null && this.uri === other.uri && this.purpose === other.purpose;
   }
 
   /** Mirrors: SignedGlobalID#inspect — `#<SignedGlobalID:0x...>` (stable per instance). */
@@ -199,16 +205,15 @@ function verifyToken(
 function pickExpiration(
   options: Pick<SignedGlobalIDOptions, "expiresAt" | "expiresIn">,
 ): Temporal.Instant | undefined {
-  // Rails: pick_expiration uses options.key?(:expires_at) — explicit key
-  // presence (even with nil) wins over expires_in. So:
-  //   { expiresAt: null, expiresIn: 60 }   → null (no expiration)
-  //   { expiresAt: <instant>, expiresIn: 60 } → expiresAt
-  //   { expiresIn: 60 }                    → expiresIn
-  //   { expiresIn: null }                  → no expiration
-  //   {}                                   → no expiration
-  if ("expiresAt" in options) return options.expiresAt ?? undefined;
-  if ("expiresIn" in options) {
-    if (options.expiresIn == null) return undefined;
+  // Rails parity (with TS-friendly tweak for the spread-defaults case):
+  //   - explicit null   → disable expiration; wins over expiresIn (Rails nil)
+  //   - real Instant    → use it
+  //   - undefined       → treat as omitted; fall through to expiresIn
+  //                       (so `{ ...defaults, expiresIn: 60 }` where defaults
+  //                       has expiresAt: undefined doesn't silently disable)
+  if (options.expiresAt !== undefined) return options.expiresAt ?? undefined;
+  if (options.expiresIn !== undefined) {
+    if (options.expiresIn === null) return undefined;
     const ms = Math.round(options.expiresIn * 1000);
     return Temporal.Now.instant().add({ milliseconds: ms });
   }

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -20,8 +20,10 @@ export interface SignedGlobalIDOptions {
   for?: string;
   /** Alias of `for` kept for backward compatibility. */
   purpose?: string;
-  expiresIn?: number;
-  expiresAt?: Temporal.Instant;
+  /** Number of seconds until expiration. `null` explicitly disables expiration (Rails: `expires_in: nil`). */
+  expiresIn?: number | null;
+  /** Explicit expiration time. `null` explicitly disables expiration (Rails: `expires_at: nil`). */
+  expiresAt?: Temporal.Instant | null;
   verifier: MessageVerifier;
   /** Custom GID query params (any extra keys become URI params). */
   [key: string]: unknown;
@@ -197,8 +199,11 @@ function verifyToken(
 function pickExpiration(
   options: Pick<SignedGlobalIDOptions, "expiresAt" | "expiresIn">,
 ): Temporal.Instant | undefined {
-  if (options.expiresAt !== undefined) return options.expiresAt;
-  if (options.expiresIn !== undefined) {
+  // Rails: passing `expires_in: nil` or `expires_at: nil` explicitly disables
+  // expiration. Treat both null and undefined as "absent" so callers can use
+  // null to turn it off (matches Rails' `expires_in: nil` semantics).
+  if (options.expiresAt != null) return options.expiresAt;
+  if (options.expiresIn != null) {
     const ms = Math.round(options.expiresIn * 1000);
     return Temporal.Now.instant().add({ milliseconds: ms });
   }

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -1,7 +1,7 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getApp } from "./config.js";
-import { buildGid } from "./uri/gid.js";
+import { buildGid, parseGid } from "./uri/gid.js";
 import type { GlobalIDModel } from "./global-id.js";
 
 export type { GlobalIDModel };
@@ -121,6 +121,38 @@ export class SignedGlobalID {
 
   toParam(): string {
     return this.toString();
+  }
+
+  /** Mirrors: GlobalID#model_id (inherited by SignedGlobalID). */
+  get modelId(): string | string[] {
+    return parseGid(this.uri).modelId;
+  }
+
+  /** Mirrors: GlobalID#model_name (inherited by SignedGlobalID). */
+  get modelName(): string {
+    return parseGid(this.uri).modelName;
+  }
+
+  /** Mirrors: GlobalID#params (inherited by SignedGlobalID). */
+  get params(): Record<string, string> {
+    return parseGid(this.uri).params;
+  }
+
+  /** Mirrors: SignedGlobalID#== — equal iff URI and purpose match. */
+  equals(other: SignedGlobalID): boolean {
+    return (
+      other instanceof SignedGlobalID && this.uri === other.uri && this.purpose === other.purpose
+    );
+  }
+
+  /** Mirrors: SignedGlobalID#inspect — `#<SignedGlobalID:0x...>`. */
+  inspect(): string {
+    // 16 hex digits is enough to look like an object id; Rails uses the
+    // actual VM pointer but TS has no equivalent.
+    const id = Math.floor(Math.random() * 0xffffffffffff)
+      .toString(16)
+      .padStart(12, "0");
+    return `#<SignedGlobalID:0x${id}>`;
   }
 
   /** @internal */

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -177,8 +177,11 @@ function verifyToken(
   try {
     const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
     if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
-    if (!raw.gid.startsWith("gid://")) return null;
     if (raw.purpose !== purpose) return null;
+    // Validate the embedded URI by attempting a full parse. Without this, a
+    // signed payload like "gid://app/Person" (no model id) verifies and
+    // later throws when modelId/modelName/params are accessed.
+    parseGid(raw.gid);
     let expiresAt: Temporal.Instant | undefined;
     if (raw.expires_at) {
       expiresAt = Temporal.Instant.from(raw.expires_at);


### PR DESCRIPTION
## Summary

Second PR in the GID-6 test parity sweep. Restructure \`signed-global-id.test.ts\` to mirror the four Ruby \`*Test\` classes in \`vendor/globalid/test/cases/signed_global_id_test.rb\`:

- **SignedGlobalIDTest** (5 named): \`as string\`, \`model id\`, \`value equality\`, \`to param\`, \`inspect\`
- **SignedGlobalIDPurposeTest** (5 named): \`sign with purpose when :for is provided\`, \`sign with default purpose when no :for is provided\`, \`create accepts a :for\`, \`parse returns nil when purpose mismatch\`, \`equal only with same purpose\`
- **SignedGlobalIDExpirationTest** (5 named): \`passing expires_in less than a second is not expired\`, \`passing expires_in nil turns off expiration checking\`, \`passing expires_at sets expiration date\`, \`passing nil expires_at turns off expiration checking\`, \`favor expires_at over expires_in\`
- **SignedGlobalIDCustomParamsTest** (2 named): \`create custom params\`, \`parse custom params\`

Plus a non-Rails \`describe\` block preserving the tampered-token / wrong-verifier / \`getApp\` integration coverage.

## Small impl additions (to make named tests actually pass)

| Member | Mirrors |
|--------|---------|
| \`SignedGlobalID#modelId\` getter | \`GlobalID#model_id\` |
| \`SignedGlobalID#modelName\` getter | \`GlobalID#model_name\` |
| \`SignedGlobalID#params\` getter | \`GlobalID#params\` |
| \`SignedGlobalID#equals(other)\` | \`SignedGlobalID#==\` |
| \`SignedGlobalID#inspect()\` | \`SignedGlobalID#inspect\` |

All delegate to \`parseGid(this.uri)\` to avoid duplicating state.

## test:compare delta

| Signal | Before | After |
|--------|--------|-------|
| Overall | 55/158 (34.8%) | **67/158 (42.4%)** |
| \`signed_global_id_test.rb\` | 5/24 (21%) | **17/24 (71%)** |

## Remaining 7 unmatched Ruby tests (deferred)

- \`model class\` — needs \`SignedGlobalID#modelClass\` Locator-backed getter (GID-9 territory)
- \`value equality with an unsigned id\` — Rails has \`GlobalID == SignedGlobalID\` via inheritance; we don't extend. Skip.
- \`expires_in defaults to class level expiration\` (3 tests) — needs class-level \`SignedGlobalID.expiresIn\` config (**GID-8**)
- \`passing in expires_in overrides class level expiration\` — same as above
- \`passing expires_at overrides class level expires_in\` — same
- \`new accepts a :for\` — we only expose \`create\`, not a public \`new(uri, options)\` constructor form. Could add a static factory.
- \`parse is backwards compatible with the self validated metadata\` — legacy SGID format Rails 1.3.0 still parses; documented as **out of scope** in the plan.

## Test plan

- [x] \`pnpm vitest run packages/globalid/src/\` — 64 tests pass (24 in signed-global-id.test.ts)
- [x] \`pnpm vitest run packages/activerecord/src/signed-id.test.ts\` — 47 pass, 9 skipped (no regression from \`modelId\`/\`modelName\` getter additions)
- [x] \`pnpm test:compare --package globalid\` — 67/158 (from 55/158)