### PR TITLE
test(activerecord): MySQL charset-collation — unit tests for #1568 helpers

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { Column } from "./mysql/column.js";
-import { ChangeColumnDefinition } from "./abstract/schema-definitions.js";
+import {
+  ChangeColumnDefinition,
+  ChangeColumnDefaultDefinition,
+} from "./abstract/schema-definitions.js";
 import { parseTableOptions } from "./abstract-mysql-adapter.js";
+import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
+import { quote as mysqlQuote } from "./mysql/quoting.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
   return new Column("id", null, { sqlType: "bigint" }, false, {
@@ -407,3 +412,222 @@ describe("parseTableOptions", () => {
     expect(opts).toEqual({ charset: "utf8mb4" });
   });
 });
+
+// Unit coverage for the four charset-collation slot helpers added in #1568.
+// The existing abstract-mysql-adapter test suite is live-DB only; these
+// exercise pure SQL-fragment shape via Object.create + minimal stubs.
+
+function makeChangeColumnTextColumn(opts: { null_?: boolean; default_?: unknown } = {}) {
+  return new Column(
+    "body",
+    opts.default_ === undefined ? "hello" : opts.default_,
+    { sqlType: "varchar(255)", type: "string" },
+    opts.null_ ?? true,
+  );
+}
+
+async function makeMinimalMysqlAdapter(overrides: Record<string, unknown> = {}) {
+  const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+  const adapter = Object.create(AbstractMysqlAdapter.prototype) as any;
+  adapter.quoteIdentifier = (s: string) => `\`${s}\``;
+  adapter.quoteTableName = (s: string) => `\`${s}\``;
+  adapter.quote = mysqlQuote;
+  Object.assign(adapter, overrides);
+  return adapter;
+}
+
+describe("AbstractMysqlAdapter#buildChangeColumnDefaultDefinition (#1568)", () => {
+  async function build(column: Column, defaultOrChanges: unknown) {
+    const adapter = await makeMinimalMysqlAdapter({
+      columnFor: async () => column,
+    });
+    return adapter.buildChangeColumnDefaultDefinition(
+      "users",
+      "body",
+      defaultOrChanges,
+    ) as Promise<ChangeColumnDefaultDefinition>;
+  }
+
+  it("returns a ChangeColumnDefaultDefinition with the extracted default", async () => {
+    const cd = await build(makeChangeColumnTextColumn(), "new");
+    expect(cd).toBeInstanceOf(ChangeColumnDefaultDefinition);
+    expect(cd.default).toBe("new");
+    expect(cd.column.name).toBe("body");
+  });
+
+  it("unwraps {from, to} change-descriptor to the new value", async () => {
+    const cd = await build(makeChangeColumnTextColumn(), { from: "old", to: "new" });
+    expect(cd.default).toBe("new");
+  });
+
+  it("normalizes undefined → null when {from, to: undefined} (JS-only defense)", async () => {
+    const cd = await build(makeChangeColumnTextColumn(), { from: "x", to: undefined });
+    expect(cd.default).toBeNull();
+  });
+
+  it("preserves explicit null default", async () => {
+    const cd = await build(makeChangeColumnTextColumn(), null);
+    expect(cd.default).toBeNull();
+  });
+
+  it("preserves the column's null option on the built ColumnDefinition", async () => {
+    const cd = await build(makeChangeColumnTextColumn({ null_: false }), "x");
+    expect(cd.column.options.null).toBe(false);
+  });
+});
+
+describe("AbstractMysqlAdapter — DROP vs SET DEFAULT fragment (#1568)", () => {
+  function visit(cd: ChangeColumnDefaultDefinition): string {
+    return new MysqlSchemaCreation().accept(cd);
+  }
+
+  async function buildFor(column: Column, defaultOrChanges: unknown) {
+    const adapter = await makeMinimalMysqlAdapter({ columnFor: async () => column });
+    return adapter.buildChangeColumnDefaultDefinition(
+      "users",
+      "body",
+      defaultOrChanges,
+    ) as Promise<ChangeColumnDefaultDefinition>;
+  }
+
+  it("emits DROP DEFAULT for null default on a NOT NULL column", async () => {
+    const cd = await buildFor(makeChangeColumnTextColumn({ null_: false }), null);
+    expect(visit(cd)).toBe("ALTER COLUMN `body` DROP DEFAULT");
+  });
+
+  it("emits SET DEFAULT NULL for null default on a nullable column", async () => {
+    const cd = await buildFor(makeChangeColumnTextColumn({ null_: true }), null);
+    expect(visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT NULL");
+  });
+
+  it("emits SET DEFAULT <literal> for a non-null default", async () => {
+    const cd = await buildFor(makeChangeColumnTextColumn({ null_: true }), "world");
+    expect(visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT 'world'");
+  });
+
+  it("undefined → null normalization yields SET DEFAULT NULL, not a bare SET", async () => {
+    // Without the undefined→null normalization, quoteDefaultExpression(undefined)
+    // returns "" and the fragment would be the malformed `ALTER COLUMN ... SET`.
+    const cd = await buildFor(makeChangeColumnTextColumn({ null_: true }), {
+      from: "a",
+      to: undefined,
+    });
+    const sql = visit(cd);
+    expect(sql).toBe("ALTER COLUMN `body` SET DEFAULT NULL");
+    expect(sql.endsWith(" SET")).toBe(false);
+  });
+});
+
+describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
+  it("emits UPDATE ... SET ... WHERE IS NULL to backfill when flipping to NOT NULL with a default", async () => {
+    const executed: string[] = [];
+    const changeColumnCalls: Array<[string, string, string, Record<string, unknown>]> = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
+      _execMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+      changeColumn: async (t: string, c: string, type: string, opts: Record<string, unknown>) => {
+        changeColumnCalls.push([t, c, type, opts]);
+      },
+    });
+    await adapter.changeColumnNull("users", "name", false, "anon");
+    expect(executed).toEqual(["UPDATE `users` SET `name`='anon' WHERE `name` IS NULL"]);
+    expect(changeColumnCalls).toEqual([["users", "name", "", { null: false }]]);
+  });
+
+  it("does NOT issue a backfill UPDATE when default_ is omitted", async () => {
+    const executed: string[] = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
+      _execMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+      changeColumn: async () => {},
+    });
+    await adapter.changeColumnNull("users", "name", false);
+    expect(executed).toEqual([]);
+  });
+
+  it("does NOT issue a backfill UPDATE when null_ is true (allowing NULLs)", async () => {
+    const executed: string[] = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
+      _execMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+      changeColumn: async () => {},
+    });
+    await adapter.changeColumnNull("users", "name", true, "anon");
+    expect(executed).toEqual([]);
+  });
+
+  it("propagates validateChangeColumnNullArgumentBang errors before any SQL", async () => {
+    const executed: string[] = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      schemaStatements: () => ({
+        validateChangeColumnNullArgumentBang: () => {
+          throw new Error("bad null arg");
+        },
+      }),
+      _execMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+      changeColumn: async () => {},
+    });
+    await expect(
+      adapter.changeColumnNull("users", "name", false as unknown as boolean, "x"),
+    ).rejects.toThrow("bad null arg");
+    expect(executed).toEqual([]);
+  });
+});
+
+describe("AbstractMysqlAdapter#changeColumnComment (#1568)", () => {
+  async function makeAdapterCapturingChangeColumn() {
+    const calls: Array<[string, string, string, Record<string, unknown>]> = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      schemaStatements: () => ({
+        extractNewCommentValue: (v: unknown) => {
+          if (v !== null && typeof v === "object" && "from" in v && "to" in v) {
+            return (v as { to: unknown }).to;
+          }
+          return v;
+        },
+      }),
+      changeColumn: async (t: string, c: string, type: string, opts: Record<string, unknown>) => {
+        calls.push([t, c, type, opts]);
+      },
+    });
+    return { adapter, calls };
+  }
+
+  it("passes a plain string comment through to changeColumn", async () => {
+    const { adapter, calls } = await makeAdapterCapturingChangeColumn();
+    await adapter.changeColumnComment("users", "name", "the user's name");
+    expect(calls).toEqual([["users", "name", "", { comment: "the user's name" }]]);
+  });
+
+  it("clears the comment when passed null", async () => {
+    const { adapter, calls } = await makeAdapterCapturingChangeColumn();
+    await adapter.changeColumnComment("users", "name", null);
+    expect(calls).toEqual([["users", "name", "", { comment: null }]]);
+  });
+
+  it("unwraps {from, to} change-descriptor to the new comment", async () => {
+    const { adapter, calls } = await makeAdapterCapturingChangeColumn();
+    await adapter.changeColumnComment("users", "name", { from: "old", to: "new" });
+    expect(calls).toEqual([["users", "name", "", { comment: "new" }]]);
+  });
+
+  it("normalizes undefined → null when {from, to: undefined} (explicit clear)", async () => {
+    const { adapter, calls } = await makeAdapterCapturingChangeColumn();
+    await adapter.changeColumnComment("users", "name", { from: "old", to: undefined });
+    // Without the normalization, comment would be undefined and changeColumn
+    // would treat the key as absent, silently keeping the old comment.
+    expect(calls).toEqual([["users", "name", "", { comment: null }]]);
+  });
+});
+
+// Sanity: ChangeColumnDefinition import kept live (it is consumed by the
+// existing buildChangeColumnDefinition suite above).
+void ChangeColumnDefinition;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -413,9 +413,8 @@ describe("parseTableOptions", () => {
   });
 });
 
-// Unit coverage for the four charset-collation slot helpers added in #1568.
-// The existing abstract-mysql-adapter test suite is live-DB only; these
-// exercise pure SQL-fragment shape via Object.create + minimal stubs.
+// Unit coverage for the four charset-collation slot helpers added in #1568,
+// complementing the existing fragment-shape coverage above.
 
 function makeChangeColumnTextColumn(opts: { null_?: boolean; default_?: unknown } = {}) {
   return new Column(
@@ -562,8 +561,9 @@ describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
     expect(executed).toEqual([]);
   });
 
-  it("propagates validateChangeColumnNullArgumentBang errors before any SQL", async () => {
+  it("propagates validateChangeColumnNullArgumentBang errors before any SQL or changeColumn dispatch", async () => {
     const executed: string[] = [];
+    const changeColumnCalls: unknown[] = [];
     const adapter = await makeMinimalMysqlAdapter({
       schemaStatements: () => ({
         validateChangeColumnNullArgumentBang: () => {
@@ -573,27 +573,24 @@ describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
       _execMutation: async (sql: string) => {
         executed.push(sql);
       },
-      changeColumn: async () => {},
+      changeColumn: async (...args: unknown[]) => {
+        changeColumnCalls.push(args);
+      },
     });
     await expect(
       adapter.changeColumnNull("users", "name", false as unknown as boolean, "x"),
     ).rejects.toThrow("bad null arg");
     expect(executed).toEqual([]);
+    expect(changeColumnCalls).toEqual([]);
   });
 });
 
 describe("AbstractMysqlAdapter#changeColumnComment (#1568)", () => {
   async function makeAdapterCapturingChangeColumn() {
+    // Use the real, inherited schemaStatements() so these tests exercise the
+    // production extractNewCommentValue path and catch regressions in it.
     const calls: Array<[string, string, string, Record<string, unknown>]> = [];
     const adapter = await makeMinimalMysqlAdapter({
-      schemaStatements: () => ({
-        extractNewCommentValue: (v: unknown) => {
-          if (v !== null && typeof v === "object" && "from" in v && "to" in v) {
-            return (v as { to: unknown }).to;
-          }
-          return v;
-        },
-      }),
       changeColumn: async (t: string, c: string, type: string, opts: Record<string, unknown>) => {
         calls.push([t, c, type, opts]);
       },
@@ -627,7 +624,3 @@ describe("AbstractMysqlAdapter#changeColumnComment (#1568)", () => {
     expect(calls).toEqual([["users", "name", "", { comment: null }]]);
   });
 });
-
-// Sanity: ChangeColumnDefinition import kept live (it is consumed by the
-// existing buildChangeColumnDefinition suite above).
-void ChangeColumnDefinition;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -517,48 +517,84 @@ describe("AbstractMysqlAdapter — DROP vs SET DEFAULT fragment (#1568)", () => 
   });
 });
 
+describe("AbstractMysqlAdapter#changeColumnDefault wiring (#1568)", () => {
+  // Drives the public surface end-to-end through changeColumnDefaultForAlter
+  // → buildChangeColumnDefaultDefinition → MysqlSchemaCreation.accept so a
+  // regression in the wiring (or in the ALTER TABLE wrap) is caught.
+  async function build(column: Column) {
+    const executed: string[] = [];
+    const adapter = await makeMinimalMysqlAdapter({
+      columnFor: async () => column,
+      _execMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+    });
+    return { adapter, executed };
+  }
+
+  it("changeColumnDefault wraps the SET DEFAULT fragment in ALTER TABLE", async () => {
+    const { adapter, executed } = await build(makeChangeColumnTextColumn({ null_: true }));
+    await adapter.changeColumnDefault("users", "body", "world");
+    expect(executed).toEqual(["ALTER TABLE `users` ALTER COLUMN `body` SET DEFAULT 'world'"]);
+  });
+
+  it("changeColumnDefault wraps DROP DEFAULT for null on a NOT NULL column", async () => {
+    const { adapter, executed } = await build(makeChangeColumnTextColumn({ null_: false }));
+    await adapter.changeColumnDefault("users", "body", null);
+    expect(executed).toEqual(["ALTER TABLE `users` ALTER COLUMN `body` DROP DEFAULT"]);
+  });
+
+  it("changeColumnDefault unwraps {from, to} via the full pipeline", async () => {
+    const { adapter, executed } = await build(makeChangeColumnTextColumn({ null_: true }));
+    await adapter.changeColumnDefault("users", "body", { from: "old", to: "new" });
+    expect(executed).toEqual(["ALTER TABLE `users` ALTER COLUMN `body` SET DEFAULT 'new'"]);
+  });
+
+  it("changeColumnDefaultForAlter returns the bare fragment (no ALTER TABLE wrap)", async () => {
+    const { adapter } = await build(makeChangeColumnTextColumn({ null_: true }));
+    const fragment = await adapter.changeColumnDefaultForAlter("users", "body", "world");
+    expect(fragment).toBe("ALTER COLUMN `body` SET DEFAULT 'world'");
+  });
+});
+
 describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
-  it("emits UPDATE ... SET ... WHERE IS NULL to backfill when flipping to NOT NULL with a default", async () => {
-    const executed: string[] = [];
-    const changeColumnCalls: Array<[string, string, string, Record<string, unknown>]> = [];
+  // Record both `_execMutation` (UPDATE backfill) and `changeColumn` (ALTER
+  // dispatch) into a single sequence so tests can assert relative ordering
+  // — Rails requires the UPDATE to run BEFORE the ALTER, otherwise existing
+  // NULL rows would fail the new NOT NULL constraint.
+  async function makeSequencingAdapter() {
+    const events: Array<["exec", string] | ["changeColumn", unknown[]]> = [];
     const adapter = await makeMinimalMysqlAdapter({
       schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
       _execMutation: async (sql: string) => {
-        executed.push(sql);
+        events.push(["exec", sql]);
       },
-      changeColumn: async (t: string, c: string, type: string, opts: Record<string, unknown>) => {
-        changeColumnCalls.push([t, c, type, opts]);
+      changeColumn: async (...args: unknown[]) => {
+        events.push(["changeColumn", args]);
       },
     });
+    return { adapter, events };
+  }
+
+  it("emits UPDATE backfill BEFORE the changeColumn ALTER dispatch", async () => {
+    const { adapter, events } = await makeSequencingAdapter();
     await adapter.changeColumnNull("users", "name", false, "anon");
-    expect(executed).toEqual(["UPDATE `users` SET `name`='anon' WHERE `name` IS NULL"]);
-    expect(changeColumnCalls).toEqual([["users", "name", "", { null: false }]]);
+    expect(events).toEqual([
+      ["exec", "UPDATE `users` SET `name`='anon' WHERE `name` IS NULL"],
+      ["changeColumn", ["users", "name", "", { null: false }]],
+    ]);
   });
 
-  it("does NOT issue a backfill UPDATE when default_ is omitted", async () => {
-    const executed: string[] = [];
-    const adapter = await makeMinimalMysqlAdapter({
-      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
-      _execMutation: async (sql: string) => {
-        executed.push(sql);
-      },
-      changeColumn: async () => {},
-    });
+  it("dispatches changeColumn with null:false but skips UPDATE when default_ is omitted", async () => {
+    const { adapter, events } = await makeSequencingAdapter();
     await adapter.changeColumnNull("users", "name", false);
-    expect(executed).toEqual([]);
+    expect(events).toEqual([["changeColumn", ["users", "name", "", { null: false }]]]);
   });
 
-  it("does NOT issue a backfill UPDATE when null_ is true (allowing NULLs)", async () => {
-    const executed: string[] = [];
-    const adapter = await makeMinimalMysqlAdapter({
-      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
-      _execMutation: async (sql: string) => {
-        executed.push(sql);
-      },
-      changeColumn: async () => {},
-    });
+  it("dispatches changeColumn with null:true and skips UPDATE when null_ is true", async () => {
+    const { adapter, events } = await makeSequencingAdapter();
     await adapter.changeColumnNull("users", "name", true, "anon");
-    expect(executed).toEqual([]);
+    expect(events).toEqual([["changeColumn", ["users", "name", "", { null: true }]]]);
   });
 
   it("propagates validateChangeColumnNullArgumentBang errors before any SQL or changeColumn dispatch", async () => {


### PR DESCRIPTION
## Summary

Adds targeted SQL-fragment + wiring unit tests for the four helpers introduced in #1568 (MySQL charset-collation Slot B-followup), complementing the existing pure-unit coverage in the same file.

## Coverage (21 new `it` blocks)

- **`buildChangeColumnDefaultDefinition`** (5) — plain values, `{from, to}` unwrap, `{from, to: undefined}` → null normalization, explicit null, `column.options.null` preservation.
- **DROP-vs-SET DEFAULT fragment** (4) via `MysqlSchemaCreation.accept` — `DROP DEFAULT` (null + NOT NULL), `SET DEFAULT NULL` (null + nullable), `SET DEFAULT '<literal>'`, undefined→null guard against malformed bare `SET`.
- **`changeColumnDefault` end-to-end wiring** (4) — drives the full `changeColumnDefault` / `changeColumnDefaultForAlter` → `buildChangeColumnDefaultDefinition` → `MysqlSchemaCreation` → `ALTER TABLE` wrap pipeline; covers `SET DEFAULT`, `DROP DEFAULT`, `{from, to}` unwrap end-to-end, and the bare-fragment shape from `changeColumnDefaultForAlter`.
- **`changeColumnNull`** (4) — UPDATE backfill and ALTER dispatch recorded through a shared event log so the primary test asserts UPDATE-before-ALTER ordering (Rails requires the backfill to precede the NOT NULL alter); suppression tests assert the ALTER still dispatches with the correct `null:` flag. Includes a validate-then-dispatch ordering test (no SQL, no ALTER on validation failure).
- **`changeColumnComment`** (4) — string passthrough, explicit null clears the comment, `{from, to}` unwrap, `{from, to: undefined}` → null normalization. Uses the real inherited `schemaStatements().extractNewCommentValue` so production-path regressions are caught.

Cross-references `vendor/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb` (`change_column_default`, `build_change_column_default_definition`, `change_column_null`, `change_column_comment`).

## `buildCreateIndexDefinition` note

The original prompt flagged this as a stub returning `{}`. On inspection the method at `abstract-mysql-adapter.ts:743` is already a real implementation — constructs and returns a `CreateIndexDefinition` (or `undefined` when `ifNotExists` short-circuits), invoked by `addIndex`, mirrors Rails' `build_create_index_definition` seam. No change needed.

## Test plan

- [x] `TEST_ADAPTER=mysql2 pnpm vitest run packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts` — 60 tests pass (39 pre-existing + 21 new)
- [x] `pnpm build` + `pnpm typecheck` pass