### PR TITLE
feat(activerecord): inverseOf wiring — inversable? + auto-detect in load helpers

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -171,8 +171,49 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
         : null);
 
     if (inverseName) {
+      // Mirrors Association#inversable?: only wire when the child's FK
+      // actually points at the owner. Chained queries that widen the
+      // scope (`.or(other.collection)`, `.unscope(:where)`) can return
+      // rows that belong to a *different* owner; wiring those would
+      // alias the wrong parent onto the child. Compare FK→PK via the
+      // reflection so composite-PK reflections work.
+      const fkCols = resolvedRefl
+        ? Array.isArray(resolvedRefl.foreignKey)
+          ? resolvedRefl.foreignKey
+          : [resolvedRefl.foreignKey]
+        : null;
+      const pkCols = resolvedRefl
+        ? Array.isArray(resolvedRefl.activeRecordPrimaryKey)
+          ? resolvedRefl.activeRecordPrimaryKey
+          : [resolvedRefl.activeRecordPrimaryKey]
+        : null;
+      const ownerRec = owner as unknown as {
+        isPersisted?: () => boolean;
+        _readAttribute: (n: string) => unknown;
+      };
+      const ownerPersisted = ownerRec.isPersisted?.() ?? true;
       for (const r of records) {
-        const cache = ((r as any)._cachedAssociations ??= new Map());
+        const childRec = r as unknown as {
+          isPersisted?: () => boolean;
+          _readAttribute: (n: string) => unknown;
+          _cachedAssociations?: Map<string, unknown>;
+        };
+        const childPersisted = childRec.isPersisted?.() ?? true;
+        let inversable = !ownerPersisted || !childPersisted;
+        if (!inversable && fkCols && pkCols && fkCols.length === pkCols.length) {
+          inversable = true;
+          for (let i = 0; i < fkCols.length; i++) {
+            if (childRec._readAttribute(fkCols[i]) !== ownerRec._readAttribute(pkCols[i])) {
+              inversable = false;
+              break;
+            }
+          }
+        } else if (!inversable && (!fkCols || !pkCols)) {
+          // No reflection metadata → preserve prior behavior and wire.
+          inversable = true;
+        }
+        if (!inversable) continue;
+        const cache = (childRec._cachedAssociations ??= new Map());
         cache.set(inverseName, owner);
       }
     }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -228,6 +228,42 @@ function validateInverseOf(targetModel: typeof Base, assocName: string, inverseO
   throw new InverseOfAssociationNotFoundError(assocName, inverseOf, corrections, targetModel.name);
 }
 
+/**
+ * Resolve the inverse association name for a load — combines an explicit
+ * `inverseOf` option with reflection-based automatic detection so both
+ * paths wire the parent reference back onto the child.
+ *
+ * Mirrors: ActiveRecord::Reflection::AssociationReflection#inverse_name
+ *
+ * @internal
+ */
+function _resolveInverseName(
+  ownerCtor: typeof Base,
+  assocName: string,
+  options: AssociationOptions,
+): string | null {
+  if (options.inverseOf === false) return null;
+  // Explicit inverseOf wins everywhere, including polymorphic belongs_to
+  // (where automatic detection can't pick a target).
+  if (typeof options.inverseOf === "string") return options.inverseOf;
+  if (options.polymorphic) return null;
+  const refl = ownerCtor._reflectOnAssociation?.(assocName);
+  return refl?.inverseName?.() ?? null;
+}
+
+/**
+ * Cache `owner` on `child` under `inverseName`. Centralizes the lazy
+ * `_cachedAssociations` init so every load/set path writes the same shape.
+ *
+ * Mirrors: ActiveRecord::Associations::Association#inversed_from
+ *
+ * @internal
+ */
+function _wireInverseAssociation(owner: Base, child: Base, inverseName: string): void {
+  child._cachedAssociations = child._cachedAssociations ?? new Map();
+  child._cachedAssociations.set(inverseName, owner);
+}
+
 function levenshtein(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
@@ -646,9 +682,13 @@ export async function loadBelongsTo(
         resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
-    if (options.inverseOf && cached) {
-      cached._cachedAssociations = cached._cachedAssociations ?? new Map();
-      cached._cachedAssociations.set(options.inverseOf, record);
+    if (cached) {
+      const inverseName = _resolveInverseName(
+        record.constructor as typeof Base,
+        assocName,
+        options,
+      );
+      if (inverseName) _wireInverseAssociation(record, cached, inverseName);
     }
     return cached;
   }
@@ -660,9 +700,13 @@ export async function loadBelongsTo(
         resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
       validateInverseOf(targetModel, assocName, options.inverseOf);
     }
-    if (options.inverseOf && preloaded) {
-      preloaded._cachedAssociations = preloaded._cachedAssociations ?? new Map();
-      preloaded._cachedAssociations.set(options.inverseOf, record);
+    if (preloaded) {
+      const inverseName = _resolveInverseName(
+        record.constructor as typeof Base,
+        assocName,
+        options,
+      );
+      if (inverseName) _wireInverseAssociation(record, preloaded, inverseName);
     }
     return preloaded;
   }
@@ -755,10 +799,12 @@ export async function loadBelongsTo(
     }
   }
 
-  // Set inverse_of: store reference back to the owner
-  if (result && options.inverseOf) {
-    result._cachedAssociations = result._cachedAssociations ?? new Map();
-    result._cachedAssociations.set(options.inverseOf, record);
+  // Set inverse_of: store reference back to the owner. Resolve via the
+  // reflection so automatic_inverse_of also wires the parent — mirrors
+  // ActiveRecord::Associations::Association#set_inverse_instance.
+  if (result) {
+    const inverseName = _resolveInverseName(ctor, assocName, options);
+    if (inverseName) _wireInverseAssociation(record, result, inverseName);
   }
 
   syncToAssociationInstance(record, assocName, result);
@@ -895,10 +941,11 @@ export async function loadHasOne(
     }
   }
 
-  // Set inverse_of: store reference back to the owner
-  if (result && options.inverseOf) {
-    result._cachedAssociations = result._cachedAssociations ?? new Map();
-    result._cachedAssociations.set(options.inverseOf, record);
+  // Set inverse_of: store reference back to the owner. Resolve via the
+  // reflection so automatic_inverse_of also wires the parent.
+  if (result) {
+    const inverseName = _resolveInverseName(ctor, assocName, options);
+    if (inverseName) _wireInverseAssociation(record, result, inverseName);
   }
 
   syncToAssociationInstance(record, assocName, result);
@@ -1103,11 +1150,13 @@ export async function loadHasMany(
   }
   const results: Base[] = await rel.toArray();
 
-  // Set inverse_of on each loaded child
-  if (options.inverseOf) {
+  // Set inverse_of on each loaded child. Resolve via the reflection so
+  // automatic_inverse_of also wires each child's parent reference.
+  // Mirrors HasManyAssociation#set_inverse_instance.
+  const inverseName = _resolveInverseName(ctor, assocName, options);
+  if (inverseName) {
     for (const child of results) {
-      child._cachedAssociations = child._cachedAssociations ?? new Map();
-      child._cachedAssociations.set(options.inverseOf, record);
+      _wireInverseAssociation(record, child, inverseName);
     }
   }
 

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -217,17 +217,64 @@ describe("InverseBelongsToTests", () => {
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in inverse-associations.test.ts
     /* needs deep recursive inverse */
   });
-  it.skip("unscope does not set inverse when incorrect", () => {
-    // BLOCKED: associations — inverse-of feature gap
-    // ROOT-CAUSE: associations/inverse-associations.ts or preloader.ts missing inverse-of semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in inverse-associations.test.ts
-    /* needs unscope support */
+  it("unscope does not set inverse when incorrect", async () => {
+    class Human extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Interest extends Base {
+      static {
+        this.attribute("topic", "string");
+        this.attribute("human_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Human, "interests");
+    Associations.belongsTo.call(Interest, "human");
+    registerModel(Human);
+    registerModel(Interest);
+
+    const human = await Human.create({ name: "Gordon" });
+    const interest = await Interest.create({ topic: "Trainspotting", human_id: human.id });
+    const createdHuman = await Human.create({ name: "wrong human" });
+    const list = (await (createdHuman as any).interests
+      .or((human as any).interests)
+      .toArray()) as Base[];
+    const found = list.find((i) => (i as any).id === (interest as any).id);
+    expect(found).toBeDefined();
+    // Without inversable? guard, the AssociationRelation would alias
+    // `createdHuman` onto the found interest. Verify the cache wasn't
+    // poisoned by the wrong owner.
+    expect((found as any)._cachedAssociations?.get("human")).not.toBe(createdHuman);
   });
-  it.skip("or does not set inverse when incorrect", () => {
-    // BLOCKED: associations — inverse-of feature gap
-    // ROOT-CAUSE: associations/inverse-associations.ts or preloader.ts missing inverse-of semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in inverse-associations.test.ts
-    /* needs or-query inverse checking */
+  it("or does not set inverse when incorrect", async () => {
+    class Human extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Interest extends Base {
+      static {
+        this.attribute("topic", "string");
+        this.attribute("human_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Human, "interests");
+    Associations.belongsTo.call(Interest, "human");
+    registerModel(Human);
+    registerModel(Interest);
+
+    const human = await Human.create({ name: "Gordon" });
+    const interest = await Interest.create({ topic: "Trainspotting", human_id: human.id });
+    const createdHuman = await Human.create({ name: "wrong human" });
+    const list = (await (createdHuman as any).interests.unscope("where").toArray()) as Base[];
+    const found = list.find((i) => (i as any).id === (interest as any).id);
+    expect(found).toBeDefined();
+    expect((found as any)._cachedAssociations?.get("human")).not.toBe(createdHuman);
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Face } = makeModels();


### PR DESCRIPTION
## Summary

Follow-up to #1699 (which closed the `AssociationRelation.toArray` path). Three remaining inverse-wiring items in `associations.ts` / `association-relation.ts`:

- **`inversable?` guard in `AssociationRelation#toArray`.** Mirrors `ActiveRecord::Associations::Association#inversable?` / `matches_foreign_key?`. Chained queries that widen the scope (`.or(other.collection)`, `.unscope(:where)`) can surface rows whose FK doesn't point at the owner; wiring those would alias the wrong parent onto the child. Now compares `child[fk] → owner[pk]` via the reflection before writing `_cachedAssociations`.
- **Automatic inverse detection in `loadHasMany` / `loadHasOne` / `loadBelongsTo`.** Previously only an explicit `inverseOf` option was honored; now each load path resolves the inverse via the registered reflection's `inverseName()`, so `automatic_inverse_of` also wires the parent reference. Cached/preloaded branches of `loadBelongsTo` use the same resolver.
- **Helper extraction.** New `_resolveInverseName(ownerCtor, assocName, options)` and `_wireInverseAssociation(owner, child, name)` dedupe across five load/cache sites so they all write the same `_cachedAssociations` shape. Explicit `inverseOf` still wins for polymorphic `belongs_to` (where auto-detection can't pick a target).

Un-skips two BLOCKED tests in `inverse-associations.test.ts`:
- `unscope does not set inverse when incorrect`
- `or does not set inverse when incorrect`

Mirrors: `ActiveRecord::Associations::Association#inversable?` / `#set_inverse_instance` / `#set_inverse_instance_from_queries`; `Reflection::AssociationReflection#inverse_name`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts` — 72 passed / 25 skipped (was 70 / 27)
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/` — all green
- [x] `pnpm vitest run packages/activerecord/src/preloader.test.ts packages/activerecord/src/relation.test.ts packages/activerecord/src/reflection.test.ts` — all green
- [x] `pnpm typecheck`