### PR TITLE
test(activerecord): TM phase 5 — inverse-associations.test.ts defineSchema (describes 1-3)

### DIFF
--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { Base, association, registerModel, InverseOfAssociationNotFoundError } from "../index.js";
 import {
   Associations,
@@ -14,6 +14,8 @@ import {
 } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
@@ -23,8 +25,21 @@ function freshAdapter(): DatabaseAdapter {
 
 describe("InverseBelongsToTests", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      men: { name: "string" },
+      faces: { description: "string", man_id: "integer", human_id: "integer" },
+      authors: { name: "string" },
+      books: { title: "string", author_id: "integer" },
+      humen: { name: "string" },
+      interests: { topic: "string", human_id: "integer", man_id: "integer" },
+      nodes: { name: "string", node_id: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModels() {
@@ -378,8 +393,31 @@ describe("InverseBelongsToTests", () => {
 
 describe("InverseHasManyTests", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      men: { name: "string" },
+      interests: { topic: "string", man_id: "integer", human_id: "integer" },
+      humen: { name: "string" },
+      nodes: { name: "string", node_id: "integer" },
+      cpk_men: {
+        columns: {
+          region_id: "integer",
+          id: "integer",
+          name: "string",
+        },
+        primaryKey: ["region_id", "id"],
+      },
+      cpk_interests: {
+        cpk_man_region_id: "integer",
+        cpk_man_id: "integer",
+        topic: "string",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   function makeModels() {
@@ -571,7 +609,6 @@ describe("InverseHasManyTests", () => {
   });
 
   it("inverse should be set on composite primary key child", async () => {
-    const adapter = freshAdapter();
     class CpkMan extends Base {
       static {
         this._tableName = "cpk_men";
@@ -716,8 +753,17 @@ describe("InverseHasManyTests", () => {
 
 describe("InverseMultipleHasManyInversesForSameModel", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      men: { name: "string" },
+      interests: { topic: "string", man_id: "integer" },
+      hobbies: { name: "string", man_id: "integer" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("that we can load associations that have the same reciprocal name from different models", async () => {


### PR DESCRIPTION
## Summary

Migrates the first three describe blocks in
`packages/activerecord/src/associations/inverse-associations.test.ts` to the
per-describe `beforeEach` `defineSchema` pattern (the `calculations.test.ts`
approach), so `AR_NO_AUTO_SCHEMA=1` resolves the tables.

Per `docs/tm-unification-plan.md` Phase 5: `inverse-associations.test.ts` is
1764 LOC across 9 describes, too large for one shared `TEST_SCHEMA`, so
describe-scoped schemas are the migration unit. This PR covers:

- `InverseBelongsToTests` (357 LOC of source)
- `InverseHasManyTests` (336 LOC)
- `InverseMultipleHasManyInversesForSameModel` (63 LOC)

Also drops the inline `const adapter = freshAdapter()` shadow at line 574 in
the CPK test so it picks up the describe-scoped adapter + schema.

Note: Trails' inflector pluralizes `Human` → `humen` (the `man` → `men`
suffix rule fires), so the schema table is named `humen`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts` — 72 pass / 25 skipped (no regression in normal mode)
- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts -t "InverseBelongsToTests|InverseHasManyTests|InverseMultipleHasManyInversesForSameModel"` — 34 pass / 63 skipped
- [ ] CI green across all three adapters

## Follow-ups

6 more describes remain (~1050 LOC of source) — to be migrated in follow-up PRs:

- `AutomaticInverseFindingTests` (line 782, 420 LOC) — many tables: men, faces, interests, weird_faces, man_as, custom_faces, man_bs, works, bosses, cards, decks, chips, boards, ratings, comments, posts, taggables, taggable_parents, auto_poly_tags, auto_poly_posts
- `InversePolymorphicBelongsToTests` (line 1204, 155 LOC)
- `InverseCachedPathTests` (line 1361, 76 LOC)
- `InverseAssociationTests` (line 1439, 107 LOC)
- `inverse_of` (line 1548, 63 LOC)
- `InverseHasOneTests` (line 1613, ~150 LOC)