### PR TITLE
feat(activerecord): batch 13 — delegatedType followups

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -60,7 +60,13 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    */
   protected override replace(record: Base | null): void {
     const typeCol = this.foreignTypeName();
-    const typeName = record ? (record.constructor as any).name : null;
+    // Rails: writes record.class.polymorphic_name, which is the Ruby class
+    // name (including "::" for namespaced classes). The closest equivalent
+    // is the registry key the class was registered under — JS class names
+    // can't contain "::", so plain `constructor.name` would clobber values
+    // like "Access::NoticeMessage" into "AccessNoticeMessage".
+    const ctor = record ? (record.constructor as { name: string; _registryKeys?: string[] }) : null;
+    const typeName = ctor ? (ctor._registryKeys?.[0] ?? ctor.name) : null;
     if (typeof (this.owner as any)._writeAttribute === "function") {
       (this.owner as any)._writeAttribute(typeCol, typeName);
     } else {

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
-import { resolveModel, loadBelongsTo } from "../associations.js";
+import { resolveModel, loadBelongsTo, modelRegistry } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { BelongsToAssociation } from "./belongs-to-association.js";
 
@@ -61,12 +61,17 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   protected override replace(record: Base | null): void {
     const typeCol = this.foreignTypeName();
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
-    // name (including "::" for namespaced classes). The closest equivalent
-    // is the registry key the class was registered under — JS class names
-    // can't contain "::", so plain `constructor.name` would clobber values
-    // like "Access::NoticeMessage" into "AccessNoticeMessage".
-    const ctor = record ? (record.constructor as { name: string; _registryKeys?: string[] }) : null;
-    const typeName = ctor ? (ctor._registryKeys?.[0] ?? ctor.name) : null;
+    // name (including "::" for namespaced classes). JS class names can't
+    // contain "::", so deriving purely from `constructor.name` would
+    // clobber values like "Access::NoticeMessage" into "AccessNoticeMessage".
+    // Prefer a registered registry key for this class — using the same
+    // selection as MacroReflection#activeRecordRegistryName:
+    //   1. If the owner already has a *_type matching one of this class's
+    //      registry keys, preserve it (so delegated_type round-trips the
+    //      exact configured type string).
+    //   2. Otherwise pick the most deeply namespaced registry key.
+    //   3. Otherwise fall back to constructor.name.
+    const typeName = record ? this.polymorphicTypeName(record) : null;
     if (typeof (this.owner as any)._writeAttribute === "function") {
       (this.owner as any)._writeAttribute(typeCol, typeName);
     } else {
@@ -85,6 +90,27 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    */
   private foreignTypeName(): string {
     return `${underscore(this.reflection.name)}_type`;
+  }
+
+  /**
+   * Mirror of MacroReflection#activeRecordRegistryName plus a
+   * "preserve existing value" rule: when the owner already stores a
+   * foreign_type that points to this record's class, keep it (covers
+   * delegated_type round-trips where the configured type string is the
+   * source of truth). Otherwise prefer the most deeply namespaced
+   * registry key, falling back to constructor.name.
+   */
+  private polymorphicTypeName(record: Base): string {
+    const ctor = record.constructor as { name: string; _registryKeys?: string[] };
+    const matching = (ctor._registryKeys ?? []).filter((k) => modelRegistry.get(k) === ctor);
+    if (matching.length > 0) {
+      const existing = this.readForeignType();
+      if (existing && matching.includes(existing)) return existing;
+      return matching.reduce((best, k) =>
+        (k.match(/::/g) ?? []).length > (best.match(/::/g) ?? []).length ? k : best,
+      );
+    }
+    return ctor.name;
   }
 
   private readForeignType(): string | null {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -250,6 +250,35 @@ describe("DelegatedTypeTest", () => {
     expect((e as any).accessNoticeMessageId).toBe(7);
   });
 
+  it("buildEntryable preserves namespaced foreign_type", () => {
+    // Rails BelongsToPolymorphicAssociation stores record.class.polymorphic_name
+    // (the Ruby class name, including "::"). JS class names can't carry "::",
+    // so the writer must prefer the registry key the class was registered
+    // under — otherwise buildEntryable on a namespaced type clobbers
+    // entryable_type from "Access::NoticeMessage" to "AccessNoticeMessage"
+    // and breaks the generated predicates/scope/accessor.
+    class AccessNoticeMessage extends Base {
+      static {
+        this.attribute("body", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Access::NoticeMessage", AccessNoticeMessage);
+    class Entry4 extends Base {
+      static {
+        this.attribute("entryable_id", "integer");
+        this.attribute("entryable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    delegatedType(Entry4, "entryable", { types: ["Access::NoticeMessage"] });
+    const e = new Entry4({ entryable_type: "Access::NoticeMessage" });
+    const built = (e as any).buildEntryable({ body: "hi" });
+    expect(built).toBeInstanceOf(AccessNoticeMessage);
+    expect(e.entryable_type).toBe("Access::NoticeMessage");
+    expect((e as any).isAccessNoticeMessage()).toBe(true);
+  });
+
   it("registers a polymorphic belongs_to for the delegated role", () => {
     const { Entry } = makeModels();
     const reflection = Entry._reflectOnAssociation("entryable");

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -231,6 +231,10 @@ describe("DelegatedTypeTest", () => {
     const built = (e as any).buildEntryable({ subject: "hi" });
     expect(built).toBeInstanceOf(Message);
     expect(built.subject).toBe("hi");
+    // Writer side-effects: role association is set and reads back as the
+    // same instance, foreign_type is preserved by the polymorphic writer.
+    expect((e as any).entryable).toBe(built);
+    expect(e.entryable_type).toBe("Message");
   });
 
   it("namespaced types", () => {
@@ -243,11 +247,24 @@ describe("DelegatedTypeTest", () => {
         this.adapter = adapter;
       }
     }
+    class NoticeMsg extends Base {
+      static {
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Access::NoticeMessage", NoticeMsg);
     delegatedType(Entry3, "entryable", { types: ["Access::NoticeMessage"] });
     expect(typeof (Entry3 as any).accessNoticeMessages).toBe("function");
     const e = new Entry3({ entryable_type: "Access::NoticeMessage", entryable_id: 7 });
     expect((e as any).isAccessNoticeMessage()).toBe(true);
     expect((e as any).accessNoticeMessageId).toBe(7);
+    // The per-type singular accessor mirrors Rails: returns the role
+    // association reader when the foreign_type matches, otherwise null.
+    const target = new NoticeMsg();
+    (e as any).entryable = target;
+    expect((e as any).accessNoticeMessage).toBe(target);
+    // entryableName also tracks the full namespaced form.
+    expect(String((e as any).entryableName)).toBe("access_notice_message");
   });
 
   it("buildEntryable preserves namespaced foreign_type", () => {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -3,7 +3,8 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
-import { Base, delegatedType } from "./index.js";
+import { Base, delegatedType, registerModel } from "./index.js";
+import { StringInquirer } from "@blazetrails/activesupport";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -81,7 +82,12 @@ describe("DelegatedTypeTest", () => {
   it("delegated type name", () => {
     const { Entry } = makeModels();
     const e = new Entry({ entryable_type: "Message", entryable_id: 1 });
-    expect((e as any).entryableName).toBe("message");
+    // Rails: entryable_name is an ActiveSupport::StringInquirer so
+    // `entryable_name.message?` works in addition to string equality.
+    expect(String((e as any).entryableName)).toBe("message");
+    expect((e as any).entryableName).toBeInstanceOf(StringInquirer);
+    expect((e as any).entryableName.message()).toBe(true);
+    expect((e as any).entryableName.comment()).toBe(false);
   });
 
   it("delegated type predicates", () => {
@@ -140,9 +146,20 @@ describe("DelegatedTypeTest", () => {
   });
 
   it("accessor", () => {
+    // Rails: @entry.message returns the associated record (a Message
+    // instance) via the polymorphic belongs_to accessor, not the FK value.
+    class Message extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Message", Message);
     const { Entry } = makeModels();
     const e = new Entry({ entryable_type: "Message", entryable_id: 42 });
-    expect((e as any).message).toBe(42);
+    const msg = new Message({ id: 42 });
+    (e as any).entryable = msg;
+    expect((e as any).message).toBe(msg);
     expect((e as any).comment).toBeNull();
   });
 
@@ -199,11 +216,38 @@ describe("DelegatedTypeTest", () => {
   });
 
   it("builder method", () => {
+    // Rails: Entry.new(entryable_type: "Message").build_entryable returns
+    // a Message instance — the role-level builder dispatches on the
+    // currently-set foreign_type rather than baking the type into the name.
+    class Message extends Base {
+      static {
+        this.attribute("subject", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Message", Message);
     const { Entry } = makeModels();
-    const e = new Entry({ title: "test" });
-    (e as any).buildMessage({ entryable_id: 5 });
-    expect(e.entryable_type).toBe("Message");
-    expect(e.entryable_id).toBe(5);
+    const e = new Entry({ entryable_type: "Message" });
+    const built = (e as any).buildEntryable({ subject: "hi" });
+    expect(built).toBeInstanceOf(Message);
+    expect(built.subject).toBe("hi");
+  });
+
+  it("namespaced types", () => {
+    // Rails: types: %w[Access::NoticeMessage] generates Entry.access_notice_messages
+    // scope and @entry.access_notice_message accessor via type.tableize.tr("/", "_").
+    class Entry3 extends Base {
+      static {
+        this.attribute("entryable_id", "integer");
+        this.attribute("entryable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    delegatedType(Entry3, "entryable", { types: ["Access::NoticeMessage"] });
+    expect(typeof (Entry3 as any).accessNoticeMessages).toBe("function");
+    const e = new Entry3({ entryable_type: "Access::NoticeMessage", entryable_id: 7 });
+    expect((e as any).isNoticeMessage()).toBe(true);
+    expect((e as any).accessNoticeMessageId).toBe(7);
   });
 
   it("registers a polymorphic belongs_to for the delegated role", () => {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -246,7 +246,7 @@ describe("DelegatedTypeTest", () => {
     delegatedType(Entry3, "entryable", { types: ["Access::NoticeMessage"] });
     expect(typeof (Entry3 as any).accessNoticeMessages).toBe("function");
     const e = new Entry3({ entryable_type: "Access::NoticeMessage", entryable_id: 7 });
-    expect((e as any).isNoticeMessage()).toBe(true);
+    expect((e as any).isAccessNoticeMessage()).toBe(true);
     expect((e as any).accessNoticeMessageId).toBe(7);
   });
 

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -39,7 +39,7 @@ const delegatedTypeRegistry = new WeakMap<
  *   });
  *
  * This adds:
- *   - entry.entryableClass         → the class of the delegated type
+ *   - entry.entryableClass         → current foreign_type string (Rails-divergence: Rails returns the constantized class; pre-existing from #1583)
  *   - entry.entryableName          → StringInquirer (e.g. inquiry("message"))
  *   - entry.isMessage()            → type predicate
  *   - entry.isComment()            → type predicate

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
-import { camelize, underscore } from "@blazetrails/activesupport";
+import { camelize, inquiry, singularize, tableize, underscore } from "@blazetrails/activesupport";
+import { resolveModel } from "./associations.js";
 
 /**
  * Configuration for a delegated type.
@@ -97,22 +98,55 @@ export function delegatedType(
     configurable: true,
   });
 
-  // Add instance method: delegatedName (e.g. entryableName)
+  // Add instance method: delegatedName (e.g. entryableName).
+  // Rails: public_send("#{role}_class").model_name.singular.inquiry — returns
+  // an ActiveSupport::StringInquirer so callers can do entryable_name.message?
   Object.defineProperty(modelClass.prototype, `${role}Name`, {
     get(this: Base) {
       const typeName = this.readAttribute(foreignType) as string | null;
       if (!typeName) return null;
-      return typeName.toLowerCase().replace(/.*::/, "");
+      const singular = underscore(typeName.replace(/.*::/, ""));
+      return inquiry(singular);
     },
     configurable: true,
   });
 
-  // For each type, add predicates, scopes, accessors, and builder methods
-  for (const typeName of options.types) {
-    const snakeName = underscore(typeName);
+  // Role-level builder: entry.buildEntryable(attrs) builds a new record of
+  // the currently-set foreign_type and assigns it via the polymorphic
+  // belongs_to writer (which also fills foreign_type/foreign_key).
+  // Rails: define_method "build_#{role}" { |*params| public_send("#{role}=", public_send("#{role}_class").new(*params)) }
+  Object.defineProperty(modelClass.prototype, `build${camelize(role, true)}`, {
+    value: function (this: Base, attrs: Record<string, unknown> = {}): Base {
+      const typeName = this.readAttribute(foreignType) as string | null;
+      if (!typeName) {
+        throw new Error(`Cannot build${camelize(role, true)}: ${foreignType} is not set`);
+      }
+      const TargetClass = resolveModel(typeName);
+      const instance = new (TargetClass as unknown as new (a: Record<string, unknown>) => Base)(
+        attrs,
+      );
+      (this as unknown as Record<string, unknown>)[role] = instance;
+      return instance;
+    },
+    writable: true,
+    configurable: true,
+  });
 
-    // Type predicate: isMessage(), isComment()
-    Object.defineProperty(modelClass.prototype, `is${typeName}`, {
+  // For each type, add predicates, scopes, and accessors.
+  // Rails: scope_name = type.tableize.tr("/", "_"); singular = scope_name.singularize
+  // Namespaced types like "Access::NoticeMessage" tableize to "access/notice_messages",
+  // then "/" → "_" gives "access_notice_messages" (a valid scope/method name).
+  for (const typeName of options.types) {
+    const scopeSnake = tableize(typeName).replace(/\//g, "_");
+    const singularSnake = singularize(scopeSnake);
+    const scopeName = camelize(scopeSnake, false);
+    const singularName = camelize(singularSnake, false);
+    // Predicate name preserves the original CamelCase tail: is${demodulized}().
+    // e.g. "Access::NoticeMessage" → isNoticeMessage()
+    const predicateSuffix = typeName.replace(/.*::/, "");
+
+    // Type predicate: isMessage(), isAccessNoticeMessage()
+    Object.defineProperty(modelClass.prototype, `is${predicateSuffix}`, {
       value: function (this: Base): boolean {
         return this.readAttribute(foreignType) === typeName;
       },
@@ -120,11 +154,8 @@ export function delegatedType(
       configurable: true,
     });
 
-    // Also add a snake_case predicate style: message?, comment? → we use isX
-
-    // Scope: Model.messages(), Model.comments()
-    const pluralName = snakeName + "s";
-    Object.defineProperty(modelClass, pluralName, {
+    // Scope: Model.messages(), Model.accessNoticeMessages()
+    Object.defineProperty(modelClass, scopeName, {
       value: function (this: typeof Base) {
         return this.where({ [foreignType]: typeName });
       },
@@ -132,37 +163,25 @@ export function delegatedType(
       configurable: true,
     });
 
-    // Accessor: entry.message → returns the FK value if type matches
-    Object.defineProperty(modelClass.prototype, snakeName, {
+    // Accessor: entry.message → returns the associated record via the
+    // polymorphic belongs_to reader when type matches, otherwise null.
+    // Rails: define_method(singular) { public_send(role) if public_send(query) }
+    Object.defineProperty(modelClass.prototype, singularName, {
       get(this: Base) {
         if (this.readAttribute(foreignType) !== typeName) return null;
-        return this.readAttribute(foreignKey);
+        return (this as unknown as Record<string, unknown>)[role];
       },
       configurable: true,
     });
 
-    // FK accessor: entry.messageId (or entry.uuidMessageUuid for UUID PKs) → returns FK if type matches
-    // Mirrors Rails' define_method("#{singular}_#{primary_key}") { public_send(role_id) if public_send(query) }
-    // Name is camelCase of `${snakeName}_${primaryKey}` (e.g. "message_id" → "messageId").
-    const fkAccessorName = camelize(`${snakeName.replace(/\//g, "_")}_${primaryKey}`, false);
+    // FK accessor: entry.messageId (or entry.uuidMessageUuid for UUID PKs).
+    // Rails: define_method("#{singular}_#{primary_key}") { public_send(role_id) if public_send(query) }
+    const fkAccessorName = camelize(`${singularSnake}_${primaryKey}`, false);
     Object.defineProperty(modelClass.prototype, fkAccessorName, {
       get(this: Base) {
         if (this.readAttribute(foreignType) !== typeName) return null;
         return this.readAttribute(foreignKey);
       },
-      configurable: true,
-    });
-
-    // Builder method: entry.buildMessage(attrs) → sets type and returns
-    Object.defineProperty(modelClass.prototype, `build${typeName}`, {
-      value: function (this: Base, attrs: Record<string, unknown> = {}): Base {
-        this.writeAttribute(foreignType, typeName);
-        for (const [k, v] of Object.entries(attrs)) {
-          this.writeAttribute(k, v);
-        }
-        return this;
-      },
-      writable: true,
       configurable: true,
     });
   }

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -39,14 +39,14 @@ const delegatedTypeRegistry = new WeakMap<
  *   });
  *
  * This adds:
- *   - entry.entryableClass      → the class of the delegated type
- *   - entry.entryableName       → lowercase type name (e.g. "message")
- *   - entry.isMessage()         → type predicate
- *   - entry.isComment()         → type predicate
- *   - Entry.messages()          → scope (returns Relation)
- *   - Entry.comments()          → scope (returns Relation)
- *   - entry.message             → accessor (returns the associated record)
- *   - entry.buildMessage(attrs) → builder method
+ *   - entry.entryableClass         → the class of the delegated type
+ *   - entry.entryableName          → StringInquirer (e.g. inquiry("message"))
+ *   - entry.isMessage()            → type predicate
+ *   - entry.isComment()            → type predicate
+ *   - Entry.messages()             → scope (returns Relation)
+ *   - Entry.comments()             → scope (returns Relation)
+ *   - entry.message                → accessor (associated record via belongs_to)
+ *   - entry.buildEntryable(attrs)  → role-level builder for the current type
  */
 export function delegatedType(
   modelClass: typeof Base,
@@ -105,7 +105,9 @@ export function delegatedType(
     get(this: Base) {
       const typeName = this.readAttribute(foreignType) as string | null;
       if (!typeName) return null;
-      const singular = underscore(typeName.replace(/.*::/, ""));
+      // Rails: model_name.singular == name.underscore.tr("/", "_").
+      // "Access::NoticeMessage" → "access/notice_message" → "access_notice_message".
+      const singular = underscore(typeName).replace(/\//g, "_");
       return inquiry(singular);
     },
     configurable: true,
@@ -141,9 +143,9 @@ export function delegatedType(
     const singularSnake = singularize(scopeSnake);
     const scopeName = camelize(scopeSnake, false);
     const singularName = camelize(singularSnake, false);
-    // Predicate name preserves the original CamelCase tail: is${demodulized}().
-    // e.g. "Access::NoticeMessage" → isNoticeMessage()
-    const predicateSuffix = typeName.replace(/.*::/, "");
+    // Predicate camelizes the singular scope name so it tracks Rails' query
+    // method (which is "#{singular}?"). "Access::NoticeMessage" → isAccessNoticeMessage().
+    const predicateSuffix = camelize(singularSnake, true);
 
     // Type predicate: isMessage(), isAccessNoticeMessage()
     Object.defineProperty(modelClass.prototype, `is${predicateSuffix}`, {

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -99,8 +99,13 @@ export function delegatedType(
   });
 
   // Add instance method: delegatedName (e.g. entryableName).
-  // Rails: public_send("#{role}_class").model_name.singular.inquiry — returns
-  // an ActiveSupport::StringInquirer so callers can do entryable_name.message?
+  // Rails: public_send("#{role}_class").model_name.singular.inquiry —
+  // returns an ActiveSupport::StringInquirer so callers can do
+  // entryable_name.message?. We derive the same string value directly from
+  // foreign_type (underscore + tr("/","_"), matching ModelName#singular)
+  // rather than routing through `${role}Class`, which currently returns
+  // the foreign_type string instead of the constantized class (Rails
+  // divergence pre-existing from #1583).
   Object.defineProperty(modelClass.prototype, `${role}Name`, {
     get(this: Base) {
       const typeName = this.readAttribute(foreignType) as string | null;


### PR DESCRIPTION
## Summary

Brings `delegated_type` closer to Rails parity following the initial wiring in #1583. Four small follow-ups:

- **`entry.message` accessor returns the associated record.** Now calls the polymorphic `belongs_to` reader via `(this as any)[role]` when the type matches, mirroring Rails `public_send(role) if public_send(query)`, instead of the raw foreign-key value.
- **Role-level `build${Role}` builder.** Adds `entry.buildEntryable(attrs)` matching Rails `define_method "build_#{role}"`, which resolves the registered model class for the currently-set foreign_type and assigns the new instance through the polymorphic writer. The per-type `build${Type}` (a Trails invention not present in Rails) is removed.
- **Namespaced types generate valid JS identifiers.** Scope / per-type accessor / predicate / FK names derive from `type.tableize.tr("/", "_")`, so `Access::NoticeMessage` yields `Entry.accessNoticeMessages()`, `entry.accessNoticeMessage`, `entry.isAccessNoticeMessage()`, `entry.accessNoticeMessageId` (previously the raw slash-bearing string produced invalid properties). Predicate names mirror Rails' `"#{singular}?"` query method, derived from the camelized full singular scope name.
- **`entryableName` returns an `ActiveSupport::StringInquirer`** (Rails `#{role}_class.model_name.singular.inquiry`), so `entryable_name.message?` works in addition to string equality. The string value mirrors `ModelName#singular` (`name.underscore.tr("/", "_")`).

Also fixes a related Rails-divergence the Copilot review surfaced: the polymorphic `belongs_to` writer derived the stored `foreign_type` from `record.constructor.name`, which silently mangled namespaced classes like `"Access::NoticeMessage"` into `"AccessNoticeMessage"` (JS class names can't contain `::`). It now prefers the first `_registryKeys` entry (set by `registerModel`), matching Rails' `record.class.polymorphic_name`.

## Out of scope

`entry.entryableClass` still returns the foreign_type string instead of the constantized class (Rails returns the class). That's pre-existing from #1583 and not part of this batch.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/delegated-type.test.ts` — 15 pass, 1 pre-existing skip
- [x] Test bodies for `accessor`, `builder method`, `delegated type name` updated to assert Rails behavior; test names preserved per CLAUDE.md.
- [x] Added `namespaced types`, `buildEntryable preserves namespaced foreign_type` regression coverage.
- [x] `pnpm run api:compare --package activerecord`: `delegated_type.rb` 2/2 (100%); overall AR 4956/4958.