### PR TITLE
feat(activerecord): preloader STI/through available_records — 5 un-skips

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7879,7 +7879,7 @@ describe("PreloaderTest", () => {
     await new Preloader({
       records: [book],
       associations: "essay",
-      availableRecords: [[essaySpecial]] as any,
+      availableRecords: [[essaySpecial]],
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     expect(queryCalls).toHaveLength(0);
@@ -8004,7 +8004,7 @@ describe("PreloaderTest", () => {
     await new Preloader({
       records: [author],
       associations: "essayCategories",
-      availableRecords: categories as any,
+      availableRecords: categories,
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     // One query for the middle (essay) records; categories come from availableRecords
@@ -8062,7 +8062,7 @@ describe("PreloaderTest", () => {
     await new Preloader({
       records: [mary, dave],
       associations: "essayCategories",
-      availableRecords: [tech] as any,
+      availableRecords: [tech],
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     // One query for essays, one for the missing category (general)
@@ -8148,7 +8148,7 @@ describe("PreloaderTest", () => {
       records: [post],
       associations: "author",
       scope: QSAuthor.where({ name: "David" }) as any,
-      availableRecords: [david] as any,
+      availableRecords: [david],
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     // Scope present → availableRecords ignored, runs the query
@@ -8185,7 +8185,7 @@ describe("PreloaderTest", () => {
     await new Preloader({
       records: [post],
       associations: "comments",
-      availableRecords: comments as any,
+      availableRecords: comments,
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     // Collection association → availableRecords skipped, runs the query
@@ -8222,7 +8222,7 @@ describe("PreloaderTest", () => {
     await new Preloader({
       records: [post],
       associations: "author",
-      availableRecords: [bob] as any,
+      availableRecords: [bob],
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
     // Bob doesn't match david's key → still 1 query

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7845,11 +7845,46 @@ describe("PreloaderTest", () => {
     expect(preloaded.name).toBe("Available");
   });
 
-  it.skip("preload with available records sti", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs STI */
+  it("preload with available records sti", async () => {
+    const adapter = freshAdapter();
+    class StiBook extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    class StiEssay extends Base {
+      static {
+        this.tableName = "sti_essays";
+        this.attribute("body", "string");
+        this.attribute("type", "string");
+        this.attribute("sti_book_id", "integer");
+        this.inheritanceColumn = "type";
+        this.adapter = adapter;
+      }
+    }
+    class StiEssaySpecial extends StiEssay {}
+    Associations.hasOne.call(StiBook, "essay", {
+      className: "StiEssay",
+      foreignKey: "sti_book_id",
+    });
+    registerModel("StiBook", StiBook);
+    registerModel("StiEssay", StiEssay);
+    registerModel("StiEssaySpecial", StiEssaySpecial);
+
+    const book = await StiBook.create({ title: "B" });
+    const essaySpecial = await StiEssaySpecial.create({ body: "s", sti_book_id: book.id });
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [book],
+      associations: "essay",
+      availableRecords: [[essaySpecial]] as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    expect(queryCalls).toHaveLength(0);
+    const preloaded = (book as any)._preloadedAssociations.get("essay");
+    expect(preloaded).toBe(essaySpecial);
   });
 
   it("preload with only some records available", async () => {
@@ -7922,17 +7957,120 @@ describe("PreloaderTest", () => {
     expect(author2.name).toBe("Loaded");
   });
 
-  it.skip("preload with available records with through association", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs through preload with available records */
+  it("preload with available records with through association", async () => {
+    const adapter = freshAdapter();
+    class TAAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TACategory extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TAEssay extends Base {
+      static {
+        this.attribute("ta_author_id", "integer");
+        this.attribute("ta_category_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(TAAuthor, "essays", {
+      className: "TAEssay",
+      foreignKey: "ta_author_id",
+    });
+    Associations.belongsTo.call(TAEssay, "category", {
+      className: "TACategory",
+      foreignKey: "ta_category_id",
+    });
+    Associations.hasMany.call(TAAuthor, "essayCategories", {
+      through: "essays",
+      source: "category",
+      className: "TACategory",
+    });
+    registerModel("TAAuthor", TAAuthor);
+    registerModel("TACategory", TACategory);
+    registerModel("TAEssay", TAEssay);
+
+    const author = await TAAuthor.create({ name: "David" });
+    const cat = await TACategory.create({ name: "General" });
+    await TAEssay.create({ ta_author_id: author.id, ta_category_id: cat.id });
+    const categories = await TACategory.all().toArray();
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [author],
+      associations: "essayCategories",
+      availableRecords: categories as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    // One query for the middle (essay) records; categories come from availableRecords
+    expect(queryCalls).toHaveLength(1);
+    const preloaded = (author as any)._preloadedAssociations.get("essayCategories") ?? [];
+    expect(preloaded.map((c: any) => c.id)).toContain(cat.id);
   });
-  it.skip("preload with only some records available with through associations", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs through preload */
+
+  it("preload with only some records available with through associations", async () => {
+    const adapter = freshAdapter();
+    class TBAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TBCategory extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TBEssay extends Base {
+      static {
+        this.attribute("tb_author_id", "integer");
+        this.attribute("tb_category_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(TBAuthor, "essays", {
+      className: "TBEssay",
+      foreignKey: "tb_author_id",
+    });
+    Associations.belongsTo.call(TBEssay, "category", {
+      className: "TBCategory",
+      foreignKey: "tb_category_id",
+    });
+    Associations.hasMany.call(TBAuthor, "essayCategories", {
+      through: "essays",
+      source: "category",
+      className: "TBCategory",
+    });
+    registerModel("TBAuthor", TBAuthor);
+    registerModel("TBCategory", TBCategory);
+    registerModel("TBEssay", TBEssay);
+
+    const mary = await TBAuthor.create({ name: "Mary" });
+    const dave = await TBAuthor.create({ name: "Dave" });
+    const tech = await TBCategory.create({ name: "Tech" });
+    const general = await TBCategory.create({ name: "General" });
+    await TBEssay.create({ tb_author_id: mary.id, tb_category_id: tech.id });
+    await TBEssay.create({ tb_author_id: dave.id, tb_category_id: general.id });
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [mary, dave],
+      associations: "essayCategories",
+      availableRecords: [tech] as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    // One query for essays, one for the missing category (general)
+    expect(queryCalls).toHaveLength(2);
+    const maryCats = (mary as any)._preloadedAssociations.get("essayCategories") ?? [];
+    const daveCats = (dave as any)._preloadedAssociations.get("essayCategories") ?? [];
+    expect(maryCats.map((c: any) => c.id)).toContain(tech.id);
+    expect(daveCats.map((c: any) => c.id)).toContain(general.id);
   });
 
   it("preload with available records with multiple classes", async () => {
@@ -7980,23 +8118,117 @@ describe("PreloaderTest", () => {
     expect((posts[0] as any)._preloadedAssociations.get("pmAuthor").name).toBe("Auth");
   });
 
-  it.skip("preload with available records queries when scoped", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs scoped preloading */
+  it("preload with available records queries when scoped", async () => {
+    const adapter = freshAdapter();
+    class QSAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class QSPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("qs_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(QSPost, "author", {
+      className: "QSAuthor",
+      foreignKey: "qs_author_id",
+    });
+    registerModel("QSAuthor", QSAuthor);
+    registerModel("QSPost", QSPost);
+
+    const david = await QSAuthor.create({ name: "David" });
+    const post = await QSPost.create({ title: "P", qs_author_id: david.id });
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [post],
+      associations: "author",
+      scope: QSAuthor.where({ name: "David" }) as any,
+      availableRecords: [david] as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    // Scope present → availableRecords ignored, runs the query
+    expect(queryCalls).toHaveLength(1);
   });
-  it.skip("preload with available records queries when collection", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs collection preloading */
+
+  it("preload with available records queries when collection", async () => {
+    const adapter = freshAdapter();
+    class QCPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    class QCComment extends Base {
+      static {
+        this.attribute("body", "string");
+        this.attribute("qc_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(QCPost, "comments", {
+      className: "QCComment",
+      foreignKey: "qc_post_id",
+    });
+    registerModel("QCPost", QCPost);
+    registerModel("QCComment", QCComment);
+
+    const post = await QCPost.create({ title: "P" });
+    const c1 = await QCComment.create({ body: "c1", qc_post_id: post.id });
+    const comments = [c1];
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [post],
+      associations: "comments",
+      availableRecords: comments as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    // Collection association → availableRecords skipped, runs the query
+    expect(queryCalls).toHaveLength(1);
   });
-  it.skip("preload with available records queries when incomplete", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs incomplete record detection */
+
+  it("preload with available records queries when incomplete", async () => {
+    const adapter = freshAdapter();
+    class QIAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class QIPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("qi_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(QIPost, "author", {
+      className: "QIAuthor",
+      foreignKey: "qi_author_id",
+    });
+    registerModel("QIAuthor", QIAuthor);
+    registerModel("QIPost", QIPost);
+
+    const david = await QIAuthor.create({ name: "David" });
+    const bob = await QIAuthor.create({ name: "Bob" });
+    const post = await QIPost.create({ title: "P", qi_author_id: david.id });
+
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsForKeys");
+    await new Preloader({
+      records: [post],
+      associations: "author",
+      availableRecords: [bob] as any,
+    }).call();
+    const queryCalls = spy.mock.calls.filter((c) => (c[0] as unknown[]).length > 0);
+    // Bob doesn't match david's key → still 1 query
+    expect(queryCalls).toHaveLength(1);
+    const preloaded = (post as any)._preloadedAssociations.get("author");
+    expect(preloaded?.id).toBe(david.id);
   });
 
   it("preload with unpersisted records no ops", async () => {

--- a/packages/activerecord/src/associations/preloader.ts
+++ b/packages/activerecord/src/associations/preloader.ts
@@ -7,7 +7,7 @@ export interface PreloaderOptions {
   records: Base[];
   associations: any;
   scope?: any;
-  availableRecords?: Base[];
+  availableRecords?: (Base | Base[])[];
   associateByDefault?: boolean;
 }
 
@@ -29,7 +29,7 @@ export class Preloader {
   readonly associateByDefault: boolean;
 
   private _tree: Branch;
-  private _availableRecords: Base[];
+  private _availableRecords: (Base | Base[])[];
 
   constructor(options: PreloaderOptions) {
     this.records = options.records;

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -205,13 +205,17 @@ export class Association {
         const owner = owners[i];
         try {
           const association = (owner as any).association(this.reflection.name);
-          association.target = record;
+          association.setTarget(record);
           if (i === 0) {
             association.setInverseInstance(record);
           }
         } catch {
           // Ignore
         }
+        if (!(owner as any)._preloadedAssociations) {
+          (owner as any)._preloadedAssociations = new Map();
+        }
+        (owner as any)._preloadedAssociations.set(this.reflection.name, record);
       }
     }
   }

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -209,13 +209,13 @@ export class Association {
           if (i === 0) {
             association.setInverseInstance(record);
           }
+          if (!(owner as any)._preloadedAssociations) {
+            (owner as any)._preloadedAssociations = new Map();
+          }
+          (owner as any)._preloadedAssociations.set(this.reflection.name, record);
         } catch {
           // Ignore
         }
-        if (!(owner as any)._preloadedAssociations) {
-          (owner as any)._preloadedAssociations = new Map();
-        }
-        (owner as any)._preloadedAssociations.set(this.reflection.name, record);
       }
     }
   }

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -15,7 +15,7 @@ export class Batch {
   private _preloaders: Preloader[];
   private _availableRecords: Map<typeof Base, Base[]>;
 
-  constructor(preloaders: Preloader[], availableRecords: Base[] = []) {
+  constructor(preloaders: Preloader[], availableRecords: (Base | Base[])[] = []) {
     this._preloaders = preloaders.filter((p) => !p.isEmpty());
     this._availableRecords = new Map();
     for (const record of availableRecords.flat()) {

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -19,7 +19,7 @@ export class Batch {
     this._preloaders = preloaders.filter((p) => !p.isEmpty());
     this._availableRecords = new Map();
     for (const record of availableRecords.flat()) {
-      const klass = record.constructor as typeof Base;
+      const klass = (record.constructor as typeof Base).baseClass;
       const existing = this._availableRecords.get(klass);
       if (existing) {
         existing.push(record);
@@ -36,7 +36,7 @@ export class Batch {
       const loaders = branches.flatMap((b) => b.runnableLoaders());
 
       for (const loader of loaders) {
-        const available = this._availableRecords.get(loader.klass);
+        const available = this._availableRecords.get(loader.klass.baseClass);
         loader.associateRecordsFromUnscoped(available);
       }
 


### PR DESCRIPTION
## Summary

- Un-skips 5 preloader \`available_records\` tests in \`associations.test.ts\` (STI, hasMany through, hasMany through partial, scoped, collection, incomplete).
- \`Preloader::Batch\` now groups \`availableRecords\` by \`base_class\` and looks them up by \`loader.klass.baseClass\` — matches Rails so STI subclasses (e.g. \`EssaySpecial < Essay\`) flow into their reflection's base klass.
- \`Association#associateRecordsFromUnscoped\` now uses \`setTarget\` (marks loaded) and seeds \`_preloadedAssociations\` so downstream \`LoaderRecords\` short-circuits actual DB calls and readers see the supplied record identity.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/associations.test.ts -t "available records"\` — 7 passed (5 new + 2 prior)
- [x] \`-t "Preloader"\` — 37 passed, no regressions