### PR TITLE
feat(activerecord): batch 7 — PG infinity + time-zone wiring

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { Range } from "../../index.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -101,17 +102,15 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("where clause with infinite range on a datetime column", async () => {
       const M = await modelClass();
-      const created = await (M as any).create({ datetime: new Date().toISOString() });
-      const found = await (M as any)
-        .where({ datetime: { begin: -Infinity, end: Infinity } })
-        .take();
+      const created = await (M as any).create({ datetime: "2020-01-01 00:00:00" });
+      const found = await (M as any).where({ datetime: new Range(-Infinity, Infinity) }).take();
       expect(found.id).toBe(created.id);
     });
 
     it("where clause with infinite range on a date column", async () => {
       const M = await modelClass();
       const created = await (M as any).create({ date: "2020-01-01" });
-      const found = await (M as any).where({ date: { begin: -Infinity, end: Infinity } }).take();
+      const found = await (M as any).where({ date: new Range(-Infinity, Infinity) }).take();
       expect(found.id).toBe(created.id);
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -99,18 +99,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       // SCOPE: ~80 LOC — InTimeZone helper + TimeZoneConverter integration test plumbing
     });
 
-    it.skip("where clause with infinite range on a datetime column", () => {
-      // BLOCKED: relation.where range support with Float::INFINITY endpoints
-      // does not yet emit "-infinity"/"infinity" wire strings via Arel range
-      // serialization. Sentinels are unified at the type layer; the gap is in
-      // QueryAttribute.serialize for endless/beginless ranges with Infinity bounds.
-      // SCOPE: ~40 LOC in arel/relation range visitor
+    it("where clause with infinite range on a datetime column", async () => {
+      const M = await modelClass();
+      const created = await (M as any).create({ datetime: new Date().toISOString() });
+      const found = await (M as any)
+        .where({ datetime: { begin: -Infinity, end: Infinity } })
+        .take();
+      expect(found.id).toBe(created.id);
     });
 
-    it.skip("where clause with infinite range on a date column", () => {
-      // BLOCKED: see "where clause with infinite range on a datetime column" —
-      // same Arel range-bound serialization gap; date column path identical.
-      // SCOPE: covered by the datetime fix above
+    it("where clause with infinite range on a date column", async () => {
+      const M = await modelClass();
+      const created = await (M as any).create({ date: "2020-01-01" });
+      const found = await (M as any).where({ date: { begin: -Infinity, end: Infinity } }).take();
+      expect(found.id).toBe(created.id);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -55,6 +55,14 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number.isNaN(record.float)).toBe(true);
     });
 
+    it("updateColumns with infinity on a float column", async () => {
+      const M = await modelClass();
+      const record = await (M as any).create({});
+      await (record as any).updateColumns({ float: Number.POSITIVE_INFINITY });
+      await (record as any).reload();
+      expect((record as any).float).toBe(Number.POSITIVE_INFINITY);
+    });
+
     it("update_all with infinity on a float column", async () => {
       const M = await modelClass();
       const record = await (M as any).create({});

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -26,6 +26,12 @@ describe("MySQL quoting — quote", () => {
     expect(quote(BigInt("9007199254740993"))).toBe("9007199254740993");
   });
 
+  it("quotes non-finite numbers as strings", () => {
+    expect(quote(Number.POSITIVE_INFINITY)).toBe("'Infinity'");
+    expect(quote(Number.NEGATIVE_INFINITY)).toBe("'-Infinity'");
+    expect(quote(NaN)).toBe("'NaN'");
+  });
+
   it("throws on Date — Date is no longer accepted", () => {
     expect(() => quote(new Date())).toThrow(TypeError);
   });

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -170,6 +170,11 @@ export function columnNameWithOrderMatcher(): RegExp {
 export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
+  // Non-finite numbers (±Infinity, NaN) have no MySQL literal — `String(Infinity)`
+  // produces the bareword `Infinity`, which MySQL parses as an identifier and
+  // throws "Unknown column 'Infinity'". Mirror PG's behavior and quote them as
+  // strings; MySQL coerces or rejects at the column-type boundary.
+  if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   if (value instanceof Temporal.Instant) return `'${formatInstantForSql(value)}'`;
   if (value instanceof Temporal.PlainDateTime) return `'${formatPlainDateTimeForSql(value)}'`;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -806,7 +806,13 @@ interface UpdateColumnsRecord {
     arelTable: InstanceType<typeof ArelTable>;
     _attributeDefinitions: Map<
       string,
-      { type: { cast(v: unknown): unknown; serialize?(v: unknown): unknown } }
+      {
+        type: {
+          cast(v: unknown): unknown;
+          serialize?(v: unknown): unknown;
+          type?(): string;
+        };
+      }
     >;
     _buildPkWhereNode(id: unknown): Parameters<UpdateManager["where"]>[0];
     adapter: {
@@ -891,13 +897,23 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     // numbers, null, booleans) are already DB-ready and must not be passed
     // through serialize() — doing so would corrupt types whose serialize()
     // has side effects (e.g. re-encrypting an already-encrypted value).
+    // Only pre-serialize for temporal types and their PG ±infinity sentinels.
+    // isDateInfinity matches `Number.POSITIVE_INFINITY`, so without the
+    // type-name gate a Float column carrying Infinity would route through
+    // serialize() — corrupting the value via the date-infinity wire string.
+    const typeName = def?.type.type?.();
+    const isTemporalType =
+      typeName === "date" ||
+      typeName === "datetime" ||
+      typeName === "time" ||
+      typeName === "timestamp" ||
+      typeName === "timestamptz";
     const dbValue =
       cast instanceof Temporal.Instant ||
       cast instanceof Temporal.PlainDate ||
       cast instanceof Temporal.PlainTime ||
       cast instanceof Temporal.ZonedDateTime ||
-      isDateInfinity(cast) ||
-      isDateNegativeInfinity(cast)
+      (isTemporalType && (isDateInfinity(cast) || isDateNegativeInfinity(cast)))
         ? (def?.type.serialize?.(cast) ?? cast)
         : cast;
     setPairs.push([table.get(key), dbValue]);

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -31,6 +31,22 @@ export class RangeHandler {
 
   callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
     const [beginVal, endVal] = this._castBounds(attribute, value);
+    // Exclusive ranges negate to `(col < begin OR col >= end)` —
+    // `NOT (gteq AND lt)` would lose the explicit ordering that AR
+    // callers (and parity tests) match on.
+    if (
+      value.excludeEnd &&
+      beginVal !== null &&
+      beginVal !== undefined &&
+      beginVal !== -Infinity &&
+      beginVal !== Infinity &&
+      endVal !== null &&
+      endVal !== undefined &&
+      endVal !== Infinity &&
+      endVal !== -Infinity
+    ) {
+      return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
+    }
     // Mirrors Rails' AR-level `where.not(col: 1..5)`: the predicate
     // builder constructs `Between` then `where.not` wraps it in `Not`,
     // yielding `NOT (col BETWEEN b AND e)`. Don't delegate to

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -31,20 +31,15 @@ export class RangeHandler {
 
   callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
     const [beginVal, endVal] = this._castBounds(attribute, value);
-    // Exclusive ranges negate to `(col < begin OR col >= end)` —
-    // `NOT (gteq AND lt)` would lose the explicit ordering that AR
-    // callers (and parity tests) match on.
-    if (
-      value.excludeEnd &&
-      beginVal !== null &&
-      beginVal !== undefined &&
-      beginVal !== -Infinity &&
-      beginVal !== Infinity &&
-      endVal !== null &&
-      endVal !== undefined &&
-      endVal !== Infinity &&
-      endVal !== -Infinity
-    ) {
+    // Exclusive ranges with finite bounds negate to `(col < begin OR
+    // col >= end)` — `NOT (gteq AND lt)` would lose the explicit ordering
+    // that AR callers (and parity tests) match on. Non-finite numeric
+    // bounds (±Infinity, NaN) and null/undefined fall through to
+    // `.between(...).invert()` so Arel's collapsed-predicate inversion
+    // handles them.
+    const isFiniteBound = (v: unknown): boolean =>
+      v !== null && v !== undefined && (typeof v !== "number" || Number.isFinite(v));
+    if (value.excludeEnd && isFiniteBound(beginVal) && isFiniteBound(endVal)) {
       return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
     }
     // Mirrors Rails WhereClause#invert: call `.invert()` on the Arel node so
@@ -62,8 +57,12 @@ export class RangeHandler {
     // nil / Float::INFINITY. We mirror the intent by passing those through
     // uncast — type.cast on null/undefined / Infinity would be a no-op or
     // worse (numeric types may coerce Infinity into something finite).
+    // Rails open_ended? recognizes ±Infinity (via Float#infinite?) but not
+    // NaN (`NaN.infinite?` returns nil); pass only nil/undefined/±Infinity
+    // through uncast so a NaN bound still flows through type.cast as a
+    // regular numeric value.
     const skipCast = (v: unknown): boolean =>
-      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
+      v === null || v === undefined || v === Infinity || v === -Infinity;
     const cast = this._castBound
       ? (v: unknown) => this._castBound!(attribute, v)
       : (v: unknown) => v;

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -47,15 +47,14 @@ export class RangeHandler {
     ) {
       return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
     }
-    // Mirrors Rails' AR-level `where.not(col: 1..5)`: the predicate
-    // builder constructs `Between` then `where.not` wraps it in `Not`,
-    // yielding `NOT (col BETWEEN b AND e)`. Don't delegate to
-    // attribute.notBetween — that returns the predications.rb-aligned
-    // `(col < b OR col > e)` shape, which is the right Arel-level
-    // behavior but the wrong AR-level one.
-    return new Nodes.Not(
-      attribute.between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd }),
-    );
+    // Mirrors Rails WhereClause#invert: call `.invert()` on the Arel node so
+    // collapsed predicates (`lteq` → `gt`, `gteq` → `lt`, `In([])` →
+    // `NotIn([])`) become canonical, instead of double-wrapping `Not(...)` over
+    // a simpler form. For full BETWEEN this still yields `Not(Between(...))`
+    // (Node#invert default), matching AR-level `where.not(col: 1..5)` exactly.
+    return attribute
+      .between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd })
+      .invert();
   }
 
   private _castBounds(attribute: Nodes.Attribute, value: Range): [unknown, unknown] {

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -22,24 +22,35 @@ export class RangeHandler {
   }
 
   call(attribute: Nodes.Attribute, value: Range): Nodes.Node {
-    // Cast bounds through the attribute's type (e.g. integer casts "1-meowmeow" → 1)
+    // Cast bounds through the attribute's type (e.g. integer casts "1-meowmeow" → 1).
+    // Mirrors Rails RangeHandler#call: bounds that are nil or `is_a?(Float)`
+    // skip the bind path so the Arel layer can recognize ±Infinity as
+    // open-ended via Predications#infinity? / open_ended?.
+    const skipCast = (v: unknown): boolean =>
+      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
     const cast = this._castBound
       ? (v: unknown) => this._castBound!(attribute, v)
       : (v: unknown) => v;
-    const beginVal =
-      value.begin !== null && value.begin !== undefined ? cast(value.begin) : value.begin;
-    const endVal = value.end !== null && value.end !== undefined ? cast(value.end) : value.end;
+    const beginVal = skipCast(value.begin) ? value.begin : cast(value.begin);
+    const endVal = skipCast(value.end) ? value.end : cast(value.end);
 
-    if (beginVal === null || beginVal === undefined) {
-      if (endVal === null || endVal === undefined) {
+    if (beginVal === null || beginVal === undefined || beginVal === -Infinity) {
+      if (endVal === null || endVal === undefined || endVal === Infinity) {
+        if (beginVal === -Infinity || endVal === Infinity) {
+          return attribute.notIn([]);
+        }
         return attribute.isNotNull();
       }
+      if (endVal === -Infinity) return attribute.in([]);
       return value.excludeEnd ? attribute.lt(endVal) : attribute.lteq(endVal);
     }
 
-    if (endVal === null || endVal === undefined) {
+    if (beginVal === Infinity) return attribute.in([]);
+
+    if (endVal === null || endVal === undefined || endVal === Infinity) {
       return attribute.gteq(beginVal);
     }
+    if (endVal === -Infinity) return attribute.in([]);
 
     if (value.excludeEnd) {
       return new Nodes.And([attribute.gteq(beginVal), attribute.lt(endVal)]);
@@ -49,20 +60,29 @@ export class RangeHandler {
   }
 
   callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
+    const skipCast = (v: unknown): boolean =>
+      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
     const cast = this._castBound
       ? (v: unknown) => this._castBound!(attribute, v)
       : (v: unknown) => v;
-    const beginVal =
-      value.begin !== null && value.begin !== undefined ? cast(value.begin) : value.begin;
-    const endVal = value.end !== null && value.end !== undefined ? cast(value.end) : value.end;
+    const beginVal = skipCast(value.begin) ? value.begin : cast(value.begin);
+    const endVal = skipCast(value.end) ? value.end : cast(value.end);
 
-    if (beginVal === null || beginVal === undefined) {
-      if (endVal === null || endVal === undefined) return attribute.isNull();
+    if (beginVal === null || beginVal === undefined || beginVal === -Infinity) {
+      if (endVal === null || endVal === undefined || endVal === Infinity) {
+        if (beginVal === -Infinity || endVal === Infinity) {
+          return attribute.in([]);
+        }
+        return attribute.isNull();
+      }
+      if (endVal === -Infinity) return attribute.notIn([]);
       return value.excludeEnd ? attribute.gteq(endVal) : attribute.gt(endVal);
     }
-    if (endVal === null || endVal === undefined) {
+    if (beginVal === Infinity) return attribute.notIn([]);
+    if (endVal === null || endVal === undefined || endVal === Infinity) {
       return attribute.lt(beginVal);
     }
+    if (endVal === -Infinity) return attribute.notIn([]);
     if (value.excludeEnd) {
       return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
     }

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -2,16 +2,19 @@ import { Nodes } from "@blazetrails/arel";
 import type { Range } from "../../connection-adapters/postgresql/oid/range.js";
 
 /**
- * Handles Range values in where conditions by converting them to
- * BETWEEN predicates or >= / < pairs for exclusive ranges.
+ * Handles Range values in where conditions by delegating to
+ * `attribute.between`, which encodes Rails' Arel `Predications#between`
+ * decision tree (open-ended, ±Infinity, exclude-end).
  *
- * Mirrors: ActiveRecord::PredicateBuilder::RangeHandler
+ * Mirrors: ActiveRecord::PredicateBuilder::RangeHandler — Rails' `call`
+ * builds bind attributes for both bounds and hands a `RangeWithBinds` to
+ * `attribute.between`; the open-ended / infinity logic lives in Arel.
  *
- * Examples:
- *   where({ age: new Range(18, 65) })              → age BETWEEN 18 AND 65
- *   where({ age: new Range(18, 65, true) })         → age >= 18 AND age < 65
- *   where({ created_at: new Range(start, null) })   → created_at >= start
- *   where({ created_at: new Range(null, end) })     → created_at <= end
+ * TS deviation: there is no `QueryAttribute`-wrapping bind step here;
+ * `_castBound` runs the attribute's type cast on the raw bound (so e.g.
+ * an integer column coerces `"1-meowmeow"` → 1). ±Infinity bounds are
+ * passed through uncast — mirroring Rails RangeHandler's reliance on
+ * `infinity?` recognizing ±Float::INFINITY at the Arel layer.
  */
 export class RangeHandler {
   private _castBound?: (attribute: Nodes.Attribute, value: unknown) => unknown;
@@ -22,77 +25,37 @@ export class RangeHandler {
   }
 
   call(attribute: Nodes.Attribute, value: Range): Nodes.Node {
-    // Cast bounds through the attribute's type (e.g. integer casts "1-meowmeow" → 1).
-    // Mirrors Rails RangeHandler#call: bounds that are nil or `is_a?(Float)`
-    // skip the bind path so the Arel layer can recognize ±Infinity as
-    // open-ended via Predications#infinity? / open_ended?.
-    const skipCast = (v: unknown): boolean =>
-      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
-    const cast = this._castBound
-      ? (v: unknown) => this._castBound!(attribute, v)
-      : (v: unknown) => v;
-    const beginVal = skipCast(value.begin) ? value.begin : cast(value.begin);
-    const endVal = skipCast(value.end) ? value.end : cast(value.end);
-
-    if (beginVal === null || beginVal === undefined || beginVal === -Infinity) {
-      if (endVal === null || endVal === undefined || endVal === Infinity) {
-        if (beginVal === -Infinity || endVal === Infinity) {
-          return attribute.notIn([]);
-        }
-        return attribute.isNotNull();
-      }
-      if (endVal === -Infinity) return attribute.in([]);
-      return value.excludeEnd ? attribute.lt(endVal) : attribute.lteq(endVal);
-    }
-
-    if (beginVal === Infinity) return attribute.in([]);
-
-    if (endVal === null || endVal === undefined || endVal === Infinity) {
-      return attribute.gteq(beginVal);
-    }
-    if (endVal === -Infinity) return attribute.in([]);
-
-    if (value.excludeEnd) {
-      return new Nodes.And([attribute.gteq(beginVal), attribute.lt(endVal)]);
-    }
-
-    return attribute.between(beginVal, endVal);
+    const [beginVal, endVal] = this._castBounds(attribute, value);
+    return attribute.between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd });
   }
 
   callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
-    const skipCast = (v: unknown): boolean =>
-      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
-    const cast = this._castBound
-      ? (v: unknown) => this._castBound!(attribute, v)
-      : (v: unknown) => v;
-    const beginVal = skipCast(value.begin) ? value.begin : cast(value.begin);
-    const endVal = skipCast(value.end) ? value.end : cast(value.end);
-
-    if (beginVal === null || beginVal === undefined || beginVal === -Infinity) {
-      if (endVal === null || endVal === undefined || endVal === Infinity) {
-        if (beginVal === -Infinity || endVal === Infinity) {
-          return attribute.in([]);
-        }
-        return attribute.isNull();
-      }
-      if (endVal === -Infinity) return attribute.notIn([]);
-      return value.excludeEnd ? attribute.gteq(endVal) : attribute.gt(endVal);
-    }
-    if (beginVal === Infinity) return attribute.notIn([]);
-    if (endVal === null || endVal === undefined || endVal === Infinity) {
-      return attribute.lt(beginVal);
-    }
-    if (endVal === -Infinity) return attribute.notIn([]);
-    if (value.excludeEnd) {
-      return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
-    }
+    const [beginVal, endVal] = this._castBounds(attribute, value);
     // Mirrors Rails' AR-level `where.not(col: 1..5)`: the predicate
     // builder constructs `Between` then `where.not` wraps it in `Not`,
     // yielding `NOT (col BETWEEN b AND e)`. Don't delegate to
     // attribute.notBetween — that returns the predications.rb-aligned
     // `(col < b OR col > e)` shape, which is the right Arel-level
     // behavior but the wrong AR-level one.
-    return new Nodes.Not(attribute.between(beginVal, endVal));
+    return new Nodes.Not(
+      attribute.between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd }),
+    );
+  }
+
+  private _castBounds(attribute: Nodes.Attribute, value: Range): [unknown, unknown] {
+    // Rails RangeHandler skips no bounds: `build_bind_attribute` wraps even
+    // nil / Float::INFINITY. We mirror the intent by passing those through
+    // uncast — type.cast on null/undefined / Infinity would be a no-op or
+    // worse (numeric types may coerce Infinity into something finite).
+    const skipCast = (v: unknown): boolean =>
+      v === null || v === undefined || (typeof v === "number" && !Number.isFinite(v));
+    const cast = this._castBound
+      ? (v: unknown) => this._castBound!(attribute, v)
+      : (v: unknown) => v;
+    return [
+      skipCast(value.begin) ? value.begin : cast(value.begin),
+      skipCast(value.end) ? value.end : cast(value.end),
+    ];
   }
 
   private get predicateBuilder(): unknown {

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -31,15 +31,17 @@ export class RangeHandler {
 
   callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
     const [beginVal, endVal] = this._castBounds(attribute, value);
-    // Exclusive ranges with finite bounds negate to `(col < begin OR
-    // col >= end)` — `NOT (gteq AND lt)` would lose the explicit ordering
-    // that AR callers (and parity tests) match on. Non-finite numeric
-    // bounds (±Infinity, NaN) and null/undefined fall through to
-    // `.between(...).invert()` so Arel's collapsed-predicate inversion
-    // handles them.
-    const isFiniteBound = (v: unknown): boolean =>
-      v !== null && v !== undefined && (typeof v !== "number" || Number.isFinite(v));
-    if (value.excludeEnd && isFiniteBound(beginVal) && isFiniteBound(endVal)) {
+    const node = attribute.between({
+      begin: beginVal,
+      end: endVal,
+      excludeEnd: value.excludeEnd,
+    });
+    // When `between` returns an `And` (exclusive-end with both bounds
+    // non-open), prefer the explicit `(col < begin OR col >= end)` shape
+    // — `Not(And(gteq, lt))` would lose the ordering AR callers (and
+    // parity tests) match on. Branching on the node class rather than the
+    // bound values catches every non-open-ended case (incl. NaN bounds).
+    if (node instanceof Nodes.And) {
       return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
     }
     // Mirrors Rails WhereClause#invert: call `.invert()` on the Arel node so
@@ -47,9 +49,7 @@ export class RangeHandler {
     // `NotIn([])`) become canonical, instead of double-wrapping `Not(...)` over
     // a simpler form. For full BETWEEN this still yields `Not(Between(...))`
     // (Node#invert default), matching AR-level `where.not(col: 1..5)` exactly.
-    return attribute
-      .between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd })
-      .invert();
+    return node.invert();
   }
 
   private _castBounds(attribute: Nodes.Attribute, value: Range): [unknown, unknown] {


### PR DESCRIPTION
## Summary

Batch 7 cleanups in the temporal serialization / PG infinity path.

- **persistence.ts** — gate `isDateInfinity` pre-serialize on temporal type name (`date`/`datetime`/`time`/`timestamp`/`timestamptz`). `isDateInfinity` matches `Number.POSITIVE_INFINITY`, so without the gate a Float column carrying Infinity was being routed through the date-infinity wire serializer.
- **mysql/quoting.ts** — quote non-finite numbers (±Infinity, NaN) as strings, mirroring PG. Preventive: same bareword bug PG had — `String(Infinity)` produced the SQL identifier `Infinity` and MySQL threw \"Unknown column 'Infinity'\".
- **relation/predicate-builder/range-handler.ts** — treat ±Infinity range bounds as open-ended, mirroring Rails `RangeHandler#call`'s `is_a?(Float)` skip-bind guard. Unblocks `where clause with infinite range` on date / datetime columns (2 un-skips in `infinity.test.ts`).

## Deferred to follow-ups

- ~80 LOC — `InTimeZone` test helper + `Base.timeZoneAwareAttributes` / `reset_column_information` / `TimeZoneConverter` sentinel wrapping for the `assigning 'infinity' on a datetime column with TZ aware attributes` test (still `it.skip`).
- ~5 LOC — `temporalToBindString` PG infinity branch trace+delete: probably dead post-sentinel-unification (PG `serialize` already returns the wire string), but a full bind-path audit is needed to confirm no raw-value path hits it.

## Test plan

- [x] Type-checks (`pnpm --filter activerecord exec tsc --noEmit` clean for changed files).
- [x] `where-chain.test.ts` still passes (existing `rewhere with infinite range` test green).
- [ ] Live PG: the 2 un-skipped tests in `infinity.test.ts` exercise actual range serialization end-to-end (requires PG-backed CI job).