### PR TITLE
feat(activerecord): batch 70 — relation core gaps bundle A (slice)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -541,19 +541,9 @@ export class Relation<T extends Base> {
         const targetModel = modelRegistry.get(className);
         rawPk = targetModel?.primaryKey ?? "id";
       }
-      // Composite PKs are supported at the WHERE level (one IS NULL per column)
-      // but the JOIN ON clause from _resolveAssociationJoin is a raw SQL string;
-      // composite FK or PK options would stringify to "a,b" → invalid SQL.
-      if (Array.isArray(assocDef.options.foreignKey)) {
-        throw new Error(
-          `whereMissing/whereAssociated: composite foreignKey on '${assocName}' is not yet supported.`,
-        );
-      }
-      if (Array.isArray(assocDef.options.primaryKey)) {
-        throw new Error(
-          `whereMissing/whereAssociated: composite primaryKey on '${assocName}' is not yet supported.`,
-        );
-      }
+      // _resolveAssociationJoin now zips composite FK/PK arrays into multiple
+      // Eq predicates AND'd together — emit one IS NOT NULL / IS NULL predicate
+      // per PK column at the call site (whereAssociated/whereMissing).
       const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
       return { joins, table: lastJoin.table, pks };
     }
@@ -1362,17 +1352,17 @@ export class Relation<T extends Base> {
 
     if (assocDef.type === "belongsTo") {
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(name)}_id`;
-      if (Array.isArray(foreignKey)) return null;
       const className = assocDef.options.className ?? _camelize(name);
       const targetModel = modelRegistry.get(className);
       if (!targetModel) return null;
       const targetTable = targetModel.tableName;
       const rawTargetPk = assocDef.options.primaryKey ?? targetModel.primaryKey ?? "id";
-      if (Array.isArray(rawTargetPk)) return null;
-      const targetPk = rawTargetPk;
+      const fkArr = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
+      const pkArr = Array.isArray(rawTargetPk) ? rawTargetPk : [rawTargetPk];
+      if (fkArr.length !== pkArr.length) return null;
       const tgt = new Table(targetTable);
       const src = new Table(sourceTable);
-      const predicates: Nodes.Node[] = [tgt.get(targetPk).eq(src.get(foreignKey))];
+      const predicates: Nodes.Node[] = pkArr.map((pk, i) => tgt.get(pk).eq(src.get(fkArr[i])));
 
       // STI type condition on target
       const inheritanceCol = getInheritanceColumn(targetModel);
@@ -1405,13 +1395,13 @@ export class Relation<T extends Base> {
       if (!targetModel) return null;
       const targetTable = targetModel.tableName;
       const rawPk = assocDef.options.primaryKey ?? sourcePk;
-      if (Array.isArray(rawPk)) return null;
-      const primaryKey = rawPk;
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`;
-      if (Array.isArray(foreignKey)) return null;
+      const pkArr = Array.isArray(rawPk) ? rawPk : [rawPk];
+      const fkArr = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
+      if (pkArr.length !== fkArr.length) return null;
       const tgt = new Table(targetTable);
       const src = new Table(sourceTable);
-      const predicates: Nodes.Node[] = [tgt.get(foreignKey).eq(src.get(primaryKey))];
+      const predicates: Nodes.Node[] = pkArr.map((pk, i) => tgt.get(fkArr[i]).eq(src.get(pk)));
 
       // Polymorphic type condition
       if (assocDef.options.as) {

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -116,11 +116,18 @@ export class AssociationQueryValue {
   }
 
   /** @internal */
-  private isPolymorphicClause(relation: unknown): boolean {
+  private isPolymorphicClause(relation: {
+    whereValuesHash?: () => Record<string, unknown>;
+  }): boolean {
     const type = this.primaryType();
     if (!type) return false;
-    const hash = (relation as any).whereValuesHash?.();
-    return !(hash && type in hash);
+    // Rails: polymorphic? && !where_values_hash.key?(primary_type). If the relation
+    // doesn't implement where_values_hash (non-Relation duck), treat as needing the
+    // polymorphic constraint — that's the safer default than skipping the type guard.
+    const hash =
+      typeof relation.whereValuesHash === "function" ? relation.whereValuesHash() : undefined;
+    if (!hash) return true;
+    return !(type in hash);
   }
 
   private isSelectClause(relation: unknown): boolean {

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -259,11 +259,39 @@ describe("WhereChainTest", () => {
     expect(results.some((r: any) => r.id === lonelyAuthor.id)).toBe(false);
   });
 
-  it.skip("associated with composite primary key", () => {
-    // BLOCKED: relation — WhereChain feature gap (not/and/or chaining)
-    // ROOT-CAUSE: relation/where-chain.ts#WhereChain missing or incomplete Rails parity
-    // SCOPE: ~50 LOC in relation/where-chain.ts; affects ~27 tests in where-chain.test.ts
-    /* needs proper composite primary key model setup */
+  it("associated with composite primary key", async () => {
+    const a = freshAdapter();
+    await defineSchema(a, {
+      cpk_shops: { name: "string" },
+      cpk_orders: { shop_id: "integer", order_id: "integer", cpk_shop_id: "integer" },
+    });
+    class CpkShop extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = a;
+      }
+    }
+    class CpkOrder extends Base {
+      static {
+        this.primaryKey = ["shop_id", "order_id"];
+        this.attribute("shop_id", "integer");
+        this.attribute("order_id", "integer");
+        this.attribute("cpk_shop_id", "integer");
+        this.adapter = a;
+      }
+    }
+    registerModel("CpkShop", CpkShop);
+    registerModel("CpkOrder", CpkOrder);
+    Associations.belongsTo.call(CpkOrder, "cpkShop", {
+      className: "CpkShop",
+      foreignKey: "cpk_shop_id",
+    });
+    const shop = await CpkShop.create({ name: "S" });
+    await CpkOrder.create({ shop_id: 1, order_id: 1, cpk_shop_id: shop.id });
+    await CpkOrder.create({ shop_id: 1, order_id: 2 });
+    const results = await CpkOrder.all().whereAssociated("cpkShop").toArray();
+    expect(results).toHaveLength(1);
+    expect((results[0] as any).readAttribute("order_id")).toBe(1);
   });
   it("missing with child association", () => {
     const sql = Post.all().whereMissing("author").toSql();


### PR DESCRIPTION
## Summary

Slice of Batch 70 from `docs/activerecord-100-plan.md`:

- Tighten `AssociationQueryValue#isPolymorphicClause`: typed parameter + sensible fallback when the value relation doesn't expose `whereValuesHash` (Item C, ~5 LOC).
- Composite primary/foreign key support in `_resolveAssociationJoin` for `belongsTo` and `hasOne`/`hasMany` — zip FK/PK column arrays into `Nodes.And`-composed Eq predicates so `whereAssociated`/`whereMissing` emits a valid INNER/LEFT JOIN against CPK targets. Drops the matching throws in `_resolveAssociationTarget` (Item C, ~15 LOC).
- Un-skips `associated with composite primary key` in `where-chain.test.ts` with a real fixture.

## Follow-ups (deferred from Batch 70)

- `cursor` uniqueness validation needs schema-cache PK/unique-index access (~10 LOC).
- `defaultScopeOverride` detection for static-method form (~10 LOC, no Rails test coverage).
- Enum/scoped association support in `whereAssociated`/`whereMissing` (~20 LOC + 10 fixture-dependent test bodies).
- `remaining` limit cap wiring in `batchOnUnloadedRelation` — code path appears wired; audit + confirm via test.
- `inBatches` placeholder CPK tests in `batches.test.ts` (lines 1657–1709) — currently boilerplate-only.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation/where-chain.test.ts packages/activerecord/src/relation.test.ts packages/activerecord/src/relation/predicate-builder/ packages/activerecord/src/relation/where.test.ts` — 290 passed