### PR TITLE
test(activerecord): consolidate enum string-status describe (batch 130)

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1033,45 +1033,26 @@ describe("EnumTest", () => {
   it("type.serialize", () => {
     expect(true).toBe(true);
   });
-  it("find via where with strings", () => {
-    class Post extends Base {
-      static {
-        this.tableName = "string_status_posts";
-        this.attribute("status", "string");
-        this.adapter = adapter;
-      }
+  class StringStatusPost extends Base {
+    static {
+      this.tableName = "string_status_posts";
+      this.attribute("status", "string");
     }
-    expect(Post.where({ status: "active" })).toBeInstanceOf(Relation);
+  }
+  beforeEach(() => {
+    StringStatusPost.adapter = adapter;
+  });
+  it("find via where with strings", () => {
+    expect(StringStatusPost.where({ status: "active" })).toBeInstanceOf(Relation);
   });
   it("find via where with large number", () => {
-    class Post extends Base {
-      static {
-        this.tableName = "string_status_posts";
-        this.attribute("status", "string");
-        this.adapter = adapter;
-      }
-    }
-    expect(Post.where({ status: "99" })).toBeInstanceOf(Relation);
+    expect(StringStatusPost.where({ status: "99" })).toBeInstanceOf(Relation);
   });
   it("find via where should be type casted", () => {
-    class Post extends Base {
-      static {
-        this.tableName = "string_status_posts";
-        this.attribute("status", "string");
-        this.adapter = adapter;
-      }
-    }
-    expect(Post.where({ status: "active" })).toBeInstanceOf(Relation);
+    expect(StringStatusPost.where({ status: "active" })).toBeInstanceOf(Relation);
   });
   it("build from scope", async () => {
-    class Post extends Base {
-      static {
-        this.tableName = "string_status_posts";
-        this.attribute("status", "string");
-        this.adapter = adapter;
-      }
-    }
-    const p = await Post.create({ status: "active" });
+    const p = await StringStatusPost.create({ status: "active" });
     expect((p as any).isPersisted()).toBe(true);
   });
   it("enum methods are overwritable", () => {


### PR DESCRIPTION
## Summary

Batch 130 from `docs/activerecord-100-plan.md` — followup from #1747.

The four "string status" Post tests in `enum.test.ts` each redeclared a Post class with `tableName = "string_status_posts"`. Hoist one shared `StringStatusPost` class for all four `it()`s, replacing four duplicated `static {}` blocks.

The plan also suggested dropping `string_status_posts` from `TEST_SCHEMA` by retargeting to `posts`, but that's not viable: `posts.status` is an integer column, and MariaDB (correctly) rejects `INSERT … VALUES ('active')` into it where SQLite would silently accept it via type-affinity. Keeping the synthetic table.

-32/+13 LOC. All 202 enum tests pass.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/enum.test.ts`
- [ ] CI MariaDB job green