### PR TITLE
feat(actionpack): AbstractController rendering port

### DIFF
--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -25,3 +25,17 @@ export {
 } from "./asset-paths.js";
 export { applyLogger, benchmark, type LoggerHost, type LoggerLike } from "./logger.js";
 export { Collector } from "./collector.js";
+export {
+  DoubleRenderError,
+  DEFAULT_PROTECTED_INSTANCE_VARIABLES,
+  render,
+  renderToString,
+  viewAssigns,
+  _normalizeArgs,
+  _normalizeOptions,
+  _processOptions,
+  _processVariant,
+  normalizeRender,
+  type RenderOptions,
+  type RenderingHost,
+} from "./rendering.js";

--- a/packages/actionpack/src/abstract-controller/rendering.test.ts
+++ b/packages/actionpack/src/abstract-controller/rendering.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DoubleRenderError,
+  DEFAULT_PROTECTED_INSTANCE_VARIABLES,
+  render,
+  renderToString,
+  viewAssigns,
+  _normalizeArgs,
+  _normalizeOptions,
+  normalizeRender,
+  type RenderOptions,
+  type RenderingHost,
+} from "./rendering.js";
+import { AbstractControllerError } from "./error.js";
+
+function makeHost(opts: Partial<RenderingHost> = {}): RenderingHost {
+  return {
+    responseBody: null,
+    renderToBody: (o: RenderOptions) => (o.html != null ? String(o.html) : "<body>"),
+    ...opts,
+  };
+}
+
+describe("AbstractController::DoubleRenderError", () => {
+  it("extends AbstractControllerError", () => {
+    expect(new DoubleRenderError()).toBeInstanceOf(AbstractControllerError);
+  });
+
+  it("uses the Rails-shaped default message when none is supplied", () => {
+    expect(new DoubleRenderError().message).toMatch(
+      /Render and\/or redirect were called multiple times/,
+    );
+  });
+
+  it("preserves a caller-supplied message", () => {
+    expect(new DoubleRenderError("custom").message).toBe("custom");
+  });
+});
+
+describe("render() and renderToString()", () => {
+  it("render delegates to renderToBody and writes responseBody", () => {
+    const host = makeHost();
+    render.call(host);
+    expect(host.responseBody).toBe("<body>");
+  });
+
+  it("renderToString returns the body without touching responseBody", () => {
+    const host = makeHost();
+    const out = renderToString.call(host, { template: "x" });
+    expect(out).toBe("<body>");
+    expect(host.responseBody).toBeNull();
+  });
+
+  it("invokes _setHtmlContentType when options.html is supplied", () => {
+    const setHtml = vi.fn();
+    const setRendered = vi.fn();
+    const host = makeHost({
+      _setHtmlContentType: setHtml,
+      _setRenderedContentType: setRendered,
+    });
+    render.call(host, { html: "<p>hi</p>" });
+    expect(setHtml).toHaveBeenCalledOnce();
+    expect(setRendered).not.toHaveBeenCalled();
+  });
+
+  it("invokes _setRenderedContentType when options.html is absent", () => {
+    const setHtml = vi.fn();
+    const setRendered = vi.fn();
+    const host = makeHost({
+      _setHtmlContentType: setHtml,
+      _setRenderedContentType: setRendered,
+      renderedFormat: () => "text/plain",
+    });
+    render.call(host, { template: "x" });
+    expect(setHtml).not.toHaveBeenCalled();
+    expect(setRendered).toHaveBeenCalledWith("text/plain");
+  });
+
+  it("always invokes _setVaryHeader", () => {
+    const setVary = vi.fn();
+    const host = makeHost({ _setVaryHeader: setVary });
+    render.call(host);
+    expect(setVary).toHaveBeenCalledOnce();
+  });
+});
+
+describe("viewAssigns()", () => {
+  it("returns non-protected, non-underscore-prefixed own properties", () => {
+    const host = {
+      title: "Hello",
+      count: 3,
+      _actionName: "show",
+      _internal: "hidden",
+    };
+    expect(viewAssigns.call(host)).toEqual({ title: "Hello", count: 3 });
+  });
+
+  it("excludes all DEFAULT_PROTECTED_INSTANCE_VARIABLES", () => {
+    const host: Record<string, unknown> = { title: "ok" };
+    for (const name of DEFAULT_PROTECTED_INSTANCE_VARIABLES) host[name] = "no";
+    expect(viewAssigns.call(host)).toEqual({ title: "ok" });
+  });
+});
+
+describe("_normalizeArgs", () => {
+  it("returns the second argument when the first is a string template name", () => {
+    // Rails uses Symbol but trails treats unknown literals as opaque.
+    expect(_normalizeArgs("foo", { layout: "bar" })).toEqual({ layout: "bar" });
+  });
+
+  it("returns the first argument when it's already an options hash", () => {
+    expect(_normalizeArgs({ template: "x" })).toEqual({ template: "x" });
+  });
+
+  it("returns a permitted params-like object directly", () => {
+    const params = { permitted: () => true, template: "x" };
+    expect(_normalizeArgs(params)).toBe(params);
+  });
+
+  it("throws when params-like input is not permitted", () => {
+    const params = { permitted: () => false };
+    expect(() => _normalizeArgs(params)).toThrow(/not permitted/);
+  });
+});
+
+describe("normalizeRender", () => {
+  it("composes args normalization, variant processing, and options normalization", () => {
+    expect(normalizeRender({ template: "x" })).toEqual({ template: "x" });
+  });
+
+  it("_normalizeOptions is the identity in the abstract layer", () => {
+    const opts = { template: "x" };
+    expect(_normalizeOptions(opts)).toBe(opts);
+  });
+});

--- a/packages/actionpack/src/abstract-controller/rendering.ts
+++ b/packages/actionpack/src/abstract-controller/rendering.ts
@@ -103,7 +103,18 @@ export function viewAssigns<T extends object>(this: T): Record<string, unknown> 
 // Internal helpers — exported for subclass override + tests.
 // ===========================================================================
 
-/** Normalize `render "foo"` → `{ action: "foo" }`. */
+/**
+ * Abstract-layer arg normalizer. Handles only the cases Rails'
+ * `AbstractController::Rendering#_normalize_args` handles:
+ * - a permitted strong-params-like object (uses it directly, or raises
+ *   if not permitted)
+ * - a plain options hash (returns it)
+ * - anything else (returns the second `options` arg as-is)
+ *
+ * String → `{ action: ... }` shorthand lives in
+ * `ActionController::Rendering#_normalize_args` (the concrete layer)
+ * and should be added there, not here.
+ */
 export function _normalizeArgs(action?: unknown, options: RenderOptions = {}): RenderOptions {
   // Strong-params-style permitted hash: trails uses a duck-typed
   // `permitted?(): boolean` predicate when applicable.

--- a/packages/actionpack/src/abstract-controller/rendering.ts
+++ b/packages/actionpack/src/abstract-controller/rendering.ts
@@ -1,0 +1,142 @@
+/**
+ * `AbstractController::Rendering` — abstract-layer hooks for the
+ * render pipeline. The host class supplies a `renderToBody(options)`
+ * implementation (ActionController's metal layer does this for trails);
+ * the methods here are mostly normalization + empty hooks that
+ * subclasses override.
+ *
+ * Ported from `vendor/rails/actionpack/lib/abstract_controller/rendering.rb`.
+ */
+
+import { AbstractControllerError } from "./error.js";
+
+const DEFAULT_DOUBLE_RENDER_MESSAGE =
+  "Render and/or redirect were called multiple times in this action. " +
+  "Please note that you may only call render OR redirect, and at most " +
+  "once per action. Also note that neither redirect nor render terminate " +
+  "execution of the action, so if you want to exit an action after " +
+  'redirecting, you need to do something like "redirect_to(...); return".';
+
+export class DoubleRenderError extends AbstractControllerError {
+  constructor(message?: string) {
+    super(message ?? DEFAULT_DOUBLE_RENDER_MESSAGE);
+    this.name = "DoubleRenderError";
+  }
+}
+
+/**
+ * Instance variables that should be excluded from `viewAssigns`.
+ * Rails: `DEFAULT_PROTECTED_INSTANCE_VARIABLES`. Trails uses
+ * underscore-prefixed names since we don't have Ruby `@` ivars; the
+ * convention is to treat any leading-underscore field as private to
+ * the controller.
+ */
+export const DEFAULT_PROTECTED_INSTANCE_VARIABLES: readonly string[] = [
+  "_actionName",
+  "_responseBody",
+  "_formats",
+  "_prefixes",
+];
+
+export interface RenderOptions {
+  html?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Host shape the rendering mixins require. The metal layer's
+ * `renderToBody(options)` plus `responseBody` writer satisfy this.
+ */
+export interface RenderingHost {
+  responseBody: unknown;
+  renderToBody(options: RenderOptions): unknown;
+  _setHtmlContentType?(): void;
+  _setRenderedContentType?(format: unknown): void;
+  _setVaryHeader?(): void;
+  renderedFormat?(): unknown;
+}
+
+/**
+ * Normalize arguments and options, delegate to `renderToBody`, then
+ * stash the result on `responseBody`. Mirrors
+ * `AbstractController::Rendering#render`.
+ */
+export function render<T extends RenderingHost>(this: T, ...args: unknown[]): void {
+  const options = normalizeRender(...args);
+  const renderedBody = this.renderToBody(options);
+  if (options.html != null) {
+    this._setHtmlContentType?.();
+  } else {
+    this._setRenderedContentType?.(this.renderedFormat?.());
+  }
+  this._setVaryHeader?.();
+  this.responseBody = renderedBody;
+}
+
+/**
+ * Similar to `render`, but only returns the rendered template as a
+ * string instead of setting `responseBody`. Mirrors
+ * `AbstractController::Rendering#render_to_string`.
+ */
+export function renderToString<T extends RenderingHost>(this: T, ...args: unknown[]): unknown {
+  const options = normalizeRender(...args);
+  return this.renderToBody(options);
+}
+
+/**
+ * Collect non-protected instance fields as a `{ name: value }` map for
+ * view rendering. Excludes anything in
+ * `DEFAULT_PROTECTED_INSTANCE_VARIABLES` and anything starting with
+ * `_` (the trails convention for "private").
+ */
+export function viewAssigns<T extends object>(this: T): Record<string, unknown> {
+  const out: Record<string, unknown> = Object.create(null);
+  const protectedSet = new Set(DEFAULT_PROTECTED_INSTANCE_VARIABLES);
+  for (const name of Object.keys(this)) {
+    if (name.startsWith("_") || protectedSet.has(name)) continue;
+    out[name] = (this as Record<string, unknown>)[name];
+  }
+  return out;
+}
+
+// ===========================================================================
+// Internal helpers — exported for subclass override + tests.
+// ===========================================================================
+
+/** Normalize `render "foo"` → `{ action: "foo" }`. */
+export function _normalizeArgs(action?: unknown, options: RenderOptions = {}): RenderOptions {
+  // Strong-params-style permitted hash: trails uses a duck-typed
+  // `permitted?(): boolean` predicate when applicable.
+  if (action != null && typeof (action as { permitted?: () => boolean }).permitted === "function") {
+    if ((action as { permitted: () => boolean }).permitted()) {
+      return action as RenderOptions;
+    }
+    throw new Error("render parameters are not permitted");
+  }
+  if (action != null && typeof action === "object" && !Array.isArray(action)) {
+    return action as RenderOptions;
+  }
+  return options;
+}
+
+/** Hook — subclasses override to post-process the options hash. */
+export function _normalizeOptions(options: RenderOptions): RenderOptions {
+  return options;
+}
+
+/** Hook — subclasses override to process individual option keys. */
+export function _processOptions(options: RenderOptions): RenderOptions {
+  return options;
+}
+
+/** Combined normalization: args → options → variant → final hash. */
+export function normalizeRender(...args: unknown[]): RenderOptions {
+  const options = _normalizeArgs(...(args as [unknown?, RenderOptions?]));
+  _processVariant(options);
+  return _normalizeOptions(options);
+}
+
+/** Hook — subclasses override to handle `:variant` option. */
+export function _processVariant(_options: RenderOptions): void {
+  // Empty in the abstract layer.
+}


### PR DESCRIPTION
## Summary
Ports `vendor/rails/actionpack/lib/abstract_controller/rendering.rb` to `abstract-controller/rendering.ts`.

The abstract layer is mostly normalization + hooks; the host class (typically ActionController via `action-controller/metal/rendering.ts`) supplies the actual `renderToBody` implementation and content-type/vary setters.

### What ships
- **`DoubleRenderError`** extends `AbstractControllerError` with the Rails default message about render/redirect being called multiple times.
- **`render(...args)`** normalizes, delegates to `host.renderToBody(options)`, sets `responseBody`, and dispatches content-type / vary hooks.
- **`renderToString(...args)`** returns the body without touching `responseBody`.
- **`viewAssigns()`** collects non-underscore-prefixed own fields. Trails uses leading-underscore as the "private to controller" convention (no Ruby `@` ivars).
- **`DEFAULT_PROTECTED_INSTANCE_VARIABLES`** lists the standard exclusions (`_actionName`, `_responseBody`, `_formats`, `_prefixes`).
- Hook helpers (`_normalizeArgs`, `_normalizeOptions`, `_processOptions`, `_processVariant`, `normalizeRender`) exported as named functions so subclasses can override them via the include() mixin pattern.

## `abstract_controller/` status after this PR (9/13)
| Rails file       | LOC | Status         |
| ---------------- | --- | -------------- |
| `base.rb`        | 299 | ✅             |
| `callbacks.rb`   | 265 | ✅             |
| `error.rb`       | 8   | ✅             |
| `translation.rb` | 42  | ✅ (#1739)     |
| `deprecator.rb`  | 9   | ✅ (#1739)     |
| `asset_paths.rb` | 14  | ✅ (#1744)     |
| `logger.rb`      | 16  | ✅ (#1744)     |
| `collector.rb`   | 44  | ✅ (#1755)     |
| `rendering.rb`   | 125 | **this PR**    |
| `caching.rb`+dir | 68+ | not ported     |
| `helpers.rb`     | 245 | not ported     |
| `url_for.rb`     | 37  | not ported     |
| `railties/`      | -   | (trailtie)     |

## Test plan
- [x] 16 new rendering tests pass (DoubleRenderError construction, render/renderToString delegation, viewAssigns filtering, `_normalizeArgs` branches, hook identity)
- [x] All 2131 actionpack tests pass
- [x] `pnpm -w build` clean
- [x] `pnpm lint` clean