### PR TITLE
test(activerecord): TM phase 5 — persistence.test.ts partial defineSchema migration

### DIFF
--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -18,6 +18,7 @@ import { Base, RecordNotFound } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -30,8 +31,12 @@ function freshAdapter(): DatabaseAdapter {
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      topics: { title: "string", body: "string", replies_count: "integer" },
+      minimals: { _: "string" },
+    });
   });
 
   it("create", async () => {
@@ -461,7 +466,14 @@ describe("PersistenceTest", () => {
 // More PersistenceTest
 // ==========================================================================
 describe("PersistenceTest", () => {
-  const adapter = freshAdapter();
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      topics: { title: "string", updated_at: "datetime" },
+      counters: { count: "integer" },
+    });
+  });
 
   it("raises error when validations failed", async () => {
     class Topic extends Base {
@@ -965,8 +977,12 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      default_records: { name: "string" },
+      posts: { title: "string", views: "integer", updated_at: "string" },
+    });
   });
 
   it("populates non primary key autoincremented column", () => {
@@ -2536,8 +2552,9 @@ describe("PersistenceTest", () => {
 
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("destroyBy destroys matching records with callbacks", async () => {
@@ -2576,8 +2593,9 @@ describe("PersistenceTest", () => {
 
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { status: "string" } });
   });
 
   it("updates all records", async () => {
@@ -2599,8 +2617,9 @@ describe("PersistenceTest", () => {
 
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("finds and updates a record by id", async () => {
@@ -2619,8 +2638,9 @@ describe("PersistenceTest", () => {
 
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { items: { name: "string" } });
   });
 
   it("destroys all records", async () => {
@@ -2775,8 +2795,9 @@ describe("PersistenceTest", () => {
 
 describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, { posts: { title: "string", views: "integer" } });
   });
 
   it("save valid record returns true", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -35,7 +35,7 @@ describe("PersistenceTest", () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       topics: { title: "string", body: "string", replies_count: "integer" },
-      minimals: { _: "string" },
+      minimals: {},
     });
   });
 
@@ -2797,7 +2797,11 @@ describe("PersistenceTest", () => {
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
     adapter = freshAdapter();
-    await defineSchema(adapter, { posts: { title: "string", views: "integer" } });
+    await defineSchema(adapter, {
+      posts: { title: "string", body: "string", views: "integer", published: "boolean" },
+      animals: { name: "string" },
+      dogs: { name: "string" },
+    });
   });
 
   it("save valid record returns true", async () => {


### PR DESCRIPTION
## Summary

Phase 5 of the TM unification plan (`docs/tm-unification-plan.md`):
migrate `persistence.test.ts` describes to the async-freshAdapter +
`defineSchema` pattern so the file runs cleanly under
`AR_NO_AUTO_SCHEMA=1`.

This PR covers **7 of the ~29 `PersistenceTest` describes** — the ones
whose schemas reduce cleanly to topics/posts/items/counters/default_records.

Migrated describes (by approx. starting line, post-edit):
- `describe @ 31` — Topic/Minimal (topics + minimals tables).
- `describe @ 468` — Topic/Counter; converted the buggy top-level
  `const adapter = freshAdapter()` into a per-test `let`+`beforeEach`.
- `describe @ 978` — DefaultRecord/Post stub cluster.
- `describe @ 2553`, `@ 2594`, `@ 2618`, `@ 2639` — the four `items`
  describes (destroyBy / deleteBy / updateAll / find-and-update /
  destroyAll).
- `describe @ 2796` — Post save/destroy/increment cluster.

## Remaining (follow-ups)

The rest of the file uses patterns that can't be migrated mechanically
inside the 300-LOC ceiling: per-test inline `freshAdapter()` /
`createTestAdapter()` calls (describes around lines 545, 725, 1144, 2358,
2453, 2662, 2682, 2724, 2744, 2777, 3393, 3501, 3557, 3662, 3866, 3911,
3995, 4115, 4197, plus the inline-`adp` blocks at the bottom). Several
also exercise STI (Animal/Dog), lock_version posts, order_items composite
PKs, query-constraints, and ts_posts/cb_posts/count_posts/timed_posts
with distinct schemas — these warrant their own PR(s) so each schema
choice is reviewable.

Each remaining describe takes ~5–8 LOC to migrate but the **schema
choices** (which columns each `class X extends Base` actually exercises)
are the part that needs reading. Sized as ~3 follow-up PRs of ~200 LOC
each.

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/persistence.test.ts -t <migrated-test>` passes on every migrated test (spot-checked one per describe).
- [x] `pnpm build` + typecheck pass via lint-staged hook.
- [ ] CI to confirm full file (migrated tests pass; non-migrated tests behave the same as on `main` — both with and without `AR_NO_AUTO_SCHEMA=1`).