### PR TITLE
fix(activerecord): ThroughReflection join keys delegate to source only

### DIFF
--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -940,6 +940,19 @@ describe("ReflectionTest", () => {
     // macro must NOT appear here.
     expect(ref.joinPrimaryKey).toBe("post_id");
     expect(ref.joinForeignKey).toBe("id");
+
+    // When sourceReflection cannot be resolved, Rails raises
+    // HasManyThroughSourceAssociationNotFoundError (reflection.rb:1469).
+    // Before this fix, joinPrimaryKey/joinForeignKey silently fell back
+    // to delegate_reflection and could leak the bogus foreignKey.
+    Associations.hasMany.call(Author, "missing", {
+      through: "posts",
+      source: "doesNotExist",
+      foreignKey: "bogus_id",
+    });
+    const bad = reflectOnAssociation(Author, "missing") as ThroughReflection;
+    expect(() => bad.joinPrimaryKey).toThrow(/source association/i);
+    expect(() => bad.joinForeignKey).toThrow(/source association/i);
   });
   it("join scope builds arel predicate for has many", () => {
     const { Author } = makeModels();

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -902,6 +902,45 @@ describe("ReflectionTest", () => {
     expect(ref.joinPrimaryKey).toBe("post_id");
     expect(ref.joinForeignKey).toBe("id");
   });
+  it("through reflection ignores foreignKey option on join keys (delegates to source)", () => {
+    // Rails parity: ThroughReflection#join_primary_key / #join_foreign_key
+    // delegate to source_reflection exclusively. `:foreign_key` on the
+    // has_many :through macro lives on the delegate_reflection and must not
+    // leak into the join keys.
+    class Author extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Comment extends Base {
+      static {
+        this.attribute("post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Author", Author);
+    registerModel("Post", Post);
+    registerModel("Comment", Comment);
+    Associations.hasMany.call(Author, "posts", {});
+    Associations.hasMany.call(Post, "comments", {});
+    Associations.hasMany.call(Author, "comments", {
+      through: "posts",
+      foreignKey: "bogus_id",
+    });
+    const ref = reflectOnAssociation(Author, "comments") as ThroughReflection;
+    // Source is `comments` on Post; source's joinPrimaryKey is "post_id"
+    // (its foreign_key). The bogus `foreignKey: "bogus_id"` on the through
+    // macro must NOT appear here.
+    expect(ref.joinPrimaryKey).toBe("post_id");
+    expect(ref.joinForeignKey).toBe("id");
+  });
   it("join scope builds arel predicate for has many", () => {
     const { Author } = makeModels();
     const ref = reflectOnAssociation(Author, "books") as AssociationReflection;

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1291,7 +1291,7 @@ export class ThroughReflection extends AbstractReflection {
   get joinPrimaryKey(): string | string[] {
     const src = this.sourceReflection;
     if (!src) this.checkValidityBang();
-    return this.sourceReflection!.joinPrimaryKey;
+    return src!.joinPrimaryKey;
   }
 
   /**
@@ -1318,7 +1318,7 @@ export class ThroughReflection extends AbstractReflection {
   get joinForeignKey(): string | string[] {
     const src = this.sourceReflection;
     if (!src) this.checkValidityBang();
-    return this.sourceReflection!.joinForeignKey;
+    return src!.joinForeignKey;
   }
 
   scopeFor(relation: any, owner?: any): any {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1290,12 +1290,8 @@ export class ThroughReflection extends AbstractReflection {
 
   get joinPrimaryKey(): string | string[] {
     const src = this.sourceReflection;
-    if (!src) {
-      throw new Error(
-        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
-      );
-    }
-    return src.joinPrimaryKey;
+    if (!src) this.checkValidityBang();
+    return this.sourceReflection!.joinPrimaryKey;
   }
 
   /**
@@ -1311,24 +1307,18 @@ export class ThroughReflection extends AbstractReflection {
       joinPrimaryKey: string | string[];
     } | null;
     if (!src) {
-      throw new Error(
-        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
-      );
+      this.checkValidityBang();
     }
-    if (typeof src.joinPrimaryKeyFor === "function") {
+    if (src && typeof src.joinPrimaryKeyFor === "function") {
       return src.joinPrimaryKeyFor(klass);
     }
-    return src.joinPrimaryKey;
+    return src!.joinPrimaryKey;
   }
 
   get joinForeignKey(): string | string[] {
     const src = this.sourceReflection;
-    if (!src) {
-      throw new Error(
-        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
-      );
-    }
-    return src.joinForeignKey;
+    if (!src) this.checkValidityBang();
+    return this.sourceReflection!.joinForeignKey;
   }
 
   scopeFor(relation: any, owner?: any): any {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1289,7 +1289,13 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   get joinPrimaryKey(): string | string[] {
-    return this.sourceReflection?.joinPrimaryKey ?? this._delegate.joinPrimaryKey;
+    const src = this.sourceReflection;
+    if (!src) {
+      throw new Error(
+        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
+      );
+    }
+    return src.joinPrimaryKey;
   }
 
   /**
@@ -1302,16 +1308,27 @@ export class ThroughReflection extends AbstractReflection {
   joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
     const src = this.sourceReflection as unknown as {
       joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
-      joinPrimaryKey?: string | string[];
+      joinPrimaryKey: string | string[];
     } | null;
-    if (src && typeof src.joinPrimaryKeyFor === "function") {
+    if (!src) {
+      throw new Error(
+        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
+      );
+    }
+    if (typeof src.joinPrimaryKeyFor === "function") {
       return src.joinPrimaryKeyFor(klass);
     }
-    return src?.joinPrimaryKey ?? this._delegate.joinPrimaryKey;
+    return src.joinPrimaryKey;
   }
 
   get joinForeignKey(): string | string[] {
-    return this.sourceReflection?.joinForeignKey ?? this._delegate.joinForeignKey;
+    const src = this.sourceReflection;
+    if (!src) {
+      throw new Error(
+        `Could not find the source association(s) ${JSON.stringify(this.options.source ?? this.name)} in model ${this.through}`,
+      );
+    }
+    return src.joinForeignKey;
   }
 
   scopeFor(relation: any, owner?: any): any {


### PR DESCRIPTION
## Summary

Rails' `ThroughReflection#join_primary_key` and `#join_foreign_key` delegate to `source_reflection` exclusively (`reflection.rb:1093`, `:974`). Our impl fell back to `delegate_reflection` when source was nil, which let a stray `foreignKey:` option on a `has_many :through` macro leak into the join keys. Match Rails by removing the fallback and raising if source is absent.

Batch 29 partial — ships Slot A (foreignKey delegation parity) only. The remaining items in the batch are non-trivial and risky to bundle:

- ~30 LOC test for `Author.joins(:ratings).where("ratings.value": N)` against nested-through chain (JoinDependency-side coverage).
- ~20 LOC `source_type` polymorphic-with-sourceType variant of nested-through preload test.
- ~10 LOC `_dataAvailable()` / `runnableLoaders()` perf in `preloader/through-association.ts` for 4+ level chains.
- ~30 LOC (B) `djMembersOrdered` / `djMembersDouble` wrong/unordered results with `.where()` / `.reorder()` chains.
- ~80-120 LOC (B) `CollectionProxy._buildThroughScope()` nested-through (Option B: seed from `DisableJoinsAssociationScope`).

These should be picked up by follow-up slots.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/reflection.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/{has,nested}*-through*.test.ts` (252 passing)
- [x] New test: through reflection ignores `foreignKey` option on join keys