### PR TITLE
feat(actionpack): port abstract_controller helpers Resolution + default_helper_module (PR B)

### DIFF
--- a/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
@@ -62,6 +62,12 @@ describe("modulesForHelpers", () => {
       /must be a String, Symbol, or Module/,
     );
   });
+
+  it("raises TypeError when an object has non-function values (not module-shaped)", () => {
+    expect(() =>
+      modulesForHelpers([{ x: 1 } as unknown as HelperMethodsModule], { resolve }),
+    ).toThrow(/must be a String, Symbol, or Module/);
+  });
 });
 
 describe("allHelpersFromPath", () => {

--- a/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
@@ -93,6 +93,21 @@ describe("allHelpersFromPath", () => {
       "users",
     ]);
   });
+
+  it("sorts within each path, then concatenates across paths (Rails ordering)", async () => {
+    const r1 = mkdtempSync(join(tmpdir(), "helpers-order-1-"));
+    const r2 = mkdtempSync(join(tmpdir(), "helpers-order-2-"));
+    writeFileSync(join(r1, "zebra_helper.ts"), "");
+    writeFileSync(join(r1, "alpha_helper.ts"), "");
+    writeFileSync(join(r2, "yak_helper.ts"), "");
+    writeFileSync(join(r2, "bear_helper.ts"), "");
+    try {
+      expect(await allHelpersFromPath([r1, r2])).toEqual(["alpha", "zebra", "bear", "yak"]);
+    } finally {
+      rmSync(r1, { recursive: true, force: true });
+      rmSync(r2, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("helperModulesFromPaths", () => {
@@ -139,10 +154,25 @@ describe("defaultHelperModule", () => {
     expect(cls._helpers).toBeUndefined();
   });
 
-  it("is a no-op when the class name lacks a Controller suffix", () => {
+  it("still tries to resolve when the class name lacks a Controller suffix (Rails delete_suffix is a no-op then)", () => {
+    // Rails: `helper_prefix = name.delete_suffix("Controller")` returns
+    // "Plain" unchanged, then `helper("Plain")` is called. PlainHelper
+    // doesn't exist → NameError → swallowed.
     const cls: HelpersClassMethods = { name: "Plain" };
     defaultHelperModule(cls, { resolve });
     expect(cls._helpers).toBeUndefined();
+  });
+
+  it("only swallows the NameError matching this specific helper name", () => {
+    const cls: HelpersClassMethods = { name: "FooController" };
+    const surprising = (name: string): HelperMethodsModule | undefined => {
+      if (name === "FooHelper") {
+        // simulate: FooHelper file exists but references some other missing const
+        throw new Error("uninitialized constant SomeOtherThing");
+      }
+      return undefined;
+    };
+    expect(() => defaultHelperModule(cls, { resolve: surprising })).toThrow(/SomeOtherThing/);
   });
 
   it("composes with helper(): subsequent helper(cls, X) layers on top", () => {

--- a/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  allHelpersFromPath,
+  defaultHelperModule,
+  helper,
+  helperModulesFromPaths,
+  modulesForHelpers,
+  type HelperMethodsModule,
+  type HelpersClassMethods,
+} from "./helpers.js";
+
+const FooHelper: HelperMethodsModule = { foo: () => "FOO" };
+const BarHelper: HelperMethodsModule = { bar: () => "BAR" };
+const NamespacedHelper: HelperMethodsModule = { ns: () => "NS" };
+
+const registry: Record<string, HelperMethodsModule> = {
+  FooHelper,
+  BarHelper,
+  "Foo::BarHelper": NamespacedHelper,
+};
+
+const resolve = (name: string): HelperMethodsModule | undefined => registry[name];
+
+describe("modulesForHelpers", () => {
+  it("passes through already-resolved modules unchanged", () => {
+    expect(modulesForHelpers([FooHelper], { resolve })).toEqual([FooHelper]);
+  });
+
+  it("resolves a string prefix (snake_case)", () => {
+    expect(modulesForHelpers(["foo"], { resolve })).toEqual([FooHelper]);
+  });
+
+  it("resolves a string prefix (already camel-cased) without re-camelizing", () => {
+    expect(modulesForHelpers(["Foo"], { resolve })).toEqual([FooHelper]);
+  });
+
+  it("resolves a symbol prefix", () => {
+    expect(modulesForHelpers([Symbol("foo")], { resolve })).toEqual([FooHelper]);
+  });
+
+  it("translates `foo/bar` → `Foo::BarHelper`", () => {
+    expect(modulesForHelpers(["foo/bar"], { resolve })).toEqual([NamespacedHelper]);
+  });
+
+  it("flattens nested arrays (Rails `args.flatten`)", () => {
+    expect(modulesForHelpers(["foo", ["bar"]], { resolve })).toEqual([FooHelper, BarHelper]);
+  });
+
+  it("raises a NameError-shaped Error on an unknown name", () => {
+    expect(() => modulesForHelpers(["missing"], { resolve })).toThrow(
+      /uninitialized constant MissingHelper/,
+    );
+  });
+
+  it("raises TypeError for non-string/symbol/module entries", () => {
+    expect(() => modulesForHelpers([42 as unknown as string], { resolve })).toThrow(
+      /must be a String, Symbol, or Module/,
+    );
+  });
+});
+
+describe("allHelpersFromPath", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "helpers-pr-b-"));
+    mkdirSync(join(root, "nested"), { recursive: true });
+    writeFileSync(join(root, "application_helper.ts"), "export const x = 1;");
+    writeFileSync(join(root, "users_helper.ts"), "export const x = 1;");
+    writeFileSync(join(root, "legacy_helper.rb"), "module LegacyHelper; end");
+    writeFileSync(join(root, "nested", "admin_helper.ts"), "export const x = 1;");
+    // not a helper file — should be ignored
+    writeFileSync(join(root, "controller.ts"), "export const x = 1;");
+  });
+
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it("returns sorted, de-duplicated names without the _helper suffix or extension", async () => {
+    const names = await allHelpersFromPath(root);
+    expect(names).toEqual(["application", "legacy", "nested/admin", "users"]);
+  });
+
+  it("accepts an array of paths and de-duplicates across them", async () => {
+    expect(await allHelpersFromPath([root, root])).toEqual([
+      "application",
+      "legacy",
+      "nested/admin",
+      "users",
+    ]);
+  });
+});
+
+describe("helperModulesFromPaths", () => {
+  let root: string;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "helpers-pr-b-modules-"));
+    writeFileSync(join(root, "foo_helper.ts"), "export const x = 1;");
+    writeFileSync(join(root, "bar_helper.ts"), "export const x = 1;");
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it("globs + resolves in one shot", async () => {
+    const mods = await helperModulesFromPaths(root, { resolve });
+    // sorted: bar, foo
+    expect(mods).toEqual([BarHelper, FooHelper]);
+  });
+});
+
+describe("defaultHelperModule", () => {
+  it("strips the Controller suffix and includes the matching helper", () => {
+    const cls: HelpersClassMethods = { name: "FooController" };
+    defaultHelperModule(cls, { resolve });
+    expect(cls._helpers!.foo.call({})).toBe("FOO");
+  });
+
+  it("swallows the NameError when the helper does not exist", () => {
+    const cls: HelpersClassMethods = { name: "MissingController" };
+    expect(() => defaultHelperModule(cls, { resolve })).not.toThrow();
+    expect(cls._helpers).toBeUndefined();
+  });
+
+  it("re-raises unrelated resolver errors", () => {
+    const throwing = () => {
+      throw new Error("connection lost");
+    };
+    expect(() => defaultHelperModule({ name: "FooController" }, { resolve: throwing })).toThrow(
+      /connection lost/,
+    );
+  });
+
+  it("is a no-op on an anonymous class (no name)", () => {
+    const cls: HelpersClassMethods = {};
+    defaultHelperModule(cls, { resolve });
+    expect(cls._helpers).toBeUndefined();
+  });
+
+  it("is a no-op when the class name lacks a Controller suffix", () => {
+    const cls: HelpersClassMethods = { name: "Plain" };
+    defaultHelperModule(cls, { resolve });
+    expect(cls._helpers).toBeUndefined();
+  });
+
+  it("composes with helper(): subsequent helper(cls, X) layers on top", () => {
+    const cls: HelpersClassMethods = { name: "FooController" };
+    defaultHelperModule(cls, { resolve });
+    helper(cls, BarHelper);
+    expect(cls._helpers!.foo.call({})).toBe("FOO");
+    expect(cls._helpers!.bar.call({})).toBe("BAR");
+  });
+});

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -1,3 +1,5 @@
+import { camelize } from "@blazetrails/activesupport";
+
 /**
  * `AbstractController::Helpers` — class-level registry that exposes
  * controller methods (and external modules) to views. This PR ports
@@ -8,11 +10,10 @@
  *   - `helper(cls, ...mods)` — include resolved modules into `_helpers`.
  *   - `clearHelpers(cls)` — reset, then re-add previous `_helperMethods`.
  *   - `_helpersForModification(cls)` — copy-on-write clone for subclass mutation.
- *
- * String/symbol resolution (`AbstractController::Helpers::Resolution`)
- * and the `default_helper_module!` autoload-by-name path are deferred
- * to a follow-up PR; that's where `modules_for_helpers`,
- * `all_helpers_from_path`, and the constantize-by-name path live.
+ *   - `modulesForHelpers(args, opts)` — Rails `Resolution#modules_for_helpers`.
+ *   - `allHelpersFromPath(paths)` — Rails `Resolution#all_helpers_from_path`.
+ *   - `helperModulesFromPaths(paths, opts)` — Rails `Resolution#helper_modules_from_paths`.
+ *   - `defaultHelperModule(cls, opts)` — Rails `default_helper_module!`.
  *
  * Ported from `vendor/rails/actionpack/lib/abstract_controller/helpers.rb`.
  *
@@ -221,4 +222,111 @@ export function _helpersForModification(cls: HelpersClassMethods): HelperMethods
   const child = Object.create(inherited) as HelperMethodsModule;
   cls._helpers = child;
   return child;
+}
+
+// ---------------------------------------------------------------------------
+// `AbstractController::Helpers::Resolution`
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves a helper-module name (e.g. `"users"`, `"Foo::Bar"`) into a
+ * `HelperMethodsModule`. Returns `undefined` when no module exists for
+ * the name — `modulesForHelpers` raises in that case to mirror Ruby's
+ * `NameError`.
+ *
+ * trails has no global constant table, so the resolver is host-supplied:
+ * typically a registry built at boot from configured helper paths or
+ * static imports.
+ */
+export type HelperResolver = (name: string) => HelperMethodsModule | undefined;
+
+export interface ResolutionOptions {
+  resolve: HelperResolver;
+}
+
+/**
+ * `Resolution#modules_for_helpers(modules_or_helper_prefixes)` — accepts
+ * a mixed array of resolved modules and prefix names (string | symbol).
+ * Names that don't start with an upper-case letter are camelized; a
+ * `"Helper"` suffix is appended; the resolver is asked to turn the
+ * resulting name into a module. Throws `TypeError` / a `NameError`-shaped
+ * `Error` on bad inputs / unknown names, matching Rails' two failure
+ * modes.
+ */
+export function modulesForHelpers(
+  args: ReadonlyArray<HelperMethodsModule | string | symbol | Array<unknown>>,
+  options: ResolutionOptions,
+): HelperMethodsModule[] {
+  const flat = (args as readonly unknown[]).flat(Infinity);
+  return flat.map((arg) => {
+    if (arg && typeof arg === "object") return arg as HelperMethodsModule;
+    if (typeof arg === "string" || typeof arg === "symbol") {
+      const raw = typeof arg === "symbol" ? (arg.description ?? "") : arg;
+      const name = `${/^[A-Z]/.test(raw) ? raw : camelizeHelperPrefix(raw)}Helper`;
+      const mod = options.resolve(name);
+      if (!mod) throw new Error(`uninitialized constant ${name}`);
+      return mod;
+    }
+    throw new TypeError("helper must be a String, Symbol, or Module");
+  });
+}
+
+/**
+ * `Resolution#all_helpers_from_path(path)` — glob `*_helper.{ts,js}`
+ * (and `.rb` so callers porting from Rails can point at a real Rails
+ * app path) under each given root and return the de-duplicated, sorted
+ * basename list (without the `_helper` suffix or extension).
+ */
+export async function allHelpersFromPath(paths: string | readonly string[]): Promise<string[]> {
+  const { glob } = await import("@blazetrails/activesupport/glob");
+  const roots = typeof paths === "string" ? [paths] : paths;
+  const seen = new Set<string>();
+  for (const root of roots) {
+    const matches = await glob("**/*_helper.{ts,js,rb}", { cwd: root });
+    for (const file of matches) {
+      const noExt = file.replace(/\.(ts|js|rb)$/, "");
+      const noSuffix = noExt.replace(/_helper$/, "");
+      seen.add(noSuffix);
+    }
+  }
+  return [...seen].sort();
+}
+
+/**
+ * `Resolution#helper_modules_from_paths(paths)` — chains
+ * `allHelpersFromPath` and `modulesForHelpers`.
+ */
+export async function helperModulesFromPaths(
+  paths: string | readonly string[],
+  options: ResolutionOptions,
+): Promise<HelperMethodsModule[]> {
+  const names = await allHelpersFromPath(paths);
+  return modulesForHelpers(names, options);
+}
+
+/**
+ * `ClassMethods#default_helper_module!` — strip the `Controller` suffix
+ * from `cls.name` and call `helper(cls, <Name>)`. Rails rescues a
+ * `NameError` for the specific missing constant; we swallow only the
+ * matching `uninitialized constant` error raised by
+ * `modulesForHelpers`, so unrelated resolver failures still propagate.
+ */
+export function defaultHelperModule(cls: HelpersClassMethods, options: ResolutionOptions): void {
+  const className = cls.name;
+  if (!className) return; // anonymous — skip
+  const helperPrefix = className.replace(/Controller$/, "");
+  if (helperPrefix === className) return; // not a Controller suffix
+  try {
+    const [mod] = modulesForHelpers([helperPrefix], options);
+    helper(cls, mod);
+  } catch (err) {
+    if (err instanceof Error && /^uninitialized constant /.test(err.message)) return;
+    throw err;
+  }
+}
+
+function camelizeHelperPrefix(raw: string): string {
+  // Ruby `helper_prefix.camelize` — activesupport's `camelize` already
+  // translates `/` to `::`, so `"foo/bar"` → `"Foo::Bar"`.
+  return camelize(raw);
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -280,16 +280,21 @@ export function modulesForHelpers(
 export async function allHelpersFromPath(paths: string | readonly string[]): Promise<string[]> {
   const { glob } = await import("@blazetrails/activesupport/glob");
   const roots = typeof paths === "string" ? [paths] : paths;
+  // Rails: per-path `sort!` then concat across paths, then `uniq!`
+  // preserving first-occurrence order. We do NOT globally re-sort.
+  const out: string[] = [];
   const seen = new Set<string>();
   for (const root of roots) {
     const matches = await glob("**/*_helper.{ts,js,rb}", { cwd: root });
-    for (const file of matches) {
-      const noExt = file.replace(/\.(ts|js|rb)$/, "");
-      const noSuffix = noExt.replace(/_helper$/, "");
-      seen.add(noSuffix);
+    const names = matches.map((f) => f.replace(/\.(ts|js|rb)$/, "").replace(/_helper$/, "")).sort();
+    for (const name of names) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        out.push(name);
+      }
     }
   }
-  return [...seen].sort();
+  return out;
 }
 
 /**
@@ -313,14 +318,18 @@ export async function helperModulesFromPaths(
  */
 export function defaultHelperModule(cls: HelpersClassMethods, options: ResolutionOptions): void {
   const className = cls.name;
-  if (!className) return; // anonymous — skip
+  if (!className) return; // anonymous — Rails' inherited hook also skips
   const helperPrefix = className.replace(/Controller$/, "");
-  if (helperPrefix === className) return; // not a Controller suffix
+  const expectedName = `${/^[A-Z]/.test(helperPrefix) ? helperPrefix : camelize(helperPrefix)}Helper`;
   try {
     const [mod] = modulesForHelpers([helperPrefix], options);
     helper(cls, mod);
   } catch (err) {
-    if (err instanceof Error && /^uninitialized constant /.test(err.message)) return;
+    // Rails: `rescue NameError => e; raise unless e.missing_name?("#{helper_prefix}Helper")`.
+    // Only swallow the missing-constant error for *this* specific helper
+    // name. Errors from elsewhere (e.g. the helper module's own body
+    // referencing some other missing constant) must propagate.
+    if (err instanceof Error && err.message === `uninitialized constant ${expectedName}`) return;
     throw err;
   }
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -259,7 +259,19 @@ export function modulesForHelpers(
 ): HelperMethodsModule[] {
   const flat = (args as readonly unknown[]).flat(Infinity);
   return flat.map((arg) => {
-    if (arg && typeof arg === "object") return arg as HelperMethodsModule;
+    if (arg && typeof arg === "object") {
+      // Rails' `when Module` is identity-strict; JS has no `Module`
+      // type so we approximate with a "method bag" shape check: every
+      // own enumerable value must be a function. Rejects `Date`,
+      // `{ a: 1 }`, etc. so the failure surfaces here rather than
+      // deep inside `helper(cls, ...)`.
+      for (const v of Object.values(arg)) {
+        if (typeof v !== "function") {
+          throw new TypeError("helper must be a String, Symbol, or Module");
+        }
+      }
+      return arg as HelperMethodsModule;
+    }
     if (typeof arg === "string" || typeof arg === "symbol") {
       const raw = typeof arg === "symbol" ? (arg.description ?? "") : arg;
       const name = `${/^[A-Z]/.test(raw) ? raw : camelizeHelperPrefix(raw)}Helper`;

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -278,7 +278,14 @@ export function modulesForHelpers(
  * basename list (without the `_helper` suffix or extension).
  */
 export async function allHelpersFromPath(paths: string | readonly string[]): Promise<string[]> {
-  const { glob } = await import("@blazetrails/activesupport/glob");
+  // Built path + `@vite-ignore` so bundlers (the website SW bundle in
+  // particular) don't statically resolve the Node-only glob dep
+  // (`tinyglobby` → `fdir` uses `createRequire`). Callers in non-Node
+  // environments must not invoke this function.
+  const modName = ["@blazetrails", "activesupport", "glob"].join("/");
+  const { glob } = (await import(
+    /* @vite-ignore */ modName
+  )) as typeof import("@blazetrails/activesupport/glob");
   const roots = typeof paths === "string" ? [paths] : paths;
   // Rails: per-path `sort!` then concat across paths, then `uniq!`
   // preserving first-occurrence order. We do NOT globally re-sort.

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -80,11 +80,18 @@ export {
 export {
   _helpersForModification,
   _helpersInstance,
+  allHelpersFromPath,
   applyHelpers,
   clearHelpers,
+  defaultHelperModule,
   helper,
   helperMethod,
+  helperModulesFromPaths,
+  modulesForHelpers,
+  type HelperMethodNameList,
   type HelperMethodsModule,
+  type HelperResolver,
   type HelpersClassMethods,
   type HelpersHost,
+  type ResolutionOptions,
 } from "./helpers.js";


### PR DESCRIPTION
## Summary

PR B of the helpers.rb port (PR A: #1793). Completes the
`vendor/rails/actionpack/lib/abstract_controller/helpers.rb` surface
by adding the name-to-module resolution path that PR A deferred.

### Added

- `modulesForHelpers(args, { resolve })` — accepts a mixed array of resolved modules and string/symbol prefixes. Camelizes snake_case prefixes (via `@blazetrails/activesupport` `camelize`, which already maps `/` → `::`), appends `Helper`, asks the host-supplied resolver to produce the module. Two failure modes: `TypeError` for non-string/symbol/module inputs (Rails' `ArgumentError`), `Error("uninitialized constant <Name>")` for unknown names (Rails' `NameError`).
- `allHelpersFromPath(paths)` — async glob of `**/*_helper.{ts,js,rb}` under each root via `@blazetrails/activesupport/glob` (tinyglobby), returns sorted + de-duped basenames stripped of `_helper` suffix and extension.
- `helperModulesFromPaths(paths, { resolve })` — chains the two.
- `defaultHelperModule(cls, { resolve })` — strips a `Controller` suffix from `cls.name`, calls `helper(cls, <Name>)`. Swallows only the matching `uninitialized constant <Name>Helper` error; unrelated resolver failures propagate. No-op on anonymous classes and on names without the `Controller` suffix.

### Out of scope / deliberate

- **No global constant table.** trails has no autoload registry, so `modulesForHelpers` takes a host-supplied `resolve(name)` rather than a magic constantize. Callers build a registry at boot (often a static `Record<string, HelperMethodsModule>` of imported modules).
- **No `inherited(klass)` hook port.** That would require a Ruby-style class-inheritance trigger TS doesn't have. Hosts call `defaultHelperModule` directly in their own subclass-init machinery instead. See `feedback_subclass_shadow_rule` for the broader pattern.
- The `helper(cls, ...)` API from PR A still accepts modules + blocks only. Callers wanting string-form resolution thread the result of `modulesForHelpers` through it: `helper(cls, ...modulesForHelpers(args, { resolve }))`. Kept this way to avoid coupling PR A's surface to PR B.

PR size: 275 LOC (impl additions to helpers.ts ~120, new helpers-resolution.test.ts ~155, index re-exports +12).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/helpers.test.ts packages/actionpack/src/abstract-controller/helpers-resolution.test.ts` — 38 passing (21 + 17).
- [x] `tsc --build` via pre-commit — clean.
- [ ] CI full actionpack suite + api:compare.