### PR TITLE
feat(activerecord): batch 44 — connection-pool fidelity sweep B+C

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -733,18 +733,24 @@ export class AbstractAdapter implements Quoting {
       let nameMatches = false;
       for (const k of entry.klasses) {
         if (typeof k !== "function") continue;
-        // "Includes Base" covers the literal Base class AND the designated
-        // primary class (ApplicationRecord), which PoolConfig normalizes to
-        // the "Base" connection descriptor — so a connected_to scope on
-        // either should apply to every pool.
-        if (
-          Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase") ||
-          (typeof (k as any).primaryClassQ === "function" && (k as any).primaryClassQ())
-        ) {
+        // Rails' `klasses.include?(Base)` matches the literal Base class by
+        // identity — so a `Base.connected_to` scope blankets every pool.
+        // ApplicationRecord is NOT promoted here; its scope should only
+        // affect pools that share its normalized descriptor name (handled
+        // below in the name-match branch).
+        if (Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase")) {
           includesBase = true;
         }
-        if (ownerName !== undefined && k.name === ownerName) {
-          nameMatches = true;
+        if (ownerName !== undefined) {
+          // PoolConfig normalizes primary-class owners (Base/ApplicationRecord)
+          // to the "Base" descriptor name. Mirror that on the read side so an
+          // `ApplicationRecord.connected_to(...)` scope targets the primary
+          // pool without leaking into unrelated abstract-class pools.
+          const targetName =
+            typeof (k as any).primaryClassQ === "function" && (k as any).primaryClassQ()
+              ? "Base"
+              : k.name;
+          if (targetName === ownerName) nameMatches = true;
         }
       }
       if (includesBase || nameMatches) return entry.preventWrites;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -733,7 +733,14 @@ export class AbstractAdapter implements Quoting {
       let nameMatches = false;
       for (const k of entry.klasses) {
         if (typeof k !== "function") continue;
-        if (Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase")) {
+        // "Includes Base" covers the literal Base class AND the designated
+        // primary class (ApplicationRecord), which PoolConfig normalizes to
+        // the "Base" connection descriptor — so a connected_to scope on
+        // either should apply to every pool.
+        if (
+          Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase") ||
+          (typeof (k as any).primaryClassQ === "function" && (k as any).primaryClassQ())
+        ) {
           includesBase = true;
         }
         if (ownerName !== undefined && k.name === ownerName) {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -738,6 +738,15 @@ export class AbstractAdapter implements Quoting {
         // ApplicationRecord is NOT promoted here; its scope should only
         // affect pools that share its normalized descriptor name (handled
         // below in the name-match branch).
+        //
+        // Note: when an abstract subclass without `connectionClass = true`
+        // (e.g. ApplicationRecord set up via `primaryAbstractClass()` only,
+        // never `connectsTo`) calls `connectedTo`, `withRoleAndShard` pushes
+        // `connectionClassForSelf()` which walks up to Base, so klasses will
+        // contain Base and this branch fires globally. That mirrors the
+        // pre-existing convention in `core.ts#matchesStack`. Realistic
+        // primary-class flows call `connectsTo` first (setting
+        // `connectionClass = true`) so the walk stops at the primary class.
         if (Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase")) {
           includesBase = true;
         }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -720,19 +720,27 @@ export class AbstractAdapter implements Quoting {
     if (pool?.preventWrites === true) return true;
     if (pool?.dbConfig?.preventWrites === true) return true;
     if (this._config.preventWrites === true) return true;
-    // Mirrors Rails: connection_descriptor.current_preventing_writes
-    // Filter by the pool's owner class name so an unrelated abstract-class
-    // connected_to block doesn't affect this adapter's connection scope.
+    // Mirrors Rails: connection_descriptor.current_preventing_writes →
+    // Base.preventing_writes?(class_name). Walks the stack in reverse and
+    // returns the entry's prevent_writes flag when (a) it includes Base by
+    // identity, or (b) any klass's name matches the pool's connection name.
     const ownerName: string | undefined = pool?.poolConfig?.connectionDescriptor?.name;
     const stack = connectedToStack();
     for (let i = stack.length - 1; i >= 0; i--) {
       const entry = stack[i];
       if (entry.preventWrites === undefined) continue;
+      let includesBase = false;
+      let nameMatches = false;
       for (const k of entry.klasses) {
-        if (typeof k === "function" && (k.name === ownerName || k.name === "Base")) {
-          return entry.preventWrites;
+        if (typeof k !== "function") continue;
+        if (Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase")) {
+          includesBase = true;
+        }
+        if (ownerName !== undefined && k.name === ownerName) {
+          nameMatches = true;
         }
       }
+      if (includesBase || nameMatches) return entry.preventWrites;
     }
     return false;
   }

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -193,7 +193,9 @@ describe("ConnectionHandlingTest", () => {
         database: { writing: "primary" },
         shards: { default: { writing: "primary" } },
       }),
-    ).toThrow(/can only accept/);
+    ).toThrow(
+      "`connects_to` can only accept a `database` or `shards` argument, but not both arguments.",
+    );
   });
 
   it("connectedTo requires role or shard", () => {
@@ -504,95 +506,127 @@ describe("withRoleAndShard loads Relation return values within scope (Story K ga
 
     expect(loadCalled).toBe(true);
   });
+});
 
-  describe("AbstractAdapter#isPreventingWrites stack matching", () => {
-    afterEach(() => {
-      connectedToStack().length = 0;
-      Base.connectionHandler.clearAllConnectionsBang();
-    });
+describe("AbstractAdapter#isPreventingWrites stack matching", () => {
+  afterEach(() => {
+    connectedToStack().length = 0;
+    Base.connectionHandler.clearAllConnectionsBang();
+  });
 
-    it("Base.connectedTo preventing writes applies globally to unrelated pools", () => {
-      class UnrelatedAbstract extends Base {
-        static {
-          this.abstractClass = true;
-          this.connectionClass = true;
-        }
+  it("Base.connectedTo preventing writes applies globally to unrelated pools", () => {
+    class UnrelatedAbstract extends Base {
+      static {
+        this.abstractClass = true;
+        this.connectionClass = true;
       }
-      Base.connectionHandler.establishConnection(
-        new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
-        {
-          owner: "UnrelatedAbstract",
-          role: "writing",
-          adapterFactory: () => new SQLite3Adapter(),
-        },
-      );
-      const conn = UnrelatedAbstract.leaseConnection();
-      expect(conn.isPreventingWrites()).toBe(false);
-      Base.connectedTo({ role: "writing", preventWrites: true }, () => {
-        expect(conn.isPreventingWrites()).toBe(true);
-      });
-      expect(conn.isPreventingWrites()).toBe(false);
+    }
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
+      {
+        owner: "UnrelatedAbstract",
+        role: "writing",
+        adapterFactory: () => new SQLite3Adapter(),
+      },
+    );
+    const conn = UnrelatedAbstract.leaseConnection();
+    expect(conn.isPreventingWrites()).toBe(false);
+    Base.connectedTo({ role: "writing", preventWrites: true }, () => {
+      expect(conn.isPreventingWrites()).toBe(true);
     });
+    expect(conn.isPreventingWrites()).toBe(false);
+  });
 
-    it("abstract-class connectedTo does not leak to unrelated pools", () => {
-      class AnimalsRecord extends Base {
-        static {
-          this.abstractClass = true;
-          this.connectionClass = true;
-        }
+  it("abstract-class connectedTo does not leak to unrelated pools", () => {
+    class AnimalsRecord extends Base {
+      static {
+        this.abstractClass = true;
+        this.connectionClass = true;
       }
-      class MealsRecord extends Base {
-        static {
-          this.abstractClass = true;
-          this.connectionClass = true;
-        }
+    }
+    class MealsRecord extends Base {
+      static {
+        this.abstractClass = true;
+        this.connectionClass = true;
       }
-      Base.connectionHandler.establishConnection(
-        new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
-        { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
-      );
-      Base.connectionHandler.establishConnection(
-        new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
-        { owner: "MealsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
-      );
-      const animals = AnimalsRecord.leaseConnection();
-      const meals = MealsRecord.leaseConnection();
-      AnimalsRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
-        expect(animals.isPreventingWrites()).toBe(true);
-        expect(meals.isPreventingWrites()).toBe(false);
-      });
+    }
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+    );
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: "MealsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+    );
+    const animals = AnimalsRecord.leaseConnection();
+    const meals = MealsRecord.leaseConnection();
+    AnimalsRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
+      expect(animals.isPreventingWrites()).toBe(true);
+      expect(meals.isPreventingWrites()).toBe(false);
     });
+  });
 
-    it("primary class connectedTo targets the Base-normalized pool only", () => {
-      class ApplicationRecord extends Base {
-        static {
-          this.abstractClass = true;
-          this.connectionClass = true;
-        }
-        static override primaryClassQ(): boolean {
-          return true;
-        }
+  it("primary class connectedTo (after connectsTo) targets the Base-normalized pool", () => {
+    // Realistic primary-class flow: primaryAbstractClass marks abstract, then
+    // connectsTo sets connectionClass=true so connectionClassForSelf walks no
+    // further than ApplicationRecord. PoolConfig normalizes the descriptor
+    // name to "Base"; the matcher must match the primary-class scope entry
+    // (klasses=[ApplicationRecord]) against that normalized "Base" pool name.
+    class ApplicationRecord extends Base {
+      static {
+        this.abstractClass = true;
+        this.connectionClass = true;
       }
-      class OtherAbstract extends Base {
-        static {
-          this.abstractClass = true;
-          this.connectionClass = true;
-        }
+      static override primaryClassQ(): boolean {
+        return true;
       }
-      Base.connectionHandler.establishConnection(
-        new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
-        { owner: ApplicationRecord, role: "writing", adapterFactory: () => new SQLite3Adapter() },
-      );
-      Base.connectionHandler.establishConnection(
-        new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
-        { owner: "OtherAbstract", role: "writing", adapterFactory: () => new SQLite3Adapter() },
-      );
-      const appConn = ApplicationRecord.leaseConnection();
-      const otherConn = OtherAbstract.leaseConnection();
-      ApplicationRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
-        expect(appConn.isPreventingWrites()).toBe(true);
-        expect(otherConn.isPreventingWrites()).toBe(false);
-      });
+    }
+    class OtherAbstract extends Base {
+      static {
+        this.abstractClass = true;
+        this.connectionClass = true;
+      }
+    }
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: ApplicationRecord, role: "writing", adapterFactory: () => new SQLite3Adapter() },
+    );
+    Base.connectionHandler.establishConnection(
+      new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
+      { owner: "OtherAbstract", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+    );
+    const appConn = ApplicationRecord.leaseConnection();
+    const otherConn = OtherAbstract.leaseConnection();
+    ApplicationRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
+      expect(appConn.isPreventingWrites()).toBe(true);
+      expect(otherConn.isPreventingWrites()).toBe(false);
     });
+  });
+});
+
+describe("resolveConfigForConnection / connectsTo with unset configurations", () => {
+  afterEach(() => {
+    Base.connectionHandler.clearAllConnectionsBang();
+    delete (Base as any)._connectionSpecificationName;
+  });
+
+  it("unknown string config name raises AdapterNotSpecified with available-configs hint", async () => {
+    const { resolveConfigForConnection } = await import("./connection-handling.js");
+    const { AdapterNotSpecified } = await import("./errors.js");
+    class Untouched extends Base {
+      static {
+        this.abstractClass = true;
+      }
+    }
+    // No `Untouched.configurations` assigned — normalizeConfigurations falls
+    // back to DatabaseConfigurations.fromEnv({}), so resolving an unknown
+    // env name must surface AdapterNotSpecified rather than passing the
+    // string through.
+    expect(() => resolveConfigForConnection.call(Untouched, "missing_env")).toThrow(
+      AdapterNotSpecified,
+    );
+    expect(() => resolveConfigForConnection.call(Untouched, "missing_env")).toThrow(
+      /`missing_env` database is not configured/,
+    );
   });
 });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -643,5 +643,39 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
     expect(() => resolveConfigForConnection.call(Untouched, "missing_env")).toThrow(
       /`missing_env` database is not configured/,
     );
+    // Pin the available-configurations hint — regressions in the hint
+    // wording shouldn't slip through.
+    expect(() => resolveConfigForConnection.call(Untouched, "missing_env")).toThrow(
+      /Available database configurations are:/,
+    );
+  });
+
+  it("connectsTo plants _connectionSpecificationName (primary class normalizes to 'Base')", async () => {
+    const { __resetPrimaryAbstractClass, primaryAbstractClass } = await import("./inheritance.js");
+    class AppRecord extends Base {}
+    class SecondaryAbstract extends Base {
+      static {
+        this.abstractClass = true;
+      }
+    }
+    try {
+      __resetPrimaryAbstractClass();
+      primaryAbstractClass(AppRecord);
+      (AppRecord as any).configurations = {
+        development: { primary: { adapter: "sqlite3", database: ":memory:" } },
+      };
+      (SecondaryAbstract as any).configurations = (AppRecord as any).configurations;
+
+      // Exercises the public connectsTo path so the
+      // resolveConfigForConnection side effect (planting
+      // _connectionSpecificationName) is covered end-to-end.
+      AppRecord.connectsTo({ database: { writing: "primary" } });
+      expect((AppRecord as any)._connectionSpecificationName).toBe("Base");
+
+      SecondaryAbstract.connectsTo({ database: { writing: "primary" } });
+      expect((SecondaryAbstract as any)._connectionSpecificationName).toBe("SecondaryAbstract");
+    } finally {
+      __resetPrimaryAbstractClass();
+    }
   });
 });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -605,7 +605,22 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
 });
 
 describe("resolveConfigForConnection / connectsTo with unset configurations", () => {
-  afterEach(() => {
+  let prevCurrentConfigs: unknown;
+  let prevBaseConfigs: unknown;
+
+  beforeEach(async () => {
+    const { DatabaseConfigurations } = await import("./database-configurations.js");
+    prevCurrentConfigs = (DatabaseConfigurations as any).current;
+    prevBaseConfigs = (Base as any).configurations;
+  });
+
+  afterEach(async () => {
+    const { DatabaseConfigurations } = await import("./database-configurations.js");
+    // fromEnv({}) mutates DatabaseConfigurations.current (the primary-config
+    // registry HashConfig#isPrimary consults), so save and restore it here
+    // — clearing connections alone leaves a stale primary registry behind.
+    (DatabaseConfigurations as any).current = prevCurrentConfigs;
+    (Base as any).configurations = prevBaseConfigs;
     Base.connectionHandler.clearAllConnectionsBang();
     delete (Base as any)._connectionSpecificationName;
   });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -506,6 +506,11 @@ describe("withRoleAndShard loads Relation return values within scope (Story K ga
   });
 
   describe("AbstractAdapter#isPreventingWrites stack matching", () => {
+    afterEach(() => {
+      connectedToStack().length = 0;
+      Base.connectionHandler.clearAllConnectionsBang();
+    });
+
     it("Base.connectedTo preventing writes applies globally to unrelated pools", () => {
       class UnrelatedAbstract extends Base {
         static {

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./base.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import {
   connectedToStack,
   currentRole,
@@ -502,5 +503,91 @@ describe("withRoleAndShard loads Relation return values within scope (Story K ga
     );
 
     expect(loadCalled).toBe(true);
+  });
+
+  describe("AbstractAdapter#isPreventingWrites stack matching", () => {
+    it("Base.connectedTo preventing writes applies globally to unrelated pools", () => {
+      class UnrelatedAbstract extends Base {
+        static {
+          this.abstractClass = true;
+          this.connectionClass = true;
+        }
+      }
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
+        {
+          owner: "UnrelatedAbstract",
+          role: "writing",
+          adapterFactory: () => new SQLite3Adapter(),
+        },
+      );
+      const conn = UnrelatedAbstract.leaseConnection();
+      expect(conn.isPreventingWrites()).toBe(false);
+      Base.connectedTo({ role: "writing", preventWrites: true }, () => {
+        expect(conn.isPreventingWrites()).toBe(true);
+      });
+      expect(conn.isPreventingWrites()).toBe(false);
+    });
+
+    it("abstract-class connectedTo does not leak to unrelated pools", () => {
+      class AnimalsRecord extends Base {
+        static {
+          this.abstractClass = true;
+          this.connectionClass = true;
+        }
+      }
+      class MealsRecord extends Base {
+        static {
+          this.abstractClass = true;
+          this.connectionClass = true;
+        }
+      }
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
+        { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+      );
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
+        { owner: "MealsRecord", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+      );
+      const animals = AnimalsRecord.leaseConnection();
+      const meals = MealsRecord.leaseConnection();
+      AnimalsRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
+        expect(animals.isPreventingWrites()).toBe(true);
+        expect(meals.isPreventingWrites()).toBe(false);
+      });
+    });
+
+    it("primary class connectedTo targets the Base-normalized pool only", () => {
+      class ApplicationRecord extends Base {
+        static {
+          this.abstractClass = true;
+          this.connectionClass = true;
+        }
+        static override primaryClassQ(): boolean {
+          return true;
+        }
+      }
+      class OtherAbstract extends Base {
+        static {
+          this.abstractClass = true;
+          this.connectionClass = true;
+        }
+      }
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
+        { owner: ApplicationRecord, role: "writing", adapterFactory: () => new SQLite3Adapter() },
+      );
+      Base.connectionHandler.establishConnection(
+        new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
+        { owner: "OtherAbstract", role: "writing", adapterFactory: () => new SQLite3Adapter() },
+      );
+      const appConn = ApplicationRecord.leaseConnection();
+      const otherConn = OtherAbstract.leaseConnection();
+      ApplicationRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
+        expect(appConn.isPreventingWrites()).toBe(true);
+        expect(otherConn.isPreventingWrites()).toBe(false);
+      });
+    });
   });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -6,7 +6,10 @@ import { getFsAsync, getPathAsync, getEnv } from "@blazetrails/activesupport";
 import { DatabaseConfigurations, type RawConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
-import { _setAdapterClassResolver } from "./database-configurations/database-config.js";
+import {
+  _setAdapterClassResolver,
+  type DatabaseConfig,
+} from "./database-configurations/database-config.js";
 import { resolve as resolveConnectionAdapter } from "./connection-adapters.js";
 import {
   AdapterNotFound,
@@ -70,27 +73,24 @@ export function connectsTo(
 
   if (Object.keys(database).length > 0 && Object.keys(shards).length > 0) {
     throw new ArgumentError(
-      "`connectsTo` can only accept a `database` or `shards` argument, but not both.",
+      "`connects_to` can only accept a `database` or `shards` argument, but not both arguments.",
     );
   }
 
   const connections: ConnectionPool[] = [];
-  // Mirrors: @shard_keys = shards.keys (before injecting :default for database: usage)
+  // Mirrors Rails' flow: capture @shard_keys before the default-merge, then
+  // inject {default: database} when no shards were given, then read
+  // shards.keys.first for default_shard from the post-merge map.
   (this as any)._shardKeys = Object.keys(shards);
-  const shardEntries = Object.keys(shards).length > 0 ? shards : { default: database };
-  // Mirrors: self.default_shard = shards.keys.first
-  (this as any)._defaultShard = Object.keys(shardEntries)[0] ?? "default";
+  const shardEntries: Record<string, Record<string, unknown>> = Object.keys(shards).length > 0
+    ? shards
+    : { default: database };
+  (this as any)._defaultShard = Object.keys(shardEntries)[0];
   (this as any).connectionClass = true;
-
-  const rawConfigs = (this as any).configurations;
-  const configs =
-    rawConfigs instanceof DatabaseConfigurations
-      ? rawConfigs
-      : DatabaseConfigurations.fromEnv(rawConfigs?.toH?.() ?? rawConfigs ?? {});
 
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const dbConfig = configs.resolve(dbKey);
+      const dbConfig = resolveConfigForConnection.call(this, dbKey);
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         owner: this.connectionClassForSelf(),
         role,
@@ -841,12 +841,38 @@ _setAdapterClassResolver(async (adapterName) => _loadAdapter(adapterName));
  *
  * @internal
  */
-export function resolveConfigForConnection(this: typeof Base, configOrEnv: unknown): unknown {
+export function resolveConfigForConnection(
+  this: typeof Base,
+  configOrEnv: unknown,
+): DatabaseConfig {
   if (!this.name) throw new Error("Anonymous class is not allowed.");
-  // Rails also sets self.connection_specification_name = connection_name as a side effect.
-  const connectionName = isPrimaryClass.call(this)
-    ? ((this as any)._baseClassName ?? this.name)
-    : this.name;
-  (this as any)._connectionSpecificationName = connectionName;
-  return (this as any).configurations?.resolve(configOrEnv) ?? configOrEnv;
+  // Rails sets self.connection_specification_name = connection_name as a side
+  // effect. Skip it for the primary class (Base/ApplicationRecord) since
+  // class statics inherit via prototype in JS and we don't want subclasses
+  // to read Base's spec name in place of their own connectionClass-derived
+  // value. The reader already returns "Base" for the primary class as a
+  // fallback, so this is a no-op for the primary case.
+  if (!isPrimaryClass.call(this)) {
+    (this as any)._connectionSpecificationName = this.name;
+  }
+
+  const rawConfigs = (this as any).configurations;
+  // `configurations` may be the unset static accessor (a function value), a
+  // plain hash assigned by tests, or an already-built DatabaseConfigurations.
+  // Mirror Rails' `Base.configurations.resolve(config_or_env)` by always
+  // normalizing to a DatabaseConfigurations instance before resolving — so
+  // string env names surface AdapterNotSpecified with the available-configs
+  // hint instead of silently passing through.
+  let configs: DatabaseConfigurations;
+  if (rawConfigs instanceof DatabaseConfigurations) {
+    configs = rawConfigs;
+  } else if (rawConfigs && typeof rawConfigs === "object") {
+    configs = DatabaseConfigurations.fromEnv(
+      (rawConfigs as { toH?: () => RawConfigurations }).toH?.() ??
+        (rawConfigs as RawConfigurations),
+    );
+  } else {
+    configs = DatabaseConfigurations.fromEnv({});
+  }
+  return configs.resolve(configOrEnv);
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -88,9 +88,16 @@ export function connectsTo(
   (this as any)._defaultShard = Object.keys(shardEntries)[0];
   (this as any).connectionClass = true;
 
+  // Normalize configurations once for the multi-shard/role loop instead of
+  // rebuilding DatabaseConfigurations.fromEnv inside resolveConfigForConnection
+  // on every iteration. The `connection_specification_name` side effect only
+  // depends on `this`, so plant it once upfront.
+  if (!this.name) throw new Error("Anonymous class is not allowed.");
+  (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
+  const configs = normalizeConfigurations(this);
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const dbConfig = resolveConfigForConnection.call(this, dbKey);
+      const dbConfig = configs.resolve(dbKey);
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         owner: this.connectionClassForSelf(),
         role,
@@ -859,26 +866,27 @@ export function resolveConfigForConnection(
   // subsequent connectionPool() lookups hit the right key. The reader uses
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
-  const connectionName = isPrimaryClass.call(this) ? "Base" : this.name;
-  (this as any)._connectionSpecificationName = connectionName;
+  (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
+  return normalizeConfigurations(this).resolve(configOrEnv);
+}
 
-  const rawConfigs = (this as any).configurations;
-  // `configurations` may be the unset static accessor (a function value), a
-  // plain hash assigned by tests, or an already-built DatabaseConfigurations.
-  // Mirror Rails' `Base.configurations.resolve(config_or_env)` by always
-  // normalizing to a DatabaseConfigurations instance before resolving — so
-  // string env names surface AdapterNotSpecified with the available-configs
-  // hint instead of silently passing through.
-  let configs: DatabaseConfigurations;
-  if (rawConfigs instanceof DatabaseConfigurations) {
-    configs = rawConfigs;
-  } else if (rawConfigs && typeof rawConfigs === "object") {
-    configs = DatabaseConfigurations.fromEnv(
+/**
+ * Normalize a class's `configurations` static into a DatabaseConfigurations
+ * instance. Mirror Rails' `Base.configurations.resolve(...)` entry point by
+ * always returning a real configurations object — string env names then
+ * surface AdapterNotSpecified with the available-configs hint instead of
+ * silently passing through.
+ *
+ * @internal
+ */
+function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
+  const rawConfigs = (klass as any).configurations;
+  if (rawConfigs instanceof DatabaseConfigurations) return rawConfigs;
+  if (rawConfigs && typeof rawConfigs === "object") {
+    return DatabaseConfigurations.fromEnv(
       (rawConfigs as { toH?: () => RawConfigurations }).toH?.() ??
         (rawConfigs as RawConfigurations),
     );
-  } else {
-    configs = DatabaseConfigurations.fromEnv({});
   }
-  return configs.resolve(configOrEnv);
+  return DatabaseConfigurations.fromEnv({});
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -364,7 +364,13 @@ export function removeConnection(this: typeof Base): void {
 }
 
 export function connectionSpecificationName(this: typeof Base): string {
-  if ((this as any)._connectionSpecificationName != null) {
+  // Check own property first to avoid prototype-static inheritance bleeding a
+  // value set on Base/ApplicationRecord into unrelated abstract subclasses.
+  // The recursive walk below handles cross-class inheritance explicitly.
+  if (
+    Object.prototype.hasOwnProperty.call(this, "_connectionSpecificationName") &&
+    (this as any)._connectionSpecificationName != null
+  ) {
     return (this as any)._connectionSpecificationName;
   }
   if (this.name === "Base") {
@@ -846,15 +852,15 @@ export function resolveConfigForConnection(
   configOrEnv: unknown,
 ): DatabaseConfig {
   if (!this.name) throw new Error("Anonymous class is not allowed.");
-  // Rails sets self.connection_specification_name = connection_name as a side
-  // effect. Skip it for the primary class (Base/ApplicationRecord) since
-  // class statics inherit via prototype in JS and we don't want subclasses
-  // to read Base's spec name in place of their own connectionClass-derived
-  // value. The reader already returns "Base" for the primary class as a
-  // fallback, so this is a no-op for the primary case.
-  if (!isPrimaryClass.call(this)) {
-    (this as any)._connectionSpecificationName = this.name;
-  }
+  // Mirrors Rails: connection_name = primary_class? ? Base.name : name, then
+  // self.connection_specification_name = connection_name. The primary class
+  // (Base/ApplicationRecord) stores its pool under "Base" — matching
+  // PoolConfig#connectionDescriptor's primary-class normalization — so
+  // subsequent connectionPool() lookups hit the right key. The reader uses
+  // an own-property check so writing here doesn't bleed through JS static
+  // inheritance into unrelated subclasses.
+  const connectionName = isPrimaryClass.call(this) ? "Base" : this.name;
+  (this as any)._connectionSpecificationName = connectionName;
 
   const rawConfigs = (this as any).configurations;
   // `configurations` may be the unset static accessor (a function value), a

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -891,10 +891,14 @@ function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
   const rawConfigs = (klass as any).configurations;
   if (rawConfigs instanceof DatabaseConfigurations) return rawConfigs;
   if (rawConfigs && typeof rawConfigs === "object") {
-    return DatabaseConfigurations.fromEnv(
-      (rawConfigs as { toH?: () => RawConfigurations }).toH?.() ??
-        (rawConfigs as RawConfigurations),
-    );
+    // Guard the `toH` call: raw config maps can carry arbitrary top-level
+    // keys, so a non-function `toH` entry is real config data — not a
+    // hash-like accessor to unwrap. Mirrors the same guard used elsewhere
+    // (see lines around 623 and `test-databases.ts`).
+    const toH = (rawConfigs as { toH?: unknown }).toH;
+    const raw =
+      typeof toH === "function" ? (toH.call(rawConfigs) as RawConfigurations) : rawConfigs;
+    return DatabaseConfigurations.fromEnv(raw as RawConfigurations);
   }
   return DatabaseConfigurations.fromEnv({});
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -893,8 +893,8 @@ function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
   if (rawConfigs && typeof rawConfigs === "object") {
     // Guard the `toH` call: raw config maps can carry arbitrary top-level
     // keys, so a non-function `toH` entry is real config data — not a
-    // hash-like accessor to unwrap. Mirrors the same guard used elsewhere
-    // (see lines around 623 and `test-databases.ts`).
+    // hash-like accessor to unwrap. Mirrors the same guard used in
+    // `establishConnection`'s in-memory branch and in `test-databases.ts`.
     const toH = (rawConfigs as { toH?: unknown }).toH;
     const raw =
       typeof toH === "function" ? (toH.call(rawConfigs) as RawConfigurations) : rawConfigs;

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -877,32 +877,24 @@ export function resolveConfigForConnection(
  * surface AdapterNotSpecified with the available-configs hint instead of
  * silently passing through.
  *
- * The normalized result is cached per (class, rawConfigs) so multi-shard
- * `connectsTo` calls don't pay an N× `DatabaseConfigurations.fromEnv` build
- * when delegating each role through `resolveConfigForConnection`.
+ * Not cached: `DatabaseConfigurations.fromEnv(...)` also folds in
+ * `DATABASE_URL`/`TRAILS_ENV` and updates `DatabaseConfigurations.current`,
+ * so a (class, rawConfigs) cache key would miss later env-state changes
+ * and leave `HashConfig.isPrimary()` consulting a stale registry.
+ * Rebuilding per resolve mirrors Rails' `Base.configurations.resolve(...)`
+ * and keeps the multi-shard `connectsTo` loop honest against later
+ * configuration or env shifts — `fromEnv` is a thin per-call build.
  *
  * @internal
  */
-const _normalizedConfigsCache = new WeakMap<
-  object,
-  { raw: unknown; configs: DatabaseConfigurations }
->();
 function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
   const rawConfigs = (klass as any).configurations;
-  const cached = _normalizedConfigsCache.get(klass);
-  if (cached && cached.raw === rawConfigs) return cached.configs;
-
-  let configs: DatabaseConfigurations;
-  if (rawConfigs instanceof DatabaseConfigurations) {
-    configs = rawConfigs;
-  } else if (rawConfigs && typeof rawConfigs === "object") {
-    configs = DatabaseConfigurations.fromEnv(
+  if (rawConfigs instanceof DatabaseConfigurations) return rawConfigs;
+  if (rawConfigs && typeof rawConfigs === "object") {
+    return DatabaseConfigurations.fromEnv(
       (rawConfigs as { toH?: () => RawConfigurations }).toH?.() ??
         (rawConfigs as RawConfigurations),
     );
-  } else {
-    configs = DatabaseConfigurations.fromEnv({});
   }
-  _normalizedConfigsCache.set(klass, { raw: rawConfigs, configs });
-  return configs;
+  return DatabaseConfigurations.fromEnv({});
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -88,16 +88,9 @@ export function connectsTo(
   (this as any)._defaultShard = Object.keys(shardEntries)[0];
   (this as any).connectionClass = true;
 
-  // Normalize configurations once for the multi-shard/role loop instead of
-  // rebuilding DatabaseConfigurations.fromEnv inside resolveConfigForConnection
-  // on every iteration. The `connection_specification_name` side effect only
-  // depends on `this`, so plant it once upfront.
-  if (!this.name) throw new Error("Anonymous class is not allowed.");
-  (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
-  const configs = normalizeConfigurations(this);
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const dbConfig = configs.resolve(dbKey);
+      const dbConfig = resolveConfigForConnection.call(this, dbKey);
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         owner: this.connectionClassForSelf(),
         role,
@@ -381,6 +374,13 @@ export function connectionSpecificationName(this: typeof Base): string {
     return (this as any)._connectionSpecificationName;
   }
   if (this.name === "Base") {
+    return "Base";
+  }
+  // Primary classes (Base/ApplicationRecord) store their pool under "Base"
+  // per PoolConfig#connectionDescriptor's normalization; reflect that here
+  // so leaseConnection() lookups hit the right pool when connectsTo hasn't
+  // run yet to plant _connectionSpecificationName.
+  if (typeof (this as any).primaryClassQ === "function" && (this as any).primaryClassQ()) {
     return "Base";
   }
   if ((this as any).connectionClassQ?.()) {
@@ -877,16 +877,32 @@ export function resolveConfigForConnection(
  * surface AdapterNotSpecified with the available-configs hint instead of
  * silently passing through.
  *
+ * The normalized result is cached per (class, rawConfigs) so multi-shard
+ * `connectsTo` calls don't pay an N× `DatabaseConfigurations.fromEnv` build
+ * when delegating each role through `resolveConfigForConnection`.
+ *
  * @internal
  */
+const _normalizedConfigsCache = new WeakMap<
+  object,
+  { raw: unknown; configs: DatabaseConfigurations }
+>();
 function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
   const rawConfigs = (klass as any).configurations;
-  if (rawConfigs instanceof DatabaseConfigurations) return rawConfigs;
-  if (rawConfigs && typeof rawConfigs === "object") {
-    return DatabaseConfigurations.fromEnv(
+  const cached = _normalizedConfigsCache.get(klass);
+  if (cached && cached.raw === rawConfigs) return cached.configs;
+
+  let configs: DatabaseConfigurations;
+  if (rawConfigs instanceof DatabaseConfigurations) {
+    configs = rawConfigs;
+  } else if (rawConfigs && typeof rawConfigs === "object") {
+    configs = DatabaseConfigurations.fromEnv(
       (rawConfigs as { toH?: () => RawConfigurations }).toH?.() ??
         (rawConfigs as RawConfigurations),
     );
+  } else {
+    configs = DatabaseConfigurations.fromEnv({});
   }
-  return DatabaseConfigurations.fromEnv({});
+  _normalizedConfigsCache.set(klass, { raw: rawConfigs, configs });
+  return configs;
 }


### PR DESCRIPTION
## Summary

Five small Rails-fidelity tweaks across `connection-handling.ts` and `abstract-adapter.ts`:

- `connectsTo`: match Rails' both-args ArgumentError wording verbatim (`connects_to` / `but not both arguments`).
- `connectsTo`: route per-shard/role resolution through `resolveConfigForConnection.call(this, dbKey)`, mirroring Rails' `connects_to -> resolve_config_for_connection` flow. The resolver normalizes `this.configurations` to a `DatabaseConfigurations` instance per call (no cross-call cache) — `fromEnv()` folds `DATABASE_URL`/`TRAILS_ENV` and mutates `DatabaseConfigurations.current`, so a stable cache key would miss env-state shifts and leave `HashConfig.isPrimary()` consulting a stale registry. Per-call cost is bounded (N ≤ ~ writing/reading × few shards) and matches Rails' `Base.configurations.resolve(...)` semantics.
- `resolveConfigForConnection` / `normalizeConfigurations`: always normalize `(this as any).configurations` to a `DatabaseConfigurations` instance (constructing an empty `fromEnv({})` when unset) so unresolved string env names surface the friendly `AdapterNotSpecified` message with the available-configs hint instead of silently passing through. Write `_connectionSpecificationName = primary_class? ? "Base" : this.name` to mirror PoolConfig's primary-class normalization, and switch the reader's first-branch to `hasOwnProperty` so the assignment doesn't bleed through JS static-inheritance.
- `connectsTo`: drop the `?? "default"` belt-suspenders on the `_defaultShard` assignment — Rails reads from the post-merge shards hash, which is never empty after the `shards[:default] = database` injection.
- `AbstractAdapter#isPreventingWrites`: split the stack-walk matcher into Rails' two-tier check. `klasses.include?(Base)` is identity-only on the literal Base (own `_isActiveRecordBase` marker) and applies globally. The name-match branch normalizes primary classes (`ApplicationRecord`) to `"Base"` to match PoolConfig's normalized descriptor name without leaking write-prevention into unrelated abstract-class pools.

## Test plan
- [x] `pnpm exec vitest run --project activerecord` for the touched test files: `connection-handling.test.ts` (incl. new isPreventingWrites + AdapterNotSpecified coverage), `base.test.ts`, `connection-pool.test.ts`, `connection-handler.test.ts`, `connection-handlers-sharding-db.test.ts`, `connection-handlers-multi-db.test.ts`, `shard-keys.test.ts`, `base-prevent-writes.test.ts`
- [x] `pnpm --filter @blazetrails/activerecord build`
- [x] `pnpm run api:compare --package activerecord` — Δ = 0 (4956/4958 on both)
- [x] `pnpm run test:compare --package activerecord` — Δ = 0 (6579/7885 on both)