### PR TITLE
feat(activerecord): pgColumn semantic types + schema-dump shorthand (batch 132)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Cidr } from "../../connection-adapters/postgresql/oid/cidr.js";
 import { Macaddr } from "../../connection-adapters/postgresql/oid/macaddr.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -122,6 +123,17 @@ describeIfPg("PostgreSQLAdapter", () => {
           `INSERT INTO "postgresql_network_addresses" ("inet_address") VALUES ('invalid addr')`,
         ),
       ).rejects.toThrow();
+    });
+
+    it("schema dump with shorthand", async () => {
+      // Rails: test_schema_dump_with_shorthand — semantic types in the dump
+      // (`t.inet`, `t.cidr`, `t.macaddr`) instead of `t.string sql_type:`.
+      // Default-value stringification for inet/cidr (IPAddr → "x.x.x.x") is a
+      // separate gap; this test pins shorthand emission only.
+      const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_network_addresses");
+      expect(output).toMatch(/t\.inet\(\s*"inet_address"/);
+      expect(output).toMatch(/t\.cidr\(\s*"cidr_address"/);
+      expect(output).toMatch(/t\.macaddr\("mac_address",\s*\{\s*default:\s*"ff:ff:ff:ff:ff:ff"/);
     });
 
     it("cidr change prefix", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -276,18 +276,22 @@ describe("TableDefinition#toSql", () => {
     td.oid("oid_col");
     td.tsrange("during");
     const sql = td.toSql();
-    expect(sql).toContain('"net" CIDR');
-    expect(sql).toContain('"addr" INET');
-    expect(sql).toContain('"props" HSTORE');
-    expect(sql).toContain('"mac" MACADDR');
-    expect(sql).toContain('"path" LTREE');
-    expect(sql).toContain('"doc" TSVECTOR');
-    expect(sql).toContain('"payload" XML');
+    // pgColumn helpers route through nativeDatabaseTypes, which stores names
+    // in lowercase (Rails parity with NATIVE_DATABASE_TYPES). bit / bitVarying
+    // remain uppercase because they carry a (limit) suffix that nativeDatabaseTypes
+    // doesn't express, so their helpers still set sqlType explicitly.
+    expect(sql).toContain('"net" cidr');
+    expect(sql).toContain('"addr" inet');
+    expect(sql).toContain('"props" hstore');
+    expect(sql).toContain('"mac" macaddr');
+    expect(sql).toContain('"path" ltree');
+    expect(sql).toContain('"doc" tsvector');
+    expect(sql).toContain('"payload" xml');
     expect(sql).toContain('"flags" BIT(8)');
     expect(sql).toContain('"flex" BIT VARYING(16)');
-    expect(sql).toContain('"price" MONEY');
-    expect(sql).toContain('"oid_col" OID');
-    expect(sql).toContain('"during" TSRANGE');
+    expect(sql).toContain('"price" money');
+    expect(sql).toContain('"oid_col" oid');
+    expect(sql).toContain('"during" tsrange');
   });
 
   it("handles default values containing doubled single-quotes without mis-parsing", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -276,10 +276,11 @@ describe("TableDefinition#toSql", () => {
     td.oid("oid_col");
     td.tsrange("during");
     const sql = td.toSql();
-    // pgColumn helpers route through nativeDatabaseTypes, which stores names
-    // in lowercase (Rails parity with NATIVE_DATABASE_TYPES). bit / bitVarying
-    // remain uppercase because they carry a (limit) suffix that nativeDatabaseTypes
-    // doesn't express, so their helpers still set sqlType explicitly.
+    // pgColumn helpers now pass a semantic column type (e.g. "cidr", "inet")
+    // and leave sqlType unset. TableDefinition#toSql's default branch emits
+    // the column type verbatim, which matches Rails' NATIVE_DATABASE_TYPES
+    // lowercase names. bit / bitVarying still set sqlType explicitly because
+    // they carry a (limit) suffix that the native map doesn't express.
     expect(sql).toContain('"net" cidr');
     expect(sql).toContain('"addr" inet');
     expect(sql).toContain('"props" hstore');

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -409,116 +409,121 @@ export class TableDefinition extends AbstractTableDefinition {
   }
 
   uuid(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "uuid" as ColumnType, "UUID", options);
+    return this.pgColumn(name, "uuid" as ColumnType, undefined, options);
   }
 
   jsonb(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "jsonb" as ColumnType, "JSONB", options);
+    return this.pgColumn(name, "jsonb" as ColumnType, undefined, options);
   }
 
   daterange(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "DATERANGE", options);
+    return this.pgColumn(name, "daterange" as ColumnType, undefined, options);
   }
 
   int4range(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "INT4RANGE", options);
+    return this.pgColumn(name, "int4range" as ColumnType, undefined, options);
   }
 
   int8range(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "INT8RANGE", options);
+    return this.pgColumn(name, "int8range" as ColumnType, undefined, options);
   }
 
   numrange(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "NUMRANGE", options);
+    return this.pgColumn(name, "numrange" as ColumnType, undefined, options);
   }
 
   tsrange(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "TSRANGE", options);
+    return this.pgColumn(name, "tsrange" as ColumnType, undefined, options);
   }
 
   tstzrange(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "TSTZRANGE", options);
+    return this.pgColumn(name, "tstzrange" as ColumnType, undefined, options);
   }
 
   oid(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "integer" as ColumnType, "OID", options);
+    return this.pgColumn(name, "oid" as ColumnType, undefined, options);
   }
 
   cidr(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "CIDR", options);
+    return this.pgColumn(name, "cidr" as ColumnType, undefined, options);
   }
 
   citext(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "text" as ColumnType, "CITEXT", options);
+    return this.pgColumn(name, "citext" as ColumnType, undefined, options);
   }
 
   hstore(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "HSTORE", options);
+    return this.pgColumn(name, "hstore" as ColumnType, undefined, options);
   }
 
   inet(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "INET", options);
+    return this.pgColumn(name, "inet" as ColumnType, undefined, options);
   }
 
   interval(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "INTERVAL", options);
+    return this.pgColumn(name, "interval" as ColumnType, undefined, options);
   }
 
   ltree(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "LTREE", options);
+    return this.pgColumn(name, "ltree" as ColumnType, undefined, options);
   }
 
   macaddr(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "MACADDR", options);
+    return this.pgColumn(name, "macaddr" as ColumnType, undefined, options);
   }
 
   money(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "decimal" as ColumnType, "MONEY", options);
+    return this.pgColumn(name, "money" as ColumnType, undefined, options);
   }
 
   point(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "POINT", options);
+    return this.pgColumn(name, "point" as ColumnType, undefined, options);
   }
 
   line(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "LINE", options);
+    return this.pgColumn(name, "line" as ColumnType, undefined, options);
   }
 
   lseg(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "LSEG", options);
+    return this.pgColumn(name, "lseg" as ColumnType, undefined, options);
   }
 
   box(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "BOX", options);
+    return this.pgColumn(name, "box" as ColumnType, undefined, options);
   }
 
   path(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "PATH", options);
+    return this.pgColumn(name, "path" as ColumnType, undefined, options);
   }
 
   polygon(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "POLYGON", options);
+    return this.pgColumn(name, "polygon" as ColumnType, undefined, options);
   }
 
   circle(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "CIRCLE", options);
+    return this.pgColumn(name, "circle" as ColumnType, undefined, options);
   }
 
   tsvector(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "string" as ColumnType, "TSVECTOR", options);
+    return this.pgColumn(name, "tsvector" as ColumnType, undefined, options);
   }
 
   xml(name: string, options: ColumnOptions = {}): this {
-    return this.pgColumn(name, "text" as ColumnType, "XML", options);
+    return this.pgColumn(name, "xml" as ColumnType, undefined, options);
   }
 
   enumType(name: string, enumName: string, options: ColumnOptions = {}): this {
     return this.pgColumn(name, "string" as ColumnType, enumName, options);
   }
 
-  private pgColumn(name: string, type: ColumnType, sqlType: string, options: ColumnOptions): this {
+  private pgColumn(
+    name: string,
+    type: ColumnType,
+    sqlType: string | undefined,
+    options: ColumnOptions,
+  ): this {
     const col = new ColumnDefinition(name, type, options);
-    col.sqlType = sqlType;
+    if (sqlType !== undefined) col.sqlType = sqlType;
     this.columns.push(col);
     return this;
   }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -204,6 +204,7 @@ const DSL_HELPER_METHODS = new Set([
   "ltree",
   "tsvector",
   "inet",
+  "cidr",
   "macaddr",
   "xml",
   "bit",


### PR DESCRIPTION
## Summary

- Switch PG `TableDefinition` helpers (`cidr`, `inet`, `hstore`, `macaddr`, `ltree`, `tsvector`, `xml`, `money`, `oid`, range types, geometric types, `uuid`, `jsonb`, `interval`, `citext`) to pass semantic type strings and rely on `NATIVE_DATABASE_TYPES` lookup, instead of hard-coding uppercase `sqlType` overrides. `bigserial`/`serial` keep their literal sqlType (not in the native map); `bit`/`bitVarying` keep uppercase + `(limit)` formatting; `enumType` keeps a custom name.
- Register `cidr` in `schema-dumper.ts` `DSL_HELPER_METHODS` so dumps emit `t.cidr(...)` instead of `t.column(name, "cidr", ...)`.
- Port Rails `network_test.rb#test_schema_dump_with_shorthand` to `adapters/postgresql/network.test.ts`.

Refs `docs/activerecord-100-plan.md` batch 132 (followup from #1761).

## Follow-ups

- IPAddr default stringification: schema dump renders `default: { address: "192.168.1.1", prefixLength: 32 }` instead of `default: "192.168.1.1"` for inet/cidr columns whose DB default is a literal address. The new test pins shorthand emission only and defers the default-formatting fix.
- DX type-test audit listed in the batch (~10 LOC) — no existing dx-tests assert `string` for inet/cidr columns, so nothing to flip.
- Pre-existing failure in `network.test.ts > invalid network address` (IPv6 `::ffff:192.168.0.1` normalization) is unrelated and remains.

## Test plan

- [x] `TEST_ADAPTER=postgresql pnpm vitest run packages/activerecord/src/adapters/postgresql/network.test.ts packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts` — new shorthand test passes; long-tail type SQL test updated to lowercase outputs from `NATIVE_DATABASE_TYPES`.
- [x] PG test suite: 114 failures vs 128 baseline (net +14 passing); remaining failures pre-existing.
- [ ] CI green