### PR TITLE
feat(activerecord): batch 9 — autosave + has-one Rails-divergence

### DIFF
--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -20,6 +20,8 @@ beforeEach(async () => {
     r_books: { title: "string", author_id: "integer" },
     r_writers: { name: "string" },
     r_novels: { title: "string", writer_id: "integer" },
+    rg_parents: { name: "string" },
+    rg_children: { title: "string", rg_parent_id: "integer" },
     // RAUser/RAProfile etc. tableize as ra_*, rh_*, rm_* (consecutive-caps
     // collapse per Rails' String#underscore; see packages/activesupport
     // inflector). The same key columns map through.
@@ -253,5 +255,50 @@ describe("belongs_to required option", () => {
     const novel = new RNovel({ title: "LotR", writer_id: writer.id });
     const saved = await novel.save();
     expect(saved).toBe(true);
+  });
+
+  // Regression: readAttributeForValidation routes through `record.association(name)`
+  // for association names; without the `assoc.target != null` guard, an unloaded
+  // association with target === null would surface null to validators that then
+  // crash or misreport. Combining `belongs_to required: true` (FK presence on
+  // child) with `has_many validate: true` (parent triggers child validation on
+  // save) is the path PR #1461 broadened, and this test pins the guard.
+  it("validates has_many children when parent saves without crashing on unloaded target", async () => {
+    const adapter = freshAdapter();
+
+    class RGChild extends Base {
+      static _tableName = "rg_children";
+    }
+    RGChild.attribute("id", "integer");
+    RGChild.attribute("title", "string");
+    RGChild.attribute("rg_parent_id", "integer");
+    RGChild.adapter = adapter;
+
+    class RGParent extends Base {
+      static _tableName = "rg_parents";
+    }
+    RGParent.attribute("id", "integer");
+    RGParent.attribute("name", "string");
+    RGParent.adapter = adapter;
+
+    registerModel("RGParent", RGParent);
+    registerModel("RGChild", RGChild);
+    Associations.belongsTo.call(RGChild, "rgParent", {
+      required: true,
+      foreignKey: "rg_parent_id",
+      className: "RGParent",
+    });
+    Associations.hasMany.call(RGParent, "rgChildren", {
+      validate: true,
+      foreignKey: "rg_parent_id",
+      className: "RGChild",
+    });
+
+    // No children built or loaded — has_many target is empty. Save must not
+    // throw and must succeed (no children to invalidate the parent).
+    const parent = new RGParent({ name: "p1" });
+    const saved = await parent.save();
+    expect(saved).toBe(true);
+    expect(parent.id).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Batch 9 — Autosave + has-one Rails-divergence sweep. Investigation found
**most slot items already shipped**; ships only the genuinely-new item:
a regression test pinning the `assoc.target != null` guard in
`readAttributeForValidation` for the combined `belongs_to required: true`
+ `has_many validate: true` path broadened by #1461.

## Slot accounting

Already shipped (verified by reading current source):

- `_newRecordBeforeSave = !prev && wasNewRecord` — `autosave-association.ts:869-871`
- `HasManyThroughAssociation#insertRecord` `validate`/`raise` propagation — `has-many-through-association.ts:59-89`
- `createThroughRecord` destroyed-record reload guard — `has-one-through-association.ts:87-90`
- In-memory `through_proxy.build` for new owner / `!save` — `has-one-through-association.ts:108-109`
- `ThroughReflection.isPolymorphic` — matches Rails (delegates to `source_reflection.polymorphic?`, which itself only honors `options[:polymorphic]`, not `as:`).
- HasOne `defineValidations` "dead else-if" — does not exist in `builder/has-one.ts` (the body is already a single `validatesPresenceOf` call).

Shipped here:

- Regression test in `associations/required.test.ts` covering the
  `belongs_to required: true` + `has_many validate: true` flow: parent
  saves cleanly when the has-many target is unloaded/empty (the path
  where the `assoc.target != null` guard in `validations.ts:203` matters).

Deferred to a follow-up PR:

- **Preloader → `associationInstanceSet` migration** (~50 LOC + ripples).
  Current `associationInstanceSet` writes to `_associationInstances` (the
  Association wrapper cache); preloader sites write to
  `_preloadedAssociations` (raw target records). Collapsing these into one
  Rails-shaped read in `_loadedAssociation` requires changing storage
  semantics and updating ~6 short-circuit read sites in `associations.ts`
  that key off `_preloadedAssociations.has(name)`. Risky for a bundled PR
  — better as a focused refactor.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/required.test.ts`