### PR TITLE
feat(action-dispatch): Wave 7 PR 10 — Journey wire-up seam on RouteSet

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -81,6 +81,16 @@ describe("RouteSet — Journey bridge", () => {
     expect(routes.journeyRecognize("GET", "/posts/x")).toBeNull();
   });
 
+  it("journeyRecognize preserves escaped \\$ in constraints (only strips true anchors)", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      // Constraint matches a literal `$` followed by digits.
+      r.get("/posts/:id", { to: "posts#show", constraints: { id: /\$\d+/ } });
+    });
+    expect(routes.journeyRecognize("GET", "/posts/$5")).not.toBeNull();
+    expect(routes.journeyRecognize("GET", "/posts/abc")).toBeNull();
+  });
+
   it("journeyRecognize strips anchors from string constraints", () => {
     const routes = new RouteSet();
     routes.draw((r) => {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -81,6 +81,23 @@ describe("RouteSet — Journey bridge", () => {
     expect(routes.journeyRecognize("GET", "/posts/x")).toBeNull();
   });
 
+  it("journeyRecognize strips anchors from string constraints", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show", constraints: { id: "^\\d+$" } });
+    });
+    expect(routes.journeyRecognize("GET", "/posts/9")).not.toBeNull();
+  });
+
+  it("journeyRecognize URI-decodes captured parameters", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:slug", { to: "posts#show" });
+    });
+    const m = routes.journeyRecognize("GET", "/posts/hello%20world");
+    expect(m!.params["slug"]).toBe("hello world");
+  });
+
   it("journeyRecognize keeps :controller/:action captures for generic routes", () => {
     const routes = new RouteSet();
     routes.draw((r) => {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -81,6 +81,16 @@ describe("RouteSet — Journey bridge", () => {
     expect(routes.journeyRecognize("GET", "/posts/x")).toBeNull();
   });
 
+  it("journeyRecognize keeps :controller/:action captures for generic routes", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/:controller/:action", {});
+    });
+    const m = routes.journeyRecognize("GET", "/users/show");
+    expect(m).not.toBeNull();
+    expect(m!.params).toEqual({ controller: "users", action: "show" });
+  });
+
   it("journeyRecognize params hold only path captures (defaults stripped)", () => {
     const routes = new RouteSet();
     routes.draw((r) => {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { RouteSet } from "./route-set.js";
+
+describe("RouteSet — Journey bridge", () => {
+  it("journeyRecognize resolves a simple GET route", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts", { to: "posts#index" });
+    });
+    const m = routes.journeyRecognize("GET", "/posts");
+    expect(m).not.toBeNull();
+    expect(m!.route.controller).toBe("posts");
+    expect(m!.route.action).toBe("index");
+  });
+
+  it("journeyRecognize captures dynamic segments", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show" });
+    });
+    const m = routes.journeyRecognize("GET", "/posts/42");
+    expect(m).not.toBeNull();
+    expect(m!.params["id"]).toBe("42");
+    expect(m!.route.controller).toBe("posts");
+  });
+
+  it("journeyRecognize filters by HTTP verb", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/x", { to: "a#index" });
+      r.post("/x", { to: "b#create" });
+    });
+    expect(routes.journeyRecognize("GET", "/x")!.route.action).toBe("index");
+    expect(routes.journeyRecognize("POST", "/x")!.route.action).toBe("create");
+  });
+
+  it("journeyRecognize returns null for unmatched paths", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts", { to: "posts#index" });
+    });
+    expect(routes.journeyRecognize("GET", "/nope")).toBeNull();
+  });
+
+  it("journeyRouter cache invalidates on draw and clear", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => r.get("/a", { to: "a#index" }));
+    const first = routes.journeyRouter;
+    routes.draw((r) => r.get("/b", { to: "b#index" }));
+    expect(routes.journeyRouter).not.toBe(first);
+    routes.clear();
+    expect(routes.journeyRouter).not.toBe(first);
+  });
+
+  it("journeyRecognize honors regex constraints", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show", constraints: { id: /\d+/ } });
+    });
+    expect(routes.journeyRecognize("GET", "/posts/42")).not.toBeNull();
+    expect(routes.journeyRecognize("GET", "/posts/abc")).toBeNull();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -91,6 +91,25 @@ describe("RouteSet — Journey bridge", () => {
     expect(m!.params).toEqual({ controller: "users", action: "show" });
   });
 
+  it("journeyRecognize does not leak defaults into missing optional captures", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts(/:id)", { to: "posts#index", defaults: { id: "1" } });
+    });
+    const m = routes.journeyRecognize("GET", "/posts");
+    expect(m).not.toBeNull();
+    expect(m!.params).not.toHaveProperty("id");
+  });
+
+  it("journeyRecognize normalizes paths (leading slash, trailing slash)", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts", { to: "posts#index" });
+    });
+    expect(routes.journeyRecognize("GET", "/posts/")).not.toBeNull();
+    expect(routes.journeyRecognize("GET", "posts")).not.toBeNull();
+  });
+
   it("journeyRecognize params hold only path captures (defaults stripped)", () => {
     const routes = new RouteSet();
     routes.draw((r) => {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.test.ts
@@ -60,4 +60,35 @@ describe("RouteSet — Journey bridge", () => {
     expect(routes.journeyRecognize("GET", "/posts/42")).not.toBeNull();
     expect(routes.journeyRecognize("GET", "/posts/abc")).toBeNull();
   });
+
+  it("journeyRecognize honors anchored regex constraints (^/$ stripped)", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show", constraints: { id: /^\d+$/ } });
+    });
+    const m = routes.journeyRecognize("GET", "/posts/7");
+    expect(m).not.toBeNull();
+    expect(m!.params["id"]).toBe("7");
+    expect(routes.journeyRecognize("GET", "/posts/abc")).toBeNull();
+  });
+
+  it("journeyRecognize honors string constraints", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show", constraints: { id: "\\d+" } });
+    });
+    expect(routes.journeyRecognize("GET", "/posts/9")).not.toBeNull();
+    expect(routes.journeyRecognize("GET", "/posts/x")).toBeNull();
+  });
+
+  it("journeyRecognize params hold only path captures (defaults stripped)", () => {
+    const routes = new RouteSet();
+    routes.draw((r) => {
+      r.get("/posts/:id", { to: "posts#show" });
+    });
+    const m = routes.journeyRecognize("GET", "/posts/1")!;
+    expect(m.params).toEqual({ id: "1" });
+    expect(m.params).not.toHaveProperty("controller");
+    expect(m.params).not.toHaveProperty("action");
+  });
 });

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -104,7 +104,17 @@ export function journeyRecognize(
 const STOP = Symbol("journey-bridge-stop");
 
 function stripAnchors(source: string): string {
-  return source.replace(/^\^/, "").replace(/\$$/, "");
+  let s = source;
+  if (s.startsWith("^")) s = s.slice(1);
+  // Only strip a trailing `$` if it's a true end-of-string anchor — i.e. not
+  // preceded by an odd number of backslashes (which would mean it's `\$`,
+  // a literal dollar sign).
+  if (s.endsWith("$")) {
+    let backslashes = 0;
+    for (let i = s.length - 2; i >= 0 && s[i] === "\\"; i--) backslashes++;
+    if (backslashes % 2 === 0) s = s.slice(0, -1);
+  }
+  return s;
 }
 
 function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -12,6 +12,7 @@ import { Pattern } from "../journey/path/pattern.js";
 import { Route as JourneyRoute, VerbMatchers } from "../journey/route.js";
 import { Routes as JourneyRoutes } from "../journey/routes.js";
 import { Router as JourneyRouter, type RouterRequest } from "../journey/router.js";
+import { normalizePath } from "../journey/router/utils.js";
 import type { Route as LocalRoute } from "./route.js";
 
 const SEPARATORS = "/.?";
@@ -66,22 +67,28 @@ export function journeyRecognize(
   method: string,
   path: string,
 ): JourneyMatch | null {
+  const pathInfo = normalizePath(path);
   const req: RouterRequest = {
-    pathInfo: path,
+    pathInfo,
     scriptName: "",
     requestMethod: method.toUpperCase(),
     pathParameters: {},
   };
   let result: JourneyMatch | null = null;
   try {
-    router.recognize(req, (journeyRoute, parameters) => {
+    router.recognize(req, (journeyRoute) => {
       const local = JOURNEY_TO_LOCAL.get(journeyRoute);
       if (!local) return;
-      const captureNames = new Set(journeyRoute.path.names);
+      // Re-match against the pattern so we get *only* captured segments —
+      // the parameters Router.recognize yields are merged with defaults,
+      // which leaks defaults into optional captures (e.g. /posts(/:id)
+      // with defaults={id:"1"} matching /posts).
+      const match = journeyRoute.path.match(pathInfo);
       const params: Record<string, string> = {};
-      for (const name of captureNames) {
-        const v = parameters[name];
-        if (v != null) params[name] = String(v);
+      if (match) {
+        for (const [name, value] of Object.entries(match.namedCaptures)) {
+          if (value != null) params[name] = value;
+        }
       }
       result = { route: local, params };
       // Router.recognize iterates all matches; short-circuit so large route

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -74,11 +74,14 @@ export function journeyRecognize(
     const local = JOURNEY_TO_LOCAL.get(journeyRoute);
     if (!local) return;
     // Router.recognize merges route.defaults into parameters; for parity with
-    // the local matcher's MatchedRoute shape, keep only path captures.
-    const defaultKeys = new Set(Object.keys(journeyRoute.defaults));
+    // the local matcher's MatchedRoute shape, keep only path captures. Pick
+    // by the pattern's name set so captures sharing a default key (e.g.
+    // /:controller/:action) survive.
+    const captureNames = new Set(journeyRoute.path.names);
     const params: Record<string, string> = {};
-    for (const [k, v] of Object.entries(parameters)) {
-      if (v != null && !defaultKeys.has(k)) params[k] = String(v);
+    for (const name of captureNames) {
+      const v = parameters[name];
+      if (v != null) params[name] = String(v);
     }
     result = { route: local, params };
   });

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -1,0 +1,81 @@
+/**
+ * Journey-bridge: builds a `Journey::Router` from a `RouteSet`'s local
+ * `Route` objects so dispatch can be exercised end-to-end through the
+ * journey engine. The bridge is a seam — `RouteSet#recognize` still
+ * delegates to the local matcher for now; consumers can opt in to the
+ * journey-backed path via `RouteSet#journeyRouter` / `journeyRecognize`.
+ */
+
+import { Parser } from "../journey/parser.js";
+import { Ast } from "../journey/ast.js";
+import { Pattern } from "../journey/path/pattern.js";
+import { Route as JourneyRoute, VerbMatchers } from "../journey/route.js";
+import { Routes as JourneyRoutes } from "../journey/routes.js";
+import { Router as JourneyRouter, type RouterRequest } from "../journey/router.js";
+import type { Route as LocalRoute } from "./route.js";
+
+const SEPARATORS = "/.?";
+
+const JOURNEY_TO_LOCAL = new WeakMap<JourneyRoute, LocalRoute>();
+
+export interface JourneyMatch {
+  route: LocalRoute;
+  params: Record<string, string>;
+}
+
+export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter {
+  const journeyRoutes = new JourneyRoutes();
+  for (let i = 0; i < routes.length; i++) {
+    const r = routes[i]!;
+    const tree = new Parser().parse(r.path);
+    const ast = new Ast(tree, true);
+    const requirements = regexpRequirements(r.constraints);
+    const pattern = new Pattern(ast, requirements, SEPARATORS, r.anchor);
+    const verb = (r.verb || "").toUpperCase();
+    const requestMethodMatch = verb ? [VerbMatchers.for(verb)] : undefined;
+    const name = r.name ?? `__r${i}`;
+    const journeyRoute = new JourneyRoute({
+      name,
+      app: { serve: () => [200, {}, []] },
+      path: pattern,
+      defaults: { controller: r.controller, action: r.action, ...r.defaults },
+      requestMethodMatch,
+    });
+    JOURNEY_TO_LOCAL.set(journeyRoute, r);
+    journeyRoutes.addRoute(name, { makeRoute: () => journeyRoute });
+  }
+  return new JourneyRouter(journeyRoutes);
+}
+
+export function journeyRecognize(
+  router: JourneyRouter,
+  method: string,
+  path: string,
+): JourneyMatch | null {
+  const req: RouterRequest = {
+    pathInfo: path,
+    scriptName: "",
+    requestMethod: method.toUpperCase(),
+    pathParameters: {},
+  };
+  let result: JourneyMatch | null = null;
+  router.recognize(req, (journeyRoute, parameters) => {
+    if (result) return;
+    const local = JOURNEY_TO_LOCAL.get(journeyRoute);
+    if (!local) return;
+    const params: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parameters)) {
+      if (v != null) params[k] = String(v);
+    }
+    result = { route: local, params };
+  });
+  return result;
+}
+
+function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> {
+  const out: Record<string, RegExp> = {};
+  for (const [k, v] of Object.entries(c)) {
+    if (v instanceof RegExp) out[k] = v;
+  }
+  return out;
+}

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -12,7 +12,7 @@ import { Pattern } from "../journey/path/pattern.js";
 import { Route as JourneyRoute, VerbMatchers } from "../journey/route.js";
 import { Routes as JourneyRoutes } from "../journey/routes.js";
 import { Router as JourneyRouter, type RouterRequest } from "../journey/router.js";
-import { normalizePath } from "../journey/router/utils.js";
+import { normalizePath, unescapeUri } from "../journey/router/utils.js";
 import type { Route as LocalRoute } from "./route.js";
 
 const SEPARATORS = "/.?";
@@ -87,7 +87,7 @@ export function journeyRecognize(
       const params: Record<string, string> = {};
       if (match) {
         for (const [name, value] of Object.entries(match.namedCaptures)) {
-          if (value != null) params[name] = value;
+          if (value != null) params[name] = unescapeUri(value);
         }
       }
       result = { route: local, params };
@@ -103,6 +103,10 @@ export function journeyRecognize(
 
 const STOP = Symbol("journey-bridge-stop");
 
+function stripAnchors(source: string): string {
+  return source.replace(/^\^/, "").replace(/\$$/, "");
+}
+
 function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> {
   const out: Record<string, RegExp> = {};
   for (const [k, v] of Object.entries(c)) {
@@ -110,10 +114,9 @@ function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> 
     // we must strip embedded anchors from RegExp sources and never add them
     // for string constraints — otherwise the anchor binds to the whole path.
     if (v instanceof RegExp) {
-      const source = v.source.replace(/^\^/, "").replace(/\$$/, "");
-      out[k] = new RegExp(source, v.flags);
+      out[k] = new RegExp(stripAnchors(v.source), v.flags);
     } else if (typeof v === "string") {
-      out[k] = new RegExp(v);
+      out[k] = new RegExp(stripAnchors(v));
     }
   }
   return out;

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -32,13 +32,15 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
     const requirements = regexpRequirements(r.constraints);
     const pattern = new Pattern(ast, requirements, SEPARATORS, r.anchor);
     const verb = (r.verb || "").toUpperCase();
-    const requestMethodMatch = verb ? [VerbMatchers.for(verb)] : undefined;
+    const requestMethodMatch = !verb || verb === "ALL" ? undefined : [VerbMatchers.for(verb)];
     const name = r.name ?? `__r${i}`;
+    // controller/action are authoritative on the local Route; user defaults
+    // must not overwrite them.
     const journeyRoute = new JourneyRoute({
       name,
       app: { serve: () => [200, {}, []] },
       path: pattern,
-      defaults: { controller: r.controller, action: r.action, ...r.defaults },
+      defaults: { ...r.defaults, controller: r.controller, action: r.action },
       requestMethodMatch,
     });
     JOURNEY_TO_LOCAL.set(journeyRoute, r);
@@ -76,6 +78,8 @@ function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> 
   const out: Record<string, RegExp> = {};
   for (const [k, v] of Object.entries(c)) {
     if (v instanceof RegExp) out[k] = v;
+    // String constraints are anchored at both ends by the local matcher.
+    else if (typeof v === "string") out[k] = new RegExp(`^${v}$`);
   }
   return out;
 }

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -35,24 +35,28 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
     const requestMethodMatch = !verb || verb === "ALL" ? undefined : [VerbMatchers.for(verb)];
     const name = r.name ?? `__r${i}`;
     // controller/action are authoritative on the local Route; user defaults
-    // must not overwrite them.
-    const journeyRoute = new JourneyRoute({
-      name,
-      // Seam routes are recognize-only; calling serve() here is a programming
-      // error — fail loudly instead of returning an empty 200.
-      app: {
-        serve: () => {
-          throw new Error(
-            `Journey-bridge route '${name}' has no app — use RouteSet.call(), not journeyRouter.serve().`,
-          );
-        },
+    // must not overwrite them. Precedence is the insertion index so
+    // Router.recognize's precedence sort preserves RouteSet order.
+    journeyRoutes.addRoute(name, {
+      makeRoute: (routeName, index) => {
+        const journeyRoute = new JourneyRoute({
+          name: routeName,
+          app: {
+            serve: () => {
+              throw new Error(
+                `Journey-bridge route '${routeName}' has no app — use RouteSet.call(), not journeyRouter.serve().`,
+              );
+            },
+          },
+          path: pattern,
+          defaults: { ...r.defaults, controller: r.controller, action: r.action },
+          requestMethodMatch,
+          precedence: index,
+        });
+        JOURNEY_TO_LOCAL.set(journeyRoute, r);
+        return journeyRoute;
       },
-      path: pattern,
-      defaults: { ...r.defaults, controller: r.controller, action: r.action },
-      requestMethodMatch,
     });
-    JOURNEY_TO_LOCAL.set(journeyRoute, r);
-    journeyRoutes.addRoute(name, { makeRoute: () => journeyRoute });
   }
   return new JourneyRouter(journeyRoutes);
 }
@@ -69,24 +73,28 @@ export function journeyRecognize(
     pathParameters: {},
   };
   let result: JourneyMatch | null = null;
-  router.recognize(req, (journeyRoute, parameters) => {
-    if (result) return;
-    const local = JOURNEY_TO_LOCAL.get(journeyRoute);
-    if (!local) return;
-    // Router.recognize merges route.defaults into parameters; for parity with
-    // the local matcher's MatchedRoute shape, keep only path captures. Pick
-    // by the pattern's name set so captures sharing a default key (e.g.
-    // /:controller/:action) survive.
-    const captureNames = new Set(journeyRoute.path.names);
-    const params: Record<string, string> = {};
-    for (const name of captureNames) {
-      const v = parameters[name];
-      if (v != null) params[name] = String(v);
-    }
-    result = { route: local, params };
-  });
+  try {
+    router.recognize(req, (journeyRoute, parameters) => {
+      const local = JOURNEY_TO_LOCAL.get(journeyRoute);
+      if (!local) return;
+      const captureNames = new Set(journeyRoute.path.names);
+      const params: Record<string, string> = {};
+      for (const name of captureNames) {
+        const v = parameters[name];
+        if (v != null) params[name] = String(v);
+      }
+      result = { route: local, params };
+      // Router.recognize iterates all matches; short-circuit so large route
+      // sets aren't fully walked after the first hit.
+      throw STOP;
+    });
+  } catch (e) {
+    if (e !== STOP) throw e;
+  }
   return result;
 }
+
+const STOP = Symbol("journey-bridge-stop");
 
 function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> {
   const out: Record<string, RegExp> = {};

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -38,7 +38,15 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
     // must not overwrite them.
     const journeyRoute = new JourneyRoute({
       name,
-      app: { serve: () => [200, {}, []] },
+      // Seam routes are recognize-only; calling serve() here is a programming
+      // error — fail loudly instead of returning an empty 200.
+      app: {
+        serve: () => {
+          throw new Error(
+            `Journey-bridge route '${name}' has no app — use RouteSet.call(), not journeyRouter.serve().`,
+          );
+        },
+      },
       path: pattern,
       defaults: { ...r.defaults, controller: r.controller, action: r.action },
       requestMethodMatch,
@@ -65,9 +73,12 @@ export function journeyRecognize(
     if (result) return;
     const local = JOURNEY_TO_LOCAL.get(journeyRoute);
     if (!local) return;
+    // Router.recognize merges route.defaults into parameters; for parity with
+    // the local matcher's MatchedRoute shape, keep only path captures.
+    const defaultKeys = new Set(Object.keys(journeyRoute.defaults));
     const params: Record<string, string> = {};
     for (const [k, v] of Object.entries(parameters)) {
-      if (v != null) params[k] = String(v);
+      if (v != null && !defaultKeys.has(k)) params[k] = String(v);
     }
     result = { route: local, params };
   });
@@ -77,9 +88,15 @@ export function journeyRecognize(
 function regexpRequirements(c: Record<string, unknown>): Record<string, RegExp> {
   const out: Record<string, RegExp> = {};
   for (const [k, v] of Object.entries(c)) {
-    if (v instanceof RegExp) out[k] = v;
-    // String constraints are anchored at both ends by the local matcher.
-    else if (typeof v === "string") out[k] = new RegExp(`^${v}$`);
+    // Journey inlines `requirements[*].source` into an outer `^…$` regex, so
+    // we must strip embedded anchors from RegExp sources and never add them
+    // for string constraints — otherwise the anchor binds to the whole path.
+    if (v instanceof RegExp) {
+      const source = v.source.replace(/^\^/, "").replace(/\$$/, "");
+      out[k] = new RegExp(source, v.flags);
+    } else if (typeof v === "string") {
+      out[k] = new RegExp(v);
+    }
   }
   return out;
 }

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -13,7 +13,11 @@ import { bodyFromString } from "@blazetrails/rack";
 import { Mapper } from "./mapper.js";
 import type { MatchedRoute } from "./route.js";
 import { Route } from "./route.js";
-import { buildJourneyRouter, journeyRecognize, type JourneyMatch } from "./journey-bridge.js";
+import {
+  buildJourneyRouter,
+  journeyRecognize as recognizeViaJourney,
+  type JourneyMatch,
+} from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
 
 export type DrawCallback = (mapper: Mapper) => void;
@@ -64,7 +68,7 @@ export class RouteSet {
 
   /** Route lookup via the Journey-backed router. */
   journeyRecognize(method: string, path: string): JourneyMatch | null {
-    return journeyRecognize(this.journeyRouter, method, path);
+    return recognizeViaJourney(this.journeyRouter, method, path);
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -13,6 +13,8 @@ import { bodyFromString } from "@blazetrails/rack";
 import { Mapper } from "./mapper.js";
 import type { MatchedRoute } from "./route.js";
 import { Route } from "./route.js";
+import { buildJourneyRouter, journeyRecognize, type JourneyMatch } from "./journey-bridge.js";
+import type { Router as JourneyRouter } from "../journey/router.js";
 
 export type DrawCallback = (mapper: Mapper) => void;
 
@@ -28,6 +30,8 @@ export class RouteSet {
   private namedRoutes: Map<string, Route> = new Map();
   private dispatcher: Dispatcher | undefined;
   private defaultUrlOptions: { host?: string } = {};
+  /** @internal */
+  private _journeyRouter: JourneyRouter | null = null;
 
   /**
    * Draw routes using the Mapper DSL. Can be called multiple times;
@@ -43,6 +47,24 @@ export class RouteSet {
         this.namedRoutes.set(route.name, route);
       }
     }
+    this._journeyRouter = null;
+  }
+
+  /**
+   * Lazily-built `Journey::Router` mirroring the current route table.
+   * Wave 7 wire-up seam — exercises Journey end-to-end while keeping
+   * the legacy matcher as the default for `recognize()`.
+   */
+  get journeyRouter(): JourneyRouter {
+    if (!this._journeyRouter) {
+      this._journeyRouter = buildJourneyRouter(this.routes);
+    }
+    return this._journeyRouter;
+  }
+
+  /** Route lookup via the Journey-backed router. */
+  journeyRecognize(method: string, path: string): JourneyMatch | null {
+    return journeyRecognize(this.journeyRouter, method, path);
   }
 
   /**
@@ -108,6 +130,7 @@ export class RouteSet {
   clear(): void {
     this.routes = [];
     this.namedRoutes.clear();
+    this._journeyRouter = null;
   }
 
   /**


### PR DESCRIPTION
## Summary
Closes Wave 7 of the actionpack restructure. Adds a Journey-backed router seam to `RouteSet` so the full journey port (PRs 1–9) is exercised end-to-end through actionpack's routing public surface, without disturbing the legacy matcher used by `recognize()`.

- `journey-bridge.ts` — `buildJourneyRouter(routes)` + `journeyRecognize()`. Maps each local `Route` to a `Journey::Route` (path → `Pattern` via Parser+Ast; verb → `VerbMatchers`; regex constraints → requirements).
- `RouteSet.journeyRouter` (lazy getter, invalidated on `draw`/`clear`).
- `RouteSet.journeyRecognize(method, path)` — Journey-backed lookup returning `{ route, params }`.

## Audit note
Per the actionpack-restructure-audit, `route-set.ts` had no router-swap seam. Audit says: "if absent, prepend a small seam-creation PR." This PR adds that seam rather than ripping out the legacy matcher in a single shot. Migrating `recognize()` itself to the Journey path is a follow-up that can land alongside Mapper rework.

## Test plan
- [x] 6 new bridge tests pass (GET/POST verb dispatch, dynamic captures, regex constraints, cache invalidation, miss path).
- [x] All 15 existing `route-set.test.ts` tests still pass (no regression in legacy matcher).
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean