### PR TITLE
feat(action-dispatch): Wave 7 PR 4 — journey/visitors + Format

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -12,17 +12,8 @@ export { Parser } from "./parser.js";
 export { Ast } from "./ast.js";
 export * as Nodes from "./nodes/node.js";
 
-export {
-  Format,
-  Parameter,
-  type FormatPart,
-  Visitor,
-  FunctionalVisitor,
-  FormatBuilder,
-  Each,
-  StringVisitor,
-  DotVisitor,
-} from "./visitors.js";
+export { Format, Parameter, type FormatPart } from "./visitors.js";
+export * as Visitors from "./visitors.js";
 
 export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 

--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -12,6 +12,18 @@ export { Parser } from "./parser.js";
 export { Ast } from "./ast.js";
 export * as Nodes from "./nodes/node.js";
 
+export {
+  Format,
+  Parameter,
+  type FormatPart,
+  Visitor,
+  FunctionalVisitor,
+  FormatBuilder,
+  Each,
+  StringVisitor,
+  DotVisitor,
+} from "./visitors.js";
+
 export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 
 export { MatchData, Simulator, type GtgState, type TransitionTable } from "./gtg/simulator.js";

--- a/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { Parser } from "./parser.js";
 import { Cat, Symbol as SymbolNode } from "./nodes/node.js";
-import { Each, StringVisitor, FormatBuilder, Format, Parameter, DotVisitor } from "./visitors.js";
+import {
+  Each,
+  String as StringVisitor,
+  FormatBuilder,
+  Format,
+  Parameter,
+  Dot as DotVisitor,
+} from "./visitors.js";
 
 // ==========================================================================
 // Rails has no visitors_test.rb — these tests lock down the contracts that

--- a/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
@@ -70,6 +70,19 @@ describe("ActionDispatch::Journey::Visitors::FormatBuilder", () => {
     expect(format.evaluate({ slug: "a/b" })).toBe("/a%2Fb");
   });
 
+  it("coerces non-string values via toString (matches Rails .to_s)", () => {
+    const tree = new Parser().parse("/posts/:id");
+    const format = new FormatBuilder().accept(tree);
+    expect(format.evaluate({ id: 42 })).toBe("/posts/42");
+  });
+
+  it("ignores Object.prototype keys when checking for parameter presence", () => {
+    const tree = new Parser().parse("/posts/:toString");
+    const format = new FormatBuilder().accept(tree);
+    // `toString` exists on Object.prototype but wasn't supplied: should return "".
+    expect(format.evaluate({})).toBe("");
+  });
+
   it("emits required_path for stars", () => {
     const tree = new Parser().parse("/*path");
     const format = new FormatBuilder().accept(tree);

--- a/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+import { Cat, Symbol as SymbolNode } from "./nodes/node.js";
+import { Each, StringVisitor, FormatBuilder, Format, Parameter, DotVisitor } from "./visitors.js";
+
+// ==========================================================================
+// Rails has no visitors_test.rb — these tests lock down the contracts that
+// upstream Visitors::String, Visitors::FormatBuilder, Visitors::Each, and
+// Visitors::Dot rely on, so PR 5+ (Path::Pattern) and beyond can use them
+// without surprises.
+// ==========================================================================
+
+describe("ActionDispatch::Journey::Visitors::String", () => {
+  const roundTrip = (str: string) =>
+    expect(StringVisitor.INSTANCE.accept(new Parser().parse(str), "")).toBe(str);
+
+  it("round-trips slash", () => roundTrip("/"));
+  it("round-trips segment", () => roundTrip("/foo"));
+  it("round-trips symbol", () => roundTrip("/:foo"));
+  it("round-trips group", () => roundTrip("(/:foo)"));
+  it("round-trips nested groups", () => roundTrip("(/:foo(/:bar))"));
+  it("round-trips dot symbol", () => roundTrip(".:format"));
+  it("round-trips star", () => roundTrip("/*foo"));
+  it("round-trips or", () => roundTrip("a|b|c"));
+  it("round-trips complex", () => roundTrip("/sprockets.js(.:format)"));
+});
+
+describe("ActionDispatch::Journey::Visitors::Each", () => {
+  it("visits every node pre-order", () => {
+    const tree = new Parser().parse("/:foo");
+    const seen: string[] = [];
+    Each.INSTANCE.accept(tree, (n) => seen.push(n.type));
+    expect(seen).toContain("CAT");
+    expect(seen).toContain("SLASH");
+    expect(seen).toContain("SYMBOL");
+  });
+});
+
+describe("ActionDispatch::Journey::Visitors::FormatBuilder", () => {
+  it("builds a Format whose evaluate substitutes values", () => {
+    const tree = new Parser().parse("/posts/:id");
+    const format = new FormatBuilder().accept(tree);
+    expect(format).toBeInstanceOf(Format);
+    expect(format.evaluate({ id: "42" })).toBe("/posts/42");
+  });
+
+  it("returns empty string when a required value is missing", () => {
+    const tree = new Parser().parse("/posts/:id");
+    const format = new FormatBuilder().accept(tree);
+    expect(format.evaluate({})).toBe("");
+  });
+
+  it("uses required_path escaping for controller", () => {
+    const tree = new Parser().parse("/:controller");
+    const format = new FormatBuilder().accept(tree);
+    // ESCAPE_PATH keeps `/` literal, while ESCAPE_SEGMENT would encode it.
+    expect(format.evaluate({ controller: "admin/posts" })).toBe("/admin/posts");
+  });
+
+  it("escapes segment values (not paths) for non-controller symbols", () => {
+    const tree = new Parser().parse("/:slug");
+    const format = new FormatBuilder().accept(tree);
+    expect(format.evaluate({ slug: "a/b" })).toBe("/a%2Fb");
+  });
+
+  it("emits required_path for stars", () => {
+    const tree = new Parser().parse("/*path");
+    const format = new FormatBuilder().accept(tree);
+    expect(format.evaluate({ path: "a/b/c" })).toBe("/a/b/c");
+  });
+});
+
+describe("ActionDispatch::Journey::Format", () => {
+  it("Parameter#escape delegates to its escaper", () => {
+    const p = Format.requiredSegment("name");
+    expect(p).toBeInstanceOf(Parameter);
+    expect(p.escape("hello world")).toBe("hello%20world");
+  });
+
+  it("required_path keeps slashes literal", () => {
+    expect(Format.requiredPath("path").escape("a/b")).toBe("a/b");
+  });
+
+  it("required_segment escapes slashes", () => {
+    expect(Format.requiredSegment("seg").escape("a/b")).toBe("a%2Fb");
+  });
+});
+
+describe("ActionDispatch::Journey::Visitors::Dot", () => {
+  it("emits a digraph string with node and edge labels", () => {
+    const tree = new Cat(new SymbolNode(":a"), new SymbolNode(":b"));
+    const dot = DotVisitor.INSTANCE.render(tree);
+    expect(dot).toContain("digraph parse_tree");
+    expect(dot).toContain('label="○"'); // CAT marker
+    expect(dot).toContain('label=":a"');
+    expect(dot).toContain('label=":b"');
+    expect(dot).toMatch(/-> /); // an edge
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Parser } from "./parser.js";
-import { Cat, Symbol as SymbolNode } from "./nodes/node.js";
+import { Cat, Or, Symbol as SymbolNode, Literal } from "./nodes/node.js";
 import {
   Each,
   String as StringVisitor,
@@ -30,16 +30,22 @@ describe("ActionDispatch::Journey::Visitors::String", () => {
   it("round-trips star", () => roundTrip("/*foo"));
   it("round-trips or", () => roundTrip("a|b|c"));
   it("round-trips complex", () => roundTrip("/sprockets.js(.:format)"));
+
+  it("Or separators are positional, not identity-based", () => {
+    // Same Literal instance used twice — separator must still be emitted.
+    const lit = new Literal("a");
+    const tree = new Or([lit, lit]);
+    expect(StringVisitor.INSTANCE.accept(tree, "")).toBe("a|a");
+  });
 });
 
 describe("ActionDispatch::Journey::Visitors::Each", () => {
-  it("visits every node pre-order", () => {
+  it("visits every node in pre-order", () => {
+    // `/:foo` parses as Cat(Slash, Symbol). Pre-order = CAT, SLASH, SYMBOL.
     const tree = new Parser().parse("/:foo");
     const seen: string[] = [];
     Each.INSTANCE.accept(tree, (n) => seen.push(n.type));
-    expect(seen).toContain("CAT");
-    expect(seen).toContain("SLASH");
-    expect(seen).toContain("SYMBOL");
+    expect(seen).toEqual(["CAT", "SLASH", "SYMBOL"]);
   });
 });
 
@@ -87,6 +93,18 @@ describe("ActionDispatch::Journey::Visitors::FormatBuilder", () => {
     const tree = new Parser().parse("/*path");
     const format = new FormatBuilder().accept(tree);
     expect(format.evaluate({ path: "a/b/c" })).toBe("/a/b/c");
+  });
+
+  it("optional group drops to empty when its parameter is missing", () => {
+    const tree = new Parser().parse("/posts(.:format)");
+    const format = new FormatBuilder().accept(tree);
+    expect(format.evaluate({})).toBe("/posts");
+    expect(format.evaluate({ format: "json" })).toBe("/posts.json");
+  });
+
+  it("throws on OR (alternation) nodes — Rails routes don't use OR for path-building", () => {
+    const tree = new Parser().parse("a|b");
+    expect(() => new FormatBuilder().accept(tree)).toThrow(/OR/);
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/journey/visitors.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.ts
@@ -15,8 +15,9 @@ export class Parameter {
     readonly escaper: Escaper,
   ) {}
 
-  escape(value: string): string {
-    return this.escaper(value);
+  /** Rails coerces with `.to_s` before escaping; mirror that here. */
+  escape(value: unknown): string {
+    return this.escaper(globalThis.String(value));
   }
 }
 
@@ -45,12 +46,15 @@ export class Format {
     });
   }
 
-  evaluate(hash: Record<string, string | null | undefined>): string {
+  evaluate(hash: Record<string, unknown>): string {
     const parts: FormatPart[] = [...this._parts];
 
     for (const index of this._parameters) {
       const param = parts[index] as Parameter;
-      const value = hash[param.name];
+      // Guard against prototype pollution: only treat own properties as supplied
+      // parameters. Without this, `toString`/`constructor` from Object.prototype
+      // would satisfy a required-parameter check.
+      const value = Object.hasOwn(hash, param.name) ? hash[param.name] : undefined;
       if (value == null) return "";
       parts[index] = param.escape(value);
     }

--- a/packages/actionpack/src/action-dispatch/journey/visitors.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.ts
@@ -286,8 +286,8 @@ export class Each extends FunctionalVisitor<(node: Node) => void> {
 /**
  * Serialize an AST back to its source string form.
  */
-export class StringVisitor extends FunctionalVisitor<string> {
-  static readonly INSTANCE = new StringVisitor();
+export class String extends FunctionalVisitor<string> {
+  static readonly INSTANCE = new String();
 
   override binary(node: Node, seed: string): string {
     const left = (node as Node & { left: Node }).left;
@@ -332,8 +332,8 @@ function dotId(node: Node): number {
   return id;
 }
 
-export class DotVisitor extends FunctionalVisitor<DotSeed> {
-  static readonly INSTANCE = new DotVisitor();
+export class Dot extends FunctionalVisitor<DotSeed> {
+  static readonly INSTANCE = new Dot();
 
   override accept(node: Node, seed: DotSeed = [[], []]): DotSeed {
     super.accept(node, seed);

--- a/packages/actionpack/src/action-dispatch/journey/visitors.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.ts
@@ -273,6 +273,10 @@ export class FormatBuilder extends Visitor {
     if (symbol === "controller") return [Format.requiredPath(symbol)];
     return [Format.requiredSegment(symbol)];
   }
+
+  protected override visitOR(_n: Node): FormatPart[] {
+    throw new Error("FormatBuilder does not support OR (alternation) nodes");
+  }
 }
 
 /**
@@ -301,12 +305,11 @@ export class String extends FunctionalVisitor<string> {
 
   override nary(node: Node, seed: string): string {
     const children = node.children();
-    const last = children[children.length - 1];
     let acc = seed;
-    for (const c of children) {
+    children.forEach((c, i) => {
       acc = this.visit(c, acc);
-      if (c !== last) acc += "|";
-    }
+      if (i < children.length - 1) acc += "|";
+    });
     return acc;
   }
 

--- a/packages/actionpack/src/action-dispatch/journey/visitors.ts
+++ b/packages/actionpack/src/action-dispatch/journey/visitors.ts
@@ -1,0 +1,401 @@
+import type { Node } from "./nodes/node.js";
+import { escapePath, escapeSegment } from "./router/utils.js";
+
+// ==========================================================================
+// Format — path-evaluation tree built by FormatBuilder
+// ==========================================================================
+
+type Escaper = (value: string) => string;
+const ESCAPE_PATH: Escaper = (value) => escapePath(value);
+const ESCAPE_SEGMENT: Escaper = (value) => escapeSegment(value);
+
+export class Parameter {
+  constructor(
+    readonly name: string,
+    readonly escaper: Escaper,
+  ) {}
+
+  escape(value: string): string {
+    return this.escaper(value);
+  }
+}
+
+export type FormatPart = string | Parameter | Format;
+
+export class Format {
+  private readonly _parts: FormatPart[];
+  private readonly _children: number[];
+  private readonly _parameters: number[];
+
+  static requiredPath(symbol: string): Parameter {
+    return new Parameter(symbol, ESCAPE_PATH);
+  }
+
+  static requiredSegment(symbol: string): Parameter {
+    return new Parameter(symbol, ESCAPE_SEGMENT);
+  }
+
+  constructor(parts: FormatPart[]) {
+    this._parts = parts;
+    this._children = [];
+    this._parameters = [];
+    parts.forEach((p, i) => {
+      if (p instanceof Format) this._children.push(i);
+      else if (p instanceof Parameter) this._parameters.push(i);
+    });
+  }
+
+  evaluate(hash: Record<string, string | null | undefined>): string {
+    const parts: FormatPart[] = [...this._parts];
+
+    for (const index of this._parameters) {
+      const param = parts[index] as Parameter;
+      const value = hash[param.name];
+      if (value == null) return "";
+      parts[index] = param.escape(value);
+    }
+
+    for (const index of this._children) {
+      parts[index] = (parts[index] as Format).evaluate(hash);
+    }
+
+    return parts.join("");
+  }
+}
+
+// ==========================================================================
+// Visitor base classes
+// ==========================================================================
+
+/**
+ * Stateful tree-walking visitor. Subclasses override `visit_<TYPE>` (camelCase
+ * `visit<TYPE>`) or the catch-alls `binary`/`nary`/`unary`/`terminal`.
+ *
+ * Rails uses a `DISPATCH_CACHE` populated by reflection; we use a static
+ * dispatch table for the same effect with explicit registration.
+ */
+export class Visitor {
+  accept(node: Node): unknown {
+    return this.visit(node);
+  }
+
+  /** @internal */
+  protected visit(node: Node): unknown {
+    switch (node.type) {
+      case "CAT":
+        return this.visitCAT(node);
+      case "OR":
+        return this.visitOR(node);
+      case "GROUP":
+        return this.visitGROUP(node);
+      case "STAR":
+        return this.visitSTAR(node);
+      case "LITERAL":
+        return this.visitLITERAL(node);
+      case "SYMBOL":
+        return this.visitSYMBOL(node);
+      case "SLASH":
+        return this.visitSLASH(node);
+      case "DOT":
+        return this.visitDOT(node);
+    }
+  }
+
+  /** @internal */
+  protected binary(node: Node): unknown {
+    this.visit((node as Node & { left: Node }).left);
+    this.visit((node as Node & { right: Node }).right);
+    return undefined;
+  }
+
+  /** @internal */
+  protected nary(node: Node): unknown {
+    for (const c of node.children()) this.visit(c);
+    return undefined;
+  }
+
+  /** @internal */
+  protected unary(node: Node): unknown {
+    return this.visit((node as Node & { left: Node }).left);
+  }
+
+  /** @internal */
+  protected terminal(_node: Node): unknown {
+    return undefined;
+  }
+
+  /** @internal */
+  protected visitCAT(n: Node): unknown {
+    return this.binary(n);
+  }
+  /** @internal */
+  protected visitOR(n: Node): unknown {
+    return this.nary(n);
+  }
+  /** @internal */
+  protected visitGROUP(n: Node): unknown {
+    return this.unary(n);
+  }
+  /** @internal */
+  protected visitSTAR(n: Node): unknown {
+    return this.unary(n);
+  }
+  /** @internal */
+  protected visitLITERAL(n: Node): unknown {
+    return this.terminal(n);
+  }
+  /** @internal */
+  protected visitSYMBOL(n: Node): unknown {
+    return this.terminal(n);
+  }
+  /** @internal */
+  protected visitSLASH(n: Node): unknown {
+    return this.terminal(n);
+  }
+  /** @internal */
+  protected visitDOT(n: Node): unknown {
+    return this.terminal(n);
+  }
+}
+
+/**
+ * Seeded variant. Each visit takes and returns an accumulator.
+ */
+export class FunctionalVisitor<S = unknown> {
+  accept(node: Node, seed: S): S {
+    return this.visit(node, seed);
+  }
+
+  visit(node: Node, seed: S): S {
+    switch (node.type) {
+      case "CAT":
+        return this.visitCAT(node, seed);
+      case "OR":
+        return this.visitOR(node, seed);
+      case "GROUP":
+        return this.visitGROUP(node, seed);
+      case "STAR":
+        return this.visitSTAR(node, seed);
+      case "LITERAL":
+        return this.visitLITERAL(node, seed);
+      case "SYMBOL":
+        return this.visitSYMBOL(node, seed);
+      case "SLASH":
+        return this.visitSLASH(node, seed);
+      case "DOT":
+        return this.visitDOT(node, seed);
+    }
+  }
+
+  binary(node: Node, seed: S): S {
+    const left = (node as Node & { left: Node }).left;
+    const right = (node as Node & { right: Node }).right;
+    return this.visit(right, this.visit(left, seed));
+  }
+  visitCAT(n: Node, seed: S): S {
+    return this.binary(n, seed);
+  }
+
+  nary(node: Node, seed: S): S {
+    let acc = seed;
+    for (const c of node.children()) acc = this.visit(c, acc);
+    return acc;
+  }
+  visitOR(n: Node, seed: S): S {
+    return this.nary(n, seed);
+  }
+
+  unary(node: Node, seed: S): S {
+    return this.visit((node as Node & { left: Node }).left, seed);
+  }
+  visitGROUP(n: Node, seed: S): S {
+    return this.unary(n, seed);
+  }
+  visitSTAR(n: Node, seed: S): S {
+    return this.unary(n, seed);
+  }
+
+  terminal(_node: Node, seed: S): S {
+    return seed;
+  }
+  visitLITERAL(n: Node, seed: S): S {
+    return this.terminal(n, seed);
+  }
+  visitSYMBOL(n: Node, seed: S): S {
+    return this.terminal(n, seed);
+  }
+  visitSLASH(n: Node, seed: S): S {
+    return this.terminal(n, seed);
+  }
+  visitDOT(n: Node, seed: S): S {
+    return this.terminal(n, seed);
+  }
+}
+
+// ==========================================================================
+// Concrete visitors
+// ==========================================================================
+
+/**
+ * Builds a Format tree (per-segment path-eval plan) from an AST.
+ */
+export class FormatBuilder extends Visitor {
+  override accept(node: Node): Format {
+    return new Format(super.accept(node) as FormatPart[]);
+  }
+
+  protected override terminal(node: Node): FormatPart[] {
+    return [typeof node.left === "string" ? node.left : ""];
+  }
+
+  protected override binary(node: Node): FormatPart[] {
+    return [
+      ...(this.visit((node as Node & { left: Node }).left) as FormatPart[]),
+      ...(this.visit((node as Node & { right: Node }).right) as FormatPart[]),
+    ];
+  }
+
+  protected override visitGROUP(n: Node): FormatPart[] {
+    return [new Format(this.unary(n) as FormatPart[])];
+  }
+
+  protected override visitSTAR(n: Node): FormatPart[] {
+    const inner = (n as Node & { left: Node }).left;
+    return [Format.requiredPath(inner.toSym())];
+  }
+
+  protected override visitSYMBOL(n: Node): FormatPart[] {
+    const symbol = n.toSym();
+    if (symbol === "controller") return [Format.requiredPath(symbol)];
+    return [Format.requiredSegment(symbol)];
+  }
+}
+
+/**
+ * Walk every node, invoking `block` once per node (pre-order).
+ */
+export class Each extends FunctionalVisitor<(node: Node) => void> {
+  static readonly INSTANCE = new Each();
+
+  override visit(node: Node, block: (node: Node) => void): (node: Node) => void {
+    block(node);
+    return super.visit(node, block);
+  }
+}
+
+/**
+ * Serialize an AST back to its source string form.
+ */
+export class StringVisitor extends FunctionalVisitor<string> {
+  static readonly INSTANCE = new StringVisitor();
+
+  override binary(node: Node, seed: string): string {
+    const left = (node as Node & { left: Node }).left;
+    const right = (node as Node & { right: Node }).right;
+    return this.visit(right, this.visit(left, seed));
+  }
+
+  override nary(node: Node, seed: string): string {
+    const children = node.children();
+    const last = children[children.length - 1];
+    let acc = seed;
+    for (const c of children) {
+      acc = this.visit(c, acc);
+      if (c !== last) acc += "|";
+    }
+    return acc;
+  }
+
+  override terminal(node: Node, seed: string): string {
+    const left = node.left;
+    return seed + (typeof left === "string" ? left : "");
+  }
+
+  override visitGROUP(node: Node, seed: string): string {
+    return this.visit((node as Node & { left: Node }).left, seed + "(") + ")";
+  }
+}
+
+/**
+ * Render an AST as a Graphviz `dot` parse-tree diagram.
+ */
+type DotSeed = [nodes: string[], edges: string[]];
+
+let __dotIdCounter = 1;
+const __dotIds = new WeakMap<Node, number>();
+function dotId(node: Node): number {
+  let id = __dotIds.get(node);
+  if (id === undefined) {
+    id = __dotIdCounter++;
+    __dotIds.set(node, id);
+  }
+  return id;
+}
+
+export class DotVisitor extends FunctionalVisitor<DotSeed> {
+  static readonly INSTANCE = new DotVisitor();
+
+  override accept(node: Node, seed: DotSeed = [[], []]): DotSeed {
+    super.accept(node, seed);
+    const [nodes, edges] = seed;
+    return [nodes, edges];
+  }
+
+  /** Render an AST to a dot-graph string. */
+  render(node: Node): string {
+    const [nodes, edges] = this.accept(node);
+    return `  digraph parse_tree {
+    size="8,5"
+    node [shape = none];
+    edge [dir = none];
+    ${nodes.join("\n")}
+    ${edges.join("\n")}
+  }
+`;
+  }
+
+  override binary(node: Node, seed: DotSeed): DotSeed {
+    for (const c of node.children()) {
+      seed[1].push(`${dotId(node)} -> ${dotId(c)};`);
+    }
+    return super.binary(node, seed);
+  }
+
+  override nary(node: Node, seed: DotSeed): DotSeed {
+    for (const c of node.children()) {
+      seed[1].push(`${dotId(node)} -> ${dotId(c)};`);
+    }
+    return super.nary(node, seed);
+  }
+
+  override unary(node: Node, seed: DotSeed): DotSeed {
+    seed[1].push(`${dotId(node)} -> ${dotId((node as Node & { left: Node }).left)};`);
+    return super.unary(node, seed);
+  }
+
+  override visitGROUP(node: Node, seed: DotSeed): DotSeed {
+    seed[0].push(`${dotId(node)} [label="()"];`);
+    return super.visitGROUP(node, seed);
+  }
+
+  override visitCAT(node: Node, seed: DotSeed): DotSeed {
+    seed[0].push(`${dotId(node)} [label="○"];`);
+    return super.visitCAT(node, seed);
+  }
+
+  override visitSTAR(node: Node, seed: DotSeed): DotSeed {
+    seed[0].push(`${dotId(node)} [label="*"];`);
+    return super.visitSTAR(node, seed);
+  }
+
+  override visitOR(node: Node, seed: DotSeed): DotSeed {
+    seed[0].push(`${dotId(node)} [label="|"];`);
+    return super.visitOR(node, seed);
+  }
+
+  override terminal(node: Node, seed: DotSeed): DotSeed {
+    const value = typeof node.left === "string" ? node.left : "";
+    seed[0].push(`${dotId(node)} [label="${value}"];`);
+    return seed;
+  }
+}


### PR DESCRIPTION
## Summary

Wave 7 PR 4 of 10. Ports Rails \`action_dispatch/journey/visitors.rb\`.

**\`journey/visitors.ts\`**:
- **Format** class with **Parameter** (replaces Rails' Struct) and the \`requiredPath\` / \`requiredSegment\` factories. \`evaluate(hash)\` walks the parts array substituting parameter values and recursing into child Format subtrees; returns \`""\` when any required parameter is missing (matches Rails).
- **Visitor** base — stateful walker. Rails uses a \`DISPATCH_CACHE\` populated reflectively; we use a static switch dispatch for the same effect.
- **FunctionalVisitor\<S\>** — seeded variant.
- **FormatBuilder** — Visitor subclass producing Format trees. \`visit_STAR\` emits \`requiredPath\`; \`visit_SYMBOL\` emits \`requiredPath\` for \`:controller\`, \`requiredSegment\` otherwise.
- **Each.INSTANCE** — pre-order walk with callback per node.
- **StringVisitor.INSTANCE** — serializes back to source form (\`|\`-joins OR children, wraps GROUP in parens, etc.).
- **DotVisitor.INSTANCE** — Graphviz parse-tree dump. Uses a WeakMap for stable per-node ids (Ruby uses \`object_id\`).

Rails has no \`visitors_test.rb\`. The 19 colocated tests here lock down the round-trip / evaluation / DOT-output contracts the rest of Wave 7 depends on (PR 5 \`Path::Pattern\` subclasses \`Visitor\`).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] 19 new visitor tests (Visitors::String round-trip × 9, Each × 1, FormatBuilder × 5, Format × 3, Dot × 1)
- [x] All 104 journey tests pass (was 85)
- [x] Full actionpack suite green: 1897 tests
- [x] api:compare actiondispatch 305→323 (+18), overall +19 — non-negative