### PR TITLE
feat(action-dispatch): Wave 7 PR 3 — journey/nodes + parser + ast

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/ast.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/ast.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+import { Ast } from "./ast.js";
+import { Symbol as SymbolNode, Terminal } from "./nodes/node.js";
+
+describe("ActionDispatch::Journey::Nodes::Ast", () => {
+  it("test_ast_sets_regular_expressions", () => {
+    const requirements: Record<string, RegExp> = { name: /(tender|love)/, value: /./ };
+    const tree = new Parser().parse("/page/:name/:value");
+    const ast = new Ast(tree, true);
+    ast.requirements = requirements;
+    const nodes = ast.root.grep(SymbolNode);
+    expect(nodes.length).toBe(2);
+    for (const n of nodes) expect(n.regexp).toBe(requirements[n.toSym()]);
+  });
+
+  it("test_sets_memo_for_terminal_nodes", () => {
+    const route = { id: "route" };
+    const tree = new Parser().parse("/path");
+    const ast = new Ast(tree, true);
+    ast.route = route;
+    for (const n of ast.root.grep(Terminal)) expect(n.memo).toBe(route);
+  });
+
+  it("test_contains_glob", () => {
+    const ast = new Ast(new Parser().parse("/*glob"), true);
+    expect(ast.isGlob()).toBe(true);
+  });
+
+  it("test_does_not_contain_glob", () => {
+    const ast = new Ast(new Parser().parse("/"), true);
+    expect(ast.isGlob()).toBe(false);
+  });
+
+  it("test_names", () => {
+    const ast = new Ast(new Parser().parse("/:path/:symbol"), true);
+    expect(ast.names).toEqual(["path", "symbol"]);
+  });
+
+  it("test_path_params", () => {
+    const ast = new Ast(new Parser().parse("/:path/:symbol"), true);
+    expect(ast.pathParams).toEqual(["path", "symbol"]);
+  });
+
+  it("test_wildcard_options_when_formatted", () => {
+    const ast = new Ast(new Parser().parse("/*glob"), true);
+    expect(String(ast.wildcardOptions["glob"])).toBe("/.+?/s");
+  });
+
+  it("test_wildcard_options_when_false", () => {
+    const ast = new Ast(new Parser().parse("/*glob"), false);
+    expect(ast.wildcardOptions["glob"]).toBeUndefined();
+  });
+
+  it("test_wildcard_options_when_nil", () => {
+    const ast = new Ast(new Parser().parse("/*glob"), null);
+    expect(String(ast.wildcardOptions["glob"])).toBe("/.+?/s");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/ast.ts
+++ b/packages/actionpack/src/action-dispatch/journey/ast.ts
@@ -1,0 +1,61 @@
+import { Node, Symbol as SymbolNode, Star } from "./nodes/node.js";
+
+export class Ast {
+  readonly tree: Node;
+  readonly pathParams: string[] = [];
+  readonly names: string[] = [];
+  readonly wildcardOptions: Record<string, RegExp> = {};
+  readonly terminals: Node[] = [];
+
+  private readonly _symbols: SymbolNode[] = [];
+  private readonly _stars: Star[] = [];
+
+  constructor(tree: Node, formatted: boolean | null | undefined) {
+    this.tree = tree;
+    this._visitTree(formatted);
+  }
+
+  /** Rails alias :root :tree */
+  get root(): Node {
+    return this.tree;
+  }
+
+  set requirements(reqs: Record<string, RegExp>) {
+    for (const node of [...this._symbols, ...this._stars]) {
+      const re = reqs[node.toSym()];
+      if (re) node.regexp = re;
+    }
+  }
+
+  set route(route: unknown) {
+    for (const n of this.terminals) n.memo = route;
+  }
+
+  isGlob(): boolean {
+    return this._stars.length > 0;
+  }
+
+  /** @internal */
+  private _visitTree(formatted: boolean | null | undefined): void {
+    for (const node of this.tree) {
+      if (node.isSymbol()) {
+        const sym = node as SymbolNode;
+        this.pathParams.push(sym.toSym());
+        this.names.push(sym.name);
+        this._symbols.push(sym);
+      } else if (node.isStar()) {
+        const star = node as Star;
+        this._stars.push(star);
+        if (formatted !== false) {
+          const key = star.name;
+          if (!(key in this.wildcardOptions)) {
+            this.wildcardOptions[key] = /.+?/s;
+          }
+        }
+      }
+      if (node.isTerminal()) {
+        this.terminals.push(node);
+      }
+    }
+  }
+}

--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -8,6 +8,10 @@ export {
 
 export { Scanner, type Token } from "./scanner.js";
 
+export { Parser } from "./parser.js";
+export { Ast } from "./ast.js";
+export * as Nodes from "./nodes/node.js";
+
 export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 
 export { MatchData, Simulator, type GtgState, type TransitionTable } from "./gtg/simulator.js";

--- a/packages/actionpack/src/action-dispatch/journey/nodes/node.ts
+++ b/packages/actionpack/src/action-dispatch/journey/nodes/node.ts
@@ -161,9 +161,11 @@ export class Group extends Unary {
 
 export class Star extends Unary {
   regexp: RegExp = /.+?/s;
+  override left: Node;
 
   constructor(left: Node) {
     super(left);
+    this.left = left;
   }
 
   override get type(): NodeType {
@@ -173,10 +175,10 @@ export class Star extends Unary {
     return true;
   }
   override get name(): string {
-    return (this.left as Node).name.replace(/[*:]/g, "");
+    return this.left.name.replace(/[*:]/g, "");
   }
   override toString(): string {
-    return (this.left as Node).toString();
+    return this.left.toString();
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/journey/nodes/node.ts
+++ b/packages/actionpack/src/action-dispatch/journey/nodes/node.ts
@@ -1,0 +1,224 @@
+export type NodeType = "LITERAL" | "SLASH" | "DOT" | "SYMBOL" | "GROUP" | "STAR" | "CAT" | "OR";
+
+export abstract class Node {
+  left: Node | string;
+  memo: unknown = null;
+
+  constructor(left: Node | string) {
+    this.left = left;
+  }
+
+  *[globalThis.Symbol.iterator](): IterableIterator<Node> {
+    yield this;
+    const children = this.children();
+    for (const child of children) {
+      yield* child;
+    }
+  }
+
+  /** Visit every descendant whose constructor is `klass`. Rails `node.grep(Klass)`. */
+  grep<T extends Node>(klass: new (...args: never[]) => T): T[] {
+    const out: T[] = [];
+    for (const n of this) if (n instanceof klass) out.push(n as T);
+    return out;
+  }
+
+  children(): readonly Node[] {
+    return [];
+  }
+
+  abstract get type(): NodeType;
+
+  /** Rails `node.name` — strips `*` and `:` from the leading marker. */
+  get name(): string {
+    return this._computeName();
+  }
+
+  /** @internal */
+  protected _computeName(): string {
+    if (typeof this.left !== "string") {
+      throw new Error("name requires a string `left`");
+    }
+    return this.left.replace(/[*:]/g, "");
+  }
+
+  toSym(): string {
+    return this.name;
+  }
+
+  toString(): string {
+    if (typeof this.left === "string") return this.left;
+    return this.left.toString();
+  }
+
+  isSymbol(): boolean {
+    return false;
+  }
+  isLiteral(): boolean {
+    return false;
+  }
+  isTerminal(): boolean {
+    return false;
+  }
+  isStar(): boolean {
+    return false;
+  }
+  isCat(): boolean {
+    return false;
+  }
+  isGroup(): boolean {
+    return false;
+  }
+}
+
+export class Terminal extends Node {
+  /** Rails alias :symbol :left — kept as a getter for callers. */
+  get symbol(): Node | string {
+    return this.left;
+  }
+
+  get type(): NodeType {
+    throw new Error("subclass must override type");
+  }
+
+  override isTerminal(): boolean {
+    return true;
+  }
+}
+
+export class Literal extends Terminal {
+  override isLiteral(): boolean {
+    return true;
+  }
+  override get type(): NodeType {
+    return "LITERAL";
+  }
+}
+
+export class Dummy extends Literal {
+  constructor(x: string = "<dummy>") {
+    super(x);
+  }
+  override isLiteral(): boolean {
+    return false;
+  }
+}
+
+export class Slash extends Terminal {
+  override get type(): NodeType {
+    return "SLASH";
+  }
+}
+
+export class Dot extends Terminal {
+  override get type(): NodeType {
+    return "DOT";
+  }
+}
+
+export class Symbol extends Terminal {
+  static readonly DEFAULT_EXP = /[^./?]+/;
+  static readonly GREEDY_EXP = /(.+)/;
+
+  regexp: RegExp;
+  private readonly _name: string;
+
+  constructor(left: string, regexp: RegExp = Symbol.DEFAULT_EXP) {
+    super(left);
+    this.regexp = regexp;
+    this._name = left.replace(/[*:]/g, "");
+  }
+
+  override get name(): string {
+    return this._name;
+  }
+
+  override get type(): NodeType {
+    return "SYMBOL";
+  }
+  override isSymbol(): boolean {
+    return true;
+  }
+}
+
+export abstract class Unary extends Node {
+  override children(): readonly Node[] {
+    return [this.left as Node];
+  }
+}
+
+export class Group extends Unary {
+  override get type(): NodeType {
+    return "GROUP";
+  }
+  override isGroup(): boolean {
+    return true;
+  }
+  override toString(): string {
+    return `(${(this.left as Node).toString()})`;
+  }
+}
+
+export class Star extends Unary {
+  regexp: RegExp = /.+?/s;
+
+  constructor(left: Node) {
+    super(left);
+  }
+
+  override get type(): NodeType {
+    return "STAR";
+  }
+  override isStar(): boolean {
+    return true;
+  }
+  override get name(): string {
+    return (this.left as Node).name.replace(/[*:]/g, "");
+  }
+  override toString(): string {
+    return (this.left as Node).toString();
+  }
+}
+
+export abstract class Binary extends Node {
+  right: Node;
+
+  constructor(left: Node, right: Node) {
+    super(left);
+    this.right = right;
+  }
+
+  override children(): readonly Node[] {
+    return [this.left as Node, this.right];
+  }
+}
+
+export class Cat extends Binary {
+  override get type(): NodeType {
+    return "CAT";
+  }
+  override isCat(): boolean {
+    return true;
+  }
+  override toString(): string {
+    return `${(this.left as Node).toString()}${this.right.toString()}`;
+  }
+}
+
+export class Or extends Node {
+  override readonly children: () => readonly Node[];
+  private readonly _children: readonly Node[];
+
+  constructor(children: readonly Node[]) {
+    super(children[0]!);
+    this._children = children;
+    this.children = () => this._children;
+  }
+
+  override get type(): NodeType {
+    return "OR";
+  }
+  override toString(): string {
+    return this._children.map((c) => c.toString()).join("|");
+  }
+}

--- a/packages/actionpack/src/action-dispatch/journey/parser.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/parser.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+
+describe("ActionDispatch::Journey::Parser", () => {
+  const parser = new Parser();
+  const roundTrip = (str: string) => expect(parser.parse(str).toString()).toBe(str);
+
+  it("test_slash", () => {
+    expect(parser.parse("/").type).toBe("SLASH");
+    roundTrip("/");
+  });
+  it("test_segment", () => roundTrip("/foo"));
+  it("test_segments", () => roundTrip("/foo/bar"));
+  it("test_segment_symbol", () => roundTrip("/foo/:id"));
+  it("test_symbol", () => roundTrip("/:foo"));
+  it("test_group", () => roundTrip("(/:foo)"));
+  it("test_groups", () => roundTrip("(/:foo)(/:bar)"));
+  it("test_nested_groups", () => roundTrip("(/:foo(/:bar))"));
+  it("test_dot_symbol", () => roundTrip(".:format"));
+  it("test_dot_literal", () => roundTrip(".xml"));
+  it("test_segment_dot", () => roundTrip("/foo.:bar"));
+  it("test_segment_group_dot", () => roundTrip("/foo(.:bar)"));
+  it("test_segment_group", () => roundTrip("/foo(/:action)"));
+  it("test_segment_groups", () => roundTrip("/foo(/:action)(/:bar)"));
+  it("test_segment_nested_groups", () => roundTrip("/foo(/:action(/:bar))"));
+  it("test_group_followed_by_path", () => roundTrip("/foo(/:action)/:bar"));
+  it("test_star *foo", () => roundTrip("*foo"));
+  it("test_star /*foo", () => roundTrip("/*foo"));
+  it("test_star /bar/*foo", () => roundTrip("/bar/*foo"));
+  it("test_star /bar/(*foo)", () => roundTrip("/bar/(*foo)"));
+  it("test_or a|b", () => roundTrip("a|b"));
+  it("test_or a|b|c", () => roundTrip("a|b|c"));
+  it("test_or (a|b)|c", () => roundTrip("(a|b)|c"));
+  it("test_or a|(b|c)", () => roundTrip("a|(b|c)"));
+  it("test_or *a|(b|c)", () => roundTrip("*a|(b|c)"));
+  it("test_or *a|:b|c", () => roundTrip("*a|:b|c"));
+  it("test_arbitrary", () => roundTrip("/bar/*foo#"));
+  it("test_literal_dot_paren", () => roundTrip("/sprockets.js(.:format)"));
+  it("test_groups_with_dot", () => roundTrip("/(:locale)(.:format)"));
+});

--- a/packages/actionpack/src/action-dispatch/journey/parser.ts
+++ b/packages/actionpack/src/action-dispatch/journey/parser.ts
@@ -1,0 +1,113 @@
+import { Scanner, type Token } from "./scanner.js";
+import {
+  Cat,
+  Group,
+  Literal,
+  Node,
+  Or,
+  Slash,
+  Star,
+  Symbol as SymbolNode,
+  Dot,
+} from "./nodes/node.js";
+
+export class Parser {
+  private _scanner: Scanner;
+  private _nextToken: Token | null;
+
+  constructor() {
+    this._scanner = new Scanner();
+    this._nextToken = null;
+  }
+
+  static parse(string: string): Node {
+    return new Parser().parse(string);
+  }
+
+  parse(string: string): Node {
+    this._scanner.scanSetup(string);
+    this._advanceToken();
+    return this._doParse();
+  }
+
+  /** @internal */
+  private _advanceToken(): void {
+    this._nextToken = this._scanner.nextToken();
+  }
+
+  /** @internal */
+  private _doParse(): Node {
+    return this._parseExpressions();
+  }
+
+  /** @internal */
+  private _parseExpressions(): Node {
+    let node = this._parseExpression();
+    while (this._nextToken !== null) {
+      if (this._nextToken === "RPAREN") break;
+      if (this._nextToken === "OR") {
+        node = this._parseOr(node);
+      } else {
+        node = new Cat(node, this._parseExpressions());
+      }
+    }
+    return node;
+  }
+
+  /** @internal */
+  private _parseOr(lhs: Node): Node {
+    this._advanceToken();
+    const rhs = this._parseExpression();
+    return new Or([lhs, rhs]);
+  }
+
+  /** @internal */
+  private _parseExpression(): Node {
+    if (this._nextToken === "STAR") return this._parseStar();
+    if (this._nextToken === "LPAREN") return this._parseGroup();
+    return this._parseTerminal();
+  }
+
+  /** @internal */
+  private _parseStar(): Node {
+    const sym = new SymbolNode(this._scanner.lastString(), SymbolNode.GREEDY_EXP);
+    const node = new Star(sym);
+    this._advanceToken();
+    return node;
+  }
+
+  /** @internal */
+  private _parseGroup(): Node {
+    this._advanceToken();
+    const inner = this._parseExpressions();
+    if (this._nextToken !== "RPAREN") {
+      throw new Error("missing right parenthesis.");
+    }
+    const node = new Group(inner);
+    this._advanceToken();
+    return node;
+  }
+
+  /** @internal */
+  private _parseTerminal(): Node {
+    let node: Node;
+    switch (this._nextToken) {
+      case "SYMBOL":
+        node = new SymbolNode(this._scanner.lastString());
+        break;
+      case "LITERAL":
+        node = new Literal(this._scanner.lastLiteral());
+        break;
+      case "SLASH":
+        node = new Slash("/");
+        break;
+      case "DOT":
+        node = new Dot(".");
+        break;
+      default:
+        throw new Error(`unexpected token: ${this._nextToken}`);
+    }
+    this._advanceToken();
+    return node;
+  }
+}


### PR DESCRIPTION
## Summary

Wave 7 PR 3 of 10. Ports Rails \`action_dispatch/journey/{nodes/node.rb, parser.rb}\` and the \`Ast\` class (Rails colocates Ast in nodes/node.rb).

**\`journey/nodes/node.ts\`** — abstract \`Node\` base + the full hierarchy:
- Terminal subclasses: \`Literal\`, \`Dummy\`, \`Slash\`, \`Dot\`, \`Symbol\` (DEFAULT_EXP / GREEDY_EXP + per-instance regexp)
- Unary subclasses: \`Group\`, \`Star\` (non-greedy /.+?/s default regexp)
- Binary subclass: \`Cat\`
- \`Or\` (owns its own children array)
- Node is iterable; \`grep<T>(klass)\` returns descendants of a given subclass; \`isSymbol\`/\`isLiteral\`/\`isTerminal\`/\`isStar\`/\`isCat\`/\`isGroup\` predicates

**\`journey/parser.ts\`** — scanner-fed recursive descent parser matching Rails verbatim. Static \`Parser.parse(string)\` and instance \`.parse\`.

**\`journey/ast.ts\`** — walks the parsed tree collecting \`pathParams\`/\`names\`/\`wildcardOptions\`/\`terminals\`. \`requirements=\` setter injects regexps onto Symbol/Star nodes; \`route=\` setter propagates \`memo\` to terminals; \`isGlob()\` predicate.

**Pre-PR-4 toString**: each node carries a recursive \`toString\` so parser round-trip tests can run without the Visitors port (PR 4 will switch to \`Visitors::String\`). Behaviorally equivalent to Rails' visitor output.

## Test plan
- [x] 29 parser round-trip cases verbatim from Rails \`parser_test.rb\`
- [x] 9 ast cases verbatim from Rails \`ast_test.rb\`
- [x] All 85 journey tests pass (was 47)
- [x] Full actionpack suite green: 1878 tests
- [x] api:compare actiondispatch 283→305 (+22), overall +22 — non-negative
- [x] test:compare non-negative