### PR TITLE
test(activerecord): batch 87 — STI annotation drift in BLOCKED/ROOT-CAUSE/SCOPE format

### DIFF
--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -212,7 +212,9 @@ describe("DelegatedTypeTest", () => {
   });
 
   it.skip("touch account", () => {
-    // BLOCKED: uuid + polymorphic-touch — requires UUID PK + touch on a polymorphic delegated_type association; no STI routing gap
+    // BLOCKED: uuid + polymorphic-touch — touch on a polymorphic delegated_type association with a UUID PK; no STI routing gap (audit-STI)
+    // ROOT-CAUSE: associations/belongs-to-association.ts#touch + connection-adapters timestamp paths do not propagate touch through a polymorphic owner whose PK is a UUID (foreign_type/foreign_key resolution falls back to integer-PK assumptions)
+    // SCOPE: ~30–50 LOC across associations/belongs-to-association.ts + persistence touch path; affects this single delegated-type touch test
   });
 
   it("builder method", () => {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -212,9 +212,9 @@ describe("DelegatedTypeTest", () => {
   });
 
   it.skip("touch account", () => {
-    // BLOCKED: uuid + polymorphic-touch — touch on a polymorphic delegated_type association with a UUID PK; no STI routing gap (audit-STI)
-    // ROOT-CAUSE: associations/belongs-to-association.ts#touch + connection-adapters timestamp paths do not propagate touch through a polymorphic owner whose PK is a UUID (foreign_type/foreign_key resolution falls back to integer-PK assumptions)
-    // SCOPE: ~30–50 LOC across associations/belongs-to-association.ts + persistence touch path; affects this single delegated-type touch test
+    // BLOCKED: fixture + delegated-type touch chain — needs Recipient/Account fixtures + multi-hop `belongs_to … touch: true` propagation through a polymorphic delegated_type owner; no STI routing gap (audit-STI)
+    // ROOT-CAUSE: missing Recipient/Account test-models for this file, plus an unverified path through `associations/builder/belongs-to.ts#touchParent` when the touched owner is the polymorphic `entryable` of a delegated_type parent (Rails chains Recipient → Message → Entry → Account via `touch: true`)
+    // SCOPE: ~20–30 LOC fixture-models in delegated-type.test.ts; if the chained-touch path also needs work, follow-up in associations/builder/belongs-to.ts; affects this single delegated-type touch test
   });
 
   it("builder method", () => {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -1434,13 +1434,15 @@ describe("InheritanceTest", () => {
   });
 
   it.skip("scope inherited properly", async () => {
-    // BLOCKED: default-scope — test requires a fixture model with a default_scope on a subclass;
-    // no STI routing gap (STI dispatch works); gap is missing test fixture model
+    // BLOCKED: fixture — STI subclass with default_scope; no STI routing gap (audit-STI: STI dispatch works)
+    // ROOT-CAUSE: test/models fixtures — Rails' SpecialComment / VerySpecialComment hierarchy with `default_scope` on a subclass is not declared in the trails test-models registry
+    // SCOPE: ~10–20 LOC fixture-models setup in inheritance.test.ts; affects 2 default-scope inheritance tests
   });
 
   it.skip("inheritance with default scope", async () => {
-    // BLOCKED: default-scope — test requires a fixture model with a default_scope on a subclass;
-    // no STI routing gap (STI dispatch works); gap is missing test fixture model
+    // BLOCKED: fixture — STI subclass with default_scope; no STI routing gap (audit-STI: STI dispatch works)
+    // ROOT-CAUSE: test/models fixtures — Rails' SpecialComment / VerySpecialComment hierarchy with `default_scope` on a subclass is not declared in the trails test-models registry
+    // SCOPE: ~10–20 LOC fixture-models setup in inheritance.test.ts; affects 2 default-scope inheritance tests
   });
 
   it("company descends from active record", async () => {

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -546,9 +546,9 @@ describe("InsertAllTest", () => {
     // BLOCKED: relation — insert_all.rb: aliasAttribute in insertAll / upsertAll
   });
   it.skip("insert all and upsert all with sti", () => {
-    // BLOCKED: fixture — test requires the Rails Category / SpecialCategory STI fixture
-    // hierarchy (categories table with `type` discriminator); no STI routing gap (insertAll /
-    // upsertAll set the type column via the existing STI dispatch); gap is missing test fixtures
+    // BLOCKED: fixture — Rails Category / SpecialCategory STI hierarchy is not declared in the trails test-models registry; no STI routing gap (audit-STI: insertAll/upsertAll set the `type` column via existing STI dispatch)
+    // ROOT-CAUSE: test fixtures — `categories` table + `Category` / `SpecialCategory` STI models with the `type` discriminator are missing from this test file's model setup
+    // SCOPE: ~15–25 LOC fixture-models setup in insert-all.test.ts; affects this single STI insert/upsert test
   });
   it.skip("upsert and db warnings", () => {
     // BLOCKED: relation — insert_all.rb: DB warnings emitted on upsert


### PR DESCRIPTION
## Summary

Closes **Batch 87 — STI annotation drift** from `docs/activerecord-100-plan.md`.

`audit-STI` found **no STI implementation gap**. The original 6 `BLOCKED: STI` annotations were mis-labeled; #1641 already retagged them into category-specific labels and un-skipped 3 sites that turned out to have no gap. This PR finishes that workflow by reformatting the 4 still-skipped sites into the canonical three-line annotation format already used by `active-record.test.ts` and `base-prevent-writes.test.ts`:

```
// BLOCKED: <category> — <short reason>
// ROOT-CAUSE: <file / what's missing>
// SCOPE: <LOC estimate + which tests affected>
```

## Sites retagged

| Test | Category | Real cause |
|---|---|---|
| `delegated-type.test.ts` — `touch account` | `fixture + delegated-type touch chain` | needs Recipient/Account fixtures + multi-hop `belongs_to … touch: true` chain through a polymorphic delegated_type owner (Rails: Recipient → Message → Entry → Account, integer-PK fixtures — not the UUID hierarchy) |
| `inheritance.test.ts` — `scope inherited properly` | `fixture` | Rails `SpecialComment` / `VerySpecialComment` hierarchy with `default_scope` not declared in trails test-models |
| `inheritance.test.ts` — `inheritance with default scope` | `fixture` | same fixture gap |
| `insert-all.test.ts` — `insert all and upsert all with sti` | `fixture` | `Category` / `SpecialCategory` STI hierarchy not declared; `insertAll` / `upsertAll` STI dispatch already wired |

Note: the prior \"uuid + polymorphic-touch\" category for the delegated-type touch site was retired during review — Rails' `test \"touch account\"` operates on `@entry_with_message` (integer-PK Entry/Message/Account), not the UUID fixtures. Corrected annotation references `associations/builder/belongs-to.ts#touchParent` (the actual touch path).

No implementation changes, no test-logic changes, no un-skipping. Annotation-only refresh so each still-skipped site is greppable in the structured format the audit-driven annotation work uses.

## Test plan

- [x] `pnpm typecheck` clean (lint-staged on commit)
- [x] No tests un-skipped — annotation-only change