### PR TITLE
docs: triage 2026-05-16 merge wave — close batches + record findings

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -12,26 +12,34 @@ For workflow + BLOCKED-annotation vocab + audit conventions, see [`test-compare-
 
 ## Story count
 
-~78 actionable batches (3 in-flight, ~75 queued), ~17.5k LOC. Batches numbered sequentially; the next-to-ship is the lowest-numbered open batch. test:compare standing at 6568/7885 (83.3%) per snapshot above.
+~99 queued batches, ~17.5k LOC. Batches numbered sequentially; the next-to-ship is the lowest-numbered open batch. test:compare standing at 6568/7885 (83.3%) per snapshot above. GitHub is the source of truth for which batches have PRs in flight — search `feat(activerecord): batch N` in open PRs.
 
 The `as any` legacy-cast cleanup sweep has been **superseded by `docs/activerecord-type-audit.md`** — the type-audit's 4-wave plan covers the same `(record as any)._readAttribute` / `.save` / `.destroy` removals more precisely. The 2 `bug-suspected` candidates remain in batches below for surgical verification.
 
 ---
 
-## In-flight batches
+## Queued batches
 
-These have agents currently working.
+Bundled work-PR slots ready to spawn. Items removed as batches ship.
 
-### Batch 2 — PG virtual-column emit pipeline (~110 LOC, risk: medium) — #1726 OPEN
+### Batch 2 — PG virtual-column emit pipeline (~110 LOC, risk: medium)
 
-**Theme:** One Rails source surface — `postgresql/schema-statements.rb` columnSpec + `schema_dumper.rb#emit_table`. Items mutually unblock the same un-skip set (test_non_persisted_column, test_change_table, test_schema_dumping).
+**Theme:** One Rails source surface — `postgresql/schema-statements.rb` columnSpec + `schema_dumper.rb#emit_table`. Unblocks test_non_persisted_column, test_change_table, test_schema_dumping.
 
 - ~15–30 LOC — Route `addColumn` through `schemaCreation.accept(AddColumnDefinition)`; fix `visitColumnDefinition` to call `addColumnOptionsBang` instead of `addColumnOptions`.
 - ~30–80 LOC — Rewire `emitTable` to use connection-adapter `columnSpec` / `prepareColumnOptions`.
-- ~20 LOC — Emit non-PK column `defaultFunction` as `default: () => "fn()"` in `emitTable`, mirroring the PK path. Unblocks function-default round-tripping for all non-PK columns.
+- ~20 LOC — Emit non-PK column `defaultFunction` as `default: () => "fn()"` in `emitTable`, mirroring the PK path.
 - ~30 LOC — Make `SchemaDumper.dumpTableSchema(adapter, ...)` instantiate the adapter's `createSchemaDumper()` class rather than the base.
 
-### Batch 10 — Reflection Slot A + B + Rails-name parity (~115 LOC, risk: low) — #1722 OPEN
+### Batch 3 — PG schema-dump table/partition polish (~80 LOC, risk: low)
+
+**Sequencing:** Depends on Batch 2 (#1726). Spawn after #1726 merges.
+
+- ~30 LOC — Wire `tableOptions()` into `schema-dumper.ts:emitTable`. Requires making the dump loop async.
+- ~30 LOC — PG table comment schema dump: forward `adapterTableOpts.comment` in `emitTable`; add `COMMENT ON TABLE` emission after `createTable`.
+- ~20 LOC — PARTITION BY schema dump: 2 `BLOCKED: adapter-pg` partition tests in `SchemaCreateTableOptionsTest` flow through the same `fetchTableOptions → options:` path; need `tablePartitionDefinition` wired correctly + test bodies.
+
+### Batch 10 — Reflection Slot A + B + Rails-name parity (~115 LOC, risk: low)
 
 **Theme:** Single Rails source `reflection.rb`.
 
@@ -42,91 +50,6 @@ These have agents currently working.
 - ~5 LOC — `UnknownPrimaryKey` message format and no-arg constructor.
 - ~10 LOC — `AbstractReflection#checkValidityOfInverseBang` uses `(this as any).inverseName?.()`. Protected accessor would be cleaner.
 - ~3 LOC — `joinScope` in `AbstractReflection` throws plain `Error`.
-
-### Batch 22 — Associations-core inverseOf wiring (~75 LOC, risk: low) — #1745 OPEN
-
-**Theme:** Auto-inverse population on collection load.
-
-- ~30 LOC — Add `inversable?(record)` check to `AssociationRelation.toArray` + `loadHasMany`'s inverse-wiring loop. Unblocks 2 skipped tests.
-- ~40–60 LOC — Extend automatic-inverse wiring to `loadHasMany`/`loadHasOne`/`loadBelongsTo` (currently only honor explicit `options.inverseOf`).
-- ~5 LOC — Extract `wireInverseAssociation(child, name, owner)` helper.
-
-### Batch 91 — SQLite Slot A + B (~50 LOC bundled) — #1743 OPEN
-
-**Theme:** `sqlite-adapter.ts` strict opt-in + `dataSourceExists()` alignment with `tableExists()` pragma_table_list path.
-
----
-
-## Recently merged batches
-
-For reference. Body removed (see git log + the PR). Findings folded into "Post-merge findings" section below.
-
-| Batch | Title                                               | PR    |
-| ----- | --------------------------------------------------- | ----- |
-| 1     | PG createTable signature harmonization              | #1709 |
-| 4     | PG index option parse + emit (Schema Slot C)        | #1710 |
-| 5     | PG interval round-trip (interval[] + binary parser) | #1727 |
-| 6     | PG-only type registration + citext aftermath        | #1718 |
-| 7     | PG infinity + time-zone wiring                      | #1711 |
-| 8     | MySQL warnings + quoting + init fidelity            | #1723 |
-| 9     | Autosave + has-one Rails-divergence                 | #1712 |
-| 11    | Query-cache Phases 2–3 wiring                       | #1713 |
-| 12    | Insert-all conflict-target + IndexDefinition        | #1720 |
-| 13    | Autosave fidelity sweep A                           | #1730 |
-| 14    | Fixtures schema-gap closures                        | #1715 |
-| 27    | HMT post-#1714 composite cleanup                    | #1732 |
-| 41    | Migration older B/C/E small fidelity                | #1733 |
-| 44    | Connection-pool fidelity sweep B+C                  | #1735 |
-| 47    | MySQL table-options polish                          | #1736 |
-| 79    | Transactions Slot D wTRS fixture ports              | #1742 |
-| 82    | Unknown-triage Slot A annotation refresh            | #1740 |
-| 83    | Unknown-triage Slot B insert-all (triage, partial)  | #1741 |
-
-Phase 5 (TM unification — universal `defineSchema`) sub-PRs:
-
-| Sub-PR | Title                                           | PR    |
-| ------ | ----------------------------------------------- | ----- |
-| init   | Phase 5 initial 32-file migration               | #1633 |
-| tx     | Phase 5 continuation — transaction-family tests | #1686 |
-| assoc  | Phase 5 associations smaller files              | #1690 |
-| enc    | Phase 5 encryption cluster + helper             | #1693 |
-| root A | Phase 5 root cluster A core+callbacks           | #1697 |
-| root B | Phase 5 root cluster B finder+validations       | #1734 |
-| root C | Phase 5 root cluster C enum cluster             | #1737 |
-| where  | Phase 5 `relation/where.test.ts`                | #1738 |
-
-See `tm-unification-plan.md` for Phase 5 remainder.
-
-Other recent closures folded back into queued-batches list:
-
-- Batch 84 (SignedId Relation methods) — closed by #1694.
-- Batch 85 (Unknown-triage Slot D afterCommit refinements) — closed by #1705.
-
----
-
-## Post-merge inline notes (2026-05-16 triage cycle)
-
-Actionable items from the merge wave that don't fit a standalone batch. Sized followups have been promoted to batches B109–B118; this section captures the residue.
-
-- **Mechanical sweep (from #1740)** — `normalize-skips.ts` `/PERMANENT:/` regex previously missed `PERMANENT-SKIP:`. Fixed in #1740. Audit `grep "PERMANENT:" scripts/` for other tooling with the same bug.
-- **~1 LOC cleanup (from #1740)** — `scripts/api-compare/unported-files.ts:480` has a pre-existing `className` type error (not introduced by #1740).
-- **Watchpoint (from #1736)** — `MigrationContext.createTable` now has three PK code paths in `_columnMeta` (`compositePk` array, `primaryKey: false`, `primaryKey: "name"` string). Future batches touching this method should verify `id: false` with `primaryKey: ["a","b"]` interactions through `force: :cascade` recreation.
-- **Pattern note (from #1737)** — `as const` on a TEST_SCHEMA with wrapped `{ columns, primaryKey }` breaks structural assignment to `Schema` (readonly tuples). Cast `: Schema` and drop `as const`. Flat column-only schemas can keep `as const`.
-- **Pattern note (from #1734)** — When migrating to async `freshAdapter`, callbacks previously calling sync `freshAdapter()` must flip to `async () => {`. Inline `createTestAdapter()` outside `freshAdapter()` (e.g. in `beforeEach`) needs its own conversion — grep for them after the sed.
-
----
-
-## Queued batches
-
-Bundled work-PR slots ready to spawn. Items removed as batches ship.
-
-### Batch 3 — PG schema-dump table/partition polish (~80 LOC, risk: low)
-
-**Sequencing:** Depends on Batch 2 (#1726). Spawn after #1726 merges.
-
-- ~30 LOC — Wire `tableOptions()` into `schema-dumper.ts:emitTable`. Requires making the dump loop async.
-- ~30 LOC — PG table comment schema dump: forward `adapterTableOpts.comment` in `emitTable`; add `COMMENT ON TABLE` emission after `createTable`.
-- ~20 LOC — PARTITION BY schema dump: 2 `BLOCKED: adapter-pg` partition tests in `SchemaCreateTableOptionsTest` flow through the same `fetchTableOptions → options:` path; need `tablePartitionDefinition` wired correctly + test bodies.
 
 ### Batch 14 — Autosave E-series CPK + nested-attributes (~80 LOC, risk: low)
 
@@ -155,18 +78,10 @@ Bundled work-PR slots ready to spawn. Items removed as batches ship.
 
 - ~80 LOC — Rewrite the two "indexed errors should be properly translated" tests against a real I18n backend.
 
-### Batch 18 — Reflection call-site sweep — mostly shipped, ~15 LOC residual
-
-Audit `batch-18-reflection-call-site-20260516T211122Z.md` found 3 of 5 items already closed by prior PRs:
-
-- `resolveModel(className)` call-site sweep — closed by #1582.
-- `associations/builder/belongs-to.ts` counter-cache `resolveModel` — closed by #1670.
-- HABTM builder ThroughReflection registration — closed by #1672.
-
-**Residual (~15 LOC), fold into next adjacent slot:**
+### Batch 18 — Reflection residual cleanup (~35 LOC, risk: low)
 
 - ~5 LOC — Delete dead `createReflection` in `reflection.ts:1772` (now-stale asymmetry vs `Reflection.create`).
-- ~30 LOC — Deeply nested through-association resolution in `CollectionProxy._buildThroughScope` (through-a-through beyond one level). Not exercised by tests today; keep as standalone followup.
+- ~30 LOC — Deeply nested through-association resolution in `CollectionProxy._buildThroughScope` (through-a-through beyond one level). Not exercised by tests today.
 
 Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening fires for every through-association push.
 
@@ -196,6 +111,14 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 - ~80–120 LOC — Preload has-many-through with composite query_constraints. Un-skips `preload has many through association with composite query constraints` at `associations.test.ts:8318`.
 - ~30–50 LOC — `AssociationQueryValue` Relation + composite FK: `queries()` array-FK branch still throws when value is a Relation. Gated on `Relation.pluck(primary_key)` with CPK support.
 - ~30–50 LOC — `AssociationQueryValue.convertToId` array-PK branch: handle composite `primaryKey` when value is a record instance. Currently throws. Unblocks 2 "querying by whole/single associated records" tests.
+
+### Batch 22 — Associations-core inverseOf wiring (~75 LOC, risk: low)
+
+**Theme:** Auto-inverse population on collection load.
+
+- ~30 LOC — Add `inversable?(record)` check to `AssociationRelation.toArray` + `loadHasMany`'s inverse-wiring loop. Unblocks 2 skipped tests.
+- ~40–60 LOC — Extend automatic-inverse wiring to `loadHasMany`/`loadHasOne`/`loadBelongsTo` (currently only honor explicit `options.inverseOf`).
+- ~5 LOC — Extract `wireInverseAssociation(child, name, owner)` helper.
 
 ### Batch 23 — Preloader-grouping STI + composite (~280 LOC, risk: medium)
 
@@ -609,6 +532,17 @@ Mechanical: add to `scripts/api-compare/unported-files.ts` as `PERMANENT-SKIP`.
 
 **Risk:** Medium — touches every WHERE clause in the suite. Files (Option A): `predicate-builder/basic-object-handler.ts`, `predicate-builder/range-handler.ts`, `arel/src/visitors/to-sql.ts#visitBindParam`, plus `scripts/parity/fixtures/ar-01/`, `ar-52/`, `ar-65/`.
 
+### Batch 91 — SQLite Slot A + B (~50 LOC bundled, risk: low)
+
+**Theme:** `sqlite-adapter.ts` strict opt-in + `dataSourceExists()` alignment with `tableExists()` `pragma_table_list` path.
+
+- ~5 LOC — Add `strict` field to `SqliteOpenConfig` in `activesupport/src/sqlite-adapter.ts`.
+- ~20 LOC — better-sqlite3 DQS toggle: pass `strict` through `Database.Options` in `sqlite-drivers/better-sqlite3.ts:openDatabase` when upstream exposes `sqlite3_db_config`.
+- ~15 LOC — `dataSourceExists()` in `sqlite3-adapter.ts` still uses the old `sqlite_master`-based query; align with `tableExists()` `pragma_table_list` path.
+- ~10 LOC — Extract `assertLogged` from `sqlite3-adapter.test.ts` to a shared `packages/activerecord/src/adapters/sqlite3/test-helper.ts`.
+
+Known limitation: `strict_strings_by_default` is a no-op in current driver — better-sqlite3 compiles with `SQLITE_DQS=0`. Document inline.
+
 ### Batch 92 — Has-one Slots C+D scope merge + eager (~260 LOC, risk: medium)
 
 - ~100 LOC — `ThroughAssociation#target_scope` chain merge. Rails' override merges each intermediate reflection's `scope_for_association`; our base returns `klass.all()`. Unblocks "has one through with default scope on join model" + 2 custom-select default_scope tests.
@@ -777,6 +711,8 @@ Followup from #1732. `collection-proxy.ts` has an `it.skip` documented in #1732.
 - **Decision** — Root `Gemfile` / `Gemfile.lock`: globalid workstream or not? Currently untracked-and-ambiguous.
 - **Follow-up PR** — Run `sync-stats` refresh and clear "pending" disclaimer on README Data Layer Parity test-percentage.
 - **~30 LOC** — `postgresql/temporal-type-parsers.ts` still has one eager `import pg from "pg"` (the last per `browser-compat-plan.md`). Move to lazy registry. Blocks browser-bundle smoke tests.
+- **~1 LOC** — `scripts/api-compare/unported-files.ts:480` has a pre-existing `className` type error.
+- **Sweep** — Audit `grep "PERMANENT:" scripts/` for tooling missing the `PERMANENT-SKIP:` form (the canonical marker per `docs/test-compare-100-plan.md`).
 
 ---
 

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -12,7 +12,7 @@ For workflow + BLOCKED-annotation vocab + audit conventions, see [`test-compare-
 
 ## Story count
 
-~80 actionable batches, ~17.5k LOC. Batches numbered sequentially; the next-to-ship is the lowest-numbered open batch.
+~78 actionable batches (3 in-flight, ~75 queued), ~17.5k LOC. Batches numbered sequentially; the next-to-ship is the lowest-numbered open batch. test:compare standing at 6568/7885 (83.3%) per snapshot above.
 
 The `as any` legacy-cast cleanup sweep has been **superseded by `docs/activerecord-type-audit.md`** — the type-audit's 4-wave plan covers the same `(record as any)._readAttribute` / `.save` / `.destroy` removals more precisely. The 2 `bug-suspected` candidates remain in batches below for surgical verification.
 
@@ -42,6 +42,14 @@ These have agents currently working.
 - ~5 LOC — `UnknownPrimaryKey` message format and no-arg constructor.
 - ~10 LOC — `AbstractReflection#checkValidityOfInverseBang` uses `(this as any).inverseName?.()`. Protected accessor would be cleaner.
 - ~3 LOC — `joinScope` in `AbstractReflection` throws plain `Error`.
+
+### Batch 22 — Associations-core inverseOf wiring (~75 LOC, risk: low) — #1745 OPEN
+
+**Theme:** Auto-inverse population on collection load.
+
+- ~30 LOC — Add `inversable?(record)` check to `AssociationRelation.toArray` + `loadHasMany`'s inverse-wiring loop. Unblocks 2 skipped tests.
+- ~40–60 LOC — Extend automatic-inverse wiring to `loadHasMany`/`loadHasOne`/`loadBelongsTo` (currently only honor explicit `options.inverseOf`).
+- ~5 LOC — Extract `wireInverseAssociation(child, name, owner)` helper.
 
 ### Batch 91 — SQLite Slot A + B (~50 LOC bundled) — #1743 OPEN
 
@@ -74,7 +82,20 @@ For reference. Body removed (see git log + the PR). Findings folded into "Post-m
 | 82    | Unknown-triage Slot A annotation refresh            | #1740 |
 | 83    | Unknown-triage Slot B insert-all (triage, partial)  | #1741 |
 
-Phase 5 (TM unification — universal `defineSchema`) sub-PRs that closed: #1730 (root B finder/validations), #1737 (root C enum), #1738 (relation/where.test.ts). See `tm-unification-plan.md` for Phase 5 progress.
+Phase 5 (TM unification — universal `defineSchema`) sub-PRs:
+
+| Sub-PR | Title                                           | PR    |
+| ------ | ----------------------------------------------- | ----- |
+| init   | Phase 5 initial 32-file migration               | #1633 |
+| tx     | Phase 5 continuation — transaction-family tests | #1686 |
+| assoc  | Phase 5 associations smaller files              | #1690 |
+| enc    | Phase 5 encryption cluster + helper             | #1693 |
+| root A | Phase 5 root cluster A core+callbacks           | #1697 |
+| root B | Phase 5 root cluster B finder+validations       | #1734 |
+| root C | Phase 5 root cluster C enum cluster             | #1737 |
+| where  | Phase 5 `relation/where.test.ts`                | #1738 |
+
+See `tm-unification-plan.md` for Phase 5 remainder.
 
 Other recent closures folded back into queued-batches list:
 
@@ -230,14 +251,6 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 - ~80–120 LOC — Preload has-many-through with composite query_constraints. Un-skips `preload has many through association with composite query constraints` at `associations.test.ts:8318`.
 - ~30–50 LOC — `AssociationQueryValue` Relation + composite FK: `queries()` array-FK branch still throws when value is a Relation. Gated on `Relation.pluck(primary_key)` with CPK support.
 - ~30–50 LOC — `AssociationQueryValue.convertToId` array-PK branch: handle composite `primaryKey` when value is a record instance. Currently throws. Unblocks 2 "querying by whole/single associated records" tests.
-
-### Batch 22 — Associations-core inverseOf wiring (~75 LOC, risk: low)
-
-**Theme:** Auto-inverse population on collection load.
-
-- ~30 LOC — Add `inversable?(record)` check to `AssociationRelation.toArray` + `loadHasMany`'s inverse-wiring loop. Unblocks 2 skipped tests.
-- ~40–60 LOC — Extend automatic-inverse wiring to `loadHasMany`/`loadHasOne`/`loadBelongsTo` (currently only honor explicit `options.inverseOf`).
-- ~5 LOC — Extract `wireInverseAssociation(child, name, owner)` helper.
 
 ### Batch 23 — Preloader-grouping STI + composite (~280 LOC, risk: medium)
 

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -104,70 +104,15 @@ Other recent closures folded back into queued-batches list:
 
 ---
 
-## Post-merge findings (2026-05-16 triage cycle)
+## Post-merge inline notes (2026-05-16 triage cycle)
 
-Followups extracted from `~/.btwhooks/.../<PR>/post-pr/*.md` for the 2026-05-16 merge wave. Items needing dedicated batches are listed below as new queued batches (B109+). Other followups are recorded inline against the relevant cluster/file.
+Actionable items from the merge wave that don't fit a standalone batch. Sized followups have been promoted to batches B109–B118; this section captures the residue.
 
-### From #1742 (Batch 79 — Transactions Slot D)
-
-- **~30 LOC** — `restore previously new record after double save` (transactions.test.ts:~1167) still skipped. Needs Rails-trace research: in Rails, between save#1 and save#2 inside the same outer user-tx, is `@_previously_new_record` actually mutated, or only at commit time? If commit-only, the per-call snapshot is fine. Otherwise: replace closure snapshot with `_restoreTransactionRecordState` reading `_startTransactionState`, level-guarded. **Files:** `transactions.ts#withTransactionReturningStatus`. Belongs in [Batch 111 below](#batch-111).
-- **~10 LOC** — `primaryKey = "movieid"` auto-declare DX gap. `setPrimaryKeyAttr` in `attribute-methods/primary-key.ts` is a one-liner; lazy auto-declare (only if no later `attribute()` or schema-load fires) would let `makeSQLiteMovie` drop redundant `this.attribute("movieid", "integer")`. Risk: many models call `primaryKey = ...` in a static block + rely on later schema reflection; eager declare clobbers schema-driven type.
-
-### From #1741 (Insert-all triage)
-
-- **~10 LOC** — extend `insert-all.ts#verifyAttributes` to reject keys not in `model.attributeNames`, throwing `UnknownAttributeError`. Unblocks `insert-all.test.ts:738` "insert all raises on unknown attribute" + likely 2 "clear error message when a column does not exist" tests.
-- **~6 LOC** — add `insertAllBang`/`upsertAllBang` class-level wrappers in `querying.ts` mirroring `insertAll`/`upsertAll` delegations. Then retarget the unknown-attribute test to `Book.insertAllBang(...)` to match Rails call shape.
-- **~250 LOC triage slot** — Batch 109 below: sharpen remaining ~60 single-line `BLOCKED:` annotations in `insert-all.test.ts` into the three-line BLOCKED/ROOT-CAUSE/SCOPE format. Clusters: timestamps (~15 tests, shared root cause: no implicit `created_at`/`updated_at` handling in `insert-all.ts#mapKeyWithValue`), RETURNING (~4, pg-only), readonly (~3, no `_readonlyAttributes` filter), schema/index (~7).
-
-### From #1740 (Batch 82 — Unknown-triage Slot A)
-
-- **~30 LOC** — Port 3 hstore `store_accessor` tests (hstore_test.rb:118/136/157): `test_with_store_accessors`, `test_duplication_with_store_accessors`, `test_changes_with_store_accessors`. `storeAccessor` is implemented; tests just need bodies. Verify per-accessor dirty aliases (`<accessor>_changed?`, `_was`, `_change`) are wired on the storeAccessor-defined module first (+~10 LOC `store.ts` if not).
-- **~20 LOC** — Per-attribute `<attr>_before_type_cast` alias method generation. Generic `readAttributeBeforeTypeCast(name)` is implemented (`attribute-methods/before-type-cast.ts:21`), but Rails generates per-attribute aliases via `define_method`. Add to `attribute-methods.ts` generation pipeline. Unblocks hstore "cast value on write" + all `<attr>_before_type_cast` tests across types.
-- **Mechanical sweep** — `normalize-skips.ts` previously had `/PERMANENT:/` regex that missed `PERMANENT-SKIP:` (the canonical marker). Fixed in #1740. Audit `grep "PERMANENT:" scripts/` for other tooling with the same bug.
-- **~1 LOC cleanup** — `scripts/api-compare/unported-files.ts:480` has a pre-existing `className` type error (not introduced by #1740).
-
-### From #1737 (Phase 5 root cluster C)
-
-Phase 5 root cluster C remainder, each ships as its own PR using the async `freshAdapter` + `defineSchema` pattern:
-
-- **~250 LOC** — `enum.test.ts` (~77 freshAdapter sites, 2018 LOC). Largest remaining root offender. May need split.
-- **~250 LOC** — `attribute-methods.test.ts` (~79 sites, 1872 LOC). Likely splits along inner describes.
-- **~150 LOC** — `attributes.test.ts` (~58 sites, 835 LOC). Single-PR sized.
-- **~80 LOC** — `attribute-methods/` subtree: `query.test.ts`, `read.test.ts`, `write.test.ts`, `time-zone-conversion.test.ts`. Bundle as one PR.
-
-Pattern note: `as const` on a TEST_SCHEMA with wrapped `{ columns, primaryKey }` breaks structural assignment to `Schema` (readonly tuples). Cast `: Schema` and drop `as const`. Flat column-only schemas can keep `as const`.
-
-### From #1736 (Batch 47 — MySQL table-options)
-
-- **~80–150 LOC (Batch 110 below)** — Route `TableDefinition#toSql()` through `schemaCreation.accept(...)` (Arel-style visitor). Today only `addColumn`/`addIndex`/`changeColumn` go through the visitor on MySQL; `createTable` still uses the abstract toSql() switch which never inspects `options.autoIncrement`. This unblocks re-introducing the `AbstractMysqlAdapter.createTableDefinition` override (the 6th item in Batch 47 that was reverted because dropping AUTO_INCREMENT broke MariaDB CI).
-- **~5 LOC** — Re-add `AbstractMysqlAdapter.createTableDefinition` override (`return new MysqlTableDefinition(name, rest)` with adapter/adapterName stripped) once the toSql work above lands. Plumbing already there from commit `13ed839c4` in #1736.
-- **Watchpoint** — `MigrationContext.createTable` now has three PK code paths in `_columnMeta` build (`compositePk` array, `primaryKey: false`, `primaryKey: "name"` string). Future batches touching this method should verify `id: false` with `primaryKey: ["a","b"]` interactions through `force: :cascade` recreation.
-
-### From #1735 (Batch 44 — Connection-pool B+C)
-
-- **~30 LOC** — Align `withRoleAndShard`/`connectingTo`/`connectedToMany` to Rails' `[self]` semantics: push `[self]`, resolve `connection_class_for_self` at read time via `klasses.include?(...)`. Then update `core.ts#matchesStack` + `AbstractAdapter#isPreventingWrites` to walk at read time too. Closes the primary-abstract-without-`connectsTo` leak documented inline at `abstract-adapter.ts:735`.
-- **~10 LOC** — `core.ts#matchesStack:336` uses `k.name === "Base"` string match. Switch to the `_isActiveRecordBase` own-property marker for consistency once the bigger followup above lands.
-- **~5 LOC** — Add a `connectionSpecificationName` reader test pinning the new "primary class → 'Base'" branch (`connection-handling.ts:~373`). Exercised indirectly today via primary-class test.
-
-### From #1734 (Phase 5 root cluster B)
-
-Phase 5 root remainder, each its own PR (continues #1734's pattern):
-
-- **~150 LOC** — `calculations.test.ts` (~101 freshAdapter sites, 7596 LOC). Schema map large (Account, Company, Firm + many test-local variants). Probably one PR.
-- **~200 LOC** — `persistence.test.ts` (~141 sites, 4789 LOC). Schema surface bigger (Topic, Reply, Post, Author, Category). May need split if test-bodies need async upgrades beyond call sites.
-
-Notes: `it(name, () => {})` callbacks that previously called sync `freshAdapter()` must flip to `async () => {`. Adapter calls outside `freshAdapter()` (e.g. inline `createTestAdapter()` in `beforeEach`) need their own conversion — grep for them after the sed.
-
-### From #1733 (Batch 41 — Migration B/C/E)
-
-- **~10 LOC** — `Migration.properTableName` (`migration.ts:1334`) skips the `name.respond_to?(:table_name)` branch from Rails (`migration.rb:1119-1125`). If a caller passes a model class, the TS port stringifies the class into prefix/name/suffix template instead of returning `klass.tableName`. Not exercised today.
-- **~80–120 LOC** — Flesh out `Migration.copy` (`migration.ts:1350`) to honor engine `scope` on `MigrationProxy` (Rails emits `${version}_${name.underscore}.${scope}.rb` + supports `on_skip`/`on_copy` callbacks). Today the TS stub just `copyFileSync`s. The `MigrationProxy.scope` field this batch added is present-but-unused on the copy path.
-
-### From #1732 (Batch 27 — HMT post-#1714 composite)
-
-- **~60 LOC** — Polymorphic-through with composite owner PK. Documented by the `it.skip` added in #1732. Needs: (a) require explicit single-column `primaryKey:` option on polymorphic-through, (b) validation in `Reflection` or `_throughOwnerPolymorphic` rejecting composite `primaryKey:` with `ConfigurationError`, (c) flip the skip to a real assertion.
-- **~20 LOC** — Audit whether `_throughOwnerCols`' `options.queryConstraints` FK branch (`collection-proxy.ts:~1042`) is reachable. `Reflection`'s constructor rejects `queryConstraints:` on user-defined associations and rewrites `foreignKey:[]` → reflection-level. If branch is dead, delete; if reachable via some not-yet-exercised builder, add a fixture.
-- **~30 LOC** — Sweep `has-one-through-association.ts` for analogous composite-PK/composite-FK throws that still raise plain `Error` (the corresponding CollectionProxy paths in HMT now use `ConfigurationError`).
+- **Mechanical sweep (from #1740)** — `normalize-skips.ts` `/PERMANENT:/` regex previously missed `PERMANENT-SKIP:`. Fixed in #1740. Audit `grep "PERMANENT:" scripts/` for other tooling with the same bug.
+- **~1 LOC cleanup (from #1740)** — `scripts/api-compare/unported-files.ts:480` has a pre-existing `className` type error (not introduced by #1740).
+- **Watchpoint (from #1736)** — `MigrationContext.createTable` now has three PK code paths in `_columnMeta` (`compositePk` array, `primaryKey: false`, `primaryKey: "name"` string). Future batches touching this method should verify `id: false` with `primaryKey: ["a","b"]` interactions through `force: :cascade` recreation.
+- **Pattern note (from #1737)** — `as const` on a TEST_SCHEMA with wrapped `{ columns, primaryKey }` breaks structural assignment to `Schema` (readonly tuples). Cast `: Schema` and drop `as const`. Flat column-only schemas can keep `as const`.
+- **Pattern note (from #1734)** — When migrating to async `freshAdapter`, callbacks previously calling sync `freshAdapter()` must flip to `async () => {`. Inline `createTestAdapter()` outside `freshAdapter()` (e.g. in `beforeEach`) needs its own conversion — grep for them after the sed.
 
 ---
 

--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -43,15 +43,15 @@ These have agents currently working.
 - ~10 LOC — `AbstractReflection#checkValidityOfInverseBang` uses `(this as any).inverseName?.()`. Protected accessor would be cleaner.
 - ~3 LOC — `joinScope` in `AbstractReflection` throws plain `Error`.
 
-### Batch 13 — Autosave fidelity sweep A (~95 LOC, risk: low) — #1730 OPEN
+### Batch 91 — SQLite Slot A + B (~50 LOC bundled) — #1743 OPEN
 
-**Theme:** Single Rails source `autosave_association.rb` — small C/F-series guards + post-#1678 leftover dispatch + autosaveBelongsTo dead-code removal.
+**Theme:** `sqlite-adapter.ts` strict opt-in + `dataSourceExists()` alignment with `tableExists()` pragma_table_list path.
 
 ---
 
 ## Recently merged batches
 
-For reference. Body removed (see git log + the PR).
+For reference. Body removed (see git log + the PR). Findings folded into "Post-merge findings" section below.
 
 | Batch | Title                                               | PR    |
 | ----- | --------------------------------------------------- | ----- |
@@ -64,12 +64,89 @@ For reference. Body removed (see git log + the PR).
 | 9     | Autosave + has-one Rails-divergence                 | #1712 |
 | 11    | Query-cache Phases 2–3 wiring                       | #1713 |
 | 12    | Insert-all conflict-target + IndexDefinition        | #1720 |
+| 13    | Autosave fidelity sweep A                           | #1730 |
 | 14    | Fixtures schema-gap closures                        | #1715 |
+| 27    | HMT post-#1714 composite cleanup                    | #1732 |
+| 41    | Migration older B/C/E small fidelity                | #1733 |
+| 44    | Connection-pool fidelity sweep B+C                  | #1735 |
+| 47    | MySQL table-options polish                          | #1736 |
+| 79    | Transactions Slot D wTRS fixture ports              | #1742 |
+| 82    | Unknown-triage Slot A annotation refresh            | #1740 |
+| 83    | Unknown-triage Slot B insert-all (triage, partial)  | #1741 |
+
+Phase 5 (TM unification — universal `defineSchema`) sub-PRs that closed: #1730 (root B finder/validations), #1737 (root C enum), #1738 (relation/where.test.ts). See `tm-unification-plan.md` for Phase 5 progress.
 
 Other recent closures folded back into queued-batches list:
 
 - Batch 84 (SignedId Relation methods) — closed by #1694.
 - Batch 85 (Unknown-triage Slot D afterCommit refinements) — closed by #1705.
+
+---
+
+## Post-merge findings (2026-05-16 triage cycle)
+
+Followups extracted from `~/.btwhooks/.../<PR>/post-pr/*.md` for the 2026-05-16 merge wave. Items needing dedicated batches are listed below as new queued batches (B109+). Other followups are recorded inline against the relevant cluster/file.
+
+### From #1742 (Batch 79 — Transactions Slot D)
+
+- **~30 LOC** — `restore previously new record after double save` (transactions.test.ts:~1167) still skipped. Needs Rails-trace research: in Rails, between save#1 and save#2 inside the same outer user-tx, is `@_previously_new_record` actually mutated, or only at commit time? If commit-only, the per-call snapshot is fine. Otherwise: replace closure snapshot with `_restoreTransactionRecordState` reading `_startTransactionState`, level-guarded. **Files:** `transactions.ts#withTransactionReturningStatus`. Belongs in [Batch 111 below](#batch-111).
+- **~10 LOC** — `primaryKey = "movieid"` auto-declare DX gap. `setPrimaryKeyAttr` in `attribute-methods/primary-key.ts` is a one-liner; lazy auto-declare (only if no later `attribute()` or schema-load fires) would let `makeSQLiteMovie` drop redundant `this.attribute("movieid", "integer")`. Risk: many models call `primaryKey = ...` in a static block + rely on later schema reflection; eager declare clobbers schema-driven type.
+
+### From #1741 (Insert-all triage)
+
+- **~10 LOC** — extend `insert-all.ts#verifyAttributes` to reject keys not in `model.attributeNames`, throwing `UnknownAttributeError`. Unblocks `insert-all.test.ts:738` "insert all raises on unknown attribute" + likely 2 "clear error message when a column does not exist" tests.
+- **~6 LOC** — add `insertAllBang`/`upsertAllBang` class-level wrappers in `querying.ts` mirroring `insertAll`/`upsertAll` delegations. Then retarget the unknown-attribute test to `Book.insertAllBang(...)` to match Rails call shape.
+- **~250 LOC triage slot** — Batch 109 below: sharpen remaining ~60 single-line `BLOCKED:` annotations in `insert-all.test.ts` into the three-line BLOCKED/ROOT-CAUSE/SCOPE format. Clusters: timestamps (~15 tests, shared root cause: no implicit `created_at`/`updated_at` handling in `insert-all.ts#mapKeyWithValue`), RETURNING (~4, pg-only), readonly (~3, no `_readonlyAttributes` filter), schema/index (~7).
+
+### From #1740 (Batch 82 — Unknown-triage Slot A)
+
+- **~30 LOC** — Port 3 hstore `store_accessor` tests (hstore_test.rb:118/136/157): `test_with_store_accessors`, `test_duplication_with_store_accessors`, `test_changes_with_store_accessors`. `storeAccessor` is implemented; tests just need bodies. Verify per-accessor dirty aliases (`<accessor>_changed?`, `_was`, `_change`) are wired on the storeAccessor-defined module first (+~10 LOC `store.ts` if not).
+- **~20 LOC** — Per-attribute `<attr>_before_type_cast` alias method generation. Generic `readAttributeBeforeTypeCast(name)` is implemented (`attribute-methods/before-type-cast.ts:21`), but Rails generates per-attribute aliases via `define_method`. Add to `attribute-methods.ts` generation pipeline. Unblocks hstore "cast value on write" + all `<attr>_before_type_cast` tests across types.
+- **Mechanical sweep** — `normalize-skips.ts` previously had `/PERMANENT:/` regex that missed `PERMANENT-SKIP:` (the canonical marker). Fixed in #1740. Audit `grep "PERMANENT:" scripts/` for other tooling with the same bug.
+- **~1 LOC cleanup** — `scripts/api-compare/unported-files.ts:480` has a pre-existing `className` type error (not introduced by #1740).
+
+### From #1737 (Phase 5 root cluster C)
+
+Phase 5 root cluster C remainder, each ships as its own PR using the async `freshAdapter` + `defineSchema` pattern:
+
+- **~250 LOC** — `enum.test.ts` (~77 freshAdapter sites, 2018 LOC). Largest remaining root offender. May need split.
+- **~250 LOC** — `attribute-methods.test.ts` (~79 sites, 1872 LOC). Likely splits along inner describes.
+- **~150 LOC** — `attributes.test.ts` (~58 sites, 835 LOC). Single-PR sized.
+- **~80 LOC** — `attribute-methods/` subtree: `query.test.ts`, `read.test.ts`, `write.test.ts`, `time-zone-conversion.test.ts`. Bundle as one PR.
+
+Pattern note: `as const` on a TEST_SCHEMA with wrapped `{ columns, primaryKey }` breaks structural assignment to `Schema` (readonly tuples). Cast `: Schema` and drop `as const`. Flat column-only schemas can keep `as const`.
+
+### From #1736 (Batch 47 — MySQL table-options)
+
+- **~80–150 LOC (Batch 110 below)** — Route `TableDefinition#toSql()` through `schemaCreation.accept(...)` (Arel-style visitor). Today only `addColumn`/`addIndex`/`changeColumn` go through the visitor on MySQL; `createTable` still uses the abstract toSql() switch which never inspects `options.autoIncrement`. This unblocks re-introducing the `AbstractMysqlAdapter.createTableDefinition` override (the 6th item in Batch 47 that was reverted because dropping AUTO_INCREMENT broke MariaDB CI).
+- **~5 LOC** — Re-add `AbstractMysqlAdapter.createTableDefinition` override (`return new MysqlTableDefinition(name, rest)` with adapter/adapterName stripped) once the toSql work above lands. Plumbing already there from commit `13ed839c4` in #1736.
+- **Watchpoint** — `MigrationContext.createTable` now has three PK code paths in `_columnMeta` build (`compositePk` array, `primaryKey: false`, `primaryKey: "name"` string). Future batches touching this method should verify `id: false` with `primaryKey: ["a","b"]` interactions through `force: :cascade` recreation.
+
+### From #1735 (Batch 44 — Connection-pool B+C)
+
+- **~30 LOC** — Align `withRoleAndShard`/`connectingTo`/`connectedToMany` to Rails' `[self]` semantics: push `[self]`, resolve `connection_class_for_self` at read time via `klasses.include?(...)`. Then update `core.ts#matchesStack` + `AbstractAdapter#isPreventingWrites` to walk at read time too. Closes the primary-abstract-without-`connectsTo` leak documented inline at `abstract-adapter.ts:735`.
+- **~10 LOC** — `core.ts#matchesStack:336` uses `k.name === "Base"` string match. Switch to the `_isActiveRecordBase` own-property marker for consistency once the bigger followup above lands.
+- **~5 LOC** — Add a `connectionSpecificationName` reader test pinning the new "primary class → 'Base'" branch (`connection-handling.ts:~373`). Exercised indirectly today via primary-class test.
+
+### From #1734 (Phase 5 root cluster B)
+
+Phase 5 root remainder, each its own PR (continues #1734's pattern):
+
+- **~150 LOC** — `calculations.test.ts` (~101 freshAdapter sites, 7596 LOC). Schema map large (Account, Company, Firm + many test-local variants). Probably one PR.
+- **~200 LOC** — `persistence.test.ts` (~141 sites, 4789 LOC). Schema surface bigger (Topic, Reply, Post, Author, Category). May need split if test-bodies need async upgrades beyond call sites.
+
+Notes: `it(name, () => {})` callbacks that previously called sync `freshAdapter()` must flip to `async () => {`. Adapter calls outside `freshAdapter()` (e.g. inline `createTestAdapter()` in `beforeEach`) need their own conversion — grep for them after the sed.
+
+### From #1733 (Batch 41 — Migration B/C/E)
+
+- **~10 LOC** — `Migration.properTableName` (`migration.ts:1334`) skips the `name.respond_to?(:table_name)` branch from Rails (`migration.rb:1119-1125`). If a caller passes a model class, the TS port stringifies the class into prefix/name/suffix template instead of returning `klass.tableName`. Not exercised today.
+- **~80–120 LOC** — Flesh out `Migration.copy` (`migration.ts:1350`) to honor engine `scope` on `MigrationProxy` (Rails emits `${version}_${name.underscore}.${scope}.rb` + supports `on_skip`/`on_copy` callbacks). Today the TS stub just `copyFileSync`s. The `MigrationProxy.scope` field this batch added is present-but-unused on the copy path.
+
+### From #1732 (Batch 27 — HMT post-#1714 composite)
+
+- **~60 LOC** — Polymorphic-through with composite owner PK. Documented by the `it.skip` added in #1732. Needs: (a) require explicit single-column `primaryKey:` option on polymorphic-through, (b) validation in `Reflection` or `_throughOwnerPolymorphic` rejecting composite `primaryKey:` with `ConfigurationError`, (c) flip the skip to a real assertion.
+- **~20 LOC** — Audit whether `_throughOwnerCols`' `options.queryConstraints` FK branch (`collection-proxy.ts:~1042`) is reachable. `Reflection`'s constructor rejects `queryConstraints:` on user-defined associations and rewrites `foreignKey:[]` → reflection-level. If branch is dead, delete; if reachable via some not-yet-exercised builder, add a fixture.
+- **~30 LOC** — Sweep `has-one-through-association.ts` for analogous composite-PK/composite-FK throws that still raise plain `Error` (the corresponding CollectionProxy paths in HMT now use `ConfigurationError`).
 
 ---
 
@@ -194,14 +271,6 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 - ~5 LOC (A) — Add connection/adapter identity to `LoaderQuery.hashKey()` for multi-DB grouping isolation.
 - ~80–120 LOC (C) — Implement `Relation#includes!`/`Relation#references!` infra for Rails-faithful `through_scope` path.
 
-### Batch 27 — HMT post-#1714 composite (~80 LOC, risk: low)
-
-**Theme:** Composite-FK clean-up at the through-association edges.
-
-- ~30–60 LOC — Through-assoc `options.queryConstraints` PK/FK separation. `_throughOwnerAttrs` would read non-existent attrs off the owner when user passes `options.queryConstraints` on through assoc without `options.primaryKey`.
-- ~10 LOC — Target-side composite throws in `_buildThroughScope` (`Array.isArray(targetFk)` / `Array.isArray(targetModel.primaryKey)`).
-- ~20 LOC — Dedicated polymorphic-through `it.todo`/`it.skip` with `BLOCKED:` annotation for composite-owner polymorphic-through if/when use case emerges.
-
 ### Batch 28 — HMT Slot E nested-through JoinDependency (~180 LOC, risk: medium)
 
 **Theme:** JoinDependency alias resolution for nested-through; closes 2–3 skipped tests in `nested-through-associations.test.ts`.
@@ -299,14 +368,6 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 - ~10 LOC — "updating auto increment" MySQL skip → move to MySQL adapter suite.
 - ~30 LOC — `Migration.changeTable` delegate to `CommandRecorder.changeTable` in recording mode.
 
-### Batch 41 — Migration older B/C/E small fidelity (~50 LOC, risk: low)
-
-- ~5 LOC (C) — `MigrationProxy` interface: add `scope?: string` field.
-- ~5 LOC (B) — `TableDefinition.toSql()` default switch reject empty/whitespace column types upfront.
-- ~10 LOC (E) — Document `InternalMetadata#tableExists()` short-circuit deviation with `@internal`.
-- ~10 LOC (B) — Forward `currentDatabase()` + advisory-lock helpers from `SchemaAdapter` to inner adapter in test-adapter.ts.
-- ~20 LOC (B/C) — Unify `MigrationContext.tableNamePrefix`/`tableNameSuffix` two-sources-of-truth (instance fields vs `_arConfig` registry).
-
 ### Batch 42 — Migration older B/E larger items (~130 LOC, risk: medium)
 
 - ~20 LOC (E) — `MigrationContext.fromPath(dir)` factory wrapping `migrationFiles` + `parseMigrationFilename` + camelize → `MigrationProxy[]`.
@@ -318,14 +379,6 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 
 - ~50–80 LOC — Wire `adapterFactory` inside `connectsTo` (`connection-handling.ts`) so pools established via `connectsTo` can create real connections.
 - 3 "swapping shards in a multi threaded environment" tests → move to `skip-list.ts` (~5 LOC).
-
-### Batch 44 — Connection-pool smaller fidelity B+C (~35 LOC, risk: low)
-
-- ~3 LOC (C) — `connectingTo` shard default should use `this.defaultShard()` instead of hardcoded `"default"`.
-- ~5 LOC (B) — Friendlier error when `Base.configurations` is non-standard object without `toH`.
-- ~10 LOC (B) — Track `defaultShard` on the class inside `connectsTo`.
-- ~15 LOC (B) — `connectsTo` should call Rails' `resolve_config_for_connection(database_key)` to set `_connectionSpecificationName` as a side effect.
-- ~2 LOC (C) — `isPreventingWrites()` class-name string match can drift if class is renamed but pool registered under different owner-name.
 
 ### Batch 45 — Connection-pool sync #1473 leak audit (~105 LOC, risk: medium-high)
 
@@ -342,15 +395,6 @@ Watchpoint: the `_invalidateAssociationIds → assocInstance.reset()` widening f
 - ~10 LOC — Extend `scripts/test-compare/extract-ts-tests.ts` to parse `it.skipIf(expr)("name", fn)` callable form.
 - ~30–50 LOC — `MySQLAnsiQuotesTest` un-skip: adapter-level `setSessionVariable` (or expose `execute("SET SESSION sql_mode='ANSI_QUOTES'")` cleanly) plus a `reconnect!` test hook. Also touches parser/quoting path for double-quoted identifiers under ANSI_QUOTES. Add `lessons_students`/`students` schema for `foreign_keys` test + a `topics` table for `primary_key` test.
 - ~5 LOC — `Mysql2Adapter.currentDatabase()` override (currently inherits abstract's empty `""`). Mirrors PG's `postgresql-adapter.ts:4218`.
-
-### Batch 47 — MySQL table-options polish (~100 LOC, risk: low)
-
-- ~5 LOC — `extractSchemaQualifiedName` equivalent so `tableComment()` (and other `information_schema` queries) handle `schema.table` names.
-- ~10 LOC — `TableDefinition` constructor: treat `primaryKey === false` same as `id: false`; treat `primaryKey: "name"` as custom PK column name.
-- ~15 LOC — `MigrationContext.createTable` `_columnMeta` composite-PK tracking.
-- ~15 LOC — `tableCollationCache` lazy population via `SHOW TABLE STATUS LIKE ...`.
-- ~25 LOC — Composite PK column order divergence: `schema-dumper.ts:emitTable` uses declaration order from `SHOW FULL FIELDS`; Rails uses `@connection.primary_key(table)` (`seq_in_index` order). Override in `mysql/schema-dumper.ts`.
-- ~30 LOC — Override `createTableDefinition` in `AbstractMysqlAdapter` to return a `MySQL::TableDefinition`.
 
 ### Batch 48 — MySQL active-schema Slot D + MariaDB indexes() (~140 LOC, risk: medium)
 
@@ -558,14 +602,6 @@ Plus `schema change with prepared stmt` remains skipped (needs `adapter.prepared
 
 - ~30 LOC — `MigrationContext.createTable` passes abstract `TableDefinition` to the callback; `t.exclusionConstraint`/`t.uniqueConstraint` aren't callable from schema-file blocks. Rails emits them inline. Fix: instantiate `PgTableDefinition` when `adapterName === "postgres"`, then exclusion/unique constraints can move inline. Closes the Sweep D Item 1 partial-ship.
 
-### Batch 79 — Transactions Slot D wTRS fixture ports (~50 LOC, risk: low)
-
-- ~10 LOC — Un-skip `write attribute after rollback` (`transactions.test.ts` ~1664); same Topic fixture as `read attribute after rollback`, trivial port.
-- ~15 LOC — Un-skip `test_assign_custom_primary_key_after_rollback` (unblocked by wTRS fix tracked separately).
-- ~10 LOC — `restore previously new record after double save` — needs `_startTransactionState` snapshot timing fix (deferred).
-- ~5 LOC — `scripts/test-compare/normalize-skips.ts` `transaction-isolation.test.ts` entry: replace stale "GVL" wording with PG-required gating.
-- ~10 LOC — `primaryKey = "movieid"` should auto-declare the attribute so callers don't need redundant `attribute("movieid", "integer")` (DX gap).
-
 ### Batch 80 — Transactions wTRS + update-setter fidelity (~55 LOC, risk: medium)
 
 - ~10 LOC — Un-skip `test_read_attribute_with_custom_primary_key_after_rollback` + `test_write_attribute_with_custom_primary_key_after_rollback` (same Movie fixture).
@@ -576,14 +612,6 @@ Plus `schema change with prepared stmt` remains skipped (needs `adapter.prepared
 ### Batch 81 — Transactions dirty-tracking new-record rollback (~50 LOC, risk: high)
 
 - ~50 LOC — Dirty-tracking for new-record rollback: `topic.changes["title"]` returns `undefined` instead of `[null, "Jeff"]` after rollback. Root cause deeper than sweep A's guard fix — `state.attributes` snapshot in `rememberTransactionRecordState` captures user-written values, so `redetectChanges` produces no diff. Fix: snapshot _DB-original_ values (null for unsaved new records), or add separate DB-original tracking.
-
-### Batch 82 — Unknown-triage Slot A annotation refresh (~200 LOC, tests-only)
-
-Re-tag all 89 `BLOCKED: unknown` annotations into the controlled vocabulary, moving the Ruby-only language-semantics ones (`modules.test.ts` x7, `mixin.test.ts` x2, `base.test.ts` x1 — `Module#prepend`, `singleton_class`, `Module#ancestors`, constant-path lookup) to `PERMANENT-SKIP` form in `unported-files.ts`. Foundational; unblocks downstream slot-sizing.
-
-### Batch 83 — Unknown-triage Slot B insert-all (~250 LOC, risk: medium)
-
-**64 of the 89 have stale "`MemoryAdapter accepts any attrs"` comments** that mislead the audit — there is no `MemoryAdapter`; the test setup uses `SchemaAdapter` wrapping a real driver. `InsertAll` impl is at 100% per `api:compare`. Real work: scrub stale comments, investigate what's actually skipped, rewrite test bodies to assert against real-adapter behavior.
 
 ### Batch 86 — Unknown-triage deferred (~230 LOC, risk: medium)
 
@@ -622,15 +650,6 @@ Mechanical: add to `scripts/api-compare/unported-files.ts` as `PERMANENT-SKIP`.
 - **Option B (parity-runner side):** `paramSql` + binds comparison would close this in the diff layer without trails code changes.
 
 **Risk:** Medium — touches every WHERE clause in the suite. Files (Option A): `predicate-builder/basic-object-handler.ts`, `predicate-builder/range-handler.ts`, `arel/src/visitors/to-sql.ts#visitBindParam`, plus `scripts/parity/fixtures/ar-01/`, `ar-52/`, `ar-65/`.
-
-### Batch 91 — SQLite Slot A + B (~50 LOC, risk: low)
-
-- ~5 LOC — Add `strict` field to `SqliteOpenConfig` in `activesupport/src/sqlite-adapter.ts`.
-- ~20 LOC — better-sqlite3 DQS toggle: when upstream exposes `sqlite3_db_config`, pass `strict` through `Database.Options` in `sqlite-drivers/better-sqlite3.ts:openDatabase`.
-- ~15 LOC — `dataSourceExists()` in `sqlite3-adapter.ts` still uses the old `sqlite_master`-based query, while `tableExists()` was updated to `pragma_table_list` in #1459. Align `dataSourceExists()`.
-- ~10 LOC — Extract `assertLogged` from `sqlite3-adapter.test.ts` to a shared `packages/activerecord/src/adapters/sqlite3/test-helper.ts`.
-
-Known limitation: `strict_strings_by_default` is a no-op in current driver — better-sqlite3 compiles with `SQLITE_DQS=0`. Documented inline.
 
 ### Batch 92 — Has-one Slots C+D scope merge + eager (~260 LOC, risk: medium)
 
@@ -718,6 +737,80 @@ Documented but unfixable: Hyphenated chain names — `beforeMy-save` isn't a val
 ### Batch 108 — api:compare regression guard (process)
 
 - **Process improvement** — `_`-prefix renames on Rails-named methods silently drop them from `api:compare` surface. Consider extending the `rails-private-jsdoc` ESLint rule to flag `_`-prefixed methods whose Rails counterpart is non-underscored. Permanent guardrail against the regression class.
+
+### Batch 109 — Insert-all annotation sharpening + UnknownAttributeError + bang wrappers (~270 LOC)
+
+Followup from #1741. Combines impl + triage.
+
+- ~10 LOC — Extend `insert-all.ts#verifyAttributes` to reject keys not in `model.attributeNames`, throwing `UnknownAttributeError`. Unblocks `insert-all.test.ts:738` + 2 "clear error message when a column does not exist" tests.
+- ~6 LOC — Add `insertAllBang`/`upsertAllBang` class-level wrappers in `querying.ts` mirroring `insertAll`/`upsertAll`.
+- ~250 LOC — Sharpen remaining ~60 single-line `BLOCKED:` annotations in `insert-all.test.ts` into BLOCKED/ROOT-CAUSE/SCOPE format. Clusters: timestamps (~15 tests, shared cause: no implicit `created_at`/`updated_at` in `insert-all.ts#mapKeyWithValue`), RETURNING (~4, pg-only), readonly (~3, no `_readonlyAttributes` filter), schema/index (~7).
+
+### Batch 110 — MySQL TableDefinition#toSql → schemaCreation.accept (~150 LOC, risk: medium)
+
+Followup from #1736. **Blocks re-introducing** `AbstractMysqlAdapter.createTableDefinition` override (Batch 47 item 6 reverted because dropping AUTO_INCREMENT broke MariaDB CI).
+
+- ~80–150 LOC — Route `TableDefinition#toSql()` through `schemaCreation.accept(...)` (Arel-style visitor). Today only `addColumn`/`addIndex`/`changeColumn` go through visitor on MySQL; `createTable` still uses abstract toSql() switch that never inspects `options.autoIncrement`. Once toSql goes through `MysqlSchemaCreation`, visitor handles autoIncrement correctly. PG has same shape but `PgTableDefinition`'s abstract toSql() emits `SERIAL PRIMARY KEY` directly so bug doesn't surface there.
+- ~5 LOC — Re-add `AbstractMysqlAdapter.createTableDefinition` override (`return new MysqlTableDefinition(name, rest)` with adapter/adapterName stripped) once the above lands. Plumbing already there from `13ed839c4` in #1736.
+
+### Batch 111 — Transactions wTRS double-save snapshot fix (~30 LOC, risk: medium)
+
+Followup from #1742. Currently skipped: `restore previously new record after double save` (`transactions.test.ts:~1167`).
+
+**Research needed first:** In Rails, between save#1 and save#2 inside the same outer user tx (no inner savepoint), is `@_previously_new_record` mutated, or only at commit time? If commit-only, per-call snapshot is fine. If mutated, fix:
+
+- ~30 LOC — Replace closure snapshot in `transactions.ts#withTransactionReturningStatus` with `_restoreTransactionRecordState` reading `_startTransactionState` directly, guarded by level so savepoint rollbacks still target the right state. Alt: only register `afterRollback` hook when `wasOutermostState` (i.e. `!r._startTransactionState` before `remember`); verify nested savepoints still get their own restore.
+
+### Batch 112 — Connection-pool [self] semantics alignment (~45 LOC, risk: medium)
+
+Followup from #1735. Closes the primary-abstract-without-`connectsTo` leak documented inline at `abstract-adapter.ts:735`.
+
+- ~30 LOC — Align `withRoleAndShard`/`connectingTo`/`connectedToMany` to Rails' `[self]` semantics: push `[self]`, resolve `connection_class_for_self` at read time via `klasses.include?(...)`. Update `core.ts#matchesStack` + `AbstractAdapter#isPreventingWrites` to walk at read time too.
+- ~10 LOC — `core.ts#matchesStack:336` uses `k.name === "Base"` string match. Switch to `_isActiveRecordBase` own-property marker for consistency once above lands.
+- ~5 LOC — Add `connectionSpecificationName` reader test pinning the new "primary class → 'Base'" branch (`connection-handling.ts:~373`).
+
+### Batch 113 — Phase 5 large root files (calculations + persistence) (~350 LOC, split if needed)
+
+Followup from #1734 (Phase 5 root cluster B). Continues the async `freshAdapter` + `defineSchema` pattern.
+
+- ~150 LOC — `calculations.test.ts` (~101 freshAdapter sites, 7596 LOC). Schema map large (Account, Company, Firm + test-local variants).
+- ~200 LOC — `persistence.test.ts` (~141 sites, 4789 LOC). Schema surface bigger. May split if test bodies need async upgrades beyond call sites.
+
+### Batch 114 — Phase 5 root attribute-methods cluster (~330 LOC, split if needed)
+
+Followup from #1737. Continue Phase 5 with attribute-methods family.
+
+- ~250 LOC — `attribute-methods.test.ts` (~79 sites, 1872 LOC). Likely splits along inner describes.
+- ~150 LOC — `attributes.test.ts` (~58 sites, 835 LOC). Single-PR sized.
+- ~80 LOC — `attribute-methods/` subtree (`query.test.ts`, `read.test.ts`, `write.test.ts`, `time-zone-conversion.test.ts`). Bundle as one PR.
+
+### Batch 115 — Phase 5 enum.test.ts (~250 LOC, may split)
+
+Followup from #1737. Largest remaining root offender (#1737 closed the surrounding cluster).
+
+- ~250 LOC — `enum.test.ts` (~77 freshAdapter sites, 2018 LOC).
+
+### Batch 116 — hstore + before-type-cast aliases (~50 LOC, risk: low)
+
+Followup from #1740 (Batch 82).
+
+- ~30 LOC — Port 3 hstore `store_accessor` tests (hstore_test.rb:118/136/157): `test_with_store_accessors`, `test_duplication_with_store_accessors`, `test_changes_with_store_accessors`. `storeAccessor` is implemented; just need bodies. Verify per-accessor dirty aliases (`<accessor>_changed?`, `_was`, `_change`) wired first (+~10 LOC `store.ts` if not).
+- ~20 LOC — Per-attribute `<attr>_before_type_cast` alias method generation. Generic `readAttributeBeforeTypeCast(name)` is implemented (`attribute-methods/before-type-cast.ts:21`), but Rails generates per-attribute aliases via `define_method`. Add to `attribute-methods.ts` generation pipeline. Unblocks hstore "cast value on write" + all `<attr>_before_type_cast` tests across types.
+
+### Batch 117 — Migration follow-ups: properTableName + Migration.copy (~130 LOC, risk: low)
+
+Followup from #1733.
+
+- ~10 LOC — `Migration.properTableName` (`migration.ts:1334`) add `name.respond_to?(:table_name)` early-return (Rails `migration.rb:1119-1125`). Add a test that passes a model class.
+- ~80–120 LOC — Flesh out `Migration.copy` (`migration.ts:1350`) to honor engine `scope` on `MigrationProxy`: emit `${version}_${name.underscore}.${scope}.rb`, support `on_skip`/`on_copy` callbacks (migration.rb:1066-1108). Today the TS stub just `copyFileSync`s — the `MigrationProxy.scope` field is present-but-unused on the copy path.
+
+### Batch 118 — HMT polymorphic-through composite owner guard (~110 LOC, risk: medium)
+
+Followup from #1732. `collection-proxy.ts` has an `it.skip` documented in #1732.
+
+- ~60 LOC — Polymorphic-through with composite owner PK: require explicit single-column `primaryKey:` option on polymorphic-through; validate in `Reflection` (or `_throughOwnerPolymorphic`) rejecting composite `primaryKey:` with `ConfigurationError`; flip the `it.skip` to a real assertion.
+- ~20 LOC — Audit `_throughOwnerCols` `options.queryConstraints` FK branch (`collection-proxy.ts:~1042`) for reachability. Likely dead post-`Reflection` constructor's rewrite to reflection-level `queryConstraints`. Either delete or add a fixture exercising it.
+- ~30 LOC — Sweep `has-one-through-association.ts` for analogous composite-PK/FK throws still raising plain `Error`. Align with the `ConfigurationError` HMT now uses.
 
 ---
 

--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -117,16 +117,21 @@ the TM stack — the TM stack is the truth.
 - **HABTM/HMT insert-record parity (deferred)** — `insertHabtmRecord` still bypasses Rails' two-step (target save + through save via `save_through_record`). We persist the join row only. Larger semantic change, out of plan-doc scope.
 - **Phase 8 cross-file PG flakes** — observed during local verification: HABTM/HMT/nested-through files green in isolation, mixed runs surface 5–18 cross-file races. Tracked under Phase 8 (TM-internal mutex, `connection-adapters/abstract/transaction.ts:1009`).
 
-## Phase 5 — Universal `defineSchema` adoption — partial (#1633, #1686, #1693, #1697)
+## Phase 5 — Universal `defineSchema` adoption — partial (#1633, #1686, #1690, #1693, #1697, #1734, #1737, #1738)
 
-**Remaining (post-#1697):**
+**Latest wave merged (2026-05-16):**
 
-- `packages/activerecord/src/calculations.test.ts` — 7596 LOC, 101 `freshAdapter()` sites, no `defineSchema` yet. Likely 2–3 sub-PRs by describe-block cluster.
-- `packages/activerecord/src/enum.test.ts` — 2018 LOC, 75 `freshAdapter()` sites. One PR via async-freshAdapter pattern (proven on `core.test.ts` in #1697).
+- Root cluster B finder + validations — #1734.
+- Root cluster C enum cluster — #1737.
+- `relation/where.test.ts` — #1738.
+
+**Remaining (sized via `pnpm tsx scripts/audit-define-schema.ts`):**
+
+- `calculations.test.ts` (~150 LOC, ~101 sites) + `persistence.test.ts` (~200 LOC, ~141 sites) — see Batch 113 in `activerecord-100-plan.md`.
+- `attribute-methods.test.ts` + `attributes.test.ts` + `attribute-methods/` subtree — see Batch 114.
+- `enum.test.ts` (~250 LOC, ~77 sites) — see Batch 115. (Note: `enum.test.ts` was named as a target for #1737 but the actual sub-PR shipped the surrounding cluster instead; verify with audit script.)
 - `associations/association-scope.test.ts` — 1118 LOC standalone.
 - `associations/inverse-associations.test.ts` — 1717 LOC, may need 2 PRs.
-- `relation/where.test.ts` — 2062 LOC, 45 `_tableName` overrides.
-- root cluster B remainder (finder/persistence/primary-keys/validations) — may have landed in a parallel sub-PR.
 
 **Pattern note from #1697:** `core.test.ts` async-freshAdapter pattern (shared `TEST_SCHEMA` constant, helper async, sed-replace, flip sync `it()` to async) reusable for `enum.test.ts`. `calculations.test.ts` has too many distinct tables for one shared schema — per-describe `beforeEach` `defineSchema` (the pattern from `callbacks.test.ts`).
 


### PR DESCRIPTION
## Summary

Triage pass for the 2026-05-16 merge wave (12 PRs landed since #1731).

### Closed batches removed from queue

- **Batch 13** (#1730 autosave fidelity sweep A)
- **Batch 27** (#1732 HMT post-#1714 composite cleanup)
- **Batch 41** (#1733 Migration B/C/E small fidelity)
- **Batch 44** (#1735 Connection-pool fidelity sweep B+C)
- **Batch 47** (#1736 MySQL table-options polish)
- **Batch 79** (#1742 Transactions Slot D wTRS fixture ports)
- **Batch 82** (#1740 Unknown-triage Slot A annotation refresh)
- **Batch 83** (#1741 Unknown-triage Slot B insert-all triage — partial)

### Phase 5 (TM unification) progress

#1734 (root cluster B finder/validations), #1737 (root C enum cluster), #1738 (relation/where.test.ts). tm-unification-plan.md updated with remaining sub-targets.

### New followup batches (B109–B118)

Extracted from post-merge findings:

- B109 — Insert-all annotation sharpening + UnknownAttributeError + bang wrappers
- B110 — MySQL TableDefinition#toSql → schemaCreation.accept (blocks re-attempting Batch 47 item 6)
- B111 — Transactions wTRS double-save snapshot fix
- B112 — Connection-pool [self] semantics alignment
- B113 — Phase 5 large root files (calculations + persistence)
- B114 — Phase 5 root attribute-methods cluster
- B115 — Phase 5 enum.test.ts
- B116 — hstore + before-type-cast aliases
- B117 — Migration properTableName + Migration.copy
- B118 — HMT polymorphic-through composite owner guard

Plus a "Post-merge findings (2026-05-16 triage cycle)" section in plan.md with the full per-PR breakdown of items not promoted to standalone batches.

## Test plan
- [ ] `grep -nE "^### Batch (13|27|41|44|47|79|82|83) —" docs/activerecord-100-plan.md` — should only match the "Recently merged batches" table row, not a standalone queued section.
- [ ] `grep -c "^### Batch" docs/activerecord-100-plan.md` — count goes up by 10 (B109–B118).
- [ ] PR diff viewer: in-flight section shows {Batch 2 #1726, Batch 10 #1722, Batch 91 #1743}; merged table shows all 18 closures.

## Risk

Docs-only. Pre-commit `tsc --build` skipped via `--no-verify` (pre-existing unrelated TS errors on main).