### PR TITLE
refactor(action-dispatch): delete legacy matchSegments engine

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
@@ -1554,20 +1554,14 @@ describe("TestRoutingMapper", () => {
     expect(m!.params.path).toBe("2024/01/hello");
   });
 
-  // BLOCKED: leading-optional groups like `(/:locale)/posts` produce a
-  // broken Pattern regex (the leading `/` is consumed outside the optional
-  // group, so neither `/posts` nor `/en/posts` matches). Pattern regex
-  // builder bug — pre-existing in the Journey port; surfaced when
-  // Route#match switched to the Journey backend.
-  it.skip("optional scoped root", () => {
+  it("optional scoped root", () => {
     const route = new Route("GET", "(/:locale)/posts", "posts", "index");
     expect(route.match("GET", "/posts")).not.toBeNull();
     expect(route.match("GET", "/en/posts")).not.toBeNull();
     expect(route.match("GET", "/en/posts")!.params.locale).toBe("en");
   });
 
-  // BLOCKED: same Pattern leading-optional-group regex bug as above.
-  it.skip("optional scoped root hierarchy", () => {
+  it("optional scoped root hierarchy", () => {
     const r1 = new Route("GET", "(/:locale)/posts", "posts", "index");
     const r2 = new Route("GET", "(/:locale)/posts/:id", "posts", "show");
     expect(r1.match("GET", "/posts")).not.toBeNull();

--- a/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
@@ -1566,6 +1566,7 @@ describe("TestRoutingMapper", () => {
     expect(route.match("GET", "/en/posts")!.params.locale).toBe("en");
   });
 
+  // BLOCKED: same Pattern leading-optional-group regex bug as above.
   it.skip("optional scoped root hierarchy", () => {
     const r1 = new Route("GET", "(/:locale)/posts", "posts", "index");
     const r2 = new Route("GET", "(/:locale)/posts/:id", "posts", "show");

--- a/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
@@ -1554,14 +1554,19 @@ describe("TestRoutingMapper", () => {
     expect(m!.params.path).toBe("2024/01/hello");
   });
 
-  it("optional scoped root", () => {
+  // BLOCKED: leading-optional groups like `(/:locale)/posts` produce a
+  // broken Pattern regex (the leading `/` is consumed outside the optional
+  // group, so neither `/posts` nor `/en/posts` matches). Pattern regex
+  // builder bug — pre-existing in the Journey port; surfaced when
+  // Route#match switched to the Journey backend.
+  it.skip("optional scoped root", () => {
     const route = new Route("GET", "(/:locale)/posts", "posts", "index");
     expect(route.match("GET", "/posts")).not.toBeNull();
     expect(route.match("GET", "/en/posts")).not.toBeNull();
     expect(route.match("GET", "/en/posts")!.params.locale).toBe("en");
   });
 
-  it("optional scoped root hierarchy", () => {
+  it.skip("optional scoped root hierarchy", () => {
     const r1 = new Route("GET", "(/:locale)/posts", "posts", "index");
     const r2 = new Route("GET", "(/:locale)/posts/:id", "posts", "show");
     expect(r1.match("GET", "/posts")).not.toBeNull();

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -24,7 +24,22 @@ export interface JourneyMatch {
   params: Record<string, string>;
 }
 
-export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter {
+export interface BuildJourneyRouterOptions {
+  /**
+   * Skip request-attribute constraints (subdomain, format, etc.) on the
+   * synthesized Journey routes. Use for path-only matchers like
+   * `Route#match(method, path)` where the caller has no real request to
+   * evaluate request constraints against — otherwise `Route#matches`
+   * would reject every request because the constraint keys are undefined
+   * on the synthetic RouterRequest.
+   */
+  skipRequestConstraints?: boolean;
+}
+
+export function buildJourneyRouter(
+  routes: readonly LocalRoute[],
+  opts: BuildJourneyRouterOptions = {},
+): JourneyRouter {
   const journeyRoutes = new JourneyRoutes();
   for (let i = 0; i < routes.length; i++) {
     const r = routes[i]!;
@@ -54,7 +69,7 @@ export function buildJourneyRouter(routes: readonly LocalRoute[]): JourneyRouter
             },
           },
           path: pattern,
-          constraints: r.requestConstraints,
+          constraints: opts.skipRequestConstraints ? {} : r.requestConstraints,
           defaults: { ...r.defaults, controller: r.controller, action: r.action },
           requestMethodMatch,
           precedence: index,

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -44,6 +44,14 @@ describe("Route", () => {
       expect(route.match("GET", "/posts")).not.toBeNull();
     });
 
+    it("returns null without throwing when the path is unparseable", () => {
+      // Mirrors the Journey-parser swallow in collectParamNamesFromJourneyAst:
+      // a malformed path shouldn't crash the route table at match time.
+      const route = new Route("GET", "/posts/(unclosed", "posts", "show");
+      expect(() => route.match("GET", "/posts/anything")).not.toThrow();
+      expect(route.match("GET", "/posts/anything")).toBeNull();
+    });
+
     it("still enforces path-capture constraints", () => {
       const route = new Route("GET", "/posts/:id", "posts", "show", {
         constraints: { id: /\d+/ },

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -33,6 +33,26 @@ describe("Route", () => {
     });
   });
 
+  describe("match() — path-only matcher", () => {
+    it("ignores request constraints since match() takes no request attributes", () => {
+      // Subdomain is a request constraint that would only be evaluated
+      // against a real request. Route#match takes (method, path) only,
+      // so it should still match by path despite the request constraint.
+      const route = new Route("GET", "/posts", "posts", "index", {
+        constraints: { subdomain: "api" },
+      });
+      expect(route.match("GET", "/posts")).not.toBeNull();
+    });
+
+    it("still enforces path-capture constraints", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show", {
+        constraints: { id: /\d+/ },
+      });
+      expect(route.match("GET", "/posts/42")).not.toBeNull();
+      expect(route.match("GET", "/posts/abc")).toBeNull();
+    });
+  });
+
   describe("pathParamNames", () => {
     it("lists dynamic and glob captures in declaration order", () => {
       const route = new Route("GET", "/a/:id/b/*rest", "x", "y");

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -158,7 +158,10 @@ export class Route {
       return null;
     }
     if (this._journeyRouter === null) {
-      this._journeyRouter = buildJourneyRouter([this]);
+      // Path-only matcher: skip request constraints since match() takes
+      // no request attributes — preserves legacy matchSegments semantics
+      // where request constraints (subdomain, format, …) didn't apply.
+      this._journeyRouter = buildJourneyRouter([this], { skipRequestConstraints: true });
     }
     const match = journeyRecognize(this._journeyRouter, method, requestPath);
     if (!match) return null;

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -65,6 +65,8 @@ export class Route {
   private readonly paramNames: string[];
   /** @internal lazy single-route Journey router for match() */
   private _journeyRouter: JourneyRouter | null = null;
+  /** @internal true once we've discovered the path can't be parsed */
+  private _journeyRouterUnbuildable = false;
 
   constructor(
     verb: string,
@@ -157,11 +159,19 @@ export class Route {
     if (this.verb !== "ALL" && this.verb !== m && !(m === "HEAD" && this.verb === "GET")) {
       return null;
     }
+    if (this._journeyRouterUnbuildable) return null;
     if (this._journeyRouter === null) {
-      // Path-only matcher: skip request constraints since match() takes
-      // no request attributes — preserves legacy matchSegments semantics
-      // where request constraints (subdomain, format, …) didn't apply.
-      this._journeyRouter = buildJourneyRouter([this], { skipRequestConstraints: true });
+      try {
+        // Path-only matcher: skip request constraints since match() takes
+        // no request attributes — preserves legacy matchSegments semantics
+        // where request constraints (subdomain, format, …) didn't apply.
+        this._journeyRouter = buildJourneyRouter([this], { skipRequestConstraints: true });
+      } catch {
+        // Mirrors collectParamNamesFromJourneyAst's swallow-and-cache policy:
+        // a malformed path shouldn't crash the route table at match time.
+        this._journeyRouterUnbuildable = true;
+        return null;
+      }
     }
     const match = journeyRecognize(this._journeyRouter, method, requestPath);
     if (!match) return null;

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -371,7 +371,12 @@ function parseSegments(path: string): PathSegment[] {
 }
 
 function normalizePath(p: string): string {
-  return "/" + p.replace(/^\/+|\/+$/g, "");
+  const stripped = p.replace(/^\/+|\/+$/g, "");
+  // Don't prepend `/` to a leading optional group: `(/:locale)/posts` must
+  // stay as-is so the `/` lives inside the optional. Prepending would
+  // produce `/(/:locale)/posts`, compiled to `^/(?:/...)?/posts$`, which
+  // requires either `//posts` (extra slash) or `/x/posts` (no plain match).
+  return stripped.startsWith("(") ? stripped : "/" + stripped;
 }
 
 function interpolateRedirect(template: string, params: Record<string, string>): string {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -150,12 +150,19 @@ export class Route {
   }
 
   match(method: string, requestPath: string): MatchedRoute | null {
+    // Verb fast-path: skip Journey router construction when the verb can
+    // be rejected up front. HEAD falls through to GET routes (Journey
+    // handles the HEAD→GET fallback inside `_matchHeadRoutes`).
+    const m = method.toUpperCase();
+    if (this.verb !== "ALL" && this.verb !== m && !(m === "HEAD" && this.verb === "GET")) {
+      return null;
+    }
     if (this._journeyRouter === null) {
       this._journeyRouter = buildJourneyRouter([this]);
     }
-    const m = journeyRecognize(this._journeyRouter, method, requestPath);
-    if (!m) return null;
-    return { route: this, params: m.params };
+    const match = journeyRecognize(this._journeyRouter, method, requestPath);
+    if (!match) return null;
+    return { route: this, params: match.params };
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -4,6 +4,8 @@
 
 import { Parser } from "../journey/parser.js";
 import { Ast } from "../journey/ast.js";
+import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
+import type { Router as JourneyRouter } from "../journey/router.js";
 
 export interface RouteConstraints {
   [key: string]: string | RegExp;
@@ -61,6 +63,8 @@ export class Route {
 
   private readonly segments: PathSegment[];
   private readonly paramNames: string[];
+  /** @internal lazy single-route Journey router for match() */
+  private _journeyRouter: JourneyRouter | null = null;
 
   constructor(
     verb: string,
@@ -146,25 +150,12 @@ export class Route {
   }
 
   match(method: string, requestPath: string): MatchedRoute | null {
-    if (this.verb !== "ALL" && this.verb !== method.toUpperCase()) {
-      return null;
+    if (this._journeyRouter === null) {
+      this._journeyRouter = buildJourneyRouter([this]);
     }
-
-    const reqSegments = normalizePath(requestPath).split("/").filter(Boolean);
-
-    const params: Record<string, string> = {};
-    const result = matchSegments(
-      this.segments,
-      reqSegments,
-      0,
-      0,
-      params,
-      this.constraints,
-      this.anchor,
-    );
-    if (!result) return null;
-
-    return { route: this, params };
+    const m = journeyRecognize(this._journeyRouter, method, requestPath);
+    if (!m) return null;
+    return { route: this, params: m.params };
   }
 
   /**
@@ -357,137 +348,6 @@ function parseSegments(path: string): PathSegment[] {
   }
 
   return segments;
-}
-
-function matchSegments(
-  segments: PathSegment[],
-  reqSegments: string[],
-  segIdx: number,
-  reqIdx: number,
-  params: Record<string, string>,
-  constraints: RouteConstraints,
-  anchor: boolean,
-): boolean {
-  // Base case: consumed all route segments
-  if (segIdx >= segments.length) {
-    if (!anchor) return true; // unanchored: ok if extra segments remain
-    return reqIdx >= reqSegments.length;
-  }
-
-  const seg = segments[segIdx];
-
-  if (seg.type === "static") {
-    if (reqIdx >= reqSegments.length) return false;
-    if (reqSegments[reqIdx] !== seg.value) return false;
-    return matchSegments(
-      segments,
-      reqSegments,
-      segIdx + 1,
-      reqIdx + 1,
-      params,
-      constraints,
-      anchor,
-    );
-  }
-
-  if (seg.type === "dynamic") {
-    if (reqIdx >= reqSegments.length) return false;
-    const val = reqSegments[reqIdx];
-    const constraint = constraints[seg.name];
-    if (constraint) {
-      const re =
-        constraint instanceof RegExp ? anchorRegExp(constraint) : new RegExp(`^${constraint}$`);
-      if (!re.test(val)) return false;
-    }
-    params[seg.name] = val;
-    return matchSegments(
-      segments,
-      reqSegments,
-      segIdx + 1,
-      reqIdx + 1,
-      params,
-      constraints,
-      anchor,
-    );
-  }
-
-  if (seg.type === "glob") {
-    // Glob matches zero or more remaining segments (greedy)
-    // Try matching the rest of the route segments first
-    for (let take = reqSegments.length - reqIdx; take >= 0; take--) {
-      const saved = { ...params };
-      const globValue = reqSegments.slice(reqIdx, reqIdx + take).join("/");
-      params[seg.name] = globValue;
-      if (
-        matchSegments(segments, reqSegments, segIdx + 1, reqIdx + take, params, constraints, anchor)
-      ) {
-        return true;
-      }
-      // Restore params
-      Object.keys(params).forEach((k) => {
-        if (!(k in saved)) delete params[k];
-        else params[k] = saved[k];
-      });
-    }
-    return false;
-  }
-
-  if (seg.type === "optional") {
-    // Try matching with the optional group
-    const savedParams = { ...params };
-    let childReqIdx = reqIdx;
-    let matched = true;
-    for (const child of seg.children) {
-      if (child.type === "static") {
-        if (childReqIdx >= reqSegments.length || reqSegments[childReqIdx] !== child.value) {
-          matched = false;
-          break;
-        }
-        childReqIdx++;
-      } else if (child.type === "dynamic") {
-        if (childReqIdx >= reqSegments.length) {
-          matched = false;
-          break;
-        }
-        const val = reqSegments[childReqIdx];
-        const constraint = constraints[child.name];
-        if (constraint) {
-          const re =
-            constraint instanceof RegExp ? anchorRegExp(constraint) : new RegExp(`^${constraint}$`);
-          if (!re.test(val)) {
-            matched = false;
-            break;
-          }
-        }
-        params[child.name] = val;
-        childReqIdx++;
-      }
-    }
-
-    if (matched) {
-      if (
-        matchSegments(segments, reqSegments, segIdx + 1, childReqIdx, params, constraints, anchor)
-      ) {
-        return true;
-      }
-    }
-
-    // Try without the optional group
-    Object.keys(params).forEach((k) => {
-      if (!(k in savedParams)) delete params[k];
-      else params[k] = savedParams[k];
-    });
-    return matchSegments(segments, reqSegments, segIdx + 1, reqIdx, params, constraints, anchor);
-  }
-
-  return false;
-}
-
-function anchorRegExp(re: RegExp): RegExp {
-  let source = re.source;
-  if (!source.startsWith("^")) source = "^" + source;
-  if (!source.endsWith("$")) source = source + "$";
-  return new RegExp(source, re.flags);
 }
 
 function normalizePath(p: string): string {


### PR DESCRIPTION
## Summary
\`Route#match\` now delegates to the Journey backend via a lazy per-instance \`buildJourneyRouter\` + \`journeyRecognize\`. The recursive \`matchSegments\` engine (and its \`anchorRegExp\` helper) is deleted — ~135 LOC of legacy path-matching code retires.

The 21 existing \`Route#match\` test callers stay as-is; they now exercise the Journey backend transparently.

## Changes through review
- **Verb fast-path** on \`Route#match\` skips Journey router construction when the verb mismatches (HEAD→GET fallback preserved).
- **\`buildJourneyRouter({ skipRequestConstraints: true })\`** — \`Route#match\` opts in since it takes no request attributes; preserves legacy semantics where request constraints (subdomain, format, …) don't affect path-only matchers.
- **try/catch in \`Route#match\`** with cached failure sentinel — a malformed Journey path returns \`null\` instead of throwing, mirroring \`collectParamNamesFromJourneyAst\`'s swallow-and-cache policy.
- **\`normalizePath\` fix** — don't prepend \`/\` when the path starts with \`(\`. \`(/:locale)/posts\` now compiles to \`^(?:/([^/.?]+))?/posts$\` (matches \`/posts\` AND \`/en/posts\`) rather than the broken \`^/(?:/([^/.?]+))?/posts$\` (matches neither). The two tests originally proposed as SKIPPED are now passing.

## Test plan
- [x] **All 1173 actionpack tests pass with zero skips**
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean