### PR TITLE
fix(activerecord): STI table-name inheritance for subclasses without _tableName

### DIFF
--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -104,7 +104,6 @@ describe("CallbacksTest", () => {
     await defineSchema(adapter, {
       people: { name: "string" },
       animals: { name: "string", type: "string" },
-      dogs: { name: "string" },
       topics: { title: "string" },
       cb_posts: { title: "string" },
     });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -8,7 +8,7 @@ import {
   typeRegistry,
   type Type,
 } from "@blazetrails/activemodel";
-import { isStiSubclass, getStiBase } from "./inheritance.js";
+import { isStiSubclass, getStiBase, isBaseClass, baseClass } from "./inheritance.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 
@@ -32,8 +32,11 @@ import { isWrappedType } from "./encryption/wrapped-type.js";
  */
 export function resolveTableName(this: typeof Base): string {
   if ((this as any)._tableName != null) return (this as any)._tableName;
-  if (isStiSubclass(this)) {
-    return resolveTableName.call(getStiBase(this));
+  // Rails compute_table_name: non-base subclasses always use base_class.table_name.
+  // This covers both STI hierarchies and any subclass of a non-abstract AR model.
+  if (!isBaseClass(this)) {
+    const base = baseClass.call(this);
+    if (base !== this) return resolveTableName.call(base);
   }
   const prefix = (this as any)._tableNamePrefix ?? "";
   const suffix = (this as any)._tableNameSuffix ?? "";

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -523,7 +523,7 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       topics: { title: "string", content: "string" },
-      very_important_topics: { title: "string", content: "string" },
+      important_topics: { title: "string", content: "string" },
     });
   });
 


### PR DESCRIPTION
## Summary

Mirror Rails' `compute_table_name` (model_schema.rb:606): any non-`base_class?` subclass uses `base_class.table_name`. Previously `resolveTableName` only inherited the parent's table when the parent had `_inheritanceColumn` explicitly set (via `enableSti`/`inheritanceColumn=`), so `class Dog extends Animal` (Animal concrete, no `enableSti` call) inferred `dogs` instead of `animals`.

Rails treats table-name inheritance as the default for any concrete subclass — STI's `type` column is for row-level type dispatch and is orthogonal to which table is used. `base_class` is already computed correctly via `setBaseClass` (mirrors `inheritance.rb:270`), so `resolveTableName` just needed to use it.

## Changes

- `packages/activerecord/src/model-schema.ts` — `resolveTableName` recurses into `baseClass` when `!isBaseClass(this)`, instead of only when `isStiSubclass(this)`.
- `packages/activerecord/src/callbacks.test.ts` — drop the `dogs` workaround table added in #1697; the `inheritance of callbacks` test now correctly resolves `Dog.tableName === "animals"`.
- `packages/activerecord/src/serialized-attribute.test.ts` — replace `very_important_topics` workaround table with `important_topics`; `class VeryImportantTopic extends ImportantTopic` now resolves to the base's table per Rails.

## Verification

- `pnpm vitest run` on callbacks, inherited, serialized-attribute, inheritance, core, base, associations, persistence, querying, attribute-methods, i18n: all green (1647 passed / 57 skipped).
- `git diff --shortstat`: 3 files, +7 −5.

## Test plan

- [ ] CI green across PG / MySQL / SQLite