### PR TITLE
fix(action-dispatch): journey Pattern pushes RegExp requirements into AST

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
@@ -1266,11 +1266,7 @@ describe("TestRoutingMapper", () => {
     expect(routes.recognize("GET", "/posts/123-abc")!.params.id).toBe("123-abc");
   });
 
-  // BLOCKED: requires Journey GTG to widen its symbol char-class based on
-  // requirement regex (Rails' filename: /(.+)/ pattern). Until then, dotted
-  // captures via custom requirements only work for routes that land in
-  // `customRoutes` (non-anchored or non-requirements-anchored).
-  it.skip("named character classes in regexp constraints", () => {
+  it("named character classes in regexp constraints", () => {
     const routes = new RouteSet();
     routes.draw((r) => {
       r.get("/purchases/:token/:filename", {

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Parser } from "../parser.js";
 import { Ast } from "../ast.js";
+import { Symbol as SymbolNode } from "../nodes/node.js";
 import { Pattern } from "./pattern.js";
 
 const SEPARATORS = "/.?";
@@ -276,8 +277,10 @@ describe("ActionDispatch::Journey::Path::Pattern — requirements", () => {
     const tree = new Parser().parse("/posts/:filename");
     const ast = new Ast(tree, true);
     new Pattern(ast, { filename: /(.+)/ }, "/.?", true);
-    const symbol = ast.terminals.find((n) => n.isSymbol() && n.name === "filename");
-    expect(symbol).toBeDefined();
-    expect((symbol as unknown as { regexp: RegExp }).regexp.source).toBe("(.+)");
+    const symbol = ast.terminals.find(
+      (n): n is SymbolNode => n instanceof SymbolNode && n.name === "filename",
+    );
+    expect(symbol).toBeInstanceOf(SymbolNode);
+    expect(symbol!.regexp.source).toBe("(.+)");
   });
 });

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -268,4 +268,16 @@ describe("ActionDispatch::Journey::Path::Pattern — requirements", () => {
     const p = buildPath("/page/:name", { name: /test/ });
     expect(p.requirementsForMissingKeysCheck).toBe(p.requirementsForMissingKeysCheck);
   });
+
+  it("Pattern pushes RegExp requirements into the SymbolNode for GTG widening", () => {
+    // Mirrors Rails `ast.requirements = …` — the symbol's effective regex
+    // becomes the user-supplied requirement so the GTG accepts characters
+    // (e.g. `.`) that the default `[^./?]+` char-class would reject.
+    const tree = new Parser().parse("/posts/:filename");
+    const ast = new Ast(tree, true);
+    new Pattern(ast, { filename: /(.+)/ }, "/.?", true);
+    const symbol = ast.terminals.find((n) => n.isSymbol() && n.name === "filename");
+    expect(symbol).toBeDefined();
+    expect((symbol as unknown as { regexp: RegExp }).regexp.source).toBe("(.+)");
+  });
 });

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -244,9 +244,10 @@ export class Pattern {
     this.anchored = anchored;
     this.names = ast.names;
     // Mirror Rails `ast.requirements = …`: push single-RegExp requirements
-    // onto each symbol's `.regexp` so the GTG sees the user's char-class
-    // (e.g. `:filename` with `/(.+)/` matches dotted segments). Skip
-    // array-form (regex union) requirements — those are pattern-level only.
+    // onto each symbol (and `*name` star) node's `.regexp` so the GTG sees
+    // the user's char-class (e.g. `:filename` with `/(.+)/` matches dotted
+    // segments). Skip array-form (regex union) requirements — those are
+    // pattern-level only.
     const flat: Record<string, RegExp> = {};
     for (const [k, v] of Object.entries(requirements)) {
       if (v instanceof RegExp) flat[k] = v;

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -243,6 +243,15 @@ export class Pattern {
     this._separators = separators;
     this.anchored = anchored;
     this.names = ast.names;
+    // Mirror Rails `ast.requirements = …`: push single-RegExp requirements
+    // onto each symbol's `.regexp` so the GTG sees the user's char-class
+    // (e.g. `:filename` with `/(.+)/` matches dotted segments). Skip
+    // array-form (regex union) requirements — those are pattern-level only.
+    const flat: Record<string, RegExp> = {};
+    for (const [k, v] of Object.entries(requirements)) {
+      if (v instanceof RegExp) flat[k] = v;
+    }
+    if (Object.keys(flat).length > 0) ast.requirements = flat;
   }
 
   buildFormatter(): Format {


### PR DESCRIPTION
## Summary
Mirrors Rails \`ast.requirements = …\`. \`Pattern\` constructor now invokes the existing \`Ast.requirements=\` setter so each \`SymbolNode\`'s effective regex is the user-supplied requirement, not the default char-class \`/[^./?]+/\`.

## Bug it fixes
Before: GTG built from the AST used the default char-class for every \`:symbol\`, so a route like \`/purchases/:token/:filename\` with \`filename: /(.+)/\` couldn't match \`/purchases/.../foo.pdf\` — the \`.\` in the filename was rejected by the symbol's default char-class.

After: the symbol carries \`/(.+)/\`, the GTG accepts dotted segments, the route matches. **Unskips** the \`named character classes in regexp constraints\` test from PR #1696.

Array-form requirements (regex unions used internally) are skipped — those remain pattern-level only.

## Test plan
- [x] Pattern unit test: SymbolNode's \`regexp.source\` equals user-supplied requirement after Pattern construction
- [x] Unskipped \`routing.test.ts\` — 'named character classes in regexp constraints' now passes
- [x] All 2032 actionpack tests pass
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean