### PR TITLE
feat(activerecord): polymorphic inverse-of autosave (batch 15)

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -274,8 +274,12 @@ export class BelongsToAssociation extends SingularAssociation {
       const pk = (record.constructor as any).primaryKey;
       if (pk) return Array.isArray(pk) ? pk : [pk];
     }
-    const pk = (this.klass as any).primaryKey;
+    const pk = (this.klass as any)?.primaryKey;
     if (pk) return Array.isArray(pk) ? pk : [pk];
+    // Polymorphic belongs_to: no resolved klass when target is absent —
+    // fall back to the loaded target's class when one is cached.
+    const targetPk = (this.target as any)?.constructor?.primaryKey;
+    if (targetPk) return Array.isArray(targetPk) ? targetPk : [targetPk];
     return ["id"];
   }
 

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1189,6 +1189,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     });
     const parent = new PolyParent({ name: "P" });
     const child = new PolyChild({ name: "C" });
+    // Mirrors Rails HasOneAssociation#set_owner_attributes which writes the
+    // polymorphic _type column at assignment time (before save).
+    child._writeAttribute("employable_type", "PolyParent");
     cacheAssoc(parent, "polyChild", child);
     await parent.save();
     expect(log).toContain("before_validation");
@@ -1279,6 +1282,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     });
     const parent = new PolyAsParent({ name: "P" });
     const child = new PolyAsChild({ name: "C" });
+    // Mirrors Rails BelongsToPolymorphicAssociation#replace_keys which
+    // writes the polymorphic _type column at assignment time.
+    child._writeAttribute("employable_type", "PolyAsParent");
     cacheAssoc(child, "employable", parent);
     await child.save();
     expect(log).toContain("parent_before_validation");
@@ -1608,6 +1614,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     const cake = await SwapCakeDesigner.create({ name: "Cake" });
     const drink = await SwapDrinkDesigner.create({ name: "Drink" });
     const chef = new SwapChef({ name: "Gordon" });
+    chef._writeAttribute("employable_type", "SwapCakeDesigner");
     cacheAssoc(cake, "chef", chef);
     await cake.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapCakeDesigner");
@@ -1615,6 +1622,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
     // Reassign chef to drink — polymorphic type column flips even when
     // employable_id may collide. autosave on drink should re-persist the chef.
+    chef._writeAttribute("employable_type", "SwapDrinkDesigner");
     cacheAssoc(drink, "chef", chef);
     await drink.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapDrinkDesigner");

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1147,11 +1147,57 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
     /* needs more callback infrastructure */
   });
-  it.skip("callbacks on child when parent autosaves polymorphic child with inverse of", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* polymorphic not implemented */
+  it("callbacks on child when parent autosaves polymorphic child with inverse of", async () => {
+    const log: string[] = [];
+    class PolyParent extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class PolyChild extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("employable_id", "integer");
+        this.attribute("employable_type", "string");
+        this.beforeValidation(function () {
+          log.push("before_validation");
+        });
+        this.afterValidation(function () {
+          log.push("after_validation");
+        });
+        this.beforeSave(function () {
+          log.push("before_save");
+        });
+        this.afterSave(function () {
+          log.push("after_save");
+        });
+      }
+    }
+    PolyParent.adapter = adapter;
+    PolyChild.adapter = adapter;
+    registerModel("PolyParent", PolyParent);
+    registerModel("PolyChild", PolyChild);
+    Associations.hasOne.call(PolyParent, "polyChild", {
+      as: "employable",
+      autosave: true,
+      className: "PolyChild",
+      inverseOf: "employable",
+    });
+    Associations.belongsTo.call(PolyChild, "employable", {
+      polymorphic: true,
+      inverseOf: "polyChild",
+    });
+    const parent = new PolyParent({ name: "P" });
+    const child = new PolyChild({ name: "C" });
+    cacheAssoc(parent, "polyChild", child);
+    await parent.save();
+    expect(log).toContain("before_validation");
+    expect(log).toContain("after_validation");
+    expect(log).toContain("before_save");
+    expect(log).toContain("after_save");
+    expect(child.isNewRecord()).toBe(false);
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
+    expect(child._readAttribute("employable_type")).toBe("PolyParent");
   });
   it("callbacks on child when child autosaves parent", async () => {
     const log: string[] = [];
@@ -1191,11 +1237,57 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
     /* needs more callback infrastructure */
   });
-  it.skip("callbacks on child when polymorphic child with inverse of autosaves parent", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* polymorphic not implemented */
+  it("callbacks on child when polymorphic child with inverse of autosaves parent", async () => {
+    const log: string[] = [];
+    class PolyAsParent extends Base {
+      static {
+        this.attribute("name", "string");
+        this.beforeValidation(function () {
+          log.push("parent_before_validation");
+        });
+        this.afterValidation(function () {
+          log.push("parent_after_validation");
+        });
+        this.beforeSave(function () {
+          log.push("parent_before_save");
+        });
+        this.afterSave(function () {
+          log.push("parent_after_save");
+        });
+      }
+    }
+    class PolyAsChild extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("employable_id", "integer");
+        this.attribute("employable_type", "string");
+      }
+    }
+    PolyAsParent.adapter = adapter;
+    PolyAsChild.adapter = adapter;
+    registerModel("PolyAsParent", PolyAsParent);
+    registerModel("PolyAsChild", PolyAsChild);
+    Associations.hasOne.call(PolyAsParent, "polyAsChild", {
+      as: "employable",
+      className: "PolyAsChild",
+      inverseOf: "employable",
+    });
+    Associations.belongsTo.call(PolyAsChild, "employable", {
+      autosave: true,
+      polymorphic: true,
+      inverseOf: "polyAsChild",
+    });
+    const parent = new PolyAsParent({ name: "P" });
+    const child = new PolyAsChild({ name: "C" });
+    cacheAssoc(child, "employable", parent);
+    await child.save();
+    expect(log).toContain("parent_before_validation");
+    expect(log).toContain("parent_after_validation");
+    expect(log).toContain("parent_before_save");
+    expect(log).toContain("parent_after_save");
+    expect(parent.isNewRecord()).toBe(false);
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
+    expect(child._readAttribute("employable_type")).toBe("PolyAsParent");
   });
 
   it("foreign key attribute is not set unless changed", async () => {
@@ -1472,11 +1564,61 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     expect(ship.isDestroyed()).toBe(false);
   });
 
-  it.skip("recognises inverse polymorphic association changes with same foreign key", () => {
-    // BLOCKED: associations — autosave feature gap
-    // ROOT-CAUSE: associations/autosave-association.ts or preloader.ts missing autosave semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in autosave-association.test.ts
-    /* polymorphic not implemented */
+  it("recognises inverse polymorphic association changes with same foreign key", async () => {
+    class SwapChef extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("employable_id", "integer");
+        this.attribute("employable_type", "string");
+      }
+    }
+    class SwapCakeDesigner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class SwapDrinkDesigner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    SwapChef.adapter = adapter;
+    SwapCakeDesigner.adapter = adapter;
+    SwapDrinkDesigner.adapter = adapter;
+    registerModel("SwapChef", SwapChef);
+    registerModel("SwapCakeDesigner", SwapCakeDesigner);
+    registerModel("SwapDrinkDesigner", SwapDrinkDesigner);
+    Associations.hasOne.call(SwapCakeDesigner, "chef", {
+      as: "employable",
+      autosave: true,
+      className: "SwapChef",
+      inverseOf: "employable",
+    });
+    Associations.hasOne.call(SwapDrinkDesigner, "chef", {
+      as: "employable",
+      autosave: true,
+      className: "SwapChef",
+      inverseOf: "employable",
+    });
+    Associations.belongsTo.call(SwapChef, "employable", {
+      polymorphic: true,
+      inverseOf: "chef",
+    });
+
+    const cake = await SwapCakeDesigner.create({ name: "Cake" });
+    const drink = await SwapDrinkDesigner.create({ name: "Drink" });
+    const chef = new SwapChef({ name: "Gordon" });
+    cacheAssoc(cake, "chef", chef);
+    await cake.save();
+    expect(chef._readAttribute("employable_type")).toBe("SwapCakeDesigner");
+    expect(chef._readAttribute("employable_id")).toBe(cake.id);
+
+    // Reassign chef to drink — polymorphic type column flips even when
+    // employable_id may collide. autosave on drink should re-persist the chef.
+    cacheAssoc(drink, "chef", chef);
+    await drink.save();
+    expect(chef._readAttribute("employable_type")).toBe("SwapDrinkDesigner");
+    expect(chef._readAttribute("employable_id")).toBe(drink.id);
   });
 });
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1004,13 +1004,17 @@ export function isInversePolymorphicAssociationChanged(reflection: any, record: 
   // but the polymorphic _type column points at a different active_record.
   const foreignType: string = inverse.foreignType ?? `${underscore(String(inverse.name))}_type`;
   const className = record._readAttribute(foreignType);
+  // Rails: polymorphic_class_for(nil) raises NameError. Treat a missing
+  // type column as "no inverse parent set" → no change detected, so the
+  // caller's `||` chain falls through to FK-changed / will-save legs.
+  if (className == null) return false;
   const recordClass = record.constructor as {
     polymorphicClassFor?: (n: string) => unknown;
   };
   const resolved =
     typeof recordClass.polymorphicClassFor === "function"
       ? recordClass.polymorphicClassFor(String(className))
-      : (modelRegistry.get(String(className)) ?? recordClass);
+      : (modelRegistry.get(String(className)) ?? reflection.activeRecord);
   return reflection.activeRecord !== resolved;
 }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -637,12 +637,6 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
         assoc.name,
       );
     }
-    // Polymorphic hasOne via `as:` — write the `<as>_type` column on the
-    // child so the inverse polymorphic belongs_to can resolve back to us.
-    const asName = (reflection?.options?.as ?? assoc.options.as) as string | undefined;
-    if (asName) {
-      childRecord._writeAttribute(`${underscore(asName)}_type`, (ctor as { name: string }).name);
-    }
     // Mirrors Rails save_has_one_association:496: set_inverse_instance fires
     // after FK assignment, before save (autosave_association.rb:497).
     inst?.setInverseInstance?.(childRecord);
@@ -738,12 +732,6 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
         (record.constructor as typeof Base).name,
         assoc.name,
       );
-    }
-    // Polymorphic belongs_to — also write the `<name>_type` column on the
-    // child so reload of the polymorphic reference can resolve correctly.
-    if (assoc.options.polymorphic) {
-      const typeCol = `${underscore(assoc.name)}_type`;
-      record._writeAttribute(typeCol, (assocRecord.constructor as { name: string }).name);
     }
     // Rails save_belongs_to_association:559-568: `association.loaded!` only
     // fires inside the `if association.updated?` branch — after the FK write.
@@ -1014,20 +1002,15 @@ export function isInversePolymorphicAssociationChanged(reflection: any, record: 
   // type column off the child record and compare the parent class to the
   // class resolved for that name. Detects swaps where the FK is unchanged
   // but the polymorphic _type column points at a different active_record.
-  const foreignType: string | undefined =
-    inverse.foreignType ?? (inverse.name ? `${underscore(String(inverse.name))}_type` : undefined);
-  if (!foreignType || typeof record?._readAttribute !== "function") {
-    return reflection.activeRecord !== record?.constructor;
-  }
+  const foreignType: string = inverse.foreignType ?? `${underscore(String(inverse.name))}_type`;
   const className = record._readAttribute(foreignType);
-  if (className == null) return reflection.activeRecord !== record?.constructor;
-  const polymorphicClassFor =
-    (record.constructor as { polymorphicClassFor?: (n: string) => unknown })?.polymorphicClassFor ??
-    null;
+  const recordClass = record.constructor as {
+    polymorphicClassFor?: (n: string) => unknown;
+  };
   const resolved =
-    typeof polymorphicClassFor === "function"
-      ? polymorphicClassFor.call(record.constructor, className)
-      : (modelRegistry.get(String(className)) ?? record.constructor);
+    typeof recordClass.polymorphicClassFor === "function"
+      ? recordClass.polymorphicClassFor(String(className))
+      : (modelRegistry.get(String(className)) ?? recordClass);
   return reflection.activeRecord !== resolved;
 }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -14,6 +14,7 @@ import {
 } from "./associations/errors.js";
 import { NestedError as AssociationsNestedError } from "./associations/nested-error.js";
 import type { AssociationDefinition } from "./associations.js";
+import { modelRegistry } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { underscore } from "@blazetrails/activesupport";
 import { included } from "@blazetrails/activesupport";
@@ -636,6 +637,12 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
         assoc.name,
       );
     }
+    // Polymorphic hasOne via `as:` — write the `<as>_type` column on the
+    // child so the inverse polymorphic belongs_to can resolve back to us.
+    const asName = (reflection?.options?.as ?? assoc.options.as) as string | undefined;
+    if (asName) {
+      childRecord._writeAttribute(`${underscore(asName)}_type`, (ctor as { name: string }).name);
+    }
     // Mirrors Rails save_has_one_association:496: set_inverse_instance fires
     // after FK assignment, before save (autosave_association.rb:497).
     inst?.setInverseInstance?.(childRecord);
@@ -731,6 +738,12 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
         (record.constructor as typeof Base).name,
         assoc.name,
       );
+    }
+    // Polymorphic belongs_to — also write the `<name>_type` column on the
+    // child so reload of the polymorphic reference can resolve correctly.
+    if (assoc.options.polymorphic) {
+      const typeCol = `${underscore(assoc.name)}_type`;
+      record._writeAttribute(typeCol, (assocRecord.constructor as { name: string }).name);
     }
     // Rails save_belongs_to_association:559-568: `association.loaded!` only
     // fires inside the `if association.updated?` branch — after the FK write.
@@ -997,7 +1010,25 @@ export function isInversePolymorphicAssociationChanged(reflection: any, record: 
       ? reflection.inverseOf()
       : (reflection.inverseOf ?? null);
   if (!inverse?.options?.polymorphic) return false;
-  return reflection.activeRecord !== record?.constructor;
+  // Rails inverse_polymorphic_association_changed? — read the polymorphic
+  // type column off the child record and compare the parent class to the
+  // class resolved for that name. Detects swaps where the FK is unchanged
+  // but the polymorphic _type column points at a different active_record.
+  const foreignType: string | undefined =
+    inverse.foreignType ?? (inverse.name ? `${underscore(String(inverse.name))}_type` : undefined);
+  if (!foreignType || typeof record?._readAttribute !== "function") {
+    return reflection.activeRecord !== record?.constructor;
+  }
+  const className = record._readAttribute(foreignType);
+  if (className == null) return reflection.activeRecord !== record?.constructor;
+  const polymorphicClassFor =
+    (record.constructor as { polymorphicClassFor?: (n: string) => unknown })?.polymorphicClassFor ??
+    null;
+  const resolved =
+    typeof polymorphicClassFor === "function"
+      ? polymorphicClassFor.call(record.constructor, className)
+      : (modelRegistry.get(String(className)) ?? record.constructor);
+  return reflection.activeRecord !== resolved;
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Batch 15 from `docs/activerecord-100-plan.md` — un-skips 3 polymorphic-inverse autosave tests and rewrites the inverse-polymorphic change detector to match Rails.

- `isInversePolymorphicAssociationChanged`: read the polymorphic type column off the record and compare against `record.class.polymorphic_class_for(class_name)`. Detects chef-style swap scenarios where the FK is unchanged but the polymorphic type points at a different `active_record`. Null type → no change (Rails' `polymorphic_class_for(nil)` raises; we short-circuit so the caller's `||` chain proceeds). Unknown class name falls back to `reflection.activeRecord` (registry miss reports "no change", not a spurious flip).
- `belongs-to-association.associationPrimaryKeys`: fall back to the cached target's class when `klass` is unresolved (polymorphic owners).

The polymorphic `_type` column is set by `HasOneAssociation#set_owner_attributes` / `BelongsToPolymorphicAssociation#replace_keys` at assignment time — not by autosave. Rails' `save_has_one_association` / `save_belongs_to_association` only ever re-write the FK. The tests use `cacheAssoc` to bypass replace() and therefore set the type column manually at the assignment point, mirroring what replace_keys would have done.

## Tests un-skipped

- callbacks on child when parent autosaves polymorphic child with inverse of
- callbacks on child when polymorphic child with inverse of autosaves parent
- recognises inverse polymorphic association changes with same foreign key

## Follow-ups (deferred)

- Auto-detected `inverseOf` for polymorphic `hasOne` (Rails detects without explicit `inverse_of:`).
- Inverse polymorphic validation tests in `inverse-associations.test.ts` (lines 1393/1399) — require polymorphic inverse-name validation; separate scope.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 3 new passing, no regressions
- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1565 passing
- [x] `pnpm api:compare --package activerecord` — 4956/4958 (100%), zero delta
- [x] `pnpm test:compare` — zero delta
- [x] `pnpm lint`