### PR TITLE
feat(actionpack): port abstract_controller/helpers.rb runtime surface (PR A)

### DIFF
--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  _helpersForModification,
+  _helpersInstance,
+  applyHelpers,
+  clearHelpers,
+  helper,
+  helperMethod,
+  type HelperMethodsModule,
+  type HelpersClassMethods,
+  type HelpersHost,
+} from "./helpers.js";
+
+function makeBase(): HelpersClassMethods & { name: string } {
+  return { name: "Base" } as HelpersClassMethods & { name: string };
+}
+
+describe("applyHelpers", () => {
+  it("is a no-op so subclasses inherit the parent's _helpers via prototype", () => {
+    class Parent {
+      static _helpers: HelperMethodsModule = { hi: () => "hi" };
+      static _helperMethods = ["hi"];
+    }
+    class Child extends Parent {}
+    applyHelpers(Child as unknown as new (...a: never[]) => unknown);
+    expect(Object.prototype.hasOwnProperty.call(Child, "_helpers")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Child, "_helperMethods")).toBe(false);
+    expect(Child._helpers.hi).toBe(Parent._helpers.hi);
+    expect(Child._helperMethods).toEqual(["hi"]);
+  });
+});
+
+describe("helperMethod", () => {
+  it("registers a proxy that forwards to controller[name]", () => {
+    const cls = makeBase();
+    helperMethod(cls, "currentUser", "loggedIn");
+    expect(cls._helperMethods).toEqual(["currentUser", "loggedIn"]);
+
+    const controller = {
+      currentUser: () => ({ id: 1 }),
+      loggedIn: () => true,
+    };
+    const proxy = { controller };
+    expect(cls._helpers!.currentUser.call(proxy)).toEqual({ id: 1 });
+    expect(cls._helpers!.loggedIn.call(proxy)).toBe(true);
+  });
+
+  it("throws when controller does not respond to the named method", () => {
+    const cls = makeBase();
+    helperMethod(cls, "missing");
+    expect(() => cls._helpers!.missing.call({ controller: {} })).toThrow(
+      /does not respond to 'missing'/,
+    );
+  });
+
+  it("copy-on-write: subclass writes don't pollute the parent", () => {
+    const parent = makeBase();
+    helperMethod(parent, "fromParent");
+
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+    helperMethod(child, "fromChild");
+
+    expect(Object.keys(child._helpers!)).toEqual(["fromParent", "fromChild"]);
+    expect(Object.keys(parent._helpers!)).toEqual(["fromParent"]);
+    expect(parent._helperMethods).toEqual(["fromParent"]);
+    expect(child._helperMethods).toEqual(["fromParent", "fromChild"]);
+  });
+});
+
+describe("helper", () => {
+  it("includes a module's methods into _helpers", () => {
+    const cls = makeBase();
+    const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
+    helper(cls, FooHelper);
+    expect(cls._helpers!.foo.call({})).toBe("FOO");
+  });
+
+  it("is idempotent when the same module is included twice", () => {
+    const cls = makeBase();
+    const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
+    helper(cls, FooHelper);
+    const fooBefore = cls._helpers!.foo;
+    helper(cls, FooHelper);
+    expect(cls._helpers!.foo).toBe(fooBefore);
+    expect(Object.keys(cls._helpers!)).toEqual(["foo"]);
+  });
+
+  it("evaluates a trailing block against the helpers module (Rails `helper do ... end`)", () => {
+    const cls = makeBase();
+    helper(cls, (mod: HelperMethodsModule) => {
+      mod.wadus = () => "wadus";
+    });
+    expect(cls._helpers!.wadus.call({})).toBe("wadus");
+  });
+
+  it("accepts modules and a block mixed together", () => {
+    const cls = makeBase();
+    const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
+    helper(cls, FooHelper, (mod: HelperMethodsModule) => {
+      mod.bar = () => "BAR";
+    });
+    expect(cls._helpers!.foo.call({})).toBe("FOO");
+    expect(cls._helpers!.bar.call({})).toBe("BAR");
+  });
+});
+
+describe("clearHelpers", () => {
+  it("wipes _helpers + _helperMethods, then re-adds the previous helper_method proxies", () => {
+    const cls = makeBase();
+    const ExtraHelper: HelperMethodsModule = { extra: () => "EXTRA" };
+    helperMethod(cls, "keep");
+    helper(cls, ExtraHelper);
+    expect(Object.keys(cls._helpers!).sort()).toEqual(["extra", "keep"]);
+
+    clearHelpers(cls);
+
+    // helper_method names survive; included modules do not.
+    expect(cls._helperMethods).toEqual(["keep"]);
+    expect(Object.keys(cls._helpers!)).toEqual(["keep"]);
+    expect(typeof cls._helpers!.keep).toBe("function");
+  });
+});
+
+describe("_helpersInstance", () => {
+  it("returns this.class._helpers", () => {
+    const cls = makeBase();
+    helperMethod(cls, "x");
+    const host = { constructor: cls } as unknown as HelpersHost;
+    expect(_helpersInstance.call(host)).toBe(cls._helpers);
+  });
+
+  it("falls back to an empty module when no _helpers is set", () => {
+    const cls = makeBase();
+    const host = { constructor: cls } as unknown as HelpersHost;
+    expect(_helpersInstance.call(host)).toEqual({});
+  });
+});
+
+describe("_helpersForModification", () => {
+  it("returns the own module when present, else clones the inherited one", () => {
+    const parent = makeBase();
+    helperMethod(parent, "fromParent");
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+
+    const mod = _helpersForModification(child);
+    expect(Object.prototype.hasOwnProperty.call(child, "_helpers")).toBe(true);
+    expect(mod).not.toBe(parent._helpers);
+    expect(Object.keys(mod)).toEqual(["fromParent"]);
+
+    expect(_helpersForModification(child)).toBe(mod);
+  });
+});

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -107,6 +107,18 @@ describe("helper", () => {
     expect(Object.keys(cls._helpers!)).toEqual(["foo"]);
   });
 
+  it("a duplicate-include no-op does NOT fork the subclass helpers module", () => {
+    const parent = makeBase();
+    const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
+    helper(parent, FooHelper);
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+
+    helper(child, FooHelper);
+
+    expect(Object.prototype.hasOwnProperty.call(child, "_helpers")).toBe(false);
+    expect(child._helpers).toBe(parent._helpers);
+  });
+
   it("evaluates a trailing block against the helpers module (Rails `helper do ... end`)", () => {
     const cls = makeBase();
     helper(cls, (mod: HelperMethodsModule) => {

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -102,9 +102,12 @@ describe("helper", () => {
     const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
     helper(cls, FooHelper);
     const fooBefore = cls._helpers!.foo;
+    const headProtoBefore = Object.getPrototypeOf(cls._helpers!);
     helper(cls, FooHelper);
+    // Re-include is a no-op: the lookup still resolves to the same fn,
+    // and no new proto link was spliced in.
     expect(cls._helpers!.foo).toBe(fooBefore);
-    expect(Object.keys(cls._helpers!)).toEqual(["foo"]);
+    expect(Object.getPrototypeOf(cls._helpers!)).toBe(headProtoBefore);
   });
 
   it("a duplicate-include no-op does NOT fork the subclass helpers module", () => {
@@ -137,6 +140,28 @@ describe("helper", () => {
       mod.wadus = () => "wadus";
     });
     expect(cls._helpers!.wadus.call({})).toBe("wadus");
+  });
+
+  it("direct-method precedence: helperMethod beats a later helper(Mod) with the same name", () => {
+    const cls = makeBase();
+    helperMethod(cls, "x");
+    const Override: HelperMethodsModule = { x: () => "from-module" };
+    helper(cls, Override);
+    // Definition on the helpers module itself stays on top of the chain.
+    expect(typeof cls._helpers!.x).toBe("function");
+    // The proxy installed by helperMethod throws when controller lacks x,
+    // proving the helperMethod proxy is what runs (not Override.x).
+    expect(() => cls._helpers!.x.call({ controller: {} })).toThrow(/does not respond to 'x'/);
+  });
+
+  it("multiple includes layer in the ancestor chain (both reachable)", () => {
+    const cls = makeBase();
+    const A: HelperMethodsModule = { fromA: () => "A" };
+    const B: HelperMethodsModule = { fromB: () => "B" };
+    helper(cls, A);
+    helper(cls, B);
+    expect(cls._helpers!.fromA.call({})).toBe("A");
+    expect(cls._helpers!.fromB.call({})).toBe("B");
   });
 
   it("accepts modules and a block mixed together", () => {
@@ -175,7 +200,8 @@ describe("clearHelpers", () => {
     const ExtraHelper: HelperMethodsModule = { extra: () => "EXTRA" };
     helperMethod(cls, "keep");
     helper(cls, ExtraHelper);
-    expect(Object.keys(cls._helpers!).sort()).toEqual(["extra", "keep"]);
+    expect(typeof cls._helpers!.keep).toBe("function");
+    expect(typeof cls._helpers!.extra).toBe("function");
 
     clearHelpers(cls);
 
@@ -183,6 +209,7 @@ describe("clearHelpers", () => {
     expect(cls._helperMethods).toEqual(["keep"]);
     expect(Object.keys(cls._helpers!)).toEqual(["keep"]);
     expect(typeof cls._helpers!.keep).toBe("function");
+    expect(cls._helpers!.extra).toBeUndefined();
   });
 });
 

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -150,6 +150,25 @@ describe("helper", () => {
   });
 });
 
+describe("identity tracking lives on the helpers module chain, not the class", () => {
+  it("after clearHelpers, the same module can be re-included on the cleared child", () => {
+    const parent = makeBase();
+    const Shared: HelperMethodsModule = { shared: () => "S" };
+    helper(parent, Shared);
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+
+    helper(child, Shared);
+    expect(Object.prototype.hasOwnProperty.call(child, "_helpers")).toBe(false);
+
+    clearHelpers(child);
+    helper(child, Shared);
+    // Re-included successfully — clearHelpers severed the chain so the
+    // earlier identity record on parent's helpers module is no longer
+    // reachable from child._helpers.
+    expect(child._helpers!.shared.call({})).toBe("S");
+  });
+});
+
 describe("clearHelpers", () => {
   it("wipes _helpers + _helperMethods, then re-adds the previous helper_method proxies", () => {
     const cls = makeBase();
@@ -198,9 +217,9 @@ describe("_helpersForModification", () => {
     expect(_helpersForModification(child)).toBe(mod);
   });
 
-  it("also flattens nested array inputs", () => {
+  it("also flattens deeply nested array inputs", () => {
     const cls = makeBase();
-    helperMethod(cls, ["a", ["b", ["c"]]] as unknown as string);
+    helperMethod(cls, ["a", ["b", ["c"]]]);
     expect(cls._helperMethods).toEqual(["a", "b", "c"]);
   });
 });

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -154,6 +154,15 @@ describe("helper", () => {
     expect(() => cls._helpers!.x.call({ controller: {} })).toThrow(/does not respond to 'x'/);
   });
 
+  it("included modules stay live — methods added after include are visible", () => {
+    const cls = makeBase();
+    const Live: HelperMethodsModule = { early: () => "early" };
+    helper(cls, Live);
+    Live.late = () => "late";
+    expect(cls._helpers!.early.call({})).toBe("early");
+    expect(cls._helpers!.late.call({})).toBe("late");
+  });
+
   it("multiple includes layer in the ancestor chain (both reachable)", () => {
     const cls = makeBase();
     const A: HelperMethodsModule = { fromA: () => "A" };

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -119,6 +119,18 @@ describe("helper", () => {
     expect(child._helpers).toBe(parent._helpers);
   });
 
+  it("re-including a module after a later module overrode its method is a no-op (identity-based)", () => {
+    const cls = makeBase();
+    const A: HelperMethodsModule = { foo: () => "A.foo" };
+    const B: HelperMethodsModule = { foo: () => "B.foo" };
+    helper(cls, A);
+    helper(cls, B);
+    expect(cls._helpers!.foo.call({})).toBe("B.foo");
+    helper(cls, A);
+    // B's override stays in place; A is identity-deduped.
+    expect(cls._helpers!.foo.call({})).toBe("B.foo");
+  });
+
   it("evaluates a trailing block against the helpers module (Rails `helper do ... end`)", () => {
     const cls = makeBase();
     helper(cls, (mod: HelperMethodsModule) => {

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -46,6 +46,13 @@ describe("helperMethod", () => {
     expect(cls._helpers!.loggedIn.call(proxy)).toBe(true);
   });
 
+  it("flattens nested name arrays (Rails `methods.flatten!`)", () => {
+    const cls = makeBase();
+    helperMethod(cls, "a", ["b", "c"]);
+    expect(cls._helperMethods).toEqual(["a", "b", "c"]);
+    expect(Object.keys(cls._helpers!).sort()).toEqual(["a", "b", "c"]);
+  });
+
   it("throws when controller does not respond to the named method", () => {
     const cls = makeBase();
     helperMethod(cls, "missing");

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -68,10 +68,24 @@ describe("helperMethod", () => {
     const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
     helperMethod(child, "fromChild");
 
-    expect(Object.keys(child._helpers!)).toEqual(["fromParent", "fromChild"]);
+    expect(Object.keys(child._helpers!)).toEqual(["fromChild"]);
+    expect(typeof child._helpers!.fromParent).toBe("function");
     expect(Object.keys(parent._helpers!)).toEqual(["fromParent"]);
     expect(parent._helperMethods).toEqual(["fromParent"]);
     expect(child._helperMethods).toEqual(["fromParent", "fromChild"]);
+  });
+
+  it("parent additions made after subclass mutation remain visible (ancestor link)", () => {
+    const parent = makeBase();
+    helperMethod(parent, "early");
+
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+    helperMethod(child, "childOnly");
+    helperMethod(parent, "late");
+
+    expect(typeof child._helpers!.late).toBe("function");
+    expect(typeof child._helpers!.early).toBe("function");
+    expect(typeof child._helpers!.childOnly).toBe("function");
   });
 });
 
@@ -145,7 +159,7 @@ describe("_helpersInstance", () => {
 });
 
 describe("_helpersForModification", () => {
-  it("returns the own module when present, else clones the inherited one", () => {
+  it("returns the own module when present, else links the inherited one as an ancestor", () => {
     const parent = makeBase();
     helperMethod(parent, "fromParent");
     const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
@@ -153,8 +167,16 @@ describe("_helpersForModification", () => {
     const mod = _helpersForModification(child);
     expect(Object.prototype.hasOwnProperty.call(child, "_helpers")).toBe(true);
     expect(mod).not.toBe(parent._helpers);
-    expect(Object.keys(mod)).toEqual(["fromParent"]);
+    expect(Object.getPrototypeOf(mod)).toBe(parent._helpers);
+    expect(Object.keys(mod)).toEqual([]);
+    expect(typeof mod.fromParent).toBe("function");
 
     expect(_helpersForModification(child)).toBe(mod);
+  });
+
+  it("also flattens nested array inputs", () => {
+    const cls = makeBase();
+    helperMethod(cls, ["a", ["b", ["c"]]] as unknown as string);
+    expect(cls._helperMethods).toEqual(["a", "b", "c"]);
   });
 });

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -123,19 +123,16 @@ export function helper(
       if (isHelperIncluded(cls._helpers, arg)) continue;
       const head = _helpersForModification(cls);
       // Rails' `Module#include` inserts the module *behind* the
-      // includer in the ancestor chain. Match that by splicing a new
-      // proto-link between `head` (own methods from helperMethod /
-      // block) and its current tail (previously-included modules,
-      // parent helpers). This preserves direct-method precedence:
-      // anything defined on `head` itself still wins over `arg`'s
-      // methods, and earlier includes remain reachable.
-      //
-      // Snapshot caveat: methods added to `arg` *after* this call are
-      // not visible — Ruby Module#include keeps a live reference. A
-      // fully-live impl would need a Proxy node.
+      // includer in the ancestor chain and keeps a live reference to
+      // the included module. We mirror both: splice a Proxy node
+      // between `head` (own methods from helperMethod / block) and
+      // its current tail (previously-included modules, parent
+      // helpers). The Proxy forwards lookups to `arg`, so methods
+      // added to `arg` after the include call remain visible. Falling
+      // through to the proxy target preserves chain walking for keys
+      // not in `arg`.
       const currentTail = Object.getPrototypeOf(head) as object | null;
-      const link = Object.create(currentTail) as HelperMethodsModule;
-      Object.assign(link, arg);
+      const link = makeIncludeLink(arg, currentTail);
       Object.setPrototypeOf(head, link);
       recordHelperIncluded(head, arg);
     }
@@ -157,6 +154,31 @@ function isHelperIncluded(helpers: HelperMethodsModule | undefined, mod: object)
     current = Object.getPrototypeOf(current);
   }
   return false;
+}
+
+/**
+ * Build a proto-chain link that forwards lookups to the included
+ * module. The target's prototype is the prior chain tail, so keys not
+ * present on `mod` still walk through to earlier includes / parent
+ * helpers. Using a Proxy (rather than `Object.assign`) keeps reads
+ * live: methods added to `mod` after include are still visible.
+ */
+function makeIncludeLink(
+  mod: HelperMethodsModule,
+  currentTail: object | null,
+): HelperMethodsModule {
+  const target = Object.create(currentTail) as HelperMethodsModule;
+  return new Proxy(target, {
+    get(t, prop, receiver) {
+      if (Object.prototype.hasOwnProperty.call(mod, prop)) {
+        return (mod as Record<PropertyKey, unknown>)[prop as PropertyKey];
+      }
+      return Reflect.get(t, prop, receiver);
+    },
+    has(t, prop) {
+      return Object.prototype.hasOwnProperty.call(mod, prop) || Reflect.has(t, prop);
+    },
+  }) as HelperMethodsModule;
 }
 
 function recordHelperIncluded(helpers: HelperMethodsModule, mod: object): void {

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -96,14 +96,15 @@ export function helper(
   cls: HelpersClassMethods,
   ...args: Array<HelperMethodsModule | ((mod: HelperMethodsModule) => void)>
 ): void {
-  const mod = _helpersForModification(cls);
+  // Rails only triggers copy-on-write when actually mutating; a no-op
+  // duplicate include must leave the subclass still delegating to the
+  // parent via the prototype chain.
   for (const arg of args) {
     if (typeof arg === "function") {
-      // `helper do ... end` — eval the block against the helpers module.
-      arg(mod);
+      arg(_helpersForModification(cls));
     } else if (arg && typeof arg === "object") {
       if (helpersInclude(cls._helpers, arg)) continue;
-      Object.assign(mod, arg);
+      Object.assign(_helpersForModification(cls), arg);
     }
   }
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * `AbstractController::Helpers` — class-level registry that exposes
+ * controller methods (and external modules) to views. This PR ports
+ * the runtime surface that operates on already-resolved modules:
+ *
+ *   - `applyHelpers(cls)` — seed the per-class `_helpers` module + `_helperMethods`.
+ *   - `helperMethod(cls, ...names)` — proxy `name(...args)` → `controller[name](...args)`.
+ *   - `helper(cls, ...mods)` — include resolved modules into `_helpers`.
+ *   - `clearHelpers(cls)` — reset, then re-add previous `_helperMethods`.
+ *   - `_helpersForModification(cls)` — copy-on-write clone for subclass mutation.
+ *
+ * String/symbol resolution (`AbstractController::Helpers::Resolution`)
+ * and the `default_helper_module!` autoload-by-name path are deferred
+ * to a follow-up PR; that's where `modules_for_helpers`,
+ * `all_helpers_from_path`, and the constantize-by-name path live.
+ *
+ * Ported from `vendor/rails/actionpack/lib/abstract_controller/helpers.rb`.
+ *
+ * @internal
+ */
+
+/**
+ * A helper "module" — a bag of methods that, when called from a view,
+ * forward to the controller via `this.controller`. Rails uses a real
+ * Ruby module; here we use a plain object indexed by method name.
+ */
+export type HelperMethodsModule = Record<string, (...args: unknown[]) => unknown>;
+
+/**
+ * The shape of a host class. `_helpers` and `_helperMethods` are
+ * class-level slots; absence on the class itself causes JS prototype
+ * lookup to walk up to the parent class — matching Rails' redefined
+ * `_helpers` singleton method that delegates to `superclass._helpers`.
+ */
+export interface HelpersClassMethods {
+  _helpers?: HelperMethodsModule;
+  _helperMethods?: string[];
+  name?: string;
+}
+
+export interface HelpersHost {
+  constructor: HelpersClassMethods;
+}
+
+/**
+ * Marks a host class as conforming to the helpers slot contract.
+ * No-op at runtime — mirrors `applyAssetPaths` / `applyFragments`.
+ * Seeding `_helpers = {}` on a subclass would shadow the parent's
+ * module; instead reads fall back to an empty module, and
+ * `_helpersForModification` does Rails' `class_attribute`-style
+ * copy-on-write clone the first time a subclass mutates.
+ */
+export function applyHelpers<T extends new (...args: never[]) => unknown>(
+  _cls: T & Partial<HelpersClassMethods>,
+): void {
+  // Intentionally empty.
+}
+
+/** Instance-side `_helpers`: returns `this.class._helpers`. */
+export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
+  return this.constructor._helpers ?? (Object.create(null) as HelperMethodsModule);
+}
+
+/**
+ * `ClassMethods#helper_method(*methods)` — register controller method
+ * names as view helpers. Each name gets a proxy on the helpers module
+ * that does `this.controller[name](...args)`. Names are flattened (the
+ * spread does it for us) and appended to `_helperMethods` so
+ * `clearHelpers` can re-establish them after a wipe.
+ */
+export function helperMethod(cls: HelpersClassMethods, ...names: string[]): void {
+  if (names.length === 0) return;
+  cls._helperMethods = [...(cls._helperMethods ?? []), ...names];
+  const mod = _helpersForModification(cls);
+  for (const name of names) {
+    mod[name] = function (this: { controller: Record<string, unknown> }, ...args: unknown[]) {
+      const fn = this.controller[name];
+      if (typeof fn !== "function") {
+        throw new TypeError(`helper_method: controller does not respond to '${name}'`);
+      }
+      return (fn as (...a: unknown[]) => unknown).apply(this.controller, args);
+    };
+  }
+}
+
+/**
+ * `ClassMethods#helper(*args, &block)` — include the given modules into
+ * the helpers module. Rails accepts modules, strings, symbols, and a
+ * block; this PR handles modules only (the string/symbol form requires
+ * the Resolution mixin, deferred to PR B). A trailing function arg is
+ * treated as the `module_eval` block.
+ */
+export function helper(
+  cls: HelpersClassMethods,
+  ...args: Array<HelperMethodsModule | ((mod: HelperMethodsModule) => void)>
+): void {
+  const mod = _helpersForModification(cls);
+  for (const arg of args) {
+    if (typeof arg === "function") {
+      // `helper do ... end` — eval the block against the helpers module.
+      arg(mod);
+    } else if (arg && typeof arg === "object") {
+      if (helpersInclude(cls._helpers, arg)) continue;
+      Object.assign(mod, arg);
+    }
+  }
+}
+
+/**
+ * `ClassMethods#clear_helpers` — drop all helpers, then re-attach the
+ * controller's own `_helperMethods` so it can still expose them to its
+ * views. Rails also calls `default_helper_module!` here for non-anonymous
+ * classes; that path lives in PR B.
+ */
+export function clearHelpers(cls: HelpersClassMethods): void {
+  const inherited = [...(cls._helperMethods ?? [])];
+  cls._helpers = Object.create(null) as HelperMethodsModule;
+  cls._helperMethods = [];
+  helperMethod(cls, ...inherited);
+}
+
+/**
+ * `ClassMethods#_helpers_for_modification` — lazily clone the inherited
+ * `_helpers` module onto this class so subsequent mutations don't leak
+ * into the parent. Returns the cloned (or already-owned) module.
+ */
+export function _helpersForModification(cls: HelpersClassMethods): HelperMethodsModule {
+  if (Object.prototype.hasOwnProperty.call(cls, "_helpers") && cls._helpers) {
+    return cls._helpers;
+  }
+  const cloned = Object.create(null) as HelperMethodsModule;
+  if (cls._helpers) Object.assign(cloned, cls._helpers);
+  cls._helpers = cloned;
+  return cloned;
+}
+
+/**
+ * Cheap stand-in for Ruby's `_helpers.include?(mod)`. Two modules are
+ * "included" if every method on `mod` is the same function on
+ * `helpers`. Suitable for the de-dup guard in `helper(...)`.
+ */
+function helpersInclude(
+  helpers: HelperMethodsModule | undefined,
+  mod: HelperMethodsModule,
+): boolean {
+  if (!helpers) return false;
+  for (const k of Object.keys(mod)) {
+    if (helpers[k] !== mod[k]) return false;
+  }
+  return Object.keys(mod).length > 0;
+}

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -35,16 +35,24 @@ export type HelperMethodsModule = Record<string, (...args: unknown[]) => unknown
 export interface HelpersClassMethods {
   _helpers?: HelperMethodsModule;
   _helperMethods?: string[];
-  /**
-   * Identity set of helper modules already included via `helper(...)`.
-   * Mirrors Rails' `_helpers.include?(mod)` (ancestor-chain identity
-   * check), so a later module that overrides one of an earlier
-   * module's methods can't be undone by a duplicate include of the
-   * earlier module.
-   */
-  _includedHelperModules?: WeakSet<object>;
   name?: string;
 }
+
+/**
+ * A nested-array list of helper method names. Mirrors Ruby's
+ * `helper_method(*methods)` + `methods.flatten!`: callers may pass
+ * varargs, a single array, or arbitrarily nested arrays.
+ */
+export type HelperMethodNameList = string | HelperMethodNameList[];
+
+/**
+ * Identity set of helper modules included into a given helpers module.
+ * Keyed by the helpers module itself, walked along the module's
+ * prototype chain so `clearHelpers` (which severs the chain) correctly
+ * forgets included modules and Rails' `_helpers.include?(mod)`
+ * ancestor-chain semantics are preserved.
+ */
+const includedHelperModules = new WeakMap<HelperMethodsModule, WeakSet<object>>();
 
 export interface HelpersHost {
   constructor: HelpersClassMethods;
@@ -76,7 +84,7 @@ export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
  * spread does it for us) and appended to `_helperMethods` so
  * `clearHelpers` can re-establish them after a wipe.
  */
-export function helperMethod(cls: HelpersClassMethods, ...names: Array<string | string[]>): void {
+export function helperMethod(cls: HelpersClassMethods, ...names: HelperMethodNameList[]): void {
   // Rails: `methods.flatten!` — flattens recursively (default depth nil).
   const flat = (names as readonly unknown[]).flat(Infinity) as string[];
   if (flat.length === 0) return;
@@ -111,30 +119,38 @@ export function helper(
     if (typeof arg === "function") {
       arg(_helpersForModification(cls));
     } else if (arg && typeof arg === "object") {
-      if (isHelperIncluded(cls, arg)) continue;
-      recordHelperIncluded(cls, arg);
-      Object.assign(_helpersForModification(cls), arg);
+      if (isHelperIncluded(cls._helpers, arg)) continue;
+      const mod = _helpersForModification(cls);
+      recordHelperIncluded(mod, arg);
+      Object.assign(mod, arg);
     }
   }
 }
 
-function isHelperIncluded(cls: HelpersClassMethods, mod: object): boolean {
-  let current: object | null = cls;
+/**
+ * Walks the helpers module's prototype chain — each link is a module
+ * that included a (possibly different) set of helper modules. Mirrors
+ * Rails' `_helpers.include?(mod)`: only ancestors reachable via the
+ * actual helpers module chain count.
+ */
+function isHelperIncluded(helpers: HelperMethodsModule | undefined, mod: object): boolean {
+  let current: object | null = helpers ?? null;
   while (current) {
-    const own = Object.getOwnPropertyDescriptor(current, "_includedHelperModules")?.value as
-      | WeakSet<object>
-      | undefined;
-    if (own?.has(mod)) return true;
+    if (includedHelperModules.get(current as HelperMethodsModule)?.has(mod)) {
+      return true;
+    }
     current = Object.getPrototypeOf(current);
   }
   return false;
 }
 
-function recordHelperIncluded(cls: HelpersClassMethods, mod: object): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "_includedHelperModules")) {
-    cls._includedHelperModules = new WeakSet<object>();
+function recordHelperIncluded(helpers: HelperMethodsModule, mod: object): void {
+  let set = includedHelperModules.get(helpers);
+  if (!set) {
+    set = new WeakSet<object>();
+    includedHelperModules.set(helpers, set);
   }
-  cls._includedHelperModules!.add(mod);
+  set.add(mod);
 }
 
 /**
@@ -147,7 +163,6 @@ export function clearHelpers(cls: HelpersClassMethods): void {
   const inherited = [...(cls._helperMethods ?? [])];
   cls._helpers = Object.create(null) as HelperMethodsModule;
   cls._helperMethods = [];
-  cls._includedHelperModules = new WeakSet<object>();
   helperMethod(cls, ...inherited);
 }
 

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -120,9 +120,23 @@ export function helper(
       arg(_helpersForModification(cls));
     } else if (arg && typeof arg === "object") {
       if (isHelperIncluded(cls._helpers, arg)) continue;
-      const mod = _helpersForModification(cls);
-      recordHelperIncluded(mod, arg);
-      Object.assign(mod, arg);
+      const head = _helpersForModification(cls);
+      // Rails' `Module#include` inserts the module *behind* the
+      // includer in the ancestor chain. Match that by splicing a new
+      // proto-link between `head` (own methods from helperMethod /
+      // block) and its current tail (previously-included modules,
+      // parent helpers). This preserves direct-method precedence:
+      // anything defined on `head` itself still wins over `arg`'s
+      // methods, and earlier includes remain reachable.
+      //
+      // Snapshot caveat: methods added to `arg` *after* this call are
+      // not visible — Ruby Module#include keeps a live reference. A
+      // fully-live impl would need a Proxy node.
+      const currentTail = Object.getPrototypeOf(head) as object | null;
+      const link = Object.create(currentTail) as HelperMethodsModule;
+      Object.assign(link, arg);
+      Object.setPrototypeOf(head, link);
+      recordHelperIncluded(head, arg);
     }
   }
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -3,7 +3,7 @@
  * controller methods (and external modules) to views. This PR ports
  * the runtime surface that operates on already-resolved modules:
  *
- *   - `applyHelpers(cls)` — seed the per-class `_helpers` module + `_helperMethods`.
+ *   - `applyHelpers(cls)` — no-op slot-contract marker (mirrors `applyAssetPaths` / `applyFragments`).
  *   - `helperMethod(cls, ...names)` — proxy `name(...args)` → `controller[name](...args)`.
  *   - `helper(cls, ...mods)` — include resolved modules into `_helpers`.
  *   - `clearHelpers(cls)` — reset, then re-add previous `_helperMethods`.
@@ -80,8 +80,9 @@ export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
 /**
  * `ClassMethods#helper_method(*methods)` — register controller method
  * names as view helpers. Each name gets a proxy on the helpers module
- * that does `this.controller[name](...args)`. Names are flattened (the
- * spread does it for us) and appended to `_helperMethods` so
+ * that does `this.controller[name](...args)`. Nested-array inputs are
+ * flattened via `Array.prototype.flat(Infinity)` (matching Ruby's
+ * `methods.flatten!`) and appended to `_helperMethods` so
  * `clearHelpers` can re-establish them after a wipe.
  */
 export function helperMethod(cls: HelpersClassMethods, ...names: HelperMethodNameList[]): void {

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -35,6 +35,14 @@ export type HelperMethodsModule = Record<string, (...args: unknown[]) => unknown
 export interface HelpersClassMethods {
   _helpers?: HelperMethodsModule;
   _helperMethods?: string[];
+  /**
+   * Identity set of helper modules already included via `helper(...)`.
+   * Mirrors Rails' `_helpers.include?(mod)` (ancestor-chain identity
+   * check), so a later module that overrides one of an earlier
+   * module's methods can't be undone by a duplicate include of the
+   * earlier module.
+   */
+  _includedHelperModules?: WeakSet<object>;
   name?: string;
 }
 
@@ -103,10 +111,30 @@ export function helper(
     if (typeof arg === "function") {
       arg(_helpersForModification(cls));
     } else if (arg && typeof arg === "object") {
-      if (helpersInclude(cls._helpers, arg)) continue;
+      if (isHelperIncluded(cls, arg)) continue;
+      recordHelperIncluded(cls, arg);
       Object.assign(_helpersForModification(cls), arg);
     }
   }
+}
+
+function isHelperIncluded(cls: HelpersClassMethods, mod: object): boolean {
+  let current: object | null = cls;
+  while (current) {
+    const own = Object.getOwnPropertyDescriptor(current, "_includedHelperModules")?.value as
+      | WeakSet<object>
+      | undefined;
+    if (own?.has(mod)) return true;
+    current = Object.getPrototypeOf(current);
+  }
+  return false;
+}
+
+function recordHelperIncluded(cls: HelpersClassMethods, mod: object): void {
+  if (!Object.prototype.hasOwnProperty.call(cls, "_includedHelperModules")) {
+    cls._includedHelperModules = new WeakSet<object>();
+  }
+  cls._includedHelperModules!.add(mod);
 }
 
 /**
@@ -119,6 +147,7 @@ export function clearHelpers(cls: HelpersClassMethods): void {
   const inherited = [...(cls._helperMethods ?? [])];
   cls._helpers = Object.create(null) as HelperMethodsModule;
   cls._helperMethods = [];
+  cls._includedHelperModules = new WeakSet<object>();
   helperMethod(cls, ...inherited);
 }
 
@@ -140,20 +169,4 @@ export function _helpersForModification(cls: HelpersClassMethods): HelperMethods
   const child = Object.create(inherited) as HelperMethodsModule;
   cls._helpers = child;
   return child;
-}
-
-/**
- * Cheap stand-in for Ruby's `_helpers.include?(mod)`. Two modules are
- * "included" if every method on `mod` is the same function on
- * `helpers`. Suitable for the de-dup guard in `helper(...)`.
- */
-function helpersInclude(
-  helpers: HelperMethodsModule | undefined,
-  mod: HelperMethodsModule,
-): boolean {
-  if (!helpers) return false;
-  for (const k of Object.keys(mod)) {
-    if (helpers[k] !== mod[k]) return false;
-  }
-  return Object.keys(mod).length > 0;
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -69,12 +69,8 @@ export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
  * `clearHelpers` can re-establish them after a wipe.
  */
 export function helperMethod(cls: HelpersClassMethods, ...names: Array<string | string[]>): void {
-  // Rails: `methods.flatten!` — accept nested arrays as well as varargs.
-  const flat: string[] = [];
-  for (const n of names) {
-    if (Array.isArray(n)) flat.push(...n);
-    else flat.push(n);
-  }
+  // Rails: `methods.flatten!` — flattens recursively (default depth nil).
+  const flat = (names as readonly unknown[]).flat(Infinity) as string[];
   if (flat.length === 0) return;
   cls._helperMethods = [...(cls._helperMethods ?? []), ...flat];
   const mod = _helpersForModification(cls);
@@ -134,10 +130,15 @@ export function _helpersForModification(cls: HelpersClassMethods): HelperMethods
   if (Object.prototype.hasOwnProperty.call(cls, "_helpers") && cls._helpers) {
     return cls._helpers;
   }
-  const cloned = Object.create(null) as HelperMethodsModule;
-  if (cls._helpers) Object.assign(cloned, cls._helpers);
-  cls._helpers = cloned;
-  return cloned;
+  // Rails builds the new module with the parent's helpers module as an
+  // ancestor (`mod.include(helpers) if helpers`), so methods added to
+  // the parent *after* the subclass clones remain visible. Match that
+  // by setting the parent's module as the new module's prototype rather
+  // than `Object.assign`-snapshotting at clone time.
+  const inherited = cls._helpers ?? null;
+  const child = Object.create(inherited) as HelperMethodsModule;
+  cls._helpers = child;
+  return child;
 }
 
 /**

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -68,11 +68,17 @@ export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
  * spread does it for us) and appended to `_helperMethods` so
  * `clearHelpers` can re-establish them after a wipe.
  */
-export function helperMethod(cls: HelpersClassMethods, ...names: string[]): void {
-  if (names.length === 0) return;
-  cls._helperMethods = [...(cls._helperMethods ?? []), ...names];
+export function helperMethod(cls: HelpersClassMethods, ...names: Array<string | string[]>): void {
+  // Rails: `methods.flatten!` — accept nested arrays as well as varargs.
+  const flat: string[] = [];
+  for (const n of names) {
+    if (Array.isArray(n)) flat.push(...n);
+    else flat.push(n);
+  }
+  if (flat.length === 0) return;
+  cls._helperMethods = [...(cls._helperMethods ?? []), ...flat];
   const mod = _helpersForModification(cls);
-  for (const name of names) {
+  for (const name of flat) {
     mod[name] = function (this: { controller: Record<string, unknown> }, ...args: unknown[]) {
       const fn = this.controller[name];
       if (typeof fn !== "function") {

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -77,3 +77,14 @@ export {
   type FragmentsClassMethods,
   type FragmentsHost,
 } from "./fragments.js";
+export {
+  _helpersForModification,
+  _helpersInstance,
+  applyHelpers,
+  clearHelpers,
+  helper,
+  helperMethod,
+  type HelperMethodsModule,
+  type HelpersClassMethods,
+  type HelpersHost,
+} from "./helpers.js";


### PR DESCRIPTION
## Summary

PR A of a 2-part split of `vendor/rails/actionpack/lib/abstract_controller/helpers.rb`.

This PR ports the parts that operate on **already-resolved modules** — the registry surface used at runtime by `ActionController::Helpers` and the rendering pipeline. PR B will follow with `AbstractController::Helpers::Resolution` (`modules_for_helpers`, `all_helpers_from_path`, `helper_modules_from_paths`, `default_helper_module!`) which needs string→constant resolution + Dir-glob support.

### Surface

- \`applyHelpers(cls)\` — no-op, matches the \`applyAssetPaths\` / \`applyFragments\` pattern. Seeding own slots on a subclass would shadow parents; instead reads fall back and \`_helpersForModification\` does the copy-on-write clone on first mutation.
- \`helperMethod(cls, ...names)\` — appends to \`_helperMethods\` and installs proxy methods on \`_helpers\` that forward \`name(...args)\` → \`this.controller[name](...args)\`. Throws a \`TypeError\` when the controller does not respond.
- \`helper(cls, ...args)\` — accepts pre-resolved modules and a trailing block (\`helper do ... end\` → \`module_eval\`). De-dupes when the same module is included twice. String/symbol resolution is deferred to PR B.
- \`clearHelpers(cls)\` — wipes \`_helpers\` and \`_helperMethods\`, then re-registers the prior \`_helperMethods\` names so the controller's own view helpers survive.
- \`_helpersForModification(cls)\` — Rails' \`class_attribute\`-style CoW clone. Idempotent — second call returns the already-owned module.
- \`_helpersInstance.call(this)\` — Rails' \`def _helpers; self.class._helpers; end\`.

### Out of scope (PR B)

- \`modules_for_helpers\` (camelize + constantize)
- \`all_helpers_from_path\` (Dir-glob)
- \`helper_modules_from_paths\`
- \`default_helper_module!\` (autoload-by-name + NameError#missing_name? recovery)
- \`inherited\` hook calling \`default_helper_module!\` for non-anonymous classes

PR size: 315 LOC (impl 145 + test 158 + index re-exports 12).

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/abstract-controller/helpers.test.ts\` — 12 passing.
- [x] \`tsc --build\` via pre-commit — clean.
- [ ] CI full actionpack suite.