### PR TITLE
feat(activerecord): MySQL onUpdate — move to MySQL override + widen function-default regex

### DIFF
--- a/docs/activerecord-100-clusters.md
+++ b/docs/activerecord-100-clusters.md
@@ -400,10 +400,10 @@ These don't merit their own multi-slot cluster section.
 
 After #1555 moved belongs_to autosave into the `before_save` chain via `defineNonCyclicMethod`, the standalone `autosaveBelongsTo` function in `packages/activerecord/src/autosave-association.ts:375` and its `_autosavingRecords` add/delete calls are unreferenced. Delete the function body; keep the `_autosavingRecords` WeakSet (still used by `autosaveChildren`). Bundle into next fidelity sweep.
 
-### MySQL onUpdate followups (~30 LOC, from #1382)
+### MySQL onUpdate followups closed (#1402, follow-up bundle)
 
-- **`onUpdate` abstract leakage** — lives in abstract `ColumnOptions`/`addColumnOptions`; MySQL-specific option leaking into abstract layer. Move to MySQL override. Low risk in practice.
-- **Function-default detection narrowness** — `renameColumnForAlter` regex only covers `CURRENT_TIMESTAMP`. Bundled into small-followup sweep.
+- `onUpdate` abstract leakage closed in #1402 — `onUpdate` moved off abstract `ColumnOptions` onto `MysqlAddColumnOptions` in mysql/schema-creation.ts.
+- Function-default detection in `renameColumnForAlter` widened — non-DEFAULT_GENERATED defaults outside `RENAME_FUNC_DEFAULT_RE` now route through `defaultType(createTableInfo, columnName)`, mirroring Rails' `new_column_from_field` broader detection.
 
 ### Unported-list additions (~30 LOC bundled, 1 PR)
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -135,6 +135,49 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     },
   );
 
+  it("detects non-DEFAULT_GENERATED keyword defaults via SHOW CREATE TABLE and emits unquoted", async () => {
+    // e.g. older MySQL function defaults outside RENAME_FUNC_DEFAULT_RE: defaultType()
+    // parses SHOW CREATE TABLE and returns "function" for any bare keyword default.
+    const adapter = await makeAdapter("col", "");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "col",
+        Type: "varchar(36)",
+        Null: "YES",
+        Default: "MY_CUSTOM_FUNC",
+        Extra: "",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    adapter.createTableInfo = async () =>
+      "CREATE TABLE `users` (\n  `col` varchar(36) DEFAULT MY_CUSTOM_FUNC\n)";
+    adapter.quoteTableName = (s: string) => `\`${s}\``;
+    const sql: string = await adapter.renameColumnForAlter("users", "col", "col2");
+    expect(sql).toContain("DEFAULT MY_CUSTOM_FUNC");
+    expect(sql).not.toContain("DEFAULT 'MY_CUSTOM_FUNC'");
+  });
+
+  it("treats non-function keyword default as quoted string when SHOW CREATE TABLE shows quoted literal", async () => {
+    const adapter = await makeAdapter("col", "");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "col",
+        Type: "varchar(36)",
+        Null: "YES",
+        Default: "hello",
+        Extra: "",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    adapter.createTableInfo = async () =>
+      "CREATE TABLE `users` (\n  `col` varchar(36) DEFAULT 'hello'\n)";
+    adapter.quoteTableName = (s: string) => `\`${s}\``;
+    const sql: string = await adapter.renameColumnForAlter("users", "col", "col2");
+    expect(sql).toContain("DEFAULT 'hello'");
+  });
+
   it("wraps arbitrary DEFAULT_GENERATED expression in parens, not as a quoted string", async () => {
     // e.g. MySQL 8 expression defaults like `json_array()` that aren't in RENAME_FUNC_DEFAULT_RE.
     // newColumnFromField wraps these in () and sets defaultFunction — we must match.

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -63,7 +63,7 @@ import {
 } from "./abstract/schema-definitions.js";
 import type { ColumnType, ColumnOptions } from "./abstract/schema-definitions.js";
 import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
-import { isRowFormatDynamicByDefault } from "./mysql/schema-statements.js";
+import { isRowFormatDynamicByDefault, defaultType } from "./mysql/schema-statements.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -1458,8 +1458,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // quoteDefaultExpression emits it unquoted: DEFAULT NOW(), not DEFAULT 'NOW()'.
     // Mirrors newColumnFromField: CURRENT_TIMESTAMP datetime cols and DEFAULT_GENERATED cols
     // always go through the function-default path; everything else only when RENAME_FUNC_DEFAULT_RE matches.
-    // RENAME_FUNC_DEFAULT_RE only applies to the non-DEFAULT_GENERATED path (e.g. CURRENT_TIMESTAMP
-    // on datetime columns, which MySQL emits without DEFAULT_GENERATED in Extra).
+    // RENAME_FUNC_DEFAULT_RE catches well-known keyword defaults without a DB round-trip;
+    // anything that isn't a literal digit-led default also gets a SHOW CREATE TABLE check
+    // via defaultType(), mirroring Rails' new_column_from_field broader function-default
+    // detection (mysql/schema_statements.rb:189-208).
     let colDefault: (() => string) | string | undefined;
     if (typeof rawDefault === "string") {
       if (extra === "default_generated") {
@@ -1468,9 +1470,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         const expr = rawDefault.startsWith("(") ? rawDefault : `(${rawDefault})`;
         colDefault = () => expr;
       } else if (RENAME_FUNC_DEFAULT_RE.test(rawDefault)) {
-        // Well-known keyword defaults on non-DEFAULT_GENERATED columns (e.g. CURRENT_TIMESTAMP
-        // on datetime): emit as-is, no parens.
+        // Well-known keyword defaults (e.g. CURRENT_TIMESTAMP): emit as-is, no parens.
         colDefault = () => rawDefault;
+      } else if (!/^\d/.test(rawDefault) && !rawDefault.startsWith("'")) {
+        // Broader function-default detection via SHOW CREATE TABLE — Rails' default_type
+        // returns :function for any DEFAULT followed by a bare keyword identifier.
+        const createInfo = await this.createTableInfo(tableName);
+        colDefault =
+          defaultType(createInfo, columnName) === "function" ? () => rawDefault : rawDefault;
       } else {
         colDefault = rawDefault;
       }


### PR DESCRIPTION
## Summary

Closes the **MySQL onUpdate followups** single-slot from `docs/activerecord-100-clusters.md` (from #1382).

- **`onUpdate` abstract leakage** — already addressed in #1402 (column-level `onUpdate` moved off abstract `ColumnOptions` onto `MysqlAddColumnOptions` in `mysql/schema-creation.ts`). Doc updated to reflect.
- **Function-default detection narrowness** — `renameColumnForAlter` previously only treated `CURRENT_TIMESTAMP`/`NOW()`/`UUID()`/`CURRENT_DATE`/`CURRENT_TIME` (`RENAME_FUNC_DEFAULT_RE`) as unquoted function defaults on the non-`DEFAULT_GENERATED` path. Now also routes through `defaultType(createTableInfo, columnName)` for defaults that aren't digit-led or quoted-string literals, mirroring Rails' `new_column_from_field` broader detection (`mysql/schema_statements.rb:189-208`). The regex is kept as a no-IO fast path.

~30 LOC net (impl + 2 tests + doc).

## Test plan

- [x] `TEST_ADAPTER=mysql2 pnpm vitest run packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts` — 39 pass (incl. 2 new)
- [x] `pnpm tsc -b packages/activerecord` — clean
- [x] lint-staged on commit — clean