### PR TITLE
feat(action-dispatch): port Http::ContentDisposition

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/content-disposition.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-disposition.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { ContentDisposition } from "./content-disposition.js";
+
+describe("ContentDispositionTest", () => {
+  it("encoding a Latin filename", () => {
+    const disposition = new ContentDisposition({ disposition: "inline", filename: "racecar.jpg" });
+    expect(disposition.asciiFilename()).toBe('filename="racecar.jpg"');
+    expect(disposition.utf8Filename()).toBe("filename*=UTF-8''racecar.jpg");
+    expect(disposition.toString()).toBe(
+      `inline; ${disposition.asciiFilename()}; ${disposition.utf8Filename()}`,
+    );
+  });
+
+  it("encoding a Latin filename with accented characters", () => {
+    const disposition = new ContentDisposition({ disposition: "inline", filename: "råcëçâr.jpg" });
+    expect(disposition.asciiFilename()).toBe('filename="racecar.jpg"');
+    expect(disposition.utf8Filename()).toBe("filename*=UTF-8''r%C3%A5c%C3%AB%C3%A7%C3%A2r.jpg");
+    expect(disposition.toString()).toBe(
+      `inline; ${disposition.asciiFilename()}; ${disposition.utf8Filename()}`,
+    );
+  });
+
+  it("encoding a non-Latin filename", () => {
+    const disposition = new ContentDisposition({
+      disposition: "inline",
+      filename: "автомобиль.jpg",
+    });
+    expect(disposition.asciiFilename()).toBe('filename="%3F%3F%3F%3F%3F%3F%3F%3F%3F%3F.jpg"');
+    expect(disposition.utf8Filename()).toBe(
+      "filename*=UTF-8''%D0%B0%D0%B2%D1%82%D0%BE%D0%BC%D0%BE%D0%B1%D0%B8%D0%BB%D1%8C.jpg",
+    );
+    expect(disposition.toString()).toBe(
+      `inline; ${disposition.asciiFilename()}; ${disposition.utf8Filename()}`,
+    );
+  });
+
+  it("encoding a filename with permitted chars", () => {
+    const disposition = new ContentDisposition({
+      disposition: "inline",
+      filename: "argh+!#$-123_|&^`~.jpg",
+    });
+    expect(disposition.asciiFilename()).toBe('filename="argh+!#$-123_|%26^`~.jpg"');
+    expect(disposition.utf8Filename()).toBe("filename*=UTF-8''argh+!#$-123_|&^`~.jpg");
+    expect(disposition.toString()).toBe(
+      `inline; ${disposition.asciiFilename()}; ${disposition.utf8Filename()}`,
+    );
+  });
+
+  it("without filename", () => {
+    const disposition = new ContentDisposition({ disposition: "inline", filename: null });
+    expect(disposition.toString()).toBe("inline");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/content-disposition.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-disposition.ts
@@ -1,0 +1,59 @@
+/**
+ * ActionDispatch::Http::ContentDisposition
+ *
+ * Builds Content-Disposition header values per RFC 5987, with an ASCII
+ * fallback for legacy clients. Used by send_file / send_data.
+ */
+
+import { transliterate } from "@blazetrails/activesupport";
+
+const TRADITIONAL_ESCAPED_CHAR = /[^ A-Za-z0-9!#$+.^_`|~-]/g;
+const RFC_5987_ESCAPED_CHAR = /[^A-Za-z0-9!#$&+.^_`|~-]/g;
+
+const utf8Encoder = new TextEncoder();
+
+export interface ContentDispositionOptions {
+  disposition: string;
+  filename: string | null;
+}
+
+export class ContentDisposition {
+  readonly disposition: string;
+  readonly filename: string | null;
+
+  constructor({ disposition, filename }: ContentDispositionOptions) {
+    this.disposition = disposition;
+    this.filename = filename;
+  }
+
+  static format(options: ContentDispositionOptions): string {
+    return new ContentDisposition(options).toString();
+  }
+
+  asciiFilename(): string {
+    const translit = transliterate(this.filename ?? "");
+    return `filename="${percentEscape(translit, TRADITIONAL_ESCAPED_CHAR)}"`;
+  }
+
+  utf8Filename(): string {
+    return `filename*=UTF-8''${percentEscape(this.filename ?? "", RFC_5987_ESCAPED_CHAR)}`;
+  }
+
+  toString(): string {
+    if (this.filename) {
+      return `${this.disposition}; ${this.asciiFilename()}; ${this.utf8Filename()}`;
+    }
+    return this.disposition;
+  }
+}
+
+function percentEscape(str: string, pattern: RegExp): string {
+  return str.replace(pattern, (char) => {
+    const bytes = utf8Encoder.encode(char);
+    let out = "";
+    for (const byte of bytes) {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+    return out;
+  });
+}

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -67,6 +67,7 @@ export {
   type DirectiveName,
 } from "./http/permissions-policy.js";
 export { UploadedFile, type UploadedFileOptions } from "./http/upload.js";
+export { ContentDisposition, type ContentDispositionOptions } from "./http/content-disposition.js";
 export { RequestId, type RequestIdOptions } from "./middleware/request-id.js";
 export {
   BasicAuth,


### PR DESCRIPTION
## Summary

1:1 port of `action_dispatch/http/content_disposition.rb` (Rails). Builds
Content-Disposition header values per RFC 5987 with an ASCII fallback for
legacy clients — used by send_file / send_data flows.

- `ContentDisposition.format({ disposition, filename })` static helper
- `asciiFilename()` / `utf8Filename()` / `toString()` instance methods
- Percent-escapes per the Rails `TRADITIONAL_ESCAPED_CHAR` / `RFC_5987_ESCAPED_CHAR` patterns
- Uses `transliterate` from \`@blazetrails/activesupport\` for the ASCII fallback (replaces non-ASCII chars with \`?\`, matching Rails' \`I18n.transliterate\`)

Closes one of the P3 missing-http-files in \`docs/actionpack-restructure-audit.md\`.

## Test plan

- [x] 5 Rails tests from \`test/dispatch/content_disposition_test.rb\` ported with matching descriptions
- [x] \`pnpm vitest run\` — 5/5 pass
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` clean