### PR TITLE
feat(actionpack): AbstractController url_for port

### DIFF
--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -39,3 +39,11 @@ export {
   type RenderOptions,
   type RenderingHost,
 } from "./rendering.js";
+export {
+  _routes,
+  _routesStatic,
+  filterActionMethodsForRoutes,
+  type NamedRoutesLike,
+  type RouteSetLike,
+  type UrlForClassMethods,
+} from "./url-for.js";

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -42,6 +42,7 @@ export {
 export {
   _routesInstanceDefault,
   _routesClassDefault,
+  UrlForDefaults,
   filterActionMethodsForRoutes,
   type NamedRoutesLike,
   type RouteSetLike,

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -42,6 +42,7 @@ export {
 export {
   _routesInstanceDefault,
   _routesClassDefault,
+  NO_ROUTES_MESSAGE,
   UrlForDefaults,
   filterActionMethodsForRoutes,
   type NamedRoutesLike,

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -40,8 +40,8 @@ export {
   type RenderingHost,
 } from "./rendering.js";
 export {
-  _routes,
-  _routesStatic,
+  _routesInstanceDefault,
+  _routesClassDefault,
   filterActionMethodsForRoutes,
   type NamedRoutesLike,
   type RouteSetLike,

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  _routes,
+  _routesStatic,
+  filterActionMethodsForRoutes,
+  type RouteSetLike,
+} from "./url-for.js";
+
+describe("AbstractController::UrlFor", () => {
+  describe("instance _routes() stub", () => {
+    it("raises with the Rails-shaped hint until the host overrides it", () => {
+      expect(() => _routes.call({})).toThrow(/include routing helpers explicitly/);
+    });
+  });
+
+  describe("static _routesStatic()", () => {
+    it("returns null by default", () => {
+      expect(_routesStatic()).toBeNull();
+    });
+  });
+
+  describe("filterActionMethodsForRoutes()", () => {
+    it("returns the unfiltered list when no route set is wired up", () => {
+      expect(filterActionMethodsForRoutes(["show", "index"], null)).toEqual(["show", "index"]);
+    });
+
+    it("removes any action name that collides with a route helper name", () => {
+      const routes: RouteSetLike = {
+        namedRoutes: { helperNames: ["postsUrl", "postPath", "show"] },
+      };
+      expect(filterActionMethodsForRoutes(["show", "index", "edit"], routes)).toEqual([
+        "index",
+        "edit",
+      ]);
+    });
+
+    it("returns a defensive copy so callers can't mutate the source", () => {
+      const original = ["a", "b"];
+      const filtered = filterActionMethodsForRoutes(original, null);
+      filtered.push("evil");
+      expect(original).toEqual(["a", "b"]);
+    });
+  });
+});

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   _routesInstanceDefault,
   _routesClassDefault,
+  UrlForDefaults,
   filterActionMethodsForRoutes,
   type RouteSetLike,
 } from "./url-for.js";
@@ -45,6 +46,23 @@ describe("AbstractController::UrlFor", () => {
       const filtered = filterActionMethodsForRoutes(original, null);
       filtered.push("evil");
       expect(original).toEqual(["a", "b"]);
+    });
+
+    it("accepts a non-array iterable for helperNames (Set, generator)", () => {
+      const routes: RouteSetLike = {
+        namedRoutes: { helperNames: new Set(["posts_path", "show"]) },
+      };
+      expect(filterActionMethodsForRoutes(["show", "index"], routes)).toEqual(["index"]);
+    });
+  });
+
+  describe("UrlForDefaults", () => {
+    it("exposes the instance stub under Rails-shaped name", () => {
+      expect(UrlForDefaults._routes).toBe(_routesInstanceDefault);
+    });
+
+    it("exposes the class default under _routesStatic", () => {
+      expect(UrlForDefaults._routesStatic).toBe(_routesClassDefault);
     });
   });
 });

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -8,17 +8,10 @@ import {
 } from "./url-for.js";
 
 describe("AbstractController::UrlFor", () => {
-  describe("_routesInstanceDefault()", () => {
-    it("raises with the Rails-shaped hint until the host overrides it", () => {
-      expect(() => _routesInstanceDefault.call({})).toThrow(/include routing helpers explicitly/);
-      expect(() => _routesInstanceDefault.call({})).toThrow(/#url_for/);
-      expect(() => _routesInstanceDefault.call({})).toThrow(/url_helpers/);
-    });
-  });
-
-  describe("_routesClassDefault()", () => {
-    it("returns null by default", () => {
-      expect(_routesClassDefault()).toBeNull();
+  describe("_routes property defaults", () => {
+    it("both instance and class defaults are null (consistent with property contract)", () => {
+      expect(_routesInstanceDefault).toBeNull();
+      expect(_routesClassDefault).toBeNull();
     });
   });
 

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -10,6 +10,8 @@ describe("AbstractController::UrlFor", () => {
   describe("_routesInstanceDefault()", () => {
     it("raises with the Rails-shaped hint until the host overrides it", () => {
       expect(() => _routesInstanceDefault.call({})).toThrow(/include routing helpers explicitly/);
+      expect(() => _routesInstanceDefault.call({})).toThrow(/#url_for/);
+      expect(() => _routesInstanceDefault.call({})).toThrow(/url_helpers/);
     });
   });
 
@@ -25,8 +27,12 @@ describe("AbstractController::UrlFor", () => {
     });
 
     it("removes any action name that collides with a route helper name", () => {
+      // Trails route-helpers.ts generates `${name}_path` / `${name}_url`
+      // in Rails-shape, so the collision surface is snake_case helper
+      // names plus the bare action names that an app might also expose
+      // as routes (e.g. `show` here).
       const routes: RouteSetLike = {
-        namedRoutes: { helperNames: ["postsUrl", "postPath", "show"] },
+        namedRoutes: { helperNames: ["posts_url", "post_path", "show"] },
       };
       expect(filterActionMethodsForRoutes(["show", "index", "edit"], routes)).toEqual([
         "index",

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -1,21 +1,21 @@
 import { describe, it, expect } from "vitest";
 import {
-  _routes,
-  _routesStatic,
+  _routesInstanceDefault,
+  _routesClassDefault,
   filterActionMethodsForRoutes,
   type RouteSetLike,
 } from "./url-for.js";
 
 describe("AbstractController::UrlFor", () => {
-  describe("instance _routes() stub", () => {
+  describe("_routesInstanceDefault()", () => {
     it("raises with the Rails-shaped hint until the host overrides it", () => {
-      expect(() => _routes.call({})).toThrow(/include routing helpers explicitly/);
+      expect(() => _routesInstanceDefault.call({})).toThrow(/include routing helpers explicitly/);
     });
   });
 
-  describe("static _routesStatic()", () => {
+  describe("_routesClassDefault()", () => {
     it("returns null by default", () => {
-      expect(_routesStatic()).toBeNull();
+      expect(_routesClassDefault()).toBeNull();
     });
   });
 

--- a/packages/actionpack/src/abstract-controller/url-for.test.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.test.ts
@@ -41,9 +41,12 @@ describe("AbstractController::UrlFor", () => {
       expect(original).toEqual(["a", "b"]);
     });
 
-    it("accepts a non-array iterable for helperNames (Set, generator)", () => {
+    it("ignores a defaultEnv on the route set when filtering", () => {
+      // defaultEnv is part of RouteSetLike (consumed by the renderer),
+      // but filterActionMethodsForRoutes shouldn't care about it.
       const routes: RouteSetLike = {
-        namedRoutes: { helperNames: new Set(["posts_path", "show"]) },
+        namedRoutes: { helperNames: ["posts_path", "show"] },
+        defaultEnv: { HTTP_HOST: "example.com" },
       };
       expect(filterActionMethodsForRoutes(["show", "index"], routes)).toEqual(["index"]);
     });

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -16,7 +16,14 @@
  */
 
 export interface NamedRoutesLike {
-  helperNames: readonly string[];
+  /**
+   * Names of generated route helpers (e.g. `posts_path`, `post_url`).
+   * Typed as a generic `Iterable<string>` so the future
+   * `NamedRouteCollection` port can return a Set or any other lazy
+   * source without forcing an array allocation just to satisfy the
+   * contract.
+   */
+  helperNames: Iterable<string>;
 }
 
 export interface RouteSetLike {
@@ -53,6 +60,24 @@ export function _routesInstanceDefault(this: object): never {
  * a route set is wired up.
  */
 export const _routesClassDefault: UrlForClassMethods["_routes"] = () => null;
+
+/**
+ * Convenience bag of Rails-shaped defaults. Use this to wire both
+ * sides of the contract at once without renaming:
+ *
+ * ```ts
+ * Host.prototype._routes = UrlForDefaults._routes;        // instance
+ * (Host as { _routes: () => RouteSetLike | null })._routes = UrlForDefaults._routesStatic;
+ * ```
+ *
+ * The two flat exports (`_routesInstanceDefault` /
+ * `_routesClassDefault`) remain the canonical names — they're
+ * unambiguous when both sides are in scope.
+ */
+export const UrlForDefaults = {
+  _routes: _routesInstanceDefault,
+  _routesStatic: _routesClassDefault,
+} as const;
 
 /**
  * Filter `actionMethods` by removing any names that collide with

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -1,0 +1,75 @@
+/**
+ * `AbstractController::UrlFor` — includes `urlFor` into the host class
+ * (an abstract controller or mailer). The host must provide a route
+ * set by implementing the `_routes` static method. Otherwise calling
+ * `urlFor` raises.
+ *
+ * Note that this module is completely decoupled from HTTP — the only
+ * requirement is a valid `_routes` implementation.
+ *
+ * Ported from `vendor/rails/actionpack/lib/abstract_controller/url_for.rb`.
+ * The deeper `ActionDispatch::Routing::UrlFor` mixin (which provides
+ * the actual `urlFor` instance method) is **not yet ported**; until
+ * then this module just declares the contract and the helper-name
+ * filtering behavior used by `actionMethods`.
+ */
+
+export interface NamedRoutesLike {
+  helperNames: readonly string[];
+}
+
+export interface RouteSetLike {
+  namedRoutes: NamedRoutesLike;
+}
+
+/**
+ * Static-side contract for `_routes`. Hosts that include UrlFor must
+ * supply this on the class (mirrors Rails' `module ClassMethods; def
+ * _routes; …; end; end`). Returning `null` is valid and means "no
+ * routes wired up yet" — `actionMethods` then returns the unfiltered
+ * action set.
+ */
+export interface UrlForClassMethods {
+  _routes(): RouteSetLike | null;
+}
+
+const NO_ROUTES_MESSAGE =
+  "In order to use #urlFor, you must include routing helpers explicitly. " +
+  "For instance, `include Rails.application.routes.urlHelpers`.";
+
+/**
+ * Instance-side `_routes` stub — raises until the host overrides it.
+ * Rails matches this behavior: trying to generate URLs before the
+ * routes are wired up should fail loudly with a hint.
+ */
+export function _routes(this: object): never {
+  throw new Error(NO_ROUTES_MESSAGE);
+}
+
+/**
+ * Default static `_routes`: returns `null`. Hosts that get their
+ * routes wired up later override this on the class (or via
+ * `setRoutes`).
+ */
+export function _routesStatic(): RouteSetLike | null {
+  return null;
+}
+
+/**
+ * Filter `actionMethods` by removing any names that collide with
+ * named-route helper names. Mirrors Rails' `ClassMethods#action_methods`
+ * override: when `_routes` is wired up, the method list shrinks by
+ * the helper names so routing helpers don't show up as actions.
+ *
+ * @param baseActionMethods The unfiltered action list (typically from
+ *   `AbstractController.actionMethods()`).
+ * @param routes The route set returned by `_routes`, or `null`.
+ */
+export function filterActionMethodsForRoutes(
+  baseActionMethods: readonly string[],
+  routes: RouteSetLike | null,
+): string[] {
+  if (!routes) return [...baseActionMethods];
+  const helpers = new Set(routes.namedRoutes.helperNames);
+  return baseActionMethods.filter((name) => !helpers.has(name));
+}

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -31,48 +31,49 @@ export interface RouteSetLike {
 }
 
 /**
- * Static-side contract for `_routes`. Hosts that include UrlFor must
- * supply this on the class (mirrors Rails' `module ClassMethods; def
- * _routes; …; end; end`). Returning `null` is valid and means "no
- * routes wired up yet" — `actionMethods` then returns the unfiltered
- * action set.
+ * Static-side contract for `_routes`. Hosts that include UrlFor expose
+ * this on the class. **It's a property, not a method** — trails reads
+ * `controller._routes` directly (see `action-controller/renderer.ts`'s
+ * `envForRequest`), unlike Rails which uses a `def _routes` method.
+ * `null` means "no routes wired up yet"; `filterActionMethodsForRoutes`
+ * then returns the unfiltered action set.
  */
 export interface UrlForClassMethods {
-  _routes(): RouteSetLike | null;
+  _routes: RouteSetLike | null;
 }
 
-const NO_ROUTES_MESSAGE =
+/**
+ * Hint shown when a host tries to use `#url_for` before any route set
+ * is wired up. Use this at the eventual `urlFor()` call site (the
+ * ActionDispatch::Routing::UrlFor mixin, not yet ported).
+ */
+export const NO_ROUTES_MESSAGE =
   "In order to use #url_for, you must include routing helpers explicitly. " +
   "For instance, `include Rails.application.routes.url_helpers`.";
 
 /**
- * Default instance-side `_routes` — raises until the host overrides
- * it. Mirrors Rails: trying to generate URLs before the routes are
- * wired up should fail loudly with a hint.
- */
-export function _routesInstanceDefault(this: object): never {
-  throw new Error(NO_ROUTES_MESSAGE);
-}
-
-/**
- * Default class-side `_routes` — returns `null`. Conforms to
- * `UrlForClassMethods#_routes`. Hosts override this on the class once
+ * Class-side default for `_routes` — `null`. Conforms to
+ * `UrlForClassMethods._routes`. Hosts override this on the class once
  * a route set is wired up.
+ *
+ * Note: trails treats `_routes` as a property (not a method), so the
+ * default is the literal value `null` rather than a function returning
+ * `null`. The renderer reads `controller._routes` and dereferences
+ * `.defaultEnv` directly.
  */
-export const _routesClassDefault: UrlForClassMethods["_routes"] = () => null;
+export const _routesClassDefault: RouteSetLike | null = null;
+
+/** Per-instance default; same property-based contract. */
+export const _routesInstanceDefault: RouteSetLike | null = null;
 
 /**
  * Convenience bag of Rails-shaped defaults. Use this to wire both
  * sides of the contract at once without renaming:
  *
  * ```ts
- * Host.prototype._routes = UrlForDefaults._routes;        // instance
- * (Host as { _routes: () => RouteSetLike | null })._routes = UrlForDefaults._routesStatic;
+ * Host.prototype._routes = UrlForDefaults._routes;
+ * (Host as { _routes: RouteSetLike | null })._routes = UrlForDefaults._routesStatic;
  * ```
- *
- * The two flat exports (`_routesInstanceDefault` /
- * `_routesClassDefault`) remain the canonical names — they're
- * unambiguous when both sides are in scope.
  */
 export const UrlForDefaults = {
   _routes: _routesInstanceDefault,

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -5,9 +5,11 @@
  * `urlFor(...)` instance method; that mixin is **not yet ported**.
  *
  * This module currently provides:
- *  - the instance-side `_routes` stub that throws until the host wires
- *    in a real route set
- *  - the class-side `_routes` default that returns `null`
+ *  - `_routesInstanceDefault` / `_routesClassDefault` — the literal
+ *    `null` defaults trails uses on hosts that haven't wired up
+ *    routes yet (`_routes` is a property in trails, not a method)
+ *  - `NO_ROUTES_MESSAGE` — the Rails-shaped hint to surface at the
+ *    eventual `urlFor()` call site
  *  - `filterActionMethodsForRoutes`, used by hosts to strip named-route
  *    helper names out of their `actionMethods` list (mirrors Rails'
  *    `ClassMethods#action_methods` override)
@@ -18,16 +20,23 @@
 export interface NamedRoutesLike {
   /**
    * Names of generated route helpers (e.g. `posts_path`, `post_url`).
-   * Typed as a generic `Iterable<string>` so the future
-   * `NamedRouteCollection` port can return a Set or any other lazy
-   * source without forcing an array allocation just to satisfy the
-   * contract.
+   * Typed as `readonly string[]` to match how consumers actually use
+   * it — `UrlGenerationError#corrections` (in
+   * `action-controller/metal/exceptions.ts`) calls `.filter().slice()`
+   * on it. If a future `NamedRouteCollection` port wants to expose a
+   * Set internally, it should still return an array here.
    */
-  helperNames: Iterable<string>;
+  helperNames: readonly string[];
 }
 
 export interface RouteSetLike {
   namedRoutes: NamedRoutesLike;
+  /**
+   * Default Rack env merged underneath request-specific env when the
+   * controller generates URLs. Consumed by
+   * `action-controller/renderer.ts#envForRequest`.
+   */
+  defaultEnv?: Record<string, unknown>;
 }
 
 /**

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -1,17 +1,18 @@
 /**
- * `AbstractController::UrlFor` — includes `urlFor` into the host class
- * (an abstract controller or mailer). The host must provide a route
- * set by implementing the `_routes` static method. Otherwise calling
- * `urlFor` raises.
+ * `AbstractController::UrlFor` — Rails-shaped contract that the route
+ * set + action-method filtering rely on. Rails additionally `include
+ * ActionDispatch::Routing::UrlFor` here to provide the actual
+ * `urlFor(...)` instance method; that mixin is **not yet ported**.
  *
- * Note that this module is completely decoupled from HTTP — the only
- * requirement is a valid `_routes` implementation.
+ * This module currently provides:
+ *  - the instance-side `_routes` stub that throws until the host wires
+ *    in a real route set
+ *  - the class-side `_routes` default that returns `null`
+ *  - `filterActionMethodsForRoutes`, used by hosts to strip named-route
+ *    helper names out of their `actionMethods` list (mirrors Rails'
+ *    `ClassMethods#action_methods` override)
  *
  * Ported from `vendor/rails/actionpack/lib/abstract_controller/url_for.rb`.
- * The deeper `ActionDispatch::Routing::UrlFor` mixin (which provides
- * the actual `urlFor` instance method) is **not yet ported**; until
- * then this module just declares the contract and the helper-name
- * filtering behavior used by `actionMethods`.
  */
 
 export interface NamedRoutesLike {
@@ -38,22 +39,20 @@ const NO_ROUTES_MESSAGE =
   "For instance, `include Rails.application.routes.urlHelpers`.";
 
 /**
- * Instance-side `_routes` stub — raises until the host overrides it.
- * Rails matches this behavior: trying to generate URLs before the
- * routes are wired up should fail loudly with a hint.
+ * Default instance-side `_routes` — raises until the host overrides
+ * it. Mirrors Rails: trying to generate URLs before the routes are
+ * wired up should fail loudly with a hint.
  */
-export function _routes(this: object): never {
+export function _routesInstanceDefault(this: object): never {
   throw new Error(NO_ROUTES_MESSAGE);
 }
 
 /**
- * Default static `_routes`: returns `null`. Hosts that get their
- * routes wired up later override this on the class (or via
- * `setRoutes`).
+ * Default class-side `_routes` — returns `null`. Conforms to
+ * `UrlForClassMethods#_routes`. Hosts override this on the class once
+ * a route set is wired up.
  */
-export function _routesStatic(): RouteSetLike | null {
-  return null;
-}
+export const _routesClassDefault: UrlForClassMethods["_routes"] = () => null;
 
 /**
  * Filter `actionMethods` by removing any names that collide with

--- a/packages/actionpack/src/abstract-controller/url-for.ts
+++ b/packages/actionpack/src/abstract-controller/url-for.ts
@@ -35,8 +35,8 @@ export interface UrlForClassMethods {
 }
 
 const NO_ROUTES_MESSAGE =
-  "In order to use #urlFor, you must include routing helpers explicitly. " +
-  "For instance, `include Rails.application.routes.urlHelpers`.";
+  "In order to use #url_for, you must include routing helpers explicitly. " +
+  "For instance, `include Rails.application.routes.url_helpers`.";
 
 /**
  * Default instance-side `_routes` — raises until the host overrides


### PR DESCRIPTION
## Summary
Ports `vendor/rails/actionpack/lib/abstract_controller/url_for.rb` (37 LOC Rails). The deeper `ActionDispatch::Routing::UrlFor` mixin (which provides the actual `urlFor(...)` instance method) is **not yet ported**; until then this module declares the surrounding contract.

### What ships
- **`_routesInstanceDefault` / `_routesClassDefault`** — both literal `null`. Trails reads `_routes` as a property (see `action-controller/renderer.ts#envForRequest`), so the Rails-method shape doesn't apply; the defaults are the literal value `null`.
- **`NO_ROUTES_MESSAGE`** — the Rails-shaped hint (\`#url_for\` / \`url_helpers\`) for the eventual `urlFor()` call site to throw.
- **`filterActionMethodsForRoutes(actions, routes)`** — strips helper-named actions from a list. Mirrors Rails' `ClassMethods#action_methods` override.
- **`UrlForDefaults`** — convenience bag of Rails-shaped names for wiring both sides.
- **`RouteSetLike` / `NamedRoutesLike` / `UrlForClassMethods`** — declarative contracts. `RouteSetLike` includes optional `defaultEnv` to unify with the inline shape in `renderer.ts`.

## `abstract_controller/` status after this PR (10/13)
| Rails file       | LOC | Status         |
| ---------------- | --- | -------------- |
| `base.rb`        | 299 | ✅             |
| `callbacks.rb`   | 265 | ✅             |
| `error.rb`       | 8   | ✅             |
| `translation.rb` | 42  | ✅ (#1739)     |
| `deprecator.rb`  | 9   | ✅ (#1739)     |
| `asset_paths.rb` | 14  | ✅ (#1744)     |
| `logger.rb`      | 16  | ✅ (#1744)     |
| `collector.rb`   | 44  | ✅ (#1755)     |
| `rendering.rb`   | 125 | ✅ (#1763)     |
| `url_for.rb`     | 37  | **this PR**    |
| `caching.rb`+dir | 68+ | not ported     |
| `helpers.rb`     | 245 | not ported     |
| `railties/`      | -   | (trailtie)     |

## Test plan
- [x] 7 url-for tests pass
- [x] \`pnpm -w build\` clean
- [x] \`pnpm lint\` clean