### PR TITLE
feat(action-dispatch): Wave 7 PR 9 — journey/router

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/index.ts
+++ b/packages/actionpack/src/action-dispatch/journey/index.ts
@@ -35,3 +35,4 @@ export {
   UrlGenerationError,
   type FormatterHost,
 } from "./formatter.js";
+export { Router, type RouterRequest, type RackishResponse, type RoutableApp } from "./router.js";

--- a/packages/actionpack/src/action-dispatch/journey/router.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { X_CASCADE } from "../constants.js";
+import { Parser } from "./parser.js";
+import { Ast } from "./ast.js";
+import { Pattern } from "./path/pattern.js";
+import { Route, VerbMatchers } from "./route.js";
+import { Routes } from "./routes.js";
+import { Router, type RouterRequest, type RackishResponse } from "./router.js";
+
+function pat(path: string, requirements: Record<string, RegExp> = {}, anchored = true): Pattern {
+  const tree = new Parser().parse(path);
+  const ast = new Ast(tree, true);
+  return new Pattern(ast, requirements, "/.?", anchored);
+}
+
+function okApp(body: string): { serve: () => RackishResponse } {
+  return { serve: () => [200, { "content-type": "text/plain" }, [body]] };
+}
+
+function cascadeApp(): { serve: () => RackishResponse } {
+  return { serve: () => [404, { [X_CASCADE]: "pass" }, ["pass"]] };
+}
+
+function buildRoutes(routes: Route[]): Routes {
+  const r = new Routes(routes);
+  for (const route of routes) r.partitionRoute(route);
+  return r;
+}
+
+function req(opts: Partial<RouterRequest> & { pathInfo: string }): RouterRequest {
+  return {
+    scriptName: "",
+    requestMethod: "GET",
+    pathParameters: {},
+    routeUriPattern: null,
+    ...opts,
+  };
+}
+
+describe("ActionDispatch::Journey::Router", () => {
+  it("serve() dispatches to the matching route's app", () => {
+    const route = new Route({
+      name: "p",
+      app: okApp("posts"),
+      path: pat("/posts"),
+    });
+    const router = new Router(buildRoutes([route]));
+    const response = router.serve(req({ pathInfo: "/posts" }));
+    expect(response[0]).toBe(200);
+    expect(response[2]).toEqual(["posts"]);
+  });
+
+  it("serve() returns 404 + X-Cascade=pass when no route matches", () => {
+    const router = new Router(buildRoutes([]));
+    const response = router.serve(req({ pathInfo: "/nope" }));
+    expect(response[0]).toBe(404);
+    expect(response[1][X_CASCADE]).toBe("pass");
+  });
+
+  it("serve() honors X-Cascade=pass and tries the next matching route", () => {
+    const passing = new Route({ name: "a", app: cascadeApp(), path: pat("/a"), precedence: 1 });
+    const winning = new Route({ name: "b", app: okApp("won"), path: pat("/a"), precedence: 2 });
+    const router = new Router(buildRoutes([passing, winning]));
+    const r = req({ pathInfo: "/a" });
+    const response = router.serve(r);
+    expect(response[2]).toEqual(["won"]);
+    expect(r.pathParameters).toEqual({});
+  });
+
+  it("serve() injects path parameters + defaults onto the request", () => {
+    let seen: Record<string, unknown> = {};
+    const app = {
+      serve: (req: RouterRequest): RackishResponse => {
+        seen = { ...req.pathParameters };
+        return [200, {}, ["ok"]];
+      },
+    };
+    const route = new Route({
+      name: "show",
+      app,
+      path: pat("/posts/:id"),
+      defaults: { controller: "posts" },
+    });
+    const router = new Router(buildRoutes([route]));
+    router.serve(req({ pathInfo: "/posts/42" }));
+    expect(seen).toEqual({ controller: "posts", id: "42" });
+  });
+
+  it("serve() sets routeUriPattern from the matched route", () => {
+    let pattern: string | null | undefined;
+    const app = {
+      serve: (req: RouterRequest): RackishResponse => {
+        pattern = req.routeUriPattern;
+        return [200, {}, ["ok"]];
+      },
+    };
+    const route = new Route({ name: "p", app, path: pat("/posts/:id") });
+    const router = new Router(buildRoutes([route]));
+    router.serve(req({ pathInfo: "/posts/1" }));
+    expect(pattern).toContain("/posts");
+  });
+
+  it("recognize() yields each matching route + merged defaults", () => {
+    const route = new Route({
+      name: "show",
+      app: okApp("x"),
+      path: pat("/posts/:id"),
+      defaults: { controller: "posts" },
+    });
+    const router = new Router(buildRoutes([route]));
+    const found: [string, Record<string, unknown>][] = [];
+    router.recognize(req({ pathInfo: "/posts/7" }), (r, params) => {
+      found.push([r.name, params]);
+    });
+    expect(found).toEqual([["show", { controller: "posts", id: "7" }]]);
+  });
+
+  it("serve() filters by HTTP verb", () => {
+    const getRoute = new Route({
+      name: "g",
+      app: okApp("get"),
+      path: pat("/x"),
+      requestMethodMatch: [VerbMatchers.for("GET")],
+    });
+    const postRoute = new Route({
+      name: "p",
+      app: okApp("post"),
+      path: pat("/x"),
+      requestMethodMatch: [VerbMatchers.for("POST")],
+    });
+    const router = new Router(buildRoutes([getRoute, postRoute]));
+    expect(router.serve(req({ pathInfo: "/x", requestMethod: "POST" }))[2]).toEqual(["post"]);
+    expect(router.serve(req({ pathInfo: "/x", requestMethod: "GET" }))[2]).toEqual(["get"]);
+  });
+
+  it("HEAD falls back to GET routes when no HEAD-specific route exists", () => {
+    const getRoute = new Route({
+      name: "g",
+      app: okApp("get"),
+      path: pat("/x"),
+      requestMethodMatch: [VerbMatchers.for("GET")],
+    });
+    const router = new Router(buildRoutes([getRoute]));
+    expect(router.serve(req({ pathInfo: "/x", requestMethod: "HEAD" }))[0]).toBe(200);
+  });
+
+  it("URI-decodes captured parameters", () => {
+    let seen: Record<string, unknown> = {};
+    const app = {
+      serve: (req: RouterRequest): RackishResponse => {
+        seen = { ...req.pathParameters };
+        return [200, {}, ["ok"]];
+      },
+    };
+    const route = new Route({ name: "show", app, path: pat("/posts/:slug") });
+    const router = new Router(buildRoutes([route]));
+    router.serve(req({ pathInfo: "/posts/hello%20world" }));
+    expect(seen["slug"]).toBe("hello world");
+  });
+
+  it("eagerLoadBang() initializes the simulator without throwing", () => {
+    const route = new Route({ name: "p", app: okApp("ok"), path: pat("/x") });
+    const router = new Router(buildRoutes([route]));
+    expect(() => router.eagerLoadBang()).not.toThrow();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/router.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.ts
@@ -1,0 +1,193 @@
+import { X_CASCADE } from "../constants.js";
+import { unescapeUri } from "./router/utils.js";
+import type { Route } from "./route.js";
+import type { Routes } from "./routes.js";
+
+/**
+ * Minimal request shape consumed by the Router. Trails' `ActionDispatch::Request`
+ * conforms; tests in this file build inline fakes.
+ */
+export interface RouterRequest {
+  pathInfo: string;
+  scriptName: string;
+  requestMethod: string;
+  pathParameters: Record<string, unknown>;
+  routeUriPattern?: string | null;
+  isHead?: boolean;
+  /** Route matching is verb-based; constraints may inspect arbitrary keys. */
+  [key: string]: unknown;
+}
+
+export interface RackishResponse {
+  0: number;
+  1: Record<string, string>;
+  2: unknown;
+}
+
+export interface RoutableApp {
+  serve(req: RouterRequest): RackishResponse;
+}
+
+/**
+ * Journey router. Drives `serve` (Rack-style dispatch with X-Cascade pass-
+ * through) and `recognize` (route introspection used by tests / inspect).
+ *
+ * Mirrors `action_dispatch/journey/router.rb`.
+ */
+export class Router {
+  routes: Routes;
+
+  constructor(routes: Routes) {
+    this.routes = routes;
+  }
+
+  eagerLoadBang(): void {
+    void this._simulator();
+  }
+
+  serve(req: RouterRequest): RackishResponse {
+    for (const { match, parameters, route } of this._findRoutes(req)) {
+      const setParams = req.pathParameters;
+      const pathInfo = req.pathInfo;
+      const scriptName = req.scriptName;
+
+      if (!route.path.anchored) {
+        req.scriptName = ((scriptName ?? "") + match.toString()).replace(/\/$/, "");
+        let post = match.postMatch();
+        if (!post.startsWith("/")) post = "/" + post;
+        req.pathInfo = post;
+      }
+
+      const tmpParams: Record<string, unknown> = { ...setParams, ...route.defaults };
+      for (const [key, val] of Object.entries(parameters)) {
+        tmpParams[key] = val;
+      }
+
+      req.pathParameters = tmpParams;
+      req.routeUriPattern = String(route.path.spec);
+
+      const app = route.app as RoutableApp | undefined;
+      if (!app) continue;
+      const response = app.serve(req);
+      const headers = response[1] ?? {};
+
+      if (headers[X_CASCADE] === "pass") {
+        req.scriptName = scriptName;
+        req.pathInfo = pathInfo;
+        req.pathParameters = setParams;
+        continue;
+      }
+
+      return response;
+    }
+
+    return [404, { [X_CASCADE]: "pass" }, ["Not Found"]] as unknown as RackishResponse;
+  }
+
+  recognize(
+    req: RouterRequest,
+    block: (route: Route, parameters: Record<string, unknown>) => void,
+  ): void {
+    for (const { match, parameters, route } of this._findRoutes(req)) {
+      if (!route.path.anchored) {
+        req.scriptName = match.toString();
+        let post = match.postMatch();
+        if (!post.startsWith("/")) post = "/" + post;
+        req.pathInfo = post;
+      }
+      const merged: Record<string, unknown> = { ...route.defaults, ...parameters };
+      block(route, merged);
+    }
+  }
+
+  /** @internal */
+  private _partitionedRoutes(): [Route[], Route[]] {
+    const anchored: Route[] = [];
+    const custom: Route[] = [];
+    for (const r of this.routes) {
+      if (r.path.anchored && r.path.isRequirementsAnchored()) anchored.push(r);
+      else custom.push(r);
+    }
+    return [anchored, custom];
+  }
+
+  /** @internal */
+  private _ast() {
+    return this.routes.ast;
+  }
+
+  /** @internal */
+  private _simulator() {
+    return this.routes.simulator;
+  }
+
+  /** @internal */
+  private _customRoutes(): readonly Route[] {
+    return this.routes.customRoutes;
+  }
+
+  /** @internal */
+  private _filterRoutes(path: string): Route[] {
+    if (!this._ast()) return [];
+    return this._simulator().memos(path, () => []) as Route[];
+  }
+
+  /** @internal */
+  private *_findRoutes(
+    req: RouterRequest,
+  ): Generator<{ match: PatternMatch; parameters: Record<string, unknown>; route: Route }> {
+    const pathInfo = req.pathInfo;
+    let routes = [
+      ...this._filterRoutes(pathInfo),
+      ...this._customRoutes().filter((r) => r.path.isMatch(pathInfo)),
+    ];
+
+    if (req.isHead || req.requestMethod === "HEAD") {
+      routes = this._matchHeadRoutes(routes, req);
+    } else {
+      routes = routes.filter((r) =>
+        r.matches(req as unknown as { requestMethod: string } & Record<string, unknown>),
+      );
+    }
+
+    routes.sort((a, b) => a.precedence - b.precedence);
+
+    for (const r of routes) {
+      const matchData = r.path.match(pathInfo);
+      if (!matchData) continue;
+      const pathParameters: Record<string, unknown> = {};
+      matchData.names.forEach((name, i) => {
+        const val = matchData.at(i + 1);
+        if (val != null) pathParameters[name] = unescapeUri(val);
+      });
+      yield { match: matchData, parameters: pathParameters, route: r };
+    }
+  }
+
+  /** @internal */
+  private _matchHeadRoutes(routes: Route[], req: RouterRequest): Route[] {
+    const head = routes.filter(
+      (r) =>
+        r.isRequiresMatchingVerb() &&
+        r.matches(req as unknown as { requestMethod: string } & Record<string, unknown>),
+    );
+    if (head.length > 0) return head;
+
+    const original = req.requestMethod;
+    try {
+      req.requestMethod = "GET";
+      return routes.filter((r) =>
+        r.matches(req as unknown as { requestMethod: string } & Record<string, unknown>),
+      );
+    } finally {
+      req.requestMethod = original;
+    }
+  }
+}
+
+interface PatternMatch {
+  names: readonly string[];
+  at(i: number): string | undefined;
+  postMatch(): string;
+  toString(): string;
+}


### PR DESCRIPTION
## Summary
Ports `action_dispatch/journey/router.rb` to TypeScript.

- `Router` with `serve()` (Rack-style dispatch with `X-Cascade=pass` cascade), `recognize()` (introspection), `eagerLoadBang()`.
- `RouterRequest` / `RackishResponse` / `RoutableApp` — minimal request surface (`pathInfo`, `scriptName`, `requestMethod`, `pathParameters`, `routeUriPattern`) that `ActionDispatch::Request` will satisfy when PR 10 wires it up.
- HEAD fallback to GET routes per Rails `request_method_match` logic.
- URI-decodes captured params via `unescapeUri`.

## Notes
- `visualizer()` not ported (graphviz dep) — matches PR 6 transition_table decision.
- `RouterRequest` is interim scaffolding; collapses to the concrete `Request` type during PR 10 wire-up.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/journey/` — 224 pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean