### PR TITLE
feat(activerecord): PG interval row-read — wire Interval.castValue in attribute materialization

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -77,8 +77,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("interval type cast from invalid string", async () => {
       const i = await IntervalDataType.createBang({ maximum_term: "1 year 2 minutes" });
       // Rails: invalid non-ISO string casts to nil before INSERT, so column is NULL.
-      // Verify at the SQL level so this can't be a false positive from the parallel
-      // row-read deserialization gap (see skipped "interval type" test).
+      // Verify at the SQL level (in addition to the reload assertion below) to pin
+      // the pre-INSERT cast independently of row-read deserialization.
       const rows = await adapter.execute(
         `SELECT maximum_term IS NULL AS is_null FROM interval_data_types WHERE id = $1`,
         [(i as any).id],

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -58,13 +58,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(columnMin.precision).toBe(3);
     });
 
-    it.skip("interval type", async () => {
-      // BLOCKED: model attribute lifecycle does not deserialize interval columns from row data
-      // ROOT-CAUSE: rows returned from PG SELECT contain interval as ISO8601 strings, but Base
-      //   does not route them through Interval.cast/castValue when materializing attributes —
-      //   the attribute reads back as null instead of a Duration.
-      // SCOPE: ~30–80 LOC — likely in attribute-set materialization or postgresql/oid type-map
-      //   wiring for interval result deserialization; see Slot B (round-trip).
+    it("interval type", async () => {
+      const sixYears = Duration.parse("P6Y5M4DT3H2M1S");
+      const oneYear = Duration.parse("P1Y2M3DT4H5M6.235S");
+      await IntervalDataType.createBang({
+        maximum_term: sixYears,
+        minimum_term: oneYear,
+        all_terms: [Duration.parse("P1M"), Duration.parse("P1Y"), Duration.parse("PT1H")],
+        legacy_term: "33 years",
+      });
+      const i = await IntervalDataType.last();
+      expect((i.maximum_term as Duration).iso8601()).toBe("P6Y5M4DT3H2M1S");
+      expect((i.minimum_term as Duration).iso8601()).toBe("P1Y2M3DT4H5M6.235S");
+      expect((i.default_term as Duration).iso8601()).toBe("P3Y");
+      expect(i.legacy_term).toBe("P33Y");
     });
 
     it("interval type cast from invalid string", async () => {
@@ -81,12 +88,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(i.maximum_term).toBeNull();
     });
 
-    it.skip("interval type cast from numeric", async () => {
-      // BLOCKED: same as "interval type" — reload() materializes interval column as null
-      //   instead of routing the ISO8601 row value through Interval.castValue.
-      // ROOT-CAUSE: postgresql interval result deserialization not wired into Base
-      //   attribute lifecycle on row reads.
-      // SCOPE: shares fix with "interval type"; see Slot B (round-trip).
+    it("interval type cast from numeric", async () => {
+      const i = await IntervalDataType.createBang({ minimum_term: 36000 });
+      await i.reload();
+      expect((i.minimum_term as Duration).iso8601()).toBe("PT10H");
     });
 
     it("interval type cast string and numeric from user", () => {


### PR DESCRIPTION
## Summary

- Un-skips `interval.test.ts > \"interval type\"` and `> \"interval type cast from numeric\"`.
- Row-read deserialization routes through `Interval` via the PostgreSQL OID type-map (oid `1186` → `Interval`). On `reload()` / `last()`, interval columns materialize as `Duration` instead of `null`, closing the row-read half of the PG interval cluster.
- No production code changes were needed — the wiring already exists via `lookupCastTypeFromColumn` → `typeMap.fetch(1186)` → `Interval`, and `intervalstyle = iso_8601` is set per connection so PG returns ISO 8601 strings that `Interval.castValue` parses via `Duration.parse`. The recent verbose-format Interval work (#1567) closed the remaining materialization gap; this PR proves it by un-skipping the BLOCKED tests.

## Cluster status

Closes the row-read part of the PG interval cluster (docs/activerecord-100-clusters.md). The remaining `splitPgDefault` cast-aware numeric→Duration follow-up for the `schema dump with default value` test is unrelated to row reads and tracked separately.

## Test plan

- [x] `TEST_ADAPTER=postgresql pnpm exec vitest run packages/activerecord/src/adapters/postgresql/interval.test.ts` — 7/7 passing (was 5 passing + 2 skipped).