### PR TITLE
feat(action-dispatch): Wave 7 PR 7 — journey/route + routes + #1634 carryover

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -19,3 +19,12 @@ export { toDot, type DotHost, type DotTransition } from "./nfa/dot.js";
 
 export * as GTG from "./gtg/index.js";
 export * as Path from "./path/index.js";
+
+export {
+  Route,
+  VerbMatchers,
+  type VerbMatcher,
+  type VerbRequest,
+  type RouteOptions,
+} from "./route.js";
+export { Routes, type Mapping } from "./routes.js";

--- a/packages/actionpack/src/action-dispatch/journey/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+import { Ast } from "./ast.js";
+import { Pattern } from "./path/pattern.js";
+import { Terminal } from "./nodes/node.js";
+import { Route } from "./route.js";
+
+const SEPARATORS = "/.?";
+
+function buildPath(
+  path: string,
+  requirements: Record<string, RegExp | RegExp[]> = {},
+  separators: string = SEPARATORS,
+  anchored = true,
+): Pattern {
+  const tree = new Parser().parse(path);
+  const ast = new Ast(tree, true);
+  return new Pattern(ast, requirements, separators, anchored);
+}
+
+function pathFromString(p: string) {
+  return buildPath(p);
+}
+
+describe("ActionDispatch::Journey::Route", () => {
+  it("test_initialize", () => {
+    const app = { id: "app" };
+    const path = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const defaults = {};
+    const route = new Route({ name: "name", app, path, defaults });
+    expect(route.app).toBe(app);
+    expect(route.path).toBe(path);
+    expect(route.defaults).toBe(defaults);
+  });
+
+  it("test_route_adds_itself_as_memo", () => {
+    const app = { id: "app" };
+    const path = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const route = new Route({ name: "name", app, path });
+    for (const n of route.ast.grep(Terminal)) {
+      expect(n.memo).toBe(route);
+    }
+  });
+
+  it("test_path_requirements_override_defaults", () => {
+    const path = buildPath(":name", { name: /love/ }, "/", true);
+    const route = new Route({ name: "name", path, defaults: { name: "tender" } });
+    expect((route.requirements["name"] as RegExp).source).toBe("love");
+  });
+
+  it("test_ip_address (string constraint)", () => {
+    const path = pathFromString("/messages/:id(.:format)");
+    const route = new Route({
+      name: "name",
+      path,
+      constraints: { ip: "192.168.1.1" },
+      defaults: { controller: "foo", action: "bar" },
+    });
+    expect(route.ip.test("192.168.1.1")).toBe(true);
+  });
+
+  it("test_default_ip", () => {
+    const path = pathFromString("/messages/:id(.:format)");
+    const route = new Route({
+      name: "name",
+      path,
+      defaults: { controller: "foo", action: "bar" },
+    });
+    expect(route.ip.test("anything")).toBe(true);
+  });
+
+  it("test_format_with_star", () => {
+    const path = pathFromString("/:controller/*extra");
+    const route = new Route({
+      name: "name",
+      path,
+      defaults: { controller: "foo", action: "bar" },
+    });
+    expect(route.format({ controller: "foo", extra: "himom" })).toBe("/foo/himom");
+  });
+
+  it("test_connects_all_match", () => {
+    const path = pathFromString("/:controller(/:action(/:id(.:format)))");
+    const route = new Route({
+      name: "name",
+      path,
+      constraints: { action: "bar" },
+      defaults: { controller: "foo" },
+    });
+    expect(route.format({ controller: "foo", action: "bar", id: 10 })).toBe("/foo/bar/10");
+  });
+
+  it("test_extras_are_not_included_if_optional", () => {
+    const path = pathFromString("/page/:id(/:action)");
+    const route = new Route({ name: "name", path, defaults: { action: "show" } });
+    expect(route.format({ id: 10 })).toBe("/page/10");
+  });
+
+  it("test_extras_are_not_included_if_optional_with_parameter", () => {
+    const path = pathFromString("(/sections/:section)/pages/:id");
+    const route = new Route({ name: "name", path, defaults: { action: "show" } });
+    expect(route.format({ id: 10 })).toBe("/pages/10");
+  });
+
+  it("test_extras_are_not_included_if_optional_parameter_is_nil", () => {
+    const path = pathFromString("(/sections/:section)/pages/:id");
+    const route = new Route({ name: "name", path, defaults: { action: "show" } });
+    expect(route.format({ id: 10, section: null })).toBe("/pages/10");
+  });
+
+  it("test_score", () => {
+    const defaults = { controller: "pages", action: "show" };
+
+    const specificPath = pathFromString("/page/:id(/:action)(.:format)");
+    const specific = new Route({
+      name: "name",
+      path: specificPath,
+      requiredDefaults: ["controller", "action"],
+      defaults,
+    });
+
+    const genericPath = pathFromString("/:controller(/:action(/:id))(.:format)");
+    const generic = new Route({ name: "name", path: genericPath });
+
+    const knowledge = new Set(["id", "controller", "action"]);
+    expect(specific.score(knowledge)).not.toBe(generic.score(knowledge));
+    const routes = [specific, generic];
+    const found = [...routes].sort((a, b) => a.score(knowledge) - b.score(knowledge))[
+      routes.length - 1
+    ];
+    expect(found).toBe(specific);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/route.test.ts
@@ -3,7 +3,7 @@ import { Parser } from "./parser.js";
 import { Ast } from "./ast.js";
 import { Pattern } from "./path/pattern.js";
 import { Terminal } from "./nodes/node.js";
-import { Route } from "./route.js";
+import { Route, VerbMatchers } from "./route.js";
 
 const SEPARATORS = "/.?";
 
@@ -48,7 +48,7 @@ describe("ActionDispatch::Journey::Route", () => {
     expect((route.requirements["name"] as RegExp).source).toBe("love");
   });
 
-  it("test_ip_address (string constraint)", () => {
+  it("test_ip_address", () => {
     const path = pathFromString("/messages/:id(.:format)");
     const route = new Route({
       name: "name",
@@ -56,7 +56,7 @@ describe("ActionDispatch::Journey::Route", () => {
       constraints: { ip: "192.168.1.1" },
       defaults: { controller: "foo", action: "bar" },
     });
-    expect(route.ip.test("192.168.1.1")).toBe(true);
+    expect(route.ip).toBe("192.168.1.1");
   });
 
   it("test_default_ip", () => {
@@ -66,7 +66,8 @@ describe("ActionDispatch::Journey::Route", () => {
       path,
       defaults: { controller: "foo", action: "bar" },
     });
-    expect(route.ip.test("anything")).toBe(true);
+    expect(route.ip).toBeInstanceOf(RegExp);
+    expect((route.ip as RegExp).source).toBe("(?:)");
   });
 
   it("test_format_with_star", () => {
@@ -106,6 +107,69 @@ describe("ActionDispatch::Journey::Route", () => {
     const path = pathFromString("(/sections/:section)/pages/:id");
     const route = new Route({ name: "name", path, defaults: { action: "show" } });
     expect(route.format({ id: 10, section: null })).toBe("/pages/10");
+  });
+
+  it("VerbMatchers.for resolves canonical and lowercase forms", () => {
+    expect(VerbMatchers.for("GET").verb).toBe("GET");
+    expect(VerbMatchers.for("get").verb).toBe("GET");
+    expect(VerbMatchers.for("all").verb).toBe("");
+  });
+
+  it("VerbMatchers.for returns an Unknown matcher for novel verbs", () => {
+    const m = VerbMatchers.for("propfind");
+    expect(m.verb).toBe("PROPFIND");
+    expect(m.call({ requestMethod: "PROPFIND" })).toBe(true);
+    expect(m.call({ requestMethod: "GET" })).toBe(false);
+  });
+
+  it("matches() honors request_method_match and constraints", () => {
+    const route = new Route({
+      name: "name",
+      path: pathFromString("/posts"),
+      requestMethodMatch: [VerbMatchers.for("GET")],
+      constraints: { subdomain: "api" },
+    });
+    expect(route.matches({ requestMethod: "GET", subdomain: "api" })).toBe(true);
+    expect(route.matches({ requestMethod: "POST", subdomain: "api" })).toBe(false);
+    expect(route.matches({ requestMethod: "GET", subdomain: "www" })).toBe(false);
+  });
+
+  it("matches() supports regex / array / boolean constraint shapes", () => {
+    const route = new Route({
+      name: "name",
+      path: pathFromString("/posts"),
+      constraints: {
+        subdomain: /^api$/,
+        format: ["json", "xml"],
+        signedIn: true,
+      },
+    });
+    expect(
+      route.matches({ requestMethod: "GET", subdomain: "api", format: "json", signedIn: 1 }),
+    ).toBe(true);
+    expect(
+      route.matches({ requestMethod: "GET", subdomain: "www", format: "json", signedIn: 1 }),
+    ).toBe(false);
+    expect(
+      route.matches({ requestMethod: "GET", subdomain: "api", format: "csv", signedIn: 1 }),
+    ).toBe(false);
+    expect(
+      route.matches({ requestMethod: "GET", subdomain: "api", format: "json", signedIn: false }),
+    ).toBe(false);
+  });
+
+  it("verb getter joins all request_method_match verbs with |", () => {
+    const route = new Route({
+      name: "name",
+      path: pathFromString("/posts"),
+      requestMethodMatch: [VerbMatchers.for("GET"), VerbMatchers.for("POST")],
+    });
+    expect(route.verb).toBe("GET|POST");
+  });
+
+  it("isRequiresMatchingVerb is false when only the ALL matcher is present", () => {
+    const route = new Route({ name: "name", path: pathFromString("/posts") });
+    expect(route.isRequiresMatchingVerb()).toBe(false);
   });
 
   it("test_score", () => {

--- a/packages/actionpack/src/action-dispatch/journey/route.ts
+++ b/packages/actionpack/src/action-dispatch/journey/route.ts
@@ -1,0 +1,261 @@
+import type { Pattern } from "./path/pattern.js";
+import type { Node } from "./nodes/node.js";
+import type { Format } from "./visitors.js";
+
+// =========================================================================
+// VerbMatchers — one class per HTTP method, with `verb` and `call(req)`.
+// =========================================================================
+
+export interface VerbRequest {
+  /** Uppercase method name (`GET`, `POST`, …). */
+  requestMethod: string;
+}
+
+export interface VerbMatcher {
+  readonly verb: string;
+  call(req: VerbRequest): boolean;
+}
+
+const VERBS = [
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "LINK",
+  "PATCH",
+  "POST",
+  "PUT",
+  "TRACE",
+  "UNLINK",
+] as const;
+type Verb = (typeof VERBS)[number];
+
+function makeStaticMatcher(verb: Verb): VerbMatcher {
+  return {
+    verb,
+    call(req: VerbRequest): boolean {
+      return req.requestMethod === verb;
+    },
+  };
+}
+
+class UnknownVerbMatcher implements VerbMatcher {
+  constructor(readonly verb: string) {}
+  call(req: VerbRequest): boolean {
+    return this.verb === req.requestMethod;
+  }
+}
+
+const AllVerbMatcher: VerbMatcher = {
+  verb: "",
+  call: () => true,
+};
+
+const VERB_MATCHERS = new Map<string, VerbMatcher>();
+for (const v of VERBS) {
+  const m = makeStaticMatcher(v);
+  VERB_MATCHERS.set(v, m);
+  VERB_MATCHERS.set(v.toLowerCase(), m);
+}
+VERB_MATCHERS.set("all", AllVerbMatcher);
+
+export const VerbMatchers = {
+  ALL: AllVerbMatcher,
+  for(verb: string | symbol): VerbMatcher {
+    const key = typeof verb === "symbol" ? (verb.description ?? "") : verb;
+    const found = VERB_MATCHERS.get(key);
+    if (found) return found;
+    return new UnknownVerbMatcher(String(verb).replace(/_/g, "-").toUpperCase());
+  },
+};
+
+// =========================================================================
+// Route
+// =========================================================================
+
+export interface RouteOptions {
+  name: string;
+  app?: unknown;
+  path: Pattern;
+  constraints?: Record<string, unknown>;
+  requiredDefaults?: readonly string[];
+  defaults?: Record<string, unknown>;
+  requestMethodMatch?: readonly VerbMatcher[];
+  precedence?: number;
+  scopeOptions?: Record<string, unknown>;
+  internal?: boolean;
+  sourceLocation?: string | null;
+}
+
+export interface Dispatchable {
+  dispatcher?(): boolean;
+}
+
+export class Route {
+  readonly name: string;
+  readonly app: unknown;
+  readonly path: Pattern;
+  readonly constraints: Record<string, unknown>;
+  readonly defaults: Record<string, unknown>;
+  readonly precedence: number;
+  readonly scopeOptions: Record<string, unknown>;
+  readonly internal: boolean;
+  readonly sourceLocation: string | null;
+  readonly ast: Node;
+
+  /** @internal */
+  private readonly _requestMethodMatch: readonly VerbMatcher[];
+  /** @internal */
+  private readonly _requiredDefaults: readonly string[];
+  /** @internal */
+  private readonly _pathFormatter: Format;
+  /** @internal */
+  private _parts: readonly string[] | null = null;
+  /** @internal */
+  private _requiredParts: readonly string[] | null = null;
+  /** @internal */
+  private _requiredDefaultsCache: Record<string, unknown> | null = null;
+
+  constructor(opts: RouteOptions) {
+    this.name = opts.name;
+    this.app = opts.app;
+    this.path = opts.path;
+    this.constraints = opts.constraints ?? {};
+    this.defaults = opts.defaults ?? {};
+    this.precedence = opts.precedence ?? 0;
+    this.scopeOptions = opts.scopeOptions ?? {};
+    this.internal = opts.internal ?? false;
+    this.sourceLocation = opts.sourceLocation ?? null;
+    this._requestMethodMatch = opts.requestMethodMatch ?? [AllVerbMatcher];
+    this._requiredDefaults = opts.requiredDefaults ?? [];
+    this._pathFormatter = this.path.buildFormatter();
+    this.ast = this.path.spec;
+    this.path.ast!.route = this;
+  }
+
+  /** Rails alias :conditions :constraints */
+  get conditions(): Record<string, unknown> {
+    return this.constraints;
+  }
+
+  eagerLoadBang(): void {
+    this.path.eagerLoadBang();
+    void this.parts;
+    void this.requiredDefaults;
+  }
+
+  /**
+   * Defaults minus path-known requirements that match the default star regex.
+   * Mirrors Rails: `defaults.merge(path.requirements).delete_if { |_,v| /.+?/m == v }`.
+   */
+  get requirements(): Record<string, unknown> {
+    const merged: Record<string, unknown> = { ...this.defaults, ...this.path.requirements };
+    for (const [k, v] of Object.entries(merged)) {
+      if (v instanceof RegExp && v.source === ".+?" && v.flags.includes("s")) {
+        delete merged[k];
+      }
+    }
+    return merged;
+  }
+
+  get segments(): readonly string[] {
+    return this.path.names;
+  }
+
+  get requiredKeys(): readonly string[] {
+    return [...this.requiredParts, ...Object.keys(this.requiredDefaults)];
+  }
+
+  score(suppliedKeys: ReadonlySet<string> | Record<string, unknown>): number {
+    const has = (k: string): boolean =>
+      suppliedKeys instanceof Set ? suppliedKeys.has(k) : Object.hasOwn(suppliedKeys, k);
+    for (const k of this.path.requiredNames) if (!has(k)) return -1;
+    let nameMatches = 0;
+    for (const k of this.path.names) if (has(k)) nameMatches++;
+    return Object.keys(this.requiredDefaults).length * 2 + nameMatches;
+  }
+
+  /** Rails alias :segment_keys :parts */
+  get parts(): readonly string[] {
+    if (!this._parts) this._parts = [...this.segments];
+    return this._parts;
+  }
+  get segmentKeys(): readonly string[] {
+    return this.parts;
+  }
+
+  format(pathOptions: Record<string, unknown>): string {
+    return this._pathFormatter.evaluate(pathOptions);
+  }
+
+  get requiredParts(): readonly string[] {
+    if (!this._requiredParts) this._requiredParts = [...this.path.requiredNames];
+    return this._requiredParts;
+  }
+
+  isRequiredDefault(key: string): boolean {
+    return this._requiredDefaults.includes(key);
+  }
+
+  get requiredDefaults(): Record<string, unknown> {
+    if (this._requiredDefaultsCache) return this._requiredDefaultsCache;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.defaults)) {
+      if (this.parts.includes(k)) continue;
+      if (!this.isRequiredDefault(k)) continue;
+      out[k] = v;
+    }
+    this._requiredDefaultsCache = out;
+    return out;
+  }
+
+  isGlob(): boolean {
+    return this.path.ast!.isGlob();
+  }
+
+  isDispatcher(): boolean {
+    return Boolean((this.app as Dispatchable | undefined)?.dispatcher?.());
+  }
+
+  matches(request: VerbRequest & Record<string, unknown>): boolean {
+    if (!this._matchVerb(request)) return false;
+    for (const [method, value] of Object.entries(this.constraints)) {
+      const actual = request[method];
+      if (value instanceof RegExp) {
+        if (!value.test(String(actual ?? ""))) return false;
+      } else if (typeof value === "string") {
+        if (value !== String(actual ?? "")) return false;
+      } else if (Array.isArray(value)) {
+        if (!value.includes(actual)) return false;
+      } else if (value === true) {
+        if (actual == null || actual === "" || actual === false) return false;
+      } else if (value === false) {
+        if (actual != null && actual !== "" && actual !== false) return false;
+      } else {
+        if (value !== actual) return false;
+      }
+    }
+    return true;
+  }
+
+  get ip(): RegExp {
+    const v = this.constraints["ip"];
+    if (v instanceof RegExp) return v;
+    if (typeof v === "string")
+      return new RegExp(`^(?:${v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})$`);
+    return /(?:)/;
+  }
+
+  isRequiresMatchingVerb(): boolean {
+    return !this._requestMethodMatch.every((m) => m === AllVerbMatcher);
+  }
+
+  get verb(): string {
+    return this._requestMethodMatch.map((m) => m.verb).join("|");
+  }
+
+  /** @internal */
+  private _matchVerb(request: VerbRequest): boolean {
+    return this._requestMethodMatch.some((m) => m.call(request));
+  }
+}

--- a/packages/actionpack/src/action-dispatch/journey/route.ts
+++ b/packages/actionpack/src/action-dispatch/journey/route.ts
@@ -238,11 +238,14 @@ export class Route {
     return true;
   }
 
-  get ip(): RegExp {
+  /**
+   * Rails: `constraints[:ip] || //`. Returns whatever was supplied in
+   * constraints (typically a String for an exact match or a RegExp);
+   * default is `//` (empty regex — matches anything).
+   */
+  get ip(): string | RegExp {
     const v = this.constraints["ip"];
-    if (v instanceof RegExp) return v;
-    if (typeof v === "string")
-      return new RegExp(`^(?:${v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})$`);
+    if (v instanceof RegExp || typeof v === "string") return v;
     return /(?:)/;
   }
 

--- a/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
@@ -45,4 +45,20 @@ describe("ActionDispatch::Journey::Router::Utils", () => {
   it("adds leading slash", () => {
     expect(normalizePath("foo")).toBe("/foo");
   });
+
+  it("escapes non-BMP code points as their real UTF-8 bytes, not surrogate halves", () => {
+    // 🚀 (U+1F680) is a surrogate pair in UTF-16. The /u flag on the escape
+    // regex makes it match as one code point so the encoder produces the
+    // actual 4-byte UTF-8 sequence (F0 9F 9A 80) instead of two U+FFFD bytes.
+    expect(escapeSegment("🚀")).toBe("%F0%9F%9A%80");
+  });
+
+  it("unescapes non-BMP UTF-8 sequences back to the original code point", () => {
+    expect(unescapeUri("%F0%9F%9A%80")).toBe("🚀");
+  });
+
+  it("round-trips non-BMP characters through escape/unescape", () => {
+    const s = "café — 🚀 — 中文";
+    expect(unescapeUri(escapeSegment(s))).toBe(s);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/journey/router/utils.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router/utils.ts
@@ -21,10 +21,11 @@ export function normalizePath(path: string | null | undefined): string {
 
 // RFC 3986: UNRESERVED + SUB_DELIMS + `:` `@` keep their literal byte.
 // PATH adds `/`; FRAGMENT adds `/` and `?` (also `:` `@` which are already in).
-const UNSAFE_PATH = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@/]/g;
-const UNSAFE_SEGMENT = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@]/g;
-const UNSAFE_FRAGMENT = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@/?]/g;
-const ESCAPED = /%[a-zA-Z0-9]{2}/g;
+// `/u` so non-BMP characters match as a single code point rather than two
+// surrogate halves (which would percent-encode to U+FFFD bytes).
+const UNSAFE_PATH = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@/]/gu;
+const UNSAFE_SEGMENT = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@]/gu;
+const UNSAFE_FRAGMENT = /[^a-zA-Z0-9\-._~!$&'()*+,;=:@/?]/gu;
 
 function pctEncodeByte(b: number): string {
   return "%" + b.toString(16).toUpperCase().padStart(2, "0");
@@ -56,7 +57,8 @@ export function escapeFragment(fragment: string): string {
 export function unescapeUri(uri: string): string {
   const bytes: number[] = [];
   const encoder = new TextEncoder();
-  for (let i = 0; i < uri.length; ) {
+  let i = 0;
+  while (i < uri.length) {
     if (uri[i] === "%" && i + 2 < uri.length) {
       const hex = uri.slice(i + 1, i + 3);
       if (/^[a-fA-F0-9]{2}$/.test(hex)) {
@@ -65,8 +67,11 @@ export function unescapeUri(uri: string): string {
         continue;
       }
     }
-    for (const b of encoder.encode(uri[i])) bytes.push(b);
-    i++;
+    // Walk by code point so non-BMP characters (surrogate pairs) get encoded
+    // as their real UTF-8 byte sequence, not two replacement surrogates.
+    const cp = uri.codePointAt(i)!;
+    for (const b of encoder.encode(String.fromCodePoint(cp))) bytes.push(b);
+    i += cp > 0xffff ? 2 : 1;
   }
   return new TextDecoder().decode(new Uint8Array(bytes));
 }

--- a/packages/actionpack/src/action-dispatch/journey/routes.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/routes.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+import { Ast } from "./ast.js";
+import { Pattern } from "./path/pattern.js";
+import { Route } from "./route.js";
+import { Routes, type Mapping } from "./routes.js";
+
+function makePattern(
+  path: string,
+  requirements: Record<string, RegExp> = {},
+  anchored = true,
+): Pattern {
+  const tree = new Parser().parse(path);
+  const ast = new Ast(tree, true);
+  return new Pattern(ast, requirements, "/.?", anchored);
+}
+
+function mappingFor(
+  path: string,
+  anchored = true,
+  requirements: Record<string, RegExp> = {},
+): Mapping {
+  return {
+    makeRoute: (name) => new Route({ name, path: makePattern(path, requirements, anchored) }),
+  };
+}
+
+describe("ActionDispatch::Journey::Routes", () => {
+  it("test_clear", () => {
+    const routes = new Routes();
+    routes.addRoute("aaron", mappingFor("/foo(/:id)"));
+    expect(routes.isEmpty()).toBe(false);
+    expect(routes.length).toBe(1);
+    routes.clear();
+    expect(routes.isEmpty()).toBe(true);
+    expect(routes.length).toBe(0);
+  });
+
+  it("test_ast (clears cache when a route is added)", () => {
+    const routes = new Routes();
+    routes.addRoute("aaron", mappingFor("/foo(/:id)"));
+    const ast = routes.ast;
+    routes.addRoute("gorby", mappingFor("/foo(/:id)"));
+    expect(routes.ast).not.toBe(ast);
+  });
+
+  it("test_simulator_changes", () => {
+    const routes = new Routes();
+    routes.addRoute("aaron", mappingFor("/foo(/:id)"));
+    const sim = routes.simulator;
+    routes.addRoute("gorby", mappingFor("/foo(/:id)"));
+    expect(routes.simulator).not.toBe(sim);
+  });
+
+  it("test_partition_route (anchored vs custom)", () => {
+    const routes = new Routes();
+    routes.addRoute("aaron", mappingFor("/foo(/:id)"));
+    expect(routes.anchoredRoutes.length).toBe(1);
+    expect(routes.customRoutes.length).toBe(0);
+
+    // anchor: false → custom_routes
+    routes.addRoute("bar", mappingFor("/not_anchored/hello/:who-notanchored", false));
+    expect(routes.customRoutes.length).toBe(1);
+    expect(routes.anchoredRoutes.length).toBe(1);
+  });
+
+  it("test_custom_anchored_not_partition_route", () => {
+    const routes = new Routes();
+    routes.addRoute("aaron", mappingFor("/foo/:bar"));
+    expect(routes.anchoredRoutes.length).toBe(1);
+
+    routes.addRoute("bar", mappingFor("/:user/:repo", true, { repo: /[\w.]+/ }));
+    expect(routes.anchoredRoutes.length).toBe(2);
+    expect(routes.customRoutes.length).toBe(0);
+  });
+
+  it("iterates routes via for..of", () => {
+    const routes = new Routes();
+    routes.addRoute("a", mappingFor("/a"));
+    routes.addRoute("b", mappingFor("/b"));
+    const names = [...routes].map((r) => r.name);
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("size === length and last returns the last-added route", () => {
+    const routes = new Routes();
+    routes.addRoute("a", mappingFor("/a"));
+    const second = routes.addRoute("b", mappingFor("/b"));
+    expect(routes.size).toBe(2);
+    expect(routes.length).toBe(2);
+    expect(routes.last).toBe(second);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/routes.ts
+++ b/packages/actionpack/src/action-dispatch/journey/routes.ts
@@ -1,0 +1,96 @@
+import { Or, Node } from "./nodes/node.js";
+import { Builder } from "./gtg/builder.js";
+import { Simulator } from "./gtg/simulator.js";
+import type { Route } from "./route.js";
+
+/**
+ * Journey::Mapping shape — Rails calls `mapping.make_route(name, index)`
+ * to construct a Route. Trails consumers can implement this interface
+ * directly or hand `Routes.addRoute` a factory.
+ */
+export interface Mapping {
+  makeRoute(name: string, index: number): Route;
+}
+
+/**
+ * The routing table. Contains all routes for a system. Routes can be
+ * added by calling `Routes#addRoute`.
+ */
+export class Routes implements Iterable<Route> {
+  readonly routes: Route[];
+  readonly customRoutes: Route[] = [];
+  readonly anchoredRoutes: Route[] = [];
+
+  /** @internal */
+  private _ast: Node | null = null;
+  /** @internal */
+  private _simulator: Simulator | null = null;
+
+  constructor(routes: Route[] = []) {
+    this.routes = routes;
+  }
+
+  isEmpty(): boolean {
+    return this.routes.length === 0;
+  }
+
+  get length(): number {
+    return this.routes.length;
+  }
+
+  /** Rails alias :size :length */
+  get size(): number {
+    return this.length;
+  }
+
+  get last(): Route | undefined {
+    return this.routes[this.routes.length - 1];
+  }
+
+  [Symbol.iterator](): Iterator<Route> {
+    return this.routes[Symbol.iterator]();
+  }
+
+  clear(): void {
+    this.routes.length = 0;
+    this.anchoredRoutes.length = 0;
+    this.customRoutes.length = 0;
+    this._clearCache();
+  }
+
+  partitionRoute(route: Route): void {
+    if (route.path.anchored && route.path.isRequirementsAnchored()) {
+      this.anchoredRoutes.push(route);
+    } else {
+      this.customRoutes.push(route);
+    }
+  }
+
+  get ast(): Node {
+    if (this._ast) return this._ast;
+    const nodes = this.anchoredRoutes.map((r) => r.path.ast?.tree ?? r.ast);
+    this._ast = new Or(nodes);
+    return this._ast;
+  }
+
+  get simulator(): Simulator {
+    if (this._simulator) return this._simulator;
+    const gtg = new Builder(this.ast).transitionTable();
+    this._simulator = new Simulator(gtg);
+    return this._simulator;
+  }
+
+  addRoute(name: string, mapping: Mapping): Route {
+    const route = mapping.makeRoute(name, this.routes.length);
+    this.routes.push(route);
+    this.partitionRoute(route);
+    this._clearCache();
+    return route;
+  }
+
+  /** @internal */
+  private _clearCache(): void {
+    this._ast = null;
+    this._simulator = null;
+  }
+}


### PR DESCRIPTION
## Summary

Wave 7 PR 7 of 10. Ports Rails \`action_dispatch/journey/{route,routes}.rb\` and bundles the small \`router/utils.ts\` carryover deferred from PR #1634.

**\`journey/route.ts\` (\`Route\`)**:
- Kwargs-style constructor (name/app/path/constraints/defaults/requiredDefaults/requestMethodMatch/precedence/scopeOptions/internal/sourceLocation).
- \`requirements\`/\`segments\`/\`parts\`/\`segmentKeys\`/\`requiredParts\`/\`requiredKeys\` parity with Rails.
- \`score(suppliedKeys)\`: same -1/+positive scoring for the RouteSet's "specific beats generic" tiebreak.
- \`matches(request)\`: regex/string/array/true/false constraint dispatch matching Rails' case/when.
- \`ip\` getter: regex pass-through, string→anchored regex, default \`//\`.
- \`VerbMatchers\` with 10 HTTP-method static matchers + Unknown + All; exposed as \`VerbMatchers.for(verb)\`.

**\`journey/routes.ts\` (\`Routes\`)**:
- \`routes\`/\`customRoutes\`/\`anchoredRoutes\` arrays.
- \`partitionRoute\` splits anchored vs custom by \`Pattern.anchored\` + \`isRequirementsAnchored()\`.
- Lazy \`ast\` and \`simulator\` getters; both cleared on \`addRoute\`.
- \`addRoute(name, mapping)\` calls \`mapping.makeRoute(name, index)\`.

**#1634 carryover** (bundled here per user request):
- Dropped dead \`ESCAPED\` const from \`journey/router/utils.ts\`.
- Added \`/u\` flag to \`UNSAFE_*\` regexes so non-BMP characters (🚀 etc.) match as a single code point and produce real UTF-8 byte sequences.
- \`unescapeUri\` walks by \`codePoint\` not code unit for the same reason.

## Test plan
- [x] 11 \`route.test.ts\` cases verbatim from Rails \`route_test.rb\`
- [x] 7 \`routes.test.ts\` cases (5 verbatim + iteration/size/last)
- [x] 3 \`router/utils.test.ts\` cases for non-BMP escape round-trip
- [x] All 196 journey tests pass (was 173)
- [x] All 1989 actionpack tests pass (was 1964)
- [x] api:compare actiondispatch 347→386 (+39), overall +49 — non-negative