### PR TITLE
refactor(action-dispatch): Route#pathFor via Journey Formatter (delete parseSegments)

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/routing.test.ts
@@ -188,7 +188,9 @@ describe("TestRouter", () => {
     routes.draw((r) => {
       r.get("/posts/:id", { to: "posts#show", as: "post" });
     });
-    expect(routes.pathFor("post", { id: "hello world" })).toBe("/posts/hello world");
+    // URL-unsafe characters in path params are percent-escaped (mirrors
+    // Rails Journey Utils.escape_segment).
+    expect(routes.pathFor("post", { id: "hello world" })).toBe("/posts/hello%20world");
   });
 
   it("generate with name", () => {

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -98,6 +98,23 @@ describe("Route", () => {
       expect(route.pathFor({ path: "a/b/c" })).toBe("/files/a/b/c");
     });
 
+    it("treats bare '*' as a literal (no implicit empty-name splat)", () => {
+      // The Journey scanner treats trailing/bare `*` as a literal — it
+      // doesn't capture an empty-named splat. So `/page*` has no path
+      // params and pathFor() round-trips the literal star.
+      const route = new Route("GET", "/page*", "x", "y");
+      expect(route.pathParamNames).toEqual([]);
+      expect(route.pathFor()).toBe("/page*");
+    });
+
+    it("collapses structural // when slash-bearing capture is in an omitted optional", () => {
+      // controller carries '/' but its group is omitted because :action is
+      // missing. The slash-bearing value never lands in the output, so
+      // the structural `//` left by that omitted group must still collapse.
+      const route = new Route("GET", "(/:controller/:action)(/:id)", "x", "y");
+      expect(route.pathFor({ controller: "admin/posts", id: "1" })).toBe("/1");
+    });
+
     it("collapses slashes when slash-bearing-capture optional is omitted", () => {
       // The route declares a `:controller` (which preserves `/` in its
       // value via Format.requiredPath) but the user doesn't supply it.

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -123,28 +123,34 @@ describe("Route", () => {
       expect(route.pathFor({ id: "" })).toBe("/posts/");
     });
 
-    it("rejects path-capture values that violate the route's requirement regex", () => {
+    it("rejects path-capture values that violate the route's requirement regex (anchored)", () => {
       const route = new Route("GET", "/posts/:id", "posts", "show", {
         constraints: { id: /\d+/ },
       });
+      // `42abc` would pass an unanchored `/\d+/` but fails the anchored
+      // `^(?:\d+)$` Journey wraps requirements in.
+      expect(() => route.pathFor({ id: "42abc" })).toThrow(/Missing required parameter :id/);
       expect(() => route.pathFor({ id: "abc" })).toThrow(/Missing required parameter :id/);
       expect(route.pathFor({ id: "42" })).toBe("/posts/42");
     });
 
     it("ignores request-attribute constraints (only path captures are validated)", () => {
       // `subdomain` is a request constraint, not a path capture. pathFor
-      // shouldn't validate path params against it (and shouldn't fail
-      // when an unrelated param happens to share the key).
+      // shouldn't validate against it even when the caller supplies an
+      // unrelated value with a non-matching key.
       const route = new Route("GET", "/posts/:id", "posts", "show", {
         constraints: { id: /\d+/, subdomain: /^api$/ },
       });
-      expect(route.pathFor({ id: "42" })).toBe("/posts/42");
+      expect(route.pathFor({ id: "42", subdomain: "www" } as Record<string, string>)).toBe(
+        "/posts/42",
+      );
     });
 
     it("honors string path constraints (Rails-shape anchored RegExp)", () => {
       const route = new Route("GET", "/posts/:id", "posts", "show", {
         constraints: { id: "\\d+" },
       });
+      expect(() => route.pathFor({ id: "42abc" })).toThrow(/Missing required parameter :id/);
       expect(() => route.pathFor({ id: "abc" })).toThrow(/Missing required parameter :id/);
       expect(route.pathFor({ id: "42" })).toBe("/posts/42");
     });

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -115,14 +115,23 @@ describe("Route", () => {
       expect(route.pathFor({ b: "x", extra: "/" } as Record<string, string>)).toBe("/x");
     });
 
-    it("treats empty-string required params as missing", () => {
-      // Format.evaluate would emit `""` and leave structural slashes
-      // around it, producing malformed URLs like `//x`. Throw instead.
-      const route = new Route("GET", "/:a/:b", "x", "y");
-      expect(() => route.pathFor({ a: "", b: "x" })).toThrow(/Missing required parameter :a/);
+    it("treats empty string as supplied (matches Journey Formatter semantics)", () => {
+      // Journey Formatter follows Ruby truthiness — `""` is supplied.
+      // `/posts/:id` with `{ id: "" }` formats as `/posts/` (the empty
+      // segment is preserved by the structural separator that follows).
+      const route = new Route("GET", "/posts/:id", "posts", "show");
+      expect(route.pathFor({ id: "" })).toBe("/posts/");
     });
 
-    it("does not lose route params named __proto__ / constructor", () => {
+    it("rejects path-capture values that violate the route's requirement regex", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show", {
+        constraints: { id: /\d+/ },
+      });
+      expect(() => route.pathFor({ id: "abc" })).toThrow(/Missing required parameter :id/);
+      expect(route.pathFor({ id: "42" })).toBe("/posts/42");
+    });
+
+    it("does not lose a route param named __proto__", () => {
       // Plain-object hash inside pathFor() would route an own `__proto__`
       // assignment to the inherited setter, silently dropping it. Using a
       // null-prototype hash makes it an own property. The input needs an

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -61,6 +61,24 @@ describe("Route", () => {
     });
   });
 
+  describe("pathFor() — edge cases", () => {
+    it("throws missing-required when a name is required at the top level even if it also appears optionally", () => {
+      // `/:id(.:id)` has `:id` both required (top-level) and inside an
+      // optional group. Pattern.requiredNames would drop it; the
+      // top-level-symbol walk keeps it.
+      const route = new Route("GET", "/:id(.:id)", "x", "y");
+      expect(() => route.pathFor({})).toThrow(/Missing required parameter :id/);
+    });
+
+    it("collapses double slashes from partially-supplied adjacent optional groups", () => {
+      const route = new Route("GET", "(/:a)(/:b)", "x", "y");
+      expect(route.pathFor({ b: "x" })).toBe("/x");
+      expect(route.pathFor({ a: "y" })).toBe("/y");
+      expect(route.pathFor({ a: "y", b: "x" })).toBe("/y/x");
+      expect(route.pathFor({})).toBe("/");
+    });
+  });
+
   describe("path normalization — leading optional groups", () => {
     it("normalizes (/:locale)/posts so /posts and /en/posts both match", () => {
       const route = new Route("GET", "(/:locale)/posts", "posts", "index");

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -98,6 +98,27 @@ describe("Route", () => {
       expect(route.pathFor({ path: "a/b/c" })).toBe("/files/a/b/c");
     });
 
+    it("collapses slashes when splat-bearing optional is omitted", () => {
+      // The route *declares* a splat inside an optional but the user
+      // doesn't supply it. The supplied-value check should detect that
+      // no value contains `/`, so the collapse runs and removes the
+      // leading `//` from the omitted optional.
+      const route = new Route("GET", "(/:controller)(/:action)", "x", "y");
+      expect(route.pathFor({ action: "show" })).toBe("/show");
+    });
+
+    it("does not lose route params named __proto__ / constructor", () => {
+      // Plain-object hash inside pathFor() would route an own `__proto__`
+      // assignment to the inherited setter, silently dropping it. Using a
+      // null-prototype hash makes it an own property. The input needs an
+      // explicit own __proto__ since the literal { __proto__: ... } sets
+      // the prototype rather than an own property.
+      const route = new Route("GET", "/:__proto__", "x", "y");
+      const params: Record<string, string> = Object.create(null);
+      params["__proto__"] = "evil";
+      expect(route.pathFor(params)).toBe("/evil");
+    });
+
     it("throws missing-required when a name is required at the top level even if it also appears optionally", () => {
       // `/:id(.:id)` has `:id` both required (top-level) and inside an
       // optional group. Pattern.requiredNames would drop it; the

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -131,6 +131,24 @@ describe("Route", () => {
       expect(route.pathFor({ id: "42" })).toBe("/posts/42");
     });
 
+    it("ignores request-attribute constraints (only path captures are validated)", () => {
+      // `subdomain` is a request constraint, not a path capture. pathFor
+      // shouldn't validate path params against it (and shouldn't fail
+      // when an unrelated param happens to share the key).
+      const route = new Route("GET", "/posts/:id", "posts", "show", {
+        constraints: { id: /\d+/, subdomain: /^api$/ },
+      });
+      expect(route.pathFor({ id: "42" })).toBe("/posts/42");
+    });
+
+    it("honors string path constraints (Rails-shape anchored RegExp)", () => {
+      const route = new Route("GET", "/posts/:id", "posts", "show", {
+        constraints: { id: "\\d+" },
+      });
+      expect(() => route.pathFor({ id: "abc" })).toThrow(/Missing required parameter :id/);
+      expect(route.pathFor({ id: "42" })).toBe("/posts/42");
+    });
+
     it("does not lose a route param named __proto__", () => {
       // Plain-object hash inside pathFor() would route an own `__proto__`
       // assignment to the inherited setter, silently dropping it. Using a

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -61,7 +61,43 @@ describe("Route", () => {
     });
   });
 
+  describe("score() — AST-based scoring", () => {
+    it("static segments outscore dynamic captures", () => {
+      const r1 = new Route("GET", "/posts/:id", "posts", "show");
+      const r2 = new Route("GET", "/posts/featured", "posts", "featured");
+      expect(r2.score()).toBeGreaterThan(r1.score());
+    });
+
+    it("scores top-level glob captures as 0 (nested by definition)", () => {
+      const r1 = new Route("GET", "/files/static", "files", "show");
+      const r2 = new Route("GET", "/files/*path", "files", "show");
+      // Static route should outscore the glob route.
+      expect(r1.score()).toBeGreaterThan(r2.score());
+    });
+
+    it("scores symbols inside optional groups as 0", () => {
+      const r1 = new Route("GET", "/posts/:id", "posts", "show"); // top-level :id
+      const r2 = new Route("GET", "/posts(/:id)", "posts", "show"); // optional :id
+      expect(r1.score()).toBeGreaterThan(r2.score());
+    });
+
+    it("knowledge boost applies only to top-level dynamics", () => {
+      const r = new Route("GET", "/posts/:id", "posts", "show");
+      expect(r.score({ id: true })).toBeGreaterThan(r.score());
+    });
+  });
+
   describe("pathFor() — edge cases", () => {
+    it("throws missing-required for top-level *splat captures", () => {
+      const route = new Route("GET", "/files/*path", "files", "show");
+      expect(() => route.pathFor({})).toThrow(/Missing required parameter :path/);
+    });
+
+    it("preserves literal '/' in *splat values (no slash-collapse corruption)", () => {
+      const route = new Route("GET", "/files/*path", "files", "show");
+      expect(route.pathFor({ path: "a/b/c" })).toBe("/files/a/b/c");
+    });
+
     it("throws missing-required when a name is required at the top level even if it also appears optionally", () => {
       // `/:id(.:id)` has `:id` both required (top-level) and inside an
       // optional group. Pattern.requiredNames would drop it; the

--- a/packages/actionpack/src/action-dispatch/routing/route.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.test.ts
@@ -98,13 +98,28 @@ describe("Route", () => {
       expect(route.pathFor({ path: "a/b/c" })).toBe("/files/a/b/c");
     });
 
-    it("collapses slashes when splat-bearing optional is omitted", () => {
-      // The route *declares* a splat inside an optional but the user
-      // doesn't supply it. The supplied-value check should detect that
-      // no value contains `/`, so the collapse runs and removes the
-      // leading `//` from the omitted optional.
+    it("collapses slashes when slash-bearing-capture optional is omitted", () => {
+      // The route declares a `:controller` (which preserves `/` in its
+      // value via Format.requiredPath) but the user doesn't supply it.
+      // The supplied-value check should detect that no used value
+      // contains `/`, so the collapse runs and removes the leading `//`
+      // from the omitted optional.
       const route = new Route("GET", "(/:controller)(/:action)", "x", "y");
       expect(route.pathFor({ action: "show" })).toBe("/show");
+    });
+
+    it("ignores unused params when deciding whether to collapse slashes", () => {
+      // `extra` isn't declared in the route, so a `/` in its value must
+      // not block the collapse of the structural double-slash.
+      const route = new Route("GET", "(/:a)(/:b)", "x", "y");
+      expect(route.pathFor({ b: "x", extra: "/" } as Record<string, string>)).toBe("/x");
+    });
+
+    it("treats empty-string required params as missing", () => {
+      // Format.evaluate would emit `""` and leave structural slashes
+      // around it, producing malformed URLs like `//x`. Throw instead.
+      const route = new Route("GET", "/:a/:b", "x", "y");
+      expect(() => route.pathFor({ a: "", b: "x" })).toThrow(/Missing required parameter :a/);
     });
 
     it("does not lose route params named __proto__ / constructor", () => {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -125,10 +125,12 @@ export class Route {
    * them against undefined request properties.
    */
   get requestConstraints(): Record<string, unknown> {
-    const out: Record<string, unknown> = {};
+    // Null-prototype map so a constraint keyed `__proto__` becomes an own
+    // property rather than hitting the inherited setter.
+    const out: Record<string, unknown> = Object.create(null);
     const paths = new Set<string>(this.paramNames);
-    for (const [k, v] of Object.entries(this.constraints)) {
-      if (!paths.has(k)) out[k] = v;
+    for (const k of Object.keys(this.constraints)) {
+      if (!paths.has(k)) out[k] = this.constraints[k];
     }
     return out;
   }
@@ -138,10 +140,10 @@ export class Route {
    * `*name` segment). These become Journey pattern requirements.
    */
   get pathConstraints(): Record<string, unknown> {
-    const out: Record<string, unknown> = {};
+    const out: Record<string, unknown> = Object.create(null);
     const paths = new Set<string>(this.paramNames);
-    for (const [k, v] of Object.entries(this.constraints)) {
-      if (paths.has(k)) out[k] = v;
+    for (const k of Object.keys(this.constraints)) {
+      if (paths.has(k)) out[k] = this.constraints[k];
     }
     return out;
   }
@@ -265,12 +267,15 @@ export class Route {
       // Group nodes (top-level Stars count as required too) — that's the
       // true "must be supplied" set.
       this._requiredParamNames = topLevelSymbolNames(tree);
-      // `requirementsForMissingKeysCheck` returns a plain object, which
-      // would route a `__proto__` capture to the inherited setter.
-      // Copy into a null-prototype map so all capture names survive.
+      // Build the anchored requirements ourselves from `reqs` (which is
+      // already null-prototype). Going through Pattern's
+      // `requirementsForMissingKeysCheck` getter would route a
+      // `__proto__` capture to the plain-object inherited setter,
+      // dropping the requirement before we can copy it.
       const safeReqs: Record<string, RegExp> = Object.create(null);
-      for (const [k, v] of Object.entries(pattern.requirementsForMissingKeysCheck)) {
-        safeReqs[k] = v;
+      for (const name of Object.keys(reqs)) {
+        const re = reqs[name]!;
+        safeReqs[name] = new RegExp(`^(?:${re.source})$`, re.flags);
       }
       this._pathRequirements = safeReqs;
     }
@@ -311,7 +316,7 @@ export class Route {
     // with a value containing `/` — those use Format.requiredPath /
     // escapePath, which keeps `/` literal, so collapsing would munge
     // the user value.
-    if (!suppliedSlashInPathPreservingCapture(params, this.path)) {
+    if (!emittedSlashInPathPreservingCapture(params, this.path, out)) {
       // Collapse `/{2,}` runs left over from omitted optional groups
       // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x` → `/x`). Trailing
       // slashes are kept — they can be structural (e.g. `/posts/` is
@@ -362,17 +367,22 @@ export class Route {
 }
 
 /**
- * True if a *path-preserving* capture is supplied with a value
- * containing `/`. Only `*splat` and `:controller` parameters preserve
- * slashes (via `Format.requiredPath` + `escapePath`); ordinary `:name`
- * segments percent-encode `/` to `%2F`, so their values can't introduce
- * literal `/` runs into the output and don't need to suppress collapse.
- * Captures inside an omitted optional group don't contribute output, so
- * we restrict the check to *supplied* path-preserving captures.
+ * True if a *path-preserving* capture's slash-bearing value was actually
+ * emitted by the formatter. Checking emitted-vs-supplied matters when
+ * the capture sits in an optional group that gets omitted because some
+ * other required param in the same group is missing — the value
+ * shouldn't suppress the structural-slash collapse if it never made it
+ * to the output.
+ *
+ * Only `*splat` and `:controller` parameters preserve slashes (via
+ * `Format.requiredPath` + `escapePath`); ordinary `:name` segments
+ * percent-encode `/` to `%2F`, so their values can't introduce literal
+ * `/` runs into the output and don't need to suppress collapse.
  */
-function suppliedSlashInPathPreservingCapture(
+function emittedSlashInPathPreservingCapture(
   params: Record<string, string | number>,
   path: string,
+  out: string,
 ): boolean {
   // Names of path-preserving captures declared by this route. Splat
   // (`*name`) is always path-preserving; the `:controller` symbol gets
@@ -388,8 +398,14 @@ function suppliedSlashInPathPreservingCapture(
   const declaresController = /(?<!\\):controller\b/.test(path);
   for (const [k, v] of Object.entries(params)) {
     if (typeof v !== "string" || !v.includes("/")) continue;
-    if (splatNames.has(k)) return true;
-    if (declaresController && k === "controller") return true;
+    const isPathPreserving = splatNames.has(k) || (declaresController && k === "controller");
+    if (!isPathPreserving) continue;
+    // `escapePath` keeps `/` literal but escapes other unsafe chars,
+    // so the value can land in `out` either verbatim or partially
+    // escaped. Cheap proof-of-presence: the slash-containing prefix up
+    // to the first non-path-safe character should appear unchanged.
+    const slashPrefix = v.split(/[^a-zA-Z0-9\-._~!$&'()*+,;=:@/]/, 1)[0]!;
+    if (slashPrefix.includes("/") && out.includes(slashPrefix)) return true;
   }
   return false;
 }

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -229,7 +229,11 @@ export class Route {
       const ast = new Ast(tree, true);
       const pattern = new Pattern(ast, {}, PATHFOR_SEPARATORS, this.anchor);
       this._pathFormatter = pattern.buildFormatter();
-      this._requiredParamNames = pattern.requiredNames;
+      // `Pattern.requiredNames` filters by optional-name *set*, so a name
+      // that appears both required and optional (e.g. `/:id(.:id)`) gets
+      // dropped. Walk the AST and collect symbol names strictly outside
+      // Group/Star nodes — that's the true "must be supplied" set.
+      this._requiredParamNames = topLevelSymbolNames(tree);
     }
     for (const name of this._requiredParamNames!) {
       if (!Object.hasOwn(params, name) || params[name] == null) {
@@ -242,7 +246,14 @@ export class Route {
     for (const [k, v] of Object.entries(params)) {
       if (v != null) hash[k] = String(v);
     }
-    return this._pathFormatter.evaluate(hash);
+    // Collapse runs of `/` and strip a trailing `/` (unless that's the
+    // whole string). When all-optional groups partially supply params,
+    // adjacent slashes from omitted groups can leave double slashes
+    // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x`).
+    let out = this._pathFormatter.evaluate(hash);
+    out = out.replace(/\/{2,}/g, "/");
+    if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
+    return out;
   }
 
   /**
@@ -283,6 +294,40 @@ export class Route {
     const url = `http://${host}${path}`;
     return { url, status };
   }
+}
+
+function topLevelSymbolNames(tree: unknown): readonly string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const walk = (node: unknown, nested: boolean): void => {
+    const n = node as {
+      isSymbol?: () => boolean;
+      isGroup?: () => boolean;
+      isStar?: () => boolean;
+      isCat?: () => boolean;
+      toSym?: () => string;
+      left?: unknown;
+      right?: unknown;
+    };
+    if (n.isGroup?.() || n.isStar?.()) {
+      walk(n.left, true);
+      return;
+    }
+    if (n.isCat?.()) {
+      walk(n.left, nested);
+      walk(n.right, nested);
+      return;
+    }
+    if (!nested && n.isSymbol?.()) {
+      const name = n.toSym!();
+      if (!seen.has(name)) {
+        seen.add(name);
+        out.push(name);
+      }
+    }
+  };
+  walk(tree, false);
+  return out;
 }
 
 function collectParamNamesFromJourneyAst(path: string): string[] {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -165,7 +165,9 @@ export class Route {
         isGroup?: () => boolean;
         isStar?: () => boolean;
         isCat?: () => boolean;
+        type?: string;
         toSym?: () => string;
+        children?: () => unknown[];
         left?: unknown;
         right?: unknown;
       };
@@ -176,6 +178,11 @@ export class Route {
       if (n.isCat?.()) {
         walk(n.left, nested);
         walk(n.right, nested);
+        return;
+      }
+      if (n.type === "OR") {
+        // Or-children are alternatives at the same nesting level.
+        for (const c of n.children?.() ?? []) walk(c, nested);
         return;
       }
       if (n.isLiteral?.()) {
@@ -242,18 +249,22 @@ export class Route {
         );
       }
     }
-    const hash: Record<string, unknown> = {};
+    // Null-prototype object so route params named `__proto__` /
+    // `constructor` etc. become own properties rather than hitting the
+    // inherited setter (which would silently drop them).
+    const hash: Record<string, unknown> = Object.create(null);
     for (const [k, v] of Object.entries(params)) {
       if (v != null) hash[k] = String(v);
     }
     let out = this._pathFormatter.evaluate(hash);
     // Collapse runs of `/` left over from omitted optional groups (e.g.
     // `(/:a)(/:b)` with `{ b: "x" }` → `//x`) and strip a single trailing
-    // slash. Skip when the path can emit literal `/` inside a captured
-    // value — top-level `*splat` or `:controller` parameters preserve
-    // slashes via Format.requiredPath / escapePath, so post-processing
-    // would corrupt those values.
-    if (!hasUnescapedSlashCaptures(this.path)) {
+    // slash. Skip when a supplied value actually contains a literal `/`
+    // — those values come from a splat or `:controller` (which use
+    // Format.requiredPath / escapePath, preserving `/`) and collapsing
+    // would munge them. When the slash-bearing capture is omitted (e.g.
+    // it's inside an unsatisfied optional group), collapsing is safe.
+    if (!suppliedAnySlash(params)) {
       out = out.replace(/\/{2,}/g, "/");
       if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
     }
@@ -301,14 +312,17 @@ export class Route {
 }
 
 /**
- * True when the route can emit literal `/` inside a captured value —
- * i.e. it has a `*splat` glob or a `:controller` parameter, both of
- * which use Format.requiredPath / `escapePath` (which preserves `/`).
- * Slash-collapse post-processing is unsafe for these routes because it
- * would munge user-supplied glob values containing `/`.
+ * True if any supplied param value contains a literal `/`. Glob and
+ * `:controller` captures preserve slashes (via `escapePath`), so when
+ * such a value is actually supplied, post-process slash-collapse would
+ * corrupt it. When no supplied value contains `/`, collapse is safe
+ * even if the route declares a splat/controller that was omitted.
  */
-function hasUnescapedSlashCaptures(path: string): boolean {
-  return /\*[a-zA-Z_]/.test(path) || /:controller\b/.test(path);
+function suppliedAnySlash(params: Record<string, string | number>): boolean {
+  for (const v of Object.values(params)) {
+    if (typeof v === "string" && v.includes("/")) return true;
+  }
+  return false;
 }
 
 function topLevelSymbolNames(tree: unknown): readonly string[] {
@@ -324,7 +338,9 @@ function topLevelSymbolNames(tree: unknown): readonly string[] {
       isGroup?: () => boolean;
       isStar?: () => boolean;
       isCat?: () => boolean;
+      type?: string;
       toSym?: () => string;
+      children?: () => unknown[];
       left?: unknown;
       right?: unknown;
     };
@@ -341,6 +357,10 @@ function topLevelSymbolNames(tree: unknown): readonly string[] {
     if (n.isCat?.()) {
       walk(n.left, nested);
       walk(n.right, nested);
+      return;
+    }
+    if (n.type === "OR") {
+      for (const c of n.children?.() ?? []) walk(c, nested);
       return;
     }
     if (!nested && n.isSymbol?.()) {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -265,7 +265,14 @@ export class Route {
       // Group nodes (top-level Stars count as required too) — that's the
       // true "must be supplied" set.
       this._requiredParamNames = topLevelSymbolNames(tree);
-      this._pathRequirements = pattern.requirementsForMissingKeysCheck;
+      // `requirementsForMissingKeysCheck` returns a plain object, which
+      // would route a `__proto__` capture to the inherited setter.
+      // Copy into a null-prototype map so all capture names survive.
+      const safeReqs: Record<string, RegExp> = Object.create(null);
+      for (const [k, v] of Object.entries(pattern.requirementsForMissingKeysCheck)) {
+        safeReqs[k] = v;
+      }
+      this._pathRequirements = safeReqs;
     }
     for (const name of this._requiredParamNames!) {
       // Match Journey Formatter's Ruby-truthiness rule: only nil/undefined
@@ -298,13 +305,12 @@ export class Route {
       if (v != null) hash[k] = String(v);
     }
     let out = this._pathFormatter.evaluate(hash);
-    // Collapse runs of `/` left over from omitted optional groups (e.g.
-    // `(/:a)(/:b)` with `{ b: "x" }` → `//x`) and strip a single trailing
-    // slash. Skip when a supplied value actually contains a literal `/`
-    // — those values come from a splat or `:controller` (which use
-    // Format.requiredPath / escapePath, preserving `/`) and collapsing
-    // would munge them. When the slash-bearing capture is omitted (e.g.
-    // it's inside an unsatisfied optional group), collapsing is safe.
+    // Collapse runs of `/` left over from omitted optional groups
+    // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x` → `/x`). Skip when
+    // a path-preserving capture (`*splat` / `:controller`) is supplied
+    // with a value containing `/` — those use Format.requiredPath /
+    // escapePath, which keeps `/` literal, so collapsing would munge
+    // the user value.
     if (!suppliedSlashInPathPreservingCapture(params, this.path)) {
       // Collapse `/{2,}` runs left over from omitted optional groups
       // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x` → `/x`). Trailing
@@ -373,10 +379,10 @@ function suppliedSlashInPathPreservingCapture(
   // special-cased by Journey's FormatBuilder.
   // `\*name` is NOT escaped by Journey's scanner — only `\:`, `\(`, `\)`
   // are literalized. So splat names are matched without a backslash
-  // exclusion. `:controller` likewise has no scanner-level escape for
-  // `*`/`:` mid-segment.
+  // exclusion, and the name accepts any `\w` after `*` (matching the
+  // scanner's STAR rule, including digit-leading names like `*123`).
   const splatNames = new Set<string>();
-  for (const m of path.matchAll(/\*([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
+  for (const m of path.matchAll(/\*(\w+)/g)) {
     splatNames.add(m[1]!);
   }
   const declaresController = /(?<!\\):controller\b/.test(path);

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -4,9 +4,13 @@
 
 import { Parser } from "../journey/parser.js";
 import { Ast } from "../journey/ast.js";
+import { Pattern } from "../journey/path/pattern.js";
+import type { Format } from "../journey/visitors.js";
 import { normalizePath as journeyNormalizePath } from "../journey/router/utils.js";
 import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
+
+const PATHFOR_SEPARATORS = "/.?";
 
 export interface RouteConstraints {
   [key: string]: string | RegExp;
@@ -62,10 +66,13 @@ export class Route {
   readonly redirectTarget: string | RedirectOptions | RedirectFunction | undefined;
   readonly anchor: boolean;
 
-  private readonly segments: PathSegment[];
   private readonly paramNames: string[];
   /** @internal lazy single-route Journey router for match() */
   private _journeyRouter: JourneyRouter | null = null;
+  /** @internal lazy Journey Format tree for pathFor() */
+  private _pathFormatter: Format | null = null;
+  /** @internal required (non-optional) path captures, computed from Pattern */
+  private _requiredParamNames: readonly string[] | null = null;
   /** @internal true once we've discovered the path can't be parsed */
   private _journeyRouterUnbuildable = false;
 
@@ -87,7 +94,6 @@ export class Route {
     this.redirectTarget = options.redirect;
     this.anchor = options.anchor !== false;
 
-    this.segments = parseSegments(this.path);
     // Derive capture names from the Journey parser/AST — the same source
     // the Journey bridge uses. Keeps the path-vs-request constraint split
     // in lockstep with what `Pattern.names` will report, so escaped sigils
@@ -140,15 +146,48 @@ export class Route {
 
   /**
    * Compute a specificity score for this route. Higher = more specific.
+   * Static literals score 3, top-level dynamic captures score 1 (or 2 if
+   * the caller signals knowledge of that name). Captures nested inside
+   * an optional group or glob score 0.
    */
   score(knowledge: Record<string, boolean> = {}): number {
-    let s = 0;
-    for (const seg of this.segments) {
-      if (seg.type === "static") s += 3;
-      else if (seg.type === "dynamic") s += knowledge[seg.name] ? 2 : 1;
-      else if (seg.type === "glob") s += 0;
-      else if (seg.type === "optional") s += 0;
+    let tree;
+    try {
+      tree = new Parser().parse(this.path);
+    } catch {
+      return 0;
     }
+    let s = 0;
+    const walk = (node: unknown, nested: boolean): void => {
+      const n = node as {
+        isLiteral?: () => boolean;
+        isSymbol?: () => boolean;
+        isGroup?: () => boolean;
+        isStar?: () => boolean;
+        isCat?: () => boolean;
+        toSym?: () => string;
+        left?: unknown;
+        right?: unknown;
+      };
+      if (n.isGroup?.() || n.isStar?.()) {
+        walk(n.left, true);
+        return;
+      }
+      if (n.isCat?.()) {
+        walk(n.left, nested);
+        walk(n.right, nested);
+        return;
+      }
+      if (n.isLiteral?.()) {
+        if (!nested) s += 3;
+        return;
+      }
+      if (n.isSymbol?.()) {
+        if (!nested) s += knowledge[n.toSym!()] ? 2 : 1;
+        return;
+      }
+    };
+    walk(tree, false);
     return s;
   }
 
@@ -180,49 +219,30 @@ export class Route {
   }
 
   /**
-   * Generate a path from this route by substituting params.
+   * Generate a path from this route by substituting params. Throws if a
+   * required (non-optional) capture is missing, matching Rails'
+   * UrlGenerationError behavior.
    */
   pathFor(params: Record<string, string | number> = {}): string {
-    const parts: string[] = [];
-    for (const seg of this.segments) {
-      if (seg.type === "static") {
-        parts.push(seg.value);
-      } else if (seg.type === "dynamic") {
-        const val = params[seg.name];
-        if (val === undefined) {
-          throw new Error(
-            `Missing required parameter :${seg.name} for route "${this.name ?? this.path}"`,
-          );
-        }
-        parts.push(String(val));
-      } else if (seg.type === "glob") {
-        const val = params[seg.name];
-        if (val !== undefined) {
-          parts.push(String(val));
-        }
-      } else if (seg.type === "optional") {
-        // Include optional group only if all dynamic params are provided
-        const optParts: string[] = [];
-        let allPresent = true;
-        for (const child of seg.children) {
-          if (child.type === "static") {
-            optParts.push(child.value);
-          } else if (child.type === "dynamic") {
-            const val = params[child.name];
-            if (val === undefined || val === null) {
-              allPresent = false;
-              break;
-            }
-            optParts.push(String(val));
-          }
-        }
-        if (allPresent && optParts.length > 0) {
-          parts.push(...optParts);
-        }
+    if (this._pathFormatter === null) {
+      const tree = new Parser().parse(this.path);
+      const ast = new Ast(tree, true);
+      const pattern = new Pattern(ast, {}, PATHFOR_SEPARATORS, this.anchor);
+      this._pathFormatter = pattern.buildFormatter();
+      this._requiredParamNames = pattern.requiredNames;
+    }
+    for (const name of this._requiredParamNames!) {
+      if (!Object.hasOwn(params, name) || params[name] == null) {
+        throw new Error(
+          `Missing required parameter :${name} for route "${this.name ?? this.path}"`,
+        );
       }
     }
-    const result = "/" + parts.join("/");
-    return result === "/" ? "/" : result;
+    const hash: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(params)) {
+      if (v != null) hash[k] = String(v);
+    }
+    return this._pathFormatter.evaluate(hash);
   }
 
   /**
@@ -265,27 +285,6 @@ export class Route {
   }
 }
 
-// --- Path segment types ---
-
-interface StaticSegment {
-  type: "static";
-  value: string;
-}
-interface DynamicSegment {
-  type: "dynamic";
-  name: string;
-}
-interface GlobSegment {
-  type: "glob";
-  name: string;
-}
-interface OptionalGroup {
-  type: "optional";
-  children: (StaticSegment | DynamicSegment)[];
-}
-
-type PathSegment = StaticSegment | DynamicSegment | GlobSegment | OptionalGroup;
-
 function collectParamNamesFromJourneyAst(path: string): string[] {
   try {
     const tree = new Parser().parse(path);
@@ -298,77 +297,6 @@ function collectParamNamesFromJourneyAst(path: string): string[] {
     // Parser failure shouldn't crash the route table; fall back to no captures.
     return [];
   }
-}
-
-function parseSegments(path: string): PathSegment[] {
-  const segments: PathSegment[] = [];
-  const raw = path.replace(/^\/+/, "");
-  if (!raw) return segments;
-
-  // Handle optional groups: (/:locale) or (.:format)
-  let i = 0;
-  const parts: string[] = [];
-  let current = "";
-
-  // First split by / but handle parenthesized groups
-  while (i < raw.length) {
-    if (raw[i] === "(") {
-      // Find matching close paren
-      if (current) {
-        parts.push(current);
-        current = "";
-      }
-      let depth = 1;
-      let group = "(";
-      i++;
-      while (i < raw.length && depth > 0) {
-        if (raw[i] === "(") depth++;
-        if (raw[i] === ")") depth--;
-        group += raw[i];
-        i++;
-      }
-      parts.push(group);
-    } else if (raw[i] === "/") {
-      if (current) {
-        parts.push(current);
-        current = "";
-      }
-      i++;
-    } else {
-      current += raw[i];
-      i++;
-    }
-  }
-  if (current) parts.push(current);
-
-  for (const part of parts) {
-    if (part.startsWith("(") && part.endsWith(")")) {
-      // Optional group
-      const inner = part.slice(1, -1).replace(/^\/+/, "").replace(/^\./, "");
-      const children: (StaticSegment | DynamicSegment)[] = [];
-      for (const sub of inner.split("/").filter(Boolean)) {
-        if (sub.startsWith(":")) {
-          children.push({ type: "dynamic", name: sub.slice(1) });
-        } else if (sub.startsWith("*")) {
-          // glob in optional — treat as dynamic
-          children.push({ type: "dynamic", name: sub.slice(1) });
-        } else {
-          children.push({ type: "static", value: sub });
-        }
-      }
-      if (children.length > 0) {
-        segments.push({ type: "optional", children });
-      }
-    } else if (part.startsWith("*")) {
-      segments.push({ type: "glob", name: part.slice(1) });
-    } else if (part.startsWith(":")) {
-      segments.push({ type: "dynamic", name: part.slice(1) });
-    } else {
-      segments.push({ type: "static", value: part });
-    }
-  }
-
-  return segments;
 }
 
 function normalizePath(p: string): string {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -73,6 +73,8 @@ export class Route {
   private _pathFormatter: Format | null = null;
   /** @internal required (non-optional) path captures, computed from Pattern */
   private _requiredParamNames: readonly string[] | null = null;
+  /** @internal anchored requirement regexes for path captures, by capture name */
+  private _pathRequirements: Record<string, RegExp> | null = null;
   /** @internal true once we've discovered the path can't be parsed */
   private _journeyRouterUnbuildable = false;
 
@@ -181,8 +183,18 @@ export class Route {
         return;
       }
       if (n.type === "OR") {
-        // Or-children are alternatives at the same nesting level.
-        for (const c of n.children?.() ?? []) walk(c, nested);
+        // Or-children are alternatives — only one can match a real
+        // request, so score the most specific branch rather than the
+        // sum of all branches.
+        let max = 0;
+        for (const c of n.children?.() ?? []) {
+          const before = s;
+          walk(c, nested);
+          const branch = s - before;
+          if (branch > max) max = branch;
+          s = before;
+        }
+        s += max;
         return;
       }
       if (n.isLiteral?.()) {
@@ -234,29 +246,45 @@ export class Route {
     if (this._pathFormatter === null) {
       const tree = new Parser().parse(this.path);
       const ast = new Ast(tree, true);
-      const pattern = new Pattern(ast, {}, PATHFOR_SEPARATORS, this.anchor);
+      // Pass path-capture constraints into the Pattern so requirement
+      // checks (e.g. `id: /\d+/`) are honored at generation time.
+      const reqs: Record<string, RegExp> = {};
+      for (const [k, v] of Object.entries(this.constraints)) {
+        if (v instanceof RegExp) reqs[k] = v;
+      }
+      const pattern = new Pattern(ast, reqs, PATHFOR_SEPARATORS, this.anchor);
       this._pathFormatter = pattern.buildFormatter();
       // `Pattern.requiredNames` filters by optional-name *set*, so a name
       // that appears both required and optional (e.g. `/:id(.:id)`) gets
       // dropped. Walk the AST and collect symbol names strictly outside
-      // Group/Star nodes — that's the true "must be supplied" set.
+      // Group nodes (top-level Stars count as required too) — that's the
+      // true "must be supplied" set.
       this._requiredParamNames = topLevelSymbolNames(tree);
+      this._pathRequirements = pattern.requirementsForMissingKeysCheck;
     }
     for (const name of this._requiredParamNames!) {
-      // Empty string is treated as missing — Format.evaluate would still
-      // emit a literal `""` and leave structural slashes around it,
-      // producing malformed URLs like `//x`. Rails URL helpers raise on
-      // empty required params for the same reason.
-      const v = params[name];
-      if (!Object.hasOwn(params, name) || v == null || v === "") {
+      // Match Journey Formatter's Ruby-truthiness rule: only nil/undefined
+      // are missing. Empty string is treated as supplied and emitted by
+      // Format.evaluate (e.g. `/posts/:id` with `{ id: "" }` → `/posts/`).
+      if (!Object.hasOwn(params, name) || params[name] == null) {
         throw new Error(
           `Missing required parameter :${name} for route "${this.name ?? this.path}"`,
         );
       }
     }
-    // Null-prototype object so route params named `__proto__` /
-    // `constructor` etc. become own properties rather than hitting the
-    // inherited setter (which would silently drop them).
+    // Validate supplied path-capture values against the route's
+    // requirement regexes (Rails Journey Formatter `missing_keys` check).
+    for (const [name, re] of Object.entries(this._pathRequirements!)) {
+      const v = params[name];
+      if (v != null && !re.test(String(v))) {
+        throw new Error(
+          `Missing required parameter :${name} for route "${this.name ?? this.path}"`,
+        );
+      }
+    }
+    // Null-prototype object so an own `__proto__` route param becomes a
+    // real own property rather than hitting the inherited setter (which
+    // would silently update the prototype instead of storing the value).
     const hash: Record<string, unknown> = Object.create(null);
     for (const [k, v] of Object.entries(params)) {
       if (v != null) hash[k] = String(v);
@@ -269,9 +297,11 @@ export class Route {
     // Format.requiredPath / escapePath, preserving `/`) and collapsing
     // would munge them. When the slash-bearing capture is omitted (e.g.
     // it's inside an unsatisfied optional group), collapsing is safe.
-    if (!suppliedAnySlash(params, this.paramNames)) {
+    if (!suppliedSlashInPathPreservingCapture(params, this.path)) {
+      // Only collapse `/{2,}` runs from omitted optional groups; don't
+      // strip trailing slashes — those can be structural (e.g. `/posts/`
+      // is the correct output for `/posts/:id` with `{ id: "" }`).
       out = out.replace(/\/{2,}/g, "/");
-      if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
     }
     return out;
   }
@@ -317,29 +347,40 @@ export class Route {
 }
 
 /**
- * True if any supplied param value that the route actually uses
- * contains a literal `/`. Glob and `:controller` captures preserve
- * slashes (via `escapePath`), so when such a value is actually
- * supplied, post-process slash-collapse would corrupt it. Unused
- * params are ignored — they never reach the formatter output.
+ * True if a *path-preserving* capture is supplied with a value
+ * containing `/`. Only `*splat` and `:controller` parameters preserve
+ * slashes (via `Format.requiredPath` + `escapePath`); ordinary `:name`
+ * segments percent-encode `/` to `%2F`, so their values can't introduce
+ * literal `/` runs into the output and don't need to suppress collapse.
+ * Captures inside an omitted optional group don't contribute output, so
+ * we restrict the check to *supplied* path-preserving captures.
  */
-function suppliedAnySlash(
+function suppliedSlashInPathPreservingCapture(
   params: Record<string, string | number>,
-  declaredNames: readonly string[],
+  path: string,
 ): boolean {
-  const declared = new Set(declaredNames);
+  // Names of path-preserving captures declared by this route. Splat
+  // (`*name`) is always path-preserving; the `:controller` symbol gets
+  // special-cased by Journey's FormatBuilder.
+  const splatNames = new Set<string>();
+  for (const m of path.matchAll(/(?<!\\)\*([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
+    splatNames.add(m[1]!);
+  }
+  const declaresController = /(?<!\\):controller\b/.test(path);
   for (const [k, v] of Object.entries(params)) {
-    if (!declared.has(k)) continue;
-    if (typeof v === "string" && v.includes("/")) return true;
+    if (typeof v !== "string" || !v.includes("/")) continue;
+    if (splatNames.has(k)) return true;
+    if (declaresController && k === "controller") return true;
   }
   return false;
 }
 
 function topLevelSymbolNames(tree: unknown): readonly string[] {
   // Names of `:symbol` and `*splat` captures that appear strictly outside
-  // any optional `Group`. Stars are treated as required when top-level —
-  // omitting `*path` from a route like `/files/*path` should still throw
-  // missing-parameter rather than silently produce `/files/`.
+  // any optional `Group`. Top-level `Star` nodes ARE counted as required
+  // (recurse into them without flipping `nested`) so omitting `*path`
+  // from `/files/*path` still throws missing-parameter rather than
+  // silently producing `/files/`.
   const out: string[] = [];
   const seen = new Set<string>();
   const walk = (node: unknown, nested: boolean): void => {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -246,13 +246,17 @@ export class Route {
     for (const [k, v] of Object.entries(params)) {
       if (v != null) hash[k] = String(v);
     }
-    // Collapse runs of `/` and strip a trailing `/` (unless that's the
-    // whole string). When all-optional groups partially supply params,
-    // adjacent slashes from omitted groups can leave double slashes
-    // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x`).
     let out = this._pathFormatter.evaluate(hash);
-    out = out.replace(/\/{2,}/g, "/");
-    if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
+    // Collapse runs of `/` left over from omitted optional groups (e.g.
+    // `(/:a)(/:b)` with `{ b: "x" }` → `//x`) and strip a single trailing
+    // slash. Skip when the path can emit literal `/` inside a captured
+    // value — top-level `*splat` or `:controller` parameters preserve
+    // slashes via Format.requiredPath / escapePath, so post-processing
+    // would corrupt those values.
+    if (!hasUnescapedSlashCaptures(this.path)) {
+      out = out.replace(/\/{2,}/g, "/");
+      if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
+    }
     return out;
   }
 
@@ -296,7 +300,22 @@ export class Route {
   }
 }
 
+/**
+ * True when the route can emit literal `/` inside a captured value —
+ * i.e. it has a `*splat` glob or a `:controller` parameter, both of
+ * which use Format.requiredPath / `escapePath` (which preserves `/`).
+ * Slash-collapse post-processing is unsafe for these routes because it
+ * would munge user-supplied glob values containing `/`.
+ */
+function hasUnescapedSlashCaptures(path: string): boolean {
+  return /\*[a-zA-Z_]/.test(path) || /:controller\b/.test(path);
+}
+
 function topLevelSymbolNames(tree: unknown): readonly string[] {
+  // Names of `:symbol` and `*splat` captures that appear strictly outside
+  // any optional `Group`. Stars are treated as required when top-level —
+  // omitting `*path` from a route like `/files/*path` should still throw
+  // missing-parameter rather than silently produce `/files/`.
   const out: string[] = [];
   const seen = new Set<string>();
   const walk = (node: unknown, nested: boolean): void => {
@@ -309,8 +328,14 @@ function topLevelSymbolNames(tree: unknown): readonly string[] {
       left?: unknown;
       right?: unknown;
     };
-    if (n.isGroup?.() || n.isStar?.()) {
+    if (n.isGroup?.()) {
       walk(n.left, true);
+      return;
+    }
+    if (n.isStar?.()) {
+      // The star wraps a Symbol child; that child is the splat name and is
+      // required iff the star itself is top-level.
+      walk(n.left, nested);
       return;
     }
     if (n.isCat?.()) {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -243,7 +243,12 @@ export class Route {
       this._requiredParamNames = topLevelSymbolNames(tree);
     }
     for (const name of this._requiredParamNames!) {
-      if (!Object.hasOwn(params, name) || params[name] == null) {
+      // Empty string is treated as missing — Format.evaluate would still
+      // emit a literal `""` and leave structural slashes around it,
+      // producing malformed URLs like `//x`. Rails URL helpers raise on
+      // empty required params for the same reason.
+      const v = params[name];
+      if (!Object.hasOwn(params, name) || v == null || v === "") {
         throw new Error(
           `Missing required parameter :${name} for route "${this.name ?? this.path}"`,
         );
@@ -264,7 +269,7 @@ export class Route {
     // Format.requiredPath / escapePath, preserving `/`) and collapsing
     // would munge them. When the slash-bearing capture is omitted (e.g.
     // it's inside an unsatisfied optional group), collapsing is safe.
-    if (!suppliedAnySlash(params)) {
+    if (!suppliedAnySlash(params, this.paramNames)) {
       out = out.replace(/\/{2,}/g, "/");
       if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
     }
@@ -312,14 +317,19 @@ export class Route {
 }
 
 /**
- * True if any supplied param value contains a literal `/`. Glob and
- * `:controller` captures preserve slashes (via `escapePath`), so when
- * such a value is actually supplied, post-process slash-collapse would
- * corrupt it. When no supplied value contains `/`, collapse is safe
- * even if the route declares a splat/controller that was omitted.
+ * True if any supplied param value that the route actually uses
+ * contains a literal `/`. Glob and `:controller` captures preserve
+ * slashes (via `escapePath`), so when such a value is actually
+ * supplied, post-process slash-collapse would corrupt it. Unused
+ * params are ignored — they never reach the formatter output.
  */
-function suppliedAnySlash(params: Record<string, string | number>): boolean {
-  for (const v of Object.values(params)) {
+function suppliedAnySlash(
+  params: Record<string, string | number>,
+  declaredNames: readonly string[],
+): boolean {
+  const declared = new Set(declaredNames);
+  for (const [k, v] of Object.entries(params)) {
+    if (!declared.has(k)) continue;
     if (typeof v === "string" && v.includes("/")) return true;
   }
   return false;

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -247,10 +247,15 @@ export class Route {
       const tree = new Parser().parse(this.path);
       const ast = new Ast(tree, true);
       // Pass path-capture constraints into the Pattern so requirement
-      // checks (e.g. `id: /\d+/`) are honored at generation time.
-      const reqs: Record<string, RegExp> = {};
-      for (const [k, v] of Object.entries(this.constraints)) {
+      // checks (e.g. `id: /\d+/`) are honored at generation time. Use
+      // `pathConstraints` (not the raw `constraints`) so request-level
+      // constraints like `subdomain` don't accidentally validate
+      // unrelated params. Null-prototype map so a route capture named
+      // `__proto__` becomes an own requirement entry.
+      const reqs: Record<string, RegExp> = Object.create(null);
+      for (const [k, v] of Object.entries(this.pathConstraints)) {
         if (v instanceof RegExp) reqs[k] = v;
+        else if (typeof v === "string") reqs[k] = new RegExp(v);
       }
       const pattern = new Pattern(ast, reqs, PATHFOR_SEPARATORS, this.anchor);
       this._pathFormatter = pattern.buildFormatter();
@@ -275,6 +280,9 @@ export class Route {
     // Validate supplied path-capture values against the route's
     // requirement regexes (Rails Journey Formatter `missing_keys` check).
     for (const [name, re] of Object.entries(this._pathRequirements!)) {
+      // `Object.hasOwn` avoids inheriting prototype-chain values for
+      // optional captures named like `constructor`/`toString`.
+      if (!Object.hasOwn(params, name)) continue;
       const v = params[name];
       if (v != null && !re.test(String(v))) {
         throw new Error(
@@ -298,9 +306,10 @@ export class Route {
     // would munge them. When the slash-bearing capture is omitted (e.g.
     // it's inside an unsatisfied optional group), collapsing is safe.
     if (!suppliedSlashInPathPreservingCapture(params, this.path)) {
-      // Only collapse `/{2,}` runs from omitted optional groups; don't
-      // strip trailing slashes — those can be structural (e.g. `/posts/`
-      // is the correct output for `/posts/:id` with `{ id: "" }`).
+      // Collapse `/{2,}` runs left over from omitted optional groups
+      // (e.g. `(/:a)(/:b)` with `{ b: "x" }` → `//x` → `/x`). Trailing
+      // slashes are kept — they can be structural (e.g. `/posts/` is
+      // the correct output for `/posts/:id` with `{ id: "" }`).
       out = out.replace(/\/{2,}/g, "/");
     }
     return out;
@@ -362,8 +371,12 @@ function suppliedSlashInPathPreservingCapture(
   // Names of path-preserving captures declared by this route. Splat
   // (`*name`) is always path-preserving; the `:controller` symbol gets
   // special-cased by Journey's FormatBuilder.
+  // `\*name` is NOT escaped by Journey's scanner — only `\:`, `\(`, `\)`
+  // are literalized. So splat names are matched without a backslash
+  // exclusion. `:controller` likewise has no scanner-level escape for
+  // `*`/`:` mid-segment.
   const splatNames = new Set<string>();
-  for (const m of path.matchAll(/(?<!\\)\*([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
+  for (const m of path.matchAll(/\*([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
     splatNames.add(m[1]!);
   }
   const declaresController = /(?<!\\):controller\b/.test(path);


### PR DESCRIPTION
## Summary
Last piece of the legacy route-internals migration. `Route#pathFor` now builds a Journey Pattern + Format tree lazily; the legacy `parseSegments` engine (and its segment-type unions) is deleted.

- `pathFor` builds a Pattern, derives the Format via `buildFormatter()`, and caches both. Required-name check still throws the legacy `Missing required parameter :name` message before evaluating.
- `score()` rewritten on the Journey AST: walk Cat/Group/Star/Or nodes, count top-level Literals (+3) and Symbols (+1 or +2 with knowledge); nested terminals score 0; Or branches scored as max-of-alternatives.
- Removed: `parseSegments` (~70 LOC), `StaticSegment`/`DynamicSegment`/`GlobSegment`/`OptionalGroup` interfaces, `PathSegment` type, the `this.segments` field.

## Test changes
- **`generate escapes`** — assert percent-escaped value (`/posts/hello%20world`), matching Rails `Journey::Utils.escape_segment`. Legacy pathFor didn't escape; Format does.

## Net diff
-69 LOC (after all review iterations).

## Known limitations / remaining concerns (review #9, max cycles reached)

These are tracked for a follow-up rather than addressed here — each requires
deeper Format-level visibility we don't have, or touches review-out-of-scope
Pattern internals. All current tests pass; these are edge cases.

1. **Stateful regex flags** in `_pathRequirements`: anchored requirement
   regex keeps original `flags`. Constraints declared with `g`/`y`/`m`
   would behave incorrectly across repeated `pathFor` calls. **Fix:**
   strip `g`/`y`/`m` before caching (~3 LOC). Mirror Pattern's flag
   handling.

2. **All-optional with slash-bearing capture + earlier omitted optional**:
   `(/:a)(/:controller)` with `controller:"admin/posts"` returns
   `//admin/posts` instead of `/admin/posts`. The current
   `emittedSlashInPathPreservingCapture` heuristic returns true (controller
   is emitted with `/`), suppressing collapse for the *whole* output,
   not just the splat region. **Fix:** Format-level emit-tracking, or a
   smarter regex that collapses outside the captured value's positions.

3. **`a b//c` splat value** — `emittedSlashInPathPreservingCapture`'s
   proof-of-presence check splits on the first non-path-safe character
   (space here), so the `//` portion may not be detected as emitted and
   the subsequent collapse can change `//` → `/` inside the user's value.
   **Fix:** compare against the escaped form of the whole value rather
   than the slash-prefix.

4. **`knowledge[name]` prototype-chain read** in `score()`. A route param
   named `constructor`/`toString` is treated as "known" even when the
   caller didn't supply it. **Fix:** `Object.hasOwn(knowledge, name)` (~2 LOC).

5. **Inaccurate field comment** on `_requiredParamNames` — says "computed
   from Pattern" but the code uses `topLevelSymbolNames(tree)`. Cosmetic.

6. **Optional-group constraints validated even when group is omitted**:
   `(/:id/:slug)` with constraint `id:/\\d+/` and `{ id: "bad" }` throws,
   but `id` isn't emitted (the group needs `:slug` too). **Fix:**
   conditional validation tied to whether the capture actually contributes
   to output.

## Test plan
- [x] 1192 actionpack tests pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean