### PR TITLE
feat(activerecord): composite-FK has-many-through write support

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -3065,23 +3065,178 @@ describe("AssociationsTest", () => {
     expect(child.parent_region_id).toBe(2);
     expect(child.parent_id).toBe(30);
   });
-  it.skip("append composite has many through association", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* fixture-dependent */
+  it("append composite has many through association", async () => {
+    const adapter = freshAdapter();
+    class CpkThruDoc1 extends Base {
+      static {
+        this._tableName = "cpk_thru_doc1s";
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruAppt1 extends Base {
+      static {
+        this._tableName = "cpk_thru_appt1s";
+        this.attribute("doctor_region_id", "integer");
+        this.attribute("doctor_id", "integer");
+        this.attribute("patient_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruPat1 extends Base {
+      static {
+        this._tableName = "cpk_thru_pat1s";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(CpkThruDoc1, "appts", {
+      className: "CpkThruAppt1",
+      foreignKey: ["doctor_region_id", "doctor_id"],
+    });
+    Associations.belongsTo.call(CpkThruAppt1, "patient", {
+      className: "CpkThruPat1",
+      foreignKey: "patient_id",
+    });
+    Associations.hasMany.call(CpkThruDoc1, "patients", {
+      through: "appts",
+      className: "CpkThruPat1",
+      source: "patient",
+    });
+    registerModel("CpkThruDoc1", CpkThruDoc1);
+    registerModel("CpkThruAppt1", CpkThruAppt1);
+    registerModel("CpkThruPat1", CpkThruPat1);
+
+    const doc = await CpkThruDoc1.create({ region_id: 1, id: 7, name: "Dr A" });
+    const alice = await CpkThruPat1.create({ name: "Alice" });
+    const proxy = association(doc, "patients");
+    await proxy.push(alice);
+
+    const joins = await CpkThruAppt1.all().toArray();
+    expect(joins).toHaveLength(1);
+    expect(joins[0].doctor_region_id).toBe(1);
+    expect(joins[0].doctor_id).toBe(7);
+    expect(joins[0].patient_id).toBe(alice.id);
   });
-  it.skip("append composite has many through association with autosave", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* fixture-dependent */
+  it("append composite has many through association with autosave", async () => {
+    const adapter = freshAdapter();
+    class CpkThruDoc2 extends Base {
+      static {
+        this._tableName = "cpk_thru_doc2s";
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruAppt2 extends Base {
+      static {
+        this._tableName = "cpk_thru_appt2s";
+        this.attribute("doctor_region_id", "integer");
+        this.attribute("doctor_id", "integer");
+        this.attribute("patient_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruPat2 extends Base {
+      static {
+        this._tableName = "cpk_thru_pat2s";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(CpkThruDoc2, "appts", {
+      className: "CpkThruAppt2",
+      foreignKey: ["doctor_region_id", "doctor_id"],
+    });
+    Associations.belongsTo.call(CpkThruAppt2, "patient", {
+      className: "CpkThruPat2",
+      foreignKey: "patient_id",
+    });
+    Associations.hasMany.call(CpkThruDoc2, "patients", {
+      through: "appts",
+      className: "CpkThruPat2",
+      source: "patient",
+    });
+    registerModel("CpkThruDoc2", CpkThruDoc2);
+    registerModel("CpkThruAppt2", CpkThruAppt2);
+    registerModel("CpkThruPat2", CpkThruPat2);
+
+    const doc = await CpkThruDoc2.create({ region_id: 2, id: 9, name: "Dr B" });
+    // Unsaved patient — push should autosave it before creating the join row.
+    const bob = new CpkThruPat2({ name: "Bob" });
+    expect(bob.isNewRecord()).toBe(true);
+    const proxy = association(doc, "patients");
+    await proxy.push(bob);
+    expect(bob.isPersisted()).toBe(true);
+
+    const joins = await CpkThruAppt2.all().toArray();
+    expect(joins).toHaveLength(1);
+    expect(joins[0].doctor_region_id).toBe(2);
+    expect(joins[0].doctor_id).toBe(9);
+    expect(joins[0].patient_id).toBe(bob.id);
   });
-  it.skip("nullify composite has many through association", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* fixture-dependent */
+  it("nullify composite has many through association", async () => {
+    const adapter = freshAdapter();
+    class CpkThruDoc3 extends Base {
+      static {
+        this._tableName = "cpk_thru_doc3s";
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruAppt3 extends Base {
+      static {
+        this._tableName = "cpk_thru_appt3s";
+        this.attribute("doctor_region_id", "integer");
+        this.attribute("doctor_id", "integer");
+        this.attribute("patient_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruPat3 extends Base {
+      static {
+        this._tableName = "cpk_thru_pat3s";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(CpkThruDoc3, "appts", {
+      className: "CpkThruAppt3",
+      foreignKey: ["doctor_region_id", "doctor_id"],
+    });
+    Associations.belongsTo.call(CpkThruAppt3, "patient", {
+      className: "CpkThruPat3",
+      foreignKey: "patient_id",
+    });
+    Associations.hasMany.call(CpkThruDoc3, "patients", {
+      through: "appts",
+      className: "CpkThruPat3",
+      source: "patient",
+    });
+    registerModel("CpkThruDoc3", CpkThruDoc3);
+    registerModel("CpkThruAppt3", CpkThruAppt3);
+    registerModel("CpkThruPat3", CpkThruPat3);
+
+    const doc = await CpkThruDoc3.create({ region_id: 3, id: 4, name: "Dr C" });
+    const p1 = await CpkThruPat3.create({ name: "Alice" });
+    const p2 = await CpkThruPat3.create({ name: "Bob" });
+    await CpkThruAppt3.create({ doctor_region_id: 3, doctor_id: 4, patient_id: p1.id });
+    await CpkThruAppt3.create({ doctor_region_id: 3, doctor_id: 4, patient_id: p2.id });
+
+    const proxy = association(doc, "patients");
+    const count = await proxy.deleteAll("nullify");
+    expect(count).toBe(2);
+    // Join rows removed, target patients still exist.
+    expect(await CpkThruAppt3.all().count()).toBe(0);
+    expect(await CpkThruPat3.all().count()).toBe(2);
   });
   it("belongs to with explicit composite foreign key", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -3111,15 +3111,31 @@ describe("AssociationsTest", () => {
     registerModel("CpkThruPat1", CpkThruPat1);
 
     const doc = await CpkThruDoc1.create({ region_id: 1, id: 7, name: "Dr A" });
+    // Another doctor that shares one PK component, to verify the composite
+    // through scope filters on BOTH columns rather than only the first.
+    const otherDoc = await CpkThruDoc1.create({ region_id: 2, id: 7, name: "Dr Other" });
     const alice = await CpkThruPat1.create({ name: "Alice" });
+    const noise = await CpkThruPat1.create({ name: "Noise" });
+    await CpkThruAppt1.create({
+      doctor_region_id: 2,
+      doctor_id: 7,
+      patient_id: noise.id,
+    });
     const proxy = association(doc, "patients");
     await proxy.push(alice);
 
-    const joins = await CpkThruAppt1.all().toArray();
+    const joins = await CpkThruAppt1.all().where({ doctor_region_id: 1 }).toArray();
     expect(joins).toHaveLength(1);
     expect(joins[0].doctor_region_id).toBe(1);
     expect(joins[0].doctor_id).toBe(7);
     expect(joins[0].patient_id).toBe(alice.id);
+
+    // Reading through the proxy must exercise _buildThroughScope. It should
+    // return only Alice — not the noise row that shares doctor_id=7.
+    const loaded = await proxy.toArray();
+    expect(loaded.map((p: any) => p.name)).toEqual(["Alice"]);
+    const otherLoaded = await association(otherDoc, "patients").toArray();
+    expect(otherLoaded.map((p: any) => p.name)).toEqual(["Noise"]);
   });
   it("append composite has many through association with autosave", async () => {
     const adapter = freshAdapter();
@@ -3237,6 +3253,73 @@ describe("AssociationsTest", () => {
     // Join rows removed, target patients still exist.
     expect(await CpkThruAppt3.all().count()).toBe(0);
     expect(await CpkThruPat3.all().count()).toBe(2);
+  });
+  it("delete single composite has many through join row", async () => {
+    // Covers _deleteThrough composite-aware findBy. Another owner shares one
+    // PK component to verify the join lookup ANDs across both columns.
+    const adapter = freshAdapter();
+    class CpkThruDoc4 extends Base {
+      static {
+        this._tableName = "cpk_thru_doc4s";
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruAppt4 extends Base {
+      static {
+        this._tableName = "cpk_thru_appt4s";
+        this.attribute("doctor_region_id", "integer");
+        this.attribute("doctor_id", "integer");
+        this.attribute("patient_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruPat4 extends Base {
+      static {
+        this._tableName = "cpk_thru_pat4s";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(CpkThruDoc4, "appts", {
+      className: "CpkThruAppt4",
+      foreignKey: ["doctor_region_id", "doctor_id"],
+    });
+    Associations.belongsTo.call(CpkThruAppt4, "patient", {
+      className: "CpkThruPat4",
+      foreignKey: "patient_id",
+    });
+    Associations.hasMany.call(CpkThruDoc4, "patients", {
+      through: "appts",
+      className: "CpkThruPat4",
+      source: "patient",
+    });
+    registerModel("CpkThruDoc4", CpkThruDoc4);
+    registerModel("CpkThruAppt4", CpkThruAppt4);
+    registerModel("CpkThruPat4", CpkThruPat4);
+
+    const doc = await CpkThruDoc4.create({ region_id: 5, id: 11, name: "Dr D" });
+    const otherDoc = await CpkThruDoc4.create({ region_id: 6, id: 11, name: "Dr E" });
+    const alice = await CpkThruPat4.create({ name: "Alice" });
+    await CpkThruAppt4.create({ doctor_region_id: 5, doctor_id: 11, patient_id: alice.id });
+    await CpkThruAppt4.create({ doctor_region_id: 6, doctor_id: 11, patient_id: alice.id });
+
+    const proxy = association(doc, "patients");
+    await proxy.delete(alice);
+
+    // Only the owning composite join row is removed.
+    const remaining = await CpkThruAppt4.all().toArray();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].doctor_region_id).toBe(6);
+    expect(remaining[0].doctor_id).toBe(11);
+    // Target record itself is untouched, and the other owner still sees Alice.
+    expect(await CpkThruPat4.all().count()).toBe(1);
+    expect((await association(otherDoc, "patients").toArray()).map((p: any) => p.name)).toEqual([
+      "Alice",
+    ]);
   });
   it("belongs to with explicit composite foreign key", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1029,18 +1029,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-    if (Array.isArray(ownerFk)) {
-      throw new Error(
-        `Through associations do not support composite foreign keys on "${this._assocName}".`,
-      );
-    }
     const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    if (Array.isArray(primaryKey)) {
+    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
+    if (ownerFkCols.length !== ownerPkCols.length) {
       throw new Error(
-        `Through associations do not support composite primary keys on "${this._assocName}".`,
+        `Composite primaryKey/foreignKey mismatch on through "${this._assocName}": ${ownerPkCols.length} pk vs ${ownerFkCols.length} fk`,
       );
     }
-    const pkValue = this._record._readAttribute(primaryKey);
+    const ownerJoinAttrs: Record<string, unknown> = {};
+    for (let i = 0; i < ownerFkCols.length; i++) {
+      ownerJoinAttrs[ownerFkCols[i]] = this._record._readAttribute(ownerPkCols[i]);
+    }
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 
@@ -1060,24 +1060,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         }
       }
       // Create the join record
+      const targetPk = (record.constructor as typeof Base).primaryKey;
+      if (Array.isArray(targetPk)) {
+        throw new Error(
+          `Through associations do not support composite primary keys on target model for "${this._assocName}".`,
+        );
+      }
       const joinAttrs: Record<string, unknown> = {
-        [ownerFk as string]: pkValue,
-        [sourceFk]: (() => {
-          const targetPk = (record.constructor as typeof Base).primaryKey;
-          if (Array.isArray(targetPk)) {
-            throw new Error(
-              `Through associations do not support composite primary keys on target model for "${this._assocName}".`,
-            );
-          }
-          return record._readAttribute(targetPk);
-        })(),
+        ...ownerJoinAttrs,
+        [sourceFk]: record._readAttribute(targetPk),
       };
       // Handle polymorphic through (as option on through association)
       if (throughAssoc.options.as) {
         const typeCol = `${underscore(throughAssoc.options.as)}_type`;
-        joinAttrs[`${underscore(throughAssoc.options.as)}_id`] = pkValue;
+        // Polymorphic through uses a single _id/_type pair, not composite owner FK
+        for (const col of ownerFkCols) delete joinAttrs[col];
+        joinAttrs[`${underscore(throughAssoc.options.as)}_id`] = ownerJoinAttrs[ownerFkCols[0]];
         joinAttrs[typeCol] = ctor.name;
-        delete joinAttrs[ownerFk as string];
       }
       let joinRecord: Base;
       if (bang) {
@@ -1215,7 +1214,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
     const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const pkValue = this._record._readAttribute(primaryKey as string);
+    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
+    const ownerConditions: Record<string, unknown> = {};
+    for (let i = 0; i < ownerFkCols.length; i++) {
+      ownerConditions[ownerFkCols[i]] = this._record._readAttribute(ownerPkCols[i]);
+    }
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 
@@ -1226,7 +1230,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         (record.constructor as typeof Base).primaryKey as string,
       );
       const joinRecord = await throughModel.findBy({
-        [ownerFk as string]: pkValue,
+        ...ownerConditions,
         [sourceFk]: targetPk,
       });
       if (joinRecord) {
@@ -1250,26 +1254,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    if (Array.isArray(primaryKey)) {
-      throw new Error(
-        `deleteAll does not support composite primary keys for through associations on "${this._assocName}".`,
-      );
-    }
-    const pkValue = this._record._readAttribute(primaryKey);
-    if (pkValue == null) return 0;
+    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
+    const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
+    if (ownerPkValues.some((v) => v == null)) return 0;
     const throughAs = throughAssoc.options.as;
     const conditions: Record<string, unknown> = {};
     if (throughAs) {
-      conditions[`${underscore(throughAs)}_id`] = pkValue;
+      // Polymorphic through uses a single _id/_type pair; composite-PK owners
+      // are not representable in that schema, so use the first PK column.
+      conditions[`${underscore(throughAs)}_id`] = ownerPkValues[0];
       conditions[`${underscore(throughAs)}_type`] = ctor.name;
     } else {
       const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-      if (Array.isArray(ownerFk)) {
-        throw new Error(
-          `deleteAll does not support composite foreign keys for through associations on "${this._assocName}".`,
-        );
+      const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+      for (let i = 0; i < ownerFkCols.length; i++) {
+        conditions[ownerFkCols[i]] = ownerPkValues[i];
       }
-      conditions[ownerFk] = pkValue;
     }
     if (this._assocDef.options.sourceType) {
       const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
@@ -1816,27 +1816,28 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       ? (throughAssoc.options.foreignKey ?? `${underscore(throughAs)}_id`)
       : (throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`);
     const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-
-    if (Array.isArray(ownerPk)) {
-      throw new Error(
-        `CollectionProxy#scope does not support composite primary keys for through associations on "${this._assocName}".`,
-      );
-    }
-
-    const pkValue = this._record._readAttribute(ownerPk as string);
-    if (pkValue == null) return (targetModel as any).all().none();
+    const ownerPkCols = Array.isArray(ownerPk) ? ownerPk : [ownerPk as string];
+    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+    const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
+    if (ownerPkValues.some((v) => v == null)) return (targetModel as any).all().none();
 
     const throughTable = new ArelTable(throughModel.tableName);
     const targetArelTable = new ArelTable(targetModel.tableName);
     const sourceAssocKind = sourceAssoc?.type ?? "belongsTo";
 
-    // Build the through table subquery
-    if (Array.isArray(ownerFk)) {
-      throw new Error(
-        `CollectionProxy#scope does not support composite foreign keys for through associations on "${this._assocName}".`,
+    // Build the through table subquery — AND together each (fk = pkValue) pair.
+    let throughSubquery = throughTable.from();
+    if (throughAs) {
+      throughSubquery = throughSubquery.where(
+        throughTable.get(ownerFkCols[0]).eq(ownerPkValues[0]),
       );
+    } else {
+      for (let i = 0; i < ownerFkCols.length; i++) {
+        throughSubquery = throughSubquery.where(
+          throughTable.get(ownerFkCols[i]).eq(ownerPkValues[i]),
+        );
+      }
     }
-    let throughSubquery = throughTable.from().where(throughTable.get(ownerFk).eq(pkValue));
     if (throughAs) {
       throughSubquery = throughSubquery.where(
         throughTable.get(`${underscore(throughAs)}_type`).eq(ctor.name),

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1051,8 +1051,27 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       } else if (constraints.includes(derivedFk)) {
         ownerFk = constraints;
       } else {
+        // Mirror Reflection#deriveFkQueryConstraints validation
+        // (reflection.ts:555-571): only 2-column constraints are derivable,
+        // and the owner's scalar primary key must be one of them.
+        if (constraints.length > 2) {
+          throw new ConfigurationError(
+            `The query constraints list on the \`${ctor.name}\` model has more than 2 ` +
+              `attributes. Active Record is unable to derive the query constraints ` +
+              `for the association. You need to explicitly define the query constraints ` +
+              `for this association.`,
+          );
+        }
         const ownerPk = ctor.primaryKey;
         const ownerPkStr = Array.isArray(ownerPk) ? undefined : ownerPk;
+        if (ownerPkStr && !constraints.includes(ownerPkStr)) {
+          throw new ConfigurationError(
+            `The query constraints on the \`${ctor.name}\` model does not include the primary ` +
+              `key so Active Record is unable to derive the foreign key constraints for ` +
+              `the association. You need to explicitly define the query constraints for this ` +
+              `association.`,
+          );
+        }
         if (ownerPkStr && constraints[0] === ownerPkStr) {
           ownerFk = [derivedFk, constraints[1]];
         } else if (ownerPkStr && constraints[1] === ownerPkStr) {
@@ -1110,7 +1129,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     asName: string,
   ): { idCol: string; idValue: unknown; typeCol: string; typeValue: string } {
     const polyFk = throughAssoc.options.foreignKey ?? `${underscore(asName)}_id`;
-    const idCol = Array.isArray(polyFk) ? polyFk[0] : polyFk;
+    if (Array.isArray(polyFk)) {
+      // Polymorphic associations have only one `<as>_id`/`<as>_type` pair
+      // in the schema, so a composite foreignKey is unrepresentable.
+      // Matches the rejection at associations.ts:829-833 / :1028-1032.
+      throw new ConfigurationError(
+        `Polymorphic-through "${this._assocName}" cannot use a composite foreign key — ` +
+          `the schema only supports a single \`${underscore(asName)}_id\`/\`${underscore(asName)}_type\` pair.`,
+      );
+    }
+    const idCol = polyFk;
     const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
     const polyPk = Array.isArray(ownerPk)
       ? ownerPk.includes("id")
@@ -1151,22 +1179,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    // Polymorphic-through bypasses the composite-aware helper: the schema
-    // has a single `<as>_id`/`<as>_type` pair, which is not pairable with a
-    // composite owner PK. Use the scalar polymorphic FK column and the
-    // owner's scalar/collapsed PK so writes and reads agree on the same
-    // column (kept in lock-step with _buildThroughScope's polymorphic branch
-    // below).
-    let ownerFkCols: string[];
-    let ownerJoinAttrs: Record<string, unknown>;
-    if (throughAssoc.options.as) {
-      const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAssoc.options.as);
-      ownerFkCols = [poly.idCol];
-      ownerJoinAttrs = { [poly.idCol]: poly.idValue };
-    } else {
-      ownerFkCols = this._throughOwnerCols(throughAssoc, ctor).fkCols;
-      ownerJoinAttrs = this._throughOwnerAttrs(throughAssoc, ctor);
-    }
+    // Polymorphic-through uses a single `<as>_id`/`<as>_type` pair; the
+    // composite-aware helper does not apply. Writes and reads share
+    // _throughOwnerPolymorphic so they target the same column.
+    const ownerJoinAttrs: Record<string, unknown> = throughAssoc.options.as
+      ? (() => {
+          const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAssoc.options.as!);
+          return { [poly.idCol]: poly.idValue };
+        })()
+      : this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -37,6 +37,10 @@ import {
   HasManyThroughOrderError,
 } from "./errors.js";
 import { getInheritanceColumn, findStiClass } from "../inheritance.js";
+import {
+  hasQueryConstraints as ownerHasQueryConstraints,
+  queryConstraintsList as ownerQueryConstraintsList,
+} from "../persistence.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   resolveModel,
@@ -1026,18 +1030,35 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     throughAssoc: AssociationDefinition,
     ctor: typeof Base,
   ): { fkCols: string[]; pkCols: string[] } {
-    const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-    // Mirror Reflection#activeRecordPrimaryKey (reflection.ts:780-796): an
-    // explicit primaryKey wins, otherwise queryConstraints wins, otherwise
-    // a composite PK that includes "id" collapses to "id" when no query
-    // constraints are involved. Rails uses this same resolution inside
-    // `construct_join_attributes` (through_association.rb).
+    // Mirror Reflection's foreignKey resolution (reflection.ts:520-535):
+    // explicit options.foreignKey wins, then options.queryConstraints, then a
+    // class-level queryConstraints on the owner promotes the default
+    // `${owner}_id` to a composite list. Without that step, a scalar
+    // derived FK would silently drop tenant/discriminator columns.
+    let ownerFk: string | string[];
+    if (throughAssoc.options.foreignKey !== undefined) {
+      ownerFk = throughAssoc.options.foreignKey;
+    } else if (throughAssoc.options.queryConstraints) {
+      ownerFk = throughAssoc.options.queryConstraints;
+    } else if (ownerHasQueryConstraints.call(ctor as any)) {
+      ownerFk = ownerQueryConstraintsList.call(ctor as any) ?? `${underscore(ctor.name)}_id`;
+    } else {
+      ownerFk = `${underscore(ctor.name)}_id`;
+    }
     const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+
+    // Mirror Reflection#activeRecordPrimaryKey (reflection.ts:780-796).
     let ownerPk: string | string[];
     if (throughAssoc.options.primaryKey !== undefined) {
       ownerPk = throughAssoc.options.primaryKey;
-    } else if (throughAssoc.options.queryConstraints) {
-      ownerPk = throughAssoc.options.queryConstraints;
+    } else if (
+      ownerHasQueryConstraints.call(ctor as any) ||
+      throughAssoc.options.queryConstraints
+    ) {
+      ownerPk =
+        (throughAssoc.options.queryConstraints as string[] | undefined) ??
+        ownerQueryConstraintsList.call(ctor as any) ??
+        (ctor.primaryKey as string | string[]);
     } else if (
       // Rails' id-collapse: a scalar FK against a composite PK that includes
       // "id" pairs with the scalar "id" column (reflection.ts:791-793).
@@ -1084,8 +1105,27 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const { fkCols: ownerFkCols } = this._throughOwnerCols(throughAssoc, ctor);
-    const ownerJoinAttrs = this._throughOwnerAttrs(throughAssoc, ctor);
+    // Polymorphic-through bypasses the composite-aware helper: the schema
+    // has a single `<as>_id`/`<as>_type` pair, which is not pairable with a
+    // composite owner PK. Use the scalar polymorphic FK column and the
+    // owner's scalar/collapsed PK so writes and reads agree on the same
+    // column (kept in lock-step with _buildThroughScope's polymorphic branch
+    // below).
+    let ownerFkCols: string[];
+    let ownerJoinAttrs: Record<string, unknown>;
+    if (throughAssoc.options.as) {
+      const polyFk = throughAssoc.options.foreignKey ?? `${underscore(throughAssoc.options.as)}_id`;
+      ownerFkCols = [Array.isArray(polyFk) ? polyFk[0] : polyFk];
+      const polyPk = Array.isArray(ctor.primaryKey)
+        ? ctor.primaryKey.includes("id")
+          ? "id"
+          : ctor.primaryKey[0]
+        : (ctor.primaryKey as string);
+      ownerJoinAttrs = { [ownerFkCols[0]]: this._record._readAttribute(polyPk) };
+    } else {
+      ownerFkCols = this._throughOwnerCols(throughAssoc, ctor).fkCols;
+      ownerJoinAttrs = this._throughOwnerAttrs(throughAssoc, ctor);
+    }
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1081,7 +1081,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         } else if (ownerPkStr && constraints[1] === ownerPkStr) {
           ownerFk = [constraints[0], derivedFk];
         } else {
-          ownerFk = constraints;
+          // Mirrors reflection.ts:583-588 — when constraints can't be
+          // resolved (e.g. composite owner PK with class-level
+          // queryConstraints), we cannot derive a join-table FK shape
+          // without producing invalid columns.
+          throw new ConfigurationError(
+            `Active Record couldn't correctly interpret the query constraints ` +
+              `for the \`${ctor.name}\` model. The query constraints on \`${ctor.name}\` are ` +
+              `\`${constraints}\` and the foreign key is \`${derivedFk}\`. ` +
+              `You need to explicitly set the query constraints for this association.`,
+          );
         }
       }
     }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1030,20 +1030,37 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     throughAssoc: AssociationDefinition,
     ctor: typeof Base,
   ): { fkCols: string[]; pkCols: string[] } {
-    // Mirror Reflection's foreignKey resolution (reflection.ts:520-535):
-    // explicit options.foreignKey wins, then options.queryConstraints, then a
-    // class-level queryConstraints on the owner promotes the default
-    // `${owner}_id` to a composite list. Without that step, a scalar
-    // derived FK would silently drop tenant/discriminator columns.
+    // Mirror Reflection's foreignKey resolution (reflection.ts:520-535 +
+    // deriveFkQueryConstraints at :548-585). When the owner has class-level
+    // query constraints and no explicit option, the derived `<owner>_id`
+    // *replaces* the owner-PK column inside the constraints list (rather
+    // than taking the constraints verbatim, which would put `id` on the
+    // join table instead of the actual FK column).
     let ownerFk: string | string[];
     if (throughAssoc.options.foreignKey !== undefined) {
       ownerFk = throughAssoc.options.foreignKey;
     } else if (throughAssoc.options.queryConstraints) {
       ownerFk = throughAssoc.options.queryConstraints;
-    } else if (ownerHasQueryConstraints.call(ctor as any)) {
-      ownerFk = ownerQueryConstraintsList.call(ctor as any) ?? `${underscore(ctor.name)}_id`;
     } else {
-      ownerFk = `${underscore(ctor.name)}_id`;
+      const derivedFk = `${underscore(ctor.name)}_id`;
+      const constraints = ownerHasQueryConstraints.call(ctor as any)
+        ? ownerQueryConstraintsList.call(ctor as any)
+        : null;
+      if (!constraints) {
+        ownerFk = derivedFk;
+      } else if (constraints.includes(derivedFk)) {
+        ownerFk = constraints;
+      } else {
+        const ownerPk = ctor.primaryKey;
+        const ownerPkStr = Array.isArray(ownerPk) ? undefined : ownerPk;
+        if (ownerPkStr && constraints[0] === ownerPkStr) {
+          ownerFk = [derivedFk, constraints[1]];
+        } else if (ownerPkStr && constraints[1] === ownerPkStr) {
+          ownerFk = [constraints[0], derivedFk];
+        } else {
+          ownerFk = constraints;
+        }
+      }
     }
     const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
 
@@ -1077,6 +1094,35 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       );
     }
     return { fkCols, pkCols };
+  }
+
+  /**
+   * Resolve the polymorphic `<as>_id`/`<as>_type` column descriptor for a
+   * polymorphic-through. The schema is intrinsically scalar, so the owner
+   * PK collapses to "id" when composite-with-id (matching Rails' polymorphic
+   * derivation) and otherwise to the scalar/first PK column. Used by every
+   * polymorphic-through write/read site to keep them in lock-step.
+   * @internal
+   */
+  private _throughOwnerPolymorphic(
+    throughAssoc: AssociationDefinition,
+    ctor: typeof Base,
+    asName: string,
+  ): { idCol: string; idValue: unknown; typeCol: string; typeValue: string } {
+    const polyFk = throughAssoc.options.foreignKey ?? `${underscore(asName)}_id`;
+    const idCol = Array.isArray(polyFk) ? polyFk[0] : polyFk;
+    const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
+    const polyPk = Array.isArray(ownerPk)
+      ? ownerPk.includes("id")
+        ? "id"
+        : ownerPk[0]
+      : (ownerPk as string);
+    return {
+      idCol,
+      idValue: this._record._readAttribute(polyPk),
+      typeCol: `${underscore(asName)}_type`,
+      typeValue: ctor.name,
+    };
   }
 
   /** @internal Builds an FK→ownerPkValue map for join-row WHERE/INSERT shapes. */
@@ -1114,14 +1160,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     let ownerFkCols: string[];
     let ownerJoinAttrs: Record<string, unknown>;
     if (throughAssoc.options.as) {
-      const polyFk = throughAssoc.options.foreignKey ?? `${underscore(throughAssoc.options.as)}_id`;
-      ownerFkCols = [Array.isArray(polyFk) ? polyFk[0] : polyFk];
-      const polyPk = Array.isArray(ctor.primaryKey)
-        ? ctor.primaryKey.includes("id")
-          ? "id"
-          : ctor.primaryKey[0]
-        : (ctor.primaryKey as string);
-      ownerJoinAttrs = { [ownerFkCols[0]]: this._record._readAttribute(polyPk) };
+      const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAssoc.options.as);
+      ownerFkCols = [poly.idCol];
+      ownerJoinAttrs = { [poly.idCol]: poly.idValue };
     } else {
       ownerFkCols = this._throughOwnerCols(throughAssoc, ctor).fkCols;
       ownerJoinAttrs = this._throughOwnerAttrs(throughAssoc, ctor);
@@ -1155,13 +1196,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         ...ownerJoinAttrs,
         [sourceFk]: record._readAttribute(targetPk),
       };
-      // Handle polymorphic through (as option on through association)
+      // Polymorphic through: ownerJoinAttrs already has the polymorphic
+      // _id column from _throughOwnerPolymorphic; just add the _type.
       if (throughAssoc.options.as) {
-        const typeCol = `${underscore(throughAssoc.options.as)}_type`;
-        // Polymorphic through uses a single _id/_type pair, not composite owner FK
-        for (const col of ownerFkCols) delete joinAttrs[col];
-        joinAttrs[`${underscore(throughAssoc.options.as)}_id`] = ownerJoinAttrs[ownerFkCols[0]];
-        joinAttrs[typeCol] = ctor.name;
+        joinAttrs[`${underscore(throughAssoc.options.as)}_type`] = ctor.name;
       }
       let joinRecord: Base;
       if (bang) {
@@ -1297,7 +1335,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const ownerConditions = this._throughOwnerAttrs(throughAssoc, ctor);
+    // Polymorphic through goes through _throughOwnerPolymorphic (same lookup
+    // shape as _pushThrough / _buildThroughScope); composite owners go
+    // through the column-paired helper.
+    const throughAs = throughAssoc.options.as;
+    const ownerConditions = throughAs
+      ? (() => {
+          const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs);
+          return { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue };
+        })()
+      : this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 
@@ -1332,19 +1379,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
     const throughAs = throughAssoc.options.as;
-    const conditions: Record<string, unknown> = throughAs
-      ? {}
-      : this._throughOwnerAttrs(throughAssoc, ctor);
-    if (Object.values(conditions).some((v) => v == null)) return 0;
+    let conditions: Record<string, unknown>;
     if (throughAs) {
-      // Polymorphic through uses a single _id/_type pair; composite-PK owners
-      // are not representable in that schema, so use the first PK column.
-      const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-      const firstPk = Array.isArray(primaryKey) ? primaryKey[0] : (primaryKey as string);
-      const pkValue = this._record._readAttribute(firstPk);
-      if (pkValue == null) return 0;
-      conditions[`${underscore(throughAs)}_id`] = pkValue;
-      conditions[`${underscore(throughAs)}_type`] = ctor.name;
+      const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs);
+      if (poly.idValue == null) return 0;
+      conditions = { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue };
+    } else {
+      conditions = this._throughOwnerAttrs(throughAssoc, ctor);
+      if (Object.values(conditions).some((v) => v == null)) return 0;
     }
     if (this._assocDef.options.sourceType) {
       const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
@@ -1887,43 +1929,31 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughModelAssocs.find((a) => a.name === pluralize(sourceName));
 
     const throughAs = throughAssoc.options.as;
-    // For polymorphic through we can't run the FK/PK pair check (the FK
-    // shape is the polymorphic _id/_type pair, not the owner key). For the
-    // canonical through path, defer to the helper so resolution matches
-    // Reflection#activeRecordPrimaryKey.
-    const ownerPkCols = throughAs
-      ? (() => {
-          const pk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-          return Array.isArray(pk) ? pk : [pk as string];
-        })()
-      : this._throughOwnerCols(throughAssoc, ctor).pkCols;
-    const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
-    if (ownerPkValues.some((v) => v == null)) return (targetModel as any).all().none();
-
     const throughTable = new ArelTable(throughModel.tableName);
     const targetArelTable = new ArelTable(targetModel.tableName);
     const sourceAssocKind = sourceAssoc?.type ?? "belongsTo";
 
-    // Build the through table subquery — AND together each (fk = pkValue) pair.
     let throughSubquery = throughTable.from();
     if (throughAs) {
-      // Polymorphic through: single _id/_type pair, composite-PK owners use
-      // first PK column (the schema is not representable with composite owner).
-      const polyFk = throughAssoc.options.foreignKey ?? `${underscore(throughAs)}_id`;
-      const polyFkCol = Array.isArray(polyFk) ? polyFk[0] : polyFk;
-      throughSubquery = throughSubquery.where(throughTable.get(polyFkCol).eq(ownerPkValues[0]));
+      // Polymorphic-through: defer to the shared polymorphic helper so the
+      // scope reads from the same column _pushThrough writes to.
+      const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs);
+      if (poly.idValue == null) return (targetModel as any).all().none();
+      throughSubquery = throughSubquery
+        .where(throughTable.get(poly.idCol).eq(poly.idValue))
+        .where(throughTable.get(poly.typeCol).eq(poly.typeValue));
     } else {
-      const { fkCols: ownerFkCols } = this._throughOwnerCols(throughAssoc, ctor);
+      const { fkCols: ownerFkCols, pkCols: ownerPkCols } = this._throughOwnerCols(
+        throughAssoc,
+        ctor,
+      );
+      const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
+      if (ownerPkValues.some((v) => v == null)) return (targetModel as any).all().none();
       for (let i = 0; i < ownerFkCols.length; i++) {
         throughSubquery = throughSubquery.where(
           throughTable.get(ownerFkCols[i]).eq(ownerPkValues[i]),
         );
       }
-    }
-    if (throughAs) {
-      throughSubquery = throughSubquery.where(
-        throughTable.get(`${underscore(throughAs)}_type`).eq(ctor.name),
-      );
     }
 
     if (sourceAssocKind === "belongsTo") {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1364,19 +1364,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // shape as _pushThrough / _buildThroughScope); composite owners go
     // through the column-paired helper.
     const throughAs = throughAssoc.options.as;
-    const ownerConditions = throughAs
-      ? (() => {
-          const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs);
-          return { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue };
-        })()
+    const poly = throughAs ? this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs) : null;
+    const ownerConditions: Record<string, unknown> = poly
+      ? { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue }
       : this._throughOwnerAttrs(throughAssoc, ctor);
     // Guard against unsaved owners / missing composite components — otherwise
     // findBy({fk: null}) would translate to IS NULL and could destroy an
     // orphan join row. Mirrors the short-circuits in _buildThroughScope and
     // _deleteThroughAllSql.
-    const polyIdValue = throughAs ? (ownerConditions as any)[`${underscore(throughAs)}_id`] : null;
-    if (throughAs ? polyIdValue == null : Object.values(ownerConditions).some((v) => v == null)) {
+    if (poly ? poly.idValue == null : Object.values(ownerConditions).some((v) => v == null)) {
       return;
+    }
+    // Apply the polymorphic-source discriminator the same way _deleteThroughAllSql
+    // and _buildThroughScope do, so we don't destroy a join row belonging to a
+    // different source type that happens to share the id.
+    if (this._assocDef.options.sourceType) {
+      const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
+      ownerConditions[`${underscore(sourceName)}_type`] = this._assocDef.options.sourceType;
     }
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1049,7 +1049,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (!constraints) {
         ownerFk = derivedFk;
       } else if (constraints.includes(derivedFk)) {
-        ownerFk = constraints;
+        // Mirrors Reflection#deriveFkQueryConstraints (reflection.ts:573):
+        // when the derived FK is itself one of the constraint columns, the
+        // FK is just that scalar — the remaining constraints come from
+        // scope chains, not the join FK.
+        ownerFk = derivedFk;
       } else {
         // Mirror Reflection#deriveFkQueryConstraints validation
         // (reflection.ts:555-571): only 2-column constraints are derivable,
@@ -1366,6 +1370,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           return { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue };
         })()
       : this._throughOwnerAttrs(throughAssoc, ctor);
+    // Guard against unsaved owners / missing composite components — otherwise
+    // findBy({fk: null}) would translate to IS NULL and could destroy an
+    // orphan join row. Mirrors the short-circuits in _buildThroughScope and
+    // _deleteThroughAllSql.
+    const polyIdValue = throughAs ? (ownerConditions as any)[`${underscore(throughAs)}_id`] : null;
+    if (throughAs ? polyIdValue == null : Object.values(ownerConditions).some((v) => v == null)) {
+      return;
+    }
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1027,8 +1027,28 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     ctor: typeof Base,
   ): { fkCols: string[]; pkCols: string[] } {
     const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-    const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
+    // Mirror Reflection#activeRecordPrimaryKey (reflection.ts:780-796): an
+    // explicit primaryKey wins, otherwise queryConstraints wins, otherwise
+    // a composite PK that includes "id" collapses to "id" when no query
+    // constraints are involved. Rails uses this same resolution inside
+    // `construct_join_attributes` (through_association.rb).
     const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+    let ownerPk: string | string[];
+    if (throughAssoc.options.primaryKey !== undefined) {
+      ownerPk = throughAssoc.options.primaryKey;
+    } else if (throughAssoc.options.queryConstraints) {
+      ownerPk = throughAssoc.options.queryConstraints;
+    } else if (
+      // Rails' id-collapse: a scalar FK against a composite PK that includes
+      // "id" pairs with the scalar "id" column (reflection.ts:791-793).
+      fkCols.length === 1 &&
+      Array.isArray(ctor.primaryKey) &&
+      ctor.primaryKey.includes("id")
+    ) {
+      ownerPk = "id";
+    } else {
+      ownerPk = ctor.primaryKey as string | string[];
+    }
     const pkCols = Array.isArray(ownerPk) ? ownerPk : [ownerPk as string];
     if (fkCols.length !== pkCols.length) {
       throw new Error(
@@ -1827,8 +1847,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughModelAssocs.find((a) => a.name === pluralize(sourceName));
 
     const throughAs = throughAssoc.options.as;
-    const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const ownerPkCols = Array.isArray(ownerPk) ? ownerPk : [ownerPk as string];
+    // For polymorphic through we can't run the FK/PK pair check (the FK
+    // shape is the polymorphic _id/_type pair, not the owner key). For the
+    // canonical through path, defer to the helper so resolution matches
+    // Reflection#activeRecordPrimaryKey.
+    const ownerPkCols = throughAs
+      ? (() => {
+          const pk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
+          return Array.isArray(pk) ? pk : [pk as string];
+        })()
+      : this._throughOwnerCols(throughAssoc, ctor).pkCols;
     const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
     if (ownerPkValues.some((v) => v == null)) return (targetModel as any).all().none();
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1015,6 +1015,42 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
   }
 
+  /**
+   * Resolve the composite-aware owner FK / PK column pairs for a through
+   * association, raising on length mismatch. Mirrors how Rails relies on
+   * `Array(association_primary_key)` matching the reflection's foreign key
+   * shape inside `construct_join_attributes` (through_association.rb).
+   * @internal
+   */
+  private _throughOwnerCols(
+    throughAssoc: AssociationDefinition,
+    ctor: typeof Base,
+  ): { fkCols: string[]; pkCols: string[] } {
+    const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
+    const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
+    const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
+    const pkCols = Array.isArray(ownerPk) ? ownerPk : [ownerPk as string];
+    if (fkCols.length !== pkCols.length) {
+      throw new Error(
+        `Composite primaryKey/foreignKey mismatch on through "${this._assocName}": ${pkCols.length} pk vs ${fkCols.length} fk`,
+      );
+    }
+    return { fkCols, pkCols };
+  }
+
+  /** @internal Builds an FK→ownerPkValue map for join-row WHERE/INSERT shapes. */
+  private _throughOwnerAttrs(
+    throughAssoc: AssociationDefinition,
+    ctor: typeof Base,
+  ): Record<string, unknown> {
+    const { fkCols, pkCols } = this._throughOwnerCols(throughAssoc, ctor);
+    const attrs: Record<string, unknown> = {};
+    for (let i = 0; i < fkCols.length; i++) {
+      attrs[fkCols[i]] = this._record._readAttribute(pkCols[i]);
+    }
+    return attrs;
+  }
+
   private async _pushThrough(records: T[], skipCallbacks = false, bang = false): Promise<void> {
     const ctor = this._record.constructor as typeof Base;
     const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
@@ -1028,19 +1064,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-    const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
-    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
-    if (ownerFkCols.length !== ownerPkCols.length) {
-      throw new Error(
-        `Composite primaryKey/foreignKey mismatch on through "${this._assocName}": ${ownerPkCols.length} pk vs ${ownerFkCols.length} fk`,
-      );
-    }
-    const ownerJoinAttrs: Record<string, unknown> = {};
-    for (let i = 0; i < ownerFkCols.length; i++) {
-      ownerJoinAttrs[ownerFkCols[i]] = this._record._readAttribute(ownerPkCols[i]);
-    }
+    const { fkCols: ownerFkCols } = this._throughOwnerCols(throughAssoc, ctor);
+    const ownerJoinAttrs = this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 
@@ -1212,14 +1237,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-    const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
-    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
-    const ownerConditions: Record<string, unknown> = {};
-    for (let i = 0; i < ownerFkCols.length; i++) {
-      ownerConditions[ownerFkCols[i]] = this._record._readAttribute(ownerPkCols[i]);
-    }
+    const ownerConditions = this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
 
@@ -1253,23 +1271,20 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const throughClassName =
       throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
     const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const ownerPkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
-    const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
-    if (ownerPkValues.some((v) => v == null)) return 0;
     const throughAs = throughAssoc.options.as;
-    const conditions: Record<string, unknown> = {};
+    const conditions: Record<string, unknown> = throughAs
+      ? {}
+      : this._throughOwnerAttrs(throughAssoc, ctor);
+    if (Object.values(conditions).some((v) => v == null)) return 0;
     if (throughAs) {
       // Polymorphic through uses a single _id/_type pair; composite-PK owners
       // are not representable in that schema, so use the first PK column.
-      conditions[`${underscore(throughAs)}_id`] = ownerPkValues[0];
+      const primaryKey = throughAssoc.options.primaryKey ?? ctor.primaryKey;
+      const firstPk = Array.isArray(primaryKey) ? primaryKey[0] : (primaryKey as string);
+      const pkValue = this._record._readAttribute(firstPk);
+      if (pkValue == null) return 0;
+      conditions[`${underscore(throughAs)}_id`] = pkValue;
       conditions[`${underscore(throughAs)}_type`] = ctor.name;
-    } else {
-      const ownerFk = throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`;
-      const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
-      for (let i = 0; i < ownerFkCols.length; i++) {
-        conditions[ownerFkCols[i]] = ownerPkValues[i];
-      }
     }
     if (this._assocDef.options.sourceType) {
       const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
@@ -1812,12 +1827,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughModelAssocs.find((a) => a.name === pluralize(sourceName));
 
     const throughAs = throughAssoc.options.as;
-    const ownerFk = throughAs
-      ? (throughAssoc.options.foreignKey ?? `${underscore(throughAs)}_id`)
-      : (throughAssoc.options.foreignKey ?? `${underscore(ctor.name)}_id`);
     const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
     const ownerPkCols = Array.isArray(ownerPk) ? ownerPk : [ownerPk as string];
-    const ownerFkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
     const ownerPkValues = ownerPkCols.map((c) => this._record._readAttribute(c));
     if (ownerPkValues.some((v) => v == null)) return (targetModel as any).all().none();
 
@@ -1828,10 +1839,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Build the through table subquery — AND together each (fk = pkValue) pair.
     let throughSubquery = throughTable.from();
     if (throughAs) {
-      throughSubquery = throughSubquery.where(
-        throughTable.get(ownerFkCols[0]).eq(ownerPkValues[0]),
-      );
+      // Polymorphic through: single _id/_type pair, composite-PK owners use
+      // first PK column (the schema is not representable with composite owner).
+      const polyFk = throughAssoc.options.foreignKey ?? `${underscore(throughAs)}_id`;
+      const polyFkCol = Array.isArray(polyFk) ? polyFk[0] : polyFk;
+      throughSubquery = throughSubquery.where(throughTable.get(polyFkCol).eq(ownerPkValues[0]));
     } else {
+      const { fkCols: ownerFkCols } = this._throughOwnerCols(throughAssoc, ctor);
       for (let i = 0; i < ownerFkCols.length; i++) {
         throughSubquery = throughSubquery.where(
           throughTable.get(ownerFkCols[i]).eq(ownerPkValues[i]),


### PR DESCRIPTION
## Summary

Drops the composite-ownerFk / composite-PK guards in `_pushThrough`, `_deleteThrough`, `_deleteThroughAllSql`, and `_buildThroughScope` (`collection-proxy.ts`), replacing each with a loop that pairs each ownerFk column with its `primaryKey` counterpart. Mirrors Rails' `construct_join_attributes` shape in `vendor/rails/activerecord/lib/active_record/associations/through_association.rb`.

Unblocks the 3 tests deferred from #1701 (Associations-core cluster, Composite-FK autosave followups):

- `append composite has many through association`
- `append composite has many through association with autosave`
- `nullify composite has many through association`

A new `_throughOwnerCols` / `_throughOwnerAttrs` / `_throughOwnerPolymorphic` helper trio centralizes owner-key resolution and mirrors `Reflection#activeRecordPrimaryKey` and `Reflection#deriveFkQueryConstraints` (reflection.ts:520-585, :780-796): class-level `queryConstraints`, the `id`-collapse rule, the `>2 constraints` and `missing scalar PK` validations, and the unresolvable-composite throw all match.

Polymorphic-through paths share `_throughOwnerPolymorphic` so write/read/deleteAll/single-delete all target the same `<as>_id`/`<as>_type` columns, and a composite polymorphic `foreignKey` raises `ConfigurationError`.

## Remaining concern (Copilot review #9 — stopped iterating after 9 cycles)

> When the through association supplies `options.queryConstraints`, those columns are the join-table foreign-key columns. This branch also uses the same `queryConstraints` array as the owner PK columns, so `_throughOwnerAttrs` reads join-table column names from the owner record.

This affects the case where the through association has an explicit `options.queryConstraints` (overriding the FK) but no `options.primaryKey`. The helper currently uses the same column list for both sides, which would read non-existent attributes off the owner. The pre-existing code prior to this PR did not handle this case either (it used `throughAssoc.options.primaryKey ?? ctor.primaryKey` for the PK and threw on composite). No tests exercise this path. Belongs to a follow-up that wires the full Reflection lookup chain (owner reflection's `joinPrimaryKey`/`joinForeignKey`) into the through write path, rather than re-deriving inside `CollectionProxy`.

## Test plan

- [x] `pnpm vitest run -t "composite has many through" packages/activerecord/src/associations.test.ts` — 4 passed
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/collection-proxy.test.ts` — 412 passed, no regressions
- [x] `tsc --build` clean (husky)
