### PR TITLE
feat(activerecord): MySQL charset-collation remaining slot

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
@@ -53,20 +53,55 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(col?.collation).toBe("utf8mb4_bin");
     });
 
-    it.skip("change column with charset and collation", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column with charset and collation", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "text", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_general_ci",
+      });
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("text");
+      expect(col?.collation).toBe("utf8mb4_general_ci");
     });
 
-    it.skip("change column doesn't preserve collation for string to binary types", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column doesn't preserve collation for string to binary types", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "binary");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("binary");
+      expect(col?.collation).toBeNull();
     });
 
-    it.skip("change column doesn't preserve collation for string to non-string types", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column doesn't preserve collation for string to non-string types", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "int");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("integer");
+      expect(col?.collation).toBeNull();
     });
 
-    it.skip("change column preserves collation for string to text", () => {
-      // BLOCKED: changeColumn not yet implemented (Slot B)
+    it("change column preserves collation for string to text", async () => {
+      await adapter.addColumn("charset_collations", "description", "string", {
+        charset: "utf8mb4",
+        collation: "utf8mb4_unicode_ci",
+      });
+      await adapter.changeColumn("charset_collations", "description", "text");
+      const columns = await adapter.columns("charset_collations");
+      const col = columns.find((c) => c.name === "description");
+      expect(col?.type).toBe("text");
+      expect(col?.collation).toBe("utf8mb4_unicode_ci");
     });
   });
 });


### PR DESCRIPTION
## Summary

Slot C of the MySQL charset-collation cluster — port the 4 `it.skip` change-column tests in `abstract-mysql-adapter/charset-collation.test.ts` to real bodies.

The BLOCKED stubs cited \"changeColumn not yet implemented (Slot B)\", but Slot B (#1533) + B-followup (#1568) landed both `changeColumn` and `buildChangeColumnDefinition` with the collation preservation/drop semantics these tests exercise. Test bodies mirror Rails `vendor/rails/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb`:

- `change column with charset and collation` — string→text with new collation
- `change column doesn't preserve collation for string to binary types` — collation dropped
- `change column doesn't preserve collation for string to non-string types` — collation dropped on int
- `change column preserves collation for string to text` — collation carried from `Column#collation`

These are live-DB tests; `describeIfMysql` keeps them inert when `MYSQL_TEST_URL` isn't reachable. CI will exercise them on the mysql2 job.

Adjacent-gap note in the cluster doc about `buildCreateIndexDefinition` returning `{}` is stale — that stub was already implemented in #1612. The schema-dump variant from the Rails source is deferred (needs SchemaDumpingHelper port).

## Test plan
- [ ] CI mysql2 job exercises all 4 newly-unskipped tests
- [ ] `pnpm api:compare --package activerecord` shows charset_collation_test.rb mapping improved