### PR TITLE
fix(activerecord): PG interval — cast-aware numeric default extraction

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -125,7 +125,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // emits intervals via the generic `t.column(...)` helper, so accept
       // either spelling so long as the default round-trips as "P3Y".
       expect(output).toMatch(
-        /t\.(?:interval|column)\("default_term",(?:\s*"interval"(?:\([^)]*\))?,)?\s*\{[^}]*default:\s*"P3Y"/,
+        /t\.interval\("default_term",\s*\{[^}]*default:\s*"P3Y"|t\.column\("default_term",\s*"interval"(?:\([^)]*\))?,\s*\{[^}]*default:\s*"P3Y"/,
       );
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -125,7 +125,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // emits intervals via the generic `t.column(...)` helper, so accept
       // either spelling so long as the default round-trips as "P3Y".
       expect(output).toMatch(
-        /t\.(?:interval|column)\("default_term",\s*"interval"(?:\([^)]*\))?,\s*\{[^}]*default:\s*"P3Y"/,
+        /t\.(?:interval|column)\("default_term",(?:\s*"interval"(?:\([^)]*\))?,)?\s*\{[^}]*default:\s*"P3Y"/,
       );
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Duration } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -115,19 +116,17 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((avg as Duration).iso8601()).toBe("P3Y2M");
     });
 
-    it.skip("schema dump with default value", async () => {
-      // BLOCKED: pg_get_expr returns the interval default as a bare numeric
-      //   (e.g. "94670856") even with `intervalstyle = iso_8601` set on the
-      //   session — the SET only affects SELECT/aggregate output, not the
-      //   pg_attrdef-stored expression text reconstructed by pg_get_expr.
-      // ROOT-CAUSE: splitPgDefault matches the bare numeric branch and
-      //   passes "94670856" to Interval.deserialize, which Duration.parse
-      //   rejects (not ISO 8601). The Column ends up with literal=null but
-      //   the dumper falls back to the raw value and emits `default: 94670856`.
-      // SCOPE: needs a coordinated fix in splitPgDefault (cast-aware
-      //   numeric→Duration conversion for interval columns) plus matching
-      //   adjustments in Interval.castValue/serialize so the seconds form
-      //   round-trips. ~50 LOC, deferred to a focused follow-up.
+    it("schema dump with default value", async () => {
+      // Mirrors Rails test_schema_dump_with_default_value: the default
+      // value "P3Y" should round-trip through schema dump as
+      //   t.interval "default_term", default: "P3Y"
+      const output = await SchemaDumper.dumpTableSchema(adapter, "interval_data_types");
+      // Rails dumps as `t.interval "default_term", default: "P3Y"`; our DSL
+      // emits intervals via the generic `t.column(...)` helper, so accept
+      // either spelling so long as the default round-trips as "P3Y".
+      expect(output).toMatch(
+        /t\.(?:interval|column)\("default_term",\s*"interval"(?:\([^)]*\))?,\s*\{[^}]*default:\s*"P3Y"/,
+      );
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -37,9 +37,12 @@ export class Interval extends ValueType<Duration> {
         return Duration.parse(value);
       } catch {
         // Mirrors Rails: rescue ISO8601Parser::ParsingError → nil. Our
-        // PG adapter sets `intervalstyle = iso_8601` per session so AVG,
-        // SELECT, and pg_get_expr default expressions all arrive in ISO
-        // 8601 form — Duration.parse handles them directly.
+        // PG adapter sets `intervalstyle = iso_8601` per session so AVG
+        // and SELECT interval results arrive in ISO 8601 form that
+        // Duration.parse accepts directly. For schema reflection,
+        // pg_get_expr returns a casted form like `'P3Y'::interval`; the
+        // adapter's splitPgDefault strips the cast before this method
+        // sees `"P3Y"`.
         return null;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -37,11 +37,9 @@ export class Interval extends ValueType<Duration> {
         return Duration.parse(value);
       } catch {
         // Mirrors Rails: rescue ISO8601Parser::ParsingError → nil. Our
-        // PG adapter sets `intervalstyle = iso_8601` per session so AVG
-        // and SELECT interval results arrive in ISO 8601 form. (Note:
-        // pg_get_expr does NOT honour intervalstyle for interval defaults
-        // — that path needs separate handling, see the deferred
-        // "schema dump with default value" test in interval.test.ts.)
+        // PG adapter sets `intervalstyle = iso_8601` per session so AVG,
+        // SELECT, and pg_get_expr default expressions all arrive in ISO
+        // 8601 form — Duration.parse handles them directly.
         return null;
       }
     }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -20,6 +20,7 @@ import type { SchemaStatements } from "./connection-adapters/abstract/schema-sta
 import { assertSchemaAdapter } from "./connection-adapters/abstract/assert-schema-adapter.js";
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { Duration } from "@blazetrails/activesupport";
 
 // Lazy-load schema-introspection to break the static cycle
 // (schema-dumper -> schema-introspection -> schema-statements ->
@@ -320,6 +321,11 @@ export function cleanRawPgExpression(raw: string): unknown {
  */
 export function cleanDefault(raw: unknown): unknown {
   if (raw === null || raw === undefined) return raw;
+  // Interval/Duration round-trips through schema dump as its ISO-8601 form.
+  // Without this branch, Duration.toString() yields seconds — e.g. P3Y →
+  // "94670856" — and the numeric coercion below would emit `default: 94670856`.
+  // Mirrors Rails OID::Interval#type_cast_for_schema → serialize(value).inspect.
+  if (raw instanceof Duration) return raw.iso8601();
   const str = String(raw);
 
   // Delegate raw PG expressions (contain a type cast or are expression defaults)


### PR DESCRIPTION
## Summary

- Un-skips the `interval.test.ts > schema dump with default value` test deferred in #1567 (PG interval cluster Slot B follow-up).
- Roots out a misdiagnosis: `pg_get_expr` *does* honour `SET intervalstyle = iso_8601` (verified against PostgreSQL 17), so the bare-numeric-default theory in the BLOCKED comment was wrong. The actual bug was in `SchemaDumper.cleanDefault`: `String(Duration{years:3})` returns `"94670856"` (Duration.toString → total seconds), which then matched the numeric coercion branch and emitted `default: 94670856` instead of `default: "P3Y"`.

## Fix

- `schema-dumper.ts cleanDefault`: detect `Duration` and return `iso8601()` — mirrors Rails `OID::Interval#type_cast_for_schema → serialize(value).inspect`.
- Corrects stale comment in `postgresql/oid/interval.ts` that claimed pg_get_expr ignored intervalstyle.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapters/postgresql/interval.test.ts` (TEST_ADAPTER=postgresql) — 5 passed, 2 still skipped (Slot B round-trip — separate issue).
- [x] `pnpm typecheck` clean.