### PR TITLE
feat(activerecord): adapter-aware quoting in JoinDependency predicates (batch 133)

### DIFF
--- a/packages/activerecord/src/associations/join-dependency-quoting.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-quoting.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Covers the adapter-aware string-quoting dispatch in JoinDependency
+ * (polymorphic source_type / STI IN-list / has_many :through polymorphic
+ * source_type predicates). Mirrors the spirit of Rails'
+ * `connection.quote` usage in `ThroughReflection` — verifies the literal
+ * routes through the active adapter's `quote()` rather than a
+ * hand-rolled escape.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import { ConnectionNotDefined } from "../errors.js";
+import { Associations } from "../associations.js";
+import { JoinDependency } from "./join-dependency.js";
+
+function stubConnection(model: typeof Base, conn: Partial<DatabaseAdapter> | (() => never)) {
+  Object.defineProperty(model, "connection", {
+    value: typeof conn === "function" ? conn : () => conn,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("JoinDependency adapter-aware quoting", () => {
+  let adapter: DatabaseAdapter;
+
+  class Owner extends Base {
+    static {
+      this.attribute("name", "string");
+    }
+  }
+  class Asset extends Base {
+    static {
+      this.attribute("owner_id", "integer");
+      this.attribute("owner_type", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    Owner.adapter = adapter;
+    Asset.adapter = adapter;
+    (Owner as any)._associations = [];
+    (Asset as any)._associations = [];
+    registerModel(Owner);
+    registerModel(Asset);
+  });
+
+  it("routes polymorphic :as type literal through the adapter's quote()", () => {
+    const calls: unknown[] = [];
+    stubConnection(Owner, { quote: (v: unknown) => (calls.push(v), `<<${String(v)}>>`) } as any);
+
+    Associations.hasMany.call(Owner, "assets", { className: "Asset", as: "owner" });
+
+    const jd = new JoinDependency(Owner);
+    const node = jd.addAssociation("assets");
+    expect(node).not.toBeNull();
+    expect(node!.joinSql).toContain(`"owner_type" = <<Owner>>`);
+    expect(calls).toContain("Owner");
+  });
+
+  it("routes STI subclass IN-list through the adapter's quote()", () => {
+    class Vehicle extends Base {
+      static {
+        this.attribute("type", "string");
+        this.attribute("owner_id", "integer");
+      }
+    }
+    class Car extends Vehicle {}
+    enableSti(Vehicle);
+    registerSubclass(Car);
+    Vehicle.adapter = adapter;
+    Car.adapter = adapter;
+    (Vehicle as any)._associations = [];
+    (Car as any)._associations = [];
+    registerModel(Vehicle);
+    registerModel(Car);
+
+    const calls: unknown[] = [];
+    stubConnection(Owner, { quote: (v: unknown) => (calls.push(v), `<<${String(v)}>>`) } as any);
+
+    Associations.hasMany.call(Owner, "cars", { className: "Car", foreignKey: "owner_id" });
+
+    const jd = new JoinDependency(Owner);
+    const node = jd.addAssociation("cars");
+    expect(node).not.toBeNull();
+    expect(node!.joinSql).toContain(`"type" IN (<<Car>>)`);
+    expect(calls).toContain("Car");
+  });
+
+  it("falls back to the abstract quote when no pool is wired", () => {
+    stubConnection(Owner, () => {
+      throw new ConnectionNotDefined("no pool");
+    });
+    Associations.hasMany.call(Owner, "assets", { className: "Asset", as: "owner" });
+    const jd = new JoinDependency(Owner);
+    const node = jd.addAssociation("assets");
+    expect(node).not.toBeNull();
+    // Abstract quote emits the same `'Owner'` literal as the inlined escape did.
+    expect(node!.joinSql).toContain(`"owner_type" = 'Owner'`);
+  });
+
+  it("propagates non-ConnectionNotDefined errors from connection()", () => {
+    stubConnection(Owner, () => {
+      throw new Error("pool exhausted");
+    });
+    expect(() => new JoinDependency(Owner)).toThrow("pool exhausted");
+  });
+});

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -22,6 +22,7 @@ import { modelRegistry } from "../associations.js";
 import { reflectOnAssociation } from "../reflection.js";
 import { getInheritanceColumn, isStiSubclass } from "../inheritance.js";
 import { ConnectionNotDefined } from "../errors.js";
+import { quote as abstractQuote } from "../connection-adapters/abstract/quoting.js";
 
 export interface JoinNode {
   tableIndex: number;
@@ -128,6 +129,10 @@ export class JoinDependency {
   // Connection used for adapter-aware string quoting in polymorphic
   // source_type / STI type predicates. Resolved eagerly in the constructor;
   // null only when no pool is wired (mirrors `quoterFor` in sanitization.ts).
+  // Eager resolution is safe because all production call sites construct
+  // JoinDependency immediately before walking it; there is no window in
+  // which the pool could become wired between construction and the first
+  // `_quoteString` call.
   private _adapter: DatabaseAdapter | null;
 
   constructor(baseModel: typeof Base) {
@@ -143,30 +148,32 @@ export class JoinDependency {
    * configured pool (`ConnectionNotDefined`) falls back to the portable
    * escape; other failures (pool exhaustion, adapter errors) propagate so
    * real connection problems don't silently downgrade the emitted SQL.
+   * Structurally rejects adapters missing `quote` for the same reason.
    * @internal
    */
   private static _resolveAdapter(baseModel: typeof Base): DatabaseAdapter | null {
     if (typeof (baseModel as any).connection !== "function") return null;
+    let conn: DatabaseAdapter | null | undefined;
     try {
-      return ((baseModel as any).connection() as DatabaseAdapter) ?? null;
+      conn = (baseModel as any).connection() as DatabaseAdapter | null | undefined;
     } catch (err) {
       if (err instanceof ConnectionNotDefined) return null;
       throw err;
     }
+    if (!conn || typeof (conn as any).quote !== "function") return null;
+    return conn;
   }
 
   /**
    * Mirrors Rails' `connection.quote(value)` for string literals embedded
    * into JOIN predicates (polymorphic source_type, STI type IN-lists).
-   * Falls back to a portable escape only when no pool is wired.
+   * Falls back to the abstract adapter's `quote` only when no pool is
+   * wired (delegates to a single source of truth for the portable escape).
    * @internal
    */
   private _quoteString(value: string): string {
-    if (this._adapter && typeof (this._adapter as any).quote === "function") {
-      return (this._adapter as any).quote(value);
-    }
-    const escaped = String(value).replaceAll("\\", "\\\\").replaceAll("'", "''");
-    return `'${escaped}'`;
+    if (this._adapter) return (this._adapter as any).quote(value);
+    return abstractQuote(value);
   }
 
   get nodes(): JoinNode[] {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Base } from "../base.js";
+import type { DatabaseAdapter } from "../adapter.js";
 import {
   underscore as _toUnderscore,
   camelize as _camelize,
@@ -123,12 +124,38 @@ export class JoinDependency {
   // When a joined table's real name is unique, we skip the tN alias in SQL
   // (matching Rails' AliasTracker which only aliases on collision).
   private _usedTableNames: Set<string>;
+  // Lazily resolved connection for adapter-aware string quoting in
+  // polymorphic source_type / STI type predicates. Resolved on first use
+  // because some tests construct JoinDependency before a pool is wired.
+  private _adapter: DatabaseAdapter | null | undefined;
 
-  constructor(baseModel: typeof Base) {
+  constructor(baseModel: typeof Base, adapter?: DatabaseAdapter) {
     this._baseModel = baseModel;
     this._baseAlias = (baseModel as any).tableName;
     this._usedTableNames = new Set([this._baseAlias]);
+    this._adapter = adapter ?? undefined;
     this._buildBaseAliases();
+  }
+
+  /**
+   * Mirrors Rails' `connection.quote(value)` for string literals embedded
+   * into JOIN predicates (polymorphic source_type, STI type IN-lists).
+   * Falls back to a portable escape when no adapter is reachable.
+   * @internal
+   */
+  private _quoteString(value: string): string {
+    if (this._adapter === undefined) {
+      try {
+        this._adapter = (this._baseModel as any).connection?.() ?? null;
+      } catch {
+        this._adapter = null;
+      }
+    }
+    if (this._adapter && typeof (this._adapter as any).quote === "function") {
+      return (this._adapter as any).quote(value);
+    }
+    const escaped = String(value).replaceAll("\\", "\\\\").replaceAll("'", "''");
+    return `'${escaped}'`;
   }
 
   get nodes(): JoinNode[] {
@@ -211,7 +238,7 @@ export class JoinDependency {
 
       if (assocDef.options.as) {
         const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
-        joinOn += ` AND PLACEHOLDER."${typeCol}" = '${modelClass.name}'`;
+        joinOn += ` AND PLACEHOLDER."${typeCol}" = ${this._quoteString(modelClass.name)}`;
       }
     } else {
       return null;
@@ -445,7 +472,7 @@ export class JoinDependency {
     const inheritanceCol = getInheritanceColumn(model);
     if (inheritanceCol && isStiSubclass(model)) {
       const stiNames = [model.name, ...((model as any).descendants ?? []).map((d: any) => d.name)];
-      const inList = stiNames.map((n: string) => `'${n}'`).join(", ");
+      const inList = stiNames.map((n: string) => this._quoteString(n)).join(", ");
       joinOn += ` AND "${alias}"."${inheritanceCol}" IN (${inList})`;
     }
     return joinOn;
@@ -708,14 +735,7 @@ export class JoinDependency {
         // polymorphic type column is `foreign_type` (options[:foreign_type]
         // || "#{name}_type"), and the value is the literal :source_type.
         const typeCol = sourceAssocDef.options.foreignType ?? `${_toUnderscore(sourceName)}_type`;
-        // Escape backslash first, then single-quote — order matters so we
-        // don't double-escape an already-escaped quote. MySQL/MariaDB treat
-        // `\` as a string escape by default (NO_BACKSLASH_ESCAPES off), so
-        // both must be escaped to be portable across adapters.
-        const sourceTypeLit = String(assocDef.options.sourceType)
-          .replaceAll("\\", "\\\\")
-          .replaceAll("'", "''");
-        targetJoinOn += ` AND "${throughAlias}"."${typeCol}" = '${sourceTypeLit}'`;
+        targetJoinOn += ` AND "${throughAlias}"."${typeCol}" = ${this._quoteString(String(assocDef.options.sourceType))}`;
       }
     } else {
       const className = sourceAssocDef?.options?.className ?? _camelize(_singularize(sourceName));

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -21,6 +21,7 @@ import { sql as arelSql, Nodes } from "@blazetrails/arel";
 import { modelRegistry } from "../associations.js";
 import { reflectOnAssociation } from "../reflection.js";
 import { getInheritanceColumn, isStiSubclass } from "../inheritance.js";
+import { ConnectionNotDefined } from "../errors.js";
 
 export interface JoinNode {
   tableIndex: number;
@@ -124,33 +125,43 @@ export class JoinDependency {
   // When a joined table's real name is unique, we skip the tN alias in SQL
   // (matching Rails' AliasTracker which only aliases on collision).
   private _usedTableNames: Set<string>;
-  // Lazily resolved connection for adapter-aware string quoting in
-  // polymorphic source_type / STI type predicates. Resolved on first use
-  // because some tests construct JoinDependency before a pool is wired.
-  private _adapter: DatabaseAdapter | null | undefined;
+  // Connection used for adapter-aware string quoting in polymorphic
+  // source_type / STI type predicates. Resolved eagerly in the constructor;
+  // null only when no pool is wired (mirrors `quoterFor` in sanitization.ts).
+  private _adapter: DatabaseAdapter | null;
 
-  constructor(baseModel: typeof Base, adapter?: DatabaseAdapter) {
+  constructor(baseModel: typeof Base) {
     this._baseModel = baseModel;
     this._baseAlias = (baseModel as any).tableName;
     this._usedTableNames = new Set([this._baseAlias]);
-    this._adapter = adapter ?? undefined;
+    this._adapter = JoinDependency._resolveAdapter(baseModel);
     this._buildBaseAliases();
+  }
+
+  /**
+   * Mirrors `quoterFor` (sanitization.ts:237): only the absence of a
+   * configured pool (`ConnectionNotDefined`) falls back to the portable
+   * escape; other failures (pool exhaustion, adapter errors) propagate so
+   * real connection problems don't silently downgrade the emitted SQL.
+   * @internal
+   */
+  private static _resolveAdapter(baseModel: typeof Base): DatabaseAdapter | null {
+    if (typeof (baseModel as any).connection !== "function") return null;
+    try {
+      return ((baseModel as any).connection() as DatabaseAdapter) ?? null;
+    } catch (err) {
+      if (err instanceof ConnectionNotDefined) return null;
+      throw err;
+    }
   }
 
   /**
    * Mirrors Rails' `connection.quote(value)` for string literals embedded
    * into JOIN predicates (polymorphic source_type, STI type IN-lists).
-   * Falls back to a portable escape when no adapter is reachable.
+   * Falls back to a portable escape only when no pool is wired.
    * @internal
    */
   private _quoteString(value: string): string {
-    if (this._adapter === undefined) {
-      try {
-        this._adapter = (this._baseModel as any).connection?.() ?? null;
-      } catch {
-        this._adapter = null;
-      }
-    }
     if (this._adapter && typeof (this._adapter as any).quote === "function") {
       return (this._adapter as any).quote(value);
     }


### PR DESCRIPTION
## Summary

First slice of batch 133 (JoinDependency nested-through fidelity). Routes the three string literals embedded into JOIN predicates through the source-model's `connection.quote()` instead of hand-rolled backslash/single-quote escaping:

- `has_many :as` polymorphic type filter: `… AND "x"."t_type" = 'Model'`
- STI subclass IN-list: `… AND "x"."type" IN ('Sub', …)`
- `has_many :through` polymorphic source_type: `… AND "th"."t_type" = 'SourceType'`

Mirrors Rails' `PolymorphicReflection#source_type_scope` (reflection.rb:1251) which builds `where(type => source_type)` and lets the predicate builder hand the literal to `connection.quote`. The adapter is resolved eagerly in the `JoinDependency` constructor following the `quoterFor` pattern in `sanitization.ts:237`: only `ConnectionNotDefined` (no pool configured) falls back to the abstract `quote()`; other failures (pool exhaustion, adapter errors) propagate so real connection problems don't silently downgrade SQL. The structural `typeof conn.quote === "function"` check lives in `_resolveAdapter` so a malformed adapter is rejected at resolution time, not at every call.

Eager resolution is safe because all production call sites construct `JoinDependency` immediately before walking it — there's no window in which the pool could become wired between construction and the first `_quoteString` call. The abstract `quote()` is the single source of truth for the portable fallback.

## Out of scope (follow-ups for the rest of batch 133)

- ~50 LOC — Port `ThroughReflection#check_validity!` polymorphic-source-needs-source_type branch; collapses the `return null` guards in `_resolveThroughJoin` + `_addThroughAssociation`.
- ~30 LOC — Extend `loadHasManyThrough` `sourceType` handling to nested-through where the inner through is itself through with polymorphic source.
- ~30 LOC — Regression-pin port of Rails 431 `test_distinct_has_many_through_a_has_many_through_association_on_through_reflection`. Attempted here; the preloader doesn't yet resolve the nested `tags through: taggings (through: posts)` chain (preloads 0 tags), so it pairs with the `loadHasManyThrough` follow-up rather than this PR.

## Test plan

- [x] `join-dependency-quoting.test.ts` (new — 4 tests covering adapter dispatch, ConnectionNotDefined fallback, error propagation, STI IN-list)
- [x] `nested-through-associations.test.ts` (66 tests, unchanged behavior)
- [x] `relation.test.ts`, `calculations.test.ts`, `has-many-associations.test.ts` (existing JD consumers)
- [x] `pnpm typecheck`
- [x] `pnpm api:compare --package activerecord` — 4956/4958 (Δ 0)