### PR TITLE
test(actionpack): align translation.test.ts with Rails abstract/translation_test.rb names

### DIFF
--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -172,6 +172,14 @@ describe("AbstractController::Translation — trails-only", () => {
     expect(translate.call(host, ".foo")).toBe("scoped people index foo");
   });
 
+  it("forwards caller options (e.g. locale) to internal lookups on dot keys", () => {
+    I18n.backend.storeTranslations("fr", {
+      people: { index: { foo: "bonjour" } },
+    });
+    const host = makeHost("people", "index");
+    expect(translate.call(host, ".foo", { locale: "fr" })).toBe("bonjour");
+  });
+
   it("converts slashes in controller path to dots", () => {
     I18n.backend.storeTranslations("en", {
       admin: { users: { show: { foo: "admin users show foo" } } },

--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -1,7 +1,150 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { I18n } from "@blazetrails/activesupport";
-import { translate, t, localize, l, type TranslationHost } from "./translation.js";
+import {
+  l,
+  localize,
+  t,
+  translate,
+  type LocalizeOptions,
+  type TranslateOptions,
+  type TranslationHost,
+} from "./translation.js";
 
+// ==========================================================================
+// abstract/translation_test.rb
+// ==========================================================================
+
+// Rails: `TranslationController < AbstractController::Base; include
+// AbstractController::Translation; end`. trails' translate/t/localize/l
+// are `this`-typed standalone functions — wire them onto a class
+// prototype here so the `respond_to` Rails tests have something to
+// observe.
+// `TranslationHost.constructor` is typed `{ controllerPath(): string }`
+// — JS classes have `constructor: Function` by default, so we cast at
+// the call sites rather than fight the `implements` clause.
+class TranslationController {
+  static controllerPath(): string {
+    return "abstract_controller/testing/translation";
+  }
+  actionName = "";
+  translate(key: string, options: TranslateOptions = {}): unknown {
+    return translate.call(this as unknown as TranslationHost, key, options);
+  }
+  t(key: string, options: TranslateOptions = {}): unknown {
+    return t.call(this as unknown as TranslationHost, key, options);
+  }
+  localize(object: Date, options: LocalizeOptions = {}): string {
+    return localize.call(this as unknown as TranslationHost, object, options);
+  }
+  l(object: Date, options: LocalizeOptions = {}): string {
+    return l.call(this as unknown as TranslationHost, object, options);
+  }
+}
+
+describe("TranslationControllerTest", () => {
+  let controller: TranslationController;
+
+  beforeEach(() => {
+    controller = new TranslationController();
+    I18n.backend.storeTranslations("en", {
+      one: { two: "bar" },
+      abstract_controller: {
+        testing: {
+          translation: {
+            index: {
+              foo: "bar",
+              hello: "<a>Hello World</a>",
+              hello_html: "<a>Hello World</a>",
+              interpolated_html: "<a>Hello %{word}</a>",
+              nested: { html: "<a>nested</a>" },
+            },
+            no_action: "no_action_tr",
+          },
+        },
+      },
+    });
+  });
+
+  it("action controller base responds to translate", () => {
+    expect(typeof controller.translate).toBe("function");
+  });
+
+  it("action controller base responds to t", () => {
+    expect(typeof controller.t).toBe("function");
+  });
+
+  it("action controller base responds to localize", () => {
+    expect(typeof controller.localize).toBe("function");
+  });
+
+  it("action controller base responds to l", () => {
+    expect(typeof controller.l).toBe("function");
+  });
+
+  // BLOCKED: `I18n.translate` does not support `{ raise: true }`. It
+  // returns a "Translation missing: ..." string for unknown keys. Adding
+  // a raise option to activesupport I18n is a ~30 LOC follow-up
+  // (introduce `MissingTranslationData` class, threading the option).
+  it.skip("raises missing translation message with raise option", () => {});
+
+  it("lazy lookup", () => {
+    controller.actionName = "index";
+    expect(controller.t(".foo")).toBe("bar");
+  });
+
+  it("nil key lookup", () => {
+    const fallback = "foo";
+    expect(controller.t(null as unknown as string, { default: fallback })).toBe(fallback);
+  });
+
+  it("lazy lookup with symbol", () => {
+    // Rails distinguishes :".foo" (symbol) from ".foo" (string). JS has
+    // no symbol literals usable as i18n keys; the string form is the
+    // direct equivalent.
+    controller.actionName = "index";
+    expect(controller.t(".foo")).toBe("bar");
+  });
+
+  it("lazy lookup fallback", () => {
+    controller.actionName = "index";
+    expect(controller.t(".no_action")).toBe("no_action_tr");
+  });
+
+  it("default translation", () => {
+    controller.actionName = "index";
+    expect(controller.t("one.two")).toBe("bar");
+    expect(controller.t(".twoz", { default: ["baz", ":twoz"] })).toBe("baz");
+  });
+
+  // BLOCKED: trails has no `html_safe?` marker on strings. The whole
+  // _html-suffix → html_safe + interpolation-escape feature is an
+  // actionview-tier concern (~200 LOC: html_safe brand on strings,
+  // sanitize-on-interpolate in I18n, _html-suffix detection in
+  // translate). All 7 of the following depend on it.
+  it.skip("default translation as unsafe html", () => {});
+  it.skip("default translation as safe html", () => {});
+  it.skip("default translation with raise as unsafe html", () => {});
+  it.skip("default translation with raise as safe html", () => {});
+
+  it("localize", () => {
+    const time = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(typeof controller.l(time)).toBe("string");
+    expect(controller.l(time)).toBe(localize.call(controller as unknown as TranslationHost, time));
+  });
+
+  it.skip("translate does not mark plain text as safe html", () => {});
+  it.skip("translate marks translations with a html suffix as safe html", () => {});
+  it.skip("translate marks translation with nested html key", () => {});
+  it.skip("translate escapes interpolations in translations with a html suffix", () => {});
+  it.skip("translate marks translation with missing html key as safe html", () => {});
+  it.skip("translate marks translation with missing nested html key as safe html", () => {});
+});
+
+// ==========================================================================
+// trails-only coverage — exercises the standalone-function shape that
+// Rails doesn't have. Kept for regression-prevention on the `this`-typed
+// call site (`translate.call(host, ...)`); no Rails counterpart.
+// ==========================================================================
 function makeHost(controllerPath: string, actionName: string): TranslationHost {
   return {
     actionName,
@@ -9,7 +152,7 @@ function makeHost(controllerPath: string, actionName: string): TranslationHost {
   } as unknown as TranslationHost;
 }
 
-describe("AbstractController::Translation", () => {
+describe("AbstractController::Translation — trails-only", () => {
   beforeEach(() => {
     I18n.backend.storeTranslations("en", {
       people: {
@@ -35,25 +178,5 @@ describe("AbstractController::Translation", () => {
     });
     const host = makeHost("admin/users", "show");
     expect(translate.call(host, ".foo")).toBe("admin users show foo");
-  });
-
-  it("prepends a default-list when caller supplies a default and the key starts with a dot", () => {
-    // The scoped lookup misses, the user default ('users.unknown') also
-    // misses, but I18n's missing-translation fallback returns a default-array
-    // structure. Easiest assertion: passing through without throwing.
-    const host = makeHost("people", "index");
-    expect(() => translate.call(host, ".missing", { default: "Hello" })).not.toThrow();
-  });
-
-  it("`t` is an alias for `translate`", () => {
-    const host = makeHost("people", "index");
-    expect(t.call(host, ".foo")).toBe(translate.call(host, ".foo"));
-  });
-
-  it("localize / l delegate to I18n.localize", () => {
-    const host = makeHost("people", "index");
-    const d = new Date("2026-05-16T12:34:56Z");
-    expect(typeof localize.call(host, d)).toBe("string");
-    expect(l.call(host, d)).toBe(localize.call(host, d));
   });
 });

--- a/packages/actionpack/src/abstract-controller/translation.ts
+++ b/packages/actionpack/src/abstract-controller/translation.ts
@@ -42,11 +42,19 @@ export function translate(
     const scopedKey = `${path}.${this.actionName}${key}`;
     const fallbackKey = `${path}${key}`;
 
-    // Try the scoped key first, then the path-scoped (no-action) fallback.
-    const direct = I18n.translate(scopedKey, {});
+    // Forward caller options (interpolation vars, locale, etc.) to
+    // every internal lookup, but strip `default` — the chain below
+    // implements its own default-walking semantics.
+    const passOptions = { ...options };
+    delete passOptions.default;
+
+    const direct = I18n.translate(scopedKey, passOptions as Parameters<typeof I18n.translate>[1]);
     if (!isMissing(direct)) return direct;
 
-    const fallback = I18n.translate(fallbackKey, {});
+    const fallback = I18n.translate(
+      fallbackKey,
+      passOptions as Parameters<typeof I18n.translate>[1],
+    );
     if (!isMissing(fallback)) return fallback;
 
     // User-supplied defaults — Rails treats Symbols as keys to try
@@ -57,7 +65,7 @@ export function translate(
       const defs = Array.isArray(options.default) ? options.default : [options.default];
       for (const d of defs as unknown[]) {
         if (typeof d === "string" && d.startsWith(":")) {
-          const r = I18n.translate(d.slice(1), {});
+          const r = I18n.translate(d.slice(1), passOptions as Parameters<typeof I18n.translate>[1]);
           if (!isMissing(r)) return r;
         } else {
           return d;

--- a/packages/actionpack/src/abstract-controller/translation.ts
+++ b/packages/actionpack/src/abstract-controller/translation.ts
@@ -32,20 +32,46 @@ export function translate(
   key: string,
   options: TranslateOptions = {},
 ): unknown {
-  if (key && key.startsWith(".")) {
+  // Rails: `t(nil, default: ...)` returns the default unchanged.
+  if (key == null) {
+    if (options.default !== undefined) return options.default;
+    return `Translation missing: ${I18n.locale}.`;
+  }
+  if (key.startsWith(".")) {
     const path = this.constructor.controllerPath().replace(/\//g, ".");
-    const defaults: string[] = [`${path}${key}`];
-    if (options.default != null) {
-      // Flatten array defaults like Rails does.
-      const userDefault = Array.isArray(options.default)
-        ? (options.default as unknown[])
-        : [options.default];
-      defaults.push(...(userDefault as string[]));
+    const scopedKey = `${path}.${this.actionName}${key}`;
+    const fallbackKey = `${path}${key}`;
+
+    // Try the scoped key first, then the path-scoped (no-action) fallback.
+    const direct = I18n.translate(scopedKey, {});
+    if (!isMissing(direct)) return direct;
+
+    const fallback = I18n.translate(fallbackKey, {});
+    if (!isMissing(fallback)) return fallback;
+
+    // User-supplied defaults — Rails treats Symbols as keys to try
+    // and Strings as literal default values. JS has no Symbol literals
+    // in this position; mirror the convention by treating
+    // `:`-prefixed strings as key paths to look up.
+    if (options.default !== undefined) {
+      const defs = Array.isArray(options.default) ? options.default : [options.default];
+      for (const d of defs as unknown[]) {
+        if (typeof d === "string" && d.startsWith(":")) {
+          const r = I18n.translate(d.slice(1), {});
+          if (!isMissing(r)) return r;
+        } else {
+          return d;
+        }
+      }
     }
-    options = { ...options, default: defaults };
-    key = `${path}.${this.actionName}${key}`;
+
+    return direct; // "Translation missing: ..." from the scoped lookup
   }
   return I18n.translate(key, options as Parameters<typeof I18n.translate>[1]);
+}
+
+function isMissing(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith("Translation missing:");
 }
 
 /** Rails alias `:t :translate`. */


### PR DESCRIPTION
## Summary

Aligns \`packages/actionpack/src/abstract-controller/translation.test.ts\`
with Rails \`abstract/translation_test.rb\`. \`test:compare\` for
\`abstractcontroller/translation_test.rb\`: **0/21 → 21/21 matched**
(10 ok + 11 skip). \`abstractcontroller\` package: 21/52 → 26/52 (50%).

This closes the abstractcontroller test-name-alignment work that started in #1814 and #1821.

### Test alignment

- 21 Rails test names ported under a \`TranslationControllerTest\` describe block.
- New \`TranslationController\` test fixture wires \`translate\` / \`t\` / \`localize\` / \`l\` onto a class prototype so the 4 \`responds to\` tests have something to observe. (trails uses standalone \`this\`-typed functions; Rails uses module-included instance methods.)
- trails-only standalone-function tests preserved under a separate describe.

### Implementation fix (translate.ts)

The lazy-lookup fallback and default-list-with-keys behaviors didn't work because \`I18n.translate\` doesn't iterate array \`default\` entries as fallback keys. Moved the chain into \`translate.ts\`:

- Try the scoped key (\`<path>.<action><key>\`).
- Try the path-scoped fallback key (\`<path><key>\`).
- Walk user-supplied defaults: \`:\`-prefixed strings are looked up (mirrors Rails' Symbol-as-key convention); plain strings are literal default values.
- Guard nil keys: \`t(null, { default: ... })\` returns the default.

### Skipped (11, all with BLOCKED annotations citing sized follow-ups)

- \`raises missing translation message with raise option\` (1): \`I18n.translate\` doesn't honor \`{ raise: true }\`. ~30 LOC to add a \`MissingTranslationData\` class and thread the option.
- \`_html\`-suffix / \`html_safe?\` cluster (10): trails has no \`html_safe\` marker on strings. ~200 LOC actionview-tier follow-up to add the \`html_safe\` brand, sanitize-on-interpolate in \`I18n\`, and \`_html\`-suffix auto-marking.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/abstract-controller/translation.test.ts\` — 13 passing + 11 skipped.
- [x] \`pnpm vitest run packages/actionpack/src/abstract-controller/ packages/activesupport/src/i18n.test.ts\` — 182 passing + 21 skipped (no regressions).
- [x] \`pnpm test:compare --package abstractcontroller\` — \`translation_test.rb 10/0/0/0/11/21 → 21/21\`.
- [x] \`tsc --build\` via pre-commit — clean.