### PR TITLE
fix(activerecord): wTRS double-save rollback snapshot (batch 111)

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1164,17 +1164,18 @@ describe("TransactionTest", () => {
     }
   });
 
-  it.skip("restore previously new record after double save", () => {
-    // BLOCKED: transactions — snapshot-overwrite on multiple saves
-    // ROOT-CAUSE: withTransactionReturningStatus registers a fresh tx.afterRollback
-    //   per save. With two saves, both register restore hooks on the same outer
-    //   transaction. Rollback fires hooks in registration order: the second save's
-    //   hook (previouslyNewRecord=false) runs last, overwriting the first save's
-    //   correct restore (previouslyNewRecord=true). Rails avoids this because
-    //   @_start_transaction_state is only captured once (||= idiom) at the outermost
-    //   save, and subsequent saves increment the level counter without taking a new
-    //   snapshot for rollback restoration.
-    // SCOPE: ~10 LOC fix in transactions.ts#withTransactionReturningStatus; deferred.
+  it("restore previously new record after double save", async () => {
+    const { Topic } = makeSQLiteTopic();
+    const topic = await Topic.create({ title: "test" });
+    expect(topic.isPreviouslyNewRecord()).toBe(true);
+
+    await Topic.transaction(async () => {
+      await topic.save();
+      await topic.save();
+      throw new Rollback();
+    });
+
+    expect(topic.isPreviouslyNewRecord()).toBe(true);
   });
 
   it("restore composite id after rollback", async () => {

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -385,7 +385,7 @@ interface TransactionRecordSnapshot {
 }
 
 /** @internal */
-export function rememberTransactionRecordState(this: Base): TransactionRecordSnapshot {
+export function rememberTransactionRecordState(this: Base): void {
   const r = this as any;
   // Initialize state once per outermost transaction, then increment level for
   // each savepoint. Mirrors Rails' @_start_transaction_state ||= {...}; level += 1.
@@ -408,20 +408,6 @@ export function rememberTransactionRecordState(this: Base): TransactionRecordSna
   } else {
     r._newRecordBeforeLastCommit = r._startTransactionState.newRecord;
   }
-
-  // Return CURRENT identity state at this savepoint level — not the outermost
-  // _startTransactionState snapshot. The returned snapshot is captured by
-  // withTransactionReturningStatus's afterRollback hook and passed to
-  // restoreTransactionRecordState. For nested savepoints, the record may have
-  // already been modified (e.g. _newRecord flipped after an outer insert), so
-  // restoring to the outermost state would be wrong.
-  return {
-    newRecord: r._newRecord,
-    destroyed: r._destroyed,
-    frozen: r._attributes.isFrozen(),
-    id: this.id,
-    previouslyNewRecord: r._previouslyNewRecord,
-  };
 }
 
 /**

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -538,9 +538,6 @@ export async function withTransactionReturningStatus<T>(
 ): Promise<T> {
   const modelClass = this.constructor as typeof Base;
 
-  // rememberTransactionRecordState also sets _newRecordBeforeLastCommit.
-  const snapshot = rememberTransactionRecordState.call(this);
-
   // _triggerUpdateCallback/_triggerDestroyCallback are NOT reset here; Rails resets
   // those only in committed!/rolledback! ensure blocks.
   const r = this as any;
@@ -552,14 +549,16 @@ export async function withTransactionReturningStatus<T>(
   const adapter = modelClass.adapter;
   const hadOuterTransaction = currentTransaction() !== null || adapter.inTransaction;
 
-  await transaction(modelClass, async (tx) => {
+  await transaction(modelClass, async () => {
     // Enroll record with the TransactionManager so it fires committedBang/
-    // rolledbackBang after the transaction commits or rolls back.
+    // rolledbackBang after the transaction commits or rolls back. The TM-driven
+    // rolledbackBang path calls _restoreTransactionRecordState which reads the
+    // persistent _startTransactionState snapshot — matching Rails exactly. We
+    // intentionally do NOT register a per-call tx.afterRollback hook here: the
+    // closure would capture per-save state, and on multi-save rollbacks the
+    // last-registered hook would overwrite the correct outermost snapshot.
     await addToTransaction.call(this, !hadOuterTransaction || hasTransactionalCallbacks.call(this));
-
-    tx.afterRollback(async () => {
-      restoreTransactionRecordState.call(this, snapshot);
-    });
+    rememberTransactionRecordState.call(this);
 
     status = await fn();
     // Ruby truthiness: only false/nil trigger rollback (0, "" are truthy in Ruby)


### PR DESCRIPTION
## Summary
- Drop the per-save `tx.afterRollback` closure snapshot in `withTransactionReturningStatus`. The TM-driven `rolledbackBang` path already calls `_restoreTransactionRecordState`, which reads the persistent `_startTransactionState` snapshot (Rails-style, captured once at the outermost save via `||=`).
- Reorder `rememberTransactionRecordState` after `addToTransaction` to match Rails `transactions.rb:413-415`.
- Unskips `transactions.test.ts` "restore previously new record after double save".

## Why
On multiple saves within the same outer transaction, each save's closure-captured snapshot registered its own `afterRollback`. Rollback fired them in registration order, so the last save's `previouslyNewRecord=false` overwrote the correct outermost `previouslyNewRecord=true`. Rails never registers such a per-call hook; the TM path is the single source of restoration.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts`