### PR TITLE
feat(activerecord): CollectionProxy#include? Rails fidelity (batch 31)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -93,12 +93,6 @@ export interface AssociationOptions {
   autosave?: boolean;
   scope?: (rel: any, owner?: any) => any;
   validate?: boolean;
-  /** When true, records loaded through this association are marked
-   * readonly, causing `save`/`destroy` on them to raise `ReadOnlyRecord`.
-   *
-   * Mirrors Rails' `has_many :foo, readonly: true` — applied at load time
-   * via `Relation#readonly!`. */
-  readonly?: boolean;
   required?: boolean;
   optional?: boolean;
   beforeAdd?:
@@ -1604,10 +1598,6 @@ export async function loadHabtm(
   // composition (where/order/select/group/having/unscope).
   let rel: any = _scopeForAssociation(targetModel).where(inNode);
   if (options.scope) rel = options.scope(rel);
-  // Rails `has_and_belongs_to_many :foo, readonly: true` propagates the
-  // readonly flag onto every loaded record. Apply after the user scope so
-  // an explicit `readonlyBang(false)` in the scope can opt out.
-  if (options.readonly) rel = rel.readonlyBang();
 
   return rel.toArray();
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -93,6 +93,12 @@ export interface AssociationOptions {
   autosave?: boolean;
   scope?: (rel: any, owner?: any) => any;
   validate?: boolean;
+  /** When true, records loaded through this association are marked
+   * readonly, causing `save`/`destroy` on them to raise `ReadOnlyRecord`.
+   *
+   * Mirrors Rails' `has_many :foo, readonly: true` — applied at load time
+   * via `Relation#readonly!`. */
+  readonly?: boolean;
   required?: boolean;
   optional?: boolean;
   beforeAdd?:
@@ -1598,6 +1604,10 @@ export async function loadHabtm(
   // composition (where/order/select/group/having/unscope).
   let rel: any = _scopeForAssociation(targetModel).where(inNode);
   if (options.scope) rel = options.scope(rel);
+  // Rails `has_and_belongs_to_many :foo, readonly: true` propagates the
+  // readonly flag onto every loaded record. Apply after the user scope so
+  // an explicit `readonlyBang(false)` in the scope can opt out.
+  if (options.readonly) rel = rel.readonlyBang();
 
   return rel.toArray();
 }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1206,14 +1206,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       : this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
-    // Rails: when the association is declared with `validate: false`, the
-    // implicit `save` during `push`/`<<` is invoked with `validate: false`,
-    // suppressing both the target record's and the join record's
-    // validations (matches `Association#insert_record` /
-    // `HasManyAssociation#insert_record` in
-    // `activerecord/lib/active_record/associations/has_many_association.rb`).
-    const skipValidate = this._assocDef.options.validate === false;
-    const saveOpts = skipValidate ? { validate: false } : undefined;
 
     for (const record of records) {
       if (
@@ -1224,14 +1216,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Save the target record if it's new
       if (record.isNewRecord()) {
         if (bang) {
-          if (skipValidate) {
-            const saved = await record.save(saveOpts);
-            if (!saved) continue;
-          } else {
-            await record.saveBang();
-          }
+          await record.saveBang(); // raises RecordInvalid if invalid
         } else {
-          const saved = await record.save(saveOpts);
+          const saved = await record.save();
           if (!saved) continue;
         }
       }
@@ -1255,14 +1242,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (bang) {
         // Bang form: raise RecordInvalid if join record is invalid (mirrors Rails' save!)
         joinRecord = new throughModel(joinAttrs);
-        if (skipValidate) {
-          await joinRecord.save(saveOpts);
-        } else {
-          await joinRecord.saveBang();
-        }
-      } else if (skipValidate) {
-        joinRecord = new throughModel(joinAttrs);
-        await joinRecord.save(saveOpts);
+        await joinRecord.saveBang();
       } else {
         joinRecord = await throughModel.create(joinAttrs);
       }
@@ -1291,41 +1271,27 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Walk the through-chain looking for `record` in already-loaded sources.
-   * Returns the boolean answer when the through-target is loaded; returns
-   * `null` to signal "not determinable in memory, caller should fall back
-   * to the database path". Mirrors Rails'
-   * `HasManyThroughAssociation#include_in_memory?`.
+   * Walk the through-chain looking for `record` via the source reflection.
+   * Mirrors the through branch of
+   * `CollectionAssociation#include_in_memory?` —
+   * `assoc.reader.any? { |source| source.send(source_reflection.name)... }`.
    */
-  private async _includeInMemoryThrough(record: T): Promise<boolean | null> {
+  private async _includeInMemoryThrough(record: T): Promise<boolean> {
     const ctor = this._record.constructor as typeof Base;
     const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
     const throughName = this._assocDef.options.through!;
     const throughAssoc = associations.find((a: any) => a.name === throughName);
-    if (!throughAssoc) return null;
-    // Only consult the cache when the through proxy was already populated;
-    // otherwise we'd issue extra queries to answer `include?`.
-    const throughProxy = (this._record as any)._collectionProxies?.get(throughName) as
-      | CollectionProxy<Base>
-      | undefined;
-    if (!throughProxy || !(throughProxy as any)._targetLoaded) return null;
+    if (!throughAssoc) return false;
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
-    const targetPk = (record.constructor as typeof Base).primaryKey;
-    if (Array.isArray(targetPk)) return null;
-    const targetId = record._readAttribute(targetPk);
-    if (targetId == null) return null;
-    for (const joinRecord of (throughProxy as any)._target as Base[]) {
-      const source = (joinRecord as any)[sourceName];
+    const sources = (await (this._record as any)[throughName]) as Base[] | undefined;
+    if (!sources) return false;
+    for (const joinRecord of sources) {
+      const source = await (joinRecord as any)[sourceName];
       if (source == null) continue;
-      const candidates: Base[] = Array.isArray(source)
-        ? source
-        : source instanceof Promise
-          ? []
-          : [source as Base];
-      for (const cand of candidates) {
-        const pk = (cand.constructor as typeof Base).primaryKey;
-        if (Array.isArray(pk)) continue;
-        if (cand._readAttribute(pk) === targetId) return true;
+      if (Array.isArray(source)) {
+        if (source.includes(record)) return true;
+      } else if (source === record) {
+        return true;
       }
     }
     return false;
@@ -1592,16 +1558,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (!(record instanceof klass)) return false;
     }
     if (record.isNewRecord()) {
+      // Mirrors `CollectionAssociation#include_in_memory?`: for through
+      // associations, walk the through target looking for `record` via the
+      // source reflection; OR fall back to the local target. For
+      // non-through associations, just check the local target.
+      if (this._assocDef.options.through) {
+        if (await this._includeInMemoryThrough(record)) return true;
+      }
       return this._target.includes(record);
-    }
-
-    // Through associations: when the through-target is already loaded in
-    // memory, walk the chain rather than re-querying. Matches Rails'
-    // `HasManyThroughAssociation#include_in_memory?` (recursively walks
-    // `through_reflection.target` looking for `source_reflection`).
-    if (this._assocDef.options.through) {
-      const inMemory = await this._includeInMemoryThrough(record);
-      if (inMemory !== null) return inMemory;
     }
 
     if (this._targetLoaded) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1206,6 +1206,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       : this._throughOwnerAttrs(throughAssoc, ctor);
     const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
     const sourceFk = `${underscore(sourceName)}_id`;
+    // Rails: when the association is declared with `validate: false`, the
+    // implicit `save` during `push`/`<<` is invoked with `validate: false`,
+    // suppressing both the target record's and the join record's
+    // validations (matches `Association#insert_record` /
+    // `HasManyAssociation#insert_record` in
+    // `activerecord/lib/active_record/associations/has_many_association.rb`).
+    const skipValidate = this._assocDef.options.validate === false;
+    const saveOpts = skipValidate ? { validate: false } : undefined;
 
     for (const record of records) {
       if (
@@ -1216,9 +1224,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Save the target record if it's new
       if (record.isNewRecord()) {
         if (bang) {
-          await record.saveBang(); // raises RecordInvalid if invalid
+          if (skipValidate) {
+            const saved = await record.save(saveOpts);
+            if (!saved) continue;
+          } else {
+            await record.saveBang();
+          }
         } else {
-          const saved = await record.save();
+          const saved = await record.save(saveOpts);
           if (!saved) continue;
         }
       }
@@ -1242,7 +1255,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (bang) {
         // Bang form: raise RecordInvalid if join record is invalid (mirrors Rails' save!)
         joinRecord = new throughModel(joinAttrs);
-        await joinRecord.saveBang();
+        if (skipValidate) {
+          await joinRecord.save(saveOpts);
+        } else {
+          await joinRecord.saveBang();
+        }
+      } else if (skipValidate) {
+        joinRecord = new throughModel(joinAttrs);
+        await joinRecord.save(saveOpts);
       } else {
         joinRecord = await throughModel.create(joinAttrs);
       }
@@ -1268,6 +1288,47 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         (assocInstance as any).reset();
       }
     }
+  }
+
+  /**
+   * Walk the through-chain looking for `record` in already-loaded sources.
+   * Returns the boolean answer when the through-target is loaded; returns
+   * `null` to signal "not determinable in memory, caller should fall back
+   * to the database path". Mirrors Rails'
+   * `HasManyThroughAssociation#include_in_memory?`.
+   */
+  private async _includeInMemoryThrough(record: T): Promise<boolean | null> {
+    const ctor = this._record.constructor as typeof Base;
+    const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+    const throughName = this._assocDef.options.through!;
+    const throughAssoc = associations.find((a: any) => a.name === throughName);
+    if (!throughAssoc) return null;
+    // Only consult the cache when the through proxy was already populated;
+    // otherwise we'd issue extra queries to answer `include?`.
+    const throughProxy = (this._record as any)._collectionProxies?.get(throughName) as
+      | CollectionProxy<Base>
+      | undefined;
+    if (!throughProxy || !(throughProxy as any)._targetLoaded) return null;
+    const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
+    const targetPk = (record.constructor as typeof Base).primaryKey;
+    if (Array.isArray(targetPk)) return null;
+    const targetId = record._readAttribute(targetPk);
+    if (targetId == null) return null;
+    for (const joinRecord of (throughProxy as any)._target as Base[]) {
+      const source = (joinRecord as any)[sourceName];
+      if (source == null) continue;
+      const candidates: Base[] = Array.isArray(source)
+        ? source
+        : source instanceof Promise
+          ? []
+          : [source as Base];
+      for (const cand of candidates) {
+        const pk = (cand.constructor as typeof Base).primaryKey;
+        if (Array.isArray(pk)) continue;
+        if (cand._readAttribute(pk) === targetId) return true;
+      }
+    }
+    return false;
   }
 
   private _raiseOnTypeMismatch(records: T[]): void {
@@ -1516,8 +1577,31 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#include?
    */
   async isInclude(record: T): Promise<boolean> {
+    // Rails `include?` short-circuits on type mismatch — a record whose
+    // class is unrelated to the reflection's `klass` can never be in the
+    // target. Without this guard, a bogus record would issue a needless
+    // `exists?` query and might silently match a row with the same PK on
+    // the wrong table.
+    // Mirrors `ActiveRecord::Associations::CollectionAssociation#include?`
+    // (`return false unless record.is_a?(reflection.klass)`).
+    if (!this._assocDef.options.polymorphic) {
+      const className =
+        (this._assocDef.options.className as string | undefined) ??
+        camelize(singularize(this._assocName));
+      const klass = resolveAssocClass(this._record, this._assocName, className);
+      if (!(record instanceof klass)) return false;
+    }
     if (record.isNewRecord()) {
       return this._target.includes(record);
+    }
+
+    // Through associations: when the through-target is already loaded in
+    // memory, walk the chain rather than re-querying. Matches Rails'
+    // `HasManyThroughAssociation#include_in_memory?` (recursively walks
+    // `through_reflection.target` looking for `source_reflection`).
+    if (this._assocDef.options.through) {
+      const inMemory = await this._includeInMemoryThrough(record);
+      if (inMemory !== null) return inMemory;
     }
 
     if (this._targetLoaded) {
@@ -2314,6 +2398,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   async appendBang(...records: T[]): Promise<void> {
     this._ensureThroughWritable();
+    this._raiseOnTypeMismatch(records);
     if (this._assocDef.options.through) {
       await this._pushThrough(records, false, true);
       return;


### PR DESCRIPTION
## Summary

Batch 31 — HABTM Slot A. Aligns `CollectionProxy#isInclude` and `appendBang` with Rails `ActiveRecord::Associations::CollectionAssociation` after auditing the relevant Rails source files.

- `isInclude` short-circuits with a `klass instanceof` guard
  (Rails `include? unless record.is_a?(reflection.klass)`).
- `isInclude` for `new_record?` dispatches to `include_in_memory?` which
  walks the through chain via the source reflection, mirroring
  `collection_association.rb:507`.
- `appendBang` now runs `_raiseOnTypeMismatch` before dispatching, matching
  `push()` and Rails' `CollectionAssociation` type guard.

## Scope notes

The original plan called for a `readonly: true` HABTM option and a
`validate: false` push-path tweak. After reading
`vendor/rails/.../associations/builder/{association,has_many}.rb` and
`collection_association.rb`, neither is Rails-aligned:
- `:readonly` is not in `VALID_OPTIONS` / `valid_options` for HABTM in
  modern Rails. Readonly propagation is achieved via a `scope` that calls
  `.readonly` — already wired in `loadHabtm`. The
  *dynamic find all should respect readonly access* test uses exactly that
  scope form and already passes.
- `insert_record` always invokes `record.save(validate: true)`. The
  `:validate` reflection option only affects autosave callbacks, already
  wired in `autosave-association.ts:327`. The two
  *validate false does not run associated validation callbacks* tests also
  already pass.

Both items were dropped from this PR rather than implementing
non-Rails-aligned behavior.

## Verification

- `pnpm api:compare --package activerecord` → 4956/4958 (100%) (no delta).
- `pnpm test:compare --package activerecord` → 6579/7880 (no delta).
- `pnpm vitest run` on the HABTM, has_many, has_many_through,
  collection-proxy, autosave-association suites: 758 passed / 44 skipped
  (no regressions; skip counts unchanged).