### PR TITLE
feat(actionpack): port ActionDispatch::Http::URL class-level helpers

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -10,3 +10,4 @@ export {
 } from "./permissions-policy.js";
 export { Headers } from "./headers.js";
 export { QueryParser, type QueryPair } from "./query-parser.js";
+export { URL, type UrlOptions } from "./url.js";

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -87,6 +87,24 @@ export class Request {
   }
 
   get rawHost(): string {
+    return this.rawHostWithPort;
+  }
+
+  /** Returns 'https://' if this is an SSL request and 'http://' otherwise. */
+  get protocol(): string {
+    return this.ssl ? "https://" : "http://";
+  }
+
+  /**
+   * Returns the host and port for this request, such as "example.com:8080".
+   * Mirrors Rails' `raw_host_with_port`: honors X-Forwarded-Host (last entry).
+   */
+  get rawHostWithPort(): string {
+    const forwarded = (this.env["HTTP_X_FORWARDED_HOST"] as string | undefined)?.trim();
+    if (forwarded) {
+      const parts = forwarded.split(/,\s?/);
+      return parts[parts.length - 1];
+    }
     return (
       (this.env["HTTP_HOST"] as string) || `${this.env["SERVER_NAME"]}:${this.env["SERVER_PORT"]}`
     );

--- a/packages/actionpack/src/action-dispatch/http/url.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/url.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { URL } from "./url.js";
+
+beforeEach(() => {
+  URL.secureProtocol = false;
+  URL.tldLength = 1;
+});
+
+describe("URL.extractDomain", () => {
+  it("returns the domain at tld_length 1", () => {
+    expect(URL.extractDomain("www.example.com", 1)).toBe("example.com");
+  });
+
+  it("returns the domain at tld_length 2", () => {
+    expect(URL.extractDomain("dev.www.example.co.uk", 2)).toBe("example.co.uk");
+  });
+
+  it("returns null for an IP host", () => {
+    expect(URL.extractDomain("192.168.1.1", 1)).toBeNull();
+  });
+});
+
+describe("URL.extractSubdomains", () => {
+  it("returns subdomains at tld_length 1", () => {
+    expect(URL.extractSubdomains("www.example.com", 1)).toEqual(["www"]);
+  });
+
+  it("returns subdomains at tld_length 2", () => {
+    expect(URL.extractSubdomains("dev.www.example.co.uk", 2)).toEqual(["dev", "www"]);
+  });
+
+  it("returns [] for an IP host", () => {
+    expect(URL.extractSubdomains("192.168.1.1", 1)).toEqual([]);
+  });
+});
+
+describe("URL.extractSubdomain", () => {
+  it("joins subdomains with .", () => {
+    expect(URL.extractSubdomain("dev.www.example.co.uk", 2)).toBe("dev.www");
+  });
+});
+
+describe("URL.urlFor / pathFor", () => {
+  it("only_path uses pathFor", () => {
+    expect(URL.urlFor({ onlyPath: true, path: "/foo" })).toBe("/foo");
+  });
+
+  it("pathFor strips trailing slash from scriptName and appends path", () => {
+    expect(URL.pathFor({ scriptName: "/app/", path: "/foo" })).toBe("/app/foo");
+  });
+
+  it("pathFor trailing_slash on blank path → /", () => {
+    expect(URL.pathFor({ trailingSlash: true })).toBe("/");
+  });
+
+  it("pathFor appends params as query", () => {
+    expect(URL.pathFor({ path: "/foo", params: { a: "1", b: "2" } })).toBe("/foo?a=1&b=2");
+  });
+
+  it("pathFor wraps non-hash params under :params", () => {
+    expect(URL.pathFor({ path: "/foo", params: "x" })).toBe("/foo?params=x");
+  });
+
+  it("pathFor appends anchor with fragment escaping", () => {
+    expect(URL.pathFor({ path: "/foo", anchor: "bar baz" })).toBe("/foo#bar%20baz");
+  });
+
+  it("pathFor skips nil-valued params", () => {
+    expect(URL.pathFor({ path: "/foo", params: { a: "1", b: null } })).toBe("/foo?a=1");
+  });
+});
+
+describe("URL.fullUrlFor", () => {
+  it("raises when host is missing", () => {
+    expect(() => URL.fullUrlFor({})).toThrow(/Missing host/);
+  });
+
+  it("builds a basic url with default http", () => {
+    expect(URL.fullUrlFor({ host: "example.com", path: "/foo" })).toBe("http://example.com/foo");
+  });
+
+  it("respects secureProtocol when protocol is nil", () => {
+    URL.secureProtocol = true;
+    expect(URL.fullUrlFor({ host: "example.com", path: "/" })).toBe("https://example.com/");
+  });
+
+  it("protocol false → //", () => {
+    expect(URL.fullUrlFor({ host: "example.com", protocol: false, path: "/" })).toBe(
+      "//example.com/",
+    );
+  });
+
+  it("normalizes a bare protocol string", () => {
+    expect(URL.fullUrlFor({ host: "example.com", protocol: "ftp", path: "/" })).toBe(
+      "ftp://example.com/",
+    );
+  });
+
+  it("omits port when standard for protocol", () => {
+    expect(URL.fullUrlFor({ host: "example.com", port: 80, path: "/" })).toBe(
+      "http://example.com/",
+    );
+    expect(URL.fullUrlFor({ host: "example.com", protocol: "https", port: 443, path: "/" })).toBe(
+      "https://example.com/",
+    );
+  });
+
+  it("includes non-standard port", () => {
+    expect(URL.fullUrlFor({ host: "example.com", port: 8080, path: "/" })).toBe(
+      "http://example.com:8080/",
+    );
+  });
+
+  it("parses protocol/port from host", () => {
+    expect(URL.fullUrlFor({ host: "https://example.com:8443", path: "/" })).toBe(
+      "https://example.com:8443/",
+    );
+  });
+
+  it("encodes user/password in userinfo", () => {
+    expect(URL.fullUrlFor({ host: "example.com", user: "a b", password: "p@ss", path: "/" })).toBe(
+      "http://a+b:p%40ss@example.com/",
+    );
+  });
+
+  it("rebuilds host from subdomain + domain options", () => {
+    expect(URL.fullUrlFor({ host: "www.example.com", subdomain: "api", path: "/" })).toBe(
+      "http://api.example.com/",
+    );
+  });
+
+  it("strips subdomain when subdomain: false", () => {
+    expect(URL.fullUrlFor({ host: "www.example.com", subdomain: false, path: "/" })).toBe(
+      "http://example.com/",
+    );
+  });
+
+  it("invalid protocol option raises", () => {
+    expect(() =>
+      URL.fullUrlFor({ host: "example.com", protocol: "::" as unknown as string }),
+    ).toThrow(/Invalid :protocol/);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/url.ts
+++ b/packages/actionpack/src/action-dispatch/http/url.ts
@@ -1,0 +1,214 @@
+/**
+ * ActionDispatch::Http::URL
+ *
+ * Port of `actionpack/lib/action_dispatch/http/url.rb`.
+ *
+ * Provides the class-level URL helpers (extractDomain, urlFor, pathFor, etc.)
+ * used by routing to assemble URLs from option hashes. The corresponding
+ * instance methods (url, host, port, ...) live on {@link Request}.
+ */
+
+import { toParam, toQuery } from "@blazetrails/activesupport";
+import { escapeFragment } from "../journey/router/utils.js";
+
+const IP_HOST_REGEXP = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+const HOST_REGEXP = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/;
+const PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/;
+
+export interface UrlOptions {
+  host?: string;
+  protocol?: string | false | null;
+  port?: number | string | null;
+  scriptName?: string;
+  path?: string;
+  trailingSlash?: boolean;
+  params?: unknown;
+  anchor?: unknown;
+  user?: string;
+  password?: string;
+  onlyPath?: boolean;
+  tldLength?: number;
+  subdomain?: string | boolean | { toParam(): string };
+  domain?: string;
+}
+
+function rackEscape(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, "+");
+}
+
+function isBlank(s: string): boolean {
+  return s.length === 0 || /^\s*$/.test(s);
+}
+
+function namedHost(host: string): boolean {
+  return !IP_HOST_REGEXP.test(host);
+}
+
+function extractDomainFrom(host: string, tldLength: number): string {
+  const parts = host.split(".");
+  return parts.slice(-(1 + tldLength)).join(".");
+}
+
+function extractSubdomainsFrom(host: string, tldLength: number): string[] {
+  const parts = host.split(".");
+  return parts.slice(0, parts.length - (tldLength + 1));
+}
+
+function addParams(parts: string[], params: unknown): void {
+  let hash: Record<string, unknown>;
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    hash = { ...(params as Record<string, unknown>) };
+  } else {
+    hash = { params };
+  }
+  for (const k of Object.keys(hash)) {
+    if (toParam(hash[k]) === null) delete hash[k];
+  }
+  const query = toQuery(hash);
+  if (query.length > 0) parts.push(`?${query}`);
+}
+
+function addAnchor(parts: string[], anchor: unknown): void {
+  if (anchor !== null && anchor !== undefined && anchor !== false) {
+    const p = toParam(anchor);
+    parts.push(`#${escapeFragment(String(p ?? ""))}`);
+  }
+}
+
+function normalizeProtocol(protocol: string | false | null | undefined): string {
+  if (protocol === null || protocol === undefined) {
+    return URL.secureProtocol ? "https://" : "http://";
+  }
+  if (protocol === false || protocol === "//") return "//";
+  if (typeof protocol === "string") {
+    const m = protocol.match(PROTOCOL_REGEXP);
+    if (m) return `${m[1]}://`;
+  }
+  throw new Error(`Invalid :protocol option: ${JSON.stringify(protocol)}`);
+}
+
+function normalizeHost(rawHost: string, options: UrlOptions): string {
+  if (!namedHost(rawHost)) return rawHost;
+
+  const tldLength = options.tldLength ?? URL.tldLength;
+  const subdomain = options.subdomain ?? true;
+  const domain = options.domain;
+
+  let host = "";
+  if (subdomain === true) {
+    if (domain === null || domain === undefined) return rawHost;
+    host += extractSubdomainsFrom(rawHost, tldLength).join(".");
+  } else if (subdomain) {
+    host += String(toParam(subdomain) ?? "");
+  }
+  if (host.length > 0) host += ".";
+  host += domain ?? extractDomainFrom(rawHost, tldLength);
+  return host;
+}
+
+function normalizePort(
+  port: number | string | null | undefined,
+  protocol: string,
+): number | string | null {
+  if (port === null || port === undefined || port === "") return null;
+  const n = typeof port === "string" ? parseInt(port, 10) : port;
+  if (protocol === "//") return port;
+  if (protocol === "https://") return n === 443 ? null : port;
+  return n === 80 ? null : port;
+}
+
+function buildHostUrl(
+  hostIn: string,
+  portIn: number | string | null | undefined,
+  protocolIn: string | false | null | undefined,
+  options: UrlOptions,
+  path: string,
+): string {
+  let host = hostIn;
+  let port = portIn;
+  let protocol = protocolIn;
+
+  const match = host.match(HOST_REGEXP);
+  if (match) {
+    if (protocol !== false && (protocol === null || protocol === undefined)) {
+      protocol = match[1] ?? null;
+    }
+    host = match[2];
+    if (!("port" in options)) port = match[3] ?? null;
+  }
+
+  const protocolStr = normalizeProtocol(protocol);
+  host = normalizeHost(host, options);
+
+  let result = protocolStr;
+  if (options.user && options.password) {
+    result += `${rackEscape(options.user)}:${rackEscape(options.password)}@`;
+  }
+  result += host;
+  const normalized = normalizePort(port, protocolStr);
+  if (normalized !== null) result += `:${normalized}`;
+  result += path;
+  return result;
+}
+
+/**
+ * ActionDispatch::Http::URL — class-level helpers.
+ *
+ * Instance methods (url, host, port, ...) live on {@link Request}.
+ */
+export const URL = {
+  secureProtocol: false as boolean,
+  tldLength: 1 as number,
+
+  /**
+   * Returns the domain part of a host given the domain level.
+   *
+   *     URL.extractDomain('www.example.com', 1) // => "example.com"
+   *     URL.extractDomain('dev.www.example.co.uk', 2) // => "example.co.uk"
+   */
+  extractDomain(host: string, tldLength: number): string | null {
+    return namedHost(host) ? extractDomainFrom(host, tldLength) : null;
+  },
+
+  /**
+   * Returns the subdomains of a host as an Array given the domain level.
+   *
+   *     URL.extractSubdomains('www.example.com', 1) // => ["www"]
+   *     URL.extractSubdomains('dev.www.example.co.uk', 2) // => ["dev", "www"]
+   */
+  extractSubdomains(host: string, tldLength: number): string[] {
+    return namedHost(host) ? extractSubdomainsFrom(host, tldLength) : [];
+  },
+
+  /**
+   * Returns the subdomains of a host as a String given the domain level.
+   */
+  extractSubdomain(host: string, tldLength: number): string {
+    return URL.extractSubdomains(host, tldLength).join(".");
+  },
+
+  urlFor(options: UrlOptions): string {
+    return options.onlyPath ? URL.pathFor(options) : URL.fullUrlFor(options);
+  },
+
+  fullUrlFor(options: UrlOptions): string {
+    const { host, protocol, port } = options;
+    if (!host) {
+      throw new Error(
+        "Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true",
+      );
+    }
+    return buildHostUrl(host, port, protocol, options, URL.pathFor(options));
+  },
+
+  pathFor(options: UrlOptions): string {
+    let path = (options.scriptName ?? "").replace(/\/$/, "");
+    if ("path" in options && options.path !== undefined) path += options.path;
+    if (options.trailingSlash && isBlank(path)) path = "/";
+
+    const parts: string[] = [path];
+    if ("params" in options) addParams(parts, options.params);
+    if ("anchor" in options) addAnchor(parts, options.anchor);
+    return parts.join("");
+  },
+};


### PR DESCRIPTION
## Summary
- Ports `actionpack/lib/action_dispatch/http/url.rb` to `packages/actionpack/src/action-dispatch/http/url.ts`, mirroring Rails 1:1
- Adds the class-level `URL` namespace: `extractDomain`, `extractSubdomains`, `extractSubdomain`, `urlFor`, `fullUrlFor`, `pathFor`, plus the `secureProtocol` / `tldLength` mattrs
- Private helpers (`normalizeProtocol`, `normalizeHost`, `normalizePort`, `buildHostUrl`, `addParams`, `addAnchor`) follow the Rails source order

The instance-side mixin (`url`, `host`, `port`, `protocol`, `domain`, `subdomains`, ...) already lives on `Request`, so this PR only adds the class-level API.

## Test plan
- [x] `vitest run packages/actionpack/src/action-dispatch/http/url.test.ts` — 26 tests, covering extractDomain/Subdomain[s], pathFor (script_name strip, trailing_slash, params/anchor escaping, nil-valued params), and fullUrlFor (missing-host raise, secureProtocol default, `false`/`"//"` protocol, parsing protocol/port from host, standard-port elision, userinfo escaping, subdomain rebuild, invalid protocol)