### PR TITLE
feat(activerecord): wire belongs_to(touch:) through counter-cache callbacks (batch 135)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2096,10 +2096,15 @@ export async function updateCounterCaches(
     const parent = await targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
     if (!parent) continue;
 
+    // Mirrors Rails' BelongsToAssociation#update_counters: forward the
+    // belongs_to(touch:) option so updated_at (and any named timestamps) get
+    // bumped in the same UPDATE that adjusts the counter column.
+    const touch = assoc.options.touch;
+    const opts = touch != null ? { touch } : undefined;
     if (direction === "increment") {
-      await parent.incrementBang(counterCol);
+      await parent.incrementBang(counterCol, 1, opts);
     } else {
-      await parent.decrementBang(counterCol);
+      await parent.decrementBang(counterCol, 1, opts);
     }
   }
 }

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -147,7 +147,9 @@ export class BelongsToAssociation extends SingularAssociation {
 
     const scope = klass.where(conditions);
     if (typeof scope.updateCounters === "function") {
-      await scope.updateCounters({ [counterCol]: by });
+      const touch = (this.reflection.options as any).touch;
+      const opts = touch != null ? { touch } : undefined;
+      await scope.updateCounters({ [counterCol]: by }, opts);
     }
   }
 
@@ -337,10 +339,12 @@ export class BelongsToAssociation extends SingularAssociation {
     }
 
     const Klass = this.klass;
+    const touch = (this.reflection.options as any).touch;
+    const opts = touch != null ? { touch } : undefined;
     if (Klass && typeof (Klass as any).where === "function") {
       const scope = (Klass as any).where(conditions);
       if (typeof scope.updateCounters === "function") {
-        await scope.updateCounters({ [counterCol]: by });
+        await scope.updateCounters({ [counterCol]: by }, opts);
       }
     }
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -3,7 +3,10 @@ import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
 import { resolveModel, resolveAssocClass, modelRegistry } from "../../associations.js";
-import { registerCounterCachedAssociation } from "../../counter-cache.js";
+import {
+  flushPendingCounterCacheColumns,
+  registerCounterCachedAssociation,
+} from "../../counter-cache.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 
@@ -71,29 +74,20 @@ export class BelongsTo extends SingularAssociation {
     const targetClassName = reflection.options?.className ?? camelize(name);
     // Rails: `klass = reflection.class_name.safe_constantize` — silently nil
     // when the target class isn't loaded yet, then guarded by
-    // `if klass && klass.respond_to?(:_counter_cache_columns)`. We mirror
-    // by treating registry-miss as the deferral signal (pending-map path);
-    // namespace-aware resolution via reflection.klass is attempted when the
-    // registry has it, allowing modular class names to resolve correctly.
-    const targetClass: typeof import("../../base.js").Base | null = modelRegistry.has(
-      targetClassName,
-    )
-      ? resolveAssocClass(model, name, targetClassName)
-      : null;
-    if (targetClass) {
-      // Mirror Rails' class_attribute `|=` semantics: copy-on-write so subclass
-      // additions don't mutate the parent class's Set in place.
-      const owns = Object.prototype.hasOwnProperty.call(targetClass, "_counterCacheColumns");
-      const inherited: Set<string> | undefined = (targetClass as any)._counterCacheColumns;
-      const next: Set<string> = owns && inherited ? inherited : new Set(inherited ?? []);
-      next.add(cacheColumn);
-      (targetClass as any)._counterCacheColumns = next;
-    } else {
-      // Target class not registered yet — store in pending map; registerModel
-      // flushes it when the target is registered, getCounterCacheColumns as fallback.
-      const pending = pendingCounterCacheColumns.get(targetClassName) ?? new Set<string>();
-      pending.add(cacheColumn);
-      pendingCounterCacheColumns.set(targetClassName, pending);
+    // `if klass && klass.respond_to?(:_counter_cache_columns)`. We mirror by
+    // always staging into the pending map first, then flushing immediately
+    // when the target is already registered. The unconditional pending stage
+    // ensures the registration survives a target class being later re-defined
+    // (test re-runs, hot reload), at which point registerModel re-flushes —
+    // mirroring Rails' behavior where re-loading the target class re-runs
+    // the include chain.
+    const pending = pendingCounterCacheColumns.get(targetClassName) ?? new Set<string>();
+    pending.add(cacheColumn);
+    pendingCounterCacheColumns.set(targetClassName, pending);
+    if (modelRegistry.has(targetClassName)) {
+      // Target already registered — flush right now (eager path).
+      const targetClass = resolveAssocClass(model, name, targetClassName);
+      if (targetClass) flushPendingCounterCacheColumns(targetClass);
     }
 
     // Mirrors Rails: `model.counter_cached_association_names |= [reflection.name]`

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -644,12 +644,37 @@ describe("CounterCacheTest", () => {
     const reloaded = await Topic.find(t.id);
     expect(reloaded.replies_count).toBe(0);
   });
-  it.skip("counter cache on unloaded association class works", () => {
-    // BLOCKED: associations — pending-registry deferred resolution edge case
-    // ROOT-CAUSE: pendingCounterCacheColumns flush in registerModel resolves _counterCacheColumns,
-    //   but cache-column auto-derivation in counter-cache.ts#counterCacheColumnName runs
-    //   eagerly against the (unloaded) target — needs deferred lookup symmetric to flushPendingCounterCacheColumns
-    // SCOPE: ~15 LOC in associations/belongs-to.ts and counter-cache.ts
+  it("counter cache on unloaded association class works", async () => {
+    // Declare Reply (with belongs_to + counterCache) BEFORE Topic exists in the
+    // registry — exercises pendingCounterCacheColumns deferred-resolution.
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    // Clear any leftover Topic from prior tests so the unloaded path is
+    // actually exercised (registerModel leaks across test cases).
+    const { modelRegistry } = await import("./associations.js");
+    modelRegistry.delete("Topic");
+    Associations.belongsTo.call(Reply, "topic", { counterCache: true });
+    registerModel(Reply);
+
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("replies_count", "integer", { default: 0 });
+        this.adapter = adapter;
+      }
+    }
+    registerModel(Topic);
+
+    expect(Topic.isCounterCacheColumn("replies_count")).toBe(true);
+    const t = await Topic.create({ title: "x" });
+    await Reply.create({ content: "r", topic_id: t.id });
+    const reloaded = await Topic.find(t.id);
+    expect(reloaded.replies_count).toBe(1);
   });
   it("update counter caches on update", async () => {
     class Topic extends Base {
@@ -704,16 +729,64 @@ describe("CounterCacheTest", () => {
     await r.destroy();
     expect((await Topic.find(t.id)).replies_count).toBe(0);
   });
-  it.skip("counter cache on association with touch true also updates the timestamps", () => {
-    // BLOCKED: associations — touch: option not wired into counter cache callbacks
-    // ROOT-CAUSE: belongs_to(touch:) does not propagate to updateCounters; updateCounters
-    //   needs an opts.touch path that bumps updated_at/columns alongside the counter delta
-    // SCOPE: ~30 LOC in counter-cache.ts + belongs-to-association.ts increment/decrement callbacks
+  it("counter cache on association with touch true also updates the timestamps", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("replies_count", "integer", { default: 0 });
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Reply, "topic", { counterCache: true, touch: true });
+    registerModel(Topic);
+    registerModel(Reply);
+    const originalTime = new Date("2020-01-01T00:00:00.000Z");
+    const t = await Topic.create({ title: "test", updated_at: originalTime });
+    await Reply.create({ content: "r", topic_id: t.id });
+    const reloaded = await Topic.find(t.id);
+    expect(reloaded.replies_count).toBe(1);
+    const updatedTime =
+      reloaded.updated_at instanceof Date
+        ? reloaded.updated_at.getTime()
+        : Number(new Date(String(reloaded.updated_at)));
+    expect(updatedTime).toBeGreaterThan(originalTime.getTime());
   });
-  it.skip("counter cache on association with touch option updates timestamps", () => {
-    // BLOCKED: associations — touch: option (named column) not wired into counter cache
-    // ROOT-CAUSE: same as above — touch: :written_on / touch: %i(…) variants unsupported
-    // SCOPE: ~30 LOC in counter-cache.ts (shared with touch: true case)
+  it("counter cache on association with touch option updates timestamps", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("replies_count", "integer", { default: 0 });
+        this.attribute("updated_at", "datetime");
+        this.attribute("written_on", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Reply, "topic", {
+      counterCache: true,
+      touch: "written_on",
+    });
+    registerModel(Topic);
+    registerModel(Reply);
+    const t = await Topic.create({ title: "test" });
+    await Reply.create({ content: "r", topic_id: t.id });
+    const reloaded = await Topic.find(t.id);
+    expect(reloaded.replies_count).toBe(1);
+    expect(reloaded.written_on).not.toBeNull();
   });
   it("counter cache with belongs to association with class name", async () => {
     class Author extends Base {
@@ -1495,11 +1568,43 @@ describe("CounterCacheTest", () => {
     }
     expect(updateCount).toBe(0);
   });
-  it.skip("reset counter performs query for correct counter with touch: true", () => {
-    // BLOCKED: associations — touch: option wiring (resetCounters branch)
-    // ROOT-CAUSE: Rails forces the UPDATE under touch: true even when counts match;
-    //   we lack touch: plumbing entirely (see "touch: true also updates the timestamps")
-    // SCOPE: ~10 LOC in counter-cache.ts#resetCounters — pair with touch: wiring
+  it("reset counter performs query for correct counter with touch: true", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("replies_count", "integer", { default: 0 });
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    class Reply extends Base {
+      static {
+        this.attribute("content", "string");
+        this.attribute("topic_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Reply, "topic", { counterCache: true });
+    Associations.hasMany.call(Topic, "replies", { foreignKey: "topic_id" });
+    registerModel(Topic);
+    registerModel(Reply);
+    const t = await Topic.create({ title: "first" });
+    await Reply.create({ content: "r1", topic_id: t.id });
+    // First reset brings the counter into agreement.
+    await Topic.resetCounters(t.id, "replies");
+    let updateCount = 0;
+    const sub = Notifications.subscribe("sql.active_record", (evt: any) => {
+      const sql = evt.payload?.sql?.trim().toUpperCase() ?? "";
+      if (sql.startsWith("UPDATE")) updateCount++;
+    });
+    try {
+      // touch: true forces the UPDATE even when the count matches, because the
+      // timestamp columns are part of the SET clause.
+      await Topic.resetCounters(t.id, "replies", { touch: true });
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(updateCount).toBe(1);
   });
   it.skip("reset counters for cpk model", () => {
     // BLOCKED: associations — composite primary key in resetCounters


### PR DESCRIPTION
## Summary

Implements Batch 135 from `docs/activerecord-100-plan.md` — wires the `belongs_to(touch:)` option through counter-cache callbacks, mirroring Rails' `BelongsToAssociation#update_counters` touch forwarding.

- `updateCounterCaches` (create/destroy path) forwards `assoc.options.touch` to `parent.incrementBang` / `decrementBang`, so `updated_at` and any named timestamp columns get bumped in the same UPDATE as the counter delta.
- `BelongsToAssociation#updateCounters` and `updateCountersViaScope` forward `reflection.options.touch` to `scope.updateCounters` for the `after_update` path and `decrement_counters_before_last_save`.
- Fixes the pending-counter-cache flush so an unloaded target class resolves on registration: `addCounterCacheCallbacks` now always stages into `pendingCounterCacheColumns`, then eagerly flushes when the target is already in the registry (symmetric with `registerModel`'s flush call).

## Closed skips

- `counter cache on association with touch true also updates the timestamps`
- `counter cache on association with touch option updates timestamps`
- `counter cache on unloaded association class works`
- `reset counter performs query for correct counter with touch: true` (already supported via `Relation#updateCounters`; un-skipped)

## Follow-ups (deferred from batch)

- Port Rails' Thread-parallel "concurrent inserts" test to `Promise.all`.
- `_counterCacheColumns` Set → Array cosmetic divergence (iteration order).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/counter-cache.test.ts` — 94 pass, 7 legitimately skipped.
- [x] `pnpm vitest run packages/activerecord/src/{associations,persistence,timestamp}.test.ts` — 850 pass.