### PR TITLE
feat(activerecord): batch 10 — Reflection Slot A+B parity

### DIFF
--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -251,7 +251,7 @@ describe("UnknownPrimaryKeyTest", () => {
     expect(err.model).toBeNull();
   });
 
-  it("description is appended on a new line (Rails format)", () => {
+  it("description is separated by newline+space", () => {
     class Dummy extends Base {
       static _tableName = "dummies";
     }

--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -251,12 +251,14 @@ describe("UnknownPrimaryKeyTest", () => {
     expect(err.model).toBeNull();
   });
 
-  it("description is separated by newline+space", () => {
+  it("description is appended on a new line (Rails format)", () => {
     class Dummy extends Base {
       static _tableName = "dummies";
     }
     const err = new UnknownPrimaryKey(Dummy, "No PK configured.");
-    expect(err.message).toContain("\n No PK configured.");
+    expect(err.message).toBe(
+      "Unknown primary key for table dummies in model Dummy.\nNo PK configured.",
+    );
     expect(err.model).toBe(Dummy);
   });
 });

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -702,12 +702,11 @@ export class UnknownPrimaryKey extends ActiveRecordError {
 
   constructor(model?: typeof import("./base.js").Base | null, description?: string) {
     let msg: string;
-    if (model == null) {
-      msg = "Unknown primary key.";
-    } else if (description) {
-      msg = `Unknown primary key for table ${model.tableName} in model ${model.name}.\n ${description}`;
-    } else {
+    if (model) {
       msg = `Unknown primary key for table ${model.tableName} in model ${model.name}.`;
+      if (description) msg += `\n${description}`;
+    } else {
+      msg = "Unknown primary key.";
     }
     super(msg);
     this.name = "UnknownPrimaryKey";

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1346,6 +1346,32 @@ describe("ReflectionTest", () => {
       }),
     ).toThrow(ArgumentError);
   });
+  it("plain function for class name does not raise (only ES classes are rejected)", () => {
+    // Rails check is `options[option_name].class == Class`; in JS we
+    // distinguish classes via Function.prototype.toString, so a non-class
+    // callable must pass through (e.g. a lambda producing a string name).
+    class HostA extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TargetA extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("HostA", HostA);
+    registerModel("TargetA", TargetA);
+    const fn = function namedFactory() {
+      return "TargetA";
+    };
+    expect(() =>
+      // @ts-expect-error className typed as string; here we exercise the runtime guard
+      Associations.hasMany.call(HostA, "targetAs", { className: fn }),
+    ).not.toThrow();
+  });
   it("join table with common prefix", () => {
     class CatalogCategory extends Base {
       static {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1346,6 +1346,36 @@ describe("ReflectionTest", () => {
       }),
     ).toThrow(ArgumentError);
   });
+  it("plain function for source type does not raise (only ES classes are rejected)", () => {
+    // Same Rails semantics as the className case, exercised through
+    // ThroughReflection so the helper's lift to AbstractReflection is
+    // covered for both call sites.
+    class NsTagB extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class NsPostB extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("NsTagB", NsTagB);
+    registerModel("NsPostB", NsPostB);
+    const fn = function namedFactory() {
+      return "NsPostB";
+    };
+    expect(() =>
+      Associations.hasMany.call(NsTagB, "taggedPostsB", {
+        through: "taggings",
+        source: "taggable",
+        // @ts-expect-error sourceType typed as string; here we exercise the runtime guard
+        sourceType: fn,
+      }),
+    ).not.toThrow();
+  });
   it("plain function for class name does not raise (only ES classes are rejected)", () => {
     // Rails check is `options[option_name].class == Class` — only literal
     // Class instances are rejected; a Proc or other callable passes through

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1347,9 +1347,13 @@ describe("ReflectionTest", () => {
     ).toThrow(ArgumentError);
   });
   it("plain function for class name does not raise (only ES classes are rejected)", () => {
-    // Rails check is `options[option_name].class == Class`; in JS we
-    // distinguish classes via Function.prototype.toString, so a non-class
-    // callable must pass through (e.g. a lambda producing a string name).
+    // Rails check is `options[option_name].class == Class` — only literal
+    // Class instances are rejected; a Proc or other callable passes through
+    // (it is not invoked as a factory, just not flagged here). We mirror
+    // that by matching `/^class[\s{]/` on Function.prototype.toString so
+    // plain functions are accepted at construction. Downstream resolution
+    // still expects a string and will fail later if the user passes a
+    // non-string — same as Rails.
     class HostA extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -140,7 +140,7 @@ export class AbstractReflection {
     const foreignKeys = this._arrayWrap((this as any).joinForeignKey);
 
     if (primaryKeys.length !== foreignKeys.length) {
-      throw new Error(
+      throw new ArgumentError(
         `joinScope: joinPrimaryKey and joinForeignKey must have the same number of columns ` +
           `(got ${primaryKeys.length} primary key column(s) and ${foreignKeys.length} foreign key column(s))`,
       );
@@ -282,6 +282,21 @@ export class AbstractReflection {
     if (Array.isArray(value)) return value;
     if (typeof value === "string") return [value];
     return [];
+  }
+
+  /**
+   * @internal
+   * Raises if the given option was passed a class instead of a string.
+   * Mirrors: AbstractReflection#ensure_option_not_given_as_class!
+   */
+  protected ensureOptionNotGivenAsClassBang(optionName: string): void {
+    const opts = (this as any).options as Record<string, unknown> | undefined;
+    const val = opts?.[optionName];
+    if (typeof val === "function" && /^class[\s{]/.test(Function.prototype.toString.call(val))) {
+      throw new ArgumentError(
+        `A class was passed to \`:${optionName}\` but we are expecting a string.`,
+      );
+    }
   }
 }
 
@@ -499,11 +514,9 @@ export class AssociationReflection extends MacroReflection {
       delete opts.foreignKey;
     }
 
-    if (opts.className && typeof opts.className === "function") {
-      throw new ArgumentError("A class was passed to `:className` but we are expecting a string.");
-    }
-
     super(name, scope, opts, activeRecord);
+
+    this.ensureOptionNotGivenAsClassBang("className");
   }
 
   get macro(): MacroType {
@@ -993,19 +1006,6 @@ export class AssociationReflection extends MacroReflection {
 
   /**
    * @internal
-   * Raises if the given option was passed a class instead of a string.
-   */
-  protected ensureOptionNotGivenAsClassBang(optionName: string): void {
-    const val = this.options[optionName];
-    if (typeof val === "function" && /^class[\s{]/.test(Function.prototype.toString.call(val))) {
-      throw new ArgumentError(
-        `A class was passed to \`:${optionName}\` but we are expecting a string.`,
-      );
-    }
-  }
-
-  /**
-   * @internal
    * Derives the join table name for hasAndBelongsToMany associations.
    */
   protected deriveJoinTable(): string {
@@ -1165,10 +1165,7 @@ export class ThroughReflection extends AbstractReflection {
   constructor(delegate: AssociationReflection) {
     super();
     this._delegate = delegate;
-    const sourceTypeVal = delegate.options.sourceType;
-    if (typeof sourceTypeVal === "function") {
-      throw new ArgumentError("A class was passed to `:sourceType` but we are expecting a string.");
-    }
+    this.ensureOptionNotGivenAsClassBang("sourceType");
   }
 
   get name(): string {


### PR DESCRIPTION
## Summary

Batch 10 partial — Reflection cluster minor parity touches in `reflection.ts`.

- Moved `ensureOptionNotGivenAsClassBang` from `AssociationReflection` up to `AbstractReflection`. `ThroughReflection` extends `AbstractReflection` (not `AssociationReflection`), so it could not previously call the helper — it had an inline duplicated check. Now both classes share the helper and pick up the same Rails-faithful class-detection (regex on `Function.prototype.toString` rather than a broad `typeof === \"function\"`).
- `AssociationReflection` ctor's `className` class-check now flows through the helper instead of an inline `typeof === \"function\"` check (which would false-positive on plain functions).
- `joinScope` length mismatch now throws `ArgumentError` instead of a generic `Error`.
- `UnknownPrimaryKey`: drop the stray space before `description`; match Rails message format exactly (`Unknown primary key for table X in model Y.\\n<desc>`).

## Deferred (follow-ups)

The batch doc lists several more items under this slot; they are deferred to follow-up PRs since they either (a) require broader refactors than fit here, or (b) are stale/already-landed:

- `static set primaryKey(null)` + `Edge` fixture / `getPrimaryKeyAttr` null semantics — both \"primary key raises when missing\" tests already pass against the existing `_primaryKey = \"\"` pattern (falsy-check at `primaryKeyForModel`). Making them Rails-fidelity (Edge fixture + `null`) needs the `_primaryKey` type widened to `string | string[] | null`, which cascades through the codebase — worth its own PR.
- Add the missing `ThroughReflection` assertion to the Rails-mirrored \"association primary key raises when missing\" test — small but depends on setting up a through chain with a fake source.
- Annotation refresh on the 22 remaining `reflection.test.ts` stubs — needs case-by-case investigation of each `BLOCKED:` reason, not a mechanical pass.
- `checkValidityOfInverseBang` `(this as any).inverseName?.()` cast removal — there is no such cast in the current code; appears stale in the batch doc.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/reflection.test.ts` — 129 passed | 14 skipped
- [x] `pnpm vitest run packages/activerecord/src/associations` — 1757 passed | 304 skipped
- [x] typecheck / lint clean (pre-commit hooks pass)