### PR TITLE
test(activerecord): port extension test bodies (batch 25)

### DIFF
--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -4415,7 +4415,8 @@ describe("EagerAssociationTest", () => {
     registerModel("AweAuthor", AweAuthor);
     registerModel("AwePost", AwePost);
     // Rails: `has_many :posts_with_extension, -> { order(:title) } do ... end`
-    // Extension block + arity-0 scope; not instance dependent.
+    // Extension block + ownerless scope (relation-only param, no owner) —
+    // checkEagerLoadableBang treats scope.length > 1 as instance-dependent.
     Associations.hasMany.call(AweAuthor, "awePostsWithExtension", {
       className: "AwePost",
       foreignKey: "awe_author_id",

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -4398,12 +4398,62 @@ describe("EagerAssociationTest", () => {
     const widgets = await PiaWidget.all().preload("nonExistent").toArray();
     expect(widgets).toHaveLength(1);
   });
-  it.skip("associations with extensions are not instance dependent", () => {
-    // extensions (do...end block) do NOT make a scope instance-dependent;
-    // only a scope lambda with arity>1 does. Deferred to follow-up sweep.
+  it("associations with extensions are not instance dependent", async () => {
+    class AweAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class AwePost extends Base {
+      static {
+        this.attribute("awe_author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("AweAuthor", AweAuthor);
+    registerModel("AwePost", AwePost);
+    // Arity-1 scope (no owner) — analog of a Rails extension block; not instance dependent.
+    Associations.hasMany.call(AweAuthor, "awePostsWithExtension", {
+      className: "AwePost",
+      foreignKey: "awe_author_id",
+      scope: (_rel: any) => _rel,
+    });
+    await AweAuthor.create({ name: "A" });
+    await expect(
+      (AweAuthor as any).includes("awePostsWithExtension").toArray(),
+    ).resolves.not.toThrow();
   });
-  it.skip("including associations with extensions and an instance dependent scope is supported", () => {
-    // Deferred — same infra as "preloading of instance dependent"; follow-up sweep.
+  it("including associations with extensions and an instance dependent scope is supported", async () => {
+    class AwexAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class AwexPost extends Base {
+      static {
+        this.attribute("awex_author_id", "integer");
+        this.attribute("mention", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("AwexAuthor", AwexAuthor);
+    registerModel("AwexPost", AwexPost);
+    Associations.hasMany.call(AwexAuthor, "awexPostsWithExtAndInstance", {
+      className: "AwexPost",
+      foreignKey: "awex_author_id",
+      scope: (_rel: any, owner?: any) =>
+        owner ? _rel.where({ mention: owner.name.toLowerCase() }) : _rel,
+    });
+    const author = await AwexAuthor.create({ name: "Alice" });
+    await AwexPost.create({ awex_author_id: author.id, mention: "alice" });
+    const authors = await (AwexAuthor as any).includes("awexPostsWithExtAndInstance").toArray();
+    expect(authors).not.toHaveLength(0);
+    for (const a of authors) {
+      expect((a as any)._preloadedAssociations?.has("awexPostsWithExtAndInstance")).toBe(true);
+    }
   });
   it("preloading readonly association", async () => {
     class PraAuthor extends Base {

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -4420,10 +4420,13 @@ describe("EagerAssociationTest", () => {
       foreignKey: "awe_author_id",
       scope: (_rel: any) => _rel,
     });
-    await AweAuthor.create({ name: "A" });
-    await expect(
-      (AweAuthor as any).includes("awePostsWithExtension").toArray(),
-    ).resolves.not.toThrow();
+    const author = await AweAuthor.create({ name: "A" });
+    await AwePost.create({ awe_author_id: author.id, title: "p" });
+    const authors = await (AweAuthor as any).includes("awePostsWithExtension").toArray();
+    expect(authors).not.toHaveLength(0);
+    for (const a of authors) {
+      expect((a as any)._preloadedAssociations?.has("awePostsWithExtension")).toBe(true);
+    }
   });
   it("including associations with extensions and an instance dependent scope is supported", async () => {
     class AwexAuthor extends Base {
@@ -4449,10 +4452,14 @@ describe("EagerAssociationTest", () => {
     });
     const author = await AwexAuthor.create({ name: "Alice" });
     await AwexPost.create({ awex_author_id: author.id, mention: "alice" });
+    await AwexPost.create({ awex_author_id: author.id, mention: "zoe" });
     const authors = await (AwexAuthor as any).includes("awexPostsWithExtAndInstance").toArray();
     expect(authors).not.toHaveLength(0);
     for (const a of authors) {
       expect((a as any)._preloadedAssociations?.has("awexPostsWithExtAndInstance")).toBe(true);
+      const loaded = (a as any)._preloadedAssociations.get("awexPostsWithExtAndInstance");
+      expect(loaded).toHaveLength(1);
+      expect((loaded[0] as any).mention).toBe("alice");
     }
   });
   it("preloading readonly association", async () => {

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
-import { Associations, loadHasMany, loadHasManyThrough } from "../associations.js";
+import { Associations, association, loadHasMany, loadHasManyThrough } from "../associations.js";
 
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
@@ -4414,11 +4414,13 @@ describe("EagerAssociationTest", () => {
     }
     registerModel("AweAuthor", AweAuthor);
     registerModel("AwePost", AwePost);
-    // Arity-1 scope (no owner) — analog of a Rails extension block; not instance dependent.
+    // Rails: `has_many :posts_with_extension, -> { order(:title) } do ... end`
+    // Extension block + arity-0 scope; not instance dependent.
     Associations.hasMany.call(AweAuthor, "awePostsWithExtension", {
       className: "AwePost",
       foreignKey: "awe_author_id",
-      scope: (_rel: any) => _rel,
+      scope: (rel: any) => rel.order("title"),
+      extend: { extensionMethod() {} },
     });
     const author = await AweAuthor.create({ name: "A" });
     await AwePost.create({ awe_author_id: author.id, title: "p" });
@@ -4427,6 +4429,8 @@ describe("EagerAssociationTest", () => {
     for (const a of authors) {
       expect((a as any)._preloadedAssociations?.has("awePostsWithExtension")).toBe(true);
     }
+    const proxy = association(authors[0], "awePostsWithExtension");
+    expect(typeof (proxy as any).extensionMethod).toBe("function");
   });
   it("including associations with extensions and an instance dependent scope is supported", async () => {
     class AwexAuthor extends Base {
@@ -4444,11 +4448,13 @@ describe("EagerAssociationTest", () => {
     }
     registerModel("AwexAuthor", AwexAuthor);
     registerModel("AwexPost", AwexPost);
+    // Rails: `has_many :posts_with_extension_and_instance, ->(record) { ... } do ... end`
     Associations.hasMany.call(AwexAuthor, "awexPostsWithExtAndInstance", {
       className: "AwexPost",
       foreignKey: "awex_author_id",
       scope: (_rel: any, owner?: any) =>
         owner ? _rel.where({ mention: owner.name.toLowerCase() }) : _rel,
+      extend: { extensionMethod() {} },
     });
     const author = await AwexAuthor.create({ name: "Alice" });
     await AwexPost.create({ awex_author_id: author.id, mention: "alice" });
@@ -4460,6 +4466,8 @@ describe("EagerAssociationTest", () => {
       const loaded = (a as any)._preloadedAssociations.get("awexPostsWithExtAndInstance");
       expect(loaded).toHaveLength(1);
       expect((loaded[0] as any).mention).toBe("alice");
+      const proxy = association(a, "awexPostsWithExtAndInstance");
+      expect(typeof (proxy as any).extensionMethod).toBe("function");
     }
   });
   it("preloading readonly association", async () => {


### PR DESCRIPTION
## Summary

Batch 25 — Associations-core test-body bundle (from docs/activerecord-100-plan.md).

**Slot C (only slot actionable today):** un-skip two \"extensions\" tests in
\`packages/activerecord/src/associations/eager.test.ts\`:

- \`associations with extensions are not instance dependent\` — arity-1 scope
  (no \`owner\` param) is the TypeScript analog of a Rails extension block; the
  test confirms \`checkEagerLoadableBang\` does not fire under \`includes()\`.
- \`including associations with extensions and an instance dependent scope is
  supported\` — optional-owner scope routes through preload and populates
  \`_preloadedAssociations\`.

**Slots B and D were already complete in earlier work** (no change required):

- B: \`preloads model with query_constraints by explicitly configured fk and pk\`
  in \`associations.test.ts\` is already a passing inline-fixture test.
- D: \`reload with query cache\` bodies in \`has-many-associations.test.ts\` are
  already passing; no \`it.skip\` variants remain.

55 LOC of additions, all under test code. Plan's ~70 LOC estimate was set
before B/D landed elsewhere.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/associations/eager.test.ts -t \"associations with extensions\"\` — both tests pass
- [x] Confirmed batch B & D tests already pass without changes
- [ ] CI green