### PR TITLE
feat(activerecord): batch 12 — insert-all conflict-target capability + IndexDefinition

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -273,6 +273,19 @@ export interface DatabaseAdapter {
   readonly schemaCache?: SchemaCache;
 
   /**
+   * Pool-bound schema cache reflection. Returns a one-arg `indexes(tableName)`
+   * form so call sites don't need to know about the connection pool. On
+   * pool-backed adapters this delegates to the pool's BoundSchemaReflection;
+   * on standalone adapters it wraps the adapter as a fake pool.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#schema_cache
+   * (Rails' raw schema_cache already exposes a one-arg `indexes(tableName)`;
+   * our TS port splits the cache from the bound handle, so this getter is
+   * the Rails-shaped surface for call sites that just want to look things up.)
+   */
+  readonly schemaCacheBound?: import("./connection-adapters/schema-cache.js").BoundSchemaReflection;
+
+  /**
    * Returns the SchemaStatements wrapper that pairs with this adapter.
    * Adapter subclasses override this to return a dialect-specific subclass
    * (e.g. PostgreSQLSchemaStatements). Used by Migration.schema and
@@ -511,6 +524,15 @@ export interface DatabaseAdapter {
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#supports_indexes_in_create?
    */
   supportsIndexesInCreate?(): boolean;
+
+  /**
+   * Whether the adapter supports a conflict target in INSERT...ON CONFLICT.
+   * True for PostgreSQL and SQLite >= 3.24. MySQL's ON DUPLICATE KEY UPDATE
+   * has no conflict-target syntax, so this stays false there (matching Rails).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#supports_insert_conflict_target?
+   */
+  supportsInsertConflictTarget?(): boolean;
 
   /**
    * Set or clear the comment on a table after it has been created.

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -20,7 +20,7 @@ import {
 } from "../errors.js";
 import { Notifications } from "@blazetrails/activesupport";
 import { Result, type ColumnTypes } from "../result.js";
-import { SchemaCache } from "./schema-cache.js";
+import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
   TransactionManager,
@@ -759,6 +759,23 @@ export class AbstractAdapter implements Quoting {
       if (poolConfig) poolConfig.schemaCache = this._schemaCache;
     }
     return this._schemaCache;
+  }
+
+  /**
+   * One-arg `indexes(tableName)` form of the schema cache. Pool-backed
+   * adapters reuse the pool's BoundSchemaReflection; standalone adapters
+   * (tests, bare adapters) wrap themselves as the pool so SchemaCache
+   * methods that need a pool handle can still call back into this adapter.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#schema_cache
+   */
+  get schemaCacheBound(): BoundSchemaReflection {
+    const pool = this.pool as { schemaCache?: BoundSchemaReflection } | null;
+    if (pool?.schemaCache instanceof BoundSchemaReflection) return pool.schemaCache;
+    return BoundSchemaReflection.forLoneConnection(
+      new SchemaReflection(null, this.schemaCache),
+      this,
+    );
   }
 
   checkIfWriteQuery(sql: string): void {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -745,6 +745,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return this.databaseVersion.gte("3.24.0");
   }
 
+  override supportsInsertConflictTarget(): boolean {
+    return this.supportsInsertOnConflict();
+  }
+
   override supportsConcurrentConnections(): boolean {
     return !this._memoryDatabase;
   }

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -186,9 +186,21 @@ describe("InsertAllTest", () => {
     const adapter = freshAdapter();
     const Book = makeBook(adapter);
     const b = await Book.create({ title: "Existing", author: "Author" });
-    await Book.upsertAll([{ id: b.id, title: "Updated", author: "Author" }], { uniqueBy: "id" });
-    const found = await Book.find(b.id);
-    expect(found.title).toBe("Updated");
+    const supports = (
+      adapter as { supportsInsertConflictTarget?: () => boolean }
+    ).supportsInsertConflictTarget?.();
+    if (supports) {
+      await Book.upsertAll([{ id: b.id, title: "Updated", author: "Author" }], { uniqueBy: "id" });
+      const found = await Book.find(b.id);
+      expect(found.title).toBe("Updated");
+    } else {
+      // Rails parity: insert_all.rb#find_unique_index_for raises ArgumentError
+      // when :unique_by is given to an adapter without conflict-target support
+      // (MySQL's ON DUPLICATE KEY UPDATE has no conflict-target syntax).
+      await expect(
+        Book.upsertAll([{ id: b.id, title: "Updated", author: "Author" }], { uniqueBy: "id" }),
+      ).rejects.toThrow(/does not support :uniqueBy/);
+    }
   });
 
   it.skip("insert all raises on unknown attribute", async () => {

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1018,4 +1018,39 @@ describe("InsertAll async uniqueIndexes regression", () => {
       Pkg.upsertAll([{ name: "foo", sha: "abc123" }], { uniqueBy: ["sha", "name"] }),
     ).resolves.toBeGreaterThanOrEqual(0);
   });
+
+  it("upsertAll with partial unique index emits WHERE in conflict target", async () => {
+    const adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      flags: { key: "string", active: "boolean" },
+    });
+    const ss = new SchemaStatements(adapter);
+    await ss.addIndex("flags", ["key"], {
+      unique: true,
+      name: "idx_flags_key_active",
+      where: '"active" = 1',
+    });
+
+    class Flag extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("key", "string");
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+        this._tableName = "flags";
+      }
+    }
+
+    const captured: string[] = [];
+    const orig = adapter.executeMutation.bind(adapter);
+    (adapter as any).executeMutation = (sql: string, ...rest: unknown[]) => {
+      captured.push(sql);
+      return (orig as any)(sql, ...rest);
+    };
+
+    await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
+    const upsertSql = captured.find((s) => s.includes("ON CONFLICT"));
+    expect(upsertSql).toBeDefined();
+    expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active" = 1/);
+  });
 });

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -5,7 +5,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, defineEnum } from "./index.js";
 import { InsertAll } from "./insert-all.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { adapterType, createTestAdapter } from "./test-adapter.js";
+
+// Rails' insert_all_test.rb skips uniqueBy-dependent tests via
+// `skip unless supports_insert_conflict_target?`. MySQL's ON DUPLICATE KEY
+// UPDATE has no conflict-target syntax, so InsertAll raises when uniqueBy
+// is given — mirror Rails by skipping those tests on MySQL here.
+const supportsConflictTarget = adapterType !== "mysql";
+const itIfConflictTarget = supportsConflictTarget ? it : it.skip;
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
@@ -221,7 +228,7 @@ describe("InsertAllTest", () => {
     // BLOCKED: adapter-pg — insert_all.rb: RETURNING clause support
     /* needs RETURNING clause support */
   });
-  it("insert all skip duplicates", async () => {
+  itIfConflictTarget("insert all skip duplicates", async () => {
     const adapter = freshAdapter();
     const Book = makeBook(adapter);
     await Book.create({ title: "Existing", author: "Auth" });
@@ -247,7 +254,7 @@ describe("InsertAllTest", () => {
     const reloaded = await Book.find(b.id);
     expect(reloaded.title).toBe("Updated");
   });
-  it("upsert all with unique by", async () => {
+  itIfConflictTarget("upsert all with unique by", async () => {
     const adapter = freshAdapter();
     const Book = makeBook(adapter);
     await Book.create({ title: "Original", author: "Auth" });
@@ -533,26 +540,29 @@ describe("InsertAllTest", () => {
   it.skip("insert all and upsert all finds index with inverted unique by columns", () => {
     // BLOCKED: schema — insert_all.rb: inverted uniqueBy column order match
   });
-  it("insert all and upsert all works with composite primary keys when unique by is provided", async () => {
-    const adapter = freshAdapter();
-    class CpkOrder extends Base {
-      static {
-        this.attribute("shop_id", "integer");
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.primaryKey = ["shop_id", "id"];
-        this.adapter = adapter;
+  itIfConflictTarget(
+    "insert all and upsert all works with composite primary keys when unique by is provided",
+    async () => {
+      const adapter = freshAdapter();
+      class CpkOrder extends Base {
+        static {
+          this.attribute("shop_id", "integer");
+          this.attribute("id", "integer");
+          this.attribute("name", "string");
+          this.primaryKey = ["shop_id", "id"];
+          this.adapter = adapter;
+        }
       }
-    }
-    await CpkOrder.insertAll([{ shop_id: 1, id: 1, name: "first" }]);
-    await CpkOrder.upsertAll([{ shop_id: 1, id: 1, name: "second" }], {
-      uniqueBy: ["shop_id", "id"],
-    });
-    const count = await CpkOrder.count();
-    expect(count).toBe(1);
-    const record = (await CpkOrder.find([1, 1])) as CpkOrder;
-    expect(record.name).toBe("second");
-  });
+      await CpkOrder.insertAll([{ shop_id: 1, id: 1, name: "first" }]);
+      await CpkOrder.upsertAll([{ shop_id: 1, id: 1, name: "second" }], {
+        uniqueBy: ["shop_id", "id"],
+      });
+      const count = await CpkOrder.count();
+      expect(count).toBe(1);
+      const record = (await CpkOrder.find([1, 1])) as CpkOrder;
+      expect(record.name).toBe("second");
+    },
+  );
   it("insert all and upsert all works with composite primary keys when unique by is not provided", async () => {
     const adapter = freshAdapter();
     class CpkOrder extends Base {
@@ -1006,65 +1016,71 @@ describe("insertAll / upsertAll (Rails-guided)", () => {
 // Regression: upsertAll on returning DBs (cache miss path)
 // ==========================================================================
 describe("InsertAll async uniqueIndexes regression", () => {
-  it("upsertAll with uniqueBy succeeds when schema cache is cold (returning DB scenario)", async () => {
-    const adapter = createTestAdapter();
-    await defineSchema(adapter, { pkgs: { name: "string", sha: "string" } });
-    const ss = new SchemaStatements(adapter);
-    await ss.addIndex("pkgs", ["sha", "name"], { unique: true, name: "idx_pkgs_sha_name" });
+  itIfConflictTarget(
+    "upsertAll with uniqueBy succeeds when schema cache is cold (returning DB scenario)",
+    async () => {
+      const adapter = createTestAdapter();
+      await defineSchema(adapter, { pkgs: { name: "string", sha: "string" } });
+      const ss = new SchemaStatements(adapter);
+      await ss.addIndex("pkgs", ["sha", "name"], { unique: true, name: "idx_pkgs_sha_name" });
 
-    class Pkg extends Base {
-      static {
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.attribute("sha", "string");
-        this.adapter = adapter;
-        this._tableName = "pkgs";
+      class Pkg extends Base {
+        static {
+          this.attribute("id", "integer");
+          this.attribute("name", "string");
+          this.attribute("sha", "string");
+          this.adapter = adapter;
+          this._tableName = "pkgs";
+        }
       }
-    }
 
-    // Clear the cache to simulate a returning DB where migrateDb skipped createTable.
-    adapter.schemaCache?.clear();
+      // Clear the cache to simulate a returning DB where migrateDb skipped createTable.
+      adapter.schemaCache?.clear();
 
-    // Should succeed — async _uniqueIndexes() fetches from the live DB.
-    await expect(
-      Pkg.upsertAll([{ name: "foo", sha: "abc123" }], { uniqueBy: ["sha", "name"] }),
-    ).resolves.toBeGreaterThanOrEqual(0);
-  });
+      // Should succeed — async _uniqueIndexes() fetches from the live DB.
+      await expect(
+        Pkg.upsertAll([{ name: "foo", sha: "abc123" }], { uniqueBy: ["sha", "name"] }),
+      ).resolves.toBeGreaterThanOrEqual(0);
+    },
+  );
 
-  it("upsertAll with partial unique index emits WHERE in conflict target", async () => {
-    const adapter = createTestAdapter();
-    await defineSchema(adapter, {
-      flags: { key: "string", active: "boolean" },
-    });
-    const ss = new SchemaStatements(adapter);
-    // WHERE "active" works on both SQLite (1=true) and PG (boolean column).
-    // Avoid '"active" = 1' which PG rejects (boolean ≠ integer).
-    await ss.addIndex("flags", ["key"], {
-      unique: true,
-      name: "idx_flags_key_active",
-      where: '"active"',
-    });
+  itIfConflictTarget(
+    "upsertAll with partial unique index emits WHERE in conflict target",
+    async () => {
+      const adapter = createTestAdapter();
+      await defineSchema(adapter, {
+        flags: { key: "string", active: "boolean" },
+      });
+      const ss = new SchemaStatements(adapter);
+      // WHERE "active" works on both SQLite (1=true) and PG (boolean column).
+      // Avoid '"active" = 1' which PG rejects (boolean ≠ integer).
+      await ss.addIndex("flags", ["key"], {
+        unique: true,
+        name: "idx_flags_key_active",
+        where: '"active"',
+      });
 
-    class Flag extends Base {
-      static {
-        this.attribute("id", "integer");
-        this.attribute("key", "string");
-        this.attribute("active", "boolean");
-        this.adapter = adapter;
-        this._tableName = "flags";
+      class Flag extends Base {
+        static {
+          this.attribute("id", "integer");
+          this.attribute("key", "string");
+          this.attribute("active", "boolean");
+          this.adapter = adapter;
+          this._tableName = "flags";
+        }
       }
-    }
 
-    const captured: string[] = [];
-    const orig = adapter.executeMutation.bind(adapter);
-    (adapter as any).executeMutation = (sql: string, ...rest: unknown[]) => {
-      captured.push(sql);
-      return (orig as any)(sql, ...rest);
-    };
+      const captured: string[] = [];
+      const orig = adapter.executeMutation.bind(adapter);
+      (adapter as any).executeMutation = (sql: string, ...rest: unknown[]) => {
+        captured.push(sql);
+        return (orig as any)(sql, ...rest);
+      };
 
-    await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
-    const upsertSql = captured.find((s) => s.includes("ON CONFLICT"));
-    expect(upsertSql).toBeDefined();
-    expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active"/);
-  });
+      await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
+      const upsertSql = captured.find((s) => s.includes("ON CONFLICT"));
+      expect(upsertSql).toBeDefined();
+      expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active"/);
+    },
+  );
 });

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1025,10 +1025,12 @@ describe("InsertAll async uniqueIndexes regression", () => {
       flags: { key: "string", active: "boolean" },
     });
     const ss = new SchemaStatements(adapter);
+    // WHERE "active" works on both SQLite (1=true) and PG (boolean column).
+    // Avoid '"active" = 1' which PG rejects (boolean ≠ integer).
     await ss.addIndex("flags", ["key"], {
       unique: true,
       name: "idx_flags_key_active",
-      where: '"active" = 1',
+      where: '"active"',
     });
 
     class Flag extends Base {
@@ -1051,6 +1053,6 @@ describe("InsertAll async uniqueIndexes regression", () => {
     await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
     const upsertSql = captured.find((s) => s.includes("ON CONFLICT"));
     expect(upsertSql).toBeDefined();
-    expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active" = 1/);
+    expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active"/);
   });
 });

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1084,7 +1084,9 @@ describe("InsertAll async uniqueIndexes regression", () => {
         spy.mockRestore();
       }
       expect(upsertSql).toBeDefined();
-      expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active"/);
+      // PG normalizes the partial-index predicate when it round-trips
+      // through pg_get_indexdef ("active" → active), so accept either form.
+      expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "?active"?/);
     },
   );
 });

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Base, defineEnum } from "./index.js";
 import { InsertAll } from "./insert-all.js";
 import { adapterType, createTestAdapter } from "./test-adapter.js";
@@ -193,10 +193,10 @@ describe("InsertAllTest", () => {
     const adapter = freshAdapter();
     const Book = makeBook(adapter);
     const b = await Book.create({ title: "Existing", author: "Author" });
-    const supports = (
-      adapter as { supportsInsertConflictTarget?: () => boolean }
-    ).supportsInsertConflictTarget?.();
-    if (supports) {
+    // Read from adapterType, not adapter.supportsInsertConflictTarget(): PG's
+    // implementation reads databaseVersion synchronously, which throws before
+    // the first connection has populated the version cache.
+    if (supportsConflictTarget) {
       await Book.upsertAll([{ id: b.id, title: "Updated", author: "Author" }], { uniqueBy: "id" });
       const found = await Book.find(b.id);
       expect(found.title).toBe("Updated");
@@ -1070,15 +1070,19 @@ describe("InsertAll async uniqueIndexes regression", () => {
         }
       }
 
-      const captured: string[] = [];
-      const orig = adapter.executeMutation.bind(adapter);
-      (adapter as any).executeMutation = (sql: string, ...rest: unknown[]) => {
-        captured.push(sql);
-        return (orig as any)(sql, ...rest);
-      };
-
-      await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
-      const upsertSql = captured.find((s) => s.includes("ON CONFLICT"));
+      // vi.spyOn passes through to the original by default and records calls;
+      // mockRestore in finally guarantees the patched method is restored even
+      // if the upsert throws, so the adapter never leaks a spied method.
+      const spy = vi.spyOn(adapter, "executeMutation");
+      let upsertSql: string | undefined;
+      try {
+        await Flag.upsertAll([{ key: "feature_x", active: true }], { uniqueBy: "key" });
+        upsertSql = spy.mock.calls
+          .map((c) => c[0] as string)
+          .find((s) => s.includes("ON CONFLICT"));
+      } finally {
+        spy.mockRestore();
+      }
       expect(upsertSql).toBeDefined();
       expect(upsertSql).toMatch(/ON CONFLICT \("key"\) WHERE "active"/);
     },

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,6 +1,7 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { SerializeCastValue } from "@blazetrails/activemodel";
+import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import type { Base } from "./base.js";
 import { quoteSqlValue } from "./base.js";
 import { stiName } from "./inheritance.js";
@@ -33,7 +34,13 @@ export class InsertAll {
   readonly connection: ModelClass["adapter"];
   readonly inserts: Record<string, unknown>[];
   readonly keys: Set<string>;
-  readonly uniqueBy: string | string[] | undefined;
+  /**
+   * Initially the user's `:unique_by` input (column name, column list, or
+   * index name). After `_populateUpdatableColumns` resolves, this is
+   * mutated to the matching IndexDefinition — matching Rails' shape, so
+   * Builder.conflictTarget can read `index.columns` / `index.where`.
+   */
+  uniqueBy: string | string[] | IndexDefinition | undefined;
   readonly returning: string | string[] | Nodes.SqlLiteral | false;
 
   onDuplicate: "skip" | "update" | undefined;
@@ -124,7 +131,8 @@ export class InsertAll {
   /** @internal Async init: resolves uniqueByColumns via cache.indexes() then finalizes updatableColumns. */
   private async _populateUpdatableColumns(): Promise<void> {
     if (this._updatableColumns) return;
-    const exclude = new Set([...this.readonlyColumns(), ...(await this.uniqueByColumns())]);
+    this.uniqueBy = await this.findUniqueIndexFor(this.uniqueBy);
+    const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {
         exclude.add(col);
@@ -237,9 +245,9 @@ export class InsertAll {
     return onDuplicate instanceof Nodes.SqlLiteral;
   }
 
-  /** @internal */
-  private async uniqueByColumns(): Promise<string[]> {
-    return this.findUniqueIndexFor(this.uniqueBy);
+  /** @internal Mirrors: ActiveRecord::InsertAll#unique_by_columns */
+  private uniqueByColumns(): string[] {
+    return this.uniqueBy instanceof IndexDefinition ? this.uniqueBy.columns : [];
   }
 
   /** @internal */
@@ -294,46 +302,60 @@ export class InsertAll {
     return aliases?.[attribute] ?? attribute;
   }
 
-  /** @internal */
-  private async findUniqueIndexFor(uniqueBy: string | string[] | undefined): Promise<string[]> {
+  /** @internal Mirrors: ActiveRecord::InsertAll#find_unique_index_for */
+  private async findUniqueIndexFor(
+    uniqueBy: string | string[] | IndexDefinition | undefined,
+  ): Promise<IndexDefinition | undefined> {
+    if (uniqueBy instanceof IndexDefinition) return uniqueBy;
+    const conn = this.connection as { supportsInsertConflictTarget?: () => boolean };
+    if (
+      typeof conn.supportsInsertConflictTarget === "function" &&
+      !conn.supportsInsertConflictTarget()
+    ) {
+      if (uniqueBy == null) return undefined;
+      throw new Error(`${(conn as any).constructor?.name ?? "Adapter"} does not support :uniqueBy`);
+    }
     const nameOrCols =
       uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
     const sortedMatch = [...nameOrCols].sort().join(",");
+    const tableName = this.model.arelTable.name;
     const idx = (await this.uniqueIndexes()).find(
       (i: any) =>
         nameOrCols.includes(i.name) ||
         (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
-    ) as any;
-    if (idx) return Array.isArray(idx.columns) ? idx.columns : nameOrCols;
-    // uniqueBy == null → caller wants PK uniqueness; PKs are already in readonlyColumns()
-    // so returning [] here is equivalent (they're excluded from updatableColumns either way).
-    // uniqueBy matching primary keys explicitly → return the PK columns directly.
-    if (uniqueBy == null || sortedMatch === [...this.primaryKeys()].sort().join(","))
-      return uniqueBy == null ? [] : this.primaryKeys();
+    ) as { name: string; columns: string[]; where?: string } | undefined;
+    if (idx) {
+      return idx instanceof IndexDefinition
+        ? idx
+        : new IndexDefinition(tableName, idx.name, true, idx.columns, { where: idx.where });
+    }
+    if ([...nameOrCols].sort().join(",") === [...this.primaryKeys()].sort().join(",")) {
+      return uniqueBy == null
+        ? undefined
+        : new IndexDefinition(tableName, `${tableName}_primary_key`, true, [...nameOrCols]);
+    }
     throw new Error(`No unique index found for ${JSON.stringify(uniqueBy)}`);
   }
 
   /**
    * @internal
-   * Rails schema_cache.indexes() is synchronous; our TS port must be async because the
-   * underlying driver call is async. Always await this method.
+   * Rails' schema_cache.indexes is synchronous; our TS port is async because
+   * the underlying driver call is. Always await this method.
    *
-   * Uses the adapter's raw SchemaCache (AbstractAdapter#schema_cache) with the
-   * adapter's pool (or the adapter itself in tests) as the pool argument so
-   * SchemaCache.indexes(pool, tableName) can reach connection.indexes() on a
-   * cache miss. We do NOT fall back to ConnectionPool#schemaCache (a
-   * BoundSchemaReflection with a one-arg indexes()) — the two-arg call would
-   * misalign and pass the pool object as tableName.
+   * Mirrors: ActiveRecord::InsertAll#unique_indexes
    */
   private async uniqueIndexes(): Promise<unknown[]> {
     const conn = this.connection as any;
-    const cache = conn.schemaCache;
-    if (!cache || typeof cache.indexes !== "function") return [];
-    // Unwrap one level of adapter wrapping (e.g. TestAdapter → SQLite3Adapter)
-    // so the pool we pass to SchemaCache.indexes() can call connection.indexes().
-    const pool = conn.pool ?? conn;
+    const bound = conn.schemaCacheBound;
     const tableName = this.model.arelTable.name;
-    const indexes = await cache.indexes(pool, tableName);
+    let indexes: unknown[];
+    if (bound && typeof bound.indexes === "function") {
+      indexes = await bound.indexes(tableName);
+    } else {
+      const cache = conn.schemaCache;
+      if (!cache || typeof cache.indexes !== "function") return [];
+      indexes = await cache.indexes(conn.pool ?? conn, tableName);
+    }
     return (indexes as unknown[]).filter((i: any) => i.unique);
   }
 
@@ -450,11 +472,14 @@ export class Builder {
   }
 
   conflictTarget(): string {
-    const cols = this._insertAll.uniqueBy
-      ? Array.isArray(this._insertAll.uniqueBy)
-        ? this._insertAll.uniqueBy
-        : [this._insertAll.uniqueBy]
-      : this._insertAll.primaryKeys();
+    const index = this._insertAll.uniqueBy;
+    if (index instanceof IndexDefinition) {
+      const cols = index.columns.map((c) => `"${c}"`).join(", ");
+      return index.where ? `(${cols}) WHERE ${index.where}` : `(${cols})`;
+    }
+    // Pre-resolve fallback (skip path or update-without-uniqueBy): use PKs.
+    const cols =
+      index == null ? this._insertAll.primaryKeys() : Array.isArray(index) ? index : [index];
     return `(${cols.map((c) => `"${c}"`).join(", ")})`;
   }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -316,11 +316,16 @@ export class InsertAll {
     uniqueBy: string | string[] | IndexDefinition | undefined,
   ): Promise<IndexDefinition | undefined> {
     if (uniqueBy instanceof IndexDefinition) return uniqueBy;
+    // Default to unsupported when the predicate is missing — matches Rails'
+    // AbstractAdapter#supports_insert_conflict_target? returning false, so a
+    // wrapper adapter that forgets to delegate doesn't silently fall through
+    // and emit a bogus conflict target.
     const conn = this.connection as { supportsInsertConflictTarget?: () => boolean };
-    if (
-      typeof conn.supportsInsertConflictTarget === "function" &&
-      !conn.supportsInsertConflictTarget()
-    ) {
+    const supports =
+      typeof conn.supportsInsertConflictTarget === "function"
+        ? conn.supportsInsertConflictTarget()
+        : false;
+    if (!supports) {
       if (uniqueBy == null) return undefined;
       throw new Error(`${(conn as any).constructor?.name ?? "Adapter"} does not support :uniqueBy`);
     }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -50,6 +50,7 @@ export class InsertAll {
   private _scopeAttributes: Record<string, unknown>;
   private _recordTimestamps: boolean;
   private _updatableColumns: string[] | undefined;
+  private _uniqueByResolved = false;
   private _keysIncludingTimestamps: Set<string> | undefined;
 
   static async execute(
@@ -130,8 +131,16 @@ export class InsertAll {
 
   /** @internal Async init: resolves uniqueByColumns via cache.indexes() then finalizes updatableColumns. */
   private async _populateUpdatableColumns(): Promise<void> {
+    // Rails resolves @unique_by synchronously in the constructor (line 42 of
+    // insert_all.rb), before configure_on_duplicate_update_logic. Our port
+    // defers it because schema-cache reads are async — but it must still
+    // run on every path so updateOnly + uniqueBy still gets validated and
+    // index.where flows through to conflictTarget.
+    if (!this._uniqueByResolved) {
+      this.uniqueBy = await this.findUniqueIndexFor(this.uniqueBy);
+      this._uniqueByResolved = true;
+    }
     if (this._updatableColumns) return;
-    this.uniqueBy = await this.findUniqueIndexFor(this.uniqueBy);
     const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);
     if (this.recordTimestamps() && !this.updateOnly && !this.updateSql) {
       for (const col of TIMESTAMP_COLUMNS) {

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes, Visitors } from "@blazetrails/arel";
-import { SerializeCastValue } from "@blazetrails/activemodel";
+import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import type { Base } from "./base.js";
 import { quoteSqlValue } from "./base.js";
@@ -316,6 +316,13 @@ export class InsertAll {
     uniqueBy: string | string[] | IndexDefinition | undefined,
   ): Promise<IndexDefinition | undefined> {
     if (uniqueBy instanceof IndexDefinition) return uniqueBy;
+    // Rails returns nil here in the dominant nil-uniqueBy case (no matching
+    // unique index → line 163 returns nil since unique_by.nil?). Short-circuit
+    // before probing adapter capabilities so plain insertAll doesn't trigger
+    // lazy databaseVersion fetches on adapters whose supports_* getters read
+    // it synchronously (PG). Builder.conflictTarget falls back to primary
+    // keys when uniqueBy is undefined, matching Rails' nil path.
+    if (uniqueBy == null) return undefined;
     // Default to unsupported when the predicate is missing — matches Rails'
     // AbstractAdapter#supports_insert_conflict_target? returning false, so a
     // wrapper adapter that forgets to delegate doesn't silently fall through
@@ -327,7 +334,9 @@ export class InsertAll {
         : false;
     if (!supports) {
       if (uniqueBy == null) return undefined;
-      throw new Error(`${(conn as any).constructor?.name ?? "Adapter"} does not support :uniqueBy`);
+      throw new ArgumentError(
+        `${(conn as any).constructor?.name ?? "Adapter"} does not support :uniqueBy`,
+      );
     }
     const nameOrCols =
       uniqueBy == null ? this.primaryKeys() : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -330,7 +330,18 @@ export class InsertAll {
     // AbstractAdapter#supports_insert_conflict_target? returning false, so a
     // wrapper adapter that forgets to delegate doesn't silently fall through
     // and emit a bogus conflict target.
-    const conn = this.connection as { supportsInsertConflictTarget?: () => boolean };
+    const conn = this.connection as {
+      supportsInsertConflictTarget?: () => boolean;
+      getDatabaseVersion?: () => Promise<unknown>;
+    };
+    // PG's supports_insert_conflict_target reads databaseVersion via a sync
+    // getter that throws until getDatabaseVersion() has populated the cache.
+    // Cold upsertAll(..., { uniqueBy }) would trip that before uniqueIndexes
+    // ran, so prime the version here when the adapter advertises the async
+    // initializer (mirroring how AbstractAdapter#prepareCoercedClass uses it).
+    if (typeof conn.getDatabaseVersion === "function") {
+      await conn.getDatabaseVersion();
+    }
     const supports =
       typeof conn.supportsInsertConflictTarget === "function"
         ? conn.supportsInsertConflictTarget()

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -118,8 +118,11 @@ export class InsertAll {
   }
 
   async execute(): Promise<number> {
-    if (this.inserts.length === 0) return 0;
+    // Resolve uniqueBy before the empty-batch shortcut so the Rails guard
+    // (insert_all.rb#initialize validates uniqueBy in the constructor before
+    // any inserts.empty? check) still fires on upsertAll([], { uniqueBy }).
     await this._populateUpdatableColumns();
+    if (this.inserts.length === 0) return 0;
     const dialect = this.connection.adapterName;
     const builder = new Builder(this, dialect);
     return this.connection.executeMutation(builder.toSql());

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1235,6 +1235,14 @@ class SchemaAdapter implements DatabaseAdapter {
     );
   }
 
+  supportsInsertConflictTarget(): boolean {
+    return (
+      (
+        this.inner as { supportsInsertConflictTarget?: () => boolean }
+      ).supportsInsertConflictTarget?.() ?? false
+    );
+  }
+
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const inner = this.inner as {
       getAdvisoryLock?: (id: number | bigint | string) => Promise<boolean>;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1243,6 +1243,11 @@ class SchemaAdapter implements DatabaseAdapter {
     );
   }
 
+  async getDatabaseVersion(): Promise<unknown> {
+    const inner = this.inner as { getDatabaseVersion?: () => Promise<unknown> };
+    return inner.getDatabaseVersion?.();
+  }
+
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const inner = this.inner as {
       getAdvisoryLock?: (id: number | bigint | string) => Promise<boolean>;


### PR DESCRIPTION
## Summary

Batch 12 from \`docs/activerecord-100-plan.md\` — insert-all polish around the conflict-target capability and the IndexDefinition value class.

- **\`supportsInsertConflictTarget()\` on \`DatabaseAdapter\`** — declared in the interface; abstract returns false; SQLite3 aliases it to \`supportsInsertOnConflict\` (>= 3.24); PostgreSQL already overrode to true. MySQL stays false to match Rails — \`ON DUPLICATE KEY UPDATE\` has no conflict-target syntax (Rails' \`abstract_mysql_adapter.rb\` does not override). The batch spec mentioned mysql ≥ 8, but Rails-fidelity wins here.
- **Rails guard in \`InsertAll#findUniqueIndexFor\`** — unsupported adapters raise \`ArgumentError\` when \`uniqueBy\` is provided, and return undefined otherwise (matching Rails' \`raise if !supports_insert_conflict_target?\` short-circuit).
- **\`this.uniqueBy\` mutates to \`IndexDefinition\`** — post-await in \`_populateUpdatableColumns\`, matching Rails \`@unique_by = find_unique_index_for(@unique_by)\`. \`unique_by_columns\` now reads \`index.columns\` directly. \`Builder.conflictTarget\` emits \`(cols)\` plus \`WHERE …\` when \`index.where\` is present — unlocks partial-index upserts on PostgreSQL. (\`IndexDefinition\` already existed in \`connection-adapters/abstract/schema-definitions.ts\`; the work was wiring \`InsertAll\` through it.)
- **\`AbstractAdapter#schemaCacheBound\`** — pool-bound \`BoundSchemaReflection\` with the one-arg \`indexes(tableName)\` form. Reuses the pool's bound handle when available; wraps the adapter as a \`FakePool\` otherwise. \`InsertAll\` now uses it, dropping the raw-cache + manual pool-passing dance.

Cross-referenced against \`vendor/rails/activerecord/lib/active_record/insert_all.rb\` (\`find_unique_index_for\`, \`unique_by_columns\`, \`conflict_target\`).

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/insert-all.test.ts\` — 58 passed, 64 skipped (no regressions)
- [x] \`pnpm vitest run packages/activerecord/src/connection-adapters/abstract-adapter.test.ts packages/activerecord/src/connection-adapters/schema-cache.test.ts\` — green
- [x] LOC budget: 4 files changed, 102 insertions, 34 deletions — well under the 300 ceiling