### PR TITLE
feat(activerecord): Transactions Slot D — isolation tests via PG secondConnection

### DIFF
--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -41,9 +41,12 @@ describe("TransactionIsolationUnsupportedTest", () => {
 });
 
 // Rails: TransactionIsolationTest — guarded by supports_transaction_isolation? && !SQLite3.
-// The skipped tests require PG/MySQL + a second connection (Slot D).
-// The un-skipped test below (isolation-when-joining) is adapter-agnostic: the
-// framework-level check fires before any DB call, so SQLite is a valid harness.
+// The two tests below (isolation-when-joining + nested-transaction) are
+// adapter-agnostic: the framework-level isolation check fires before any DB
+// call, so the SQLite harness is sufficient. The four PG-required cases
+// (read uncommitted / read committed / repeatable read / serializable) live
+// in the `describeIfPg("TransactionIsolationTest", ...)` block at the bottom
+// of this file.
 describe("TransactionIsolationTest", () => {
   it("setting isolation when joining a transaction raises an error", async () => {
     // When already inside a transaction, trying to join with an isolation level set

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -111,7 +111,7 @@ describeIfPg("TransactionIsolationTest", () => {
       await Tag.transaction(
         async () => {
           expect(await Tag.count()).toBe(0);
-          await Tag2.create({ name: "x" });
+          await Tag2.create({});
           expect(await Tag.count()).toBe(1);
         },
         { isolation: "read_uncommitted" },
@@ -127,7 +127,7 @@ describeIfPg("TransactionIsolationTest", () => {
         async () => {
           expect(await Tag.count()).toBe(0);
           await Tag2.transaction(async () => {
-            await Tag2.create({ name: "x" });
+            await Tag2.create({});
             expect(await Tag.count()).toBe(0);
           });
         },
@@ -167,7 +167,7 @@ describeIfPg("TransactionIsolationTest", () => {
       const { Tag } = tagModels(adapter, adapter2);
       await Tag.transaction(
         async () => {
-          await Tag.create({ name: "x" });
+          await Tag.create({});
         },
         { isolation: "serializable" },
       );

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Base, TransactionIsolationError } from "./index.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
+import { withSecondAdapter } from "./test-helpers/second-connection.js";
 
 const openAdapters: SQLite3Adapter[] = [];
 
@@ -43,34 +45,6 @@ describe("TransactionIsolationUnsupportedTest", () => {
 // The un-skipped test below (isolation-when-joining) is adapter-agnostic: the
 // framework-level check fires before any DB call, so SQLite is a valid harness.
 describe("TransactionIsolationTest", () => {
-  it.skip("read uncommitted", () => {
-    // BLOCKED: transactions — needs secondConnection wiring
-    // ROOT-CAUSE: test uses Tag + Tag2 on separate connections to observe
-    //   dirty-read behavior across connections; requires `withSecondAdapter`
-    //   helper (Slot D, #1411).
-    // SCOPE: ~20 LOC; unblocked when Slot D harness lands.
-  });
-  it.skip("read committed", () => {
-    // BLOCKED: transactions — needs secondConnection wiring
-    // ROOT-CAUSE: test uses Tag + Tag2 on separate connections to verify
-    //   no dirty read at read-committed isolation level; requires
-    //   `withSecondAdapter` helper (Slot D, #1411).
-    // SCOPE: ~20 LOC; unblocked when Slot D harness lands.
-  });
-  it.skip("repeatable read", () => {
-    // BLOCKED: transactions — needs secondConnection wiring
-    // ROOT-CAUSE: test uses Tag + Tag2 on separate connections to verify
-    //   non-repeatable-read protection at repeatable-read isolation level;
-    //   requires `withSecondAdapter` helper (Slot D, #1411).
-    // SCOPE: ~20 LOC; unblocked when Slot D harness lands.
-  });
-  it.skip("serializable", () => {
-    // BLOCKED: transactions — needs real PG/MySQL adapter
-    // ROOT-CAUSE: SQLite3 raises TransactionIsolationError for serializable;
-    //   test only runs for adapters with supportsTransactionIsolation()=true.
-    //   Needs real PG/MySQL connection via Slot D adapter setup.
-    // SCOPE: ~10 LOC; unblocked when Slot D harness lands.
-  });
   it("setting isolation when joining a transaction raises an error", async () => {
     // When already inside a transaction, trying to join with an isolation level set
     // must raise TransactionIsolationError — same adapter-agnostic check as Rails.
@@ -89,6 +63,114 @@ describe("TransactionIsolationTest", () => {
       await expect(
         Tag.transaction(async () => {}, { requiresNew: true, isolation: "serializable" }),
       ).rejects.toThrow(TransactionIsolationError);
+    });
+  });
+});
+
+// Rails: TransactionIsolationTest, guarded by supports_transaction_isolation? && !SQLite3.
+// Mirrors vendor/rails/activerecord/test/cases/transaction_isolation_test.rb. Uses two
+// independent PostgreSQLAdapter instances (via withSecondAdapter) as the second
+// connection — Rails uses pool checkout; we use a fresh adapter for full isolation.
+describeIfPg("TransactionIsolationTest", () => {
+  const TABLE = "pg_iso_tags";
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS "${TABLE}"`);
+    await adapter.exec(`CREATE TABLE "${TABLE}" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
+  });
+  afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "${TABLE}"`);
+    await adapter.close();
+  });
+
+  function tagModels(adapter1: PostgreSQLAdapter, adapter2: PostgreSQLAdapter) {
+    class Tag extends Base {
+      static {
+        this._tableName = TABLE;
+        this.attribute("name", "string");
+        this.adapter = adapter1;
+      }
+    }
+    class Tag2 extends Base {
+      static {
+        this._tableName = TABLE;
+        this.attribute("name", "string");
+        this.adapter = adapter2;
+      }
+    }
+    return { Tag, Tag2 };
+  }
+
+  // PG aliases READ UNCOMMITTED to READ COMMITTED — Rails notes this test only
+  // asserts that the second connection's committed insert becomes visible.
+  it("read uncommitted", async () => {
+    await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+      const { Tag, Tag2 } = tagModels(adapter, adapter2);
+      await Tag.transaction(
+        async () => {
+          expect(await Tag.count()).toBe(0);
+          await Tag2.create({ name: "x" });
+          expect(await Tag.count()).toBe(1);
+        },
+        { isolation: "read_uncommitted" },
+      );
+    });
+  });
+
+  // A dirty read must not happen: Tag2's uncommitted insert is invisible to Tag.
+  it("read committed", async () => {
+    await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+      const { Tag, Tag2 } = tagModels(adapter, adapter2);
+      await Tag.transaction(
+        async () => {
+          expect(await Tag.count()).toBe(0);
+          await Tag2.transaction(async () => {
+            await Tag2.create({ name: "x" });
+            expect(await Tag.count()).toBe(0);
+          });
+        },
+        { isolation: "read_committed" },
+      );
+      expect(await Tag.count()).toBe(1);
+    });
+  });
+
+  // A non-repeatable read must not happen: a committed update from the second
+  // connection is invisible to the first connection's repeatable-read snapshot.
+  it("repeatable read", async () => {
+    await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+      const { Tag, Tag2 } = tagModels(adapter, adapter2);
+      const tag = await Tag.create({ name: "jon" });
+
+      await Tag.transaction(
+        async () => {
+          await tag.reload();
+          const t2 = await Tag2.find(tag.id);
+          await t2.update({ name: "emily" });
+
+          await tag.reload();
+          expect(tag.name).toBe("jon");
+        },
+        { isolation: "repeatable_read" },
+      );
+
+      await tag.reload();
+      expect(tag.name).toBe("emily");
+    });
+  });
+
+  // No-error smoke test for serializable — DBs enforce serializability differently.
+  it("serializable", async () => {
+    await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
+      const { Tag } = tagModels(adapter, adapter2);
+      await Tag.transaction(
+        async () => {
+          await Tag.create({ name: "x" });
+        },
+        { isolation: "serializable" },
+      );
     });
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -44,6 +44,7 @@ function makeSQLiteMovie() {
   class Movie extends Base {
     static {
       this.primaryKey = "movieid";
+      this.attribute("movieid", "integer");
       this.attribute("name", "string");
       this._tableName = "movies";
       this.adapter = adapter;
@@ -1683,7 +1684,7 @@ describe("TransactionTest", () => {
     });
 
     movie.writeAttribute("movieid", null);
-    expect(movie.readAttribute("movieid")).toBeNull();
+    expect(movie.movieid).toBeNull();
   });
   it("sqlite add column in transaction", () => {
     expect(true).toBe(true);

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -37,6 +37,21 @@ function makeSQLiteTopic() {
   return { Topic, adapter };
 }
 
+function makeSQLiteMovie() {
+  const adapter = new SQLite3Adapter(":memory:");
+  openAdapters.push(adapter);
+  adapter.exec("CREATE TABLE movies (movieid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+  class Movie extends Base {
+    static {
+      this.primaryKey = "movieid";
+      this.attribute("name", "string");
+      this._tableName = "movies";
+      this.adapter = adapter;
+    }
+  }
+  return { Movie, adapter };
+}
+
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
@@ -1644,14 +1659,31 @@ describe("TransactionTest", () => {
   it("assign custom primary key after rollback", () => {
     expect(true).toBe(true);
   });
-  it("read attribute with custom primary key after rollback", () => {
-    expect(true).toBe(true);
+  it("read attribute with custom primary key after rollback", async () => {
+    const { Movie } = makeSQLiteMovie();
+    const movie = Movie.new({ name: "foo" }) as any;
+
+    await Movie.transaction(async () => {
+      await movie.save();
+      throw new Rollback();
+    });
+
+    expect(movie.readAttribute("movieid")).toBeNull();
   });
   it("write attribute after rollback", () => {
     expect(true).toBe(true);
   });
-  it("write attribute with custom primary key after rollback", () => {
-    expect(true).toBe(true);
+  it("write attribute with custom primary key after rollback", async () => {
+    const { Movie } = makeSQLiteMovie();
+    const movie = (await Movie.create({ name: "foo" })) as any;
+
+    await Movie.transaction(async () => {
+      await movie.save();
+      throw new Rollback();
+    });
+
+    movie.writeAttribute("movieid", null);
+    expect(movie.readAttribute("movieid")).toBeNull();
   });
   it("sqlite add column in transaction", () => {
     expect(true).toBe(true);

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -158,12 +158,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   // --- Permanently not-portable: GVL / thread-model ---
   {
-    testFile: "transaction_isolation_test.rb",
-    reason:
-      "All tests require concurrent Ruby threads exercising the GVL. " +
-      "Node.js is single-threaded; transaction-isolation guarantees verified by the DB engine, not the runtime.",
-  },
-  {
     testFile: "schema_loading_test.rb",
     reason:
       "Tests ActiveSupport.on_load / Zeitwerk autoload hooks triggered from background threads. " +


### PR DESCRIPTION
## Summary

- Wires the four PG-required tests from Rails' `transaction_isolation_test.rb` (read uncommitted / read committed / repeatable read / serializable) through the existing `withSecondAdapter` helper. The framework-level `transaction-isolation.test.ts` keeps its SQLite smoke tests and adds a `describeIfPg` block mirroring Rails' setup: a `pg_iso_tags` table plus Tag/Tag2 classes bound to two independent `PostgreSQLAdapter` instances.
- Folds in two Transactions-cluster followups using the existing Movie fixture: `read attribute with custom primary key after rollback` and `write attribute with custom primary key after rollback` are un-skipped.

Closes Transactions Slot D from `docs/activerecord-100-clusters.md` (4 un-skips). Custom-PK followup folded in (2 un-skips, ~10 LOC). The `restore previously new record after double save` followup is deferred — it needs an `_startTransactionState` capture-timing fix, not just an un-skip.

## Test plan
- [ ] CI green on PG job (4 isolation tests should pass).
- [x] Local SQLite vitest run passes for both modified files.