### PR TITLE
feat(activerecord): batch 47 — MySQL table-options polish

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -63,7 +63,11 @@ import {
 } from "./abstract/schema-definitions.js";
 import type { ColumnType, ColumnOptions } from "./abstract/schema-definitions.js";
 import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
-import { isRowFormatDynamicByDefault, defaultType } from "./mysql/schema-statements.js";
+import {
+  isRowFormatDynamicByDefault,
+  defaultType,
+  quotedScope,
+} from "./mysql/schema-statements.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -485,9 +489,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async tableComment(tableName: string): Promise<string | null> {
+    const scope = quotedScope(tableName);
+    if (!scope.name) return null;
     const rows = await this.schemaQuery(
       `SELECT table_comment FROM information_schema.tables` +
-        ` WHERE table_schema = database() AND table_name = ${this.quote(tableName)}`,
+        ` WHERE table_schema = ${scope.schema} AND table_name = ${scope.name}`,
     );
     const val = rows[0]?.["table_comment"] as string | null | undefined;
     return val || null;
@@ -725,6 +731,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const td = new MysqlTableDefinition(tableName, { id: false });
     const colDef = td.newColumnDefinition(column.name, resolvedType as any, opts as any);
     return new ChangeColumnDefinition(colDef, column.name);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition.
+   * Routes `createTable` through the MySQL-specific `TableDefinition` so MySQL column
+   * methods (`blob`, `tinytext`, `unsignedInteger`, …) and the MySQL `primary_key` /
+   * unsigned alias handling are available inside the createTable block.
+   * @internal
+   */
+  createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
+    const { adapter: _adapter, adapterName: _adapterName, ...rest } = options;
+    return new MysqlTableDefinition(name, rest as any);
   }
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -733,18 +733,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return new ChangeColumnDefinition(colDef, column.name);
   }
 
-  /**
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition.
-   * Routes `createTable` through the MySQL-specific `TableDefinition` so MySQL column
-   * methods (`blob`, `tinytext`, `unsignedInteger`, …) and the MySQL `primary_key` /
-   * unsigned alias handling are available inside the createTable block.
-   * @internal
-   */
-  createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
-    const { adapter: _adapter, adapterName: _adapterName, ...rest } = options;
-    return new MysqlTableDefinition(name, rest as any);
-  }
-
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
     void tableName;
     void columnName;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -115,6 +115,19 @@ describe("TableDefinition#raise_on_duplicate_column", () => {
   });
 });
 
+describe("TableDefinition#primary_key option", () => {
+  it("treats primaryKey: false same as id: false", () => {
+    const td = new TableDefinition("t", { primaryKey: false });
+    expect(td.columns.find((c) => c.options.primaryKey)).toBeUndefined();
+  });
+
+  it("treats primaryKey: 'uuid' as a custom PK column name", () => {
+    const td = new TableDefinition("t", { primaryKey: "uuid" });
+    const pk = td.columns.find((c) => c.options.primaryKey);
+    expect(pk?.name).toBe("uuid");
+  });
+});
+
 describe("TableDefinition#integer_like_primary_key?", () => {
   it("newColumnDefinition preserves integer pk type in base class", () => {
     const td = new TableDefinition("t", { id: false });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -620,7 +620,16 @@ export class TableDefinition {
     if (Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length === 0) {
       throw new ArgumentError("primaryKey array must not be empty");
     }
-    this._id = hasCompositePk ? false : (tdOptions.id ?? true);
+    // primaryKey: false ⇒ same as id: false (no auto-PK column).
+    // primaryKey: "custom_name" ⇒ keep auto-PK but rename the column.
+    const pkFalse = tdOptions.primaryKey === false;
+    const pkNameOverride =
+      typeof tdOptions.primaryKey === "string" ? tdOptions.primaryKey : undefined;
+    if (hasCompositePk || pkFalse) {
+      this._id = false;
+    } else {
+      this._id = tdOptions.id ?? true;
+    }
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
     this.as = tdOptions.as;
@@ -653,7 +662,7 @@ export class TableDefinition {
         pkOpts = { primaryKey: true };
         if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
       }
-      this.columns.push(this.newColumnDefinition("id", pkType, pkOpts));
+      this.columns.push(this.newColumnDefinition(pkNameOverride ?? "id", pkType, pkOpts));
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -50,20 +50,13 @@ export class TableDefinition extends AbstractTableDefinition {
   constructor(
     tableName: string,
     options: {
-      id?: boolean | "uuid" | string | Record<string, unknown>;
-      primaryKey?: string | string[] | false;
+      id?: boolean | "uuid";
       charset?: string | null;
       collation?: string | null;
-      temporary?: boolean;
-      ifNotExists?: boolean;
-      options?: string;
-      comment?: string;
-      as?: string;
-      default?: unknown;
     } = {},
   ) {
     super(tableName, {
-      ...(options as any),
+      ...options,
       charset: options.charset ?? undefined,
       collation: options.collation ?? undefined,
       adapterName: "mysql",

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -50,13 +50,20 @@ export class TableDefinition extends AbstractTableDefinition {
   constructor(
     tableName: string,
     options: {
-      id?: boolean | "uuid";
+      id?: boolean | "uuid" | string | Record<string, unknown>;
+      primaryKey?: string | string[] | false;
       charset?: string | null;
       collation?: string | null;
+      temporary?: boolean;
+      ifNotExists?: boolean;
+      options?: string;
+      comment?: string;
+      as?: string;
+      default?: unknown;
     } = {},
   ) {
     super(tableName, {
-      ...options,
+      ...(options as any),
       charset: options.charset ?? undefined,
       collation: options.collation ?? undefined,
       adapterName: "mysql",

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -206,5 +206,47 @@ describe("MySQL::SchemaDumper", () => {
       const d = make();
       expect(await (d as any).fetchTableOptions("users")).toEqual({});
     });
+
+    it("falls back to SHOW TABLE STATUS for collation when not in options", async () => {
+      const d = make();
+      d.connection = {
+        tableOptions: async () => ({ charset: "utf8mb4" }),
+        schemaQuery: async () => [{ Collation: "utf8mb4_general_ci" }],
+        quote: (v) => `'${String(v)}'`,
+      };
+      await (d as any).fetchTableOptions("users");
+      expect(d.tableCollationCache["users"]).toBe("utf8mb4_general_ci");
+    });
+  });
+
+  describe("orderPrimaryKeyColumns", () => {
+    it("reorders composite PK columns by primaryKeyOrderCache", () => {
+      const d = make();
+      d.primaryKeyOrderCache["t"] = ["b", "a"];
+      const result = (d as any).orderPrimaryKeyColumns("t", [
+        col({ name: "a" }),
+        col({ name: "b" }),
+      ]);
+      expect(result.map((c: { name: string }) => c.name)).toEqual(["b", "a"]);
+    });
+
+    it("preserves input order when cache is empty", () => {
+      const d = make();
+      const result = (d as any).orderPrimaryKeyColumns("t", [
+        col({ name: "a" }),
+        col({ name: "b" }),
+      ]);
+      expect(result.map((c: { name: string }) => c.name)).toEqual(["a", "b"]);
+    });
+
+    it("appends columns not present in cache", () => {
+      const d = make();
+      d.primaryKeyOrderCache["t"] = ["b"];
+      const result = (d as any).orderPrimaryKeyColumns("t", [
+        col({ name: "a" }),
+        col({ name: "b" }),
+      ]);
+      expect(result.map((c: { name: string }) => c.name)).toEqual(["b", "a"]);
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -34,6 +34,9 @@ interface MysqlColumn extends ColumnInfo {
 
 interface MysqlAdapterLike {
   tableOptions(tableName: string): Promise<Record<string, string>>;
+  primaryKeys?(tableName: string): Promise<string[]>;
+  schemaQuery?(sql: string): Promise<Record<string, unknown>[]>;
+  quote?(value: unknown): string;
 }
 
 export class SchemaDumper extends AbstractSchemaDumper {
@@ -48,6 +51,15 @@ export class SchemaDumper extends AbstractSchemaDumper {
    */
   virtualExpressionCache: Record<string, Record<string, string> | undefined> = Object.create(null);
 
+  /**
+   * Per-table PK column order from `@connection.primary_key(table)` (MySQL returns
+   * columns in `seq_in_index` order). Used by `emitTable` to render
+   * `primaryKey: [...]` in index order rather than `SHOW FULL FIELDS` declaration
+   * order, matching Rails.
+   * @internal
+   */
+  primaryKeyOrderCache: Record<string, string[] | undefined> = Object.create(null);
+
   /** @internal */
   protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
     if (!this.connection) return {};
@@ -56,8 +68,32 @@ export class SchemaDumper extends AbstractSchemaDumper {
     // schemaCollation can suppress per-column collation that matches the table default.
     if (Object.hasOwn(opts, "collation")) {
       this.tableCollationCache[tableName] = opts["collation"];
+    } else {
+      await this.populateTableCollationFromStatus(tableName);
     }
     return opts;
+  }
+
+  /**
+   * Lazily fill `tableCollationCache` via `SHOW TABLE STATUS LIKE ...` when the
+   * cached `tableOptions` parse didn't surface a `COLLATE` clause (e.g. when the
+   * table uses the schema default and the dumper still needs to know that
+   * default in order to suppress per-column collation).
+   *
+   * Mirrors Rails' `MySQL::SchemaDumper#table_collation`, which falls back to
+   * `information_schema.tables.table_collation` when `SHOW CREATE TABLE` omits
+   * an explicit collation.
+   * @internal
+   */
+  protected async populateTableCollationFromStatus(tableName: string): Promise<void> {
+    if (Object.hasOwn(this.tableCollationCache, tableName)) return;
+    const conn = this.connection;
+    if (!conn?.schemaQuery || !conn.quote) return;
+    const rows = await conn.schemaQuery(`SHOW TABLE STATUS LIKE ${conn.quote(tableName)}`);
+    const collation = rows[0]?.["Collation"] as string | null | undefined;
+    if (typeof collation === "string" && collation.length > 0) {
+      this.tableCollationCache[tableName] = collation;
+    }
   }
 
   defaultPrimaryKeyType(): string {
@@ -131,6 +167,38 @@ export class SchemaDumper extends AbstractSchemaDumper {
     if (column.type === "datetime")
       return column.precision === 0 ? "nil" : super.schemaPrecision(column);
     return super.schemaPrecision(column);
+  }
+
+  /** @internal */
+  override async table(tableName: string, lines: string[]): Promise<void> {
+    if (this.connection?.primaryKeys) {
+      try {
+        this.primaryKeyOrderCache[tableName] = await this.connection.primaryKeys(tableName);
+      } catch {
+        // Live introspection is best-effort; fall through to declaration order.
+      }
+    }
+    await super.table(tableName, lines);
+  }
+
+  /** @internal */
+  protected override orderPrimaryKeyColumns(
+    tableName: string,
+    pkColumns: ColumnInfo[],
+  ): ColumnInfo[] {
+    const order = this.primaryKeyOrderCache[tableName];
+    if (!order || order.length === 0) return pkColumns;
+    const byName = new Map(pkColumns.map((c) => [c.name, c]));
+    const reordered: ColumnInfo[] = [];
+    for (const name of order) {
+      const col = byName.get(name);
+      if (col) {
+        reordered.push(col);
+        byName.delete(name);
+      }
+    }
+    for (const col of byName.values()) reordered.push(col);
+    return reordered;
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -131,6 +131,32 @@ describe("MigrationTest", () => {
     expect(ctx.columnExists("users", "new_name")).toBe(true);
   });
 
+  it("tracks composite primary key columns in column metadata", async () => {
+    const { ctx } = freshContext();
+    await ctx.createTable("memberships", { primaryKey: ["user_id", "group_id"] }, (t) => {
+      t.integer("user_id");
+      t.integer("group_id");
+      t.string("role");
+    });
+    const cols = ctx.columns("memberships");
+    const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+    expect(byName.user_id.primaryKey).toBe(true);
+    expect(byName.group_id.primaryKey).toBe(true);
+    expect(byName.role.primaryKey).toBeFalsy();
+    expect(cols.find((c) => c.name === "id")).toBeUndefined();
+  });
+
+  it("tracks custom primary key column name in column metadata", async () => {
+    const { ctx } = freshContext();
+    await ctx.createTable("widgets", { primaryKey: "uuid" }, (t) => {
+      t.string("name");
+    });
+    const cols = ctx.columns("widgets");
+    const pk = cols.find((c) => c.primaryKey);
+    expect(pk?.name).toBe("uuid");
+    expect(cols.find((c) => c.name === "id")).toBeUndefined();
+  });
+
   it("add index", async () => {
     const { ctx } = freshContext();
     await ctx.createTable("users", {}, (t) => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1623,15 +1623,25 @@ export class MigrationContext {
         scale?: number | null;
       }
     >();
-    if (options?.id !== false && !Array.isArray(options?.primaryKey) && options?.as == null) {
+    const compositePk =
+      Array.isArray(options?.primaryKey) && options.primaryKey.length > 0
+        ? new Set(options.primaryKey)
+        : null;
+    if (
+      options?.id !== false &&
+      !compositePk &&
+      options?.primaryKey !== false &&
+      options?.as == null
+    ) {
       const idType = typeof options?.id === "string" ? options.id : "integer";
-      meta.set("id", { type: idType, primaryKey: true });
+      const idName = typeof options?.primaryKey === "string" ? options.primaryKey : "id";
+      meta.set(idName, { type: idType, primaryKey: true });
     }
     for (const col of tdCols) {
-      if (col.name === "id" && meta.has("id")) continue;
+      if (meta.has(col.name)) continue;
       meta.set(col.name, {
         type: col.type,
-        primaryKey: col.options.primaryKey,
+        primaryKey: col.options.primaryKey || compositePk?.has(col.name) || undefined,
         null: col.options.null,
         default: col.options.default,
         limit: col.options.limit,

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -854,6 +854,18 @@ export class SchemaDumper {
     return {};
   }
 
+  /**
+   * Hook for adapter subclasses to reorder the primary-key column list emitted
+   * inside `tableOpts.primaryKey` for composite PKs. Default: identity
+   * (preserve `SHOW COLUMNS` declaration order). MySQL overrides this to
+   * mirror Rails' `@connection.primary_key(table)`, which returns columns in
+   * `seq_in_index` order.
+   * @internal
+   */
+  protected orderPrimaryKeyColumns(_tableName: string, pkColumns: ColumnInfo[]): ColumnInfo[] {
+    return pkColumns;
+  }
+
   /** @internal */
   protected emitTable(
     lines: string[],
@@ -863,7 +875,10 @@ export class SchemaDumper {
     adapterTableOpts: Record<string, unknown> = {},
     inlineConstraints: string[] = [],
   ): void {
-    const pkColumns = columns.filter((c) => c.primaryKey);
+    const pkColumns = this.orderPrimaryKeyColumns(
+      tableName,
+      columns.filter((c) => c.primaryKey),
+    );
     const hasCompositePk = pkColumns.length > 1;
     const pkColumn = pkColumns[0];
     const hasId = !hasCompositePk && pkColumn?.name === "id";


### PR DESCRIPTION
## Summary

Five small fidelity items from `docs/activerecord-100-plan.md` Batch 47 (MySQL table-options polish, low risk).

- `tableComment()` routes through `quotedScope`/`extractSchemaQualifiedName` so `schema.table` names are scoped correctly (mirrors Rails).
- `TableDefinition` constructor: `primaryKey: false` now behaves like `id: false`, and `primaryKey: "name"` renames the auto-PK column.
- `MigrationContext.createTable` populates `_columnMeta` for composite-PK columns and the custom-named single-PK case, so `ctx.columns()` reflects them.
- `mysql/SchemaDumper` falls back to `SHOW TABLE STATUS LIKE …` to populate `tableCollationCache` when the parsed `tableOptions` didn't surface a `COLLATE` clause (mirrors Rails' `table_collation`).
- Adds an `orderPrimaryKeyColumns` hook on the abstract `SchemaDumper`. `mysql/SchemaDumper` overrides it (and `table()`) to reorder composite-PK columns by `primaryKeyOrderCache`, populated from `@connection.primaryKey(table)` (Rails uses `seq_in_index` order, not `SHOW FULL FIELDS` declaration order).

### Deferred

The 6th item in Batch 47 — `AbstractMysqlAdapter.createTableDefinition` override returning `MysqlTableDefinition` — was reverted because `abstract TableDefinition#toSql` doesn't honor `options.autoIncrement`, and `MysqlTableDefinition#newColumnDefinition` rewrites `primary_key` → `integer`, which drops `AUTO_INCREMENT` from the auto-PK column. Re-enabling this needs `td.toSql()` to route through `schemaCreation.accept(...)` (so `MysqlSchemaCreation` handles auto-PK emission). Will land in a follow-up.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts packages/activerecord/src/schema-dumper.test.ts`
- [x] `TEST_ADAPTER=mysql2 pnpm vitest run packages/activerecord/src/connection-adapters/mysql`
- [x] `TEST_ADAPTER=mysql2 pnpm vitest run packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts`