### PR TITLE
test(activerecord): Phase 5 — defineSchema for AutomaticInverseFindingTests

### DIFF
--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -827,8 +827,20 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 
 describe("AutomaticInverseFindingTests", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      men: { name: "string" },
+      faces: { description: "string", man_id: "integer" },
+      interests: { topic: "string", man_id: "integer" },
+      ratings: { score: "integer", comment_id: "integer" },
+      comments: { body: "string", post_id: "integer" },
+      posts: { title: "string" },
+    });
+  });
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
   });
 
   it("has one and belongs to should find inverse automatically on multiple word name", () => {


### PR DESCRIPTION
## Summary

Migrates the `AutomaticInverseFindingTests` describe block in
`packages/activerecord/src/associations/inverse-associations.test.ts`
to declare its schema explicitly via `defineSchema()` so it passes
under `AR_NO_AUTO_SCHEMA=1`.

Continues TM unification Phase 5 (follow-up to #1747 and prior). The
other describe blocks at the top of the file (`InverseBelongsToTests`,
`InverseHasManyTests`, `InverseMultipleHasManyInversesForSameModel`)
were already on the pattern; this block was still using a sync
`freshAdapter()` with no schema declaration.

## Pattern

- `beforeEach` becomes `async`, runs `defineSchema(adapter, {...})`
  for the tables the block touches via `Base.create`: `men`, `faces`,
  `interests`, `ratings`, `comments`, `posts`.
- Adds `afterAll(() => dropAllTables(adapter))` matching the other
  blocks.

## Follow-ups (Batch 122b+)

Remaining unmigrated blocks in the same file:

- `InversePolymorphicBelongsToTests`
- `InverseCachedPathTests`
- `InverseAssociationTests`
- `inverse_of`
- `InverseHasOneTests`

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts -t AutomaticInverseFindingTests` — 14 pass, 83 skipped
- [x] Default (auto-schema) mode — 72 pass, 25 skipped