### PR TITLE
feat(action-dispatch): port AssumeSSL + Callbacks middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -77,3 +77,5 @@ export {
   type DigestAuthParams,
 } from "./http-authentication.js";
 export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
+export { AssumeSSL } from "./middleware/assume-ssl.js";
+export { Callbacks } from "./middleware/callbacks.js";

--- a/packages/actionpack/src/action-dispatch/middleware/assume-ssl.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/assume-ssl.test.ts
@@ -3,7 +3,7 @@ import { bodyFromString } from "@blazetrails/rack";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { AssumeSSL } from "./assume-ssl.js";
 
-describe("AssumeSSL", () => {
+describe("AssumeSSLTest", () => {
   it("sets expected headers", async () => {
     const env: RackEnv = {};
     const app = async (_env: RackEnv): Promise<RackResponse> => [200, {}, bodyFromString("")];

--- a/packages/actionpack/src/action-dispatch/middleware/assume-ssl.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/assume-ssl.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { bodyFromString } from "@blazetrails/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { AssumeSSL } from "./assume-ssl.js";
+
+describe("AssumeSSL", () => {
+  it("sets expected headers", async () => {
+    const env: RackEnv = {};
+    const app = async (_env: RackEnv): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    await new AssumeSSL(app).call(env);
+
+    expect(env["HTTPS"]).toBe("on");
+    expect(env["HTTP_X_FORWARDED_PORT"]).toBe("443");
+    expect(env["HTTP_X_FORWARDED_PROTO"]).toBe("https");
+    expect(env["rack.url_scheme"]).toBe("https");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/assume-ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/assume-ssl.ts
@@ -1,0 +1,28 @@
+/**
+ * ActionDispatch::AssumeSSL
+ *
+ * When proxying through a load balancer that terminates SSL, the forwarded
+ * request will appear as though it's HTTP instead of HTTPS to the application.
+ * This makes redirects and cookie security target HTTP instead of HTTPS. This
+ * middleware makes the server assume that the proxy already terminated SSL,
+ * and that the request really is HTTPS.
+ */
+
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+
+export class AssumeSSL {
+  private app: RackApp;
+
+  constructor(app: RackApp) {
+    this.app = app;
+  }
+
+  call(env: RackEnv): Promise<RackResponse> {
+    env["HTTPS"] = "on";
+    env["HTTP_X_FORWARDED_PORT"] = "443";
+    env["HTTP_X_FORWARDED_PROTO"] = "https";
+    env["rack.url_scheme"] = "https";
+
+    return this.app(env);
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/callbacks.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/callbacks.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { bodyFromString } from "@blazetrails/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { Callbacks } from "./callbacks.js";
+
+const dummyApp = async (_env: RackEnv): Promise<RackResponse> => [
+  200,
+  {},
+  bodyFromString("response"),
+];
+
+const counts = { a: 0, b: 0 };
+
+async function dispatch(block?: () => Promise<RackResponse>): Promise<RackResponse> {
+  const app = block ?? dummyApp;
+  return new Callbacks(app).call({});
+}
+
+describe("Dispatcher", () => {
+  beforeEach(() => {
+    counts.a = 0;
+    counts.b = 0;
+    Callbacks.resetCallbacks("call");
+  });
+
+  it("test_before_and_after_callbacks", async () => {
+    Callbacks.before(() => {
+      counts.a += 1;
+      counts.b += 1;
+    });
+    Callbacks.after(() => {
+      counts.a += 1;
+      counts.b += 1;
+    });
+
+    await dispatch();
+    expect(counts.a).toBe(2);
+    expect(counts.b).toBe(2);
+
+    await dispatch();
+    expect(counts.a).toBe(4);
+    expect(counts.b).toBe(4);
+
+    try {
+      await dispatch(async () => {
+        throw new Error("error");
+      });
+    } catch {
+      // expected
+    }
+    expect(counts.a).toBe(6);
+    expect(counts.b).toBe(6);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/callbacks.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/callbacks.test.ts
@@ -16,14 +16,14 @@ async function dispatch(block?: () => Promise<RackResponse>): Promise<RackRespon
   return new Callbacks(app).call({});
 }
 
-describe("Dispatcher", () => {
+describe("DispatcherTest", () => {
   beforeEach(() => {
     counts.a = 0;
     counts.b = 0;
     Callbacks.resetCallbacks("call");
   });
 
-  it("test_before_and_after_callbacks", async () => {
+  it("before and after callbacks", async () => {
     Callbacks.before(() => {
       counts.a += 1;
       counts.b += 1;

--- a/packages/actionpack/src/action-dispatch/middleware/callbacks.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/callbacks.ts
@@ -41,6 +41,6 @@ export class Callbacks extends CallbacksBase {
       }
     });
     if (error) throw error;
-    return result as RackResponse;
+    return result!;
   }
 }

--- a/packages/actionpack/src/action-dispatch/middleware/callbacks.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/callbacks.ts
@@ -1,0 +1,46 @@
+/**
+ * ActionDispatch::Callbacks
+ *
+ * Provides callbacks to be executed before and after dispatching the request.
+ */
+
+import {
+  CallbacksMixin,
+  type BeforeCallback,
+  type AfterCallback,
+} from "@blazetrails/activesupport";
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+
+class CallbacksBase extends CallbacksMixin() {}
+CallbacksBase.defineCallbacks("call");
+
+export class Callbacks extends CallbacksBase {
+  private app: RackApp;
+
+  constructor(app: RackApp) {
+    super();
+    this.app = app;
+  }
+
+  static before(callback: BeforeCallback): void {
+    this.beforeCallback("call", callback);
+  }
+
+  static after(callback: AfterCallback): void {
+    this.afterCallback("call", callback);
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    let result: RackResponse | undefined;
+    let error: unknown = null;
+    await this.runCallbacks("call", async () => {
+      try {
+        result = await this.app(env);
+      } catch (e) {
+        error = e;
+      }
+    });
+    if (error) throw error;
+    return result as RackResponse;
+  }
+}


### PR DESCRIPTION
## Summary

Two standalone middleware ports from the P3 missing-middleware list in
`docs/actionpack-restructure-audit.md`.

- **AssumeSSL** (`middleware/assume-ssl.ts`) — sets `HTTPS=on`,
  `HTTP_X_FORWARDED_PORT=443`, `HTTP_X_FORWARDED_PROTO=https`, and
  `rack.url_scheme=https` for use behind an SSL-terminating proxy.
- **Callbacks** (`middleware/callbacks.ts`) — `before`/`after` callbacks
  around request dispatch via ActiveSupport `CallbacksMixin`.

Both are 1:1 Rails ports (`action_dispatch/middleware/assume_ssl.rb`
and `action_dispatch/middleware/callbacks.rb`) with matching test
names from the corresponding Rails test files
(`AssumeSSLTest#sets expected headers`,
`DispatcherTest#test_before_and_after_callbacks`).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/{assume-ssl,callbacks}.test.ts` — 2/2 pass
- [x] `pnpm build` clean
- [x] `pnpm lint --fix` clean