### PR TITLE
feat(actionpack): port abstract_controller/caching/fragments.rb

### DIFF
--- a/packages/actionpack/src/abstract-controller/fragments.test.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryStore, Notifications } from "@blazetrails/activesupport";
+
+import {
+  applyFragments,
+  combinedFragmentCacheKey,
+  expireFragment,
+  fragmentCacheKey,
+  fragmentExist,
+  instrumentFragmentCache,
+  readFragment,
+  writeFragment,
+  type FragmentsClassMethods,
+  type FragmentsHost,
+} from "./fragments.js";
+
+class HostClass {
+  static cacheStore: MemoryStore | null = null;
+  static performCaching = true;
+  static fragmentCacheKeys: Array<(this: FragmentsHost) => unknown> | undefined;
+
+  account = { id: 7 };
+  urlFor(o: Record<string, unknown>) {
+    return `http://test.host/${o.controller}/${o.action}/${o.id ?? ""}`;
+  }
+}
+
+function makeHost(store?: MemoryStore): HostClass & FragmentsHost {
+  HostClass.cacheStore = store ?? null;
+  HostClass.performCaching = true;
+  HostClass.fragmentCacheKeys = [];
+  return new HostClass() as unknown as HostClass & FragmentsHost;
+}
+
+beforeEach(() => {
+  vi.stubEnv("RAILS_CACHE_ID", "");
+  vi.stubEnv("RAILS_APP_VERSION", "");
+  delete process.env.RAILS_CACHE_ID;
+  delete process.env.RAILS_APP_VERSION;
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe("class config", () => {
+  it("applyFragments seeds a key list, preserving an existing one", () => {
+    class A {}
+    applyFragments(A as unknown as new (...a: never[]) => unknown);
+    expect((A as unknown as FragmentsClassMethods).fragmentCacheKeys).toEqual([]);
+
+    class B {
+      static fragmentCacheKeys = [() => "v1"];
+    }
+    applyFragments(B as unknown as new (...a: never[]) => unknown);
+    expect(B.fragmentCacheKeys).toHaveLength(1);
+  });
+
+  it("fragmentCacheKey appends constants-as-thunks and blocks in order", () => {
+    const cls: FragmentsClassMethods = { fragmentCacheKeys: [() => "a"] };
+    fragmentCacheKey(cls, "b");
+    fragmentCacheKey(cls, undefined, function (this: FragmentsHost) {
+      return 42;
+    });
+    expect(cls.fragmentCacheKeys!.map((f) => f.call({} as FragmentsHost))).toEqual(["a", "b", 42]);
+  });
+});
+
+describe("combinedFragmentCacheKey", () => {
+  it("prepends :views, includes RAILS_CACHE_ID || RAILS_APP_VERSION, drops nulls", () => {
+    expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "n"]);
+
+    process.env.RAILS_APP_VERSION = "1.2.3";
+    expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "1.2.3", "n"]);
+
+    process.env.RAILS_CACHE_ID = "deploy-42";
+    expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "deploy-42", "n"]);
+  });
+
+  it("evaluates prefix blocks in instance scope and flattens one level", () => {
+    const host = makeHost();
+    HostClass.fragmentCacheKeys = [
+      function (this: FragmentsHost) {
+        return (this as unknown as HostClass).account.id;
+      },
+      () => ["a", "b"],
+    ];
+    expect(combinedFragmentCacheKey.call(host, ["c", "d"])).toEqual([
+      "views",
+      7,
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("treats a plain-object key as urlFor and strips the scheme", () => {
+    expect(
+      combinedFragmentCacheKey.call(makeHost(), { controller: "pages", action: "notes", id: 45 }),
+    ).toEqual(["views", "test.host/pages/notes/45"]);
+  });
+});
+
+describe("read/write/expire fragment", () => {
+  let host: HostClass & FragmentsHost;
+  beforeEach(() => {
+    host = makeHost(new MemoryStore());
+  });
+
+  it("round-trips content, reports existence, and expires by key", () => {
+    expect(fragmentExist.call(host, "n")).toBe(false);
+    expect(writeFragment.call(host, "n", "body")).toBe("body");
+    expect(readFragment.call(host, "n")).toBe("body");
+    expect(fragmentExist.call(host, "n")).toBe(true);
+    expireFragment.call(host, "n");
+    expect(readFragment.call(host, "n")).toBeNull();
+  });
+
+  it("RegExp expiry delegates to deleteMatched", () => {
+    writeFragment.call(host, "pages/45/notes", "a");
+    writeFragment.call(host, "pages/46/notes", "b");
+    writeFragment.call(host, "other", "c");
+    expireFragment.call(host, /pages\/\d+\/notes/);
+    expect(readFragment.call(host, "pages/45/notes")).toBeNull();
+    expect(readFragment.call(host, "other")).toBe("c");
+  });
+
+  it("returns content / undefined when caching is not configured", () => {
+    HostClass.performCaching = false;
+    expect(writeFragment.call(host, "n", "body")).toBe("body");
+    expect(readFragment.call(host, "n")).toBeUndefined();
+    expect(fragmentExist.call(host, "n")).toBeUndefined();
+    expect(expireFragment.call(host, "n")).toBeUndefined();
+  });
+});
+
+describe("instrumentFragmentCache", () => {
+  it("fires under abstract_controller by default and honours host overrides", () => {
+    const host = makeHost();
+    const sub = vi.fn();
+    const h1 = Notifications.subscribe("write_fragment.abstract_controller", sub);
+    try {
+      expect(instrumentFragmentCache(host, "write_fragment", "k", () => "ok")).toBe("ok");
+      expect(sub.mock.calls[0][0]?.payload).toEqual({ key: "k" });
+    } finally {
+      Notifications.unsubscribe(h1);
+    }
+
+    host.instrumentName = () => "action_controller";
+    host.instrumentPayload = (key) => ({ key, controller: "Pages" });
+    const sub2 = vi.fn();
+    const h2 = Notifications.subscribe("read_fragment.action_controller", sub2);
+    try {
+      instrumentFragmentCache(host, "read_fragment", "k", () => null);
+      expect(sub2.mock.calls[0][0]?.payload).toEqual({ key: "k", controller: "Pages" });
+    } finally {
+      Notifications.unsubscribe(h2);
+    }
+  });
+});

--- a/packages/actionpack/src/abstract-controller/fragments.test.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.test.ts
@@ -41,16 +41,16 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs());
 
 describe("class config", () => {
-  it("applyFragments seeds a key list, preserving an existing one", () => {
-    class A {}
-    applyFragments(A as unknown as new (...a: never[]) => unknown);
-    expect((A as unknown as FragmentsClassMethods).fragmentCacheKeys).toEqual([]);
-
-    class B {
+  it("applyFragments is a no-op so subclasses inherit the parent key list", () => {
+    class Parent {
       static fragmentCacheKeys = [() => "v1"];
     }
-    applyFragments(B as unknown as new (...a: never[]) => unknown);
-    expect(B.fragmentCacheKeys).toHaveLength(1);
+    class Child extends Parent {}
+    applyFragments(Child as unknown as new (...a: never[]) => unknown);
+    // Child must NOT have its own fragmentCacheKeys property — the
+    // parent's list inherits via the prototype chain.
+    expect(Object.prototype.hasOwnProperty.call(Child, "fragmentCacheKeys")).toBe(false);
+    expect(Child.fragmentCacheKeys).toHaveLength(1);
   });
 
   it("fragmentCacheKey appends constants-as-thunks and blocks in order", () => {

--- a/packages/actionpack/src/abstract-controller/fragments.test.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.test.ts
@@ -32,13 +32,18 @@ function makeHost(store?: MemoryStore): HostClass & FragmentsHost {
   return new HostClass() as unknown as HostClass & FragmentsHost;
 }
 
+const origCache = process.env.RAILS_CACHE_ID;
+const origVer = process.env.RAILS_APP_VERSION;
 beforeEach(() => {
-  vi.stubEnv("RAILS_CACHE_ID", "");
-  vi.stubEnv("RAILS_APP_VERSION", "");
   delete process.env.RAILS_CACHE_ID;
   delete process.env.RAILS_APP_VERSION;
 });
-afterEach(() => vi.unstubAllEnvs());
+afterEach(() => {
+  if (origCache === undefined) delete process.env.RAILS_CACHE_ID;
+  else process.env.RAILS_CACHE_ID = origCache;
+  if (origVer === undefined) delete process.env.RAILS_APP_VERSION;
+  else process.env.RAILS_APP_VERSION = origVer;
+});
 
 describe("class config", () => {
   it("applyFragments is a no-op so subclasses inherit the parent key list", () => {
@@ -72,6 +77,27 @@ describe("combinedFragmentCacheKey", () => {
 
     process.env.RAILS_CACHE_ID = "deploy-42";
     expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "deploy-42", "n"]);
+  });
+
+  it("falls through empty-string env vars (|| semantics, not ??)", () => {
+    process.env.RAILS_CACHE_ID = "";
+    process.env.RAILS_APP_VERSION = "1.2.3";
+    expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "1.2.3", "n"]);
+
+    process.env.RAILS_APP_VERSION = "";
+    expect(combinedFragmentCacheKey.call(makeHost(), "n")).toEqual(["views", "n"]);
+  });
+
+  it("throws when a hash key is given without a host urlFor", () => {
+    const host = makeHost();
+    (host as { urlFor?: unknown }).urlFor = undefined;
+    expect(() => combinedFragmentCacheKey.call(host, { a: 1 })).toThrow(/requires a host/);
+  });
+
+  it("throws when host urlFor returns a non-string", () => {
+    const host = makeHost();
+    host.urlFor = () => 123 as unknown as string;
+    expect(() => combinedFragmentCacheKey.call(host, { a: 1 })).toThrow(/must return a string/);
   });
 
   it("evaluates prefix blocks in instance scope and flattens one level", () => {

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -107,6 +107,11 @@ export function readFragment(this: FragmentsHost, key: unknown, options?: CacheO
   );
 }
 
+// `_options` on fragmentExist / expireFragment: Rails forwards options
+// to `cache_store.exist?` / `delete` / `delete_matched`, but the trails
+// `CacheStore` interface in activesupport doesn't accept options on
+// those methods. Follow-up: widen `CacheStore.exist` / `delete` /
+// `deleteMatched` signatures, then drop the `_` prefix here.
 export function fragmentExist(
   this: FragmentsHost,
   key: unknown,

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -1,0 +1,164 @@
+/**
+ * `AbstractController::Caching::Fragments` — fragment-level cache reads,
+ * writes, existence checks, and expiry, plus the `combinedFragmentCacheKey`
+ * helper that controllers use to namespace keys. Hosts may override
+ * `instrumentName` / `instrumentPayload` (abstract in Rails, supplied by
+ * `ActionController::Caching`); defaults are namespace `"abstract_controller"`
+ * and payload `{ key }`. Rails' `.html_safe` step on `readFragment` results
+ * is a no-op here — trails has no html-safe marker.
+ *
+ * Ported from `vendor/rails/actionpack/lib/abstract_controller/caching/fragments.rb`.
+ *
+ * @internal
+ */
+
+import { Notifications } from "@blazetrails/activesupport";
+import type { CacheOptions, CacheStore } from "@blazetrails/activesupport";
+
+import { cacheConfigured } from "./caching.js";
+
+export type FragmentCacheKeyBlock = (this: FragmentsHost) => unknown;
+
+export interface FragmentsClassMethods {
+  fragmentCacheKeys?: FragmentCacheKeyBlock[];
+  cacheStore?: CacheStore | null;
+  performCaching?: boolean;
+}
+
+export interface FragmentsHost {
+  constructor: FragmentsClassMethods;
+  urlFor?(options: Record<string, unknown>): string;
+  instrumentName?(): string;
+  instrumentPayload?(key: unknown): Record<string, unknown>;
+}
+
+export function applyFragments<T extends new (...args: never[]) => unknown>(
+  cls: T & Partial<FragmentsClassMethods>,
+): void {
+  if (!Object.prototype.hasOwnProperty.call(cls, "fragmentCacheKeys")) {
+    cls.fragmentCacheKeys = [];
+  }
+}
+
+export function fragmentCacheKey(
+  cls: FragmentsClassMethods,
+  valueOrBlock: unknown | FragmentCacheKeyBlock,
+  block?: FragmentCacheKeyBlock,
+): void {
+  const entry: FragmentCacheKeyBlock =
+    block ??
+    (typeof valueOrBlock === "function"
+      ? (valueOrBlock as FragmentCacheKeyBlock)
+      : () => valueOrBlock);
+  cls.fragmentCacheKeys = [...(cls.fragmentCacheKeys ?? []), entry];
+}
+
+export function combinedFragmentCacheKey(this: FragmentsHost, key: unknown): unknown[] {
+  const heads = (this.constructor.fragmentCacheKeys ?? []).map((k) => k.call(this));
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env;
+  const version = env?.RAILS_CACHE_ID ?? env?.RAILS_APP_VERSION ?? null;
+
+  let tail: unknown;
+  if (isPlainObject(key) && typeof this.urlFor === "function") {
+    const url = this.urlFor(key);
+    const idx = url.indexOf("://");
+    tail = idx >= 0 ? url.slice(idx + 3) : url;
+  } else {
+    tail = key;
+  }
+
+  const out: unknown[] = ["views", version];
+  for (const h of heads) flattenOne(out, h);
+  flattenOne(out, tail);
+  return out.filter((v) => v != null);
+}
+
+function flattenOne(out: unknown[], value: unknown): void {
+  if (Array.isArray(value)) for (const v of value) out.push(v);
+  else out.push(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+export function writeFragment(
+  this: FragmentsHost,
+  key: unknown,
+  content: string,
+  options?: CacheOptions,
+): string {
+  if (!cacheConfigured(this)) return content;
+  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "write_fragment", combined, () => {
+    this.constructor.cacheStore!.write(combined, content, options);
+    return content;
+  });
+}
+
+export function readFragment(this: FragmentsHost, key: unknown, options?: CacheOptions): unknown {
+  if (!cacheConfigured(this)) return undefined;
+  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "read_fragment", combined, () =>
+    this.constructor.cacheStore!.read(combined, options),
+  );
+}
+
+export function fragmentExist(
+  this: FragmentsHost,
+  key: unknown,
+  _options?: CacheOptions,
+): boolean | undefined {
+  if (!cacheConfigured(this)) return undefined;
+  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "exist_fragment?", combined, () =>
+    this.constructor.cacheStore!.exist(combined),
+  );
+}
+
+export function expireFragment(
+  this: FragmentsHost,
+  key: unknown,
+  _options?: CacheOptions,
+): unknown {
+  if (!cacheConfigured(this)) return undefined;
+  const store = this.constructor.cacheStore!;
+  if (key instanceof RegExp) {
+    return instrumentFragmentCache(this, "expire_fragment", key, () => store.deleteMatched(key));
+  }
+  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "expire_fragment", combined, () => store.delete(combined));
+}
+
+export function instrumentFragmentCache<T>(
+  host: FragmentsHost,
+  name: string,
+  key: unknown,
+  block: () => T,
+): T {
+  const ns = host.instrumentName?.() ?? "abstract_controller";
+  const payload = host.instrumentPayload?.(key) ?? { key };
+  return Notifications.instrument(`${name}.${ns}`, payload, block) as T;
+}
+
+function stringifyKey(parts: unknown[]): string {
+  return parts.map(stringifyPart).join("/");
+}
+
+function stringifyPart(part: unknown): string {
+  if (part == null) return "";
+  if (typeof part === "string") return part;
+  if (typeof part === "number" || typeof part === "boolean" || typeof part === "bigint") {
+    return String(part);
+  }
+  const maybe = (part as { cacheKey?: () => string }).cacheKey;
+  if (typeof maybe === "function") return maybe.call(part);
+  try {
+    return JSON.stringify(part) ?? "";
+  } catch {
+    return String(part);
+  }
+}

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -32,12 +32,17 @@ export interface FragmentsHost {
   instrumentPayload?(key: unknown): Record<string, unknown>;
 }
 
+/**
+ * Marks a host class as conforming to the fragments slot contract.
+ * No-op at runtime — mirrors `applyAssetPaths` / `applyCaching`. Seeding
+ * an own `fragmentCacheKeys = []` here would shadow an inherited list
+ * on subclasses; instead `fragmentCacheKey` and reads treat `undefined`
+ * as an empty list, preserving Rails' `class_attribute` copy-on-write.
+ */
 export function applyFragments<T extends new (...args: never[]) => unknown>(
-  cls: T & Partial<FragmentsClassMethods>,
+  _cls: T & Partial<FragmentsClassMethods>,
 ): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "fragmentCacheKeys")) {
-    cls.fragmentCacheKeys = [];
-  }
+  // Intentionally empty.
 }
 
 export function fragmentCacheKey(
@@ -57,7 +62,9 @@ export function combinedFragmentCacheKey(this: FragmentsHost, key: unknown): unk
   const heads = (this.constructor.fragmentCacheKeys ?? []).map((k) => k.call(this));
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
     ?.env;
-  const version = env?.RAILS_CACHE_ID ?? env?.RAILS_APP_VERSION ?? null;
+  // Rails uses `||` here (`ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]`),
+  // so empty strings fall through — not `??`.
+  const version = env?.RAILS_CACHE_ID || env?.RAILS_APP_VERSION || null;
 
   let tail: unknown;
   if (isPlainObject(key) && typeof this.urlFor === "function") {

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -27,7 +27,10 @@ export interface FragmentsClassMethods {
 
 export interface FragmentsHost {
   constructor: FragmentsClassMethods;
-  urlFor?(options: Record<string, unknown>): string;
+  // Widened to `unknown` so hosts with a string-form `urlFor` (e.g.
+  // `ActionController::Metal`) still satisfy the host interface. Rails'
+  // `url_for` likewise accepts strings, hashes, arrays, or nil.
+  urlFor?(options: unknown): string;
   instrumentName?(): string;
   instrumentPayload?(key: unknown): Record<string, unknown>;
 }
@@ -67,8 +70,16 @@ export function combinedFragmentCacheKey(this: FragmentsHost, key: unknown): unk
   const version = env?.RAILS_CACHE_ID || env?.RAILS_APP_VERSION || null;
 
   let tail: unknown;
-  if (isPlainObject(key) && typeof this.urlFor === "function") {
+  if (isPlainObject(key)) {
+    if (typeof this.urlFor !== "function") {
+      throw new TypeError("combinedFragmentCacheKey: hash key requires a host with `urlFor`");
+    }
     const url = this.urlFor(key);
+    if (typeof url !== "string") {
+      throw new TypeError(
+        `combinedFragmentCacheKey: urlFor must return a string, got ${typeof url}`,
+      );
+    }
     const idx = url.indexOf("://");
     tail = idx >= 0 ? url.slice(idx + 3) : url;
   } else {

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -64,3 +64,16 @@ export {
   type CachingSlot,
   type ViewCacheDependency,
 } from "./caching.js";
+export {
+  applyFragments,
+  combinedFragmentCacheKey,
+  expireFragment,
+  fragmentCacheKey,
+  fragmentExist,
+  instrumentFragmentCache,
+  readFragment,
+  writeFragment,
+  type FragmentCacheKeyBlock,
+  type FragmentsClassMethods,
+  type FragmentsHost,
+} from "./fragments.js";


### PR DESCRIPTION
## Summary

Ports `AbstractController::Caching::Fragments` from
`vendor/rails/actionpack/lib/abstract_controller/caching/fragments.rb`,
completing the abstract-controller caching surface (caching.rb landed
in #1780).

- `applyFragments(cls)` / `fragmentCacheKey(cls, value | block)` — class-level wiring.
- `combinedFragmentCacheKey(key)` — `[:views, RAILS_CACHE_ID || RAILS_APP_VERSION, ...heads, tail]`, flatten-one, compact. Plain-object keys are funnelled through `urlFor` with the scheme stripped, matching Rails.
- `writeFragment` / `readFragment` / `fragmentExist` / `expireFragment` — early-return when caching isn't configured; RegExp keys route to `cacheStore.deleteMatched`.
- `instrumentFragmentCache(host, name, key, block)` — fires `Notifications.instrument("<name>.<ns>", payload, block)`. `instrumentName` and `instrumentPayload` are abstract in Rails (supplied by `ActionController::Caching`) and overridable on the host; defaults are `"abstract_controller"` and `{ key }`.

Rails' `.html_safe` step on `readFragment` results is a no-op here — trails has no html-safe marker. Noted in the source docstring.

PR size: 335 LOC (impl 168 + test 154 + index re-exports 13). Slightly over the 300 soft ceiling; trimmed comments and consolidated tests to bring it down from 450.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/fragments.test.ts` — 9 passing.
- [x] `tsc --build` (via pre-commit) — green.
- [ ] CI: full actionpack suite + api:compare.