### PR TITLE
fix(activerecord): honor ColumnDefinition.sqlType in abstract TableDefinition#toSql

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -15,16 +15,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("CidrTest", () => {
-    it.skip("cidr column", async () => {
-      // BLOCKED: adapter-pg — requires live schema with cidr column
-    });
-    it.skip("cidr type cast", async () => {
-      // BLOCKED: adapter-pg — requires live DB round-trip
-    });
-    it.skip("cidr invalid", async () => {
-      // BLOCKED: adapter-pg — requires live DB
-    });
-
     it("type casting IPAddr for database", async () => {
       const type = new Cidr();
       const ip = new IPAddr("255.0.0.0", 8);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1036,98 +1036,106 @@ export class TableDefinition {
     const columnDefs = this.columns.map((col) => {
       const parts = [this._adapter.quoteIdentifier(col.name)];
 
-      switch (col.type) {
-        case "primary_key":
-          if (this._adapterName === "postgres") {
-            parts.push("SERIAL PRIMARY KEY");
-          } else if (this._adapterName === "mysql") {
-            parts.push("BIGINT AUTO_INCREMENT PRIMARY KEY");
-          } else {
-            parts.push("INTEGER PRIMARY KEY AUTOINCREMENT");
-          }
-          break;
-        case "uuid": {
-          if (this._adapterName === "postgres") {
-            parts.push("UUID");
-          } else if (this._adapterName === "mysql") {
-            parts.push("CHAR(36)");
-          } else {
-            parts.push("VARCHAR(36)");
-          }
-          if (col.options.primaryKey) {
-            if (this._adapterName === "postgres" && col.options.default === undefined) {
-              parts.push("DEFAULT gen_random_uuid()");
+      // Honor pre-populated sqlType from adapter-specific helpers (e.g. PG's
+      // t.cidr/t.inet/t.bit, MySQL's t.mediumblob/t.unsigned_integer). The
+      // schema_creation visitor does the same at visit_ColumnDefinition; this
+      // path is hit when TableDefinition#toSql() runs directly (createTable).
+      if (col.sqlType != null && col.type !== "primary_key") {
+        parts.push(col.sqlType);
+      } else {
+        switch (col.type) {
+          case "primary_key":
+            if (this._adapterName === "postgres") {
+              parts.push("SERIAL PRIMARY KEY");
+            } else if (this._adapterName === "mysql") {
+              parts.push("BIGINT AUTO_INCREMENT PRIMARY KEY");
+            } else {
+              parts.push("INTEGER PRIMARY KEY AUTOINCREMENT");
             }
-            parts.push("PRIMARY KEY");
+            break;
+          case "uuid": {
+            if (this._adapterName === "postgres") {
+              parts.push("UUID");
+            } else if (this._adapterName === "mysql") {
+              parts.push("CHAR(36)");
+            } else {
+              parts.push("VARCHAR(36)");
+            }
+            if (col.options.primaryKey) {
+              if (this._adapterName === "postgres" && col.options.default === undefined) {
+                parts.push("DEFAULT gen_random_uuid()");
+              }
+              parts.push("PRIMARY KEY");
+            }
+            break;
           }
-          break;
-        }
-        case "string":
-          parts.push(`VARCHAR(${col.options.limit ?? 255})`);
-          break;
-        case "text":
-          parts.push("TEXT");
-          break;
-        case "integer":
-          parts.push("INTEGER");
-          break;
-        case "float":
-          parts.push(this._adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL");
-          break;
-        case "decimal":
-          parts.push(`DECIMAL(${col.options.precision ?? 10}, ${col.options.scale ?? 0})`);
-          break;
-        case "boolean":
-          parts.push("BOOLEAN");
-          break;
-        case "date":
-          parts.push("DATE");
-          break;
-        case "time": {
-          const tp = col.options.precision;
-          if (tp != null && !(tp >= 0 && tp <= 6))
-            throw new ArgumentError(
-              `No TIME type has precision of ${tp}. The allowed range of precision is from 0 to 6`,
-            );
-          parts.push(tp != null ? `TIME(${tp})` : "TIME");
-          break;
-        }
-        case "datetime":
-        case "timestamp": {
-          const base = this._adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
-          // precision: undefined → Rails default of 6; precision: null → no precision suffix
-          const tp = col.options.precision === undefined ? 6 : col.options.precision;
-          if (tp != null && !(tp >= 0 && tp <= 6))
-            throw new ArgumentError(
-              `No ${base} type has precision of ${tp}. The allowed range of precision is from 0 to 6`,
-            );
-          parts.push(tp != null ? `${base}(${tp})` : base);
-          break;
-        }
-        case "binary":
-          parts.push(this._adapterName === "postgres" ? "BYTEA" : "BLOB");
-          break;
-        case "json":
-          parts.push("JSON");
-          break;
-        case "jsonb":
-          parts.push(this._adapterName === "postgres" ? "JSONB" : "JSON");
-          break;
-        case "bigint":
-          parts.push("BIGINT");
-          break;
-        case "char":
-          parts.push(`CHAR(${col.options.limit ?? 1})`);
-          break;
-        default:
-          if (!col.type || !col.type.trim()) {
-            throw new Error(
-              `Column ${JSON.stringify(col.name)} has an empty or blank type — specify a valid SQL type`,
-            );
+          case "string":
+            parts.push(`VARCHAR(${col.options.limit ?? 255})`);
+            break;
+          case "text":
+            parts.push("TEXT");
+            break;
+          case "integer":
+            parts.push("INTEGER");
+            break;
+          case "float":
+            parts.push(this._adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL");
+            break;
+          case "decimal":
+            parts.push(`DECIMAL(${col.options.precision ?? 10}, ${col.options.scale ?? 0})`);
+            break;
+          case "boolean":
+            parts.push("BOOLEAN");
+            break;
+          case "date":
+            parts.push("DATE");
+            break;
+          case "time": {
+            const tp = col.options.precision;
+            if (tp != null && !(tp >= 0 && tp <= 6))
+              throw new ArgumentError(
+                `No TIME type has precision of ${tp}. The allowed range of precision is from 0 to 6`,
+              );
+            parts.push(tp != null ? `TIME(${tp})` : "TIME");
+            break;
           }
-          // Pass arbitrary type strings through verbatim (case matters for PG enums).
-          parts.push(col.type);
-          break;
+          case "datetime":
+          case "timestamp": {
+            const base = this._adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
+            // precision: undefined → Rails default of 6; precision: null → no precision suffix
+            const tp = col.options.precision === undefined ? 6 : col.options.precision;
+            if (tp != null && !(tp >= 0 && tp <= 6))
+              throw new ArgumentError(
+                `No ${base} type has precision of ${tp}. The allowed range of precision is from 0 to 6`,
+              );
+            parts.push(tp != null ? `${base}(${tp})` : base);
+            break;
+          }
+          case "binary":
+            parts.push(this._adapterName === "postgres" ? "BYTEA" : "BLOB");
+            break;
+          case "json":
+            parts.push("JSON");
+            break;
+          case "jsonb":
+            parts.push(this._adapterName === "postgres" ? "JSONB" : "JSON");
+            break;
+          case "bigint":
+            parts.push("BIGINT");
+            break;
+          case "char":
+            parts.push(`CHAR(${col.options.limit ?? 1})`);
+            break;
+          default:
+            if (!col.type || !col.type.trim()) {
+              throw new Error(
+                `Column ${JSON.stringify(col.name)} has an empty or blank type — specify a valid SQL type`,
+              );
+            }
+            // Pass arbitrary type strings through verbatim (case matters for PG enums).
+            parts.push(col.type);
+            break;
+        }
       }
 
       // For types that don't handle PRIMARY KEY internally, append it if requested

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -261,6 +261,35 @@ describe("TableDefinition#toSql", () => {
     expect(sql).toContain("AS SELECT");
   });
 
+  it("emits PG-specific long-tail column SQL types verbatim from pgColumn helpers", () => {
+    const td = new TableDefinition("widgets", { id: false });
+    td.cidr("net");
+    td.inet("addr");
+    td.hstore("props");
+    td.macaddr("mac");
+    td.ltree("path");
+    td.tsvector("doc");
+    td.xml("payload");
+    td.bit("flags", { limit: 8 });
+    td.bitVarying("flex", { limit: 16 });
+    td.money("price");
+    td.oid("oid_col");
+    td.tsrange("during");
+    const sql = td.toSql();
+    expect(sql).toContain('"net" CIDR');
+    expect(sql).toContain('"addr" INET');
+    expect(sql).toContain('"props" HSTORE');
+    expect(sql).toContain('"mac" MACADDR');
+    expect(sql).toContain('"path" LTREE');
+    expect(sql).toContain('"doc" TSVECTOR');
+    expect(sql).toContain('"payload" XML');
+    expect(sql).toContain('"flags" BIT(8)');
+    expect(sql).toContain('"flex" BIT VARYING(16)');
+    expect(sql).toContain('"price" MONEY');
+    expect(sql).toContain('"oid_col" OID');
+    expect(sql).toContain('"during" TSRANGE');
+  });
+
   it("handles default values containing doubled single-quotes without mis-parsing", () => {
     const td = new TableDefinition("messages", { id: false });
     td.string("body", { default: "Bob's" });


### PR DESCRIPTION
## Summary

Batch 57 — PG long-tail `pgColumn` SQL emission fix + cidr test cleanup.

PG `TableDefinition` helpers (`t.cidr`, `t.inet`, `t.hstore`, `t.bit`, `t.bitVarying`, `t.macaddr`, `t.ltree`, `t.tsvector`, `t.xml`, `t.money`, `t.oid`, `t.tsrange`, ...) pre-populate `col.sqlType` with a dialect literal while keeping `col.type` as a generic semantic type so the abstract switch knows which Rails-named typecaster to wire. The `schema_creation` visitor already honored that (`o.sqlType ??= ...` in `visit_ColumnDefinition`), but the abstract `TableDefinition#toSql()` — called directly from `createTable` in `migration.ts` and `abstract/schema_statements.ts` — ignored `sqlType` and fell through to the type switch, emitting e.g. `VARCHAR(255)` for `t.cidr`.

This honors `sqlType` first in the abstract `toSql()` column loop, mirroring the visitor.

## Cleanup

- Delete 3 stub `it.skip` tests in `adapters/postgresql/cidr.test.ts` (`cidr column`, `cidr type cast`, `cidr invalid`) — Rails `cidr_test.rb` has no counterparts; network-column schema-reflection tests live in `network_test.rb` (covered by a follow-up if/when wired).

## Follow-ups (not in this PR)

- Port `network_test.rb` (cidr/inet/macaddr column reflection + round-trip) as `adapters/postgresql/network.test.ts` once `defineSchema` PG-type mappings cover `cidr`/`inet`/`macaddr`.
- Audit DX type tests asserting `string` for `inet`/`cidr` columns (per Batch 57 note on `type-registry.ts` mapping to `IPAddr`).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts`
- [x] `TEST_ADAPTER=postgresql pnpm vitest run packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts` (new long-tail toSql assertions)
- [x] `pnpm test:types`
- [x] `pnpm lint --fix`