### PR TITLE
feat(activerecord): insert-all UnknownAttributeError + bang wrappers + annotation sharpening (batch 109)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2148,7 +2148,10 @@ export class Base extends Model {
   declare static leftOuterJoins: typeof Querying.leftOuterJoins;
   declare static none: typeof Querying.none;
   declare static insert: typeof Querying.insert;
+  declare static insertBang: typeof Querying.insertBang;
   declare static insertAll: typeof Querying.insertAll;
+  declare static insertAllBang: typeof Querying.insertAllBang;
+  declare static upsert: typeof Querying.upsert;
   declare static upsertAll: typeof Querying.upsertAll;
   declare static updateAll: typeof Querying.updateAll;
   declare static deleteAll: typeof Querying.deleteAll;

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -201,10 +201,14 @@ describe("InsertAllTest", () => {
   });
 
   it.skip("insert all raises on duplicate records", () => {
-    // BLOCKED: relation — insert_all.rb: raises on duplicate (unique constraint)
+    // BLOCKED: relation
+    // ROOT-CAUSE: insertAll uses onDuplicate="raise" semantics only via DB-native constraint violation; current path swallows the adapter error and returns affected-row count rather than re-raising as RecordNotUnique. insertAllBang delegates to insertAll so inherits the gap.
+    // SCOPE: ~30 LOC — re-raise adapter unique-violation as RecordNotUnique in execute() for bang variants and onDuplicate=undefined; affects ~5 duplicate-raise tests
   });
   it.skip("insert all with returning", () => {
-    // BLOCKED: adapter-pg — insert_all.rb: RETURNING clause support
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: returning clause currently passes through to executeMutation which returns affected-row counts; PG-only RETURNING extraction (Result rows + type-cast) is not wired through Builder.toSql + execute path.
+    // SCOPE: ~50 LOC across insert-all.ts (Builder.returningClause select_values + execute branch) and pg adapter (executeInsertAll → Result); affects ~4 RETURNING tests
   });
   itIfConflictTarget("insert all skip duplicates", async () => {
     const adapter = freshAdapter();
@@ -245,7 +249,9 @@ describe("InsertAllTest", () => {
   });
 
   it.skip("upsert all does not update readonly attributes", () => {
-    // BLOCKED: relation — insert_all.rb: readonly attrs not updated
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts does not consult model.readonlyAttributes() when building keysIncludingTimestamps or _updatableColumns, so readonly columns flow into both INSERT column list and ON CONFLICT update set.
+    // SCOPE: ~15 LOC — filter this.keys against readonlyAttributes() in resolveAttributeAliases path and exclude from _updatableColumns; affects ~3 readonly tests
   });
 
   it.skip("upsert all updates changed columns only", () => {
@@ -263,8 +269,12 @@ describe("InsertAllTest", () => {
     expect(all.some((b: any) => b.title === "EnumBook")).toBe(true);
   });
 
-  it.skip("insert_all has a clear error message when a column does not exist", () => {
-    // BLOCKED: relation — insert_all.rb: clear error on missing column
+  it("insert_all has a clear error message when a column does not exist", async () => {
+    const { UnknownAttributeError } = await import("./errors.js");
+    const Book = makeBookWithAdapter();
+    await expect(Book.insertAll([{ title: "Valid", no_such_column: 1 }])).rejects.toThrow(
+      UnknownAttributeError,
+    );
   });
 
   it("insert_all can insert records with timestamps", async () => {
@@ -286,7 +296,9 @@ describe("InsertAllTest", () => {
   });
 
   it.skip("insert_all with on_duplicate updates record timestamps", () => {
-    // BLOCKED: relation — insert_all.rb: timestamp touch on on_duplicate
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it("insert_all with raw sql on_duplicate", async () => {
     const Book = makeBookWithAdapter();
@@ -301,11 +313,17 @@ describe("InsertAllTest", () => {
     expect(all).toHaveLength(1);
     expect((all[0] as any).author).toBe("Updated");
   });
-  it.skip("upsert all has a clear error message when a column does not exist", () => {
-    // BLOCKED: relation — insert_all.rb: clear error on missing column in upsert
+  it("upsert all has a clear error message when a column does not exist", async () => {
+    const { UnknownAttributeError } = await import("./errors.js");
+    const Book = makeBookWithAdapter();
+    await expect(Book.upsertAll([{ title: "Valid", no_such_column: 1 }])).rejects.toThrow(
+      UnknownAttributeError,
+    );
   });
   it.skip("upsert all with unique_by column not an index raises error", () => {
-    // BLOCKED: schema — insert_all.rb: uniqueBy column must be an index
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
 
   it.skip("upsert all supports update_only option", () => {
@@ -317,7 +335,9 @@ describe("InsertAllTest", () => {
     // BLOCKED: adapter-pg — insert_all.rb: RETURNING clause support
   });
   it.skip("insert_all! raises on duplicate", () => {
-    // BLOCKED: relation — insert_all.rb: insert_all! raises on duplicate
+    // BLOCKED: relation
+    // ROOT-CAUSE: insertAll uses onDuplicate="raise" semantics only via DB-native constraint violation; current path swallows the adapter error and returns affected-row count rather than re-raising as RecordNotUnique. insertAllBang delegates to insertAll so inherits the gap.
+    // SCOPE: ~30 LOC — re-raise adapter unique-violation as RecordNotUnique in execute() for bang variants and onDuplicate=undefined; affects ~5 duplicate-raise tests
   });
   it("insert_all with empty array", async () => {
     const adapter = freshAdapter();
@@ -332,7 +352,9 @@ describe("InsertAllTest", () => {
     expect(count).toBe(0);
   });
   it.skip("insert all with partial unique index", () => {
-    // BLOCKED: schema — insert_all.rb: partial unique index support
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   it("insert_all works without callbacks or validations", async () => {
     const adapter = freshAdapter();
@@ -442,7 +464,9 @@ describe("InsertAllTest", () => {
     // BLOCKED: relation — insert_all.rb: SQL generation for upsertAll
   });
   it.skip("insert_all with returning and on_duplicate", () => {
-    // BLOCKED: adapter-pg — insert_all.rb: RETURNING + ON CONFLICT clause
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: returning clause currently passes through to executeMutation which returns affected-row counts; PG-only RETURNING extraction (Result rows + type-cast) is not wired through Builder.toSql + execute path.
+    // SCOPE: ~50 LOC across insert-all.ts (Builder.returningClause select_values + execute branch) and pg adapter (executeInsertAll → Result); affects ~4 RETURNING tests
   });
   it("insert_all with on_duplicate raw sql", async () => {
     const Book = makeBookWithAdapter();
@@ -457,13 +481,19 @@ describe("InsertAllTest", () => {
     expect((book as any).author).toBe("B");
   });
   it.skip("insert_all does not include readonly attributes", () => {
-    // BLOCKED: relation — insert_all.rb: readonly attrs excluded from insertAll
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts does not consult model.readonlyAttributes() when building keysIncludingTimestamps or _updatableColumns, so readonly columns flow into both INSERT column list and ON CONFLICT update set.
+    // SCOPE: ~15 LOC — filter this.keys against readonlyAttributes() in resolveAttributeAliases path and exclude from _updatableColumns; affects ~3 readonly tests
   });
   it.skip("upsert_all does not include readonly attributes", () => {
-    // BLOCKED: relation — insert_all.rb: readonly attrs excluded from upsertAll
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts does not consult model.readonlyAttributes() when building keysIncludingTimestamps or _updatableColumns, so readonly columns flow into both INSERT column list and ON CONFLICT update set.
+    // SCOPE: ~15 LOC — filter this.keys against readonlyAttributes() in resolveAttributeAliases path and exclude from _updatableColumns; affects ~3 readonly tests
   });
   it.skip("insert_all! raises for duplicate records", () => {
-    // BLOCKED: relation — insert_all.rb: insert_all! raises for duplicate records
+    // BLOCKED: relation
+    // ROOT-CAUSE: insertAll uses onDuplicate="raise" semantics only via DB-native constraint violation; current path swallows the adapter error and returns affected-row count rather than re-raising as RecordNotUnique. insertAllBang delegates to insertAll so inherits the gap.
+    // SCOPE: ~30 LOC — re-raise adapter unique-violation as RecordNotUnique in execute() for bang variants and onDuplicate=undefined; affects ~5 duplicate-raise tests
   });
   it.skip("insert! raises for invalid records", () => {
     // BLOCKED: validation — insert_all.rb: insert! validates records
@@ -479,7 +509,9 @@ describe("InsertAllTest", () => {
     // BLOCKED: type — insert_all.rb: type-cast + serialize consistency
   });
   it.skip("insert all returns requested sql fields", () => {
-    // BLOCKED: adapter-pg — insert_all.rb: RETURNING requested sql fields
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: returning clause currently passes through to executeMutation which returns affected-row counts; PG-only RETURNING extraction (Result rows + type-cast) is not wired through Builder.toSql + execute path.
+    // SCOPE: ~50 LOC across insert-all.ts (Builder.returningClause select_values + execute branch) and pg adapter (executeInsertAll → Result); affects ~4 RETURNING tests
   });
   it.skip("insert all with skip duplicates and autonumber id not given", () => {
     // BLOCKED: relation — insert_all.rb: skip duplicates, autonumber id absent
@@ -488,19 +520,29 @@ describe("InsertAllTest", () => {
     // BLOCKED: relation — insert_all.rb: skip duplicates, autonumber id given
   });
   it.skip("insert all will raise if duplicates are skipped only for a certain conflict target", () => {
-    // BLOCKED: relation — insert_all.rb: conflict-target-specific duplicate skip
+    // BLOCKED: relation
+    // ROOT-CAUSE: insertAll uses onDuplicate="raise" semantics only via DB-native constraint violation; current path swallows the adapter error and returns affected-row count rather than re-raising as RecordNotUnique. insertAllBang delegates to insertAll so inherits the gap.
+    // SCOPE: ~30 LOC — re-raise adapter unique-violation as RecordNotUnique in execute() for bang variants and onDuplicate=undefined; affects ~5 duplicate-raise tests
   });
   it.skip("insert all and upsert all with index finding options", () => {
-    // BLOCKED: schema — insert_all.rb: index lookup for uniqueBy
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   it.skip("insert all and upsert all with expression index", () => {
-    // BLOCKED: schema — insert_all.rb: expression index support
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   it.skip("insert all and upsert all raises when index is missing", () => {
-    // BLOCKED: schema — insert_all.rb: raises when matching index missing
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   it.skip("insert all and upsert all finds index with inverted unique by columns", () => {
-    // BLOCKED: schema — insert_all.rb: inverted uniqueBy column order match
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   itIfConflictTarget(
     "insert all and upsert all works with composite primary keys when unique by is provided",
@@ -563,46 +605,74 @@ describe("InsertAllTest", () => {
     // BLOCKED: relation — insert_all.rb: PK columns not overwritten by upsert
   });
   it.skip("upsert all does not perform an upsert if a partial index doesnt apply", () => {
-    // BLOCKED: schema — insert_all.rb: partial index condition gate
+    // BLOCKED: schema
+    // ROOT-CAUSE: schema-cache.indexes() returns IndexDefinition without partial-index where clause, expression-index sql, or inverted column-order match; findUniqueIndexFor falls back to first match and Builder.conflictTarget emits raw columns only.
+    // SCOPE: ~60–80 LOC across schema-cache index extraction (pg/mysql/sqlite index introspection) and findUniqueIndexFor matching; affects ~7 index/partial-index tests
   });
   it.skip("upsert all respects updated at precision when touched implicitly", () => {
-    // BLOCKED: relation — insert_all.rb: updated_at precision respected
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all uses given updated at over implicit updated at", () => {
-    // BLOCKED: relation — insert_all.rb: explicit updated_at wins over implicit
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all uses given updated on over implicit updated on", () => {
-    // BLOCKED: relation — insert_all.rb: explicit updated_on wins over implicit
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all implicitly sets timestamps on create when model record timestamps is true", () => {
-    // BLOCKED: relation — insert_all.rb: implicit timestamps on create (true)
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all does not implicitly set timestamps on create when model record timestamps is true but overridden", () => {
-    // BLOCKED: relation — insert_all.rb: no implicit timestamps on create when overridden
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all does not implicitly set timestamps on create when model record timestamps is false", () => {
-    // BLOCKED: relation — insert_all.rb: no implicit timestamps on create (false)
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all implicitly sets timestamps on create when model record timestamps is false but overridden", () => {
-    // BLOCKED: relation — insert_all.rb: implicit timestamps on create when false overridden
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all respects created at precision when touched implicitly", () => {
-    // BLOCKED: relation — insert_all.rb: created_at precision respected
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all implicitly sets timestamps on update when model record timestamps is true", () => {
-    // BLOCKED: relation — insert_all.rb: implicit timestamps on update (true)
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all does not implicitly set timestamps on update when model record timestamps is true but overridden", () => {
-    // BLOCKED: relation — insert_all.rb: no implicit timestamps on update when overridden
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all does not implicitly set timestamps on update when model record timestamps is false", () => {
-    // BLOCKED: relation — insert_all.rb: no implicit timestamps on update (false)
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all implicitly sets timestamps on update when model record timestamps is false but overridden", () => {
-    // BLOCKED: relation — insert_all.rb: implicit timestamps on update when false overridden
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all implicitly sets timestamps even when columns are aliased", () => {
-    // BLOCKED: relation — insert_all.rb: implicit timestamps with aliased columns
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
   });
   it.skip("upsert all works with partitioned indexes", () => {
     // BLOCKED: adapter-pg — insert_all.rb: partitioned index support
@@ -735,10 +805,7 @@ describe("InsertAllTest", () => {
     expect(found.title).toBe("Updated");
   });
 
-  it.skip("insert all raises on unknown attribute", async () => {
-    // BLOCKED: relation
-    // ROOT-CAUSE: insert-all.ts#verifyAttributes checks row-key uniformity across rows but not membership in model.attributeNames; Rails raises ActiveRecord::UnknownAttributeError (insert_all_test.rb#test_insert_all_raises_on_unknown_attribute).
-    // SCOPE: ~10 LOC — extend verifyAttributes to assert keys ⊆ model.attributeNames; affects ~3 tests
+  it("insert all raises on unknown attribute", async () => {
     const { UnknownAttributeError } = await import("./errors.js");
     const Book = makeBookWithAdapter();
     await expect(
@@ -762,17 +829,23 @@ describe("InsertAllTest", () => {
   });
 
   it.skip("insert all returns primary key if returning is supported", async () => {
-    // BLOCKED: adapter-pg — insert_all.rb: RETURNING primary key
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: returning clause currently passes through to executeMutation which returns affected-row counts; PG-only RETURNING extraction (Result rows + type-cast) is not wired through Builder.toSql + execute path.
+    // SCOPE: ~50 LOC across insert-all.ts (Builder.returningClause select_values + execute branch) and pg adapter (executeInsertAll → Result); affects ~4 RETURNING tests
     // RETURNING clause support depends on the adapter
   });
 
   it.skip("upsert all does not touch updated at when values do not change", async () => {
-    // BLOCKED: relation — insert_all.rb: no updated_at touch when values unchanged
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
     // requires timestamps tracking
   });
 
   it.skip("upsert all touches updated at and updated on when values change", async () => {
-    // BLOCKED: relation — insert_all.rb: updated_at + updated_on touch on change
+    // BLOCKED: relation
+    // ROOT-CAUSE: insert-all.ts#mapKeyWithValue seeds created_at/updated_at via timestampsForCreate() on insert only; upsert/on-duplicate paths in Builder.toSql do not refresh updated_at, do not honor recordTimestamps overrides, and ignore precision config.
+    // SCOPE: ~80–120 LOC across insert-all.ts (split mapKeyWithValue insert vs update + touch_timestamp_attribute? gate) and schemaCreation timestamp formatting; affects ~15 timestamp tests
     // requires timestamps tracking
   });
 

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Base, defineEnum } from "./index.js";
 import { InsertAll } from "./insert-all.js";
+import { UnknownAttributeError } from "./errors.js";
 import { adapterType, createTestAdapter } from "./test-adapter.js";
 
 // Rails' insert_all_test.rb skips uniqueBy-dependent tests via
@@ -270,7 +271,6 @@ describe("InsertAllTest", () => {
   });
 
   it("insert_all has a clear error message when a column does not exist", async () => {
-    const { UnknownAttributeError } = await import("./errors.js");
     const Book = makeBookWithAdapter();
     await expect(Book.insertAll([{ title: "Valid", no_such_column: 1 }])).rejects.toThrow(
       UnknownAttributeError,
@@ -314,7 +314,6 @@ describe("InsertAllTest", () => {
     expect((all[0] as any).author).toBe("Updated");
   });
   it("upsert all has a clear error message when a column does not exist", async () => {
-    const { UnknownAttributeError } = await import("./errors.js");
     const Book = makeBookWithAdapter();
     await expect(Book.upsertAll([{ title: "Valid", no_such_column: 1 }])).rejects.toThrow(
       UnknownAttributeError,
@@ -806,7 +805,6 @@ describe("InsertAllTest", () => {
   });
 
   it("insert all raises on unknown attribute", async () => {
-    const { UnknownAttributeError } = await import("./errors.js");
     const Book = makeBookWithAdapter();
     await expect(
       Book.all().insertAllBang([{ title: "Valid", unknown_attribute: "x" }]),

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -235,7 +235,10 @@ export class InsertAll {
     for (const col of TIMESTAMP_ATTR_ALLOWLIST) known.add(col);
     for (const key of this.keys) {
       if (!known.has(key)) {
-        throw new UnknownAttributeError(new (this.model as any)(), key);
+        // UnknownAttributeError only reads record?.constructor?.name; skip the
+        // full constructor (attribute init, defaults, callbacks) on the error
+        // path by handing it a bare object with the right constructor link.
+        throw new UnknownAttributeError({ constructor: this.model }, key);
       }
     }
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -2,6 +2,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
+import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 import { quoteSqlValue } from "./base.js";
 import { stiName } from "./inheritance.js";
@@ -213,11 +214,24 @@ export class InsertAll {
 
   /** @internal */
   private verifyAttributes(): void {
-    if (this.inserts.length <= 1) return;
-    for (const row of this.inserts.slice(1)) {
-      const rowKeys = new Set([...Object.keys(row), ...Object.keys(this._scopeAttributes)]);
-      if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
-        throw new Error("All objects being inserted must have the same keys");
+    if (this.inserts.length > 1) {
+      for (const row of this.inserts.slice(1)) {
+        const rowKeys = new Set([...Object.keys(row), ...Object.keys(this._scopeAttributes)]);
+        if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
+          throw new Error("All objects being inserted must have the same keys");
+        }
+      }
+    }
+    // Rails raises UnknownAttributeError in extract_types_from_columns_on against
+    // schema_cache.columns_hash; we mirror the same intent against the model's
+    // declared attribute set so the error surfaces before any SQL is built.
+    const known = new Set(this.model.attributeNames());
+    if (known.size === 0) return;
+    for (const pk of this.primaryKeys()) known.add(pk);
+    for (const col of TIMESTAMP_COLUMNS) known.add(col);
+    for (const key of this.keys) {
+      if (!known.has(key)) {
+        throw new UnknownAttributeError(new (this.model as any)(), key);
       }
     }
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -14,6 +14,10 @@ type AdapterDialect = AdapterName;
 
 const TIMESTAMP_COLUMNS = ["created_at", "updated_at"] as const;
 const UPDATE_TIMESTAMP_COLUMNS = ["updated_at"] as const;
+// Mirrors timestamp.ts CREATED_ATTRS/UPDATED_ATTRS: both _at and _on are magic
+// timestamp columns, so verifyAttributes must allow either pair even when only
+// the other is in the model's declared attribute set.
+const TIMESTAMP_ATTR_ALLOWLIST = ["created_at", "created_on", "updated_at", "updated_on"] as const;
 
 // Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#column_name_with_order_matcher
 // Intentionally more restrictive than Rails: quoted identifiers ("col", `col`) and COLLATE
@@ -228,7 +232,7 @@ export class InsertAll {
     const known = new Set(this.model.attributeNames());
     if (known.size === 0) return;
     for (const pk of this.primaryKeys()) known.add(pk);
-    for (const col of TIMESTAMP_COLUMNS) known.add(col);
+    for (const col of TIMESTAMP_ATTR_ALLOWLIST) known.add(col);
     for (const key of this.keys) {
       if (!known.has(key)) {
         throw new UnknownAttributeError(new (this.model as any)(), key);

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -298,8 +298,9 @@ export function insert<T extends typeof Base>(
 export function insertBang<T extends typeof Base>(
   this: T,
   record: Record<string, unknown>,
+  options?: Parameters<Relation<InstanceType<T>>["insertBang"]>[1],
 ): Promise<number> {
-  return this.all().insertBang(record);
+  return this.all().insertBang(record, options);
 }
 
 /** Mirrors: ActiveRecord::Querying#insert_all */
@@ -315,8 +316,9 @@ export function insertAll<T extends typeof Base>(
 export function insertAllBang<T extends typeof Base>(
   this: T,
   records: Record<string, unknown>[],
+  options?: Parameters<Relation<InstanceType<T>>["insertAllBang"]>[1],
 ): Promise<number> {
-  return this.all().insertAllBang(records);
+  return this.all().insertAllBang(records, options);
 }
 
 /** Mirrors: ActiveRecord::Querying#upsert */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -294,6 +294,14 @@ export function insert<T extends typeof Base>(
   return this.all().insert(record, options);
 }
 
+/** Mirrors: ActiveRecord::Querying#insert! */
+export function insertBang<T extends typeof Base>(
+  this: T,
+  record: Record<string, unknown>,
+): Promise<number> {
+  return this.all().insertBang(record);
+}
+
 /** Mirrors: ActiveRecord::Querying#insert_all */
 export function insertAll<T extends typeof Base>(
   this: T,
@@ -301,6 +309,23 @@ export function insertAll<T extends typeof Base>(
   options?: Parameters<Relation<InstanceType<T>>["insertAll"]>[1],
 ): Promise<number> {
   return this.all().insertAll(records, options);
+}
+
+/** Mirrors: ActiveRecord::Querying#insert_all! */
+export function insertAllBang<T extends typeof Base>(
+  this: T,
+  records: Record<string, unknown>[],
+): Promise<number> {
+  return this.all().insertAllBang(records);
+}
+
+/** Mirrors: ActiveRecord::Querying#upsert */
+export function upsert<T extends typeof Base>(
+  this: T,
+  attrs: Record<string, unknown>,
+  options?: Parameters<Relation<InstanceType<T>>["upsert"]>[1],
+): Promise<number> {
+  return this.all().upsert(attrs, options);
 }
 
 /** Mirrors: ActiveRecord::Querying#upsert_all */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -60,7 +60,7 @@ import {
   batchOnUnloadedRelation as _batchOnUnloadedRelation,
 } from "./relation/batches.js";
 import { wrapWithScopeProxy } from "./relation/delegation.js";
-import { InsertAll } from "./insert-all.js";
+import { InsertAll, type InsertAllOptions } from "./insert-all.js";
 import { ScopeRegistry } from "./scoping.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { include, type Included } from "@blazetrails/activesupport";
@@ -3964,17 +3964,27 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Base.insert!
    */
-  async insertBang(attrs: Record<string, unknown>): Promise<number> {
-    return this.insertAll([attrs]);
+  async insertBang(
+    attrs: Record<string, unknown>,
+    options?: Pick<InsertAllOptions, "returning" | "recordTimestamps">,
+  ): Promise<number> {
+    return this.insertAllBang([attrs], options);
   }
 
   /**
    * Insert multiple records, raising on failure.
    *
-   * Mirrors: ActiveRecord::Base.insert_all!
+   * Mirrors: ActiveRecord::Base.insert_all! — accepts the same `returning` /
+   * `recordTimestamps` keyword options as `insertAll` (Rails relation.rb:790).
    */
-  async insertAllBang(records: Record<string, unknown>[]): Promise<number> {
-    return this.insertAll(records);
+  async insertAllBang(
+    records: Record<string, unknown>[],
+    options?: Pick<InsertAllOptions, "returning" | "recordTimestamps">,
+  ): Promise<number> {
+    return InsertAll.execute(this, records, {
+      returning: options?.returning,
+      recordTimestamps: options?.recordTimestamps,
+    });
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3974,8 +3974,8 @@ export class Relation<T extends Base> {
   /**
    * Insert multiple records, raising on failure.
    *
-   * Mirrors: ActiveRecord::Base.insert_all! — accepts the same `returning` /
-   * `recordTimestamps` keyword options as `insertAll` (Rails relation.rb:790).
+   * Mirrors: ActiveRecord::Base.insert_all! (Rails relation.rb:790 —
+   * `def insert_all!(attributes, returning: nil, record_timestamps: nil)`).
    */
   async insertAllBang(
     records: Record<string, unknown>[],


### PR DESCRIPTION
## Summary

Batch 109 from docs/activerecord-100-plan.md. Followup from #1741.

- **UnknownAttributeError on unknown keys**: `insert-all.ts#verifyAttributes` now rejects row keys not in `model.attributeNames()` (plus PK + timestamp columns), raising `UnknownAttributeError` to mirror Rails' `extract_types_from_columns_on` (`insert_all.rb:310`).
- **Class-level bang wrappers in `querying.ts`**: `insertBang`, `insertAllBang`, `upsert` added to round out Rails' `Querying::QUERYING_METHODS` surface. `upsert_all!` intentionally omitted — Rails has no such method (`querying.rb:22`).
- **Three tests un-skipped**:
  - `insert all raises on unknown attribute`
  - `insert_all has a clear error message when a column does not exist`
  - `upsert all has a clear error message when a column does not exist`
- **Sharpened ~30 single-line `BLOCKED:` annotations** in `insert-all.test.ts` into BLOCKED/ROOT-CAUSE/SCOPE format across clusters: timestamps (~15), RETURNING (~4), readonly (~3), schema/index (~7), duplicate-raise (~5).

## LOC
`4 files changed, 162 insertions(+), 47 deletions(-)` — within the 300-LOC ceiling.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/insert-all.test.ts` — 61 passed / 60 skipped (was 58 / 63).
- [x] `pnpm typecheck` (build) passes; no new TS errors introduced.