### PR TITLE
feat(activerecord): Association#targetScope chain merge (batch 92 slice)

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -463,41 +463,16 @@ export class Association {
   }
 
   /**
-   * Mirrors Rails' `Association#target_scope` (association.rb).
-   *
-   * For non-through associations, returns `klass.all()`. Through
-   * associations walk `reflection.chain.drop(1)` and merge each
-   * intermediate reflection's `klass.scopeForAssociation()` — this is
-   * what propagates `default_scope` declared on join models into the
-   * target query.
-   *
-   * Rails calls `.except(:select, :create_with, :includes, :preload,
-   * :eager_load, :joins, :left_outer_joins)` before merging; our
-   * `Relation#except` is a set-operation (SQL EXCEPT) and does not yet
-   * support clause-removal. As a result we merge the full intermediate
-   * scope; this is correct for `default_scope { where(...) }` (the
-   * common case) but may pull through unwanted clauses for more exotic
-   * default scopes. Tracking as a follow-up.
+   * Mirrors Rails' `Association#target_scope` (association.rb): returns
+   * `klass.all`. The through-association chain merge that propagates
+   * intermediate `default_scope` is the
+   * `ThroughAssociation#target_scope` override — see
+   * `through-association.ts` / `_throughTargetScope`.
    *
    * @internal
    */
-  private targetScope(): any {
-    const klass = this.klass as any;
-    if (!klass?.all) return null;
-    let scope = klass.all();
-    const refl = (this.owner.constructor as any)._reflectOnAssociation?.(this.reflection.name) as
-      | { chain?: Array<{ klass?: typeof Base }> }
-      | undefined;
-    const chain = refl?.chain;
-    if (!chain || chain.length <= 1) return scope;
-    for (let i = 1; i < chain.length; i++) {
-      const interKlass = chain[i]?.klass as any;
-      const interScope = interKlass?.scopeForAssociation?.();
-      if (interScope && typeof scope.merge === "function") {
-        scope = scope.merge(interScope);
-      }
-    }
-    return scope;
+  protected targetScope(): any {
+    return (this.klass as any)?.all?.() ?? null;
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -462,8 +462,42 @@ export class Association {
     );
   }
 
+  /**
+   * Mirrors Rails' `Association#target_scope` (association.rb).
+   *
+   * For non-through associations, returns `klass.all()`. Through
+   * associations walk `reflection.chain.drop(1)` and merge each
+   * intermediate reflection's `klass.scopeForAssociation()` — this is
+   * what propagates `default_scope` declared on join models into the
+   * target query.
+   *
+   * Rails calls `.except(:select, :create_with, :includes, :preload,
+   * :eager_load, :joins, :left_outer_joins)` before merging; our
+   * `Relation#except` is a set-operation (SQL EXCEPT) and does not yet
+   * support clause-removal. As a result we merge the full intermediate
+   * scope; this is correct for `default_scope { where(...) }` (the
+   * common case) but may pull through unwanted clauses for more exotic
+   * default scopes. Tracking as a follow-up.
+   *
+   * @internal
+   */
   private targetScope(): any {
-    return (this.klass as any)?.all?.() ?? null;
+    const klass = this.klass as any;
+    if (!klass?.all) return null;
+    let scope = klass.all();
+    const refl = (this.owner.constructor as any)._reflectOnAssociation?.(this.reflection.name) as
+      | { chain?: Array<{ klass?: typeof Base }> }
+      | undefined;
+    const chain = refl?.chain;
+    if (!chain || chain.length <= 1) return scope;
+    for (let i = 1; i < chain.length; i++) {
+      const interKlass = chain[i]?.klass as any;
+      const interScope = interKlass?.scopeForAssociation?.();
+      if (interScope && typeof scope.merge === "function") {
+        scope = scope.merge(interScope);
+      }
+    }
+    return scope;
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -9,6 +9,7 @@ import { compositeQueryConstraintsList } from "../persistence.js";
 import { raiseValidationError } from "../validations.js";
 import { underscore, singularize, camelize } from "@blazetrails/activesupport";
 import { resolveAssocClass } from "../associations.js";
+import { throughTargetScope } from "./through-association.js";
 
 function safeKlass(refl: { klass?: unknown } | null | undefined): any {
   try {
@@ -24,6 +25,14 @@ function safeKlass(refl: { klass?: unknown } | null | undefined): any {
 export class HasManyThroughAssociation extends HasManyAssociation {
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  /**
+   * Mirrors Rails' `ThroughAssociation#target_scope` override.
+   * @internal
+   */
+  protected override targetScope(): unknown {
+    return throughTargetScope(this, super["targetScope"]());
   }
 
   // Rails uses scope.pluck(*reflection.association_primary_key) where `scope`

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -6,6 +6,7 @@ import {
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
 import { queryConstraintsList } from "../persistence.js";
+import { throughTargetScope } from "./through-association.js";
 
 function safeKlass(refl: { klass?: unknown } | null | undefined): any {
   try {
@@ -21,6 +22,14 @@ function safeKlass(refl: { klass?: unknown } | null | undefined): any {
 export class HasOneThroughAssociation extends HasOneAssociation {
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  /**
+   * Mirrors Rails' `ThroughAssociation#target_scope` override.
+   * @internal
+   */
+  protected override targetScope(): unknown {
+    return throughTargetScope(this, super["targetScope"]());
   }
 
   /**

--- a/packages/activerecord/src/associations/through-association.ts
+++ b/packages/activerecord/src/associations/through-association.ts
@@ -123,6 +123,59 @@ function staleState(assoc: { owner: Base; reflection: any }): unknown[] | null {
   return vals.length > 0 ? vals : null;
 }
 
+/**
+ * Mirrors Rails' `ThroughAssociation#target_scope`
+ * (through_association.rb):
+ *
+ *     def target_scope
+ *       scope = super
+ *       reflection.chain.drop(1).each do |reflection|
+ *         relation = reflection.klass.scope_for_association
+ *         scope.merge!(
+ *           relation.except(:select, :create_with, :includes, :preload,
+ *                           :eager_load, :joins, :left_outer_joins)
+ *         )
+ *       end
+ *       scope
+ *     end
+ *
+ * `superScope` is the base `Association#targetScope` (= `klass.all()`).
+ * This helper folds in each intermediate reflection's
+ * `klass.scopeForAssociation()` to propagate `default_scope` declared on
+ * join models into the target query.
+ *
+ * The clause-removal (`.except(:select, ...)`) is not applied: our
+ * `Relation#except` is a set-operation (SQL EXCEPT). Correct for
+ * `default_scope { where(...) }`; lossy for exotic default scopes
+ * (tracked as a follow-up).
+ *
+ * @internal
+ */
+export function throughTargetScope(
+  assoc: { owner: Base; reflection: { name: string } },
+  superScope: unknown,
+): unknown {
+  let scope = superScope;
+  if (!scope) return scope;
+  const ctor = assoc.owner.constructor as {
+    _reflectOnAssociation?: (n: string) => unknown;
+  };
+  const refl = ctor._reflectOnAssociation?.(assoc.reflection.name) as
+    | { chain?: Array<{ klass?: { scopeForAssociation?: () => unknown } }> }
+    | null
+    | undefined;
+  const chain = refl?.chain;
+  if (!chain || chain.length <= 1) return scope;
+  for (let i = 1; i < chain.length; i++) {
+    const interKlass = chain[i]?.klass;
+    const interScope = interKlass?.scopeForAssociation?.();
+    if (interScope && typeof (scope as { merge?: unknown }).merge === "function") {
+      scope = (scope as { merge: (r: unknown) => unknown }).merge(interScope);
+    }
+  }
+  return scope;
+}
+
 /** @internal */
 function foreignKeyPresent(assoc: { owner: Base; reflection: any }): boolean {
   const tr = throughReflection(assoc) as any;


### PR DESCRIPTION
## Summary

Implements Rails' \`ThroughAssociation#target_scope\` chain merge on \`Association#targetScope\`. Walks \`reflection.chain.drop(1)\` and merges each intermediate reflection's \`klass.scopeForAssociation()\` into the base scope — the mechanism Rails uses to propagate \`default_scope\` declared on join models into the target query.

## Caveat

Rails calls \`.except(:select, :create_with, :includes, :preload, :eager_load, :joins, :left_outer_joins)\` before merging. Our \`Relation#except\` is a set-operation (SQL EXCEPT), not Rails-style clause-removal. As a result we merge the full intermediate scope; correct for the common \`default_scope { where(...) }\` case, lossy for exotic default scopes. Tracking as a follow-up.

## Batch 92 — remaining slots deferred

Each entangles fixture infra (Author/Post/Comment/Minivan/etc. fixture models that aren't yet defined in the test suite), so unblocking the BLOCKED tests in this batch needs fixture work first. Splitting them out as follow-up slots:

- Non-preload (JOIN-based) eager loading (~50 LOC) — 3 BLOCKED tests in \`has-one-through-associations.test.ts\`.
- Scoped \`has_one_through\` lambda scope on through/source (~80 LOC + fixtures).
- Scope-based \`associationScope\` cache invalidation when through-model has default scopes (~30 LOC; consumer test additionally blocked on custom-select default-scope wiring).
- \`Relation#except(...clauseKeys)\` clause-removal to make this PR's chain merge bit-for-bit Rails-equivalent.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/associations/{has-one-through-associations,has-many-through-associations,association-scope-cache}.test.ts\` — all 219 (202 passing / 17 BLOCKED) still pass.