### PR TITLE
refactor(activerecord): TM unification Phase 3 — wire transactional fixtures through TM

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1093,11 +1093,11 @@ class SchemaAdapter implements DatabaseAdapter {
     this.inner.clearCacheBang?.();
   }
   get inTransaction(): boolean {
-    // Async-chain-aware (see currentTransaction comment). transactions.ts:142
-    // uses adapter.inTransaction in the duck-type check; if we returned true
-    // for foreign chains, that caller would route to _transactionFallback,
-    // bypass the outer mutex, and run as a nested savepoint inside the
-    // unrelated chain's transaction.
+    // Async-chain-aware (see currentTransaction comment).
+    // withTransactionReturningStatus still uses adapter.inTransaction in its
+    // external-transaction check; if we returned true for foreign chains,
+    // that caller would bypass the outer mutex and run as a nested savepoint
+    // inside the unrelated chain's transaction.
     if (!this._txVisible()) return false;
     return this.inner.inTransaction;
   }

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -135,13 +135,15 @@ export async function transaction<T>(
   const adapter = modelClass.adapter;
 
   // If the adapter supports the full TransactionManager path, use it.
-  // Also check adapter.inTransaction to detect external transactions
-  // (e.g., fixtures) that TransactionManager doesn't know about — fall
-  // through to the fallback which handles nesting via savepoints.
-  if (
-    typeof (adapter as any).withinNewTransaction === "function" &&
-    !(currentTransaction() === null && adapter.inTransaction)
-  ) {
+  //
+  // Invariant (TM unification, Phase 3): the only way to begin a transaction
+  // on a trails adapter is through TM. Raw `BEGIN` via `exec()` is reserved
+  // for migrations. Transactional fixtures (see test-helpers/
+  // with-transactional-fixtures.ts) route through `transactionManager.
+  // beginTransaction()` so the TM stack is the single source of truth — no
+  // "external transaction" guard is needed here. The fallback path below is
+  // dead for all in-use adapters and slated for removal in Phase 2.
+  if (typeof (adapter as any).withinNewTransaction === "function") {
     // No per-adapter lock needed: TransactionManager's join-or-savepoint
     // logic handles concurrent callers. The second caller either joins the
     // existing transaction (if joinable) or creates a SavepointTransaction.


### PR DESCRIPTION
## Summary

Phase 3 of `docs/tm-unification-plan.md`. Removes the `inTransaction && currentTransaction === null` guard at `transactions.ts:142`. After Phase 1 (SchemaAdapter delegation, #1627) and the `withTransactionalFixtures` helper (#1632) routing fixtures through `transactionManager.beginTransaction()`, the TM stack is the single source of truth.

**Audit.** Every test/fixture helper that opens a transaction already goes through TM. Remaining raw `BEGIN` callers are adapter-internal `beginDbTransaction` methods (invoked by TM itself) and SQLite3's isolation-level path — none bypass TM from user code.

**Invariant established** in a comment in `transactions.ts`: the only way to begin a transaction on a trails adapter is through TM. Raw `BEGIN` via `exec()` is reserved for migrations.

The fallback path (`_transactionFallback`) is now dead for all in-use adapters; deletion is Phase 2's scope.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts` — 164 passed
- [x] `pnpm vitest run packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts` — 4 passed
- [x] `pnpm vitest run packages/activerecord/src/transaction-instrumentation.test.ts` — 22 passed
- [x] `pnpm typecheck`
- [ ] Full CI (PG / MySQL / SQLite live runs)