### PR TITLE
feat(activerecord): batch 41 — migration older B/C/E small fidelity

### DIFF
--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -17,6 +17,14 @@ import {
   star,
 } from "@blazetrails/arel";
 
+/**
+ * Stand-in for InternalMetadata when metadata storage is disabled
+ * (`use_metadata_table: false`). All methods short-circuit and the
+ * physical `ar_internal_metadata` table is never touched.
+ *
+ * Mirrors: ActiveRecord::InternalMetadata::NullInternalMetadata
+ * @internal
+ */
 export class NullInternalMetadata {
   async createTable(): Promise<void> {}
   async dropTable(): Promise<void> {}
@@ -25,6 +33,7 @@ export class NullInternalMetadata {
     return null;
   }
 
+  /** @internal */
   async tableExists(): Promise<boolean> {
     return false;
   }
@@ -168,6 +177,14 @@ export class InternalMetadata {
     return Number(rows[0]?.cnt ?? 0);
   }
 
+  /**
+   * Whether `ar_internal_metadata` exists on the wrapped adapter. Reads the
+   * table directly (SELECT 1) rather than consulting the schema cache, so
+   * the result is fresh after recent DDL.
+   *
+   * Mirrors: ActiveRecord::InternalMetadata#table_exists?
+   * @internal
+   */
   async tableExists(): Promise<boolean> {
     // When disabled, report the table as absent so callers don't
     // accidentally trust it. The physical table may still exist on disk

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -346,6 +346,27 @@ describe("MigrationTest", () => {
     expect(ctx.tableExists("pre_new_suf")).toBe(true);
   });
 
+  it("MigrationContext inherits tableNamePrefix and tableNameSuffix from Base config", () => {
+    const savedPrefix = Base.tableNamePrefix;
+    const savedSuffix = Base.tableNameSuffix;
+    Base.tableNamePrefix = "ctxpre_";
+    Base.tableNameSuffix = "_ctxsuf";
+    try {
+      const { ctx } = freshContext();
+      expect(ctx.tableNamePrefix).toBe("ctxpre_");
+      expect(ctx.tableNameSuffix).toBe("_ctxsuf");
+      // Explicit override on the context still wins over the global config.
+      ctx.tableNamePrefix = "override_";
+      expect(ctx.tableNamePrefix).toBe("override_");
+      // Other context still tracks the configured value.
+      const { ctx: ctx2 } = freshContext();
+      expect(ctx2.tableNamePrefix).toBe("ctxpre_");
+    } finally {
+      Base.tableNamePrefix = savedPrefix;
+      Base.tableNameSuffix = savedSuffix;
+    }
+  });
+
   it("decimal scale without precision should raise", () => {
     const td = new TableDefinition("products");
     expect(() => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1511,8 +1511,31 @@ export class MigrationContext {
       include?: string[];
     }[]
   >();
-  tableNamePrefix = "";
-  tableNameSuffix = "";
+  private _tableNamePrefix: string | null = null;
+  private _tableNameSuffix: string | null = null;
+
+  /**
+   * Effective table-name prefix. Defaults to `Migration.tableNameOptions().tableNamePrefix`
+   * (i.e. the configured `ActiveRecord::Base.table_name_prefix` value) when no explicit
+   * value has been assigned to this context. Mirrors Rails, where `MigrationContext`
+   * does not carry its own prefix and reads from the active record config at use time.
+   */
+  get tableNamePrefix(): string {
+    return this._tableNamePrefix ?? Migration.tableNameOptions().tableNamePrefix;
+  }
+  set tableNamePrefix(value: string) {
+    this._tableNamePrefix = value;
+  }
+
+  /**
+   * Effective table-name suffix. Symmetric with {@link tableNamePrefix}.
+   */
+  get tableNameSuffix(): string {
+    return this._tableNameSuffix ?? Migration.tableNameOptions().tableNameSuffix;
+  }
+  set tableNameSuffix(value: string) {
+    this._tableNameSuffix = value;
+  }
 
   constructor(private adapter: DatabaseAdapter) {}
 


### PR DESCRIPTION
## Summary

Bundles a small fidelity sweep over migration-adjacent infrastructure. Two of the five items the parent slot enumerated were already shipped on `main` (`TableDefinition#toSql` empty-type guard + `SchemaAdapter` forwarding of `currentDatabase`/advisory-lock); the remaining three items below cover the rest of the bundle, plus an extra cosmetic JSDoc pass to mirror Rails' `:nodoc:` markers.

- **Unify `MigrationContext` table-name prefix/suffix source.** `tableNamePrefix` / `tableNameSuffix` are now getters that fall back to `Migration.tableNameOptions()` (which already reads `_arConfig` → `Base.tableNamePrefix`/`Suffix`). A freshly-constructed `MigrationContext` therefore picks up the configured prefix/suffix automatically, instead of starting at `""` and silently diverging from `Base`. Existing per-context overrides via the setter still win, so the rename-with-prefix path keeps working.
- **`InternalMetadata#tableExists` + `NullInternalMetadata` marked `@internal`.** Rails has `:nodoc:` on the class and the method; the TS port gets the matching `@internal` JSDoc so TypeDoc (with `excludeInternal: true`) hides them.

Two pre-existing items confirmed in place — see `packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts` (`toSql` blank-type guard) and `test-adapter.ts` (`SchemaAdapter.currentDatabase` + advisory-lock methods forwarding to `inner`). The `MigrationProxy` `scope` field is already typed on both the interface (`migration.ts`) and the `deprecator.ts` class, so no change there either.

## Test plan

- [x] new `MigrationContext inherits tableNamePrefix and tableNameSuffix from Base config` test passes
- [x] existing `rename table with prefix and suffix` and `add drop table with prefix and suffix` tests still pass
- [ ] CI green

Diffstat: 3 files, +63/−2.