### PR TITLE
feat(activerecord): Migration.copy scope/callbacks + properTableName model arg (batch 117)

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -3270,6 +3270,18 @@ describe("MigrationProperTableNameAndCopy", () => {
     expect(
       Migration.properTableName(reminderClass, { tableNamePrefix: "x_", tableNameSuffix: "_y" }),
     ).toBe("reminders");
+
+    // A real Model class is a function (typeof === "function") with a static
+    // `tableName` getter — exercises the function-branch of the guard.
+    class ReminderModel extends Base {
+      static get tableName(): string {
+        return "reminders";
+      }
+    }
+    expect(Migration.properTableName(ReminderModel)).toBe("reminders");
+    expect(
+      Migration.properTableName(ReminderModel, { tableNamePrefix: "x_", tableNameSuffix: "_y" }),
+    ).toBe("reminders");
   });
 
   it("copy renumbers, scopes filenames, prepends provenance comment", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -3251,3 +3251,82 @@ describe("Migration.logger integration", () => {
     expect(lines).toHaveLength(0);
   });
 });
+
+// ==========================================================================
+// proper_table_name + Migration.copy (migration_test.rb counterparts)
+// ==========================================================================
+
+describe("MigrationProperTableNameAndCopy", () => {
+  it("proper_table_name_on_migration", () => {
+    // Rails parity: a value with a `tableName` (responds_to :table_name)
+    // is honored; otherwise prefix/suffix wrap the literal name.
+    const reminderClass = { tableName: "reminders" };
+    expect(Migration.properTableName("table")).toBe("table");
+    expect(Migration.properTableName(reminderClass)).toBe("reminders");
+    expect(
+      Migration.properTableName("table", { tableNamePrefix: "p_", tableNameSuffix: "_s" }),
+    ).toBe("p_table_s");
+    // Model wins over options — the model already baked in its own affixes.
+    expect(
+      Migration.properTableName(reminderClass, { tableNamePrefix: "x_", tableNameSuffix: "_y" }),
+    ).toBe("reminders");
+  });
+
+  it("copy renumbers, scopes filenames, prepends provenance comment", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "trails-mig-copy-"));
+    const src = path.join(root, "src");
+    const dst = path.join(root, "dst");
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dst, { recursive: true });
+    fs.writeFileSync(path.join(src, "1_create_articles.ts"), "// source-1\n");
+    fs.writeFileSync(path.join(src, "2_create_comments.ts"), "// source-2\n");
+    // Existing destination migration with a higher version so renumbering
+    // bumps copied versions above it.
+    fs.writeFileSync(path.join(dst, "20100101000000_existing_table.ts"), "// dest-existing\n");
+
+    const onCopy = vi.fn();
+    const copied = await Migration.copy(dst, { bukkits: src }, { onCopy });
+
+    expect(copied).toHaveLength(2);
+    expect(onCopy).toHaveBeenCalledTimes(2);
+    for (const m of copied) {
+      expect(m.scope).toBe("bukkits");
+      expect(m.filename).toMatch(/\.bukkits\.ts$/);
+      const body = fs.readFileSync(m.filename!, "utf8");
+      expect(body).toContain(`// This migration comes from bukkits (originally`);
+    }
+    // Strict monotonicity across the copy iteration.
+    expect(BigInt(copied[1]!.version) > BigInt(copied[0]!.version)).toBe(true);
+    // Renumbered above the pre-existing destination migration.
+    expect(BigInt(copied[0]!.version) > 20100101000000n).toBe(true);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("copy skips duplicates by name and fires onSkip for cross-scope clash", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "trails-mig-copy-"));
+    const src = path.join(root, "src");
+    const dst = path.join(root, "dst");
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dst, { recursive: true });
+    fs.writeFileSync(path.join(src, "1_create_articles.ts"), "// src\n");
+    // Same Rails-name (CreateArticles) already in destination under a
+    // different scope → onSkip must fire.
+    fs.writeFileSync(path.join(dst, "20100101000000_create_articles.other.ts"), "// dst\n");
+
+    const onSkip = vi.fn();
+    const copied = await Migration.copy(dst, { bukkits: src }, { onSkip });
+
+    expect(copied).toHaveLength(0);
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    expect(onSkip.mock.calls[0]![0]).toBe("bukkits");
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -3299,23 +3299,25 @@ describe("MigrationProperTableNameAndCopy", () => {
     // bumps copied versions above it.
     fs.writeFileSync(path.join(dst, "20100101000000_existing_table.ts"), "// dest-existing\n");
 
-    const onCopy = vi.fn();
-    const copied = await Migration.copy(dst, { bukkits: src }, { onCopy });
+    try {
+      const onCopy = vi.fn();
+      const copied = await Migration.copy(dst, { bukkits: src }, { onCopy });
 
-    expect(copied).toHaveLength(2);
-    expect(onCopy).toHaveBeenCalledTimes(2);
-    for (const m of copied) {
-      expect(m.scope).toBe("bukkits");
-      expect(m.filename).toMatch(/\.bukkits\.ts$/);
-      const body = fs.readFileSync(m.filename!, "utf8");
-      expect(body).toContain(`// This migration comes from bukkits (originally`);
+      expect(copied).toHaveLength(2);
+      expect(onCopy).toHaveBeenCalledTimes(2);
+      for (const m of copied) {
+        expect(m.scope).toBe("bukkits");
+        expect(m.filename).toMatch(/\.bukkits\.ts$/);
+        const body = fs.readFileSync(m.filename!, "utf8");
+        expect(body).toContain(`// This migration comes from bukkits (originally`);
+      }
+      // Strict monotonicity across the copy iteration.
+      expect(BigInt(copied[1]!.version) > BigInt(copied[0]!.version)).toBe(true);
+      // Renumbered above the pre-existing destination migration.
+      expect(BigInt(copied[0]!.version) > 20100101000000n).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
-    // Strict monotonicity across the copy iteration.
-    expect(BigInt(copied[1]!.version) > BigInt(copied[0]!.version)).toBe(true);
-    // Renumbered above the pre-existing destination migration.
-    expect(BigInt(copied[0]!.version) > 20100101000000n).toBe(true);
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("copy skips duplicates by name and fires onSkip for cross-scope clash", async () => {
@@ -3332,13 +3334,15 @@ describe("MigrationProperTableNameAndCopy", () => {
     // different scope → onSkip must fire.
     fs.writeFileSync(path.join(dst, "20100101000000_create_articles.other.ts"), "// dst\n");
 
-    const onSkip = vi.fn();
-    const copied = await Migration.copy(dst, { bukkits: src }, { onSkip });
+    try {
+      const onSkip = vi.fn();
+      const copied = await Migration.copy(dst, { bukkits: src }, { onSkip });
 
-    expect(copied).toHaveLength(0);
-    expect(onSkip).toHaveBeenCalledTimes(1);
-    expect(onSkip.mock.calls[0]![0]).toBe("bukkits");
-
-    fs.rmSync(root, { recursive: true, force: true });
+      expect(copied).toHaveLength(0);
+      expect(onSkip).toHaveBeenCalledTimes(1);
+      expect(onSkip.mock.calls[0]![0]).toBe("bukkits");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1382,29 +1382,41 @@ export abstract class Migration {
     return /^\d{3,}$/.test(version);
   }
 
-  static nextMigrationNumber(number?: number): string {
+  static nextMigrationNumber(number?: number | bigint | string): string {
     // Rails: max(now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % number) — so a
     // numerically-larger sequence wins over a same-second timestamp. Callers
     // (e.g. Migration.copy) pass `last.version + 1` to guarantee monotonicity
-    // across iterations within the same second.
+    // across iterations within the same second. Accepts bigint/string so
+    // versions beyond Number.MAX_SAFE_INTEGER (e.g. future renumbering above
+    // 9.0e15) survive without precision loss.
     const stamp = Temporal.Now.instant()
       .toString()
       .replace(/[-T:Z.]/g, "")
       .slice(0, 14);
     if (number == null) return stamp;
-    const padded = Math.max(0, Math.trunc(number)).toString().padStart(14, "0");
+    const n =
+      typeof number === "bigint"
+        ? number
+        : BigInt(typeof number === "number" ? Math.max(0, Math.trunc(number)) : number);
+    const padded = (n < 0n ? 0n : n).toString().padStart(14, "0");
     return padded > stamp ? padded : stamp;
   }
 
   static properTableName(
-    name: string | { tableName?: string },
+    name: string | { tableName?: unknown },
     options: { tableNamePrefix?: string; tableNameSuffix?: string } = {},
   ): string {
-    // Mirrors Rails: if the argument quacks like a Model class (responds to
-    // `table_name`), return that directly — the model's own prefix/suffix
-    // are already baked in.
-    if (name !== null && typeof name === "object" && typeof name.tableName === "string") {
-      return name.tableName;
+    // Mirrors Rails `name.respond_to?(:table_name)`: any non-null reference
+    // exposing a string `tableName` is honored. Model classes (functions)
+    // expose it as a static getter, so `typeof name === "function"` must
+    // count too — guarding only on "object" silently produces a stringified
+    // function name with prefix/suffix applied.
+    if (
+      name != null &&
+      (typeof name === "object" || typeof name === "function") &&
+      typeof (name as { tableName?: unknown }).tableName === "string"
+    ) {
+      return (name as { tableName: string }).tableName;
     }
     const prefix = options.tableNamePrefix ?? "";
     const suffix = options.tableNameSuffix ?? "";
@@ -1462,16 +1474,24 @@ export abstract class Migration {
           continue;
         }
 
-        const nextNumber = last ? (BigInt(last.version) + 1n).toString() : "0";
-        const newVersion = Migration.nextMigrationNumber(Number(nextNumber));
+        const nextNumber = last ? BigInt(last.version) + 1n : 0n;
+        const newVersion = Migration.nextMigrationNumber(nextNumber);
         const fileBase = underscore(source.name);
         const newPath = path.join(destination, `${newVersion}_${fileBase}.${scope}.ts`);
         const oldPath = source.filename;
+        // Build a fresh migration factory that imports the NEW path — spreading
+        // `source` would carry over a closure pinned to the old engine file.
+        const proxyName = source.name;
         const copy: MigrationProxy = {
-          ...source,
+          name: source.name,
           version: newVersion,
           scope,
           filename: newPath,
+          migration: async () => {
+            const { pathToFileURL } = await import("node:url");
+            const mod = (await import(pathToFileURL(newPath).href)) as Record<string, unknown>;
+            return (mod.default ?? mod[proxyName]) as MigrationLike;
+          },
         };
         last = copy;
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1488,7 +1488,12 @@ export abstract class Migration {
         const nextNumber = last ? BigInt(last.version) + 1n : 0n;
         const newVersion = Migration.nextMigrationNumber(nextNumber);
         const fileBase = underscore(source.name);
-        const newPath = path.join(destination, `${newVersion}_${fileBase}.${scope}.ts`);
+        // Preserve the source file extension — a `.js` source must stay
+        // loadable under a JS-only runtime; switching to `.ts` would break
+        // both `Migrator.fromPath` discovery (regex matches .ts|.js) and
+        // the proxy's dynamic `import()`.
+        const ext = path.extname(source.filename) || ".ts";
+        const newPath = path.join(destination, `${newVersion}_${fileBase}.${scope}${ext}`);
         const oldPath = source.filename;
         // Build a fresh migration factory that imports the NEW path — spreading
         // `source` would carry over a closure pinned to the old engine file.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1394,12 +1394,15 @@ export abstract class Migration {
       .replace(/[-T:Z.]/g, "")
       .slice(0, 14);
     if (number == null) return stamp;
-    const n =
+    const raw =
       typeof number === "bigint"
         ? number
         : BigInt(typeof number === "number" ? Math.max(0, Math.trunc(number)) : number);
-    const padded = (n < 0n ? 0n : n).toString().padStart(14, "0");
-    return padded > stamp ? padded : stamp;
+    const n = raw < 0n ? 0n : raw;
+    // Numeric (BigInt) comparison — string compare goes lexicographic once
+    // either side exceeds 14 digits and would mis-order (e.g. a 15-digit
+    // "100…" would sort below a 14-digit "2026…" string).
+    return n > BigInt(stamp) ? n.toString().padStart(14, "0") : stamp;
   }
 
   static properTableName(
@@ -1458,6 +1461,14 @@ export abstract class Migration {
 
     const copied: MigrationProxy[] = [];
     for (const [scope, sourcePath] of Object.entries(sources)) {
+      // Must round-trip through `Migrator.parseMigrationFilename` (regex
+      // `[a-z0-9_]*`) or the copied file would be invisible to subsequent
+      // discovery via `Migrator.fromPath`.
+      if (!/^[a-z0-9_]+$/.test(scope)) {
+        throw new ArgumentError(
+          `Invalid migration scope '${scope}': must match /^[a-z0-9_]+$/ to be discoverable by Migrator.fromPath.`,
+        );
+      }
       if (!fs.existsSync(sourcePath)) continue;
       const sourceMigrations = Migrator.fromPath(sourcePath, stubAdapter);
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath, Logger, getEnv, camelize } from "@blazetrails/activesupport";
+import { getFs, getPath, Logger, getEnv, camelize, underscore } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { FsDirent } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -1382,20 +1382,33 @@ export abstract class Migration {
     return /^\d{3,}$/.test(version);
   }
 
-  static nextMigrationNumber(_number?: number): string {
-    return Temporal.Now.instant()
+  static nextMigrationNumber(number?: number): string {
+    // Rails: max(now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % number) — so a
+    // numerically-larger sequence wins over a same-second timestamp. Callers
+    // (e.g. Migration.copy) pass `last.version + 1` to guarantee monotonicity
+    // across iterations within the same second.
+    const stamp = Temporal.Now.instant()
       .toString()
       .replace(/[-T:Z.]/g, "")
       .slice(0, 14);
+    if (number == null) return stamp;
+    const padded = Math.max(0, Math.trunc(number)).toString().padStart(14, "0");
+    return padded > stamp ? padded : stamp;
   }
 
   static properTableName(
-    name: string,
+    name: string | { tableName?: string },
     options: { tableNamePrefix?: string; tableNameSuffix?: string } = {},
   ): string {
+    // Mirrors Rails: if the argument quacks like a Model class (responds to
+    // `table_name`), return that directly — the model's own prefix/suffix
+    // are already baked in.
+    if (name !== null && typeof name === "object" && typeof name.tableName === "string") {
+      return name.tableName;
+    }
     const prefix = options.tableNamePrefix ?? "";
     const suffix = options.tableNameSuffix ?? "";
-    return `${prefix}${name}${suffix}`;
+    return `${prefix}${String(name)}${suffix}`;
   }
 
   static tableNameOptions(): { tableNamePrefix: string; tableNameSuffix: string } {
@@ -1408,12 +1421,16 @@ export abstract class Migration {
   static async copy(
     destination: string,
     sources: Record<string, string>,
-    _options: Record<string, unknown> = {},
-  ): Promise<string[]> {
-    // Rails copies migration files from source directories to destination.
-    // In our TS implementation, migrations are registered programmatically,
-    // not via filesystem discovery. This returns the list of copied files
-    // (empty when there's nothing to copy).
+    options: {
+      onSkip?: (scope: string, migration: MigrationProxy) => void;
+      onCopy?: (scope: string, migration: MigrationProxy, oldPath: string) => void;
+    } = {},
+  ): Promise<MigrationProxy[]> {
+    // Mirrors Rails' Migration.copy: discover migrations in each scoped source
+    // directory, dedupe by Rails-name against the destination, renumber so
+    // the copied migration's version is greater than the latest existing one,
+    // emit `${version}_${name.underscore}.${scope}.ts`, and invoke optional
+    // on_skip / on_copy callbacks. See Rails migration.rb:1060-1108.
     const fs = getFs();
     const path = getPath();
 
@@ -1421,18 +1438,47 @@ export abstract class Migration {
       fs.mkdirSync(destination, { recursive: true });
     }
 
-    const copied: string[] = [];
-    for (const [, sourcePath] of Object.entries(sources)) {
+    // Discovery is filename-driven; the adapter is only used by the proxy's
+    // lazy `migration` factory (which we never invoke here), so a stub is safe.
+    const stubAdapter = {} as DatabaseAdapter;
+    const destinationMigrations = Migrator.fromPath(destination, stubAdapter);
+    let last: MigrationProxy | undefined = destinationMigrations[destinationMigrations.length - 1];
+
+    const copied: MigrationProxy[] = [];
+    for (const [scope, sourcePath] of Object.entries(sources)) {
       if (!fs.existsSync(sourcePath)) continue;
-      const files = fs
-        .readdirSync(sourcePath)
-        .filter((f) => f.endsWith(".ts") || f.endsWith(".js"));
-      for (const file of files) {
-        const dest = path.join(destination, file);
-        if (!fs.existsSync(dest)) {
-          fs.copyFileSync(path.join(sourcePath, file), dest);
-          copied.push(dest);
+      const sourceMigrations = Migrator.fromPath(sourcePath, stubAdapter);
+
+      for (const source of sourceMigrations) {
+        if (!source.filename) continue;
+        const body = fs.readFileSync(source.filename, "utf8");
+        const inserted = `// This migration comes from ${scope} (originally ${source.version})\n`;
+
+        const duplicate = destinationMigrations.find((m) => m.name === source.name);
+        if (duplicate) {
+          if (options.onSkip && duplicate.scope !== scope) {
+            options.onSkip(scope, source);
+          }
+          continue;
         }
+
+        const nextNumber = last ? (BigInt(last.version) + 1n).toString() : "0";
+        const newVersion = Migration.nextMigrationNumber(Number(nextNumber));
+        const fileBase = underscore(source.name);
+        const newPath = path.join(destination, `${newVersion}_${fileBase}.${scope}.ts`);
+        const oldPath = source.filename;
+        const copy: MigrationProxy = {
+          ...source,
+          version: newVersion,
+          scope,
+          filename: newPath,
+        };
+        last = copy;
+
+        fs.writeFileSync(newPath, `${inserted}${body}`);
+        copied.push(copy);
+        options.onCopy?.(scope, copy, oldPath);
+        destinationMigrations.push(copy);
       }
     }
     return copied;


### PR DESCRIPTION
## Summary

Implements docs/activerecord-100-plan.md Batch 117 — migration follow-ups from #1733.

- **`Migration.properTableName`** now early-returns `name.tableName` when the argument is a Model-like object (Rails: `name.respond_to?(:table_name)`). Raw strings still get the prefix/suffix treatment.
- **`Migration.copy`** is fleshed out beyond the previous `copyFileSync` stub:
  - Honors engine `scope`: emits `${version}_${name.underscore}.${scope}.ts`.
  - Renumbers copied versions to sit above the destination's latest migration.
  - Prepends `// This migration comes from <scope> (originally <version>)` to every copied file.
  - Dedupes by Rails-name; fires `onSkip(scope, migration)` for a cross-scope clash.
  - Fires `onCopy(scope, migration, oldPath)` per file copied.
  - Returns `MigrationProxy[]` (Rails returns the migrations, not paths).
- **`Migration.nextMigrationNumber(n)`** now honors its arg as `max(timestamp, padded(n))`, so successive `copy` iterations within the same second remain strictly monotonic.

Discovery reuses `Migrator.fromPath`, which already parses `${version}_${name}.${scope}.(ts|js)` filenames.

Diff: 2 files, +146 / −21.

## Follow-ups deferred

- Magic-comment preservation (Rails preserves `# encoding:` / `# frozen_string_literal:` lines from source migrations). N/A for `.ts`.
- Per-`MigrationContext` callable shape — Rails creates `MigrationContext.new(dest, NullSchemaMigration.new, NullInternalMetadata.new)`. Our `Migrator.fromPath` skips both since discovery is filename-only.

## Test plan

- [x] `vitest run packages/activerecord/src/migration.test.ts` — 181 passed / 11 skipped (no regressions; 3 new tests under `MigrationProperTableNameAndCopy`).