### PR TITLE
test(activerecord): MySQL charset-collation Slot C + B-followups

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
@@ -53,20 +53,55 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(col?.collation).toBe("utf8mb4_bin");
     });
 
-    it.skip("change column with charset and collation", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column with charset and collation", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "text", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_general_ci",
+      });
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("text");
+      expect(col?.collation).toBe("utf8mb4_general_ci");
     });
 
-    it.skip("change column doesn't preserve collation for string to binary types", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column doesn't preserve collation for string to binary types", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "binary");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("binary");
+      expect(col?.collation).toBeFalsy();
     });
 
-    it.skip("change column doesn't preserve collation for string to non-string types", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column doesn't preserve collation for string to non-string types", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "int");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("integer");
+      expect(col?.collation).toBeFalsy();
     });
 
-    it.skip("change column preserves collation for string to text", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column preserves collation for string to text", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "text");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("text");
+      expect(col?.collation).toBe("utf8mb4_unicode_ci");
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
@@ -77,7 +77,7 @@ describeIfMysql("Mysql2Adapter", () => {
       const columns = await adapter.columns("charset_collations");
       const col = columns.find((c) => c.name === "description");
       expect(col?.type).toBe("binary");
-      expect(col?.collation).toBeFalsy();
+      expect(col?.collation).toBeUndefined();
     });
 
     it("change column doesn't preserve collation for string to non-string types", async () => {
@@ -89,7 +89,7 @@ describeIfMysql("Mysql2Adapter", () => {
       const columns = await adapter.columns("charset_collations");
       const col = columns.find((c) => c.name === "description");
       expect(col?.type).toBe("integer");
-      expect(col?.collation).toBeFalsy();
+      expect(col?.collation).toBeUndefined();
     });
 
     it("change column preserves collation for string to text", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
@@ -77,7 +77,7 @@ describeIfMysql("Mysql2Adapter", () => {
       const columns = await adapter.columns("charset_collations");
       const col = columns.find((c) => c.name === "description");
       expect(col?.type).toBe("binary");
-      expect(col?.collation).toBeUndefined();
+      expect(col?.collation).toBeNull();
     });
 
     it("change column doesn't preserve collation for string to non-string types", async () => {
@@ -89,7 +89,7 @@ describeIfMysql("Mysql2Adapter", () => {
       const columns = await adapter.columns("charset_collations");
       const col = columns.find((c) => c.name === "description");
       expect(col?.type).toBe("integer");
-      expect(col?.collation).toBeUndefined();
+      expect(col?.collation).toBeNull();
     });
 
     it("change column preserves collation for string to text", async () => {


### PR DESCRIPTION
## Summary

Slot C of the MySQL charset-collation cluster: BLOCKED annotation cleanup. Unskips 4 `change_column`-dependent tests in `charset-collation.test.ts` that were previously blocked on Slot B (changeColumn). Slot B (#1533), B-followups (#1568), and the #1568 helper unit tests (#1692) are all merged, so these tests are now valid.

Ports test bodies verbatim from `vendor/rails/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb` lines 41-77:

- `change column with charset and collation`
- `change column doesn't preserve collation for string to binary types`
- `change column doesn't preserve collation for string to non-string types`
- `change column preserves collation for string to text`

The Slot B-followup carry-over described in `docs/activerecord-100-clusters.md` (~150 LOC unit tests for #1568 helpers) was already shipped in #1692, so this PR scopes to Slot C only.

Live-DB only — gated by `describeIfMysql`, runs in CI's mysql2 lane.

## Test plan

- [ ] CI mysql2 lane: 4 newly-unskipped tests pass
- [ ] Other lanes (sqlite/pg): file remains skipped