### PR TITLE
feat(activerecord): migration Slot F invertibility (batch 40)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
@@ -2,14 +2,35 @@
  * Mirrors Rails activerecord/test/cases/migration_test.rb
  * BulkAlterTableMigrationsTest — MySQL/Trilogy-only cases.
  */
-import { describe, it } from "vitest";
-import { describeIfMysql } from "./test-helper.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 
 describeIfMysql("Migration", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(async () => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    await adapter.exec("DROP TABLE IF EXISTS delete_me");
+    await adapter.exec("CREATE TABLE delete_me (id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id))");
+  });
+  afterEach(async () => {
+    await adapter.exec("DROP TABLE IF EXISTS delete_me");
+    await adapter.close();
+  });
+
   describe("BulkAlterTableMigrationsTest", () => {
-    it.skip("updating auto increment", () => {
-      // BLOCKED: AUTO_INCREMENT introspection — Column#autoIncrement? not
-      // wired through Mysql2Adapter#newColumnFromField yet.
+    it("updating auto increment", async () => {
+      const ss = adapter.schemaStatements();
+      await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("id", "bigint", { autoIncrement: true });
+      });
+      let cols = await adapter.columns("delete_me");
+      expect((cols.find((c) => c.name === "id") as any).autoIncrement).toBe(true);
+
+      await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("id", "bigint", { autoIncrement: false });
+      });
+      cols = await adapter.columns("delete_me");
+      expect((cols.find((c) => c.name === "id") as any).autoIncrement).toBeFalsy();
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
@@ -19,18 +19,27 @@ describeIfMysql("Migration", () => {
 
   describe("BulkAlterTableMigrationsTest", () => {
     it("updating auto increment", async () => {
+      // Query EXTRA directly from information_schema — Mysql2Adapter#columns
+      // doesn't surface auto_increment metadata on Column yet (separate gap).
+      const isAutoIncrement = async (): Promise<boolean> => {
+        const rows = (await adapter.execute(
+          `SELECT EXTRA FROM information_schema.columns
+             WHERE table_schema = DATABASE() AND table_name = 'delete_me' AND column_name = 'id'`,
+        )) as Array<{ EXTRA?: string; extra?: string }>;
+        const extra = String(rows[0]?.EXTRA ?? rows[0]?.extra ?? "").toLowerCase();
+        return extra.includes("auto_increment");
+      };
+
       const ss = adapter.schemaStatements();
       await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("id", "bigint", { autoIncrement: true });
       });
-      let cols = await adapter.columns("delete_me");
-      expect((cols.find((c) => c.name === "id") as any).autoIncrement).toBe(true);
+      expect(await isAutoIncrement()).toBe(true);
 
       await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("id", "bigint", { autoIncrement: false });
       });
-      cols = await adapter.columns("delete_me");
-      expect((cols.find((c) => c.name === "id") as any).autoIncrement).toBeFalsy();
+      expect(await isAutoIncrement()).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
@@ -1,0 +1,15 @@
+/**
+ * Mirrors Rails activerecord/test/cases/migration_test.rb
+ * BulkAlterTableMigrationsTest — MySQL/Trilogy-only cases.
+ */
+import { describe, it } from "vitest";
+import { describeIfMysql } from "./test-helper.js";
+
+describeIfMysql("Migration", () => {
+  describe("BulkAlterTableMigrationsTest", () => {
+    it.skip("updating auto increment", () => {
+      // BLOCKED: AUTO_INCREMENT introspection — Column#autoIncrement? not
+      // wired through Mysql2Adapter#newColumnFromField yet.
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -14,10 +14,12 @@ describeIfPg("Migration", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec("DROP TABLE IF EXISTS strings");
+    await adapter.exec("DROP TABLE IF EXISTS delete_me");
     await adapter.exec(`CREATE TABLE strings (id serial primary key, somedate character varying)`);
   });
   afterEach(async () => {
     await adapter.exec("DROP TABLE IF EXISTS strings");
+    await adapter.exec("DROP TABLE IF EXISTS delete_me");
     await adapter.close();
   });
 
@@ -154,7 +156,6 @@ describeIfPg("Migration", () => {
     // PG-only because they exercise ALTER COLUMN TYPE / DEFAULT functions
     // that aren't supported by SQLite.
     it("changing columns", async () => {
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
       await adapter.exec(
         `CREATE TABLE delete_me (id serial primary key, name varchar, birthdate date)`,
       );
@@ -168,11 +169,9 @@ describeIfPg("Migration", () => {
       const birthdate = cols.find((c) => c.name === "birthdate")!;
       expect(String(name.default)).toBe("NONAME");
       expect(birthdate.type).toBe("datetime");
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
     });
 
     it("changing column null with default", async () => {
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
       await adapter.exec(
         `CREATE TABLE delete_me (id serial primary key, name varchar, age integer, birthdate date)`,
       );
@@ -186,11 +185,9 @@ describeIfPg("Migration", () => {
       expect(String(cols.find((c) => c.name === "name")!.default)).toBe("NONAME");
       expect(cols.find((c) => c.name === "birthdate")!.type).toBe("datetime");
       expect(cols.find((c) => c.name === "age")!.null).toBe(false);
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
     });
 
     it("default functions on columns", async () => {
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
       await adapter.exec(`CREATE TABLE delete_me (id serial primary key)`);
       const ss = adapter.schemaStatements();
       await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
@@ -200,7 +197,6 @@ describeIfPg("Migration", () => {
       const name = cols.find((c) => c.name === "name")!;
       expect(name.default).toBeNull();
       expect((name as any).defaultFunction).toBe("gen_random_uuid()");
-      await adapter.exec("DROP TABLE IF EXISTS delete_me");
     });
 
     it("change type with array", async () => {

--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -150,6 +150,59 @@ describeIfPg("Migration", () => {
       });
     });
 
+    // Bulk-alter tests moved from migration.test.ts BulkAlterTableMigrationsTest.
+    // PG-only because they exercise ALTER COLUMN TYPE / DEFAULT functions
+    // that aren't supported by SQLite.
+    it("changing columns", async () => {
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+      await adapter.exec(
+        `CREATE TABLE delete_me (id serial primary key, name varchar, birthdate date)`,
+      );
+      const ss = adapter.schemaStatements();
+      await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("name", "string", { default: "NONAME" });
+        t.change("birthdate", "datetime", { comment: "This is a comment" });
+      });
+      const cols = await adapter.columns("delete_me");
+      const name = cols.find((c) => c.name === "name")!;
+      const birthdate = cols.find((c) => c.name === "birthdate")!;
+      expect(String(name.default)).toBe("NONAME");
+      expect(birthdate.type).toBe("datetime");
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+    });
+
+    it("changing column null with default", async () => {
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+      await adapter.exec(
+        `CREATE TABLE delete_me (id serial primary key, name varchar, age integer, birthdate date)`,
+      );
+      const ss = adapter.schemaStatements();
+      await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("name", "string", { default: "NONAME" });
+        t.change("birthdate", "datetime");
+        t.changeNull("age", false, 0);
+      });
+      const cols = await adapter.columns("delete_me");
+      expect(String(cols.find((c) => c.name === "name")!.default)).toBe("NONAME");
+      expect(cols.find((c) => c.name === "birthdate")!.type).toBe("datetime");
+      expect(cols.find((c) => c.name === "age")!.null).toBe(false);
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+    });
+
+    it("default functions on columns", async () => {
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+      await adapter.exec(`CREATE TABLE delete_me (id serial primary key)`);
+      const ss = adapter.schemaStatements();
+      await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.string("name", { default: () => "gen_random_uuid()" });
+      });
+      const cols = await adapter.columns("delete_me");
+      const name = cols.find((c) => c.name === "name")!;
+      expect(name.default).toBeNull();
+      expect((name as any).defaultFunction).toBe("gen_random_uuid()");
+      await adapter.exec("DROP TABLE IF EXISTS delete_me");
+    });
+
     it("change type with array", async () => {
       await adapter.changeColumn("strings", "somedate", "timestamp", {
         array: true,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -694,18 +694,43 @@ export class SchemaStatements {
     return `index_${tableName}_on_${cols.join("_and_")}`;
   }
 
-  async removeColumns(tableName: string, ...columns: string[]): Promise<void> {
+  async removeColumns(tableName: string, ...columns: string[]): Promise<void>;
+  async removeColumns(
+    tableName: string,
+    ...args: [...string[], { type?: ColumnType; ifExists?: boolean }]
+  ): Promise<void>;
+  async removeColumns(
+    tableName: string,
+    ...columnsOrOptions: Array<string | ({ type?: ColumnType } & Record<string, unknown>)>
+  ): Promise<void> {
+    const last = columnsOrOptions[columnsOrOptions.length - 1];
+    const hasOpts = typeof last === "object" && last !== null;
+    const opts = (hasOpts ? (columnsOrOptions.pop() as Record<string, unknown>) : {}) as {
+      type?: ColumnType;
+      ifExists?: boolean;
+    };
+    const columns = columnsOrOptions as string[];
     for (const col of columns) {
-      await this.removeColumn(tableName, col);
+      await this.removeColumn(tableName, col, opts.type, { ifExists: opts.ifExists });
     }
   }
 
   async addColumns(
     tableName: string,
-    ...columns: Array<{ name: string; type: ColumnType; options?: ColumnOptions }>
+    ...args: [...string[], { type: ColumnType } & ColumnOptions]
+  ): Promise<void>;
+  async addColumns(
+    tableName: string,
+    ...columnsAndOptions: Array<string | ({ type: ColumnType } & ColumnOptions)>
   ): Promise<void> {
+    const last = columnsAndOptions[columnsAndOptions.length - 1];
+    if (typeof last !== "object" || last === null || !("type" in last)) {
+      throw new TypeError("addColumns requires a trailing options hash with a :type entry");
+    }
+    const { type, ...rest } = columnsAndOptions.pop() as { type: ColumnType } & ColumnOptions;
+    const columns = columnsAndOptions as string[];
     for (const col of columns) {
-      await this.addColumn(tableName, col.name, col.type, col.options ?? {});
+      await this.addColumn(tableName, col, type, rest);
     }
   }
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2316,21 +2316,11 @@ describe("MigrationTest", () => {
       expect(rows.length).toBe(1);
     });
 
-    it.skip("changing columns", () => {
-      // BLOCKED: adapter — changeColumn requires ALTER COLUMN TYPE not supported by SQLite
-    });
-
-    it.skip("changing column null with default", () => {
-      // BLOCKED: adapter — changeColumnNull requires ALTER COLUMN ... SET NOT NULL not supported by SQLite
-    });
-
-    it.skip("default functions on columns", () => {
-      // BLOCKED: adapter — gen_random_uuid() / UUID() requires PostgreSQL or MySQL
-    });
-
-    it.skip("updating auto increment", () => {
-      // BLOCKED: adapter — auto_increment is MySQL-only (Mysql2Adapter / TrilogyAdapter)
-    });
+    // "changing columns", "changing column null with default", and "default
+    // functions on columns" live in adapters/postgresql/change-schema.test.ts
+    // (describeIfPg) — they require PostgreSQL.
+    // "updating auto increment" lives in adapters/mysql2/bulk-alter.test.ts
+    // (describeIfMysql) — it requires MySQL/Trilogy.
 
     it("changing index", async () => {
       // Create table with a non-unique index, then swap to a unique index

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2319,7 +2319,7 @@ describe("MigrationTest", () => {
     // "changing columns", "changing column null with default", and "default
     // functions on columns" live in adapters/postgresql/change-schema.test.ts
     // (describeIfPg) — they require PostgreSQL.
-    // "updating auto increment" lives in adapters/mysql2/bulk-alter.test.ts
+    // "updating auto increment" lives in adapters/abstract-mysql-adapter/bulk-alter.test.ts
     // (describeIfMysql) — it requires MySQL/Trilogy.
 
     it("changing index", async () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1018,6 +1018,12 @@ export abstract class Migration {
   ): Promise<void> {
     const options = typeof fnOrOptions === "function" ? {} : (fnOrOptions ?? {});
     const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
+    if (this._recording) {
+      // Rails: change_table delegates to the CommandRecorder so individual
+      // ops inside the block can be inverted (or batched, in the bulk path).
+      await (this._recorder as any).changeTable(tableName, options, callback);
+      return;
+    }
     if (options.bulk) {
       // Bulk path mirrors Rails: delegate to SchemaStatements#changeTable which
       // records ops via a Proxy and coalesces into a single ALTER. Apply
@@ -1046,6 +1052,12 @@ export abstract class Migration {
   }
 
   async removeColumns(tableName: string, ...columns: string[]): Promise<void> {
+    if (this._recording) {
+      // Record as a single removeColumns op so invertRemoveColumns can flip
+      // it back to addColumns (Rails: CommandRecorder#invert_remove_columns).
+      this._recorder.record("removeColumns", [tableName, ...columns]);
+      return;
+    }
     for (const col of columns) {
       await this.removeColumn(tableName, col);
     }
@@ -1055,6 +1067,10 @@ export abstract class Migration {
     tableName: string,
     ...columns: Array<{ name: string; type: ColumnType; options?: ColumnOptions }>
   ): Promise<void> {
+    if (this._recording) {
+      this._recorder.record("addColumns", [tableName, ...columns]);
+      return;
+    }
     for (const col of columns) {
       await this.addColumn(tableName, col.name, col.type, col.options ?? {});
     }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1051,6 +1051,11 @@ export abstract class Migration {
     return this.schema.indexName(this._pt(tableName), options);
   }
 
+  async removeColumns(tableName: string, ...columns: string[]): Promise<void>;
+  async removeColumns(
+    tableName: string,
+    ...args: [...string[], { type?: ColumnType; ifExists?: boolean }]
+  ): Promise<void>;
   async removeColumns(
     tableName: string,
     ...columnsOrOptions: Array<string | ({ type?: ColumnType } & Record<string, unknown>)>
@@ -1073,6 +1078,10 @@ export abstract class Migration {
     }
   }
 
+  async addColumns(
+    tableName: string,
+    ...args: [...string[], { type: ColumnType } & ColumnOptions]
+  ): Promise<void>;
   async addColumns(
     tableName: string,
     ...columnsAndOptions: Array<string | ({ type: ColumnType } & ColumnOptions)>

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1051,28 +1051,44 @@ export abstract class Migration {
     return this.schema.indexName(this._pt(tableName), options);
   }
 
-  async removeColumns(tableName: string, ...columns: string[]): Promise<void> {
+  async removeColumns(
+    tableName: string,
+    ...columnsOrOptions: Array<string | ({ type?: ColumnType } & Record<string, unknown>)>
+  ): Promise<void> {
     if (this._recording) {
       // Record as a single removeColumns op so invertRemoveColumns can flip
       // it back to addColumns (Rails: CommandRecorder#invert_remove_columns).
-      this._recorder.record("removeColumns", [tableName, ...columns]);
+      this._recorder.record("removeColumns", [tableName, ...columnsOrOptions]);
       return;
     }
+    const last = columnsOrOptions[columnsOrOptions.length - 1];
+    const hasOpts = typeof last === "object" && last !== null;
+    const opts = (hasOpts ? (columnsOrOptions.pop() as Record<string, unknown>) : {}) as {
+      type?: ColumnType;
+      ifExists?: boolean;
+    };
+    const columns = columnsOrOptions as string[];
     for (const col of columns) {
-      await this.removeColumn(tableName, col);
+      await this.removeColumn(tableName, col, opts.type, { ifExists: opts.ifExists });
     }
   }
 
   async addColumns(
     tableName: string,
-    ...columns: Array<{ name: string; type: ColumnType; options?: ColumnOptions }>
+    ...columnsAndOptions: Array<string | ({ type: ColumnType } & ColumnOptions)>
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("addColumns", [tableName, ...columns]);
+      this._recorder.record("addColumns", [tableName, ...columnsAndOptions]);
       return;
     }
+    const last = columnsAndOptions[columnsAndOptions.length - 1];
+    if (typeof last !== "object" || last === null || !("type" in last)) {
+      throw new TypeError("addColumns requires a trailing options hash with a :type entry");
+    }
+    const { type, ...rest } = columnsAndOptions.pop() as { type: ColumnType } & ColumnOptions;
+    const columns = columnsAndOptions as string[];
     for (const col of columns) {
-      await this.addColumn(tableName, col.name, col.type, col.options ?? {});
+      await this.addColumn(tableName, col, type, rest);
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -556,8 +556,21 @@ export abstract class Migration {
         await this.addUniqueConstraint(rucTable, rucColumn, rucOpts);
         break;
       }
-      default:
-        throw new IrreversibleMigration(`Cannot reverse operation: ${cmd}`);
+      default: {
+        // Delegate unknown commands to CommandRecorder's invert dispatch so
+        // Rails-shape ops like removeColumns/addColumns/changeTable round-
+        // trip. Mirrors Rails: revert { } -> recorder.replay(self) where
+        // replayed cmds are the inverted ones.
+        const { cmd: iCmd, args: iArgs } = this._recorder.inverseOf(cmd, args);
+        const method = (this as unknown as Record<string, (...a: unknown[]) => Promise<void>>)[
+          iCmd
+        ];
+        if (typeof method !== "function") {
+          throw new IrreversibleMigration(`Cannot reverse operation: ${cmd}`);
+        }
+        await method.apply(this, iArgs);
+        break;
+      }
     }
   }
 
@@ -1021,7 +1034,11 @@ export abstract class Migration {
     if (this._recording) {
       // Rails: change_table delegates to the CommandRecorder so individual
       // ops inside the block can be inverted (or batched, in the bulk path).
-      await (this._recorder as any).changeTable(tableName, options, callback);
+      await this._recorder.changeTable(
+        tableName,
+        options as Record<string, unknown>,
+        callback as Parameters<CommandRecorder["changeTable"]>[2],
+      );
       return;
     }
     if (options.bulk) {


### PR DESCRIPTION
## Summary

Batch 40 from `docs/activerecord-100-plan.md` — Migration Slot F invertibility.

- **`_recording` guards on `Migration.removeColumns` / `Migration.addColumns`** — record as a single op during `change()` so `invertRemoveColumns` / `invertAddColumns` flip them. Signatures now match Rails (`*column_names, type:, **options`) via overloads so the type required by `invertRemoveColumns` round-trips.
- **`Migration.changeTable` recording delegate** — when `_recording`, delegate to `CommandRecorder.changeTable(...)` so nested ops inside the block invert individually (Rails `migration.rb:588` / `command_recorder.rb:136`).
- **3 PG-only BulkAlterTableMigrationsTest cases moved** to `adapters/postgresql/change-schema.test.ts` under `describeIfPg`:
  - `changing columns`, `changing column null with default`, `default functions on columns`
- **`updating auto increment` ported** to a new `adapters/abstract-mysql-adapter/bulk-alter.test.ts` under `describeIfMysql` (real bulk-alter test exercising `t.change(:id, :bigint, auto_increment: true/false)`).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/migration/command-recorder.test.ts`
- [x] `pnpm api:compare --package activerecord` (4956/4958, unchanged)
- [x] `pnpm test:compare` (12664/21718, unchanged)
- [ ] CI PG job: 3 new tests in `adapters/postgresql/change-schema.test.ts`
- [ ] CI MySQL job: `adapters/abstract-mysql-adapter/bulk-alter.test.ts`