### PR TITLE
refactor(activerecord): TM unification Phase 3+4 — transactional fixtures through TM + HABTM cleanup

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -669,17 +669,6 @@ export class CollectionAssociation extends Association {
 
 /** @internal */
 function transaction(assoc: CollectionAssociation, block: () => Promise<void>): Promise<void> {
-  // Rails wraps replace_records in transaction { ... } for all associations.
-  // DEVIATION: HABTM skips the wrapper because our fallback transaction path
-  // and the TM path use independent savepoint counters.  When the test
-  // environment has an external transaction (adapter.inTransaction=true,
-  // currentTransaction()=null), persistReplace uses the fallback (creates
-  // SAVEPOINT active_record_N).  insertAll inside then calls
-  // executeMutation→materializeTransactions via the TM path, which can
-  // consume that savepoint.  Root fix belongs in the TM/fallback counter
-  // coordination — tracked as a follow-up.  HABTM join inserts via
-  // insertAll are atomic SQL statements so skipping the wrapper is safe.
-  if ((assoc.reflection as any).type === "hasAndBelongsToMany") return block();
   // Rails: reflection.klass.transaction(&block) — uses the reflection's klass, not assoc.klass
   const klass = (assoc.reflection as any).klass ?? assoc.klass;
   if (klass && typeof (klass as any).transaction === "function") {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -107,7 +107,7 @@ function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Bas
 async function insertHabtmRecord(
   assoc: HasManyThroughAssociation,
   record: Base,
-  _validate: boolean,
+  validate: boolean,
   raise: boolean,
 ): Promise<boolean> {
   const ctor = assoc.owner.constructor as any;
@@ -134,12 +134,10 @@ async function insertHabtmRecord(
     [ownerFk as string]: pkValue,
     [sourceFk]: (record as any)._readAttribute?.(targetPk) ?? (record as any)[targetPk],
   };
-  // Use insertAll (no callbacks/no nested transaction) so we don't create a
-  // second savepoint inside persistReplace's outer transaction — which causes
-  // "SAVEPOINT active_record_N does not exist" on MySQL/MariaDB when the TM
-  // and the fallback path use independent savepoint counters.
-  const count = await throughModel.insertAll([joinAttrs]);
-  if (!count) {
+  // Rails: new(record_to_save_attributes(record)).save(validate: validate)
+  const joinRecord = new (throughModel as any)(joinAttrs);
+  const saved = await joinRecord.save({ validate });
+  if (!saved) {
     if (raise) throw new Error(`Failed to create join record for ${assocDef.name}`);
     return false;
   }

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -134,14 +134,13 @@ export async function transaction<T>(
 ): Promise<T | undefined> {
   const adapter = modelClass.adapter;
 
-  // If the adapter supports the full TransactionManager path, use it.
-  // Also check adapter.inTransaction to detect external transactions
-  // (e.g., fixtures) that TransactionManager doesn't know about — fall
-  // through to the fallback which handles nesting via savepoints.
-  if (
-    typeof (adapter as any).withinNewTransaction === "function" &&
-    !(currentTransaction() === null && adapter.inTransaction)
-  ) {
+  // Invariant: every trails adapter begins transactions through TM. The
+  // only legitimate raw `BEGIN` (via `exec()` / `executeMutation`) is
+  // reserved for migrations performing DDL. Transactional fixtures route
+  // through `adapter.beginTransaction()` → TM, so the previously needed
+  // `inTransaction && currentTransaction() === null` "external BEGIN"
+  // bypass is gone (TM Phase 3 unification).
+  if (typeof (adapter as any).withinNewTransaction === "function") {
     // No per-adapter lock needed: TransactionManager's join-or-savepoint
     // logic handles concurrent callers. The second caller either joins the
     // existing transaction (if joinable) or creates a SavepointTransaction.


### PR DESCRIPTION
## Summary

Phase 3 + Phase 4 of `docs/tm-unification-plan.md`, bundled.

**Phase 3 — fixtures through TM.** Remove the `inTransaction && currentTransaction() === null` bypass at `transactions.ts:142`. After Phase 1 (`SchemaAdapter.withinNewTransaction` delegation, #1627) and Phase 2 (`withTransactionalFixtures` helper, #1632), every fixture path begins via `adapter.beginTransaction()` → TM, so the "external BEGIN" branch is unreachable. Replaced the legacy comment with an inline invariant: raw `BEGIN` via `exec()`/`executeMutation` is reserved for migration DDL.

Audit of `exec("BEGIN")` / `beginDbTransaction` / `executeMutation("BEGIN...")` confirmed remaining callers are either:
- adapter-internal (`connection-adapters/*/database-statements.ts`) — TM uses these,
- migration code in `migration.ts` (DDL),
- adapter API tests calling `beginDbTransaction()` directly to *test* that API.

No test-helper or fixture caller routes around TM.

**Phase 4 — HABTM workarounds removed.**
- `collection-association.ts`: drop the HABTM-only short-circuit in the `replaceRecords` transaction wrapper. With the fallback's independent savepoint counter gone (Phase 2), TM's `SavepointTransaction.rollback` no longer leaks across error boundaries.
- `has-many-through-association.ts`: restore `insertHabtmRecord` to Rails fidelity — `new throughModel(joinAttrs).save({ validate })` instead of the `insertAll` bypass.

## Verification

- `transactions.test.ts` (sqlite default): 160 passed.
- `associations/` (sqlite default): 1337 passed.
- HABTM/HMT/nested-through against live PG (`postgres:17`) per file in isolation: all green. Cross-file PG runs surface the same shared-`_sharedAdapter` concurrency leakage tracked as Phase 8 (per-connection mutex); not introduced here.
- HABTM/HMT against live MariaDB (`mariadb:11`): 222 passed.

## Out of scope

- Deleting `_transactionFallback` itself (Phase 2 deletion proper): the guard is the only consumer left; the dead-code removal is left as a trivial follow-up to keep this PR small.
- Phase 7 (SchemaAdapter recovery cleanup), Phase 8 (per-connection mutex in TM).

LOC: 12 insertions, 26 deletions.