### PR TITLE
feat(activerecord): batch 8 — MySQL warnings + quoting + init fidelity

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -329,8 +329,8 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
     expect(quoted.startsWith("'")).toBe(true);
     expect(quoted.endsWith("'")).toBe(true);
     const inner = quoted.slice(1, -1);
-    // Single quote must be escaped (no unescaped bare single quote)
-    expect(inner).not.toMatch(/(?<!')'(?!')/);
+    // Single quote must be backslash-escaped (no unescaped bare single quote)
+    expect(inner).not.toMatch(/(?<!\\)'/);
     // Backslash must be doubled
     expect(inner).toContain("\\\\");
     // Control chars must be escaped — no raw bytes

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -477,11 +477,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async charset(): Promise<string> {
-    return "";
+    return (await this.showVariable("character_set_database")) ?? "";
   }
 
   async collation(): Promise<string> {
-    return "";
+    return (await this.showVariable("collation_database")) ?? "";
   }
 
   async tableComment(tableName: string): Promise<string | null> {
@@ -510,9 +510,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     await this.getDatabaseVersion();
     this.schemaStatements().validateIndexLengthBang(tableName, newName);
     if (!this.supportsRenameIndex()) {
-      throw new Error(
-        "renameIndex requires MySQL >= 5.7.6 or MariaDB >= 10.5.2; upgrade your server to use this feature",
-      );
+      // Mirrors Rails AbstractAdapter#rename_index super path: drop the
+      // existing index and recreate under the new name.
+      const idx = (
+        await (this as unknown as { indexes(t: string): Promise<unknown[]> }).indexes(tableName)
+      ).find((i) => (i as { name?: string }).name === oldName) as
+        | { name: string; columns: string[]; unique: boolean }
+        | undefined;
+      if (!idx) return;
+      await (
+        this as unknown as {
+          addIndex(t: string, c: string[], o: Record<string, unknown>): Promise<void>;
+        }
+      ).addIndex(tableName, idx.columns, { name: newName, unique: idx.unique });
+      await (
+        this as unknown as { removeIndex(t: string, o: { name: string }): Promise<void> }
+      ).removeIndex(tableName, { name: oldName });
+      return;
     }
     await this._execMutation(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME INDEX ` +

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -39,7 +39,8 @@ describe("MySQL quoting — quote", () => {
   it("quotes strings with MySQL-specific escapes (\\n, \\0, \\Z, \\\\)", () => {
     expect(quote("a\nb")).toBe("'a\\nb'");
     expect(quote("null\0byte")).toBe("'null\\0byte'");
-    expect(quote("with 'quote'")).toBe("'with ''quote'''");
+    expect(quote("with 'quote'")).toBe("'with \\'quote\\''");
+    expect(quote('a "double" quote')).toBe("'a \\\"double\\\" quote'");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -67,9 +67,11 @@ export function quoteIdentifier(name: string): string {
 }
 
 // eslint-disable-next-line no-control-regex
-const MYSQL_ESCAPE_RE = /[\\\x00\n\r\x1a]/g;
+const MYSQL_ESCAPE_RE = /[\\'"\x00\n\r\x1a]/g;
 const MYSQL_ESCAPE_MAP: Record<string, string> = {
   "\\": "\\\\",
+  "'": "\\'",
+  '"': '\\"',
   "\0": "\\0",
   "\n": "\\n",
   "\r": "\\r",
@@ -77,16 +79,15 @@ const MYSQL_ESCAPE_MAP: Record<string, string> = {
 };
 
 /**
- * Quote a string value for use in SQL. Single quotes are escaped using
- * SQL-standard quote doubling (''), which is safe regardless of
- * NO_BACKSLASH_ESCAPES. Backslash and control characters (NUL, newline,
- * carriage return, Ctrl-Z) are escaped with backslashes for safe
- * transport across protocols.
+ * Quote a string value for use in SQL. Single/double quotes, backslash,
+ * and control characters (NUL, newline, carriage return, Ctrl-Z) are
+ * escaped with backslashes. Mirrors Rails MySQL `quote_string`, which
+ * delegates to `mysql2`/`trilogy`'s connection-level escape — both of
+ * which use backslash-escapes (not SQL-standard `''` doubling). The npm
+ * `mysql2` driver's `escape()` matches this same shape.
  */
 export function quoteString(value: string): string {
-  const withDoubledQuotes = value.replace(/'/g, "''");
-  const escaped = withDoubledQuotes.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch);
-  return `'${escaped}'`;
+  return `'${value.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch)}'`;
 }
 
 export function quotedBinary(value: Buffer | Uint8Array | string): string {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -34,11 +34,6 @@ interface MysqlColumn extends ColumnInfo {
 
 interface MysqlAdapterLike {
   tableOptions(tableName: string): Promise<Record<string, string>>;
-  /**
-   * Returns column → pre-`.inspect`'d generation_expression for each
-   * virtual/generated column in `tableName`. Empty object when none.
-   */
-  virtualColumnExpressions?(tableName: string): Promise<Record<string, string>>;
 }
 
 export class SchemaDumper extends AbstractSchemaDumper {
@@ -61,10 +56,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
     // schemaCollation can suppress per-column collation that matches the table default.
     if (Object.hasOwn(opts, "collation")) {
       this.tableCollationCache[tableName] = opts["collation"];
-    }
-    if (this.connection.virtualColumnExpressions) {
-      const exprs = await this.connection.virtualColumnExpressions(tableName);
-      if (Object.keys(exprs).length > 0) this.virtualExpressionCache[tableName] = exprs;
     }
     return opts;
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -34,6 +34,11 @@ interface MysqlColumn extends ColumnInfo {
 
 interface MysqlAdapterLike {
   tableOptions(tableName: string): Promise<Record<string, string>>;
+  /**
+   * Returns column → pre-`.inspect`'d generation_expression for each
+   * virtual/generated column in `tableName`. Empty object when none.
+   */
+  virtualColumnExpressions?(tableName: string): Promise<Record<string, string>>;
 }
 
 export class SchemaDumper extends AbstractSchemaDumper {
@@ -56,6 +61,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
     // schemaCollation can suppress per-column collation that matches the table default.
     if (Object.hasOwn(opts, "collation")) {
       this.tableCollationCache[tableName] = opts["collation"];
+    }
+    if (this.connection.virtualColumnExpressions) {
+      const exprs = await this.connection.virtualColumnExpressions(tableName);
+      if (Object.keys(exprs).length > 0) this.virtualExpressionCache[tableName] = exprs;
     }
     return opts;
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -913,29 +913,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return dumper;
   }
 
-  /**
-   * Fetch generation expressions for virtual/generated columns in a table
-   * via `information_schema.columns.generation_expression`. Used by
-   * `MysqlSchemaDumper` to render `as: "<expr>"` for virtual columns.
-   * @internal
-   */
-  async virtualColumnExpressions(tableName: string): Promise<Record<string, string>> {
-    const rows = (await this.schemaQuery(
-      `SELECT column_name, generation_expression FROM information_schema.columns ` +
-        `WHERE table_schema = database() AND table_name = ${this.quote(tableName)} ` +
-        `AND generation_expression <> ''`,
-    )) as Array<{ column_name?: string; generation_expression?: string }>;
-    const out: Record<string, string> = Object.create(null);
-    for (const row of rows) {
-      const name = row.column_name;
-      const expr = row.generation_expression;
-      if (typeof name === "string" && typeof expr === "string" && expr.length > 0) {
-        out[name] = JSON.stringify(expr);
-      }
-    }
-    return out;
-  }
-
   override schemaStatements(host?: DatabaseAdapter): MysqlSchemaStatements {
     return new MysqlSchemaStatements((host ?? this) as DatabaseAdapter);
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -913,6 +913,29 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return dumper;
   }
 
+  /**
+   * Fetch generation expressions for virtual/generated columns in a table
+   * via `information_schema.columns.generation_expression`. Used by
+   * `MysqlSchemaDumper` to render `as: "<expr>"` for virtual columns.
+   * @internal
+   */
+  async virtualColumnExpressions(tableName: string): Promise<Record<string, string>> {
+    const rows = (await this.schemaQuery(
+      `SELECT column_name, generation_expression FROM information_schema.columns ` +
+        `WHERE table_schema = database() AND table_name = ${this.quote(tableName)} ` +
+        `AND generation_expression <> ''`,
+    )) as Array<{ column_name?: string; generation_expression?: string }>;
+    const out: Record<string, string> = Object.create(null);
+    for (const row of rows) {
+      const name = row.column_name;
+      const expr = row.generation_expression;
+      if (typeof name === "string" && typeof expr === "string" && expr.length > 0) {
+        out[name] = JSON.stringify(expr);
+      }
+    }
+    return out;
+  }
+
   override schemaStatements(host?: DatabaseAdapter): MysqlSchemaStatements {
     return new MysqlSchemaStatements((host ?? this) as DatabaseAdapter);
   }
@@ -1620,6 +1643,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * @internal
    */
   protected async _warningCount(conn: mysql.PoolConnection): Promise<number> {
+    // Optimization: when the mysql2 npm driver exposes the protocol's
+    // last `serverStatus` packet, the bottom 16 bits of the per-connection
+    // `warningCount` are populated for the most recent statement (mirrors
+    // Rails reading `@raw_connection.warning_count` directly instead of
+    // round-tripping `SHOW COUNT(*) WARNINGS`). Fall back to the SHOW
+    // query when the field is absent or non-numeric.
+    const raw = (conn as unknown as { warningCount?: unknown; _warningCount?: unknown })
+      .warningCount;
+    if (typeof raw === "number") return raw;
     const [rows] = await conn.query("SHOW COUNT(*) WARNINGS");
     const row = (rows as Record<string, unknown>[])[0];
     if (!row) return 0;
@@ -1661,7 +1693,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       const level = row.Level ?? null;
       const code = row.Code == null ? null : String(row.Code);
       const message = row.Message ?? "";
-      const warning = new SQLWarning(message, code, level, sql);
+      const warning = new SQLWarning(message, code, level, sql, this.pool);
       if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
         continue;
       if (action === "raise") throw warning;
@@ -1742,10 +1774,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // mysql2's `charset` pool option corresponds to Rails' database.yml `encoding:`.
     const SAFE_CHARSET_RE = /^[A-Za-z0-9_]+$/;
     // mysql2 uses `charset`; Rails database.yml uses `encoding`. Support both, preferring charset.
+    // `variables: { encoding:, collation: }` from database.yml is also accepted and removed
+    // from the SET-variable list so it doesn't get emitted as `@@SESSION.encoding = …`.
+    const varEncoding = vars["encoding"];
+    if (varEncoding !== undefined) delete vars["encoding"];
+    const varCollation = vars["collation"];
+    if (varCollation !== undefined) delete vars["collation"];
     const charset =
       (this._poolConfig.charset as string | undefined) ??
-      (this._poolConfig as { encoding?: string }).encoding;
-    const charsetCollation = (this._poolConfig as { collation?: string }).collation;
+      (this._poolConfig as { encoding?: string }).encoding ??
+      (typeof varEncoding === "string" ? varEncoding : undefined);
+    const charsetCollation =
+      (this._poolConfig as { collation?: string }).collation ??
+      (typeof varCollation === "string" ? varCollation : undefined);
     if (charset && !SAFE_CHARSET_RE.test(charset)) {
       throw new Error(`Invalid MySQL charset: ${JSON.stringify(charset)}`);
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1759,6 +1759,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
     const sqlModeClause = sqlMode ? `@@SESSION.sql_mode = ${sqlMode}` : "";
 
+    // mysql2 uses `charset`; Rails database.yml uses `encoding`. Support both, preferring charset.
+    // `variables: { encoding:, collation: }` from database.yml is also accepted and removed from
+    // the SET-variable list (before varClauses is computed) so it doesn't also get emitted as
+    // `@@SESSION.encoding = …` alongside the SET NAMES prepend.
+    const varEncoding = vars["encoding"];
+    if (varEncoding !== undefined) delete vars["encoding"];
+    const varCollation = vars["collation"];
+    if (varCollation !== undefined) delete vars["collation"];
+
     const varClauses = Object.entries(vars)
       .filter(([, v]) => v !== null && v !== undefined)
       .map(([k, v]) => {
@@ -1773,13 +1782,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Mirrors Rails: `if @config[:encoding]` → `SET NAMES encoding [COLLATE collation], ...`
     // mysql2's `charset` pool option corresponds to Rails' database.yml `encoding:`.
     const SAFE_CHARSET_RE = /^[A-Za-z0-9_]+$/;
-    // mysql2 uses `charset`; Rails database.yml uses `encoding`. Support both, preferring charset.
-    // `variables: { encoding:, collation: }` from database.yml is also accepted and removed
-    // from the SET-variable list so it doesn't get emitted as `@@SESSION.encoding = …`.
-    const varEncoding = vars["encoding"];
-    if (varEncoding !== undefined) delete vars["encoding"];
-    const varCollation = vars["collation"];
-    if (varCollation !== undefined) delete vars["collation"];
     const charset =
       (this._poolConfig.charset as string | undefined) ??
       (this._poolConfig as { encoding?: string }).encoding ??

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -672,8 +672,19 @@ export class SQLWarning extends AdapterError {
   readonly level: string | null;
   sql?: string;
 
-  constructor(message?: string, code?: string | null, level?: string | null, sql?: string) {
-    super(message ?? "SQL Warning");
+  /**
+   * `connectionPool` is inherited via {@link AdapterError}'s accessor; we
+   * accept it as a constructor argument mirroring Rails'
+   * `SQLWarning.new(message, code, level, sql, pool)`.
+   */
+  constructor(
+    message?: string,
+    code?: string | null,
+    level?: string | null,
+    sql?: string,
+    connectionPool?: unknown,
+  ) {
+    super(message ?? "SQL Warning", { connectionPool });
     this.name = "SQLWarning";
     this.code = code ?? null;
     this.level = level ?? null;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1689,7 +1689,7 @@ export class MigrationContext {
     const ifExists = options?.ifExists === false ? "" : " IF EXISTS";
     const cascade =
       options?.force === "cascade" && this._adapterName === "postgres" ? " CASCADE" : "";
-    const quoted = this._adapterName === "mysql" ? `\`${name}\`` : `"${name}"`;
+    const quoted = this.adapter.quoteTableName(name);
     await this.adapter.executeMutation(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
     this._tables.delete(name);
     this._columns.delete(name);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1677,10 +1677,20 @@ export class MigrationContext {
     }
   }
 
-  async dropTable(name: string, options?: { force?: "cascade" }): Promise<void> {
+  async dropTable(
+    name: string,
+    options?: { ifExists?: boolean; force?: "cascade"; temporary?: boolean },
+  ): Promise<void> {
+    // Mirrors Rails MySQL drop_table: emit `DROP TEMPORARY TABLE` when `temporary: true`.
+    // `IF EXISTS` is included by default (matches the abstract drop_table contract); pass
+    // `ifExists: false` to omit it. `force: "cascade"` adds `CASCADE` on Postgres.
+    const temporary =
+      options?.temporary === true && this._adapterName === "mysql" ? " TEMPORARY" : "";
+    const ifExists = options?.ifExists === false ? "" : " IF EXISTS";
     const cascade =
       options?.force === "cascade" && this._adapterName === "postgres" ? " CASCADE" : "";
-    await this.adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"${cascade}`);
+    const quoted = this._adapterName === "mysql" ? `\`${name}\`` : `"${name}"`;
+    await this.adapter.executeMutation(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
     this._tables.delete(name);
     this._columns.delete(name);
     this._columnMeta.delete(name);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -598,7 +598,10 @@ export abstract class Migration {
     await this.schema.createTable(tname, optionsOrFn, fn);
   }
 
-  async dropTable(name: string, options?: { ifExists?: boolean }): Promise<void> {
+  async dropTable(
+    name: string,
+    options?: { ifExists?: boolean; force?: "cascade"; temporary?: boolean },
+  ): Promise<void> {
     if (this._recording) {
       this._recorder.record("dropTable", [name]);
       return;


### PR DESCRIPTION
## Summary

Batch 8 from the activerecord-100 plan — MySQL warnings, quoting, and init-SQL fidelity. Single adapter scope (`AbstractMysqlAdapter` + `mysql/quoting.ts`).

- **SQLWarning.connectionPool** — constructor now accepts a pool argument (forwarded via the existing `AdapterError` accessor); mysql2 `_handleWarningsOn` plumbs `this.pool` into each warning so `db_warnings_action` callbacks can attribute warnings back to the owning role/shard.
- **warning_count optimization** — `Mysql2Adapter._warningCount` short-circuits to `conn.warningCount` when the npm `mysql2` driver exposes it on the protocol's `serverStatus` packet, avoiding the `SHOW COUNT(*) WARNINGS` round-trip. Mirrors Rails reading `@raw_connection.warning_count` directly.
- **MySQL `quoteString` backslash-escapes** — switched from SQL-standard `''` doubling to backslash-escape for single quotes (and double quotes), mirroring Rails' MySQL `quote_string` which delegates to mysql2/trilogy connection-level escape (both use backslash escapes). Test expectations updated.
- **`MigrationContext.dropTable`** — now accepts `{ ifExists, force, temporary }`, forwarding all three to `schema.dropTable`. `MysqlSchemaStatements.dropTable` already accepted `temporary`; this closes the recorder-side gap.
- **`MysqlSchemaDumper.virtualExpressionCache`** — populated via a new `Mysql2Adapter#virtualColumnExpressions(table)` that queries `information_schema.columns.generation_expression`. `fetchTableOptions` calls it alongside the existing `tableCollationCache` populate.
- **`_buildInitSql`** — also reads `variables.encoding` / `variables.collation` from database.yml so they trigger the `SET NAMES <enc> [COLLATE <coll>]` prepend instead of being silently emitted as `@@SESSION.encoding = …`.
- **`AbstractMysqlAdapter#charset` / `#collation`** — now call `showVariable(\"character_set_database\")` / `showVariable(\"collation_database\")` instead of returning empty string.
- **`AbstractMysqlAdapter#renameIndex`** — when `supportsRenameIndex()` is false, falls back to the Rails super path: look up the existing index via `indexes()`, then `addIndex` + `removeIndex`. Previously threw.

## Follow-ups (deferred)

- **Fold `_handleWarningsOn` into `AbstractMysqlAdapter._handleWarnings(sql)`** behind an abstract `_currentConn()` accessor. Mysql2's connection lifecycle is per-query lease (no persistent \"current conn\"), so this needs an async-local context-store; deferred as a structural follow-up to keep this batch focused.

## Test plan

- [x] `packages/activerecord/src/connection-adapters/mysql/quoting.test.ts` — quoting (34 tests passing)
- [x] `packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts` — quote-string injection expectations updated (60 tests passing)
- [x] `packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts` — schema dumper (32 tests passing)
- [x] `packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts` — `_buildInitSql` etc. (66 tests, 61 skipped behind live MySQL)
- [ ] Live MySQL CI exercises charset/collation, renameIndex fallback, virtualExpressionCache, warnings.