### PR TITLE
test(activerecord): TM phase 5 — defineSchema for cache-key + autosave

### DIFF
--- a/packages/activerecord/src/autosave.test.ts
+++ b/packages/activerecord/src/autosave.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
   markForDestruction,
@@ -13,8 +14,24 @@ import {
 } from "./autosave-association.js";
 import { Associations } from "./associations.js";
 
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+const TEST_SCHEMA = {
+  posts: { title: "string", author_id: "integer" },
+  authors: { name: "string" },
+  books: { title: "string", author_id: "integer" },
+  companies: { name: "string" },
+  accounts: { credit_limit: "integer", company_id: "integer" },
+  strict_accounts: { credit_limit: "integer", company_id: "integer" },
+  employees: { name: "string", company_id: "integer" },
+  ships: { name: "string" },
+  parts: { name: "string", ship_id: "integer" },
+  pirates: { catchphrase: "string" },
+  pirate_ships: { name: "string", pirate_id: "integer" },
+} as const;
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 // ==========================================================================
@@ -24,8 +41,8 @@ function freshAdapter(): DatabaseAdapter {
 describe("TestAutosaveAssociationsInGeneral", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("markForDestruction and isMarkedForDestruction", () => {
@@ -152,8 +169,8 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     Company.adapter = adapter;
     Account.adapter = adapter;
     registerModel("Company", Company);
@@ -245,8 +262,8 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     Post.adapter = adapter;
     Author.adapter = adapter;
     registerModel("Post", Post);
@@ -318,8 +335,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     Company.adapter = adapter;
     Employee.adapter = adapter;
     registerModel("Company", Company);
@@ -401,8 +418,8 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     Ship.adapter = adapter;
     Part.adapter = adapter;
     registerModel("Ship", Ship);

--- a/packages/activerecord/src/cache-key.test.ts
+++ b/packages/activerecord/src/cache-key.test.ts
@@ -8,11 +8,25 @@ import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Base } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+const TEST_SCHEMA = {
+  posts: {
+    title: "string",
+    updated_at: "datetime",
+  },
+  users: {
+    name: "string",
+    updated_at: "datetime",
+  },
+} as const;
+
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 // ==========================================================================
@@ -21,8 +35,8 @@ function freshAdapter(): DatabaseAdapter {
 describe("CacheKeyTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("cache_key format is not too precise", async () => {
@@ -126,7 +140,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version is only there when versioning is on", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -142,7 +156,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version is the same when it comes from the DB or from the user", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -164,7 +178,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version does NOT call updated_at when value is from the database", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -182,7 +196,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version does call updated_at when it is assigned via a Time object", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -200,7 +214,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version does call updated_at when it is assigned via a string", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -215,8 +229,8 @@ describe("CacheKeyTest", () => {
     expect(version).toBe("20250101000000000000");
   });
 
-  it("cache_version does call updated_at when it is assigned via a hash", () => {
-    const adapter = freshAdapter();
+  it("cache_version does call updated_at when it is assigned via a hash", async () => {
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -231,8 +245,8 @@ describe("CacheKeyTest", () => {
     expect(typeof version).toBe("string");
   });
 
-  it("updated_at on class but not on instance raises an error", () => {
-    const adapter = freshAdapter();
+  it("updated_at on class but not on instance raises an error", async () => {
+    const adapter = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -244,19 +258,20 @@ describe("CacheKeyTest", () => {
     expect(version).toBeNull();
   });
 
-  it("cache key format for new records", () => {
+  it("cache key format for new records", async () => {
+    const adp = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = freshAdapter();
       }
     }
+    Post.adapter = adp;
     const p = new Post({ title: "new" });
     expect(p.cacheKey()).toBe("posts/new");
   });
 
   it("cache key for timestamp", async () => {
-    const a = freshAdapter();
+    const a = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -271,19 +286,20 @@ describe("CacheKeyTest", () => {
     expect(key).toBe(`posts/${p.id}-20230615120000000000`);
   });
 
-  it("cache version for new records", () => {
+  it("cache version for new records", async () => {
+    const adp = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = freshAdapter();
       }
     }
+    Post.adapter = adp;
     const p = new Post({ title: "new" });
     expect(p.cacheVersion()).toBeNull();
   });
 
   it("cache_key has no version when versioning is on", async () => {
-    const a = freshAdapter();
+    const a = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -299,7 +315,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version does not truncate zeros when timestamp ends in zeros", async () => {
-    const a = freshAdapter();
+    const a = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -315,7 +331,7 @@ describe("CacheKeyTest", () => {
   });
 
   it("cache_version calls updated_at when the value is generated at create time", async () => {
-    const a = freshAdapter();
+    const a = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -335,8 +351,8 @@ describe("CacheKeyTest", () => {
 });
 
 describe("cacheKey / cacheKeyWithVersion", () => {
-  it("returns model/new for new records", () => {
-    const adapter = freshAdapter();
+  it("returns model/new for new records", async () => {
+    const adapter = await freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -349,7 +365,7 @@ describe("cacheKey / cacheKeyWithVersion", () => {
   });
 
   it("returns model/id for persisted records", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -362,7 +378,7 @@ describe("cacheKey / cacheKeyWithVersion", () => {
   });
 
   it("cacheKeyWithVersion includes updated_at", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -377,7 +393,7 @@ describe("cacheKey / cacheKeyWithVersion", () => {
   });
 
   it("cacheVersion returns timestamp string", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5. Migrates two root activerecord test files
to async \`freshAdapter()\` + \`defineSchema()\` so they pass under
\`AR_NO_AUTO_SCHEMA=1\`:

- **\`cache-key.test.ts\`** — \`posts\` (title, updated_at) + \`users\`
  (name, updated_at). 30 tests pass.
- **\`autosave.test.ts\`** — 11 tables for the association-heavy
  describes: posts, authors, books, companies, accounts, strict_accounts,
  employees, ships, parts, pirates, pirate_ships. 19 tests pass.

## Out of scope (follow-ups)

The brief grouped 5 files; status of the other three:

- **\`annotate.test.ts\`** — already green under \`AR_NO_AUTO_SCHEMA=1\`
  (only calls \`toSql()\`, no DB writes). The audit lists it because no
  \`defineSchema\` is present, but no migration is needed. Could be marked
  with a no-op call or simply removed from the offender list.
- **\`batches.test.ts\`** (2083 LOC, 90 failing under
  \`AR_NO_AUTO_SCHEMA=1\`) — needs its own PR; schema enumeration alone
  exceeds the 300-LOC ceiling.
- **\`counter-cache.test.ts\`** (2208 LOC, 85 failing) — same, separate PR.

## Verification

- \`AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/cache-key.test.ts\`: 30 passed
- \`AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/autosave.test.ts\`: 19 passed
- Normal mode: 49/49 across both files
- Diff: 2 files, +71 / −38

## Test plan

- [x] \`AR_NO_AUTO_SCHEMA=1\` green on both files
- [x] Normal mode green
- [ ] CI green across PG / MySQL / SQLite