### PR TITLE
feat(activerecord): polymorphic-through composite owner PK guard (batch 118)

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -3377,16 +3377,109 @@ describe("AssociationsTest", () => {
     // composite target PK surfaces as a ConfigurationError at construction.
     expect(() => association(doc, "patients")).toThrow(ConfigurationError);
   });
-  it.skip("polymorphic-through with composite owner primary key", async () => {
-    // BLOCKED: associations — polymorphic-through uses a single
-    // `<as>_id`/`<as>_type` schema pair, so the join row can only carry a
-    // *scalar* owner identifier. When the owner has a composite primary key,
-    // `_throughOwnerPolymorphic` collapses to "id" (when present) or the
-    // first PK column, but there is no Rails-side schema convention for
-    // splitting a composite owner across the polymorphic columns. Needs an
-    // explicit `primaryKey:` option (single column) on the polymorphic-through
-    // association, plus validation that rejects a composite `primaryKey:`
-    // here. Tracked under Batch 27 HMT composite follow-ups.
+  it("polymorphic-through with composite owner primary key requires explicit single-column primaryKey", async () => {
+    // The polymorphic join schema (`<as>_id`/`<as>_type`) only carries a
+    // *scalar* owner identifier — composite owner PKs cannot be split across
+    // the two polymorphic columns. `_throughOwnerPolymorphic` now requires an
+    // explicit single-column `primaryKey:` option on the polymorphic-through
+    // when the owner has a composite PK, and rejects an array `primaryKey:`.
+    const adapter = freshAdapter();
+    const makeOwner = (
+      suffix: string,
+    ): {
+      Owner: typeof Base;
+      Tag: typeof Base;
+      Article: typeof Base;
+    } => {
+      const ownerName = `CpkPolyOwner${suffix}`;
+      const tagName = `CpkPolyTag${suffix}`;
+      const articleName = `CpkPolyArticle${suffix}`;
+      const Owner = class extends Base {
+        static {
+          this._tableName = `cpk_poly_owners_${suffix.toLowerCase()}`;
+          this.attribute("region_id", "integer");
+          this.attribute("id", "integer");
+          this.attribute("name", "string");
+          this.primaryKey = ["region_id", "id"];
+          this.adapter = adapter;
+        }
+      };
+      Object.defineProperty(Owner, "name", { value: ownerName });
+      const Tag = class extends Base {
+        static {
+          this._tableName = `cpk_poly_tags_${suffix.toLowerCase()}`;
+          this.attribute("id", "integer");
+          this.attribute("taggable_id", "integer");
+          this.attribute("taggable_type", "string");
+          this.attribute("article_id", "integer");
+          this.adapter = adapter;
+        }
+      };
+      Object.defineProperty(Tag, "name", { value: tagName });
+      const Article = class extends Base {
+        static {
+          this._tableName = `cpk_poly_articles_${suffix.toLowerCase()}`;
+          this.attribute("id", "integer");
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
+      };
+      Object.defineProperty(Article, "name", { value: articleName });
+      registerModel(ownerName, Owner);
+      registerModel(tagName, Tag);
+      registerModel(articleName, Article);
+      return { Owner, Tag, Article };
+    };
+
+    // No `primaryKey:` on the polymorphic through + composite owner PK ⇒ rejected.
+    {
+      const { Owner, Tag } = makeOwner("A");
+      Associations.hasMany.call(Owner, "tags", { className: Tag.name, as: "taggable" });
+      Associations.belongsTo.call(Tag, "article", { className: "CpkPolyArticleA" });
+      Associations.hasMany.call(Owner, "articles", {
+        through: "tags",
+        className: "CpkPolyArticleA",
+        source: "article",
+      });
+      const owner = await Owner.create({ region_id: 1, id: 5, name: "O" });
+      expect(() => association(owner, "articles")).toThrow(ConfigurationError);
+    }
+
+    // Composite `primaryKey:` on the polymorphic through ⇒ still rejected.
+    {
+      const { Owner, Tag } = makeOwner("B");
+      Associations.hasMany.call(Owner, "tags", {
+        className: Tag.name,
+        as: "taggable",
+        primaryKey: ["region_id", "id"],
+      });
+      Associations.belongsTo.call(Tag, "article", { className: "CpkPolyArticleB" });
+      Associations.hasMany.call(Owner, "articles", {
+        through: "tags",
+        className: "CpkPolyArticleB",
+        source: "article",
+      });
+      const owner = await Owner.create({ region_id: 1, id: 6, name: "O" });
+      expect(() => association(owner, "articles")).toThrow(ConfigurationError);
+    }
+
+    // Explicit single-column `primaryKey:` on the polymorphic through unblocks it.
+    {
+      const { Owner, Tag } = makeOwner("C");
+      Associations.hasMany.call(Owner, "tags", {
+        className: Tag.name,
+        as: "taggable",
+        primaryKey: "id",
+      });
+      Associations.belongsTo.call(Tag, "article", { className: "CpkPolyArticleC" });
+      Associations.hasMany.call(Owner, "articles", {
+        through: "tags",
+        className: "CpkPolyArticleC",
+        source: "article",
+      });
+      const owner = await Owner.create({ region_id: 1, id: 7, name: "O" });
+      expect(() => association(owner, "articles")).not.toThrow();
+    }
   });
   it("belongs to with explicit composite foreign key", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1193,12 +1193,26 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       );
     }
     const idCol = polyFk;
-    const ownerPk = throughAssoc.options.primaryKey ?? ctor.primaryKey;
-    const polyPk = Array.isArray(ownerPk)
-      ? ownerPk.includes("id")
-        ? "id"
-        : ownerPk[0]
-      : (ownerPk as string);
+    // The polymorphic schema (`<as>_id`/`<as>_type`) only carries a scalar
+    // owner identifier. Composite owner primary keys are unrepresentable —
+    // require an explicit single-column `primaryKey:` on the association so
+    // the choice of identifier is deliberate rather than silently collapsed.
+    const ownerPkOption = throughAssoc.options.primaryKey;
+    if (Array.isArray(ownerPkOption)) {
+      throw new ConfigurationError(
+        `Polymorphic-through "${this._assocName}" cannot use a composite primary key — ` +
+          `the schema only supports a single \`${underscore(asName)}_id\`/\`${underscore(asName)}_type\` pair. ` +
+          `Set \`primaryKey:\` to a single column on the association.`,
+      );
+    }
+    if (ownerPkOption === undefined && Array.isArray(ctor.primaryKey)) {
+      throw new ConfigurationError(
+        `Polymorphic-through "${this._assocName}" requires an explicit single-column ` +
+          `\`primaryKey:\` option because owner "${ctor.name}" has a composite primary key. ` +
+          `The polymorphic schema only stores a single \`${underscore(asName)}_id\` value.`,
+      );
+    }
+    const polyPk = (ownerPkOption ?? (ctor.primaryKey as string)) as string;
     return {
       idCol,
       idValue: this._record._readAttribute(polyPk),

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1194,9 +1194,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
     const idCol = polyFk;
     // The polymorphic schema (`<as>_id`/`<as>_type`) only carries a scalar
-    // owner identifier. Composite owner primary keys are unrepresentable —
-    // require an explicit single-column `primaryKey:` on the association so
-    // the choice of identifier is deliberate rather than silently collapsed.
+    // owner identifier. Rails' `Reflection#active_record_primary_key`
+    // (reflection.rb:587-604) freely returns a composite-PK array here, and
+    // `check_validity!` (reflection.rb:621) explicitly *skips* the
+    // composite-PK arity check for polymorphic associations — `join_id_for`
+    // (reflection.rb:642-644) then writes an array of values into the
+    // single `<as>_id` column, producing a silently-broken IN-shaped WHERE.
+    // Trails surfaces the misconfiguration as `ConfigurationError` instead:
+    // reject a composite `primaryKey:` outright, and require an explicit
+    // single-column `primaryKey:` when the owner has a composite PK so the
+    // chosen scalar identifier is deliberate, not silently collapsed.
     const ownerPkOption = throughAssoc.options.primaryKey;
     if (Array.isArray(ownerPkOption)) {
       throw new ConfigurationError(


### PR DESCRIPTION
## Summary

Batch 118 from `docs/activerecord-100-plan.md` — followup from #1732.

`_throughOwnerPolymorphic` now rejects composite owner primary keys with `ConfigurationError` rather than silently collapsing them. The polymorphic join schema (`<as>_id`/`<as>_type`) only stores a scalar owner identifier, so when the owner has a composite PK an explicit single-column `primaryKey:` option on the polymorphic-through is required; an array `primaryKey:` is also rejected.

Flips the `it.skip("polymorphic-through with composite owner primary key")` documented in #1732 into a real assertion covering three branches (missing option, composite option, single-column option).

## Follow-ups (Batch 118 remainder, deferred)

- `_throughOwnerCols` `options.queryConstraints` FK branch (collection-proxy.ts ~1080): likely dead post the `Reflection` constructor rewrite of `queryConstraints:`. Either delete or add a fixture exercising it.
- `has-one-through-association.ts` composite-PK/FK throw sweep: no matching `throw new Error(...)` sites found there; plain `throw new Error` calls in `through-association.ts` are non-composite (read-only / nested-through). No-op.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/has-many-through.test.ts packages/activerecord/src/associations/has-many-through-associations.test.ts` — 556 passed, 12 skipped
- [x] `pnpm lint` clean