### PR TITLE
feat(activerecord): Associations-core — composite-FK autosave

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2993,17 +2993,77 @@ describe("AssociationsTest", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toEqual([2, 7]);
   });
-  it.skip("append composite foreign key has many association with autosave", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* fixture-dependent */
+  it("append composite foreign key has many association with autosave", async () => {
+    const adapter = freshAdapter();
+    class AsCpkOwner extends Base {
+      static {
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class AsCpkItem extends Base {
+      static {
+        this.attribute("owner_region_id", "integer");
+        this.attribute("owner_id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("AsCpkOwner", AsCpkOwner);
+    registerModel("AsCpkItem", AsCpkItem);
+    Associations.hasMany.call(AsCpkOwner, "asCpkItems", {
+      className: "AsCpkItem",
+      foreignKey: ["owner_region_id", "owner_id"],
+    });
+    const owner = await AsCpkOwner.create({ region_id: 1, id: 10, name: "Owner" });
+    const item = new AsCpkItem({ label: "New" });
+    expect(item.isNewRecord()).toBe(true);
+    const proxy = association(owner, "asCpkItems");
+    await proxy.push(item);
+    expect(item.isPersisted()).toBe(true);
+    expect(item.owner_region_id).toBe(1);
+    expect(item.owner_id).toBe(10);
   });
-  it.skip("assign composite foreign key belongs to association with autosave", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* fixture-dependent */
+  it("assign composite foreign key belongs to association with autosave", async () => {
+    const adapter = freshAdapter();
+    class AsCpkParent extends Base {
+      static {
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class AsCpkChild extends Base {
+      static {
+        this.attribute("parent_region_id", "integer");
+        this.attribute("parent_id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("AsCpkParent", AsCpkParent);
+    registerModel("AsCpkChild", AsCpkChild);
+    Associations.belongsTo.call(AsCpkChild, "asCpkParent", {
+      foreignKey: ["parent_region_id", "parent_id"],
+      className: "AsCpkParent",
+      autosave: true,
+    });
+    const child = await AsCpkChild.create({ label: "Child" });
+    const parent = new AsCpkParent({ region_id: 2, id: 30, name: "Parent" });
+    expect(parent.isNewRecord()).toBe(true);
+    setBelongsTo(child, "asCpkParent", parent, {
+      foreignKey: ["parent_region_id", "parent_id"],
+      className: "AsCpkParent",
+    });
+    await child.save();
+    expect(parent.isPersisted()).toBe(true);
+    expect(child.parent_region_id).toBe(2);
+    expect(child.parent_id).toBe(30);
   });
   it.skip("append composite has many through association", () => {
     // BLOCKED: associations — collection/singular feature gap

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -651,7 +651,8 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
     // Rails save_belongs_to_association:544-547 — when destroying the
     // associated record, null out the FK on self first so the owner save
     // doesn't keep a dangling reference.
-    const foreignKey = assoc.options.foreignKey ?? `${underscore(assoc.name)}_id`;
+    const foreignKey =
+      assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
     const fkList: string[] = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
     for (const key of fkList) record._writeAttribute(key, null);
     if (!assocRecord.isNewRecord()) await assocRecord.destroy();

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -671,7 +671,8 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       _setAutosavingBelongsToFor(record, assoc, false);
     }
 
-    const foreignKey = assoc.options.foreignKey ?? `${underscore(assoc.name)}_id`;
+    const foreignKey =
+      assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
     const primaryKey =
       assoc.options.primaryKey ?? (assocRecord.constructor as typeof Base).primaryKey ?? "id";
     if (Array.isArray(primaryKey) && Array.isArray(foreignKey)) {


### PR DESCRIPTION
## Summary

Unblocks 2 of the 5 autosave tests in the Associations-core cluster (`associations.test.ts`):

- `append composite foreign key has many association with autosave` — pushing a new (unsaved) child onto a CollectionProxy with composite FK already saves it via `proxy.push()`. Test body just exercises the path.
- `assign composite foreign key belongs to association with autosave` — `setBelongsTo` + `child.save()` autosaves a new composite-PK parent and copies FKs. Required one prod fix in `_autosaveBelongsTo`: honor `options.queryConstraints` as a fallback for `foreignKey`. The belongs_to builder normalizes a caller-passed `foreignKey: [...]` array onto `queryConstraints` on the reflection, so the autosave path was hitting the `CompositePrimaryKeyMismatchError` gate (one array, one string).

## Followups (deferred — clearly larger than 300 LOC ceiling)

3 tests remain skipped in this file (`append`/`append with autosave`/`nullify composite has many through`). They require composite-ownerFk support in `_pushThrough` and `_deleteThroughAllSql`, both of which explicitly throw on composite ownerFk today (`collection-proxy.ts:1032-1041`, `:1267-1271`). Belongs to has-many-through cluster Slot C in `docs/activerecord-100-clusters.md`.

Separately: belongs_to autosave-on-new-target fires only with `autosave: true` explicit; Rails wires the callback unconditionally. Test 2 sets `autosave: true` in options to exercise the path. Default-autosave for belongs_to is a separate (broader) followup.

## Test plan

- [x] `pnpm vitest run -t "composite foreign key" packages/activerecord/src/associations.test.ts` — 15 passed
- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts packages/activerecord/src/associations.test.ts` — 564 passed, no regressions
- [x] `tsc --build` clean (via husky)