### PR TITLE
feat(action-dispatch): Wave 7 PR 5 — journey/path/pattern

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/gtg/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/gtg/index.ts
@@ -1,0 +1,1 @@
+export { MatchData, Simulator, type GtgState, type TransitionTable } from "./simulator.js";

--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -17,4 +17,5 @@ export * as Visitors from "./visitors.js";
 
 export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 
-export { MatchData, Simulator, type GtgState, type TransitionTable } from "./gtg/simulator.js";
+export * as GTG from "./gtg/index.js";
+export * as Path from "./path/index.js";

--- a/packages/actionpack/src/action-dispatch/journey/path/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/index.ts
@@ -1,0 +1,1 @@
+export { Pattern, MatchData, AnchoredRegexp, UnanchoredRegexp } from "./pattern.js";

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "../parser.js";
+import { Ast } from "../ast.js";
+import { Pattern } from "./pattern.js";
+
+const SEPARATORS = "/.?";
+
+function buildPath(
+  path: string,
+  requirements: Record<string, RegExp> = {},
+  separators: string = SEPARATORS,
+  anchored = true,
+): Pattern {
+  const tree = new Parser().parse(path);
+  const ast = new Ast(tree, true);
+  return new Pattern(ast, requirements, separators, anchored);
+}
+
+const pathFromString = (p: string) => buildPath(p);
+
+describe("ActionDispatch::Journey::Path::Pattern — anchored to_regexp", () => {
+  const x = ".+";
+  const cases: Array<[string, string]> = [
+    ["/:controller(/:action)", `^/(${x})(?:/([^/.?]+))?$`],
+    ["/:controller/foo", `^/(${x})/foo$`],
+    ["/:controller/:action", `^/(${x})/([^/.?]+)$`],
+    ["/:controller", `^/(${x})$`],
+    ["/:controller(/:action(/:id))", `^/(${x})(?:/([^/.?]+)(?:/([^/.?]+))?)?$`],
+    ["/:controller/:action.xml", `^/(${x})/([^/.?]+)\\.xml$`],
+    ["/:controller.:format", `^/(${x})\\.([^/.?]+)$`],
+    ["/:controller(.:format)", `^/(${x})(?:\\.([^/.?]+))?$`],
+    ["/:controller/*foo", `^/(${x})/(.+)$`],
+    ["/:controller/*foo/bar", `^/(${x})/(.+)/bar$`],
+    ["/:foo|*bar", `^/(?:([^/.?]+)|(.+))$`],
+  ];
+  for (const [path, expected] of cases) {
+    it(`to_regexp ${path}`, () => {
+      const p = buildPath(path, { controller: /.+/ }, SEPARATORS, true);
+      expect(p.toRegexp().source).toBe(new RegExp(expected).source);
+    });
+  }
+});
+
+describe("ActionDispatch::Journey::Path::Pattern — unanchored to_regexp", () => {
+  const x = ".+";
+  const cases: Array<[string, string]> = [
+    ["/:controller(/:action)", `^/(${x})(?:/([^/.?]+))?(?:\\b|$|/)`],
+    ["/:controller/foo", `^/(${x})/foo(?:\\b|$|/)`],
+    ["/:controller", `^/(${x})(?:\\b|$|/)`],
+    ["/:controller/*foo", `^/(${x})/(.+)(?:\\b|$|/)`],
+    ["/:foo|*bar", `^/(?:([^/.?]+)|(.+))(?:\\b|$|/)`],
+  ];
+  for (const [path, expected] of cases) {
+    it(`to_non_anchored_regexp ${path}`, () => {
+      const p = buildPath(path, { controller: /.+/ }, SEPARATORS, false);
+      expect(p.toRegexp().source).toBe(new RegExp(expected).source);
+    });
+  }
+});
+
+describe("ActionDispatch::Journey::Path::Pattern — names", () => {
+  const cases: Array<[string, string[]]> = [
+    ["/:controller(/:action)", ["controller", "action"]],
+    ["/:controller/foo", ["controller"]],
+    ["/:controller/:action", ["controller", "action"]],
+    ["/:controller", ["controller"]],
+    ["/:controller(/:action(/:id))", ["controller", "action", "id"]],
+    ["/:controller.:format", ["controller", "format"]],
+    ["/:controller(.:format)", ["controller", "format"]],
+    ["/:controller/*foo", ["controller", "foo"]],
+  ];
+  for (const [path, expected] of cases) {
+    it(`names ${path}`, () => {
+      const p = buildPath(path, { controller: /.+/ }, SEPARATORS, true);
+      expect(p.names).toEqual(expected);
+    });
+  }
+});
+
+describe("ActionDispatch::Journey::Path::Pattern — matching", () => {
+  it("test_to_regexp_match_non_optional", () => {
+    const p = buildPath("/:name", { name: /\d+/ });
+    expect(p.isMatch("/123")).toBe(true);
+    expect(p.isMatch("/")).toBe(false);
+  });
+
+  it("test_to_regexp_with_group", () => {
+    const p = buildPath("/page/:name", { name: /(tender|love)/ });
+    expect(p.isMatch("/page/tender")).toBe(true);
+    expect(p.isMatch("/page/love")).toBe(true);
+    expect(p.isMatch("/page/loving")).toBe(false);
+  });
+
+  it("test_match_data_with_group", () => {
+    const p = buildPath("/page/:name", { name: /(tender|love)/ });
+    const match = p.match("/page/tender")!;
+    expect(match.at(1)).toBe("tender");
+    expect(match.length).toBe(2);
+  });
+
+  it("test_match_data_with_multi_group", () => {
+    const p = buildPath("/page/:name/:id", { name: /t(((ender|love)))()/ });
+    const match = p.match("/page/tender/10")!;
+    expect(match.at(1)).toBe("tender");
+    expect(match.at(2)).toBe("10");
+    expect(match.length).toBe(3);
+    expect([...match.captures]).toEqual(["tender", "10"]);
+  });
+
+  it("test_star_with_custom_re", () => {
+    const p = buildPath("/page/*foo", { foo: /\d+/ });
+    expect(p.toRegexp().source).toBe(new RegExp(`^/page/(\\d+)$`).source);
+  });
+
+  it("test_insensitive_regexp_with_group", () => {
+    // Note: trails preserves regex flags via Regexp.union behavior;
+    // upstream Rails relies on Regexp.union to incorporate /i. Our
+    // regexUnion uses `.source` which drops flags. Skip the inner-flag
+    // case and assert literal match instead to lock down the surface.
+    const p = buildPath("/page/:name/aaron", { name: /tender|love/ });
+    expect(p.isMatch("/page/tender/aaron")).toBe(true);
+    expect(p.isMatch("/page/love/aaron")).toBe(true);
+  });
+
+  it("test_to_regexp_defaults", () => {
+    const p = pathFromString("/:controller(/:action(/:id))");
+    expect(p.toRegexp().source).toBe(
+      new RegExp(`^/([^/.?]+)(?:/([^/.?]+)(?:/([^/.?]+))?)?$`).source,
+    );
+  });
+
+  it("test_failed_match", () => {
+    const p = pathFromString("/:controller(/:action(/:id(.:format)))");
+    expect(p.match("content")).toBeUndefined();
+  });
+
+  it("test_match_controller", () => {
+    const p = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const m = p.match("/content")!;
+    expect(m.names).toEqual(["controller", "action", "id", "format"]);
+    expect(m.at(1)).toBe("content");
+    expect(m.at(2)).toBeUndefined();
+    expect(m.at(3)).toBeUndefined();
+    expect(m.at(4)).toBeUndefined();
+  });
+
+  it("test_match_controller_action", () => {
+    const p = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const m = p.match("/content/list")!;
+    expect(m.at(1)).toBe("content");
+    expect(m.at(2)).toBe("list");
+    expect(m.at(3)).toBeUndefined();
+  });
+
+  it("test_match_controller_action_id", () => {
+    const p = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const m = p.match("/content/list/10")!;
+    expect(m.at(1)).toBe("content");
+    expect(m.at(2)).toBe("list");
+    expect(m.at(3)).toBe("10");
+  });
+
+  it("test_match_literal", () => {
+    const p = pathFromString("/books(/:action(.:format))");
+    const m = p.match("/books")!;
+    expect(m.names).toEqual(["action", "format"]);
+    expect(m.at(1)).toBeUndefined();
+    expect(m.at(2)).toBeUndefined();
+  });
+
+  it("test_match_literal_with_action", () => {
+    const p = pathFromString("/books(/:action(.:format))");
+    const m = p.match("/books/list")!;
+    expect(m.at(1)).toBe("list");
+    expect(m.at(2)).toBeUndefined();
+  });
+
+  it("test_match_literal_with_action_and_format", () => {
+    const p = pathFromString("/books(/:action(.:format))");
+    const m = p.match("/books/list.rss")!;
+    expect(m.at(1)).toBe("list");
+    expect(m.at(2)).toBe("rss");
+  });
+
+  it("test_named_captures", () => {
+    const p = pathFromString("/books(/:action(.:format))");
+    const m = p.match("/books/list.rss")!;
+    expect(m.namedCaptures).toEqual({ action: "list", format: "rss" });
+  });
+});
+
+describe("ActionDispatch::Journey::Path::Pattern — optional names", () => {
+  it("test_optional_names", () => {
+    const cases: Array<[string, string[]]> = [
+      ["/:foo(/:bar(/:baz))", ["bar", "baz"]],
+      ["/:foo(/:bar)", ["bar"]],
+      ["/:foo(/:bar)/:lol(/:baz)", ["bar", "baz"]],
+    ];
+    for (const [pattern, list] of cases) {
+      const p = pathFromString(pattern);
+      expect([...p.optionalNames].sort()).toEqual([...list].sort());
+    }
+  });
+});
+
+describe("ActionDispatch::Journey::Path::Pattern — requirements", () => {
+  it("test_requirements_for_missing_keys_check", () => {
+    const nameRegex = /test/;
+    const p = buildPath("/page/:name", { name: nameRegex });
+    const transformed = p.requirementsForMissingKeysCheck["name"]!;
+    expect(transformed.source).toBe(new RegExp(`^test$`).source);
+  });
+
+  it("test_requirements_for_missing_keys_check_memoization", () => {
+    const p = buildPath("/page/:name", { name: /test/ });
+    expect(p.requirementsForMissingKeysCheck).toBe(p.requirementsForMissingKeysCheck);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -122,6 +122,13 @@ describe("ActionDispatch::Journey::Path::Pattern — matching", () => {
     expect(p.isMatch("/page/loVE/aaron")).toBe(true);
   });
 
+  it("propagates /u flag so Unicode property escapes compile", () => {
+    // \p{Letter} requires the /u flag — would throw without flag lifting.
+    const p = buildPath("/page/:name", { name: /\p{Letter}+/u });
+    expect(p.isMatch("/page/Größe")).toBe(true);
+    expect(p.isMatch("/page/123")).toBe(false);
+  });
+
   it("MatchData.at(0) returns the full match", () => {
     const p = buildPath("/page/:name", { name: /\d+/ });
     const m = p.match("/page/42")!;

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -123,11 +123,20 @@ describe("ActionDispatch::Journey::Path::Pattern — matching", () => {
   });
 
   it("does not lift /m flag — would break ^/$ anchoring", () => {
-    // If /m leaked to the outer regex, `^/page/foo$` would match
-    // "anything\n/page/foo" because ^/$ would become line-anchored.
-    const p = buildPath("/page/foo", { ignored: /x/m });
+    // If /m leaked to the outer regex, ^/$ would become line-anchors.
+    // Use a USED requirement so the flag is actually a candidate.
+    const p = buildPath("/page/:name", { name: /foo/m });
     expect(p.isMatch("xxx\n/page/foo")).toBe(false);
     expect(p.isMatch("/page/foo")).toBe(true);
+  });
+
+  it("does not lift flags from unused requirements", () => {
+    // {ignored: /x/i} would have made the whole pattern case-insensitive
+    // before the names-filter landed. With it, the unused requirement is
+    // ignored entirely.
+    const p = buildPath("/Page", { ignored: /x/i });
+    expect(p.isMatch("/Page")).toBe(true);
+    expect(p.isMatch("/page")).toBe(false);
   });
 
   it("escapes char-class metacharacters in separators", () => {

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -7,7 +7,7 @@ const SEPARATORS = "/.?";
 
 function buildPath(
   path: string,
-  requirements: Record<string, RegExp> = {},
+  requirements: Record<string, RegExp | RegExp[]> = {},
   separators: string = SEPARATORS,
   anchored = true,
 ): Pattern {
@@ -113,13 +113,25 @@ describe("ActionDispatch::Journey::Path::Pattern — matching", () => {
   });
 
   it("test_insensitive_regexp_with_group", () => {
-    // Note: trails preserves regex flags via Regexp.union behavior;
-    // upstream Rails relies on Regexp.union to incorporate /i. Our
-    // regexUnion uses `.source` which drops flags. Skip the inner-flag
-    // case and assert literal match instead to lock down the surface.
-    const p = buildPath("/page/:name/aaron", { name: /tender|love/ });
-    expect(p.isMatch("/page/tender/aaron")).toBe(true);
-    expect(p.isMatch("/page/love/aaron")).toBe(true);
+    // /i flags on requirement regexes are lifted to the compiled
+    // Pattern regex. Rails inline-scopes flags via Regexp.union (impossible
+    // in JS), so the flag leaks to the whole pattern — practical impact is
+    // limited because the surrounding regex is mostly non-letter.
+    const p = buildPath("/page/:name/aaron", { name: /(tender|love)/i });
+    expect(p.isMatch("/page/TENDER/aaron")).toBe(true);
+    expect(p.isMatch("/page/loVE/aaron")).toBe(true);
+  });
+
+  it("MatchData.at(0) returns the full match", () => {
+    const p = buildPath("/page/:name", { name: /\d+/ });
+    const m = p.match("/page/42")!;
+    expect(m.at(0)).toBe("/page/42");
+  });
+
+  it("MatchData.at(negative) returns undefined", () => {
+    const p = buildPath("/page/:name", { name: /\d+/ });
+    const m = p.match("/page/42")!;
+    expect(m.at(-1)).toBeUndefined();
   });
 
   it("test_to_regexp_defaults", () => {
@@ -208,7 +220,18 @@ describe("ActionDispatch::Journey::Path::Pattern — requirements", () => {
     const nameRegex = /test/;
     const p = buildPath("/page/:name", { name: nameRegex });
     const transformed = p.requirementsForMissingKeysCheck["name"]!;
-    expect(transformed.source).toBe(new RegExp(`^test$`).source);
+    expect(transformed.source).toBe(new RegExp(`^(?:test)$`).source);
+  });
+
+  it("anchors the union as a single alternation, not split anchors", () => {
+    // /^a|b$/ parses as /(^a)|(b$)/. Verify the (?:…) wrapping by
+    // checking that neither branch leaks past its anchor.
+    const p = buildPath("/page/:name", { name: [/foo/, /bar/] });
+    const re = p.requirementsForMissingKeysCheck["name"]!;
+    expect(re.test("foo")).toBe(true);
+    expect(re.test("bar")).toBe(true);
+    expect(re.test("xfooy")).toBe(false);
+    expect(re.test("xbary")).toBe(false);
   });
 
   it("test_requirements_for_missing_keys_check_memoization", () => {

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -122,6 +122,20 @@ describe("ActionDispatch::Journey::Path::Pattern — matching", () => {
     expect(p.isMatch("/page/loVE/aaron")).toBe(true);
   });
 
+  it("does not lift /m flag — would break ^/$ anchoring", () => {
+    // If /m leaked to the outer regex, `^/page/foo$` would match
+    // "anything\n/page/foo" because ^/$ would become line-anchored.
+    const p = buildPath("/page/foo", { ignored: /x/m });
+    expect(p.isMatch("xxx\n/page/foo")).toBe(false);
+    expect(p.isMatch("/page/foo")).toBe(true);
+  });
+
+  it("escapes char-class metacharacters in separators", () => {
+    // Separators containing `]`, `-`, `^`, or `\` would have produced
+    // invalid regex / unintended ranges before escapeCharClass landed.
+    expect(() => buildPath("/:foo", { foo: /.+/ }, "]^-\\", true)).not.toThrow();
+  });
+
   it("propagates /u flag so Unicode property escapes compile", () => {
     // \p{Letter} requires the /u flag — would throw without flag lifting.
     const p = buildPath("/page/:name", { name: /\p{Letter}+/u });

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -1,0 +1,293 @@
+import { Ast } from "../ast.js";
+import type {
+  Cat,
+  Dot,
+  Group,
+  Literal,
+  Node,
+  Or,
+  Slash,
+  Star,
+  Symbol as SymbolNode,
+} from "../nodes/node.js";
+import { FormatBuilder, Format, Visitor } from "../visitors.js";
+
+type Matchers = Record<string, RegExp | RegExp[]>;
+
+function escapeRegex(s: string): string {
+  // Mirrors Ruby `Regexp.escape`: does NOT escape `/` (`/` has no special
+  // meaning in a regex source string; it's only delimiter-significant in
+  // JS regex literals, not in the `RegExp` constructor).
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function regexUnion(re: RegExp | RegExp[]): string {
+  const arr = Array.isArray(re) ? re : [re];
+  return arr.map((r) => r.source).join("|");
+}
+
+// =========================================================================
+// AnchoredRegexp visitor — builds the `\A...\Z` regex source for a Pattern.
+// =========================================================================
+
+export class AnchoredRegexp extends Visitor {
+  protected readonly _separator: string;
+  protected readonly _matchers: Matchers;
+  private readonly _separatorRe: string;
+
+  constructor(separator: string, matchers: Matchers) {
+    super();
+    this._separator = separator;
+    this._matchers = matchers;
+    this._separatorRe = `([^${separator}]+)`;
+  }
+
+  override accept(node: Node): RegExp {
+    return new RegExp(`^${this.visit(node)}$`);
+  }
+
+  protected override visitCAT(node: Node): string {
+    const cat = node as Cat;
+    return `${this.visit(cat.left as Node) as string}${this.visit(cat.right) as string}`;
+  }
+
+  protected override visitSYMBOL(node: Node): string {
+    const name = node.toSym();
+    if (!Object.hasOwn(this._matchers, name)) return this._separatorRe;
+    return `(${regexUnion(this._matchers[name]!)})`;
+  }
+
+  protected override visitGROUP(node: Node): string {
+    return `(?:${this.visit((node as Group).left as Node) as string})?`;
+  }
+
+  protected override visitLITERAL(node: Node): string {
+    return escapeRegex((node as Literal).left as string);
+  }
+
+  protected override visitDOT(node: Node): string {
+    return escapeRegex((node as Dot).left as string);
+  }
+
+  protected override visitSLASH(node: Node): string {
+    return (node as Slash).left as string;
+  }
+
+  protected override visitSTAR(node: Node): string {
+    const inner = (node as Star).left as Node;
+    const re = this._matchers[inner.toSym()];
+    return re ? `(${regexUnion(re)})` : "(.+)";
+  }
+
+  protected override visitOR(node: Node): string {
+    const children = (node as Or).children().map((c) => this.visit(c) as string);
+    return `(?:${children.join("|")})`;
+  }
+}
+
+// =========================================================================
+// UnanchoredRegexp — like AnchoredRegexp but with `(?:\b|$|/)` suffix.
+// =========================================================================
+
+export class UnanchoredRegexp extends AnchoredRegexp {
+  override accept(node: Node): RegExp {
+    const path = this.visit(node) as string;
+    if (path === "/") return /^\//;
+    // Rails uses `(?:\b|\Z|/)` — `\Z` is "end of string or before trailing
+    // newline"; in JS `$` (in default mode) is end-of-string. `\b` is the
+    // same word-boundary semantic.
+    return new RegExp(`^${path}(?:\\b|$|/)`);
+  }
+}
+
+// =========================================================================
+// MatchData — wraps a RegExp match with offset-aware indexed access.
+// =========================================================================
+
+export class MatchData {
+  readonly names: readonly string[];
+  private readonly _offsets: readonly number[];
+  private readonly _match: RegExpMatchArray;
+  private readonly _input: string;
+
+  constructor(
+    names: readonly string[],
+    offsets: readonly number[],
+    match: RegExpMatchArray,
+    input: string,
+  ) {
+    this.names = names;
+    this._offsets = offsets;
+    this._match = match;
+    this._input = input;
+  }
+
+  /** Captures, 1-indexed in Rails — here returned as a 0-indexed array. */
+  get captures(): readonly (string | undefined)[] {
+    return Array.from({ length: this.length - 1 }, (_, i) => this.at(i + 1));
+  }
+
+  get namedCaptures(): Record<string, string | undefined> {
+    const caps = this.captures;
+    const out: Record<string, string | undefined> = {};
+    this.names.forEach((n, i) => {
+      out[n] = caps[i];
+    });
+    return out;
+  }
+
+  /** Rails `match[i]` — adjusts by offset before indexing into the underlying match. */
+  at(x: number): string | undefined {
+    const idx = this._offsets[x - 1]! + x;
+    return this._match[idx];
+  }
+
+  get length(): number {
+    return this._offsets.length;
+  }
+
+  postMatch(): string {
+    const matched = this._match[0] ?? "";
+    const start = (this._match.index ?? 0) + matched.length;
+    return this._input.slice(start);
+  }
+
+  toString(): string {
+    return this._match[0] ?? "";
+  }
+}
+
+// =========================================================================
+// Pattern — the main class.
+// =========================================================================
+
+export class Pattern {
+  ast: Ast | null;
+  readonly spec: Node;
+  readonly requirements: Matchers;
+  readonly anchored: boolean;
+  readonly names: readonly string[];
+
+  private readonly _separators: string;
+  private _optionalNames: readonly string[] | null = null;
+  private _requiredNames: readonly string[] | null = null;
+  private _re: RegExp | null = null;
+  private _offsets: readonly number[] | null = null;
+  private _requirementsAnchoredCache?: Record<string, RegExp>;
+
+  constructor(ast: Ast, requirements: Matchers, separators: string, anchored: boolean) {
+    this.ast = ast;
+    this.spec = ast.root;
+    this.requirements = requirements;
+    this._separators = separators;
+    this.anchored = anchored;
+    this.names = ast.names;
+  }
+
+  buildFormatter(): Format {
+    return new FormatBuilder().accept(this.spec);
+  }
+
+  eagerLoadBang(): void {
+    void this.requiredNames;
+    void this._computeOffsets();
+    void this.toRegexp();
+    this.ast = null;
+  }
+
+  isRequirementsAnchored(): boolean {
+    if (!this.ast) return true;
+    const terminals = this.ast.terminals;
+    for (let i = 1; i < terminals.length; i++) {
+      const s = terminals[i]!;
+      if (s.type === "DOT" || s.type === "SLASH") continue;
+      const back = terminals[i - 1]!;
+      const fwd = terminals[i + 1];
+      if (s.isSymbol() && Array.isArray((s as SymbolNode).regexp)) return false;
+      if (back.isLiteral()) return false;
+      if (fwd && fwd.isLiteral()) return false;
+    }
+    return true;
+  }
+
+  get requiredNames(): readonly string[] {
+    if (this._requiredNames) return this._requiredNames;
+    const opt = new Set(this.optionalNames);
+    this._requiredNames = this.names.filter((n) => !opt.has(n));
+    return this._requiredNames;
+  }
+
+  get optionalNames(): readonly string[] {
+    if (this._optionalNames) return this._optionalNames;
+    const groups: Group[] = [];
+    for (const n of this.spec) if (n.isGroup()) groups.push(n as Group);
+    const names: string[] = [];
+    for (const g of groups) {
+      for (const child of g.left as Node) {
+        if (child.isSymbol() && !names.includes(child.name)) {
+          names.push(child.name);
+        }
+      }
+    }
+    this._optionalNames = names;
+    return names;
+  }
+
+  match(other: string): MatchData | undefined {
+    const re = this.toRegexp();
+    const m = other.match(re);
+    if (!m) return undefined;
+    return new MatchData(this.names, this._computeOffsets(), m, other);
+  }
+
+  isMatch(other: string): boolean {
+    return this.toRegexp().test(other);
+  }
+
+  get source(): string {
+    return this.toRegexp().source;
+  }
+
+  toRegexp(): RegExp {
+    if (this._re) return this._re;
+    const Klass = this.anchored ? AnchoredRegexp : UnanchoredRegexp;
+    this._re = new Klass(this._separators, this.requirements).accept(this.spec);
+    return this._re;
+  }
+
+  get requirementsForMissingKeysCheck(): Record<string, RegExp> {
+    if (this._requirementsAnchoredCache) return this._requirementsAnchoredCache;
+    const out: Record<string, RegExp> = {};
+    for (const [k, v] of Object.entries(this.requirements)) {
+      out[k] = new RegExp(`^${regexUnion(v)}$`);
+    }
+    this._requirementsAnchoredCache = out;
+    return out;
+  }
+
+  /** @internal */
+  private _computeOffsets(): readonly number[] {
+    if (this._offsets) return this._offsets;
+    const offsets: number[] = [0];
+    for (const n of this.spec) {
+      if (!n.isSymbol()) continue;
+      const name = n.toSym();
+      if (Object.hasOwn(this.requirements, name)) {
+        // Count capture groups in the requirement regex by matching empty
+        // against `re|` (so the alternation succeeds with an empty match)
+        // and reading the resulting capture count. Mirrors Rails:
+        //   re = /#{Regexp.union(reqs)}|/
+        //   offsets.push((re.match("").length - 1) + last)
+        const src = regexUnion(this.requirements[name]!);
+        const re = new RegExp(`(?:${src})|`);
+        const m = re.exec("");
+        const groupCount = m ? m.length - 1 : 0;
+        offsets.push(groupCount + offsets[offsets.length - 1]!);
+      } else {
+        offsets.push(offsets[offsets.length - 1]!);
+      }
+    }
+    this._offsets = offsets;
+    return offsets;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -1,15 +1,5 @@
 import { Ast } from "../ast.js";
-import type {
-  Cat,
-  Dot,
-  Group,
-  Literal,
-  Node,
-  Or,
-  Slash,
-  Star,
-  Symbol as SymbolNode,
-} from "../nodes/node.js";
+import type { Cat, Dot, Group, Literal, Node, Or, Slash, Star } from "../nodes/node.js";
 import { FormatBuilder, Format, Visitor } from "../visitors.js";
 
 type Matchers = Record<string, RegExp | RegExp[]>;
@@ -24,6 +14,22 @@ function escapeRegex(s: string): string {
 function regexUnion(re: RegExp | RegExp[]): string {
   const arr = Array.isArray(re) ? re : [re];
   return arr.map((r) => r.source).join("|");
+}
+
+/**
+ * Collect the union of regex flags across a list of requirement regexes.
+ * Rails' `Regexp.union` produces inline flag scopes (`(?i-mx:…)`); JS lacks
+ * inline flag groups, so we apply the combined flag set at the outer
+ * `RegExp` level. `g`/`y` are filtered out since they change matching
+ * semantics in ways that break Pattern's anchored regex.
+ */
+function combinedFlags(matchers: Record<string, RegExp | RegExp[]>): string {
+  const seen = new Set<string>();
+  for (const v of Object.values(matchers)) {
+    const arr = Array.isArray(v) ? v : [v];
+    for (const r of arr) for (const f of r.flags) seen.add(f);
+  }
+  return [...seen].filter((f) => "ims".includes(f)).join("");
 }
 
 // =========================================================================
@@ -43,7 +49,7 @@ export class AnchoredRegexp extends Visitor {
   }
 
   override accept(node: Node): RegExp {
-    return new RegExp(`^${this.visit(node)}$`);
+    return new RegExp(`^${this.visit(node)}$`, combinedFlags(this._matchers));
   }
 
   protected override visitCAT(node: Node): string {
@@ -92,11 +98,12 @@ export class AnchoredRegexp extends Visitor {
 export class UnanchoredRegexp extends AnchoredRegexp {
   override accept(node: Node): RegExp {
     const path = this.visit(node) as string;
-    if (path === "/") return /^\//;
+    const flags = combinedFlags(this._matchers);
+    if (path === "/") return new RegExp(`^/`, flags);
     // Rails uses `(?:\b|\Z|/)` — `\Z` is "end of string or before trailing
     // newline"; in JS `$` (in default mode) is end-of-string. `\b` is the
     // same word-boundary semantic.
-    return new RegExp(`^${path}(?:\\b|$|/)`);
+    return new RegExp(`^${path}(?:\\b|$|/)`, flags);
   }
 }
 
@@ -136,8 +143,15 @@ export class MatchData {
     return out;
   }
 
-  /** Rails `match[i]` — adjusts by offset before indexing into the underlying match. */
+  /**
+   * Rails `match[i]` — adjusts by offset before indexing into the underlying match.
+   *
+   * `at(0)` returns the full match (Rails `match[0]`); positive indices apply
+   * the per-symbol offset adjustment. Negative indices return undefined.
+   */
   at(x: number): string | undefined {
+    if (x === 0) return this._match[0];
+    if (x < 0 || x >= this.length) return undefined;
     const idx = this._offsets[x - 1]! + x;
     return this._match[idx];
   }
@@ -203,7 +217,10 @@ export class Pattern {
       if (s.type === "DOT" || s.type === "SLASH") continue;
       const back = terminals[i - 1]!;
       const fwd = terminals[i + 1];
-      if (s.isSymbol() && Array.isArray((s as SymbolNode).regexp)) return false;
+      // Rails consults the SymbolNode's regexp after `ast.requirements=`
+      // wires it in; trails-side Pattern stores requirements separately,
+      // so consult the requirements map directly.
+      if (s.isSymbol() && Array.isArray(this.requirements[s.toSym()])) return false;
       if (back.isLiteral()) return false;
       if (fwd && fwd.isLiteral()) return false;
     }
@@ -259,7 +276,10 @@ export class Pattern {
     if (this._requirementsAnchoredCache) return this._requirementsAnchoredCache;
     const out: Record<string, RegExp> = {};
     for (const [k, v] of Object.entries(this.requirements)) {
-      out[k] = new RegExp(`^${regexUnion(v)}$`);
+      // Wrap the union in `(?:…)` so the anchors bind around the whole
+      // alternation: `^a|b$` parses as `(^a)|(b$)`, which isn't what we
+      // want for a missing-keys equality check.
+      out[k] = new RegExp(`^(?:${regexUnion(v)})$`, combinedFlags({ k: v }));
     }
     this._requirementsAnchoredCache = out;
     return out;

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -33,11 +33,12 @@ function regexUnion(re: RegExp | RegExp[]): string {
  *
  * - `g`/`y` are filtered: they change matching semantics in ways that
  *   would break Pattern's anchored regex.
- * - `m` is filtered for the outer Pattern regex: it changes `^`/`$` to
- *   match line boundaries, which would break our `^…$` anchoring (Rails'
- *   `\A…\Z` is unaffected by `/m`). Use `outer: false` when computing
- *   flags for a contained-source RegExp (e.g. requirementsForMissingKeysCheck)
- *   to keep `m`.
+ * - `m` is filtered for the outer Pattern regex (`outer: true`, default):
+ *   it changes `^`/`$` to match line boundaries, which would break our
+ *   `^…$` anchoring (Rails' `\A…\Z` is unaffected by `/m`). Pass
+ *   `outer: false` only when building a non-anchored regex from the
+ *   same sources (e.g. the offset-computation `(?:src)|` regex), where
+ *   preserving the requirement's `m` semantics is safe.
  * - `u` and `v` are mutually exclusive. If any source uses `v`, `v` wins
  *   (it's the superset); otherwise `u` is preserved so Unicode property
  *   escapes (`\p{…}`) remain valid.

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -62,8 +62,18 @@ function combinedFlagsFor(
   return out.join("");
 }
 
-function combinedFlags(matchers: Record<string, RegExp | RegExp[]>): string {
-  return combinedFlagsFor(Object.values(matchers));
+/**
+ * Union flags only across matchers actually referenced by a list of names.
+ * Avoids leaking flags from extra `requirements` entries (e.g. `{ ignored: /x/i }`)
+ * onto the compiled Pattern regex when the AST never references `:ignored`.
+ */
+function combinedFlagsUsed(
+  matchers: Record<string, RegExp | RegExp[]>,
+  names: readonly string[],
+): string {
+  const values: Array<RegExp | RegExp[]> = [];
+  for (const n of names) if (Object.hasOwn(matchers, n)) values.push(matchers[n]!);
+  return combinedFlagsFor(values);
 }
 
 // =========================================================================
@@ -73,17 +83,19 @@ function combinedFlags(matchers: Record<string, RegExp | RegExp[]>): string {
 export class AnchoredRegexp extends Visitor {
   protected readonly _separator: string;
   protected readonly _matchers: Matchers;
+  protected readonly _names: readonly string[];
   private readonly _separatorRe: string;
 
-  constructor(separator: string, matchers: Matchers) {
+  constructor(separator: string, matchers: Matchers, names: readonly string[] = []) {
     super();
     this._separator = separator;
     this._matchers = matchers;
+    this._names = names;
     this._separatorRe = `([^${escapeCharClass(separator)}]+)`;
   }
 
   override accept(node: Node): RegExp {
-    return new RegExp(`^${this.visit(node)}$`, combinedFlags(this._matchers));
+    return new RegExp(`^${this.visit(node)}$`, combinedFlagsUsed(this._matchers, this._names));
   }
 
   protected override visitCAT(node: Node): string {
@@ -133,7 +145,7 @@ export class AnchoredRegexp extends Visitor {
 export class UnanchoredRegexp extends AnchoredRegexp {
   override accept(node: Node): RegExp {
     const path = this.visit(node) as string;
-    const flags = combinedFlags(this._matchers);
+    const flags = combinedFlagsUsed(this._matchers, this._names);
     if (path === "/") return new RegExp(`^/`, flags);
     // Rails uses `(?:\b|\Z|/)` — `\Z` is "end of string or before trailing
     // newline"; in JS `$` (in default mode) is end-of-string. `\b` is the
@@ -303,7 +315,7 @@ export class Pattern {
   toRegexp(): RegExp {
     if (this._re) return this._re;
     const Klass = this.anchored ? AnchoredRegexp : UnanchoredRegexp;
-    this._re = new Klass(this._separators, this.requirements).accept(this.spec);
+    this._re = new Klass(this._separators, this.requirements, this.names).accept(this.spec);
     return this._re;
   }
 
@@ -335,7 +347,7 @@ export class Pattern {
         //   offsets.push((re.match("").length - 1) + last)
         const reqs = this.requirements[name]!;
         const src = regexUnion(reqs);
-        const re = new RegExp(`(?:${src})|`, combinedFlagsFor([reqs]));
+        const re = new RegExp(`(?:${src})|`, combinedFlagsFor([reqs], { outer: false }));
         const m = re.exec("");
         const groupCount = m ? m.length - 1 : 0;
         offsets.push(groupCount + offsets[offsets.length - 1]!);

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -20,16 +20,31 @@ function regexUnion(re: RegExp | RegExp[]): string {
  * Collect the union of regex flags across a list of requirement regexes.
  * Rails' `Regexp.union` produces inline flag scopes (`(?i-mx:…)`); JS lacks
  * inline flag groups, so we apply the combined flag set at the outer
- * `RegExp` level. `g`/`y` are filtered out since they change matching
- * semantics in ways that break Pattern's anchored regex.
+ * `RegExp` level.
+ *
+ * - `g`/`y` are filtered: they change matching semantics in ways that
+ *   would break Pattern's anchored regex.
+ * - `u` and `v` are mutually exclusive. If any source uses `v`, `v` wins
+ *   (it's the superset); otherwise `u` is preserved when present so
+ *   Unicode property escapes (`\p{…}`) remain valid.
+ * - `i`/`m`/`s`/`d` are passed through.
  */
-function combinedFlags(matchers: Record<string, RegExp | RegExp[]>): string {
+function combinedFlagsFor(values: ReadonlyArray<RegExp | RegExp[]>): string {
   const seen = new Set<string>();
-  for (const v of Object.values(matchers)) {
+  for (const v of values) {
     const arr = Array.isArray(v) ? v : [v];
     for (const r of arr) for (const f of r.flags) seen.add(f);
   }
-  return [...seen].filter((f) => "ims".includes(f)).join("");
+  const out: string[] = [];
+  for (const f of "imsd") if (seen.has(f)) out.push(f);
+  // `v` supersedes `u`; never include both.
+  if (seen.has("v")) out.push("v");
+  else if (seen.has("u")) out.push("u");
+  return out.join("");
+}
+
+function combinedFlags(matchers: Record<string, RegExp | RegExp[]>): string {
+  return combinedFlagsFor(Object.values(matchers));
 }
 
 // =========================================================================
@@ -280,7 +295,7 @@ export class Pattern {
       // Wrap the union in `(?:…)` so the anchors bind around the whole
       // alternation: `^a|b$` parses as `(^a)|(b$)`, which isn't what we
       // want for a missing-keys equality check.
-      out[k] = new RegExp(`^(?:${regexUnion(v)})$`, combinedFlags({ k: v }));
+      out[k] = new RegExp(`^(?:${regexUnion(v)})$`, combinedFlagsFor([v]));
     }
     this._requirementsAnchoredCache = out;
     return out;
@@ -299,8 +314,9 @@ export class Pattern {
         // and reading the resulting capture count. Mirrors Rails:
         //   re = /#{Regexp.union(reqs)}|/
         //   offsets.push((re.match("").length - 1) + last)
-        const src = regexUnion(this.requirements[name]!);
-        const re = new RegExp(`(?:${src})|`);
+        const reqs = this.requirements[name]!;
+        const src = regexUnion(reqs);
+        const re = new RegExp(`(?:${src})|`, combinedFlagsFor([reqs]));
         const m = re.exec("");
         const groupCount = m ? m.length - 1 : 0;
         offsets.push(groupCount + offsets[offsets.length - 1]!);

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -11,6 +11,15 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Escape characters that would be significant inside a `[…]` character class.
+ * Distinct from `escapeRegex` because the metacharacter set is different
+ * (e.g. `.` and `+` are literals inside a class, but `]` and `-` are not).
+ */
+function escapeCharClass(s: string): string {
+  return s.replace(/[\]\\^-]/g, "\\$&");
+}
+
 function regexUnion(re: RegExp | RegExp[]): string {
   const arr = Array.isArray(re) ? re : [re];
   return arr.map((r) => r.source).join("|");
@@ -24,20 +33,29 @@ function regexUnion(re: RegExp | RegExp[]): string {
  *
  * - `g`/`y` are filtered: they change matching semantics in ways that
  *   would break Pattern's anchored regex.
+ * - `m` is filtered for the outer Pattern regex: it changes `^`/`$` to
+ *   match line boundaries, which would break our `^…$` anchoring (Rails'
+ *   `\A…\Z` is unaffected by `/m`). Use `outer: false` when computing
+ *   flags for a contained-source RegExp (e.g. requirementsForMissingKeysCheck)
+ *   to keep `m`.
  * - `u` and `v` are mutually exclusive. If any source uses `v`, `v` wins
- *   (it's the superset); otherwise `u` is preserved when present so
- *   Unicode property escapes (`\p{…}`) remain valid.
- * - `i`/`m`/`s`/`d` are passed through.
+ *   (it's the superset); otherwise `u` is preserved so Unicode property
+ *   escapes (`\p{…}`) remain valid.
+ * - `i`/`s`/`d` are passed through.
  */
-function combinedFlagsFor(values: ReadonlyArray<RegExp | RegExp[]>): string {
+function combinedFlagsFor(
+  values: ReadonlyArray<RegExp | RegExp[]>,
+  opts: { outer?: boolean } = {},
+): string {
+  const outer = opts.outer ?? true;
   const seen = new Set<string>();
   for (const v of values) {
     const arr = Array.isArray(v) ? v : [v];
     for (const r of arr) for (const f of r.flags) seen.add(f);
   }
   const out: string[] = [];
-  for (const f of "imsd") if (seen.has(f)) out.push(f);
-  // `v` supersedes `u`; never include both.
+  for (const f of "isd") if (seen.has(f)) out.push(f);
+  if (!outer && seen.has("m")) out.push("m");
   if (seen.has("v")) out.push("v");
   else if (seen.has("u")) out.push("u");
   return out.join("");
@@ -60,7 +78,7 @@ export class AnchoredRegexp extends Visitor {
     super();
     this._separator = separator;
     this._matchers = matchers;
-    this._separatorRe = `([^${separator}]+)`;
+    this._separatorRe = `([^${escapeCharClass(separator)}]+)`;
   }
 
   override accept(node: Node): RegExp {

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -81,8 +81,9 @@ export class AnchoredRegexp extends Visitor {
 
   protected override visitSTAR(node: Node): string {
     const inner = (node as Star).left as Node;
-    const re = this._matchers[inner.toSym()];
-    return re ? `(${regexUnion(re)})` : "(.+)";
+    const name = inner.toSym();
+    if (!Object.hasOwn(this._matchers, name)) return "(.+)";
+    return `(${regexUnion(this._matchers[name]!)})`;
   }
 
   protected override visitOR(node: Node): string {


### PR DESCRIPTION
## Summary

Wave 7 PR 5 of 10. Ports Rails \`action_dispatch/journey/path/pattern.rb\` — the regex-building visitor pair, the offset-aware \`MatchData\`, and the \`Pattern\` class itself.

**\`journey/path/pattern.ts\`**:
- **AnchoredRegexp** (extends \`Visitor\`) builds the \`\A…\Z\` regex source. \`visitSYMBOL\` injects \`Regexp.union\` constraints when a requirement is registered; otherwise emits the separator-aware \`([^/.?]+)\`. \`visitSTAR\` mirrors the same logic, default \`(.+)\`.
- **UnanchoredRegexp** extends Anchored; appends \`(?:\b|$|/)\`.
- **MatchData** wraps a JS \`RegExpMatchArray\` with offset-aware \`.at(i)\`, \`.length\`, \`.captures\`, \`.namedCaptures\`, \`.postMatch\`.
- **Pattern**: \`buildFormatter\`, \`match\`, \`isMatch\`, \`source\`, \`toRegexp\`, \`optionalNames\`, \`requiredNames\`, \`isRequirementsAnchored\`, \`requirementsForMissingKeysCheck\` (memoized), \`eagerLoadBang\`.
- Offsets computed via the Rails idiom \`(re|).match("").length - 1\` to count capture groups in requirement regexes.

**\`journey/index.ts\`** now namespaces gtg + path subtrees:
- \`export * as GTG from './gtg/index.js'\`
- \`export * as Path from './path/index.js'\`

The old root-level \`MatchData\`/\`Simulator\` re-exports went away (no external consumers); \`Journey.GTG.MatchData\` and \`Journey.Path.MatchData\` disambiguate the two \`MatchData\` classes Rails ships.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] 42 pattern tests verbatim from Rails \`path/pattern_test.rb\` (anchored + unanchored round-trips, names, match data, optional names, requirements_for_missing_keys_check + memoization)
- [x] Test assertions wrap expected source via \`new RegExp(expected).source\` to handle JS canonical \`/\`→\`\\/\` source normalization
- [x] Full actionpack suite: 1944 tests pass (was 1897)
- [x] api:compare actiondispatch 323→339 (+16), overall +35 — non-negative