### PR TITLE
test(activerecord): Batch 89 unported-list additions

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -504,20 +504,6 @@ describe("SQLite3AdapterTest", () => {
     expect(id).toBe(3);
   });
 
-  it("supports extensions", () => {
-    expect(adapter.supportsExtensions()).toBe(false);
-  });
-
-  it("respond to enable extension", () => {
-    // better-sqlite3 doesn't support loadExtension by default
-    // but we verify the adapter exists and is functional
-    expect(adapter.isOpen).toBe(true);
-  });
-
-  it("respond to disable extension", () => {
-    expect(adapter.isOpen).toBe(true);
-  });
-
   it("statement closed", async () => {
     const a = new SQLite3Adapter(":memory:");
     expect(a.isOpen).toBe(true);

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -618,30 +618,6 @@ describe("BasicsTest", () => {
     await p.destroy();
     expect(p.isDestroyed()).toBe(true);
   });
-  it("generated association methods module name", () => {
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    // In TS, the class itself serves as the association methods container
-    expect(typeof Post).toBe("function");
-  });
-
-  it("generated relation methods module name", () => {
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    // Verify the model has relation-building methods
-    expect(typeof Post.where).toBe("function");
-    expect(typeof Post.order).toBe("function");
-  });
 
   it("arel attribute normalization", () => {
     const adp = freshAdapter();

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -106,44 +106,4 @@ describe("ModulesTest", () => {
     }
     expect(Account.tableName).toBe("accounts_archive_v2");
   });
-
-  it("compute type can infer class name of sibling inside module", () => {
-    class Vehicle extends Base {
-      static {
-        this.attribute("type", "string");
-        this.inheritanceColumn = "type";
-        this.adapter = adapter;
-      }
-    }
-    class Car extends Vehicle {}
-    expect(Car.name).toBe("Car");
-  });
-
-  it("nested models should not raise exception when using delete all dependency on association", async () => {
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    const p1 = await Post.create({ title: "a" });
-    const p2 = await Post.create({ title: "b" });
-    await p1.destroy();
-    await p2.destroy();
-    expect(await Post.count()).toBe(0);
-  });
-
-  it("nested models should not raise exception when using nullify dependency on association", async () => {
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("author_id", "integer");
-        this.adapter = adapter;
-      }
-    }
-    const p = await Post.create({ title: "a", author_id: 1 });
-    p.author_id = null;
-    await p.save();
-    expect(p.author_id).toBeNull();
-  });
 });

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -214,6 +214,15 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Cross-connection read_uncommitted visibility requires SQLITE_OPEN_SHAREDCACHE. " +
       "better-sqlite3 does not expose this flag, so two connections cannot share a cache.",
   },
+  {
+    testFile: "adapters/sqlite3/sqlite3_adapter_test.rb",
+    tests: ["supports extensions", "respond to enable extension", "respond to disable extension"],
+    reason:
+      "Rails' SQLite3::Database exposes load_extension / enable_load_extension via the " +
+      "sqlite3-ruby C bindings. better-sqlite3 does not expose the SQLITE_LOAD_EXTENSION " +
+      "entry points, so supports_extensions? / enable_extension / disable_extension cannot " +
+      "be implemented against the driver Trails uses.",
+  },
   // --- Permanently not-portable: Ruby Module namespace / constant-path semantics ---
   {
     testFile: "reflection_test.rb",
@@ -235,6 +244,9 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "associations spanning cross modules",
       "find account and include company",
       "eager loading in modules",
+      "compute type can infer class name of sibling inside module",
+      "nested models should not raise exception when using delete all dependency on association",
+      "nested models should not raise exception when using nullify dependency on association",
     ],
     reason:
       "Ruby Module#ancestors / constant-path lookup for cross-module association resolution. " +
@@ -313,10 +325,17 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "default in local time",
       "switching default time zone",
       "mutating time objects",
+      // Ruby Module#inspect — assert generated mixin Module's #inspect returns
+      // "Post::GeneratedAssociationMethods" / "Post::GeneratedRelationMethods".
+      // TS has no Module objects with namespaced #inspect; generated method bags
+      // are plain prototype-extension objects with no inspectable class name.
+      "generated association methods module name",
+      "generated relation methods module name",
     ],
     reason:
       "GVL / Ruby Thread semantics, Marshal binary serialization, Encoding.default_internal, " +
-      'and with_env_tz (process-level ENV["TZ"] reload) — all Ruby-only with no Node.js equivalent.',
+      'with_env_tz (process-level ENV["TZ"] reload), and Ruby Module#inspect for ' +
+      "namespaced generated-method modules — all Ruby-only with no Node.js equivalent.",
   },
   {
     testFile: "hstore_test.rb",


### PR DESCRIPTION
Batch 89 from docs/activerecord-100-plan.md — mechanical PERMANENT-SKIP additions to `scripts/api-compare/unported-files.ts` for tests that exercise Ruby module-system or sqlite3 C-binding semantics with no Node.js equivalent.

## Additions

- **sqlite3_adapter_test.rb x3** — `supports_extensions`, `respond_to_enable_extension`, `respond_to_disable_extension`. better-sqlite3 does not expose `SQLITE_LOAD_EXTENSION` entry points.
- **modules_test.rb +3** — `compute_type_can_infer_class_name_of_sibling_inside_module` and the two `nested_models_should_not_raise_exception_*` tests. Ruby `Module#ancestors` / constant-path lookup; no JS analogue.
- **base_test.rb +2** — `generated_association_methods_module_name`, `generated_relation_methods_module_name`. Assert Ruby `Module#inspect` on namespaced generated-method modules (`"Post::GeneratedAssociationMethods"`); TS generated method bags have no namespaced module identity.

## Follow-ups

The plan also calls for `mixin_test.rb x2` entries — the file's 4 tests (`test_update`, `test_create`, `test_many_updates`, `test_create_turned_off`) exercise the `Mixin` AR model's timestamps + `lft_will_change!`, not Ruby module semantics. Skipped here pending clarification on which 2 should be permanent vs. ported.