### PR TITLE
feat(actionpack): AbstractController collector port + MimeType.all()

### DIFF
--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -62,6 +62,24 @@ describe("AbstractController::Collector", () => {
     expect(() => c.thisIsNotAMime()).toThrow(/register it as a MIME type/);
   });
 
+  it("binds `this` inside custom() to the Proxy receiver, not the raw target", () => {
+    class ThisChecker extends Collector {
+      seenThis: unknown;
+      custom(_mime: MimeType): unknown {
+        this.seenThis = this;
+        return null;
+      }
+    }
+    const c = new ThisChecker() as ThisChecker & { html: () => unknown };
+    // Direct call → `this` is the proxy
+    c.custom(MimeType.HTML);
+    const viaDirect = c.seenThis;
+    c.seenThis = undefined;
+    // Per-MIME dispatch → `this` must be the same proxy
+    c.html();
+    expect(c.seenThis).toBe(viaDirect);
+  });
+
   it("is not assimilated by Promise.resolve (no synthesized `then`)", async () => {
     const c = new TestCollector();
     const resolved = await Promise.resolve(c);

--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -88,6 +88,25 @@ describe("AbstractController::Collector", () => {
     expect(resolved).toBe(c);
   });
 
+  it("JSON.stringify does not trip the unknown-format thrower (toJSON is inert)", () => {
+    const c = new TestCollector();
+    expect(() => JSON.stringify(c)).not.toThrow();
+  });
+
+  it("`has` returns false for reserved keys even when a MIME type collides", () => {
+    const c = new TestCollector();
+    // Register a MIME called `then` to simulate a collision. The
+    // unknown-format thrower would otherwise become reachable via
+    // `await collector`, and the `in` check would report true.
+    MimeType.register("application/then", "then");
+    try {
+      expect("then" in c).toBe(false);
+      expect((c as unknown as { then?: unknown }).then).toBeUndefined();
+    } finally {
+      MimeType.unregister("then");
+    }
+  });
+
   it("shadows real properties even when they hold undefined", () => {
     class WithUndef extends Collector {
       myFlag: string | undefined = undefined;

--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -29,8 +29,8 @@ describe("AbstractController::Collector", () => {
       latefmt?: (...args: unknown[]) => unknown;
     };
     expect(MimeType.lookup("latefmt")).toBeUndefined();
-    // No extension mapping — unregister() doesn't clean extensionMap, so
-    // leaving one behind leaks global MIME state across the test suite.
+    // Only the registry lookup matters for Collector dispatch; skip the
+    // extension mapping to keep this test focused.
     MimeType.register("application/latefmt", "latefmt");
     try {
       expect(c.latefmt!("ok")).toBe("dispatched:latefmt");

--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -93,6 +93,14 @@ describe("AbstractController::Collector", () => {
     expect(() => JSON.stringify(c)).not.toThrow();
   });
 
+  it("util.inspect / logging does not trip the unknown-format thrower", () => {
+    const c = new TestCollector();
+    // Node's util.inspect calls obj.inspect() when present. The Proxy
+    // must NOT synthesize a throwing function here.
+    expect((c as unknown as { inspect?: unknown }).inspect).toBeUndefined();
+    expect("inspect" in c).toBe(false);
+  });
+
   it("`has` returns false for reserved keys even when a MIME type collides", () => {
     const c = new TestCollector();
     // Register a MIME called `then` to simulate a collision. The

--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { MimeType } from "../action-dispatch/http/mime-type.js";
+import { Collector } from "./collector.js";
+
+class TestCollector extends Collector {
+  readonly calls: [string, unknown[]][] = [];
+  custom(mime: MimeType, ...args: unknown[]): unknown {
+    this.calls.push([mime.symbol, args]);
+    return `dispatched:${mime.symbol}`;
+  }
+}
+
+describe("AbstractController::Collector", () => {
+  it("dispatches per-MIME methods through custom()", () => {
+    const c = new TestCollector() as TestCollector & {
+      html: (...args: unknown[]) => unknown;
+      json: (...args: unknown[]) => unknown;
+    };
+    expect(c.html(1, 2)).toBe("dispatched:html");
+    expect(c.json("x")).toBe("dispatched:json");
+    expect(c.calls).toEqual([
+      ["html", [1, 2]],
+      ["json", ["x"]],
+    ]);
+  });
+
+  it("picks up MIME types registered AFTER construction", () => {
+    const c = new TestCollector() as TestCollector & {
+      latefmt?: (...args: unknown[]) => unknown;
+    };
+    expect(MimeType.lookup("latefmt")).toBeUndefined();
+    MimeType.register("application/latefmt", "latefmt", [], ["latefmt"]);
+    try {
+      expect(c.latefmt!("ok")).toBe("dispatched:latefmt");
+    } finally {
+      MimeType.unregister("latefmt");
+    }
+  });
+
+  it("preserves real subclass properties and methods", () => {
+    class WithState extends Collector {
+      counter = 0;
+      bump(): number {
+        return ++this.counter;
+      }
+      custom(_mime: MimeType): unknown {
+        return null;
+      }
+    }
+    const c = new WithState();
+    expect(c.bump()).toBe(1);
+    expect(c.bump()).toBe(2);
+    expect(c.counter).toBe(2);
+  });
+
+  it("throws a useful error for unknown MIME symbols", () => {
+    const c = new TestCollector() as TestCollector & {
+      thisIsNotAMime: () => unknown;
+    };
+    expect(() => c.thisIsNotAMime()).toThrow(/register it as a MIME type/);
+  });
+
+  it("has() responds true for both real props and registered MIME symbols", () => {
+    const c = new TestCollector();
+    expect("custom" in c).toBe(true);
+    expect("html" in c).toBe(true);
+    expect("bogusFormatXyz" in c).toBe(false);
+  });
+});

--- a/packages/actionpack/src/abstract-controller/collector.test.ts
+++ b/packages/actionpack/src/abstract-controller/collector.test.ts
@@ -29,7 +29,9 @@ describe("AbstractController::Collector", () => {
       latefmt?: (...args: unknown[]) => unknown;
     };
     expect(MimeType.lookup("latefmt")).toBeUndefined();
-    MimeType.register("application/latefmt", "latefmt", [], ["latefmt"]);
+    // No extension mapping — unregister() doesn't clean extensionMap, so
+    // leaving one behind leaks global MIME state across the test suite.
+    MimeType.register("application/latefmt", "latefmt");
     try {
       expect(c.latefmt!("ok")).toBe("dispatched:latefmt");
     } finally {
@@ -58,6 +60,27 @@ describe("AbstractController::Collector", () => {
       thisIsNotAMime: () => unknown;
     };
     expect(() => c.thisIsNotAMime()).toThrow(/register it as a MIME type/);
+  });
+
+  it("is not assimilated by Promise.resolve (no synthesized `then`)", async () => {
+    const c = new TestCollector();
+    const resolved = await Promise.resolve(c);
+    // If `then` were intercepted, Promise.resolve(c) would attempt to
+    // call it as a thenable and resolve to whatever value it produced.
+    expect(resolved).toBe(c);
+  });
+
+  it("shadows real properties even when they hold undefined", () => {
+    class WithUndef extends Collector {
+      myFlag: string | undefined = undefined;
+      custom(_mime: MimeType): unknown {
+        return null;
+      }
+    }
+    const c = new WithUndef();
+    // `myFlag` reads should return undefined, NOT a synthesized
+    // unknown-format thrower function.
+    expect(c.myFlag).toBeUndefined();
   });
 
   it("has() responds true for both real props and registered MIME symbols", () => {

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -26,9 +26,12 @@ export abstract class Collector {
   }
 }
 
-// Keys we must never intercept, or the Collector instance becomes
-// thenable and gets assimilated by Promise.resolve / `await`.
-const PROMISE_KEYS = new Set<string | symbol>(["then", "catch", "finally"]);
+// Keys we must never intercept. `then`/`catch`/`finally` would make
+// the instance look thenable (assimilated by Promise.resolve / await).
+// `toJSON` would be called by JSON.stringify; synthesizing a thrower
+// there breaks serialization. `Symbol.toPrimitive` and `toString` are
+// kept inert too so coercion never hits the unknown-format thrower.
+const RESERVED_KEYS = new Set<string | symbol>(["then", "catch", "finally", "toJSON"]);
 
 const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
   get(target, prop, receiver) {
@@ -37,7 +40,7 @@ const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
     // than the undefined check so a subclass `myProp = undefined` isn't
     // mistakenly routed through MIME dispatch.
     if (Reflect.has(target, prop)) return Reflect.get(target, prop, receiver);
-    if (PROMISE_KEYS.has(prop)) return undefined;
+    if (RESERVED_KEYS.has(prop)) return undefined;
     if (typeof prop !== "string") return undefined;
     const mime = MimeType.lookup(prop);
     if (mime) {
@@ -63,6 +66,10 @@ const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
 
   has(target, prop) {
     if (Reflect.has(target, prop)) return true;
+    // Keep `has` in lockstep with `get`: if get returns undefined for
+    // these keys, has must report false even when a MIME type is
+    // registered under a colliding symbol.
+    if (RESERVED_KEYS.has(prop)) return false;
     return typeof prop === "string" && MimeType.lookup(prop) !== undefined;
   },
 };

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -41,7 +41,15 @@ const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
     if (typeof prop !== "string") return undefined;
     const mime = MimeType.lookup(prop);
     if (mime) {
-      return (...args: unknown[]): unknown => target.custom(mime, ...args);
+      // Bind `this` inside custom() to the Proxy receiver, not the raw
+      // target — otherwise property access inside custom() would bypass
+      // this proxy and miss the MIME dispatch / shadowing rules. Mirrors
+      // how `format.html(...)` and `format.custom(...)` should resolve
+      // the same `this` for subclasses.
+      return (...args: unknown[]): unknown => {
+        const fn = Reflect.get(target, "custom", receiver) as Collector["custom"];
+        return fn.call(receiver, mime, ...args);
+      };
     }
     // Unknown format — mirror Rails' NoMethodError message so callers
     // who try `format.fakemime { … }` get a useful hint.

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -13,6 +13,15 @@ import { MimeType } from "../action-dispatch/http/mime-type.js";
  *
  * Subclasses must implement `custom(mime, …args)` and may declare
  * additional non-MIME methods normally.
+ *
+ * **Limitation — ECMAScript `#private` fields:** the constructor
+ * returns a Proxy, so `this` inside instance methods is the Proxy
+ * (intentional — lets `this.html()` inside `custom()` re-enter the
+ * MIME dispatch). ECMAScript private fields are looked up on the
+ * underlying object, not through a Proxy, so a subclass that uses
+ * `#state`-style fields will throw at runtime. Use a normal
+ * `private` TypeScript field or a `_` prefix instead — both are
+ * stored as regular own properties and traverse the Proxy correctly.
  */
 export abstract class Collector {
   /** Implemented by subclasses; invoked when a per-MIME method is called. */

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -1,0 +1,52 @@
+import { MimeType } from "../action-dispatch/http/mime-type.js";
+
+/**
+ * `AbstractController::Collector` — base class for objects that
+ * dispatch per-MIME-type method calls (e.g. `format.html { … }`,
+ * `format.json { … }`) to a single `custom(mime, …)` handler.
+ *
+ * In Rails this is a module that `class_eval`s a method per registered
+ * MIME and uses `method_missing` for newly-registered ones. JS has no
+ * `method_missing`; we use a `Proxy` so any property access for a
+ * registered MIME symbol auto-dispatches to `custom()`. The same Proxy
+ * also picks up MIME types registered after construction.
+ *
+ * Subclasses must implement `custom(mime, …args)` and may declare
+ * additional non-MIME methods normally.
+ */
+export abstract class Collector {
+  /** Implemented by subclasses; invoked when a per-MIME method is called. */
+  abstract custom(mime: MimeType, ...args: unknown[]): unknown;
+
+  constructor() {
+    // Return a Proxy of `this` so unknown gets resolve to a per-MIME
+    // function bound through `custom()`. Real properties on the subclass
+    // (`html`, `custom`, `_state`, etc.) shadow the Proxy fallback.
+    return new Proxy(this, COLLECTOR_HANDLER) as this;
+  }
+}
+
+const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
+  get(target, prop, receiver) {
+    const existing = Reflect.get(target, prop, receiver);
+    if (existing !== undefined) return existing;
+    if (typeof prop !== "string") return existing;
+    const mime = MimeType.lookup(prop);
+    if (mime) {
+      return (...args: unknown[]): unknown => target.custom(mime, ...args);
+    }
+    // Unknown format — mirror Rails' NoMethodError message so callers
+    // who try `format.fakemime { … }` get a useful hint.
+    return (): never => {
+      throw new TypeError(
+        `To respond to a custom format, register it as a MIME type first. ` +
+          `Unknown format: ${prop}`,
+      );
+    };
+  },
+
+  has(target, prop) {
+    if (Reflect.has(target, prop)) return true;
+    return typeof prop === "string" && MimeType.lookup(prop) !== undefined;
+  },
+};

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -31,7 +31,15 @@ export abstract class Collector {
 // `toJSON` would be called by JSON.stringify; synthesizing a thrower
 // there breaks serialization. `Symbol.toPrimitive` and `toString` are
 // kept inert too so coercion never hits the unknown-format thrower.
-const RESERVED_KEYS = new Set<string | symbol>(["then", "catch", "finally", "toJSON"]);
+const RESERVED_KEYS = new Set<string | symbol>([
+  "then",
+  "catch",
+  "finally",
+  "toJSON",
+  // Node's util.inspect / console.log call `obj.inspect()` when it
+  // exists. Synthesizing a thrower there breaks routine logging.
+  "inspect",
+]);
 
 const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
   get(target, prop, receiver) {

--- a/packages/actionpack/src/abstract-controller/collector.ts
+++ b/packages/actionpack/src/abstract-controller/collector.ts
@@ -26,11 +26,19 @@ export abstract class Collector {
   }
 }
 
+// Keys we must never intercept, or the Collector instance becomes
+// thenable and gets assimilated by Promise.resolve / `await`.
+const PROMISE_KEYS = new Set<string | symbol>(["then", "catch", "finally"]);
+
 const COLLECTOR_HANDLER: ProxyHandler<Collector> = {
   get(target, prop, receiver) {
-    const existing = Reflect.get(target, prop, receiver);
-    if (existing !== undefined) return existing;
-    if (typeof prop !== "string") return existing;
+    // Shadowing: any real own/inherited property — including ones that
+    // intentionally hold `undefined` — must win. Use Reflect.has rather
+    // than the undefined check so a subclass `myProp = undefined` isn't
+    // mistakenly routed through MIME dispatch.
+    if (Reflect.has(target, prop)) return Reflect.get(target, prop, receiver);
+    if (PROMISE_KEYS.has(prop)) return undefined;
+    if (typeof prop !== "string") return undefined;
     const mime = MimeType.lookup(prop);
     if (mime) {
       return (...args: unknown[]): unknown => target.custom(mime, ...args);

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -24,3 +24,4 @@ export {
   type AssetPathsHost,
 } from "./asset-paths.js";
 export { applyLogger, benchmark, type LoggerHost, type LoggerLike } from "./logger.js";
+export { Collector } from "./collector.js";

--- a/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
@@ -179,6 +179,13 @@ describe("MimeTypeTest", () => {
     expect(jsonIdx).toBeGreaterThan(htmlIdx);
   });
 
+  it("unregister sweeps extensionMap so lookupByExtension can't resolve a removed type", () => {
+    MimeType.register("application/ext-test", "exttest", [], ["exttest"]);
+    expect(MimeType.lookupByExtension("exttest")?.symbol).toBe("exttest");
+    MimeType.unregister("exttest");
+    expect(MimeType.lookupByExtension("exttest")).toBeUndefined();
+  });
+
   it("unregister sweeps aliases too — type is no longer reachable via any key", () => {
     MimeType.register("application/aliased", "aliased");
     MimeType.registerAlias("aliased", "aliased_alias");

--- a/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
@@ -179,6 +179,16 @@ describe("MimeTypeTest", () => {
     expect(jsonIdx).toBeGreaterThan(htmlIdx);
   });
 
+  it("unregister sweeps aliases too — type is no longer reachable via any key", () => {
+    MimeType.register("application/aliased", "aliased");
+    MimeType.registerAlias("aliased", "aliased_alias");
+    expect(MimeType.lookup("aliased_alias")?.symbol).toBe("aliased");
+    MimeType.unregister("aliased");
+    expect(MimeType.lookup("aliased")).toBeUndefined();
+    expect(MimeType.lookup("aliased_alias")).toBeUndefined();
+    expect(MimeType.lookup("application/aliased")).toBeUndefined();
+  });
+
   it("all() picks up a newly registered type and drops it on unregister", () => {
     const before = MimeType.all().length;
     MimeType.register("application/all-test", "alltest");

--- a/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
@@ -168,4 +168,27 @@ describe("MimeTypeTest", () => {
     expect(MimeType.HTML.match("text/*")).toBe(true);
     expect(MimeType.HTML.match("application/*")).toBe(false);
   });
+
+  it("all() returns unique registered types in registration order", () => {
+    const all = MimeType.all();
+    expect(new Set(all).size).toBe(all.length);
+    // HTML is registered first (see static initializers), JSON after.
+    const htmlIdx = all.indexOf(MimeType.HTML);
+    const jsonIdx = all.indexOf(MimeType.JSON);
+    expect(htmlIdx).toBeGreaterThanOrEqual(0);
+    expect(jsonIdx).toBeGreaterThan(htmlIdx);
+  });
+
+  it("all() picks up a newly registered type and drops it on unregister", () => {
+    const before = MimeType.all().length;
+    MimeType.register("application/all-test", "alltest");
+    try {
+      const fresh = MimeType.all();
+      expect(fresh.length).toBe(before + 1);
+      expect(fresh.map((t) => t.symbol)).toContain("alltest");
+    } finally {
+      MimeType.unregister("alltest");
+    }
+    expect(MimeType.all().length).toBe(before);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -76,12 +76,18 @@ export class MimeType {
   static unregister(symbol: string): void {
     const type = MimeType.registry.get(symbol);
     if (!type) return;
-    // Sweep every entry whose value is this type — captures the
-    // symbol, string, synonyms, AND any aliases added later via
+    // Sweep every registry entry whose value is this type — captures
+    // the symbol, string, synonyms, AND any aliases added later via
     // registerAlias(). Avoids partial removals where lookup() still
     // resolves the type through a stale alias key.
     for (const [key, value] of MimeType.registry) {
       if (value === type) MimeType.registry.delete(key);
+    }
+    // Same sweep for extensionMap — register() can install extension
+    // mappings, and leaving them behind would let lookupByExtension()
+    // resolve an unregistered type.
+    for (const [ext, value] of MimeType.extensionMap) {
+      if (value === type) MimeType.extensionMap.delete(ext);
     }
   }
 

--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -75,12 +75,13 @@ export class MimeType {
 
   static unregister(symbol: string): void {
     const type = MimeType.registry.get(symbol);
-    if (type) {
-      MimeType.registry.delete(symbol);
-      MimeType.registry.delete(type.string);
-      for (const syn of type.synonyms) {
-        MimeType.registry.delete(syn);
-      }
+    if (!type) return;
+    // Sweep every entry whose value is this type — captures the
+    // symbol, string, synonyms, AND any aliases added later via
+    // registerAlias(). Avoids partial removals where lookup() still
+    // resolves the type through a stale alias key.
+    for (const [key, value] of MimeType.registry) {
+      if (value === type) MimeType.registry.delete(key);
     }
   }
 

--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -92,6 +92,22 @@ export class MimeType {
     return MimeType.extensionMap.get(ext.replace(/^\./, ""));
   }
 
+  /**
+   * All registered MIME types, deduplicated. Mirrors Rails `Mime::SET`.
+   * Iteration order follows registration order (Map preserves it).
+   */
+  static all(): MimeType[] {
+    const seen = new Set<MimeType>();
+    const out: MimeType[] = [];
+    for (const type of MimeType.registry.values()) {
+      if (!seen.has(type)) {
+        seen.add(type);
+        out.push(type);
+      }
+    }
+    return out;
+  }
+
   static onRegister(callback: (type: MimeType) => void): void {
     MimeType.callbacks.push(callback);
   }


### PR DESCRIPTION
## Summary
- **`abstract-controller/collector.ts`** — `Collector` base class for per-MIME method dispatch. Subclasses implement `custom(mime, ...args)` and inherit dynamic methods for every registered MIME via a Proxy that intercepts unknown gets and resolves them through `MimeType.lookup`. Newly-registered MIME types automatically become callable on existing instances.
- **`mime-type.ts`** — adds `MimeType.all()` returning unique registered types (Rails `Mime::SET`).

The Proxy approach mirrors Rails' `method_missing` + `generate_method_for_mime` trick without `class_eval`-style codegen.

## Why a Proxy
Rails generates a `def html(...); custom(Mime[:html], ...); end` method per registered MIME via `class_eval`, plus a `method_missing` fallback for types registered later. JS has no `method_missing`; a Proxy is the closest analog — it intercepts unknown property access at runtime and lets us synthesize the per-MIME function lazily, including for types registered after the Collector instance was constructed.

## Out of scope
- `actiondispatch/respond-to.ts` already exposes its own `Collector` class with explicit `html`/`json`/etc methods. Unifying the two (probably by having the dispatch Collector extend this one) is a future PR.

## `abstract_controller/` status after this PR
| Rails file       | LOC | Status         |
| ---------------- | --- | -------------- |
| `base.rb`        | 299 | ✅             |
| `callbacks.rb`   | 265 | ✅             |
| `error.rb`       | 8   | ✅             |
| `translation.rb` | 42  | ✅ (#1739)     |
| `deprecator.rb`  | 9   | ✅ (#1739)     |
| `asset_paths.rb` | 14  | ✅ (#1744)     |
| `logger.rb`      | 16  | ✅ (#1744)     |
| `collector.rb`   | 44  | **this PR**    |
| `caching.rb`+dir | 68+ | not ported     |
| `helpers.rb`     | 245 | not ported     |
| `rendering.rb`   | 125 | not ported     |
| `url_for.rb`     | 37  | not ported     |
| `railties/`      | -   | (trailtie)     |

## Test plan
- [x] 5 new Collector tests pass (dispatch, late-registered MIME, real-property preservation, unknown-format error, `has()` semantics)
- [x] All 2101 actionpack tests pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean