### PR TITLE
feat(action-dispatch): port Http::QueryParser

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -9,3 +9,4 @@ export {
   type DirectiveName,
 } from "./permissions-policy.js";
 export { Headers } from "./headers.js";
+export { QueryParser, type QueryPair } from "./query-parser.js";

--- a/packages/actionpack/src/action-dispatch/http/query-parser.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/query-parser.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { QueryParser, type QueryPair } from "./query-parser.js";
+
+function parsedPairs(query: string, separator?: string | null): QueryPair[] {
+  return Array.from(QueryParser.eachPair(query, separator));
+}
+
+describe("QueryParserTest", () => {
+  const previousSeparator = QueryParser.strictQueryStringSeparator;
+  afterEach(() => {
+    QueryParser.strictQueryStringSeparator = previousSeparator;
+  });
+
+  it("simple query string", () => {
+    expect(parsedPairs("foo=bar&baz=quux")).toEqual([
+      ["foo", "bar"],
+      ["baz", "quux"],
+    ]);
+  });
+
+  it("query string with empty and missing values", () => {
+    expect(parsedPairs("foo=bar&empty=&missing&baz=quux")).toEqual([
+      ["foo", "bar"],
+      ["empty", ""],
+      ["missing", null],
+      ["baz", "quux"],
+    ]);
+  });
+
+  it("custom separator", () => {
+    expect(parsedPairs("foo=bar;baz=quux", ";")).toEqual([
+      ["foo", "bar"],
+      ["baz", "quux"],
+    ]);
+  });
+
+  it("non-standard separator", () => {
+    expect(parsedPairs("foo=bar/baz=quux", "/")).toEqual([
+      ["foo", "bar"],
+      ["baz", "quux"],
+    ]);
+  });
+
+  it("mixed separators", () => {
+    expect(parsedPairs("a=aa&b=bb;c=cc", "&;")).toEqual([
+      ["a", "aa"],
+      ["b", "bb"],
+      ["c", "cc"],
+    ]);
+  });
+
+  it("(rack 3) defaults to ampersand separator only", () => {
+    expect(parsedPairs("a=aa&b=bb;c=cc")).toEqual([
+      ["a", "aa"],
+      ["b", "bb;c=cc"],
+    ]);
+  });
+
+  it("configured for strict separator", () => {
+    QueryParser.strictQueryStringSeparator = true;
+    expect(parsedPairs("a=aa&b=bb;c=cc", "&")).toEqual([
+      ["a", "aa"],
+      ["b", "bb;c=cc"],
+    ]);
+  });
+
+  it("configured for mixed separator", () => {
+    QueryParser.strictQueryStringSeparator = false;
+    expect(parsedPairs("a=aa&b=bb;c=cc", "&;")).toEqual([
+      ["a", "aa"],
+      ["b", "bb"],
+      ["c", "cc"],
+    ]);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/query-parser.ts
+++ b/packages/actionpack/src/action-dispatch/http/query-parser.ts
@@ -12,12 +12,12 @@
  */
 
 const DEFAULT_SEP = /& */;
-const COMMON_SEP: Record<string, RegExp> = {
+const COMMON_SEP: Record<string, RegExp> = Object.assign(Object.create(null), {
   ";": /; */,
   ";,": /[;,] */,
   "&": /& */,
   "&;": /[&;] */,
-};
+});
 
 export type QueryPair = [string, string | null];
 

--- a/packages/actionpack/src/action-dispatch/http/query-parser.ts
+++ b/packages/actionpack/src/action-dispatch/http/query-parser.ts
@@ -1,0 +1,69 @@
+/**
+ * ActionDispatch::QueryParser
+ *
+ * Parses application/x-www-form-urlencoded query strings into key/value pairs.
+ *
+ * Departs from WHATWG's specified parsing algorithm by giving a null value
+ * for keys that do not use `=`. Callers that need the standard's
+ * interpretation can coerce with `v ?? ""`.
+ *
+ * Rack 3 only — the Rack 2 semicolon-compat branch is omitted (trails targets
+ * Rack 3 exclusively, see `action-dispatch/constants.ts`).
+ */
+
+const DEFAULT_SEP = /& */;
+const COMMON_SEP: Record<string, RegExp> = {
+  ";": /; */,
+  ";,": /[;,] */,
+  "&": /& */,
+  "&;": /[&;] */,
+};
+
+export type QueryPair = [string, string | null];
+
+export class QueryParser {
+  /**
+   * When true, semicolons are not treated as separators. Mirrors Rails'
+   * `cattr_accessor :strict_query_string_separator`.
+   */
+  static strictQueryStringSeparator: boolean | null = null;
+
+  static *eachPair(s: string | null | undefined, separator?: string | null): Generator<QueryPair> {
+    const str = s ?? "";
+
+    let splitter: RegExp;
+    if (separator) {
+      splitter = COMMON_SEP[separator] ?? new RegExp(`[${escapeChars(separator)}] *`);
+    } else {
+      splitter = DEFAULT_SEP;
+    }
+
+    for (const part of str.split(splitter)) {
+      if (part === "") continue;
+
+      const eq = part.indexOf("=");
+      let k: string;
+      let v: string | null;
+      if (eq === -1) {
+        k = part;
+        v = null;
+      } else {
+        k = part.slice(0, eq);
+        v = part.slice(eq + 1);
+      }
+
+      k = decodeFormComponent(k);
+      if (v !== null) v = decodeFormComponent(v);
+
+      yield [k, v];
+    }
+  }
+}
+
+function escapeChars(s: string): string {
+  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+function decodeFormComponent(s: string): string {
+  return decodeURIComponent(s.replace(/\+/g, " "));
+}

--- a/packages/actionpack/src/action-dispatch/http/query-parser.ts
+++ b/packages/actionpack/src/action-dispatch/http/query-parser.ts
@@ -23,8 +23,14 @@ export type QueryPair = [string, string | null];
 
 export class QueryParser {
   /**
-   * When true, semicolons are not treated as separators. Mirrors Rails'
-   * `cattr_accessor :strict_query_string_separator`.
+   * Mirrors Rails' `cattr_accessor :strict_query_string_separator`.
+   *
+   * Under Rack 3 this toggle is a no-op (matching Rails behavior on
+   * Rack 3): Rails' `each_pair` only consults it inside the
+   * `SEMICOLON_COMPAT` elsif branch, which is unreachable when
+   * `Rack::QueryParser::DEFAULT_SEP` doesn't include `;` — i.e. on
+   * Rack 3. Surface is preserved for source-level parity and for
+   * callers that pre-set it on the assumption of forward Rack 4 work.
    */
   static strictQueryStringSeparator: boolean | null = null;
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -68,6 +68,7 @@ export {
 } from "./http/permissions-policy.js";
 export { UploadedFile, type UploadedFileOptions } from "./http/upload.js";
 export { ContentDisposition, type ContentDispositionOptions } from "./http/content-disposition.js";
+export { QueryParser, type QueryPair } from "./http/query-parser.js";
 export { RequestId, type RequestIdOptions } from "./middleware/request-id.js";
 export {
   BasicAuth,


### PR DESCRIPTION
## Summary

1:1 port of `action_dispatch/http/query_parser.rb`. Parses
application/x-www-form-urlencoded query strings into `[key, value]` pairs.

- Static `QueryParser.eachPair(s, separator?)` generator.
- `strictQueryStringSeparator` class-level toggle (Rails `cattr_accessor`).
- Returns `null` for keys without `=` (intentional Rails departure from
  WHATWG, preserved).
- Rack 3 only — the Rack 2 semicolon-compat deprecation branch is omitted
  per trails policy (consistent with `action-dispatch/constants.ts`).

Closes one of the P3 missing-http-files in `docs/actionpack-restructure-audit.md`.

## Test plan

- [x] 8 Rails tests from `test/dispatch/query_parser_test.rb` (Rack 3 subset)
      ported with matching descriptions — 8/8 pass.
- [x] `pnpm build` clean
- [x] `pnpm lint` clean