### PR TITLE
feat(action-dispatch): Wave 7 PR 8 — journey/formatter

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/formatter.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { Parser } from "./parser.js";
+import { Ast } from "./ast.js";
+import { Pattern } from "./path/pattern.js";
+import { Route } from "./route.js";
+import { Routes } from "./routes.js";
+import { Formatter, MissingRoute, RouteWithParams, UrlGenerationError } from "./formatter.js";
+
+function makePattern(path: string, requirements: Record<string, RegExp> = {}): Pattern {
+  const tree = new Parser().parse(path);
+  const ast = new Ast(tree, true);
+  return new Pattern(ast, requirements, "/.?", true);
+}
+
+function makeRoute(
+  name: string,
+  path: string,
+  opts: {
+    defaults?: Record<string, unknown>;
+    requirements?: Record<string, RegExp>;
+    requiredDefaults?: readonly string[];
+    dispatcher?: boolean;
+  } = {},
+): Route {
+  const app = opts.dispatcher ? { dispatcher: () => true } : undefined;
+  return new Route({
+    name,
+    app,
+    path: makePattern(path, opts.requirements ?? {}),
+    defaults: opts.defaults ?? {},
+    requiredDefaults: opts.requiredDefaults,
+  });
+}
+
+function buildHost(named: Record<string, Route>, routesList: Route[] = Object.values(named)) {
+  const routes = new Routes(routesList);
+  for (const r of routesList) routes.partitionRoute(r);
+  return {
+    routes,
+    namedRoutes: {
+      has: (n: string) => Object.hasOwn(named, n),
+      get: (n: string) => named[n],
+    },
+  };
+}
+
+describe("ActionDispatch::Journey::Formatter", () => {
+  it("generates a URL for a named route", () => {
+    const r = makeRoute("show", "/posts/:id(.:format)");
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", { id: 7 }, {});
+    expect(result).toBeInstanceOf(RouteWithParams);
+    expect((result as RouteWithParams).path()).toBe("/posts/7");
+  });
+
+  it("preserves extra options as query params (deleting consumed keys)", () => {
+    const r = makeRoute("show", "/posts/:id");
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", { id: 1, page: 2 }, {}) as RouteWithParams;
+    expect(result.path()).toBe("/posts/1");
+    expect(result.params).toEqual({ page: 2 });
+  });
+
+  it("returns MissingRoute when required parts are missing", () => {
+    const r = makeRoute("show", "/posts/:id");
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", {}, {});
+    expect(result).toBeInstanceOf(MissingRoute);
+    expect((result as MissingRoute).missingKeys).toEqual(["id"]);
+  });
+
+  it("MissingRoute#path raises UrlGenerationError", () => {
+    const r = makeRoute("show", "/posts/:id");
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", {}, {}) as MissingRoute;
+    expect(() => result.path("post_path")).toThrow(UrlGenerationError);
+  });
+
+  it("anonymous lookup only picks dispatcher routes", () => {
+    const dispatchable = makeRoute("a", "/a", { dispatcher: true });
+    const plain = makeRoute("b", "/b");
+    const host = buildHost({}, [dispatchable, plain]);
+    const f = new Formatter(host);
+    expect(f.generate(null, {}, {})).toBeInstanceOf(RouteWithParams);
+  });
+
+  it("anonymous lookup with no dispatcher routes returns MissingRoute", () => {
+    const plain = makeRoute("b", "/b");
+    const host = buildHost({}, [plain]);
+    const f = new Formatter(host);
+    expect(f.generate(null, {}, {})).toBeInstanceOf(MissingRoute);
+  });
+
+  it("strips trailing parts equal to defaults", () => {
+    const r = makeRoute("idx", "/:controller(/:action(/:id))", {
+      defaults: { action: "index" },
+    });
+    const f = new Formatter(buildHost({ idx: r }));
+    const result = f.generate(
+      "idx",
+      { controller: "posts", action: "index" },
+      {},
+    ) as RouteWithParams;
+    expect(result.path()).toBe("/posts");
+  });
+
+  it("keeps trailing parts that differ from defaults", () => {
+    const r = makeRoute("idx", "/:controller(/:action)", {
+      defaults: { action: "index" },
+    });
+    const f = new Formatter(buildHost({ idx: r }));
+    const result = f.generate(
+      "idx",
+      { controller: "posts", action: "edit" },
+      {},
+    ) as RouteWithParams;
+    expect(result.path()).toBe("/posts/edit");
+  });
+
+  it("validates parts against requirements regex (missing_keys)", () => {
+    const r = makeRoute("show", "/posts/:id", { requirements: { id: /\d+/ } });
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", { id: "abc" }, {});
+    expect(result).toBeInstanceOf(MissingRoute);
+    expect((result as MissingRoute).unmatchedKeys).toContain("id");
+  });
+
+  it("clear() and eagerLoadBang() exercise the cache", () => {
+    const r = makeRoute("a", "/a", {
+      dispatcher: true,
+      requiredDefaults: ["controller"],
+      defaults: { controller: "x" },
+    });
+    const f = new Formatter(buildHost({}, [r]));
+    f.eagerLoadBang();
+    f.clear();
+    expect(f.generate(null, { controller: "x" }, {})).toBeInstanceOf(RouteWithParams);
+  });
+
+  it("pathParams option merges underneath top-level options", () => {
+    const r = makeRoute("show", "/posts/:id");
+    const f = new Formatter(buildHost({ show: r }));
+    const result = f.generate("show", { pathParams: { id: 1 }, q: "x" }, {}) as RouteWithParams;
+    expect(result.path()).toBe("/posts/1");
+    expect(result.params).toEqual({ q: "x" });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/formatter.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.test.ts
@@ -137,6 +137,16 @@ describe("ActionDispatch::Journey::Formatter", () => {
     expect(f.generate(null, { controller: "x" }, {})).toBeInstanceOf(RouteWithParams);
   });
 
+  it("treats falsey-but-present values (0, empty string) as supplied (Ruby semantics)", () => {
+    const r = makeRoute("show", "/posts/:id");
+    const f = new Formatter(buildHost({ show: r }));
+    const zero = f.generate("show", { id: 0 }, {}) as RouteWithParams;
+    expect(zero.path()).toBe("/posts/0");
+    // Empty string is truthy in Ruby (`unless ""` is false), so it's "supplied".
+    const empty = f.generate("show", { id: "" }, {}) as RouteWithParams;
+    expect(empty.path()).toBe("/posts/");
+  });
+
   it("pathParams option merges underneath top-level options", () => {
     const r = makeRoute("show", "/posts/:id");
     const f = new Formatter(buildHost({ show: r }));

--- a/packages/actionpack/src/action-dispatch/journey/formatter.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.ts
@@ -226,7 +226,7 @@ export class Formatter {
     const queue: CacheNode[] = [cache];
     for (let i = 0; i < queue.length; i++) {
       const c = queue[i]!;
-      if (c.routes) routes.push(...c.routes);
+      routes.push(...c.routes);
       for (const [k, v] of Object.entries(options)) {
         const key = pairKey(k, v);
         const child = c.children.get(key);
@@ -274,7 +274,7 @@ export class Formatter {
         }
         h = child;
       }
-      (h.routes ??= []).push([i, route]);
+      h.routes.push([i, route]);
     }
     this._cache = root;
     return root;
@@ -320,6 +320,10 @@ function rubyInspect(v: unknown): string {
   if (v == null) return "nil";
   if (typeof v === "string") return `"${escapeRubyString(v)}"`;
   if (typeof v === "symbol") return `:${v.description ?? ""}`;
+  if (Array.isArray(v)) return rubyInspectArray(v);
+  if (typeof v === "object") {
+    return rubyInspectHash(Object.entries(v as Record<string, unknown>));
+  }
   return String(v);
 }
 

--- a/packages/actionpack/src/action-dispatch/journey/formatter.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.ts
@@ -1,4 +1,7 @@
+import { UrlGenerationError } from "../../action-controller/metal/exceptions.js";
 import type { Route } from "./route.js";
+
+export { UrlGenerationError };
 
 /**
  * Host shape the Formatter needs from the higher-level RouteSet.
@@ -23,22 +26,6 @@ export class RouteWithParams {
   /** Rails `path(_)` — argument unused, kept for parity with MissingRoute. */
   path(_methodName?: string): string {
     return this._route.format(this._parameterizedParts);
-  }
-}
-
-/**
- * Thrown when `generate` cannot find a matching route. Mirrors Rails'
- * `ActionController::UrlGenerationError`.
- */
-export class UrlGenerationError extends Error {
-  constructor(
-    message: string,
-    readonly routes: FormatterHost,
-    readonly routeName: string | null,
-    readonly methodName: string,
-  ) {
-    super(message);
-    this.name = "UrlGenerationError";
   }
 }
 
@@ -208,11 +195,12 @@ export class Formatter {
 
     const routes = this._nonRecursive(this._buildOrGetCache(), options);
 
-    const suppliedKeys: Record<string, boolean> = {};
+    // Rails: `h[k.to_s] = true if v` — Ruby truthiness only excludes nil/false,
+    // so `0` and `""` are considered supplied.
+    const suppliedSet = new Set<string>();
     for (const [k, v] of Object.entries(options)) {
-      if (v) suppliedKeys[String(k)] = true;
+      if (v != null && v !== false) suppliedSet.add(String(k));
     }
-    const suppliedSet = new Set(Object.keys(suppliedKeys));
 
     const buckets = new Map<number, [number, Route][]>();
     for (const entry of routes) {
@@ -235,9 +223,8 @@ export class Formatter {
   private _nonRecursive(cache: CacheNode, options: Record<string, unknown>): [number, Route][] {
     const routes: [number, Route][] = [];
     const queue: CacheNode[] = [cache];
-
-    while (queue.length > 0) {
-      const c = queue.shift()!;
+    for (let i = 0; i < queue.length; i++) {
+      const c = queue[i]!;
       if (c.routes) routes.push(...c.routes);
       for (const [k, v] of Object.entries(options)) {
         const key = pairKey(k, v);
@@ -255,7 +242,9 @@ export class Formatter {
     for (const key of route.requiredParts) {
       const test = tests[key];
       if (test == null) {
-        if (!parts[key]) {
+        // Ruby `unless parts[key]` — only nil/false count as missing.
+        const v = parts[key];
+        if (v == null || v === false) {
           (missing ??= []).push(key);
         }
       } else {

--- a/packages/actionpack/src/action-dispatch/journey/formatter.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.ts
@@ -1,0 +1,350 @@
+import type { Route } from "./route.js";
+
+/**
+ * Host shape the Formatter needs from the higher-level RouteSet.
+ *
+ * Rails: `routes.named_routes` is the RouteSet's NamedRouteCollection and
+ * `routes.routes` is the underlying Journey::Routes collection. Until
+ * NamedRouteCollection lands in a later wave, callers pass any object
+ * conforming to this shape.
+ */
+export interface FormatterHost {
+  routes: { routes: readonly Route[] };
+  namedRoutes: { has(name: string): boolean; get(name: string): Route | undefined };
+}
+
+export class RouteWithParams {
+  constructor(
+    private readonly _route: Route,
+    private readonly _parameterizedParts: Record<string, unknown>,
+    readonly params: Record<string, unknown>,
+  ) {}
+
+  /** Rails `path(_)` — argument unused, kept for parity with MissingRoute. */
+  path(_methodName?: string): string {
+    return this._route.format(this._parameterizedParts);
+  }
+}
+
+/**
+ * Thrown when `generate` cannot find a matching route. Mirrors Rails'
+ * `ActionController::UrlGenerationError`.
+ */
+export class UrlGenerationError extends Error {
+  constructor(
+    message: string,
+    readonly routes: FormatterHost,
+    readonly routeName: string | null,
+    readonly methodName: string,
+  ) {
+    super(message);
+    this.name = "UrlGenerationError";
+  }
+}
+
+export class MissingRoute {
+  constructor(
+    readonly constraints: Record<string, unknown>,
+    readonly missingKeys: readonly string[],
+    readonly unmatchedKeys: readonly string[],
+    readonly routes: FormatterHost,
+    readonly name: string | null,
+  ) {}
+
+  path(methodName: string): never {
+    throw new UrlGenerationError(this.message, this.routes, this.name, methodName);
+  }
+
+  get params(): never {
+    return this.path("unknown");
+  }
+
+  get message(): string {
+    const sorted = Object.entries(this.constraints).sort(([a], [b]) =>
+      a < b ? -1 : a > b ? 1 : 0,
+    );
+    let msg = `No route matches ${rubyInspectHash(sorted)}`;
+    if (this.missingKeys.length > 0) {
+      msg += `, missing required keys: ${rubyInspectArray([...this.missingKeys].sort())}`;
+    }
+    if (this.unmatchedKeys.length > 0) {
+      msg += `, possible unmatched constraints: ${rubyInspectArray([...this.unmatchedKeys].sort())}`;
+    }
+    return msg;
+  }
+}
+
+/**
+ * Generates URLs given a name + options + path_parameters. Mirrors Rails'
+ * `ActionDispatch::Journey::Formatter`.
+ */
+export class Formatter {
+  readonly routes: FormatterHost;
+  /** @internal */
+  private _cache: CacheNode | null = null;
+
+  constructor(routes: FormatterHost) {
+    this.routes = routes;
+  }
+
+  generate(
+    name: string | null,
+    options: Record<string, unknown>,
+    pathParameters: Record<string, unknown>,
+  ): RouteWithParams | MissingRoute {
+    const originalOptions = { ...options };
+    let pathParams: Record<string, unknown> | null = null;
+    const rawPathParams = options["pathParams"];
+    options = { ...options };
+    delete options["pathParams"];
+    if (isPlainObject(rawPathParams)) {
+      pathParams = rawPathParams as Record<string, unknown>;
+      options = { ...pathParams, ...options };
+    }
+    const constraints = { ...pathParameters, ...options };
+    let missingKeys: string[] | null = null;
+
+    for (const route of this._matchRoute(name, constraints)) {
+      const parameterizedParts = this._extractParameterizedParts(route, options, pathParameters);
+
+      // Skip this route unless a name has been provided or it is a standard Rails
+      // route since we can't determine whether an options hash passed to url_for
+      // matches a Rack application or a redirect.
+      if (!name && !route.isDispatcher()) continue;
+
+      missingKeys = this._missingKeys(route, parameterizedParts);
+      if (missingKeys && missingKeys.length > 0) continue;
+
+      const remainingOptions = { ...options };
+      for (const key of Object.keys(remainingOptions)) {
+        if (
+          Object.hasOwn(parameterizedParts, key) ||
+          Object.hasOwn(route.defaults, key) ||
+          (pathParams && Object.hasOwn(pathParams, key) && !Object.hasOwn(originalOptions, key))
+        ) {
+          delete remainingOptions[key];
+        }
+      }
+
+      const defaults = route.defaults;
+      const requiredParts = route.requiredParts;
+      const parts = [...route.parts];
+
+      for (let i = parts.length - 1; i >= 0; i--) {
+        const key = parts[i];
+        const partVal = parameterizedParts[key];
+        if (defaults[key] == null && isPresent(partVal)) break;
+        if (toS(partVal) !== toS(defaults[key])) continue;
+        if (requiredParts.includes(key)) break;
+        delete parameterizedParts[key];
+      }
+
+      return new RouteWithParams(route, parameterizedParts, remainingOptions);
+    }
+
+    const constraintKeys = Object.keys(constraints);
+    const unmatchedKeys = (missingKeys ?? []).filter((k) => constraintKeys.includes(k));
+    const trulyMissing = (missingKeys ?? []).filter((k) => !unmatchedKeys.includes(k));
+
+    return new MissingRoute(constraints, trulyMissing, unmatchedKeys, this.routes, name);
+  }
+
+  clear(): void {
+    this._cache = null;
+  }
+
+  eagerLoadBang(): void {
+    this._buildOrGetCache();
+  }
+
+  /** @internal */
+  private _extractParameterizedParts(
+    route: Route,
+    options: Record<string, unknown>,
+    recall: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const parameterizedParts: Record<string, unknown> = { ...recall, ...options };
+
+    const parts = [...route.parts].reverse();
+    let dropping = true;
+    const keysToKeep = new Set<string>();
+    for (const part of parts) {
+      if (dropping) {
+        const supplied = Object.hasOwn(options, part) || Object.hasOwn(route.scopeOptions, part);
+        const present = options[part] != null || recall[part] != null;
+        if (supplied && present) dropping = false;
+        else continue;
+      }
+      keysToKeep.add(part);
+    }
+    for (const p of route.requiredParts) keysToKeep.add(p);
+
+    for (const badKey of Object.keys(parameterizedParts)) {
+      if (!keysToKeep.has(badKey)) delete parameterizedParts[badKey];
+    }
+
+    for (const [k, v] of Object.entries(parameterizedParts)) {
+      if (k === "controller") {
+        parameterizedParts[k] = v;
+      } else {
+        parameterizedParts[k] = toParam(v);
+      }
+    }
+
+    for (const k of Object.keys(parameterizedParts)) {
+      if (parameterizedParts[k] == null) delete parameterizedParts[k];
+    }
+    return parameterizedParts;
+  }
+
+  /** @internal */
+  private *_matchRoute(name: string | null, options: Record<string, unknown>): Generator<Route> {
+    const named = this.routes.namedRoutes;
+    if (name != null && named.has(name)) {
+      const r = named.get(name);
+      if (r) yield r;
+      return;
+    }
+
+    const routes = this._nonRecursive(this._buildOrGetCache(), options);
+
+    const suppliedKeys: Record<string, boolean> = {};
+    for (const [k, v] of Object.entries(options)) {
+      if (v) suppliedKeys[String(k)] = true;
+    }
+    const suppliedSet = new Set(Object.keys(suppliedKeys));
+
+    const buckets = new Map<number, [number, Route][]>();
+    for (const entry of routes) {
+      const score = entry[1].score(suppliedSet);
+      let bucket = buckets.get(score);
+      if (!bucket) buckets.set(score, (bucket = []));
+      bucket.push(entry);
+    }
+
+    const scores = [...buckets.keys()].sort((a, b) => b - a);
+    for (const s of scores) {
+      if (s < 0) break;
+      const bucket = buckets.get(s)!;
+      bucket.sort((a, b) => a[0] - b[0]);
+      for (const [, r] of bucket) yield r;
+    }
+  }
+
+  /** @internal */
+  private _nonRecursive(cache: CacheNode, options: Record<string, unknown>): [number, Route][] {
+    const routes: [number, Route][] = [];
+    const queue: CacheNode[] = [cache];
+
+    while (queue.length > 0) {
+      const c = queue.shift()!;
+      if (c.routes) routes.push(...c.routes);
+      for (const [k, v] of Object.entries(options)) {
+        const key = pairKey(k, v);
+        const child = c.children.get(key);
+        if (child) queue.push(child);
+      }
+    }
+    return routes;
+  }
+
+  /** @internal */
+  private _missingKeys(route: Route, parts: Record<string, unknown>): string[] | null {
+    let missing: string[] | null = null;
+    const tests = route.path.requirementsForMissingKeysCheck;
+    for (const key of route.requiredParts) {
+      const test = tests[key];
+      if (test == null) {
+        if (!parts[key]) {
+          (missing ??= []).push(key);
+        }
+      } else {
+        if (!test.test(String(parts[key] ?? ""))) {
+          (missing ??= []).push(key);
+        }
+      }
+    }
+    return missing;
+  }
+
+  /** @internal */
+  private _buildOrGetCache(): CacheNode {
+    if (this._cache) return this._cache;
+    const root: CacheNode = { children: new Map(), routes: [] };
+    const list = this.routes.routes.routes;
+    for (let i = 0; i < list.length; i++) {
+      const route = list[i];
+      let h = root;
+      for (const [k, v] of Object.entries(route.requiredDefaults)) {
+        const key = pairKey(k, v);
+        let child = h.children.get(key);
+        if (!child) {
+          child = { children: new Map(), routes: [] };
+          h.children.set(key, child);
+        }
+        h = child;
+      }
+      (h.routes ??= []).push([i, route]);
+    }
+    this._cache = root;
+    return root;
+  }
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+interface CacheNode {
+  children: Map<string, CacheNode>;
+  routes: [number, Route][];
+}
+
+function pairKey(k: string, v: unknown): string {
+  return JSON.stringify([k, v ?? null]);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isPresent(v: unknown): boolean {
+  if (v == null) return false;
+  if (v === false) return false;
+  if (typeof v === "string") return v.length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === "object") return Object.keys(v).length > 0;
+  return true;
+}
+
+function toS(v: unknown): string {
+  return v == null ? "" : String(v);
+}
+
+function toParam(v: unknown): unknown {
+  if (v == null) return v;
+  if (
+    typeof v === "object" &&
+    "toParam" in v &&
+    typeof (v as { toParam: unknown }).toParam === "function"
+  ) {
+    return (v as { toParam(): unknown }).toParam();
+  }
+  return String(v);
+}
+
+function rubyInspectHash(entries: [string, unknown][]): string {
+  const parts = entries.map(([k, v]) => `:${k}=>${rubyInspect(v)}`);
+  return `{${parts.join(", ")}}`;
+}
+
+function rubyInspectArray(arr: readonly unknown[]): string {
+  return `[${arr.map((x) => rubyInspect(x)).join(", ")}]`;
+}
+
+function rubyInspect(v: unknown): string {
+  if (v == null) return "nil";
+  if (typeof v === "string") return `"${v}"`;
+  if (typeof v === "symbol") return `:${v.description ?? ""}`;
+  return String(v);
+}

--- a/packages/actionpack/src/action-dispatch/journey/formatter.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.ts
@@ -1,3 +1,4 @@
+import { isPlainObject, toParam } from "@blazetrails/activesupport";
 import { UrlGenerationError } from "../../action-controller/metal/exceptions.js";
 import type { Route } from "./route.js";
 
@@ -293,10 +294,6 @@ function pairKey(k: string, v: unknown): string {
   return JSON.stringify([k, v ?? null]);
 }
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
 function isPresent(v: unknown): boolean {
   if (v == null) return false;
   if (v === false) return false;
@@ -310,18 +307,6 @@ function toS(v: unknown): string {
   return v == null ? "" : String(v);
 }
 
-function toParam(v: unknown): unknown {
-  if (v == null) return v;
-  if (
-    typeof v === "object" &&
-    "toParam" in v &&
-    typeof (v as { toParam: unknown }).toParam === "function"
-  ) {
-    return (v as { toParam(): unknown }).toParam();
-  }
-  return String(v);
-}
-
 function rubyInspectHash(entries: [string, unknown][]): string {
   const parts = entries.map(([k, v]) => `:${k}=>${rubyInspect(v)}`);
   return `{${parts.join(", ")}}`;
@@ -333,7 +318,22 @@ function rubyInspectArray(arr: readonly unknown[]): string {
 
 function rubyInspect(v: unknown): string {
   if (v == null) return "nil";
-  if (typeof v === "string") return `"${v}"`;
+  if (typeof v === "string") return `"${escapeRubyString(v)}"`;
   if (typeof v === "symbol") return `:${v.description ?? ""}`;
   return String(v);
+}
+
+function escapeRubyString(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    const code = ch.charCodeAt(0);
+    if (ch === "\\") out += "\\\\";
+    else if (ch === '"') out += '\\"';
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch === "\t") out += "\\t";
+    else if (code < 0x20) out += `\\x${code.toString(16).padStart(2, "0").toUpperCase()}`;
+    else out += ch;
+  }
+  return out;
 }

--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -28,3 +28,10 @@ export {
   type RouteOptions,
 } from "./route.js";
 export { Routes, type Mapping } from "./routes.js";
+export {
+  Formatter,
+  RouteWithParams,
+  MissingRoute,
+  UrlGenerationError,
+  type FormatterHost,
+} from "./formatter.js";

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -194,6 +194,7 @@ export {
   extractKeys,
   toParam,
   toQuery,
+  isPlainObject,
   compact,
   compactBlankObj,
 } from "./hash-utils.js";


### PR DESCRIPTION
## Summary
Ports `action_dispatch/journey/formatter.rb` (Rails 231 LOC) to TypeScript.

- `Formatter` — URL generation with score-based route matching + required-defaults cache.
- `RouteWithParams` / `MissingRoute` returned by `generate`.
- `UrlGenerationError` — TS equivalent of `ActionController::UrlGenerationError`.
- `FormatterHost` interface bridges to the higher-level RouteSet (`routes`, `namedRoutes`) until `NamedRouteCollection` lands in PR 10.

## Notes
- 488 LOC total (350 impl + 138 tests) — single Rails file port, can't split without an artificial seam. Wave 7 mechanical work.
- `dispatcher?` dispatched through `Route#isDispatcher` (duck-typed); will revisit during PR 10 wire-up.
- Rails has no dedicated `formatter_test.rb`; tests here cover the public surface (named/anonymous lookup, defaults trimming, requirements validation, `pathParams` merging, cache clear/eager-load).

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/journey/` — 213 pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean