### PR TITLE
feat(activerecord): batch 11 — query-cache Phases 2-3 wiring

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -245,7 +245,7 @@ export class ConnectionPool implements ReapablePool {
     this._idleTimeout = this.dbConfig.idleTimeout;
     this._available = new ConnectionLeasingQueue();
     this._cacheConfig = new ConnectionPoolConfiguration(
-      this.dbConfig.queryCache as number | false | null | undefined,
+      normalizeQueryCacheConfig(this.dbConfig.queryCache),
     );
 
     this.reaper = new Reaper(this, this.dbConfig.reapingFrequency ?? 0);
@@ -615,7 +615,7 @@ export class ConnectionPool implements ReapablePool {
       throw new ConnectionNotEstablished("Connection pool has been discarded");
     }
     this._checkedOut.add(c);
-    (c as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+    this._cacheConfig.checkoutAndVerify(c as unknown as QueryCacheHost);
     return c;
   }
 
@@ -993,6 +993,21 @@ export class ConnectionPool implements ReapablePool {
     }
     return this._leases.get(String(executionContextId()));
   }
+}
+
+/**
+ * Map `DatabaseConfig#queryCache` to the shape ConnectionPoolConfiguration
+ * expects. Rails' initializer case-matches on `0/false/Integer/nil`; trails'
+ * public config type also accepts the documented "enabled"/"disabled"
+ * strings, which Rails would never see as raw values. Normalize them so a
+ * pool configured with `queryCache: "disabled"` actually disables storage
+ * instead of falling through to DEFAULT_MAX_SIZE.
+ */
+function normalizeQueryCacheConfig(raw: unknown): number | false | null | undefined {
+  if (raw === "disabled" || raw === false || raw === 0) return false;
+  if (raw === "enabled" || raw === true || raw == null) return raw as null | undefined;
+  if (typeof raw === "number") return raw;
+  return undefined;
 }
 
 function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConnection {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -19,7 +19,12 @@ import { AbstractAdapter } from "../abstract-adapter.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
 import { ConnectionLeasingQueue } from "./connection-pool/queue.js";
 import type { TransactionManager } from "./transaction.js";
-import { ConnectionPoolConfiguration, QueryCache, type QueryCacheHost } from "./query-cache.js";
+import {
+  ConnectionPoolConfiguration,
+  QueryCache,
+  type QueryCacheHost,
+  type Store,
+} from "./query-cache.js";
 import { executionContextId } from "./connection-pool/execution-context.js";
 import { SchemaMigration } from "../../schema-migration.js";
 import { InternalMetadata } from "../../internal-metadata.js";
@@ -239,7 +244,9 @@ export class ConnectionPool implements ReapablePool {
     this.checkoutTimeout = this.dbConfig.checkoutTimeout;
     this._idleTimeout = this.dbConfig.idleTimeout;
     this._available = new ConnectionLeasingQueue();
-    this._cacheConfig = new ConnectionPoolConfiguration();
+    this._cacheConfig = new ConnectionPoolConfiguration(
+      this.dbConfig.queryCache as number | false | null | undefined,
+    );
 
     this.reaper = new Reaper(this, this.dbConfig.reapingFrequency ?? 0);
     this.reaper.run();
@@ -368,11 +375,63 @@ export class ConnectionPool implements ReapablePool {
     return this._migrationContext;
   }
 
-  // --- Pool state ---
+  // --- Query cache (delegated to ConnectionPoolConfiguration) ---
+  //
+  // Rails wires ConnectionPool with `include QueryCache::ConnectionPoolConfiguration`.
+  // Trails composes via the `_cacheConfig` field; these forwarders give the
+  // pool the same surface so connection-level QueryCache mixin methods
+  // (cache, enableQueryCacheBang, ...) can detect `this.pool.<method>` and
+  // delegate.
+
+  get queryCache(): Store {
+    return this._cacheConfig.queryCache;
+  }
+
+  get queryCacheEnabled(): boolean {
+    return this._cacheConfig.queryCacheEnabled;
+  }
 
   get dirtiesQueryCache(): boolean {
-    return true;
+    return this._cacheConfig.dirtiesQueryCache;
   }
+
+  enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
+    return this._cacheConfig.enableQueryCache(fn);
+  }
+
+  disableQueryCache<T>(fn: () => T | Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
+    return this._cacheConfig.disableQueryCache(fn, options);
+  }
+
+  enableQueryCacheBang(): void {
+    this._cacheConfig.enableQueryCacheBang();
+  }
+
+  disableQueryCacheBang(): void {
+    this._cacheConfig.disableQueryCacheBang();
+  }
+
+  clearQueryCache(): void {
+    this._cacheConfig.clearQueryCache();
+  }
+
+  /**
+   * Enable the query cache for the duration of `fn`, then disable and clear
+   * it on exit. Used by request middleware / job adapters to bracket a unit
+   * of work with caching enabled. Trails-specific helper — Rails wraps the
+   * equivalent via `QueryCache::ExecutorHooks`.
+   */
+  async withQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
+    this.enableQueryCacheBang();
+    try {
+      return await fn();
+    } finally {
+      this.disableQueryCacheBang();
+      this.clearQueryCache();
+    }
+  }
+
+  // --- Pool state ---
 
   get activeConnection(): DatabaseAdapter | null {
     return this._connectionLease().connection;
@@ -507,11 +566,11 @@ export class ConnectionPool implements ReapablePool {
       if (this._connections && !this._connections.includes(pin.connection)) {
         this._connections.push(pin.connection);
       }
-      (pin.connection as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+      this._cacheConfig.checkoutAndVerify(pin.connection as unknown as QueryCacheHost);
       return pin.connection;
     }
     const conn = this._acquireConnection();
-    (conn as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+    this._cacheConfig.checkoutAndVerify(conn as unknown as QueryCacheHost);
     return conn;
   }
 
@@ -524,12 +583,12 @@ export class ConnectionPool implements ReapablePool {
       if (this._connections && !this._connections.includes(pin.connection)) {
         this._connections.push(pin.connection);
       }
-      (pin.connection as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+      this._cacheConfig.checkoutAndVerify(pin.connection as unknown as QueryCacheHost);
       return pin.connection;
     }
     const conn = this._tryAcquire();
     if (conn) {
-      (conn as unknown as QueryCacheHost)._queryCache = this._cacheConfig.queryCache;
+      this._cacheConfig.checkoutAndVerify(conn as unknown as QueryCacheHost);
       return conn;
     }
 
@@ -1302,7 +1361,7 @@ function checkoutAndVerify(pool: Pool, c: DatabaseAdapter): DatabaseAdapter {
     const cleanable = c as unknown as { cleanBang?: () => void; clean?: () => void };
     if (typeof cleanable.cleanBang === "function") cleanable.cleanBang();
     else cleanable.clean?.();
-    (c as unknown as QueryCacheHost)._queryCache = pool._cacheConfig.queryCache;
+    pool._cacheConfig.checkoutAndVerify(c as unknown as QueryCacheHost);
     return c;
   } catch (err) {
     pool.remove(c);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -416,18 +416,23 @@ export class ConnectionPool implements ReapablePool {
   }
 
   /**
-   * Enable the query cache for the duration of `fn`, then disable and clear
-   * it on exit. Used by request middleware / job adapters to bracket a unit
-   * of work with caching enabled. Trails-specific helper — Rails wraps the
-   * equivalent via `QueryCache::ExecutorHooks`.
+   * Enable the query cache for the duration of `fn`. If the cache wasn't
+   * previously enabled, clear it on exit. Mirrors Rails'
+   * `ActiveRecord::QueryCache.cache(&block)`:
+   *
+   *     was_enabled = pool.query_cache_enabled
+   *     begin
+   *       pool.enable_query_cache(&block)
+   *     ensure
+   *       pool.clear_query_cache unless was_enabled
+   *     end
    */
   async withQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
-    this.enableQueryCacheBang();
+    const wasEnabled = this.queryCacheEnabled;
     try {
-      return await fn();
+      return await this.enableQueryCache(fn);
     } finally {
-      this.disableQueryCacheBang();
-      this.clearQueryCache();
+      if (!wasEnabled) this.clearQueryCache();
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
@@ -43,7 +43,11 @@ export function withExecutionContext<T>(fn: () => T): T {
       throw err;
     }
     if (result && typeof (result as unknown as PromiseLike<unknown>).then === "function") {
-      return (result as unknown as Promise<unknown>).finally(runHooks) as unknown as T;
+      // Wrap via Promise.resolve so bare PromiseLike thenables (which only
+      // need to implement `then`) still get a `.finally` to attach the hook.
+      return Promise.resolve(result as unknown as PromiseLike<unknown>).finally(
+        runHooks,
+      ) as unknown as T;
     }
     runHooks();
     return result;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
@@ -3,6 +3,13 @@ import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
 let _contextIdCounter = 0;
 let _contextStorage: AsyncContext<number> | null = null;
 
+const _exitHooks: ((contextId: string) => void)[] = [];
+
+/** @internal */
+export function registerContextExitHook(hook: (contextId: string) => void): void {
+  _exitHooks.push(hook);
+}
+
 /** @internal */
 export function executionContextId(): number {
   if (!_contextStorage) {
@@ -14,10 +21,31 @@ export function executionContextId(): number {
 /**
  * Run a callback in a new isolated execution context.
  * Leases obtained inside will not collide with the outer context.
+ * On exit, registered hooks fire with the context id so per-context state
+ * (e.g., per-pool query-cache Stores) can be evicted — mirrors Rails' GC of
+ * `IsolatedExecutionState.context`.
  */
 export function withExecutionContext<T>(fn: () => T): T {
   if (!_contextStorage) {
     _contextStorage = getAsyncContext().create<number>();
   }
-  return _contextStorage.run(++_contextIdCounter, fn);
+  const id = ++_contextIdCounter;
+  const runHooks = () => {
+    const key = String(id);
+    for (const hook of _exitHooks) hook(key);
+  };
+  return _contextStorage.run(id, () => {
+    let result: T;
+    try {
+      result = fn();
+    } catch (err) {
+      runHooks();
+      throw err;
+    }
+    if (result && typeof (result as unknown as PromiseLike<unknown>).then === "function") {
+      return (result as unknown as Promise<unknown>).finally(runHooks) as unknown as T;
+    }
+    runHooks();
+    return result;
+  });
 }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,6 +1,9 @@
 import { Notifications } from "@blazetrails/activesupport";
 import { typeCastedBinds, type DatabaseStatementsHost } from "./database-statements.js";
-import { executionContextId } from "./connection-pool/execution-context.js";
+import {
+  executionContextId,
+  registerContextExitHook,
+} from "./connection-pool/execution-context.js";
 
 const DEFAULT_MAX_SIZE = 100;
 
@@ -113,7 +116,31 @@ export class QueryCacheRegistry {
     }
     this._caches.clear();
   }
+
+  deleteStore(key: string): void {
+    this._caches.delete(key);
+  }
 }
+
+/**
+ * Module-level registry of live ConnectionPoolConfigurations. Wired so the
+ * execution-context exit hook in `withExecutionContext` can evict each pool's
+ * per-context Store, mirroring Rails' GC of `IsolatedExecutionState.context`.
+ */
+const ACTIVE_CACHE_CONFIGS = new Set<WeakRef<ConnectionPoolConfiguration>>();
+
+function evictQueryCacheStoresForContext(contextId: string): void {
+  for (const ref of ACTIVE_CACHE_CONFIGS) {
+    const cfg = ref.deref();
+    if (!cfg) {
+      ACTIVE_CACHE_CONFIGS.delete(ref);
+      continue;
+    }
+    cfg.deleteStore(contextId);
+  }
+}
+
+registerContextExitHook(evictQueryCacheStoresForContext);
 
 /**
  * Host interface for QueryCache connection-level mixin methods.
@@ -151,6 +178,12 @@ export class ConnectionPoolConfiguration {
     } else {
       this._queryCacheMaxSize = DEFAULT_MAX_SIZE;
     }
+    ACTIVE_CACHE_CONFIGS.add(new WeakRef(this));
+  }
+
+  /** @internal */
+  deleteStore(contextId: string): void {
+    this._threadQueryCaches.deleteStore(contextId);
   }
 
   checkoutAndVerify(connection: QueryCacheHost): QueryCacheHost {

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -187,7 +187,11 @@ export class ConnectionPoolConfiguration {
   }
 
   checkoutAndVerify(connection: QueryCacheHost): QueryCacheHost {
-    connection._queryCache = this.queryCache;
+    // Mirrors Rails' `connection.query_cache ||= query_cache`: only assign if
+    // the connection has no cache yet. Checkin nulls `_queryCache`, so this
+    // is equivalent to an unconditional set in steady state — but matches
+    // Rails for callers that wire a Store directly before pool adoption.
+    if (!connection._queryCache) connection._queryCache = this.queryCache;
     return connection;
   }
 

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1389,4 +1389,74 @@ describe("ConnectionPoolConfiguration query cache", () => {
       });
     });
   });
+
+  describe("pool-level enable/disable propagation", () => {
+    it("enableQueryCacheBang on the pool flips the checked-out connection's Store", () => {
+      const pool = makePool(1);
+      pool.enableQueryCacheBang();
+      const conn = pool.checkout();
+      const qc = (conn as unknown as { _queryCache: Store | null })._queryCache!;
+      expect(qc.enabled).toBe(true);
+      pool.disableQueryCacheBang();
+      expect(qc.enabled).toBe(false);
+      pool.checkin(conn);
+    });
+
+    it("withQueryCache enables for the duration of fn and clears on exit", async () => {
+      const pool = makePool(1);
+      let observed: Store | null = null;
+      await pool.withQueryCache(async () => {
+        const conn = pool.checkout();
+        observed = (conn as unknown as { _queryCache: Store | null })._queryCache;
+        expect(observed!.enabled).toBe(true);
+        await observed!.computeIfAbsent("SELECT 1", async () => [{ x: 1 }]);
+        expect(observed!.size).toBe(1);
+        pool.checkin(conn);
+      });
+      expect(observed!.enabled).toBe(false);
+      expect(observed!.size).toBe(0);
+    });
+  });
+
+  describe("queryCacheMaxSize wiring", () => {
+    it("threads dbConfig.queryCache through to the Store's max size", () => {
+      const dbConfig = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: "test.db",
+        pool: 1,
+        reapingFrequency: null,
+        queryCache: 7,
+      });
+      const pc = new PoolConfig(
+        new ConnectionDescriptor("primary"),
+        dbConfig,
+        "writing",
+        "default",
+        { adapterFactory: createTestAdapter },
+      );
+      const pool = new ConnectionPool(pc);
+      const max = (pool.queryCache as unknown as { _maxSize: number })._maxSize;
+      expect(max).toBe(7);
+    });
+  });
+
+  describe("execution-context exit eviction", () => {
+    it("evicts the per-context Store from _threadQueryCaches when the context exits", async () => {
+      const pool = makePool(1);
+      const registry = (
+        pool as unknown as {
+          _cacheConfig: { _threadQueryCaches: { _caches: Map<string, Store> } };
+        }
+      )._cacheConfig._threadQueryCaches;
+
+      let seenSize = -1;
+      await withExecutionContext(async () => {
+        const conn = pool.checkout();
+        pool.checkin(conn);
+        seenSize = registry._caches.size;
+      });
+      expect(seenSize).toBeGreaterThan(0);
+      expect(registry._caches.size).toBe(0);
+    });
+  });
 });

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -20,7 +20,7 @@ export interface DatabaseConfigOptions {
   checkoutTimeout?: number | string;
   idleTimeout?: number | string | null;
   reapingFrequency?: number | string | null;
-  queryCache?: boolean | "enabled" | "disabled";
+  queryCache?: boolean | "enabled" | "disabled" | number;
   migrationsPaths?: string | string[];
   schemaCachePath?: string;
   schemaDump?: string | false | null;


### PR DESCRIPTION
## Summary

Wires Rails' query-cache enable/disable/eviction protocol through the connection pool's checkout/checkin path. Phase 4 (ExecutorHooks middleware) is excluded — blocked on ConnectionHandler PR 6.

### Phase 2

- **Per-context Store eviction.** `ConnectionPoolConfiguration` instances register in a module-level `WeakRef` set. `withExecutionContext` now runs registered exit hooks on context teardown (sync or after the promise settles), and `query-cache.ts` registers a hook that calls `_cacheConfig.deleteStore(ctxId)` on every live pool config — mirroring Rails' GC of `IsolatedExecutionState.context`. Picked option (a) from the batch (try/finally exit hook) over AsyncLocalStorage / LRU because it matches the existing `withExecutionContext` / `executionContextId` model already in use.
- **`DatabaseConfig.queryCacheMaxSize` wiring.** `ConnectionPool` now threads `this.dbConfig.queryCache` into `new ConnectionPoolConfiguration(...)`. `DatabaseConfigOptions.queryCache` widened to allow `number` (Rails accepts an integer max-size).

### Phase 3

- **Pool-level enable/disable delegation.** `ConnectionPool` exposes `enableQueryCache(fn)`, `disableQueryCache(fn, opts)`, `enableQueryCacheBang()`, `disableQueryCacheBang()`, `clearQueryCache()`, `queryCache`, `queryCacheEnabled`, and `dirtiesQueryCache`, each delegating to `_cacheConfig`. Connection-level mixins (which already check `this.pool?.enableQueryCacheBang` etc.) now forward correctly.
- **`withQueryCache(fn)` public API.** Brackets `fn` with `enableQueryCacheBang()` and `disableQueryCacheBang()` + `clearQueryCache()` on exit.

### Cleanup

- Pool `checkout` / `checkoutAsync` / module-level `checkoutAndVerify` now route Store attachment through `_cacheConfig.checkoutAndVerify(conn)` instead of duplicated inline `_queryCache = _cacheConfig.queryCache` assignments.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-pool.test.ts packages/activerecord/src/query-cache.test.ts` — 4 new smoke tests added (pool-level enableBang propagation, `withQueryCache` enables+clears, `queryCacheMaxSize` wired, exit-eviction).
- [ ] CI: full activerecord suite.

LOC: 202 insertions / 12 deletions across 5 files.