### PR TITLE
feat(action-dispatch): Wave 7 PR 2 — journey/scanner.ts

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -6,6 +6,8 @@ export {
   unescapeUri,
 } from "./router/utils.js";
 
+export { Scanner, type Token } from "./scanner.js";
+
 export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 
 export { MatchData, Simulator, type GtgState, type TransitionTable } from "./gtg/simulator.js";

--- a/packages/actionpack/src/action-dispatch/journey/scanner.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/scanner.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { Scanner, type Token } from "./scanner.js";
+
+function tokens(pattern: string): Token[] {
+  const s = new Scanner();
+  s.scanSetup(pattern);
+  const out: Token[] = [];
+  let t: Token | null;
+  while ((t = s.nextToken()) !== null) out.push(t);
+  return out;
+}
+
+describe("ActionDispatch::Journey::Scanner", () => {
+  const CASES: Array<[string, Token[]]> = [
+    ["/", ["SLASH"]],
+    ["*omg", ["STAR"]],
+    ["/page", ["SLASH", "LITERAL"]],
+    ["/page!", ["SLASH", "LITERAL"]],
+    ["/page$", ["SLASH", "LITERAL"]],
+    ["/page&", ["SLASH", "LITERAL"]],
+    ["/page'", ["SLASH", "LITERAL"]],
+    ["/page*", ["SLASH", "LITERAL"]],
+    ["/page+", ["SLASH", "LITERAL"]],
+    ["/page,", ["SLASH", "LITERAL"]],
+    ["/page;", ["SLASH", "LITERAL"]],
+    ["/page=", ["SLASH", "LITERAL"]],
+    ["/page@", ["SLASH", "LITERAL"]],
+    ["/page\\:", ["SLASH", "LITERAL"]],
+    ["/page\\(", ["SLASH", "LITERAL"]],
+    ["/page\\)", ["SLASH", "LITERAL"]],
+    ["/~page", ["SLASH", "LITERAL"]],
+    ["/pa-ge", ["SLASH", "LITERAL"]],
+    ["/:page", ["SLASH", "SYMBOL"]],
+    ["/:page|*foo", ["SLASH", "SYMBOL", "OR", "STAR"]],
+    ["/(:page)", ["SLASH", "LPAREN", "SYMBOL", "RPAREN"]],
+    ["(/:action)", ["LPAREN", "SLASH", "SYMBOL", "RPAREN"]],
+    ["(())", ["LPAREN", "LPAREN", "RPAREN", "RPAREN"]],
+    ["(.:format)", ["LPAREN", "DOT", "SYMBOL", "RPAREN"]],
+    ["/sort::sort", ["SLASH", "LITERAL", "LITERAL", "SYMBOL"]],
+  ];
+
+  for (const [pattern, expected] of CASES) {
+    it(`Scanning \`${pattern}\``, () => {
+      expect(tokens(pattern)).toEqual(expected);
+    });
+  }
+
+  it("lastString and lastLiteral expose the last scanned text", () => {
+    const s = new Scanner();
+    s.scanSetup("/page\\:foo");
+    s.nextToken(); // SLASH
+    s.nextToken(); // LITERAL (page\:foo)
+    expect(s.lastString()).toBe("page\\:foo");
+    expect(s.lastLiteral()).toBe("page:foo");
+  });
+
+  it("nextToken returns null at end", () => {
+    const s = new Scanner();
+    s.scanSetup("/");
+    expect(s.nextToken()).toBe("SLASH");
+    expect(s.nextToken()).toBeNull();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/scanner.ts
+++ b/packages/actionpack/src/action-dispatch/journey/scanner.ts
@@ -1,0 +1,78 @@
+export type Token = "SLASH" | "DOT" | "LPAREN" | "RPAREN" | "OR" | "SYMBOL" | "STAR" | "LITERAL";
+
+const STATIC_TOKENS: Record<string, Token> = {
+  ".": "DOT",
+  "/": "SLASH",
+  "(": "LPAREN",
+  ")": "RPAREN",
+  "|": "OR",
+  ":": "SYMBOL",
+  "*": "STAR",
+};
+
+const WORD = /\w+/y;
+const LITERAL_RUN = /(?:[\w%\-~!$&'*+,;=@]|\\[:()])+/y;
+
+export class Scanner {
+  private _str = "";
+  private _pos = 0;
+  private _length = 0;
+
+  scanSetup(str: string): void {
+    this._str = str;
+    this._pos = 0;
+    this._length = 0;
+  }
+
+  nextToken(): Token | null {
+    if (this._pos >= this._str.length) return null;
+    let token: Token | null = null;
+    while (this._pos < this._str.length && (token = this._scan()) === null) {
+      // continue scanning
+    }
+    return token;
+  }
+
+  lastString(): string {
+    return this._str.slice(this._pos - this._length, this._pos);
+  }
+
+  lastLiteral(): string {
+    return this.lastString().replace(/\\/g, "");
+  }
+
+  private _scan(): Token | null {
+    const ch = this._str[this._pos];
+    const staticTok = STATIC_TOKENS[ch];
+
+    if (staticTok !== undefined && (staticTok !== "SYMBOL" || this._nextByteIsNotAToken())) {
+      this._pos += 1;
+      if (staticTok === "SYMBOL" || staticTok === "STAR") {
+        WORD.lastIndex = this._pos;
+        const m = WORD.exec(this._str);
+        const skipped = m ? m[0].length : 0;
+        this._pos += skipped;
+        this._length = skipped + 1;
+      }
+      return staticTok;
+    }
+
+    LITERAL_RUN.lastIndex = this._pos;
+    const litMatch = LITERAL_RUN.exec(this._str);
+    if (litMatch) {
+      this._length = litMatch[0].length;
+      this._pos += this._length;
+      return "LITERAL";
+    }
+
+    // Fallback: consume one character as a literal (matches Rails `skip(/./)`).
+    this._length = 1;
+    this._pos += 1;
+    return "LITERAL";
+  }
+
+  private _nextByteIsNotAToken(): boolean {
+    const next = this._str[this._pos + 1];
+    return next === undefined || STATIC_TOKENS[next] === undefined;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/journey/scanner.ts
+++ b/packages/actionpack/src/action-dispatch/journey/scanner.ts
@@ -18,6 +18,8 @@ export class Scanner {
   private _pos = 0;
   private _length = 0;
 
+  constructor() {}
+
   scanSetup(str: string): void {
     this._str = str;
     this._pos = 0;
@@ -41,6 +43,7 @@ export class Scanner {
     return this.lastString().replace(/\\/g, "");
   }
 
+  /** @internal */
   private _scan(): Token | null {
     const ch = this._str[this._pos];
     const staticTok = STATIC_TOKENS[ch];
@@ -71,6 +74,7 @@ export class Scanner {
     return "LITERAL";
   }
 
+  /** @internal */
   private _nextByteIsNotAToken(): boolean {
     const next = this._str[this._pos + 1];
     return next === undefined || STATIC_TOKENS[next] === undefined;


### PR DESCRIPTION
## Summary

Wave 7 PR 2 of 10. Ports Rails \`action_dispatch/journey/scanner.rb\` to TypeScript. Tokenizes route pattern strings into SLASH/DOT/LPAREN/RPAREN/OR/SYMBOL/STAR/LITERAL for the parser (PR 3) to consume.

Key behaviors mirrored from Rails:
- STATIC_TOKENS dispatch (byte-indexed in Rails; char-keyed map here)
- The \`:\` disambiguation — only emit \`SYMBOL\` when the NEXT char is not also a static token. Lets \`/sort::sort\` tokenize as LITERAL "sort:" + LITERAL ":" + SYMBOL "sort", matching Rails
- After \`SYMBOL\` or \`STAR\`, skip \`\\w+\` so the symbol's name is captured in the recorded length (for \`lastString\` / \`lastLiteral\`)
- \`lastLiteral\` strips \`\\\` to undo the route-DSL escape syntax for literal \`:\`, \`(\`, \`)\`
- LITERAL_RUN regex matches Rails verbatim
- Fallback: skip one char (mirrors Rails \`skip(/./)\`)

Uses \`/y\` (sticky) regex flag in place of StringScanner's position-based matching. No external deps.

## Test plan
- [x] 25 test cases mirror Rails \`scanner_test.rb\` CASES verbatim, plus 2 extras covering \`lastString\`/\`lastLiteral\` and EOF
- [x] All 47 journey tests pass (was 20)
- [x] Full actionpack suite green
- [x] api:compare actiondispatch 278→282 (+4), overall +4 — non-negative
- [x] test:compare overall +48 — non-negative