### PR TITLE
feat(activerecord): drop SQLite virtualTableExists fallback + strict driver forwarding tests (batch 126)

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -684,6 +684,7 @@ describe("SQLite3AdapterTest", () => {
       },
     };
 
+    const originalDefault = SQLite3Adapter.strictStringsByDefault;
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const conn = new SQLite3Adapter(":memory:", { driver: fakeDriver });
@@ -694,7 +695,7 @@ describe("SQLite3AdapterTest", () => {
         await conn.close();
       }
     } finally {
-      SQLite3Adapter.strictStringsByDefault = false;
+      SQLite3Adapter.strictStringsByDefault = originalDefault;
     }
 
     capture.config = null;

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -4,6 +4,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { Notifications } from "@blazetrails/activesupport";
+import type {
+  SqliteDriver,
+  SqliteOpenConfig,
+  SyncSqliteConnection,
+  SyncSqliteStatement,
+} from "@blazetrails/activesupport/sqlite-adapter";
 import { assertLogged } from "./test-helper.js";
 
 let adapter: SQLite3Adapter;
@@ -636,6 +642,71 @@ describe("SQLite3AdapterTest", () => {
       }
     } finally {
       SQLite3Adapter.strictStringsByDefault = false;
+    }
+  });
+
+  it("forwards strictStringsByDefault to the driver via openSync(config)", () => {
+    // Mirrors Rails: strict_strings_by_default = true reaches the adapter
+    // through `strict: true` on the per-connection config, not via a runtime
+    // override after open. The driver hook receives that resolved value.
+    const capture: { config: SqliteOpenConfig | null } = { config: null };
+    const fakeStmt: SyncSqliteStatement = {
+      run: () => ({ changes: 0, lastInsertRowid: 0 }),
+      get: () => ({ v: "3.37.0" }),
+      all: () => [],
+      iterate: () => [].values(),
+      columns: () => [],
+      setReadBigInts: () => {},
+      reader: true,
+    };
+    const fakeConn: SyncSqliteConnection = {
+      prepare: () => fakeStmt,
+      exec: () => {},
+      pragma: () => [],
+      close: () => {},
+      isOpen: () => true,
+      raw: null,
+    };
+    const fakeDriver: SqliteDriver = {
+      name: "fake-strict-capture",
+      capabilities: {
+        inProcessSync: true,
+        streaming: false,
+        loadExtension: false,
+        concurrentStatements: true,
+        foreignKeysOnByDefault: false,
+        immediateTransactions: false,
+      },
+      open: () => Promise.reject(new Error("sync only")),
+      openSync: (config: SqliteOpenConfig) => {
+        capture.config = config;
+        return fakeConn;
+      },
+    };
+
+    SQLite3Adapter.strictStringsByDefault = true;
+    try {
+      const conn = new SQLite3Adapter(":memory:", { driver: fakeDriver });
+      try {
+        expect((capture.config as SqliteOpenConfig | null)?.strict).toBe(true);
+        expect(conn.strictStrings).toBe(true);
+      } finally {
+        void conn.close();
+      }
+    } finally {
+      SQLite3Adapter.strictStringsByDefault = false;
+    }
+
+    capture.config = null;
+    const explicit = new SQLite3Adapter(":memory:", {
+      driver: fakeDriver,
+      strict: false,
+    });
+    try {
+      expect((capture.config as SqliteOpenConfig | null)?.strict).toBe(false);
+      expect(explicit.strictStrings).toBe(false);
+    } finally {
+      void explicit.close();
     }
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -645,7 +645,7 @@ describe("SQLite3AdapterTest", () => {
     }
   });
 
-  it("forwards strictStringsByDefault to the driver via openSync(config)", () => {
+  it("forwards strictStringsByDefault to the driver via openSync(config)", async () => {
     // Mirrors Rails: strict_strings_by_default = true reaches the adapter
     // through `strict: true` on the per-connection config, not via a runtime
     // override after open. The driver hook receives that resolved value.
@@ -691,7 +691,7 @@ describe("SQLite3AdapterTest", () => {
         expect((capture.config as SqliteOpenConfig | null)?.strict).toBe(true);
         expect(conn.strictStrings).toBe(true);
       } finally {
-        void conn.close();
+        await conn.close();
       }
     } finally {
       SQLite3Adapter.strictStringsByDefault = false;
@@ -706,7 +706,7 @@ describe("SQLite3AdapterTest", () => {
       expect((capture.config as SqliteOpenConfig | null)?.strict).toBe(false);
       expect(explicit.strictStrings).toBe(false);
     } finally {
-      void explicit.close();
+      await explicit.close();
     }
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -845,9 +845,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override checkVersion(): void {
-    if (this.databaseVersion.lt("3.37.0")) {
+    if (this.databaseVersion.lt("3.8.0")) {
       throw new Error(
-        `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.37.0.`,
+        `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.8.`,
       );
     }
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -845,9 +845,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override checkVersion(): void {
-    if (this.databaseVersion.lt("3.8.0")) {
+    if (this.databaseVersion.lt("3.37.0")) {
       throw new Error(
-        `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.8.0.`,
+        `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.37.0.`,
       );
     }
   }
@@ -921,21 +921,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#virtual_table_exists?
   async virtualTableExists(tableName: string): Promise<boolean> {
-    try {
-      const rows = await this.execute(
-        `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND type = 'virtual' AND name = ?`,
-        [tableName],
-        "SCHEMA",
-      );
-      return rows.length > 0;
-    } catch {
-      const rows = await this.execute(
-        `SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%VIRTUAL%' AND name = ?`,
-        [tableName],
-        "SCHEMA",
-      );
-      return rows.length > 0;
-    }
+    const rows = await this.execute(
+      `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND type = 'virtual' AND name = ?`,
+      [tableName],
+      "SCHEMA",
+    );
+    return rows.length > 0;
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#virtual_tables

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -120,11 +120,10 @@ describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite strict", (
   it("rejects unknown double-quoted identifiers under strict: true", async () => {
     const conn = await nodeSqliteDriver.open({ database: ":memory:", strict: true });
     try {
-      const stmt = await conn.prepare(`SELECT "missing_col" AS v`);
-      // node:sqlite's stmt.get() is synchronous and throws inline — wrap the
-      // call in a thunk so expect() catches the throw rather than evaluating
-      // it inside the argument expression.
-      expect(() => stmt.get()).toThrow(/no such column/i);
+      // node:sqlite raises at prepare() time (not get()) when DQS is off and
+      // the identifier is unknown — wrap the call so expect() catches the
+      // synchronous throw rather than evaluating it as an argument.
+      expect(() => conn.prepare(`SELECT "missing_col" AS v`)).toThrow(/no such column/i);
     } finally {
       await conn.close();
     }

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -110,3 +110,31 @@ describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite round-trip
     expect(nodeSqliteDriver.capabilities.foreignKeysOnByDefault).toBe(false);
   });
 });
+
+describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite strict", () => {
+  // node:sqlite exposes SQLITE_DBCONFIG_DQS_* via the
+  // `enableDoubleQuotedStringLiterals` open option. With strict: true DQS is
+  // disabled, so `SELECT "missing_col"` raises "no such column". With
+  // strict: false (the default) the unknown double-quoted token is parsed
+  // as a string literal and SELECT returns its text verbatim.
+  it("rejects unknown double-quoted identifiers under strict: true", async () => {
+    const conn = await nodeSqliteDriver.open({ database: ":memory:", strict: true });
+    try {
+      const stmt = await conn.prepare(`SELECT "missing_col" AS v`);
+      await expect(Promise.resolve(stmt.get())).rejects.toThrow(/no such column/i);
+    } finally {
+      await conn.close();
+    }
+  });
+
+  it("treats unknown double-quoted identifiers as literals under strict: false", async () => {
+    const conn = await nodeSqliteDriver.open({ database: ":memory:", strict: false });
+    try {
+      const stmt = await conn.prepare(`SELECT "missing_col" AS v`);
+      const row = (await stmt.get()) as Record<string, unknown>;
+      expect(row["v"]).toBe("missing_col");
+    } finally {
+      await conn.close();
+    }
+  });
+});

--- a/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
+++ b/packages/activesupport/src/sqlite-drivers/node-sqlite.test.ts
@@ -121,7 +121,10 @@ describe.skipIf(!isNodeSqliteAvailable)("SqliteDriver — node-sqlite strict", (
     const conn = await nodeSqliteDriver.open({ database: ":memory:", strict: true });
     try {
       const stmt = await conn.prepare(`SELECT "missing_col" AS v`);
-      await expect(Promise.resolve(stmt.get())).rejects.toThrow(/no such column/i);
+      // node:sqlite's stmt.get() is synchronous and throws inline — wrap the
+      // call in a thunk so expect() catches the throw rather than evaluating
+      // it inside the argument expression.
+      expect(() => stmt.get()).toThrow(/no such column/i);
     } finally {
       await conn.close();
     }


### PR DESCRIPTION
## Summary

Batch 126 followup from #1743.

- Drop the `sqlite_master` try/catch fallback in `SQLite3Adapter#virtualTableExists` — Rails `virtual_table_exists?` (vendor `sqlite3/schema_statements.rb:87`) has no fallback either. pragma_table_list is used unconditionally.
- New test: adapter→driver `strict` forwarding via a fake `SqliteDriver` whose `openSync()` captures the config. Asserts `SQLite3Adapter.strictStringsByDefault = true` yields `strict: true` on the resolved config (no per-connection override), and that explicit `strict: false` overrides the class default.
- New test (gated on Node 22.10+ via `isNodeSqliteAvailable`): `SELECT "missing_col"` raises under `strict: true` and returns the literal text under `strict: false` on the `node:sqlite` driver.

Not done:
- The plan suggested raising `checkVersion` floor to 3.37 with "matches Rails" justification, but vendor `sqlite3_adapter.rb:481` actually uses 3.8.0 — kept at 3.8 for Rails parity. An initial 3.37 bump in this branch was reverted.
- Per-table `STRICT` docstring cross-link — deferred until the per-table STRICT mechanism actually lands.
- Shared `pragma_table_list` lookup helper — cosmetic; leaving as-is keeps the diff focused.

## Parity checks

- api:compare unchanged: 4956/4958 (100%) before and after.
- Rails source consulted: vendor `sqlite3_adapter.rb` + `sqlite3/schema_statements.rb`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts` — 80 pass
- [x] `pnpm tsc --build`
- [ ] CI: node-sqlite strict tests skip on Node 20 (local), exercise on a Node 22.10+ lane if one is configured.