### PR TITLE
feat(activerecord): HABTM Slot I — build/create with scope-attr inheritance

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -653,6 +653,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       : (this._assocDef.options.foreignKey ?? `${underscore(ctor.name)}_id`);
 
     const buildAttrs: Record<string, unknown> = {
+      ...this._scopeForCreateAttrs(attrs),
       ...attrs,
       [foreignKey as string]: this._record._readAttribute(primaryKey as string),
     };
@@ -681,7 +682,26 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       targetModel = findStiClass(targetModel, typeName);
     }
 
-    return new targetModel(attrs);
+    const merged = { ...this._scopeForCreateAttrs(attrs), ...attrs };
+    return new targetModel(merged);
+  }
+
+  // Mirrors Rails' Association#initialize_attributes: scope_for_create
+  // pre-fills attributes from where-conditions on the association scope,
+  // letting user-supplied attrs win.
+  private _scopeForCreateAttrs(userAttrs: Record<string, unknown>): Record<string, unknown> {
+    const sfc =
+      typeof (this as unknown as { scopeForCreate?: () => Record<string, unknown> })
+        .scopeForCreate === "function"
+        ? (this as unknown as { scopeForCreate: () => Record<string, unknown> }).scopeForCreate()
+        : {};
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(sfc)) {
+      if (!Object.prototype.hasOwnProperty.call(userAttrs, k)) {
+        out[k] = v;
+      }
+    }
+    return out;
   }
 
   /**

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -28,6 +28,8 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   class Project extends Base {
     static {
       this.attribute("name", "string");
+      this.attribute("approved", "boolean");
+      this.attribute("featured", "boolean");
     }
   }
 
@@ -1077,16 +1079,34 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     // SCOPE: collection-proxy.ts — transaction() delegation to target model
   });
 
-  it.skip("attributes are being set when initialized from habtm association with where clause", () => {
-    // BLOCKED: associations — scope chain composition
-    // ROOT-CAUSE: build() on a where-scoped collection does not pre-fill attributes from the where condition
-    // SCOPE: collection-proxy.ts — scope_attributes on build/new
+  it("attributes are being set when initialized from habtm association with where clause", async () => {
+    (Developer as any)._associations = [];
+    Associations.hasAndBelongsToMany.call(Developer, "projects", {
+      className: "Project",
+      joinTable: "developer_projects",
+      scope: (r: any) => r.where({ approved: true }),
+    });
+    const dev = await Developer.create({ name: "Scoped", salary: 100000 });
+    const proxy = association<Project>(dev, "projects");
+    const built = proxy.build({ name: "ScopedProj" });
+    expect((built as any).approved).toBe(true);
+    // User-supplied attrs win over the scope.
+    const override = proxy.build({ name: "Override", approved: false });
+    expect((override as any).approved).toBe(false);
   });
 
-  it.skip("attributes are being set when initialized from habtm association with multiple where clauses", () => {
-    // BLOCKED: associations — scope chain composition
-    // ROOT-CAUSE: build() on a multi-condition where scope does not pre-fill all scoped attributes
-    // SCOPE: collection-proxy.ts — scope_attributes merging for chained where conditions
+  it("attributes are being set when initialized from habtm association with multiple where clauses", async () => {
+    (Developer as any)._associations = [];
+    Associations.hasAndBelongsToMany.call(Developer, "projects", {
+      className: "Project",
+      joinTable: "developer_projects",
+      scope: (r: any) => r.where({ approved: true }).where({ featured: true }),
+    });
+    const dev = await Developer.create({ name: "Scoped2", salary: 100000 });
+    const proxy = association<Project>(dev, "projects");
+    const built = proxy.build({ name: "ScopedProj2" });
+    expect((built as any).approved).toBe(true);
+    expect((built as any).featured).toBe(true);
   });
 
   it("include method in has and belongs to many association should return true for instance added with build", async () => {


### PR DESCRIPTION
## Summary
- Mirrors Rails' `Association#initialize_attributes` (`scope_for_create`): `build` / `create` on a where-scoped HABTM proxy now pre-fill the target record with attributes from the scope's where conditions.
- User-supplied attrs win over scope attrs (Rails parity).
- Closes the HABTM cluster Slot I; unskips two `attributes are being set when initialized from habtm association ...` tests.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts has-many-through-associations.test.ts collection-proxy.test.ts`