### PR TITLE
feat(activerecord): MySQL TableDefinition#toSql via SchemaCreation.accept (batch 110)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -165,6 +165,21 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     throw new Error(`${this.constructor.name} must implement columns()`);
   }
 
+  /**
+   * Override `SchemaStatements#createTableDefinition` to instantiate the
+   * MySQL-specific {@link MysqlTableDefinition} subclass, so its overrides
+   * (`newColumnDefinition` primary-key rewrite, `integerLikePrimaryKeyType`
+   * → `autoIncrement: true`, `aliasedTypes` identity, MySQL-only options)
+   * apply to `createTable` as well as `changeColumn`.
+   *
+   * Mirrors: `ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition`
+   * @internal
+   */
+  createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
+    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
+    return new MysqlTableDefinition(name, { ...rest, adapter: this });
+  }
+
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
   // Rails' `statement_limit` database.yml key — max prepared

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -176,12 +176,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * @internal
    */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
-    // Pass `this` (the MySQL adapter) as the `adapter` option so `MysqlTableDefinition#toSql`
-    // can build a host-aware visitor (support flags + MariaDB). `MysqlTableDefinition` is the
-    // authoritative layer for normalizing `adapter` / `adapterName` — it discards anything we
-    // pass for `adapterName` and the bare SchemaQuoter shape supplied by abstract
-    // SchemaStatements#createTable — so we don't strip those here.
-    return new MysqlTableDefinition(name, { ...options, adapter: this });
+    // Strip caller-supplied adapter/adapterName (abstract SchemaStatements#createTable forwards
+    // a bare SchemaQuoter shape) and substitute `this` — the full MySQL adapter — so the
+    // TableDefinition's `toSql()` can build a host-aware visitor. Matches the PG sibling
+    // (postgresql-adapter.ts) so the dispatch is symmetric across dialects.
+    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
+    return new MysqlTableDefinition(name, { ...rest, adapter: this });
   }
 
   protected _mariadb = false;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -176,6 +176,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * @internal
    */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
+    // SchemaStatements#createTable forwards `adapter: this.adapter, adapterName: this.adapterName`
+    // (the bare SchemaQuoter shape). MySQL needs the full adapter so `toSql()` can reach
+    // `schemaStatements().schemaCreation` for the host-aware visitor — drop the bare
+    // signal and substitute `this` (the MySQL adapter).
     const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
     return new MysqlTableDefinition(name, { ...rest, adapter: this });
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -176,12 +176,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * @internal
    */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
-    // SchemaStatements#createTable forwards `adapter: this.adapter, adapterName: this.adapterName`
-    // (the bare SchemaQuoter shape). MySQL needs the full adapter so `toSql()` can reach
-    // `schemaStatements().schemaCreation` for the host-aware visitor — drop the bare
-    // signal and substitute `this` (the MySQL adapter).
-    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
-    return new MysqlTableDefinition(name, { ...rest, adapter: this });
+    // Pass `this` (the MySQL adapter) as the `adapter` option so `MysqlTableDefinition#toSql`
+    // can build a host-aware visitor (support flags + MariaDB). `MysqlTableDefinition` is the
+    // authoritative layer for normalizing `adapter` / `adapterName` — it discards anything we
+    // pass for `adapterName` and the bare SchemaQuoter shape supplied by abstract
+    // SchemaStatements#createTable — so we don't strip those here.
+    return new MysqlTableDefinition(name, { ...options, adapter: this });
   }
 
   protected _mariadb = false;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -138,3 +138,55 @@ describe("MySQL::SchemaCreation", () => {
     expect(result).not.toContain("ON UPDATE");
   });
 });
+
+describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
+  it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("users", {});
+    td.string("name");
+    expect(td.toSql()).toBe(
+      "CREATE TABLE `users` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(255))",
+    );
+  });
+
+  it("honors id: false (no primary key column)", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("logs", { id: false });
+    td.string("body");
+    expect(td.toSql()).toBe("CREATE TABLE `logs` (`body` varchar(255))");
+  });
+
+  it("appends DEFAULT CHARSET and COLLATE from table options", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("posts", { charset: "utf8mb4", collation: "utf8mb4_unicode_ci" });
+    td.string("title");
+    const sql = td.toSql();
+    expect(sql).toContain("DEFAULT CHARSET=utf8mb4");
+    expect(sql).toContain("COLLATE=utf8mb4_unicode_ci");
+  });
+
+  it("emits IF NOT EXISTS and TEMPORARY modifiers", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("tmp", { id: false, temporary: true, ifNotExists: true });
+    td.integer("n");
+    expect(td.toSql()).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
+  });
+
+  it("emits composite PRIMARY KEY clause", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("memberships", { primaryKey: ["user_id", "group_id"] });
+    td.bigint("user_id", { null: false });
+    td.bigint("group_id", { null: false });
+    const sql = td.toSql();
+    expect(sql).toContain("PRIMARY KEY (`user_id`, `group_id`)");
+  });
+
+  it("inlines indexes when supportsIndexesInCreate (MySQL)", async () => {
+    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+    const td = new MyTd("users", {});
+    td.string("email");
+    td.index(["email"], { unique: true, name: "idx_users_email" });
+    const sql = td.toSql();
+    expect(sql).toContain("UNIQUE INDEX `idx_users_email` (`email`)");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -9,6 +9,7 @@ import {
   ColumnDefinition,
   TableDefinition,
 } from "../abstract/schema-definitions.js";
+import { TableDefinition as MyTd } from "./schema-definitions.js";
 
 describe("MySQL::SchemaCreation", () => {
   const sc = new SchemaCreation();
@@ -140,8 +141,7 @@ describe("MySQL::SchemaCreation", () => {
 });
 
 describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
-  it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", () => {
     const td = new MyTd("users", {});
     td.string("name");
     expect(td.toSql()).toBe(
@@ -149,15 +149,13 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     );
   });
 
-  it("honors id: false (no primary key column)", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("honors id: false (no primary key column)", () => {
     const td = new MyTd("logs", { id: false });
     td.string("body");
     expect(td.toSql()).toBe("CREATE TABLE `logs` (`body` varchar(255))");
   });
 
-  it("appends DEFAULT CHARSET and COLLATE from table options", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("appends DEFAULT CHARSET and COLLATE from table options", () => {
     const td = new MyTd("posts", { charset: "utf8mb4", collation: "utf8mb4_unicode_ci" });
     td.string("title");
     const sql = td.toSql();
@@ -165,15 +163,13 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     expect(sql).toContain("COLLATE=utf8mb4_unicode_ci");
   });
 
-  it("emits IF NOT EXISTS and TEMPORARY modifiers", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("emits IF NOT EXISTS and TEMPORARY modifiers", () => {
     const td = new MyTd("tmp", { id: false, temporary: true, ifNotExists: true });
     td.integer("n");
     expect(td.toSql()).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
   });
 
-  it("emits composite PRIMARY KEY clause", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("emits composite PRIMARY KEY clause", () => {
     const td = new MyTd("memberships", { primaryKey: ["user_id", "group_id"] });
     td.bigint("user_id", { null: false });
     td.bigint("group_id", { null: false });
@@ -181,8 +177,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     expect(sql).toContain("PRIMARY KEY (`user_id`, `group_id`)");
   });
 
-  it("inlines indexes when supportsIndexesInCreate (MySQL)", async () => {
-    const { TableDefinition: MyTd } = await import("./schema-definitions.js");
+  it("inlines indexes when supportsIndexesInCreate (MySQL)", () => {
     const td = new MyTd("users", {});
     td.string("email");
     td.index(["email"], { unique: true, name: "idx_users_email" });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -184,4 +184,51 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     const sql = td.toSql();
     expect(sql).toContain("UNIQUE INDEX `idx_users_email` (`email`)");
   });
+
+  it("inlines FOREIGN KEY constraints", () => {
+    const td = new MyTd("posts", {});
+    td.bigint("author_id");
+    td.foreignKey("authors", { column: "author_id" });
+    const sql = td.toSql();
+    expect(sql).toContain("CONSTRAINT ");
+    expect(sql).toContain("FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)");
+  });
+
+  it("inlines CHECK constraints", () => {
+    const td = new MyTd("products", {});
+    td.integer("price");
+    td.checkConstraint("price > 0", { name: "price_positive" });
+    const sql = td.toSql();
+    expect(sql).toContain("CONSTRAINT `price_positive` CHECK (price > 0)");
+  });
+
+  it("appends MySQL COMMENT on table option", () => {
+    const td = new MyTd("notes", { comment: "user-supplied" });
+    td.string("body");
+    expect(td.toSql()).toContain("COMMENT 'user-supplied'");
+  });
+
+  it("emits AS clause after table options for CTAS", () => {
+    const td = new MyTd("snapshot", { id: false, as: "SELECT 1" });
+    expect(td.toSql()).toMatch(/CREATE TABLE `snapshot`.* AS SELECT 1$/);
+  });
+
+  it("skips FK emission when host adapter has foreignKeys disabled", () => {
+    const host = {
+      supportsForeignKeys: () => true,
+      config: { foreignKeys: false },
+    };
+    const td = new MyTd("posts", { adapter: host });
+    td.bigint("author_id");
+    td.foreignKey("authors", { column: "author_id" });
+    expect(td.toSql()).not.toContain("FOREIGN KEY");
+  });
+
+  it("skips CHECK emission when host adapter reports !supportsCheckConstraints", () => {
+    const host = { supportsCheckConstraints: () => false };
+    const td = new MyTd("products", { adapter: host });
+    td.integer("price");
+    td.checkConstraint("price > 0", { name: "p_pos" });
+    expect(td.toSql()).not.toContain("CHECK");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -346,8 +346,14 @@ export class SchemaCreation extends AbstractSchemaCreation {
         sql += " NULL";
       }
     }
-    if (mo.charset) sql += ` CHARACTER SET ${mo.charset}`;
-    if (mo.collation) sql += ` COLLATE ${mo.collation}`;
+    if (mo.charset) {
+      assertSafeMysqlIdentifier(mo.charset, "charset");
+      sql += ` CHARACTER SET ${mo.charset}`;
+    }
+    if (mo.collation) {
+      assertSafeMysqlIdentifier(mo.collation, "collation");
+      sql += ` COLLATE ${mo.collation}`;
+    }
     if (mo.as) {
       sql += ` AS (${mo.as})`;
       if (mo.stored) sql += this.isMariadb() ? " PERSISTENT" : " STORED";

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -182,6 +182,47 @@ export class SchemaCreation extends AbstractSchemaCreation {
     );
   }
 
+  /**
+   * MySQL CREATE TABLE generator. Mirrors Rails'
+   * `abstract/schema_creation.rb#visit_TableDefinition`, routing every
+   * column through {@link SchemaCreation#visitColumnDefinition} so
+   * `addColumnOptions` (this subclass) handles `AUTO_INCREMENT`,
+   * `ON UPDATE`, charset/collation, etc. consistently with addColumn.
+   *
+   * @internal
+   */
+  protected override visitTableDefinition(o: TableDefinition): string {
+    let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
+    if (o.ifNotExists) sql += " IF NOT EXISTS";
+    sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
+
+    if (o.as) {
+      let inline = "";
+      if (o.indexes.length > 0) {
+        const idxSql = o.indexes.map((idx) => this.visitIndexDefinition(idx, false));
+        inline = ` (${idxSql.join(", ")})`;
+      }
+      sql += `${inline} AS ${o.as}`;
+    } else {
+      const parts: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
+      for (const chk of o.checkConstraints) {
+        parts.push(this.visitCheckConstraintDefinition(chk));
+      }
+      for (const fk of o.foreignKeys) {
+        parts.push(this.visitForeignKeyDefinition(fk));
+      }
+      if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
+        const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
+        parts.push(`PRIMARY KEY (${cols})`);
+      }
+      for (const idx of o.indexes) {
+        parts.push(this.visitIndexDefinition(idx, false));
+      }
+      sql += ` (${parts.join(", ")})`;
+    }
+    return this.addTableOptionsBang(sql, o);
+  }
+
   /** @internal */
   override accept(
     o:

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -182,6 +182,21 @@ export class SchemaCreation extends AbstractSchemaCreation {
     );
   }
 
+  /** @internal Mirrors `AbstractMysqlAdapter#supportsIndexesInCreate` (always true on MySQL/MariaDB). */
+  protected supportsIndexesInCreate(): boolean {
+    return true;
+  }
+
+  /** @internal Mirrors Rails' `use_foreign_keys?` — true on MySQL/MariaDB. */
+  protected useForeignKeys(): boolean {
+    return true;
+  }
+
+  /** @internal Mirrors `AbstractMysqlAdapter#supportsCheckConstraints` — true on MySQL 8+/MariaDB 10.2+. */
+  protected supportsCheckConstraints(): boolean {
+    return true;
+  }
+
   /**
    * MySQL CREATE TABLE generator. Mirrors Rails'
    * `abstract/schema_creation.rb#visit_TableDefinition`, routing every
@@ -201,14 +216,15 @@ export class SchemaCreation extends AbstractSchemaCreation {
       const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
       statements.push(`PRIMARY KEY (${cols})`);
     }
-    for (const idx of o.indexes) {
-      statements.push(this.visitIndexDefinition(idx, false));
+    if (this.supportsIndexesInCreate()) {
+      for (const idx of o.indexes) statements.push(this.visitIndexDefinition(idx, false));
     }
-    for (const fk of o.foreignKeys) {
-      statements.push(this.visitForeignKeyDefinition(fk));
+    if (this.useForeignKeys()) {
+      for (const fk of o.foreignKeys) statements.push(this.visitForeignKeyDefinition(fk));
     }
-    for (const chk of o.checkConstraints) {
-      statements.push(this.visitCheckConstraintDefinition(chk));
+    if (this.supportsCheckConstraints()) {
+      for (const chk of o.checkConstraints)
+        statements.push(this.visitCheckConstraintDefinition(chk));
     }
 
     if (statements.length > 0) sql += `(${statements.join(", ")})`;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -194,33 +194,27 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected override visitTableDefinition(o: TableDefinition): string {
     let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) sql += " IF NOT EXISTS";
-    sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
+    sql += ` ${this.adapter.quoteTableName(o.tableName)} `;
 
-    if (o.as) {
-      let inline = "";
-      if (o.indexes.length > 0) {
-        const idxSql = o.indexes.map((idx) => this.visitIndexDefinition(idx, false));
-        inline = ` (${idxSql.join(", ")})`;
-      }
-      sql += `${inline} AS ${o.as}`;
-    } else {
-      const parts: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
-      for (const chk of o.checkConstraints) {
-        parts.push(this.visitCheckConstraintDefinition(chk));
-      }
-      for (const fk of o.foreignKeys) {
-        parts.push(this.visitForeignKeyDefinition(fk));
-      }
-      if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
-        const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
-        parts.push(`PRIMARY KEY (${cols})`);
-      }
-      for (const idx of o.indexes) {
-        parts.push(this.visitIndexDefinition(idx, false));
-      }
-      sql += ` (${parts.join(", ")})`;
+    const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
+    if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
+      const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
+      statements.push(`PRIMARY KEY (${cols})`);
     }
-    return this.addTableOptionsBang(sql, o);
+    for (const idx of o.indexes) {
+      statements.push(this.visitIndexDefinition(idx, false));
+    }
+    for (const fk of o.foreignKeys) {
+      statements.push(this.visitForeignKeyDefinition(fk));
+    }
+    for (const chk of o.checkConstraints) {
+      statements.push(this.visitCheckConstraintDefinition(chk));
+    }
+
+    if (statements.length > 0) sql += `(${statements.join(", ")})`;
+    sql = this.addTableOptionsBang(sql, o);
+    if (o.as) sql += ` AS ${o.as}`;
+    return sql;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -49,11 +49,19 @@ interface MysqlColumnOptions extends Record<string, unknown> {
 
 type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
 
-/** @internal Adapter surface consulted by the visitor's support flags. */
+/** @internal Adapter surface consulted by the visitor's support flags and MariaDB branches. */
 interface VisitorHostAdapter {
   supportsCheckConstraints?(): boolean;
   supportsForeignKeys?(): boolean;
   supportsIndexesInCreate?(): boolean;
+  isMariadb?(): boolean;
+}
+
+/** @internal Shared identifier guard for MySQL bare-identifier emission (charset/collation). */
+export function assertSafeMysqlIdentifier(value: string, kind: string): void {
+  if (!/^[A-Za-z0-9_]+$/.test(value)) {
+    throw new ArgumentError(`Invalid MySQL ${kind}: ${JSON.stringify(value)}`);
+  }
 }
 
 export class SchemaCreation extends AbstractSchemaCreation {
@@ -69,6 +77,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
       quoteDefaultExpression: quoteDefaultExpression,
     });
     this._hostAdapter = host;
+    if (host?.isMariadb?.()) this._mariadb = true;
   }
 
   /** @internal */
@@ -219,7 +228,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected override visitTableDefinition(o: TableDefinition): string {
     let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) sql += " IF NOT EXISTS";
-    sql += ` ${this.adapter.quoteTableName(o.tableName)} `;
+    sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
     const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
@@ -237,7 +246,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
         statements.push(this.visitCheckConstraintDefinition(chk));
     }
 
-    if (statements.length > 0) sql += `(${statements.join(", ")})`;
+    if (statements.length > 0) sql += ` (${statements.join(", ")})`;
     sql = this.addTableOptionsBang(sql, o);
     if (o.as) sql += ` AS ${o.as}`;
     return sql;
@@ -311,20 +320,12 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   protected override addTableOptionsBang(sql: string, o: TableDefinition): string {
     const mo = o as MysqlTableDef;
-    // Mirror the pre-existing TableDefinition.toSql() guard (abstract/schema-definitions.ts):
-    // MySQL emits charset/collation as bare identifiers, so reject anything that isn't a
-    // safe identifier to prevent DDL injection via untrusted Migration input.
-    const safeIdentRe = /^[A-Za-z0-9_]+$/;
     if (mo.charset) {
-      if (!safeIdentRe.test(mo.charset)) {
-        throw new ArgumentError(`Invalid MySQL charset: ${JSON.stringify(mo.charset)}`);
-      }
+      assertSafeMysqlIdentifier(mo.charset, "charset");
       sql += ` DEFAULT CHARSET=${mo.charset}`;
     }
     if (mo.collation) {
-      if (!safeIdentRe.test(mo.collation)) {
-        throw new ArgumentError(`Invalid MySQL collation: ${JSON.stringify(mo.collation)}`);
-      }
+      assertSafeMysqlIdentifier(mo.collation, "collation");
       sql += ` COLLATE=${mo.collation}`;
     }
     return this.addSqlCommentBang(super.addTableOptionsBang(sql, o), o.comment);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -49,16 +49,26 @@ interface MysqlColumnOptions extends Record<string, unknown> {
 
 type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
 
+/** @internal Adapter surface consulted by the visitor's support flags. */
+interface VisitorHostAdapter {
+  supportsCheckConstraints?(): boolean;
+  supportsForeignKeys?(): boolean;
+  supportsIndexesInCreate?(): boolean;
+}
+
 export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal Whether this is a MariaDB connection. */
   protected _mariadb = false;
+  /** @internal Optional adapter ref so `supports*` helpers mirror Rails' `@conn`-delegated flags. */
+  protected _hostAdapter?: VisitorHostAdapter;
 
-  constructor() {
+  constructor(host?: VisitorHostAdapter) {
     super("mysql", {
       quoteIdentifier: quoteIdentifier,
       quoteTableName: quoteTableName,
       quoteDefaultExpression: quoteDefaultExpression,
     });
+    this._hostAdapter = host;
   }
 
   /** @internal */
@@ -182,19 +192,19 @@ export class SchemaCreation extends AbstractSchemaCreation {
     );
   }
 
-  /** @internal Mirrors `AbstractMysqlAdapter#supportsIndexesInCreate` (always true on MySQL/MariaDB). */
+  /** @internal Delegates to the adapter when wired (Rails: `@conn.supports_indexes_in_create?`). */
   protected supportsIndexesInCreate(): boolean {
-    return true;
+    return this._hostAdapter?.supportsIndexesInCreate?.() ?? true;
   }
 
-  /** @internal Mirrors Rails' `use_foreign_keys?` — true on MySQL/MariaDB. */
+  /** @internal Mirrors Rails' `use_foreign_keys?` → adapter `supports_foreign_keys?`. */
   protected useForeignKeys(): boolean {
-    return true;
+    return this._hostAdapter?.supportsForeignKeys?.() ?? true;
   }
 
-  /** @internal Mirrors `AbstractMysqlAdapter#supportsCheckConstraints` — true on MySQL 8+/MariaDB 10.2+. */
+  /** @internal Delegates to the adapter; honors MySQL 8.0.16+ / MariaDB 10.2.1+ version gating. */
   protected supportsCheckConstraints(): boolean {
-    return true;
+    return this._hostAdapter?.supportsCheckConstraints?.() ?? true;
   }
 
   /**
@@ -301,8 +311,22 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   protected override addTableOptionsBang(sql: string, o: TableDefinition): string {
     const mo = o as MysqlTableDef;
-    if (mo.charset) sql += ` DEFAULT CHARSET=${mo.charset}`;
-    if (mo.collation) sql += ` COLLATE=${mo.collation}`;
+    // Mirror the pre-existing TableDefinition.toSql() guard (abstract/schema-definitions.ts):
+    // MySQL emits charset/collation as bare identifiers, so reject anything that isn't a
+    // safe identifier to prevent DDL injection via untrusted Migration input.
+    const safeIdentRe = /^[A-Za-z0-9_]+$/;
+    if (mo.charset) {
+      if (!safeIdentRe.test(mo.charset)) {
+        throw new ArgumentError(`Invalid MySQL charset: ${JSON.stringify(mo.charset)}`);
+      }
+      sql += ` DEFAULT CHARSET=${mo.charset}`;
+    }
+    if (mo.collation) {
+      if (!safeIdentRe.test(mo.collation)) {
+        throw new ArgumentError(`Invalid MySQL collation: ${JSON.stringify(mo.collation)}`);
+      }
+      sql += ` COLLATE=${mo.collation}`;
+    }
     return this.addSqlCommentBang(super.addTableOptionsBang(sql, o), o.comment);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -50,7 +50,7 @@ interface MysqlColumnOptions extends Record<string, unknown> {
 type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
 
 /** @internal Adapter surface consulted by the visitor's support flags and MariaDB branches. */
-interface VisitorHostAdapter {
+export interface VisitorHostAdapter {
   supportsCheckConstraints?(): boolean;
   supportsForeignKeys?(): boolean;
   supportsIndexesInCreate?(): boolean;
@@ -77,7 +77,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
       quoteDefaultExpression: quoteDefaultExpression,
     });
     this._hostAdapter = host;
-    if (host?.isMariadb?.()) this._mariadb = true;
+  }
+
+  /** @internal Live MariaDB lookup — consults the host adapter every call so a late
+   * `getFullVersion()` flip (lazy detection on first probe) is honored. Falls back to the
+   * `_mariadb` field so existing tests that set it directly continue to work. */
+  protected isMariadb(): boolean {
+    return this._hostAdapter?.isMariadb?.() ?? this._mariadb;
   }
 
   /** @internal */
@@ -190,7 +196,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal */
   protected visitDropCheckConstraint(name: string): string {
-    return `DROP ${this._mariadb ? "CONSTRAINT" : "CHECK"} ${name}`;
+    return `DROP ${this.isMariadb() ? "CONSTRAINT" : "CHECK"} ${name}`;
   }
 
   /** @internal */
@@ -344,7 +350,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (mo.collation) sql += ` COLLATE ${mo.collation}`;
     if (mo.as) {
       sql += ` AS (${mo.as})`;
-      if (mo.stored) sql += this._mariadb ? " PERSISTENT" : " STORED";
+      if (mo.stored) sql += this.isMariadb() ? " PERSISTENT" : " STORED";
     }
     // Call super without primaryKey so ON UPDATE can be inserted before PRIMARY KEY,
     // matching the original abstract ordering: DEFAULT → NOT NULL → AUTO_INCREMENT → ON UPDATE → PRIMARY KEY.

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -55,6 +55,8 @@ export interface VisitorHostAdapter {
   supportsForeignKeys?(): boolean;
   supportsIndexesInCreate?(): boolean;
   isMariadb?(): boolean;
+  /** Mirrors `SchemaStatements#isForeignKeysEnabled` (`adapter.config?.foreignKeys !== false`). */
+  config?: { foreignKeys?: boolean };
 }
 
 /** @internal Shared identifier guard for MySQL bare-identifier emission (charset/collation). */
@@ -212,9 +214,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
     return this._hostAdapter?.supportsIndexesInCreate?.() ?? true;
   }
 
-  /** @internal Mirrors Rails' `use_foreign_keys?` → adapter `supports_foreign_keys?`. */
+  /** @internal Mirrors Rails' `use_foreign_keys?` (`supports_foreign_keys? &&
+   * foreign_keys_enabled?`). The enabled half reads `adapter.config.foreignKeys`, matching
+   * `SchemaStatements#isForeignKeysEnabled`. */
   protected useForeignKeys(): boolean {
-    return this._hostAdapter?.supportsForeignKeys?.() ?? true;
+    const supports = this._hostAdapter?.supportsForeignKeys?.() ?? true;
+    const enabled = this._hostAdapter?.config?.foreignKeys !== false;
+    return supports && enabled;
   }
 
   /** @internal Delegates to the adapter; honors MySQL 8.0.16+ / MariaDB 10.2.1+ version gating. */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -42,10 +42,14 @@ export interface ColumnMethods {
 }
 
 export class TableDefinition extends AbstractTableDefinition {
-  /** @internal Full adapter when constructed by `createTableDefinition`; used so `toSql()`
-   * can obtain a host-aware `MysqlSchemaCreation` (carrying adapter support flags). */
+  /** @internal Full adapter when constructed by `createTableDefinition`; consulted by `toSql()`
+   * for a host-aware visitor (support flags + MariaDB) or to construct one in the fallback path. */
   private readonly _mysqlAdapter?: {
     schemaStatements?: () => { schemaCreation: MysqlSchemaCreation };
+    supportsCheckConstraints?(): boolean;
+    supportsForeignKeys?(): boolean;
+    supportsIndexesInCreate?(): boolean;
+    isMariadb?(): boolean;
   };
 
   constructor(
@@ -94,7 +98,9 @@ export class TableDefinition extends AbstractTableDefinition {
     // addColumnOptions / charset handling.
     const fromAdapter = this._mysqlAdapter?.schemaStatements?.().schemaCreation;
     const visitor =
-      fromAdapter instanceof MysqlSchemaCreation ? fromAdapter : new MysqlSchemaCreation();
+      fromAdapter instanceof MysqlSchemaCreation
+        ? fromAdapter
+        : new MysqlSchemaCreation(this._mysqlAdapter);
     return visitor.accept(this);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -48,6 +48,9 @@ export class TableDefinition extends AbstractTableDefinition {
   /** @internal Full adapter when constructed by `createTableDefinition`; consulted by
    * `toSql()` to build a host-aware MySQL visitor (support flags + MariaDB). */
   private readonly _mysqlAdapter?: VisitorHostAdapter;
+  /** @internal Lazily-allocated visitor; the host adapter ref is fixed for our lifetime so
+   * one instance is reused across `toSql()` calls. */
+  private _visitor?: MysqlSchemaCreation;
 
   constructor(
     tableName: string,
@@ -61,7 +64,7 @@ export class TableDefinition extends AbstractTableDefinition {
       as?: string;
       options?: string;
       comment?: string;
-      adapter?: unknown;
+      adapter?: VisitorHostAdapter;
       adapterName?: "sqlite" | "postgres" | "mysql";
     } = {},
   ) {
@@ -77,9 +80,7 @@ export class TableDefinition extends AbstractTableDefinition {
         quoteDefaultExpression: quoteDefaultExpression,
       },
     });
-    if (adapter && typeof adapter === "object") {
-      this._mysqlAdapter = adapter as TableDefinition["_mysqlAdapter"];
-    }
+    this._mysqlAdapter = adapter;
   }
 
   /**
@@ -93,7 +94,8 @@ export class TableDefinition extends AbstractTableDefinition {
     // `isMariadb()` are the only state the visitor consults, and going through
     // `schemaStatements().schemaCreation` would allocate a fresh `SchemaStatements` per call
     // on adapters whose `schemaStatements()` isn't memoized (current behavior on Mysql2Adapter).
-    return new MysqlSchemaCreation(this._mysqlAdapter).accept(this);
+    // Memoize the visitor since the host adapter ref is fixed for our lifetime.
+    return (this._visitor ??= new MysqlSchemaCreation(this._mysqlAdapter)).accept(this);
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -18,6 +18,7 @@ import type {
 } from "../abstract/schema-definitions.js";
 import { quoteIdentifier, quoteTableName } from "./quoting.js";
 import { quoteDefaultExpression } from "../abstract/quoting.js";
+import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
 
 /**
  * MySQL-specific column type methods mixed into TableDefinition.
@@ -38,27 +39,34 @@ export interface ColumnMethods {
   unsignedDecimal(name: string, options?: ColumnOptions): unknown;
 }
 
-/**
- * @todo `SchemaStatements#createTable` instantiates `AbstractTableDefinition` directly (not this
- *   subclass) via `new TableDefinition(...)`. The MySQL-specific overrides here
- *   (`newColumnDefinition`, `integerLikePrimaryKeyType`, `validColumnDefinitionOptions`) are
- *   exercised by `changeColumn` (see `abstract-mysql-adapter.ts`) but NOT by `createTable`.
- *   Fix: override `createTableDefinition()` in an MySQL-specific SchemaStatements to return
- *   this subclass, mirroring Rails' `MySQL::SchemaStatements#create_table_definition`.
- */
 export class TableDefinition extends AbstractTableDefinition {
+  /** @internal Full adapter when constructed by `createTableDefinition`; used so `toSql()`
+   * reuses the adapter's pre-configured `MysqlSchemaCreation` (carrying MariaDB flag, etc.). */
+  private readonly _mysqlAdapter?: {
+    schemaStatements?: () => { schemaCreation: MysqlSchemaCreation };
+  };
+
   constructor(
     tableName: string,
     options: {
       id?: boolean | "uuid";
       charset?: string | null;
       collation?: string | null;
+      primaryKey?: string | string[] | false;
+      temporary?: boolean;
+      ifNotExists?: boolean;
+      as?: string;
+      options?: string;
+      comment?: string;
+      adapter?: unknown;
+      adapterName?: "sqlite" | "postgres" | "mysql";
     } = {},
   ) {
+    const { adapter, adapterName: _ignoredAdapterName, ...rest } = options;
     super(tableName, {
-      ...options,
-      charset: options.charset ?? undefined,
-      collation: options.collation ?? undefined,
+      ...rest,
+      charset: rest.charset ?? undefined,
+      collation: rest.collation ?? undefined,
       adapterName: "mysql",
       adapter: {
         quoteIdentifier: quoteIdentifier,
@@ -66,6 +74,21 @@ export class TableDefinition extends AbstractTableDefinition {
         quoteDefaultExpression: quoteDefaultExpression,
       },
     });
+    if (adapter && typeof adapter === "object") {
+      this._mysqlAdapter = adapter as TableDefinition["_mysqlAdapter"];
+    }
+  }
+
+  /**
+   * Routes `CREATE TABLE` SQL generation through the MySQL `SchemaCreation`
+   * visitor (Arel-style accept). Doing so makes `options.autoIncrement` and
+   * other column options consistent between `createTable`, `addColumn`, and
+   * `changeColumn` — they all go through {@link SchemaCreation#addColumnOptions}.
+   */
+  override toSql(): string {
+    const fromAdapter = this._mysqlAdapter?.schemaStatements?.().schemaCreation;
+    const visitor = fromAdapter ?? new MysqlSchemaCreation();
+    return visitor.accept(this);
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -41,7 +41,7 @@ export interface ColumnMethods {
 
 export class TableDefinition extends AbstractTableDefinition {
   /** @internal Full adapter when constructed by `createTableDefinition`; used so `toSql()`
-   * reuses the adapter's pre-configured `MysqlSchemaCreation` (carrying MariaDB flag, etc.). */
+   * reuses the adapter's `MysqlSchemaCreation` instance rather than allocating a new one. */
   private readonly _mysqlAdapter?: {
     schemaStatements?: () => { schemaCreation: MysqlSchemaCreation };
   };

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -49,7 +49,10 @@ export class TableDefinition extends AbstractTableDefinition {
    * `toSql()` to build a host-aware MySQL visitor (support flags + MariaDB). */
   private readonly _mysqlAdapter?: VisitorHostAdapter;
   /** @internal Lazily-allocated visitor; the host adapter ref is fixed for our lifetime so
-   * one instance is reused across `toSql()` calls. */
+   * one instance is reused across `toSql()` calls. Note: when no host adapter is supplied
+   * (direct `new MysqlTableDefinition(...)` paths in tests), the visitor's `_mariadb` field
+   * defaults to `false` and cannot be flipped through this TD — set it on the visitor
+   * directly if a test needs MariaDB-flavored output. */
   private _visitor?: MysqlSchemaCreation;
 
   constructor(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -20,7 +20,10 @@ import type {
 } from "../abstract/schema-definitions.js";
 import { quoteIdentifier, quoteTableName } from "./quoting.js";
 import { quoteDefaultExpression } from "../abstract/quoting.js";
-import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
+import {
+  SchemaCreation as MysqlSchemaCreation,
+  type VisitorHostAdapter,
+} from "./schema-creation.js";
 
 /**
  * MySQL-specific column type methods mixed into TableDefinition.
@@ -42,15 +45,9 @@ export interface ColumnMethods {
 }
 
 export class TableDefinition extends AbstractTableDefinition {
-  /** @internal Full adapter when constructed by `createTableDefinition`; consulted by `toSql()`
-   * for a host-aware visitor (support flags + MariaDB) or to construct one in the fallback path. */
-  private readonly _mysqlAdapter?: {
-    schemaStatements?: () => { schemaCreation: MysqlSchemaCreation };
-    supportsCheckConstraints?(): boolean;
-    supportsForeignKeys?(): boolean;
-    supportsIndexesInCreate?(): boolean;
-    isMariadb?(): boolean;
-  };
+  /** @internal Full adapter when constructed by `createTableDefinition`; consulted by
+   * `toSql()` to build a host-aware MySQL visitor (support flags + MariaDB). */
+  private readonly _mysqlAdapter?: VisitorHostAdapter;
 
   constructor(
     tableName: string,
@@ -92,16 +89,11 @@ export class TableDefinition extends AbstractTableDefinition {
    * `changeColumn` — they all go through {@link SchemaCreation#addColumnOptions}.
    */
   override toSql(): string {
-    // Ask the adapter for a host-aware visitor (carries support flags + MariaDB flag) when
-    // available. Guard with instanceof in case a non-MySQL SchemaStatements ever surfaces here
-    // — falling back to the abstract visitor would silently drop MySQL-specific
-    // addColumnOptions / charset handling.
-    const fromAdapter = this._mysqlAdapter?.schemaStatements?.().schemaCreation;
-    const visitor =
-      fromAdapter instanceof MysqlSchemaCreation
-        ? fromAdapter
-        : new MysqlSchemaCreation(this._mysqlAdapter);
-    return visitor.accept(this);
+    // Build the visitor directly from the stored host adapter — its support flags and
+    // `isMariadb()` are the only state the visitor consults, and going through
+    // `schemaStatements().schemaCreation` would allocate a fresh `SchemaStatements` per call
+    // on adapters whose `schemaStatements()` isn't memoized (current behavior on Mysql2Adapter).
+    return new MysqlSchemaCreation(this._mysqlAdapter).accept(this);
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -14,6 +14,8 @@ import {
 import type {
   ColumnOptions,
   ColumnType,
+  IdHashOptions,
+  PrimaryKeyType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
 import { quoteIdentifier, quoteTableName } from "./quoting.js";
@@ -41,7 +43,7 @@ export interface ColumnMethods {
 
 export class TableDefinition extends AbstractTableDefinition {
   /** @internal Full adapter when constructed by `createTableDefinition`; used so `toSql()`
-   * reuses the adapter's `MysqlSchemaCreation` instance rather than allocating a new one. */
+   * can obtain a host-aware `MysqlSchemaCreation` (carrying adapter support flags). */
   private readonly _mysqlAdapter?: {
     schemaStatements?: () => { schemaCreation: MysqlSchemaCreation };
   };
@@ -49,7 +51,7 @@ export class TableDefinition extends AbstractTableDefinition {
   constructor(
     tableName: string,
     options: {
-      id?: boolean | "uuid";
+      id?: boolean | PrimaryKeyType | IdHashOptions;
       charset?: string | null;
       collation?: string | null;
       primaryKey?: string | string[] | false;
@@ -86,9 +88,10 @@ export class TableDefinition extends AbstractTableDefinition {
    * `changeColumn` — they all go through {@link SchemaCreation#addColumnOptions}.
    */
   override toSql(): string {
-    // Prefer the adapter's pre-wired visitor (carries host-adapter support flags). Guard with
-    // instanceof in case a non-MySQL SchemaStatements ever surfaces here — falling back to the
-    // abstract visitor would silently drop MySQL-specific addColumnOptions / charset handling.
+    // Ask the adapter for a host-aware visitor (carries support flags + MariaDB flag) when
+    // available. Guard with instanceof in case a non-MySQL SchemaStatements ever surfaces here
+    // — falling back to the abstract visitor would silently drop MySQL-specific
+    // addColumnOptions / charset handling.
     const fromAdapter = this._mysqlAdapter?.schemaStatements?.().schemaCreation;
     const visitor =
       fromAdapter instanceof MysqlSchemaCreation ? fromAdapter : new MysqlSchemaCreation();

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -86,8 +86,12 @@ export class TableDefinition extends AbstractTableDefinition {
    * `changeColumn` — they all go through {@link SchemaCreation#addColumnOptions}.
    */
   override toSql(): string {
+    // Prefer the adapter's pre-wired visitor (carries host-adapter support flags). Guard with
+    // instanceof in case a non-MySQL SchemaStatements ever surfaces here — falling back to the
+    // abstract visitor would silently drop MySQL-specific addColumnOptions / charset handling.
     const fromAdapter = this._mysqlAdapter?.schemaStatements?.().schemaCreation;
-    const visitor = fromAdapter ?? new MysqlSchemaCreation();
+    const visitor =
+      fromAdapter instanceof MysqlSchemaCreation ? fromAdapter : new MysqlSchemaCreation();
     return visitor.accept(this);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -43,7 +43,7 @@ import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.j
 class MysqlSchemaStatements extends SchemaStatements {
   private _mysqlSchemaCreation?: MysqlSchemaCreation;
   override get schemaCreation(): MysqlSchemaCreation {
-    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation());
+    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this.adapter));
   }
 
   /**


### PR DESCRIPTION
## Summary

Batch 110 — Route MySQL `TableDefinition#toSql()` through
`MysqlSchemaCreation.accept(...)` (Arel-style visitor) so `createTable` honors
`options.autoIncrement` the same way `addColumn` / `changeColumn` already do.

- `MysqlSchemaCreation.visitTableDefinition` ports Rails'
  `abstract/schema_creation.rb#visit_TableDefinition` for MySQL, calling
  `visitColumnDefinition` per column so the MySQL `addColumnOptions` override
  (`AUTO_INCREMENT`, `ON UPDATE`, charset/collation, comment) participates.
- `MysqlTableDefinition#toSql()` is overridden to dispatch through the visitor.
  When constructed via the adapter, it reuses the adapter's own
  `schemaCreation` (carrying e.g. the MariaDB flag); otherwise it instantiates
  a fresh `MysqlSchemaCreation`.
- `AbstractMysqlAdapter.createTableDefinition` is reintroduced so
  `SchemaStatements#createTable` instantiates the MySQL subclass — mirroring
  Rails' `MySQL::SchemaStatements#create_table_definition`. (Plumbing from
  `13ed839c4` in #1736; original Batch 47 item 6 was reverted for MariaDB CI,
  unblocked now that the visitor path handles AUTO_INCREMENT correctly.)
- PG keeps its abstract `td.toSql()` path (its `SERIAL PRIMARY KEY` already
  emits AUTO_INCREMENT equivalent; bug doesn't surface there).

## Test plan

- [x] `mysql/schema-creation.test.ts` — added six toSql cases (default id,
  id: false, charset/collation, TEMPORARY+IF NOT EXISTS, composite PK, inline
  index)
- [x] Existing mysql/abstract schema unit tests still pass
- [ ] CI: full MySQL/MariaDB integration suites