### PR TITLE
feat(activerecord): Relation Slot H inBatches port (batch 68)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2670,6 +2670,11 @@ export class Base extends Model {
     }
     const updateDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
     if (updateDefaultConstraint != null) um.where(updateDefaultConstraint as any);
+    const updateGlobalScope = ScopeRegistry.globalCurrentScope(ctor);
+    if (updateGlobalScope) {
+      const ast = updateGlobalScope._whereClause?.ast;
+      if (ast != null) um.where(ast as any);
+    }
 
     const umVisitor = ctor.adapter.arelVisitor;
     this._pendingOperation = ctor.adapter
@@ -2712,6 +2717,11 @@ export class Base extends Model {
         }
         const destroyDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
         if (destroyDefaultConstraint != null) dm.where(destroyDefaultConstraint as any);
+        const destroyGlobalScope = ScopeRegistry.globalCurrentScope(ctor);
+        if (destroyGlobalScope) {
+          const ast = destroyGlobalScope._whereClause?.ast;
+          if (ast != null) dm.where(ast as any);
+        }
 
         const affected = await ctor.adapter.execDelete(dm.toSql(), `${ctor.name} Destroy`);
         if (ctor.lockingEnabled && affected === 0) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2668,13 +2668,7 @@ export class Base extends Model {
         um.where(table.get(lockCol).eq(Number(rawVersion) || 0));
       }
     }
-    const updateDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
-    if (updateDefaultConstraint != null) um.where(updateDefaultConstraint as any);
-    const updateGlobalScope = ScopeRegistry.globalCurrentScope(ctor);
-    if (updateGlobalScope) {
-      const ast = updateGlobalScope._whereClause?.ast;
-      if (ast != null) um.where(ast as any);
-    }
+    _Persistence.applyDefaultAndGlobalConstraints(um as any, ctor);
 
     const umVisitor = ctor.adapter.arelVisitor;
     this._pendingOperation = ctor.adapter
@@ -2715,13 +2709,7 @@ export class Base extends Model {
             dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
           }
         }
-        const destroyDefaultConstraint = _Persistence.buildDefaultConstraint.call(ctor as any);
-        if (destroyDefaultConstraint != null) dm.where(destroyDefaultConstraint as any);
-        const destroyGlobalScope = ScopeRegistry.globalCurrentScope(ctor);
-        if (destroyGlobalScope) {
-          const ast = destroyGlobalScope._whereClause?.ast;
-          if (ast != null) dm.where(ast as any);
-        }
+        _Persistence.applyDefaultAndGlobalConstraints(dm as any, ctor);
 
         const affected = await ctor.adapter.execDelete(dm.toSql(), `${ctor.name} Destroy`);
         if (ctor.lockingEnabled && affected === 0) {

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -587,8 +587,30 @@ describe("EachTest", () => {
     }).rejects.toThrow();
   });
 
-  it.skip("find in batches should not error if config overridden", () => {
-    // ROOT-CAUSE fixed: activeRecordConfig.errorOnIgnoredOrder + errorOnIgnore:false override
+  it("find in batches should not error if config overridden", async () => {
+    const adp = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    await Post.create({ title: "a" });
+    activeRecordConfig.errorOnIgnoredOrder = true;
+    let threw = false;
+    try {
+      for await (const _b of Post.order("title").findInBatches({
+        batchSize: 1,
+        errorOnIgnore: false,
+      })) {
+        /* noop */
+      }
+    } catch {
+      threw = true;
+    } finally {
+      activeRecordConfig.errorOnIgnoredOrder = false;
+    }
+    expect(threw).toBe(false);
   });
 
   it("find in batches should error on config specified to error", async () => {
@@ -633,8 +655,25 @@ describe("EachTest", () => {
     expect(batches.length).toBe(1);
   });
 
-  it.skip("find in batches should use any column as primary key when start is not specified", () => {
-    // ROOT-CAUSE fixed: cursor option supported; needs Subscriber test fixture
+  it("find in batches should use any column as primary key when start is not specified", async () => {
+    const adp = freshAdapter();
+    class Subscriber extends Base {
+      static {
+        this.primaryKey = "nick";
+        this.attribute("nick", "string");
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    await Subscriber.create({ nick: "a", name: "Alice" });
+    await Subscriber.create({ nick: "b", name: "Bob" });
+    await Subscriber.create({ nick: "c", name: "Carol" });
+    const collected: any[] = [];
+    for await (const batch of Subscriber.findInBatches({ batchSize: 1, cursor: "nick" })) {
+      expect(Array.isArray(batch)).toBe(true);
+      collected.push(...batch);
+    }
+    expect(collected.map((r) => r.readAttribute("nick"))).toEqual(["a", "b", "c"]);
   });
 
   it("in batches update all returns zero when no batches", async () => {
@@ -729,8 +768,25 @@ describe("EachTest", () => {
     expect(total).toBe(0);
   });
 
-  it.skip("in batches should use any column as primary key when start is not specified", () => {
-    // ROOT-CAUSE fixed: cursor option supported; needs Subscriber test fixture
+  it("in batches should use any column as primary key when start is not specified", async () => {
+    const adp = freshAdapter();
+    class Subscriber extends Base {
+      static {
+        this.primaryKey = "nick";
+        this.attribute("nick", "string");
+        this.attribute("name", "string");
+        this.adapter = adp;
+      }
+    }
+    await Subscriber.create({ nick: "a", name: "Alice" });
+    await Subscriber.create({ nick: "b", name: "Bob" });
+    await Subscriber.create({ nick: "c", name: "Carol" });
+    let count = 0;
+    for await (const rel of Subscriber.all().inBatches({ batchSize: 1, cursor: "nick" })) {
+      expect(rel).toBeInstanceOf(Relation);
+      count += (await rel.toArray()).length;
+    }
+    expect(count).toBe(3);
   });
 
   it("in_batches should return no records if the limit is 0 and load is ", async () => {
@@ -801,6 +857,22 @@ describe("EachTest", () => {
     const lastBatch = batches[batches.length - 1];
     const records = await lastBatch.toArray();
     expect(records[records.length - 1].readAttribute("id")).toBe(secondToLast.readAttribute("id"));
+  });
+
+  it("in batches with useRanges yields batches that cover all rows", async () => {
+    const adp = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    for (let i = 0; i < 7; i++) await Post.create({ title: `t-${i}` });
+    let total = 0;
+    for await (const rel of Post.all().inBatches({ batchSize: 3, useRanges: true })) {
+      total += (await rel.toArray()).length;
+    }
+    expect(total).toBe(7);
   });
 });
 

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -596,6 +596,7 @@ describe("EachTest", () => {
       }
     }
     await Post.create({ title: "a" });
+    const prev = activeRecordConfig.errorOnIgnoredOrder;
     activeRecordConfig.errorOnIgnoredOrder = true;
     let threw = false;
     try {
@@ -608,7 +609,7 @@ describe("EachTest", () => {
     } catch {
       threw = true;
     } finally {
-      activeRecordConfig.errorOnIgnoredOrder = false;
+      activeRecordConfig.errorOnIgnoredOrder = prev;
     }
     expect(threw).toBe(false);
   });
@@ -621,6 +622,7 @@ describe("EachTest", () => {
         this.adapter = adp;
       }
     }
+    const prevErrCfg = activeRecordConfig.errorOnIgnoredOrder;
     activeRecordConfig.errorOnIgnoredOrder = true;
     try {
       await expect(async () => {
@@ -629,7 +631,7 @@ describe("EachTest", () => {
         }
       }).rejects.toThrow();
     } finally {
-      activeRecordConfig.errorOnIgnoredOrder = false;
+      activeRecordConfig.errorOnIgnoredOrder = prevErrCfg;
     }
   });
 
@@ -859,7 +861,7 @@ describe("EachTest", () => {
     expect(records[records.length - 1].readAttribute("id")).toBe(secondToLast.readAttribute("id"));
   });
 
-  it("in batches with useRanges yields batches that cover all rows", async () => {
+  it("in batches with useRanges emits range predicate and covers all rows", async () => {
     const adp = freshAdapter();
     class Post extends Base {
       static {
@@ -869,10 +871,19 @@ describe("EachTest", () => {
     }
     for (let i = 0; i < 7; i++) await Post.create({ title: `t-${i}` });
     let total = 0;
+    const sqls: string[] = [];
     for await (const rel of Post.all().inBatches({ batchSize: 3, useRanges: true })) {
+      sqls.push(rel.toSql());
       total += (await rel.toArray()).length;
     }
     expect(total).toBe(7);
+    // useRanges yields a range predicate (>= AND <=), never an IN clause.
+    expect(sqls.length).toBeGreaterThan(0);
+    for (const sql of sqls) {
+      expect(sql).toMatch(/>=/);
+      expect(sql).toMatch(/<=/);
+      expect(sql).not.toMatch(/\bIN\s*\(/i);
+    }
   });
 });
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -38,6 +38,7 @@ import {
   type ValidationContextArg,
 } from "./validations.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
+import { ScopeRegistry } from "./scoping.js";
 
 interface PersistenceHost {
   new (attrs?: Record<string, unknown>): any;
@@ -246,6 +247,12 @@ export async function _updateRecord(
   const defaultConstraint = buildDefaultConstraint.call(this as any);
   if (defaultConstraint != null) um.where(defaultConstraint as any);
 
+  const globalScope = ScopeRegistry.globalCurrentScope(this as any);
+  if (globalScope) {
+    const ast = (globalScope as any)._whereClause?.ast;
+    if (ast != null) um.where(ast);
+  }
+
   const adapter = (this as any).adapter;
   if (typeof adapter.update === "function") {
     return adapter.update(um);
@@ -273,6 +280,12 @@ export async function _deleteRecord(
 
   const defaultConstraint = buildDefaultConstraint.call(this as any);
   if (defaultConstraint != null) dm.where(defaultConstraint as any);
+
+  const globalScope = ScopeRegistry.globalCurrentScope(this as any);
+  if (globalScope) {
+    const ast = (globalScope as any)._whereClause?.ast;
+    if (ast != null) dm.where(ast);
+  }
 
   const adapter = (this as any).adapter;
   if (typeof adapter.delete === "function") {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -244,14 +244,7 @@ export async function _updateRecord(
     um.where(table.get(col).eq(val));
   }
 
-  const defaultConstraint = buildDefaultConstraint.call(this as any);
-  if (defaultConstraint != null) um.where(defaultConstraint as any);
-
-  const globalScope = ScopeRegistry.globalCurrentScope(this as any);
-  if (globalScope) {
-    const ast = (globalScope as any)._whereClause?.ast;
-    if (ast != null) um.where(ast);
-  }
+  applyDefaultAndGlobalConstraints(um as any, this as any);
 
   const adapter = (this as any).adapter;
   if (typeof adapter.update === "function") {
@@ -278,14 +271,7 @@ export async function _deleteRecord(
     dm.where(table.get(col).eq(val));
   }
 
-  const defaultConstraint = buildDefaultConstraint.call(this as any);
-  if (defaultConstraint != null) dm.where(defaultConstraint as any);
-
-  const globalScope = ScopeRegistry.globalCurrentScope(this as any);
-  if (globalScope) {
-    const ast = (globalScope as any)._whereClause?.ast;
-    if (ast != null) dm.where(ast);
-  }
+  applyDefaultAndGlobalConstraints(dm as any, this as any);
 
   const adapter = (this as any).adapter;
   if (typeof adapter.delete === "function") {
@@ -1411,6 +1397,25 @@ function instantiateInstanceOf(
 /** @internal */
 function discriminateClassForRecord<T>(klass: T, _record: Record<string, unknown>): T {
   return klass;
+}
+
+/**
+ * Append the default constraint and the global-current-scope WHERE clause
+ * (if any) to an Arel UpdateManager or DeleteManager. Mirrors the constraint
+ * stacking in Rails `persistence.rb` `_update_record` / `_delete_record`.
+ * @internal
+ */
+export function applyDefaultAndGlobalConstraints(
+  manager: { where(node: unknown): unknown },
+  ctor: object,
+): void {
+  const defaultConstraint = buildDefaultConstraint.call(ctor as any);
+  if (defaultConstraint != null) manager.where(defaultConstraint);
+  const globalScope = ScopeRegistry.globalCurrentScope(ctor);
+  if (globalScope) {
+    const ast = (globalScope as any)._whereClause?.ast;
+    if (ast != null) manager.where(ast);
+  }
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3202,6 +3202,7 @@ export class Relation<T extends Base> {
     cursor,
     errorOnIgnore,
     load = false,
+    useRanges,
   }: {
     batchSize?: number;
     start?: unknown;
@@ -3210,6 +3211,7 @@ export class Relation<T extends Base> {
     cursor?: string | string[];
     errorOnIgnore?: boolean;
     load?: boolean;
+    useRanges?: boolean | null;
   } = {}): BatchEnumerator<LoadedRelation<Relation<T>>> {
     const self = this;
     const pk = this._modelClass.primaryKey;
@@ -3277,7 +3279,18 @@ export class Relation<T extends Base> {
           const tuples = (batchRows as any[]).map((r) =>
             cursorArr.map((c) => (r as any).readAttribute(c)),
           );
-          if (cursorArr.length === 1) {
+          if (useRanges && !load && cursorArr.length === 1 && tuples.length > 0) {
+            // Range-mode: emit `col >= first AND col <= last` (reversed for desc)
+            // instead of `col IN (...)`. Mirrors Rails apply_finish_limit path.
+            const col = cursorArr[0];
+            const dir = batchOrders[0][1];
+            const first = tuples[0][0];
+            const last = tuples[tuples.length - 1][0];
+            const attr = self._modelClass.arelTable.get(col) as any;
+            const lo = dir === "desc" ? last : first;
+            const hi = dir === "desc" ? first : last;
+            batchRel._whereClause.predicates.push(attr.gteq(lo).and(attr.lteq(hi)));
+          } else if (cursorArr.length === 1) {
             const ids = tuples.map((t) => t[0]);
             batchRel._whereClause.predicates.push(
               ...self.predicateBuilder.buildFromHash({ [cursorArr[0]]: ids }),


### PR DESCRIPTION
## Summary

Batch 68 from `docs/activerecord-100-plan.md` — Relation Slot H inBatches port.

- **`base.ts`**: wire `globalCurrentScope` WHERE into `_performUpdate` and `_destroyRow` (mirrors Rails `persistence.rb` `_update_record` / `_delete_record`).
- **`relation.ts` `inBatches`**: add `useRanges` option. For single-column cursor in the unloaded path, emit `WHERE cursor >= first AND cursor <= last` (reversed for desc) instead of `WHERE cursor IN (...)`.
- **`batches.test.ts`**: port 3 previously-skipped test bodies (`should not error if config overridden`, two `should use any column as primary key when start is not specified` variants using inline Subscriber-like model). Add a `useRanges` smoke test.

## Follow-ups (still skipped)

- `find in batches should quote batch order` — needs `assertQueriesMatch` infra.
- `find in batches should ignore the order default scope` — needs `PostWithDefaultScope` fixture (default_scope with order, batches must ignore it).
- `.find_each respects table alias` — needs `Relation.create` test infra.
- `useRanges` empty-scope auto-detection (Rails: `empty_scope && use_ranges != false`) not yet wired; currently triggered only by explicit `useRanges: true`.

## Test plan

- [x] `vitest run packages/activerecord/src/batches.test.ts` — 141 passed, 3 skipped (was 6 skipped).
- [x] `tsc --build` — clean.