### PR TITLE
refactor(activerecord): TM unification Phase 5 continuation — defineSchema for transaction-family tests

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2311,6 +2311,7 @@ describe("SchemaAdapter TM delegation", () => {
   // TM does not track them and never tries to release them again.
   it("transaction() routes SchemaAdapter through TM (spy on inner.withinNewTransaction)", async () => {
     const testAdapter = createTestAdapter();
+    await defineSchema(testAdapter, { items: { name: "string" } });
     const inner = (testAdapter as any).innerAdapter;
     const spy = vi.spyOn(inner, "withinNewTransaction");
     class Item extends Base {
@@ -2330,6 +2331,7 @@ describe("SchemaAdapter TM delegation", () => {
     const { SavepointTransaction, RealTransaction } =
       await import("./connection-adapters/abstract/transaction.js");
     const testAdapter = createTestAdapter();
+    await defineSchema(testAdapter, { items: { name: "string" } });
     class Item extends Base {
       static {
         this.attribute("name", "string");
@@ -2369,6 +2371,7 @@ describe("SchemaAdapter TM delegation", () => {
     // shared TM stack and corrupt instrumenter state (the failure that
     // hit MariaDB CI).
     const testAdapter = createTestAdapter();
+    await defineSchema(testAdapter, { items: { name: "string" } });
     class Item extends Base {
       static {
         this.attribute("name", "string");
@@ -2426,6 +2429,7 @@ describe("SchemaAdapter TM delegation", () => {
     // set the AsyncLocalStorage flag. _manualTxDepth tracks them per
     // wrapper so the chain-aware delegations expose inner state.
     const testAdapter = createTestAdapter();
+    await defineSchema(testAdapter, { items: { name: "string" } });
     class Item extends Base {
       static {
         this.attribute("name", "string");


### PR DESCRIPTION
## Summary
- Adds explicit `defineSchema()` to the 4 `SchemaAdapter TM delegation` tests in `transactions.test.ts` so they pass under `AR_NO_AUTO_SCHEMA=1`.
- The other two transaction-family files (`transaction-instrumentation.test.ts`, `transaction-isolation.test.ts`) already passed under the flag — no changes needed there.
- Unblocks the Phase 7 prerequisite in `docs/tm-unification-plan.md`: validate the auto-schema recovery infra in `test-adapter.ts` is dead by running a CI cycle with `AR_NO_AUTO_SCHEMA=1` set unconditionally.

## Verification
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` across all three files: **185 passed | 11 skipped** (was 4 failed before).
- `pnpm vitest run packages/activerecord/src/transactions.test.ts` (normal mode): **160 passed | 5 skipped**.

## Test plan
- [x] All three transaction-family files green under `AR_NO_AUTO_SCHEMA=1`
- [x] Normal mode still green
- [ ] CI green