### PR TITLE
chore(activerecord): Schema Slot K — annotation normalization across BLOCKED tests

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -154,12 +154,13 @@ describeIfMysql("Mysql2Adapter", () => {
 
   describe("MySQLAnsiQuotesTest", () => {
     it.skip("primary key method with ansi quotes", () => {
-      // BLOCKED: ansi-quotes — requires SET SESSION sql_mode='ANSI_QUOTES' which
+      // BLOCKED: adapter-mysql — requires SET SESSION sql_mode='ANSI_QUOTES' which
       // needs adapter-level session-variable setter not yet wired for test setup
+      // (ansi-quotes mode)
     });
 
     it.skip("foreign keys method with ansi quotes", () => {
-      // BLOCKED: ansi-quotes — same session-variable setup gap as above
+      // BLOCKED: adapter-mysql — same session-variable setup gap as above (ansi-quotes mode)
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -69,13 +69,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("default", async () => {
-      // BLOCKED: schema-statements — add_column with hstore default not yet wired
+      // BLOCKED: schema — add_column with hstore default not yet wired
       // ROOT-CAUSE: postgresql/schema-statements.ts addColumn does not call columnDefaults
       //   to resolve hstore defaults via the OID type map.
       // SCOPE: ~10 LOC in schema-statements.ts; add columnDefaults support for hstore columns.
     });
     it.skip("change column default with hstore", async () => {
-      // BLOCKED: schema-statements — changeColumnDefault for hstore-typed columns
+      // BLOCKED: schema — changeColumnDefault for hstore-typed columns
       // ROOT-CAUSE: changeColumnDefault in schema-statements.ts passes the value through quoteDefault
       //   without serializing hstore objects first.
       // SCOPE: ~10 LOC in connection-adapters/postgresql/schema-statements.ts.
@@ -169,18 +169,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("hstore with store accessors", async () => {
-      // BLOCKED: store-accessor — Base.store_accessor not implemented
+      // BLOCKED: unknown — store-accessor: Base.store_accessor not implemented
       // ROOT-CAUSE: store_accessor in base.ts does not generate per-key getters/setters that
       //   read/write sub-keys of a hstore attribute.
       // SCOPE: ~50 LOC in base.ts; pairs with the store DSL.
     });
     it.skip("hstore dirty tracking", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore dirty tracking" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore dirty tracking" in hstore_test.rb
       // ROOT-CAUSE: Placeholder with no Rails reference; cannot port faithfully.
       // SCOPE: Permanent skip-list candidate.
     });
     it.skip("hstore duplication", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore duplication" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore duplication" in hstore_test.rb
       // ROOT-CAUSE: Closest Rails match is test_duplication_with_store_accessors (store_accessor blocked).
       // SCOPE: Permanent skip-list candidate.
     });
@@ -196,7 +196,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((hstore as any).changed).toBe(false);
     });
     it.skip("hstore nested", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore nested" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore nested" in hstore_test.rb
       // ROOT-CAUSE: No Rails reference; cannot port faithfully.
       // SCOPE: Permanent skip-list candidate.
     });
@@ -350,12 +350,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(JSON.parse(rows[0].r as string)).toEqual({ a: "1", b: "2" });
     });
     it.skip("hstore populate", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore populate" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore populate" in hstore_test.rb
       // ROOT-CAUSE: No Rails reference; populate_record() is PG SQL, not an AR API.
       // SCOPE: Permanent skip-list candidate.
     });
     it.skip("hstore schema dump", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore schema dump" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore schema dump" in hstore_test.rb
       // ROOT-CAUSE: Closest Rails test is "schema dump with shorthand".
       // SCOPE: Permanent skip-list candidate.
     });
@@ -365,13 +365,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: ~30 LOC in migration.ts; unblocked after Wave 8 PR 46c.
     });
     it.skip("hstore gen random uuid", async () => {
-      // BLOCKED: test-name mismatch — not in hstore_test.rb; permanent skip-list candidate.
+      // BLOCKED: unknown — test-name mismatch: not in hstore_test.rb; permanent skip-list candidate.
     });
     it.skip("hstore gen random uuid default", async () => {
-      // BLOCKED: test-name mismatch — not in hstore_test.rb; permanent skip-list candidate.
+      // BLOCKED: unknown — test-name mismatch: not in hstore_test.rb; permanent skip-list candidate.
     });
     it.skip("hstore fixture", async () => {
-      // BLOCKED: test-name mismatch — no Rails test named "hstore fixture" in hstore_test.rb
+      // BLOCKED: unknown — test-name mismatch: no Rails test named "hstore fixture" in hstore_test.rb
       // ROOT-CAUSE: Rails fixtures are a test infrastructure feature with no direct TS port.
       // SCOPE: Permanent skip-list candidate.
     });
@@ -384,32 +384,32 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("disable enable hstore", () => {
-      // BLOCKED: schema-statements — enableExtension/disableExtension not implemented
+      // BLOCKED: schema — enableExtension/disableExtension not implemented
       // ROOT-CAUSE: adapter does not expose enableExtension("hstore") / disableExtension("hstore");
       //   Rails uses `@connection.enable_extension` / `@connection.disable_extension`.
       // SCOPE: ~20 LOC in connection-adapters/postgresql/schema-statements.ts.
     });
     it.skip("change table supports hstore", () => {
-      // BLOCKED: schema-statements — changeTable t.hstore not wired
+      // BLOCKED: schema — changeTable t.hstore not wired
       // ROOT-CAUSE: change_table DSL in schema-statements.ts does not register hstore as a column
       //   type that can be added via t.hstore(...).
       // SCOPE: ~10 LOC in schema-statements.ts; pairs with hstore migration support.
     });
     it.skip("cast value on write", () => {
-      // BLOCKED: attribute-methods — readAttributeBeforeTypeCast not implemented
+      // BLOCKED: unknown — attribute-methods: readAttributeBeforeTypeCast not implemented
       // ROOT-CAUSE: Rails test asserts `x.tags_before_type_cast` returns the pre-cast hash
       //   ({ "bool" => true, "number" => 5 }); we have no readAttributeBeforeTypeCast accessor.
       //   The save/reload assertions themselves would pass; only the before-type-cast step is blocked.
       // SCOPE: ~20 LOC in attribute-methods/read.ts; affects all `_before_type_cast` tests.
     });
     it.skip("with store accessors", () => {
-      // BLOCKED: store-accessor — Base.store_accessor not implemented
+      // BLOCKED: unknown — store-accessor: Base.store_accessor not implemented
       // ROOT-CAUSE: store_accessor in base.ts does not generate per-key getters/setters that
       //   read/write sub-keys of a hstore attribute.
       // SCOPE: ~50 LOC in base.ts; pairs with the store DSL.
     });
     it.skip("duplication with store accessors", () => {
-      // BLOCKED: store-accessor — same as "with store accessors"
+      // BLOCKED: unknown — store-accessor: same as "with store accessors"
       // ROOT-CAUSE: store_accessor must generate getters/setters before dup can propagate them.
       // SCOPE: ~50 LOC in base.ts (store_accessor) + verify dup copies attribute hash.
     });
@@ -419,7 +419,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: Permanent skip-list candidate; no faithful port is possible.
     });
     it.skip("changes with store accessors", () => {
-      // BLOCKED: store-accessor + dirty-tracking — both gaps must close first
+      // BLOCKED: unknown — store-accessor + dirty-tracking: both gaps must close first
       // ROOT-CAUSE: (1) store_accessor not implemented; (2) Attribute.changedInPlace() does not
       //   call type.isChangedInPlace() for mutable types.
       // SCOPE: ~50 LOC store_accessor + ~5 LOC attribute.ts changedInPlace delegation.
@@ -547,18 +547,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("hstore with serialized attributes", () => {
-      // BLOCKED: serialize-coder — Base.serialize({ coder: ... }) not implemented
+      // BLOCKED: serialization — serialize-coder: Base.serialize({ coder: ... }) not implemented
       // ROOT-CAUSE: Rails wraps the hstore attribute with a coder that implements .load/.dump;
       //   Base.serialize(col, coder:) in base.ts does not wire the encode/decode lifecycle.
       // SCOPE: ~50 LOC in base.ts serialize decorator + integration with attribute-set lifecycle.
     });
     it.skip("clone hstore with serialized attributes", () => {
-      // BLOCKED: serialize-coder — same as "hstore with serialized attributes"
+      // BLOCKED: serialization — serialize-coder: same as "hstore with serialized attributes"
       // ROOT-CAUSE: dup/clone of a coder-wrapped hstore also needs the coder path wired.
       // SCOPE: Unblocked automatically once "hstore with serialized attributes" passes.
     });
     it.skip("supports to unsafe h values", () => {
-      // BLOCKED: Ruby-specific — ActionController::Parameters#to_unsafe_h has no Node.js equivalent
+      // BLOCKED: unknown — Ruby-specific: ActionController::Parameters#to_unsafe_h has no Node.js equivalent
       // ROOT-CAUSE: Rails' ProtectedParams (ActionController::Parameters) exposes to_unsafe_h;
       //   there is no TS equivalent. The test verifies that hstore.serialize() accepts such objects.
       // SCOPE: Implement a ProtectedParams TS stub that exposes toUnsafeH() + wire in hstore.serialize().
@@ -576,7 +576,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it.skip("schema dump with shorthand", async () => {
-      // BLOCKED: schema-dumper — SchemaDumper does not emit t.hstore(...) for hstore columns
+      // BLOCKED: schema — SchemaDumper does not emit t.hstore(...) for hstore columns
       // ROOT-CAUSE: schema-dumper.ts maps column types to t.type() calls but does not have a
       //   shorthand mapping for hstore; it would emit a generic t.column() instead of t.hstore().
       //   Rails expects: `t.hstore "tags", default: {}`.

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -239,7 +239,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).rejects.toBeInstanceOf(StatementInvalid);
     });
     it.skip("schema change with prepared stmt", () => {
-      // BLOCKED: needs-prepared-statements — requires adapter.preparedStatements=true path
+      // BLOCKED: adapter-pg — requires adapter.preparedStatements=true path
       // ROOT-CAUSE: test exercises schema changes invalidating prepared statement cache; our adapter
       // doesn't expose a prepared_statements toggle in the test helper
       // SCOPE: needs AdapterPool prepared-statements mode wired in schema test setup

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2016,7 +2016,7 @@ describe("BasicsTest", () => {
     expect(Account.tableName).toBe("accounts");
   });
   it.skip("utc as time zone", () => {
-    // BLOCKED: fixtures + with_env_tz — reads Topic.find(1).bonus_time after assigning "5:42:00AM" string; requires process-level TZ env var and Topic fixture data
+    // BLOCKED: fixture — with_env_tz: reads Topic.find(1).bonus_time after assigning "5:42:00AM" string; requires process-level TZ env var and Topic fixture data
   });
   it("utc as time zone and new", async () => {
     await withTimezoneConfig({ default: "utc" }, () => {
@@ -2288,7 +2288,7 @@ describe("BasicsTest", () => {
     await expect(post2.update({ author_id: author2.id })).rejects.toThrow(ReadonlyAttributeError);
   });
   it.skip("respect internal encoding", () => {
-    // BLOCKED: Ruby-only — tests Encoding.default_internal (EUC-JP) on column names; JS has no string encoding model
+    // BLOCKED: unknown — Ruby-only: tests Encoding.default_internal (EUC-JP) on column names; JS has no string encoding model
   });
   it("non valid identifier column name", async () => {
     class Weird extends Base {
@@ -2302,7 +2302,7 @@ describe("BasicsTest", () => {
     expect(reloaded.readAttribute("a$b")).toBe("value");
   });
   it.skip("attributes on dummy time", () => {
-    // BLOCKED: fixtures + with_env_tz — assigns "5:42:00AM" string to Topic.find(1).bonus_time; needs Topic fixture and process-level TZ change; then assert_equal using find_by, requiring DB
+    // BLOCKED: fixture — with_env_tz: assigns "5:42:00AM" string to Topic.find(1).bonus_time; needs Topic fixture and process-level TZ change; then assert_equal using find_by, requiring DB
   });
   it("attributes on dummy time with invalid time", async () => {
     const adp = freshAdapter();
@@ -2394,7 +2394,7 @@ describe("BasicsTest", () => {
     expect(u.name).toBe("");
   });
   it.skip("default in local time", () => {
-    // BLOCKED: with_env_tz — requires process-level TZ change (ENV["TZ"]); Node.js does not support changing the system TZ after startup
+    // BLOCKED: unknown — with_env_tz: requires process-level TZ change (ENV["TZ"]); Node.js does not support changing the system TZ after startup
   });
   it("default in utc", async () => {
     await withTimezoneConfig({ default: "utc" }, () => {
@@ -2437,16 +2437,16 @@ describe("BasicsTest", () => {
     });
   });
   it.skip("switching default time zone", () => {
-    // BLOCKED: with_env_tz — toggles default_timezone between :local and :utc using process-level TZ; Node.js does not support this
+    // BLOCKED: unknown — with_env_tz: toggles default_timezone between :local and :utc using process-level TZ; Node.js does not support this
   });
   it.skip("mutating time objects", () => {
-    // BLOCKED: with_env_tz — reads Default.new.fixed_time in local TZ, calls .utc; requires process-level TZ change
+    // BLOCKED: unknown — with_env_tz: reads Default.new.fixed_time in local TZ, calls .utc; requires process-level TZ change
   });
   it.skip("connection in local time", () => {
-    // BLOCKED: establish_connection — requires Base.establish_connection with per-connection default_timezone; SchemaAdapter does not support reconnecting with new config
+    // BLOCKED: connection-pool — establish_connection: requires Base.establish_connection with per-connection default_timezone; SchemaAdapter does not support reconnecting with new config
   });
   it.skip("connection in utc time", () => {
-    // BLOCKED: establish_connection — same as "connection in local time"
+    // BLOCKED: connection-pool — establish_connection: same as "connection in local time"
   });
   it("column name properly quoted", () => {
     class User extends Base {


### PR DESCRIPTION
## Summary

Schema cluster **Slot K** per `docs/activerecord-100-clusters.md`. Lands after Slot H-b/I/J (all closed). Re-tags every off-vocabulary `BLOCKED:` annotation in the Schema cluster's test surface to the controlled vocabulary defined in `docs/test-compare-100-plan.md`. The original tag is preserved inline in the comment trailer for traceability.

Comment-only diff (+33 / −32). No test logic changes. No impl changes. No un-skips (verified test surface; no impl already supports an un-skip in scope).

## Files & re-tags

### `adapters/abstract-mysql-adapter/schema.test.ts` (2)
- `ansi-quotes` → `adapter-mysql` — Both tests require `SET SESSION sql_mode='ANSI_QUOTES'`. The blocker is an adapter-level session-variable setter (MySQL-specific feature gap), so it sits squarely in the `adapter-mysql` category.

### `adapters/postgresql/schema.test.ts` (1)
- `needs-prepared-statements` → `adapter-pg` — `schema change with prepared stmt` needs the adapter's prepared-statements mode toggle, a PG-adapter feature gap.

### `adapters/postgresql/hstore.test.ts` (19)
- `schema-statements` → `schema` (3) — `add_column`/`changeColumnDefault`/`enableExtension`/`changeTable t.hstore` are schema-introspection/definition gaps.
- `schema-dumper` → `schema` (1) — `SchemaDumper` not emitting `t.hstore(...)` falls under schema definition/dumper.
- `store-accessor` → `unknown` (4) — `Base.store_accessor` has no direct vocab match; flagged for triage so a category can be added if/when a store cluster forms.
- `test-name mismatch` → `unknown` (7) — Tests with no Rails counterpart; flagged for triage to either rename to the closest Rails test or move to `unported-files.ts`. Out of scope here (comment-only).
- `attribute-methods` → `unknown` (1) — `readAttributeBeforeTypeCast` gap; no direct vocab fit.
- `serialize-coder` → `serialization` (2) — `Base.serialize({ coder })` is a serialization-subsystem gap.
- `Ruby-specific` → `unknown` (1) — `ActionController::Parameters#to_unsafe_h`; flagged for human triage to decide between `unknown` retention and `PERMANENT-SKIP` (would require `unported-files.ts` change, out of scope).

### `base.test.ts` (8)
- `fixtures + with_env_tz` → `fixture` (2) — Need Topic fixture data (the primary structural blocker); TZ env is a secondary concern noted inline.
- `Ruby-only` → `unknown` (1) — `Encoding.default_internal` (EUC-JP) column-name test; JS has no equivalent encoding model. Flagged for triage (likely PERMANENT-SKIP).
- `with_env_tz` → `unknown` (3) — Tests toggle process-level `ENV['TZ']` which Node.js does not support after startup. Flagged for triage (likely PERMANENT-SKIP).
- `establish_connection` → `connection-pool` (2) — Requires `Base.establishConnection` with per-connection `default_timezone`; this is a connection-pool/handler API gap.

## Verification

After this PR, the grep:

```bash
grep -rhn 'BLOCKED:' packages/activerecord/src --include='*.test.ts' \
  | awk '{for(i=1;i<=NF;i++) if($i=="BLOCKED:") {print $(i+1); break}}' \
  | sort | uniq -c | sort -rn
```

shows zero off-vocab tags in the Schema cluster's test surface files. Remaining off-vocab tags live in other clusters (relation/migration/date-time) and are out of scope for Slot K.

## Follow-ups (out of scope)

- ~30 LOC — `unknown`-tagged tests for `Ruby-only` / `Ruby-specific` / `with_env_tz` / `test-name mismatch` should likely be moved to `scripts/api-compare/unported-files.ts` with `PERMANENT-SKIP`. Requires impl-adjacent change; deliberately deferred to keep this PR comment-only.
- Adding a `store-accessor` (or `store`) category to the controlled vocabulary in `docs/test-compare-100-plan.md` once a store-cluster plan is sized.

## Test plan
- [ ] CI green (comment-only diff; no behavior change expected)
- [ ] No new off-vocab BLOCKED tags introduced in the Schema cluster surface