### PR TITLE
refactor(activerecord)!: make Base.signedId sync (no I/O)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2979,16 +2979,14 @@ export class Base extends Model {
   /**
    * Generate a signed ID for this record using HMAC-SHA256 via MessageVerifier.
    * The purpose parameter scopes the signed ID. expiresIn is in seconds.
-   * Returns a Promise so callers can use the `await expect(...).rejects`
-   * pattern to assert on missing-secret / invalid-config errors.
    *
    * Mirrors: ActiveRecord::SignedId#signed_id
    */
-  async signedId(options?: {
+  signedId(options?: {
     purpose?: string;
     expiresIn?: number;
     expiresAt?: Temporal.Instant;
-  }): Promise<string> {
+  }): string {
     return _signedId(this, options);
   }
 

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -98,7 +98,7 @@ describe("SignedIdTest", () => {
   it("cannot get a signed ID for a new record", async () => {
     const { User } = makeModel();
     const u = new User({ name: "Gina" });
-    await expect(u.signedId()).rejects.toThrow();
+    expect(() => u.signedId()).toThrow();
   });
 
   it("can get a signed ID in an after_create", async () => {
@@ -237,9 +237,7 @@ describe("SignedIdTest", () => {
     const u = await User.create({ name: "NoSecret" });
     setSignedIdVerifierSecret(null);
     try {
-      await expect(Promise.resolve().then(() => u.signedId())).rejects.toThrow(
-        /signed_id_verifier_secret|signed ids/i,
-      );
+      expect(() => u.signedId()).toThrow(/signed_id_verifier_secret|signed ids/i);
     } finally {
       setSignedIdVerifierSecret("blazetrails-test-secret");
     }
@@ -250,9 +248,7 @@ describe("SignedIdTest", () => {
     const u = await User.create({ name: "NilLambda" });
     setSignedIdVerifierSecret(() => null);
     try {
-      await expect(Promise.resolve().then(() => u.signedId())).rejects.toThrow(
-        /signed_id_verifier_secret|signed ids/i,
-      );
+      expect(() => u.signedId()).toThrow(/signed_id_verifier_secret|signed ids/i);
     } finally {
       setSignedIdVerifierSecret("blazetrails-test-secret");
     }
@@ -554,7 +550,7 @@ describe("signedId / findSigned / findSignedBang", () => {
       }
     }
     const user = new User({ name: "Alice" });
-    await expect(user.signedId()).rejects.toThrow("Cannot get a signed_id for a new record");
+    expect(() => user.signedId()).toThrow("Cannot get a signed_id for a new record");
   });
 
   it("findSigned recovers the record from its signed ID", async () => {

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -254,7 +254,7 @@ describe("TokenForTest", () => {
       }
     }
     const item = new NoPkItem({ name: "test" });
-    await expect(item.signedId()).rejects.toThrow();
+    expect(() => item.signedId()).toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
Carryover from #1675's post-merge findings. \`Base.signedId\` only signs an HMAC token via MessageVerifier — no DB queries, no awaited work. The async signature was a leftover from when the method went through a lazy import (dropped in #1675). The Promise-rejection assertion pattern in tests was the only thing keeping it async; converting those 4 sites to throw-assertions lets the type tell the truth.

### Changes
- \`Base.signedId(options?)\` returns \`string\` (was \`Promise<string>\`).
- 4 test sites (\`signed-id.test.ts:101, :240, :253, :532\`, \`token-for.test.ts:257\`) switch from \`await expect(...).rejects.toThrow()\` to \`expect(() => ...).toThrow()\`.
- \`Base.findSigned\` / \`findSignedBang\` **stay async** — they call \`modelClass.findBy(...)\` which performs real DB I/O.

### Rails fidelity
Rails \`ActiveRecord::SignedId#signed_id\` (\`activerecord/lib/active_record/signed_id.rb\`) is synchronous in Ruby (Ruby doesn't have async). The Trails sync signature matches that semantic faithfully.

## Test plan
- [x] \`pnpm typecheck\` — clean
- [x] AR \`signed-id.test.ts\` + \`token-for.test.ts\` — 65 pass, 2 skipped

## Out of scope
- The \`KNOWN_SGID_KEYS\` audit from #1676's post-merge findings was investigated: Rails strips \`(:app, :verifier, :for)\` and lets \`:expires_in\`/\`:expires_at\` flow through to URI params as a side-effect, but **no Ruby test asserts this**. The Trails filtering is an ergonomic choice with zero test:compare delta. No code change needed; resolution documented here.

## Breaking change
\`Base.signedId()\` now returns \`string\` instead of \`Promise<string>\`. Callers using \`await\` still work (the await of a non-Promise just yields the value), but \`.rejects.toThrow()\` assertions must switch to \`() => fn()\` form.