### PR TITLE
feat(activerecord): migration older B/E larger items (batch 42)

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2057,6 +2057,33 @@ describe("MigrationTest", () => {
     expect(N("jsonb", "postgres")).toEqual({ type: "jsonb" });
   });
 
+  it("_introspectColumns handles PG ARRAY + USER-DEFINED + datetime_precision rows", async () => {
+    // Stub the adapter to feed PG-shaped catalog rows through the live
+    // _introspectColumns code path (sqlite test adapter can't return them).
+    const stub = {
+      adapterName: "postgres" as const,
+      quoteTableName: (n: string) => `"${n}"`,
+      execute: async () => [
+        { column_name: "tags", data_type: "ARRAY", udt_name: "_int4" },
+        { column_name: "score", data_type: "numeric", numeric_precision: 10, numeric_scale: 2 },
+        { column_name: "doc", data_type: "USER-DEFINED", udt_name: "citext" },
+        { column_name: "made_at", data_type: "timestamp with time zone", datetime_precision: 6 },
+        { column_name: "name", data_type: "character varying", character_maximum_length: 100 },
+      ],
+    };
+    const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
+    const cols = await (
+      ctx as unknown as { _introspectColumns: (n: string) => Promise<unknown[]> }
+    )._introspectColumns("things");
+    expect(cols).toEqual([
+      { name: "tags", type: "integer", limit: 4, array: true },
+      { name: "score", type: "decimal", precision: 10, scale: 2 },
+      { name: "doc", type: "citext" },
+      { name: "made_at", type: "timestamptz", precision: 6 },
+      { name: "name", type: "string", limit: 100 },
+    ]);
+  });
+
   it.skipIf(adapterType === "mysql")("create table with query", async () => {
     const adapter = freshAdapter();
     const ctx = new MigrationContext(adapter);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2000,7 +2000,8 @@ describe("MigrationTest", () => {
     expect(N("smallint", "mysql")).toEqual({ type: "integer", limit: 2 });
     expect(N("mediumint", "mysql")).toEqual({ type: "integer", limit: 3 });
     expect(N("int(11)", "mysql")).toEqual({ type: "integer", limit: 4 });
-    expect(N("year", "mysql")).toEqual({ type: "integer", limit: 4 });
+    // MySQL `year` is registered as plain IntegerType (abstract-mysql-adapter.ts:1422).
+    expect(N("year", "mysql")).toEqual({ type: "integer" });
     expect(N("enum('a','b')", "mysql")).toEqual({ type: "string" });
     expect(N("set('a','b')", "mysql")).toEqual({ type: "string" });
     expect(N("bit(8)", "mysql")).toEqual({ type: "binary", limit: 8 });
@@ -2042,10 +2043,12 @@ describe("MigrationTest", () => {
     expect(N("timestamptz", "postgres")).toEqual({ type: "timestamptz" });
     expect(N("timestamp", "postgres")).toEqual({ type: "datetime" });
 
-    // PG bit / bit varying are their own types (NOT binary like MySQL)
+    // PG bit / bit varying are their own types (NOT binary like MySQL).
+    // bit varying is stored as the SQL form so schema-dumper.ts:142-143
+    // resolves it to the bitVarying DSL.
     expect(N("bit", "postgres")).toEqual({ type: "bit" });
-    expect(N("bit varying", "postgres")).toEqual({ type: "bitVarying" });
-    expect(N("varbit", "postgres")).toEqual({ type: "bitVarying" });
+    expect(N("bit varying", "postgres")).toEqual({ type: "bit varying" });
+    expect(N("varbit", "postgres")).toEqual({ type: "bit varying" });
 
     // Binary / uuid / json
     expect(N("bytea", "postgres")).toEqual({ type: "binary" });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1890,6 +1890,94 @@ describe("MigrationTest", () => {
     }
   });
 
+  it("schema mutators honor table_name_prefix and table_name_suffix", async () => {
+    // Regression coverage: each Migration schema method must route the table
+    // argument through `_pt()` so global table_name_prefix/suffix wraps it.
+    // Stub the underlying schema and assert the wrapped name reached the
+    // adapter — independent of which DDL each ALTER would emit per adapter.
+    const savedPrefix = Base.tableNamePrefix;
+    const savedSuffix = Base.tableNameSuffix;
+    Base.tableNamePrefix = "p_";
+    Base.tableNameSuffix = "_s";
+    try {
+      class CoverPrefix extends Migration {}
+      const m = new CoverPrefix();
+      const fakeConn = {} as any;
+      m.connection = fakeConn;
+      (m as any)._schemaConn = fakeConn;
+      const calls: Array<[string, string]> = [];
+      const stub =
+        (method: string) =>
+        async (tname: string, ..._rest: unknown[]) => {
+          calls.push([method, tname]);
+        };
+      // Stub schema and connection methods that Migration delegates to.
+      (m as any)._schema = {
+        addColumn: stub("addColumn"),
+        removeColumn: stub("removeColumn"),
+        renameColumn: stub("renameColumn"),
+        changeColumn: stub("changeColumn"),
+        changeColumnDefault: stub("changeColumnDefault"),
+        changeColumnNull: stub("changeColumnNull"),
+        addIndex: stub("addIndex"),
+        removeIndex: stub("removeIndex"),
+        renameIndex: stub("renameIndex"),
+        addReference: stub("addReference"),
+        removeReference: stub("removeReference"),
+        addForeignKey: stub("addForeignKey"),
+        removeForeignKey: stub("removeForeignKey"),
+        addCheckConstraint: stub("addCheckConstraint"),
+        removeCheckConstraint: stub("removeCheckConstraint"),
+        addTimestamps: stub("addTimestamps"),
+        removeTimestamps: stub("removeTimestamps"),
+        createJoinTable: stub("createJoinTable"),
+        dropJoinTable: stub("dropJoinTable"),
+        indexName: (tname: string) => `index_${tname}_x`,
+      };
+      Object.assign(fakeConn, {
+        changeColumnComment: stub("changeColumnComment"),
+        changeTableComment: stub("changeTableComment"),
+        validateCheckConstraint: stub("validateCheckConstraint"),
+        validateForeignKey: stub("validateForeignKey"),
+      });
+
+      await m.addColumn("widgets", "price", "integer");
+      await m.removeColumn("widgets", "note");
+      await m.renameColumn("widgets", "a", "b");
+      await m.changeColumn("widgets", "price", "decimal");
+      await m.changeColumnDefault("widgets", "price", 0);
+      await m.changeColumnNull("widgets", "price", false);
+      await m.addIndex("widgets", "category_id");
+      await m.removeIndex("widgets", { column: "category_id" });
+      await m.renameIndex("widgets", "old", "new");
+      await m.addReference("widgets", "bucket");
+      await m.removeReference("widgets", "bucket");
+      await m.addForeignKey("widgets", "buckets");
+      await m.removeForeignKey("widgets", "buckets");
+      await m.addCheckConstraint("widgets", "price >= 0", { name: "c" });
+      await m.removeCheckConstraint("widgets", { name: "c" });
+      await m.addTimestamps("widgets");
+      await m.removeTimestamps("widgets");
+      await m.createJoinTable("widgets", "buckets");
+      await m.dropJoinTable("widgets", "buckets");
+      await m.changeColumnComment("widgets", "price", "msg");
+      await m.changeTableComment("widgets", "msg");
+      await m.validateCheckConstraint("widgets", "c");
+      await m.validateForeignKey("widgets", "buckets");
+
+      // Every recorded call must have received the prefixed/suffixed name.
+      expect(calls).not.toHaveLength(0);
+      for (const [method, tname] of calls) {
+        expect(tname, `${method} did not apply prefix/suffix`).toBe("p_widgets_s");
+      }
+      // indexName itself must apply the wrapper.
+      expect(m.indexName("widgets", { column: "category_id" })).toBe("index_p_widgets_s_x");
+    } finally {
+      Base.tableNamePrefix = savedPrefix;
+      Base.tableNameSuffix = savedSuffix;
+    }
+  });
+
   it.skipIf(adapterType === "mysql")("create table with query", async () => {
     const adapter = freshAdapter();
     const ctx = new MigrationContext(adapter);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1984,12 +1984,18 @@ describe("MigrationTest", () => {
         _normalizeIntrospectedType: (
           raw: string,
           a?: "sqlite" | "postgres" | "mysql",
+          opts?: { emulateBooleans?: boolean },
         ) => { type: string; limit?: number; precision?: number; scale?: number };
       }
     )._normalizeIntrospectedType;
 
     // MySQL boolean emulation + integer byte limits + enum/set/year/bit
     expect(N("tinyint(1)", "mysql")).toEqual({ type: "boolean" });
+    // emulateBooleans=false falls back to a 1-byte integer (mysql-type-lookup parity).
+    expect(N("tinyint(1)", "mysql", { emulateBooleans: false })).toEqual({
+      type: "integer",
+      limit: 1,
+    });
     expect(N("tinyint", "mysql")).toEqual({ type: "integer", limit: 1 });
     expect(N("smallint", "mysql")).toEqual({ type: "integer", limit: 2 });
     expect(N("mediumint", "mysql")).toEqual({ type: "integer", limit: 3 });
@@ -2031,7 +2037,10 @@ describe("MigrationTest", () => {
     expect(N("datetime(6)", "mysql")).toEqual({ type: "datetime", precision: 6 });
     expect(N("time(3)", "mysql")).toEqual({ type: "time", precision: 3 });
     expect(N("time with time zone", "postgres")).toEqual({ type: "time" });
-    expect(N("timestamp with time zone", "postgres")).toEqual({ type: "datetime" });
+    // PG schema-dumper.ts:117-118 distinguishes `timestamptz` DSL from `datetime`.
+    expect(N("timestamp with time zone", "postgres")).toEqual({ type: "timestamptz" });
+    expect(N("timestamptz", "postgres")).toEqual({ type: "timestamptz" });
+    expect(N("timestamp", "postgres")).toEqual({ type: "datetime" });
 
     // PG bit / bit varying are their own types (NOT binary like MySQL)
     expect(N("bit", "postgres")).toEqual({ type: "bit" });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1978,6 +1978,62 @@ describe("MigrationTest", () => {
     }
   });
 
+  it("_normalizeIntrospectedType maps catalog rows to Rails-canonical types", () => {
+    const N = (
+      MigrationContext as unknown as {
+        _normalizeIntrospectedType: (
+          raw: string,
+          a?: "sqlite" | "postgres" | "mysql",
+        ) => { type: string; limit?: number; precision?: number; scale?: number };
+      }
+    )._normalizeIntrospectedType;
+
+    // MySQL boolean emulation + integer byte limits + enum/set/year/bit
+    expect(N("tinyint(1)", "mysql")).toEqual({ type: "boolean" });
+    expect(N("tinyint", "mysql")).toEqual({ type: "integer", limit: 1 });
+    expect(N("smallint", "mysql")).toEqual({ type: "integer", limit: 2 });
+    expect(N("mediumint", "mysql")).toEqual({ type: "integer", limit: 3 });
+    expect(N("int(11)", "mysql")).toEqual({ type: "integer", limit: 4 });
+    expect(N("year", "mysql")).toEqual({ type: "integer", limit: 4 });
+    expect(N("enum('a','b')", "mysql")).toEqual({ type: "string" });
+    expect(N("set('a','b')", "mysql")).toEqual({ type: "string" });
+    expect(N("bit(8)", "mysql")).toEqual({ type: "binary", limit: 8 });
+
+    // Strings vs text vs citext
+    expect(N("varchar(255)", "mysql")).toEqual({ type: "string", limit: 255 });
+    expect(N("text", "mysql")).toEqual({ type: "text" });
+    expect(N("longtext", "mysql")).toEqual({ type: "text" });
+    expect(N("citext", "postgres")).toEqual({ type: "citext" });
+
+    // Decimal: one-arg → precision, two-arg → precision+scale
+    expect(N("decimal(10)", "mysql")).toEqual({ type: "decimal", precision: 10 });
+    expect(N("numeric(10,2)", "postgres")).toEqual({ type: "decimal", precision: 10, scale: 2 });
+
+    // Float byte limits: PG vs MySQL `real` divergence
+    expect(N("float", "mysql")).toEqual({ type: "float", limit: 24 });
+    expect(N("double", "mysql")).toEqual({ type: "float", limit: 53 });
+    expect(N("real", "postgres")).toEqual({ type: "float", limit: 24 });
+    expect(N("real", "mysql")).toEqual({ type: "float", limit: 53 });
+    expect(N("double precision", "postgres")).toEqual({ type: "float", limit: 53 });
+
+    // Date/time precision propagation
+    expect(N("datetime(6)", "mysql")).toEqual({ type: "datetime", precision: 6 });
+    expect(N("time(3)", "mysql")).toEqual({ type: "time", precision: 3 });
+    expect(N("time with time zone", "postgres")).toEqual({ type: "time" });
+    expect(N("timestamp with time zone", "postgres")).toEqual({ type: "datetime" });
+
+    // PG bit / bit varying are their own types (NOT binary like MySQL)
+    expect(N("bit", "postgres")).toEqual({ type: "bit" });
+    expect(N("bit varying", "postgres")).toEqual({ type: "bitVarying" });
+    expect(N("varbit", "postgres")).toEqual({ type: "bitVarying" });
+
+    // Binary / uuid / json
+    expect(N("bytea", "postgres")).toEqual({ type: "binary" });
+    expect(N("blob", "mysql")).toEqual({ type: "binary" });
+    expect(N("uuid", "postgres")).toEqual({ type: "uuid" });
+    expect(N("jsonb", "postgres")).toEqual({ type: "jsonb" });
+  });
+
   it.skipIf(adapterType === "mysql")("create table with query", async () => {
     const adapter = freshAdapter();
     const ctx = new MigrationContext(adapter);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2009,12 +2009,23 @@ describe("MigrationTest", () => {
     expect(N("decimal(10)", "mysql")).toEqual({ type: "decimal", precision: 10 });
     expect(N("numeric(10,2)", "postgres")).toEqual({ type: "decimal", precision: 10, scale: 2 });
 
-    // Float byte limits: PG vs MySQL `real` divergence
+    // Float byte limits — mirror per-adapter type maps:
+    //  - MySQL: float→24, double→53, real==double (53)
+    //  - PG (type-map-init.ts:138-139): float4→24, float8→no limit;
+    //    real==float4 → 24, double precision==float8 → no limit
+    //  - SQLite (sqlite3-adapter.ts:2224): all float-like → no limit
     expect(N("float", "mysql")).toEqual({ type: "float", limit: 24 });
     expect(N("double", "mysql")).toEqual({ type: "float", limit: 53 });
-    expect(N("real", "postgres")).toEqual({ type: "float", limit: 24 });
     expect(N("real", "mysql")).toEqual({ type: "float", limit: 53 });
-    expect(N("double precision", "postgres")).toEqual({ type: "float", limit: 53 });
+    expect(N("float4", "postgres")).toEqual({ type: "float", limit: 24 });
+    expect(N("real", "postgres")).toEqual({ type: "float", limit: 24 });
+    expect(N("float8", "postgres")).toEqual({ type: "float" });
+    expect(N("double precision", "postgres")).toEqual({ type: "float" });
+    expect(N("float", "sqlite")).toEqual({ type: "float" });
+
+    // SQLite integer collapses to dynamic 8-byte int (sqlite3-adapter.ts:2188).
+    expect(N("integer", "sqlite")).toEqual({ type: "integer", limit: 8 });
+    expect(N("bigint", "sqlite")).toEqual({ type: "integer", limit: 8 });
 
     // Date/time precision propagation
     expect(N("datetime(6)", "mysql")).toEqual({ type: "datetime", precision: 6 });
@@ -2048,6 +2059,12 @@ describe("MigrationTest", () => {
     const rows = await adapter.execute(`SELECT * FROM "table_from_query_testings"`);
     expect(rows).toHaveLength(1);
     expect(ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
+
+    // _introspectColumns / _normalizeIntrospectedType should populate
+    // _columnMeta with a Rails-canonical type (not the raw catalog string).
+    const cols = ctx.columns("table_from_query_testings");
+    const pid = cols.find((c) => c.name === "person_id");
+    expect(pid?.type).toBe("integer");
 
     await ctx.dropTable("table_from_query_testings");
     await ctx.dropTable("people_src");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1685,8 +1685,10 @@ export class MigrationContext {
   /**
    * @internal Map raw catalog types (PG/MySQL/SQLite) to Rails-canonical
    * names plus precision/scale/limit. Mirrors the per-adapter type-lookup
-   * registrations (mysql-type-lookup, postgresql/oid). Assumes MySQL
-   * `emulate_booleans: true` (Rails default) so `tinyint(1)` → boolean.
+   * registrations (mysql-type-lookup, postgresql/oid). Callers may pass
+   * `emulateBooleans` (default true) so MySQL `tinyint(1)` follows the
+   * adapter's configured emulation mode; `_introspectColumns` threads in
+   * the live `abstract-mysql-adapter#emulateBooleans` value.
    */
   static _normalizeIntrospectedType(
     raw: string,
@@ -1776,8 +1778,10 @@ export class MigrationContext {
     if (/^(time|time without time zone)$/.test(head)) return { type: "time", ...precOnly };
     if (/^(timetz|time with time zone)$/.test(head)) return { type: "time", ...precOnly };
     // Distinguish PG timestamptz from naive datetime — schema-dumper.ts:117-118
-    // emits the `timestamptz` DSL for timestamp-with-time-zone, separate from
-    // the `datetime` DSL used for naive timestamps.
+    // maps `timestamp with time zone` to the `timestamptz` SQL_TYPE_MAP entry
+    // (the emitter then falls back to `t.column(..., "timestamptz")` since
+    // `timestamptz` isn't in DSL_HELPER_METHODS). Separate from the `datetime`
+    // DSL used for naive timestamps.
     if (/^(timestamptz|timestamp with time zone)$/.test(head))
       return { type: "timestamptz", ...precOnly };
     if (/^(datetime|timestamp|timestamp without time zone)$/.test(head))
@@ -1866,6 +1870,7 @@ export class MigrationContext {
         limit?: number | null;
         precision?: number | null;
         scale?: number | null;
+        array?: boolean;
       }
     >();
     const compositePk =
@@ -1892,6 +1897,7 @@ export class MigrationContext {
         limit: col.options.limit,
         precision: col.options.precision,
         scale: col.options.scale,
+        array: (col.options as { array?: boolean }).array,
       });
     }
     if (options?.as != null) {
@@ -2054,6 +2060,7 @@ export class MigrationContext {
       limit: _options?.limit,
       precision: _options?.precision,
       scale: _options?.scale,
+      array: (_options as { array?: boolean } | undefined)?.array,
     });
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1602,7 +1602,9 @@ export class MigrationContext {
   }
 
   /** @internal Query catalog for column names+types — used after CTAS where columns derive from the SELECT. */
-  private async _introspectColumns(name: string): Promise<{ name: string; type: string }[]> {
+  private async _introspectColumns(
+    name: string,
+  ): Promise<{ name: string; type: string; limit?: number; precision?: number; scale?: number }[]> {
     const a = this._adapterName;
     const qt = this.adapter.quoteTableName(name);
     let sql: string;
@@ -1621,40 +1623,59 @@ export class MigrationContext {
       const colName = (x.name ?? x.column_name ?? x.Field) as string;
       // SQLite: type field; PG: data_type; MySQL: Type
       const rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
-      return { name: colName, type: MigrationContext._normalizeIntrospectedType(rawType) };
+      return { name: colName, ...MigrationContext._normalizeIntrospectedType(rawType) };
     });
   }
 
-  /** @internal Map raw catalog types (PG/MySQL/SQLite) to Rails-canonical names. */
-  private static _normalizeIntrospectedType(raw: string): string {
+  /**
+   * @internal Map raw catalog types (PG/MySQL/SQLite) to Rails-canonical
+   * names plus precision/scale/limit. Mirrors the per-adapter type-lookup
+   * registrations (mysql-type-lookup, postgresql/oid). Assumes MySQL
+   * `emulate_booleans: true` (Rails default) so `tinyint(1)` → boolean.
+   */
+  private static _normalizeIntrospectedType(raw: string): {
+    type: string;
+    limit?: number;
+    precision?: number;
+    scale?: number;
+  } {
     const t = raw.toLowerCase().trim();
-    if (!t) return "string";
-    // Strip trailing modifiers e.g. "varchar(255)", "numeric(10,2)", "integer unsigned"
-    const head = t.replace(/\s*\(.*$/, "").split(/\s+/, 1)[0]!;
-    if (
-      /^(varchar|character varying|character|char|nvarchar|nchar|text|tinytext|mediumtext|longtext|citext|clob)$/.test(
-        head,
-      )
-    )
-      return "string";
-    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial)$/.test(head))
-      return "integer";
-    if (/^(bigint|int8|bigserial)$/.test(head)) return "bigint";
-    if (/^(float|float4|float8|double|double precision|real)$/.test(head)) return "float";
-    if (/^(numeric|decimal|number)$/.test(head)) return "decimal";
-    if (/^(bool|boolean|bit)$/.test(head)) return "boolean";
-    if (/^(date)$/.test(head)) return "date";
-    if (/^(time)$/.test(head)) return "time";
+    if (!t) return { type: "string" };
+    // MySQL boolean emulation must run before modifier stripping.
+    if (/^tinyint\s*\(\s*1\s*\)/.test(t)) return { type: "boolean" };
+    // enum/set carry a literal value list, not a length.
+    if (/^enum\s*\(/.test(t) || /^set\s*\(/.test(t)) return { type: "string" };
+    const parenMatch = t.match(/^([a-z_ ]+?)\s*\((\d+)(?:\s*,\s*(\d+))?\)/);
+    const head = (parenMatch?.[1] ?? t.replace(/\s+unsigned\b.*$/, "")).trim();
+    const sizes = parenMatch
+      ? parenMatch[3] != null
+        ? { precision: Number(parenMatch[2]), scale: Number(parenMatch[3]) }
+        : { limit: Number(parenMatch[2]) }
+      : {};
+    if (/^(varchar|character varying|character|char|nvarchar|nchar)$/.test(head))
+      return { type: "string", ...sizes };
+    if (/^(text|tinytext|mediumtext|longtext|clob)$/.test(head)) return { type: "text" };
+    if (/^citext$/.test(head)) return { type: "citext" };
+    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head))
+      return { type: "integer", ...sizes };
+    if (/^(bigint|int8|bigserial)$/.test(head)) return { type: "bigint" };
+    if (/^(float|float4|float8|double|double precision|real)$/.test(head)) return { type: "float" };
+    if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...sizes };
+    if (/^(bool|boolean)$/.test(head)) return { type: "boolean" };
+    if (/^bit$/.test(head)) return { type: "binary", ...sizes }; // MySQL BIT is binary per mysql-type-lookup
+    if (/^date$/.test(head)) return { type: "date" };
+    if (/^time$/.test(head)) return { type: "time" };
     if (
       /^(datetime|timestamp|timestamptz|timestamp with time zone|timestamp without time zone)$/.test(
         head,
       )
     )
-      return "datetime";
-    if (/^(uuid)$/.test(head)) return "uuid";
-    if (/^(json|jsonb)$/.test(head)) return head;
-    if (/^(bytea|blob|tinyblob|mediumblob|longblob|binary|varbinary)$/.test(head)) return "binary";
-    return head;
+      return { type: "datetime" };
+    if (/^uuid$/.test(head)) return { type: "uuid" };
+    if (/^(json|jsonb)$/.test(head)) return { type: head };
+    if (/^(bytea|blob|tinyblob|mediumblob|longblob|binary|varbinary)$/.test(head))
+      return { type: "binary", ...sizes };
+    return { type: head };
   }
 
   async createTable(
@@ -1763,9 +1784,10 @@ export class MigrationContext {
       });
     }
     if (options?.as != null) {
-      for (const { name: c, type } of await this._introspectColumns(name)) {
+      for (const col of await this._introspectColumns(name)) {
+        const { name: c, ...rest } = col;
         cols.add(c);
-        meta.set(c, { type });
+        meta.set(c, rest);
       }
     }
     this._columns.set(name, cols);
@@ -2692,7 +2714,13 @@ export class Migrator {
         },
       });
     }
-    return proxies;
+    // Rails MigrationContext#migrations: `migrations.sort_by(&:version)` —
+    // numeric (not lexicographic) so "10" sorts after "2".
+    return proxies.sort((a, b) => {
+      const va = BigInt(a.version);
+      const vb = BigInt(b.version);
+      return va < vb ? -1 : va > vb ? 1 : 0;
+    });
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1613,7 +1613,10 @@ export class MigrationContext {
     } else if (a === "postgres") {
       const [s, t] = name.includes(".") ? name.split(".", 2) : ["public", name];
       const e = (x: string) => x.replace(/'/g, "''");
-      sql = `SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = '${e(s)}' AND table_name = '${e(t)}' ORDER BY ordinal_position`;
+      // Pull udt_name for user-defined types (citext, hstore, …) which
+      // surface as "USER-DEFINED" via data_type, plus size fields for
+      // limit/precision/scale propagation.
+      sql = `SELECT column_name, data_type, udt_name, character_maximum_length, numeric_precision, numeric_scale, datetime_precision FROM information_schema.columns WHERE table_schema = '${e(s)}' AND table_name = '${e(t)}' ORDER BY ordinal_position`;
     } else {
       sql = `SHOW COLUMNS FROM ${qt}`;
     }
@@ -1621,9 +1624,34 @@ export class MigrationContext {
     return rows.map((r) => {
       const x = r as Record<string, unknown>;
       const colName = (x.name ?? x.column_name ?? x.Field) as string;
-      // SQLite: type field; PG: data_type; MySQL: Type
-      const rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
-      return { name: colName, ...MigrationContext._normalizeIntrospectedType(rawType) };
+      // SQLite: type; PG: data_type (with udt_name for USER-DEFINED); MySQL: Type
+      let rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
+      if (a === "postgres" && rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
+        rawType = String(x.udt_name);
+      }
+      const normalized = MigrationContext._normalizeIntrospectedType(rawType);
+      // Prefer PG's authoritative size columns when present — they sit in
+      // information_schema rather than baked into the type string.
+      if (a === "postgres") {
+        const charLen = x.character_maximum_length;
+        const numPrec = x.numeric_precision;
+        const numScale = x.numeric_scale;
+        const dtPrec = x.datetime_precision;
+        if (typeof charLen === "number") normalized.limit = charLen;
+        if (
+          typeof numPrec === "number" &&
+          (normalized.type === "decimal" || normalized.type === "float")
+        ) {
+          normalized.precision = numPrec;
+          if (typeof numScale === "number") normalized.scale = numScale;
+        }
+        if (
+          typeof dtPrec === "number" &&
+          (normalized.type === "datetime" || normalized.type === "time")
+        )
+          normalized.precision = dtPrec;
+      }
+      return { name: colName, ...normalized };
     });
   }
 
@@ -1647,34 +1675,54 @@ export class MigrationContext {
     if (/^enum\s*\(/.test(t) || /^set\s*\(/.test(t)) return { type: "string" };
     const parenMatch = t.match(/^([a-z_ ]+?)\s*\((\d+)(?:\s*,\s*(\d+))?\)/);
     const head = (parenMatch?.[1] ?? t.replace(/\s+unsigned\b.*$/, "")).trim();
-    const sizes = parenMatch
-      ? parenMatch[3] != null
-        ? { precision: Number(parenMatch[2]), scale: Number(parenMatch[3]) }
-        : { limit: Number(parenMatch[2]) }
-      : {};
+    const arg1 = parenMatch ? Number(parenMatch[2]) : undefined;
+    const arg2 = parenMatch && parenMatch[3] != null ? Number(parenMatch[3]) : undefined;
+    const limit = arg1 !== undefined && arg2 === undefined ? { limit: arg1 } : {};
+    // decimal(N) / decimal(N,M) — one-arg is precision (Rails decimal_columns).
+    const decSizes =
+      arg1 !== undefined
+        ? arg2 !== undefined
+          ? { precision: arg1, scale: arg2 }
+          : { precision: arg1 }
+        : {};
+    // datetime(N) / time(N) — N is fractional-seconds precision.
+    const precOnly = arg1 !== undefined && arg2 === undefined ? { precision: arg1 } : {};
+    // MySQL fixed byte-limits for small-int variants (mirrors mysql-type-lookup).
+    const intByteLimit: Record<string, number> = {
+      tinyint: 1,
+      smallint: 2,
+      int2: 2,
+      mediumint: 3,
+      int: 4,
+      integer: 4,
+      int4: 4,
+      year: 4,
+    };
     if (/^(varchar|character varying|character|char|nvarchar|nchar)$/.test(head))
-      return { type: "string", ...sizes };
+      return { type: "string", ...limit };
     if (/^(text|tinytext|mediumtext|longtext|clob)$/.test(head)) return { type: "text" };
     if (/^citext$/.test(head)) return { type: "citext" };
     if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head))
-      return { type: "integer", ...sizes };
+      // MySQL `int(N)` is a display width, not a Rails limit — use byte limit.
+      return { type: "integer", limit: intByteLimit[head] ?? 4 };
     if (/^(bigint|int8|bigserial)$/.test(head)) return { type: "bigint" };
-    if (/^(float|float4|float8|double|double precision|real)$/.test(head)) return { type: "float" };
-    if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...sizes };
+    if (/^(float|float4)$/.test(head)) return { type: "float", limit: 24 };
+    if (/^(double|double precision|float8|real)$/.test(head)) return { type: "float", limit: 53 };
+    if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...decSizes };
     if (/^(bool|boolean)$/.test(head)) return { type: "boolean" };
-    if (/^bit$/.test(head)) return { type: "binary", ...sizes }; // MySQL BIT is binary per mysql-type-lookup
+    if (/^bit$/.test(head)) return { type: "binary", ...limit }; // MySQL BIT is binary per mysql-type-lookup
     if (/^date$/.test(head)) return { type: "date" };
-    if (/^time$/.test(head)) return { type: "time" };
+    if (/^time$/.test(head)) return { type: "time", ...precOnly };
     if (
       /^(datetime|timestamp|timestamptz|timestamp with time zone|timestamp without time zone)$/.test(
         head,
       )
     )
-      return { type: "datetime" };
+      return { type: "datetime", ...precOnly };
     if (/^uuid$/.test(head)) return { type: "uuid" };
     if (/^(json|jsonb)$/.test(head)) return { type: head };
     if (/^(bytea|blob|tinyblob|mediumblob|longblob|binary|varbinary)$/.test(head))
-      return { type: "binary", ...sizes };
+      return { type: "binary", ...limit };
     return { type: head };
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1620,9 +1620,41 @@ export class MigrationContext {
       const x = r as Record<string, unknown>;
       const colName = (x.name ?? x.column_name ?? x.Field) as string;
       // SQLite: type field; PG: data_type; MySQL: Type
-      const colType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "string";
-      return { name: colName, type: colType };
+      const rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
+      return { name: colName, type: MigrationContext._normalizeIntrospectedType(rawType) };
     });
+  }
+
+  /** @internal Map raw catalog types (PG/MySQL/SQLite) to Rails-canonical names. */
+  private static _normalizeIntrospectedType(raw: string): string {
+    const t = raw.toLowerCase().trim();
+    if (!t) return "string";
+    // Strip trailing modifiers e.g. "varchar(255)", "numeric(10,2)", "integer unsigned"
+    const head = t.replace(/\s*\(.*$/, "").split(/\s+/, 1)[0]!;
+    if (
+      /^(varchar|character varying|character|char|nvarchar|nchar|text|tinytext|mediumtext|longtext|citext|clob)$/.test(
+        head,
+      )
+    )
+      return "string";
+    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial)$/.test(head))
+      return "integer";
+    if (/^(bigint|int8|bigserial)$/.test(head)) return "bigint";
+    if (/^(float|float4|float8|double|double precision|real)$/.test(head)) return "float";
+    if (/^(numeric|decimal|number)$/.test(head)) return "decimal";
+    if (/^(bool|boolean|bit)$/.test(head)) return "boolean";
+    if (/^(date)$/.test(head)) return "date";
+    if (/^(time)$/.test(head)) return "time";
+    if (
+      /^(datetime|timestamp|timestamptz|timestamp with time zone|timestamp without time zone)$/.test(
+        head,
+      )
+    )
+      return "datetime";
+    if (/^(uuid)$/.test(head)) return "uuid";
+    if (/^(json|jsonb)$/.test(head)) return head;
+    if (/^(bytea|blob|tinyblob|mediumblob|longblob|binary|varbinary)$/.test(head)) return "binary";
+    return head;
   }
 
   async createTable(
@@ -2579,13 +2611,30 @@ export class Migrator {
     Array<{ status: "up" | "down"; version: string; name: string }>
   > {
     await this._ensureSchemaTable();
-    const applied = await this._appliedVersions();
+    const applied = new Set(await this._appliedVersions());
 
-    return this._migrations.map((m) => ({
-      status: applied.has(m.version) ? ("up" as const) : ("down" as const),
-      version: m.version,
-      name: m.name,
+    const fileList = this._migrations.map((m) => {
+      const isUp = applied.delete(m.version);
+      return {
+        status: (isUp ? "up" : "down") as "up" | "down",
+        version: m.version,
+        name: m.name,
+      };
+    });
+
+    // Mirrors Rails Migrator#migrations_status: applied versions with no
+    // matching file get a placeholder name. Combined list sorts numerically.
+    const dbList = [...applied].map((version) => ({
+      status: "up" as const,
+      version,
+      name: "********** NO FILE **********",
     }));
+
+    return [...dbList, ...fileList].sort((a, b) => {
+      const va = BigInt(a.version);
+      const vb = BigInt(b.version);
+      return va < vb ? -1 : va > vb ? 1 : 0;
+    });
   }
 
   /**
@@ -2613,10 +2662,20 @@ export class Migrator {
    * Mirrors: ActiveRecord::MigrationContext#migrations (the discovery half)
    */
   static fromDir(dir: string, adapter: DatabaseAdapter): Migrator {
+    return new Migrator(adapter, Migrator.fromPath(dir, adapter));
+  }
+
+  /**
+   * Scan `dir` for migration files and build `MigrationProxy[]` (without
+   * wrapping them in a Migrator). Mirrors the discovery half of Rails'
+   * `MigrationContext#migrations`.
+   *
+   * Mirrors: ActiveRecord::MigrationContext#migrations (discovery)
+   */
+  static fromPath(dir: string, adapter: DatabaseAdapter): MigrationProxy[] {
     const helper = new Migrator(adapter, []);
-    const files = helper.migrationFiles([dir]);
     const proxies: MigrationProxy[] = [];
-    for (const file of files) {
+    for (const file of helper.migrationFiles([dir])) {
       const parsed = helper.parseMigrationFilename(file);
       if (!parsed) continue;
       const [version, rawName, scope] = parsed;
@@ -2633,7 +2692,7 @@ export class Migrator {
         },
       });
     }
-    return new Migrator(adapter, proxies);
+    return proxies;
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1655,7 +1655,9 @@ export class MigrationContext {
         }
         if (
           typeof dtPrec === "number" &&
-          (normalized.type === "datetime" || normalized.type === "time")
+          (normalized.type === "datetime" ||
+            normalized.type === "time" ||
+            normalized.type === "timestamptz")
         )
           normalized.precision = dtPrec;
       }
@@ -2739,11 +2741,20 @@ export class Migrator {
     }));
 
     // Rails sorts by `version.to_i` — non-numeric rows coerce to 0 rather
-    // than raising. Avoid BigInt here so a legacy non-numeric row preserved
-    // by _appliedVersions() doesn't crash status reporting.
-    return [...dbList, ...fileList].sort(
-      (a, b) => (parseInt(a.version, 10) || 0) - (parseInt(b.version, 10) || 0),
-    );
+    // than raising. Use BigInt for precision (versions can exceed
+    // MAX_SAFE_INTEGER) with a 0-fallback for non-numeric legacy rows.
+    const toBig = (v: string): bigint => {
+      try {
+        return /^-?\d+$/.test(v) ? BigInt(v) : 0n;
+      } catch {
+        return 0n;
+      }
+    };
+    return [...dbList, ...fileList].sort((a, b) => {
+      const va = toBig(a.version);
+      const vb = toBig(b.version);
+      return va < vb ? -1 : va > vb ? 1 : 0;
+    });
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1553,6 +1553,7 @@ export class MigrationContext {
         limit?: number | null;
         precision?: number | null;
         scale?: number | null;
+        array?: boolean;
       }
     >
   >();
@@ -1602,9 +1603,16 @@ export class MigrationContext {
   }
 
   /** @internal Query catalog for column names+types — used after CTAS where columns derive from the SELECT. */
-  private async _introspectColumns(
-    name: string,
-  ): Promise<{ name: string; type: string; limit?: number; precision?: number; scale?: number }[]> {
+  private async _introspectColumns(name: string): Promise<
+    {
+      name: string;
+      type: string;
+      limit?: number;
+      precision?: number;
+      scale?: number;
+      array?: boolean;
+    }[]
+  > {
     const a = this._adapterName;
     const qt = this.adapter.quoteTableName(name);
     let sql: string;
@@ -1626,8 +1634,17 @@ export class MigrationContext {
       const colName = (x.name ?? x.column_name ?? x.Field) as string;
       // SQLite: type; PG: data_type (with udt_name for USER-DEFINED); MySQL: Type
       let rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
-      if (a === "postgres" && rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
-        rawType = String(x.udt_name);
+      let isArray = false;
+      if (a === "postgres") {
+        // PG reports array columns as data_type='ARRAY' + udt_name='_int4'
+        // etc. — strip the leading underscore and surface as the base type
+        // plus array:true (schema-dumper/array.test.ts pattern).
+        if (rawType.toUpperCase() === "ARRAY" && typeof x.udt_name === "string") {
+          rawType = (x.udt_name as string).replace(/^_/, "");
+          isArray = true;
+        } else if (rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
+          rawType = String(x.udt_name);
+        }
       }
       // Mirror the configured MySQL emulateBooleans setting rather than
       // hard-coding Rails' default — abstract-mysql-adapter exposes it.
@@ -1661,7 +1678,7 @@ export class MigrationContext {
         )
           normalized.precision = dtPrec;
       }
-      return { name: colName, ...normalized };
+      return { name: colName, ...normalized, ...(isArray ? { array: true } : {}) };
     });
   }
 
@@ -1725,6 +1742,10 @@ export class MigrationContext {
     if (/^citext$/.test(head)) return { type: "citext" };
     if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head)) {
       if (adapter === "sqlite") return { type: "integer", limit: 8 };
+      // MySQL `year` is registered as a plain IntegerType with no limit
+      // (abstract-mysql-adapter.ts:1422). Other integer aliases keep their
+      // adapter-registered byte limit.
+      if (head === "year") return { type: "integer" };
       return { type: "integer", limit: intByteLimit[head] ?? 4 };
     }
     if (/^(bigint|int8|bigserial)$/.test(head))
@@ -1748,7 +1769,9 @@ export class MigrationContext {
     // mysql-type-lookup. PG `bit varying` arrives via information_schema.
     if (/^bit$/.test(head))
       return adapter === "postgres" ? { type: "bit", ...limit } : { type: "binary", ...limit };
-    if (/^(varbit|bit varying)$/.test(head)) return { type: "bitVarying", ...limit };
+    // Store the raw SQL form 'bit varying' so SchemaDumper SQL_TYPE_MAP
+    // (schema-dumper.ts:142-143) resolves it to the bitVarying DSL helper.
+    if (/^(varbit|bit varying)$/.test(head)) return { type: "bit varying", ...limit };
     if (/^date$/.test(head)) return { type: "date" };
     if (/^(time|time without time zone)$/.test(head)) return { type: "time", ...precOnly };
     if (/^(timetz|time with time zone)$/.test(head)) return { type: "time", ...precOnly };
@@ -2262,6 +2285,7 @@ export class MigrationContext {
     limit?: number | null;
     precision?: number | null;
     scale?: number | null;
+    array?: boolean;
   }> {
     const meta = this._columnMeta.get(tableName);
     if (meta) {
@@ -2743,9 +2767,13 @@ export class Migrator {
     // Rails sorts by `version.to_i` — non-numeric rows coerce to 0 rather
     // than raising. Use BigInt for precision (versions can exceed
     // MAX_SAFE_INTEGER) with a 0-fallback for non-numeric legacy rows.
+    // Mirror Ruby String#to_i: take the leading signed integer prefix and
+    // return 0 when none — strings like "123abc" sort as 123 (Rails parity).
     const toBig = (v: string): bigint => {
+      const m = v.match(/^\s*(-?\d+)/);
+      if (!m) return 0n;
       try {
-        return /^-?\d+$/.test(v) ? BigInt(v) : 0n;
+        return BigInt(m[1]!);
       } catch {
         return 0n;
       }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1629,7 +1629,15 @@ export class MigrationContext {
       if (a === "postgres" && rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
         rawType = String(x.udt_name);
       }
-      const normalized = MigrationContext._normalizeIntrospectedType(rawType, a);
+      // Mirror the configured MySQL emulateBooleans setting rather than
+      // hard-coding Rails' default — abstract-mysql-adapter exposes it.
+      const emulateBooleans =
+        a === "mysql"
+          ? ((this.adapter as { emulateBooleans?: boolean }).emulateBooleans ?? true)
+          : true;
+      const normalized = MigrationContext._normalizeIntrospectedType(rawType, a, {
+        emulateBooleans,
+      });
       // Prefer PG's authoritative size columns when present — they sit in
       // information_schema rather than baked into the type string.
       if (a === "postgres") {
@@ -1664,16 +1672,19 @@ export class MigrationContext {
   static _normalizeIntrospectedType(
     raw: string,
     adapter: "sqlite" | "postgres" | "mysql" = "sqlite",
+    opts: { emulateBooleans?: boolean } = {},
   ): {
     type: string;
     limit?: number;
     precision?: number;
     scale?: number;
   } {
+    const emulateBooleans = opts.emulateBooleans ?? true;
     const t = raw.toLowerCase().trim();
     if (!t) return { type: "string" };
     // MySQL boolean emulation must run before modifier stripping.
-    if (/^tinyint\s*\(\s*1\s*\)/.test(t)) return { type: "boolean" };
+    if (/^tinyint\s*\(\s*1\s*\)/.test(t))
+      return emulateBooleans ? { type: "boolean" } : { type: "integer", limit: 1 };
     // enum/set carry a literal value list, not a length.
     if (/^enum\s*\(/.test(t) || /^set\s*\(/.test(t)) return { type: "string" };
     const parenMatch = t.match(/^([a-z_ ]+?)\s*\((\d+)(?:\s*,\s*(\d+))?\)/);
@@ -1739,11 +1750,12 @@ export class MigrationContext {
     if (/^date$/.test(head)) return { type: "date" };
     if (/^(time|time without time zone)$/.test(head)) return { type: "time", ...precOnly };
     if (/^(timetz|time with time zone)$/.test(head)) return { type: "time", ...precOnly };
-    if (
-      /^(datetime|timestamp|timestamptz|timestamp with time zone|timestamp without time zone)$/.test(
-        head,
-      )
-    )
+    // Distinguish PG timestamptz from naive datetime — schema-dumper.ts:117-118
+    // emits the `timestamptz` DSL for timestamp-with-time-zone, separate from
+    // the `datetime` DSL used for naive timestamps.
+    if (/^(timestamptz|timestamp with time zone)$/.test(head))
+      return { type: "timestamptz", ...precOnly };
+    if (/^(datetime|timestamp|timestamp without time zone)$/.test(head))
       return { type: "datetime", ...precOnly };
     if (/^uuid$/.test(head)) return { type: "uuid" };
     if (/^(json|jsonb)$/.test(head)) return { type: head };

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1629,7 +1629,7 @@ export class MigrationContext {
       if (a === "postgres" && rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
         rawType = String(x.udt_name);
       }
-      const normalized = MigrationContext._normalizeIntrospectedType(rawType);
+      const normalized = MigrationContext._normalizeIntrospectedType(rawType, a);
       // Prefer PG's authoritative size columns when present — they sit in
       // information_schema rather than baked into the type string.
       if (a === "postgres") {
@@ -1638,10 +1638,10 @@ export class MigrationContext {
         const numScale = x.numeric_scale;
         const dtPrec = x.datetime_precision;
         if (typeof charLen === "number") normalized.limit = charLen;
-        if (
-          typeof numPrec === "number" &&
-          (normalized.type === "decimal" || normalized.type === "float")
-        ) {
+        // numeric_precision is meaningless for floats per PG type-map-init
+        // (float4 carries a fixed limit, float8 carries nothing) — only fill
+        // it for decimal.
+        if (typeof numPrec === "number" && normalized.type === "decimal") {
           normalized.precision = numPrec;
           if (typeof numScale === "number") normalized.scale = numScale;
         }
@@ -1661,7 +1661,10 @@ export class MigrationContext {
    * registrations (mysql-type-lookup, postgresql/oid). Assumes MySQL
    * `emulate_booleans: true` (Rails default) so `tinyint(1)` → boolean.
    */
-  private static _normalizeIntrospectedType(raw: string): {
+  static _normalizeIntrospectedType(
+    raw: string,
+    adapter: "sqlite" | "postgres" | "mysql" = "sqlite",
+  ): {
     type: string;
     limit?: number;
     precision?: number;
@@ -1707,12 +1710,22 @@ export class MigrationContext {
       return { type: "integer", limit: intByteLimit[head] ?? 4 };
     if (/^(bigint|int8|bigserial)$/.test(head)) return { type: "bigint" };
     if (/^(float|float4)$/.test(head)) return { type: "float", limit: 24 };
-    if (/^(double|double precision|float8|real)$/.test(head)) return { type: "float", limit: 53 };
+    // PG `real` is single-precision (float4 → limit 24); MySQL `real` is
+    // an alias for double (float8 → limit 53).
+    if (/^real$/.test(head))
+      return adapter === "postgres" ? { type: "float", limit: 24 } : { type: "float", limit: 53 };
+    if (/^(double|double precision|float8)$/.test(head)) return { type: "float", limit: 53 };
     if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...decSizes };
     if (/^(bool|boolean)$/.test(head)) return { type: "boolean" };
-    if (/^bit$/.test(head)) return { type: "binary", ...limit }; // MySQL BIT is binary per mysql-type-lookup
+    // PG registers `bit`/`varbit` as standalone Bit/BitVarying types
+    // (postgresql/type-map-init.ts); MySQL `bit` is a binary blob per
+    // mysql-type-lookup. PG `bit varying` arrives via information_schema.
+    if (/^bit$/.test(head))
+      return adapter === "postgres" ? { type: "bit", ...limit } : { type: "binary", ...limit };
+    if (/^(varbit|bit varying)$/.test(head)) return { type: "bitVarying", ...limit };
     if (/^date$/.test(head)) return { type: "date" };
-    if (/^time$/.test(head)) return { type: "time", ...precOnly };
+    if (/^(time|time without time zone)$/.test(head)) return { type: "time", ...precOnly };
+    if (/^(timetz|time with time zone)$/.test(head)) return { type: "time", ...precOnly };
     if (
       /^(datetime|timestamp|timestamptz|timestamp with time zone|timestamp without time zone)$/.test(
         head,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1690,8 +1690,13 @@ export class MigrationContext {
         : {};
     // datetime(N) / time(N) — N is fractional-seconds precision.
     const precOnly = arg1 !== undefined && arg2 === undefined ? { precision: arg1 } : {};
-    // MySQL fixed byte-limits for small-int variants (mirrors mysql-type-lookup).
-    const intByteLimit: Record<string, number> = {
+    // Per-adapter integer byte limits, mirroring the canonical type maps:
+    //  - postgresql/type-map-init.ts:134-136 (int2=2, int4=4, int8=8)
+    //  - mysql-type-lookup tests (tinyint=1, smallint=2, mediumint=3, int=4)
+    //  - sqlite3-adapter.ts:2188 (sqlite3Int defaults to limit 8)
+    // SQLite collapses everything to its dynamic integer; don't pretend
+    // otherwise. PG/MySQL share byte-sized variants below.
+    const intByteLimit: Record<string, number | undefined> = {
       tinyint: 1,
       smallint: 2,
       int2: 2,
@@ -1705,16 +1710,24 @@ export class MigrationContext {
       return { type: "string", ...limit };
     if (/^(text|tinytext|mediumtext|longtext|clob)$/.test(head)) return { type: "text" };
     if (/^citext$/.test(head)) return { type: "citext" };
-    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head))
-      // MySQL `int(N)` is a display width, not a Rails limit — use byte limit.
+    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head)) {
+      if (adapter === "sqlite") return { type: "integer", limit: 8 };
       return { type: "integer", limit: intByteLimit[head] ?? 4 };
-    if (/^(bigint|int8|bigserial)$/.test(head)) return { type: "bigint" };
-    if (/^(float|float4)$/.test(head)) return { type: "float", limit: 24 };
-    // PG `real` is single-precision (float4 → limit 24); MySQL `real` is
-    // an alias for double (float8 → limit 53).
+    }
+    if (/^(bigint|int8|bigserial)$/.test(head))
+      return adapter === "sqlite" ? { type: "integer", limit: 8 } : { type: "bigint" };
+    // Float byte-limits: PG float4 has limit 24 and float8 has no limit
+    // (postgresql/type-map-init.ts:138-139). SQLite registers all float-like
+    // declarations as FloatType() with no limit (sqlite3-adapter.ts:2224).
+    // MySQL retains the float/double precision split.
+    if (/^float4$/.test(head)) return { type: "float", limit: 24 };
+    if (/^float8$/.test(head)) return { type: "float" };
+    if (/^float$/.test(head))
+      return adapter === "mysql" ? { type: "float", limit: 24 } : { type: "float" };
     if (/^real$/.test(head))
-      return adapter === "postgres" ? { type: "float", limit: 24 } : { type: "float", limit: 53 };
-    if (/^(double|double precision|float8)$/.test(head)) return { type: "float", limit: 53 };
+      return adapter === "mysql" ? { type: "float", limit: 53 } : { type: "float", limit: 24 };
+    if (/^(double|double precision)$/.test(head))
+      return adapter === "mysql" ? { type: "float", limit: 53 } : { type: "float" };
     if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...decSizes };
     if (/^(bool|boolean)$/.test(head)) return { type: "boolean" };
     // PG registers `bit`/`varbit` as standalone Bit/BitVarying types
@@ -2713,11 +2726,12 @@ export class Migrator {
       name: "********** NO FILE **********",
     }));
 
-    return [...dbList, ...fileList].sort((a, b) => {
-      const va = BigInt(a.version);
-      const vb = BigInt(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
+    // Rails sorts by `version.to_i` — non-numeric rows coerce to 0 rather
+    // than raising. Avoid BigInt here so a legacy non-numeric row preserved
+    // by _appliedVersions() doesn't crash status reporting.
+    return [...dbList, ...fileList].sort(
+      (a, b) => (parseInt(a.version, 10) || 0) - (parseInt(b.version, 10) || 0),
+    );
   }
 
   /**

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -287,6 +287,47 @@ describe("MigratorTest", () => {
     }
   });
 
+  it("migrations status emits NO FILE entries for applied versions absent from migrations", async () => {
+    const sm = new SchemaMigration(adapter);
+    await sm.createTable();
+    await sm.createVersion("2");
+    await sm.createVersion("10");
+
+    const migrator = new Migrator(adapter, [
+      makeMigration("1", "ValidPeopleHaveLastNames"),
+      makeMigration("2", "WeNeedReminders"),
+      makeMigration("3", "InnocentJointable"),
+    ]);
+    const status = await migrator.migrationsStatus();
+    expect(status).toHaveLength(4);
+    expect(status[0]).toEqual({ status: "down", version: "1", name: "ValidPeopleHaveLastNames" });
+    expect(status[1]).toEqual({ status: "up", version: "2", name: "WeNeedReminders" });
+    expect(status[2]).toEqual({ status: "down", version: "3", name: "InnocentJointable" });
+    expect(status[3]).toEqual({
+      status: "up",
+      version: "10",
+      name: "********** NO FILE **********",
+    });
+  });
+
+  it("MigrationContext.fromPath returns MigrationProxy array from directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "trails-frompath-"));
+    try {
+      await mkdir(join(root, "sub"), { recursive: true });
+      await writeFile(join(root, "1_valid_people_have_last_names.ts"), "");
+      await writeFile(join(root, "sub", "2_we_need_reminders.ts"), "");
+
+      const proxies = Migrator.fromPath(root, adapter);
+      expect(proxies).toHaveLength(2);
+      expect(proxies[0]!.version).toBe("1");
+      expect(proxies[0]!.name).toBe("ValidPeopleHaveLastNames");
+      expect(proxies[1]!.version).toBe("2");
+      expect(proxies[1]!.name).toBe("WeNeedReminders");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("migrations status from two directories", async () => {
     const migrator = Migrator.fromPaths(
       adapter,

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -317,12 +317,16 @@ describe("MigratorTest", () => {
       await writeFile(join(root, "1_valid_people_have_last_names.ts"), "");
       await writeFile(join(root, "sub", "2_we_need_reminders.ts"), "");
 
+      // Include "10" so the numeric-vs-lexicographic ordering matters
+      // (Rails MigrationContext#migrations sort_by(&:version) is numeric).
+      await writeFile(join(root, "10_late_migration.ts"), "");
+
       const proxies = Migrator.fromPath(root, adapter);
-      expect(proxies).toHaveLength(2);
-      expect(proxies[0]!.version).toBe("1");
+      expect(proxies).toHaveLength(3);
+      expect(proxies.map((p) => p.version)).toEqual(["1", "2", "10"]);
       expect(proxies[0]!.name).toBe("ValidPeopleHaveLastNames");
-      expect(proxies[1]!.version).toBe("2");
       expect(proxies[1]!.name).toBe("WeNeedReminders");
+      expect(proxies[2]!.name).toBe("LateMigration");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -129,6 +129,7 @@ describe("MultiDbMigratorTest", () => {
       { status: "down", version: "1", name: "ValidPeopleHaveLastNames" },
       { status: "up", version: "2", name: "WeNeedReminders" },
       { status: "down", version: "3", name: "InnocentJointable" },
+      { status: "up", version: "10", name: "********** NO FILE **********" },
     ]);
 
     await smB.createVersion("4");
@@ -137,6 +138,7 @@ describe("MultiDbMigratorTest", () => {
     expect(statusB).toEqual([
       { status: "down", version: "1", name: "PeopleHaveHobbies" },
       { status: "down", version: "2", name: "PeopleHaveDescriptions" },
+      { status: "up", version: "4", name: "********** NO FILE **********" },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Batch 42 from docs/activerecord-100-plan.md — four older Migration B/E items:

- **`Migrator.fromPath(dir, adapter)`** — static factory returning `MigrationProxy[]` with numeric version sort (mirrors Rails `MigrationContext#migrations` `sort_by(&:version)`). `Migrator.fromDir` delegates to it.
- **`Migrator#migrationsStatus`** — emits `{status:"up", version, name:"********** NO FILE **********"}` for `schema_migrations` versions absent from `this._migrations`, combined-sort via BigInt-safe Ruby `String#to_i` (leading-integer prefix). Mirrors Rails `Migrator#migrations_status`.
- **`MigrationContext._introspectColumns`** — per-adapter catalog-row normalization to Rails-canonical DSL types + precision/scale/limit/array. Threads in MySQL `emulateBooleans`; PG `udt_name` for `USER-DEFINED`; PG `data_type='ARRAY'` → `array:true` + base type; `bit varying` round-trips through `schema-dumper` `SQL_TYPE_MAP`. Floats/integers branch by adapter (PG `float4` limit 24 / `float8` no limit, MySQL `float` 24 / `double` 53, SQLite all unlimited / integer→limit 8).
- **`createTable`/`addColumn`** now persist `col.options.array` into `_columnMeta` (parity with limit/precision/scale).
- **Prefix/suffix regression coverage** — new test stubs `schema`/`connection` on a `Migration` instance and asserts every schema mutator routes the table argument through `_pt()` so `table_name_prefix`/`table_name_suffix` is honored.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts packages/activerecord/src/migrator.test.ts packages/activerecord/src/multi-db-migrator.test.ts` — 250 passed, 11 skipped.
- [x] `pnpm api:compare --package activerecord` — 4956/4958 (Δ 0).
- [x] `pnpm test:compare` — 12664/21718 (Δ 0).

## Deferred follow-ups (Copilot review #9, max cycles hit)

Non-blocking refinements for a future fidelity PR — none alter the Rails-canonical DSL type emitted, only edge-case sizing fields on `_columnMeta`:

- PG `numeric(p)` with no declared scale: `information_schema.numeric_scale` returns 0, which `_introspectColumns` currently copies — could dump `decimal(p, 0)` instead of the precision-only form.
- PG `interval(p)` precision: `datetime_precision` is populated for intervals but currently only copied for datetime/time/timestamptz columns.
- `to_i` regex accepts `-` but not `+` (Ruby `"+123".to_i == 123`); legacy rows with leading `+` sort as 0.
- `smallserial` falls through `intByteLimit` to the 4-byte default (should be 2 since it's backed by `int2`).
- Prefix-coverage stubs record the first arg only; per Rails `migration.rb:1044-1058` `method_missing` and `migration/join_table.rb:7-13` only `arguments[0]` is prefixed for `add_foreign_key`/`create_join_table`/`drop_join_table`, so asserting on the second argument would diverge from Rails (intentionally not addressed).