### PR TITLE
feat(activerecord): HABTM Slot G — counter-cache install on belongs_to + through

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -188,8 +188,14 @@ export function resolveModel(name: string): typeof Base {
  * Non-polymorphic errors (e.g. not-an-AR-subclass) propagate unchanged.
  * @internal
  */
-export function resolveAssocClass(record: Base, assocName: string, className: string): typeof Base {
-  const ctor = record.constructor as typeof Base & {
+export function resolveAssocClass(
+  recordOrClass: Base | typeof Base,
+  assocName: string,
+  className: string,
+): typeof Base {
+  const ctor = (
+    typeof recordOrClass === "function" ? recordOrClass : recordOrClass.constructor
+  ) as typeof Base & {
     _reflectOnAssociation?: (
       name: string,
     ) => { klass?: typeof Base; isPolymorphic?: () => boolean } | null;

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -2,7 +2,8 @@ import { underscore, pluralize, camelize } from "@blazetrails/activesupport";
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
-import { resolveModel, modelRegistry } from "../../associations.js";
+import { resolveModel, resolveAssocClass, modelRegistry } from "../../associations.js";
+import { registerCounterCachedAssociation } from "../../counter-cache.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 
@@ -68,8 +69,13 @@ export class BelongsTo extends SingularAssociation {
         ? (reflection.counterCacheColumn() ?? `${pluralize(underscore(model.name))}_count`)
         : `${pluralize(underscore(model.name))}_count`;
     const targetClassName = reflection.options?.className ?? camelize(name);
-    if (modelRegistry.has(targetClassName)) {
-      const targetClass = resolveModel(targetClassName);
+    let targetClass: typeof import("../../base.js").Base | null = null;
+    try {
+      targetClass = resolveAssocClass(model, name, targetClassName);
+    } catch {
+      targetClass = modelRegistry.has(targetClassName) ? resolveModel(targetClassName) : null;
+    }
+    if (targetClass) {
       const existing: Set<string> = (targetClass as any)._counterCacheColumns ?? new Set();
       existing.add(cacheColumn);
       (targetClass as any)._counterCacheColumns = existing;
@@ -80,6 +86,9 @@ export class BelongsTo extends SingularAssociation {
       pending.add(cacheColumn);
       pendingCounterCacheColumns.set(targetClassName, pending);
     }
+
+    // Mirrors Rails: `model.counter_cached_association_names |= [reflection.name]`
+    registerCounterCachedAssociation(model, name);
 
     // Rails only registers after_update in add_counter_cache_callbacks.
     // Create/destroy counter handling is done by updateCounterCaches()

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -69,12 +69,17 @@ export class BelongsTo extends SingularAssociation {
         ? (reflection.counterCacheColumn() ?? `${pluralize(underscore(model.name))}_count`)
         : `${pluralize(underscore(model.name))}_count`;
     const targetClassName = reflection.options?.className ?? camelize(name);
-    let targetClass: typeof import("../../base.js").Base | null = null;
-    try {
-      targetClass = resolveAssocClass(model, name, targetClassName);
-    } catch {
-      targetClass = modelRegistry.has(targetClassName) ? resolveModel(targetClassName) : null;
-    }
+    // Rails: `klass = reflection.class_name.safe_constantize` — silently nil
+    // when the target class isn't loaded yet, then guarded by
+    // `if klass && klass.respond_to?(:_counter_cache_columns)`. We mirror
+    // by treating registry-miss as the deferral signal (pending-map path);
+    // namespace-aware resolution via reflection.klass is attempted when the
+    // registry has it, allowing modular class names to resolve correctly.
+    const targetClass: typeof import("../../base.js").Base | null = modelRegistry.has(
+      targetClassName,
+    )
+      ? resolveAssocClass(model, name, targetClassName)
+      : null;
     if (targetClass) {
       const existing: Set<string> = (targetClass as any)._counterCacheColumns ?? new Set();
       existing.add(cacheColumn);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2223,6 +2223,7 @@ export class Base extends Model {
   declare static updateCounters: typeof CounterCache.updateCounters;
   declare static resetCounters: typeof CounterCache.resetCounters;
   declare static isCounterCacheColumn: typeof CounterCache.isCounterCacheColumn;
+  declare static counterCachedAssociationNames: typeof CounterCache.getCounterCachedAssociationNames;
 
   /**
    * Instantiate a model from a database row (marks it as persisted).

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -241,12 +241,24 @@ function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
  */
+/**
+ * Class-attribute accessor mirroring Rails'
+ * `class_attribute :counter_cached_association_names`. Returns an array
+ * (Rails parity) snapshot of the registered association names.
+ *
+ * Mirrors: ActiveRecord::CounterCache#counter_cached_association_names
+ */
+export function getCounterCachedAssociationNames(this: typeof Base): string[] {
+  return counterCachedAssociationNames(this);
+}
+
 export const ClassMethods = {
   incrementCounter,
   decrementCounter,
   updateCounters,
   resetCounters,
   isCounterCacheColumn,
+  counterCachedAssociationNames: getCounterCachedAssociationNames,
 };
 
 type InstanceCounterHost = {
@@ -255,7 +267,23 @@ type InstanceCounterHost = {
   association(name: string): any;
 };
 
+/**
+ * Mirrors: `model.counter_cached_association_names |= [name]` in
+ * Rails' Associations::Builder::BelongsTo.add_counter_cache_callbacks.
+ * Stored as a Set on the owning class for O(1) dedupe.
+ * @internal
+ */
+export function registerCounterCachedAssociation(model: any, name: string): void {
+  const existing: Set<string> = model._counterCachedAssociationNames ?? new Set();
+  existing.add(name);
+  model._counterCachedAssociationNames = existing;
+}
+
 function counterCachedAssociationNames(ctor: typeof Base): string[] {
+  const registered: Set<string> | undefined = (ctor as any)._counterCachedAssociationNames;
+  if (registered && registered.size > 0) return [...registered];
+  // Fallback for models whose belongs_to was registered before the explicit
+  // registry was wired (or via dynamic _associations entries with counterCache).
   const associations: Array<{ type: string; name: string; options: any }> =
     (ctor as any)._associations ?? [];
   return associations

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -274,9 +274,13 @@ type InstanceCounterHost = {
  * @internal
  */
 export function registerCounterCachedAssociation(model: any, name: string): void {
-  const existing: Set<string> = model._counterCachedAssociationNames ?? new Set();
-  existing.add(name);
-  model._counterCachedAssociationNames = existing;
+  // Mirror Rails' class_attribute `|=` semantics: copy-on-write so subclass
+  // additions don't mutate the parent class's Set in place.
+  const owns = Object.prototype.hasOwnProperty.call(model, "_counterCachedAssociationNames");
+  const inherited: Set<string> | undefined = model._counterCachedAssociationNames;
+  const next: Set<string> = owns && inherited ? inherited : new Set(inherited ?? []);
+  next.add(name);
+  model._counterCachedAssociationNames = next;
 }
 
 function counterCachedAssociationNames(ctor: typeof Base): string[] {


### PR DESCRIPTION
## Summary

Associations-HABTM Slot G from `docs/activerecord-100-clusters.md` — wire Rails-parity counter-cache install path on `belongs_to`, with the namespace-aware target class resolution (Slot E follow-up) folded in.

- Add explicit `counterCachedAssociationNames` class registry, populated by the `belongs_to` builder (mirrors Rails: `model.counter_cached_association_names |= [reflection.name]` in `Associations::Builder::BelongsTo.add_counter_cache_callbacks`).
- Read from the explicit registry in `_createRecord` / `destroyRow`; fall back to deriving from `_associations` for models registered before the explicit registry existed.
- Builder counter-cache wiring now resolves the target class via `resolveAssocClass` (namespace-aware `reflection.klass` lookup), falling back to flat `resolveModel`/pending-map when no rich reflection is attached yet. This closes the Slot E follow-up from the Associations-reflection section.
- `resolveAssocClass` accepts either a record or a model class so it can be called from class-level builder code.
- Expose `counterCachedAssociationNames` as a `ClassMethods` accessor on `Base` (Rails parity surface).

Rails HABTM does not propagate `counter_cache` through the auto-built join model (see `vendor/rails/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb#belongs_to_options`), so no HABTM-side propagation was needed.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/counter-cache.test.ts` (86 passed | 15 skipped)
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts`
- [x] `pnpm test:types`
- [x] `git diff --shortstat` 4 files / 49 insertions / 5 deletions — well under 300 LOC ceiling