### PR TITLE
feat(actionpack): Metal responseBody= + isPerformed (metal.rb 84%→95%)

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -207,12 +207,12 @@ export class AbstractController {
     const executeAction = async (): Promise<void> => {
       // Run before callbacks
       for (const entry of befores) {
-        if (this._performed) return;
+        if (this.performed) return;
         const result = await (entry.callback as ActionCallback)(this);
         if (result === false) return; // Halt chain
       }
 
-      if (this._performed) return;
+      if (this.performed) return;
 
       // Execute the action (only if it's a recognized action method)
       if (Constructor.hasAction(action)) {
@@ -246,9 +246,15 @@ export class AbstractController {
     await chain();
   }
 
-  /** Whether a render or redirect has been performed. */
+  /**
+   * Whether a render or redirect has been performed. Mirrors Rails'
+   * `AbstractController::Base#performed?` which is defined as
+   * `response_body` — i.e. truthy iff the response body has been
+   * assigned. The `_performed` flag is also honored so internal helpers
+   * (e.g. `head`) can mark performed without assigning a body.
+   */
   get performed(): boolean {
-    return this._performed;
+    return this._performed || this._responseBody !== null;
   }
 
   /** Mark the response as performed. */

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -26,8 +26,17 @@ export class AbstractController {
   /** The action currently being processed. */
   actionName: string = "";
 
+  /** Internal storage for response body. Subclasses may override the
+   * `responseBody` accessor (e.g. Metal writes through to the response). */
+  protected _responseBody: string | Buffer | null = null;
+
   /** Response body. */
-  responseBody: string | Buffer | null = null;
+  get responseBody(): string | Buffer | null {
+    return this._responseBody;
+  }
+  set responseBody(value: string | Buffer | null) {
+    this._responseBody = value;
+  }
 
   /** Whether a response has been committed (render/redirect called). */
   private _performed: boolean = false;

--- a/packages/actionpack/src/action-controller/controller/metal.test.ts
+++ b/packages/actionpack/src/action-controller/controller/metal.test.ts
@@ -260,11 +260,13 @@ describe("MetalControllerInstanceTests", () => {
     expect(c.responseBody).toBe("");
   });
 
-  it("isPerformed reflects body presence", () => {
+  it("isPerformed mirrors performed and reflects responseBody=", () => {
     const c = new (class extends Metal {})();
     expect(c.isPerformed()).toBe(false);
-    c.body = "x";
+    c.response = makeResponse();
+    c.responseBody = "x";
     expect(c.isPerformed()).toBe(true);
+    expect(c.performed).toBe(true);
   });
 
   it("callbacks work through dispatch", async () => {

--- a/packages/actionpack/src/action-controller/controller/metal.test.ts
+++ b/packages/actionpack/src/action-controller/controller/metal.test.ts
@@ -236,6 +236,37 @@ describe("MetalControllerInstanceTests", () => {
     }
   });
 
+  it("responseBody= writes through to response and marks performed", () => {
+    const c = new (class extends Metal {})();
+    c.response = makeResponse();
+    c.responseBody = "hello";
+    expect(c.responseBody).toBe("hello");
+    expect(c.response.body).toBe("hello");
+    expect(c.isPerformed()).toBe(true);
+  });
+
+  it("responseBody= accepts array form", () => {
+    const c = new (class extends Metal {})();
+    c.response = makeResponse();
+    c.responseBody = ["a", "b"];
+    expect(c.responseBody).toBe("ab");
+  });
+
+  it("responseBody= with null resets body", () => {
+    const c = new (class extends Metal {})();
+    c.response = makeResponse();
+    c.responseBody = "hi";
+    c.responseBody = null;
+    expect(c.responseBody).toBe("");
+  });
+
+  it("isPerformed reflects body presence", () => {
+    const c = new (class extends Metal {})();
+    expect(c.isPerformed()).toBe(false);
+    c.body = "x";
+    expect(c.isPerformed()).toBe(true);
+  });
+
   it("callbacks work through dispatch", async () => {
     const log: string[] = [];
     class CallbackController extends Metal {

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -234,6 +234,41 @@ export class Metal extends AbstractController {
     return this._body;
   }
 
+  /**
+   * Public Rails-style setter that writes through to the underlying
+   * response and marks the controller as performed. Mirrors
+   * `ActionController::Metal#response_body=`.
+   */
+  set responseBody(body: string | string[] | Buffer | null | undefined) {
+    if (body === null || body === undefined) {
+      this._body = "";
+      this._responseBody = null;
+      if (this.response) this.response.body = "";
+      return;
+    }
+    const str = Array.isArray(body)
+      ? body.join("")
+      : Buffer.isBuffer(body)
+        ? body.toString()
+        : body;
+    this._body = str;
+    this._responseBody = str;
+    if (this.response) this.response.body = str;
+    this.markPerformed();
+  }
+
+  override get responseBody(): string {
+    return this._body;
+  }
+
+  /**
+   * Tests if render or redirect has already happened. Mirrors
+   * `ActionController::Metal#performed?`.
+   */
+  isPerformed(): boolean {
+    return Boolean(this._body) || (this.response?.committed ?? false);
+  }
+
   /** Convert controller to a Rack-compatible response. */
   toRackResponse(): RackResponse {
     const headers = { ...this._headers };

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -241,8 +241,10 @@ export class Metal extends AbstractController {
    */
   set responseBody(body: string | string[] | Buffer | null | undefined) {
     if (body === null || body === undefined) {
+      // Mirror Rails' `else: response.reset_body!` — only the response
+      // stream is reset; `@_response_body` is left untouched, so a
+      // controller that previously assigned a body remains "performed?".
       this._body = "";
-      this._responseBody = null;
       if (this.response) this.response.body = "";
       return;
     }
@@ -266,9 +268,7 @@ export class Metal extends AbstractController {
    * `response_body || response.committed?`.
    */
   isPerformed(): boolean {
-    return (
-      this._responseBody !== null || Boolean(this._body) || (this.response?.committed ?? false)
-    );
+    return this.performed || (this.response?.committed ?? false);
   }
 
   /** Convert controller to a Rack-compatible response. */

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -236,8 +236,8 @@ export class Metal extends AbstractController {
 
   /**
    * Public Rails-style setter that writes through to the underlying
-   * response and marks the controller as performed. Mirrors
-   * `ActionController::Metal#response_body=`.
+   * response. Mirrors `ActionController::Metal#response_body=`. After
+   * assignment, `isPerformed()` returns true.
    */
   set responseBody(body: string | string[] | Buffer | null | undefined) {
     if (body === null || body === undefined) {
@@ -254,7 +254,6 @@ export class Metal extends AbstractController {
     this._body = str;
     this._responseBody = str;
     if (this.response) this.response.body = str;
-    this.markPerformed();
   }
 
   override get responseBody(): string {
@@ -263,10 +262,13 @@ export class Metal extends AbstractController {
 
   /**
    * Tests if render or redirect has already happened. Mirrors
-   * `ActionController::Metal#performed?`.
+   * `ActionController::Metal#performed?` which returns
+   * `response_body || response.committed?`.
    */
   isPerformed(): boolean {
-    return Boolean(this._body) || (this.response?.committed ?? false);
+    return (
+      this._responseBody !== null || Boolean(this._body) || (this.response?.committed ?? false)
+    );
   }
 
   /** Convert controller to a Rack-compatible response. */


### PR DESCRIPTION
## Summary

Closes 2 of 3 api:compare gaps on `actionpack/metal.rb` (84% → 95%, 18/19):

- `response_body=` → `responseBody` setter on `Metal` that writes through to the underlying response, mirroring Rails' `ActionController::Metal#response_body=`. Handles `string`, `string[]`, `Buffer`, and `null`/`undefined` (reset). Marks the controller performed.
- `performed?` → `isPerformed()` returns `true` when the body has been set or the response has been committed.

To allow the Metal subclass to override the inherited accessor, `AbstractController.responseBody` becomes a getter/setter pair backed by `_responseBody` (the previous plain field initializer was shadowing prototype accessors on instances).

## Remaining gap

`build_middleware` (private `MiddlewareStack` helper for `only`/`except` action filtering) — deferred; porting it cleanly requires extending `Middleware` to carry action filters and a `valid?(action)` dispatch.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/metal.test.ts` — 29 passed (4 new for `responseBody=` / `isPerformed`)
- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/ packages/actionpack/src/abstract-controller/` — 807 passed
- [x] `pnpm --filter actionpack exec tsc --noEmit` — clean
- [x] `pnpm api:compare --package actioncontroller` — `metal.rb` 84% → 95%