### PR TITLE
feat(activerecord): PG-schema Slot A followup — indexes() INCLUDE columns + nullsNotDistinct un-skips

### DIFF
--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -320,13 +320,9 @@ Slot D was 2 notification un-skips. Gap 8 (process-fork lifecycle) was a phantom
 
 ---
 
-## PG-schema audit cluster (~50 LOC followup remaining)
+## PG-schema audit cluster (closed)
 
-Slots A (#1504 indexes() opclass + nulls order), B (#1458 INHERITS + #1469 comment/partition), and C (#1469 schema-qualified createJoinTable) closed.
-
-- **Slot A followup** (~50 LOC) — `indexes()` `columns` array includes INCLUDE column names (PG11+ stores them in `indkey`); switch to `ix.indnkeyatts` to limit subquery to key columns, fetch INCLUDE separately. Plus the 3 `SchemaIndexNullsNotDistinctTest` tests still skipped because they need the same try/finally + dumpTable scaffolding the un-skipped tests in #1504 got.
-
-Plus: `setSchemaSearchPath` unquoted-`$user` rejection + 5 fixture-model gaps (`Thing1..5`, `Song`/`Album` habtm) — small enough to bundle with the followup.
+Slots A (#1504 indexes() opclass + nulls order), B (#1458 INHERITS + #1469 comment/partition), C (#1469 schema-qualified createJoinTable), and Slot A followup (`indexes()` INCLUDE column filtering via `ix.indnkeyatts`) all closed. The 3 `SchemaIndexNullsNotDistinctTest` tests, `setSchemaSearchPath` unquoted-`$user` rejection, and Thing1..5 / Song-Album fixture-model gaps were resolved by prior Slot H-b work (#1592 / #1618).
 
 ## Unknown-triage cluster (~640 LOC, from audit-unknown-triage)
 

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -873,7 +873,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         if (adapter.supportsIndexInclude()) {
           expect(indexLine).toContain(`include: ["name","account_id"]`);
           // INCLUDE columns must not appear in the key columns list (PG11+ stores them in indkey).
-          expect(indexLine).not.toMatch(/\[("firm_id","type"|"firm_id", "type")\][^,]*"name"/);
+          // Assert the exact key columns argument follows the table name.
+          expect(indexLine).toContain(`"trains", ["firm_id", "type"]`);
+          expect(indexLine).not.toContain(`["firm_id", "type", "name"`);
         } else {
           expect(indexLine).not.toContain("include:");
         }

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -872,6 +872,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(indexLine).toBeDefined();
         if (adapter.supportsIndexInclude()) {
           expect(indexLine).toContain(`include: ["name","account_id"]`);
+          // INCLUDE columns must not appear in the key columns list (PG11+ stores them in indkey).
+          expect(indexLine).not.toMatch(/\[("firm_id","type"|"firm_id", "type")\][^,]*"name"/);
         } else {
           expect(indexLine).not.toContain("include:");
         }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2597,6 +2597,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       tableCondition = `t.oid = to_regclass($1)`;
     }
 
+    // ix.indnkeyatts was added in PG11 (covering indexes); on older servers
+    // INCLUDE columns don't exist, so all indkey columns are key columns.
+    const includeFilter = this.supportsIndexInclude() ? `WHERE k < ix.indnkeyatts` : "";
+
     const rows = await this.schemaQuery(
       `SELECT i.relname AS index_name,
               ix.indisunique AS is_unique,
@@ -2604,7 +2608,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
               ARRAY(
                 SELECT pg_get_indexdef(ix.indexrelid, k + 1, true)
                 FROM generate_subscripts(ix.indkey, 1) AS k
-                WHERE k < ix.indnkeyatts
+                ${includeFilter}
                 ORDER BY k
               ) AS columns,
               pg_get_indexdef(ix.indexrelid) AS definition,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2604,6 +2604,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
               ARRAY(
                 SELECT pg_get_indexdef(ix.indexrelid, k + 1, true)
                 FROM generate_subscripts(ix.indkey, 1) AS k
+                WHERE k < ix.indnkeyatts
                 ORDER BY k
               ) AS columns,
               pg_get_indexdef(ix.indexrelid) AS definition,
@@ -2655,12 +2656,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
 
       // concise_options: collapse to a single scalar when all key columns share the same value.
-      const keyColumns = include ? columns.filter((c) => !include.includes(c)) : columns;
-
+      // `columns` is already key-only because the SQL limits to ix.indnkeyatts.
       let opclasses: Record<string, string> | string | undefined;
       const opclassVals = Object.values(opclassesMap);
       if (opclassVals.length > 0) {
-        if (keyColumns.length === opclassVals.length && new Set(opclassVals).size === 1) {
+        if (columns.length === opclassVals.length && new Set(opclassVals).size === 1) {
           opclasses = opclassVals[0];
         } else {
           opclasses = opclassesMap;
@@ -2670,7 +2670,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       let orders: Record<string, string> | string | undefined;
       const orderVals = Object.values(ordersMap);
       if (orderVals.length > 0) {
-        if (keyColumns.length === orderVals.length && new Set(orderVals).size === 1) {
+        if (columns.length === orderVals.length && new Set(orderVals).size === 1) {
           orders = orderVals[0];
         } else {
           orders = ordersMap;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2584,6 +2584,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async indexes(tableName: string): Promise<IndexDefinition[]> {
+    // supportsIndexInclude() reads databaseVersion; ensure it's populated.
+    await this.getDatabaseVersion();
     const { schema, table } = this.parseSchemaQualifiedName(tableName);
 
     let tableCondition: string;


### PR DESCRIPTION
## Summary

Closes the PG-schema audit cluster.

- **`indexes()` INCLUDE filtering** — Switch the columns subquery to limit by `ix.indnkeyatts`, so PG11+ INCLUDE columns no longer leak into the `columns` array. They continue to be parsed out separately from `pg_get_indexdef`.
- **`SchemaIndexIncludeColumnsTest`** strengthened to verify INCLUDE columns are absent from the key-columns list (the previous assertion only checked `include:` was present).
- **Cluster doc** updated — the 3 `SchemaIndexNullsNotDistinctTest` tests, `setSchemaSearchPath` unquoted-`$user` rejection, and `Thing1..5` / `Song`-`Album` habtm fixtures were already shipped via Slot H-b (#1592, #1618). No additional work needed here.

## Test plan

- [ ] CI `SchemaIndexIncludeColumnsTest` passes (verifies columns array no longer contains INCLUDE column names).
- [ ] CI `SchemaIndexNullsNotDistinctTest` (3 tests) continue to pass.