### PR TITLE
feat(globalid): GID-7 — URI::GID class wrapper

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -9,14 +9,14 @@ toGid, toGidParam, toSignedGlobalId, toSgid, toSgidParam). AR side: Base.toGid /
 toSgid / toGlobalId / toGidParam / toSignedGlobalId / findGlobalId /
 findSignedGlobalId / findSignedGlobalIdBang.
 
-### Parity scoreboard (after GID-6c)
+### Parity scoreboard (after GID-7)
 
 Targets are **pre-skip** — the unportable-surface skip list (see below)
 brings the practical 100% to 56/56 api / 149/149 tests.
 
 | Signal       | Current          | 100% target (pre-skip) | Gap          |
 | ------------ | ---------------- | ---------------------- | ------------ |
-| api:compare  | 19 / 59 (32.2%)  | 59 / 59                | 40 methods   |
+| api:compare  | 39 / 59 (66.1%)  | 59 / 59                | 20 methods   |
 | test:compare | 95 / 158 (60.1%) | 158 / 158              | 63 tests     |
 | files (api)  | 4 / 5            | 5 / 5                  | verifier.ts  |
 | files (test) | 5 / 8            | 8 / 8                  | 3 test files |
@@ -26,9 +26,9 @@ Per-file api:compare:
 | Ruby file             | Match | Total | %    |
 | --------------------- | ----- | ----- | ---- |
 | `identification.rb`   | 4     | 4     | 100% |
+| `uri/gid.rb`          | 21    | 21    | 100% |
 | `signed_global_id.rb` | 8     | 16    | 50%  |
-| `locator.rb`          | 5     | 16    | 31%  |
-| `uri/gid.rb`          | 2     | 21    | 10%  |
+| `locator.rb`          | 6     | 16    | 38%  |
 | `verifier.rb`         | 0     | 2     | 0%   |
 
 Per-file test:compare:
@@ -91,26 +91,24 @@ tests, **GID-9**); `app locator is case insensitive` / `locator name
 cannot have underscore` (**GID-9**); `ScopedRecordLocatingTest`
 (model.unscoped block helper, **GID-9**).
 
-### GID-7 — `URI::GID` class wrapping (~120 LOC)
+### GID-7 — `URI::GID` class wrapping — **done**
 
-`uri/gid.rb` exposes 21 methods; we expose 2 (`parseGid`, `buildGid`). Wrap
-them into a `URI.GID` class that holds parsed components and exposes the
-Rails surface:
+Added `URI::GID` class to `packages/globalid/src/uri/gid.ts` wrapping the
+existing `parseGid`/`buildGid` standalone functions. Public surface:
+`GID.parse(uri)`, `GID.create(app, model, params)`, `GID.build(args)`,
+`GID.validateApp(app)` plus instance accessors `app` / `modelName` /
+`modelId` / `params` / `toString()` / `deconstructKeys()`. Internal
+URI::Generic subclass hooks (`setPath` / `setQuery` / `setParams` /
+`checkHost` / `checkPath` / `checkScheme` / `setModelComponents` /
+`validateComponent` / `validateModelIdSection` / `validateModelId` /
+`parseQueryParams`) implemented as protected nominal stubs that delegate
+to the existing functional helpers — kept for api:compare matching and
+to preserve the invariants in OO callers.
 
-- Public: `URI.GID.parse(uri)`, `URI.GID.create(app, model, params)`,
-  `URI.GID.build(args)`, instance: `modelName`, `modelId`, `params`,
-  `toString()`, `deconstructKeys()` (TS stub — no Ruby pattern-matching).
-- Protected/private (URI::Generic subclass hooks): `setPath`, `setQuery`,
-  `setParams`, `checkHost`, `checkPath`, `checkScheme`,
-  `setModelComponents`, `validateComponent`, `validateModelIdSection`,
-  `validateModelId`, `parseQueryParams`.
-
-Most private methods are RFC2396 parser hooks Rails inherits from
-`URI::Generic`. We don't subclass URI, so they're nominal-only — implement
-as `@internal` no-op stubs that exercise the same invariants.
-
-Keep `parseGid`/`buildGid` exports as the public functional API (used
-internally + by AR's `toGid`). The class wraps them.
+api:compare `uri/gid.rb`: 10% → **100% (21/21)**. Overall api:compare
+32.2% → **66.1%**. `parseGid` / `buildGid` exports remain the public
+functional API (used by SignedGlobalID and GlobalID internally + by AR's
+`toGid`); the class is the OO veneer on top.
 
 ### GID-8 — `SignedGlobalID` class-level config + verify split (~80 LOC)
 

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -9,6 +9,7 @@ export {
   parseGid,
   buildGid,
   validateApp,
+  GID,
   MissingModelIdError,
   InvalidModelIdError,
 } from "./uri/gid.js";

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -211,12 +211,22 @@ describe("URI::GID class wrapper", () => {
     expect(GID.validateApp("foo-bar")).toBe("foo-bar");
   });
 
-  it("GID#deconstructKeys returns a copy of the component hash", () => {
-    const gid = GID.parse("gid://bcx/Person/5");
+  it("GID#deconstructKeys returns a deep-enough copy of the component hash", () => {
+    const gid = GID.parse("gid://bcx/Person/5?k=v");
     const a = gid.deconstructKeys();
-    expect(a).toEqual({ app: "bcx", modelName: "Person", modelId: "5", params: {} });
-    // Mutating the returned object must not affect the GID's state.
+    expect(a).toEqual({ app: "bcx", modelName: "Person", modelId: "5", params: { k: "v" } });
+    // Mutating any field of the returned object must not affect the GID.
     (a as { app: string }).app = "evil";
+    a.params["k"] = "evil";
     expect(gid.app).toBe("bcx");
+    expect(gid.params).toEqual({ k: "v" });
+  });
+
+  it("GID#deconstructKeys also copies composite modelId arrays", () => {
+    const gid = GID.parse("gid://bcx/CompositePrimaryKeyModel/tenant/id");
+    const a = gid.deconstructKeys();
+    expect(a.modelId).toEqual(["tenant", "id"]);
+    (a.modelId as string[]).push("evil");
+    expect(gid.modelId).toEqual(["tenant", "id"]);
   });
 });

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -3,6 +3,7 @@ import {
   parseGid,
   buildGid,
   validateApp,
+  GID,
   MissingModelIdError,
   InvalidComponentError,
   BadURIError,
@@ -179,8 +180,7 @@ describe("URI::GIDParamsTest", () => {
 });
 
 describe("URI::GID class wrapper", () => {
-  it("GID.parse exposes app / modelName / modelId / params", async () => {
-    const { GID } = await import("./uri/gid.js");
+  it("GID.parse exposes app / modelName / modelId / params", () => {
     const gid = GID.parse("gid://bcx/Person/5?hello=world");
     expect(gid.app).toBe("bcx");
     expect(gid.modelName).toBe("Person");
@@ -189,14 +189,12 @@ describe("URI::GID class wrapper", () => {
     expect(gid.toString()).toBe("gid://bcx/Person/5?hello=world");
   });
 
-  it("GID.create builds from app + model instance", async () => {
-    const { GID } = await import("./uri/gid.js");
+  it("GID.create builds from app + model instance", () => {
     const gid = GID.create("bcx", { id: 5, constructor: { name: "Person" } });
     expect(gid.toString()).toBe("gid://bcx/Person/5");
   });
 
-  it("GID.build accepts a components-hash with composite primary key", async () => {
-    const { GID } = await import("./uri/gid.js");
+  it("GID.build accepts a components-hash with composite primary key", () => {
     const gid = GID.build({
       app: "bcx",
       modelName: "CompositePrimaryKeyModel",
@@ -207,19 +205,18 @@ describe("URI::GID class wrapper", () => {
     expect(gid.modelId).toEqual(["tenant", "id"]);
   });
 
-  it("GID.validateApp rejects invalid app names", async () => {
-    const { GID } = await import("./uri/gid.js");
+  it("GID.validateApp rejects invalid app names", () => {
     expect(() => GID.validateApp(null)).toThrow();
     expect(() => GID.validateApp("foo_bar")).toThrow();
     expect(GID.validateApp("foo-bar")).toBe("foo-bar");
   });
 
-  it("GID#deconstructKeys returns the component hash", async () => {
-    const { GID } = await import("./uri/gid.js");
+  it("GID#deconstructKeys returns a copy of the component hash", () => {
     const gid = GID.parse("gid://bcx/Person/5");
-    const { app, modelName, modelId } = gid.deconstructKeys();
-    expect(app).toBe("bcx");
-    expect(modelName).toBe("Person");
-    expect(modelId).toBe("5");
+    const a = gid.deconstructKeys();
+    expect(a).toEqual({ app: "bcx", modelName: "Person", modelId: "5", params: {} });
+    // Mutating the returned object must not affect the GID's state.
+    (a as { app: string }).app = "evil";
+    expect(gid.app).toBe("bcx");
   });
 });

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -177,3 +177,49 @@ describe("URI::GIDParamsTest", () => {
     expect(uri).toBe("gid://bcx/Person/5?hello=world");
   });
 });
+
+describe("URI::GID class wrapper", () => {
+  it("GID.parse exposes app / modelName / modelId / params", async () => {
+    const { GID } = await import("./uri/gid.js");
+    const gid = GID.parse("gid://bcx/Person/5?hello=world");
+    expect(gid.app).toBe("bcx");
+    expect(gid.modelName).toBe("Person");
+    expect(gid.modelId).toBe("5");
+    expect(gid.params).toEqual({ hello: "world" });
+    expect(gid.toString()).toBe("gid://bcx/Person/5?hello=world");
+  });
+
+  it("GID.create builds from app + model instance", async () => {
+    const { GID } = await import("./uri/gid.js");
+    const gid = GID.create("bcx", { id: 5, constructor: { name: "Person" } });
+    expect(gid.toString()).toBe("gid://bcx/Person/5");
+  });
+
+  it("GID.build accepts a components-hash with composite primary key", async () => {
+    const { GID } = await import("./uri/gid.js");
+    const gid = GID.build({
+      app: "bcx",
+      modelName: "CompositePrimaryKeyModel",
+      modelId: ["tenant", "id"],
+      params: { db: "primary" },
+    });
+    expect(gid.toString()).toBe("gid://bcx/CompositePrimaryKeyModel/tenant/id?db=primary");
+    expect(gid.modelId).toEqual(["tenant", "id"]);
+  });
+
+  it("GID.validateApp rejects invalid app names", async () => {
+    const { GID } = await import("./uri/gid.js");
+    expect(() => GID.validateApp(null)).toThrow();
+    expect(() => GID.validateApp("foo_bar")).toThrow();
+    expect(GID.validateApp("foo-bar")).toBe("foo-bar");
+  });
+
+  it("GID#deconstructKeys returns the component hash", async () => {
+    const { GID } = await import("./uri/gid.js");
+    const gid = GID.parse("gid://bcx/Person/5");
+    const { app, modelName, modelId } = gid.deconstructKeys();
+    expect(app).toBe("bcx");
+    expect(modelName).toBe("Person");
+    expect(modelId).toBe("5");
+  });
+});

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -201,7 +201,12 @@ export class GID {
    * mutate the GID via the returned object).
    */
   deconstructKeys(_keys: readonly string[] | null = null): GidComponents {
-    return { ...this._components, params: { ...this._components.params } };
+    const { modelId } = this._components;
+    return {
+      ...this._components,
+      modelId: Array.isArray(modelId) ? [...modelId] : modelId,
+      params: { ...this._components.params },
+    };
   }
 
   // ─── Static factories ────────────────────────────────────────────────────
@@ -294,7 +299,17 @@ export class GID {
     }
     return true;
   }
-  /** @internal Mirrors URI::GID#set_model_components — parses path → model_name + model_id. */
+  /**
+   * @internal Mirrors URI::GID#set_model_components.
+   *
+   * Nominal stub for api:compare parity. In Rails this assigns
+   * `@model_name` and `@model_id` from the path; our GID instances are
+   * built from a parsed `GidComponents` snapshot at construction time
+   * (via parseGid in the public path, or directly from args in build()),
+   * so re-deriving model components from the path string after the fact
+   * isn't needed. We still run the same validation a Rails caller would
+   * see so a TS subclass that overrides this gets predictable failures.
+   */
   protected setModelComponents(path: string, validate = false): void {
     const parts = path.split("/");
     const modelName = parts[1];

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -196,10 +196,12 @@ export class GID {
 
   /**
    * Mirrors: URI::GID#deconstruct_keys. Ruby uses this for pattern
-   * matching; TS has no equivalent, so we expose the components hash.
+   * matching; TS has no equivalent, so we return a shallow copy of the
+   * components hash (a copy, not the internal state, so callers can't
+   * mutate the GID via the returned object).
    */
   deconstructKeys(_keys: readonly string[] | null = null): GidComponents {
-    return this._components;
+    return { ...this._components, params: { ...this._components.params } };
   }
 
   // ─── Static factories ────────────────────────────────────────────────────
@@ -226,7 +228,19 @@ export class GID {
     params?: Record<string, string> | null;
   }): GID {
     const uri = buildGid(args.app, args.modelName, args.modelId, args.params);
-    return new GID(uri, parseGid(uri));
+    // Construct components directly from inputs — buildGid already validated
+    // them, so skipping the round-trip through parseGid saves a regex match
+    // + URL decode pass. modelId is normalized to the same shape parseGid
+    // produces: arrays for composite, string for scalar.
+    const modelId = Array.isArray(args.modelId)
+      ? args.modelId.map((p) => String(p))
+      : String(args.modelId ?? "");
+    return new GID(uri, {
+      app: args.app,
+      modelName: args.modelName,
+      modelId,
+      params: args.params ?? {},
+    });
   }
 
   /** Mirrors: URI::GID.validate_app */
@@ -234,7 +248,17 @@ export class GID {
     return validateApp(app);
   }
 
-  // ─── URI::Generic subclass hooks (nominal — kept for api:compare) ────────
+  // ─── URI::Generic subclass hooks ─────────────────────────────────────────
+  //
+  // Rails URI::GID inherits from URI::Generic and overrides these hooks so
+  // the standard URI library calls them while parsing/assigning. We don't
+  // subclass URI in TS — public parsing goes through GID.parse → parseGid,
+  // not through these hooks. They exist for two reasons:
+  //   1. api:compare parity (the methods need to be present on URI::GID).
+  //   2. Subclass extension points: a TS subclass of GID can override these
+  //      to plug into the validation pipeline if needed.
+  // Each delegates to the same standalone helpers parseGid/validateApp use,
+  // so behavior matches if anyone does call them directly.
 
   /** @internal Mirrors URI::GID#set_path — re-parses model components from path. */
   protected setPath(path: string): void {

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -149,3 +149,163 @@ function cgiEscape(s: string): string {
 function cgiUnescape(s: string): string {
   return decodeURIComponent(s.replace(/\+/g, "%20"));
 }
+
+// ─── URI::GID class wrapper (Rails parity) ─────────────────────────────────
+
+/**
+ * Class form of the GID URI. Wraps {@link parseGid}/{@link buildGid} so the
+ * Rails `URI::GID` method surface (parse / create / build / validate_app on
+ * the class; modelName / modelId / params / toString / deconstructKeys on
+ * the instance) is reachable for api:compare matching and for callers who
+ * prefer an OO shape.
+ *
+ * Mirrors: URI::GID (vendor/globalid/lib/global_id/uri/gid.rb)
+ */
+export class GID {
+  /** The raw GID URI string. */
+  readonly uri: string;
+  private readonly _components: GidComponents;
+
+  /** @internal — callers should use {@link GID.parse} / {@link GID.create} / {@link GID.build}. */
+  constructor(uri: string, components?: GidComponents) {
+    this.uri = uri;
+    this._components = components ?? parseGid(uri);
+  }
+
+  /** Mirrors `alias :app :host`. */
+  get app(): string {
+    return this._components.app;
+  }
+  /** Mirrors `attr_reader :model_name`. */
+  get modelName(): string {
+    return this._components.modelName;
+  }
+  /** Mirrors `attr_reader :model_id`. */
+  get modelId(): string | string[] {
+    return this._components.modelId;
+  }
+  /** Mirrors `attr_reader :params`. */
+  get params(): Record<string, string> {
+    return this._components.params;
+  }
+
+  /** Mirrors: URI::GID#to_s */
+  toString(): string {
+    return this.uri;
+  }
+
+  /**
+   * Mirrors: URI::GID#deconstruct_keys. Ruby uses this for pattern
+   * matching; TS has no equivalent, so we expose the components hash.
+   */
+  deconstructKeys(_keys: readonly string[] | null = null): GidComponents {
+    return this._components;
+  }
+
+  // ─── Static factories ────────────────────────────────────────────────────
+
+  /** Mirrors: URI::GID.parse */
+  static parse(uri: string): GID {
+    return new GID(uri);
+  }
+
+  /** Mirrors: URI::GID.create(app, model, params) */
+  static create(
+    app: string,
+    model: { id: unknown; constructor: { name: string } },
+    params: Record<string, string> | null = null,
+  ): GID {
+    return GID.build({ app, modelName: model.constructor.name, modelId: model.id, params });
+  }
+
+  /** Mirrors: URI::GID.build({app:, model_name:, model_id:, params:}) */
+  static build(args: {
+    app: string;
+    modelName: string;
+    modelId: unknown;
+    params?: Record<string, string> | null;
+  }): GID {
+    const uri = buildGid(args.app, args.modelName, args.modelId, args.params);
+    return new GID(uri, parseGid(uri));
+  }
+
+  /** Mirrors: URI::GID.validate_app */
+  static validateApp(app: string | null | undefined): string {
+    return validateApp(app);
+  }
+
+  // ─── URI::Generic subclass hooks (nominal — kept for api:compare) ────────
+
+  /** @internal Mirrors URI::GID#set_path — re-parses model components from path. */
+  protected setPath(path: string): void {
+    this.setModelComponents(path, true);
+  }
+  /** @internal Mirrors URI::GID#query= — assigns parsed params via a setter. */
+  protected set query(value: string | undefined) {
+    this.setParams(this.parseQueryParams(value));
+  }
+  /** @internal Mirrors URI::GID#set_query (Ruby ≤ 2.1 alias of query=). */
+  protected setQuery(query: string | undefined): void {
+    this.query = query;
+  }
+  /** @internal Mirrors URI::GID#set_params. */
+  protected setParams(params: Record<string, string>): void {
+    (this._components as { params: Record<string, string> }).params = params;
+  }
+  /** @internal Mirrors URI::GID#check_host. */
+  protected checkHost(host: string): true {
+    this.validateComponent(host);
+    return true;
+  }
+  /** @internal Mirrors URI::GID#check_path. */
+  protected checkPath(path: string): true {
+    this.validateComponent(path);
+    this.setModelComponents(path, true);
+    return true;
+  }
+  /** @internal Mirrors URI::GID#check_scheme — only "gid" is valid. */
+  protected checkScheme(scheme: string): true {
+    if (scheme !== "gid") {
+      throw new BadURIError(`Not a gid:// URI scheme: ${scheme}`);
+    }
+    return true;
+  }
+  /** @internal Mirrors URI::GID#set_model_components — parses path → model_name + model_id. */
+  protected setModelComponents(path: string, validate = false): void {
+    const parts = path.split("/");
+    const modelName = parts[1];
+    const rawModelId = parts.slice(2).join("/");
+    if (validate) {
+      this.validateComponent(modelName);
+      this.validateModelIdSection(rawModelId, modelName);
+    }
+  }
+  /** @internal Mirrors URI::GID#validate_component — must be non-blank. */
+  protected validateComponent(component: string | null | undefined): string {
+    if (!component) {
+      throw new InvalidComponentError(`Expected a URI like gid://app/Person/1234`);
+    }
+    return component;
+  }
+  /** @internal Mirrors URI::GID#validate_model_id_section. */
+  protected validateModelIdSection(modelId: string, modelName: string): string {
+    if (!modelId) {
+      throw new MissingModelIdError(
+        `Unable to create a Global ID for ${modelName} without a model id.`,
+      );
+    }
+    return modelId;
+  }
+  /** @internal Mirrors URI::GID#validate_model_id — composite parts cannot contain '/'. */
+  protected validateModelId(modelIdPart: string): void {
+    if (modelIdPart.includes("/")) {
+      throw new InvalidModelIdError(
+        `Unable to create a Global ID for ${this.modelName} with a malformed model id.`,
+      );
+    }
+  }
+  /** @internal Mirrors URI::GID#parse_query_params. */
+  protected parseQueryParams(query: string | undefined): Record<string, string> {
+    return parseQueryParams(query);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a class form of \`URI::GID\` over the existing \`parseGid\`/\`buildGid\` standalone functions. The class is an OO veneer; the standalone exports remain the public functional API used by \`SignedGlobalID\`, \`GlobalID\`, and AR \`Base#toGid\`.

## Public surface (mirrors Rails URI::GID)

| Static | Instance |
|--------|----------|
| \`GID.parse(uri)\` | \`get app\` (alias of host) |
| \`GID.create(app, model, params?)\` | \`get modelName\` |
| \`GID.build({app, modelName, modelId, params?})\` | \`get modelId\` |
| \`GID.validateApp(app)\` | \`get params\` |
| | \`toString()\` |
| | \`deconstructKeys()\` |

## Protected URI::Generic subclass hooks (nominal — kept for api:compare)

\`setPath\` / \`query=\` setter / \`setQuery\` / \`setParams\` / \`checkHost\` / \`checkPath\` / \`checkScheme\` / \`setModelComponents\` / \`validateComponent\` / \`validateModelIdSection\` / \`validateModelId\` / \`parseQueryParams\` — these are method names Rails inherits/overrides from \`URI::Generic\`. We don't subclass URI, so they delegate to the existing functional helpers.

## api:compare delta

| File | Before | After |
|------|--------|-------|
| \`uri/gid.ts\` | 2/21 (10%) | **21/21 (100%)** |
| Overall | 32.2% | **66.1%** |

\`locator.ts\` also picked up one method (\`modelIdIsValid\`) from GID-6c which landed before this PR — that's reflected in the new scoreboard.

## Test plan

- [x] \`pnpm vitest run packages/globalid/src/\` — 124 tests pass (5 new GID class tests)
- [x] \`pnpm api:compare --package globalid\` — 66.1% (from 32.2%)
- [x] \`pnpm vitest run packages/activerecord/src/signed-id.test.ts\` — 47 pass, 9 skipped (no regression)