### PR TITLE
feat(actionpack): AbstractController translation + deprecator ports

### DIFF
--- a/packages/actionpack/src/abstract-controller/deprecator.test.ts
+++ b/packages/actionpack/src/abstract-controller/deprecator.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { Deprecation } from "@blazetrails/activesupport";
+import { deprecator } from "./deprecator.js";
+
+describe("AbstractController.deprecator", () => {
+  it("returns a Deprecation instance", () => {
+    expect(deprecator()).toBeInstanceOf(Deprecation);
+  });
+
+  it("memoizes the instance across calls", () => {
+    expect(deprecator()).toBe(deprecator());
+  });
+});

--- a/packages/actionpack/src/abstract-controller/deprecator.ts
+++ b/packages/actionpack/src/abstract-controller/deprecator.ts
@@ -1,0 +1,13 @@
+import { Deprecation } from "@blazetrails/activesupport";
+
+/**
+ * Lazily-initialized Deprecation instance for the AbstractController
+ * namespace. Mirrors Rails `AbstractController.deprecator`.
+ *
+ * @internal
+ */
+let _deprecator: Deprecation | undefined;
+export function deprecator(): Deprecation {
+  if (!_deprecator) _deprecator = new Deprecation();
+  return _deprecator;
+}

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -7,3 +7,13 @@ export {
 } from "./base.js";
 export type { CallbackEntry } from "./callbacks.js";
 export { AbstractControllerError } from "./error.js";
+export {
+  translate,
+  t,
+  localize,
+  l,
+  type TranslationHost,
+  type TranslateOptions,
+  type LocalizeOptions,
+} from "./translation.js";
+export { deprecator } from "./deprecator.js";

--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { I18n } from "@blazetrails/activesupport";
+import { translate, t, localize, l, type TranslationHost } from "./translation.js";
+
+function makeHost(controllerPath: string, actionName: string): TranslationHost {
+  return {
+    actionName,
+    constructor: { controllerPath: () => controllerPath },
+  } as unknown as TranslationHost;
+}
+
+describe("AbstractController::Translation", () => {
+  beforeEach(() => {
+    I18n.backend.storeTranslations("en", {
+      people: {
+        index: { foo: "scoped people index foo" },
+      },
+      shared: { foo: "shared foo" },
+    });
+  });
+
+  it("delegates to I18n.translate for a top-level key", () => {
+    const host = makeHost("people", "index");
+    expect(translate.call(host, "shared.foo")).toBe("shared foo");
+  });
+
+  it("scopes leading-dot keys by controller path and action name", () => {
+    const host = makeHost("people", "index");
+    expect(translate.call(host, ".foo")).toBe("scoped people index foo");
+  });
+
+  it("converts slashes in controller path to dots", () => {
+    I18n.backend.storeTranslations("en", {
+      admin: { users: { show: { foo: "admin users show foo" } } },
+    });
+    const host = makeHost("admin/users", "show");
+    expect(translate.call(host, ".foo")).toBe("admin users show foo");
+  });
+
+  it("prepends a default-list when caller supplies a default and the key starts with a dot", () => {
+    // The scoped lookup misses, the user default ('users.unknown') also
+    // misses, but I18n's missing-translation fallback returns a default-array
+    // structure. Easiest assertion: passing through without throwing.
+    const host = makeHost("people", "index");
+    expect(() => translate.call(host, ".missing", { default: "Hello" })).not.toThrow();
+  });
+
+  it("`t` is an alias for `translate`", () => {
+    const host = makeHost("people", "index");
+    expect(t.call(host, ".foo")).toBe(translate.call(host, ".foo"));
+  });
+
+  it("localize / l delegate to I18n.localize", () => {
+    const host = makeHost("people", "index");
+    const d = new Date("2026-05-16T12:34:56Z");
+    expect(typeof localize.call(host, d)).toBe("string");
+    expect(l.call(host, d)).toBe(localize.call(host, d));
+  });
+});

--- a/packages/actionpack/src/abstract-controller/translation.ts
+++ b/packages/actionpack/src/abstract-controller/translation.ts
@@ -1,0 +1,72 @@
+import { I18n } from "@blazetrails/activesupport";
+
+/**
+ * Host shape `translate` / `localize` mix into. Trails' `Metal` provides
+ * both via its static `controllerPath()` and instance `actionName` —
+ * any class with the same shape can include this module.
+ */
+export interface TranslationHost {
+  actionName: string;
+  constructor: { controllerPath(): string };
+}
+
+export interface TranslateOptions {
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Delegates to `I18n.translate`.
+ *
+ * When the given key starts with a period, it is scoped by the current
+ * controller and action. So calling `translate(".foo")` from
+ * `PeopleController#index` translates `"people.index.foo"`. This makes
+ * it less repetitive to translate many keys within the same
+ * controller / action and gives a simple framework for scoping them
+ * consistently.
+ *
+ * Mirrors `AbstractController::Translation#translate`.
+ */
+export function translate(
+  this: TranslationHost,
+  key: string,
+  options: TranslateOptions = {},
+): unknown {
+  if (key && key.startsWith(".")) {
+    const path = this.constructor.controllerPath().replace(/\//g, ".");
+    const defaults: string[] = [`${path}${key}`];
+    if (options.default != null) {
+      // Flatten array defaults like Rails does.
+      const userDefault = Array.isArray(options.default)
+        ? (options.default as unknown[])
+        : [options.default];
+      defaults.push(...(userDefault as string[]));
+    }
+    options = { ...options, default: defaults };
+    key = `${path}.${this.actionName}${key}`;
+  }
+  return I18n.translate(key, options as Parameters<typeof I18n.translate>[1]);
+}
+
+/** Rails alias `:t :translate`. */
+export function t(this: TranslationHost, key: string, options: TranslateOptions = {}): unknown {
+  return translate.call(this, key, options);
+}
+
+export interface LocalizeOptions {
+  [key: string]: unknown;
+}
+
+/** Delegates to `I18n.localize`. */
+export function localize(
+  this: TranslationHost,
+  object: Date,
+  options: LocalizeOptions = {},
+): string {
+  return I18n.localize(object, options as Parameters<typeof I18n.localize>[1]);
+}
+
+/** Rails alias `:l :localize`. */
+export function l(this: TranslationHost, object: Date, options: LocalizeOptions = {}): string {
+  return I18n.localize(object, options as Parameters<typeof I18n.localize>[1]);
+}


### PR DESCRIPTION
## Summary
First abstract_controller/ fill-in PR (Wave 8 territory). Two of the smaller Rails files ported.

- **`translation.ts`** (~80 LOC) — `translate` / `t` / `localize` / `l` mixins as this-typed functions per the CLAUDE.md include-pattern. Leading-dot keys are scoped by controller path (slashes → dots) and action name, so `.foo` from `PeopleController#index` translates `people.index.foo`. Defaults pass through.
- **`deprecator.ts`** (~12 LOC) — lazy `AbstractController.deprecator()` mirroring Rails' module-level memoized accessor.

Wired through the `abstract-controller` barrel.

## Out of scope
`HtmlSafeTranslation` integration — Rails calls it after the scoping step to HTML-escape user-supplied default strings. Trails doesn't have an HTML-safe-string type yet (lands with actionview HTML helpers); the call would be a no-op here. Straightforward follow-up when that lands.

## Status of `abstract_controller/` fill-in
| Rails file              | LOC | Status                |
| ----------------------- | --- | --------------------- |
| `base.rb`               | 299 | ✅ (base.ts)          |
| `callbacks.rb`          | 265 | ✅ (callbacks.ts)     |
| `error.rb`              | 8   | ✅ (error.ts)         |
| `translation.rb`        | 42  | **this PR**           |
| `deprecator.rb`         | 9   | **this PR**           |
| `asset_paths.rb`        | 14  | not ported            |
| `caching.rb` + dir      | 68+ | not ported            |
| `collector.rb`          | 44  | not ported            |
| `helpers.rb`            | 245 | not ported            |
| `logger.rb`             | 16  | not ported            |
| `rendering.rb`          | 125 | not ported            |
| `url_for.rb`            | 37  | not ported            |
| `railties/`             | -   | not ported (trailtie) |

## Test plan
- [x] 8 new tests pass (6 translation + 2 deprecator)
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean