### PR TITLE
feat(activerecord): NIE elimination Phase 2 — drop dead stubs + downgrade strategy hooks

### DIFF
--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -1,4 +1,4 @@
-import { SerializationTypeMismatch, NotImplementedError } from "../errors.js";
+import { SerializationTypeMismatch } from "../errors.js";
 
 type CoderLike = { dump(obj: unknown): string | null; load(payload: unknown): unknown };
 type ClassLike = new (...args: unknown[]) => unknown;
@@ -105,12 +105,4 @@ export class ColumnSerializer {
       );
     }
   }
-}
-
-/** @internal */
-function checkArityOfConstructor(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/coders/column_serializer.rb
-  throw new NotImplementedError(
-    "ActiveRecord::Coders::ColumnSerializer#check_arity_of_constructor is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::ConnectionAdapters
  */
-import { AdapterNotFound, NotImplementedError } from "./errors.js";
+import { AdapterNotFound } from "./errors.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 export interface ConnectionAdapters {
@@ -115,26 +115,4 @@ export {
  */
 export function defaultPrimaryKey(): string {
   return "id";
-}
-
-function name(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
-  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#name is not implemented");
-}
-
-function isValidate(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
-  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#validate? is not implemented");
-}
-
-function isExportNameOnSchemaDump(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters#export_name_on_schema_dump? is not implemented",
-  );
-}
-
-function isDefinedFor(toTable?: any, validate?: any, options?: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
-  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#defined_for? is not implemented");
 }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1534,7 +1534,7 @@ export function rawExecute(
   materializeTransactions?: any,
   batch?: any,
 ): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:552
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:552
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute is not implemented",
   );
@@ -1554,7 +1554,7 @@ export function performQuery(
   _typeCastedBinds: unknown[],
   _options?: { prepare?: boolean; notificationPayload?: unknown; batch?: boolean },
 ): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:561
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#perform_query is not implemented",
   );
@@ -1562,7 +1562,7 @@ export function performQuery(
 
 /** @internal */
 function castResult(rawResult: any): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:566
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#cast_result is not implemented",
   );
@@ -1570,7 +1570,7 @@ function castResult(rawResult: any): never {
 
 /** @internal */
 function affectedRows(rawResult: any): never {
-  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+  // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:570
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#affected_rows is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -8,7 +8,6 @@
  *   `instanceof Date` alongside Temporal types and handles each separately.
  */
 
-import { NotImplementedError } from "../../errors.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getDefaultTimezone } from "../../type/internal/timezone.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
@@ -497,14 +496,6 @@ function typeCastedBinds(
     }
     return this.typeCast(value);
   });
-}
-
-/** @internal */
-function lookupCastType(sqlType: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:234
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
-  );
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2065,7 +2065,7 @@ export class SchemaStatements {
 
   /** @internal */
   dataSourceSql(_name?: string, _options?: { type?: string }): string {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#data_source_sql is not implemented",
     );
@@ -2073,7 +2073,7 @@ export class SchemaStatements {
 
   /** @internal */
   quotedScope(_name?: string, _options?: { type?: string }): Record<string, string> {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1894
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#quoted_scope is not implemented",
     );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -25,7 +25,6 @@ import {
   ConnectionNotEstablished,
   DatabaseConnectionError,
   TransactionIsolationError,
-  NotImplementedError,
 } from "../errors.js";
 import { TypeMap } from "../type/type-map.js";
 import { Date as DateType } from "../type/date.js";
@@ -2309,20 +2308,4 @@ function translateException(
     return new ConnectionNotEstablished(message, { cause: exception });
   }
   return new StatementInvalid(message, { sql, binds, cause: exception });
-}
-
-/** @internal */
-function arelVisitor(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:798
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#arel_visitor is not implemented",
-  );
-}
-
-/** @internal */
-function reconnect(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#reconnect is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -59,7 +59,7 @@ export function connectsTo(
   },
 ): ConnectionPool[] {
   if (!isBaseClass(this) && !this.abstractClass) {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb:82 cluster=connection-pool
     throw new NotImplementedError(
       "`connects_to` can only be called on ActiveRecord::Base or abstract classes",
     );
@@ -109,14 +109,14 @@ export function connectedTo<T>(
   fn: () => T,
 ): T {
   if (!isBaseClass(this) && !this.abstractClass) {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb:138 cluster=connection-pool
     throw new NotImplementedError(
       "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes.",
     );
   }
 
   if (!this.connectionClassQ() && !isPrimaryClass.call(this)) {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb:142 cluster=connection-pool
     throw new NotImplementedError(
       "calling `connected_to` is only allowed on the abstract class that established the connection.",
     );
@@ -166,12 +166,12 @@ export function connectedToMany<T>(this: typeof Base, ...args: unknown[]): T {
   }
 
   if (!isBaseClass(this)) {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb:169 cluster=connection-pool
     throw new NotImplementedError("connected_to_many can only be called on ActiveRecord::Base.");
   }
 
   if (normalized.some((klass) => isBaseClass(klass))) {
-    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb cluster=connection-pool
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_handling.rb:169 cluster=connection-pool
     throw new NotImplementedError("connected_to_many cannot include ActiveRecord::Base.");
   }
 


### PR DESCRIPTION
## Summary

Cleans up the NotImplementedError elimination Phase 2 — drops 8 dead NIE stubs, downgrades 1 mislabeled annotation, and back-fills Rails line numbers on 10 strategy-hook annotations.

`@nie disposition=port-real` tally: **16 → 7** (9 sites eliminated).

## Dead standalones deleted

Each was a top-level `function foo(): never { throw NotImplementedError }` that was never exported and never called. The real implementations exist on classes/objects in the same or sibling files.

| File | Removed |
|---|---|
| `connection-adapters.ts` | `name`, `isValidate`, `isExportNameOnSchemaDump`, `isDefinedFor` (real impls on `ForeignKeyDefinition` / `CheckConstraintDefinition` in `schema-definitions.ts`) |
| `coders/column-serializer.ts` | standalone `checkArityOfConstructor` (real impl is the class method invoked at lines 33/45) |
| `connection-adapters/abstract/quoting.ts` | standalone `lookupCastType` (adapter subclasses define it; not part of the `Quoting` mixin export) |
| `connection-adapters/sqlite3-adapter.ts` | standalone `arelVisitor` and `reconnect` (class override exists at line 162) |

## Downgrade

`abstract/database-statements.ts` `rawExecute`: flipped `port-real` → `keep-as-strategy-hook`. It's a real abstract-class hook (`AbstractAdapter` overrides at line 339), matching its `performQuery` / `castResult` / `affectedRows` siblings. The task heads-up explicitly listed `rawExecute` as a strategy hook to leave alone.

## Mechanical followup

Added Rails line numbers to 10 strategy-hook annotations that previously only named the file:

- `connection_handling.rb` ×5 (`:82`, `:138`, `:142`, `:169` ×2)
- `abstract/database_statements.rb` ×3 (`:561`, `:566`, `:570`)
- `abstract/schema_statements.rb` ×2 (`:1890`, `:1894`)

Remaining 6 line-numberless sites are all cluster=mysql-mysql2-adapter / pg-long-tail — leaving those for the cluster slots.

## Verification

- `grep "@nie disposition=port-real" packages/activerecord/src/ | wc -l` → 7 (was 16)
- No behavior change: every deleted function was unreachable.

## Test plan

- [ ] CI green