### PR TITLE
feat(activerecord): Schema Slot I — PG partitioning + inheritance dumper

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -928,67 +928,74 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("SchemaCreateTableOptionsTest", () => {
+    // Mirrors Rails schema_test.rb SchemaCreateTableOptionsTest:
+    // exercises the createTable → DDL → dump round-trip via the
+    // `options:` table-option string.
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS trains`);
+      await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
+      await adapter.exec(`DROP TABLE IF EXISTS vehicles`);
+    });
+
     it("list partition options is dumped", async () => {
-      try {
-        await adapter.exec(
-          `CREATE TABLE list_partitioned (id integer, city varchar(50)) PARTITION BY LIST (city)`,
-        );
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "list_partitioned");
-        expect(lines.join("\n")).toContain(`options: "PARTITION BY LIST (city)"`);
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS list_partitioned`);
-      }
+      await adapter.getDatabaseVersion();
+      if (!adapter.supportsNativePartitioning()) return;
+      const options = "PARTITION BY LIST (kind)";
+      await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
+        t.string("name");
+        t.string("kind");
+      });
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
+
     it("range partition options is dumped", async () => {
-      try {
-        await adapter.exec(
-          `CREATE TABLE range_partitioned (id integer, amount integer) PARTITION BY RANGE (amount)`,
-        );
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "range_partitioned");
-        expect(lines.join("\n")).toContain(`options: "PARTITION BY RANGE (amount)"`);
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS range_partitioned`);
-      }
+      await adapter.getDatabaseVersion();
+      if (!adapter.supportsNativePartitioning()) return;
+      const options = "PARTITION BY RANGE (created_at)";
+      await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
+        t.string("name");
+        t.datetime("created_at", { null: false });
+      });
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
+
     it("inherited table options is dumped", async () => {
-      try {
-        await adapter.exec(
-          `CREATE TABLE transportation_modes (name varchar(50), kind varchar(50))`,
-        );
-        await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes)`);
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
-        expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes)"`);
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS trains`);
-        await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
-      }
+      await adapter.schemaStatements().createTable("transportation_modes", (t) => {
+        t.string("name");
+        t.string("kind");
+      });
+      const options = "INHERITS (transportation_modes)";
+      await adapter.schemaStatements().createTable("trains", { options });
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
+
     it("multiple inherited table options is dumped", async () => {
-      try {
-        await adapter.exec(`CREATE TABLE vehicles (name varchar(50))`);
-        await adapter.exec(`CREATE TABLE transportation_modes (kind varchar(50))`);
-        await adapter.exec(`CREATE TABLE trains () INHERITS (transportation_modes, vehicles)`);
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
-        expect(lines.join("\n")).toContain(`options: "INHERITS (transportation_modes, vehicles)"`);
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS trains`);
-        await adapter.exec(`DROP TABLE IF EXISTS transportation_modes`);
-        await adapter.exec(`DROP TABLE IF EXISTS vehicles`);
-      }
+      await adapter.schemaStatements().createTable("vehicles", (t) => {
+        t.string("name");
+      });
+      await adapter.schemaStatements().createTable("transportation_modes", (t) => {
+        t.string("kind");
+      });
+      const options = "INHERITS (transportation_modes, vehicles)";
+      await adapter.schemaStatements().createTable("trains", { options });
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
+
     it("no partition options are dumped", async () => {
-      try {
-        await adapter.exec(`CREATE TABLE regular_table (id integer, name varchar(50))`);
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "regular_table");
-        expect(lines.join("\n")).not.toContain("PARTITION BY");
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS regular_table`);
-      }
+      await adapter.schemaStatements().createTable("trains", (t) => {
+        t.string("name");
+      });
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      expect(lines.join("\n")).not.toContain("options:");
     });
     it("table comment is dumped and round-trips via createTable", async () => {
       try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4323,7 +4323,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (inherited.length > 0) {
       options.options = `INHERITS (${inherited.join(", ")})`;
     }
-    if (!options.options) {
+    if (!options.options && this.supportsNativePartitioning()) {
       const partDef = await this.tablePartitionDefinition(tableName);
       if (partDef) options.options = `PARTITION BY ${partDef}`;
     }


### PR DESCRIPTION
## Summary

Schema cluster Slot I per `docs/activerecord-100-clusters.md`. Targets PG partitioning + inheritance introspection in the schema dumper.

- Rewrites `SchemaCreateTableOptionsTest` bodies (5 tests: list/range partition, inherited, multiple inherited, no-partition) to mirror Rails parity — uses `schemaStatements().createTable(..., { options: "PARTITION BY ..." })` round-trip via DDL, not raw `adapter.exec()` CREATE TABLE.
- Adds `supportsNativePartitioning()` guard to `pgAdapter.tableOptions()` (Rails: `if !options[:options] && supports_native_partitioning?` in `postgresql/schema_statements.rb#table_options`).

The dump path was already wired (`pgSchemaDumper.fetchTableOptions` → `tableOptions` → `inheritedTableNames` / `tablePartitionDefinition`); this PR closes parity on the test side and on the version guard.

## Scope notes

Slot was billed at ~250 LOC / 6 un-skips. Inspection of the codebase found the 5 `SchemaCreateTableOptionsTest` tests and the 1 `PostgresqlPartitionsTest` test (`partitions_test.ts`) already non-skipped (gated by `describeIfPg`, executed when PG is configured). The remaining work was test-body parity + the missing version guard. The original ~250 LOC estimate appears to have been written before the dumper wiring landed in Slot H.

Followups not in this PR:

- ~10 LOC — `partitions.test.ts` has an extra non-Rails `partition table` test; could be dropped or aligned with Rails `partitions_test.rb` (1 test).
- The `no partition options are dumped` assertion uses `not.toContain("options:")` for full Rails parity with `assert_no_match("options:", output)`.

## Test plan

- [ ] CI: full AR test suite (PG job) — runs the rewritten `SchemaCreateTableOptionsTest` tests.
- [ ] CI: `api:compare` parity unchanged.