### PR TITLE
feat(activerecord): unknown-triage Slot D — afterCommit refinements

### DIFF
--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -337,15 +337,6 @@ describe("CallbacksTest", () => {
     expect(log).toContain("initialized");
   });
 
-  it.skip("after_commit_on_create_in_transaction", () => {
-    // BLOCKED: transactions — transaction_callbacks_test.rb: after_commit fires on create inside transaction
-    /* needs transaction + afterCommit on create */
-  });
-  it.skip("after_commit callback doesnt fire for readonly", () => {
-    // BLOCKED: transactions — transaction_callbacks_test.rb: after_commit skipped for readonly records
-    /* needs readonly check in commit callbacks */
-  });
-
   it("new valid?", async () => {
     class CbPost extends Base {
       static {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -8,6 +8,7 @@ import {
   transaction,
   savepoint,
   Rollback,
+  ReadOnlyRecord,
   afterAllTransactionsCommit,
   Associations,
   registerModel,
@@ -771,9 +772,9 @@ describe("TransactionTest", () => {
     log.length = 0;
     t.readonlyBang();
     t.title = "changed";
-    await expect(t.save()).rejects.toThrow(/readonly/);
+    await expect(t.save()).rejects.toThrow(ReadOnlyRecord);
     expect(log).toEqual([]);
-    await expect(t.destroy()).rejects.toThrow(/readonly/);
+    await expect(t.destroy()).rejects.toThrow(ReadOnlyRecord);
     expect(log).toEqual([]);
   });
   it("transaction within transaction", async () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -756,12 +756,25 @@ describe("TransactionTest", () => {
     });
     expect(history).toEqual(["rolled_back"]);
   });
-  it.skip("after_commit callback doesnt fire for readonly", () => {
-    // NOT IN RAILS — our addition; no matching Rails test found.
-    // BLOCKED: transactions — unverified behavior
-    // ROOT-CAUSE: undefined behavior for readonly records and commit callbacks;
-    //   Rails does not have a test for this. Needs investigation before implementing.
-    // SCOPE: ~10 LOC test body + implementation verification.
+  it("after_commit callback doesnt fire for readonly", async () => {
+    const log: string[] = [];
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        this.afterCommit(() => {
+          log.push("committed");
+        });
+      }
+    }
+    const t = await Topic.create({ title: "frozen" });
+    log.length = 0;
+    t.readonlyBang();
+    t.title = "changed";
+    await expect(t.save()).rejects.toThrow(/readonly/);
+    expect(log).toEqual([]);
+    await expect(t.destroy()).rejects.toThrow(/readonly/);
+    expect(log).toEqual([]);
   });
   it("transaction within transaction", async () => {
     class TxPost extends Base {


### PR DESCRIPTION
## Summary

Per `docs/activerecord-100-clusters.md` Unknown-triage Slot D (~50 LOC).

- Un-skips `after_commit callback doesnt fire for readonly` in `transactions.test.ts` with a real body. Verifies that calling `save()` or `destroy()` on a readonly record raises `ReadOnlyRecord` and the registered `afterCommit` callback does not fire. The existing `persistence.ts` readonly guards short-circuit before `withTransactionReturningStatus`, so no impl change was needed — this PR pins the behavior with a test.
- Removes the two empty stubs in `callbacks.test.ts` (`after_commit_on_create_in_transaction`, `after_commit callback doesnt fire for readonly`). Both are duplicates of tests in `transactions.test.ts`; the create-in-tx case already passes there, and the readonly case is now un-skipped above. The stubs had no test bodies — pure annotation duplicates from the Slot A re-tag.

## LOC

19 ins + 15 del = 34 LOC total (well under 300 ceiling).

## Verification

```
pnpm vitest run packages/activerecord/src/transactions.test.ts -t "after_commit callback doesnt fire for readonly"
# → 1 passed
pnpm vitest run packages/activerecord/src/transactions.test.ts -t "after_commit_on_create_in_transaction"
# → 1 passed
```