### PR TITLE
feat(activerecord): batch 4 — PG index option parse + emit (Schema Slot C)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -104,6 +104,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(idx).toBeDefined();
     });
 
+    it("indexes() returns where and nullsNotDistinct from definition", async () => {
+      await adapter.exec(`CREATE TABLE "ex_idx_opts" ("id" SERIAL PRIMARY KEY, "n" INTEGER)`);
+      await adapter.exec(`CREATE INDEX "ex_idx_opts_where" ON "ex_idx_opts" ("n") WHERE n > 0`);
+      const pgVersion = await adapter.getDatabaseVersion();
+      const supportsNnd = pgVersion >= 150000;
+      if (supportsNnd) {
+        await adapter.exec(
+          `CREATE UNIQUE INDEX "ex_idx_opts_nnd" ON "ex_idx_opts" ("n") NULLS NOT DISTINCT`,
+        );
+      }
+      const indexes = await adapter.indexes("ex_idx_opts");
+      const whereIdx = indexes.find((i) => i.name === "ex_idx_opts_where") as
+        | { where?: string }
+        | undefined;
+      expect(whereIdx?.where).toMatch(/n > 0/);
+      if (supportsNnd) {
+        const nndIdx = indexes.find((i) => i.name === "ex_idx_opts_nnd") as
+          | { nullsNotDistinct?: boolean }
+          | undefined;
+        expect(nndIdx?.nullsNotDistinct).toBe(true);
+      }
+    });
+
     it("index with opclass", async () => {
       await adapter.exec(`CREATE TABLE "ex_opclass" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
       await adapter.addIndex("ex_opclass", ["name"], {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -190,6 +190,31 @@ describe("MigrationTest", () => {
     expect(indexes[0].name).toBe("index_posts_on_slug");
   });
 
+  it("addIndex emits PG using/include/nulls_not_distinct/where in Rails clause order", async () => {
+    const executed: string[] = [];
+    const adapter = {
+      adapterName: "postgres" as const,
+      quoteIdentifier: (s: string) => `"${s}"`,
+      quoteTableName: (s: string) => `"${s}"`,
+      executeMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+    } as unknown as DatabaseAdapter;
+    const ctx = new MigrationContext(adapter);
+    await ctx.addIndex("posts", ["data"], {
+      unique: true,
+      using: "gin",
+      include: ["author_id"],
+      nullsNotDistinct: true,
+      where: "active",
+      name: "idx_posts_data",
+    });
+    expect(executed).toHaveLength(1);
+    expect(executed[0]).toBe(
+      `CREATE UNIQUE INDEX "idx_posts_data" ON "posts" USING gin ("data") INCLUDE ("author_id") NULLS NOT DISTINCT WHERE active`,
+    );
+  });
+
   it("rename table", async () => {
     const { ctx } = freshContext();
     await ctx.createTable("old_name", {}, (t) => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -215,6 +215,45 @@ describe("MigrationTest", () => {
     );
   });
 
+  it("createTable inline index propagates using/include/nullsNotDistinct/where through addIndex", async () => {
+    const executed: string[] = [];
+    const adapter = {
+      adapterName: "postgres" as const,
+      quoteIdentifier: (s: string) => `"${s}"`,
+      quoteTableName: (s: string) => `"${s}"`,
+      executeMutation: async (sql: string) => {
+        executed.push(sql);
+      },
+      supportsIndexesInCreate: () => false,
+      schemaCache: { clearDataSourceCacheBang: () => {} },
+    } as unknown as DatabaseAdapter;
+    const ctx = new MigrationContext(adapter);
+    await ctx.createTable("posts", {}, (t) => {
+      t.string("data");
+      t.index(["data"], {
+        unique: true,
+        using: "gin",
+        include: ["author_id"],
+        nullsNotDistinct: true,
+        where: "active",
+        name: "idx_posts_data",
+      });
+    });
+    const indexSql = executed.find((s) => s.startsWith("CREATE UNIQUE INDEX"));
+    expect(indexSql).toBe(
+      `CREATE UNIQUE INDEX "idx_posts_data" ON "posts" USING gin ("data") INCLUDE ("author_id") NULLS NOT DISTINCT WHERE active`,
+    );
+    const tracked = ctx.indexes("posts");
+    expect(tracked[0]).toMatchObject({
+      using: "gin",
+      include: ["author_id"],
+      nullsNotDistinct: true,
+      where: "active",
+      unique: true,
+      name: "idx_posts_data",
+    });
+  });
+
   it("rename table", async () => {
     const { ctx } = freshContext();
     await ctx.createTable("old_name", {}, (t) => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1503,6 +1503,7 @@ export class MigrationContext {
       name?: string;
       where?: string;
       orders?: Record<string, string>;
+      using?: string;
       nullsNotDistinct?: boolean;
       include?: string[];
     }[]
@@ -1655,26 +1656,20 @@ export class MigrationContext {
       return;
     }
     for (const idx of td.indexes) {
-      const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
-      const ordersMap: Record<string, string> =
+      const ordersMap: Record<string, string> | undefined =
         typeof idx.orders === "string"
           ? Object.fromEntries(idx.columns.map((c) => [c, idx.orders as string]))
-          : (idx.orders ?? {});
-      const unique = idx.unique ? "UNIQUE " : "";
-      const using = idx.using && idx.using !== "btree" ? ` USING ${idx.using}` : "";
-      const colsList = idx.columns
-        .map((c) => {
-          const isExpr = /\W/.test(c);
-          const quoted = isExpr ? c : this.adapter.quoteIdentifier(c);
-          const order = ordersMap[c];
-          return `${quoted}${order ? ` ${order.toUpperCase()}` : ""}`;
-        })
-        .join(", ");
-      let sql = `CREATE ${unique}INDEX ${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(name)}${using} (${colsList})`;
-      if (idx.where) sql += ` WHERE ${idx.where}`;
-      await this.adapter.executeMutation(sql);
-      if (!this._indexes.has(name)) this._indexes.set(name, []);
-      this._indexes.get(name)!.push({ ...idx, name: indexName, orders: ordersMap });
+          : idx.orders;
+      await this.addIndex(name, idx.columns, {
+        unique: idx.unique,
+        name: idx.name,
+        where: idx.where,
+        order: ordersMap,
+        using: idx.using,
+        nullsNotDistinct: idx.nullsNotDistinct,
+        include: idx.include,
+        ifNotExists: idx.ifNotExists,
+      });
     }
   }
 
@@ -1880,6 +1875,7 @@ export class MigrationContext {
       nullsNotDistinct?: boolean;
       ifNotExists?: boolean;
       include?: string[];
+      using?: string;
     },
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
@@ -1899,7 +1895,11 @@ export class MigrationContext {
         return col;
       })
       .join(", ");
-    let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(table)} (${colsStr})`;
+    const usingStr =
+      an === "postgres" && options?.using && options.using !== "btree"
+        ? ` USING ${options.using}`
+        : "";
+    let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(table)}${usingStr} (${colsStr})`;
     if (an === "postgres" && options?.nullsNotDistinct) sql += " NULLS NOT DISTINCT";
     if (an === "postgres" && options?.include && options.include.length > 0)
       sql += ` INCLUDE (${options.include.map((c) => this.adapter.quoteIdentifier(c)).join(", ")})`;
@@ -1912,6 +1912,7 @@ export class MigrationContext {
       name: indexName,
       where: options?.where,
       orders: options?.order,
+      using: options?.using,
       nullsNotDistinct: options?.nullsNotDistinct,
       include: options?.include,
     });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1900,9 +1900,11 @@ export class MigrationContext {
         ? ` USING ${options.using}`
         : "";
     let sql = `CREATE ${uniqueStr}INDEX ${ifNotExistsStr}${this.adapter.quoteIdentifier(indexName)} ON ${this.adapter.quoteTableName(table)}${usingStr} (${colsStr})`;
-    if (an === "postgres" && options?.nullsNotDistinct) sql += " NULLS NOT DISTINCT";
+    // Clause order mirrors Rails' visit_CreateIndexDefinition
+    // (abstract/schema_creation.rb): INCLUDE → NULLS NOT DISTINCT → WHERE.
     if (an === "postgres" && options?.include && options.include.length > 0)
       sql += ` INCLUDE (${options.include.map((c) => this.adapter.quoteIdentifier(c)).join(", ")})`;
+    if (an === "postgres" && options?.nullsNotDistinct) sql += " NULLS NOT DISTINCT";
     if (an !== "mysql" && options?.where) sql += ` WHERE ${options.where}`;
     await this.adapter.executeMutation(sql);
     if (!this._indexes.has(table)) this._indexes.set(table, []);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2031,7 +2031,9 @@ export class MigrationContext {
     name?: string;
     where?: string;
     orders?: Record<string, string>;
+    using?: string;
     nullsNotDistinct?: boolean;
+    include?: string[];
   }> {
     const idxs = this._indexes.get(tableName);
     if (!idxs) return [];

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1656,10 +1656,11 @@ export class MigrationContext {
       return;
     }
     for (const idx of td.indexes) {
-      const ordersMap: Record<string, string> | undefined =
+      const rawOrders =
         typeof idx.orders === "string"
           ? Object.fromEntries(idx.columns.map((c) => [c, idx.orders as string]))
           : idx.orders;
+      const ordersMap = rawOrders && Object.keys(rawOrders).length > 0 ? rawOrders : undefined;
       await this.addIndex(name, idx.columns, {
         unique: idx.unique,
         name: idx.name,
@@ -2037,7 +2038,11 @@ export class MigrationContext {
   }> {
     const idxs = this._indexes.get(tableName);
     if (!idxs) return [];
-    return idxs.map((i) => ({ ...i, columns: [...i.columns] }));
+    return idxs.map((i) => ({
+      ...i,
+      columns: [...i.columns],
+      include: i.include ? [...i.include] : undefined,
+    }));
   }
 }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1915,7 +1915,7 @@ export class MigrationContext {
       name: indexName,
       where: options?.where,
       orders: options?.order,
-      using: options?.using,
+      using: usingStr ? options?.using : undefined,
       nullsNotDistinct: options?.nullsNotDistinct,
       include: options?.include,
     });


### PR DESCRIPTION
## Summary

Batch 4 from `docs/activerecord-100-batches.md` — PG index option parse + emit.

- **`MigrationContext.createTable` inline-index path** now delegates to `addIndex`, picking up `nullsNotDistinct`, `include`, `using`, and `ifNotExists` from `td.indexes`. These were previously dropped on the manual SQL build (Copilot flagged 4× during #1460).
- **`MigrationContext.addIndex`** gains a `using?: string` option (PG-only emission, skips the default `btree`) and tracks it in `_indexes`.
- **Live PG test** asserts `idx.where` and `idx.nullsNotDistinct` populate from `indexes()` on a real DB (NNDistinct gated on PG15+).

PG `NULLS FIRST/LAST` and `INCLUDE (...)` parsing in `postgresql-adapter#indexes()` are already implemented (#1460 + #1638), so the two parse-side slots from the batch doc are already covered by existing code — this PR closes only the emit-side gap and adds the live-DB confirmation test.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts`
- [ ] CI runs the new live PG test on `postgresql-adapter.test.ts`