### PR TITLE
feat(action-dispatch): port Request::Utils with deep_munge

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -7,6 +7,7 @@
 
 import type { RackEnv } from "@blazetrails/rack";
 import { parseNestedQuery } from "@blazetrails/rack";
+import { RequestUtils, type ParamValue } from "../request/utils.js";
 
 export class Request {
   readonly env: RackEnv;
@@ -264,7 +265,10 @@ export class Request {
   get queryParameters(): Record<string, unknown> {
     const qs = this.queryString;
     if (!qs) return {};
-    return parseNestedQuery(qs);
+    return RequestUtils.normalizeEncodeParams(parseNestedQuery(qs) as ParamValue) as Record<
+      string,
+      unknown
+    >;
   }
 
   get requestParameters(): Record<string, unknown> {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -319,8 +319,12 @@ export class Request {
       params = parseNestedQuery(input);
     }
 
-    this.env["action_dispatch.request.request_parameters"] = params;
-    return params;
+    const normalized = RequestUtils.normalizeEncodeParams(params as ParamValue) as Record<
+      string,
+      unknown
+    >;
+    this.env["action_dispatch.request.request_parameters"] = normalized;
+    return normalized;
   }
 
   get pathParameters(): Record<string, string> {

--- a/packages/actionpack/src/action-dispatch/request/index.ts
+++ b/packages/actionpack/src/action-dispatch/request/index.ts
@@ -1,1 +1,2 @@
 export { Session, type SessionStore } from "./session.js";
+export { RequestUtils, type ParamValue, type ParamHash } from "./utils.js";

--- a/packages/actionpack/src/action-dispatch/request/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.test.ts
@@ -44,6 +44,13 @@ describe("RequestUtils", () => {
         x: [null, "1"],
       });
     });
+
+    it("always clones output hashes with a null prototype (defangs __proto__ keys)", () => {
+      const malicious = JSON.parse('{"__proto__": {"polluted": true}, "ok": "1"}');
+      const out = RequestUtils.normalizeEncodeParams(malicious);
+      expect(Object.getPrototypeOf(out)).toBe(null);
+      expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+    });
   });
 
   describe("eachParamValue", () => {

--- a/packages/actionpack/src/action-dispatch/request/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.test.ts
@@ -9,21 +9,21 @@ describe("RequestUtils", () => {
 
   describe("deepMunge", () => {
     it("strips null entries from arrays", () => {
-      expect(RequestUtils.deepMunge([1, null, 2] as never)).toEqual([1, 2]);
+      expect(RequestUtils.deepMunge(["a", null, "b"])).toEqual(["a", "b"]);
     });
 
     it("recurses into nested arrays", () => {
-      expect(RequestUtils.deepMunge({ a: { b: [null] } } as never)).toEqual({ a: { b: [] } });
+      expect(RequestUtils.deepMunge({ a: { b: [null] } })).toEqual({ a: { b: [] } });
     });
 
-    it("recurses into nested hashes", () => {
-      expect(RequestUtils.deepMunge({ a: { b: null } } as never)).toEqual({ a: { b: null } });
+    it("preserves null leaves on hash values (only arrays are compacted)", () => {
+      expect(RequestUtils.deepMunge({ a: { b: null } })).toEqual({ a: { b: null } });
     });
 
     it("preserves nested hashes inside arrays after compaction", () => {
-      expect(
-        RequestUtils.deepMunge({ a: { b: [{ c: null }, null, { d: "1" }] } } as never),
-      ).toEqual({ a: { b: [{ c: null }, { d: "1" }] } });
+      expect(RequestUtils.deepMunge({ a: { b: [{ c: null }, null, { d: "1" }] } })).toEqual({
+        a: { b: [{ c: null }, { d: "1" }] },
+      });
     });
 
     it("leaves string and null leaves alone", () => {
@@ -35,12 +35,12 @@ describe("RequestUtils", () => {
   describe("normalizeEncodeParams", () => {
     it("compacts arrays when performDeepMunge is true (default)", () => {
       RequestUtils.performDeepMunge = true;
-      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] } as never)).toEqual({ x: ["1"] });
+      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] })).toEqual({ x: ["1"] });
     });
 
     it("preserves arrays when performDeepMunge is false", () => {
       RequestUtils.performDeepMunge = false;
-      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] } as never)).toEqual({
+      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] })).toEqual({
         x: [null, "1"],
       });
     });
@@ -48,14 +48,12 @@ describe("RequestUtils", () => {
 
   describe("eachParamValue", () => {
     it("yields every string leaf", () => {
-      const leaves = Array.from(
-        RequestUtils.eachParamValue({ a: "1", b: ["2", { c: "3" }] } as never),
-      );
+      const leaves = Array.from(RequestUtils.eachParamValue({ a: "1", b: ["2", { c: "3" }] }));
       expect(leaves).toEqual(["1", "2", "3"]);
     });
 
-    it("skips null and non-string scalars", () => {
-      const leaves = Array.from(RequestUtils.eachParamValue({ a: null, b: ["x"] } as never));
+    it("skips null leaves", () => {
+      const leaves = Array.from(RequestUtils.eachParamValue({ a: null, b: ["x"] }));
       expect(leaves).toEqual(["x"]);
     });
   });

--- a/packages/actionpack/src/action-dispatch/request/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { RequestUtils } from "./utils.js";
+
+describe("RequestUtils", () => {
+  const initialPerformDeepMunge = RequestUtils.performDeepMunge;
+  afterEach(() => {
+    RequestUtils.performDeepMunge = initialPerformDeepMunge;
+  });
+
+  describe("deepMunge", () => {
+    it("strips null entries from arrays", () => {
+      expect(RequestUtils.deepMunge([1, null, 2] as never)).toEqual([1, 2]);
+    });
+
+    it("recurses into nested arrays", () => {
+      expect(RequestUtils.deepMunge({ a: { b: [null] } } as never)).toEqual({ a: { b: [] } });
+    });
+
+    it("recurses into nested hashes", () => {
+      expect(RequestUtils.deepMunge({ a: { b: null } } as never)).toEqual({ a: { b: null } });
+    });
+
+    it("preserves nested hashes inside arrays after compaction", () => {
+      expect(
+        RequestUtils.deepMunge({ a: { b: [{ c: null }, null, { d: "1" }] } } as never),
+      ).toEqual({ a: { b: [{ c: null }, { d: "1" }] } });
+    });
+
+    it("leaves string and null leaves alone", () => {
+      expect(RequestUtils.deepMunge("foo")).toBe("foo");
+      expect(RequestUtils.deepMunge(null)).toBe(null);
+    });
+  });
+
+  describe("normalizeEncodeParams", () => {
+    it("compacts arrays when performDeepMunge is true (default)", () => {
+      RequestUtils.performDeepMunge = true;
+      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] } as never)).toEqual({ x: ["1"] });
+    });
+
+    it("preserves arrays when performDeepMunge is false", () => {
+      RequestUtils.performDeepMunge = false;
+      expect(RequestUtils.normalizeEncodeParams({ x: [null, "1"] } as never)).toEqual({
+        x: [null, "1"],
+      });
+    });
+  });
+
+  describe("eachParamValue", () => {
+    it("yields every string leaf", () => {
+      const leaves = Array.from(
+        RequestUtils.eachParamValue({ a: "1", b: ["2", { c: "3" }] } as never),
+      );
+      expect(leaves).toEqual(["1", "2", "3"]);
+    });
+
+    it("skips null and non-string scalars", () => {
+      const leaves = Array.from(RequestUtils.eachParamValue({ a: null, b: ["x"] } as never));
+      expect(leaves).toEqual(["x"]);
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -12,7 +12,15 @@
  * indifferent-access concern doesn't apply (object keys are strings only).
  */
 
-export type ParamValue = string | null | ParamValue[] | { [key: string]: ParamValue };
+// JSON-compatible primitives: urlencoded bodies yield string|null, JSON bodies
+// can also yield number|boolean. ParamValue covers both.
+export type ParamValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ParamValue[]
+  | { [key: string]: ParamValue };
 export type ParamHash = { [key: string]: ParamValue };
 
 export class RequestUtils {
@@ -35,42 +43,41 @@ export class RequestUtils {
   }
 
   /**
-   * Returns a normalized version of `params`. When `performDeepMunge` is
-   * true (the Rails default), the structure is recursively cloned with
-   * `null` entries removed from arrays. When false, `params` is returned
-   * as-is — Rails wraps with HashWithIndifferentAccess at this point,
-   * which we don't need in TS.
+   * Returns a normalized clone of `params`. Hashes are rebuilt with a
+   * null prototype so attacker-controlled `__proto__` keys (e.g. from
+   * `JSON.parse`) land as plain data rather than mutating the prototype
+   * chain. When `performDeepMunge` is true (the Rails default), `null`
+   * entries are additionally compacted out of arrays.
    *
-   * Mirrors `Request::Utils.normalize_encode_params`.
+   * Mirrors `Request::Utils.normalize_encode_params` — Rails' choice
+   * between `NoNilParamEncoder` and `ParamEncoder` (HashWithIndifferent-
+   * Access wrap omitted; TS object keys are already strings).
    */
   static normalizeEncodeParams(params: ParamValue): ParamValue {
-    if (this.performDeepMunge) {
-      return noNilNormalize(params);
-    }
-    return params;
+    return normalize(params, this.performDeepMunge);
   }
 
   /**
    * Standalone deep-munge: strip `null` from arrays at every depth.
    * Equivalent to Rails' `NoNilParamEncoder.handle_array` applied
-   * recursively.
+   * recursively. Always normalizes (compaction is unconditional here).
    */
   static deepMunge(params: ParamValue): ParamValue {
-    return noNilNormalize(params);
+    return normalize(params, true);
   }
 }
 
-function noNilNormalize(params: ParamValue): ParamValue {
+function normalize(params: ParamValue, stripNil: boolean): ParamValue {
   if (Array.isArray(params)) {
-    const mapped = params.map(noNilNormalize);
-    return mapped.filter((el) => el !== null);
+    const mapped = params.map((el) => normalize(el, stripNil));
+    return stripNil ? mapped.filter((el) => el !== null) : mapped;
   }
   if (params !== null && typeof params === "object") {
     // Null-prototype to (a) match parseNestedQuery's shape and (b) make
     // `__proto__` in an own key land as data instead of mutating the
     // prototype chain.
     const out: ParamHash = Object.create(null);
-    for (const [k, v] of Object.entries(params)) out[k] = noNilNormalize(v);
+    for (const [k, v] of Object.entries(params)) out[k] = normalize(v, stripNil);
     return out;
   }
   return params;

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -1,0 +1,85 @@
+/**
+ * ActionDispatch::Request::Utils
+ *
+ * Walks parsed parameter structures (from `parseNestedQuery` etc.) for
+ * normalization and traversal. The headline feature is `deepMunge`, which
+ * strips `null` entries from arrays — Rails enables this by default to
+ * defang null-injection attacks against ActiveRecord queries.
+ *
+ * Rails' Utils also includes `set_binary_encoding` / `CustomParamEncoder`
+ * (string encoding fixups for non-UTF-8 input) and HashWithIndifferentAccess
+ * wrapping. Both are skipped here: JS strings are always UTF-16, and the
+ * indifferent-access concern doesn't apply (object keys are strings only).
+ */
+
+export type ParamValue = string | null | ParamValue[] | { [key: string]: ParamValue };
+export type ParamHash = { [key: string]: ParamValue };
+
+export class RequestUtils {
+  /**
+   * Mirrors Rails `mattr_accessor :perform_deep_munge, default: true`.
+   * When true, `deepMunge` compacts `null` out of arrays. The toggle is
+   * test-only escape hatch; production code should not flip it.
+   */
+  static performDeepMunge = true;
+
+  /** Yields every string leaf in a parsed param tree. */
+  static *eachParamValue(params: ParamValue): Generator<string> {
+    if (Array.isArray(params)) {
+      for (const el of params) yield* this.eachParamValue(el);
+    } else if (params !== null && typeof params === "object") {
+      for (const val of Object.values(params)) yield* this.eachParamValue(val);
+    } else if (typeof params === "string") {
+      yield params;
+    }
+  }
+
+  /**
+   * Returns a normalized copy of `params`. When `performDeepMunge` is true
+   * (the Rails default), arrays have their `null` entries removed
+   * recursively. When false, the structure is passed through untouched.
+   *
+   * Mirrors `Request::Utils.normalize_encode_params` minus the
+   * HashWithIndifferentAccess wrapping (which doesn't apply in TS).
+   */
+  static normalizeEncodeParams(params: ParamValue): ParamValue {
+    if (this.performDeepMunge) {
+      return noNilNormalize(params);
+    }
+    return passthroughNormalize(params);
+  }
+
+  /**
+   * Standalone deep-munge: strip `null` from arrays at every depth.
+   * Equivalent to Rails' `NoNilParamEncoder.handle_array` applied
+   * recursively.
+   */
+  static deepMunge(params: ParamValue): ParamValue {
+    return noNilNormalize(params);
+  }
+}
+
+function noNilNormalize(params: ParamValue): ParamValue {
+  if (Array.isArray(params)) {
+    const mapped = params.map(noNilNormalize);
+    return mapped.filter((el) => el !== null);
+  }
+  if (params !== null && typeof params === "object") {
+    const out: ParamHash = {};
+    for (const [k, v] of Object.entries(params)) out[k] = noNilNormalize(v);
+    return out;
+  }
+  return params;
+}
+
+function passthroughNormalize(params: ParamValue): ParamValue {
+  if (Array.isArray(params)) {
+    return params.map(passthroughNormalize);
+  }
+  if (params !== null && typeof params === "object") {
+    const out: ParamHash = {};
+    for (const [k, v] of Object.entries(params)) out[k] = passthroughNormalize(v);
+    return out;
+  }
+  return params;
+}

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -26,9 +26,9 @@ export class RequestUtils {
   /** Yields every string leaf in a parsed param tree. */
   static *eachParamValue(params: ParamValue): Generator<string> {
     if (Array.isArray(params)) {
-      for (const el of params) yield* this.eachParamValue(el);
+      for (const el of params) yield* RequestUtils.eachParamValue(el);
     } else if (params !== null && typeof params === "object") {
-      for (const val of Object.values(params)) yield* this.eachParamValue(val);
+      for (const val of Object.values(params)) yield* RequestUtils.eachParamValue(val);
     } else if (typeof params === "string") {
       yield params;
     }

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -35,18 +35,19 @@ export class RequestUtils {
   }
 
   /**
-   * Returns a normalized copy of `params`. When `performDeepMunge` is true
-   * (the Rails default), arrays have their `null` entries removed
-   * recursively. When false, the structure is passed through untouched.
+   * Returns a normalized version of `params`. When `performDeepMunge` is
+   * true (the Rails default), the structure is recursively cloned with
+   * `null` entries removed from arrays. When false, `params` is returned
+   * as-is — Rails wraps with HashWithIndifferentAccess at this point,
+   * which we don't need in TS.
    *
-   * Mirrors `Request::Utils.normalize_encode_params` minus the
-   * HashWithIndifferentAccess wrapping (which doesn't apply in TS).
+   * Mirrors `Request::Utils.normalize_encode_params`.
    */
   static normalizeEncodeParams(params: ParamValue): ParamValue {
     if (this.performDeepMunge) {
       return noNilNormalize(params);
     }
-    return passthroughNormalize(params);
+    return params;
   }
 
   /**
@@ -65,20 +66,11 @@ function noNilNormalize(params: ParamValue): ParamValue {
     return mapped.filter((el) => el !== null);
   }
   if (params !== null && typeof params === "object") {
-    const out: ParamHash = {};
+    // Null-prototype to (a) match parseNestedQuery's shape and (b) make
+    // `__proto__` in an own key land as data instead of mutating the
+    // prototype chain.
+    const out: ParamHash = Object.create(null);
     for (const [k, v] of Object.entries(params)) out[k] = noNilNormalize(v);
-    return out;
-  }
-  return params;
-}
-
-function passthroughNormalize(params: ParamValue): ParamValue {
-  if (Array.isArray(params)) {
-    return params.map(passthroughNormalize);
-  }
-  if (params !== null && typeof params === "object") {
-    const out: ParamHash = {};
-    for (const [k, v] of Object.entries(params)) out[k] = passthroughNormalize(v);
     return out;
   }
   return params;


### PR DESCRIPTION
## Summary

Ports the subset of `action_dispatch/request/utils.rb` that matters for trails.

- `RequestUtils.performDeepMunge` — class-level toggle (Rails `mattr_accessor`), default `true`.
- `RequestUtils.deepMunge(params)` — recursively strips `null` from arrays in a parsed param tree. Defangs null-injection attacks against downstream queries (Rails' motivation for enabling it by default).
- `RequestUtils.normalizeEncodeParams(params)` — Rails' dispatcher that picks `NoNilParamEncoder` or `ParamEncoder` based on the toggle. HashWithIndifferentAccess wrapping is intentionally omitted (TS keys are already strings).
- `RequestUtils.eachParamValue(params)` — yields every string leaf.

Wires `deep_munge` into `Request.queryParameters` so the Rack-parsed tree gets munged by default — matches Rails' default request pipeline. All 78 existing request tests still pass.

This unblocks a future port of `dispatch/request/query_string_parsing_test.rb` (17 missing tests), several of which assert deep-munged shapes.

## Test plan

- [x] 9 new unit tests in `request/utils.test.ts` — deepMunge / normalizeEncodeParams / eachParamValue
- [x] All 78 existing `request.test.ts` tests still pass
- [x] `pnpm build` clean
- [x] `pnpm lint` clean