### PR TITLE
feat(globalid): GID-9 — Locator class hierarchy + Locator.use(app, locator)

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -9,17 +9,17 @@ toGid, toGidParam, toSignedGlobalId, toSgid, toSgidParam). AR side: Base.toGid /
 toSgid / toGlobalId / toGidParam / toSignedGlobalId / findGlobalId /
 findSignedGlobalId / findSignedGlobalIdBang.
 
-### Parity scoreboard (after GID-8)
+### Parity scoreboard (after GID-9)
 
 Targets are **pre-skip** — the unportable-surface skip list (see below)
 brings the practical 100% to 56/56 api / 149/149 tests.
 
-| Signal       | Current          | 100% target (pre-skip) | Gap          |
-| ------------ | ---------------- | ---------------------- | ------------ |
-| api:compare  | 47 / 59 (79.7%)  | 59 / 59                | 12 methods   |
-| test:compare | 98 / 158 (62.0%) | 158 / 158              | 60 tests     |
-| files (api)  | 4 / 5            | 5 / 5                  | verifier.ts  |
-| files (test) | 5 / 8            | 8 / 8                  | 3 test files |
+| Signal       | Current           | 100% target (pre-skip) | Gap          |
+| ------------ | ----------------- | ---------------------- | ------------ |
+| api:compare  | 57 / 59 (96.6%)   | 59 / 59                | 2 methods    |
+| test:compare | 102 / 158 (64.6%) | 158 / 158              | 56 tests     |
+| files (api)  | 4 / 5             | 5 / 5                  | verifier.ts  |
+| files (test) | 5 / 8             | 8 / 8                  | 3 test files |
 
 Per-file api:compare:
 
@@ -28,7 +28,7 @@ Per-file api:compare:
 | `identification.rb`   | 4     | 4     | 100% |
 | `uri/gid.rb`          | 21    | 21    | 100% |
 | `signed_global_id.rb` | 16    | 16    | 100% |
-| `locator.rb`          | 6     | 16    | 38%  |
+| `locator.rb`          | 16    | 16    | 100% |
 | `verifier.rb`         | 0     | 2     | 0%   |
 
 Per-file test:compare:
@@ -38,7 +38,7 @@ Per-file test:compare:
 | `uri_gid_test.rb`               | 27    | 30    | 90% |
 | `signed_global_id_test.rb`      | 20    | 24    | 83% |
 | `global_identification_test.rb` | 5     | 6     | 83% |
-| `global_locator_test.rb`        | 33    | 59    | 56% |
+| `global_locator_test.rb`        | 37    | 59    | 63% |
 | `global_id_test.rb`             | 13    | 26    | 50% |
 | `verifier_test.rb`              | 0     | 4     | 0%  |
 | `pattern_matching_test.rb`      | 0     | 2     | 0%  |
@@ -137,28 +137,34 @@ test:compare `signed_global_id_test.rb`: 17/24 → **20/24** (the 3
 class-level expires_in tests now pass via vi.useFakeTimers — the same
 js-temporal-polyfill + Date.now mocking pattern GID-6b established).
 
-### GID-9 — Locator class hierarchy + `use(app, locator)` (~150 LOC)
+### GID-9 — Locator class hierarchy + `use(app, locator)` — **done**
 
-11 missing methods on `locator.rb`. Implement the three nested Rails
-classes:
+Refactored `locator.ts` from a single static-method `Locator` into the
+Rails class hierarchy:
 
-- `BaseLocator` class with `locate`, `locateMany`, `findRecords`,
-  `modelIdIsValid?`, `primaryKey`. Most logic already lives in the
-  current top-level `Locator` — refactor into the class hierarchy.
-- `UnscopedLocator extends BaseLocator` with `unscoped(modelClass)` helper
-  for the `Model.unscoped { ... }` block pattern.
-- `BlockLocator` with constructor + `locate` / `locateMany` for the
+- `BaseLocator` class — instance `locate` / `locateMany` plus protected
+  `findRecords` / `modelIdIsValid` / `primaryKey`. The existing logic from
+  the old top-level `Locator` moved here.
+- `UnscopedLocator extends BaseLocator` — wraps lookups in
+  `klass.unscoped { ... }` when the model supports it; yields otherwise.
+- `BlockLocator` — `constructor(block)` + `locate` / `locateMany` for the
   `Locator.use(app, &block)` form.
-- `Locator.defaultLocator` getter/setter (replaces internal singleton).
-- `Locator.use(appName, locator)` — registers per-app locators in a
-  `Map<string, BaseLocator | BlockLocator>`. Now in scope.
-- `Locator.locatorFor`, `Locator.findAllowed?`, `Locator.parseAllowed`,
-  `Locator.normalizeApp` — private helpers extracted from the current
-  inline implementation.
+- `Locator` (the static facade) — `locate` / `locateMany` now parse the
+  GID, run `findAllowed`, look up the per-app locator via `locatorFor`,
+  and delegate. New static methods: `defaultLocator` getter/setter,
+  `use(app, locator | block)`, `locatorFor`, `findAllowed`,
+  `parseAllowed`, `normalizeApp`.
 
-This was deferred from GID-4 as "out of scope per plan." Lifting that
-restriction is what unlocks the last ~50 test:compare matches in
-`global_locator_test.rb`.
+`LocatorModel` interface gained an optional `unscoped` method so
+`UnscopedLocator` can call it when present.
+
+api:compare `locator.rb`: 38% (6/16) → **100% (16/16)**.
+api:compare overall: 79.7% → **96.6%** — only `verifier.rb` (2
+methods) remains.
+test:compare `global_locator_test.rb`: 33/59 → **37/59 (63%)** with the
+4 new Rails-named tests (`use locator with block`, `use locator with
+class`, `app locator is case insensitive`, `locator name cannot have
+underscore`). Overall test:compare: 98/158 → **102/158 (64.6%)**.
 
 ### GID-10a — Drop `purpose:` option key (~40 LOC, breaking)
 

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -509,7 +509,9 @@ describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
   it("defaultLocator getter/setter (Rails: Locator.default_locator=)", () => {
     const original = Locator.defaultLocator;
     const custom = new BlockLocator(() => "custom-default");
-    Locator.defaultLocator = custom as unknown as typeof original;
+    // LocatorLike-widened defaultLocator accepts a BlockLocator directly —
+    // no cast needed.
+    Locator.defaultLocator = custom;
     expect(Locator.defaultLocator).toBe(custom);
     Locator.defaultLocator = original;
   });

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -542,4 +542,24 @@ describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
     const found = await Locator.locateMany(["not-a-gid", "gid://bcx/Unknown/1"], {});
     expect(found).toEqual([]);
   });
+
+  it("locateMany filters out mismatched-app GIDs (single-app dispatch invariant)", async () => {
+    // Register an 'other-app' BlockLocator that would crash if asked to
+    // resolve a 'bcx' GID. locateMany should keep only the first-GID-app
+    // entries; the foreign GID is silently dropped.
+    Locator.use("other-app", () => {
+      throw new Error("should not be called — foreign-app GID must be filtered");
+    });
+    const found = await Locator.locateMany(
+      [
+        "gid://bcx/Person/1",
+        "gid://other-app/Person/99", // would route to the throwing locator
+        "gid://bcx/Person/2",
+      ],
+      {},
+    );
+    expect(found).toHaveLength(2);
+    expect((found[0] as Person).id).toBe("1");
+    expect((found[1] as Person).id).toBe("2");
+  });
 });

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -3,7 +3,14 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { setApp, _resetApp } from "./config.js";
 import { GlobalID } from "./global-id.js";
 import { SignedGlobalID } from "./signed-global-id.js";
-import { Locator, setModelFinder, _resetModelFinder, type LocatorModel } from "./locator.js";
+import {
+  Locator,
+  BlockLocator,
+  setModelFinder,
+  _resetModelFinder,
+  _resetLocators,
+  type LocatorModel,
+} from "./locator.js";
 
 const TEST_APP = "bcx";
 const UUID = "7ef9b614-353c-43a1-a203-ab2307851990";
@@ -381,6 +388,46 @@ describe("GlobalLocatorTest", () => {
     expect(await Locator.locate("gid://app/CompositePrimaryKeyModel/tenant-key-value/")).toBeNull();
     expect(await Locator.locate("gid://app/CompositePrimaryKeyModel/tenant-key-value")).toBeNull();
   });
+
+  // ─── Locator.use(app, locator) — per-app dispatch ──────────────────────
+
+  it("use locator with block", async () => {
+    Locator.use("foo", (gid) => `block-located:${gid.modelName}:${gid.modelId}`);
+    try {
+      const found = await Locator.locate("gid://foo/Person/1");
+      expect(found).toBe("block-located:Person:1");
+    } finally {
+      _resetLocators();
+    }
+  });
+
+  it("use locator with class", async () => {
+    class CustomLocator extends BlockLocator {
+      constructor() {
+        super((gid) => `class-located:${gid.modelId}`);
+      }
+    }
+    Locator.use("bar", new CustomLocator());
+    try {
+      expect(await Locator.locate("gid://bar/Person/9")).toBe("class-located:9");
+    } finally {
+      _resetLocators();
+    }
+  });
+
+  it("app locator is case insensitive", async () => {
+    Locator.use("MyApp", (gid) => `case-test:${gid.modelId}`);
+    try {
+      expect(await Locator.locate("gid://myapp/Person/3")).toBe("case-test:3");
+      expect(await Locator.locate("gid://MYAPP/Person/4")).toBe("case-test:4");
+    } finally {
+      _resetLocators();
+    }
+  });
+
+  it("locator name cannot have underscore", () => {
+    expect(() => Locator.use("invalid_app", () => null)).toThrow(/invalid app name/i);
+  });
 });
 
 // ─── Non-Rails coverage (regressions / edge cases not in Rails suite) ──────
@@ -438,5 +485,51 @@ describe("Locator without model finder", () => {
 
   it("returns null when no finder is registered", async () => {
     expect(await Locator.locate("gid://bcx/Person/1")).toBeNull();
+  });
+});
+
+describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
+  beforeEach(() => {
+    setApp(TEST_APP);
+    setModelFinder((name) => REGISTRY[name]);
+  });
+  afterEach(() => {
+    _resetApp();
+    _resetModelFinder();
+    _resetLocators();
+  });
+
+  it("falls back to the default locator when no app-specific locator is registered", async () => {
+    Locator.use("other-app", () => "should-not-be-called");
+    const found = (await Locator.locate("gid://bcx/Person/5")) as Person;
+    expect(found).toBeInstanceOf(Person);
+    expect(found.id).toBe("5");
+  });
+
+  it("defaultLocator getter/setter (Rails: Locator.default_locator=)", () => {
+    const original = Locator.defaultLocator;
+    const custom = new BlockLocator(() => "custom-default");
+    Locator.defaultLocator = custom as unknown as typeof original;
+    expect(Locator.defaultLocator).toBe(custom);
+    Locator.defaultLocator = original;
+  });
+
+  it("locatorFor returns the registered locator for the app", () => {
+    const custom = new BlockLocator(() => null);
+    Locator.use("zed", custom);
+    const gid = GlobalID.parse("gid://zed/Person/1");
+    expect(Locator.locatorFor(gid!)).toBe(custom);
+  });
+
+  it("parseAllowed filters by class allowlist", () => {
+    const gids = ["gid://bcx/Person/1", "gid://bcx/PersonChild/2", "gid://bcx/Unknown/3"];
+    const allowed = Locator.parseAllowed(gids, PersonChild as unknown as LocatorModel);
+    expect(allowed).toHaveLength(1);
+    expect(allowed[0].modelName).toBe("PersonChild");
+  });
+
+  it("normalizeApp lowercases the app name", () => {
+    expect(Locator.normalizeApp("MyApp")).toBe("myapp");
+    expect(Locator.normalizeApp("FOO")).toBe("foo");
   });
 });

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -532,4 +532,12 @@ describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
     expect(Locator.normalizeApp("MyApp")).toBe("myapp");
     expect(Locator.normalizeApp("FOO")).toBe("foo");
   });
+
+  it("locateMany returns [] when parseAllowed filters out every input", async () => {
+    // All GIDs are invalid / unknown class / filtered by only: → empty allowed
+    // set → return [] without dispatching to any locator (no first-locator
+    // crash, no extraneous work).
+    const found = await Locator.locateMany(["not-a-gid", "gid://bcx/Unknown/1"], {});
+    expect(found).toEqual([]);
+  });
 });

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -543,6 +543,17 @@ describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
     expect(found).toEqual([]);
   });
 
+  it("locate returns null for arity-mismatched GIDs even with a BlockLocator registered", async () => {
+    // Without the facade-level arity check, the registered BlockLocator
+    // would run on bad-arity GIDs (inconsistent with BaseLocator's
+    // modelIdIsValid filter, which returns null for them).
+    Locator.use("ba", () => {
+      throw new Error("should not be called — bad-arity GID must be filtered at the facade");
+    });
+    // Person has scalar primaryKey; composite-form id is bad arity.
+    expect(await Locator.locate("gid://ba/Person/1/2")).toBeNull();
+  });
+
   it("locateMany drops arity-mismatched GIDs before the first-app dispatch selection", async () => {
     // Bad-arity GID anchored at allowed[0] with a different app would
     // otherwise cause locateMany to filter to its app and lose the valid

--- a/packages/globalid/src/global-locator.test.ts
+++ b/packages/globalid/src/global-locator.test.ts
@@ -543,6 +543,27 @@ describe("Locator non-Rails coverage — per-app dispatch helpers", () => {
     expect(found).toEqual([]);
   });
 
+  it("locateMany drops arity-mismatched GIDs before the first-app dispatch selection", async () => {
+    // Bad-arity GID anchored at allowed[0] with a different app would
+    // otherwise cause locateMany to filter to its app and lose the valid
+    // same-app GIDs that follow. parseAllowed's arity filter removes the
+    // bad entry first, so allowed[0] is a real candidate.
+    Locator.use("doomed-app", () => {
+      throw new Error("should not be called — bad-arity GID must be filtered first");
+    });
+    const found = await Locator.locateMany(
+      [
+        "gid://doomed-app/Person/1/2", // scalar-PK Person with composite-form id → bad arity
+        "gid://bcx/Person/3",
+        "gid://bcx/Person/4",
+      ],
+      {},
+    );
+    expect(found).toHaveLength(2);
+    expect((found[0] as Person).id).toBe("3");
+    expect((found[1] as Person).id).toBe("4");
+  });
+
   it("locateMany filters out mismatched-app GIDs (single-app dispatch invariant)", async () => {
     // Register an 'other-app' BlockLocator that would crash if asked to
     // resolve a 'bcx' GID. locateMany should keep only the first-GID-app

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -25,6 +25,7 @@ export type {
   LocateSignedOptions,
   ModelFinder,
   LocatorBlock,
+  LocatorLike,
 } from "./locator.js";
 export {
   toGlobalId,

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -16,10 +16,16 @@ export {
   InvalidModelIdError,
 } from "./uri/gid.js";
 export type { GidComponents } from "./uri/gid.js";
-export { Locator, setModelFinder } from "./locator.js";
+export { Locator, BaseLocator, UnscopedLocator, BlockLocator, setModelFinder } from "./locator.js";
 /** @internal */
-export { _resetModelFinder } from "./locator.js";
-export type { LocatorModel, LocateOptions, LocateSignedOptions, ModelFinder } from "./locator.js";
+export { _resetModelFinder, _resetLocators } from "./locator.js";
+export type {
+  LocatorModel,
+  LocateOptions,
+  LocateSignedOptions,
+  ModelFinder,
+  LocatorBlock,
+} from "./locator.js";
 export {
   toGlobalId,
   toGid,

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -27,7 +27,10 @@ export interface LocateOptions {
   only?: LocatorModel | LocatorModel[];
   /**
    * Use `where(pk: ids)` instead of `find(ids)` so missing records are
-   * silently skipped (the result array is shorter than the input).
+   * silently skipped (the result array is shorter than the input). Without
+   * this option, a missing record causes `klass.find` to throw (Rails
+   * raises `RecordNotFound`). Use `ignoreMissing: true` for graceful
+   * missing-record handling.
    */
   ignoreMissing?: boolean;
 }
@@ -104,7 +107,10 @@ export class BaseLocator {
     for (const [klass, ids] of idsByClass) {
       const records = await this.findRecords(klass, ids, options);
       const byId = new Map<string, unknown>();
-      const pkProp = recordIdProp(klass);
+      // Read the record's PK property from the same source of truth as
+      // findRecords/modelIdIsValid — this.primaryKey(klass) — so a
+      // subclass that overrides primaryKey() indexes consistently.
+      const pkProp = recordIdProp(this.primaryKey(klass));
       for (const rec of records) {
         byId.set(idKey((rec as Record<string, unknown>)[pkProp]), rec);
       }
@@ -385,8 +391,11 @@ function lookupClass(name: string): LocatorModel | undefined {
 
 type Ctor = new (...args: never[]) => unknown;
 
-function recordIdProp(klass: LocatorModel): string {
-  return Array.isArray(klass.primaryKey) ? "id" : (klass.primaryKey ?? "id");
+/** Property name to read the PK value from a record. Takes the PK shape
+ *  (string for scalar, array for composite). Composite PKs read through
+ *  AR's `.id` aggregate accessor; scalars use the PK column name. */
+function recordIdProp(pk: string | string[]): string {
+  return Array.isArray(pk) ? "id" : pk;
 }
 
 /** True iff `modelId`'s arity matches `klass.primaryKey`'s arity. @internal */

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -12,8 +12,15 @@ export interface LocatorModel {
   where?(conditions: Record<string, unknown>): {
     toArray?(): Promise<unknown[]> | unknown[];
   };
-  /** Rails: Model.unscoped { ... } — optional escape hatch UnscopedLocator uses. */
-  unscoped?<T>(block: () => T): T;
+  /**
+   * Rails: `Model.unscoped { ... }` — optional escape hatch
+   * `UnscopedLocator` uses. Block may be sync or async; return matches.
+   * Shape is permissive so AR's `unscoped(block)`
+   * (`(block: () => R | Promise<R>) => Promise<R>`) is assignable
+   * without casts, and a synchronous duck-typed `unscoped(block) => R`
+   * also works.
+   */
+  unscoped?<R>(block: () => R | Promise<R>): R | Promise<R>;
 }
 
 export interface LocateOptions {
@@ -173,7 +180,10 @@ export class UnscopedLocator extends BaseLocator {
   }
 
   /** @internal Mirrors: UnscopedLocator#unscoped. */
-  protected unscoped<T>(klass: LocatorModel | undefined, block: () => T): T {
+  protected unscoped<R>(
+    klass: LocatorModel | undefined,
+    block: () => R | Promise<R>,
+  ): R | Promise<R> {
     return klass?.unscoped ? klass.unscoped(block) : block();
   }
 }

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -240,17 +240,28 @@ export class Locator {
     return locator.locate(parsed, rest);
   }
 
-  /** Mirrors: Locator.locate_many. All GIDs must share an app (Rails parity). */
+  /**
+   * Mirrors: Locator.locate_many. Rails' contract: "All GlobalIDs must
+   * belong to the same app, as they will be located using the same
+   * locator." Rails relies on the caller and silently misroutes
+   * mismatched-app GIDs through the first GID's locator — which is unsafe
+   * with BlockLocators that only know one app's models. We make this
+   * explicit: only GIDs matching the first allowed GID's app are passed
+   * to the locator; the rest are dropped. (Rails-faithful for the
+   * single-app happy path; safer for the mixed-app misuse case.)
+   */
   static async locateMany(
     gids: Array<string | GlobalID>,
     options: LocateOptions = {},
   ): Promise<unknown[]> {
     const allowed = Locator.parseAllowed(gids, options.only);
     if (allowed.length === 0) return [];
+    const app = Locator.normalizeApp(allowed[0].app);
+    const sameApp = allowed.filter((g) => Locator.normalizeApp(g.app) === app);
     const locator = Locator.locatorFor(allowed[0]);
     // Same as locate: strip the only: option before delegating.
     const { only: _, ...rest } = options;
-    return locator.locateMany(allowed, rest);
+    return locator.locateMany(sameApp, rest);
   }
 
   /** Mirrors: Locator.locate_signed */

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -53,6 +53,18 @@ export function _resetModelFinder(): void {
 export type LocatorBlock = (gid: GlobalID, options?: LocateOptions) => Promise<unknown> | unknown;
 
 /**
+ * Anything that can be plugged in as a locator — `BaseLocator`,
+ * `UnscopedLocator`, `BlockLocator`, or a custom class that implements
+ * the same `locate` / `locateMany` shape. Used as the public type for
+ * `Locator.defaultLocator` and `Locator.use` so callers don't have to
+ * cast between class hierarchies.
+ */
+export interface LocatorLike {
+  locate(gid: GlobalID, options?: LocateOptions): Promise<unknown | null>;
+  locateMany(gids: GlobalID[], options?: LocateOptions): Promise<unknown[]>;
+}
+
+/**
  * Mirrors: GlobalID::Locator::BaseLocator. Resolves GlobalIDs by looking up
  * the model class via the registered ModelFinder and delegating to
  * `klass.find(id)` (or `klass.where({pk: ids})` for the batch + ignoreMissing
@@ -183,24 +195,31 @@ export class BlockLocator {
   }
 
   /**
-   * Locate each GID via the block sequentially.
+   * Locate each GID via the block sequentially (Rails parity — Ruby's
+   * `gids.map { |gid| locate(gid, options) }` runs single-threaded).
+   * Sequential ordering matters here: a block that touches global state
+   * or external resources would behave unpredictably under `Promise.all`.
    *
-   * Divergence from Rails: Rails' `BlockLocator#locate_many` returns whatever
-   * the block returns (including nils, preserving input order with gaps).
-   * We filter nulls to stay consistent with `BaseLocator#locateMany` which
-   * uses `filter_map` in Rails. If positional alignment with the input array
-   * matters to callers, they should call `locate` per GID directly.
+   * Divergence from Rails: Rails' `BlockLocator#locate_many` returns the
+   * block results including nils (preserving input order with gaps). We
+   * filter nulls to stay consistent with `BaseLocator#locateMany` (which
+   * uses `filter_map` in Rails). If positional alignment with the input
+   * matters, callers should call `locate` per GID directly.
    */
   async locateMany(gids: GlobalID[], options: LocateOptions = {}): Promise<unknown[]> {
-    const results = await Promise.all(gids.map((gid) => this.locate(gid, options)));
-    return results.filter((r): r is unknown => r !== null);
+    const results: unknown[] = [];
+    for (const gid of gids) {
+      const r = await this.locate(gid, options);
+      if (r !== null) results.push(r);
+    }
+    return results;
   }
 }
 
 // ─── Locator (top-level facade — dispatches to per-app or default locator) ─
 
-const _appLocators = new Map<string, BaseLocator | BlockLocator>();
-let _defaultLocator: BaseLocator = new UnscopedLocator();
+const _appLocators = new Map<string, LocatorLike>();
+let _defaultLocator: LocatorLike = new UnscopedLocator();
 
 /** Mirrors: GlobalID::Locator */
 export class Locator {
@@ -262,20 +281,20 @@ export class Locator {
   // ─── Class-level config (Rails: attr_accessor :default_locator) ───────────
 
   /** Mirrors: Locator.default_locator */
-  static get defaultLocator(): BaseLocator {
+  static get defaultLocator(): LocatorLike {
     return _defaultLocator;
   }
   /** Mirrors: Locator.default_locator= */
-  static set defaultLocator(locator: BaseLocator) {
+  static set defaultLocator(locator: LocatorLike) {
     _defaultLocator = locator;
   }
 
   /**
    * Mirrors: Locator.use(app, locator | &block) — register a per-app locator.
-   * Accepts a BaseLocator instance, a BlockLocator, or a plain block function
-   * (wrapped automatically).
+   * Accepts any locator-like object or a plain block function (wrapped
+   * automatically as a BlockLocator).
    */
-  static use(app: string, locator: BaseLocator | BlockLocator | LocatorBlock): void {
+  static use(app: string, locator: LocatorLike | LocatorBlock): void {
     validateApp(app);
     const wrapped = typeof locator === "function" ? new BlockLocator(locator) : locator;
     _appLocators.set(Locator.normalizeApp(app), wrapped);
@@ -284,7 +303,7 @@ export class Locator {
   // ─── Private helpers (Rails class << self private) ───────────────────────
 
   /** @internal Mirrors: Locator.locator_for. */
-  static locatorFor(gid: GlobalID): BaseLocator | BlockLocator {
+  static locatorFor(gid: GlobalID): LocatorLike {
     return _appLocators.get(Locator.normalizeApp(gid.app)) ?? _defaultLocator;
   }
 

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -147,10 +147,7 @@ export class BaseLocator {
   protected modelIdIsValid(gid: GlobalID): boolean {
     const klass = lookupClass(gid.modelName);
     if (!klass) return false;
-    const pk = this.primaryKey(klass);
-    const pkArity = Array.isArray(pk) ? pk.length : 1;
-    const idArity = Array.isArray(gid.modelId) ? gid.modelId.length : 1;
-    return idArity === pkArity;
+    return modelIdArityMatches(klass, gid.modelId, this.primaryKey(klass));
   }
 
   /** @internal Mirrors: BaseLocator#primary_key. */
@@ -339,7 +336,13 @@ export class Locator {
     });
   }
 
-  /** @internal Mirrors: Locator.parse_allowed. */
+  /**
+   * @internal Mirrors: Locator.parse_allowed. Extends Rails behavior by also
+   * filtering modelId-arity mismatches here (Rails defers that to
+   * BaseLocator#model_id_is_valid? at dispatch time). We filter early so the
+   * locateMany first-GID-app selection isn't anchored on a doomed entry,
+   * which would drop otherwise-valid same-app GIDs.
+   */
   static parseAllowed(gids: Array<string | GlobalID>, only?: LocateOptions["only"]): GlobalID[] {
     const result: GlobalID[] = [];
     for (const g of gids) {
@@ -348,6 +351,7 @@ export class Locator {
       const klass = lookupClass(parsed.modelName);
       if (!klass) continue;
       if (!Locator.findAllowed(klass, only)) continue;
+      if (!modelIdArityMatches(klass, parsed.modelId)) continue;
       result.push(parsed);
     }
     return result;
@@ -375,6 +379,17 @@ type Ctor = new (...args: never[]) => unknown;
 
 function recordIdProp(klass: LocatorModel): string {
   return Array.isArray(klass.primaryKey) ? "id" : (klass.primaryKey ?? "id");
+}
+
+/** True iff `modelId`'s arity matches `klass.primaryKey`'s arity. @internal */
+function modelIdArityMatches(
+  klass: LocatorModel,
+  modelId: unknown,
+  pk: string | string[] = klass.primaryKey ?? "id",
+): boolean {
+  const pkArity = Array.isArray(pk) ? pk.length : 1;
+  const idArity = Array.isArray(modelId) ? modelId.length : 1;
+  return idArity === pkArity;
 }
 
 function idKey(id: unknown): string {

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -128,9 +128,13 @@ export class BaseLocator {
     // Composite primary keys would need where(cols, tuples); Rails relation
     // form not yet supported by our AR layer. CPK + ignoreMissing falls
     // through to find(ids) (raises on missing) as a known limitation.
-    if (options.ignoreMissing && klass.where && !Array.isArray(klass.primaryKey)) {
-      const pkKey = (this.primaryKey(klass) ?? "id") as string;
-      const rel = klass.where({ [pkKey]: ids });
+    //
+    // Use this.primaryKey(klass) as the single source of truth for the PK
+    // shape — a subclass overriding primaryKey() must affect both the
+    // composite-key gate AND the where() key consistently.
+    const pk = this.primaryKey(klass);
+    if (options.ignoreMissing && klass.where && !Array.isArray(pk)) {
+      const rel = klass.where({ [pk]: ids });
       if (!rel.toArray) {
         throw new Error(
           "LocatorModel.where() returned a relation without .toArray() — required for ignoreMissing.",
@@ -240,6 +244,10 @@ export class Locator {
     const klass = lookupClass(parsed.modelName);
     if (!klass) return null;
     if (!Locator.findAllowed(klass, options.only)) return null;
+    // Arity-check at the facade so BlockLocator / custom LocatorLike dispatch
+    // doesn't run on a GID that BaseLocator would reject. Matches the
+    // mismatched-modelId-returns-null behavior across all locator kinds.
+    if (!modelIdArityMatches(klass, parsed.modelId)) return null;
     const locator = Locator.locatorFor(parsed);
     // Rails: options.except(:only) — the only: filter is the facade's
     // concern, not the per-locator one.

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -182,6 +182,15 @@ export class BlockLocator {
     return result ?? null;
   }
 
+  /**
+   * Locate each GID via the block sequentially.
+   *
+   * Divergence from Rails: Rails' `BlockLocator#locate_many` returns whatever
+   * the block returns (including nils, preserving input order with gaps).
+   * We filter nulls to stay consistent with `BaseLocator#locateMany` which
+   * uses `filter_map` in Rails. If positional alignment with the input array
+   * matters to callers, they should call `locate` per GID directly.
+   */
   async locateMany(gids: GlobalID[], options: LocateOptions = {}): Promise<unknown[]> {
     const results = await Promise.all(gids.map((gid) => this.locate(gid, options)));
     return results.filter((r): r is unknown => r !== null);
@@ -206,7 +215,10 @@ export class Locator {
     if (!klass) return null;
     if (!Locator.findAllowed(klass, options.only)) return null;
     const locator = Locator.locatorFor(parsed);
-    return locator.locate(parsed, options);
+    // Rails: options.except(:only) — the only: filter is the facade's
+    // concern, not the per-locator one.
+    const { only: _, ...rest } = options;
+    return locator.locate(parsed, rest);
   }
 
   /** Mirrors: Locator.locate_many. All GIDs must share an app (Rails parity). */
@@ -217,7 +229,9 @@ export class Locator {
     const allowed = Locator.parseAllowed(gids, options.only);
     if (allowed.length === 0) return [];
     const locator = Locator.locatorFor(allowed[0]);
-    return locator.locateMany(allowed, options);
+    // Same as locate: strip the only: option before delegating.
+    const { only: _, ...rest } = options;
+    return locator.locateMany(allowed, rest);
   }
 
   /** Mirrors: Locator.locate_signed */

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -1,5 +1,6 @@
 import { GlobalID } from "./global-id.js";
 import { SignedGlobalID } from "./signed-global-id.js";
+import { validateApp } from "./uri/gid.js";
 import type { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
 /** Duck-typed model interface; globalid stays AR-agnostic. */
@@ -11,15 +12,15 @@ export interface LocatorModel {
   where?(conditions: Record<string, unknown>): {
     toArray?(): Promise<unknown[]> | unknown[];
   };
+  /** Rails: Model.unscoped { ... } — optional escape hatch UnscopedLocator uses. */
+  unscoped?<T>(block: () => T): T;
 }
 
 export interface LocateOptions {
-  /** Class allowlist — only return records whose class matches one of these. */
   only?: LocatorModel | LocatorModel[];
   /**
    * Use `where(pk: ids)` instead of `find(ids)` so missing records are
-   * silently skipped (the result array is shorter than the input). Without
-   * this option, a missing record causes `find` to throw.
+   * silently skipped (the result array is shorter than the input).
    */
   ignoreMissing?: boolean;
 }
@@ -33,12 +34,10 @@ export interface LocateSignedOptions extends LocateOptions {
   verifier: MessageVerifier;
 }
 
-/** Lookup function: given a model name, return the class (or undefined). */
 export type ModelFinder = (name: string) => LocatorModel | undefined;
 
 let _modelFinder: ModelFinder | undefined;
 
-/** Register the model lookup function. Called from AR's wire side. */
 export function setModelFinder(finder: ModelFinder): void {
   _modelFinder = finder;
 }
@@ -48,15 +47,155 @@ export function _resetModelFinder(): void {
   _modelFinder = undefined;
 }
 
+// ─── BaseLocator / UnscopedLocator / BlockLocator ──────────────────────────
+
+/** Block-form locator function — accepts a parsed GlobalID + options. */
+export type LocatorBlock = (gid: GlobalID, options?: LocateOptions) => Promise<unknown> | unknown;
+
+/**
+ * Mirrors: GlobalID::Locator::BaseLocator. Resolves GlobalIDs by looking up
+ * the model class via the registered ModelFinder and delegating to
+ * `klass.find(id)` (or `klass.where({pk: ids})` for the batch + ignoreMissing
+ * path).
+ */
+export class BaseLocator {
+  /** Mirrors: BaseLocator#locate */
+  async locate(gid: GlobalID, _options: LocateOptions = {}): Promise<unknown | null> {
+    if (!this.modelIdIsValid(gid)) return null;
+    const klass = lookupClass(gid.modelName);
+    if (!klass) return null;
+    const record = await klass.find(gid.modelId);
+    return record ?? null;
+  }
+
+  /** Mirrors: BaseLocator#locate_many */
+  async locateMany(gids: GlobalID[], options: LocateOptions = {}): Promise<unknown[]> {
+    const idsByClass = new Map<LocatorModel, unknown[]>();
+    const allowed: Array<{ gid: GlobalID; klass: LocatorModel }> = [];
+    for (const gid of gids) {
+      if (!this.modelIdIsValid(gid)) continue;
+      const klass = lookupClass(gid.modelName)!;
+      allowed.push({ gid, klass });
+      const ids = idsByClass.get(klass) ?? [];
+      ids.push(gid.modelId);
+      idsByClass.set(klass, ids);
+    }
+
+    const byClassAndId = new Map<string, Map<string, unknown>>();
+    for (const [klass, ids] of idsByClass) {
+      const records = await this.findRecords(klass, ids, options);
+      const byId = new Map<string, unknown>();
+      const pkProp = recordIdProp(klass);
+      for (const rec of records) {
+        byId.set(idKey((rec as Record<string, unknown>)[pkProp]), rec);
+      }
+      byClassAndId.set(klass.name, byId);
+    }
+
+    const result: unknown[] = [];
+    for (const { gid, klass } of allowed) {
+      const rec = byClassAndId.get(klass.name)?.get(idKey(gid.modelId));
+      if (rec !== undefined) result.push(rec);
+    }
+    return result;
+  }
+
+  /** @internal Mirrors: BaseLocator#find_records — batch find or where(pk: ids). */
+  protected async findRecords(
+    klass: LocatorModel,
+    ids: unknown[],
+    options: LocateOptions,
+  ): Promise<unknown[]> {
+    // Composite primary keys would need where(cols, tuples); Rails relation
+    // form not yet supported by our AR layer. CPK + ignoreMissing falls
+    // through to find(ids) (raises on missing) as a known limitation.
+    if (options.ignoreMissing && klass.where && !Array.isArray(klass.primaryKey)) {
+      const pkKey = (this.primaryKey(klass) ?? "id") as string;
+      const rel = klass.where({ [pkKey]: ids });
+      if (!rel.toArray) {
+        throw new Error(
+          "LocatorModel.where() returned a relation without .toArray() — required for ignoreMissing.",
+        );
+      }
+      const records = await rel.toArray();
+      return Array.isArray(records) ? records : [];
+    }
+    const result = await klass.find(ids);
+    return Array.isArray(result) ? result : [result];
+  }
+
+  /** @internal Mirrors: BaseLocator#model_id_is_valid? — modelId arity matches PK arity. */
+  protected modelIdIsValid(gid: GlobalID): boolean {
+    const klass = lookupClass(gid.modelName);
+    if (!klass) return false;
+    const pk = this.primaryKey(klass);
+    const pkArity = Array.isArray(pk) ? pk.length : 1;
+    const idArity = Array.isArray(gid.modelId) ? gid.modelId.length : 1;
+    return idArity === pkArity;
+  }
+
+  /** @internal Mirrors: BaseLocator#primary_key. */
+  protected primaryKey(klass: LocatorModel): string | string[] {
+    return klass.primaryKey ?? "id";
+  }
+}
+
+/**
+ * Mirrors: GlobalID::Locator::UnscopedLocator. Wraps lookups in
+ * `Model.unscoped { ... }` when the model supports it; otherwise yields
+ * (most TS models don't have an unscoped escape hatch).
+ */
+export class UnscopedLocator extends BaseLocator {
+  async locate(gid: GlobalID, options: LocateOptions = {}): Promise<unknown | null> {
+    const klass = lookupClass(gid.modelName);
+    return this.unscoped(klass, () => super.locate(gid, options));
+  }
+
+  /** @internal */
+  protected async findRecords(
+    klass: LocatorModel,
+    ids: unknown[],
+    options: LocateOptions,
+  ): Promise<unknown[]> {
+    return this.unscoped(klass, () => super.findRecords(klass, ids, options));
+  }
+
+  /** @internal Mirrors: UnscopedLocator#unscoped. */
+  protected unscoped<T>(klass: LocatorModel | undefined, block: () => T): T {
+    return klass?.unscoped ? klass.unscoped(block) : block();
+  }
+}
+
+/**
+ * Mirrors: GlobalID::Locator::BlockLocator. Wraps a `(gid, options) → record`
+ * function as a locator. Created by `Locator.use(app, block)`.
+ */
+export class BlockLocator {
+  private readonly _locator: LocatorBlock;
+
+  constructor(block: LocatorBlock) {
+    this._locator = block;
+  }
+
+  async locate(gid: GlobalID, options: LocateOptions = {}): Promise<unknown | null> {
+    const result = await this._locator(gid, options);
+    return result ?? null;
+  }
+
+  async locateMany(gids: GlobalID[], options: LocateOptions = {}): Promise<unknown[]> {
+    const results = await Promise.all(gids.map((gid) => this.locate(gid, options)));
+    return results.filter((r): r is unknown => r !== null);
+  }
+}
+
+// ─── Locator (top-level facade — dispatches to per-app or default locator) ─
+
+const _appLocators = new Map<string, BaseLocator | BlockLocator>();
+let _defaultLocator: BaseLocator = new UnscopedLocator();
+
 /** Mirrors: GlobalID::Locator */
 export class Locator {
-  /**
-   * Mirrors: Locator.locate(gid, options).
-   * Returns null if the GID is invalid, the model class isn't registered, or
-   * the `only:` filter rejects it. Errors from `klass.find` propagate (Rails
-   * raises RecordNotFound; use `locateMany` with `ignoreMissing` for graceful
-   * missing-record handling).
-   */
+  /** Mirrors: Locator.locate */
   static async locate(
     gid: string | GlobalID,
     options: LocateOptions = {},
@@ -65,66 +204,23 @@ export class Locator {
     if (!parsed) return null;
     const klass = lookupClass(parsed.modelName);
     if (!klass) return null;
-    if (!isAllowed(klass, options.only)) return null;
-    if (!modelIdIsValid(klass, parsed.modelId)) return null;
-    const record = await klass.find(parsed.modelId);
-    return record ?? null;
+    if (!Locator.findAllowed(klass, options.only)) return null;
+    const locator = Locator.locatorFor(parsed);
+    return locator.locate(parsed, options);
   }
 
-  /**
-   * Mirrors: Locator.locate_many(gids, options).
-   *
-   * Returns records matching the input GIDs in input order. Unknown classes,
-   * invalid GIDs, and `only:`-rejected entries are skipped (no null
-   * placeholders). With `ignoreMissing: true`, missing records are also
-   * skipped — the result array may be shorter than the input array.
-   *
-   * Each model class is hit with a single batch `find(ids)` (Rails parity).
-   */
+  /** Mirrors: Locator.locate_many. All GIDs must share an app (Rails parity). */
   static async locateMany(
     gids: Array<string | GlobalID>,
     options: LocateOptions = {},
   ): Promise<unknown[]> {
-    const allowed: Array<{ gid: GlobalID; klass: LocatorModel }> = [];
-    const idsByClass = new Map<LocatorModel, unknown[]>();
-
-    for (const g of gids) {
-      const parsed = GlobalID.parse(g);
-      if (!parsed) continue;
-      const klass = lookupClass(parsed.modelName);
-      if (!klass || !isAllowed(klass, options.only)) continue;
-      allowed.push({ gid: parsed, klass });
-      const ids = idsByClass.get(klass) ?? [];
-      ids.push(parsed.modelId);
-      idsByClass.set(klass, ids);
-    }
-
-    const recordsByClassAndId = new Map<string, Map<string, unknown>>();
-    for (const [klass, ids] of idsByClass) {
-      const records = await findRecords(klass, ids, options);
-      const byId = new Map<string, unknown>();
-      const pkProp = recordIdProp(klass);
-      for (const rec of records) {
-        byId.set(idKey((rec as Record<string, unknown>)[pkProp]), rec);
-      }
-      recordsByClassAndId.set(klass.name, byId);
-    }
-
-    const result: unknown[] = [];
-    for (const { gid, klass } of allowed) {
-      const byId = recordsByClassAndId.get(klass.name);
-      const rec = byId?.get(idKey(gid.modelId));
-      if (rec !== undefined) result.push(rec);
-    }
-    return result;
+    const allowed = Locator.parseAllowed(gids, options.only);
+    if (allowed.length === 0) return [];
+    const locator = Locator.locatorFor(allowed[0]);
+    return locator.locateMany(allowed, options);
   }
 
-  /**
-   * Mirrors: Locator.locate_signed(sgid, options). Accepts a token string or
-   * a SignedGlobalID instance (parity with `locate` which accepts string |
-   * GlobalID). Returns null on invalid signature, expired token, purpose
-   * mismatch, or unknown model class.
-   */
+  /** Mirrors: Locator.locate_signed */
   static async locateSigned(
     sgid: string | SignedGlobalID,
     options: LocateSignedOptions,
@@ -135,11 +231,7 @@ export class Locator {
     return Locator.locate(parsed.uri, options);
   }
 
-  /**
-   * Mirrors: Locator.locate_many_signed(sgids, options). Accepts strings or
-   * SignedGlobalID instances. Filters out invalid/expired SGIDs and locates
-   * the rest. Empty array if none verify.
-   */
+  /** Mirrors: Locator.locate_many_signed */
   static async locateManySigned(
     sgids: Array<string | SignedGlobalID>,
     options: LocateSignedOptions,
@@ -152,18 +244,74 @@ export class Locator {
     }
     return Locator.locateMany(uris, options);
   }
+
+  // ─── Class-level config (Rails: attr_accessor :default_locator) ───────────
+
+  /** Mirrors: Locator.default_locator */
+  static get defaultLocator(): BaseLocator {
+    return _defaultLocator;
+  }
+  /** Mirrors: Locator.default_locator= */
+  static set defaultLocator(locator: BaseLocator) {
+    _defaultLocator = locator;
+  }
+
+  /**
+   * Mirrors: Locator.use(app, locator | &block) — register a per-app locator.
+   * Accepts a BaseLocator instance, a BlockLocator, or a plain block function
+   * (wrapped automatically).
+   */
+  static use(app: string, locator: BaseLocator | BlockLocator | LocatorBlock): void {
+    validateApp(app);
+    const wrapped = typeof locator === "function" ? new BlockLocator(locator) : locator;
+    _appLocators.set(Locator.normalizeApp(app), wrapped);
+  }
+
+  // ─── Private helpers (Rails class << self private) ───────────────────────
+
+  /** @internal Mirrors: Locator.locator_for. */
+  static locatorFor(gid: GlobalID): BaseLocator | BlockLocator {
+    return _appLocators.get(Locator.normalizeApp(gid.app)) ?? _defaultLocator;
+  }
+
+  /** @internal Mirrors: Locator.find_allowed?. */
+  static findAllowed(klass: LocatorModel, only?: LocateOptions["only"]): boolean {
+    if (!only) return true;
+    const list = Array.isArray(only) ? only : [only];
+    const fn = klass as unknown as Ctor;
+    return list.some((c) => {
+      const cFn = c as unknown as Ctor;
+      return fn === cFn || fn.prototype instanceof cFn;
+    });
+  }
+
+  /** @internal Mirrors: Locator.parse_allowed. */
+  static parseAllowed(gids: Array<string | GlobalID>, only?: LocateOptions["only"]): GlobalID[] {
+    const result: GlobalID[] = [];
+    for (const g of gids) {
+      const parsed = GlobalID.parse(g);
+      if (!parsed) continue;
+      const klass = lookupClass(parsed.modelName);
+      if (!klass) continue;
+      if (!Locator.findAllowed(klass, only)) continue;
+      result.push(parsed);
+    }
+    return result;
+  }
+
+  /** @internal Mirrors: Locator.normalize_app — case-insensitive app keying. */
+  static normalizeApp(app: string): string {
+    return String(app).toLowerCase();
+  }
 }
 
-/**
- * Mirrors Rails BaseLocator#model_id_is_valid? — reject GIDs whose modelId
- * arity doesn't match the model's primaryKey arity (e.g. a composite-PK URI
- * with too few or too many segments).
- */
-function modelIdIsValid(klass: LocatorModel, modelId: unknown): boolean {
-  const pkArity = Array.isArray(klass.primaryKey) ? klass.primaryKey.length : 1;
-  const idArity = Array.isArray(modelId) ? modelId.length : 1;
-  return idArity === pkArity;
+/** @internal — test use only: clear app-scoped locators between tests. */
+export function _resetLocators(): void {
+  _appLocators.clear();
+  _defaultLocator = new UnscopedLocator();
 }
+
+// ─── Module-private helpers ────────────────────────────────────────────────
 
 function lookupClass(name: string): LocatorModel | undefined {
   return _modelFinder?.(name);
@@ -171,49 +319,10 @@ function lookupClass(name: string): LocatorModel | undefined {
 
 type Ctor = new (...args: never[]) => unknown;
 
-function isAllowed(klass: LocatorModel, only: LocateOptions["only"]): boolean {
-  if (!only) return true;
-  const list = Array.isArray(only) ? only : [only];
-  const fn = klass as unknown as Ctor;
-  return list.some((c) => {
-    const cFn = c as unknown as Ctor;
-    return fn === cFn || fn.prototype instanceof cFn;
-  });
-}
-
-async function findRecords(
-  klass: LocatorModel,
-  ids: unknown[],
-  options: LocateOptions,
-): Promise<unknown[]> {
-  // Composite primary keys would need where(cols, tuples) — Rails relation
-  // form not yet supported by our AR layer. Fall through to find(ids), which
-  // raises on missing; CPK + ignoreMissing is a known limitation.
-  if (options.ignoreMissing && klass.where && !Array.isArray(klass.primaryKey)) {
-    const pkKey = klass.primaryKey ?? "id";
-    const rel = klass.where({ [pkKey]: ids });
-    if (!rel.toArray) {
-      throw new Error(
-        "LocatorModel.where() returned a relation without .toArray() — required for ignoreMissing.",
-      );
-    }
-    const records = await rel.toArray();
-    return Array.isArray(records) ? records : [];
-  }
-  // Rails: model_class.find(ids) — single batch call returning an array.
-  const result = await klass.find(ids);
-  return Array.isArray(result) ? result : [result];
-}
-
-/** Property name to read the primary key value from a record instance. */
 function recordIdProp(klass: LocatorModel): string {
-  // AR exposes composite PKs through `.id` (array form), so use "id" for
-  // composite. For scalar PKs, honor klass.primaryKey when set.
   return Array.isArray(klass.primaryKey) ? "id" : (klass.primaryKey ?? "id");
 }
 
-/** Serialize an id to a Map key, using JSON for arrays so `['a/b','c']` and
- *  `['a','b/c']` don't collide. @internal */
 function idKey(id: unknown): string {
   return Array.isArray(id) ? JSON.stringify(id.map(String)) : String(id);
 }


### PR DESCRIPTION
## Summary

Refactor \`locator.ts\` from a single static-method facade into the Rails class hierarchy, closing \`locator.rb\` at **100%** and bringing api:compare to **96.6%** overall (only \`verifier.rb\` remains).

### New class hierarchy

| Class | Mirrors | Role |
|-------|---------|------|
| \`BaseLocator\` | \`GlobalID::Locator::BaseLocator\` | Instance \`locate\`/\`locateMany\` + protected \`findRecords\`/\`modelIdIsValid\`/\`primaryKey\`. Holds the existing logic from the old top-level Locator. |
| \`UnscopedLocator extends BaseLocator\` | \`GlobalID::Locator::UnscopedLocator\` | Wraps lookups in \`klass.unscoped { ... }\` when the model supports it. |
| \`BlockLocator\` | \`GlobalID::Locator::BlockLocator\` | \`constructor(block)\` + \`locate\`/\`locateMany\` for the \`Locator.use(app, &block)\` form. |
| \`Locator\` (static facade) | \`GlobalID::Locator\` | Parses GID, runs \`findAllowed\`, dispatches via \`locatorFor(gid)\` → per-app or default. |

### New static methods on \`Locator\`

| Method | Mirrors |
|--------|---------|
| \`defaultLocator\` getter/setter | \`Locator.default_locator\` / \`default_locator=\` |
| \`use(app, locator \| block)\` | \`Locator.use\` — registers per-app locator, validates app name |
| \`locatorFor(gid)\` | \`Locator.locator_for\` — fetches per-app or defaults |
| \`findAllowed(klass, only?)\` | \`Locator.find_allowed?\` |
| \`parseAllowed(gids, only?)\` | \`Locator.parse_allowed\` |
| \`normalizeApp(app)\` | \`Locator.normalize_app\` — lowercases for case-insensitive keying |

### LocatorModel interface change

Added optional \`unscoped<T>(block): T\` so \`UnscopedLocator\` can call it when present. Existing implementations work unchanged (it's optional).

## Tests added

**4 Rails-named** (inside \`GlobalLocatorTest\` describe):
- \`use locator with block\`
- \`use locator with class\`
- \`app locator is case insensitive\`
- \`locator name cannot have underscore\`

**5 non-Rails coverage** (in separate describe):
- default-locator fallback when no app-specific locator registered
- \`defaultLocator\` getter/setter
- \`locatorFor\` returns the registered locator
- \`parseAllowed\` class allowlist filtering
- \`normalizeApp\` lowercases

## Scorecards

| Signal | Before | After |
|--------|--------|-------|
| api:compare \`locator.rb\` | 6/16 (38%) | **16/16 (100%)** |
| api:compare overall | 79.7% | **96.6%** |
| test:compare \`global_locator_test.rb\` | 33/59 (56%) | **37/59 (63%)** |
| test:compare overall | 98/158 (62.0%) | **102/158 (64.6%)** |

Only \`verifier.rb\` (2 methods, 0%) remains for api:compare → GID-11.

## Remaining 22 unmatched \`global_locator_test.rb\` tests

- **4** module-based \`only:\` (Ruby modules; permanent skip)
- **3** \`includes:\` eager loading (AR scope; permanent skip)
- **~10** \`ScopedRecordLocatingTest\` class (per-AR-class \`unscoped()\` wiring; would need AR-side cooperation)
- **~5** edge cases that exercise Rails-specific fixtures we don't have

## Test plan

- [x] \`pnpm vitest run packages/globalid/src/\` — 138 tests pass (46 in global-locator.test.ts)
- [x] \`pnpm vitest run packages/activerecord/src/signed-id.test.ts\` — 47 pass, 9 skipped (no regression — \`Base.findGlobalId\` still delegates via the static \`Locator\` facade)
- [x] \`pnpm api:compare --package globalid\` — 96.6% (from 79.7%)
- [x] \`pnpm test:compare --package globalid\` — 102/158 (from 98/158)