### PR TITLE
refactor(activerecord): Phase 5 associations cluster — defineSchema for smaller test files

### DIFF
--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -23,6 +23,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("CollectionProxy#count — disable_joins through", () => {
@@ -49,8 +50,14 @@ describe("CollectionProxy#count — disable_joins through", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      cd_authors: { name: "string" },
+      cd_posts: { cd_author_id: "integer", title: "string" },
+      cd_comments: { cd_post_id: "integer", body: "string" },
+      cd_ratings: { cd_comment_id: "integer", value: "integer" },
+    });
     CdAuthor.adapter = adapter;
     CdPost.adapter = adapter;
     CdComment.adapter = adapter;

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -24,6 +24,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("DJAS routing widening — nested-through", () => {
@@ -60,8 +61,14 @@ describe("DJAS routing widening — nested-through", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      nt_authors: { name: "string" },
+      nt_posts: { nt_author_id: "integer", title: "string" },
+      nt_comments: { nt_post_id: "integer", body: "string" },
+      nt_ratings: { nt_comment_id: "integer", value: "integer" },
+    });
     NtAuthor.adapter = adapter;
     NtPost.adapter = adapter;
     NtComment.adapter = adapter;

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -23,6 +23,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, association, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("DJAS routing widening — sourceType + polymorphic source", () => {
@@ -55,8 +56,14 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      rw_authors: { name: "string" },
+      rw_comments: { rw_author_id: "integer", origin_id: "integer", origin_type: "string" },
+      rw_members: { name: "string" },
+      rw_other_origins: { label: "string" },
+    });
     RwAuthor.adapter = adapter;
     RwComment.adapter = adapter;
     RwMember.adapter = adapter;

--- a/packages/activerecord/src/associations/nested-through-preloader.test.ts
+++ b/packages/activerecord/src/associations/nested-through-preloader.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("HMT Slot D — nested-through preloader / STI / joins+includes", () => {
@@ -65,8 +66,14 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
   enableSti(NtdRating);
   registerSubclass(NtdHighRating);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      ntd_authors: { name: "string" },
+      ntd_posts: { ntd_author_id: "integer", title: "string" },
+      ntd_comments: { ntd_post_id: "integer", body: "string" },
+      ntd_ratings: { ntd_comment_id: "integer", value: "integer", type: "string" },
+    });
     NtdAuthor.adapter = adapter;
     NtdPost.adapter = adapter;
     NtdComment.adapter = adapter;


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5 (follow-up to #1633, #1686). Migrates 4 smaller `associations/` test files to call `defineSchema()` in `beforeEach` so they pass under `AR_NO_AUTO_SCHEMA=1`:

- `cp-count-disable-joins-through.test.ts`
- `disable-joins-nested-through.test.ts`
- `disable-joins-routing-widening.test.ts`
- `nested-through-preloader.test.ts`

Each file uses the per-test setup pattern from #1633. Schemas mirror the `_tableName` + `attribute()` declarations on the test models; `cp-count-disable-joins-through` also gets `cd_ratings` because one test declares an additional `CdRating` model inline.

## Out of scope (follow-ups)

The two largest associations files (`association-scope.test.ts` 1118 LOC, `inverse-associations.test.ts` 1717 LOC) and the remaining larger failing files (`callbacks`, `cascaded-eager-loading`, `collection-proxy`, `disable-joins-association-scope`, `disable-joins-composite-key`, `disable-joins-composite-nested`, `disable-joins-polymorphic-nonid-pk`, `extension`, `inner-join-association`, `left-outer-join-association`, `nested-through-advanced`, `polymorphic-sti-through`, `source-type-validation`, `belongs-to-associations`, `has-and-belongs-to-many-associations`, `has-many-associations`, `has-many-through-associations`, `has-many-through-disable-joins-associations`, `has-one-associations`, `has-one-through-associations`, `eager`, `nested-through-associations`) remain. Encryption cluster is being migrated in a sibling PR.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` on all 4 files: **12 passed**
- Normal mode `pnpm vitest run` on all 4 files: **12 passed**
- Diff: 4 files, +32 −4 (well under the 300 LOC ceiling)

## Test plan

- [x] All 4 migrated files green under `AR_NO_AUTO_SCHEMA=1`
- [x] Normal mode still green
- [ ] CI green across PG / MySQL / SQLite