### PR TITLE
feat(activerecord): has_many_inversing config + inverse-wire dedup (batch 119)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -261,6 +261,24 @@ function _resolveInverseName(
  */
 function _wireInverseAssociation(owner: Base, child: Base, inverseName: string): void {
   child._cachedAssociations = child._cachedAssociations ?? new Map();
+  const childCtor = child.constructor as typeof Base;
+  const inverseRefl = childCtor._reflectOnAssociation?.(inverseName);
+  // When the inverse is a has_many collection AND the child's class opts into
+  // has_many_inversing, the inverse instance must be pushed onto the parent's
+  // cached collection (deduped by identity) — mirrors Rails
+  // `replace_on_target(..., inversing: true)` seeding @replaced_or_added_targets.
+  // Without this gate Rails (and trails) leave the parent collection alone, so
+  // that loading a child's belongs_to does not eagerly mutate parent state.
+  if (
+    inverseRefl?.macro === "hasMany" &&
+    (childCtor as typeof Base & { hasManyInversing: boolean }).hasManyInversing
+  ) {
+    const existing = child._cachedAssociations.get(inverseName);
+    const collection = Array.isArray(existing) ? (existing as Base[]) : [];
+    if (!collection.includes(owner)) collection.push(owner);
+    child._cachedAssociations.set(inverseName, collection);
+    return;
+  }
   child._cachedAssociations.set(inverseName, owner);
 }
 
@@ -2160,9 +2178,8 @@ export function setBelongsTo(
   record._cachedAssociations.set(assocName, target);
 
   // Set inverse on target
-  if (target && options.inverseOf) {
-    if (!target._cachedAssociations) target._cachedAssociations = new Map();
-    target._cachedAssociations.set(options.inverseOf, record);
+  if (target && typeof options.inverseOf === "string") {
+    _wireInverseAssociation(record, target, options.inverseOf);
   }
 }
 
@@ -2212,9 +2229,8 @@ export async function setHasOne(
   record._cachedAssociations.set(assocName, target);
 
   // Set inverse
-  if (target && options.inverseOf) {
-    if (!target._cachedAssociations) target._cachedAssociations = new Map();
-    target._cachedAssociations.set(options.inverseOf, record);
+  if (target && typeof options.inverseOf === "string") {
+    _wireInverseAssociation(record, target, options.inverseOf);
   }
 }
 
@@ -2262,9 +2278,8 @@ export async function setHasMany(
     if (t.isPersisted()) await t.save();
 
     // Set inverse
-    if (options.inverseOf) {
-      if (!t._cachedAssociations) t._cachedAssociations = new Map();
-      t._cachedAssociations.set(options.inverseOf, record);
+    if (typeof options.inverseOf === "string") {
+      _wireInverseAssociation(record, t, options.inverseOf);
     }
   }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -260,27 +260,31 @@ function _resolveInverseName(
  * @internal
  */
 function _wireInverseAssociation(owner: Base, child: Base, inverseName: string): void {
-  child._cachedAssociations = child._cachedAssociations ?? new Map();
   const childCtor = child.constructor as typeof Base;
   const inverseRefl = childCtor._reflectOnAssociation?.(inverseName);
-  // When the inverse is a has_many collection AND the child's class opts into
-  // has_many_inversing, push the owner onto the parent's cached collection
-  // (deduped by identity). Rails models this as `replace_on_target(...,
-  // inversing: true)` writing into `CollectionAssociation#@target` and
-  // `@replaced_or_added_targets`; trails' equivalent target for inverse-of
-  // wiring is `_cachedAssociations`, so the dedup lives here. The
-  // CollectionProxy `<<` / `build` paths read this cache, so the invariant
-  // carries through; full proxy-side dedup is a deferred follow-up.
-  if (
-    inverseRefl?.macro === "hasMany" &&
-    (childCtor as typeof Base & { hasManyInversing: boolean }).hasManyInversing
-  ) {
+  // Rails `BelongsToAssociation#invertible_for?` (belongs_to_association.rb:159):
+  // when the inverse is a has_many, wiring is gated on `klass.has_many_inversing`.
+  // Without the flag, Rails does NOT touch the parent collection cache. trails'
+  // equivalent cache target is `_cachedAssociations`; mirror the gate here so we
+  // never poison a hasMany cache slot with a scalar (loadHasMany casts the slot
+  // to Base[] unconditionally).
+  if (inverseRefl?.macro === "hasMany") {
+    if (!childCtor.hasManyInversing) return;
+    child._cachedAssociations = child._cachedAssociations ?? new Map();
+    // Mirror Rails `replace_on_target(..., inversing: true)`: append + identity
+    // dedup. Promote a stray scalar value (legacy pre-flag write) into a 1-element
+    // array so we never silently drop a previously-cached record.
     const existing = child._cachedAssociations.get(inverseName);
-    const collection = Array.isArray(existing) ? (existing as Base[]) : [];
+    const collection: Base[] = Array.isArray(existing)
+      ? (existing as Base[])
+      : existing != null
+        ? [existing as Base]
+        : [];
     if (!collection.includes(owner)) collection.push(owner);
     child._cachedAssociations.set(inverseName, collection);
     return;
   }
+  child._cachedAssociations = child._cachedAssociations ?? new Map();
   child._cachedAssociations.set(inverseName, owner);
 }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -272,14 +272,25 @@ function _wireInverseAssociation(owner: Base, child: Base, inverseName: string):
     if (!childCtor.hasManyInversing) return;
     child._cachedAssociations = child._cachedAssociations ?? new Map();
     // Mirror Rails `replace_on_target(..., inversing: true)`: append + identity
-    // dedup. Promote a stray scalar value (legacy pre-flag write) into a 1-element
-    // array so we never silently drop a previously-cached record.
+    // dedup. Rails has a single `@target` per CollectionAssociation; trails
+    // splits state across `_cachedAssociations` and `_collectionProxies`, so
+    // seed `collection` from the proxy's loaded target when one exists to keep
+    // them in sync (otherwise a later `_cachedAssociations` read could return
+    // a partial array). Promote stray scalars from legacy pre-flag writes.
+    const proxy = child._collectionProxies?.get(inverseName) as
+      | { loaded?: boolean; target?: Base[] }
+      | undefined;
     const existing = child._cachedAssociations.get(inverseName);
-    const collection: Base[] = Array.isArray(existing)
-      ? (existing as Base[])
-      : existing != null
-        ? [existing as Base]
-        : [];
+    let collection: Base[];
+    if (proxy?.loaded && Array.isArray(proxy.target)) {
+      collection = proxy.target;
+    } else if (Array.isArray(existing)) {
+      collection = existing as Base[];
+    } else if (existing != null) {
+      collection = [existing as Base];
+    } else {
+      collection = [];
+    }
     if (!collection.includes(owner)) collection.push(owner);
     child._cachedAssociations.set(inverseName, collection);
     return;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -264,11 +264,13 @@ function _wireInverseAssociation(owner: Base, child: Base, inverseName: string):
   const childCtor = child.constructor as typeof Base;
   const inverseRefl = childCtor._reflectOnAssociation?.(inverseName);
   // When the inverse is a has_many collection AND the child's class opts into
-  // has_many_inversing, the inverse instance must be pushed onto the parent's
-  // cached collection (deduped by identity) — mirrors Rails
-  // `replace_on_target(..., inversing: true)` seeding @replaced_or_added_targets.
-  // Without this gate Rails (and trails) leave the parent collection alone, so
-  // that loading a child's belongs_to does not eagerly mutate parent state.
+  // has_many_inversing, push the owner onto the parent's cached collection
+  // (deduped by identity). Rails models this as `replace_on_target(...,
+  // inversing: true)` writing into `CollectionAssociation#@target` and
+  // `@replaced_or_added_targets`; trails' equivalent target for inverse-of
+  // wiring is `_cachedAssociations`, so the dedup lives here. The
+  // CollectionProxy `<<` / `build` paths read this cache, so the invariant
+  // carries through; full proxy-side dedup is a deferred follow-up.
   if (
     inverseRefl?.macro === "hasMany" &&
     (childCtor as typeof Base & { hasManyInversing: boolean }).hasManyInversing

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -120,11 +120,13 @@ describe("InverseBelongsToTests", () => {
     Associations.belongsTo.call(Book, "author", { inverseOf: "books" });
     registerModel(Author);
     registerModel(Book);
+    Author.hasManyInversing = true;
     const a = await Author.create({ name: "Alice" });
     const b = await Book.create({ title: "Wonderland", author_id: a.id });
     const parent = await loadBelongsTo(b, "author", { inverseOf: "books" });
     expect(parent).not.toBeNull();
-    expect((parent as any)._cachedAssociations?.get("books")).toBe(b);
+    const cached = (parent as any)._cachedAssociations?.get("books") as Base[];
+    expect(cached).toEqual([b]);
   });
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
@@ -215,6 +217,7 @@ describe("InverseBelongsToTests", () => {
       inverseOf: "children",
     });
     registerModel(Node);
+    Node.hasManyInversing = true;
     const parent = await Node.create({ name: "root" });
     const child = await Node.create({ name: "leaf", node_id: parent.id });
     const foundParent = await loadBelongsTo(child, "parent", {
@@ -223,7 +226,8 @@ describe("InverseBelongsToTests", () => {
       inverseOf: "children",
     });
     expect(foundParent).not.toBeNull();
-    expect((foundParent as any)._cachedAssociations?.get("children")).toBe(child);
+    const cached = (foundParent as any)._cachedAssociations?.get("children") as Base[];
+    expect(cached).toEqual([child]);
   });
 
   it.skip("recursive inverse on recursive model has many inversing", () => {
@@ -455,21 +459,15 @@ describe("InverseHasManyTests", () => {
 
   it("with has many inversing inverse wire-up pushes onto cached collection and dedupes by identity", async () => {
     const { Man, Interest } = makeModels();
-    (Man as any).hasManyInversing = true;
-    try {
-      const created = await Man.create({ name: "Gordon" });
-      await Interest.create({ topic: "stamps", man_id: created.id });
-      const i = (await Interest.first()) as Base;
-      const m = await loadBelongsTo(i, "man", { inverseOf: "interests" });
-      // Re-load: cached-hit path also runs _wireInverseAssociation; must dedup.
-      await loadBelongsTo(i, "man", { inverseOf: "interests" });
-      const cached = (m as any)._cachedAssociations?.get("interests") as Base[];
-      expect(Array.isArray(cached)).toBe(true);
-      expect(cached.length).toBe(1);
-      expect(cached[0]).toBe(i);
-    } finally {
-      (Man as any).hasManyInversing = false;
-    }
+    Man.hasManyInversing = true;
+    const created = await Man.create({ name: "Gordon" });
+    await Interest.create({ topic: "stamps", man_id: created.id });
+    const i = (await Interest.first()) as Base;
+    const m = await loadBelongsTo(i, "man", { inverseOf: "interests" });
+    // Re-load: cached-hit path also runs _wireInverseAssociation; must dedup.
+    await loadBelongsTo(i, "man", { inverseOf: "interests" });
+    const cached = (m as any)._cachedAssociations?.get("interests") as Base[];
+    expect(cached).toEqual([i]);
   });
 
   it.skip("parent instance should be shared with every child on find for sti", () => {
@@ -1178,11 +1176,13 @@ describe("AutomaticInverseFindingTests", () => {
     Associations.belongsTo.call(Interest, "man", { inverseOf: "interests" });
     registerModel(Man);
     registerModel(Interest);
+    Man.hasManyInversing = true;
     const m = await Man.create({ name: "Gordon" });
     const i = await Interest.create({ topic: "stamps", man_id: m.id });
     const parent = await loadBelongsTo(i, "man", { inverseOf: "interests" });
     expect(parent).not.toBeNull();
-    expect((parent as any)._cachedAssociations?.get("interests")).toBe(i);
+    const cached = (parent as any)._cachedAssociations?.get("interests") as Base[];
+    expect(cached).toEqual([i]);
   });
 
   it("polymorphic and has many through relationships should not have inverses", () => {
@@ -1304,6 +1304,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const { Man, Tag } = makeModels();
+    Man.hasManyInversing = true;
     const m = await Man.create({ name: "Gordon" });
     await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
     const parent = await loadBelongsTo((await Tag.findBy({ taggable_id: m.id }))!, "taggable", {
@@ -1320,6 +1321,7 @@ describe("InversePolymorphicBelongsToTests", () => {
     // loadBelongsTo (with inverseOf) is stored in the parent's inverse cache —
     // object sharing, not just equal values.
     const { Man, Tag } = makeModels();
+    Man.hasManyInversing = true;
     const m = await Man.create({ name: "Gordon" });
     await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
 
@@ -1338,10 +1340,12 @@ describe("InversePolymorphicBelongsToTests", () => {
     });
     expect(parent).not.toBeNull();
     expect(parent).toBe(preloadedParent);
-    expect((parent as any)._cachedAssociations?.get("tags")).toBe(tags[0]);
+    const cached = (parent as any)._cachedAssociations?.get("tags") as Base[];
+    expect(cached).toEqual([tags[0]]);
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Tag } = makeModels();
+    Man.hasManyInversing = true;
     const m1 = await Man.create({ name: "Gordon" });
     const t = await Tag.create({ name: "cool", taggable_id: m1.id, taggable_type: "Man" });
     const m2 = await Man.create({ name: "New" });
@@ -1351,7 +1355,8 @@ describe("InversePolymorphicBelongsToTests", () => {
       foreignKey: "taggable_id",
     });
     expect((t as any)._cachedAssociations.get("taggable")).toBe(m2);
-    expect((m2 as any)._cachedAssociations?.get("tags")).toBe(t);
+    const cached = (m2 as any)._cachedAssociations?.get("tags") as Base[];
+    expect(cached).toEqual([t]);
   });
   it.skip("inversed instance should not be reloaded after stale state changed", () => {
     // BLOCKED: associations — inverse-of feature gap

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -453,6 +453,25 @@ describe("InverseHasManyTests", () => {
     }
   });
 
+  it("with has many inversing inverse wire-up pushes onto cached collection and dedupes by identity", async () => {
+    const { Man, Interest } = makeModels();
+    (Man as any).hasManyInversing = true;
+    try {
+      const created = await Man.create({ name: "Gordon" });
+      await Interest.create({ topic: "stamps", man_id: created.id });
+      const i = (await Interest.first()) as Base;
+      const m = await loadBelongsTo(i, "man", { inverseOf: "interests" });
+      // Re-load: cached-hit path also runs _wireInverseAssociation; must dedup.
+      await loadBelongsTo(i, "man", { inverseOf: "interests" });
+      const cached = (m as any)._cachedAssociations?.get("interests") as Base[];
+      expect(Array.isArray(cached)).toBe(true);
+      expect(cached.length).toBe(1);
+      expect(cached[0]).toBe(i);
+    } finally {
+      (Man as any).hasManyInversing = false;
+    }
+  });
+
   it.skip("parent instance should be shared with every child on find for sti", () => {
     // BLOCKED: associations — inverse-of feature gap
     // ROOT-CAUSE: associations/inverse-associations.ts or preloader.ts missing inverse-of semantics

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -675,6 +675,7 @@ export class Base extends Model {
   static _connectionClass = false;
   static automaticScopeInversing = false;
   static automaticallyInvertPluralAssociations = false;
+  static hasManyInversing = false;
   static paramDelimiter = "_";
   static cacheVersioning = false;
   static cacheTimestampFormat: "usec" | "number" = "usec";


### PR DESCRIPTION
## Summary

Foundation slice of [Batch 119](https://github.com/blazetrailsdev/trails/blob/main/docs/activerecord-100-plan.md) (`has_many_inversing` + collection-target dedup). Lays the config flag and the identity-dedup invariant used by Rails' `collection_association.rb#replace_on_target(..., inversing: true)` without yet wiring it into the collection-proxy `<<` / `build` / `load` paths.

- `Base.hasManyInversing` static config (Rails default `false`, mirrors `ActiveRecord::Core` `class_attribute`).
- `_wireInverseAssociation` dedups by identity when the inverse is a has_many AND the child's class enables `hasManyInversing`.
- `setBelongsTo` / `setHasOne` / `setHasMany` route their inverse cache writes through `_wireInverseAssociation` (uniform gate, kills 3 inline `_cachedAssociations.set(...)` duplicates).
- New regression test covering re-entrant `loadBelongsTo` → inverse dedup.

## Follow-ups (split out to keep this slot reviewable)

- Collection-proxy `<<` / `build` / `load` dedup via the same identity invariant so `human.interests << interest` after a `new Interest(human: human)` wire-up doesn't double-push. Unblocks the 4 "does not add duplicate ... when collection is loaded" skips.
- `InverseOfAssociationRecursiveError` for the recursive-inverse skip.
- Callback-tracking infra for the "does not trigger callbacks" skip.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations/` (1389 passed)
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/autosave-association.test.ts` (575 passed)
- [x] `pnpm lint`