### PR TITLE
feat(activerecord): HABTM builder ThroughReflection wrap

### DIFF
--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -268,7 +268,11 @@ export class HasAndBelongsToMany {
       typeof habtmOptions.scope === "function"
         ? (habtmOptions.scope as (...args: any[]) => any)
         : null;
-    const { through: _through, scope: _scope, ...habtmReflectionOptions } = habtmOptions;
+    // Keep `through:` in the options passed to Reflection.create so it wraps
+    // the HasAndBelongsToManyReflection in a ThroughReflection — mirrors
+    // Rails' `Builder::HasAndBelongsToMany`, which builds an internal
+    // has_many :through and registers the HABTM as a through reflection.
+    const { scope: _scope, ...habtmReflectionOptions } = habtmOptions;
     const habtmReflection = Reflection.create(
       "hasAndBelongsToMany" as any,
       name,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1099,7 +1099,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   private _invalidateAssociationIds(): void {
     const assocInstance = (this._record as any)._associationInstances?.get(this._assocName);
-    if (assocInstance) (assocInstance as any)._associationIds = null;
+    if (assocInstance) {
+      (assocInstance as any)._associationIds = null;
+      // Mirrors Rails' `reset_scope` after insert_record — without it an
+      // instance that was previously loaded via the `record.collectionIds`
+      // reader keeps `loaded`/`target` from the pre-push fetch and returns
+      // stale data on the next read.
+      if (typeof (assocInstance as any).reset === "function") {
+        (assocInstance as any).reset();
+      }
+    }
   }
 
   private _raiseOnTypeMismatch(records: T[]): void {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1338,10 +1338,7 @@ export class ThroughReflection extends AbstractReflection {
   isNested(): boolean {
     return (
       !!(this.sourceReflection as any)?.isThroughReflection?.() ||
-      !!(this.throughReflection as any)?.isThroughReflection?.() ||
-      // Rails registers a ThroughReflection for the HABTM name (via has_many :through internally);
-      // our builder registers HasAndBelongsToManyReflection instead, so check macro directly.
-      this.throughReflection?.macro === "hasAndBelongsToMany"
+      !!(this.throughReflection as any)?.isThroughReflection?.()
     );
   }
 


### PR DESCRIPTION
## Summary

- HABTM builder now keeps `through:` in the options passed to `Reflection.create`, so the HABTM reflection is wrapped in `ThroughReflection` — mirrors Rails' `Builder::HasAndBelongsToMany`, which builds an internal `has_many :through` and registers the HABTM as a through reflection.
- Drops the `throughReflection?.macro === "hasAndBelongsToMany"` workaround in `ThroughReflection#isNested` that the divergence required.
- Fixes the regression that blocked the previous attempt (#1670 followup): `CollectionProxy._invalidateAssociationIds` now also calls `assocInstance.reset()`. Previously it only nulled the cached id list — leaving `loaded`/`target` populated from the pre-push fetch — so a re-read after `proxy.push(...)` returned the stale `record.collectionIds`. The new path mirrors Rails' `reset_scope` after `insert_record`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts` (incl. `singular ids are reloaded after collection concat`)
- [x] `pnpm vitest run packages/activerecord/src/associations/ packages/activerecord/src/reflection.test.ts packages/activerecord/src/associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts packages/activerecord/src/nested-attributes.test.ts packages/activerecord/src/autosave.test.ts`
- [ ] CI full suite