### PR TITLE
ci: setup-pnpm composite + runner switch for install-heavy jobs

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -51,11 +51,18 @@ runs:
         EXPECTED: ${{ inputs.pnpm-version }}
         STORE_DIR: ${{ inputs.store-dir }}
       run: |
+        set -euo pipefail
         if ! command -v pnpm >/dev/null 2>&1; then
           echo "::error::self-hosted runner has no preinstalled pnpm on PATH — rebuild the runner image"
           exit 1
         fi
-        ACTUAL=$(pnpm --version)
+        # Capture exit status separately: `pnpm --version` can find pnpm on
+        # PATH but fail to execute (e.g. broken Node install), leaving
+        # ACTUAL empty. Report that distinctly from a version mismatch.
+        if ! ACTUAL=$(pnpm --version 2>&1); then
+          echo "::error::pnpm is on PATH but failed to run: $ACTUAL"
+          exit 1
+        fi
         if [ "$ACTUAL" != "$EXPECTED" ]; then
           echo "::error::self-hosted runner has pnpm $ACTUAL; expected $EXPECTED"
           exit 1

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -45,6 +45,16 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
 
+    # setup-node first so the pnpm sanity check below runs under the same
+    # Node the install/build steps will use. If the runner image's system
+    # Node differs from inputs.node-version, validating pnpm under the
+    # wrong Node could spuriously fail (or worse, succeed for the wrong
+    # reason). No `cache: pnpm` — the whole point of the self-hosted path
+    # is to avoid GitHub's hosted cache service.
+    - if: runner.environment != 'github-hosted'
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ inputs.node-version }}
     - if: runner.environment != 'github-hosted'
       shell: bash
       env:
@@ -70,7 +80,3 @@ runs:
         # pnpm config writes to ~/.npmrc, which is OUTSIDE the mounted
         # volume — re-run every job. Cheap no-op when already set.
         pnpm config set store-dir "$STORE_DIR"
-    - if: runner.environment != 'github-hosted'
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-      with:
-        node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -6,15 +6,17 @@ description: Picks hosted vs self-hosted pnpm + cache strategy.
 #
 # Self-hosted runners: use the preinstalled pnpm from the runner image, pin
 # store-dir to the persistent mounted volume, and skip cache: pnpm so no
-# tarballs traverse the WAN. See docs/self-hosted-runner-restart-plan.md
-# for the bandwidth incident context.
+# tarballs traverse the WAN. Context: a prior incident on the home runner
+# burned ~1 TB WAN egress over 36 h because actions/setup-node's pnpm cache
+# pulled the store tarball from GitHub's hosted cache service on every job.
 #
 # Branch selection uses runner.environment != 'github-hosted' so an
 # empty/missing value fails open to the self-hosted branch — surfaces as a
 # loud "no cache" CI run rather than silently fetching from GitHub's cache.
 #
-# Third-party actions are pinned by SHA, not tag, so a retag can't change
-# CI without a PR. Renovate/dependabot bumps the SHAs.
+# Third-party actions are pinned by SHA, not tag, so a retag can't change CI
+# without a PR. There is no Dependabot/Renovate config in this repo yet;
+# SHA bumps are manual until one is added.
 
 inputs:
   pnpm-version:

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -16,23 +16,43 @@ description: Picks hosted vs self-hosted pnpm + cache strategy.
 # Third-party actions are pinned by SHA, not tag, so a retag can't change
 # CI without a PR. Renovate/dependabot bumps the SHAs.
 
+inputs:
+  pnpm-version:
+    description: pnpm version. Hosted installs this; self-hosted asserts the preinstalled pnpm matches.
+    required: false
+    default: "10.27.0"
+  node-version:
+    description: Node.js version for setup-node.
+    required: false
+    default: "22"
+  store-dir:
+    description: pnpm store-dir on self-hosted runners. Must be inside the mounted persistent volume.
+    required: false
+    default: /home/runner/.local/share/pnpm/store
+
 runs:
   using: composite
   steps:
     - if: runner.environment == 'github-hosted'
       uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
-        version: 10.27.0
+        version: ${{ inputs.pnpm-version }}
     - if: runner.environment == 'github-hosted'
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - if: runner.environment != 'github-hosted'
       shell: bash
+      env:
+        EXPECTED: ${{ inputs.pnpm-version }}
+        STORE_DIR: ${{ inputs.store-dir }}
       run: |
-        EXPECTED=10.27.0
+        if ! command -v pnpm >/dev/null 2>&1; then
+          echo "::error::self-hosted runner has no preinstalled pnpm on PATH — rebuild the runner image"
+          exit 1
+        fi
         ACTUAL=$(pnpm --version)
         if [ "$ACTUAL" != "$EXPECTED" ]; then
           echo "::error::self-hosted runner has pnpm $ACTUAL; expected $EXPECTED"
@@ -40,8 +60,8 @@ runs:
         fi
         # pnpm config writes to ~/.npmrc, which is OUTSIDE the mounted
         # volume — re-run every job. Cheap no-op when already set.
-        pnpm config set store-dir /home/runner/.local/share/pnpm/store
+        pnpm config set store-dir "$STORE_DIR"
     - if: runner.environment != 'github-hosted'
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,47 @@
+name: Setup pnpm
+description: Picks hosted vs self-hosted pnpm + cache strategy.
+
+# Hosted runners: install pnpm via action-setup + use GitHub's Actions Cache
+# service for the pnpm store (current behavior).
+#
+# Self-hosted runners: use the preinstalled pnpm from the runner image, pin
+# store-dir to the persistent mounted volume, and skip cache: pnpm so no
+# tarballs traverse the WAN. See docs/self-hosted-runner-restart-plan.md
+# for the bandwidth incident context.
+#
+# Branch selection uses runner.environment != 'github-hosted' so an
+# empty/missing value fails open to the self-hosted branch — surfaces as a
+# loud "no cache" CI run rather than silently fetching from GitHub's cache.
+#
+# Third-party actions are pinned by SHA, not tag, so a retag can't change
+# CI without a PR. Renovate/dependabot bumps the SHAs.
+
+runs:
+  using: composite
+  steps:
+    - if: runner.environment == 'github-hosted'
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      with:
+        version: 10.27.0
+    - if: runner.environment == 'github-hosted'
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: 22
+        cache: pnpm
+
+    - if: runner.environment != 'github-hosted'
+      shell: bash
+      run: |
+        EXPECTED=10.27.0
+        ACTUAL=$(pnpm --version)
+        if [ "$ACTUAL" != "$EXPECTED" ]; then
+          echo "::error::self-hosted runner has pnpm $ACTUAL; expected $EXPECTED"
+          exit 1
+        fi
+        # pnpm config writes to ~/.npmrc, which is OUTSIDE the mounted
+        # volume — re-run every job. Cheap no-op when already set.
+        pnpm config set store-dir /home/runner/.local/share/pnpm/store
+    - if: runner.environment != 'github-hosted'
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
               ;;
           esac
 
+  # `vars.RUNNER` is a single runner label (e.g. `self-hosted` or
+  # `ubuntu-latest`). GitHub treats `runs-on:` as one literal label when given
+  # a string, so a comma-separated value like `self-hosted,Linux,X64` will
+  # NOT match any runner. If a multi-label selector is ever needed, switch
+  # this expression to `fromJSON(vars.RUNNER)` and store the variable as a
+  # JSON array. Today the plan is to set it to exactly `self-hosted`.
   build-and-typecheck:
     name: Build & Type Check
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,17 +113,11 @@ jobs:
     name: Build & Type Check
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm typecheck
@@ -131,33 +125,21 @@ jobs:
     name: Lint
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
   prettier:
     name: Prettier
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
 
@@ -165,17 +147,11 @@ jobs:
     name: Guides Code Type Check
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm guides:typecheck
@@ -184,17 +160,11 @@ jobs:
     name: DX Type Tests
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:types
 


### PR DESCRIPTION
## Summary

- New `.github/actions/setup-pnpm` composite branches on `runner.environment`: hosted keeps `pnpm/action-setup` + `cache: pnpm`; self-hosted uses preinstalled pnpm with `store-dir` pinned to the mounted persistent volume — no `actions/cache` WAN traffic.
- Five install-heavy jobs (build-and-typecheck, lint, prettier, guides-typecheck, dx-type-tests) switch to `runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}` + the composite.
- `vars.RUNNER` is unset on merge, so hosted behavior is identical to today. Flipping to `self-hosted` is one Settings change, no deploy.
- Third-party actions inside the composite (`pnpm/action-setup`, `actions/setup-node`) are pinned by SHA. `actions/checkout@v4` in the workflow itself is unchanged — pinning the rest of the workflow is out of scope here.

Implements Deliverable 1 of an in-flight self-hosted-runner restart plan (doc currently uncommitted on local main). Deliverable 2 (mount canary), 3 (staged switch), 4 (switch-back drill) follow.

## Test plan

- [ ] CI green on this PR with `vars.RUNNER` unset (hosted path runs as before)
- [ ] Composite logs show the hosted branch firing (pnpm/action-setup + setup-node with cache: pnpm)
- [ ] No diff in install behavior vs. main (same lockfile, same install step)