### PR TITLE
fix(action-dispatch): port Rails' Mapper.normalize_path leading-optional handling

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -61,6 +61,32 @@ describe("Route", () => {
     });
   });
 
+  describe("path normalization — leading optional groups", () => {
+    it("normalizes (/:locale)/posts so /posts and /en/posts both match", () => {
+      const route = new Route("GET", "(/:locale)/posts", "posts", "index");
+      expect(route.match("GET", "/posts")).not.toBeNull();
+      const m = route.match("GET", "/en/posts");
+      expect(m).not.toBeNull();
+      expect(m!.params["locale"]).toBe("en");
+    });
+
+    it("normalizes when caller passes the leading '/' explicitly", () => {
+      // Rails' normalize_path collapses '/(' to '(/' so both forms classify
+      // identically.
+      const route = new Route("GET", "/(/:locale)/posts", "posts", "index");
+      expect(route.match("GET", "/posts")).not.toBeNull();
+      expect(route.match("GET", "/en/posts")).not.toBeNull();
+    });
+
+    it("keeps leading /( for all-optional paths (root-style routes)", () => {
+      // Rails restores '/(' when the path is composed entirely of optional
+      // segments, so the root '/' case still matches.
+      const route = new Route("GET", "(/:locale)(/:platform)", "x", "y");
+      expect(route.match("GET", "/")).not.toBeNull();
+      expect(route.match("GET", "/en")).not.toBeNull();
+    });
+  });
+
   describe("pathParamNames", () => {
     it("lists dynamic and glob captures in declaration order", () => {
       const route = new Route("GET", "/a/:id/b/*rest", "x", "y");

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -85,6 +85,19 @@ describe("Route", () => {
       expect(route.match("GET", "/")).not.toBeNull();
       expect(route.match("GET", "/en")).not.toBeNull();
     });
+
+    it("handles all-optional paths with non-`/:` groups (e.g. dot-prefix format)", () => {
+      // `(/:locale)(.:format)` is all-optional but the second group starts
+      // with `.` rather than `/:`. The balanced-paren scan should still
+      // classify this as all-optional and restore the leading `/(`.
+      const route = new Route("GET", "(/:locale)(.:format)", "x", "y");
+      expect(route.match("GET", "/")).not.toBeNull();
+      expect(route.match("GET", "/en")).not.toBeNull();
+      const m = route.match("GET", "/en.json");
+      expect(m).not.toBeNull();
+      expect(m!.params["locale"]).toBe("en");
+      expect(m!.params["format"]).toBe("json");
+    });
   });
 
   describe("pathParamNames", () => {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -371,12 +371,17 @@ function parseSegments(path: string): PathSegment[] {
 }
 
 function normalizePath(p: string): string {
-  const stripped = p.replace(/^\/+|\/+$/g, "");
-  // Don't prepend `/` to a leading optional group: `(/:locale)/posts` must
-  // stay as-is so the `/` lives inside the optional. Prepending would
-  // produce `/(/:locale)/posts`, compiled to `^/(?:/...)?/posts$`, which
-  // requires either `//posts` (extra slash) or `/x/posts` (no plain match).
-  return stripped.startsWith("(") ? stripped : "/" + stripped;
+  // Mirrors Rails `ActionDispatch::Routing::Mapper.normalize_path`:
+  // first apply Journey's normalize (leading-`/` + collapse runs + strip
+  // trailing) then swap `/(` → `(/` so leading optional groups keep the
+  // `/` *inside* the optional. The leading `/(` form is restored only when
+  // the entire path is composed of optional segments (root-style routes).
+  let path = "/" + p.replace(/^\/+|\/+$/g, "");
+  path = path.replace(/\/(\(+)\/?/g, "$1/");
+  if (/^(\(+[^)]+\))(\(+\/:[^)]+\))*$/.test(path)) {
+    path = path.replace(/^(\(+)\//, "/$1");
+  }
+  return path;
 }
 
 function interpolateRedirect(template: string, params: Record<string, string>): string {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -4,6 +4,7 @@
 
 import { Parser } from "../journey/parser.js";
 import { Ast } from "../journey/ast.js";
+import { normalizePath as journeyNormalizePath } from "../journey/router/utils.js";
 import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
 
@@ -372,16 +373,42 @@ function parseSegments(path: string): PathSegment[] {
 
 function normalizePath(p: string): string {
   // Mirrors Rails `ActionDispatch::Routing::Mapper.normalize_path`:
-  // first apply Journey's normalize (leading-`/` + collapse runs + strip
-  // trailing) then swap `/(` → `(/` so leading optional groups keep the
-  // `/` *inside* the optional. The leading `/(` form is restored only when
-  // the entire path is composed of optional segments (root-style routes).
-  let path = "/" + p.replace(/^\/+|\/+$/g, "");
+  // first apply Journey's `Utils.normalize_path` (leading-`/`, collapse
+  // duplicate slashes, strip trailing, uppercase `%xx`), then swap `/(`
+  // → `(/` so leading optional groups keep the `/` *inside* the optional.
+  // The leading `/(` form is restored only when the entire path is
+  // composed of adjacent optional segments (root-style routes).
+  let path = journeyNormalizePath(p);
   path = path.replace(/\/(\(+)\/?/g, "$1/");
-  if (/^(\(+[^)]+\))(\(+\/:[^)]+\))*$/.test(path)) {
+  if (isAllOptional(path)) {
     path = path.replace(/^(\(+)\//, "/$1");
   }
   return path;
+}
+
+/**
+ * True when `path` consists only of adjacent balanced-paren optional
+ * groups (no top-level literal characters between them). Mirrors what
+ * Rails' Mapper.normalize_path treats as the "all-optional" shape —
+ * paths like `(/:locale)(.:format)` or `(/:a)(/:b)(/:c)`.
+ */
+function isAllOptional(path: string): boolean {
+  if (!path.startsWith("(")) return false;
+  let depth = 0;
+  for (let i = 0; i < path.length; i++) {
+    const ch = path[i];
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")") {
+      depth--;
+      if (depth < 0) return false;
+      // After closing a top-level group, only another `(` may follow
+      // (adjacent optional groups). Any literal between groups
+      // disqualifies the all-optional shape.
+      if (depth === 0 && i + 1 < path.length && path[i + 1] !== "(") return false;
+    }
+  }
+  return depth === 0;
 }
 
 function interpolateRedirect(template: string, params: Record<string, string>): string {


### PR DESCRIPTION
## Summary
The PR #1721 workaround (\`startsWith(\"(\") ? stripped : \"/\" + stripped\`) only handled the simplest leading-optional case. Rails' \`Mapper.normalize_path\` uses two gsubs that together handle nested and all-optional shapes:

\`\`\`ruby
path.gsub!(%r{/(\\(+)/?}, '\\1/')                    # /( → (/
path.sub!(%r{^(\\(+)/}, '/\\1') if all_optional?    # restore for roots
\`\`\`

Port both. Now:
- \`/(/:locale)/posts\` and \`(/:locale)/posts\` classify identically.
- Nested cases like \`/((/...))/posts\` normalize correctly.
- Root-style all-optional paths like \`(/:locale)(/:platform)\` keep the leading \`/(\` so the bare \`/\` case still matches.

## Investigation note
I started this thinking it was a Pattern regex-builder bug. It isn't — Pattern produces correct regexes for whatever AST the Parser feeds it. The discrepancy was upstream, in path normalization. Rails' Mapper.normalize_path has been doing this rewrite forever; we just hadn't ported that step.

## Test plan
- [x] 3 regression tests for the leading-optional shapes (simple, leading-slash form, all-optional root-style)
- [x] All 2054 actionpack tests pass
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean