### PR TITLE
test(activerecord): STI annotation drift — re-tag 6 mis-labeled BLOCKED: STI annotations

### DIFF
--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -562,7 +562,9 @@ describe("InsertAllTest", () => {
     // BLOCKED: relation — insert_all.rb: aliasAttribute in insertAll / upsertAll
   });
   it.skip("insert all and upsert all with sti", () => {
-    // BLOCKED: STI — insert_all.rb: STI type-column handling
+    // BLOCKED: fixture — test requires the Rails Category / SpecialCategory STI fixture
+    // hierarchy (categories table with `type` discriminator); no STI routing gap (insertAll /
+    // upsertAll set the type column via the existing STI dispatch); gap is missing test fixtures
   });
   it.skip("upsert and db warnings", () => {
     // BLOCKED: relation — insert_all.rb: DB warnings emitted on upsert


### PR DESCRIPTION
## Summary

Closes the **STI annotation drift** cluster from `docs/activerecord-100-clusters.md`.

audit-STI found **no STI implementation gap** — all 6 `BLOCKED: STI` annotations were mis-labeled. This PR finishes re-tagging the last stale annotation.

## Status of the 6 sites

5 of 6 were already addressed on main (some un-skipped after the impl gap turned out to be cosmetic, others re-tagged):

| Test | Status on main | Real cause |
|---|---|---|
| `delegated-type.test.ts` — `association uuid` | un-skipped | (passes; no gap) |
| `delegated-type.test.ts` — `touch account` | re-tagged | `BLOCKED: uuid + polymorphic-touch` |
| `inheritance.test.ts` — `scope inherited properly` | re-tagged | `BLOCKED: default-scope` |
| `inheritance.test.ts` — `inheritance with default scope` | re-tagged | `BLOCKED: default-scope` |
| `adapters/postgresql/schema.test.ts` — `inherited table options is dumped` | un-skipped | (PG INHERITS dump landed) |
| `adapters/postgresql/schema.test.ts` — `multiple inherited table options is dumped` | un-skipped | (PG INHERITS dump landed) |
| `insert-all.test.ts` — `insert all and upsert all with sti` | **re-tagged here** | `BLOCKED: fixture` |

## This PR

Re-tags the lone remaining mis-labeled site:

- `insert-all.test.ts:565` — `BLOCKED: STI` → `BLOCKED: fixture`. The Rails test (`test_insert_all_and_upsert_all_with_sti`, `activerecord/test/cases/insert_all_test.rb:330`) relies on the `Category` / `SpecialCategory` STI fixture hierarchy. The STI type-column dispatch in `insertAll` / `upsertAll` is wired; the missing piece is the fixture models.

No implementation or test-logic changes. Diff: 4 lines.

## Test plan

- [x] `pnpm typecheck` clean (run by lint-staged)
- [x] No skipped tests un-skipped — annotation-only change