### PR TITLE
feat(globalid)!: drop purpose: option key, for: is canonical

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -166,23 +166,15 @@ test:compare `global_locator_test.rb`: 33/59 → **37/59 (63%)** with the
 class`, `app locator is case insensitive`, `locator name cannot have
 underscore`). Overall test:compare: 98/158 → **102/158 (64.6%)**.
 
-### GID-10a — Drop `purpose:` option key (~40 LOC, breaking)
+### GID-10a — Drop `purpose:` option key — **done**
 
-Rails has never accepted `purpose:` as an option key — it only reads `for:`
-(`options.fetch :for, DEFAULT_PURPOSE`). `purpose` exists only as the
-internal `@purpose` attribute on the SGID instance. GID-2 introduced
-`purpose:` as a Trails-only option key; GID-5 added `for:` alongside it.
-Match Rails exactly:
-
-- Remove `purpose?: string` from `SignedGlobalIDOptions`, `ParseOptions`,
-  `LocateSignedOptions`, `ToSgidOptions`.
-- Remove the `options.for ?? options.purpose` fallbacks in
-  `SignedGlobalID.create`/`parse` and `Locator.locateSigned` /
-  `locateManySigned`.
-- `SignedGlobalID#purpose` (the instance accessor) stays — that mirrors
-  Rails' `attr_reader :purpose`.
-- Breaking change: any caller passing `{ purpose: "login" }` must switch
-  to `{ for: "login" }`.
+Removed the Trails-only `purpose:` option key from `SignedGlobalIDOptions`,
+`ParseOptions`, `LocateSignedOptions`, and `ToSgidOptions`. `for:` is now
+the only purpose key (Rails-canonical: `options.fetch :for, DEFAULT_PURPOSE`).
+`SignedGlobalID#purpose` (the instance accessor) stays — mirrors Rails'
+`attr_reader :purpose`. Internal verifier payload `purpose:` field is wire
+format and untouched. Breaking: callers passing `{ purpose: "..." }` must
+switch to `{ for: "..." }`.
 
 ### GID-10b — Unify `Base.toGid()` to return GlobalID instance (~80 LOC, breaking)
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -19,10 +19,8 @@ import {
  */
 interface ToSgidOptions {
   app?: string;
-  /** Rails-canonical purpose option. */
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string;
-  /** Alias of `for` kept for backward compatibility. */
-  purpose?: string;
   expiresIn?: number;
   expiresAt?: Temporal.Instant;
   [key: string]: unknown;

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -538,11 +538,11 @@ describe("signedId / findSigned / findSignedBang", () => {
       }
     }
     const u = await User.create({ name: "Dave" });
-    const sgid = await u.toSgid({ purpose: "test", app: "TestApp" });
+    const sgid = await u.toSgid({ for: "test", app: "TestApp" });
     expect(sgid.purpose).toBe("test");
     expect(sgid.uri).toContain(`/${u.id}`);
     const parsed = SignedGlobalID.parse(sgid.toParam(), {
-      purpose: "test",
+      for: "test",
       verifier: signedIdVerifier(User),
     });
     expect(parsed).not.toBeNull();

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -128,7 +128,7 @@ describe("Locator.locateSigned + locateManySigned", () => {
   it("locate_signed returns null for invalid signature or purpose mismatch", async () => {
     const v1 = makeVerifier();
     const v2 = new MessageVerifier("other", { digest: "sha256", url_safe: true });
-    const sgid = SignedGlobalID.create(new Person("7"), { verifier: v1, purpose: "login" });
+    const sgid = SignedGlobalID.create(new Person("7"), { verifier: v1, for: "login" });
     expect(await Locator.locateSigned(sgid.toString(), { verifier: v2 })).toBeNull();
     expect(await Locator.locateSigned(sgid.toString(), { verifier: v1, for: "signup" })).toBeNull();
   });

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -38,8 +38,6 @@ export interface LocateOptions {
 export interface LocateSignedOptions extends LocateOptions {
   /** Purpose to verify against (Rails: `for:`). */
   for?: string;
-  /** Alias of `for` kept consistent with SignedGlobalIDOptions/ParseOptions. */
-  purpose?: string;
   /** Verifier to validate the SGID signature. */
   verifier: MessageVerifier;
 }
@@ -290,8 +288,10 @@ export class Locator {
     sgid: string | SignedGlobalID,
     options: LocateSignedOptions,
   ): Promise<unknown | null> {
-    const purpose = options.for ?? options.purpose;
-    const parsed = SignedGlobalID.parse(String(sgid), { for: purpose, verifier: options.verifier });
+    const parsed = SignedGlobalID.parse(String(sgid), {
+      for: options.for,
+      verifier: options.verifier,
+    });
     if (!parsed) return null;
     return Locator.locate(parsed.uri, options);
   }
@@ -301,10 +301,12 @@ export class Locator {
     sgids: Array<string | SignedGlobalID>,
     options: LocateSignedOptions,
   ): Promise<unknown[]> {
-    const purpose = options.for ?? options.purpose;
     const uris: string[] = [];
     for (const s of sgids) {
-      const parsed = SignedGlobalID.parse(String(s), { for: purpose, verifier: options.verifier });
+      const parsed = SignedGlobalID.parse(String(s), {
+        for: options.for,
+        verifier: options.verifier,
+      });
       if (parsed) uris.push(parsed.uri);
     }
     return Locator.locateMany(uris, options);

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -287,6 +287,16 @@ describe("SignedGlobalIDCustomParamsTest", () => {
     const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
     expect(parsed!.params["hello"]).toBe("world");
   });
+
+  it("purpose key flows through as a URI param (not reserved)", () => {
+    // Rails GlobalID.create strips only (:app, :verifier, :for); any other
+    // key — including :purpose — flows through to URI params. The internal
+    // @purpose attr is set via pick_purpose(:for), not from this URI param.
+    const verifier = makeVerifier();
+    const sgid = SignedGlobalID.create(person(5), { verifier, purpose: "vip" });
+    expect(sgid.params["purpose"]).toBe("vip");
+    expect(sgid.purpose).toBe("default");
+  });
 });
 
 describe("SignedGlobalID (non-Rails coverage)", () => {

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -20,10 +20,8 @@ let _classExpiresIn: number | null | undefined;
 
 export interface SignedGlobalIDOptions {
   app?: string;
-  /** Rails-canonical purpose option. */
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string;
-  /** Alias of `for` kept for backward compatibility. */
-  purpose?: string;
   /** Number of seconds until expiration. `null` explicitly disables expiration (Rails: `expires_in: nil`). */
   expiresIn?: number | null;
   /** Explicit expiration time. `null` explicitly disables expiration (Rails: `expires_at: nil`). */
@@ -35,10 +33,8 @@ export interface SignedGlobalIDOptions {
 }
 
 export interface ParseOptions {
-  /** Rails-canonical purpose option. */
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string;
-  /** Alias of `for` kept for backward compatibility. */
-  purpose?: string;
   /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
   verifier?: MessageVerifier;
 }
@@ -162,8 +158,8 @@ export class SignedGlobalID {
   }
 
   /** Mirrors: SignedGlobalID.pick_purpose. */
-  static pickPurpose(options: { for?: string; purpose?: string }): string {
-    return options.for ?? options.purpose ?? DEFAULT_PURPOSE;
+  static pickPurpose(options: { for?: string }): string {
+    return options.for ?? DEFAULT_PURPOSE;
   }
 
   // ─── Verify dispatch (Rails private class methods) ────────────────────────

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -9,7 +9,12 @@ export type { GlobalIDModel };
 const DEFAULT_PURPOSE = "default";
 
 /** Option keys that are NOT forwarded as GID URI params. @internal */
-const KNOWN_SGID_KEYS = new Set(["app", "for", "purpose", "expiresIn", "expiresAt", "verifier"]);
+// Mirrors GlobalID.create's `options.except(:app, :verifier, :for)` plus
+// the SGID-specific expiration options. Any other key — including
+// `purpose` — flows through to URI params, matching Rails: SGID does
+// not reserve `purpose` as an option, only as the internal @purpose
+// attr set via pick_purpose(:for).
+const KNOWN_SGID_KEYS = new Set(["app", "for", "expiresIn", "expiresAt", "verifier"]);
 
 /** Monotonic counter for stable inspect() ids; mirrors Ruby's object_id. @internal */
 let _nextObjectId = 0;


### PR DESCRIPTION
## Summary
Rails has never accepted \`purpose:\` as an option key on the GlobalID surface. \`vendor/globalid/lib/global_id/signed_global_id.rb:25\`:

\`\`\`ruby
def pick_purpose(options)
  options.fetch :for, DEFAULT_PURPOSE
end
\`\`\`

\`@purpose\` exists only as the internal SGID attribute (\`attr_reader :purpose\` at line 53). GID-2 introduced \`purpose:\` as a Trails-only option-key alias; GID-5 added \`for:\` alongside. This drops the Trails-only alias so the option surface matches Rails exactly.

### Changes
- Remove \`purpose?: string\` from \`SignedGlobalIDOptions\`, \`ParseOptions\`, \`LocateSignedOptions\`, \`ToSgidOptions\`.
- Drop the \`options.for ?? options.purpose\` fallbacks in \`SignedGlobalID.pickPurpose\`, \`Locator.locateSigned\`, \`Locator.locateManySigned\`.
- \`pickPurpose\` body is now exactly \`options.for ?? DEFAULT_PURPOSE\` — semantic parity with the Ruby \`options.fetch :for, DEFAULT_PURPOSE\`.
- \`SignedGlobalID#purpose\` instance accessor stays (mirrors \`attr_reader :purpose\`).
- Internal verifier-payload \`purpose:\` field stays (wire format, not an API surface).
- Updated 2 test call sites that passed \`{ purpose: ... }\` to use \`{ for: ... }\`.

### Breaking
Callers passing \`{ purpose: "..." }\` to \`SignedGlobalID.create\` / \`.parse\` / \`Locator.locateSigned\` / \`.locateManySigned\` / \`Base.toSgid\` / \`.toSgidParam\` / \`.toSignedGlobalId\` must switch to \`{ for: "..." }\`. No deprecation period — the alias was only ever Trails-side, was unreleased, and \`for:\` has been the documented spelling since GID-5.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] globalid suite + AR signed-id test — 189 pass, 9 skipped
- [x] grep across packages confirms no remaining \`purpose:\` option-key callers (only internal SGID attr + wire format)