### PR TITLE
refactor(activerecord): mysql isClientNotConnected predicate + configureConnection tz seed

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -460,6 +460,22 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(adapter.databaseTimezone).toBe("utc");
     });
 
+    it("configure connection seeds database timezone from default", async () => {
+      // Mirrors Rails' `Mysql2Adapter#configure_connection` which assigns
+      // `@raw_connection.query_options[:database_timezone] = default_timezone`
+      // up front. Asserts the seed lands immediately — the per-query re-sync
+      // is covered by the test above.
+      adapter.databaseTimezone = "utc";
+      await withTimezoneConfig({ default: "local" }, () => {
+        adapter.configureConnection();
+        expect(adapter.databaseTimezone).toBe("local");
+      });
+      await withTimezoneConfig({ default: "utc" }, () => {
+        adapter.configureConnection();
+        expect(adapter.databaseTimezone).toBe("utc");
+      });
+    });
+
     it("warnings do not change returned value of exec update", async () => {
       // Mirrors: test_warnings_do_not_change_returned_value_of_exec_update.
       // Pin a single pool connection via beginTransaction so SET SESSION

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1036,6 +1036,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly CLIENT_NOT_CONNECTED_RE = /MySQL client is not connected/i;
 
   /**
+   * Predicate form of {@link CLIENT_NOT_CONNECTED_RE}. Single point of truth
+   * shared by the abstract `when nil` branch and the `Mysql2Adapter`
+   * `ConnectionError` branch so they cannot drift.
+   * @internal
+   */
+  static isClientNotConnected(e: unknown): boolean {
+    const msg = e instanceof Error ? e.message : typeof e === "string" ? e : "";
+    return AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg);
+  }
+
+  /**
    * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
    * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
    * and `PARTITIONS`. Format is handled separately via the
@@ -1216,7 +1227,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       // errno (e.g. node-mysql2 surfacing a closed-socket failure as a
       // generic Error) get promoted to ConnectionNotEstablished when the
       // message indicates the client lost the server handshake.
-      if (AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg)) {
+      if (AbstractMysqlAdapter.isClientNotConnected(e)) {
         return new ConnectionNotEstablished(msg, { cause });
       }
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -250,7 +250,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // connected" message is promoted to ConnectionNotEstablished;
       // everything else in this family is ConnectionFailed.
       const msg = (e as Error).message;
-      if (AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg)) {
+      if (AbstractMysqlAdapter.isClientNotConnected(e)) {
         return new ConnectionNotEstablished(msg, { cause: e });
       }
       return new ConnectionFailed(msg, { sql, binds, cause: e });
@@ -1515,6 +1515,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // database_timezone on the single raw connection. In our pool model
     // we have no single raw connection to configure here; mysql2's typeCast
     // handles temporal fields and results are returned as objects (not arrays).
+    // The database_timezone equivalent ({@link databaseTimezone}) is seeded
+    // from the global default here and re-synced per-query in perform_query,
+    // mirroring Rails' `query_options[:database_timezone] = default_timezone`.
+    this._syncDatabaseTimezone();
     super.configureConnection();
   }
 


### PR DESCRIPTION
## Summary

Batch 50 residual fidelity (per `docs/activerecord-100-plan.md`). The bulk of the listed items — the four `_translateException` lock/range/canceled errno cases (`ER_LOCK_DEADLOCK` → `Deadlocked`, `ER_LOCK_WAIT_TIMEOUT` → `LockWaitTimeout`, `ER_QUERY_INTERRUPTED` → `QueryCanceled`, `ER_OUT_OF_RANGE` → `RangeError`), the `Mysql2Adapter` `ConnectionError` branch + abstract `when nil → ConnectionNotEstablished`, and `ER_DB_CREATE_EXISTS → DatabaseAlreadyExists` — already landed in prior PRs. What remains in this PR:

- Hoist `CLIENT_NOT_CONNECTED_RE` into `AbstractMysqlAdapter.isClientNotConnected(e)` predicate so the abstract `when nil` branch and the `Mysql2Adapter` `ConnectionError` branch share one matcher.
- Seed `databaseTimezone` from `getDefaultTimezone()` in `Mysql2Adapter#configureConnection`, mirroring Rails' `query_options[:database_timezone] = default_timezone`. Per-query `_syncDatabaseTimezone` was already wired.

## Deferred follow-ups

- **`Rails.error.report` wiring** for the `report` warning action in both `Mysql2Adapter#_flushWarnings` and `PostgreSQLAdapter#_flushWarnings` is blocked on a global `ErrorReporter` singleton. `TODO(report)` comments left in place.

## Test plan

- [ ] CI: existing mysql2 fabricated-error translateException tests still pass (covers `ConnectionNotEstablished` promotion path now routed through `isClientNotConnected`).
- [ ] CI: existing `databaseTimezone` re-sync tests continue to pass (seed on configureConnection is additive).