### PR TITLE
feat(activerecord): mysql2-adapter Slot C — timezone + db_warnings_action + translate-exception fidelity

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -399,9 +399,15 @@ describeIfMysql("Mysql2Adapter", () => {
       for (const code of [
         "PROTOCOL_CONNECTION_LOST",
         "PROTOCOL_ENQUEUE_AFTER_QUIT",
+        "PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR",
+        "PROTOCOL_ENQUEUE_HANDSHAKE_TWICE",
+        "POOL_CLOSED",
         "ECONNRESET",
         "ECONNREFUSED",
         "ENOTFOUND",
+        "EHOSTUNREACH",
+        "ENETUNREACH",
+        "EPIPE",
       ]) {
         const driverErr = Object.assign(new Error("connection lost"), { code });
         const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
@@ -447,16 +453,19 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts (title) VALUES ('Title')`);
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        await withDbWarningsAction("log", async () => {
-          // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
-          // under db_warnings_action=:log that warning is logged, not raised, and
-          // must not corrupt the affected-row count returned by executeMutation.
-          const affected = await adapter.executeMutation(
-            `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
-          );
-          expect(affected).toBe(1);
-        });
-        warnSpy.mockRestore();
+        try {
+          await withDbWarningsAction("log", async () => {
+            // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
+            // under db_warnings_action=:log that warning is logged, not raised, and
+            // must not corrupt the affected-row count returned by executeMutation.
+            const affected = await adapter.executeMutation(
+              `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
+            );
+            expect(affected).toBe(1);
+          });
+        } finally {
+          warnSpy.mockRestore();
+        }
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`).catch(() => {});
@@ -474,13 +483,16 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts_d (title) VALUES ('Title')`);
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        await withDbWarningsAction("log", async () => {
-          const affected = await adapter.executeMutation(
-            `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
-          );
-          expect(affected).toBe(1);
-        });
-        warnSpy.mockRestore();
+        try {
+          await withDbWarningsAction("log", async () => {
+            const affected = await adapter.executeMutation(
+              `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
+            );
+            expect(affected).toBe(1);
+          });
+        } finally {
+          warnSpy.mockRestore();
+        }
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts_d`).catch(() => {});

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -11,10 +11,17 @@ import {
 import { withTimezoneConfig } from "../../test-helper.js";
 import {
   AdapterTimeout,
+  ConnectionFailed,
+  ConnectionNotEstablished,
+  DatabaseAlreadyExists,
+  Deadlocked,
   InvalidForeignKey,
+  LockWaitTimeout,
   MismatchedForeignKey,
   NotNullViolation,
   QueryAborted,
+  QueryCanceled,
+  RangeError as ARRangeError,
   RecordNotUnique,
   StatementTimeout,
   ValueTooLong,
@@ -335,6 +342,65 @@ describeIfMysql("Mysql2Adapter", () => {
         expect((translated as StatementTimeout).cause).toBe(driverErr);
       }
     });
+    it("translates connection-loss errnos to ConnectionFailed", () => {
+      // Mirrors Rails' AbstractMysqlAdapter#translate_exception cases for
+      // ER_CONNECTION_KILLED / ER_SERVER_SHUTDOWN / CR_SERVER_GONE_ERROR /
+      // CR_SERVER_LOST / ER_CLIENT_INTERACTION_TIMEOUT.
+      for (const errno of [
+        AbstractMysqlAdapter.ER_CONNECTION_KILLED,
+        AbstractMysqlAdapter.ER_SERVER_SHUTDOWN,
+        AbstractMysqlAdapter.CR_SERVER_GONE_ERROR,
+        AbstractMysqlAdapter.CR_SERVER_LOST,
+        AbstractMysqlAdapter.ER_CLIENT_INTERACTION_TIMEOUT,
+      ]) {
+        const driverErr = Object.assign(new Error("conn lost"), { errno });
+        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+        expect(translated).toBeInstanceOf(ConnectionFailed);
+        expect((translated as ConnectionFailed).cause).toBe(driverErr);
+      }
+    });
+
+    it("translates ER_LOCK_DEADLOCK / ER_LOCK_WAIT_TIMEOUT / ER_QUERY_INTERRUPTED / ER_OUT_OF_RANGE / ER_DB_CREATE_EXISTS", () => {
+      const cases: Array<[number, new (...a: any[]) => Error]> = [
+        [AbstractMysqlAdapter.ER_LOCK_DEADLOCK, Deadlocked],
+        [AbstractMysqlAdapter.ER_LOCK_WAIT_TIMEOUT, LockWaitTimeout],
+        [AbstractMysqlAdapter.ER_QUERY_INTERRUPTED, QueryCanceled],
+        [AbstractMysqlAdapter.ER_OUT_OF_RANGE, ARRangeError],
+        [AbstractMysqlAdapter.ER_DB_CREATE_EXISTS, DatabaseAlreadyExists],
+      ];
+      for (const [errno, klass] of cases) {
+        const driverErr = Object.assign(new Error("fail"), { errno });
+        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+        expect(translated).toBeInstanceOf(klass);
+        expect((translated as Error & { cause?: unknown }).cause).toBe(driverErr);
+      }
+    });
+
+    it("promotes 'MySQL client is not connected' to ConnectionNotEstablished", () => {
+      // Mirrors Mysql2Adapter#translate_exception's ConnectionError branch.
+      const driverErr = Object.assign(new Error("MySQL client is not connected"), {
+        code: "PROTOCOL_CONNECTION_LOST",
+      });
+      const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+      expect(translated).toBeInstanceOf(ConnectionNotEstablished);
+    });
+
+    it("translates node-mysql2 connection codes to ConnectionFailed", () => {
+      // node-mysql2 / Node net codes for a lost or refused connection —
+      // Rails catches the equivalent via Mysql2::Error::ConnectionError.
+      for (const code of [
+        "PROTOCOL_CONNECTION_LOST",
+        "PROTOCOL_ENQUEUE_AFTER_QUIT",
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "ENOTFOUND",
+      ]) {
+        const driverErr = Object.assign(new Error("connection lost"), { code });
+        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+        expect(translated).toBeInstanceOf(ConnectionFailed);
+      }
+    });
+
     it("database timezone changes synced to connection", async () => {
       // Mirrors: test_database_timezone_changes_synced_to_connection. The Ruby
       // mysql2 driver carries `query_options[:database_timezone]` on the raw

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -29,6 +29,89 @@ import {
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { Result } from "../../result.js";
 
+// Fabricated-error translate_exception checks. These don't touch a live
+// MySQL server (they feed Object.assign(new Error(...), { errno/code })
+// straight into translateException), so they live outside describeIfMysql
+// to keep coverage on dev machines without MySQL installed.
+describe("Mysql2Adapter#translateException (fabricated errors)", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(() => {
+    adapter = new Mysql2Adapter({ _fakeConnection: true } as any);
+  });
+  afterEach(async () => {
+    await adapter.close().catch(() => {});
+  });
+
+  it("translates connection-loss errnos to ConnectionFailed", () => {
+    // Mirrors AbstractMysqlAdapter#translate_exception cases for
+    // ER_CONNECTION_KILLED / ER_SERVER_SHUTDOWN / CR_SERVER_GONE_ERROR /
+    // CR_SERVER_LOST / ER_CLIENT_INTERACTION_TIMEOUT.
+    for (const errno of [
+      AbstractMysqlAdapter.ER_CONNECTION_KILLED,
+      AbstractMysqlAdapter.ER_SERVER_SHUTDOWN,
+      AbstractMysqlAdapter.CR_SERVER_GONE_ERROR,
+      AbstractMysqlAdapter.CR_SERVER_LOST,
+      AbstractMysqlAdapter.ER_CLIENT_INTERACTION_TIMEOUT,
+    ]) {
+      const driverErr = Object.assign(new Error("conn lost"), { errno });
+      const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+      expect(translated).toBeInstanceOf(ConnectionFailed);
+      expect((translated as ConnectionFailed).cause).toBe(driverErr);
+    }
+  });
+
+  it("translates ER_LOCK_DEADLOCK / ER_LOCK_WAIT_TIMEOUT / ER_QUERY_INTERRUPTED / ER_OUT_OF_RANGE / ER_DB_CREATE_EXISTS", () => {
+    const cases: Array<[number, new (...a: any[]) => Error]> = [
+      [AbstractMysqlAdapter.ER_LOCK_DEADLOCK, Deadlocked],
+      [AbstractMysqlAdapter.ER_LOCK_WAIT_TIMEOUT, LockWaitTimeout],
+      [AbstractMysqlAdapter.ER_QUERY_INTERRUPTED, QueryCanceled],
+      [AbstractMysqlAdapter.ER_OUT_OF_RANGE, ARRangeError],
+      [AbstractMysqlAdapter.ER_DB_CREATE_EXISTS, DatabaseAlreadyExists],
+    ];
+    for (const [errno, klass] of cases) {
+      const driverErr = Object.assign(new Error("fail"), { errno });
+      const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+      expect(translated).toBeInstanceOf(klass);
+      expect((translated as Error & { cause?: unknown }).cause).toBe(driverErr);
+    }
+  });
+
+  it("promotes 'MySQL client is not connected' to ConnectionNotEstablished", () => {
+    // Mirrors Mysql2Adapter#translate_exception's ConnectionError branch
+    // AND AbstractMysqlAdapter#translate_exception's `when nil` branch.
+    const codedErr = Object.assign(new Error("MySQL client is not connected"), {
+      code: "PROTOCOL_CONNECTION_LOST",
+    });
+    expect(adapter.translateException(codedErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
+      ConnectionNotEstablished,
+    );
+    const plainErr = new Error("MySQL client is not connected");
+    expect(adapter.translateException(plainErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
+      ConnectionNotEstablished,
+    );
+  });
+
+  it("translates node-mysql2 connection codes to ConnectionFailed", () => {
+    for (const code of [
+      "PROTOCOL_CONNECTION_LOST",
+      "PROTOCOL_ENQUEUE_AFTER_QUIT",
+      "PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR",
+      "PROTOCOL_ENQUEUE_HANDSHAKE_TWICE",
+      "POOL_CLOSED",
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "EPIPE",
+    ]) {
+      const driverErr = Object.assign(new Error("connection lost"), { code });
+      const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
+      expect(translated).toBeInstanceOf(ConnectionFailed);
+    }
+  });
+});
+
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
@@ -342,79 +425,6 @@ describeIfMysql("Mysql2Adapter", () => {
         expect((translated as StatementTimeout).cause).toBe(driverErr);
       }
     });
-    it("translates connection-loss errnos to ConnectionFailed", () => {
-      // Mirrors Rails' AbstractMysqlAdapter#translate_exception cases for
-      // ER_CONNECTION_KILLED / ER_SERVER_SHUTDOWN / CR_SERVER_GONE_ERROR /
-      // CR_SERVER_LOST / ER_CLIENT_INTERACTION_TIMEOUT.
-      for (const errno of [
-        AbstractMysqlAdapter.ER_CONNECTION_KILLED,
-        AbstractMysqlAdapter.ER_SERVER_SHUTDOWN,
-        AbstractMysqlAdapter.CR_SERVER_GONE_ERROR,
-        AbstractMysqlAdapter.CR_SERVER_LOST,
-        AbstractMysqlAdapter.ER_CLIENT_INTERACTION_TIMEOUT,
-      ]) {
-        const driverErr = Object.assign(new Error("conn lost"), { errno });
-        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
-        expect(translated).toBeInstanceOf(ConnectionFailed);
-        expect((translated as ConnectionFailed).cause).toBe(driverErr);
-      }
-    });
-
-    it("translates ER_LOCK_DEADLOCK / ER_LOCK_WAIT_TIMEOUT / ER_QUERY_INTERRUPTED / ER_OUT_OF_RANGE / ER_DB_CREATE_EXISTS", () => {
-      const cases: Array<[number, new (...a: any[]) => Error]> = [
-        [AbstractMysqlAdapter.ER_LOCK_DEADLOCK, Deadlocked],
-        [AbstractMysqlAdapter.ER_LOCK_WAIT_TIMEOUT, LockWaitTimeout],
-        [AbstractMysqlAdapter.ER_QUERY_INTERRUPTED, QueryCanceled],
-        [AbstractMysqlAdapter.ER_OUT_OF_RANGE, ARRangeError],
-        [AbstractMysqlAdapter.ER_DB_CREATE_EXISTS, DatabaseAlreadyExists],
-      ];
-      for (const [errno, klass] of cases) {
-        const driverErr = Object.assign(new Error("fail"), { errno });
-        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
-        expect(translated).toBeInstanceOf(klass);
-        expect((translated as Error & { cause?: unknown }).cause).toBe(driverErr);
-      }
-    });
-
-    it("promotes 'MySQL client is not connected' to ConnectionNotEstablished", () => {
-      // Mirrors Mysql2Adapter#translate_exception's ConnectionError branch
-      // AND AbstractMysqlAdapter#translate_exception's `when nil` branch
-      // (the latter is reached for a plain Error without any driver code,
-      // covering callers that don't go through the Mysql2Adapter override).
-      const codedErr = Object.assign(new Error("MySQL client is not connected"), {
-        code: "PROTOCOL_CONNECTION_LOST",
-      });
-      expect(adapter.translateException(codedErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
-        ConnectionNotEstablished,
-      );
-      const plainErr = new Error("MySQL client is not connected");
-      expect(adapter.translateException(plainErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
-        ConnectionNotEstablished,
-      );
-    });
-
-    it("translates node-mysql2 connection codes to ConnectionFailed", () => {
-      // node-mysql2 / Node net codes for a lost or refused connection —
-      // Rails catches the equivalent via Mysql2::Error::ConnectionError.
-      for (const code of [
-        "PROTOCOL_CONNECTION_LOST",
-        "PROTOCOL_ENQUEUE_AFTER_QUIT",
-        "PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR",
-        "PROTOCOL_ENQUEUE_HANDSHAKE_TWICE",
-        "POOL_CLOSED",
-        "ECONNRESET",
-        "ECONNREFUSED",
-        "ENOTFOUND",
-        "EHOSTUNREACH",
-        "ENETUNREACH",
-        "EPIPE",
-      ]) {
-        const driverErr = Object.assign(new Error("connection lost"), { code });
-        const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
-        expect(translated).toBeInstanceOf(ConnectionFailed);
-      }
-    });
-
     it("database timezone changes synced to connection", async () => {
       // Mirrors: test_database_timezone_changes_synced_to_connection. The Ruby
       // mysql2 driver carries `query_options[:database_timezone]` on the raw

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -36,7 +36,7 @@ import { Result } from "../../result.js";
 describe("Mysql2Adapter#translateException (fabricated errors)", () => {
   let adapter: Mysql2Adapter;
   beforeEach(() => {
-    adapter = new Mysql2Adapter({ _fakeConnection: true } as any);
+    adapter = new Mysql2Adapter({ _fakeConnection: true });
   });
   afterEach(async () => {
     await adapter.close().catch(() => {});
@@ -118,6 +118,11 @@ describeIfMysql("Mysql2Adapter", () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
   });
   afterEach(async () => {
+    // Restore any console / logger spies installed by the warning-handler
+    // tests so a throw before the inner mockRestore() can't leak the stub
+    // into subsequent suites — matches the cleanup pattern in
+    // adapters/abstract-mysql-adapter/warnings.test.ts.
+    vi.restoreAllMocks();
     await adapter.close();
   });
 
@@ -444,6 +449,9 @@ describeIfMysql("Mysql2Adapter", () => {
         adapter.databaseTimezone = "utc";
         await adapter.executeMutation("DO 1");
         expect(adapter.databaseTimezone).toBe("local");
+        adapter.databaseTimezone = "utc";
+        await adapter.exec("DO 1");
+        expect(adapter.databaseTimezone).toBe("local");
       });
       await adapter.execute("SELECT 1");
       expect(adapter.databaseTimezone).toBe("utc");
@@ -463,23 +471,20 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts (title) VALUES ('Title')`);
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        try {
-          await withDbWarningsAction("log", async () => {
-            // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
-            // under db_warnings_action=:log that warning is logged, not raised, and
-            // must not corrupt the affected-row count returned by executeMutation.
-            const affected = await adapter.executeMutation(
-              `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
-            );
-            expect(affected).toBe(1);
-          });
-          // The warning handler must have actually fired — otherwise this
-          // test would silently still pass on a regression that disconnected
-          // executeMutation from _handleWarningsOn.
-          expect(warnSpy).toHaveBeenCalled();
-        } finally {
-          warnSpy.mockRestore();
-        }
+        // Spy is restored by the outer afterEach via vi.restoreAllMocks().
+        await withDbWarningsAction("log", async () => {
+          // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
+          // under db_warnings_action=:log that warning is logged, not raised, and
+          // must not corrupt the affected-row count returned by executeMutation.
+          const affected = await adapter.executeMutation(
+            `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
+          );
+          expect(affected).toBe(1);
+        });
+        // The warning handler must have actually fired — otherwise this
+        // test would silently still pass on a regression that disconnected
+        // executeMutation from _handleWarningsOn.
+        expect(warnSpy).toHaveBeenCalled();
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`).catch(() => {});
@@ -497,20 +502,14 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts_d (title) VALUES ('Title')`);
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        try {
-          await withDbWarningsAction("log", async () => {
-            const affected = await adapter.executeMutation(
-              `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
-            );
-            expect(affected).toBe(1);
-          });
-          // The warning handler must have actually fired — otherwise this
-          // test would silently still pass on a regression that disconnected
-          // executeMutation from _handleWarningsOn.
-          expect(warnSpy).toHaveBeenCalled();
-        } finally {
-          warnSpy.mockRestore();
-        }
+        // Spy is restored by the outer afterEach via vi.restoreAllMocks().
+        await withDbWarningsAction("log", async () => {
+          const affected = await adapter.executeMutation(
+            `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
+          );
+          expect(affected).toBe(1);
+        });
+        expect(warnSpy).toHaveBeenCalled();
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts_d`).catch(() => {});

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -463,6 +463,10 @@ describeIfMysql("Mysql2Adapter", () => {
             );
             expect(affected).toBe(1);
           });
+          // The warning handler must have actually fired — otherwise this
+          // test would silently still pass on a regression that disconnected
+          // executeMutation from _handleWarningsOn.
+          expect(warnSpy).toHaveBeenCalled();
         } finally {
           warnSpy.mockRestore();
         }
@@ -490,6 +494,10 @@ describeIfMysql("Mysql2Adapter", () => {
             );
             expect(affected).toBe(1);
           });
+          // The warning handler must have actually fired — otherwise this
+          // test would silently still pass on a regression that disconnected
+          // executeMutation from _handleWarningsOn.
+          expect(warnSpy).toHaveBeenCalled();
         } finally {
           warnSpy.mockRestore();
         }

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -6,7 +6,9 @@ import {
   describeIfMysql,
   Mysql2Adapter,
   MYSQL_TEST_URL,
+  withDbWarningsAction,
 } from "../abstract-mysql-adapter/test-helper.js";
+import { withTimezoneConfig } from "../../test-helper.js";
 import {
   AdapterTimeout,
   InvalidForeignKey,
@@ -333,20 +335,70 @@ describeIfMysql("Mysql2Adapter", () => {
         expect((translated as StatementTimeout).cause).toBe(driverErr);
       }
     });
-    it.skip("database timezone changes synced to connection", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+    it("database timezone changes synced to connection", async () => {
+      // Mirrors: test_database_timezone_changes_synced_to_connection. The Ruby
+      // mysql2 driver carries `query_options[:database_timezone]` on the raw
+      // socket; trails surfaces the same via `adapter.databaseTimezone`,
+      // re-synced from the global default in the perform-query path so a
+      // runtime `withTimezoneConfig` flip takes effect on the next statement.
+      await adapter.execute("SELECT 1");
+      expect(adapter.databaseTimezone).toBe("utc");
+      await withTimezoneConfig({ default: "local" }, async () => {
+        await adapter.execute("SELECT 1");
+        expect(adapter.databaseTimezone).toBe("local");
+      });
+      await adapter.execute("SELECT 1");
+      expect(adapter.databaseTimezone).toBe("utc");
     });
-    it.skip("warnings do not change returned value of exec update", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+
+    it("warnings do not change returned value of exec update", async () => {
+      // Mirrors: test_warnings_do_not_change_returned_value_of_exec_update.
+      // Pin a single pool connection via beginTransaction so SET SESSION
+      // sql_mode='' carries over to the warning-producing UPDATE (DDL on
+      // MySQL auto-commits, so the table persists even on rollback).
+      await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`);
+      await adapter.beginTransaction();
+      try {
+        await adapter.executeMutation(
+          `CREATE TABLE warn_posts (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(20))`,
+        );
+        await adapter.executeMutation(`SET SESSION sql_mode=''`);
+        await adapter.executeMutation(`INSERT INTO warn_posts (title) VALUES ('Title')`);
+        await withDbWarningsAction("log", async () => {
+          // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
+          // under db_warnings_action=:log that warning is logged, not raised, and
+          // must not corrupt the affected-row count returned by executeMutation.
+          const affected = await adapter.executeMutation(
+            `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
+          );
+          expect(affected).toBe(1);
+        });
+      } finally {
+        await adapter.rollback().catch(() => {});
+        await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`).catch(() => {});
+      }
     });
-    it.skip("warnings do not change returned value of exec delete", () => {
-      // BLOCKED: adapter-mysql — MySQL-specific adapter gap in mysql2-adapter
-      // ROOT-CAUSE: adapters/mysql2/mysql2-adapter.ts or abstract-mysql-adapter/mysql2-adapter.ts missing Rails parity
-      // SCOPE: ~50–150 LOC fix in adapters/mysql2/mysql2-adapter.ts; affects ~10–26 tests in mysql2-adapter.test.ts
+
+    it("warnings do not change returned value of exec delete", async () => {
+      // Mirrors: test_warnings_do_not_change_returned_value_of_exec_delete.
+      await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts_d`);
+      await adapter.beginTransaction();
+      try {
+        await adapter.executeMutation(
+          `CREATE TABLE warn_posts_d (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(20))`,
+        );
+        await adapter.executeMutation(`SET SESSION sql_mode=''`);
+        await adapter.executeMutation(`INSERT INTO warn_posts_d (title) VALUES ('Title')`);
+        await withDbWarningsAction("log", async () => {
+          const affected = await adapter.executeMutation(
+            `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
+          );
+          expect(affected).toBe(1);
+        });
+      } finally {
+        await adapter.rollback().catch(() => {});
+        await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts_d`).catch(() => {});
+      }
     });
   });
 });

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -452,6 +452,9 @@ describeIfMysql("Mysql2Adapter", () => {
         adapter.databaseTimezone = "utc";
         await adapter.exec("DO 1");
         expect(adapter.databaseTimezone).toBe("local");
+        adapter.databaseTimezone = "utc";
+        await adapter.explain("SELECT 1");
+        expect(adapter.databaseTimezone).toBe("local");
       });
       await adapter.execute("SELECT 1");
       expect(adapter.databaseTimezone).toBe("utc");

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   describeIfMysql,
   Mysql2Adapter,
@@ -377,12 +377,20 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("promotes 'MySQL client is not connected' to ConnectionNotEstablished", () => {
-      // Mirrors Mysql2Adapter#translate_exception's ConnectionError branch.
-      const driverErr = Object.assign(new Error("MySQL client is not connected"), {
+      // Mirrors Mysql2Adapter#translate_exception's ConnectionError branch
+      // AND AbstractMysqlAdapter#translate_exception's `when nil` branch
+      // (the latter is reached for a plain Error without any driver code,
+      // covering callers that don't go through the Mysql2Adapter override).
+      const codedErr = Object.assign(new Error("MySQL client is not connected"), {
         code: "PROTOCOL_CONNECTION_LOST",
       });
-      const translated = adapter.translateException(driverErr, { sql: "SELECT 1", binds: [] });
-      expect(translated).toBeInstanceOf(ConnectionNotEstablished);
+      expect(adapter.translateException(codedErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
+        ConnectionNotEstablished,
+      );
+      const plainErr = new Error("MySQL client is not connected");
+      expect(adapter.translateException(plainErr, { sql: "SELECT 1", binds: [] })).toBeInstanceOf(
+        ConnectionNotEstablished,
+      );
     });
 
     it("translates node-mysql2 connection codes to ConnectionFailed", () => {
@@ -412,6 +420,14 @@ describeIfMysql("Mysql2Adapter", () => {
       await withTimezoneConfig({ default: "local" }, async () => {
         await adapter.execute("SELECT 1");
         expect(adapter.databaseTimezone).toBe("local");
+        // execQuery and executeMutation are also on the perform-query path
+        // and must re-sync — guard against accidental removal.
+        adapter.databaseTimezone = "utc";
+        await adapter.execQuery("SELECT 1");
+        expect(adapter.databaseTimezone).toBe("local");
+        adapter.databaseTimezone = "utc";
+        await adapter.executeMutation("DO 1");
+        expect(adapter.databaseTimezone).toBe("local");
       });
       await adapter.execute("SELECT 1");
       expect(adapter.databaseTimezone).toBe("utc");
@@ -430,6 +446,7 @@ describeIfMysql("Mysql2Adapter", () => {
         );
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts (title) VALUES ('Title')`);
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         await withDbWarningsAction("log", async () => {
           // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
           // under db_warnings_action=:log that warning is logged, not raised, and
@@ -439,6 +456,7 @@ describeIfMysql("Mysql2Adapter", () => {
           );
           expect(affected).toBe(1);
         });
+        warnSpy.mockRestore();
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`).catch(() => {});
@@ -455,12 +473,14 @@ describeIfMysql("Mysql2Adapter", () => {
         );
         await adapter.executeMutation(`SET SESSION sql_mode=''`);
         await adapter.executeMutation(`INSERT INTO warn_posts_d (title) VALUES ('Title')`);
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         await withDbWarningsAction("log", async () => {
           const affected = await adapter.executeMutation(
             `DELETE FROM warn_posts_d WHERE id > (0+'foo') LIMIT 1`,
           );
           expect(affected).toBe(1);
         });
+        warnSpy.mockRestore();
       } finally {
         await adapter.rollback().catch(() => {});
         await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts_d`).catch(() => {});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1006,6 +1006,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_CLIENT_INTERACTION_TIMEOUT = ER_CLIENT_INTERACTION_TIMEOUT;
 
   /**
+   * Mirrors the message regex Rails' `Mysql2Adapter#translate_exception`
+   * uses to distinguish `ConnectionNotEstablished` from `ConnectionFailed`
+   * when a `Mysql2::Error::ConnectionError` arrives. Centralized so the
+   * abstract `when nil` branch and the Mysql2Adapter `ConnectionError`
+   * branch cannot drift if mysql2 changes the wording.
+   * @internal
+   */
+  static readonly CLIENT_NOT_CONNECTED_RE = /MySQL client is not connected/i;
+
+  /**
    * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
    * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
    * and `PARTITIONS`. Format is handled separately via the
@@ -1186,7 +1196,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       // errno (e.g. node-mysql2 surfacing a closed-socket failure as a
       // generic Error) get promoted to ConnectionNotEstablished when the
       // message indicates the client lost the server handshake.
-      if (/MySQL client is not connected/i.test(msg)) {
+      if (AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg)) {
         return new ConnectionNotEstablished(msg, { cause });
       }
     }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -13,10 +13,17 @@ import type { AdapterName, ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Column } from "./column.js";
 import {
+  ConnectionFailed,
+  ConnectionNotEstablished,
+  DatabaseAlreadyExists,
   DatabaseVersionError,
+  Deadlocked,
   InvalidForeignKey,
+  LockWaitTimeout,
   MismatchedForeignKey,
   NotNullViolation,
+  QueryCanceled,
+  RangeError as ARRangeError,
   RecordNotUnique,
   SQLWarning,
   StatementInvalid,
@@ -109,6 +116,12 @@ const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
 const ER_FILSORT_ABORT = 1028;
 const ER_TABLE_EXISTS = 1050;
+const ER_DB_CREATE_EXISTS = 1007;
+const ER_SERVER_SHUTDOWN = 1053;
+const ER_CONNECTION_KILLED = 1927;
+const CR_SERVER_GONE_ERROR = 2006;
+const CR_SERVER_LOST = 2013;
+const ER_CLIENT_INTERACTION_TIMEOUT = 4031;
 
 // Function defaults emitted without DEFAULT_GENERATED in Extra (e.g. CURRENT_TIMESTAMP on
 // datetime columns). Used by renameColumnForAlter to emit them unquoted in the CHANGE clause.
@@ -985,6 +998,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_QUERY_TIMEOUT = ER_QUERY_TIMEOUT;
   static readonly ER_FILSORT_ABORT = ER_FILSORT_ABORT;
   static readonly ER_TABLE_EXISTS = ER_TABLE_EXISTS;
+  static readonly ER_DB_CREATE_EXISTS = ER_DB_CREATE_EXISTS;
+  static readonly ER_SERVER_SHUTDOWN = ER_SERVER_SHUTDOWN;
+  static readonly ER_CONNECTION_KILLED = ER_CONNECTION_KILLED;
+  static readonly CR_SERVER_GONE_ERROR = CR_SERVER_GONE_ERROR;
+  static readonly CR_SERVER_LOST = CR_SERVER_LOST;
+  static readonly ER_CLIENT_INTERACTION_TIMEOUT = ER_CLIENT_INTERACTION_TIMEOUT;
 
   /**
    * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
@@ -1162,7 +1181,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const errno = (e as { errno?: number }).errno;
     const msg = e.message;
     const cause = e;
+    if (typeof errno !== "number") {
+      // Mirrors Rails' `when nil` branch — driver errors without a MySQL
+      // errno (e.g. node-mysql2 surfacing a closed-socket failure as a
+      // generic Error) get promoted to ConnectionNotEstablished when the
+      // message indicates the client lost the server handshake.
+      if (/MySQL client is not connected/i.test(msg)) {
+        return new ConnectionNotEstablished(msg, { cause });
+      }
+    }
     switch (errno) {
+      case ER_DB_CREATE_EXISTS:
+        return new DatabaseAlreadyExists(msg, { sql, binds, cause });
       case ER_DUP_ENTRY:
         return new RecordNotUnique(msg, { sql, binds, cause });
       case ER_NO_REFERENCED_ROW:
@@ -1183,9 +1213,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         return new NotNullViolation(msg, { sql, binds, cause });
       case ER_DATA_TOO_LONG:
         return new ValueTooLong(msg, { sql, binds, cause });
+      case ER_OUT_OF_RANGE:
+        return new ARRangeError(msg, { sql, binds, cause });
+      case ER_LOCK_DEADLOCK:
+        return new Deadlocked(msg, { sql, binds, cause });
+      case ER_LOCK_WAIT_TIMEOUT:
+        return new LockWaitTimeout(msg, { sql, binds, cause });
       case ER_QUERY_TIMEOUT:
       case ER_FILSORT_ABORT:
         return new StatementTimeout(msg, { sql, binds, cause });
+      case ER_QUERY_INTERRUPTED:
+        return new QueryCanceled(msg, { sql, binds, cause });
+      case ER_CONNECTION_KILLED:
+      case ER_SERVER_SHUTDOWN:
+      case CR_SERVER_GONE_ERROR:
+      case CR_SERVER_LOST:
+      case ER_CLIENT_INTERACTION_TIMEOUT:
+        return new ConnectionFailed(msg, { sql, binds, cause });
       default:
         // Driver errors expose a positive MySQL errno and usually a
         // sqlState. Node/system errors (ECONNREFUSED etc.) also carry

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -250,7 +250,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // connected" message is promoted to ConnectionNotEstablished;
       // everything else in this family is ConnectionFailed.
       const msg = (e as Error).message;
-      if (/MySQL client is not connected/i.test(msg)) {
+      if (AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg)) {
         return new ConnectionNotEstablished(msg, { cause: e });
       }
       return new ConnectionFailed(msg, { sql, binds, cause: e });
@@ -1781,7 +1781,8 @@ function isMysql2DriverTimeout(e: unknown): boolean {
  * Detect a node-mysql2 error that mirrors Ruby's
  * `Mysql2::Error::ConnectionError` family — driver-level connection-loss
  * conditions surfaced without a positive MySQL errno. These include
- * socket-level failures (`ECONNRESET` / `ECONNREFUSED` / `EPIPE`),
+ * socket-level failures (`ECONNRESET` / `ECONNREFUSED` / `EPIPE` /
+ * `ENOTFOUND` / `EHOSTUNREACH` / `ENETUNREACH`),
  * mysql2 protocol errors after the connection died
  * (`PROTOCOL_CONNECTION_LOST`, `PROTOCOL_ENQUEUE_AFTER_QUIT`,
  * `PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR`, `PROTOCOL_ENQUEUE_HANDSHAKE_TWICE`),

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1802,6 +1802,9 @@ function isMysql2ConnectionError(e: unknown): boolean {
     code === "POOL_CLOSED" ||
     code === "ECONNRESET" ||
     code === "ECONNREFUSED" ||
+    code === "ENOTFOUND" ||
+    code === "EHOSTUNREACH" ||
+    code === "ENETUNREACH" ||
     code === "EPIPE"
   );
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -895,6 +895,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Execute raw SQL (for DDL and other non-query statements).
    */
   async exec(sql: string): Promise<void> {
+    this._syncDatabaseTimezone();
     const conn = await this.getConn();
     try {
       await conn.query(this.mysqlQuote(sql));

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -22,6 +22,7 @@ import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
+import { getDefaultTimezone } from "../type/internal/timezone.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
@@ -202,6 +203,28 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // checkin/checkout cycle. WeakMap lets mysql2.Pool reap connections
   // without us leaking entries.
   private _statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
+
+  /**
+   * The timezone applied to result rows for the most recent query. Mirrors
+   * the Ruby mysql2 driver's `query_options[:database_timezone]`, which
+   * Rails' `Mysql2Adapter#perform_query` re-syncs to
+   * `ActiveRecord.default_timezone` before each query so a runtime change to
+   * the global default takes effect on the next statement (no reconnect).
+   *
+   * Updated by {@link _syncDatabaseTimezone} from the perform-query path.
+   */
+  databaseTimezone: "utc" | "local" = "utc";
+
+  /**
+   * Refresh {@link databaseTimezone} from the global default. Called from
+   * the perform-query path so a `withTimezoneConfig({ default: "local" })`
+   * block is observable on the very next query — matching Rails'
+   * `raw_connection.query_options[:database_timezone] = default_timezone`
+   * line in `Mysql2Adapter#perform_query`.
+   */
+  private _syncDatabaseTimezone(): void {
+    this.databaseTimezone = getDefaultTimezone();
+  }
 
   protected override _onStatementLimitChanged(value: number): void {
     if (this._conn) this._statementPools.get(this._conn)?.setMaxSize(value);
@@ -421,6 +444,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     options?: { prepare?: boolean },
   ): Promise<Result> {
     await this.materializeTransactions();
+    this._syncDatabaseTimezone();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds ?? []);
     const payload: Record<string, unknown> = {
@@ -597,6 +621,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     name: string = "SQL",
   ): Promise<Record<string, unknown>[]> {
     await this.materializeTransactions();
+    this._syncDatabaseTimezone();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds);
     // payload records the exact values sent to mysql2 so LogSubscriber /
@@ -660,6 +685,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     await this.materializeTransactions();
+    this._syncDatabaseTimezone();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds);
     const payload: Record<string, unknown> = {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -862,6 +862,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     binds: unknown[] = [],
     options: ExplainOption[] = [],
   ): Promise<string> {
+    // Rails' MySQL::DatabaseStatements#explain runs through internal_exec_query
+    // and therefore through perform_query, which re-syncs the database timezone.
+    this._syncDatabaseTimezone();
     const conn = await this.getConn();
     try {
       const clause = this._explainStatementClause(options);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -10,6 +10,8 @@ import {
 import { Version } from "./abstract-adapter.js";
 import {
   AdapterTimeout,
+  ConnectionFailed,
+  ConnectionNotEstablished,
   MismatchedForeignKey,
   NoDatabaseError,
   NotImplementedError,
@@ -241,6 +243,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (isMysql2DriverTimeout(e)) {
       const msg = e instanceof Error ? e.message : String(e);
       return new AdapterTimeout(msg, { sql, binds, cause: e });
+    }
+    if (isMysql2ConnectionError(e)) {
+      // Mirrors `Mysql2Adapter#translate_exception`'s
+      // `Mysql2::Error::ConnectionError` branch: a "MySQL client is not
+      // connected" message is promoted to ConnectionNotEstablished;
+      // everything else in this family is ConnectionFailed.
+      const msg = (e as Error).message;
+      if (/MySQL client is not connected/i.test(msg)) {
+        return new ConnectionNotEstablished(msg, { cause: e });
+      }
+      return new ConnectionFailed(msg, { sql, binds, cause: e });
     }
     return super._translateException(e, sql, binds);
   }
@@ -1762,6 +1775,35 @@ function isMysql2DriverTimeout(e: unknown): boolean {
   if (typeof errno === "number" && errno > 0) return false;
   const code = (e as { code?: string }).code;
   return code === "PROTOCOL_SEQUENCE_TIMEOUT" || code === "ETIMEDOUT";
+}
+
+/**
+ * Detect a node-mysql2 error that mirrors Ruby's
+ * `Mysql2::Error::ConnectionError` family — driver-level connection-loss
+ * conditions surfaced without a positive MySQL errno. These include
+ * socket-level failures (`ECONNRESET` / `ECONNREFUSED` / `EPIPE`),
+ * mysql2 protocol errors after the connection died
+ * (`PROTOCOL_CONNECTION_LOST`, `PROTOCOL_ENQUEUE_AFTER_QUIT`,
+ * `PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR`, `PROTOCOL_ENQUEUE_HANDSHAKE_TWICE`),
+ * and the pool-closed sentinel (`POOL_CLOSED`).
+ *
+ * @internal
+ */
+function isMysql2ConnectionError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const errno = (e as { errno?: number }).errno;
+  if (typeof errno === "number" && errno > 0) return false;
+  const code = (e as { code?: string }).code;
+  return (
+    code === "PROTOCOL_CONNECTION_LOST" ||
+    code === "PROTOCOL_ENQUEUE_AFTER_QUIT" ||
+    code === "PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR" ||
+    code === "PROTOCOL_ENQUEUE_HANDSHAKE_TWICE" ||
+    code === "POOL_CLOSED" ||
+    code === "ECONNRESET" ||
+    code === "ECONNREFUSED" ||
+    code === "EPIPE"
+  );
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Closes the **mysql2-adapter cluster** (Slot C + folded-in Slot B follow-ups).

**Slot C — timezone re-sync + db_warnings_action wiring.** Mirrors `Mysql2Adapter#perform_query`'s `raw_connection.query_options[:database_timezone] = default_timezone` line: a new public `databaseTimezone` field on `Mysql2Adapter` is refreshed from the global default in the perform-query path (`execQuery` / `execute` / `executeMutation`), so a `withTimezoneConfig({ default: 'local' })` flip is observable on the very next statement. The warnings-handler infrastructure was already in place from prior work — the two warnings tests just needed bodies that pin a single pool connection (via `beginTransaction`) so `SET SESSION sql_mode=''` carries over to the warning-producing UPDATE/DELETE.

**Slot B follow-ups — translate-exception depth.** Wires the remaining errno cases into `AbstractMysqlAdapter#_translateException` (Deadlocked, LockWaitTimeout, QueryCanceled, RangeError, DatabaseAlreadyExists, ConnectionFailed for the connection-loss errno group, ConnectionNotEstablished for the `nil` + "MySQL client is not connected" branch). `Mysql2Adapter#_translateException` adds the ConnectionError branch covering node-mysql2's no-errno connection-loss surface (PROTOCOL_CONNECTION_LOST/PROTOCOL_ENQUEUE_*, ECONNRESET/ECONNREFUSED/ENOTFOUND/EHOSTUNREACH/ENETUNREACH/EPIPE, POOL_CLOSED).

Un-skips 3 BLOCKED tests; adds 4 fabricated-error unit tests covering the new branches.

## Copilot review #1 dispositions

- **#1 (temporal cast doesn't read `databaseTimezone`):** Intentional Rails parity — Rails' test (`test_database_timezone_changes_synced_to_connection`) only asserts the `query_options` field flips and runs `SELECT 1`; no temporal round-trip. Our `temporalTypeCast` reads `getDefaultTimezone()` at decode time, which is the same source the new `_syncDatabaseTimezone` reads at perform-query time, so the observable behavior matches Rails (where mysql2's C type-cast reads `query_options[:database_timezone]` set in `perform_query`). Threading a per-connection cached value through `temporalTypeCast` would be a divergence, not a fix.
- **#2 (no tests for new errno mappings):** Addressed — added 4 fabricated-error unit tests mirroring the existing "statement timeout error codes" pattern.
- **#3 (no temporal round-trip in timezone-sync test):** Intentional Rails parity — see #1; the Rails test does not include one.
- **#4 (missing ENOTFOUND/EHOSTUNREACH/ENETUNREACH):** Addressed — added to `isMysql2ConnectionError`.

## Test plan

- [ ] `TEST_ADAPTER=mysql2 pnpm vitest run packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts` (CI runs against live MySQL).
- [ ] `pnpm -w build` — passes.
- [ ] `pnpm lint` — clean.
- [ ] `pnpm api:compare` — `abstract_mysql_adapter.rb` 92/92 (100%), `mysql2_adapter.rb` 22/22 (100%).

## Final review-cycle status (max cycles reached)

Last open Copilot concern (review #9): "Several internal methods (`beginDbTransaction`, savepoint ops, advisory locks, `getFullVersion`) still issue SQL via direct `conn.query` without calling `_syncDatabaseTimezone`." **Disposition: declined — Rails parity.** Rails' `Mysql2Adapter#perform_query` is the only place `query_options[:database_timezone]` is re-synced, and Rails' transaction control (`BEGIN`/`COMMIT`/`SAVEPOINT`), advisory locks, and `full_version` probe all bypass `perform_query` and call `@raw_connection.query` / `any_raw_connection.server_info` directly. Our coverage (`execute` / `execQuery` / `executeMutation` / `exec` / `explain`) mirrors Rails exactly. Adding the sync to internal-control SQL would be a divergence, not a fix.
