### PR TITLE
feat(activerecord): Associations-reflection Slot C residual — Hotel/Department/Chef fixtures + builder fix

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -928,7 +928,7 @@ export function buildHasOne(
     buildAttrs[`${underscore(options.as)}_type`] = ctor.name;
   }
 
-  let targetModel = resolveModel(className);
+  let targetModel = resolveAssocClass(record, _assocName, className);
   const inheritanceCol = getInheritanceColumn(targetModel);
   if (inheritanceCol && buildAttrs[inheritanceCol]) {
     const typeName = buildAttrs[inheritanceCol] as string;
@@ -951,7 +951,7 @@ export function buildBelongsTo(
 ): Base {
   const className = options.className ?? camelize(_assocName);
 
-  let targetModel = resolveModel(className);
+  let targetModel = resolveAssocClass(_record, _assocName, className);
   const inheritanceCol = getInheritanceColumn(targetModel);
   if (inheritanceCol && attrs[inheritanceCol]) {
     const typeName = attrs[inheritanceCol] as string;
@@ -1379,7 +1379,7 @@ export async function loadHasOneThrough(
   const targetFk = `${underscore(sourceName)}_id`;
   const fkValue = throughRecord._readAttribute(targetFk);
   if (fkValue === null || fkValue === undefined) return null;
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(throughRecord, sourceName, className);
   return targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
 }
 
@@ -1515,7 +1515,7 @@ export async function loadHabtm(
 
   const ctor = record.constructor as typeof Base;
   const className = options.className ?? camelize(singularize(assocName));
-  const targetModel = resolveModel(className);
+  const targetModel = resolveAssocClass(record, assocName, className);
   const joinTable = options.joinTable ?? defaultJoinTableName(ctor, assocName);
   const ownerFk = singleFk(options.foreignKey, `${underscore(ctor.name)}_id`);
   const targetFk = `${underscore(singularize(assocName))}_id`;
@@ -1576,7 +1576,9 @@ export async function processDependentAssociations(record: Base): Promise<void> 
         }
       } else if (dep === "delete") {
         // Bulk delete avoids N+1 on join tables (HABTM middle hasMany)
-        const childModel = resolveModel(
+        const childModel = resolveAssocClass(
+          record,
+          assoc.name,
           (assoc.options.className as string) ?? camelize(singularize(assoc.name)),
         );
         const fk = (assoc.options.foreignKey as string) ?? `${underscore(ctor.name)}_id`;
@@ -1996,7 +1998,7 @@ export async function updateCounterCaches(
     } else {
       className = assoc.options.className ?? camelize(assoc.name);
     }
-    const targetModel = resolveModel(className);
+    const targetModel = resolveAssocClass(record, assoc.name, className);
 
     // Counter column name
     const counterCol =
@@ -2239,7 +2241,7 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
     } else {
       className = assoc.options.className ?? camelize(assoc.name);
     }
-    const targetModel = resolveModel(className);
+    const targetModel = resolveAssocClass(record, assoc.name, className);
 
     const parent = await targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
     if (!parent) continue;

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1458,8 +1458,36 @@ describe("ReflectionTest", () => {
     expect(ref).not.toBeNull();
     expect(ref!.name).toBe("books");
   });
-  it.skip("reflect on missing source assocation raise exception", () => {
-    // BLOCKED: Hotel/Chef fixture models + check_validity! not yet ported — Slot C.
+  it("reflect on missing source assocation raise exception", () => {
+    // Mirrors Rails test/cases/reflection_test.rb: Hotel has_many :lost_items,
+    // through: :departments; Department has no :lost_items assoc.
+    class MsHotel extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class MsDepartment extends Base {
+      static {
+        this.attribute("hotel_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("MsHotel", MsHotel);
+    registerModel("MsDepartment", MsDepartment);
+    Associations.hasMany.call(MsHotel, "departments", {
+      className: "MsDepartment",
+      foreignKey: "hotel_id",
+    });
+    Associations.hasMany.call(MsHotel, "lostItems", {
+      through: "departments",
+      className: "MsLostItem",
+    });
+
+    const ref = reflectOnAssociation(MsHotel, "lostItems") as ThroughReflection;
+    expect(ref).not.toBeNull();
+    expect(ref.sourceReflection).toBeNull();
+    expect(() => (ref as any).checkValidityBang()).toThrow(/Could not find the source association/);
   });
   it.skip("name error from incidental code is not converted to name error for association", () => {
     // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.


### PR DESCRIPTION
## Summary

- Un-skips `reflect on missing source assocation raise exception` using inline `MsHotel`/`MsDepartment` fixtures mirroring Rails' `Hotel has_many :lost_items, through: :departments` where Department has no `:lost_items` source. The TS `ThroughReflection#checkValidityBang` already raises `HasManyThroughSourceAssociationNotFoundError`; this exercises it end-to-end.
- Sweeps 7 `resolveModel(className)` call-sites to `resolveAssocClass(record, assocName, className)` so namespace-aware `reflection.klass` wins over the flat registry: `loadHasOneThrough` fallback, `loadHabtm`, `processDependentAssociations` (delete branch), `updateCounterCaches`, `touchBelongsToParents`, `buildHasOne`, `buildBelongsTo`.

## Followups deferred

- **HABTM builder ThroughReflection wrap** — tried locally (keep `through:` in `habtmReflectionOptions` so `Reflection.create` wraps in `ThroughReflection`, plus drop the `throughReflection?.macro === "hasAndBelongsToMany"` workaround in `ThroughReflection#isNested`). Broke `singular ids are reloaded after collection concat` (`proxy.push` → `projectIds` reload). Some consumer downstream branches on `reflection.macro` / wraps-vs-doesn't and needs an audit before flipping. Reverted in this PR; leaving the workaround in place.
- `MacroReflection.computeClass` error message wording divergence — pre-existing.
- `belongs-to.ts:188` counter-cache call-site is polymorphic (resolves via the `_type` column value) — `resolveModel` is intentional there.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/reflection.test.ts` — new test passes; no regressions
- [x] HABTM suites: `has-and-belongs-to-many-associations.test.ts`, `associations/habtm.test.ts`, `habtm-destroy-order.test.ts` — all green
- [x] Broader associations suite: `associations.test.ts`, `has-many-associations.test.ts`, `has-one-associations.test.ts`, `belongs-to-associations.test.ts` — all green (888 passed)