### PR TITLE
feat(activerecord): wire adapterFactory into connectsTo (batch 43)

### DIFF
--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -19,6 +19,22 @@ const adapters = new Map<string, AdapterLoader>();
 // Memoize the loader's result so resolve() is effectively a cached lookup
 // (like Rails' adapter registry). Cleared when a name is re-registered.
 const resolved = new Map<string, Promise<AdapterClass>>();
+// Sync mirror of `resolved`, populated when each promise settles. Lets
+// sync entry points (like `connectsTo`) hand the pool a sync
+// `adapterFactory` once async adapter loading has completed at least once.
+const resolvedSyncCache = new Map<string, AdapterClass>();
+
+/**
+ * Synchronous companion to `resolve(name)`. Returns the adapter class if it
+ * has been resolved at least once (via `resolve()`), or null. Used by
+ * `connectsTo` to build a sync `adapterFactory` without changing its
+ * signature.
+ *
+ * @internal
+ */
+export function resolveSync(adapterName: string): AdapterClass | null {
+  return resolvedSyncCache.get(adapterName) ?? null;
+}
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters.register
@@ -32,6 +48,7 @@ const resolved = new Map<string, Promise<AdapterClass>>();
 export function register(name: string, loader: AdapterLoader): void {
   adapters.set(name, loader);
   resolved.delete(name);
+  resolvedSyncCache.delete(name);
 }
 
 /**
@@ -51,10 +68,15 @@ export async function resolve(adapterName: string): Promise<AdapterClass> {
         `Available adapters are: ${available}.`,
     );
   }
-  const promise = loader().catch((err) => {
-    resolved.delete(adapterName);
-    throw err;
-  });
+  const promise = loader()
+    .then((klass) => {
+      resolvedSyncCache.set(adapterName, klass);
+      return klass;
+    })
+    .catch((err) => {
+      resolved.delete(adapterName);
+      throw err;
+    });
   resolved.set(adapterName, promise);
   return promise;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -224,6 +224,14 @@ export class ConnectionPool implements ReapablePool {
 
   automaticReconnect = true;
   checkoutTimeout: number;
+  /**
+   * Resolves once the adapter class for this pool has been loaded by the
+   * async ConnectionAdapters resolver. Set by sync entry points like
+   * `connectsTo` so callers can await preload before issuing real queries;
+   * defaults to a resolved promise for pools whose adapterFactory is
+   * supplied directly.
+   */
+  adapterReady: Promise<unknown> = Promise.resolve();
 
   private _connections: DatabaseAdapter[] | null = [];
   private _available: ConnectionLeasingQueue | null;

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, afterEach } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
 import { Base } from "../base.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -33,8 +37,54 @@ describe("ConnectionHandlersShardingDbTest", () => {
     (Base as any).connectionClass = undefined;
   });
 
-  it.skip("establishing a connection in connected to block uses current role and shard", () => {
-    // BLOCKED: connection-pool — needs file-backed DB; establish_connection inside connected_to
+  it("establishing a connection in connected to block uses current role and shard", async () => {
+    const tmpfile = path.join(os.tmpdir(), `trails-connectsto-${randomUUID()}.sqlite3`);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          if (fs.existsSync(tmpfile)) fs.unlinkSync(tmpfile);
+        };
+        withBaseConfigs(
+          {
+            default_env: { primary: { adapter: "sqlite3", database: tmpfile } },
+          },
+          () => {
+            (async () => {
+              try {
+                const pools = Base.connectsTo({
+                  shards: { default: { writing: "primary" } },
+                });
+                await Promise.all(pools.map((p) => (p as any).adapterReady ?? Promise.resolve()));
+
+                await Base.connectedTo({ role: "writing", shard: "shard_one" }, async () => {
+                  await Base.establishConnection({
+                    adapter: "sqlite3",
+                    database: tmpfile,
+                  });
+                  const conn = Base.leaseConnection();
+                  await conn.executeMutation(
+                    `CREATE TABLE IF NOT EXISTS "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+                  );
+                  const rows = await conn.execute(`SELECT * FROM "people" LIMIT 1`);
+                  expect(Array.isArray(rows)).toBe(true);
+
+                  const pm = (Base.connectionHandler as any).getPoolManager("Base");
+                  expect([...pm.shardNames].sort()).toEqual(["default", "shard_one"]);
+                });
+                cleanup();
+                resolve();
+              } catch (e) {
+                cleanup();
+                reject(e);
+              }
+            })();
+          },
+          { defaultEnv: "default_env" },
+        );
+      });
+    } finally {
+      if (fs.existsSync(tmpfile)) fs.unlinkSync(tmpfile);
+    }
   });
   it("establish connection using 3 levels config", () => {
     withBaseConfigs(
@@ -523,16 +573,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
       (SecondaryBase as any).connectionClass = undefined;
     }
   });
-  it.skip("swapping shards globally in a multi threaded environment", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
-  });
-  it.skip("swapping shards and roles in a multi threaded environment", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
-  });
-  it.skip("swapping granular shards and roles in a multi threaded environment", () => {
-    // BLOCKED: GVL — Ruby thread / GVL semantics, no Node.js equivalent
-    // SCOPE: ~0 LOC fix; permanent skip-list.ts candidate
-  });
+  // The 3 "swapping shards (and roles) in a multi threaded environment" Rails
+  // tests are permanently unported (Ruby GVL / Thread semantics). Tracked in
+  // scripts/api-compare/unported-files.ts.
 });

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -9,18 +9,18 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { currentRole, connectedToStack } from "../core.js";
 
-function withBaseConfigs(
+async function withBaseConfigs(
   raw: Record<string, unknown>,
-  fn: () => void,
+  fn: () => void | Promise<void>,
   opts: { defaultEnv?: string } = {},
-): void {
+): Promise<void> {
   const prevConfigs = (Base as any).configurations;
   const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
   const prevCurrent = (DatabaseConfigurations as any).current;
   if (opts.defaultEnv) DatabaseConfigurations.defaultEnv = opts.defaultEnv;
   (Base as any).configurations = raw;
   try {
-    fn();
+    await fn();
   } finally {
     (Base as any).configurations = prevConfigs;
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
@@ -40,54 +40,37 @@ describe("ConnectionHandlersShardingDbTest", () => {
   it("establishing a connection in connected to block uses current role and shard", async () => {
     const tmpfile = path.join(os.tmpdir(), `trails-connectsto-${randomUUID()}.sqlite3`);
     try {
-      await new Promise<void>((resolve, reject) => {
-        const cleanup = () => {
-          if (fs.existsSync(tmpfile)) fs.unlinkSync(tmpfile);
-        };
-        withBaseConfigs(
-          {
-            default_env: { primary: { adapter: "sqlite3", database: tmpfile } },
-          },
-          () => {
-            (async () => {
-              try {
-                const pools = Base.connectsTo({
-                  shards: { default: { writing: "primary" } },
-                });
-                await Promise.all(pools.map((p) => (p as any).adapterReady ?? Promise.resolve()));
+      await withBaseConfigs(
+        {
+          default_env: { primary: { adapter: "sqlite3", database: tmpfile } },
+        },
+        async () => {
+          const pools = Base.connectsTo({
+            shards: { default: { writing: "primary" } },
+          });
+          await Promise.all(pools.map((p) => p.adapterReady));
 
-                await Base.connectedTo({ role: "writing", shard: "shard_one" }, async () => {
-                  await Base.establishConnection({
-                    adapter: "sqlite3",
-                    database: tmpfile,
-                  });
-                  const conn = Base.leaseConnection();
-                  await conn.executeMutation(
-                    `CREATE TABLE IF NOT EXISTS "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
-                  );
-                  const rows = await conn.execute(`SELECT * FROM "people" LIMIT 1`);
-                  expect(Array.isArray(rows)).toBe(true);
+          await Base.connectedTo({ role: "writing", shard: "shard_one" }, async () => {
+            await Base.establishConnection({ adapter: "sqlite3", database: tmpfile });
+            const conn = Base.leaseConnection();
+            await conn.executeMutation(
+              `CREATE TABLE IF NOT EXISTS "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+            );
+            const rows = await conn.execute(`SELECT * FROM "people" LIMIT 1`);
+            expect(Array.isArray(rows)).toBe(true);
 
-                  const pm = (Base.connectionHandler as any).getPoolManager("Base");
-                  expect([...pm.shardNames].sort()).toEqual(["default", "shard_one"]);
-                });
-                cleanup();
-                resolve();
-              } catch (e) {
-                cleanup();
-                reject(e);
-              }
-            })();
-          },
-          { defaultEnv: "default_env" },
-        );
-      });
+            const pm = (Base.connectionHandler as any).getPoolManager("Base");
+            expect([...pm.shardNames].sort()).toEqual(["default", "shard_one"]);
+          });
+        },
+        { defaultEnv: "default_env" },
+      );
     } finally {
       if (fs.existsSync(tmpfile)) fs.unlinkSync(tmpfile);
     }
   });
-  it("establish connection using 3 levels config", () => {
-    withBaseConfigs(
+  it("establish connection using 3 levels config", async () => {
+    await withBaseConfigs(
       {
         default_env: {
           primary: { adapter: "sqlite3", database: ":memory:" },
@@ -123,8 +106,8 @@ describe("ConnectionHandlersShardingDbTest", () => {
       { defaultEnv: "default_env" },
     );
   });
-  it("establish connection using 3 levels config with shards and replica", () => {
-    withBaseConfigs(
+  it("establish connection using 3 levels config with shards and replica", async () => {
+    await withBaseConfigs(
       {
         default_env: {
           primary: { adapter: "sqlite3", database: ":memory:" },
@@ -230,8 +213,8 @@ describe("ConnectionHandlersShardingDbTest", () => {
     }
   });
 
-  it("retrieves proper connection with nested connected to", () => {
-    withBaseConfigs(
+  it("retrieves proper connection with nested connected to", async () => {
+    await withBaseConfigs(
       {
         default_env: {
           primary: { adapter: "sqlite3", database: ":memory:" },
@@ -290,8 +273,8 @@ describe("ConnectionHandlersShardingDbTest", () => {
     expect(Base.connectionHandler.retrieveConnectionPool("Base", { shard: "foo" })).toBeUndefined();
   });
 
-  it("calling connected to on a non existent shard raises", () => {
-    withBaseConfigs(
+  it("calling connected to on a non existent shard raises", async () => {
+    await withBaseConfigs(
       { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
       () => {
         Base.connectsTo({ shards: { default: { writing: "arunit", reading: "arunit" } } });
@@ -314,8 +297,8 @@ describe("ConnectionHandlersShardingDbTest", () => {
       { defaultEnv: "default_env" },
     );
   });
-  it("calling connected to on a non existent role for shard raises", () => {
-    withBaseConfigs(
+  it("calling connected to on a non existent role for shard raises", async () => {
+    await withBaseConfigs(
       { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
       () => {
         Base.connectsTo({
@@ -343,8 +326,8 @@ describe("ConnectionHandlersShardingDbTest", () => {
       { defaultEnv: "default_env" },
     );
   });
-  it("calling connected to on a default role for non existent shard raises", () => {
-    withBaseConfigs(
+  it("calling connected to on a default role for non existent shard raises", async () => {
+    await withBaseConfigs(
       { default_env: { arunit: { adapter: "sqlite3", database: ":memory:" } } },
       () => {
         Base.connectsTo({ shards: { default: { writing: "arunit", reading: "arunit" } } });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -150,7 +150,12 @@ function buildAdapterArg(adapterName: string, configuration: Record<string, unkn
   const url = configuration.url as string | undefined;
   const database = configuration.database as string | undefined;
   if (normalized === "sqlite") {
-    return parseSqliteUrl(database || url || ":memory:");
+    // Mirrors establishWithConfig's `url || config?.database || ":memory:"`
+    // precedence so connectsTo and establishConnection normalize SQLite
+    // configs identically. autoConnect already pre-zeroes `url` when the
+    // configuration hash carries a `database`, so the resolved-database-
+    // wins semantic is preserved on the public entrypoint.
+    return parseSqliteUrl(url || database || ":memory:");
   }
   // Mirrors establishWithConfig's `else if (url) adapterArg = url` branch:
   // URL-only configs (e.g. opaque adapter strings like jdbc:...) are passed

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -136,12 +136,17 @@ export function connectsTo(
  */
 function buildAdapterArg(adapterName: string, configuration: Record<string, unknown>): unknown {
   const normalized = normalizeAdapterName(adapterName);
+  const url = configuration.url as string | undefined;
+  const database = configuration.database as string | undefined;
   if (normalized === "sqlite") {
-    const dbOrUrl =
-      (configuration.database as string | undefined) ??
-      (configuration.url as string | undefined) ??
-      ":memory:";
-    return parseSqliteUrl(dbOrUrl);
+    return parseSqliteUrl(database || url || ":memory:");
+  }
+  // Mirrors establishWithConfig's `else if (url) adapterArg = url` branch:
+  // URL-only configs (e.g. opaque adapter strings like jdbc:...) are passed
+  // through as the raw URL string. Hash-form configs (no url, or url + an
+  // explicit database) get the normalized hash with username/host defaults.
+  if (url && database === undefined) {
+    return url;
   }
   const { adapter: _a, url: _u, username, ...rest } = configuration;
   const adapterConfig: Record<string, unknown> = { ...rest };

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -118,7 +118,7 @@ export function connectsTo(
           return new AdapterClass(adapterArg);
         },
       });
-      (pool as unknown as { adapterReady: Promise<unknown> }).adapterReady = adapterReady;
+      pool.adapterReady = adapterReady;
       connections.push(pool);
     }
   }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -99,15 +99,26 @@ export function connectsTo(
       // Kick off async load so the sync adapter cache is populated by the
       // time the pool first asks for a connection. The returned promise is
       // attached to the pool as `adapterReady` so callers running real
-      // queries can await it before leaseConnection().
-      const adapterReady = adapterName
-        ? resolveConnectionAdapter(adapterName)
+      // queries can await it before leaseConnection(). Capture any
+      // rejection in `loadError` so the sync factory below can surface the
+      // real cause (AdapterNotFound, loader import error, ...) instead of
+      // a generic "not preloaded" message — and swallow the rejection on a
+      // detached `.catch` so callers that never await `adapterReady` don't
+      // trip an unhandled-promise warning.
+      let loadError: unknown = null;
+      const adapterReady: Promise<unknown> = adapterName
+        ? resolveConnectionAdapter(adapterName).catch((err) => {
+            loadError = err;
+            throw err;
+          })
         : Promise.resolve(null);
+      adapterReady.catch(() => {});
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         owner: this.connectionClassForSelf(),
         role,
         shard,
         adapterFactory: () => {
+          if (loadError) throw loadError;
           const AdapterClass = resolveConnectionAdapterSync(adapterName);
           if (!AdapterClass) {
             throw new ConnectionNotEstablished(

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -10,7 +10,10 @@ import {
   _setAdapterClassResolver,
   type DatabaseConfig,
 } from "./database-configurations/database-config.js";
-import { resolve as resolveConnectionAdapter } from "./connection-adapters.js";
+import {
+  resolve as resolveConnectionAdapter,
+  resolveSync as resolveConnectionAdapterSync,
+} from "./connection-adapters.js";
 import {
   AdapterNotFound,
   AdapterNotSpecified,
@@ -91,16 +94,64 @@ export function connectsTo(
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
       const dbConfig = resolveConfigForConnection.call(this, dbKey);
+      const adapterName = dbConfig.adapter ?? "";
+      const adapterArg = buildAdapterArg(adapterName, dbConfig.configuration);
+      // Kick off async load so the sync adapter cache is populated by the
+      // time the pool first asks for a connection. The returned promise is
+      // attached to the pool as `adapterReady` so callers running real
+      // queries can await it before leaseConnection().
+      const adapterReady = adapterName
+        ? resolveConnectionAdapter(adapterName)
+        : Promise.resolve(null);
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         owner: this.connectionClassForSelf(),
         role,
         shard,
+        adapterFactory: () => {
+          const AdapterClass = resolveConnectionAdapterSync(adapterName);
+          if (!AdapterClass) {
+            throw new ConnectionNotEstablished(
+              `Adapter ${adapterName || "(missing)"} for ${this.name} pool not preloaded; ` +
+                `await the pool's \`adapterReady\` promise after \`connectsTo\` returns.`,
+            );
+          }
+          return new AdapterClass(adapterArg);
+        },
       });
+      (pool as unknown as { adapterReady: Promise<unknown> }).adapterReady = adapterReady;
       connections.push(pool);
     }
   }
 
   return connections;
+}
+
+/**
+ * Build the adapter-constructor argument used by `connectsTo` and
+ * `establishConnection`. SQLite expects the database string directly; other
+ * adapters take a config hash. Mirrors the inline normalization done by
+ * `establishWithConfig`.
+ *
+ * @internal
+ */
+function buildAdapterArg(adapterName: string, configuration: Record<string, unknown>): unknown {
+  const normalized = normalizeAdapterName(adapterName);
+  if (normalized === "sqlite") {
+    const dbOrUrl =
+      (configuration.database as string | undefined) ??
+      (configuration.url as string | undefined) ??
+      ":memory:";
+    return parseSqliteUrl(dbOrUrl);
+  }
+  const { adapter: _a, url: _u, username, ...rest } = configuration;
+  const adapterConfig: Record<string, unknown> = { ...rest };
+  if (adapterConfig.user === undefined && username !== undefined) {
+    adapterConfig.user = username;
+  }
+  if (adapterConfig.host === undefined) {
+    adapterConfig.host = "localhost";
+  }
+  return adapterConfig;
 }
 
 export function connectedTo<T>(
@@ -571,7 +622,6 @@ async function establishWithConfig(
   const normalized = normalizeAdapterName(adapterName);
   // Pass the original adapter name to the registry so caller overrides
   // like register("mysql2", ...) aren't shadowed by normalization.
-  // `normalized` is only used below for adapter-arg construction.
   const AdapterClass = await _loadAdapter(adapterName);
 
   let adapterArg: unknown;
@@ -580,15 +630,7 @@ async function establishWithConfig(
   } else if (url) {
     adapterArg = url;
   } else if (config) {
-    const { adapter: _a, url: _u, username, ...rest } = config;
-    const adapterConfig: Record<string, unknown> = { ...rest };
-    if (adapterConfig.user === undefined && username !== undefined) {
-      adapterConfig.user = username;
-    }
-    if (adapterConfig.host === undefined) {
-      adapterConfig.host = "localhost";
-    }
-    adapterArg = adapterConfig;
+    adapterArg = buildAdapterArg(adapterName, config);
   } else {
     adapterArg = url;
   }
@@ -603,8 +645,16 @@ async function establishWithConfig(
     },
   );
 
+  // Honor the active connected_to scope so callers like
+  // `connected_to(role:, shard:) { establish_connection(db_config) }` register
+  // the new pool under the current role/shard instead of writing/default.
+  const role = coreCurrentRole.call(modelClass as any);
+  const shard = coreCurrentShard.call(modelClass as any);
+
   modelClass.connectionHandler.establishConnection(dbConfig, {
     owner: modelClass.connectionClassForSelf(),
+    role,
+    shard,
     adapterFactory: () => new AdapterClass(adapterArg),
   });
 }


### PR DESCRIPTION
## Summary

- Pools established via `connectsTo` previously had no `adapterFactory`, so calling `leaseConnection()` on them threw `ConnectionNotEstablished`. Wires a sync adapter factory through `connectsTo` so multi-shard pools are actually usable.
- Adds `resolveSync(name)` to `connection-adapters.ts` as a sync companion to the async `resolve()`. Populated when the loader promise settles, it lets `connectsTo` (sync) hand the pool a sync factory closing over the resolved adapter class. Each returned pool also exposes an `adapterReady` promise so async callers can await preload before issuing real queries.
- `establishConnection` (the no-args / explicit-config path) now reads the current role/shard from the connected_to stack, so `connected_to(role:, shard:) { establish_connection(db_config) }` registers the new pool under the active scope instead of always writing/default.
- Un-skips `establishing a connection in connected_to block uses current role and shard` using a file-backed sqlite tmpfile, and removes three `it.skip` GVL stubs at the bottom of `connection-handlers-sharding-db.test.ts` — they're already permanent entries in `scripts/api-compare/unported-files.ts`.

Implements Batch 43 from `docs/activerecord-100-plan.md`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts` (17/17 pass; previously 4 skips).
- [x] `pnpm vitest run packages/activerecord/src/connection-handling.test.ts packages/activerecord/src/connection-adapters/connection-handler.test.ts` (no regressions).
- [x] `pnpm lint`.