### PR TITLE
test(activerecord): batch 79 — transactions slot D wTRS fixture ports

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1671,8 +1671,17 @@ describe("TransactionTest", () => {
   it("dont restore new record in subsequent transaction", () => {
     expect(true).toBe(true);
   });
-  it("assign custom primary key after rollback", () => {
-    expect(true).toBe(true);
+  it("assign custom primary key after rollback", async () => {
+    const { Movie } = makeSQLiteMovie();
+    const movie = (await Movie.create({ name: "foo" })) as any;
+
+    await Movie.transaction(async () => {
+      await movie.save();
+      throw new Rollback();
+    });
+
+    movie.movieid = null;
+    expect(movie.movieid).toBeNull();
   });
   it("read attribute with custom primary key after rollback", async () => {
     const { Movie } = makeSQLiteMovie();
@@ -1685,8 +1694,17 @@ describe("TransactionTest", () => {
 
     expect(movie.readAttribute("movieid")).toBeNull();
   });
-  it("write attribute after rollback", () => {
-    expect(true).toBe(true);
+  it("write attribute after rollback", async () => {
+    const { Topic } = makeSQLiteTopic();
+    const topic = (await Topic.create({ title: "foo" })) as any;
+
+    await Topic.transaction(async () => {
+      await topic.save();
+      throw new Rollback();
+    });
+
+    topic.writeAttribute("id", null);
+    expect(topic.id).toBeNull();
   });
   it("write attribute with custom primary key after rollback", async () => {
     const { Movie } = makeSQLiteMovie();

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1696,7 +1696,7 @@ describe("TransactionTest", () => {
   });
   it("write attribute after rollback", async () => {
     const { Topic } = makeSQLiteTopic();
-    const topic = (await Topic.create({ title: "foo" })) as any;
+    const topic = (await Topic.create({})) as any;
 
     await Topic.transaction(async () => {
       await topic.save();

--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -425,10 +425,11 @@ function categorize(relPath: string, describeName: string, testName: string): An
 
   if (p === "transaction-isolation.test.ts") {
     return {
-      blocked: "GVL — Ruby thread isolation semantics, no Node.js equivalent",
+      blocked:
+        "transactions — isolation-level semantics across concurrent connections, not implemented",
       rootCause:
-        "Node.js has no Thread.new / GVL concept; transaction isolation tests depend on concurrent threads",
-      scope: "~0 LOC fix; permanent skip-list.ts candidate",
+        "Tests assert visibility between two open connections under READ COMMITTED / REPEATABLE READ; our connection-pool checkout + per-connection isolation plumbing is not wired",
+      scope: "multi-PR effort across adapter + pool + transaction-manager",
     };
   }
 


### PR DESCRIPTION
## Summary
- Port `test_assign_custom_primary_key_after_rollback` (Movie + writer assignment)
- Port `test_write_attribute_after_rollback` (Topic + `writeAttribute`)
- Refresh `transaction-isolation.test.ts` skip-annotation wording — old text categorized as GVL but the actual blocker is multi-connection isolation-level plumbing, not threading

## Deferred follow-ups
- `restore previously new record after double save` — still blocked. The closure-snapshot in `withTransactionReturningStatus` vs Rails' single `@_start_transaction_state` semantics needs a deeper trace of when `_previously_new_record` is mutated (per-save vs at commit). Not safe to land alongside the small fixture ports.
- `primaryKey = "movieid"` auto-attribute (DX gap) — setting a non-default primary key currently still requires an explicit `this.attribute(pk, "integer")` declaration. Implementation would touch `setPrimaryKeyAttr` and risk clobbering later schema-driven attribute reflection; deferred.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts -t "write attribute after rollback|assign custom primary key after rollback"` — 3 tests pass
- [x] typecheck + lint via pre-commit hook