### PR TITLE
refactor(activerecord): TM unification Phase 8 — push per-connection mutex into TransactionManager

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -848,8 +848,6 @@ export class TransactionManager {
   private _materializingOwnerAdapter: ReturnType<typeof getAsyncContext> | null = null;
   /** @internal Token identifying the chain currently materializing. */
   private _currentMaterializingOwner: symbol | null = null;
-  /** @internal In-flight materialization promise; rejects with the underlying error. */
-  private _materializingPromise: Promise<void> | null = null;
 
   static readonly NULL_TRANSACTION = Object.freeze(new NullTransaction());
 
@@ -870,6 +868,20 @@ export class TransactionManager {
   async beginTransaction(
     options: { isolation?: string | null; joinable?: boolean; _lazy?: boolean } = {},
   ): Promise<Transaction> {
+    return await this.synchronize(() => this._beginTransactionInner(options));
+  }
+
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::TransactionManager#begin_transaction
+   * inner body (the part inside `@connection.lock.synchronize`,
+   * `abstract/transaction.rb:507`).
+   * @internal
+   */
+  private async _beginTransactionInner(options: {
+    isolation?: string | null;
+    joinable?: boolean;
+    _lazy?: boolean;
+  }): Promise<Transaction> {
     const { isolation = null, joinable = true, _lazy = true } = options;
     const current = this.currentTransaction;
     const runCommitCallbacks = current instanceof Transaction ? !current.joinable : true;
@@ -964,42 +976,35 @@ export class TransactionManager {
   async materializeTransactions(): Promise<void> {
     // Re-entrant call from inside an in-progress materializeBang on the same
     // chain — skip to avoid infinite recursion (queries issued by
-    // materializeBang itself call back into here). Owner-token check so a
-    // foreign chain (no token, or stale token from an earlier completed pass)
-    // falls through to wait on _materializingPromise instead of racing to
-    // issue queries against an unmaterialized stack.
+    // materializeBang itself call back into here).
     const storage = this._materializingStorage();
     if (this._currentMaterializingOwner && storage.getStore() === this._currentMaterializingOwner) {
       return;
     }
-    if (this._materializingPromise) {
-      // Surfaces materialization failures to foreign waiters (otherwise they
-      // would proceed assuming a materialized stack and fire queries against
-      // an unmaterialized one).
-      await this._materializingPromise;
-      return;
-    }
-    if (!this._hasUnmaterializedTransactions) return;
-
-    const owner = Symbol("tm.materialize");
-    const op = (async () => {
-      await storage.run(owner, async () => {
-        for (const t of this._stack) {
-          if (t instanceof Transaction && !t.isMaterialized()) {
-            await t.materializeBang();
+    // Mirrors Rails (`abstract/transaction.rb:577-591`): the pass runs under
+    // the per-connection lock. Foreign chains block here; once they enter,
+    // an earlier holder will have flipped `_hasUnmaterializedTransactions`
+    // off and they no-op. `beginTransaction` is wrapped in the same lock
+    // (mirroring Rails line 507) so `_hasUnmaterializedTransactions` cannot
+    // flip back to true mid-pass — making the unconditional clear at the
+    // end of the loop safe by exclusion.
+    await this.synchronize(async () => {
+      if (!this._hasUnmaterializedTransactions) return;
+      const owner = Symbol("tm.materialize");
+      this._currentMaterializingOwner = owner;
+      try {
+        await storage.run(owner, async () => {
+          for (const t of this._stack) {
+            if (t instanceof Transaction && !t.isMaterialized()) {
+              await t.materializeBang();
+            }
           }
-        }
-      });
-      this._hasUnmaterializedTransactions = false;
-    })();
-    this._materializingPromise = op;
-    this._currentMaterializingOwner = owner;
-    try {
-      await op;
-    } finally {
-      this._currentMaterializingOwner = null;
-      this._materializingPromise = null;
-    }
+        });
+        this._hasUnmaterializedTransactions = false;
+      } finally {
+        this._currentMaterializingOwner = null;
+      }
+    });
   }
 
   async commitTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1007,7 +1007,19 @@ export class TransactionManager {
     });
   }
 
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::TransactionManager#commit_transaction
+   * (`abstract/transaction.rb:593`). Wrapped in `synchronize` so direct
+   * callers (manual TM use outside `within_new_transaction`) get the same
+   * exclusion the body-internal callers already have. Reentrant for the
+   * common case where this is called from inside `_withinNewTransactionBody`.
+   */
   async commitTransaction(): Promise<void> {
+    await this.synchronize(() => this._commitTransactionInner());
+  }
+
+  /** @internal */
+  private async _commitTransactionInner(): Promise<void> {
     const transaction = this._stack[this._stack.length - 1];
     if (!(transaction instanceof Transaction)) return;
 
@@ -1025,7 +1037,17 @@ export class TransactionManager {
     await transaction.commitRecords();
   }
 
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::TransactionManager#rollback_transaction
+   * (`abstract/transaction.rb:610`). Wrapped in `synchronize` for the same
+   * reason as {@link commitTransaction}.
+   */
   async rollbackTransaction(transaction?: Transaction): Promise<void> {
+    await this.synchronize(() => this._rollbackTransactionInner(transaction));
+  }
+
+  /** @internal */
+  private async _rollbackTransactionInner(transaction?: Transaction): Promise<void> {
     const txn = transaction || this._stack[this._stack.length - 1];
 
     if (!(txn instanceof Transaction)) return;

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -834,17 +834,21 @@ export class TransactionManager {
   private _connection: TransactionConnection;
   private _hasUnmaterializedTransactions = false;
   private _lazyTransactionsEnabled = true;
-  /** @internal Async-chain re-entrancy flag for {@link withinNewTransaction}. */
-  private _lockHeld: AsyncContext<true> | null = null;
+  /** @internal AsyncContext carrying the per-acquisition lock-owner token. */
+  private _lockOwner: AsyncContext<symbol> | null = null;
   /** @internal Cached AsyncContext adapter (refresh on swap, like other call sites). */
-  private _lockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
+  private _lockOwnerAdapter: ReturnType<typeof getAsyncContext> | null = null;
+  /** @internal Token identifying the chain that currently holds the lock. */
+  private _currentLockOwner: symbol | null = null;
   /** @internal Outermost-call mutex; non-null while a foreign chain holds it. */
   private _lockChain: Promise<void> | null = null;
-  /** @internal Async-chain re-entrancy flag for {@link materializeTransactions}. */
-  private _materializing: AsyncContext<true> | null = null;
-  /** @internal Cached AsyncContext adapter for the materialize flag. */
-  private _materializingAdapter: ReturnType<typeof getAsyncContext> | null = null;
-  /** @internal In-flight materialization promise for cross-chain waiters. */
+  /** @internal AsyncContext carrying the per-materialization owner token. */
+  private _materializingOwner: AsyncContext<symbol> | null = null;
+  /** @internal Cached AsyncContext adapter for the materialize owner. */
+  private _materializingOwnerAdapter: ReturnType<typeof getAsyncContext> | null = null;
+  /** @internal Token identifying the chain currently materializing. */
+  private _currentMaterializingOwner: symbol | null = null;
+  /** @internal In-flight materialization promise; rejects with the underlying error. */
   private _materializingPromise: Promise<void> | null = null;
 
   static readonly NULL_TRANSACTION = Object.freeze(new NullTransaction());
@@ -948,34 +952,38 @@ export class TransactionManager {
   }
 
   /** @internal */
-  private _materializingStorage(): AsyncContext<true> {
+  private _materializingStorage(): AsyncContext<symbol> {
     const asyncContext = getAsyncContext();
-    if (!this._materializing || this._materializingAdapter !== asyncContext) {
-      this._materializing = asyncContext.create<true>();
-      this._materializingAdapter = asyncContext;
+    if (!this._materializingOwner || this._materializingOwnerAdapter !== asyncContext) {
+      this._materializingOwner = asyncContext.create<symbol>();
+      this._materializingOwnerAdapter = asyncContext;
     }
-    return this._materializing;
+    return this._materializingOwner;
   }
 
   async materializeTransactions(): Promise<void> {
     // Re-entrant call from inside an in-progress materializeBang on the same
     // chain — skip to avoid infinite recursion (queries issued by
-    // materializeBang itself call back into here). Async-chain-aware so a
-    // foreign chain falls through to wait on _materializingPromise instead of
-    // racing to issue queries against an unmaterialized stack.
-    if (this._materializingStorage().getStore() === true) return;
+    // materializeBang itself call back into here). Owner-token check so a
+    // foreign chain (no token, or stale token from an earlier completed pass)
+    // falls through to wait on _materializingPromise instead of racing to
+    // issue queries against an unmaterialized stack.
+    const storage = this._materializingStorage();
+    if (this._currentMaterializingOwner && storage.getStore() === this._currentMaterializingOwner) {
+      return;
+    }
     if (this._materializingPromise) {
+      // Surfaces materialization failures to foreign waiters (otherwise they
+      // would proceed assuming a materialized stack and fire queries against
+      // an unmaterialized one).
       await this._materializingPromise;
       return;
     }
     if (!this._hasUnmaterializedTransactions) return;
 
-    let resolveDone!: () => void;
-    this._materializingPromise = new Promise<void>((r) => {
-      resolveDone = r;
-    });
-    try {
-      await this._materializingStorage().run(true, async () => {
+    const owner = Symbol("tm.materialize");
+    const op = (async () => {
+      await storage.run(owner, async () => {
         for (const t of this._stack) {
           if (t instanceof Transaction && !t.isMaterialized()) {
             await t.materializeBang();
@@ -983,9 +991,14 @@ export class TransactionManager {
         }
       });
       this._hasUnmaterializedTransactions = false;
+    })();
+    this._materializingPromise = op;
+    this._currentMaterializingOwner = owner;
+    try {
+      await op;
     } finally {
+      this._currentMaterializingOwner = null;
       this._materializingPromise = null;
-      resolveDone();
     }
   }
 
@@ -1053,40 +1066,60 @@ export class TransactionManager {
    * recursive call from inside the body (e.g. `after_commit` re-entry) skips
    * re-acquisition to avoid self-deadlock.
    *
+   * Token-based ownership: each acquisition mints a fresh symbol stored both
+   * in the AsyncContext and in `_currentLockOwner`. Reentry requires both to
+   * match — so a detached task that inherits the AsyncContext but outlives
+   * the holder's release (token cleared) correctly re-acquires the lock.
+   *
    * @internal
    */
-  private _lockStorage(): AsyncContext<true> {
+  private _lockStorage(): AsyncContext<symbol> {
     const asyncContext = getAsyncContext();
-    if (!this._lockHeld || this._lockHeldAdapter !== asyncContext) {
-      this._lockHeld = asyncContext.create<true>();
-      this._lockHeldAdapter = asyncContext;
+    if (!this._lockOwner || this._lockOwnerAdapter !== asyncContext) {
+      this._lockOwner = asyncContext.create<symbol>();
+      this._lockOwnerAdapter = asyncContext;
     }
-    return this._lockHeld;
+    return this._lockOwner;
+  }
+
+  /**
+   * Run `fn` under the per-connection lock that serializes
+   * {@link withinNewTransaction}. Mirrors Rails'
+   * `@connection.lock.synchronize do … end` so callers can extend the lock
+   * scope across pre-/post-transaction work (e.g. DDL setup) without
+   * starting a transaction. Same reentrance rules as
+   * {@link withinNewTransaction}.
+   */
+  async synchronize<T>(fn: () => Promise<T> | T): Promise<T> {
+    const storage = this._lockStorage();
+    if (this._currentLockOwner && storage.getStore() === this._currentLockOwner) {
+      return await fn();
+    }
+    while (this._lockChain) {
+      await this._lockChain;
+    }
+    const owner = Symbol("tm.lock");
+    let release!: () => void;
+    this._lockChain = new Promise<void>((r) => {
+      release = () => {
+        this._lockChain = null;
+        this._currentLockOwner = null;
+        r();
+      };
+    });
+    this._currentLockOwner = owner;
+    try {
+      return await storage.run(owner, () => fn());
+    } finally {
+      release();
+    }
   }
 
   async withinNewTransaction<T>(
     options: { isolation?: string | null; joinable?: boolean },
     fn: (tx: UserTransaction) => Promise<T> | T,
   ): Promise<T> {
-    const storage = this._lockStorage();
-    if (storage.getStore() === true) {
-      return await this._withinNewTransactionBody(options, fn);
-    }
-    while (this._lockChain) {
-      await this._lockChain;
-    }
-    let release!: () => void;
-    this._lockChain = new Promise<void>((r) => {
-      release = () => {
-        this._lockChain = null;
-        r();
-      };
-    });
-    try {
-      return await storage.run(true, () => this._withinNewTransactionBody(options, fn));
-    } finally {
-      release();
-    }
+    return await this.synchronize(() => this._withinNewTransactionBody(options, fn));
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -833,7 +833,6 @@ export class TransactionManager {
   private _stack: (Transaction | NullTransaction)[] = [];
   private _connection: TransactionConnection;
   private _hasUnmaterializedTransactions = false;
-  private _materializingTransactions = false;
   private _lazyTransactionsEnabled = true;
   /** @internal Async-chain re-entrancy flag for {@link withinNewTransaction}. */
   private _lockHeld: AsyncContext<true> | null = null;
@@ -841,6 +840,10 @@ export class TransactionManager {
   private _lockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
   /** @internal Outermost-call mutex; non-null while a foreign chain holds it. */
   private _lockChain: Promise<void> | null = null;
+  /** @internal Async-chain re-entrancy flag for {@link materializeTransactions}. */
+  private _materializing: AsyncContext<true> | null = null;
+  /** @internal Cached AsyncContext adapter for the materialize flag. */
+  private _materializingAdapter: ReturnType<typeof getAsyncContext> | null = null;
   /** @internal In-flight materialization promise for cross-chain waiters. */
   private _materializingPromise: Promise<void> | null = null;
 
@@ -944,14 +947,23 @@ export class TransactionManager {
     });
   }
 
+  /** @internal */
+  private _materializingStorage(): AsyncContext<true> {
+    const asyncContext = getAsyncContext();
+    if (!this._materializing || this._materializingAdapter !== asyncContext) {
+      this._materializing = asyncContext.create<true>();
+      this._materializingAdapter = asyncContext;
+    }
+    return this._materializing;
+  }
+
   async materializeTransactions(): Promise<void> {
     // Re-entrant call from inside an in-progress materializeBang on the same
     // chain — skip to avoid infinite recursion (queries issued by
-    // materializeBang itself call back into here).
-    if (this._materializingTransactions) return;
-    // Foreign-chain caller: wait for the in-flight pass to finish before
-    // proceeding so this caller observes a materialized stack rather than
-    // racing to issue queries against an unmaterialized one.
+    // materializeBang itself call back into here). Async-chain-aware so a
+    // foreign chain falls through to wait on _materializingPromise instead of
+    // racing to issue queries against an unmaterialized stack.
+    if (this._materializingStorage().getStore() === true) return;
     if (this._materializingPromise) {
       await this._materializingPromise;
       return;
@@ -962,16 +974,16 @@ export class TransactionManager {
     this._materializingPromise = new Promise<void>((r) => {
       resolveDone = r;
     });
-    this._materializingTransactions = true;
     try {
-      for (const t of this._stack) {
-        if (t instanceof Transaction && !t.isMaterialized()) {
-          await t.materializeBang();
+      await this._materializingStorage().run(true, async () => {
+        for (const t of this._stack) {
+          if (t instanceof Transaction && !t.isMaterialized()) {
+            await t.materializeBang();
+          }
         }
-      }
+      });
       this._hasUnmaterializedTransactions = false;
     } finally {
-      this._materializingTransactions = false;
       this._materializingPromise = null;
       resolveDone();
     }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -6,7 +6,12 @@ import {
   NotImplementedError,
   TransactionIsolationError,
 } from "../../errors.js";
-import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
+import {
+  Notifications,
+  NotificationEvent,
+  getAsyncContext,
+  type AsyncContext,
+} from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
@@ -830,6 +835,14 @@ export class TransactionManager {
   private _hasUnmaterializedTransactions = false;
   private _materializingTransactions = false;
   private _lazyTransactionsEnabled = true;
+  /** @internal Async-chain re-entrancy flag for {@link withinNewTransaction}. */
+  private _lockHeld: AsyncContext<true> | null = null;
+  /** @internal Cached AsyncContext adapter (refresh on swap, like other call sites). */
+  private _lockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
+  /** @internal Outermost-call mutex; non-null while a foreign chain holds it. */
+  private _lockChain: Promise<void> | null = null;
+  /** @internal In-flight materialization promise for cross-chain waiters. */
+  private _materializingPromise: Promise<void> | null = null;
 
   static readonly NULL_TRANSACTION = Object.freeze(new NullTransaction());
 
@@ -932,20 +945,35 @@ export class TransactionManager {
   }
 
   async materializeTransactions(): Promise<void> {
+    // Re-entrant call from inside an in-progress materializeBang on the same
+    // chain — skip to avoid infinite recursion (queries issued by
+    // materializeBang itself call back into here).
     if (this._materializingTransactions) return;
+    // Foreign-chain caller: wait for the in-flight pass to finish before
+    // proceeding so this caller observes a materialized stack rather than
+    // racing to issue queries against an unmaterialized one.
+    if (this._materializingPromise) {
+      await this._materializingPromise;
+      return;
+    }
+    if (!this._hasUnmaterializedTransactions) return;
 
-    if (this._hasUnmaterializedTransactions) {
-      try {
-        this._materializingTransactions = true;
-        for (const t of this._stack) {
-          if (t instanceof Transaction && !t.isMaterialized()) {
-            await t.materializeBang();
-          }
+    let resolveDone!: () => void;
+    this._materializingPromise = new Promise<void>((r) => {
+      resolveDone = r;
+    });
+    this._materializingTransactions = true;
+    try {
+      for (const t of this._stack) {
+        if (t instanceof Transaction && !t.isMaterialized()) {
+          await t.materializeBang();
         }
-      } finally {
-        this._materializingTransactions = false;
       }
       this._hasUnmaterializedTransactions = false;
+    } finally {
+      this._materializingTransactions = false;
+      this._materializingPromise = null;
+      resolveDone();
     }
   }
 
@@ -1006,7 +1034,51 @@ export class TransactionManager {
     this._connection.clearCacheBang?.();
   }
 
+  /**
+   * Async-chain-aware mutex storage. Mirrors Rails'
+   * `@connection.lock.synchronize` (`abstract/transaction.rb:622`): outermost
+   * `within_new_transaction` calls on the same connection serialize, but a
+   * recursive call from inside the body (e.g. `after_commit` re-entry) skips
+   * re-acquisition to avoid self-deadlock.
+   *
+   * @internal
+   */
+  private _lockStorage(): AsyncContext<true> {
+    const asyncContext = getAsyncContext();
+    if (!this._lockHeld || this._lockHeldAdapter !== asyncContext) {
+      this._lockHeld = asyncContext.create<true>();
+      this._lockHeldAdapter = asyncContext;
+    }
+    return this._lockHeld;
+  }
+
   async withinNewTransaction<T>(
+    options: { isolation?: string | null; joinable?: boolean },
+    fn: (tx: UserTransaction) => Promise<T> | T,
+  ): Promise<T> {
+    const storage = this._lockStorage();
+    if (storage.getStore() === true) {
+      return await this._withinNewTransactionBody(options, fn);
+    }
+    while (this._lockChain) {
+      await this._lockChain;
+    }
+    let release!: () => void;
+    this._lockChain = new Promise<void>((r) => {
+      release = () => {
+        this._lockChain = null;
+        r();
+      };
+    });
+    try {
+      return await storage.run(true, () => this._withinNewTransactionBody(options, fn));
+    } finally {
+      release();
+    }
+  }
+
+  /** @internal */
+  private async _withinNewTransactionBody<T>(
     options: { isolation?: string | null; joinable?: boolean },
     fn: (tx: UserTransaction) => Promise<T> | T,
   ): Promise<T> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -167,7 +167,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return this.driver?.isOpen() ?? false;
   }
   private _inTransaction = false;
-  private _savepointCounter = 0;
   private _readonly: boolean;
   private _strict: boolean;
   private _preventWrites = false;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -758,7 +758,7 @@ class SchemaAdapter implements DatabaseAdapter {
       const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
       // Force TM materialization (BEGIN on the wire) before SAVEPOINT — TM uses
       // lazy materialization so openTransactions>0 alone doesn't mean BEGIN was sent.
-      // Since Phase 8 (#TBD) materializeTransactions() awaits any in-flight
+      // Since Phase 8 (#1669) materializeTransactions() awaits any in-flight
       // materialization on another chain, so concurrent statements inside the
       // same lazy transaction no longer race SAVEPOINT-before-BEGIN.
       if (useSp) await this.materializeTransactions();

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -993,7 +993,7 @@ class SchemaAdapter implements DatabaseAdapter {
       await this.setup();
       return await inner.withinNewTransaction(opts, fn);
     };
-    const tm = inner._transactionManager as
+    const tm = inner.transactionManager as
       | { synchronize?<R>(fn: () => Promise<R> | R): Promise<R> }
       | undefined;
     const wrapped = storage.getStore() === true ? run : () => storage.run(true, run);

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -980,17 +980,25 @@ class SchemaAdapter implements DatabaseAdapter {
     opts: { isolation?: string | null; joinable?: boolean },
     fn: (tx?: unknown) => Promise<T> | T,
   ): Promise<T> {
-    // setup() runs before TM enters its frame: MySQL DDL implicit-commits
-    // an open tx; PG would try SAVEPOINT before BEGIN was sent.
-    await this.setup();
     const inner = this.inner as any;
-    // Per-connection serialization moved into TransactionManager in Phase 8.
-    // The wrapper still marks "this chain is inside a TM frame on this
-    // adapter" so _txVisible() can expose transaction state to in-chain
-    // callers without leaking it to foreign chains.
+    // Per-connection serialization lives in TransactionManager in Phase 8
+    // (#1669). Wrap setup() in the same TM-owned mutex so lazy DDL can't
+    // interleave with a concurrent transaction on the shared connection
+    // (MySQL DDL implicit-commits, PG would race SAVEPOINT-before-BEGIN).
+    // The wrapper also tags this async chain so _txVisible() can expose
+    // transaction state to in-chain callers without leaking it across
+    // foreign chains.
     const storage = _txLockStorage();
-    if (storage.getStore() === true) return inner.withinNewTransaction(opts, fn);
-    return await storage.run(true, () => inner.withinNewTransaction(opts, fn));
+    const run = async () => {
+      await this.setup();
+      return await inner.withinNewTransaction(opts, fn);
+    };
+    const tm = inner._transactionManager as
+      | { synchronize?<R>(fn: () => Promise<R> | R): Promise<R> }
+      | undefined;
+    const wrapped = storage.getStore() === true ? run : () => storage.run(true, run);
+    if (tm?.synchronize) return tm.synchronize(wrapped);
+    return wrapped();
   }
 
   currentTransaction() {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -77,29 +77,12 @@ const _registeredModelClasses = new Set<any>();
 // Module-level lock to serialize setup() across all SchemaAdapter instances.
 let _setupLock: Promise<void> | null = null;
 
-// Per-inner-adapter mutex for outermost withinNewTransaction calls. Rails uses
-// `connection.lock.synchronize` to serialize concurrent transactions on a
-// shared connection. Concurrent `Promise.all([Model.create, ...])`
-// callers would otherwise corrupt the TM stack on the shared inner adapter.
-// This mutex restores serialization for that case.
-//
-// Reentrancy: AsyncLocalStorage marks "we already hold the lock in THIS async
-// chain." Nested transaction() calls within the same chain (including those
-// fired by after_commit/after_rollback callbacks before
-// inner.withinNewTransaction returns) skip lock acquisition, avoiding deadlock.
-// A concurrent call from a DIFFERENT async chain sees an empty store and
-// correctly blocks on the mutex.
-//
-// Known limitations (both fixed by Phase 8 — push lock into TM itself):
-//   1. `Promise.all([transaction(M, …, requiresNew), transaction(M, …,
-//      requiresNew)])` started from inside a transaction body shares the
-//      parent's storage flag. Both child branches see "in our own chain"
-//      and skip the mutex, then race the TM stack at await points. Exotic
-//      pattern; the common Promise.all(top-level) case IS serialized.
-//   2. Cross-wrapper manual transactions on the same inner adapter aren't
-//      visible to other wrappers in the same chain (_manualTxDepth is
-//      per-instance). Phase 7 deletes SchemaAdapter so this becomes moot.
-const _withinNewTxLocks = new WeakMap<object, Promise<void>>();
+// Async-chain visibility flag for `currentTransaction()` / `inTransaction` /
+// `openTransactions` on the wrapper. Set while a `withinNewTransaction` body
+// is executing on this chain so callers in OUR chain see the inner adapter's
+// transaction state; callers from foreign chains see an empty wrapper. The
+// per-adapter mutex moved to `TransactionManager` in Phase 8 (Rails parity
+// with `@connection.lock.synchronize`).
 let _txLockHeld: AsyncContext<true> | null = null;
 let _txLockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
 function _txLockStorage(): AsyncContext<true> {
@@ -113,21 +96,6 @@ function _txLockStorage(): AsyncContext<true> {
     _txLockHeldAdapter = asyncContext;
   }
   return _txLockHeld;
-}
-
-async function _acquireWithinNewTxLock(adapter: object): Promise<() => void> {
-  while (_withinNewTxLocks.has(adapter)) {
-    await _withinNewTxLocks.get(adapter);
-  }
-  let release!: () => void;
-  const lock = new Promise<void>((resolve) => {
-    release = () => {
-      _withinNewTxLocks.delete(adapter);
-      resolve();
-    };
-  });
-  _withinNewTxLocks.set(adapter, lock);
-  return release;
 }
 
 // Set true when createTestAdapter() is called; cleared after data cleanup.
@@ -790,12 +758,9 @@ class SchemaAdapter implements DatabaseAdapter {
       const useSp = isPg() && (this.openTransactions > 0 || this.inTransaction);
       // Force TM materialization (BEGIN on the wire) before SAVEPOINT — TM uses
       // lazy materialization so openTransactions>0 alone doesn't mean BEGIN was sent.
-      // Known limitation: TM.materializeTransactions() returns immediately when
-      // another caller is already materializing, so concurrent statements
-      // inside the same lazy transaction can still race SAVEPOINT-before-BEGIN.
-      // The proper fix lives in TransactionManager (Phase 8 of the plan doc).
-      // The outer mutex in withinNewTransaction prevents the cross-transaction
-      // race that hits MariaDB CI; this case requires deeper TM changes.
+      // Since Phase 8 (#TBD) materializeTransactions() awaits any in-flight
+      // materialization on another chain, so concurrent statements inside the
+      // same lazy transaction no longer race SAVEPOINT-before-BEGIN.
       if (useSp) await this.materializeTransactions();
       const sp = useSp ? `_sr_${attempt}` : "";
       try {
@@ -1015,26 +980,17 @@ class SchemaAdapter implements DatabaseAdapter {
     opts: { isolation?: string | null; joinable?: boolean },
     fn: (tx?: unknown) => Promise<T> | T,
   ): Promise<T> {
+    // setup() runs before TM enters its frame: MySQL DDL implicit-commits
+    // an open tx; PG would try SAVEPOINT before BEGIN was sent.
+    await this.setup();
     const inner = this.inner as any;
-    // Detect "nested in our OWN async chain" via AsyncLocalStorage — not via
-    // shared adapter state. An unrelated concurrent transaction on the same
-    // inner adapter must NOT cause us to bypass the mutex (would race the TM
-    // stack); conversely, callbacks fired from within our own transaction
-    // (after_commit, etc.) must skip the lock to avoid self-deadlock.
+    // Per-connection serialization moved into TransactionManager in Phase 8.
+    // The wrapper still marks "this chain is inside a TM frame on this
+    // adapter" so _txVisible() can expose transaction state to in-chain
+    // callers without leaking it to foreign chains.
     const storage = _txLockStorage();
-    const inOurOwnTx = storage.getStore() === true;
-    if (inOurOwnTx) return inner.withinNewTransaction(opts, fn);
-
-    const release = await _acquireWithinNewTxLock(inner);
-    try {
-      // setup() runs before TM enters its frame (mirrors beginTransaction()'s
-      // existing invariant): MySQL DDL implicit-commits an open tx; PG would
-      // try SAVEPOINT before BEGIN was sent.
-      await this.setup();
-      return await storage.run(true, () => inner.withinNewTransaction(opts, fn));
-    } finally {
-      release();
-    }
+    if (storage.getStore() === true) return inner.withinNewTransaction(opts, fn);
+    return await storage.run(true, () => inner.withinNewTransaction(opts, fn));
   }
 
   currentTransaction() {
@@ -1042,7 +998,7 @@ class SchemaAdapter implements DatabaseAdapter {
     // chain's TM frame as joinable. database-statements.transaction() checks
     // currentTransaction() before falling through to withinNewTransaction;
     // if we exposed a foreign frame here it would "join" and bypass the
-    // outer mutex entirely (failure mode: Promise.all top-level transactions
+    // TM mutex entirely (failure mode: Promise.all top-level transactions
     // observing each other's frame as joinable, breaking serialization).
     // Return null when our own chain has no transaction open.
     if (!this._txVisible()) return null;


### PR DESCRIPTION
## Summary

Phase 8 of `docs/tm-unification-plan.md`. Mirrors Rails'
`@connection.lock.synchronize` inside `within_new_transaction`
(`activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:622`)
by moving the per-inner-adapter mutex out of `test-adapter.ts` and
into `TransactionManager` itself. Production callers that share a
connection across async chains now get the same serialization that
the test wrapper has been faking.

- `TransactionManager.withinNewTransaction` acquires a per-instance
  async mutex on the outermost call. Reentrancy from inside the body
  (e.g. `after_commit` issuing another `transaction`) skips
  re-acquisition via an `AsyncContext<true>` flag — Rails `Monitor`
  semantics. Body extracted to private `_withinNewTransactionBody`.
- `materializeTransactions` no longer early-returns when another
  chain is mid-materialization. Foreign callers `await` the in-flight
  pass and observe a materialized stack instead of racing
  SAVEPOINT-before-BEGIN. Same-chain re-entrancy guard (the
  materializeBang-issued-query case) is retained.
- `SchemaAdapter.withinNewTransaction` collapses to setup() +
  storage-tagged delegation. `_withinNewTxLocks` /
  `_acquireWithinNewTxLock` and the two documented limitations
  (Promise.all-inside-tx + cross-wrapper) are gone.
- Dead `_savepointCounter` field on `SQLite3Adapter` removed
  (#1658 finding).

Resolves the three Phase 1 (#1627) limitations: intra-tx
materialize race, `after_commit` reentry outliving the TM frame, and
mutex placement diverging from Rails. Unblocks Phase 7
(`SchemaAdapter` deletion) — the wrapper no longer owns
serialization state.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/transaction-instrumentation.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-through-associations.test.ts`
- [ ] CI: live PG + MySQL/MariaDB matrix (the cross-file flakes Phase 8 targets)