### PR TITLE
feat(activerecord): HMT Slot C constructor-form + reset_scope (batch 30)

### DIFF
--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -21,6 +21,9 @@ beforeEach(async () => {
     b30_profiles: { name: "string", owner_id: "integer" },
     b30_posts: { title: "string" },
     b30_tags: { name: "string" },
+    // HABTM defaults from associations/builder/has-and-belongs-to-many.ts:
+    //   ownerFk  = `${underscore(model.name)}_id`             = "b30_post_id"
+    //   sourceFk = `${underscore(demodulize(className))}_id`  = "b30_tag_id"
     b30_posts_b30_tags: { b30_post_id: "integer", b30_tag_id: "integer" },
   });
 });
@@ -118,8 +121,11 @@ describe("HABTM insert_record two-step", () => {
     expect(ok).toBe(true);
     // super.insertRecord saved the target
     expect(tag.isPersisted()).toBe(true);
-    // join row exists with correct FKs — verify via the through proxy
-    const tags = await (post as any).association("tags").loadTarget();
+    // Reload to force a fresh through-load from the DB so we know the join
+    // row was actually persisted (rather than just cached in the in-memory
+    // proxy from build()).
+    const reloaded = await B30Post.find(post.id);
+    const tags = await (reloaded as any).association("tags").loadTarget();
     expect(tags).toHaveLength(1);
     expect((tags[0] as any).id).toBe(tag.id);
   });

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -62,6 +62,31 @@ describe("constructor-form association writer", () => {
     expect(target[1]).toBe(i2);
   });
 
+  it("dispatches via assignAttributes (manual-call path, non-multiparameter)", () => {
+    const { B30Owner, B30Item } = makeHasManyModels();
+    const owner = new B30Owner();
+    const i1 = new B30Item({ name: "a" });
+    owner.assignAttributes({ name: "Acme", items: [i1] });
+    expect((owner as any).readAttribute("name")).toBe("Acme");
+    expect((owner as any).association("items").target).toEqual([i1]);
+  });
+
+  it("dispatches via assignAttributes (multiparameter branch)", () => {
+    const { B30Owner, B30Item } = makeHasManyModels();
+    const owner = new B30Owner();
+    const i1 = new B30Item({ name: "a" });
+    // Mix in a multiparameter key so assignAttributes takes the
+    // hasMultiparameterKeys branch — association routing must still happen.
+    owner.assignAttributes({
+      items: [i1],
+      // Force the multiparameter branch via a parenthesized key —
+      // value content is irrelevant; we only care that `items` still
+      // routes through assignAssociationIfMatch in this branch.
+      "name(1)": "x",
+    });
+    expect((owner as any).association("items").target).toEqual([i1]);
+  });
+
   it("dispatches single record to hasOne association on construction", () => {
     class B30Profile extends Base {
       static {

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Batch 30 — HMT Slot C smoke tests:
+ *   - constructor-form collection writer in assignAttributes
+ *   - association.resetScope invocation during saveCollectionAssociation
+ *   - HMT insert_record two-step alignment (super.insertRecord →
+ *     save_through_record) for HABTM
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+let _adapter: DatabaseAdapter;
+beforeEach(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, {
+    b30_owners: { name: "string" },
+    b30_items: { name: "string", owner_id: "integer" },
+    b30_profiles: { name: "string", owner_id: "integer" },
+    b30_posts: { title: "string" },
+    b30_tags: { name: "string" },
+    b30_posts_b30_tags: { b30_post_id: "integer", b30_tag_id: "integer" },
+  });
+});
+
+describe("constructor-form association writer", () => {
+  function makeHasManyModels() {
+    class B30Item extends Base {
+      static {
+        this._tableName = "b30_items";
+        this.attribute("name", "string");
+        this.attribute("owner_id", "integer");
+        this.adapter = _adapter;
+      }
+    }
+    class B30Owner extends Base {
+      static {
+        this._tableName = "b30_owners";
+        this.attribute("name", "string");
+        this.adapter = _adapter;
+      }
+    }
+    Associations.hasMany.call(B30Owner, "items", { className: "B30Item", foreignKey: "owner_id" });
+    registerModel("B30Item", B30Item);
+    registerModel("B30Owner", B30Owner);
+    return { B30Owner, B30Item };
+  }
+
+  it("dispatches array values to hasMany association on construction", () => {
+    const { B30Owner, B30Item } = makeHasManyModels();
+    const i1 = new B30Item({ name: "a" });
+    const i2 = new B30Item({ name: "b" });
+    const owner = new B30Owner({ name: "Acme", items: [i1, i2] });
+    const target = (owner as any).association("items").target as Base[];
+    expect(target).toHaveLength(2);
+    expect(target[0]).toBe(i1);
+    expect(target[1]).toBe(i2);
+  });
+
+  it("dispatches single record to hasOne association on construction", () => {
+    class B30Profile extends Base {
+      static {
+        this._tableName = "b30_profiles";
+        this.attribute("name", "string");
+        this.attribute("owner_id", "integer");
+        this.adapter = _adapter;
+      }
+    }
+    class B30Owner2 extends Base {
+      static {
+        this._tableName = "b30_owners";
+        this.attribute("name", "string");
+        this.adapter = _adapter;
+      }
+    }
+    Associations.hasOne.call(B30Owner2, "profile", {
+      className: "B30Profile",
+      foreignKey: "owner_id",
+    });
+    registerModel("B30Profile", B30Profile);
+    registerModel("B30Owner2", B30Owner2);
+
+    const p = new B30Profile({ name: "p" });
+    const owner = new B30Owner2({ name: "x", profile: p });
+    expect((owner as any).association("profile").target).toBe(p);
+  });
+});
+
+describe("HABTM insert_record two-step", () => {
+  function makeHabtmModels() {
+    class B30Post extends Base {
+      static {
+        this._tableName = "b30_posts";
+        this.attribute("title", "string");
+        this.adapter = _adapter;
+      }
+    }
+    class B30Tag extends Base {
+      static {
+        this._tableName = "b30_tags";
+        this.attribute("name", "string");
+        this.adapter = _adapter;
+      }
+    }
+    Associations.hasAndBelongsToMany.call(B30Post, "tags", { className: "B30Tag" });
+    registerModel("B30Post", B30Post);
+    registerModel("B30Tag", B30Tag);
+    return { B30Post, B30Tag };
+  }
+
+  it("super.insertRecord saves the target, save_through_record persists join row", async () => {
+    const { B30Post, B30Tag } = makeHabtmModels();
+    const post = await B30Post.create({ title: "Hello" });
+    const tag = new B30Tag({ name: "ruby" });
+    const ok = await (post as any).association("tags").insertRecord(tag, true, false);
+    expect(ok).toBe(true);
+    // super.insertRecord saved the target
+    expect(tag.isPersisted()).toBe(true);
+    // join row exists with correct FKs — verify via the through proxy
+    const tags = await (post as any).association("tags").loadTarget();
+    expect(tags).toHaveLength(1);
+    expect((tags[0] as any).id).toBe(tag.id);
+  });
+});
+
+describe("resetScope on owner save", () => {
+  it("clears the memoized association scope before iterating children", async () => {
+    class B30Item2 extends Base {
+      static {
+        this._tableName = "b30_items";
+        this.attribute("name", "string");
+        this.attribute("owner_id", "integer");
+        this.adapter = _adapter;
+      }
+    }
+    class B30Owner3 extends Base {
+      static {
+        this._tableName = "b30_owners";
+        this.attribute("name", "string");
+        this.adapter = _adapter;
+      }
+    }
+    Associations.hasMany.call(B30Owner3, "items", {
+      className: "B30Item2",
+      foreignKey: "owner_id",
+    });
+    registerModel("B30Item2", B30Item2);
+    registerModel("B30Owner3", B30Owner3);
+
+    const owner = await B30Owner3.create({ name: "o" });
+    const assoc = (owner as any).association("items");
+    // saveCollectionAssociation must call resetScope() before iterating
+    // children so a stale scope doesn't survive into per-child saves.
+    let resetCount = 0;
+    const original = assoc.resetScope.bind(assoc);
+    assoc.resetScope = function () {
+      resetCount++;
+      return original();
+    };
+    (owner as any).items = [];
+    await owner.save();
+    expect(resetCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -112,8 +112,16 @@ function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base)
   const ownerPk = throughAssocDef.options.primaryKey ?? ctor.primaryKey ?? "id";
   const ownerFk = throughAssocDef.options.foreignKey ?? `${underscore(ctor.name)}_id`;
   const pkValue = (assoc.owner as any)._readAttribute?.(ownerPk) ?? (assoc.owner as any)[ownerPk];
-  const sourceName = assocDef.options?.source ?? singularize(assocDef.name);
-  const sourceFk = `${underscore(sourceName)}_id`;
+  // Prefer the HABTM builder's rightReflection FK (className-derived) so
+  // the join row writes to the same column the builder declared on the
+  // generated JoinModel. Fall back to the source/singularized name only
+  // when the right reflection is absent (non-builder-constructed habtm).
+  const rightReflection = (
+    throughModel as { rightReflection?: { options?: { foreignKey?: string } } }
+  ).rightReflection;
+  const sourceFk =
+    rightReflection?.options?.foreignKey ??
+    `${underscore(assocDef.options?.source ?? singularize(assocDef.name))}_id`;
   const targetPk = (record.constructor as any).primaryKey ?? "id";
   const joinAttrs: Record<string, unknown> = {
     [ownerFk as string]: pkValue,

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -90,14 +90,22 @@ function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Bas
 }
 
 /** @internal */
-function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base | null {
+function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base {
   const ctor = assoc.owner.constructor as any;
   const assocDef = assoc.reflection as any;
   const throughName = assocDef.options?.through as string | undefined;
-  if (!throughName) return null;
+  // The HABTM builder (associations/builder/has-and-belongs-to-many.ts) always
+  // sets options.through to the generated middle reflection, so a missing
+  // through-name or missing through definition signals genuine misconfiguration —
+  // surface it loudly rather than silently dropping the join write.
+  if (!throughName)
+    throw new Error(`HABTM association '${assocDef.name}' on ${ctor.name} has no through name`);
   const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssocDef = associations.find((a: any) => a.name === throughName);
-  if (!throughAssocDef) return null;
+  if (!throughAssocDef)
+    throw new Error(
+      `HABTM association '${assocDef.name}' on ${ctor.name}: through association '${throughName}' not found`,
+    );
   const throughClassName =
     throughAssocDef.options.className ?? `${ctor.name}::HABTM_${camelize(assocDef.name)}`;
   const throughModel = resolveAssocClass(assoc.owner, throughName, throughClassName);

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -112,15 +112,19 @@ function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base)
   const ownerPk = throughAssocDef.options.primaryKey ?? ctor.primaryKey ?? "id";
   const ownerFk = throughAssocDef.options.foreignKey ?? `${underscore(ctor.name)}_id`;
   const pkValue = (assoc.owner as any)._readAttribute?.(ownerPk) ?? (assoc.owner as any)[ownerPk];
-  // Prefer the HABTM builder's rightReflection FK (className-derived) so
-  // the join row writes to the same column the builder declared on the
-  // generated JoinModel. Fall back to the source/singularized name only
-  // when the right reflection is absent (non-builder-constructed habtm).
-  const rightReflection = (
-    throughModel as { rightReflection?: { options?: { foreignKey?: string } } }
-  ).rightReflection;
+  // The HABTM JoinModel (createHabtmJoinModel in associations.ts) declares
+  // two belongsTo entries on `_associations`: "leftSide" (owner-side) and a
+  // right-side entry whose `foreignKey` is the builder-computed targetFk
+  // (className-derived, honoring `associationForeignKey`). Read it from
+  // there so we write to the column the JoinModel actually declared, rather
+  // than re-deriving via `singularize(assocName)` and silently dropping the
+  // value when the conventions diverge.
+  const joinAssocs = (throughModel as { _associations?: AssociationDefinition[] })._associations;
+  const rightSide = joinAssocs?.find(
+    (a) => a.type === "belongsTo" && a.name !== "leftSide" && a.options?.foreignKey,
+  );
   const sourceFk =
-    rightReflection?.options?.foreignKey ??
+    (rightSide?.options?.foreignKey as string | undefined) ??
     `${underscore(assocDef.options?.source ?? singularize(assocDef.name))}_id`;
   const targetPk = (record.constructor as any).primaryKey ?? "id";
   const joinAttrs: Record<string, unknown> = {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -66,35 +66,21 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       const saved = await super.insertRecord(record, validate, raise);
       if (!saved) return false;
     }
-
-    // HABTM: constructJoinAttributes relies on a sourceReflection chain that
-    // isn't wired for habtm reflections.  Use a direct join-record path instead,
-    // matching what CollectionProxy._pushThrough does.
-    if ((this.reflection as any).type === "hasAndBelongsToMany") {
-      return insertHabtmRecord(this, record, validate, raise);
-    }
-
-    // Regular has_many :through — build the join record via reflection.
-    // buildThroughRecord always calls proxy.build() which returns a new unsaved
-    // record, so isNewRecord() is always true here.  The check mirrors Rails'
-    // save_through_record which calls record.changed? (always true for new records).
-    const joinRecord = buildThroughRecord(this, record);
-    if (joinRecord && (joinRecord.isNewRecord() || (joinRecord as any).hasChangesToSave?.())) {
-      const saved = await (joinRecord as any).save({ validate });
-      if (!saved) {
-        if (raise) raiseValidationError(joinRecord);
-        return false;
-      }
-    }
-    return true;
+    // Rails' two-step: super.insert_record (above) saves the target; then
+    // save_through_record builds + saves the join row via the through proxy.
+    return saveThroughRecord(this, record, validate, raise);
   }
 }
 
 /** @internal */
 function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base | null {
-  // Mutability is enforced inside constructJoinAttributes — keep the
-  // precondition in one place (Rails' build_through_record calls
-  // ensure_mutable once; our equivalent inherits it via the helper).
+  // HABTM associations don't expose a sourceReflection chain, so
+  // constructJoinAttributes (which keys off source_reflection) can't run.
+  // Build the join row from the habtm options instead — matches Rails'
+  // build_through_record path for habtm under the hood.
+  if ((assoc.reflection as any).type === "hasAndBelongsToMany") {
+    return buildHabtmThroughRecord(assoc, record);
+  }
   const proxy = throughAssociation(assoc) as {
     build?: (attrs: Record<string, unknown>) => Base;
   } | null;
@@ -104,23 +90,14 @@ function buildThroughRecord(assoc: HasManyThroughAssociation, record: Base): Bas
 }
 
 /** @internal */
-async function insertHabtmRecord(
-  assoc: HasManyThroughAssociation,
-  record: Base,
-  validate: boolean,
-  raise: boolean,
-): Promise<boolean> {
+function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base): Base | null {
   const ctor = assoc.owner.constructor as any;
   const assocDef = assoc.reflection as any;
   const throughName = assocDef.options?.through as string | undefined;
-  if (!throughName)
-    throw new Error(`HABTM association '${assocDef.name}' on ${ctor.name} has no through name`);
+  if (!throughName) return null;
   const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssocDef = associations.find((a: any) => a.name === throughName);
-  if (!throughAssocDef)
-    throw new Error(
-      `HABTM association '${assocDef.name}' on ${ctor.name}: through association '${throughName}' not found`,
-    );
+  if (!throughAssocDef) return null;
   const throughClassName =
     throughAssocDef.options.className ?? `${ctor.name}::HABTM_${camelize(assocDef.name)}`;
   const throughModel = resolveAssocClass(assoc.owner, throughName, throughClassName);
@@ -134,14 +111,13 @@ async function insertHabtmRecord(
     [ownerFk as string]: pkValue,
     [sourceFk]: (record as any)._readAttribute?.(targetPk) ?? (record as any)[targetPk],
   };
-  // Rails: new(record_to_save_attributes(record)).save(validate: validate)
-  const joinRecord = new (throughModel as any)(joinAttrs);
-  const saved = await joinRecord.save({ validate });
-  if (!saved) {
-    if (raise) throw new Error(`Failed to create join record for ${assocDef.name}`);
-    return false;
+  const throughProxy = (assoc.owner as any).association?.(throughName) as {
+    build?: (a: Record<string, unknown>) => Base;
+  } | null;
+  if (throughProxy && typeof throughProxy.build === "function") {
+    return throughProxy.build(joinAttrs);
   }
-  return true;
+  return new (throughModel as any)(joinAttrs);
 }
 
 /** @internal */
@@ -172,15 +148,29 @@ function throughScopeAttributes(assoc: HasManyThroughAssociation): Record<string
 }
 
 /** @internal */
-function saveThroughRecord(assoc: HasManyThroughAssociation, record: Base): Promise<boolean> {
-  // Find and save the first unsaved through record for this target.
-  const records = throughRecordsFor(assoc, record);
-  const first = records[0];
-  if (!first || (first as any).isDestroyed?.()) return Promise.resolve(true);
-  if (typeof (first as any).save === "function") {
-    return (first as any).save({ validate: true });
+async function saveThroughRecord(
+  assoc: HasManyThroughAssociation,
+  record: Base,
+  validate = true,
+  raise = false,
+): Promise<boolean> {
+  // Mirrors Rails' has_many_through_association#save_through_record: build
+  // the join row (via the through proxy for HMT, or via habtm options for
+  // HABTM) and save it when it has pending changes.
+  const joinRecord = buildThroughRecord(assoc, record);
+  if (!joinRecord) return true;
+  const isUnsaved =
+    joinRecord.isNewRecord() ||
+    (typeof (joinRecord as any).hasChangesToSave === "function"
+      ? (joinRecord as any).hasChangesToSave()
+      : true);
+  if (!isUnsaved) return true;
+  const saved = await (joinRecord as any).save({ validate });
+  if (!saved) {
+    if (raise) raiseValidationError(joinRecord);
+    return false;
   }
-  return Promise.resolve(true);
+  return true;
 }
 
 /** @internal */

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -35,7 +35,13 @@ export function _assignAttributes(
   for (const [k, v] of Object.entries(attributes)) {
     if (k.includes("(")) {
       (multiParameterAttributes ??= Object.create(null))[k] = v;
-    } else if (assignAssociationIfMatch(this, k, v)) {
+    } else if (
+      assignAssociationIfMatch(
+        this as { constructor?: unknown; association?: (name: string) => unknown },
+        k,
+        v,
+      )
+    ) {
       // Routed to association proxy writer (constructor-form collection / singular).
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
       (nestedParameterAttributes ??= Object.create(null))[k] = v;
@@ -136,13 +142,18 @@ export function findParameterPosition(multiparameterName: string): number {
 
 /**
  * @internal
- * Constructor-form association writer. When `key` matches a declared
- * association on the host's constructor, dispatch `value` to the
- * association proxy's `replace`/`writer` rather than `writeAttribute`.
- * Mirrors Rails' `_assign_attribute` routing into association writers.
+ * Shared dispatch for constructor-form / assignAttributes association
+ * writers. When `key` matches a declared association on `host.constructor`,
+ * route `value` to the proxy's `replace`/`writer` rather than
+ * `writeAttribute`. Mirrors Rails' `_assign_attribute` routing through
+ * `public_send("#{k}=")` into association writer methods.
+ *
+ * Single source of truth used by `persistence.ts#assignAttributes`,
+ * `attribute-assignment.ts#_assignAttributes`, and the constructor
+ * dispatch in `base.ts`.
  */
-function assignAssociationIfMatch(
-  host: AttributeAssignmentHost,
+export function assignAssociationIfMatch(
+  host: { constructor?: unknown; association?: (name: string) => unknown },
   key: string,
   value: unknown,
 ): boolean {

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -170,7 +170,12 @@ export function assignAssociationIfMatch(
   if (!proxy) return false;
   if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
     if (typeof proxy.replace !== "function") return false;
-    proxy.replace(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
+    // Rails fidelity: pass the value through unchanged. The normal writer
+    // path (`record.items = value` → CollectionAssociation#writer →
+    // #replace) does not Array.wrap — Rails' replace calls `.each` on the
+    // argument and raises on nil / scalars. Coercing here would silently
+    // accept inputs the regular writer rejects.
+    proxy.replace(value as unknown[]);
     return true;
   }
   if (assoc.type === "hasOne" || assoc.type === "belongsTo") {

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -18,6 +18,7 @@ import {
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
   constructor: unknown;
+  association?: (name: string) => unknown;
 }
 
 /**
@@ -34,6 +35,8 @@ export function _assignAttributes(
   for (const [k, v] of Object.entries(attributes)) {
     if (k.includes("(")) {
       (multiParameterAttributes ??= Object.create(null))[k] = v;
+    } else if (assignAssociationIfMatch(this, k, v)) {
+      // Routed to association proxy writer (constructor-form collection / singular).
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
       (nestedParameterAttributes ??= Object.create(null))[k] = v;
     } else {
@@ -129,6 +132,42 @@ export function typeCastAttributeValue(multiparameterName: string, value: string
 export function findParameterPosition(multiparameterName: string): number {
   const match = multiparameterName.match(/\((\d+)/);
   return match ? parseInt(match[1], 10) : 0;
+}
+
+/**
+ * @internal
+ * Constructor-form association writer. When `key` matches a declared
+ * association on the host's constructor, dispatch `value` to the
+ * association proxy's `replace`/`writer` rather than `writeAttribute`.
+ * Mirrors Rails' `_assign_attribute` routing into association writers.
+ */
+function assignAssociationIfMatch(
+  host: AttributeAssignmentHost,
+  key: string,
+  value: unknown,
+): boolean {
+  const ctor = host.constructor as
+    | { _associations?: Array<{ name: string; type: string }> }
+    | undefined;
+  const assoc = ctor?._associations?.find((a) => a.name === key);
+  if (!assoc) return false;
+  if (typeof host.association !== "function") return false;
+  const proxy = host.association(key) as
+    | { replace?: (v: unknown[]) => void; writer?: (v: unknown) => void }
+    | null
+    | undefined;
+  if (!proxy) return false;
+  if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
+    if (typeof proxy.replace !== "function") return false;
+    proxy.replace(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
+    return true;
+  }
+  if (assoc.type === "hasOne" || assoc.type === "belongsTo") {
+    if (typeof proxy.writer !== "function") return false;
+    proxy.writer(value);
+    return true;
+  }
+  return false;
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -747,6 +747,12 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
 
 async function autosaveHabtm(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
+  // Rails save_collection_association resets the scope cache for every
+  // collection macro (hasMany + HABTM). HABTM is backed by
+  // HasManyThroughAssociation, which also memoizes associationScope().
+  if (inst && typeof (inst as { resetScope?: () => void }).resetScope === "function") {
+    (inst as { resetScope: () => void }).resetScope();
+  }
   const children: Base[] = Array.isArray(inst?.target) ? (inst.target as Base[]) : [];
 
   for (const child of children) {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -451,6 +451,12 @@ async function autosaveAssociation(record: Base, assoc: AssociationDefinition): 
 
 async function autosaveHasMany(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
+  // Rails: save_collection_association resets the scope before iterating so
+  // the per-child save path (which may re-read the scope) doesn't keep a
+  // stale memoized association_scope across the owner save.
+  if (inst && typeof (inst as { resetScope?: () => void }).resetScope === "function") {
+    (inst as { resetScope: () => void }).resetScope();
+  }
   const children: Base[] = Array.isArray(inst?.target) ? (inst.target as Base[]) : [];
 
   for (const child of children) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -577,11 +577,13 @@ function _extractAssociationAttrs(
     if (def) {
       (assocs ??= []).push({ name: def.name, value: v });
     } else {
-      (rest ??= {})[k] = v;
+      // Null-prototype to avoid `__proto__`/`constructor` keys mutating
+      // Object.prototype before `rest` is handed to super().
+      (rest ??= Object.create(null) as Record<string, unknown>)[k] = v;
     }
   }
   if (!assocs) return null;
-  return { rest: rest ?? {}, assocs };
+  return { rest: rest ?? (Object.create(null) as Record<string, unknown>), assocs };
 }
 
 /** @internal */
@@ -2375,6 +2377,10 @@ export class Base extends Model {
         (this as any)._dirty.snapshot((this as any)._attributes);
         if (assocPending) {
           _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+          // belongsTo writers may write the owner FK; re-snapshot so
+          // constructor-form association assignment lands in the clean
+          // baseline, matching regular constructor attrs.
+          (this as any)._dirty.snapshot((this as any)._attributes);
           assocPending = null;
         }
         cbRunAfter(ctor.prototype, "initialize", this, { strict: "sync" });
@@ -2415,6 +2421,10 @@ export class Base extends Model {
         (this as any)._dirty.snapshot((this as any)._attributes);
         if (assocPending) {
           _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+          // belongsTo writers may write the owner FK; re-snapshot so
+          // constructor-form association assignment lands in the clean
+          // baseline, matching regular constructor attrs.
+          (this as any)._dirty.snapshot((this as any)._attributes);
           assocPending = null;
         }
         cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
@@ -2424,6 +2434,10 @@ export class Base extends Model {
     // we still dispatch first to keep Rails' "assign → after_initialize" order.
     if (assocPending) {
       _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+      // Match the dispatch sites above: re-snapshot so any belongsTo FK
+      // writes from the association writers don't leave construction in a
+      // dirty state.
+      (this as any)._dirty.snapshot((this as any)._attributes);
     }
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -589,15 +589,12 @@ function _dispatchAssociationAttrs(
   record: Base,
   assocs: Array<{ type: string; name: string; value: unknown }>,
 ): void {
-  for (const { type, name, value } of assocs) {
-    const proxy = (record as unknown as { association: (n: string) => unknown }).association(
+  for (const { name, value } of assocs) {
+    _AttributeAssignment.assignAssociationIfMatch(
+      record as unknown as { constructor?: unknown; association?: (name: string) => unknown },
       name,
-    ) as { replace?: (v: unknown[]) => void; writer?: (v: unknown) => void };
-    if (type === "hasMany" || type === "hasAndBelongsToMany") {
-      proxy.replace?.(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
-    } else {
-      proxy.writer?.(value);
-    }
+      value,
+    );
   }
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2328,7 +2328,7 @@ export class Base extends Model {
     // Split out constructor-form association values (e.g. `new Owner({items:
     // [...]})`) so super() never sees them as plain attributes. Dispatched
     // after super() so the association proxy exists on `this`.
-    const assocPending = _extractAssociationAttrs(new.target as typeof Base, attrs);
+    let assocPending = _extractAssociationAttrs(new.target as typeof Base, attrs);
     if (assocPending) attrs = assocPending.rest;
     if (hasMultiparameterKeys(attrs)) {
       // Mirrors Rails: Base#initialize calls assign_attributes which handles
@@ -2376,6 +2376,10 @@ export class Base extends Model {
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
+        if (assocPending) {
+          _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+          assocPending = null;
+        }
         cbRunAfter(ctor.prototype, "initialize", this, { strict: "sync" });
       }
     } else {
@@ -2412,9 +2416,15 @@ export class Base extends Model {
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
+        if (assocPending) {
+          _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+          assocPending = null;
+        }
         cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
       }
     }
+    // Suppressed-callback fallback: parent caller fires after_initialize, so
+    // we still dispatch first to keep Rails' "assign → after_initialize" order.
     if (assocPending) {
       _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -565,17 +565,17 @@ function _extractAssociationAttrs(
   attrs: Record<string, unknown>,
 ): {
   rest: Record<string, unknown>;
-  assocs: Array<{ type: string; name: string; value: unknown }>;
+  assocs: Array<{ name: string; value: unknown }>;
 } | null {
   const defs = (ctor as { _associations?: Array<{ name: string; type: string }> } | undefined)
     ?._associations;
   if (!defs || defs.length === 0) return null;
-  let assocs: Array<{ type: string; name: string; value: unknown }> | null = null;
+  let assocs: Array<{ name: string; value: unknown }> | null = null;
   let rest: Record<string, unknown> | null = null;
   for (const [k, v] of Object.entries(attrs)) {
     const def = defs.find((a) => a.name === k);
     if (def) {
-      (assocs ??= []).push({ type: def.type, name: def.name, value: v });
+      (assocs ??= []).push({ name: def.name, value: v });
     } else {
       (rest ??= {})[k] = v;
     }
@@ -587,7 +587,7 @@ function _extractAssociationAttrs(
 /** @internal */
 function _dispatchAssociationAttrs(
   record: Base,
-  assocs: Array<{ type: string; name: string; value: unknown }>,
+  assocs: Array<{ name: string; value: unknown }>,
 ): void {
   for (const { name, value } of assocs) {
     _AttributeAssignment.assignAssociationIfMatch(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -553,6 +553,54 @@ function _applyScopeAttributes(
   }
 }
 
+/**
+ * @internal
+ * Pull constructor-form association assignments (e.g. `new Owner({items:
+ * [...], profile: p})`) out of the regular attribute bag. Returns null
+ * when no key matches a declared association so the hot path allocates
+ * nothing.
+ */
+function _extractAssociationAttrs(
+  ctor: typeof Base | undefined,
+  attrs: Record<string, unknown>,
+): {
+  rest: Record<string, unknown>;
+  assocs: Array<{ type: string; name: string; value: unknown }>;
+} | null {
+  const defs = (ctor as { _associations?: Array<{ name: string; type: string }> } | undefined)
+    ?._associations;
+  if (!defs || defs.length === 0) return null;
+  let assocs: Array<{ type: string; name: string; value: unknown }> | null = null;
+  let rest: Record<string, unknown> | null = null;
+  for (const [k, v] of Object.entries(attrs)) {
+    const def = defs.find((a) => a.name === k);
+    if (def) {
+      (assocs ??= []).push({ type: def.type, name: def.name, value: v });
+    } else {
+      (rest ??= {})[k] = v;
+    }
+  }
+  if (!assocs) return null;
+  return { rest: rest ?? {}, assocs };
+}
+
+/** @internal */
+function _dispatchAssociationAttrs(
+  record: Base,
+  assocs: Array<{ type: string; name: string; value: unknown }>,
+): void {
+  for (const { type, name, value } of assocs) {
+    const proxy = (record as unknown as { association: (n: string) => unknown }).association(
+      name,
+    ) as { replace?: (v: unknown[]) => void; writer?: (v: unknown) => void };
+    if (type === "hasMany" || type === "hasAndBelongsToMany") {
+      proxy.replace?.(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
+    } else {
+      proxy.writer?.(value);
+    }
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
   // --- Translation mixin (wired via extend() after class) ---
@@ -2277,6 +2325,11 @@ export class Base extends Model {
 
   constructor(attrs: Record<string, unknown> = {}) {
     (new.target as typeof Base | undefined)?._requireConcreteClass();
+    // Split out constructor-form association values (e.g. `new Owner({items:
+    // [...]})`) so super() never sees them as plain attributes. Dispatched
+    // after super() so the association proxy exists on `this`.
+    const assocPending = _extractAssociationAttrs(new.target as typeof Base, attrs);
+    if (assocPending) attrs = assocPending.rest;
     if (hasMultiparameterKeys(attrs)) {
       // Mirrors Rails: Base#initialize calls assign_attributes which handles
       // multiparameter keys. We split: regular attrs go through the Model
@@ -2361,6 +2414,9 @@ export class Base extends Model {
         (this as any)._dirty.snapshot((this as any)._attributes);
         cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
       }
+    }
+    if (assocPending) {
+      _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
     }
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -570,20 +570,25 @@ function _extractAssociationAttrs(
   const defs = (ctor as { _associations?: Array<{ name: string; type: string }> } | undefined)
     ?._associations;
   if (!defs || defs.length === 0) return null;
+  // Common case: models that declare associations but receive only regular
+  // attrs at construction (`new Post({title})`). First pass detects whether
+  // any key matches an association; only then do we allocate `rest` and
+  // copy entries. Avoids per-construction overhead for the hot path.
   let assocs: Array<{ name: string; value: unknown }> | null = null;
-  let rest: Record<string, unknown> | null = null;
-  for (const [k, v] of Object.entries(attrs)) {
-    const def = defs.find((a) => a.name === k);
-    if (def) {
-      (assocs ??= []).push({ name: def.name, value: v });
-    } else {
-      // Null-prototype to avoid `__proto__`/`constructor` keys mutating
-      // Object.prototype before `rest` is handed to super().
-      (rest ??= Object.create(null) as Record<string, unknown>)[k] = v;
+  for (const k of Object.keys(attrs)) {
+    if (defs.find((a) => a.name === k)) {
+      (assocs ??= []).push({ name: k, value: attrs[k] });
     }
   }
   if (!assocs) return null;
-  return { rest: rest ?? (Object.create(null) as Record<string, unknown>), assocs };
+  // Null-prototype to avoid `__proto__`/`constructor` keys mutating
+  // Object.prototype before `rest` is handed to super().
+  const rest = Object.create(null) as Record<string, unknown>;
+  const assocNames = new Set(assocs.map((a) => a.name));
+  for (const [k, v] of Object.entries(attrs)) {
+    if (!assocNames.has(k)) rest[k] = v;
+  }
+  return { rest, assocs };
 }
 
 /** @internal */

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -711,8 +711,8 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
     const { multiparams, regular } = extractMultiparameterCallstack(attrs);
     // Assign regular attributes first (with existing error wrapping)
     for (const [key, value] of Object.entries(regular)) {
-      if (assignIfAssociation(this, key, value)) continue;
       try {
+        if (assignIfAssociation(this, key, value)) continue;
         this.writeAttribute(key, value);
       } catch (e) {
         let repr: string;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -28,6 +28,7 @@ import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
+import { assignAssociationIfMatch } from "./attribute-assignment.js";
 import { clearAutosaveState } from "./autosave-association.js";
 import { getStiBase, getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 import { withTransactionReturningStatus } from "./transactions.js";
@@ -712,7 +713,14 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
     // Assign regular attributes first (with existing error wrapping)
     for (const [key, value] of Object.entries(regular)) {
       try {
-        if (assignIfAssociation(this, key, value)) continue;
+        if (
+          assignAssociationIfMatch(
+            this as { constructor?: unknown; association?: (name: string) => unknown },
+            key,
+            value,
+          )
+        )
+          continue;
         this.writeAttribute(key, value);
       } catch (e) {
         let repr: string;
@@ -734,8 +742,15 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
   }
 
   for (const [key, value] of Object.entries(attrs)) {
-    if (assignIfAssociation(this, key, value)) continue;
     try {
+      if (
+        assignAssociationIfMatch(
+          this as { constructor?: unknown; association?: (name: string) => unknown },
+          key,
+          value,
+        )
+      )
+        continue;
       this.writeAttribute(key, value);
     } catch (e) {
       let repr: string;
@@ -751,43 +766,6 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
       );
     }
   }
-}
-
-/**
- * Constructor-form association writer. When the key matches a declared
- * association (via `ctor._associations`), dispatch the value to the
- * association proxy's `replace`/`writer` rather than `writeAttribute`.
- * Mirrors Rails' `_assign_attribute` routing through `public_send("#{k}=")`
- * to association writer methods.
- *
- * Returns true if the key was an association and was handled.
- *
- * @internal
- */
-function assignIfAssociation(host: AttributeIO, key: string, value: unknown): boolean {
-  const ctor = (host as { constructor?: unknown }).constructor as
-    | { _associations?: Array<{ name: string; type: string }> }
-    | undefined;
-  const assoc = ctor?._associations?.find((a) => a.name === key);
-  if (!assoc) return false;
-  const assocFn = (host as unknown as { association?: (n: string) => unknown }).association;
-  if (typeof assocFn !== "function") return false;
-  const proxy = assocFn.call(host, key) as
-    | { replace?: (v: unknown[]) => void; writer?: (v: unknown) => void }
-    | null
-    | undefined;
-  if (!proxy) return false;
-  if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
-    if (typeof proxy.replace !== "function") return false;
-    proxy.replace(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
-    return true;
-  }
-  if (assoc.type === "hasOne" || assoc.type === "belongsTo") {
-    if (typeof proxy.writer !== "function") return false;
-    proxy.writer(value);
-    return true;
-  }
-  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -711,6 +711,7 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
     const { multiparams, regular } = extractMultiparameterCallstack(attrs);
     // Assign regular attributes first (with existing error wrapping)
     for (const [key, value] of Object.entries(regular)) {
+      if (assignIfAssociation(this, key, value)) continue;
       try {
         this.writeAttribute(key, value);
       } catch (e) {
@@ -733,6 +734,7 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
   }
 
   for (const [key, value] of Object.entries(attrs)) {
+    if (assignIfAssociation(this, key, value)) continue;
     try {
       this.writeAttribute(key, value);
     } catch (e) {
@@ -749,6 +751,43 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
       );
     }
   }
+}
+
+/**
+ * Constructor-form association writer. When the key matches a declared
+ * association (via `ctor._associations`), dispatch the value to the
+ * association proxy's `replace`/`writer` rather than `writeAttribute`.
+ * Mirrors Rails' `_assign_attribute` routing through `public_send("#{k}=")`
+ * to association writer methods.
+ *
+ * Returns true if the key was an association and was handled.
+ *
+ * @internal
+ */
+function assignIfAssociation(host: AttributeIO, key: string, value: unknown): boolean {
+  const ctor = (host as { constructor?: unknown }).constructor as
+    | { _associations?: Array<{ name: string; type: string }> }
+    | undefined;
+  const assoc = ctor?._associations?.find((a) => a.name === key);
+  if (!assoc) return false;
+  const assocFn = (host as unknown as { association?: (n: string) => unknown }).association;
+  if (typeof assocFn !== "function") return false;
+  const proxy = assocFn.call(host, key) as
+    | { replace?: (v: unknown[]) => void; writer?: (v: unknown) => void }
+    | null
+    | undefined;
+  if (!proxy) return false;
+  if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
+    if (typeof proxy.replace !== "function") return false;
+    proxy.replace(Array.isArray(value) ? (value as unknown[]) : value == null ? [] : [value]);
+    return true;
+  }
+  if (assoc.type === "hasOne" || assoc.type === "belongsTo") {
+    if (typeof proxy.writer !== "function") return false;
+    proxy.writer(value);
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Batch 30 from `docs/activerecord-100-plan.md` — three Rails-fidelity gaps in the HMT/HABTM slot:

- **Constructor-form association writer.** `new Owner({items: [...], profile: p})` now dispatches association keys to the proxy's `replace` / `writer` rather than `writeAttribute` (which silently dropped them as unknown attrs). Mirrors Rails' `_assign_attribute` → `public_send("#{k}=")` routing into association writer methods. Wired in `Base` constructor (so `Model`'s `writeAttribute`-only constructor doesn't see the association keys) and mirrored in both `attribute-assignment.ts` `_assignAttributes` and `persistence.ts` `assignAttributes` for Rails fidelity on the manual-call paths.
- **`Association#resetScope` on owner save.** `saveCollectionAssociation` now invokes `inst.resetScope()` before delegating to `autosaveHasMany`, matching Rails' `save_collection_association`. Prevents a stale memoized `@association_scope` from surviving into per-child save paths.
- **HMT `insert_record` two-step alignment.** `HasManyThroughAssociation#insertRecord` now follows Rails' two-step: `super.insertRecord(record)` → `save_through_record(record)`. The HABTM branch (previously bypassed via a single-row `insertHabtmRecord` write) is unified under `saveThroughRecord` + `buildThroughRecord`; HABTM builds the join row via the through proxy so it's tracked by the through association, matching Rails' `build_through_record`.

~228 LOC total (additions + deletions, excluding tests).

## Test plan

- [x] New smoke tests in `packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts`
- [x] No regressions across `packages/activerecord/src/associations/`, `attribute-assignment.test.ts`, `autosave-association.test.ts`, `has-many-through{,-associations}.test.ts`
- [ ] CI green

## Open Copilot concerns (deferred — review cycle max reached)

- `buildHabtmThroughRecord` (`has-many-through-association.ts`) derives `ownerPk` from `throughAssocDef.options.primaryKey ?? ctor.primaryKey ?? "id"` and does not assert it is a single column. Composite primary keys would flow into `_readAttribute(ownerPk)` as an array and produce an incorrect/undefined join FK value rather than a clear `ConfigurationError`. Fix path: route through the existing `habtmOwnerPk` helper (or replicate its `ConfigurationError` throw) before reading the value. HABTM with composite PKs is not exercised in this PR — captured here for a follow-up rather than blocking the slot.
