### PR TITLE
test(globalid): port 4 Rails test mirrors (uri_gid + identification → 100%)

### DIFF
--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -80,6 +80,17 @@ describe("GlobalIdentificationTest", () => {
     expect(parsed!.uri).toContain("?db=primary");
   });
 
+  it("dup should clear memoized to_global_id", () => {
+    // Rails: dup'd model with a mutated id yields a different to_global_id.
+    // Trails: toGlobalId is not memoized — each call builds afresh from
+    // the current id, so the dup-then-mutate behavior is the default.
+    const model = new Person("1");
+    const globalId = toGlobalId.call(model);
+    const dupModel = new Person(String(Number(model.id) + 1));
+    const dupGlobalId = toGlobalId.call(dupModel);
+    expect(globalId.uri).not.toBe(dupGlobalId.uri);
+  });
+
   it("toGidParam round-trips through GlobalID.parse", () => {
     const p = new Person("5");
     const parsed = GlobalID.parse(toGidParam.call(p));

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -81,14 +81,19 @@ describe("GlobalIdentificationTest", () => {
   });
 
   it("dup should clear memoized to_global_id", () => {
-    // Rails: dup'd model with a mutated id yields a different to_global_id.
-    // Trails: toGlobalId is not memoized — each call builds afresh from
-    // the current id, so the dup-then-mutate behavior is the default.
+    // Rails calls model.dup (which clears @global_id memoization) and
+    // mutates the dup's id. The test verifies the resulting GID reflects
+    // the new id, not a stale memoized one. Trails doesn't memoize
+    // toGlobalId, so the same invariant holds without dup: mutating id
+    // on the original instance and re-calling toGlobalId must return a
+    // fresh GID for the new id. Mutating in-place is the stricter check —
+    // if memoization ever creeps in, this test catches it.
     const model = new Person("1");
-    const globalId = toGlobalId.call(model);
-    const dupModel = new Person(String(Number(model.id) + 1));
-    const dupGlobalId = toGlobalId.call(dupModel);
-    expect(globalId.uri).not.toBe(dupGlobalId.uri);
+    const before = toGlobalId.call(model);
+    model.id = "2";
+    const after = toGlobalId.call(model);
+    expect(after.uri).not.toBe(before.uri);
+    expect(after.modelId).toBe("2");
   });
 
   it("toGidParam round-trips through GlobalID.parse", () => {

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -70,6 +70,29 @@ describe("URI::GIDTest", () => {
     const c = parseGid("gid://bcxxx/Persona/1");
     expect(a.app).not.toBe(c.app);
   });
+
+  it("build with wrong ordered array creates a wrong ordered gid", () => {
+    // Rails: URI::GID.build(['Person', '5', 'bcx', nil]) misorders the
+    // positional (app, modelName, modelId, params) tuple. The resulting
+    // URI is not equal to the canonical gid://bcx/Person/5.
+    const wrong = buildGid("Person", "5", "bcx");
+    expect(wrong).not.toBe("gid://bcx/Person/5");
+  });
+
+  it("new returns invalid gid when not checking", () => {
+    // Rails: URI::GID.new(*URI.split('gid:///')) bypasses URI::GID.parse
+    // validation. The Trails analog is constructing GID directly with
+    // synthetic components — the parse path is skipped so no error is
+    // raised even though the URI string is non-canonical.
+    const synthetic = new GID("gid:///", {
+      app: "",
+      modelName: "",
+      modelId: "",
+      params: {},
+    });
+    expect(synthetic).toBeTruthy();
+    expect(synthetic.uri).toBe("gid:///");
+  });
 });
 
 describe("URI::GIDModelIDEncodingTest", () => {
@@ -176,6 +199,17 @@ describe("URI::GIDParamsTest", () => {
   it("as String", () => {
     const uri = buildGid("bcx", "Person", "5", { hello: "world" });
     expect(uri).toBe("gid://bcx/Person/5?hello=world");
+  });
+
+  it("immutable params", () => {
+    // Rails: mutating @gid.params doesn't affect @gid.to_s, because to_s
+    // returns the URI string fixed at construction time. Trails: toString()
+    // returns the cached uri, so post-construction params writes don't
+    // leak into the rendered URI either.
+    const gid = GID.parse("gid://bcx/Person/5?hello=world")!;
+    (gid.params as Record<string, string>)["param"] = "value";
+    expect(gid.toString()).not.toBe("gid://bcx/Person/5?hello=world&param=value");
+    expect(gid.toString()).toBe("gid://bcx/Person/5?hello=world");
   });
 });
 

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -76,6 +76,7 @@ describe("URI::GIDTest", () => {
     // positional (app, modelName, modelId, params) tuple. The resulting
     // URI is not equal to the canonical gid://bcx/Person/5.
     const wrong = buildGid("Person", "5", "bcx");
+    expect(wrong).toBe("gid://Person/5/bcx");
     expect(wrong).not.toBe("gid://bcx/Person/5");
   });
 
@@ -206,8 +207,8 @@ describe("URI::GIDParamsTest", () => {
     // returns the URI string fixed at construction time. Trails: toString()
     // returns the cached uri, so post-construction params writes don't
     // leak into the rendered URI either.
-    const gid = GID.parse("gid://bcx/Person/5?hello=world")!;
-    (gid.params as Record<string, string>)["param"] = "value";
+    const gid = GID.parse("gid://bcx/Person/5?hello=world");
+    gid.params["param"] = "value";
     expect(gid.toString()).not.toBe("gid://bcx/Person/5?hello=world&param=value");
     expect(gid.toString()).toBe("gid://bcx/Person/5?hello=world");
   });


### PR DESCRIPTION
## Summary
4 direct Rails test ports that don't need new implementation:

**`global-identification.test.ts`** (+1):
- \`dup should clear memoized to_global_id\` — Rails dup'd-model semantic. Trails doesn't memoize \`toGlobalId\` so the dup-then-mutate behavior is the default.

**`uri-gid.test.ts`** (+3):
- \`build with wrong ordered array creates a wrong ordered gid\` — positional misorder produces a non-canonical URI.
- \`new returns invalid gid when not checking\` — TS analog of \`URI::GID.new(*URI.split(...))\`: \`new GID(uri, components)\` with synthetic components bypasses validation.
- \`immutable params\` — post-construction mutation of \`params\` doesn't leak into \`toString()\` (which returns the cached URI).

## Test:compare delta
| File | Before | After |
|---|---|---|
| \`global-identification.test.ts\` | 5/6 | **6/6 ✓** |
| \`uri-gid.test.ts\` | 27/30 | **30/30 ✓** |
| **Overall** | 104/139 (74.8%) | **108/139 (77.7%)** |

## Remaining 31-test gap (out of scope)
The other missing tests need new implementation, not just test mirrors:
- **global_id_test.rb (13 missing)**: all \`find\` / \`find with X\` / \`finding\` / \`model class\` — need \`GlobalID#find\` and \`GlobalID#model_class\` (~80 LOC).
- **signed_global_id_test.rb (2 missing)**: \`model class\` (needs \`SignedGlobalID#modelClass\` via finder) and \`new accepts a :for\` (needs Rails-style \`SignedGlobalID.new(uri, options)\` constructor form).
- **global_locator_test.rb (16 missing)**: \`includes:\`/eager-loading (AR feature; plan calls for permanent skip), \`ScopedRecordLocatingTest\` (needs model.unscoped block fixture), \`by GID without a primary key method\`, etc.

These are tracked separately; this PR ships only the pure test-mirror wins.

## Test plan
- [x] \`pnpm vitest run packages/globalid/src/\` — 156/156 pass
- [x] \`pnpm typecheck\` clean