### PR TITLE
feat(activerecord): MySQL schema Slot C ANSI quotes (batch 46)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -7,11 +7,6 @@ import { Base } from "../../base.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
 import { defineFixtures } from "../../test-helpers/define-fixtures.js";
 
-async function currentDatabase(adapter: Mysql2Adapter): Promise<string> {
-  const rows = (await adapter.execute("SELECT DATABASE() AS db")) as Array<{ db: string }>;
-  return rows[0]!.db;
-}
-
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
@@ -71,7 +66,7 @@ describeIfMysql("Mysql2Adapter", () => {
           welcome: { title: "Welcome to the weblog", body: "Such a lovely day", type: "Post" },
         });
 
-        const db = await currentDatabase(adapter);
+        const db = await adapter.currentDatabase();
         class OmgPost extends Base {
           static _tableName = `${db}.posts`;
         }
@@ -99,7 +94,7 @@ describeIfMysql("Mysql2Adapter", () => {
     it("data source exists?", async () => {
       await defineSchema(adapter, { topics: { title: "string" } });
       try {
-        const db = await currentDatabase(adapter);
+        const db = await adapter.currentDatabase();
         // Rails passes @omgpost.table_name, which is the qualified `db.topics` form.
         expect(await adapter.dataSourceExists(`${db}.topics`)).toBe(true);
       } finally {
@@ -108,7 +103,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("data source exists wrong schema", async () => {
-      const db = await currentDatabase(adapter);
+      const db = await adapter.currentDatabase();
       expect(await adapter.dataSourceExists(`${db}.zomg`)).toBe(false);
     });
 
@@ -153,14 +148,46 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("MySQLAnsiQuotesTest", () => {
-    it.skip("primary key method with ansi quotes", () => {
-      // BLOCKED: adapter-mysql — requires SET SESSION sql_mode='ANSI_QUOTES' which
-      // needs adapter-level session-variable setter not yet wired for test setup
-      // (ansi-quotes mode)
+    // Build a fresh adapter with sql_mode='ANSI_QUOTES' applied in the pool init SQL
+    // so it persists across every checked-out connection — Rails uses
+    // `execute("SET SESSION sql_mode='ANSI_QUOTES'")` on its single leased connection;
+    // we apply the variable per-connection via the pool init hook (newClient).
+    let ansi: Mysql2Adapter;
+    beforeEach(async () => {
+      ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
+    });
+    afterEach(async () => {
+      // Mirrors Rails' teardown `@connection.reconnect!` — rebuild the pool so any leaked
+      // session state on the test runner's connection cache is cleared.
+      ansi.reconnectBang();
+      await ansi.close();
     });
 
-    it.skip("foreign keys method with ansi quotes", () => {
-      // BLOCKED: adapter-mysql — same session-variable setup gap as above (ansi-quotes mode)
+    it("primary key method with ansi quotes", async () => {
+      await defineSchema(ansi, { topics: { title: "string" } });
+      try {
+        expect(await ansi.primaryKey("topics")).toBe("id");
+      } finally {
+        await ansi.dropTable("topics", { ifExists: true });
+      }
+    });
+
+    it("foreign keys method with ansi quotes", async () => {
+      await defineSchema(ansi, {
+        students: { name: "string" },
+        lessons_students: { student_id: "integer" },
+      });
+      try {
+        await ansi.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
+        const fks = await ansi.foreignKeys("lessons_students");
+        expect(fks).toHaveLength(1);
+        expect(fks[0].fromTable).toBe("lessons_students");
+        expect(fks[0].toTable).toBe("students");
+        expect(fks[0].onDelete).toBe("cascade");
+      } finally {
+        await ansi.dropTable("lessons_students", { ifExists: true });
+        await ansi.dropTable("students", { ifExists: true });
+      }
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -173,9 +173,15 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("foreign keys method with ansi quotes", async () => {
+      // Mirrors Rails test/schema/schema.rb: lessons_students is id:false with a
+      // bigint student_id referencing students(id). Bigint width matches the
+      // default Rails PK so addForeignKey doesn't trip MySQL's type-match rule.
       await defineSchema(ansi, {
         students: { name: "string" },
-        lessons_students: { student_id: "integer" },
+        lessons_students: {
+          columns: { student_id: "big_integer" },
+          primaryKey: false,
+        },
       });
       try {
         await ansi.addForeignKey("lessons_students", "students", { onDelete: "cascade" });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -146,54 +146,62 @@ describeIfMysql("Mysql2Adapter", () => {
       });
     });
   });
+});
 
-  describe("MySQLAnsiQuotesTest", () => {
-    // Build a fresh adapter with sql_mode='ANSI_QUOTES' applied in the pool init SQL
-    // so it persists across every checked-out connection — Rails uses
-    // `execute("SET SESSION sql_mode='ANSI_QUOTES'")` on its single leased connection;
-    // we apply the variable per-connection via the pool init hook (newClient).
-    let ansi: Mysql2Adapter;
-    beforeEach(async () => {
-      ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
-    });
-    afterEach(async () => {
-      // Rails' teardown calls `@connection.reconnect!` to clear ANSI_QUOTES on
-      // the shared leased connection. We use a dedicated adapter per test, so
-      // close() fully drains the pool and no extra reconnect is needed.
-      await ansi.close();
-    });
+// Top-level suite mirrors Rails: MysqlAnsiQuotesTest is a separate test class
+// (not nested inside SchemaTest's module). Keeping it outside the "Mysql2Adapter"
+// describe also avoids spinning up the SchemaTest adapter pool for ANSI tests.
+describeIfMysql("MySQLAnsiQuotesTest", () => {
+  // Build a fresh adapter with sql_mode='ANSI_QUOTES' applied in the pool init SQL
+  // so it persists across every checked-out connection — Rails uses
+  // `execute("SET SESSION sql_mode='ANSI_QUOTES'")` on its single leased connection;
+  // we apply the variable per-connection via the pool init hook (newClient).
+  let ansi: Mysql2Adapter | undefined;
+  beforeEach(() => {
+    ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
+  });
+  afterEach(async () => {
+    // Rails' teardown calls `@connection.reconnect!` to clear ANSI_QUOTES on
+    // the shared leased connection. We use a dedicated adapter per test, so
+    // close() fully drains the pool and no extra reconnect is needed.
+    // Optional-chain so a beforeEach construction failure doesn't mask itself
+    // with a secondary TypeError here.
+    await ansi?.close();
+    ansi = undefined;
+  });
 
-    it("primary key method with ansi quotes", async () => {
-      await defineSchema(ansi, { topics: { title: "string" } });
-      try {
-        expect(await ansi.primaryKey("topics")).toBe("id");
-      } finally {
-        await ansi.dropTable("topics", { ifExists: true });
-      }
-    });
+  it("primary key method with ansi quotes", async () => {
+    const a = ansi!;
+    await defineSchema(a, { topics: { title: "string" } });
+    try {
+      expect(await a.primaryKey("topics")).toBe("id");
+    } finally {
+      await a.dropTable("topics", { ifExists: true });
+    }
+  });
 
-    it("foreign keys method with ansi quotes", async () => {
-      // Mirrors Rails test/schema/schema.rb: lessons_students is id:false with a
-      // bigint student_id referencing students(id). Bigint width matches the
-      // default Rails PK so addForeignKey doesn't trip MySQL's type-match rule.
-      await defineSchema(ansi, {
-        students: { name: "string" },
-        lessons_students: {
-          columns: { student_id: "big_integer" },
-          primaryKey: false,
-        },
-      });
-      try {
-        await ansi.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
-        const fks = await ansi.foreignKeys("lessons_students");
-        expect(fks).toHaveLength(1);
-        expect(fks[0].fromTable).toBe("lessons_students");
-        expect(fks[0].toTable).toBe("students");
-        expect(fks[0].onDelete).toBe("cascade");
-      } finally {
-        await ansi.dropTable("lessons_students", { ifExists: true });
-        await ansi.dropTable("students", { ifExists: true });
-      }
+  it("foreign keys method with ansi quotes", async () => {
+    const a = ansi!;
+    // Mirrors Rails test/schema/schema.rb: lessons_students is id:false with a
+    // bigint student_id referencing students(id). Bigint width matches the
+    // default Rails PK so addForeignKey doesn't trip MySQL's type-match rule.
+    await defineSchema(a, {
+      students: { name: "string" },
+      lessons_students: {
+        columns: { student_id: "big_integer" },
+        primaryKey: false,
+      },
     });
+    try {
+      await a.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
+      const fks = await a.foreignKeys("lessons_students");
+      expect(fks).toHaveLength(1);
+      expect(fks[0].fromTable).toBe("lessons_students");
+      expect(fks[0].toTable).toBe("students");
+      expect(fks[0].onDelete).toBe("cascade");
+    } finally {
+      await a.dropTable("lessons_students", { ifExists: true });
+      await a.dropTable("students", { ifExists: true });
+    }
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -157,9 +157,9 @@ describeIfMysql("Mysql2Adapter", () => {
       ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
     });
     afterEach(async () => {
-      // Mirrors Rails' teardown `@connection.reconnect!` — rebuild the pool so any leaked
-      // session state on the test runner's connection cache is cleared.
-      ansi.reconnectBang();
+      // Rails' teardown calls `@connection.reconnect!` to clear ANSI_QUOTES on
+      // the shared leased connection. We use a dedicated adapter per test, so
+      // close() fully drains the pool and no extra reconnect is needed.
       await ansi.close();
     });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -482,9 +482,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * row and coerce a null DATABASE() (no current schema) to "".
    */
   async currentDatabase(): Promise<string> {
-    const rows = await this.schemaQuery("SELECT database()");
+    const rows = (await this.schemaQuery("SELECT database() AS name")) as Array<{
+      name?: string | null;
+      NAME?: string | null;
+    }>;
     if (rows.length === 0) return "";
-    const val = Object.values(rows[0])[0] as string | null | undefined;
+    const val = rows[0].name ?? rows[0].NAME;
     return val == null ? "" : String(val);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -476,8 +476,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     await this._execMutation(`DROP DATABASE IF EXISTS ${this.quoteTableName(name)}`);
   }
 
+  /**
+   * Mirrors AbstractMysqlAdapter#current_database — `query_value("SELECT database()", "SCHEMA")`.
+   * The Ruby form returns a single scalar; we project the first column off the schemaQuery
+   * row and coerce a null DATABASE() (no current schema) to "".
+   */
   async currentDatabase(): Promise<string> {
-    return "";
+    const rows = await this.schemaQuery("SELECT database()");
+    if (rows.length === 0) return "";
+    const val = Object.values(rows[0])[0] as string | null | undefined;
+    return val == null ? "" : String(val);
   }
 
   async charset(): Promise<string> {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1031,6 +1031,22 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * Returns the name of the currently-connected database via `SELECT DATABASE()`.
+   * Mirrors Rails' AbstractMysqlAdapter#current_database. The abstract base returns
+   * `""`; this override hits the server so callers see the live session value.
+   */
+  override async currentDatabase(): Promise<string> {
+    const rows = (await this.schemaQuery("SELECT database() AS db")) as Array<{
+      db?: string | null;
+      DB?: string | null;
+    }>;
+    if (rows.length === 0) return "";
+    const row = rows[0];
+    const val = row.db ?? row.DB ?? (Object.values(row)[0] as string | null | undefined);
+    return val == null ? "" : String(val);
+  }
+
+  /**
    * Return the primary key: scalar string for single-column PKs,
    * array for composite PKs, null for no-PK tables. Uses the same
    * `information_schema.statistics` + `seq_in_index` shape Rails

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1031,22 +1031,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Returns the name of the currently-connected database via `SELECT DATABASE()`.
-   * Mirrors Rails' AbstractMysqlAdapter#current_database. The abstract base returns
-   * `""`; this override hits the server so callers see the live session value.
-   */
-  override async currentDatabase(): Promise<string> {
-    const rows = (await this.schemaQuery("SELECT database() AS db")) as Array<{
-      db?: string | null;
-      DB?: string | null;
-    }>;
-    if (rows.length === 0) return "";
-    const row = rows[0];
-    const val = row.db ?? row.DB ?? (Object.values(row)[0] as string | null | undefined);
-    return val == null ? "" : String(val);
-  }
-
-  /**
    * Return the primary key: scalar string for single-column PKs,
    * array for composite PKs, null for no-PK tables. Uses the same
    * `information_schema.statistics` + `seq_in_index` shape Rails

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -4,6 +4,8 @@ import * as fs from "fs";
 import { globSync } from "tinyglobby";
 import type { TestManifest, TestPackageInfo, TestFileInfo, TestCaseInfo } from "./types.js";
 
+const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
+
 const SCRIPT_DIR = __dirname;
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "../..");
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
@@ -161,7 +163,6 @@ function extractFileTests(filePath: string): TestFileInfo {
         const inner = expression.expression;
         const base = inner.expression;
         const modifier = inner.name.text;
-        const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
         if (ts.isIdentifier(base) && GATING_MODIFIERS.has(modifier)) {
           if (
             base.text === "describe" ||

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -146,6 +146,32 @@ function extractFileTests(filePath: string): TestFileInfo {
             fileInfo.testCases.push(testCase);
           }
         }
+      } else if (
+        ts.isCallExpression(expression) &&
+        ts.isPropertyAccessExpression(expression.expression)
+      ) {
+        // Handle the callable-modifier form: it.skipIf(expr)("name", fn) / test.runIf(expr)("name", fn).
+        // The outer CallExpression's expression is itself a CallExpression whose expression is a
+        // PropertyAccessExpression like `it.skipIf`. Treat these as a regular test case (modifier
+        // gating happens at runtime; static extraction just needs to recognize the name).
+        const inner = expression.expression;
+        const base = inner.expression;
+        if (ts.isIdentifier(base) && (base.text === "it" || base.text === "test")) {
+          const title = getFirstArgString(node);
+          if (title) {
+            const testCase: TestCaseInfo = {
+              path: [...currentAncestors, title].join(" > "),
+              description: title,
+              ancestors: [...currentAncestors],
+              file: relativePath,
+              line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+              style: base.text as "it" | "test",
+              assertions: [],
+              pending: false,
+            };
+            fileInfo.testCases.push(testCase);
+          }
+        }
       } else if (ts.isPropertyAccessExpression(expression)) {
         // Handle describe.skip, it.skip, it.todo, it.only, etc.
         const base = expression.expression;

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -160,7 +160,7 @@ function extractFileTests(filePath: string): TestFileInfo {
         // Restricted to gating modifiers (skipIf / runIf) — `each` and friends
         // generate multiple runtime tests from a template title, so static
         // extraction of the template name would add noise to test:compare.
-        const inner = expression.expression;
+        const inner: ts.PropertyAccessExpression = expression.expression;
         const base = inner.expression;
         const modifier = inner.name.text;
         if (ts.isIdentifier(base) && GATING_MODIFIERS.has(modifier)) {

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -150,26 +150,46 @@ function extractFileTests(filePath: string): TestFileInfo {
         ts.isCallExpression(expression) &&
         ts.isPropertyAccessExpression(expression.expression)
       ) {
-        // Handle the callable-modifier form: it.skipIf(expr)("name", fn) / test.runIf(expr)("name", fn).
-        // The outer CallExpression's expression is itself a CallExpression whose expression is a
-        // PropertyAccessExpression like `it.skipIf`. Treat these as a regular test case (modifier
-        // gating happens at runtime; static extraction just needs to recognize the name).
+        // Handle the callable-modifier form: it.skipIf(expr)("name", fn) /
+        // test.runIf(expr)("name", fn) / describe.skipIf(expr)("suite", fn).
+        // The outer CallExpression's expression is itself a CallExpression whose
+        // expression is a PropertyAccessExpression like `it.skipIf`.
+        //
+        // Restricted to gating modifiers (skipIf / runIf) — `each` and friends
+        // generate multiple runtime tests from a template title, so static
+        // extraction of the template name would add noise to test:compare.
         const inner = expression.expression;
         const base = inner.expression;
-        if (ts.isIdentifier(base) && (base.text === "it" || base.text === "test")) {
-          const title = getFirstArgString(node);
-          if (title) {
-            const testCase: TestCaseInfo = {
-              path: [...currentAncestors, title].join(" > "),
-              description: title,
-              ancestors: [...currentAncestors],
-              file: relativePath,
-              line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
-              style: base.text as "it" | "test",
-              assertions: [],
-              pending: false,
-            };
-            fileInfo.testCases.push(testCase);
+        const modifier = inner.name.text;
+        const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
+        if (ts.isIdentifier(base) && GATING_MODIFIERS.has(modifier)) {
+          if (
+            base.text === "describe" ||
+            base.text === "describeIfPg" ||
+            base.text === "describeIfMysql"
+          ) {
+            const title = getFirstArgString(node);
+            if (title) {
+              currentAncestors.push(title);
+              ts.forEachChild(node, visit);
+              currentAncestors.pop();
+              return;
+            }
+          } else if (base.text === "it" || base.text === "test") {
+            const title = getFirstArgString(node);
+            if (title) {
+              const testCase: TestCaseInfo = {
+                path: [...currentAncestors, title].join(" > "),
+                description: title,
+                ancestors: [...currentAncestors],
+                file: relativePath,
+                line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+                style: base.text as "it" | "test",
+                assertions: [],
+                pending: false,
+              };
+              fileInfo.testCases.push(testCase);
+            }
           }
         }
       } else if (ts.isPropertyAccessExpression(expression)) {


### PR DESCRIPTION
## Summary

Implements batch 46 from `docs/activerecord-100-plan.md` (MySQL schema Slot C, ANSI quotes).

- **Extractor (`scripts/test-compare/extract-ts-tests.ts`)** — recognize the callable-modifier form `it.skipIf(expr)("name", fn)` / `test.skipIf(...)` / `describe.skipIf(...)` (restricted to gating modifiers, so `it.each` isn't statically captured). Unblocks recognition of tests like `float_limits` for `test:compare`.
- **`AbstractMysqlAdapter#currentDatabase()`** — replace the `""` stub with a real `SELECT database() AS name` round-trip (mirrors `abstract_mysql_adapter.rb:296`). `schema.test.ts` swaps its local helper for the adapter method.
- **`MySQLAnsiQuotesTest` un-skip** — build a fresh adapter with `variables: { sql_mode: 'ANSI_QUOTES' }` so the pool's per-connection init SQL applies the mode to every checked-out connection. Adds `topics` and `lessons_students`/`students` schemas via `defineSchema` + `addForeignKey({ onDelete: 'cascade' })`, mirroring `test/schema/schema.rb` (`id: false` + bigint `student_id`). Teardown calls `close()` to drain the dedicated pool (Rails uses `reconnect!` to clear ANSI_QUOTES on its shared leased connection — not needed here since we own the adapter).

## Test plan

- [ ] `pnpm tsx scripts/test-compare/extract-ts-tests.ts` — float_limits now extracted (verified locally).
- [ ] CI MySQL job runs `schema.test.ts` — primary-key/foreign-keys ANSI-quotes cases exercise the variables-based ANSI_QUOTES wiring.
- [ ] `pnpm typecheck` / `pnpm lint` (passes locally).