### PR TITLE
feat(activerecord): PG IPv6 canonicalization in parseIpAddr (RFC 5952)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
@@ -34,4 +34,37 @@ describe("PostgreSQL::OID::Cidr", () => {
     const ip = new IPAddr("10.0.0.1", 32);
     expect(type.castValue(ip)).toBe(ip);
   });
+
+  it("canonicalizes IPv6 to RFC 5952 form on cast (matches Ruby IPAddr#to_s)", () => {
+    const type = new Cidr();
+    // Lowercase hex + leading-zero stripping.
+    expect(type.castValue("2001:DB8::1")?.address).toBe("2001:db8::1");
+    expect(type.castValue("2001:0DB8:0000:0000:0000:0000:0000:0001")?.address).toBe("2001:db8::1");
+    // Longest run of zeros compressed; leftmost run wins on ties.
+    expect(type.castValue("2001:db8:0:0:1:0:0:1")?.address).toBe("2001:db8::1:0:0:1");
+    // Edge cases.
+    expect(type.castValue("::1")?.address).toBe("::1");
+    expect(type.castValue("::")?.address).toBe("::");
+    expect(type.castValue("0:0:0:0:0:0:0:0")?.address).toBe("::");
+    // IPv4-tailed forms convert to all-hex (Ruby IPAddr#to_s behavior).
+    expect(type.castValue("::ffff:192.168.0.1")?.address).toBe("::ffff:c0a8:1");
+    // Single zero groups are not compressed (RFC 5952: run must be ≥ 2).
+    expect(type.castValue("2001:db8:0:1:1:1:1:1")?.address).toBe("2001:db8:0:1:1:1:1:1");
+  });
+
+  it("isChanged uses canonical form so textual variants don't mark dirty", () => {
+    const type = new Cidr();
+    const a = type.castValue("2001:DB8::1");
+    const b = type.castValue("2001:0db8:0000:0000:0000:0000:0000:0001");
+    expect(type.isChanged(a, b)).toBe(false);
+    // Different prefix is still a change.
+    const c = type.castValue("2001:db8::1/64");
+    expect(type.isChanged(a, c)).toBe(true);
+  });
+
+  it("serialize emits the canonical form", () => {
+    const type = new Cidr();
+    const ip = type.castValue("2001:0DB8:0:0:0:0:0:1");
+    expect(type.serialize(ip)).toBe("2001:db8::1/128");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -138,11 +138,73 @@ function parseIpAddr(value: string): IPAddr | null {
     return new IPAddr(address, Number(prefixStr));
   }
   if (isIpv6(address)) {
-    if (prefixStr == null) return new IPAddr(address, 128);
+    const canonical = canonicalizeIpv6(address);
+    if (prefixStr == null) return new IPAddr(canonical, 128);
     if (!isValidPrefix(prefixStr, 128)) return null;
-    return new IPAddr(address, Number(prefixStr));
+    return new IPAddr(canonical, Number(prefixStr));
   }
   return null;
+}
+
+/**
+ * Canonicalize an IPv6 address to its RFC 5952 form. Ruby's `IPAddr#to_s`
+ * always emits the canonical form (lowercase hex, no leading zeros per group,
+ * longest run of zero groups compressed to `::`, leftmost run on ties, only
+ * when the run is ≥ 2 groups). IPv4-tailed forms (`::ffff:192.168.0.1`) are
+ * converted to all-hex form to match Ruby (`::ffff:c0a8:1`).
+ *
+ * Without this, two textually different inputs that parse to the same address
+ * (e.g. `2001:DB8::1` vs `2001:db8:0:0:0:0:0:1`) would compare unequal in
+ * `isChanged`, marking the attribute spuriously dirty. PG normalizes on
+ * round-trip, so DB-loaded rows are unaffected — this matters only for
+ * manually-assigned values before save.
+ */
+function canonicalizeIpv6(value: string): string {
+  let head = value;
+  const lastColon = value.lastIndexOf(":");
+  if (lastColon !== -1 && value.slice(lastColon + 1).includes(".")) {
+    const tail = value.slice(lastColon + 1);
+    const [a, b, c, d] = tail.split(".").map(Number);
+    const h1 = ((a << 8) | b).toString(16);
+    const h2 = ((c << 8) | d).toString(16);
+    head = `${value.slice(0, lastColon + 1)}${h1}:${h2}`;
+  }
+
+  let groups: string[];
+  if (head.includes("::")) {
+    const [left, right] = head.split("::");
+    const l = left === "" ? [] : left.split(":");
+    const r = right === "" ? [] : right.split(":");
+    const missing = 8 - l.length - r.length;
+    groups = [...l, ...Array(missing).fill("0"), ...r];
+  } else {
+    groups = head.split(":");
+  }
+
+  groups = groups.map((g) => parseInt(g, 16).toString(16));
+
+  let bestStart = -1;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  for (let i = 0; i <= groups.length; i++) {
+    if (i < groups.length && groups[i] === "0") {
+      if (curStart === -1) curStart = i;
+      curLen++;
+    } else {
+      if (curLen > bestLen) {
+        bestStart = curStart;
+        bestLen = curLen;
+      }
+      curStart = -1;
+      curLen = 0;
+    }
+  }
+
+  if (bestLen < 2) return groups.join(":");
+  const before = groups.slice(0, bestStart).join(":");
+  const after = groups.slice(bestStart + bestLen).join(":");
+  return `${before}::${after}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `parseIpAddr` now returns IPv6 addresses in **RFC 5952 canonical form** (lowercase hex, no leading zeros per group, longest run of zero groups compressed to `::`, leftmost run wins on ties). Matches Ruby `IPAddr#to_s`.
- IPv4-tailed inputs (`::ffff:192.168.0.1`) convert to all-hex form (`::ffff:c0a8:1`), matching Ruby.
- Without this, two textually distinct inputs that parse to the same address (e.g. `2001:DB8::1` vs `2001:db8:0:0:0:0:0:1`) compared unequal in `Cidr#isChanged`, spuriously marking the attribute dirty. PG normalizes on round-trip so DB-loaded rows were unaffected — this matters for manually-assigned values before save.
- Inline expander/compressor; no `node:net` (blocked by browser-compat rule).

Scope from `docs/activerecord-100-clusters.md` PG long-tail cluster.

## Test plan

- [x] `TEST_ADAPTER=postgresql pnpm vitest run packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts` — 5/5 pass
- New tests cover: lowercase + leading-zero strip, leftmost-run tie-break, `::1`/`::`/all-zero, IPv4-tailed → all-hex, single-zero-group not compressed, `isChanged` stability across textual variants, `serialize` emits canonical form.