### PR TITLE
feat(activerecord): Relation.findSigned scoping wrappers (mirrors SignedId::RelationMethods)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4287,6 +4287,24 @@ export class Relation<T extends Base> {
     }
   }
 
+  /**
+   * Mirrors: ActiveRecord::SignedId::RelationMethods#find_signed
+   */
+  async findSigned(token: string, options?: { purpose?: string }): Promise<T | null> {
+    return this.scoping(() =>
+      (this._modelClass as any).findSigned(token, options),
+    ) as Promise<T | null>;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::SignedId::RelationMethods#find_signed!
+   */
+  async findSignedBang(token: string, options?: { purpose?: string }): Promise<T> {
+    return this.scoping(() =>
+      (this._modelClass as any).findSignedBang(token, options),
+    ) as Promise<T>;
+  }
+
   // Memoized per timestamp column, matching Rails' @cache_keys / @cache_versions.
   private _cacheKeys: Map<string, Promise<string>> | undefined;
   private _cacheVersions: Map<string, Promise<string | null>> | undefined;

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -297,9 +297,20 @@ describe("SignedIdTest", () => {
     expect(found!.id).toBe(u.id);
   });
 
-  it.skip("find signed record on relation", () => {
-    // BLOCKED: feature — Relation.findSigned scoping wrapper (Rails SignedId::RelationMethods).
-    // Needs Relation.findSigned / findSignedBang that call scoping { model.findSigned(...) }.
+  it("find signed record on relation", async () => {
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Alice" });
+    const token = await u.signedId();
+    const found = await User.where({ name: "Alice" }).findSigned(token);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(u.id);
+    const miss = await User.where({ name: "Bob" }).findSigned(token);
+    expect(miss).toBeNull();
   });
 
   it("find signed record with a bang", async () => {
@@ -315,8 +326,18 @@ describe("SignedIdTest", () => {
     expect(found.id).toBe(u.id);
   });
 
-  it.skip("find signed record with a bang on relation", () => {
-    // BLOCKED: feature — Relation.findSignedBang scoping wrapper (Rails SignedId::RelationMethods).
+  it("find signed record with a bang on relation", async () => {
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const u = await User.create({ name: "Alice" });
+    const token = await u.signedId();
+    const found = await User.where({ name: "Alice" }).findSignedBang(token);
+    expect(found.id).toBe(u.id);
+    await expect(User.where({ name: "Bob" }).findSignedBang(token)).rejects.toThrow();
   });
 
   it("find signed record with purpose", async () => {


### PR DESCRIPTION
## Summary

- Adds `Relation#findSigned` and `Relation#findSignedBang` that wrap the `Base` class methods in `this.scoping(...)`, so `where`/etc. constraints on the relation narrow the `findBy` inside `findSigned`.
- Mirrors Rails `ActiveRecord::SignedId::RelationMethods` (`vendor/rails/activerecord/lib/active_record/signed_id.rb`).
- Un-skips the 2 remaining BLOCKED tests in `signed-id.test.ts`:
  - `find signed record on relation`
  - `find signed record with a bang on relation`

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/signed-id.test.ts -t "on relation"` (2 pass)