### PR TITLE
feat(activerecord): HABTM destroy_associations override mixin (batch 33)

### DIFF
--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -194,9 +194,32 @@ export class HasAndBelongsToMany {
     const middleReflection = Reflection.create("hasMany", middleName, null, middleOptions, model);
     Reflection.addReflection(model, middleName, middleReflection as any);
 
-    beforeDestroy(model, (record: any) => {
-      return record.association(middleName).handleDependency();
-    });
+    // Mirrors Rails associations.rb:1886-1894 — instead of registering a
+    // bare `before_destroy` callback per HABTM, Rails includes an anonymous
+    // module that overrides `destroy_associations` and chains with `super`.
+    // Each HABTM declaration layers its own override; multiple HABTMs on
+    // the same class chain naturally through the captured `prev` reference.
+    // Translation note: `destroyAssociations` isn't yet wired into the
+    // standard destroy flow (see Batch 37), so we still register a
+    // class-level `beforeDestroy` once that invokes it — this preserves
+    // current behavior while installing the Rails-shape override module.
+    const prevDestroyAssociations = model.prototype.destroyAssociations;
+    model.prototype.destroyAssociations = async function (this: any): Promise<void> {
+      await this.association(middleName).handleDependency();
+      this.association(name).reset?.();
+      if (typeof prevDestroyAssociations === "function") {
+        await prevDestroyAssociations.call(this);
+      }
+    };
+    const HABTM_DESTROY_INSTALLED = Symbol.for("blazetrails.habtm.destroyAssociations.installed");
+    if (!Object.prototype.hasOwnProperty.call(model, HABTM_DESTROY_INSTALLED)) {
+      Object.defineProperty(model, HABTM_DESTROY_INSTALLED, {
+        value: true,
+        configurable: true,
+        writable: false,
+      });
+      beforeDestroy(model, (record: any) => record.destroyAssociations());
+    }
 
     // Tightened option set forwarded to the public HABTM reflection.
     // Rails' `hm_options` allowlist for the generated `has_many :through`

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -203,20 +203,41 @@ export class HasAndBelongsToMany {
     // standard destroy flow (see Batch 37), so we still register a
     // class-level `beforeDestroy` once that invokes it — this preserves
     // current behavior while installing the Rails-shape override module.
+    // Per-association guard: re-declaring the same HABTM (same `name` on
+    // the same class) would otherwise layer a duplicate wrapper around the
+    // existing chain, causing the join cleanup to run twice. Track the set
+    // of names already wrapped on this class's prototype and short-circuit.
+    const HABTM_WRAPPED_NAMES = Symbol.for("blazetrails.habtm.destroyAssociations.names");
+    const ownWrappedNames: Set<string> = Object.prototype.hasOwnProperty.call(
+      model.prototype,
+      HABTM_WRAPPED_NAMES,
+    )
+      ? (model.prototype as any)[HABTM_WRAPPED_NAMES]
+      : Object.defineProperty(model.prototype, HABTM_WRAPPED_NAMES, {
+          value: new Set<string>(),
+          configurable: true,
+          writable: false,
+        })[HABTM_WRAPPED_NAMES];
     const prevDestroyAssociations = model.prototype.destroyAssociations;
-    model.prototype.destroyAssociations = async function (this: any): Promise<void> {
-      await this.association(middleName).handleDependency();
-      this.association(name).reset?.();
-      // Rails' `association(:name).reset` only clears the Association
-      // instance's loaded state. In this codebase, collection readers are
-      // additionally memoized in `_collectionProxies` (see associations.ts
-      // ~2334), so the user-facing reader would still return the stale
-      // proxy unless we evict it too.
-      this._collectionProxies?.delete(name);
-      if (typeof prevDestroyAssociations === "function") {
-        await prevDestroyAssociations.call(this);
-      }
-    };
+    if (ownWrappedNames.has(name)) {
+      // Skip wrapper layering on redeclaration — the existing chain already
+      // handles this association.
+    } else {
+      ownWrappedNames.add(name);
+      model.prototype.destroyAssociations = async function (this: any): Promise<void> {
+        await this.association(middleName).handleDependency();
+        this.association(name).reset?.();
+        // Rails' `association(:name).reset` only clears the Association
+        // instance's loaded state. In this codebase, collection readers are
+        // additionally memoized in `_collectionProxies` (see associations.ts
+        // ~2334), so the user-facing reader would still return the stale
+        // proxy unless we evict it too.
+        this._collectionProxies?.delete(name);
+        if (typeof prevDestroyAssociations === "function") {
+          await prevDestroyAssociations.call(this);
+        }
+      };
+    }
     const HABTM_DESTROY_INSTALLED = Symbol.for("blazetrails.habtm.destroyAssociations.installed");
     // Use `in` (inheritance walk) rather than own-property: when a subclass
     // declares its own HABTM, the parent already installed a bridge that the

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -207,12 +207,23 @@ export class HasAndBelongsToMany {
     model.prototype.destroyAssociations = async function (this: any): Promise<void> {
       await this.association(middleName).handleDependency();
       this.association(name).reset?.();
+      // Rails' `association(:name).reset` only clears the Association
+      // instance's loaded state. In this codebase, collection readers are
+      // additionally memoized in `_collectionProxies` (see associations.ts
+      // ~2334), so the user-facing reader would still return the stale
+      // proxy unless we evict it too.
+      this._collectionProxies?.delete(name);
       if (typeof prevDestroyAssociations === "function") {
         await prevDestroyAssociations.call(this);
       }
     };
     const HABTM_DESTROY_INSTALLED = Symbol.for("blazetrails.habtm.destroyAssociations.installed");
-    if (!Object.prototype.hasOwnProperty.call(model, HABTM_DESTROY_INSTALLED)) {
+    // Use `in` (inheritance walk) rather than own-property: when a subclass
+    // declares its own HABTM, the parent already installed a bridge that the
+    // callback engine COW'd into the subclass's chain. Installing a second
+    // bridge on the subclass would dispatch `destroyAssociations` twice,
+    // running the full chained override stack twice (duplicate cleanup).
+    if (!(HABTM_DESTROY_INSTALLED in model)) {
       Object.defineProperty(model, HABTM_DESTROY_INSTALLED, {
         value: true,
         configurable: true,

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1492,13 +1492,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const origAssoc = (owner as any).association.bind(owner);
     (owner as any).association = (n: string) => {
       const a = origAssoc(n);
-      if (n.endsWith("tag_as") || n.endsWith("tag_bs")) {
-        const orig = a.handleDependency.bind(a);
-        a.handleDependency = async () => {
-          calls.push(n);
-          return orig();
-        };
-      }
+      const orig = a.handleDependency.bind(a);
+      a.handleDependency = async () => {
+        calls.push(n);
+        return orig();
+      };
       return a;
     };
 
@@ -1507,7 +1505,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(calls.length).toBe(2);
   });
 
-  it("does not double-install the destroy bridge on subclasses", () => {
+  it("subclass HABTM extends destroyAssociations chain via super", async () => {
     const a2 = createTestAdapter();
     class ParentOwner extends Base {
       static {
@@ -1520,18 +1518,33 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
       className: "TagA",
       joinTable: "parent_owners_p_tags",
     });
-    const parentDestroyCount = (ParentOwner as any)._callbacks?.destroy?.length ?? 0;
 
     class ChildOwner extends ParentOwner {}
+    ChildOwner.adapter = a2;
     registerModel(ChildOwner);
     Associations.hasAndBelongsToMany.call(ChildOwner, "c_tags", {
       className: "TagB",
       joinTable: "child_owners_c_tags",
     });
-    const childDestroyCount = (ChildOwner as any)._callbacks?.destroy?.length ?? 0;
 
-    // Subclass should not add a second bridge dispatcher — the parent's
-    // bridge is COW'd into the child chain by the callback engine.
-    expect(childDestroyCount).toBeLessThanOrEqual(parentDestroyCount);
+    // A ChildOwner instance's destroyAssociations override should chain
+    // through parent's override too, hitting both HABTM middles.
+    const child = await ChildOwner.create({ name: "Child" });
+    const calls: string[] = [];
+    const origAssoc = (child as any).association.bind(child);
+    (child as any).association = (n: string) => {
+      const a = origAssoc(n);
+      const orig = a.handleDependency.bind(a);
+      a.handleDependency = async () => {
+        calls.push(n);
+        return orig();
+      };
+      return a;
+    };
+
+    await (child as any).destroyAssociations();
+    // Two middle hasMany associations should be visited — one from
+    // parent's HABTM override, one from child's, chained via super.
+    expect(calls.length).toBe(2);
   });
 });

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1501,8 +1501,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     };
 
     await (owner as any).destroyAssociations();
-    // Both layered overrides should have run — chained super reaches both.
-    expect(calls.length).toBe(2);
+    // Both layered overrides should have run with distinct middle
+    // associations — chained super reaches both, not the same one twice.
+    expect(new Set(calls).size).toBe(2);
   });
 
   it("subclass HABTM extends destroyAssociations chain via super", async () => {
@@ -1543,8 +1544,8 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     };
 
     await (child as any).destroyAssociations();
-    // Two middle hasMany associations should be visited — one from
-    // parent's HABTM override, one from child's, chained via super.
-    expect(calls.length).toBe(2);
+    // Two distinct middle hasMany associations should be visited — one
+    // from parent's HABTM override, one from child's, chained via super.
+    expect(new Set(calls).size).toBe(2);
   });
 });

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1445,4 +1445,93 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     await proxy.destroy(proj);
     expect(proj.isDestroyed()).toBe(true);
   });
+
+  // ==========================================================================
+  // destroy_associations override mixin chaining
+  // Mirrors Rails associations.rb:1886-1894 — each HABTM declaration layers an
+  // anonymous module override of destroy_associations that chains via super.
+  // ==========================================================================
+
+  it("layers destroyAssociations chain for multiple HABTMs on one class", async () => {
+    const a2 = createTestAdapter();
+    class MultiOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class TagA extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class TagB extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    MultiOwner.adapter = a2;
+    TagA.adapter = a2;
+    TagB.adapter = a2;
+    registerModel(MultiOwner);
+    registerModel(TagA);
+    registerModel(TagB);
+    Associations.hasAndBelongsToMany.call(MultiOwner, "tag_as", {
+      className: "TagA",
+      joinTable: "multi_owners_tag_as",
+    });
+    Associations.hasAndBelongsToMany.call(MultiOwner, "tag_bs", {
+      className: "TagB",
+      joinTable: "multi_owners_tag_bs",
+    });
+
+    const owner = await MultiOwner.create({ name: "Owner" });
+    const calls: string[] = [];
+    // The HABTM override targets the middle hasMany (one per HABTM
+    // declaration). Stub each middle association's handleDependency to
+    // observe whether the chained `super` calls reach both layers.
+    const origAssoc = (owner as any).association.bind(owner);
+    (owner as any).association = (n: string) => {
+      const a = origAssoc(n);
+      if (n.endsWith("tag_as") || n.endsWith("tag_bs")) {
+        const orig = a.handleDependency.bind(a);
+        a.handleDependency = async () => {
+          calls.push(n);
+          return orig();
+        };
+      }
+      return a;
+    };
+
+    await (owner as any).destroyAssociations();
+    // Both layered overrides should have run — chained super reaches both.
+    expect(calls.length).toBe(2);
+  });
+
+  it("does not double-install the destroy bridge on subclasses", () => {
+    const a2 = createTestAdapter();
+    class ParentOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    ParentOwner.adapter = a2;
+    registerModel(ParentOwner);
+    Associations.hasAndBelongsToMany.call(ParentOwner, "p_tags", {
+      className: "TagA",
+      joinTable: "parent_owners_p_tags",
+    });
+    const parentDestroyCount = (ParentOwner as any)._callbacks?.destroy?.length ?? 0;
+
+    class ChildOwner extends ParentOwner {}
+    registerModel(ChildOwner);
+    Associations.hasAndBelongsToMany.call(ChildOwner, "c_tags", {
+      className: "TagB",
+      joinTable: "child_owners_c_tags",
+    });
+    const childDestroyCount = (ChildOwner as any)._callbacks?.destroy?.length ?? 0;
+
+    // Subclass should not add a second bridge dispatcher — the parent's
+    // bridge is COW'd into the child chain by the callback engine.
+    expect(childDestroyCount).toBeLessThanOrEqual(parentDestroyCount);
+  });
 });


### PR DESCRIPTION
## Summary

Batch 33 of `docs/activerecord-100-plan.md` (HABTM Slot D options + `parent_reflection`). Three of the four items were already shipped in #1652 and #1672:

- ✅ `defineAutosaveValidationCallbacks` wired unconditionally on HABTM (#1672)
- ✅ `parent_reflection` set on middle reflection (#1672)
- ✅ `habtmOptions → hm_options` allowlist tightened (#1672)
- 🆕 **This PR:** Move HABTM `beforeDestroy` into anonymous `destroy_associations` override mixin (Rails-shape)

### Mixin override

Mirrors Rails `associations.rb:1886-1894` — instead of registering a bare `beforeDestroy` per HABTM, we override the instance-level `destroyAssociations` and chain via a captured `prev` reference. Multiple HABTMs on the same class layer correctly, matching Ruby's anonymous-module `include` + `super` chain.

### Bridging note

`destroyAssociations` isn't yet invoked by the standard destroy flow — that wiring is deferred to Batch 37. To preserve current behavior, a single class-level `beforeDestroy` is installed lazily (gated by a `Symbol.for` flag on the class) to dispatch `destroyAssociations` once per class.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts` — 72 passed, 24 skipped (no regressions)
- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1378 passed
- [x] `pnpm vitest run packages/activerecord/src/callbacks.test.ts packages/activerecord/src/persistence.test.ts` — 478 passed