### PR TITLE
feat(activerecord): align connected_to stack to Rails [self] semantics (batch 112)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -739,14 +739,13 @@ export class AbstractAdapter implements Quoting {
         // affect pools that share its normalized descriptor name (handled
         // below in the name-match branch).
         //
-        // Note: when an abstract subclass without `connectionClass = true`
-        // (e.g. ApplicationRecord set up via `primaryAbstractClass()` only,
-        // never `connectsTo`) calls `connectedTo`, `withRoleAndShard` pushes
-        // `connectionClassForSelf()` which walks up to Base, so klasses will
-        // contain Base and this branch fires globally. That mirrors the
-        // pre-existing convention in `core.ts#matchesStack`. Realistic
-        // primary-class flows call `connectsTo` first (setting
-        // `connectionClass = true`) so the walk stops at the primary class.
+        // `withRoleAndShard`/`connectingTo`/`connectedToMany` push the raw
+        // caller class (`[self]`) onto the stack and let read sites resolve
+        // `connection_class_for_self` — so an `ApplicationRecord` scope set
+        // up without `connectsTo` no longer collapses to Base and leak into
+        // every pool. Realistic primary-class flows call `connectsTo` first
+        // (setting `connectionClass = true`) so reads against Base still
+        // match via the descriptor-name branch below.
         if (Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase")) {
           includesBase = true;
         }

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -156,6 +156,24 @@ describe("ConnectionHandlingTest", () => {
     expect(Base.connectionSpecificationName).toBe("Base");
   });
 
+  it("connection_specification_name returns 'Base' for a primary class even before connectsTo plants it", async () => {
+    const { __resetPrimaryAbstractClass, primaryAbstractClass } = await import("./inheritance.js");
+    class AppRecord extends Base {}
+    try {
+      __resetPrimaryAbstractClass();
+      primaryAbstractClass(AppRecord);
+      // primaryClassQ() is true but _connectionSpecificationName has not been
+      // planted yet (connectsTo not called) — the reader's primary-class
+      // branch should still normalize to "Base".
+      expect(Object.prototype.hasOwnProperty.call(AppRecord, "_connectionSpecificationName")).toBe(
+        false,
+      );
+      expect(AppRecord.connectionSpecificationName).toBe("Base");
+    } finally {
+      __resetPrimaryAbstractClass();
+    }
+  });
+
   it("shard_keys and sharded?", () => {
     expect(Base.shardKeys()).toEqual([]);
     expect(Base.isSharded()).toBe(false);

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -250,7 +250,11 @@ export function connectedToMany<T>(this: typeof Base, ...args: unknown[]): T {
   const { role, shard } = options;
   const preventWrites = role === READING_ROLE || !!options.preventWrites;
 
-  const klasses = new Set(normalized.map((klass) => klass.connectionClassForSelf()));
+  // Mirrors Rails: push the literal classes (`klasses: classes`) rather than
+  // their resolved connection_class_for_self. The caller's CCFS is resolved
+  // at read time in core.ts#matchesStack, so a `connected_to_many` scope
+  // doesn't leak across abstract subclasses that happen to share a CCFS.
+  const klasses = new Set<any>(normalized);
   const entry = { role, shard, preventWrites, klasses };
   appendToConnectedToStack(entry);
 
@@ -313,7 +317,9 @@ export function connectingTo(
     role,
     shard,
     preventWrites,
-    klasses: new Set([this.connectionClassForSelf()]),
+    // Mirrors Rails: push `[self]` (resolution to connection_class_for_self
+    // happens at read time in core.ts#matchesStack).
+    klasses: new Set([this]),
   });
 }
 
@@ -530,12 +536,16 @@ export function withRoleAndShard<T>(
   fn: () => T,
 ): T {
   const resolvedPreventWrites = role === READING_ROLE || preventWrites;
-  const connectionClass = this.connectionClassForSelf();
+  // Mirrors Rails `with_role_and_shard`: push `[self]` raw, and let
+  // core.ts#matchesStack resolve the caller's connection_class_for_self at
+  // read time. Pushing the pre-resolved CCFS would leak a scope opened on
+  // an abstract subclass without `connectsTo` (so CCFS walks up to Base)
+  // into every pool.
   const entry = {
     role,
     shard,
     preventWrites: resolvedPreventWrites,
-    klasses: new Set([connectionClass]),
+    klasses: new Set<any>([this]),
   };
   appendToConnectedToStack(entry);
 

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -333,7 +333,8 @@ export function withIsolatedConnectionState<T>(fn: () => T): T {
 function klassesInclude(klasses: Set<any>, target: any): boolean {
   if (klasses.has(target)) return true;
   for (const k of klasses) {
-    if (typeof k === "function" && k.name === "Base") return true;
+    if (typeof k === "function" && Object.prototype.hasOwnProperty.call(k, "_isActiveRecordBase"))
+      return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

Batch 112 — Connection-pool `[self]` semantics alignment (followup from #1735, closes the primary-abstract-without-`connectsTo` leak documented inline at `abstract-adapter.ts:735`).

- `withRoleAndShard` / `connectingTo` / `connectedToMany` now push the literal caller class (`[self]`) onto `connected_to_stack` instead of its pre-resolved `connection_class_for_self`. The caller's CCFS is resolved at read time in `core.ts#matchesStack`, mirroring Rails (`core.rb:160-201`). An `ApplicationRecord` scope opened without `connectsTo` no longer collapses to `Base` and leaks across every pool.
- `core.ts#klassesInclude` swaps the `k.name === "Base"` string match for the `_isActiveRecordBase` own-property marker — Rails' `klasses.include?(Base)` is identity, not name, and the marker is already the canonical sentinel elsewhere (`abstract-adapter.ts:750`, `inheritance.ts:118`).
- Pinned the `connectionSpecificationName` primary-class branch with a reader test that asserts `"Base"` *before* `connectsTo` plants `_connectionSpecificationName`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-handling.test.ts` (43 passed / 6 pre-existing skips)
- [x] `pnpm vitest run packages/activerecord/src/core.test.ts packages/activerecord/src/connection-adapters/abstract-adapter.test.ts` (118 passed)
- [ ] CI full suite