### PR TITLE
feat(activerecord): counter-cache resetCounters fidelity (batch 134)

### DIFF
--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { Associations, association } from "./associations.js";
 import { Notifications } from "@blazetrails/activesupport";
@@ -303,6 +303,10 @@ describe("CounterCacheTest", () => {
 
   beforeEach(() => {
     adapter = freshAdapter();
+  });
+
+  afterEach(() => {
+    Notifications.unsubscribeAll();
   });
 
   // Rails: test_counters_are_updated_both_in_memory_and_in_the_database_on_create

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { Associations, association } from "./associations.js";
+import { Notifications } from "@blazetrails/activesupport";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1415,11 +1416,39 @@ describe("CounterCacheTest", () => {
     // ROOT-CAUSE: same gap as "reset counters with modular association" — namespaced target
     // SCOPE: ~10 LOC in counter-cache.ts#resetCounters (shared with modular case)
   });
-  it.skip("reset counter with belongs_to which has class_name", () => {
-    // BLOCKED: associations — class_name option not consulted for counter target
-    // ROOT-CAUSE: resetCounters resolves the counter target via association name; needs to
-    //   honor reflection.options.className (Rails: `reflection.class_name.constantize`)
-    // SCOPE: ~10 LOC in counter-cache.ts#resetCounters
+  it("reset counter with belongs_to which has class_name", async () => {
+    // Rails: Engine `belongs_to :my_car, class_name: "Car", counter_cache: :engines_count`.
+    // The belongs_to *name* differs from the parent class name; resolution must
+    // walk `options.className` rather than `camelize(name)`.
+    class Car extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("engines_count", "integer", { default: 0 });
+        this.adapter = adapter;
+      }
+    }
+    class Engine extends Base {
+      static {
+        this.attribute("car_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Engine, "myCar", {
+      className: "Car",
+      foreignKey: "car_id",
+      counterCache: "engines_count",
+    });
+    Associations.hasMany.call(Car, "engines", { foreignKey: "car_id" });
+    registerModel(Car);
+    registerModel(Engine);
+    const car = await Car.create({ name: "Honda" });
+    await Engine.create({ car_id: car.id });
+    await Car.incrementCounter("engines_count", car.id);
+    const before = await Car.find(car.id);
+    expect(before.engines_count).toBe(2);
+    await Car.resetCounters(car.id, "engines");
+    const after = await Car.find(car.id);
+    expect(after.engines_count).toBe(1);
   });
   it.skip("reset the right counter if two have the same class_name", () => {
     // BLOCKED: associations — multiple belongs_to to same target class
@@ -1427,11 +1456,40 @@ describe("CounterCacheTest", () => {
     //   (e.g. Reply belongs_to :topic, :other_topic) it picks the wrong reflection
     // SCOPE: ~15 LOC — dispatch on reflection name, not class_name
   });
-  it.skip("reset counter skips query for correct counter", () => {
-    // BLOCKED: associations — resetCounters always re-counts via SELECT COUNT(*)
-    // ROOT-CAUSE: Rails skips the UPDATE when the counted value already matches; ours
-    //   always issues the UPDATE. Behavioral parity check uses assert_no_queries.
-    // SCOPE: ~10 LOC in counter-cache.ts#resetCounters — short-circuit when counts equal
+  it("reset counter skips query for correct counter", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("replies_count", "integer", { default: 0 });
+        this.adapter = adapter;
+      }
+    }
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Reply, "topic", { counterCache: true });
+    Associations.hasMany.call(Topic, "replies", { foreignKey: "topic_id" });
+    registerModel(Topic);
+    registerModel(Reply);
+    const t = await Topic.create({ title: "first" });
+    await Reply.create({ content: "r1", topic_id: t.id });
+    // First reset brings the counter into agreement.
+    await Topic.resetCounters(t.id, "replies");
+    let updateCount = 0;
+    const sub = Notifications.subscribe("sql.active_record", (evt: any) => {
+      const sql = evt.payload?.sql?.trim().toUpperCase() ?? "";
+      if (sql.startsWith("UPDATE")) updateCount++;
+    });
+    try {
+      await Topic.resetCounters(t.id, "replies");
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(updateCount).toBe(0);
   });
   it.skip("reset counter performs query for correct counter with touch: true", () => {
     // BLOCKED: associations — touch: option wiring (resetCounters branch)
@@ -1441,9 +1499,13 @@ describe("CounterCacheTest", () => {
   });
   it.skip("reset counters for cpk model", () => {
     // BLOCKED: associations — composite primary key in resetCounters
-    // ROOT-CAUSE: resetCounters builds the WHERE via single-column id; primaryKey
-    //   may be string[] (cpk), needs composite-aware WHERE generation
-    // SCOPE: ~15 LOC in counter-cache.ts#resetCounters
+    // ROOT-CAUSE: resetCounters' UPDATE WHERE is now CPK-aware (uses caller-supplied
+    //   id rather than record.id), but countHasMany still raises
+    //   CompositePrimaryKeyMismatchError when the parent has a CPK and the hasMany
+    //   uses a scalar foreignKey — the Rails Cpk::Order/Cpk::Book setup uses a
+    //   composite FK ([:shop_id, :order_id]) which we do not yet support for hasMany.
+    // SCOPE: ~30 LOC in associations.ts to thread composite FK through
+    //   computeHasManyWhere / buildHasManyRelation; punt to follow-up PR.
   });
   it("update counter for decrement", async () => {
     class Topic extends Base {
@@ -1504,11 +1566,48 @@ describe("CounterCacheTest", () => {
     const reloaded = (await CpkOrder.find([1, 1])) as CpkOrder;
     expect(reloaded.items_count).toBe(7);
   });
-  it.skip("reset the right counter if two have the same foreign key", () => {
-    // BLOCKED: associations — multiple belongs_to sharing a foreign_key
-    // ROOT-CAUSE: resetCounters dispatch by name rather than FK; needs to disambiguate
-    //   when two reflections share foreignKey but differ by counter_cache column
-    // SCOPE: ~10 LOC in counter-cache.ts#resetCounters
+  it("reset the right counter if two have the same foreign key", async () => {
+    // Rails: Friendship has both `belongs_to :friend` (no counter_cache) and
+    // `belongs_to :friend_too` (counter_cache: :friends_too_count), sharing
+    // `friend_id`. Resetting `:friends_too` on Person must find the belongs_to
+    // that actually carries `counter_cache:` (the second one), not just any
+    // belongs_to whose className matches the parent.
+    class FriendPerson extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("friends_too_count", "integer", { default: 0 });
+        this.adapter = adapter;
+      }
+    }
+    class Friendship extends Base {
+      static {
+        this.attribute("friend_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Friendship, "friend", {
+      className: "FriendPerson",
+      foreignKey: "friend_id",
+    });
+    Associations.belongsTo.call(Friendship, "friendToo", {
+      className: "FriendPerson",
+      foreignKey: "friend_id",
+      counterCache: "friends_too_count",
+    });
+    Associations.hasMany.call(FriendPerson, "friends_too", {
+      className: "Friendship",
+      foreignKey: "friend_id",
+    });
+    registerModel(FriendPerson);
+    registerModel(Friendship);
+    const michael = await FriendPerson.create({ name: "Michael" });
+    await Friendship.create({ friend_id: michael.id });
+    await FriendPerson.incrementCounter("friends_too_count", michael.id);
+    const before = await FriendPerson.find(michael.id);
+    expect(before.friends_too_count).toBe(2);
+    await FriendPerson.resetCounters(michael.id, "friends_too");
+    const after = await FriendPerson.find(michael.id);
+    expect(after.friends_too_count).toBe(1);
   });
   it.skip("reset counter of has_many :through association", () => {
     // BLOCKED: associations — has_many :through target in resetCounters

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -1503,11 +1503,13 @@ describe("CounterCacheTest", () => {
   });
   it.skip("reset counters for cpk model", () => {
     // BLOCKED: associations — composite primary key in resetCounters
-    // ROOT-CAUSE: resetCounters' UPDATE WHERE is now CPK-aware (uses caller-supplied
-    //   id rather than record.id), but countHasMany still raises
-    //   CompositePrimaryKeyMismatchError when the parent has a CPK and the hasMany
-    //   uses a scalar foreignKey — the Rails Cpk::Order/Cpk::Book setup uses a
-    //   composite FK ([:shop_id, :order_id]) which we do not yet support for hasMany.
+    // ROOT-CAUSE: resetCounters' UPDATE WHERE (record.id, mirroring Rails'
+    //   `unscoped.where(primary_key => [object.id])`) is already CPK-aware
+    //   because trails' id getter returns the composite tuple. The blocker
+    //   is countHasMany, which raises CompositePrimaryKeyMismatchError when
+    //   the parent has a CPK and the hasMany uses a scalar foreignKey —
+    //   Rails' Cpk::Order/Cpk::Book setup uses a composite FK
+    //   ([:shop_id, :order_id]) which we do not yet support for hasMany.
     // SCOPE: ~30 LOC in associations.ts to thread composite FK through
     //   computeHasManyWhere / buildHasManyRelation; punt to follow-up PR.
   });

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -185,9 +185,10 @@ export async function resetCounters(
   }
 
   if (Object.keys(updates).length > 0) {
-    // Use the caller-supplied id (not `record.id`) so composite-PK arrays
-    // flow through `buildPkPredicate` untouched.
-    await this.unscoped().where(buildPkPredicate(this, id)).updateAll(updates);
+    // Mirrors Rails: `unscoped.where(primary_key => [object.id]).update_all(updates)`.
+    // `record.id` returns the CPK tuple via the PrimaryKey#id accessor, and
+    // matches the cast already applied by `find` for scalar PKs.
+    await this.unscoped().where(buildPkPredicate(this, record.id)).updateAll(updates);
   }
 }
 

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -132,7 +132,7 @@ export async function resetCounters(
     }
   }
 
-  const record = await this.find(id as any);
+  const record = await this.find(id);
   const assocDefs = (this as any)._associations as
     | Array<{ type: string; name: string; options: any }>
     | undefined;

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -170,9 +170,15 @@ export async function resetCounters(
     const count = await countHasMany(record, assoc.name, assoc.options);
     // Mirrors Rails: `updates[counter_name] = count if count != count_was` — skip
     // the UPDATE entirely when the stored counter already matches the recount.
+    // Ruby's `!=` is type-coercing across Integer/Bignum; in TS we have to match
+    // explicitly when the stored attribute is bigint (e.g. big_integer columns).
     const countWas =
       (record as any).readAttribute?.(counterColumn) ?? (record as any)[counterColumn];
-    if (count !== countWas) updates[counterColumn] = count;
+    const sameCount =
+      typeof countWas === "bigint" ? countWas === BigInt(count) : count === countWas;
+    if (!sameCount) {
+      updates[counterColumn] = typeof countWas === "bigint" ? BigInt(count) : count;
+    }
   }
 
   if (options.touch) {

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -132,7 +132,7 @@ export async function resetCounters(
     }
   }
 
-  const record = await this.find(id);
+  const record = await this.find(id as any);
   const assocDefs = (this as any)._associations as
     | Array<{ type: string; name: string; options: any }>
     | undefined;
@@ -168,7 +168,11 @@ export async function resetCounters(
     }
 
     const count = await countHasMany(record, assoc.name, assoc.options);
-    updates[counterColumn] = count;
+    // Mirrors Rails: `updates[counter_name] = count if count != count_was` — skip
+    // the UPDATE entirely when the stored counter already matches the recount.
+    const countWas =
+      (record as any).readAttribute?.(counterColumn) ?? (record as any)[counterColumn];
+    if (count !== countWas) updates[counterColumn] = count;
   }
 
   if (options.touch) {
@@ -181,7 +185,9 @@ export async function resetCounters(
   }
 
   if (Object.keys(updates).length > 0) {
-    await this.unscoped().where(buildPkPredicate(this, record.id)).updateAll(updates);
+    // Use the caller-supplied id (not `record.id`) so composite-PK arrays
+    // flow through `buildPkPredicate` untouched.
+    await this.unscoped().where(buildPkPredicate(this, id)).updateAll(updates);
   }
 }
 


### PR DESCRIPTION
## Summary

Three small pieces of Rails parity for `ActiveRecord::CounterCache#reset_counters`, drawn from `docs/activerecord-100-plan.md` Batch 134.

- **Short-circuit UPDATE** when `SELECT COUNT(*)` already matches the stored counter — mirrors Rails' `updates[counter_name] = count if count != count_was`. Eliminates an unnecessary UPDATE round-trip when the cache is already correct.
- **Test bodies** for two already-implemented cases that were stub-skipped:
  - `belongs_to which has class_name` — Engine has `belongs_to :my_car, class_name: 'Car'`; resolution must consult `options.className` rather than `camelize(name)`.
  - `two have the same foreign key` — Friendship has two `belongs_to` to Person sharing `friend_id` but only one has `counter_cache:`; we already pick the one with `counter_cache:` set.

Implementation continues to use `record.id` for the UPDATE WHERE, mirroring Rails' `unscoped.where(primary_key => [object.id])`. trails' `id` getter (`attribute-methods/primary-key.ts:102`) returns the composite tuple for CPK, so this is correct for both scalar and composite primary keys.

Skipped tests in slot 134 that remain blocked:

- **CPK reset_counters** — blocked downstream in `countHasMany`, which raises `CompositePrimaryKeyMismatchError` when a parent with CPK has a hasMany with a scalar foreignKey (Rails' Cpk::Order/Cpk::Book setup uses a composite FK `[:shop_id, :order_id]`).
- **Modular / camelized classnames** — namespace-style `"Module::Class"` resolution; less load-bearing in TS.
- **Same class_name disambiguation** — needs foreign-key tiebreaker in `resolveCounterColumn`.
- **Through-reflection branch** in `reset_counters` (~30 LOC).
- **Reflection scope (select/where)** applied during the COUNT (~15 LOC).
- **touch: true forces UPDATE** — depends on `touch:` wiring (Batch 135).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/counter-cache.test.ts` — 90 passed, 11 skipped (was 87 / 14).
- [x] `pnpm lint` for the two touched files — clean.
- [x] `pnpm api:compare --package activerecord` — `counter_cache.rb` 8/8 (100%) maintained.
- [ ] CI full suite.