### PR TITLE
feat(activerecord)!: Base.toGid() returns GlobalID instance

### DIFF
--- a/docs/globalid-plan.md
+++ b/docs/globalid-plan.md
@@ -183,19 +183,11 @@ Match Rails exactly:
 - Breaking change: any caller passing `{ purpose: "login" }` must switch
   to `{ for: "login" }`.
 
-### GID-10b — Unify `Base.toGid()` to return GlobalID instance (~80 LOC, breaking)
+### GID-10b — Unify `Base.toGid()` to return GlobalID instance — **done**
 
-Rails has `to_gid` as an alias of `to_global_id`; both return a GlobalID
-instance. Trails currently has `toGid()` returning the URI string and
-`toGlobalId()` returning the instance — a divergence inherited from GID-1.
-Unify:
-
-- `Base.toGid()` returns a GlobalID instance (alias of `Base.toGlobalId()`).
-- Audit call sites in tests for `expect(u.toGid()).toBe("gid://...")` and
-  rewrite to `.toString()` or `.uri`. Known sites: `signed-id.test.ts`,
-  `calculations.test.ts`. AR's `signed-global-id.ts` may inline-use the
-  string form — switch to `.toString()`.
-- Update CLAUDE.md and any guide docs referencing the string form.
+`Base.toGid()` is now an alias of `Base.toGlobalId()` and returns a
+GlobalID instance, matching Rails' `to_gid → to_global_id` alias.
+Breaking: callers expecting a URI string need `.toString()` or `.uri`.
 
 ### GID-10c — Global `SignedGlobalID.verifier` — **done (shipped in GID-8)**
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,7 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
-  getApp as _getGlobalIdApp,
-  buildGid as _buildGid,
   Locator as _Locator,
   GlobalID as _GlobalIDCtor,
   SignedGlobalID as _SignedGlobalIDType,
@@ -2845,22 +2843,16 @@ export class Base extends Model {
   // slice extracted to persistence.ts.
 
   /**
-   * Return a GlobalID URI for this record.
+   * Return a GlobalID for this record.
    *
-   * Mirrors: ActiveRecord::Base#to_gid
-   *
-   * Requires setApp() from \@blazetrails/globalid to be called first;
-   * throws when no app is configured.
+   * Mirrors: ActiveRecord::Base#to_gid — alias of to_global_id; returns a
+   * GlobalID instance. Requires setApp() from \@blazetrails/globalid to be
+   * called first.
    */
-  toGid(): string {
-    const ctor = this.constructor as typeof Base;
-    const app = _getGlobalIdApp();
-    if (!app) {
-      throw new Error(
-        "An app is required to create a GlobalID. Call setApp() from @blazetrails/globalid before using toGid().",
-      );
-    }
-    return _buildGid(app, ctor.name, this.id);
+  toGid(
+    options?: import("@blazetrails/globalid").GlobalIDOptions,
+  ): import("@blazetrails/globalid").GlobalID {
+    return this.toGlobalId(options);
   }
 
   /**

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6981,7 +6981,7 @@ describe("CalculationsTest", () => {
         }
       }
       const u = await User.create({ name: "Alice" });
-      expect(u.toGid()).toContain("gid://TestApp/User/");
+      expect(u.toGid().toString()).toContain("gid://TestApp/User/");
     } finally {
       _resetApp();
     }

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -290,7 +290,7 @@ describe("toGid", () => {
       }
     }
     const u = await User.create({ name: "Alice" });
-    expect(u.toGid()).toBe(`gid://MyApp/User/${u.id}`);
+    expect(u.toGid().toString()).toBe(`gid://MyApp/User/${u.id}`);
   });
 
   it("throws when no app is configured", async () => {


### PR DESCRIPTION
## Summary
Rails' \`to_gid\` is an alias of \`to_global_id\` — both return a GlobalID instance. Trails inherited a divergence from GID-1 where \`toGid()\` returned the URI string while \`toGlobalId()\` returned the instance. Unify to match Rails.

- \`Base.toGid(options?)\` is now an alias of \`Base.toGlobalId(options?)\` and returns a GlobalID instance.
- Drop unused \`_buildGid\` / \`_getGlobalIdApp\` imports — \`GlobalID.create\` already enforces the app-required guard with the same error.
- Test call sites in \`calculations.test.ts\` and \`signed-id.test.ts\` updated to call \`.toString()\` on the returned GlobalID.

**Breaking:** callers expecting \`Base.toGid()\` to return a string need \`.toString()\` or \`.uri\`. \`Base.findGlobalId\` accepts both string and GlobalID, so passing \`toGid()\` through it still works without changes.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] AR signed-id + calculations + globalid suites — 732 pass, 12 skipped