### PR TITLE
feat(activerecord): unknown-triage Slot C — SignedId real-feature gaps

### DIFF
--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base, RecordNotFound, registerSubclass } from "./index.js";
-import { setSignedIdVerifierSecret, signedIdVerifier } from "./signed-id.js";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { setSignedIdVerifierSecret, setSignedIdVerifier, signedIdVerifier } from "./signed-id.js";
+import { UnknownPrimaryKey } from "./errors.js";
 import { SignedGlobalID, setApp, _resetApp } from "@blazetrails/globalid";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -111,8 +113,20 @@ describe("SignedIdTest", () => {
     expect(found).not.toBeNull();
   });
 
-  it.skip("find signed record with custom primary key", () => {
-    // BLOCKED: relation — signed_id_test.rb: findSigned with custom primary key
+  it("find signed record with custom primary key", async () => {
+    class Toy extends Base {
+      static {
+        this._primaryKey = "toy_id";
+        this.attribute("toy_id", "string");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t = await Toy.create({ toy_id: "abc-123", name: "Block" });
+    const token = await t.signedId();
+    const found = await Toy.findSigned(token);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("Block");
   });
 
   it("find signed record for single table inheritance (STI Models)", async () => {
@@ -134,12 +148,32 @@ describe("SignedIdTest", () => {
     expect(found!.name).toBe("Rex");
   });
 
-  it.skip("find signed record raises UnknownPrimaryKey when a model has no primary key", () => {
-    // BLOCKED: relation — signed_id_test.rb: UnknownPrimaryKey error on no-pk model
+  it("find signed record raises UnknownPrimaryKey when a model has no primary key", async () => {
+    class Matey extends Base {
+      static {
+        this._primaryKey = "";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    await expect(Matey.findSigned("this will not be even verified")).rejects.toThrow(
+      UnknownPrimaryKey,
+    );
   });
 
-  it.skip("find signed record with a bang with custom primary key", () => {
-    // BLOCKED: relation — signed_id_test.rb: findSignedBang with custom primary key
+  it("find signed record with a bang with custom primary key", async () => {
+    class Toy extends Base {
+      static {
+        this._primaryKey = "toy_id";
+        this.attribute("toy_id", "string");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t = await Toy.create({ toy_id: "k-9", name: "Robot" });
+    const token = await t.signedId();
+    const found = await Toy.findSignedBang(token);
+    expect(found.name).toBe("Robot");
   });
 
   it("find signed record with a bang for single table inheritance (STI Models)", async () => {
@@ -198,12 +232,30 @@ describe("SignedIdTest", () => {
     );
   });
 
-  it.skip("fail to work without a signed_id_verifier_secret", () => {
-    // BLOCKED: relation — signed_id_test.rb: signedIdVerifierSecret config required
+  it("fail to work without a signed_id_verifier_secret", async () => {
+    const { User } = makeModel();
+    const u = await User.create({ name: "NoSecret" });
+    setSignedIdVerifierSecret(null);
+    try {
+      await expect(Promise.resolve().then(() => u.signedId())).rejects.toThrow(
+        /signed_id_verifier_secret|signed ids/i,
+      );
+    } finally {
+      setSignedIdVerifierSecret("blazetrails-test-secret");
+    }
   });
 
-  it.skip("fail to work without when signed_id_verifier_secret lambda is nil", () => {
-    // BLOCKED: relation — signed_id_test.rb: raises when verifier secret lambda returns nil
+  it("fail to work without when signed_id_verifier_secret lambda is nil", async () => {
+    const { User } = makeModel();
+    const u = await User.create({ name: "NilLambda" });
+    setSignedIdVerifierSecret(() => null);
+    try {
+      await expect(Promise.resolve().then(() => u.signedId())).rejects.toThrow(
+        /signed_id_verifier_secret|signed ids/i,
+      );
+    } finally {
+      setSignedIdVerifierSecret("blazetrails-test-secret");
+    }
   });
 
   it("always output url_safe", async () => {
@@ -216,8 +268,19 @@ describe("SignedIdTest", () => {
     expect(token.length).toBeGreaterThan(0);
   });
 
-  it.skip("use a custom verifier", () => {
-    // BLOCKED: relation — signed_id_test.rb: custom verifier via signedIdVerifier=
+  it("use a custom verifier", async () => {
+    const { User } = makeModel();
+    const customVerifier = new MessageVerifier("sekret", {
+      digest: "sha256",
+      url_safe: true,
+    });
+    setSignedIdVerifier(User as any, customVerifier);
+    expect(signedIdVerifier(User as any)).toBe(customVerifier);
+    const u = await User.create({ name: "Custom" });
+    const token = await u.signedId();
+    const found = await User.findSigned(token);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(u.id);
   });
 
   it("find signed record", async () => {
@@ -235,7 +298,8 @@ describe("SignedIdTest", () => {
   });
 
   it.skip("find signed record on relation", () => {
-    // BLOCKED: relation — signed_id_test.rb: findSigned on Relation scope
+    // BLOCKED: feature — Relation.findSigned scoping wrapper (Rails SignedId::RelationMethods).
+    // Needs Relation.findSigned / findSignedBang that call scoping { model.findSigned(...) }.
   });
 
   it("find signed record with a bang", async () => {
@@ -252,7 +316,7 @@ describe("SignedIdTest", () => {
   });
 
   it.skip("find signed record with a bang on relation", () => {
-    // BLOCKED: relation — signed_id_test.rb: findSignedBang on Relation scope
+    // BLOCKED: feature — Relation.findSignedBang scoping wrapper (Rails SignedId::RelationMethods).
   });
 
   it("find signed record with purpose", async () => {
@@ -271,8 +335,12 @@ describe("SignedIdTest", () => {
     expect(wrongPurpose).toBeNull();
   });
 
-  it.skip("find signed record with a bang within expiration duration", () => {
-    // BLOCKED: relation — signed_id_test.rb: findSignedBang raises when expired
+  it("find signed record with a bang within expiration duration", async () => {
+    const { User } = makeModel();
+    const u = await User.create({ name: "Timely" });
+    const token = await u.signedId({ expiresIn: 60 });
+    const found = await User.findSignedBang(token);
+    expect(found.id).toBe(u.id);
   });
 });
 

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -533,7 +533,7 @@ describe("signedId / findSigned / findSignedBang", () => {
       }
     }
     const user = new User({ name: "Alice" });
-    await expect(user.signedId()).rejects.toThrow("Cannot generate a signed_id for a new record");
+    await expect(user.signedId()).rejects.toThrow("Cannot get a signed_id for a new record");
   });
 
   it("findSigned recovers the record from its signed ID", async () => {

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -2,6 +2,7 @@ import type { Base } from "./base.js";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { underscore } from "@blazetrails/activesupport";
 import type { Temporal } from "@blazetrails/activesupport/temporal";
+import { UnknownPrimaryKey } from "./errors.js";
 
 /**
  * Signed ID generation and lookup for ActiveRecord models.
@@ -11,7 +12,7 @@ import type { Temporal } from "@blazetrails/activesupport/temporal";
  * Mirrors: ActiveRecord::SignedId
  */
 
-let _signedIdVerifierSecret: string | (() => string) | null = null;
+let _signedIdVerifierSecret: string | (() => string | null | undefined) | null = null;
 const _cachedVerifierClasses = new Set<any>();
 
 /**
@@ -20,7 +21,9 @@ const _cachedVerifierClasses = new Set<any>();
  *
  * Mirrors: ActiveRecord::Base.signed_id_verifier_secret=
  */
-export function setSignedIdVerifierSecret(secret: string | (() => string)): void {
+export function setSignedIdVerifierSecret(
+  secret: string | (() => string | null | undefined) | null,
+): void {
   _signedIdVerifierSecret = secret;
   for (const cls of _cachedVerifierClasses) {
     cls._signedIdVerifier = null;
@@ -40,14 +43,11 @@ export function signedIdVerifier(modelClass: typeof Base): MessageVerifier {
   }
 
   const secret = _signedIdVerifierSecret;
-  if (!secret) {
-    throw new Error(
-      "You must configure a signed ID verifier secret before using signed IDs. " +
-        "Call setSignedIdVerifierSecret('your-secret-key') before generating or verifying signed IDs.",
-    );
+  const resolvedSecret = typeof secret === "function" ? secret() : secret;
+  if (!resolvedSecret) {
+    throw new Error("You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids");
   }
 
-  const resolvedSecret = typeof secret === "function" ? secret() : secret;
   const verifier = new MessageVerifier(resolvedSecret, {
     digest: "sha256",
     url_safe: true,
@@ -64,6 +64,13 @@ export function signedIdVerifier(modelClass: typeof Base): MessageVerifier {
  */
 export function setSignedIdVerifier(modelClass: typeof Base, verifier: MessageVerifier): void {
   (modelClass as any)._signedIdVerifier = verifier;
+}
+
+function _hasPrimaryKey(pk: unknown): boolean {
+  if (pk == null) return false;
+  if (Array.isArray(pk))
+    return pk.length > 0 && pk.every((k) => typeof k === "string" && k.length > 0);
+  return typeof pk === "string" && pk.length > 0;
 }
 
 function combinePurposes(modelClass: typeof Base, purpose?: string): string | undefined {
@@ -104,12 +111,15 @@ export async function findSigned<T extends typeof Base>(
   token: string,
   options?: { purpose?: string },
 ): Promise<InstanceType<T> | null> {
+  const pk = modelClass.primaryKey;
+  if (!_hasPrimaryKey(pk)) {
+    throw new UnknownPrimaryKey(modelClass);
+  }
   const verifier = signedIdVerifier(modelClass);
   const id = verifier.verified(token, {
     purpose: combinePurposes(modelClass, options?.purpose),
   });
   if (id === null) return null;
-  const pk = modelClass.primaryKey;
   if (Array.isArray(pk)) {
     const conditions: Record<string, unknown> = {};
     (pk as string[]).forEach((col, i) => {

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -89,7 +89,7 @@ export function signedId(
   options?: { purpose?: string; expiresIn?: number; expiresAt?: Temporal.Instant },
 ): string {
   if (!instance.isPersisted()) {
-    throw new Error("Cannot generate a signed_id for a new record");
+    throw new Error("Cannot get a signed_id for a new record");
   }
   const ctor = instance.constructor as typeof Base;
   const verifier = signedIdVerifier(ctor);


### PR DESCRIPTION
## Summary

Unknown-triage **Slot C** per `docs/activerecord-100-clusters.md` — fills real feature gaps in `SignedId` and un-skips 7 of 9 BLOCKED tests in `signed-id.test.ts`.

Impl changes (`packages/activerecord/src/signed-id.ts`):

- `findSigned` now raises `UnknownPrimaryKey` when `modelClass.primaryKey` is nullish / empty / empty-string array element (Rails parity — `find_signed` raises `UnknownPrimaryKey.new(self) if primary_key.nil?`).
- `signedIdVerifier` resolves the secret lambda **before** the null check, so a `() => null` lambda triggers the same `ArgumentError`-style throw Rails uses. Error message updated to Rails wording.
- `setSignedIdVerifierSecret` accepts `null` to clear the secret (Rails sets it back to `nil` in the same test).

Un-skipped tests:

- `find signed record with custom primary key`
- `find signed record with a bang with custom primary key`
- `find signed record raises UnknownPrimaryKey when a model has no primary key`
- `fail to work without a signed_id_verifier_secret`
- `fail to work without when signed_id_verifier_secret lambda is nil`
- `use a custom verifier` (impl already in place via `setSignedIdVerifier`)
- `find signed record with a bang within expiration duration`

Two remaining skips (`find signed record on relation` / `... with a bang on relation`) need `Relation.findSigned` / `findSignedBang` scoping wrappers (Rails `SignedId::RelationMethods`). Re-tagged from the stale `BLOCKED: relation` catch-all to `BLOCKED: feature` with the actual gap. Deferred to a follow-up.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/signed-id.test.ts` → 45 passed, 2 skipped (down from 9)
- [x] `pnpm vitest run packages/activerecord/src/token-for.test.ts` → 20 passed (no regression)
- [x] LOC: 131 (under 300 ceiling)