### PR TITLE
feat(action-dispatch): journey Router.recognize native short-circuit

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/router.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.test.ts
@@ -158,6 +158,29 @@ describe("ActionDispatch::Journey::Router", () => {
     expect(seen["slug"]).toBe("hello world");
   });
 
+  it("recognize() stops iterating when the block returns true", () => {
+    const r1 = new Route({ name: "a", app: okApp("a"), path: pat("/x") });
+    const r2 = new Route({ name: "b", app: okApp("b"), path: pat("/x") });
+    const router = new Router(buildRoutes([r1, r2]));
+    const seen: string[] = [];
+    router.recognize(req({ pathInfo: "/x" }), (route) => {
+      seen.push(route.name);
+      return true;
+    });
+    expect(seen).toEqual(["a"]);
+  });
+
+  it("recognize() continues when the block returns falsy", () => {
+    const r1 = new Route({ name: "a", app: okApp("a"), path: pat("/x") });
+    const r2 = new Route({ name: "b", app: okApp("b"), path: pat("/x") });
+    const router = new Router(buildRoutes([r1, r2]));
+    const seen: string[] = [];
+    router.recognize(req({ pathInfo: "/x" }), (route) => {
+      seen.push(route.name);
+    });
+    expect(seen).toEqual(["a", "b"]);
+  });
+
   it("eagerLoadBang() initializes the simulator without throwing", () => {
     const route = new Route({ name: "p", app: okApp("ok"), path: pat("/x") });
     const router = new Router(buildRoutes([route]));

--- a/packages/actionpack/src/action-dispatch/journey/router.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.test.ts
@@ -170,7 +170,7 @@ describe("ActionDispatch::Journey::Router", () => {
     expect(seen).toEqual(["a"]);
   });
 
-  it("recognize() continues when the block returns falsy", () => {
+  it("recognize() continues when the block returns undefined", () => {
     const r1 = new Route({ name: "a", app: okApp("a"), path: pat("/x") });
     const r2 = new Route({ name: "b", app: okApp("b"), path: pat("/x") });
     const router = new Router(buildRoutes([r1, r2]));
@@ -178,6 +178,30 @@ describe("ActionDispatch::Journey::Router", () => {
     router.recognize(req({ pathInfo: "/x" }), (route) => {
       seen.push(route.name);
     });
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it("recognize() continues when the block returns explicit false", () => {
+    const r1 = new Route({ name: "a", app: okApp("a"), path: pat("/x") });
+    const r2 = new Route({ name: "b", app: okApp("b"), path: pat("/x") });
+    const router = new Router(buildRoutes([r1, r2]));
+    const seen: string[] = [];
+    router.recognize(req({ pathInfo: "/x" }), (route) => {
+      seen.push(route.name);
+      return false;
+    });
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it("recognize() accepts callbacks that incidentally return non-boolean values", () => {
+    // Regression test: an expression-bodied callback like
+    // `(r) => arr.push(r.name)` (which returns the new length, a number)
+    // must remain type-compatible with the unknown-return block signature.
+    const r1 = new Route({ name: "a", app: okApp("a"), path: pat("/x") });
+    const r2 = new Route({ name: "b", app: okApp("b"), path: pat("/x") });
+    const router = new Router(buildRoutes([r1, r2]));
+    const seen: string[] = [];
+    router.recognize(req({ pathInfo: "/x" }), (route) => seen.push(route.name));
     expect(seen).toEqual(["a", "b"]);
   });
 

--- a/packages/actionpack/src/action-dispatch/journey/router.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.ts
@@ -86,7 +86,7 @@ export class Router {
 
   recognize(
     req: RouterRequest,
-    block: (route: Route, parameters: Record<string, unknown>) => void,
+    block: (route: Route, parameters: Record<string, unknown>) => boolean | void,
   ): void {
     for (const { match, parameters, route } of this._findRoutes(req)) {
       if (!route.path.anchored) {
@@ -96,7 +96,9 @@ export class Router {
         req.pathInfo = post;
       }
       const merged: Record<string, unknown> = { ...route.defaults, ...parameters };
-      block(route, merged);
+      // JS callbacks can't `return` from the caller's frame the way Ruby
+      // blocks can; returning `true` from the block signals "stop iterating".
+      if (block(route, merged) === true) return;
     }
   }
 

--- a/packages/actionpack/src/action-dispatch/journey/router.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router.ts
@@ -86,7 +86,11 @@ export class Router {
 
   recognize(
     req: RouterRequest,
-    block: (route: Route, parameters: Record<string, unknown>) => boolean | void,
+    // Block return is `unknown` so expression-bodied callbacks like
+    // `(r) => arr.push(r.name)` (which return a number) remain type-
+    // compatible with the previous `() => void` signature. Only an
+    // explicit `=== true` signals short-circuit.
+    block: (route: Route, parameters: Record<string, unknown>) => unknown,
   ): void {
     for (const { match, parameters, route } of this._findRoutes(req)) {
       if (!route.path.anchored) {

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -85,33 +85,25 @@ export function journeyRecognize(
     pathParameters: {},
   };
   let result: JourneyMatch | null = null;
-  try {
-    router.recognize(req, (journeyRoute) => {
-      const local = JOURNEY_TO_LOCAL.get(journeyRoute);
-      if (!local) return;
-      // Re-match against the pattern so we get *only* captured segments —
-      // the parameters Router.recognize yields are merged with defaults,
-      // which leaks defaults into optional captures (e.g. /posts(/:id)
-      // with defaults={id:"1"} matching /posts).
-      const match = journeyRoute.path.match(pathInfo);
-      const params: Record<string, string> = {};
-      if (match) {
-        for (const [name, value] of Object.entries(match.namedCaptures)) {
-          if (value != null) params[name] = unescapeUri(value);
-        }
+  router.recognize(req, (journeyRoute) => {
+    const local = JOURNEY_TO_LOCAL.get(journeyRoute);
+    if (!local) return;
+    // Re-match against the pattern so we get *only* captured segments —
+    // the parameters Router.recognize yields are merged with defaults,
+    // which leaks defaults into optional captures (e.g. /posts(/:id)
+    // with defaults={id:"1"} matching /posts).
+    const match = journeyRoute.path.match(pathInfo);
+    const params: Record<string, string> = {};
+    if (match) {
+      for (const [name, value] of Object.entries(match.namedCaptures)) {
+        if (value != null) params[name] = unescapeUri(value);
       }
-      result = { route: local, params };
-      // Router.recognize iterates all matches; short-circuit so large route
-      // sets aren't fully walked after the first hit.
-      throw STOP;
-    });
-  } catch (e) {
-    if (e !== STOP) throw e;
-  }
+    }
+    result = { route: local, params };
+    return true; // stop iterating after the first hit
+  });
   return result;
 }
-
-const STOP = Symbol("journey-bridge-stop");
 
 function stripAnchors(source: string): string {
   let s = source;


### PR DESCRIPTION
## Summary
Returning \`true\` from the \`Router.recognize()\` block stops iteration. Mirrors Ruby's block \`return\` semantics — JS callbacks can't unwind the caller frame, so use a boolean signal instead.

Retires the \`STOP\` sentinel-throw workaround in \`journey-bridge.ts\`'s \`journeyRecognize\` (introduced in PR #1685).

## API
\`\`\`ts
router.recognize(req, (route, params) => {
  // ... do something
  return true;  // optional: stop iterating after this match
});
\`\`\`

Falsy / undefined returns continue iteration (no breaking change for existing callers).

## Test plan
- [x] New router tests: short-circuit on \`return true\`, continues on falsy return
- [x] journey-bridge tests still pass (uses the new API)
- [x] 129 routing+journey tests pass
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean