### PR TITLE
feat(activerecord): mysql2-adapter Slot B — timeout + statement-timeout exception translation

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -8,12 +8,16 @@ import {
   MYSQL_TEST_URL,
 } from "../abstract-mysql-adapter/test-helper.js";
 import {
+  AdapterTimeout,
   InvalidForeignKey,
   MismatchedForeignKey,
   NotNullViolation,
+  QueryAborted,
   RecordNotUnique,
+  StatementTimeout,
   ValueTooLong,
 } from "../../errors.js";
+import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { Result } from "../../result.js";
 
 describeIfMysql("Mysql2Adapter", () => {
@@ -295,15 +299,39 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(error.cause).toBeInstanceOf(Error);
     });
 
-    it.skip("read timeout exception", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("read timeout exception", () => {
+      // Mirrors: test_read_timeout_exception. The node-mysql2 driver surfaces
+      // a read_timeout-tripped query as an Error with code
+      // 'PROTOCOL_SEQUENCE_TIMEOUT' and no MySQL errno. Fabricate the same
+      // shape and feed it through translateException to assert the mapping.
+      const driverErr = Object.assign(new Error("read ETIMEDOUT"), {
+        code: "PROTOCOL_SEQUENCE_TIMEOUT",
+      });
+      const translated = adapter.translateException(driverErr, {
+        sql: "SELECT SLEEP(2)",
+        binds: [],
+      });
+      expect(translated).toBeInstanceOf(AdapterTimeout);
+      expect(translated).toBeInstanceOf(QueryAborted);
+      expect((translated as AdapterTimeout).cause).toBe(driverErr);
+      expect((translated as AdapterTimeout).sql).toBe("SELECT SLEEP(2)");
     });
-    it.skip("statement timeout error codes", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("statement timeout error codes", () => {
+      // Mirrors: test_statement_timeout_error_codes. ER_QUERY_TIMEOUT (3024)
+      // and ER_FILSORT_ABORT (1028) both map to StatementTimeout.
+      for (const errno of [
+        AbstractMysqlAdapter.ER_QUERY_TIMEOUT,
+        AbstractMysqlAdapter.ER_FILSORT_ABORT,
+      ]) {
+        const driverErr = Object.assign(new Error("fail"), { errno });
+        const translated = adapter.translateException(driverErr, {
+          sql: "SELECT 1",
+          binds: [],
+        });
+        expect(translated).toBeInstanceOf(StatementTimeout);
+        expect(translated).toBeInstanceOf(QueryAborted);
+        expect((translated as StatementTimeout).cause).toBe(driverErr);
+      }
     });
     it.skip("database timezone changes synced to connection", () => {
       // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -20,6 +20,7 @@ import {
   RecordNotUnique,
   SQLWarning,
   StatementInvalid,
+  StatementTimeout,
   ValueTooLong,
   sqlTypeToMigrationKeyword,
 } from "../errors.js";
@@ -106,6 +107,7 @@ const ER_LOCK_DEADLOCK = 1213;
 const ER_LOCK_WAIT_TIMEOUT = 1205;
 const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
+const ER_FILSORT_ABORT = 1028;
 const ER_TABLE_EXISTS = 1050;
 
 // Function defaults emitted without DEFAULT_GENERATED in Extra (e.g. CURRENT_TIMESTAMP on
@@ -981,6 +983,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_LOCK_WAIT_TIMEOUT = ER_LOCK_WAIT_TIMEOUT;
   static readonly ER_QUERY_INTERRUPTED = ER_QUERY_INTERRUPTED;
   static readonly ER_QUERY_TIMEOUT = ER_QUERY_TIMEOUT;
+  static readonly ER_FILSORT_ABORT = ER_FILSORT_ABORT;
   static readonly ER_TABLE_EXISTS = ER_TABLE_EXISTS;
 
   /**
@@ -1180,6 +1183,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         return new NotNullViolation(msg, { sql, binds, cause });
       case ER_DATA_TOO_LONG:
         return new ValueTooLong(msg, { sql, binds, cause });
+      case ER_QUERY_TIMEOUT:
+      case ER_FILSORT_ABORT:
+        return new StatementTimeout(msg, { sql, binds, cause });
       default:
         // Driver errors expose a positive MySQL errno and usually a
         // sqlState. Node/system errors (ECONNREFUSED etc.) also carry

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1723,10 +1723,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 }
 
 /**
- * Detect a node-mysql2 driver-level timeout (no MySQL errno). Mirrors
- * Rails' `exception.is_a?(Mysql2::Error::TimeoutError) && !exception.error_number`
+ * Detect a node-mysql2 driver-level timeout (no positive MySQL errno).
+ * Mirrors Rails' `exception.is_a?(Mysql2::Error::TimeoutError) && !exception.error_number`
  * — the node driver surfaces these as `code === 'PROTOCOL_SEQUENCE_TIMEOUT'`
- * or `code === 'ETIMEDOUT'` with no `errno`.
+ * or `code === 'ETIMEDOUT'`. A non-positive `errno` (e.g. libuv's
+ * negative `-ETIMEDOUT`) counts as "no MySQL errno", matching Rails'
+ * `!error_number` predicate which is true for nil and unset values.
  *
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -9,6 +9,7 @@ import {
 } from "./abstract-mysql-adapter.js";
 import { Version } from "./abstract-adapter.js";
 import {
+  AdapterTimeout,
   MismatchedForeignKey,
   NoDatabaseError,
   NotImplementedError,
@@ -204,6 +205,21 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   protected override _onStatementLimitChanged(value: number): void {
     if (this._conn) this._statementPools.get(this._conn)?.setMaxSize(value);
+  }
+
+  /**
+   * Mirrors `Mysql2Adapter#translate_exception`. Promotes a driver-level
+   * read-timeout (a node-mysql2 error with no MySQL errno) to
+   * `AdapterTimeout`. Everything else falls through to the
+   * AbstractMysqlAdapter mapping, which handles the statement-timeout
+   * codes (`ER_QUERY_TIMEOUT` / `ER_FILSORT_ABORT`).
+   */
+  protected override _translateException(e: unknown, sql: string, binds: unknown[]): Error {
+    if (isMysql2DriverTimeout(e)) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return new AdapterTimeout(msg, { sql, binds, cause: e });
+    }
+    return super._translateException(e, sql, binds);
   }
 
   /**
@@ -1706,19 +1722,27 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 }
 
+/**
+ * Detect a node-mysql2 driver-level timeout (no MySQL errno). Mirrors
+ * Rails' `exception.is_a?(Mysql2::Error::TimeoutError) && !exception.error_number`
+ * — the node driver surfaces these as `code === 'PROTOCOL_SEQUENCE_TIMEOUT'`
+ * or `code === 'ETIMEDOUT'` with no `errno`.
+ *
+ * @internal
+ */
+function isMysql2DriverTimeout(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const errno = (e as { errno?: number }).errno;
+  if (typeof errno === "number" && errno > 0) return false;
+  const code = (e as { code?: string }).code;
+  return code === "PROTOCOL_SEQUENCE_TIMEOUT" || code === "ETIMEDOUT";
+}
+
 /** @internal */
 function reconnect(): never {
   // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#reconnect is not implemented",
-  );
-}
-
-/** @internal */
-function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#translate_exception is not implemented",
   );
 }
 

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -294,6 +294,28 @@ export class LockWaitTimeout extends StatementInvalid {
   }
 }
 
+/** Mirrors `ActiveRecord::StatementTimeout`. */
+export class StatementTimeout extends QueryAborted {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "StatementTimeout";
+  }
+}
+
+/** Mirrors `ActiveRecord::AdapterTimeout`. */
+export class AdapterTimeout extends QueryAborted {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "AdapterTimeout";
+  }
+}
+
 /** Mirrors `ActiveRecord::QueryCanceled`. */
 export class QueryCanceled extends QueryAborted {
   constructor(

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -231,6 +231,8 @@ export {
   SerializationFailure,
   Deadlocked,
   LockWaitTimeout,
+  StatementTimeout,
+  AdapterTimeout,
   QueryCanceled,
   RangeError,
   AssociationTypeMismatch,


### PR DESCRIPTION
## Summary

MySQL mysql2-adapter cluster, **Slot B** (translate-exception depth — timeout + statement-timeout). Closes 2 BLOCKED tests in `adapters/mysql2/mysql2-adapter.test.ts`.

- **`AdapterTimeout`** / **`StatementTimeout`** error classes added (extend `QueryAborted`).
- `AbstractMysqlAdapter._translateException` maps `ER_QUERY_TIMEOUT` (3024) and `ER_FILSORT_ABORT` (1028) → `StatementTimeout`.
- `Mysql2Adapter._translateException` override promotes driver-level read-timeouts (no MySQL errno; `code === 'PROTOCOL_SEQUENCE_TIMEOUT'` / `'ETIMEDOUT'`) → `AdapterTimeout`, mirroring Rails' `Mysql2::Error::TimeoutError && !exception.error_number` branch.
- Removes the prior `translateException` NIE stub in `mysql2-adapter.ts` (replaced by the class override).

Mirrors: `mysql2_adapter.rb#translate_exception` + `abstract_mysql_adapter.rb` (lines 849–850, `ER_QUERY_TIMEOUT, ER_FILSORT_ABORT → StatementTimeout`).

## Test plan

- [x] `pnpm build` clean
- [ ] CI: `read timeout exception` + `statement timeout error codes` un-skipped (synthesize driver errors and route through `adapter.translateException`)
- [ ] CI: no regressions in mysql2 / abstract-mysql translate_exception suite