### PR TITLE
feat(activerecord): Associations-core — inverseOf population on collection load

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"063f8261-7f3d-48b3-b3af-8eb198800781","pid":2704219,"procStart":"84944654","acquiredAt":1778939163548}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"063f8261-7f3d-48b3-b3af-8eb198800781","pid":2704219,"procStart":"84944654","acquiredAt":1778939163548}

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -159,12 +159,21 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     const records = await super.toArray();
     const owner = this._association.owner;
     const reflection = this._association.reflection;
-    const inverseOf = reflection.options.inverseOf;
+    // Resolve the inverse association name via the registered Reflection,
+    // so automatic inverse_of (no explicit option) wires the parent onto
+    // each loaded child — mirrors `set_inverse_instance_from_queries`.
+    const ownerCtor = owner.constructor as typeof import("./base.js").Base;
+    const resolvedRefl = ownerCtor._reflectOnAssociation?.(reflection.name);
+    const inverseName: string | null =
+      resolvedRefl?.inverseName?.() ??
+      (reflection.options.inverseOf && !reflection.options.polymorphic
+        ? (reflection.options.inverseOf as string)
+        : null);
 
-    if (inverseOf && !reflection.options.polymorphic) {
+    if (inverseName) {
       for (const r of records) {
         const cache = ((r as any)._cachedAssociations ??= new Map());
-        cache.set(inverseOf, owner);
+        cache.set(inverseName, owner);
       }
     }
 

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -6850,11 +6850,36 @@ describe("AssociationProxyTest", () => {
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
     /* Rails: Mocha stub test — no JS equivalent for this Ruby testing infrastructure check */
   });
-  it.skip("inverses get set of subsets of the association", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* Rails: sets inverse_of on loaded records — needs inverse_of population on collection load */
+  it("inverses get set of subsets of the association", async () => {
+    // Rails: human.interests.where("1=1").first.human should not re-query —
+    // automatic inverse_of wires the parent onto each loaded child.
+    class IsHuman extends Base {
+      static {
+        this._tableName = "is_humans";
+        this.attribute("name", "string");
+        this.adapter = apAdapter;
+      }
+    }
+    class IsInterest extends Base {
+      static {
+        this._tableName = "is_interests";
+        this.attribute("topic", "string");
+        this.attribute("is_human_id", "integer");
+        this.adapter = apAdapter;
+      }
+    }
+    Associations.hasMany.call(IsHuman, "isInterests", { className: "IsInterest" });
+    Associations.belongsTo.call(IsInterest, "isHuman", { className: "IsHuman" });
+    registerModel("IsHuman", IsHuman);
+    registerModel("IsInterest", IsInterest);
+
+    const human = await IsHuman.create({ name: "Gordon" });
+    await IsInterest.create({ topic: "Trainspotting", is_human_id: (human as any).id });
+    const found = (await IsHuman.find((human as any).id)) as InstanceType<typeof IsHuman>;
+    const proxy = association(found, "isInterests");
+    const subset = await proxy.where("1=1").first();
+    expect(subset).not.toBeNull();
+    expect((subset as any)._cachedAssociations?.get("isHuman")).toBe(found);
   });
   it("pluck uses loaded target", async () => {
     const { APPost, APComment } = setupProxyModels();

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -657,16 +657,18 @@ export class AssociationReflection extends MacroReflection {
 
     let reflection: AssociationReflection | ThroughReflection | null | false = null;
     try {
-      for (const n of candidateNames) {
-        reflection = this.klass._reflectOnAssociation(n);
-        if (reflection) break;
+      const lookupNames: string[] = [...candidateNames];
+      if (this.activeRecord.automaticallyInvertPluralAssociations) {
+        for (const n of candidateNames) lookupNames.push(pluralize(n));
       }
-
-      if (!reflection && this.activeRecord.automaticallyInvertPluralAssociations) {
-        for (const n of candidateNames) {
-          const pluralInverseName = pluralize(n);
-          reflection = this.klass._reflectOnAssociation(pluralInverseName);
-          if (reflection) break;
+      // Pick the first candidate whose reflection is a valid inverse. A
+      // hit on an invalid candidate (e.g. inverseOf:false, mismatched FK,
+      // wrong target class) must not shadow a later valid one.
+      for (const n of lookupNames) {
+        const r = this.klass._reflectOnAssociation(n);
+        if (r && this.validInverseReflection(r)) {
+          reflection = r;
+          break;
         }
       }
     } catch (e: unknown) {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -643,17 +643,31 @@ export class AssociationReflection extends MacroReflection {
   private automaticInverseOf(): string | null {
     if (!this.canFindInverseOfAutomatically(this)) return null;
 
-    const inverseName = this.options.as
+    const snakeInverseName = this.options.as
       ? underscore(this.options.as as string)
       : underscore(demodulize(this.activeRecord.name));
+    // Codebase convention is camelCase association names; Rails uses
+    // snake_case. Try both so automatic inverse detection works regardless
+    // of which form the user registered the inverse under.
+    const camelInverseName = camelize(snakeInverseName, false);
+    const candidateNames =
+      camelInverseName === snakeInverseName
+        ? [snakeInverseName]
+        : [camelInverseName, snakeInverseName];
 
-    let reflection: AssociationReflection | ThroughReflection | null | false;
+    let reflection: AssociationReflection | ThroughReflection | null | false = null;
     try {
-      reflection = this.klass._reflectOnAssociation(inverseName);
+      for (const n of candidateNames) {
+        reflection = this.klass._reflectOnAssociation(n);
+        if (reflection) break;
+      }
 
       if (!reflection && this.activeRecord.automaticallyInvertPluralAssociations) {
-        const pluralInverseName = pluralize(inverseName);
-        reflection = this.klass._reflectOnAssociation(pluralInverseName);
+        for (const n of candidateNames) {
+          const pluralInverseName = pluralize(n);
+          reflection = this.klass._reflectOnAssociation(pluralInverseName);
+          if (reflection) break;
+        }
       }
     } catch (e: unknown) {
       // Rails: rescue NameError => error; raise unless error.name.to_s == class_name


### PR DESCRIPTION
## Summary

- `AssociationRelation.toArray` now resolves the inverse association name via the registered reflection's `inverseName()`, which already handles both explicit `inverseOf` and automatic detection. Previously it only honored the explicit `inverseOf` option, so chained queries on a collection (`human.interests.where(...)`) failed to pre-populate the parent reference on each loaded child unless `inverseOf` was set by hand.
- `automaticInverseOf` in `reflection.ts` now also tries the camelCase form of the derived inverse name, since the codebase convention is camelCase association names (Rails uses snake_case).
- Un-skips `inverses get set of subsets of the association` in `associations.test.ts` (mirrors the Rails test in `vendor/rails/activerecord/test/cases/associations_test.rb:620`).

Mirrors: `ActiveRecord::AssociationRelation#exec_queries` / `set_inverse_instance_from_queries` and `has_many_association.rb#set_inverse_instance`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/reflection.test.ts packages/activerecord/src/associations` (all association suites)
- [x] `pnpm typecheck`