### PR TITLE
feat(actionpack): port ActionDispatch::RemoteIp middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -238,16 +238,22 @@ export class Request {
 
   // --- IP addresses ---
 
-  get remoteIp(): string {
-    // Check for ActionDispatch::RemoteIp result first
-    if (this.env["action_dispatch.remote_ip"]) {
-      return String(this.env["action_dispatch.remote_ip"]);
+  get remoteIp(): string | null {
+    const v = this.env["action_dispatch.remote_ip"];
+    if (v != null) {
+      if (typeof v === "object" && typeof (v as { calculate?: unknown }).calculate === "function") {
+        return (v as { calculate(): string | null }).calculate();
+      }
+      return typeof v === "string" ? v : String(v);
     }
-    // Fall back to REMOTE_ADDR
     return (this.env["REMOTE_ADDR"] as string) || "127.0.0.1";
   }
 
-  get ip(): string {
+  set remoteIp(value: string | null) {
+    this.env["action_dispatch.remote_ip"] = value;
+  }
+
+  get ip(): string | null {
     return this.remoteIp;
   }
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -81,3 +81,10 @@ export {
 export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
 export { AssumeSSL } from "./middleware/assume-ssl.js";
 export { Callbacks } from "./middleware/callbacks.js";
+export {
+  RemoteIp,
+  GetIp,
+  IpSpoofAttackError,
+  TRUSTED_PROXIES,
+  type Proxy,
+} from "./middleware/remote-ip.js";

--- a/packages/actionpack/src/action-dispatch/middleware/remote-ip.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/remote-ip.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Smoke tests for RemoteIp middleware. Full Rails-mirrored cases
+ * (actionpack/test/dispatch/request_test.rb RequestIP class) follow up
+ * in a sibling PR.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Request } from "../http/request.js";
+import { RemoteIp, IpSpoofAttackError, TRUSTED_PROXIES, type Proxy } from "./remote-ip.js";
+
+async function callMw(
+  env: Record<string, unknown>,
+  check = true,
+  proxies: Proxy[] = [...TRUSTED_PROXIES],
+) {
+  async function* emptyBody(): AsyncGenerator<string> {}
+  const mw = new RemoteIp(async () => [200, {}, emptyBody()], check, proxies);
+  await mw.call(env);
+  return new Request(env);
+}
+
+describe("RemoteIp middleware (smoke)", () => {
+  it("returns REMOTE_ADDR when no proxy headers", async () => {
+    expect((await callMw({ REMOTE_ADDR: "1.2.3.4" })).remoteIp).toBe("1.2.3.4");
+  });
+
+  it("prefers X-Forwarded-For over trusted REMOTE_ADDR", async () => {
+    expect(
+      (await callMw({ REMOTE_ADDR: "127.0.0.1", HTTP_X_FORWARDED_FOR: "3.4.5.6" })).remoteIp,
+    ).toBe("3.4.5.6");
+  });
+
+  it("filters trusted proxies and returns the leftmost untrusted IP", async () => {
+    expect(
+      (await callMw({ HTTP_X_FORWARDED_FOR: "9.9.9.9, 3.4.5.6, 172.31.4.4, 10.0.0.1" })).remoteIp,
+    ).toBe("3.4.5.6");
+  });
+
+  it("supports IPv6 with CIDR-based trusted proxies", async () => {
+    const v6 = "fe80:0000:0000:0000:0202:b3ff:fe1e:8329";
+    expect((await callMw({ REMOTE_ADDR: "::1", HTTP_X_FORWARDED_FOR: v6 })).remoteIp).toBe(v6);
+  });
+
+  it("raises IpSpoofAttackError when Client-Ip and X-Forwarded-For disagree", async () => {
+    const req = await callMw({ HTTP_X_FORWARDED_FOR: "1.1.1.1", HTTP_CLIENT_IP: "2.2.2.2" });
+    expect(() => req.remoteIp).toThrow(IpSpoofAttackError);
+  });
+
+  it("respects ip_spoofing_check = false", async () => {
+    const req = await callMw({ HTTP_X_FORWARDED_FOR: "1.1.1.1", HTTP_CLIENT_IP: "2.2.2.2" }, false);
+    expect(req.remoteIp).toBe("1.1.1.1");
+  });
+
+  it("returns null when no valid IP can be derived", async () => {
+    expect((await callMw({ HTTP_X_FORWARDED_FOR: "not_ip_address" })).remoteIp).toBeNull();
+  });
+
+  it("accepts a RegExp custom proxy", async () => {
+    const req = await callMw(
+      { REMOTE_ADDR: "67.205.106.73", HTTP_X_FORWARDED_FOR: "3.4.5.6" },
+      true,
+      [...TRUSTED_PROXIES, /^67\.205\.106\.73$/i],
+    );
+    expect(req.remoteIp).toBe("3.4.5.6");
+  });
+
+  it("allows the setter to override", async () => {
+    const req = await callMw({ REMOTE_ADDR: "1.2.3.4" });
+    req.remoteIp = "2.3.4.5";
+    expect(req.remoteIp).toBe("2.3.4.5");
+  });
+
+  it("Request#remoteIp falls back to REMOTE_ADDR without middleware", () => {
+    expect(new Request({ REMOTE_ADDR: "127.0.0.1" }).remoteIp).toBe("127.0.0.1");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/remote-ip.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/remote-ip.ts
@@ -1,0 +1,188 @@
+/**
+ * ActionDispatch::RemoteIp
+ *
+ * Calculates the IP address of the remote client by inspecting REMOTE_ADDR,
+ * HTTP_CLIENT_IP, and HTTP_X_FORWARDED_FOR, then discarding trusted proxies.
+ *
+ * Mirrors Rails actionpack/lib/action_dispatch/middleware/remote_ip.rb.
+ */
+
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+
+type RackApp = (env: RackEnv) => Promise<RackResponse> | RackResponse;
+
+export class IpSpoofAttackError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IpSpoofAttackError";
+  }
+}
+
+/** Default trusted proxy ranges, mirroring Rails RemoteIp::TRUSTED_PROXIES. */
+export const TRUSTED_PROXIES: readonly string[] = [
+  "127.0.0.0/8",
+  "::1",
+  "fc00::/7",
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+];
+
+export type Proxy = string | RegExp;
+
+interface ParsedIp {
+  value: bigint;
+  bits: 32 | 128;
+}
+interface ParsedCidr extends ParsedIp {
+  prefix: number;
+}
+
+/** Parse an IPv4 or IPv6 address (no netmask). Returns null on invalid input. */
+function parseIp(s: string): ParsedIp | null {
+  if (!s || s.includes("/")) return null;
+  if (s.includes(".") && !s.includes(":")) {
+    const parts = s.split(".");
+    if (parts.length !== 4) return null;
+    let v = 0n;
+    for (const p of parts) {
+      if (!/^\d{1,3}$/.test(p)) return null;
+      const n = Number(p);
+      if (n > 255) return null;
+      v = (v << 8n) | BigInt(n);
+    }
+    return { value: v, bits: 32 };
+  }
+  if (!s.includes(":")) return null;
+  const dc = s.indexOf("::");
+  let parts: string[];
+  if (dc !== -1) {
+    if (s.indexOf("::", dc + 1) !== -1) return null;
+    const hParts = dc === 0 ? [] : s.slice(0, dc).split(":");
+    const tParts = dc === s.length - 2 ? [] : s.slice(dc + 2).split(":");
+    const missing = 8 - hParts.length - tParts.length;
+    if (missing < 0) return null;
+    parts = [...hParts, ...new Array<string>(missing).fill("0"), ...tParts];
+  } else {
+    parts = s.split(":");
+  }
+  if (parts.length !== 8) return null;
+  let v = 0n;
+  for (const p of parts) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(p)) return null;
+    v = (v << 16n) | BigInt(parseInt(p, 16));
+  }
+  return { value: v, bits: 128 };
+}
+
+function parseCidr(s: string): ParsedCidr | null {
+  const slash = s.indexOf("/");
+  const ip = parseIp(slash === -1 ? s : s.slice(0, slash));
+  if (!ip) return null;
+  if (slash === -1) return { ...ip, prefix: ip.bits };
+  const prefix = Number(s.slice(slash + 1));
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > ip.bits) return null;
+  return { ...ip, prefix };
+}
+
+function cidrContains(cidr: ParsedCidr, ip: ParsedIp): boolean {
+  if (cidr.bits !== ip.bits) return false;
+  if (cidr.prefix === 0) return true;
+  const shift = BigInt(cidr.bits - cidr.prefix);
+  return cidr.value >> shift === ip.value >> shift;
+}
+
+function proxyMatches(proxy: Proxy, ipStr: string): boolean {
+  if (proxy instanceof RegExp) return proxy.test(ipStr);
+  const cidr = parseCidr(proxy);
+  const ip = parseIp(ipStr);
+  return !!cidr && !!ip && cidrContains(cidr, ip);
+}
+
+/** Lazy IP calculator. Stored in env["action_dispatch.remote_ip"] by RemoteIp. */
+export class GetIp {
+  private readonly env: RackEnv;
+  private readonly checkIp: boolean;
+  private readonly proxies: readonly Proxy[];
+  private memoized: string | null | undefined;
+
+  constructor(env: RackEnv, checkIp: boolean, proxies: readonly Proxy[]) {
+    this.env = env;
+    this.checkIp = checkIp;
+    this.proxies = proxies;
+  }
+
+  toString(): string {
+    return this.calculate() ?? "";
+  }
+
+  calculate(): string | null {
+    if (this.memoized !== undefined) return this.memoized;
+    this.memoized = this.calculateIp();
+    return this.memoized;
+  }
+
+  private calculateIp(): string | null {
+    const remoteAddrs = this.ipsFrom(this.env["REMOTE_ADDR"] as string | undefined);
+    const remoteAddr = remoteAddrs[remoteAddrs.length - 1];
+    const clientIps = this.ipsFrom(this.env["HTTP_CLIENT_IP"] as string | undefined).reverse();
+    const forwardedIps = this.ipsFrom(
+      this.env["HTTP_X_FORWARDED_FOR"] as string | undefined,
+    ).reverse();
+
+    const clientLast = clientIps[clientIps.length - 1];
+    const forwardedLast = forwardedIps[forwardedIps.length - 1];
+    if (this.checkIp && clientLast && forwardedLast && !forwardedIps.includes(clientLast)) {
+      throw new IpSpoofAttackError(
+        `IP spoofing attack?! ` +
+          `HTTP_CLIENT_IP=${JSON.stringify(this.env["HTTP_CLIENT_IP"] ?? null)} ` +
+          `HTTP_X_FORWARDED_FOR=${JSON.stringify(this.env["HTTP_X_FORWARDED_FOR"] ?? null)}`,
+      );
+    }
+
+    const ips = [...forwardedIps, ...clientIps];
+    const withRemote = remoteAddr ? [...ips, remoteAddr] : ips;
+    const filtered = withRemote.filter((ip) => !this.proxies.some((p) => proxyMatches(p, ip)));
+    return filtered[0] ?? ips[ips.length - 1] ?? remoteAddr ?? null;
+  }
+
+  private ipsFrom(header: string | undefined): string[] {
+    if (!header) return [];
+    return header
+      .trim()
+      .split(/[,\s]+/)
+      .filter((ip) => !!ip && parseIp(ip) !== null);
+  }
+}
+
+/**
+ * RemoteIp middleware. Wires a GetIp instance into env so downstream
+ * Request#remoteIp can resolve the calculated value lazily.
+ */
+export class RemoteIp {
+  static readonly TRUSTED_PROXIES = TRUSTED_PROXIES;
+
+  readonly checkIp: boolean;
+  readonly proxies: readonly Proxy[];
+  private readonly app: RackApp;
+
+  constructor(app: RackApp, ipSpoofingCheck = true, customProxies?: readonly Proxy[] | null) {
+    this.app = app;
+    this.checkIp = ipSpoofingCheck;
+    if (customProxies == null || (Array.isArray(customProxies) && customProxies.length === 0)) {
+      this.proxies = TRUSTED_PROXIES;
+    } else if (Array.isArray(customProxies)) {
+      this.proxies = customProxies;
+    } else {
+      throw new TypeError(
+        "Setting config.action_dispatch.trusted_proxies to a single value isn't supported. " +
+          "Please set this to an enumerable instead.",
+      );
+    }
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    env["action_dispatch.remote_ip"] = new GetIp(env, this.checkIp, this.proxies);
+    return await this.app(env);
+  }
+}


### PR DESCRIPTION
## Summary

- Ports Rails' `ActionDispatch::RemoteIp` middleware (`vendor/rails/actionpack/lib/action_dispatch/middleware/remote_ip.rb`) into `packages/actionpack/src/action-dispatch/middleware/remote-ip.ts`.
- Mirrors the Rails surface: `RemoteIp` class, lazy `GetIp` calculator with memoized `toString()`/`calculate()`, `TRUSTED_PROXIES` defaults, and `IpSpoofAttackError`.
- Includes a small in-package IPv4/IPv6 + CIDR parser (`parseIp`, `parseCidr`, `cidrContains`) so we can match the Ruby `IPAddr === ip` semantics without an external dep.
- Wires `Request#remoteIp` to resolve a `GetIp` instance via duck-typed `calculate()` lookup, and adds a writable setter (matching Rails `remote_ip=`).

## Follow-ups

- Full Rails-mirrored test port from `actionpack/test/dispatch/request_test.rb` `RequestIP` (IPv4 + IPv6 + custom proxy String/Regexp + spoof detection + private-address protection). This PR ships smoke coverage only to stay under the 300-LOC ceiling; the comprehensive port lands in a sibling PR.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/remote-ip.test.ts` (10 cases pass)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/request.test.ts` (78 existing tests still pass after the `remoteIp` getter/setter change)
- [x] `pnpm test:types`