### PR TITLE
refactor(action-dispatch): Route owns the path-vs-request constraint split

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -30,17 +30,12 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
     const r = routes[i]!;
     const tree = new Parser().parse(r.path);
     const ast = new Ast(tree, true);
-    const requirements = regexpRequirements(r.constraints);
+    // Path-capture constraints become pattern requirements; request-attribute
+    // constraints (subdomain, format, etc.) stay on the Journey Route so
+    // Route#matches can apply them per-request. Route owns this split because
+    // it already knows which constraint keys are path captures.
+    const requirements = regexpRequirements(r.pathConstraints);
     const pattern = new Pattern(ast, requirements, SEPARATORS, r.anchor);
-    // Path-name constraints belong in the pattern, not on the JourneyRoute,
-    // or Route#matches will recheck them against request properties (where
-    // the captured value isn't yet) and reject every request. Rails splits
-    // these the same way.
-    const pathNames = new Set(pattern.names);
-    const requestConstraints: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(r.constraints)) {
-      if (!pathNames.has(k)) requestConstraints[k] = v;
-    }
     const verb = (r.verb || "").toUpperCase();
     const requestMethodMatch = !verb || verb === "ALL" ? undefined : [VerbMatchers.for(verb)];
     const name = r.name ?? `__r${i}`;
@@ -59,7 +54,7 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
             },
           },
           path: pattern,
-          constraints: requestConstraints,
+          constraints: r.requestConstraints,
           defaults: { ...r.defaults, controller: r.controller, action: r.action },
           requestMethodMatch,
           precedence: index,

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { Route } from "./route.js";
+
+describe("Route", () => {
+  describe("pathConstraints / requestConstraints", () => {
+    it("splits constraints by whether the key is a path capture", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show", {
+        constraints: {
+          id: /\d+/,
+          subdomain: /^api$/,
+          format: "json",
+        },
+      });
+      expect(route.pathConstraints).toEqual({ id: /\d+/ });
+      expect(route.requestConstraints).toEqual({
+        subdomain: /^api$/,
+        format: "json",
+      });
+    });
+
+    it("treats glob (*name) segments as path captures", () => {
+      const route = new Route("GET", "/assets/*path", "assets", "show", {
+        constraints: { path: /.+/, format: "json" },
+      });
+      expect(route.pathConstraints).toEqual({ path: /.+/ });
+      expect(route.requestConstraints).toEqual({ format: "json" });
+    });
+
+    it("returns empty maps when no constraints are declared", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show");
+      expect(route.pathConstraints).toEqual({});
+      expect(route.requestConstraints).toEqual({});
+    });
+  });
+
+  describe("pathParamNames", () => {
+    it("lists dynamic and glob captures in declaration order", () => {
+      const route = new Route("GET", "/a/:id/b/*rest", "x", "y");
+      expect(route.pathParamNames).toEqual(["id", "rest"]);
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -54,12 +54,15 @@ describe("Route", () => {
       expect(route.pathParamNames).toEqual(["controller", "format"]);
     });
 
-    it("treats escaped sigils (\\: / \\*) and bare * as literals, not captures", () => {
+    it("classifies sigils the way Journey's scanner does", () => {
+      // `\:foo` is a literal escaped colon — Journey's LITERAL_RUN absorbs `\:`.
       const escapedColon = new Route("GET", "/page\\:foo", "x", "y");
       expect(escapedColon.pathParamNames).toEqual([]);
 
+      // `\*rest` is NOT an escaped sequence in Journey's scanner — the
+      // backslash is literal, the STAR captures `rest`.
       const escapedStar = new Route("GET", "/page\\*rest", "x", "y");
-      expect(escapedStar.pathParamNames).toEqual([]);
+      expect(escapedStar.pathParamNames).toEqual(["rest"]);
 
       // A bare `*` with no name is literal in Journey.
       const bareStar = new Route("GET", "/page*", "x", "y");

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -39,9 +39,26 @@ describe("Route", () => {
       expect(route.pathParamNames).toEqual(["id", "rest"]);
     });
 
-    it("includes captures inside optional groups", () => {
+    it("includes captures inside optional groups in declaration order", () => {
       const route = new Route("GET", "/posts(/:id)(.:format)", "posts", "show");
-      expect(route.pathParamNames).toEqual(expect.arrayContaining(["id", "format"]));
+      expect(route.pathParamNames).toEqual(["id", "format"]);
+    });
+
+    it("includes captures inside nested optional groups", () => {
+      const route = new Route("GET", "/:c(/:a(/:id(.:format)))", "x", "y");
+      expect(route.pathParamNames).toEqual(["c", "a", "id", "format"]);
+    });
+
+    it("includes embedded captures inside static text", () => {
+      const route = new Route("GET", "/:controller.:format", "x", "y");
+      expect(route.pathParamNames).toEqual(["controller", "format"]);
+    });
+
+    it("returns a defensive copy that cannot mutate route internals", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show");
+      const names = route.pathParamNames as string[];
+      names.push("evil");
+      expect(route.pathParamNames).toEqual(["id"]);
     });
 
     it("treats optional-group captures as path constraints", () => {

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -54,6 +54,18 @@ describe("Route", () => {
       expect(route.pathParamNames).toEqual(["controller", "format"]);
     });
 
+    it("treats escaped sigils (\\: / \\*) and bare * as literals, not captures", () => {
+      const escapedColon = new Route("GET", "/page\\:foo", "x", "y");
+      expect(escapedColon.pathParamNames).toEqual([]);
+
+      const escapedStar = new Route("GET", "/page\\*rest", "x", "y");
+      expect(escapedStar.pathParamNames).toEqual([]);
+
+      // A bare `*` with no name is literal in Journey.
+      const bareStar = new Route("GET", "/page*", "x", "y");
+      expect(bareStar.pathParamNames).toEqual([]);
+    });
+
     it("returns a defensive copy that cannot mutate route internals", () => {
       const route = new Route("GET", "/posts/:id", "posts", "show");
       const names = route.pathParamNames as string[];

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -69,6 +69,11 @@ describe("Route", () => {
       expect(bareStar.pathParamNames).toEqual([]);
     });
 
+    it("preserves duplicate capture names (in lockstep with Pattern.names)", () => {
+      const route = new Route("GET", "/:id/:id", "x", "y");
+      expect(route.pathParamNames).toEqual(["id", "id"]);
+    });
+
     it("returns a defensive copy that cannot mutate route internals", () => {
       const route = new Route("GET", "/posts/:id", "posts", "show");
       const names = route.pathParamNames as string[];

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -38,5 +38,18 @@ describe("Route", () => {
       const route = new Route("GET", "/a/:id/b/*rest", "x", "y");
       expect(route.pathParamNames).toEqual(["id", "rest"]);
     });
+
+    it("includes captures inside optional groups", () => {
+      const route = new Route("GET", "/posts(/:id)(.:format)", "posts", "show");
+      expect(route.pathParamNames).toEqual(expect.arrayContaining(["id", "format"]));
+    });
+
+    it("treats optional-group captures as path constraints", () => {
+      const route = new Route("GET", "/posts(/:id)", "posts", "show", {
+        constraints: { id: /\d+/ },
+      });
+      expect(route.pathConstraints).toEqual({ id: /\d+/ });
+      expect(route.requestConstraints).toEqual({});
+    });
   });
 });

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -270,13 +270,19 @@ interface OptionalGroup {
 
 type PathSegment = StaticSegment | DynamicSegment | GlobSegment | OptionalGroup;
 
-const CAPTURE_RE = /[:*]([a-zA-Z_][a-zA-Z0-9_]*)/g;
+// Capture sigil (`:` or `*`) followed by a name, but only when the sigil
+// itself isn't escaped — Journey's scanner treats `\:foo` / `\*foo` as
+// literals. A bare `*` with no name (e.g. trailing `/page*`) is also
+// literal in Journey, which the `+` quantifier on the name already
+// excludes.
+const CAPTURE_RE = /(\\)?[:*]([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
 function collectParamNamesFromPath(path: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const m of path.matchAll(CAPTURE_RE)) {
-    const name = m[1]!;
+    if (m[1] === "\\") continue; // escaped sigil → literal
+    const name = m[2]!;
     if (!seen.has(name)) {
       seen.add(name);
       out.push(name);

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -2,6 +2,9 @@
  * A single route entry, mirroring ActionDispatch::Journey::Route.
  */
 
+import { Parser } from "../journey/parser.js";
+import { Ast } from "../journey/ast.js";
+
 export interface RouteConstraints {
   [key: string]: string | RegExp;
 }
@@ -78,11 +81,12 @@ export class Route {
     this.anchor = options.anchor !== false;
 
     this.segments = parseSegments(this.path);
-    // Extract capture names directly from the path source so we catch
-    // captures inside nested optional groups (e.g. `/:c(/:a(/:id))`) and
-    // embedded captures inside static text (e.g. `/:controller.:format`)
-    // that a segment-level walk would miss.
-    this.paramNames = collectParamNamesFromPath(this.path);
+    // Derive capture names from the Journey parser/AST — the same source
+    // the Journey bridge uses. Keeps the path-vs-request constraint split
+    // in lockstep with what `Pattern.names` will report, so escaped sigils
+    // (`\:`, `\(`, `\)`), bare `*`, embedded captures, and nested optional
+    // groups all classify identically.
+    this.paramNames = collectParamNamesFromJourneyAst(this.path);
   }
 
   get isRedirect(): boolean {
@@ -270,25 +274,23 @@ interface OptionalGroup {
 
 type PathSegment = StaticSegment | DynamicSegment | GlobSegment | OptionalGroup;
 
-// Capture sigil (`:` or `*`) followed by a name, but only when the sigil
-// itself isn't escaped — Journey's scanner treats `\:foo` / `\*foo` as
-// literals. A bare `*` with no name (e.g. trailing `/page*`) is also
-// literal in Journey, which the `+` quantifier on the name already
-// excludes.
-const CAPTURE_RE = /(\\)?[:*]([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-function collectParamNamesFromPath(path: string): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const m of path.matchAll(CAPTURE_RE)) {
-    if (m[1] === "\\") continue; // escaped sigil → literal
-    const name = m[2]!;
-    if (!seen.has(name)) {
-      seen.add(name);
-      out.push(name);
+function collectParamNamesFromJourneyAst(path: string): string[] {
+  try {
+    const tree = new Parser().parse(path);
+    const ast = new Ast(tree, true);
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const name of ast.names) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        out.push(name);
+      }
     }
+    return out;
+  } catch {
+    // Parser failure shouldn't crash the route table; fall back to no captures.
+    return [];
   }
-  return out;
 }
 
 function parseSegments(path: string): PathSegment[] {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -78,7 +78,11 @@ export class Route {
     this.anchor = options.anchor !== false;
 
     this.segments = parseSegments(this.path);
-    this.paramNames = collectParamNames(this.segments);
+    // Extract capture names directly from the path source so we catch
+    // captures inside nested optional groups (e.g. `/:c(/:a(/:id))`) and
+    // embedded captures inside static text (e.g. `/:controller.:format`)
+    // that a segment-level walk would miss.
+    this.paramNames = collectParamNamesFromPath(this.path);
   }
 
   get isRedirect(): boolean {
@@ -87,10 +91,11 @@ export class Route {
 
   /**
    * Returns the path-capture (dynamic/glob) parameter names declared by
-   * this route, e.g. `["id"]` for `/posts/:id`.
+   * this route, e.g. `["id"]` for `/posts/:id`. Returns a defensive copy
+   * so external callers can't mutate the route's internal classification.
    */
   get pathParamNames(): readonly string[] {
-    return this.paramNames;
+    return this.paramNames.slice();
   }
 
   /**
@@ -265,15 +270,16 @@ interface OptionalGroup {
 
 type PathSegment = StaticSegment | DynamicSegment | GlobSegment | OptionalGroup;
 
-function collectParamNames(segments: readonly PathSegment[]): string[] {
+const CAPTURE_RE = /[:*]([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+function collectParamNamesFromPath(path: string): string[] {
+  const seen = new Set<string>();
   const out: string[] = [];
-  for (const s of segments) {
-    if (s.type === "dynamic" || s.type === "glob") {
-      out.push(s.name);
-    } else if (s.type === "optional") {
-      for (const child of s.children) {
-        if (child.type === "dynamic") out.push(child.name);
-      }
+  for (const m of path.matchAll(CAPTURE_RE)) {
+    const name = m[1]!;
+    if (!seen.has(name)) {
+      seen.add(name);
+      out.push(name);
     }
   }
   return out;

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -88,6 +88,43 @@ export class Route {
   }
 
   /**
+   * Returns the path-capture (dynamic/glob) parameter names declared by
+   * this route, e.g. `["id"]` for `/posts/:id`.
+   */
+  get pathParamNames(): readonly string[] {
+    return this.paramNames;
+  }
+
+  /**
+   * Constraints that apply to *request* attributes (subdomain, format,
+   * signed-in, etc.) rather than to path captures. Path-capture
+   * constraints are passed into the pattern requirements instead, so the
+   * Journey `Route#matches` request-constraint loop should not re-check
+   * them against undefined request properties.
+   */
+  get requestConstraints(): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    const paths = new Set<string>(this.paramNames);
+    for (const [k, v] of Object.entries(this.constraints)) {
+      if (!paths.has(k)) out[k] = v;
+    }
+    return out;
+  }
+
+  /**
+   * Constraints that apply to path captures (key matches a `:name` /
+   * `*name` segment). These become Journey pattern requirements.
+   */
+  get pathConstraints(): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    const paths = new Set<string>(this.paramNames);
+    for (const [k, v] of Object.entries(this.constraints)) {
+      if (paths.has(k)) out[k] = v;
+    }
+    return out;
+  }
+
+  /**
    * Compute a specificity score for this route. Higher = more specific.
    */
   score(knowledge: Record<string, boolean> = {}): number {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -78,9 +78,7 @@ export class Route {
     this.anchor = options.anchor !== false;
 
     this.segments = parseSegments(this.path);
-    this.paramNames = this.segments
-      .filter((s): s is DynamicSegment | GlobSegment => s.type === "dynamic" || s.type === "glob")
-      .map((s) => s.name);
+    this.paramNames = collectParamNames(this.segments);
   }
 
   get isRedirect(): boolean {
@@ -266,6 +264,20 @@ interface OptionalGroup {
 }
 
 type PathSegment = StaticSegment | DynamicSegment | GlobSegment | OptionalGroup;
+
+function collectParamNames(segments: readonly PathSegment[]): string[] {
+  const out: string[] = [];
+  for (const s of segments) {
+    if (s.type === "dynamic" || s.type === "glob") {
+      out.push(s.name);
+    } else if (s.type === "optional") {
+      for (const child of s.children) {
+        if (child.type === "dynamic") out.push(child.name);
+      }
+    }
+  }
+  return out;
+}
 
 function parseSegments(path: string): PathSegment[] {
   const segments: PathSegment[] = [];

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -278,15 +278,10 @@ function collectParamNamesFromJourneyAst(path: string): string[] {
   try {
     const tree = new Parser().parse(path);
     const ast = new Ast(tree, true);
-    const seen = new Set<string>();
-    const out: string[] = [];
-    for (const name of ast.names) {
-      if (!seen.has(name)) {
-        seen.add(name);
-        out.push(name);
-      }
-    }
-    return out;
+    // Preserve duplicates so this stays in lockstep with Pattern.names —
+    // e.g. `/:id/:id` keeps two captures. Constraint splitters that need
+    // uniqueness build their own Set.
+    return ast.names.slice();
   } catch {
     // Parser failure shouldn't crash the route table; fall back to no captures.
     return [];


### PR DESCRIPTION
## Summary
Push the path-name-vs-request-constraints split from \`journey-bridge.ts\` into \`Route\`. The local Route already tracks path captures via \`paramNames\`, so it can expose:

- \`pathParamNames\` — readonly array of \`:name\` / \`*name\` captures.
- \`pathConstraints\` — keys that match a path capture (become Journey pattern requirements).
- \`requestConstraints\` — keys that don't (become Journey Route constraints checked per-request).

\`journey-bridge.ts\` no longer probes \`pattern.names\` to do the split — it just reads \`r.pathConstraints\` / \`r.requestConstraints\`. Removes the bridge's coupling to Pattern internals.

## Test plan
- [x] New \`route.test.ts\`: 4 unit tests for the new getters
- [x] All 121 routing tests pass
- [x] All 1159 actionpack tests pass
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean