### PR TITLE
feat(sqlite): batch 91 — strict opt-in, dataSourceExists via pragma_table_list

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -3,25 +3,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { Notifications, squish } from "@blazetrails/activesupport";
-import type { NotificationEvent } from "@blazetrails/activesupport";
-
-async function assertLogged(
-  expected: Array<[string, string, unknown[]]>,
-  fn: () => unknown | Promise<unknown>,
-): Promise<void> {
-  const logged: Array<[string, string, unknown[]]> = [];
-  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
-    const p = event.payload as Record<string, unknown>;
-    logged.push([squish(String(p.sql ?? "")), String(p.name ?? ""), (p.binds as unknown[]) ?? []]);
-  });
-  try {
-    await fn();
-  } finally {
-    Notifications.unsubscribe(sub);
-  }
-  expect(logged).toEqual(expected);
-}
+import { Notifications } from "@blazetrails/activesupport";
+import { assertLogged } from "./test-helper.js";
 
 let adapter: SQLite3Adapter;
 

--- a/packages/activerecord/src/adapters/sqlite3/test-helper.ts
+++ b/packages/activerecord/src/adapters/sqlite3/test-helper.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for `adapters/sqlite3/*.test.ts`. Keep this file tiny —
+ * anything beyond cross-test glue belongs in the source tree, not here.
+ */
+import { expect } from "vitest";
+import { Notifications, squish } from "@blazetrails/activesupport";
+import type { NotificationEvent } from "@blazetrails/activesupport";
+
+/**
+ * Subscribe to `sql.active_record` for the duration of `fn`, then assert the
+ * logged `[sql, name, binds]` triples match `expected`. Mirrors the
+ * `assert_logged` helper in Rails' sqlite3 adapter tests.
+ */
+export async function assertLogged(
+  expected: Array<[string, string, unknown[]]>,
+  fn: () => unknown | Promise<unknown>,
+): Promise<void> {
+  const logged: Array<[string, string, unknown[]]> = [];
+  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+    const p = event.payload as Record<string, unknown>;
+    logged.push([squish(String(p.sql ?? "")), String(p.name ?? ""), (p.binds as unknown[]) ?? []]);
+  });
+  try {
+    await fn();
+  } finally {
+    Notifications.unsubscribe(sub);
+  }
+  expect(logged).toEqual(expected);
+}

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1392,7 +1392,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (name.includes(".")) {
       // Schema-qualified name (e.g. "aux.widgets") — pragma_table_list does
       // not accept a schema scope, so fall back to the attached catalog.
+      // Mirror the bare-name exclusions so qualified and unqualified callers
+      // agree on names like `aux.sqlite_sequence`.
       const { sqliteMaster, bare } = this._sqliteMasterFor(name);
+      if (bare === "sqlite_sequence" || bare === "sqlite_schema") return false;
       const rows = (await this.execute(
         `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${sqliteQuoteStringLiteral(bare)}`,
         [],
@@ -2087,7 +2090,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
             "Async drivers require an async constructor path (not yet implemented).",
         );
       }
-      const syncConn = factory.openSync({ database: this._filename, readOnly: this._readonly });
+      const syncConn = factory.openSync({
+        database: this._filename,
+        readOnly: this._readonly,
+        strict: this._strict,
+      });
       // Pre-warm version cache while the connection is a known-sync handle so
       // getDatabaseVersion() never needs to touch this.driver directly. (#1269)
       const vRow = syncConn.prepare("SELECT sqlite_version() AS v").get() as any;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1389,12 +1389,22 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    const { sqliteMaster, bare } = this._sqliteMasterFor(name);
+    if (name.includes(".")) {
+      // Schema-qualified name (e.g. "aux.widgets") — pragma_table_list does
+      // not accept a schema scope, so fall back to the attached catalog.
+      const { sqliteMaster, bare } = this._sqliteMasterFor(name);
+      const rows = (await this.execute(
+        `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${sqliteQuoteStringLiteral(bare)}`,
+        [],
+        "SCHEMA",
+      )) as Array<{ one: number }>;
+      return rows.length > 0;
+    }
     const rows = (await this.execute(
-      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${sqliteQuoteStringLiteral(bare)}`,
+      `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(name)} AND type IN ('table','view')`,
       [],
       "SCHEMA",
-    )) as Array<{ one: number }>;
+    )) as Array<{ name: string }>;
     return rows.length > 0;
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1394,10 +1394,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       // rows for every attached schema and exposes the schema name as a
       // column, so we can scope by it directly — keeping the qualified and
       // bare-name branches on the same exclusion semantics (no virtuals,
-      // no FTS shadow tables, no sqlite_* internals).
-      const dot = name.indexOf(".");
-      const schema = name.slice(0, dot);
-      const bare = name.slice(dot + 1);
+      // no FTS shadow tables).
+      const { schema, bare } = this._splitTableName(name);
       const rows = (await this.execute(
         `SELECT name FROM pragma_table_list WHERE schema = ${sqliteQuoteStringLiteral(schema)} AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(bare)} AND type IN ('table','view')`,
         [],

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1397,7 +1397,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       // no FTS shadow tables).
       const { schema, bare } = this._splitTableName(name);
       const rows = (await this.execute(
-        `SELECT name FROM pragma_table_list WHERE schema = ${sqliteQuoteStringLiteral(schema)} AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(bare)} AND type IN ('table','view')`,
+        `SELECT name FROM pragma_table_list WHERE schema = ${sqliteQuoteStringLiteral(schema)} COLLATE NOCASE AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(bare)} AND type IN ('table','view')`,
         [],
         "SCHEMA",
       )) as Array<{ name: string }>;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1396,8 +1396,16 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       // agree on names like `aux.sqlite_sequence`.
       const { sqliteMaster, bare } = this._sqliteMasterFor(name);
       if (bare === "sqlite_sequence" || bare === "sqlite_schema") return false;
+      // sqlite_master stores virtual tables as type='table' with sql LIKE
+      // 'CREATE VIRTUAL%', and FTS/shadow tables with sql IS NULL. The
+      // pragma_table_list path filters those out as 'virtual'/'shadow', so
+      // mirror that here to keep the two branches in agreement.
       const rows = (await this.execute(
-        `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${sqliteQuoteStringLiteral(bare)}`,
+        `SELECT 1 AS one FROM ${sqliteMaster}
+         WHERE type IN ('table','view')
+           AND name=${sqliteQuoteStringLiteral(bare)}
+           AND sql IS NOT NULL
+           AND sql NOT LIKE 'CREATE VIRTUAL%'`,
         [],
         "SCHEMA",
       )) as Array<{ one: number }>;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1390,25 +1390,19 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   async dataSourceExists(name: string): Promise<boolean> {
     if (name.includes(".")) {
-      // Schema-qualified name (e.g. "aux.widgets") — pragma_table_list does
-      // not accept a schema scope, so fall back to the attached catalog.
-      // Mirror the bare-name exclusions so qualified and unqualified callers
-      // agree on names like `aux.sqlite_sequence`.
-      const { sqliteMaster, bare } = this._sqliteMasterFor(name);
-      if (bare === "sqlite_sequence" || bare === "sqlite_schema") return false;
-      // sqlite_master stores virtual tables as type='table' with sql LIKE
-      // 'CREATE VIRTUAL%', and FTS/shadow tables with sql IS NULL. The
-      // pragma_table_list path filters those out as 'virtual'/'shadow', so
-      // mirror that here to keep the two branches in agreement.
+      // Schema-qualified name (e.g. "aux.widgets"). pragma_table_list returns
+      // rows for every attached schema and exposes the schema name as a
+      // column, so we can scope by it directly — keeping the qualified and
+      // bare-name branches on the same exclusion semantics (no virtuals,
+      // no FTS shadow tables, no sqlite_* internals).
+      const dot = name.indexOf(".");
+      const schema = name.slice(0, dot);
+      const bare = name.slice(dot + 1);
       const rows = (await this.execute(
-        `SELECT 1 AS one FROM ${sqliteMaster}
-         WHERE type IN ('table','view')
-           AND name=${sqliteQuoteStringLiteral(bare)}
-           AND sql IS NOT NULL
-           AND sql NOT LIKE 'CREATE VIRTUAL%'`,
+        `SELECT name FROM pragma_table_list WHERE schema = ${sqliteQuoteStringLiteral(schema)} AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(bare)} AND type IN ('table','view')`,
         [],
         "SCHEMA",
-      )) as Array<{ one: number }>;
+      )) as Array<{ name: string }>;
       return rows.length > 0;
     }
     const rows = (await this.execute(

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -88,6 +88,18 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(indexes).toEqual([{ name: "widgets_on_name", columns: ["name"], unique: false }]);
   });
 
+  it("dataSourceExists matches both tables and views, hides sqlite_* internals", async () => {
+    await adapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)",
+    );
+    await adapter.executeMutation("CREATE VIEW widget_names AS SELECT name FROM widgets");
+    expect(await adapter.dataSourceExists("widgets")).toBe(true);
+    expect(await adapter.dataSourceExists("widget_names")).toBe(true);
+    expect(await adapter.dataSourceExists("missing")).toBe(false);
+    expect(await adapter.dataSourceExists("sqlite_sequence")).toBe(false);
+    expect(await adapter.dataSourceExists("sqlite_schema")).toBe(false);
+  });
+
   it("tableExists/dataSourceExists resolve schema-qualified names correctly", async () => {
     // Companion to the PRAGMA test: sqlite_master lookups must route to
     // `<schema>.sqlite_master` for ATTACHed DBs. Matching on

--- a/packages/activesupport/src/sqlite-adapter.ts
+++ b/packages/activesupport/src/sqlite-adapter.ts
@@ -103,6 +103,15 @@ export interface SqliteOpenConfig {
   noMutex?: boolean;
   /** busy_timeout ms for SQLITE_BUSY contention. Default 5000. */
   timeout?: number;
+  /**
+   * Opt into SQLite's strict-strings / strict-types modes when the driver
+   * supports it. Maps to `sqlite3_db_config(SQLITE_DBCONFIG_DQS_DDL=0,
+   * SQLITE_DBCONFIG_DQS_DML=0)` and `STRICT` table semantics where exposed.
+   * Drivers that can't honor this MUST silently ignore it (e.g. better-sqlite3
+   * compiles with `SQLITE_DQS=0` so DQS is already off, and the upstream
+   * binding doesn't expose `sqlite3_db_config`). Default: false.
+   */
+  strict?: boolean;
   /** Driver-specific options pass-through. AR core never inspects this. */
   driverOptions?: Record<string, unknown>;
 }

--- a/packages/activesupport/src/sqlite-adapter.ts
+++ b/packages/activesupport/src/sqlite-adapter.ts
@@ -104,12 +104,14 @@ export interface SqliteOpenConfig {
   /** busy_timeout ms for SQLITE_BUSY contention. Default 5000. */
   timeout?: number;
   /**
-   * Opt into SQLite's strict-strings / strict-types modes when the driver
+   * Opt into SQLite's connection-level strict-strings mode when the driver
    * supports it. Maps to `sqlite3_db_config(SQLITE_DBCONFIG_DQS_DDL=0,
-   * SQLITE_DBCONFIG_DQS_DML=0)` and `STRICT` table semantics where exposed.
+   * SQLITE_DBCONFIG_DQS_DML=0)`, which rejects double-quoted string literals.
    * Drivers that can't honor this MUST silently ignore it (e.g. better-sqlite3
    * compiles with `SQLITE_DQS=0` so DQS is already off, and the upstream
-   * binding doesn't expose `sqlite3_db_config`). Default: false.
+   * binding doesn't expose `sqlite3_db_config`). Per-table `STRICT` semantics
+   * are a `CREATE TABLE` clause and belong to schema-creation, not here.
+   * Default: false.
    */
   strict?: boolean;
   /** Driver-specific options pass-through. AR core never inspects this. */

--- a/packages/activesupport/src/sqlite-drivers/better-sqlite3.ts
+++ b/packages/activesupport/src/sqlite-drivers/better-sqlite3.ts
@@ -134,6 +134,12 @@ function openDatabase(config: SqliteOpenConfig): Database.Database {
     readonly: config.readOnly ?? false,
   };
   if (config.timeout !== undefined) opts.timeout = config.timeout;
+  // `strict` is a no-op here: better-sqlite3's npm build compiles with
+  // SQLITE_DQS=0 (double-quoted-string literals already rejected), and the
+  // upstream binding does not expose sqlite3_db_config to toggle the DML/DDL
+  // flags at runtime. Surface the field on Options if a future release adds
+  // it; today we pass it through unchanged so user-set driverOptions still
+  // win, but emit nothing of our own.
   return new Database(config.database, opts);
 }
 

--- a/packages/activesupport/src/sqlite-drivers/better-sqlite3.ts
+++ b/packages/activesupport/src/sqlite-drivers/better-sqlite3.ts
@@ -134,12 +134,9 @@ function openDatabase(config: SqliteOpenConfig): Database.Database {
     readonly: config.readOnly ?? false,
   };
   if (config.timeout !== undefined) opts.timeout = config.timeout;
-  // `strict` is a no-op here: better-sqlite3's npm build compiles with
-  // SQLITE_DQS=0 (double-quoted-string literals already rejected), and the
-  // upstream binding does not expose sqlite3_db_config to toggle the DML/DDL
-  // flags at runtime. Surface the field on Options if a future release adds
-  // it; today we pass it through unchanged so user-set driverOptions still
-  // win, but emit nothing of our own.
+  // `config.strict` is intentionally unread: better-sqlite3 compiles with
+  // SQLITE_DQS=0 and exposes no sqlite3_db_config binding, so the strict
+  // flag has nothing to attach to here.
   return new Database(config.database, opts);
 }
 

--- a/packages/activesupport/src/sqlite-drivers/expo-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/expo-sqlite.ts
@@ -189,8 +189,9 @@ export const expoSqliteDriver: SqliteDriver = {
         "expo-sqlite is not available. This driver requires an Expo / React Native runtime.",
       );
     }
-    // readOnly, timeout, noMutex are not exposed by expo-sqlite's openDatabaseAsync;
-    // pass driverOptions through for any driver-specific overrides.
+    // readOnly, timeout, noMutex, strict are not exposed by expo-sqlite's
+    // openDatabaseAsync; pass driverOptions through for any driver-specific
+    // overrides.
     const db = await expoSqlite.openDatabaseAsync(config.database, {
       ...(config.driverOptions as Parameters<ExpoSqliteModule["openDatabaseAsync"]>[1] | undefined),
     });

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -159,6 +159,9 @@ function openDatabase(config: SqliteOpenConfig): import("node:sqlite").DatabaseS
     enableForeignKeyConstraints: false, // match better-sqlite3 default
   };
   if (config.timeout !== undefined) opts.timeout = config.timeout;
+  // `config.strict` is intentionally unread: node:sqlite's DatabaseSync
+  // options object does not expose the SQLITE_DBCONFIG_DQS_DDL/DML flags,
+  // so there is nothing to attach the strict toggle to here.
   return new nodeSqlite.DatabaseSync(config.database, opts);
 }
 

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -159,9 +159,13 @@ function openDatabase(config: SqliteOpenConfig): import("node:sqlite").DatabaseS
     enableForeignKeyConstraints: false, // match better-sqlite3 default
   };
   if (config.timeout !== undefined) opts.timeout = config.timeout;
-  // `config.strict` is intentionally unread: node:sqlite's DatabaseSync
-  // options object does not expose the SQLITE_DBCONFIG_DQS_DDL/DML flags,
-  // so there is nothing to attach the strict toggle to here.
+  // node:sqlite's `enableDoubleQuotedStringLiterals` defaults to false (DQS
+  // off = strict), so leaving it alone for `strict: false` would still open
+  // a strict connection. Map from config.strict to keep AR's setting and
+  // the actual driver behavior in lockstep.
+  if (config.strict !== undefined) {
+    opts.enableDoubleQuotedStringLiterals = !config.strict;
+  }
   return new nodeSqlite.DatabaseSync(config.database, opts);
 }
 

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.ts
@@ -160,12 +160,10 @@ function openDatabase(config: SqliteOpenConfig): import("node:sqlite").DatabaseS
   };
   if (config.timeout !== undefined) opts.timeout = config.timeout;
   // node:sqlite's `enableDoubleQuotedStringLiterals` defaults to false (DQS
-  // off = strict), so leaving it alone for `strict: false` would still open
-  // a strict connection. Map from config.strict to keep AR's setting and
-  // the actual driver behavior in lockstep.
-  if (config.strict !== undefined) {
-    opts.enableDoubleQuotedStringLiterals = !config.strict;
-  }
+  // off = strict), but SqliteOpenConfig.strict documents a default of false.
+  // Mirror that contract for direct driver users by mapping `strict ?? false`
+  // onto the option, not just when the caller passes it explicitly.
+  opts.enableDoubleQuotedStringLiterals = !(config.strict ?? false);
   return new nodeSqlite.DatabaseSync(config.database, opts);
 }
 


### PR DESCRIPTION
Bundles four small sqlite cleanup items (~70 LOC):

- **Slot A — `strict` field on `SqliteOpenConfig`** (activesupport). Adds an opt-in `strict?: boolean` flag in the driver spec for connection-level strict-strings (DQS) mode. Documented inline.
- **Slot A — better-sqlite3 `strict` pass-through** (activesupport). `openDatabase()` accepts the field but treats it as a no-op: better-sqlite3 compiles with `SQLITE_DQS=0` and the upstream binding does not expose `sqlite3_db_config`. Wired through `SQLite3Adapter#connect()` so drivers that can honor it will see it.
- **Slot B — `dataSourceExists()` via `pragma_table_list`**. Both bare-name and schema-qualified paths now use `pragma_table_list` filtered to `type IN ('table','view')` with the `sqlite_sequence` / `sqlite_schema` exclusion, matching Rails' `data_source_sql` (`vendor/rails/.../sqlite3/schema_statements.rb:181`). Schema-qualified names scope by the `schema` column rather than falling back to `<schema>.sqlite_master`, so virtual tables and FTS shadow tables are filtered consistently on both branches.
- **Slot B — extract `assertLogged`**. Moved from `adapters/sqlite3/sqlite3-adapter.test.ts` into a new `adapters/sqlite3/test-helper.ts` so the other sqlite3 test files can adopt the same `sql.active_record` subscription glue without duplication.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts` (80 passed)
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts` (8 passed, includes new `dataSourceExists` coverage for tables/views/internals)
- [x] `pnpm vitest run packages/activesupport/src/sqlite-drivers/better-sqlite3.test.ts` (13 passed)
- [x] `pnpm build` + `pnpm typecheck` (via lint-staged)

## Unaddressed Copilot review concerns (hit max review cycles)

1. **`pragma_table_list` requires SQLite 3.37+** (raised repeatedly). Rails uses `pragma_table_list` unconditionally in `data_source_sql` (`vendor/rails/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb:185`), accepting the same implicit floor. Keeping Rails fidelity is the stated objective for this codebase; if we want to add a `sqlite_master` fallback or raise the adapter's `checkVersion()` floor, that should be done as a separate decision that also re-examines every other `pragma_table_list` call site.
2. **No test for `node-sqlite` strict↔DQS mapping.** The driver's vitest suite is skipped in CI on environments without `node:sqlite` available; adding a strict-true / strict-false assertion is worthwhile but requires the suite to actually run. Track as follow-up.
3. **No test for custom-driver `strict` forwarding through `SQLite3Adapter`.** Plumbing test for a one-line forward — deferred until a driver beyond node-sqlite honors the flag, since the value covered would be "this assignment is still there."
