### PR TITLE
feat(globalid): GID-8 — SignedGlobalID class config + verify split

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -9,15 +9,15 @@ toGid, toGidParam, toSignedGlobalId, toSgid, toSgidParam). AR side: Base.toGid /
 toSgid / toGlobalId / toGidParam / toSignedGlobalId / findGlobalId /
 findSignedGlobalId / findSignedGlobalIdBang.
 
-### Parity scoreboard (after GID-7)
+### Parity scoreboard (after GID-8)
 
 Targets are **pre-skip** — the unportable-surface skip list (see below)
 brings the practical 100% to 56/56 api / 149/149 tests.
 
 | Signal       | Current          | 100% target (pre-skip) | Gap          |
 | ------------ | ---------------- | ---------------------- | ------------ |
-| api:compare  | 39 / 59 (66.1%)  | 59 / 59                | 20 methods   |
-| test:compare | 95 / 158 (60.1%) | 158 / 158              | 63 tests     |
+| api:compare  | 47 / 59 (79.7%)  | 59 / 59                | 12 methods   |
+| test:compare | 98 / 158 (62.0%) | 158 / 158              | 60 tests     |
 | files (api)  | 4 / 5            | 5 / 5                  | verifier.ts  |
 | files (test) | 5 / 8            | 8 / 8                  | 3 test files |
 
@@ -27,7 +27,7 @@ Per-file api:compare:
 | --------------------- | ----- | ----- | ---- |
 | `identification.rb`   | 4     | 4     | 100% |
 | `uri/gid.rb`          | 21    | 21    | 100% |
-| `signed_global_id.rb` | 8     | 16    | 50%  |
+| `signed_global_id.rb` | 16    | 16    | 100% |
 | `locator.rb`          | 6     | 16    | 38%  |
 | `verifier.rb`         | 0     | 2     | 0%   |
 
@@ -36,8 +36,8 @@ Per-file test:compare:
 | Ruby file                       | Match | Total | %   |
 | ------------------------------- | ----- | ----- | --- |
 | `uri_gid_test.rb`               | 27    | 30    | 90% |
+| `signed_global_id_test.rb`      | 20    | 24    | 83% |
 | `global_identification_test.rb` | 5     | 6     | 83% |
-| `signed_global_id_test.rb`      | 17    | 24    | 71% |
 | `global_locator_test.rb`        | 33    | 59    | 56% |
 | `global_id_test.rb`             | 13    | 26    | 50% |
 | `verifier_test.rb`              | 0     | 4     | 0%  |
@@ -110,19 +110,32 @@ api:compare `uri/gid.rb`: 10% → **100% (21/21)**. Overall api:compare
 functional API (used by SignedGlobalID and GlobalID internally + by AR's
 `toGid`); the class is the OO veneer on top.
 
-### GID-8 — `SignedGlobalID` class-level config + verify split (~80 LOC)
+### GID-8 — `SignedGlobalID` class-level config + verify split — **done**
 
-8 missing methods on `SignedGlobalID`:
+Added 8 methods on `SignedGlobalID`:
 
-- `expiresIn` / `expiresIn=` (class-level default; currently per-call only).
-  Mirrors Rails' `SignedGlobalID.expires_in = 1.month` config.
-- Refactor existing `verifyToken` helper into the Rails method layout:
-  `pickVerifier(options)`, `pickPurpose(options)`,
-  `verifyWithVerifierValidatedMetadata`,
-  `verifyWithLegacySelfValidatedMetadata`,
-  `raiseIfExpired`, `verify` (dispatcher). These are mostly internal
-  helpers — exposing them as static methods keeps api:compare happy
-  without changing behavior.
+- `verifier` / `verifier=` and `expiresIn` / `expiresIn=` (Rails
+  `attr_accessor` — class-level defaults). `SignedGlobalID.create` /
+  `parse` now make `verifier:` optional and fall back to the class
+  default via `pickVerifier()`; `expires_in` is consulted by
+  `pickExpiration()` when no per-call value is provided.
+- `pickVerifier(options)` / `pickPurpose(options)` — public class methods
+  matching Rails. `pickVerifier` throws if neither option nor class-level
+  is set.
+- `verify(sgid, options)` — private class method dispatching to
+  `verifyWithVerifierValidatedMetadata` then falling back to
+  `verifyWithLegacySelfValidatedMetadata` (always returns null — Trails
+  has no Rails 1.3.0-era legacy SGIDs; kept for api:compare parity).
+- `raiseIfExpired(expiresAt)` — private class method throwing
+  `ExpiredMessage` when the ISO 8601 timestamp is in the past. Used by
+  the legacy verify path; nominal for our verifier-validated flow.
+- New `ExpiredMessage` exception class.
+
+api:compare `signed_global_id.rb`: 50% (8/16) → **100% (16/16)**.
+Overall api:compare: 66.1% → **79.7%**.
+test:compare `signed_global_id_test.rb`: 17/24 → **20/24** (the 3
+class-level expires_in tests now pass via vi.useFakeTimers — the same
+js-temporal-polyfill + Date.now mocking pattern GID-6b established).
 
 ### GID-9 — Locator class hierarchy + `use(app, locator)` (~150 LOC)
 

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -3,7 +3,9 @@ export { getApp, setApp } from "./config.js";
 export { _resetApp } from "./config.js";
 export { GlobalID } from "./global-id.js";
 export type { GlobalIDModel, GlobalIDOptions } from "./global-id.js";
-export { SignedGlobalID } from "./signed-global-id.js";
+export { SignedGlobalID, ExpiredMessage } from "./signed-global-id.js";
+/** @internal */
+export { _resetSignedGlobalIDClassConfig } from "./signed-global-id.js";
 export type { SignedGlobalIDOptions, ParseOptions } from "./signed-global-id.js";
 export {
   parseGid,

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { SignedGlobalID } from "./signed-global-id.js";
+import {
+  SignedGlobalID,
+  ExpiredMessage,
+  _resetSignedGlobalIDClassConfig,
+} from "./signed-global-id.js";
 import { setApp, _resetApp } from "./config.js";
 
 function makeVerifier(secret = "test-secret"): MessageVerifier {
@@ -227,7 +231,7 @@ describe("SignedGlobalIDExpirationTest", () => {
       expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
     } finally {
       vi.useRealTimers();
-      SignedGlobalID.expiresIn = undefined;
+      _resetSignedGlobalIDClassConfig();
     }
   });
 
@@ -245,7 +249,7 @@ describe("SignedGlobalIDExpirationTest", () => {
       expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
     } finally {
       vi.useRealTimers();
-      SignedGlobalID.expiresIn = undefined;
+      _resetSignedGlobalIDClassConfig();
     }
   });
 
@@ -262,7 +266,7 @@ describe("SignedGlobalIDExpirationTest", () => {
       expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
     } finally {
       vi.useRealTimers();
-      SignedGlobalID.expiresIn = undefined;
+      _resetSignedGlobalIDClassConfig();
     }
   });
 });
@@ -353,9 +357,7 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
   });
 
   describe("class-level verifier config (Rails: SignedGlobalID.verifier=)", () => {
-    afterEach(() => {
-      SignedGlobalID.verifier = undefined;
-    });
+    afterEach(() => _resetSignedGlobalIDClassConfig());
 
     it("create uses class-level verifier when none in options", () => {
       const v = makeVerifier();
@@ -381,6 +383,36 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
       // Class-level verifier can't verify a token signed with a different one.
       expect(SignedGlobalID.parse(sgid.toString())).toBeNull();
       expect(SignedGlobalID.parse(sgid.toString(), { verifier: callV })).not.toBeNull();
+    });
+  });
+
+  describe("verify dispatch + raiseIfExpired (Rails private class methods)", () => {
+    it("verify dispatches to verifyWithVerifierValidatedMetadata first", () => {
+      const verifier = makeVerifier();
+      const sgid = SignedGlobalID.create(person(5), { verifier });
+      const result = SignedGlobalID.verify(sgid.toString(), { verifier });
+      expect(result).not.toBeNull();
+      expect(result!.uri).toBe("gid://bcx/Person/5");
+    });
+
+    it("verifyWithLegacySelfValidatedMetadata always returns null (Trails has no legacy SGIDs)", () => {
+      const verifier = makeVerifier();
+      const sgid = SignedGlobalID.create(person(5), { verifier });
+      expect(
+        SignedGlobalID.verifyWithLegacySelfValidatedMetadata(sgid.toString(), { verifier }),
+      ).toBeNull();
+    });
+
+    it("raiseIfExpired throws ExpiredMessage for past timestamps", () => {
+      expect(() => SignedGlobalID.raiseIfExpired("2020-01-01T00:00:00.000Z")).toThrow(
+        ExpiredMessage,
+      );
+    });
+
+    it("raiseIfExpired is a no-op for future timestamps and null", () => {
+      expect(() => SignedGlobalID.raiseIfExpired("2099-01-01T00:00:00.000Z")).not.toThrow();
+      expect(() => SignedGlobalID.raiseIfExpired(null)).not.toThrow();
+      expect(() => SignedGlobalID.raiseIfExpired(undefined)).not.toThrow();
     });
   });
 });

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -213,6 +213,58 @@ describe("SignedGlobalIDExpirationTest", () => {
     const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: -1 });
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
   });
+
+  it("expires_in defaults to class level expiration", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      SignedGlobalID.expiresIn = 3600; // 1 hour class-level default
+      const sgid = SignedGlobalID.create(person(5), { verifier });
+      vi.setSystemTime(new Date("2024-01-01T00:59:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+      vi.setSystemTime(new Date("2024-01-01T01:01:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+      SignedGlobalID.expiresIn = undefined;
+    }
+  });
+
+  it("passing in expires_in overrides class level expiration", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      SignedGlobalID.expiresIn = 3600;
+      // Per-call expiresIn: 2 hours wins over class-level 1 hour
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 7200 });
+      vi.setSystemTime(new Date("2024-01-01T01:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+      vi.setSystemTime(new Date("2024-01-01T01:00:03.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      SignedGlobalID.expiresIn = undefined;
+    }
+  });
+
+  it("passing expires_at overrides class level expires_in", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      SignedGlobalID.expiresIn = 3600;
+      // Per-call expiresAt: tomorrow wins over class-level 1 hour
+      const tomorrow = Temporal.Instant.from("2024-01-02T00:00:00.000Z");
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: tomorrow });
+      vi.setSystemTime(new Date("2024-01-01T02:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      SignedGlobalID.expiresIn = undefined;
+    }
+  });
 });
 
 describe("SignedGlobalIDCustomParamsTest", () => {
@@ -297,6 +349,38 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
     it("throws when no app configured and no app option", () => {
       const verifier = makeVerifier();
       expect(() => SignedGlobalID.create(person(5), { verifier })).toThrow(/app is required/i);
+    });
+  });
+
+  describe("class-level verifier config (Rails: SignedGlobalID.verifier=)", () => {
+    afterEach(() => {
+      SignedGlobalID.verifier = undefined;
+    });
+
+    it("create uses class-level verifier when none in options", () => {
+      const v = makeVerifier();
+      SignedGlobalID.verifier = v;
+      const sgid = SignedGlobalID.create(person(5));
+      // Token verifies with the class-level verifier (no option needed).
+      const parsed = SignedGlobalID.parse(sgid.toString());
+      expect(parsed).not.toBeNull();
+      expect(parsed!.uri).toBe("gid://bcx/Person/5");
+    });
+
+    it("pickVerifier throws when neither option nor class-level is set", () => {
+      expect(() => SignedGlobalID.pickVerifier({})).toThrow(
+        /Pass a `verifier:` option .* SignedGlobalID\.verifier/,
+      );
+    });
+
+    it("per-call verifier wins over class-level", () => {
+      const classV = makeVerifier("class-secret");
+      const callV = makeVerifier("call-secret");
+      SignedGlobalID.verifier = classV;
+      const sgid = SignedGlobalID.create(person(5), { verifier: callV });
+      // Class-level verifier can't verify a token signed with a different one.
+      expect(SignedGlobalID.parse(sgid.toString())).toBeNull();
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier: callV })).not.toBeNull();
     });
   });
 });

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -14,6 +14,10 @@ const KNOWN_SGID_KEYS = new Set(["app", "for", "purpose", "expiresIn", "expiresA
 /** Monotonic counter for stable inspect() ids; mirrors Ruby's object_id. @internal */
 let _nextObjectId = 0;
 
+/** Class-level defaults — mirror Rails' `SignedGlobalID.verifier` / `.expires_in` attr_accessors. @internal */
+let _classVerifier: MessageVerifier | undefined;
+let _classExpiresIn: number | null | undefined;
+
 export interface SignedGlobalIDOptions {
   app?: string;
   /** Rails-canonical purpose option. */
@@ -24,7 +28,8 @@ export interface SignedGlobalIDOptions {
   expiresIn?: number | null;
   /** Explicit expiration time. `null` explicitly disables expiration (Rails: `expires_at: nil`). */
   expiresAt?: Temporal.Instant | null;
-  verifier: MessageVerifier;
+  /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
+  verifier?: MessageVerifier;
   /** Custom GID query params (any extra keys become URI params). */
   [key: string]: unknown;
 }
@@ -34,8 +39,12 @@ export interface ParseOptions {
   for?: string;
   /** Alias of `for` kept for backward compatibility. */
   purpose?: string;
-  verifier: MessageVerifier;
+  /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
+  verifier?: MessageVerifier;
 }
+
+/** Mirrors: SignedGlobalID::ExpiredMessage. */
+export class ExpiredMessage extends Error {}
 
 /** @internal */
 interface SgidPayload {
@@ -79,7 +88,7 @@ export class SignedGlobalID {
    *
    * Mirrors: SignedGlobalID.new
    */
-  static create(model: GlobalIDModel, options: SignedGlobalIDOptions): SignedGlobalID {
+  static create(model: GlobalIDModel, options: SignedGlobalIDOptions = {}): SignedGlobalID {
     const app = options.app ?? getApp();
     if (!app) {
       throw new Error(
@@ -99,24 +108,129 @@ export class SignedGlobalID {
       Object.keys(filteredParams).length ? filteredParams : null,
     );
 
-    const purpose = options.for ?? options.purpose ?? DEFAULT_PURPOSE;
+    const verifier = SignedGlobalID.pickVerifier(options);
+    const purpose = SignedGlobalID.pickPurpose(options);
     const expiresAt = pickExpiration(options);
 
-    return new SignedGlobalID(uri, purpose, expiresAt, options.verifier);
+    return new SignedGlobalID(uri, purpose, expiresAt, verifier);
   }
 
   /**
    * Parse a signed SGID token. Returns null on invalid signature, expiration,
    * or purpose mismatch.
    *
-   * Mirrors: SignedGlobalID.parse (verify_with_verifier_validated_metadata path)
+   * Mirrors: SignedGlobalID.parse
    */
-  static parse(sgid: string, options: ParseOptions): SignedGlobalID | null {
-    const purpose = options.for ?? options.purpose ?? DEFAULT_PURPOSE;
-    const result = verifyToken(sgid, purpose, options.verifier);
-    if (result === null) return null;
-    const { uri, expiresAt } = result;
-    return new SignedGlobalID(uri, purpose, expiresAt, options.verifier);
+  static parse(sgid: string, options: ParseOptions = {}): SignedGlobalID | null {
+    const verifier = SignedGlobalID.pickVerifier(options);
+    const purpose = SignedGlobalID.pickPurpose(options);
+    const verified = SignedGlobalID.verify(sgid, options);
+    if (verified === null) return null;
+    return new SignedGlobalID(verified.uri, purpose, verified.expiresAt, verifier);
+  }
+
+  // ─── Class-level config (Rails: attr_accessor :verifier, :expires_in) ─────
+
+  /** Default verifier used when an SGID create/parse call omits the `verifier:` option. */
+  static get verifier(): MessageVerifier | undefined {
+    return _classVerifier;
+  }
+  static set verifier(v: MessageVerifier | undefined) {
+    _classVerifier = v;
+  }
+
+  /** Default `expires_in` (seconds) for new SGIDs that omit both expiresIn and expiresAt. */
+  static get expiresIn(): number | null | undefined {
+    return _classExpiresIn;
+  }
+  static set expiresIn(v: number | null | undefined) {
+    _classExpiresIn = v;
+  }
+
+  /**
+   * Mirrors: SignedGlobalID.pick_verifier. Falls back to the class-level
+   * verifier when the option isn't passed. Throws if neither is set.
+   */
+  static pickVerifier(options: { verifier?: MessageVerifier }): MessageVerifier {
+    const v = options.verifier ?? _classVerifier;
+    if (!v) {
+      throw new Error(
+        "Pass a `verifier:` option with a MessageVerifier instance, or set a default SignedGlobalID.verifier.",
+      );
+    }
+    return v;
+  }
+
+  /** Mirrors: SignedGlobalID.pick_purpose. */
+  static pickPurpose(options: { for?: string; purpose?: string }): string {
+    return options.for ?? options.purpose ?? DEFAULT_PURPOSE;
+  }
+
+  // ─── Verify dispatch (Rails private class methods) ────────────────────────
+
+  /**
+   * @internal Mirrors SignedGlobalID.verify — dispatches to the verifier-
+   * validated path, then falls back to the legacy self-validated path.
+   */
+  static verify(
+    sgid: string,
+    options: ParseOptions,
+  ): { uri: string; expiresAt: Temporal.Instant | undefined } | null {
+    return (
+      SignedGlobalID.verifyWithVerifierValidatedMetadata(sgid, options) ??
+      SignedGlobalID.verifyWithLegacySelfValidatedMetadata(sgid, options)
+    );
+  }
+
+  /**
+   * @internal Mirrors verify_with_verifier_validated_metadata. Verifier
+   * validates purpose + expires_at; we then re-check the embedded URI parses.
+   */
+  static verifyWithVerifierValidatedMetadata(
+    sgid: string,
+    options: ParseOptions,
+  ): { uri: string; expiresAt: Temporal.Instant | undefined } | null {
+    try {
+      const verifier = SignedGlobalID.pickVerifier(options);
+      const purpose = SignedGlobalID.pickPurpose(options);
+      const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
+      if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
+      if (raw.purpose !== purpose) return null;
+      parseGid(raw.gid);
+      let expiresAt: Temporal.Instant | undefined;
+      if (raw.expires_at) {
+        expiresAt = Temporal.Instant.from(raw.expires_at);
+        if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) <= 0) return null;
+      }
+      return { uri: raw.gid, expiresAt };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * @internal Mirrors verify_with_legacy_self_validated_metadata — Rails
+   * 1.3.0 still parses SGIDs issued before the verifier-validated form.
+   * Trails has no legacy SGIDs to read; documented as out of scope in the
+   * GlobalID plan, so this always returns null. Kept for api:compare parity.
+   */
+  static verifyWithLegacySelfValidatedMetadata(
+    _sgid: string,
+    _options: ParseOptions,
+  ): { uri: string; expiresAt: Temporal.Instant | undefined } | null {
+    return null;
+  }
+
+  /**
+   * @internal Mirrors raise_if_expired. Throws `ExpiredMessage` when
+   * `expiresAt` (ISO 8601 string) is in the past; no-op for null/missing.
+   * Only used by the legacy verify path in Rails; we expose it for parity.
+   */
+  static raiseIfExpired(expiresAt: string | null | undefined): void {
+    if (!expiresAt) return;
+    const instant = Temporal.Instant.from(expiresAt);
+    if (Temporal.Instant.compare(instant, Temporal.Now.instant()) > 0) return;
+    throw new ExpiredMessage("This signed global id has expired.");
   }
 
   toString(): string {
@@ -177,45 +291,23 @@ export class SignedGlobalID {
 }
 
 /** @internal */
-function verifyToken(
-  sgid: string,
-  purpose: string,
-  verifier: MessageVerifier,
-): { uri: string; expiresAt: Temporal.Instant | undefined } | null {
-  try {
-    const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
-    if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
-    if (raw.purpose !== purpose) return null;
-    // Validate the embedded URI by attempting a full parse. Without this, a
-    // signed payload like "gid://app/Person" (no model id) verifies and
-    // later throws when modelId/modelName/params are accessed.
-    parseGid(raw.gid);
-    let expiresAt: Temporal.Instant | undefined;
-    if (raw.expires_at) {
-      expiresAt = Temporal.Instant.from(raw.expires_at);
-      if (Temporal.Instant.compare(expiresAt, Temporal.Now.instant()) <= 0) return null;
-    }
-    return { uri: raw.gid, expiresAt };
-  } catch {
-    return null;
-  }
-}
-
-/** @internal */
 function pickExpiration(
   options: Pick<SignedGlobalIDOptions, "expiresAt" | "expiresIn">,
 ): Temporal.Instant | undefined {
-  // Rails parity (with TS-friendly tweak for the spread-defaults case):
+  // Rails parity:
   //   - explicit null   → disable expiration; wins over expiresIn (Rails nil)
   //   - real Instant    → use it
   //   - undefined       → treat as omitted; fall through to expiresIn
-  //                       (so `{ ...defaults, expiresIn: 60 }` where defaults
-  //                       has expiresAt: undefined doesn't silently disable)
+  //   - both omitted    → fall through to class-level SignedGlobalID.expiresIn
   if (options.expiresAt !== undefined) return options.expiresAt ?? undefined;
-  if (options.expiresIn !== undefined) {
-    if (options.expiresIn === null) return undefined;
-    const ms = Math.round(options.expiresIn * 1000);
-    return Temporal.Now.instant().add({ milliseconds: ms });
-  }
-  return undefined;
+  const expiresIn = options.expiresIn !== undefined ? options.expiresIn : _classExpiresIn;
+  if (expiresIn == null) return undefined;
+  const ms = Math.round(expiresIn * 1000);
+  return Temporal.Now.instant().add({ milliseconds: ms });
+}
+
+/** @internal — test use only: clear class-level config between tests. */
+export function _resetSignedGlobalIDClassConfig(): void {
+  _classVerifier = undefined;
+  _classExpiresIn = undefined;
 }


### PR DESCRIPTION
## Summary

Closes \`signed_global_id.rb\` at 100% by adding 8 methods on \`SignedGlobalID\`.

### Class-level config (Rails \`attr_accessor :verifier, :expires_in\`)

| Method | Description |
|--------|-------------|
| \`SignedGlobalID.verifier\` / \`verifier=\` | Default verifier for \`create\`/\`parse\` when no \`verifier:\` option |
| \`SignedGlobalID.expiresIn\` / \`expiresIn=\` | Default \`expires_in\` (seconds) when neither option is supplied |

### Verify dispatch (Rails private class methods)

| Method | Description |
|--------|-------------|
| \`pickVerifier(options)\` | Option ?? class-level; throws if neither set |
| \`pickPurpose(options)\` | \`for:\` ?? \`purpose:\` ?? \`"default"\` |
| \`verify(sgid, options)\` | Dispatches to verifier-validated, then legacy |
| \`verifyWithVerifierValidatedMetadata\` | The existing path, refactored as a static method |
| \`verifyWithLegacySelfValidatedMetadata\` | Always returns null — Trails has no legacy SGIDs (documented out-of-scope; kept for api:compare parity) |
| \`raiseIfExpired(expiresAtIso)\` | Throws new \`ExpiredMessage\` class when timestamp is in the past |

### Wiring changes

- \`SignedGlobalID.create\` / \`parse\` make \`verifier:\` optional, falling back via \`pickVerifier()\`
- \`pickExpiration\` falls back to class-level \`expiresIn\` when neither option is supplied
- Internal \`verifyToken\` helper removed (logic moved to \`verifyWithVerifierValidatedMetadata\`)

### New exception class

\`ExpiredMessage extends Error\` — mirrors Rails \`SignedGlobalID::ExpiredMessage\`.

## Scorecards

| Signal | Before | After |
|--------|--------|-------|
| api:compare \`signed_global_id.rb\` | 8/16 (50%) | **16/16 (100%)** |
| api:compare overall | 66.1% | **79.7%** |
| test:compare \`signed_global_id_test.rb\` | 17/24 (71%) | **20/24 (83%)** |
| test:compare overall | 95/158 (60.1%) | **98/158 (62.0%)** |

The 3 newly-matching tests in \`signed_global_id_test.rb\` are the class-level expires_in cases (\`expires_in defaults to class level expiration\`, \`passing in expires_in overrides class level expiration\`, \`passing expires_at overrides class level expires_in\`) — all use the \`vi.useFakeTimers()\` + \`setSystemTime()\` pattern established in GID-6b (js-temporal-polyfill drives \`Temporal.Now\` from \`Date.now()\`).

## Remaining gaps

\`signed_global_id_test.rb\` still has 4 unmatched: \`model class\` (needs Locator wiring, GID-9), \`value equality with an unsigned id\` (Trails has no cross-class equality, permanent skip), \`new accepts a :for\` (Rails exposes a \`new(uri, options)\` ctor we don't), \`parse is backwards compatible with the self validated metadata\` (legacy SGID format, out of scope).

## Test plan

- [x] \`pnpm vitest run packages/globalid/src/\` — 102 tests pass (35 in signed-global-id.test.ts)
- [x] \`pnpm vitest run packages/activerecord/src/signed-id.test.ts\` — 47 pass, 9 skipped
- [x] \`pnpm api:compare --package globalid\` — 79.7% (from 66.1%)
- [x] \`pnpm test:compare --package globalid\` — 98/158 (from 95/158)