### PR TITLE
test(activerecord): align PG partitions + schema dump tests with Rails (batch 72)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/partitions.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/partitions.test.ts
@@ -16,6 +16,8 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgresqlPartitionsTest", () => {
     it("partitions table exists", async () => {
+      await adapter.getDatabaseVersion();
+      if (!adapter.supportsNativePartitioning()) return;
       await adapter.createTable(
         "partitioned_events",
         {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -997,26 +997,26 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
       expect(lines.join("\n")).not.toContain("options:");
     });
+  });
+
+  describe("SchemaTableCommentTest", () => {
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
+    });
+
     it("table comment is dumped and round-trips via createTable", async () => {
-      try {
-        await adapter.exec(
-          `CREATE TABLE commented_table (id serial primary key, name varchar(50))`,
-        );
-        await adapter.exec(`COMMENT ON TABLE commented_table IS 'a test table'`);
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "commented_table");
-        const dump = lines.join("\n");
-        expect(dump).toContain(`comment: "a test table"`);
-        await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
-        // Round-trip: createTable with comment: re-applies the comment via changeTableComment
-        const ss = adapter.schemaStatements();
-        await ss.createTable("commented_table", { comment: "a test table" }, (t) => {
-          t.string("name");
-        });
-        expect(await adapter.tableComment("commented_table")).toBe("a test table");
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
-      }
+      await adapter.exec(`CREATE TABLE commented_table (id serial primary key, name varchar(50))`);
+      await adapter.exec(`COMMENT ON TABLE commented_table IS 'a test table'`);
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "commented_table");
+      expect(lines.join("\n")).toContain(`comment: "a test table"`);
+      await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
+
+      const ss = adapter.schemaStatements();
+      await ss.createTable("commented_table", { comment: "a test table" }, (t) => {
+        t.string("name");
+      });
+      expect(await adapter.tableComment("commented_table")).toBe("a test table");
     });
   });
 });


### PR DESCRIPTION
## Summary

Batch 72 — Schema Slot I PG partitioning cleanup from docs/activerecord-100-plan.md.

- **partitions.test.ts**: add \`supportsNativePartitioning()\` skip guard to mirror Rails \`skip unless database_version >= 100000\` in \`partitions_test.rb\`.
- **schema.test.ts**: move the \`commented_table\` round-trip out of \`SchemaCreateTableOptionsTest\` into its own \`SchemaTableCommentTest\` describe block — it isn't part of the Rails \`SchemaCreateTableOptionsTest\` cluster. Switched the manual try/finally to \`afterEach\` for cleanup.

The plan also mentioned dropping an extra "partition table" test in \`partitions.test.ts\`, but our file already only contains the single \`partitions table exists\` test that mirrors Rails \`test_partitions_table_exists\`, so nothing to drop.

## Test plan
- [ ] CI green (PG live tests run the guarded test against PG ≥ 10).