### PR TITLE
feat(activerecord): HMT Slot C — autosave-through propagation + Marshal exclusion

### DIFF
--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -30,9 +30,12 @@ export class CollectionAssociation extends Association {
     for (const callbackName of CALLBACKS) {
       this.defineCallback(model, callbackName, name, options);
     }
-    if (options.autosave) {
-      addAutosaveAssociationCallbacks(model, reflection);
-    }
+    // Mirrors Rails AutosaveAssociation::AssociationBuilderExtension.build —
+    // save_collection_association is registered for every collection
+    // association regardless of the `autosave:` option. The option only
+    // gates extra behavior inside save_collection_association; insert-of-new
+    // children must always propagate so failures surface on owner.save.
+    addAutosaveAssociationCallbacks(model, reflection);
   }
 
   static override defineExtensions(model: any, name: string, block?: (...args: any[]) => any): any {

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -26,9 +26,7 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   it.skip("marshal dump", () => {
-    // BLOCKED: associations — has-many-through feature gap
-    // ROOT-CAUSE: associations/has-many-through-associations.ts or preloader.ts missing has-many-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-many-through-associations.test.ts
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal
   });
 
   it("through association with joins", async () => {
@@ -5617,14 +5615,65 @@ describe("HasManyThroughAssociationsTest", () => {
     await expect((owner as any).sbang_items.appendBang(item)).rejects.toThrow(RecordInvalid);
   });
 
-  it.skip("save returns falsy when join record has errors", () => {
-    // BLOCKED: associations — has-many-through feature gap
-    // ROOT-CAUSE: associations/has-many-through-associations.ts or preloader.ts missing has-many-through semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in has-many-through-associations.test.ts
+  it("save returns falsy when join record has errors", async () => {
     // Rails: c = Category.new(name: "Fishing", authors: [Author.first]); assert_not c.save
-    // Requires autosave-through support: saving a new record with pre-set through
-    // associations must attempt join record creation and propagate failures to the
-    // parent save() returning false — not yet implemented
+    // Pre-populating the through-association's target on a new owner mirrors
+    // Rails' constructor-form collection writer; autosave then attempts to
+    // create the join record, whose validation fails, so owner.save() is falsy.
+    class FbangJoin extends Base {
+      static {
+        this.attribute("fbang_owner_id", "integer");
+        this.attribute("fbang_item_id", "integer");
+        this.adapter = adapter;
+        this.validate((r: any) => {
+          r.errors.add("base", "Invalid Join");
+        });
+      }
+    }
+    class FbangItem extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class FbangOwner extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("FbangJoin", FbangJoin);
+    registerModel("FbangItem", FbangItem);
+    registerModel("FbangOwner", FbangOwner);
+    Associations.belongsTo.call(FbangJoin, "fbang_item", {
+      className: "FbangItem",
+      foreignKey: "fbang_item_id",
+    });
+    Associations.hasMany.call(FbangOwner, "fbang_joins", {
+      className: "FbangJoin",
+      foreignKey: "fbang_owner_id",
+    });
+    Associations.hasMany.call(FbangOwner, "fbang_items", {
+      className: "FbangItem",
+      through: "fbang_joins",
+      source: "fbang_item",
+    });
+
+    const item = await FbangItem.create({ name: "A" });
+    const owner = new FbangOwner();
+    (owner as any).name = "Fishing";
+    // Pre-populate the through-association target so autosave attempts join
+    // creation when the new owner is saved — mirrors Rails' constructor-form
+    // collection writer `Category.new(name:, authors: [author])`.
+    (owner as any)._cachedAssociations = (owner as any)._cachedAssociations ?? new Map();
+    (owner as any)._cachedAssociations.set("fbang_items", [item]);
+
+    const result = await owner.save();
+    expect(result).toBeFalsy();
+    // Owner row may have been written before autosave failure surfaces, but the
+    // failing join record must not be persisted (Rails: c.save returns false).
+    const joins = await FbangJoin.all().toArray();
+    expect(joins).toHaveLength(0);
   });
   it("preloading empty through association via joins", async () => {
     class HmtEmptyThrOwner extends Base {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -504,7 +504,14 @@ async function _insertCollectionRecord(
   }
   if (inst && typeof inst.insertRecord === "function") {
     inst.setInverseInstance?.(child);
-    return !!(await inst.insertRecord(child, false, false));
+    // Mirrors Rails save_collection_association branching: with `autosave:
+    // true` the records were already validated during the validation phase
+    // and we pass `validate: false`; without `autosave` (the default), we
+    // pass `validate: true` so a failing join record surfaces here and
+    // owner.save returns false (has_many_through_associations_test.rb
+    // `save returns falsy when join record has errors`).
+    const validate = !assoc.options.autosave;
+    return !!(await inst.insertRecord(child, validate, false));
   }
   return _insertCollectionRecordFallback(record, assoc, child);
 }
@@ -1063,22 +1070,28 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
         return aroundSaveCollectionAssociation.call(record, proceed);
       });
     }
-    const collectionName = reflection.name;
     defineNonCyclicMethod(model, saveMethod, async function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
     });
+    // Mirrors Rails: save_collection_association runs for every collection
+    // association unless `autosave: false` opts out. The option's true-form
+    // gates additional behavior (validating already-persisted records,
+    // destroying marked-for-destruction children); its absence still
+    // propagates inserts of new children so owner.save surfaces failures —
+    // see autosave_association.rb `save_collection_association`.
+    const collectionName = reflection.name;
     afterCreate(model, async (record: any) => {
       const assocDef = (record.constructor as any)._associations?.find(
         (a: any) => a.name === collectionName,
       );
-      if (!assocDef?.options?.autosave) return;
+      if (assocDef?.options?.autosave === false) return;
       if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
     });
     afterUpdate(model, async (record: any) => {
       const assocDef = (record.constructor as any)._associations?.find(
         (a: any) => a.name === collectionName,
       );
-      if (!assocDef?.options?.autosave) return;
+      if (assocDef?.options?.autosave === false) return;
       if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
     });
   } else if (isHasOne) {


### PR DESCRIPTION
## Summary

Associations has-many-through cluster, Slot C (per `docs/activerecord-100-clusters.md`).

- **Autosave-through propagation.** Register `save_collection_association` callbacks for every has_many / has_many :through / habtm association (Rails parity in `AutosaveAssociation::AssociationBuilderExtension.build`). The `autosave:` option now only opts out via explicit `false`; its absence still propagates inserts of new children so `owner.save` returns false when a join record fails.
- **Validate flag.** `_insertCollectionRecord` passes `validate: true` when the reflection has no explicit `autosave:` — mirrors Rails' `elsif !reflection.nested? association.insert_record(record)` (validate defaults to `true`). With `autosave: true` it stays `false` since the validation phase already ran.
- **Un-skip** `save returns falsy when join record has errors` — pre-populates the through target on a new owner (`_cachedAssociations.set("items", [item])`), mirroring Rails' constructor-form `Category.new(name:, authors: [author])`. A validator on the join model causes `owner.save()` to return false; no join row is persisted.
- **Marshal exclusion.** Re-tag `marshal dump` as `PERMANENT-SKIP`, matching `marshal-serialization.test.ts` and `has-and-belongs-to-many-associations.test.ts` (Ruby-only `Marshal.dump`/`Marshal.load` round-trip).

Cross-referenced against `vendor/rails/activerecord/lib/active_record/autosave_association.rb` and `has_many_through_association.rb`.

## Out of scope (flagged in clusters.md)

The deferred semantic question about Rails' `insert_record` doing target-save + `save_through_record` two-step vs our single-row `insertHabtmRecord` was not touched; no related tests failed in this slot.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 203 pass, 18 skip
- [x] `pnpm vitest run packages/activerecord/src/autosave.test.ts` — 19 pass
- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-through-associations.test.ts` — 166 pass, 1 skip (was 2)
- [x] `pnpm vitest run` over has_many / habtm / has_one / has_one_through / nested-through / collection-proxy / callbacks / validations — all green