### PR TITLE
feat(activerecord): NIE annotation completion + ESLint extension (batch 88)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -204,7 +204,14 @@ export default defineConfig(
   // carry a `// @nie disposition=…` comment. Tracks the elimination
   // initiative (docs/activerecord-100-clusters.md).
   {
-    files: ["packages/activerecord/src/**/*.ts"],
+    files: [
+      "packages/activerecord/src/**/*.ts",
+      "packages/actionpack/src/**/*.ts",
+      "packages/actionview/src/**/*.ts",
+      "packages/activemodel/src/**/*.ts",
+      "packages/activesupport/src/**/*.ts",
+      "packages/arel/src/**/*.ts",
+    ],
     ignores: ["**/*.test.ts"],
     rules: {
       "blazetrails/nie-requires-annotation": "error",

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1836,7 +1836,7 @@ function isMysql2ConnectionError(e: unknown): boolean {
 
 /** @internal */
 function reconnect(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:150 cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#reconnect is not implemented",
   );
@@ -1844,7 +1844,7 @@ function reconnect(): never {
 
 /** @internal */
 function initializeTypeMap(m: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb cluster=mysql-mysql2-adapter
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:40 cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -72,7 +72,7 @@ export async function executeBatch(
 
 /** @internal */
 function lastInsertedId(result: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb cluster=mysql-mysql2-adapter
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb:23 cluster=mysql-mysql2-adapter
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id is not implemented",
   );

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -630,7 +630,7 @@ export class AlterTable extends AbstractAlterTable {
 
 /** @internal */
 function validColumnDefinitionOptions(): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:285 cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#valid_column_definition_options is not implemented",
   );
@@ -638,7 +638,7 @@ function validColumnDefinitionOptions(): never {
 
 /** @internal */
 function aliasedTypes(name: any, fallback: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:289 cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#aliased_types is not implemented",
   );
@@ -646,7 +646,7 @@ function aliasedTypes(name: any, fallback: any): never {
 
 /** @internal */
 function integerLikePrimaryKeyType(type: any, options: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb cluster=pg-long-tail
+  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:293 cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -467,6 +467,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected visitArelNodesDistinctOn(_node: Nodes.DistinctOn): SQLString {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:194 cluster=arel-visitor-strategy
     throw new NotImplementedError(
       "DISTINCT ON is not supported by the base ToSql visitor. Use the PostgreSQL visitor instead.",
     );
@@ -848,12 +849,14 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected visitArelNodesRegexp(_node: Nodes.Regexp): SQLString {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:520 cluster=arel-visitor-strategy
     throw new NotImplementedError(
       "Regexp (~ operator) is not supported by the base ToSql visitor. Use a database-specific visitor (e.g. PostgreSQL) instead.",
     );
   }
 
   protected visitArelNodesNotRegexp(_node: Nodes.NotRegexp): SQLString {
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:524 cluster=arel-visitor-strategy
     throw new NotImplementedError(
       "NotRegexp (!~ operator) is not supported by the base ToSql visitor. Use a database-specific visitor (e.g. PostgreSQL) instead.",
     );


### PR DESCRIPTION
## Summary

Batch 88 from docs/activerecord-100-plan.md.

- Add `rails=file:line` line numbers to NIE annotations that previously had only file paths:
  - `mysql2-adapter.ts` — `reconnect` (rb:150), `initialize_type_map` (rb:40)
  - `mysql2/database-statements.ts` — `last_inserted_id` (rb:23)
  - `postgresql/schema-definitions.ts` — `valid_column_definition_options` (rb:285), `aliased_types` (rb:289), `integer_like_primary_key_type` (rb:293)
- Annotate the 3 strategy-hook NIE throws in `arel/visitors/to-sql.ts` (`DistinctOn`, `Regexp`, `NotRegexp`) as `disposition=keep-as-strategy-hook` so they are covered once the rule scope expands.
- Extend the `blazetrails/nie-requires-annotation` ESLint rule scope to actionpack, actionview, activemodel, activesupport, and arel. Future `throw new NotImplementedError(...)` in those packages now requires an `@nie disposition=…` annotation.

Optional companion warn-rule on `disposition=TODO` was considered but not included — no `TODO` dispositions currently exist in the tree, so the rule would be a no-op.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm typecheck` pass (run in pre-commit)