### PR TITLE
feat(activerecord): batch 27 — HMT post-#1714 composite cleanup

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -3321,6 +3321,73 @@ describe("AssociationsTest", () => {
       "Alice",
     ]);
   });
+  it("composite has many through raises ConfigurationError when target model has composite primary key", async () => {
+    // Mirrors the schema constraint behind the throws in _buildThroughScope
+    // and _pushThrough: the target-side IN-subquery / join row carry a single
+    // source FK column, so a composite primaryKey on the target model is
+    // unrepresentable. Promoted from plain Error to ConfigurationError so
+    // misconfiguration surfaces with the same error class as the rest of the
+    // through-association validations (reflection.ts:556-588).
+    const adapter = freshAdapter();
+    class CpkThruTgtDoc extends Base {
+      static {
+        this._tableName = "cpk_thru_tgt_docs";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruTgtAppt extends Base {
+      static {
+        this._tableName = "cpk_thru_tgt_appts";
+        this.attribute("doctor_id", "integer");
+        this.attribute("patient_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CpkThruTgtPat extends Base {
+      static {
+        this._tableName = "cpk_thru_tgt_pats";
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.primaryKey = ["region_id", "id"];
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(CpkThruTgtDoc, "appts", {
+      className: "CpkThruTgtAppt",
+      foreignKey: "doctor_id",
+    });
+    Associations.belongsTo.call(CpkThruTgtAppt, "patient", {
+      className: "CpkThruTgtPat",
+      foreignKey: "patient_id",
+    });
+    Associations.hasMany.call(CpkThruTgtDoc, "patients", {
+      through: "appts",
+      className: "CpkThruTgtPat",
+      source: "patient",
+    });
+    registerModel("CpkThruTgtDoc", CpkThruTgtDoc);
+    registerModel("CpkThruTgtAppt", CpkThruTgtAppt);
+    registerModel("CpkThruTgtPat", CpkThruTgtPat);
+
+    const doc = await CpkThruTgtDoc.create({ id: 1, name: "Dr X" });
+    // _buildThroughScope runs eagerly when the CollectionProxy is built —
+    // composite target PK surfaces as a ConfigurationError at construction.
+    expect(() => association(doc, "patients")).toThrow(ConfigurationError);
+  });
+  it.skip("polymorphic-through with composite owner primary key", async () => {
+    // BLOCKED: associations — polymorphic-through uses a single
+    // `<as>_id`/`<as>_type` schema pair, so the join row can only carry a
+    // *scalar* owner identifier. When the owner has a composite primary key,
+    // `_throughOwnerPolymorphic` collapses to "id" (when present) or the
+    // first PK column, but there is no Rails-side schema convention for
+    // splitting a composite owner across the polymorphic columns. Needs an
+    // explicit `primaryKey:` option (single column) on the polymorphic-through
+    // association, plus validation that rejects a composite `primaryKey:`
+    // here. Tracked under Batch 27 HMT composite follow-ups.
+  });
   it("belongs to with explicit composite foreign key", async () => {
     const adapter = freshAdapter();
     class CfkOrder extends Base {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1096,7 +1096,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
     const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
 
-    // Mirror Reflection#activeRecordPrimaryKey (reflection.rb:587-603).
+    // Mirror Reflection#active_record_primary_key (reflection.rb:587-603).
     // `options[:query_constraints]` describes the *foreign-key* shape on the
     // join table — Rails never reuses it as the owner PK. The owner PK comes
     // from the class-level `query_constraints_list`, falling back to the

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1096,7 +1096,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
     const fkCols = Array.isArray(ownerFk) ? ownerFk : [ownerFk as string];
 
-    // Mirror Reflection#activeRecordPrimaryKey (reflection.ts:780-796).
+    // Mirror Reflection#activeRecordPrimaryKey (reflection.rb:587-603).
+    // `options[:query_constraints]` describes the *foreign-key* shape on the
+    // join table — Rails never reuses it as the owner PK. The owner PK comes
+    // from the class-level `query_constraints_list`, falling back to the
+    // model's primaryKey when the option is set on the association but the
+    // owner class itself has no class-level constraints.
     let ownerPk: string | string[];
     if (throughAssoc.options.primaryKey !== undefined) {
       ownerPk = throughAssoc.options.primaryKey;
@@ -1105,9 +1110,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       throughAssoc.options.queryConstraints
     ) {
       ownerPk =
-        (throughAssoc.options.queryConstraints as string[] | undefined) ??
-        ownerQueryConstraintsList.call(ctor as any) ??
-        (ctor.primaryKey as string | string[]);
+        ownerQueryConstraintsList.call(ctor as any) ?? (ctor.primaryKey as string | string[]);
     } else if (
       // Rails' id-collapse: a scalar FK against a composite PK that includes
       // "id" pairs with the scalar "id" column (reflection.ts:791-793).
@@ -1222,8 +1225,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Create the join record
       const targetPk = (record.constructor as typeof Base).primaryKey;
       if (Array.isArray(targetPk)) {
-        throw new Error(
-          `Through associations do not support composite primary keys on target model for "${this._assocName}".`,
+        throw new ConfigurationError(
+          `Through association "${this._assocName}" does not support a composite primary key on the target model "${(record.constructor as typeof Base).name}" — the join row needs a single source FK column.`,
         );
       }
       const joinAttrs: Record<string, unknown> = {
@@ -2005,13 +2008,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (sourceAssocKind === "belongsTo") {
       const targetFk = sourceAssoc?.options?.foreignKey ?? `${underscore(sourceName)}_id`;
       if (Array.isArray(targetFk)) {
-        throw new Error(
-          `CollectionProxy#scope does not support composite foreign keys for through associations on "${this._assocName}".`,
+        throw new ConfigurationError(
+          `Through association "${this._assocName}" does not support a composite foreign key on the source belongsTo — the target-side IN-subquery needs a single column.`,
         );
       }
       if (Array.isArray(targetModel.primaryKey)) {
-        throw new Error(
-          `CollectionProxy#scope does not support composite primary keys on target model for through associations on "${this._assocName}".`,
+        throw new ConfigurationError(
+          `Through association "${this._assocName}" does not support a composite primary key on the target model "${targetModel.name}" — the target-side IN-subquery needs a single column.`,
         );
       }
       const targetFkStr = targetFk;
@@ -2037,13 +2040,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         ? (sourceAssoc?.options?.foreignKey ?? `${underscore(sourceAsName)}_id`)
         : (sourceAssoc?.options?.foreignKey ?? `${underscore(throughClassName)}_id`);
       if (Array.isArray(sourceFk)) {
-        throw new Error(
-          `CollectionProxy#scope does not support composite foreign keys for through associations on "${this._assocName}".`,
+        throw new ConfigurationError(
+          `Through association "${this._assocName}" does not support a composite foreign key on the hasMany source — the target-side IN-subquery needs a single column.`,
         );
       }
       if (Array.isArray(throughModel.primaryKey)) {
-        throw new Error(
-          `CollectionProxy#scope does not support composite primary keys on through model for "${this._assocName}".`,
+        throw new ConfigurationError(
+          `Through association "${this._assocName}" does not support a composite primary key on the through model "${throughModel.name}" — the target-side IN-subquery needs a single column.`,
         );
       }
       const sourceFkStr = sourceFk;


### PR DESCRIPTION
## Summary

Three small Rails-fidelity refinements layered on top of the composite-FK has-many-through write support landed in #1714.

- **`_throughOwnerCols` PK/FK separation.** `options.queryConstraints` is no longer reused as the owner-PK fallback. Rails' `Reflection#active_record_primary_key` (`reflection.rb:587-603`) takes the owner PK from the class-level `query_constraints_list` (or `primaryKey`); `options[:query_constraints]` is the *foreign-key* shape on the join table.
- **Composite throws in `_buildThroughScope` / `_pushThrough` → `ConfigurationError`.** Promotes plain `Error` raises (composite target PK, composite source FK, composite through PK) to `ConfigurationError`, matching the rest of the through-association validations (`reflection.ts:556-588`), with consistent wording.
- **`it.skip` (BLOCKED) for polymorphic-through with composite owner PK.** Documents that the `<as>_id`/`<as>_type` schema only carries a scalar owner identifier so `_throughOwnerPolymorphic` collapses composite owners to a single column. Needs an explicit single-column `primaryKey:` on the polymorphic-through plus validation that rejects a composite `primaryKey:` — tracked as a follow-up.

Includes a new test asserting that constructing a `CollectionProxy` for a through whose target carries a composite primary key fails with `ConfigurationError`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/has-many-through.test.ts packages/activerecord/src/associations/has-many-through-associations.test.ts` — 555 passed, 13 skipped
- [x] `pnpm lint` clean