### PR TITLE
feat(activerecord): batch 5 — PG interval round-trip (interval[] + binary parser)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -71,6 +71,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((i.maximum_term as Duration).iso8601()).toBe("P6Y5M4DT3H2M1S");
       expect((i.minimum_term as Duration).iso8601()).toBe("P1Y2M3DT4H5M6.235S");
       expect((i.default_term as Duration).iso8601()).toBe("P3Y");
+      // Rails: assert_equal %w[ P1M P1Y PT1H ], i.all_terms.map(&:iso8601)
+      expect((i.all_terms as Duration[]).map((d) => d.iso8601())).toEqual(["P1M", "P1Y", "PT1H"]);
       expect(i.legacy_term).toBe("P33Y");
     });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -72,6 +72,7 @@ import { makeGetTypeParser } from "./postgresql/temporal-type-parsers.js";
 const getTemporalTypeParser = makeGetTypeParser(pg.types);
 const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
 const OID_INTERVAL = 1186;
+const OID_INTERVAL_ARRAY = 1187;
 import {
   READ_QUERY,
   executeBatch as pgExecuteBatch,
@@ -333,8 +334,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           getTypeParser: (oid: number, format?: string) => {
             // PG interval (OID 1186): return the raw ISO 8601 string so the
             // AR Interval type can Duration.parse() it (Rails sets
-            // intervalstyle = iso_8601 per connection).
-            if (oid === OID_INTERVAL && format !== "binary") return (v: unknown) => v;
+            // intervalstyle = iso_8601 per connection). For binary format
+            // pg-types ships no interval decoder, so explicitly delegate to
+            // the built-in (text-only assumption: configureConnection sets
+            // intervalstyle, so we never receive binary intervals in
+            // practice — this branch is documented passthrough).
+            if (oid === OID_INTERVAL) {
+              return format === "binary"
+                ? pg.types.getTypeParser(OID_INTERVAL, "binary")
+                : (v: unknown) => v;
+            }
+            // PG interval[] (OID 1187): pg-types hard-codes parseInterval as
+            // the element parser, bypassing our OID 1186 override. Return the
+            // raw array literal so AR Array.deserialize parses the elements
+            // through Interval.castValue (Duration.parse on ISO 8601).
+            if (oid === OID_INTERVAL_ARRAY && format !== "binary") return (v: unknown) => v;
             if ((oid === OID_JSON || oid === OID_JSONB) && format !== "binary")
               return (v: unknown) => v;
             return oid === 1082 && !PostgreSQLAdapter.decodeDates
@@ -410,8 +424,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // When decodeDates is false, skip the date parser (OID 1082) so
           // pg returns the raw string — mirrors Rails' decode_dates flag.
           // PG interval (OID 1186): return raw ISO 8601 string for AR
-          // Interval (intervalstyle = iso_8601 is set on connect).
-          if (oid === OID_INTERVAL && format !== "binary") {
+          // Interval (intervalstyle = iso_8601 is set on connect). Binary
+          // format is delegated to the pg-types built-in — see the
+          // matching branch in the connectionString constructor for the
+          // text-only-in-practice rationale.
+          if (oid === OID_INTERVAL) {
+            const fallback =
+              format === "binary"
+                ? pg.types.getTypeParser(OID_INTERVAL, "binary")
+                : (v: unknown) => v;
+            return userGetTypeParser?.(oid, format) ?? fallback;
+          }
+          // PG interval[] (OID 1187): pg-types hard-codes parseInterval as
+          // the element parser, so we must override the array OID too. Raw
+          // array literal is handed to AR Array.deserialize, which routes
+          // each element through Interval.castValue.
+          if (oid === OID_INTERVAL_ARRAY && format !== "binary") {
             const fallback = (v: unknown) => v;
             return userGetTypeParser?.(oid, format) ?? fallback;
           }


### PR DESCRIPTION
## Summary

- Override pg-types parser for OID 1187 (interval[]) so interval arrays round-trip through `Duration`. pg-types hard-codes its own `parseInterval` as the element parser for interval arrays, bypassing our per-connection OID 1186 override; without this fix, `Array.deserialize` receives an array of `PostgresInterval` objects and `Interval.castValue` falls through to `null`. Returning the raw array literal lets `Array.deserialize` → `parseArray` route each element through `Interval.cast` (`Duration.parse` on ISO 8601).
- Explicitly delegate the OID 1186 binary-format branch to `pg.types.getTypeParser(1186, "binary")` and document the text-only assumption (`configureConnection` sets `intervalstyle = iso_8601`, so binary intervals never arrive in practice — this is documented passthrough rather than a working path).
- Un-skip the `all_terms` iso8601 assertion in the `interval type` test to mirror the Rails `test_interval_type` body exactly.

## Plan items covered (`docs/activerecord-100-plan.md` § PG types)

- Interval row-read deserialization — already in place via `Interval.castValue` (PR #1687); this PR closes the array-element gap so the round-trip is end-to-end.
- Aggregate result type-cast — already wired in `relation/calculations.ts` via `colType.deserialize` for non-numeric column types.
- `extractValueFromDefault` for interval — schema-dumper `schemaDefault` already routes through `lookupCastTypeFromColumn` → `Interval.typeCastForSchema`, exercised by `schema dump with default value`.
- Binary-format parser delegation — explicit delegation + documentation in this PR.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapters/postgresql/interval.test.ts` against PG: 7/7 pass, including the strengthened `all_terms` assertion.
- [x] `pnpm vitest run` for adjacent PG datatype + Array OID test files: green.
- [ ] CI full suite.