### PR TITLE
feat(actionpack): AbstractController asset_paths + logger ports

### DIFF
--- a/packages/actionpack/src/abstract-controller/asset-paths.test.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.test.ts
@@ -26,6 +26,16 @@ describe("AbstractController::AssetPaths", () => {
     expect(Host.assetHost).toBe("https://cdn.example.com");
   });
 
+  it("does not shadow inherited values when applied to a subclass", () => {
+    class Base {
+      static assetHost = "https://cdn.example.com";
+    }
+    class Sub extends Base {}
+    applyAssetPaths(Sub);
+    expect(Sub.assetHost).toBe("https://cdn.example.com");
+    expect(Object.hasOwn(Sub, "assetHost")).toBe(false);
+  });
+
   it("exposes the canonical slot list (matches Rails config_accessor args)", () => {
     expect(ASSET_PATH_SLOTS).toEqual([
       "assetHost",

--- a/packages/actionpack/src/abstract-controller/asset-paths.test.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.test.ts
@@ -2,15 +2,7 @@ import { describe, it, expect } from "vitest";
 import { applyAssetPaths, ASSET_PATH_SLOTS } from "./asset-paths.js";
 
 describe("AbstractController::AssetPaths", () => {
-  it("installs all six Rails-named slots on the host class", () => {
-    class Host {}
-    applyAssetPaths(Host);
-    for (const slot of ASSET_PATH_SLOTS) {
-      expect(Object.hasOwn(Host as object, slot)).toBe(true);
-    }
-  });
-
-  it("defaults each slot to undefined", () => {
+  it("reads slots as undefined when nothing is set anywhere", () => {
     class Host {}
     applyAssetPaths(Host);
     for (const slot of ASSET_PATH_SLOTS) {
@@ -18,7 +10,7 @@ describe("AbstractController::AssetPaths", () => {
     }
   });
 
-  it("does not clobber slots that already carry a value", () => {
+  it("does not clobber slots that already carry a value on the host class", () => {
     class Host {
       static assetHost = "https://cdn.example.com";
     }
@@ -26,7 +18,17 @@ describe("AbstractController::AssetPaths", () => {
     expect(Host.assetHost).toBe("https://cdn.example.com");
   });
 
-  it("does not shadow inherited values when applied to a subclass", () => {
+  it("does not shadow inherited values when applied to a subclass before the parent sets the slot", () => {
+    class Base {}
+    class Sub extends Base {}
+    applyAssetPaths(Sub);
+    // Now the parent sets the slot AFTER applyAssetPaths(Sub).
+    (Base as unknown as { assetHost?: string }).assetHost = "https://cdn.example.com";
+    expect((Sub as unknown as { assetHost?: string }).assetHost).toBe("https://cdn.example.com");
+    expect(Object.hasOwn(Sub, "assetHost")).toBe(false);
+  });
+
+  it("does not shadow inherited values when the parent already had the slot set", () => {
     class Base {
       static assetHost = "https://cdn.example.com";
     }

--- a/packages/actionpack/src/abstract-controller/asset-paths.test.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { applyAssetPaths, ASSET_PATH_SLOTS } from "./asset-paths.js";
+
+describe("AbstractController::AssetPaths", () => {
+  it("installs all six Rails-named slots on the host class", () => {
+    class Host {}
+    applyAssetPaths(Host);
+    for (const slot of ASSET_PATH_SLOTS) {
+      expect(Object.hasOwn(Host as object, slot)).toBe(true);
+    }
+  });
+
+  it("defaults each slot to undefined", () => {
+    class Host {}
+    applyAssetPaths(Host);
+    for (const slot of ASSET_PATH_SLOTS) {
+      expect((Host as unknown as Record<string, unknown>)[slot]).toBeUndefined();
+    }
+  });
+
+  it("does not clobber slots that already carry a value", () => {
+    class Host {
+      static assetHost = "https://cdn.example.com";
+    }
+    applyAssetPaths(Host);
+    expect(Host.assetHost).toBe("https://cdn.example.com");
+  });
+
+  it("exposes the canonical slot list (matches Rails config_accessor args)", () => {
+    expect(ASSET_PATH_SLOTS).toEqual([
+      "assetHost",
+      "assetsDir",
+      "javascriptsDir",
+      "stylesheetsDir",
+      "defaultAssetHostProtocol",
+      "relativeUrlRoot",
+    ]);
+  });
+});

--- a/packages/actionpack/src/abstract-controller/asset-paths.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.ts
@@ -1,10 +1,14 @@
 /**
- * `AbstractController::AssetPaths` — config slots for asset URL
- * generation. Rails uses `config_accessor :asset_host, :assets_dir, …`
- * which creates both class- and instance-level accessors. Trails uses
- * static fields with a `mixin()` applicator: callers pass the host
- * class and the slots are installed with `undefined` defaults so the
- * usual `Cls.assetHost = "…"` assignment Just Works at runtime.
+ * `AbstractController::AssetPaths` — config slot contract for asset
+ * URL generation. Rails uses `config_accessor :asset_host, :assets_dir,
+ * …` which creates both class- and instance-level accessors.
+ *
+ * Trails doesn't install anything at runtime: JS static-field
+ * inheritance already gives Rails-style propagation (reading an unset
+ * slot on a subclass walks to the parent transparently). The slots are
+ * exposed as a TypeScript contract via `AssetPathsHost` and an
+ * introspection list via `ASSET_PATH_SLOTS`. `applyAssetPaths(cls)`
+ * is a named no-op kept so call sites mirror Rails' include shape.
  *
  * @internal
  */
@@ -44,6 +48,10 @@ export interface AssetPathsHost {
  * `include AbstractController::AssetPaths` shape and serve as a
  * grep-able marker that the host opts into this slot contract.
  */
-export function applyAssetPaths(_cls: object): void {
-  // Intentionally empty — see docstring.
+export function applyAssetPaths<T extends new (...args: never[]) => unknown>(
+  _cls: T & Partial<AssetPathsHost>,
+): void {
+  // Intentionally empty — see docstring. The `Partial<AssetPathsHost>`
+  // bound surfaces the slot contract at call sites without requiring
+  // the host to pre-declare every slot.
 }

--- a/packages/actionpack/src/abstract-controller/asset-paths.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.ts
@@ -1,0 +1,45 @@
+/**
+ * `AbstractController::AssetPaths` — config slots for asset URL
+ * generation. Rails uses `config_accessor :asset_host, :assets_dir, …`
+ * which creates both class- and instance-level accessors. Trails uses
+ * static fields with a `mixin()` applicator: callers pass the host
+ * class and the slots are installed with `undefined` defaults so the
+ * usual `Cls.assetHost = "…"` assignment Just Works at runtime.
+ *
+ * @internal
+ */
+
+const SLOTS = [
+  "assetHost",
+  "assetsDir",
+  "javascriptsDir",
+  "stylesheetsDir",
+  "defaultAssetHostProtocol",
+  "relativeUrlRoot",
+] as const;
+
+export type AssetPathSlot = (typeof SLOTS)[number];
+
+/** Reified list of slot names — useful for introspection / api:compare. */
+export const ASSET_PATH_SLOTS: readonly AssetPathSlot[] = SLOTS;
+
+export interface AssetPathsHost {
+  assetHost?: string;
+  assetsDir?: string;
+  javascriptsDir?: string;
+  stylesheetsDir?: string;
+  defaultAssetHostProtocol?: string;
+  relativeUrlRoot?: string;
+}
+
+/**
+ * Install the AssetPaths config slots on `cls` as static properties
+ * with `undefined` defaults. Idempotent — re-applying does not clobber
+ * an already-set value.
+ */
+export function applyAssetPaths(cls: object): void {
+  const host = cls as Record<AssetPathSlot, unknown>;
+  for (const slot of SLOTS) {
+    if (!Object.hasOwn(host, slot)) host[slot] = undefined;
+  }
+}

--- a/packages/actionpack/src/abstract-controller/asset-paths.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.ts
@@ -33,15 +33,17 @@ export interface AssetPathsHost {
 }
 
 /**
- * Install the AssetPaths config slots on `cls` as static properties
- * with `undefined` defaults. Idempotent — re-applying does not clobber
- * a value, and the prototype-chain check (`slot in host` rather than
- * `Object.hasOwn`) preserves inherited values so subclasses don't
- * shadow a parent's configuration with `undefined`.
+ * Marks a host class as conforming to the `AssetPathsHost` slot
+ * contract. **Does not install anything at runtime** — eager writes of
+ * `undefined` would create own properties on subclasses that
+ * permanently shadow later assignments on a parent class. JS static
+ * inheritance already gives Rails-style propagation: reading an unset
+ * slot from a subclass walks to the parent transparently.
+ *
+ * Kept as a named no-op so call sites mirror Rails'
+ * `include AbstractController::AssetPaths` shape and serve as a
+ * grep-able marker that the host opts into this slot contract.
  */
-export function applyAssetPaths(cls: object): void {
-  const host = cls as Record<AssetPathSlot, unknown>;
-  for (const slot of SLOTS) {
-    if (!(slot in host)) host[slot] = undefined;
-  }
+export function applyAssetPaths(_cls: object): void {
+  // Intentionally empty — see docstring.
 }

--- a/packages/actionpack/src/abstract-controller/asset-paths.ts
+++ b/packages/actionpack/src/abstract-controller/asset-paths.ts
@@ -35,11 +35,13 @@ export interface AssetPathsHost {
 /**
  * Install the AssetPaths config slots on `cls` as static properties
  * with `undefined` defaults. Idempotent — re-applying does not clobber
- * an already-set value.
+ * a value, and the prototype-chain check (`slot in host` rather than
+ * `Object.hasOwn`) preserves inherited values so subclasses don't
+ * shadow a parent's configuration with `undefined`.
  */
 export function applyAssetPaths(cls: object): void {
   const host = cls as Record<AssetPathSlot, unknown>;
   for (const slot of SLOTS) {
-    if (!Object.hasOwn(host, slot)) host[slot] = undefined;
+    if (!(slot in host)) host[slot] = undefined;
   }
 }

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -17,3 +17,10 @@ export {
   type LocalizeOptions,
 } from "./translation.js";
 export { deprecator } from "./deprecator.js";
+export {
+  applyAssetPaths,
+  ASSET_PATH_SLOTS,
+  type AssetPathSlot,
+  type AssetPathsHost,
+} from "./asset-paths.js";
+export { applyLogger, benchmark, type LoggerHost, type LoggerLike } from "./logger.js";

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -52,6 +52,40 @@ describe("benchmark()", () => {
     expect(ran).toBe(true);
   });
 
+  it("awaits a promise-returning block and logs exactly once after resolution", async () => {
+    const lines: string[] = [];
+    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    const result = await benchmark(logger, "fetch", async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^fetch \(\d+\.\d+ms\)$/);
+  });
+
+  it("still logs when a sync block throws, and rethrows the error", () => {
+    const lines: string[] = [];
+    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    expect(() =>
+      benchmark(logger, "bad work", () => {
+        throw new Error("boom");
+      }),
+    ).toThrow(/boom/);
+    expect(lines).toHaveLength(1);
+  });
+
+  it("still logs when an async block rejects, and the rejection propagates", async () => {
+    const lines: string[] = [];
+    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    await expect(
+      benchmark(logger, "bad fetch", async () => {
+        throw new Error("kaboom");
+      }),
+    ).rejects.toThrow(/kaboom/);
+    expect(lines).toHaveLength(1);
+  });
+
   it("tolerates a logger whose `info` is not a function", () => {
     let ran = false;
     benchmark({ info: "not a function" } as unknown as LoggerLike, "work", () => {

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -52,6 +52,14 @@ describe("benchmark()", () => {
     expect(ran).toBe(true);
   });
 
+  it("tolerates a logger whose `info` is not a function", () => {
+    let ran = false;
+    benchmark({ info: "not a function" } as unknown as LoggerLike, "work", () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
   it("logs an info line with elapsed ms when a logger is attached", () => {
     const lines: string[] = [];
     const logger: LoggerLike = { info: (m) => lines.push(m) };

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -57,6 +57,6 @@ describe("benchmark()", () => {
     const logger: LoggerLike = { info: (m) => lines.push(m) };
     benchmark(logger, "render template", () => 1 + 1);
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^render template \(\d+ms\)$/);
+    expect(lines[0]).toMatch(/^render template \(\d+\.\d+ms\)$/);
   });
 });

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect } from "vitest";
 import { applyLogger, benchmark, type LoggerLike } from "./logger.js";
 
 describe("AbstractController::Logger", () => {
-  it("installs a logger slot defaulting to undefined", () => {
+  it("reads logger as undefined when nothing is set anywhere", () => {
     class Host {}
     applyLogger(Host);
-    expect("logger" in Host).toBe(true);
     expect((Host as { logger?: LoggerLike }).logger).toBeUndefined();
   });
 
-  it("does not clobber an already-set logger", () => {
+  it("does not clobber an already-set logger on the host class", () => {
     const noop: LoggerLike = { info() {} };
     class Host {
       static logger: LoggerLike = noop;
@@ -26,6 +25,16 @@ describe("AbstractController::Logger", () => {
     class Sub extends Base {}
     applyLogger(Sub);
     expect(Sub.logger).toBe(noop);
+    expect(Object.hasOwn(Sub, "logger")).toBe(false);
+  });
+
+  it("does not shadow a logger set on the parent AFTER applyLogger(Sub)", () => {
+    const noop: LoggerLike = { info() {} };
+    class Base {}
+    class Sub extends Base {}
+    applyLogger(Sub);
+    (Base as unknown as { logger?: LoggerLike }).logger = noop;
+    expect((Sub as unknown as { logger?: LoggerLike }).logger).toBe(noop);
     expect(Object.hasOwn(Sub, "logger")).toBe(false);
   });
 });

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -17,6 +17,17 @@ describe("AbstractController::Logger", () => {
     applyLogger(Host);
     expect(Host.logger).toBe(noop);
   });
+
+  it("does not shadow a logger inherited from a base class", () => {
+    const noop: LoggerLike = { info() {} };
+    class Base {
+      static logger: LoggerLike = noop;
+    }
+    class Sub extends Base {}
+    applyLogger(Sub);
+    expect(Sub.logger).toBe(noop);
+    expect(Object.hasOwn(Sub, "logger")).toBe(false);
+  });
 });
 
 describe("benchmark()", () => {

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { applyLogger, benchmark, type LoggerLike } from "./logger.js";
+
+describe("AbstractController::Logger", () => {
+  it("installs a logger slot defaulting to undefined", () => {
+    class Host {}
+    applyLogger(Host);
+    expect("logger" in Host).toBe(true);
+    expect((Host as { logger?: LoggerLike }).logger).toBeUndefined();
+  });
+
+  it("does not clobber an already-set logger", () => {
+    const noop: LoggerLike = { info() {} };
+    class Host {
+      static logger: LoggerLike = noop;
+    }
+    applyLogger(Host);
+    expect(Host.logger).toBe(noop);
+  });
+});
+
+describe("benchmark()", () => {
+  it("returns the block's return value", () => {
+    expect(benchmark(undefined, "work", () => 42)).toBe(42);
+  });
+
+  it("runs the block even when no logger is attached", () => {
+    let ran = false;
+    benchmark(undefined, "work", () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("logs an info line with elapsed ms when a logger is attached", () => {
+    const lines: string[] = [];
+    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    benchmark(logger, "render template", () => 1 + 1);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^render template \(\d+ms\)$/);
+  });
+});

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -33,19 +33,49 @@ export function applyLogger<T extends new (...args: never[]) => unknown>(
 }
 
 /**
- * Mirrors `ActiveSupport::Benchmarkable#benchmark`. Logs the elapsed
- * milliseconds for `block` to `logger.info`, returning whatever the
- * block returns. If no logger is attached the block still runs.
+ * Mirrors `ActiveSupport::Benchmarkable#benchmark` (and the
+ * `ActiveRecord::Base.benchmark` shape used elsewhere in trails). Logs
+ * the elapsed milliseconds for `block` to `logger.info` and returns
+ * whatever the block returns.
+ *
+ * - Synchronous: logs immediately, then returns the result.
+ * - Promise-returning: logs after the promise settles (resolve OR
+ *   reject), and rejections propagate to the caller.
+ * - Throwing sync block: logs the elapsed time, then rethrows.
+ * - No logger attached: block runs unchanged; no timing.
  */
-export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T {
+export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T;
+export function benchmark<T>(
+  logger: LoggerLike | undefined,
+  message: string,
+  block: () => Promise<T>,
+): Promise<T>;
+export function benchmark<T>(
+  logger: LoggerLike | undefined,
+  message: string,
+  block: () => T | Promise<T>,
+): T | Promise<T> {
   if (typeof logger?.info !== "function") return block();
   // Monotonic timing where available — `Date.now()` is wall-clock and
   // can jump under NTP adjustments. The fallback matches the pattern
   // used by `ActiveRecord::Base.benchmark`.
   const now = () => globalThis.performance?.now() ?? Date.now();
   const start = now();
-  const result = block();
-  const ms = (now() - start).toFixed(1);
-  logger.info(`${message} (${ms}ms)`);
-  return result;
+  const log = (): void => {
+    const ms = (now() - start).toFixed(1);
+    logger.info!(`${message} (${ms}ms)`);
+  };
+  try {
+    const result = block();
+    if (result instanceof Promise) {
+      // `.finally` fires on both resolve and reject, and the rejection
+      // still propagates to callers.
+      return result.finally(log);
+    }
+    log();
+    return result;
+  } catch (err) {
+    log();
+    throw err;
+  }
 }

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -37,11 +37,13 @@ export function applyLogger<T extends new (...args: never[]) => unknown>(
  */
 export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T {
   if (!logger?.info) return block();
-  // Use `performance.now()` for monotonic timing — `Date.now()` is
-  // wall-clock and can jump under NTP adjustments (negative durations).
-  const start = performance.now();
+  // Monotonic timing where available — `Date.now()` is wall-clock and
+  // can jump under NTP adjustments. The fallback matches the pattern
+  // used by `ActiveRecord::Base.benchmark`.
+  const now = () => globalThis.performance?.now() ?? Date.now();
+  const start = now();
   const result = block();
-  const ms = Math.round(performance.now() - start);
+  const ms = (now() - start).toFixed(1);
   logger.info(`${message} (${ms}ms)`);
   return result;
 }

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -11,6 +11,8 @@ export interface LoggerLike {
   info?(message: string): void;
   debug?(message: string): void;
   warn?(message: string): void;
+  error?(message: string): void;
+  fatal?(message: string): void;
 }
 
 export interface LoggerHost {
@@ -36,7 +38,7 @@ export function applyLogger<T extends new (...args: never[]) => unknown>(
  * block returns. If no logger is attached the block still runs.
  */
 export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T {
-  if (!logger?.info) return block();
+  if (typeof logger?.info !== "function") return block();
   // Monotonic timing where available — `Date.now()` is wall-clock and
   // can jump under NTP adjustments. The fallback matches the pattern
   // used by `ActiveRecord::Base.benchmark`.

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -17,10 +17,14 @@ export interface LoggerHost {
   logger?: LoggerLike;
 }
 
-/** Install the `logger` config slot on `cls` with an `undefined` default. */
+/**
+ * Install the `logger` config slot on `cls` with an `undefined` default.
+ * Uses a prototype-chain presence check (`"logger" in host`) so applying
+ * to a subclass doesn't shadow a logger already set on a base class.
+ */
 export function applyLogger(cls: object): void {
   const host = cls as Record<string, unknown>;
-  if (!Object.hasOwn(host, "logger")) host.logger = undefined;
+  if (!("logger" in host)) host.logger = undefined;
 }
 
 /**

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -22,8 +22,12 @@ export interface LoggerHost {
  * No-op at runtime — see `applyAssetPaths` for the rationale. JS static
  * inheritance gives Rails-style propagation of `logger` for free.
  */
-export function applyLogger(_cls: object): void {
-  // Intentionally empty — see asset-paths.ts docstring.
+export function applyLogger<T extends new (...args: never[]) => unknown>(
+  _cls: T & Partial<LoggerHost>,
+): void {
+  // Intentionally empty — see asset-paths.ts docstring. The
+  // `Partial<LoggerHost>` bound surfaces the slot contract at call
+  // sites without requiring the host to pre-declare the slot.
 }
 
 /**
@@ -33,9 +37,11 @@ export function applyLogger(_cls: object): void {
  */
 export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T {
   if (!logger?.info) return block();
-  const start = Date.now();
+  // Use `performance.now()` for monotonic timing — `Date.now()` is
+  // wall-clock and can jump under NTP adjustments (negative durations).
+  const start = performance.now();
   const result = block();
-  const ms = Date.now() - start;
+  const ms = Math.round(performance.now() - start);
   logger.info(`${message} (${ms}ms)`);
   return result;
 }

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -18,13 +18,12 @@ export interface LoggerHost {
 }
 
 /**
- * Install the `logger` config slot on `cls` with an `undefined` default.
- * Uses a prototype-chain presence check (`"logger" in host`) so applying
- * to a subclass doesn't shadow a logger already set on a base class.
+ * Marks a host class as conforming to the `LoggerHost` slot contract.
+ * No-op at runtime — see `applyAssetPaths` for the rationale. JS static
+ * inheritance gives Rails-style propagation of `logger` for free.
  */
-export function applyLogger(cls: object): void {
-  const host = cls as Record<string, unknown>;
-  if (!("logger" in host)) host.logger = undefined;
+export function applyLogger(_cls: object): void {
+  // Intentionally empty — see asset-paths.ts docstring.
 }
 
 /**

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -1,0 +1,38 @@
+/**
+ * `AbstractController::Logger` — config slot for a per-controller
+ * logger. Rails additionally mixes in `ActiveSupport::Benchmarkable`
+ * (`benchmark(message, &block)`); we expose a small standalone
+ * `benchmark` helper that the same callers can reuse.
+ *
+ * @internal
+ */
+
+export interface LoggerLike {
+  info?(message: string): void;
+  debug?(message: string): void;
+  warn?(message: string): void;
+}
+
+export interface LoggerHost {
+  logger?: LoggerLike;
+}
+
+/** Install the `logger` config slot on `cls` with an `undefined` default. */
+export function applyLogger(cls: object): void {
+  const host = cls as Record<string, unknown>;
+  if (!Object.hasOwn(host, "logger")) host.logger = undefined;
+}
+
+/**
+ * Mirrors `ActiveSupport::Benchmarkable#benchmark`. Logs the elapsed
+ * milliseconds for `block` to `logger.info`, returning whatever the
+ * block returns. If no logger is attached the block still runs.
+ */
+export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T {
+  if (!logger?.info) return block();
+  const start = Date.now();
+  const result = block();
+  const ms = Date.now() - start;
+  logger.info(`${message} (${ms}ms)`);
+  return result;
+}


### PR DESCRIPTION
## Summary
Two more `abstract_controller/` config-slot mixins (~30 LOC Rails total).

- **`asset-paths.ts`** — `ASSET_PATH_SLOTS` and the `AssetPathsHost` interface declare the six Rails-named config slots (`assetHost`, `assetsDir`, `javascriptsDir`, `stylesheetsDir`, `defaultAssetHostProtocol`, `relativeUrlRoot`).
- **`logger.ts`** — `LoggerHost` declares the `logger` slot; `LoggerLike` covers `info`/`debug`/`warn`/`error`/`fatal`. Standalone `benchmark(logger, message, block)` helper mirrors `ActiveRecord::Base.benchmark` — promise-aware, logs in `finally`/catch so timing fires on resolve, reject, and throw; preserves return-type inference via overloads.

### Runtime semantics
`applyAssetPaths` / `applyLogger` are **named no-ops** kept as grep-able markers that the host opts into the slot contract. They do **not** install runtime properties — earlier revisions wrote `undefined` defaults, but that permanently shadowed inherited values when applied to a subclass before the parent set the slot. JS static-field inheritance already gives Rails-style propagation (an unset slot on Sub reads through to Base), so no install is needed. Slot lists are exposed via `ASSET_PATH_SLOTS` for introspection.

## `abstract_controller/` status after this PR
| Rails file       | LOC | Status         |
| ---------------- | --- | -------------- |
| `base.rb`        | 299 | ✅             |
| `callbacks.rb`   | 265 | ✅             |
| `error.rb`       | 8   | ✅             |
| `translation.rb` | 42  | ✅ (#1739)     |
| `deprecator.rb`  | 9   | ✅ (#1739)     |
| `asset_paths.rb` | 14  | **this PR**    |
| `logger.rb`      | 16  | **this PR**    |
| `collector.rb`   | 44  | not ported     |
| `caching.rb`+dir | 68+ | not ported     |
| `helpers.rb`     | 245 | not ported     |
| `rendering.rb`   | 125 | not ported     |
| `url_for.rb`     | 37  | not ported     |
| `railties/`      | -   | (trailtie)     |

## Test plan
- [x] 46 actionpack `abstract-controller/` tests pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean