### PR TITLE
feat(activerecord): batch 137 — polymorphic-inverse follow-ups

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2149,6 +2149,22 @@ export function setBelongsTo(
       ? primaryKey.map((col: string) => `${underscore(assocName)}_${col}`)
       : `${underscore(assocName)}_id`);
 
+  // Rails BelongsToPolymorphicAssociation: `polymorphic_inverse_of` raises
+  // when the configured inverse name doesn't resolve on the assigned
+  // record's class. Validate up-front so a failed assignment leaves owner
+  // attributes / association cache untouched.
+  if (target && options.polymorphic && typeof options.inverseOf === "string") {
+    const inv = (targetCtor as any)?._reflectOnAssociation?.(options.inverseOf);
+    if (!inv) {
+      throw new InverseOfAssociationNotFoundError(
+        assocName,
+        options.inverseOf,
+        [],
+        targetCtor!.name,
+      );
+    }
+  }
+
   if (target) {
     if (Array.isArray(foreignKey) && !Array.isArray(primaryKey)) {
       throw new Error(
@@ -2199,22 +2215,8 @@ export function setBelongsTo(
   if (!record._cachedAssociations) record._cachedAssociations = new Map();
   record._cachedAssociations.set(assocName, target);
 
-  // Set inverse on target
+  // Set inverse on target (polymorphic existence validated above).
   if (target && typeof options.inverseOf === "string") {
-    // Rails BelongsToPolymorphicAssociation: `polymorphic_inverse_of`
-    // raises when the inverseOf name does not resolve on the assigned
-    // record's class — caught here at set time, before wiring.
-    if (options.polymorphic) {
-      const inv = (targetCtor as any)?._reflectOnAssociation?.(options.inverseOf);
-      if (!inv) {
-        throw new InverseOfAssociationNotFoundError(
-          assocName,
-          options.inverseOf,
-          [],
-          targetCtor!.name,
-        );
-      }
-    }
     _wireInverseAssociation(record, target, options.inverseOf);
   }
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2201,6 +2201,20 @@ export function setBelongsTo(
 
   // Set inverse on target
   if (target && typeof options.inverseOf === "string") {
+    // Rails BelongsToPolymorphicAssociation: `polymorphic_inverse_of`
+    // raises when the inverseOf name does not resolve on the assigned
+    // record's class — caught here at set time, before wiring.
+    if (options.polymorphic) {
+      const inv = (targetCtor as any)?._reflectOnAssociation?.(options.inverseOf);
+      if (!inv) {
+        throw new InverseOfAssociationNotFoundError(
+          assocName,
+          options.inverseOf,
+          [],
+          targetCtor!.name,
+        );
+      }
+    }
     _wireInverseAssociation(record, target, options.inverseOf);
   }
 }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -416,12 +416,25 @@ export class Association {
   }
 
   private inverseAssociationFor(record: Base): Association | null {
-    const inverseOf = this.reflection.options.inverseOf;
-    if (!inverseOf) return null;
+    // Rails routes both polymorphic and non-polymorphic through
+    // `inverse_reflection_for(record)` (association.rb:350-361). For
+    // polymorphic belongs_to, the override raises
+    // `InverseOfAssociationNotFoundError` when the configured
+    // inverse name doesn't exist on the assigned record's class
+    // (belongs_to_polymorphic_association.rb:35-37, reflection.rb:678).
+    let inverseName: string | null = null;
+    if ((this.reflection.options as any).polymorphic) {
+      const inv = this.inverseReflectionFor(record) as any;
+      if (!inv) return null;
+      inverseName = typeof inv === "string" ? inv : (inv.name ?? null);
+    } else {
+      inverseName = (this.reflection.options.inverseOf as string | undefined) ?? null;
+    }
+    if (!inverseName) return null;
     const recordAny = record as any;
     if (typeof recordAny.association === "function") {
       try {
-        return recordAny.association(inverseOf);
+        return recordAny.association(inverseName);
       } catch {
         return null;
       }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -497,7 +497,7 @@ export class Association {
     }
   }
 
-  private inverseReflectionFor(_record: Base): unknown {
+  protected inverseReflectionFor(_record: Base): unknown {
     return (this.reflection as any).inverseOf ?? null;
   }
 

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -286,7 +286,7 @@ export class BelongsToAssociation extends SingularAssociation {
    * Handles composite keys by zipping FK columns with PK columns.
    * Rails: replace_keys(record, force: false)
    */
-  private replaceKeys(record: Base | null): void {
+  protected replaceKeys(record: Base | null): void {
     const fks = this.foreignKeyNames();
     const pks = this.associationPrimaryKeys(record);
 

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -252,7 +252,7 @@ export class BelongsToAssociation extends SingularAssociation {
     return `${underscore(this.reflection.name)}_id`;
   }
 
-  private foreignKeyNames(): string[] {
+  protected foreignKeyNames(): string[] {
     const fk = this.reflection.options.foreignKey;
     if (typeof fk === "string") return [fk];
     if (Array.isArray(fk)) return fk;
@@ -267,7 +267,7 @@ export class BelongsToAssociation extends SingularAssociation {
     return [`${underscore(this.reflection.name)}_id`];
   }
 
-  private associationPrimaryKeys(record: Base | null): string[] {
+  protected associationPrimaryKeys(record: Base | null): string[] {
     const configured = this.reflection.options.primaryKey;
     if (configured) {
       return Array.isArray(configured) ? configured : [configured];
@@ -278,10 +278,6 @@ export class BelongsToAssociation extends SingularAssociation {
     }
     const pk = (this.klass as any)?.primaryKey;
     if (pk) return Array.isArray(pk) ? pk : [pk];
-    // Polymorphic belongs_to: no resolved klass when target is absent —
-    // fall back to the loaded target's class when one is cached.
-    const targetPk = (this.target as any)?.constructor?.primaryKey;
-    if (targetPk) return Array.isArray(targetPk) ? targetPk : [targetPk];
     return ["id"];
   }
 

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -55,10 +55,14 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   }
 
   /**
-   * Override replace to also write/clear the polymorphic type column.
-   * Rails: BelongsToPolymorphicAssociation#replace_keys sets foreign_type.
+   * Write the polymorphic type column alongside the foreign key. Mirrors
+   * Rails `BelongsToPolymorphicAssociation#replace_keys` — both column
+   * writes happen here (after `super.replace` has already run
+   * `setInverseInstance`, so a missing-inverse raise leaves owner state
+   * untouched).
    */
-  protected override replace(record: Base | null): void {
+  protected override replaceKeys(record: Base | null): void {
+    super.replaceKeys(record);
     const typeCol = this.foreignTypeName();
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
     // name (including "::" for namespaced classes). JS class names can't
@@ -77,7 +81,6 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     } else {
       (this.owner as any)[typeCol] = typeName;
     }
-    super.replace(record);
   }
 
   /**

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -65,10 +65,16 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     // Write the polymorphic type column FIRST so that the dynamic
     // `this.klass` resolves via the _type column before
     // `super.replaceKeys` derives composite foreign-key names via
-    // `foreignKeyNames() → associationPrimaryKeys(null)`. Atomicity
-    // with respect to inverse-validation is unaffected: the
-    // `setInverseInstance` raise happens in `replace()` above us,
-    // before `replaceKeys` runs.
+    // `foreignKeyNames() → associationPrimaryKeys(null)`.
+    //
+    // Note: `replaceKeys` is called from both `replace(record)` (writer
+    // path) and `inversedFrom(record)` (inverse-wiring path). On the
+    // writer path, `setInverseInstance` runs in `replace()` before
+    // `replaceKeys`, so a missing-inverse raise leaves owner state
+    // untouched. On the `inversedFrom` path no inverse validation runs
+    // at all — the caller has already resolved the inverse pair — so
+    // the ordering inside `replaceKeys` is independent of that
+    // atomicity guarantee.
     const typeCol = this.foreignTypeName();
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
     // name (including "::" for namespaced classes). JS class names can't

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -107,7 +107,16 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    * inverse name does not exist on that class.
    */
   protected override inverseReflectionFor(record: Base): unknown {
-    const refl: any = this.reflection;
+    // `this.reflection` is the lightweight `AssociationDefinition` attached
+    // at macro time. The rich `Reflection` (carrying `polymorphicInverseOf`)
+    // lives on the owner class via `_reflectOnAssociation` — resolve it
+    // there so the Rails-parity raise actually fires on the regular
+    // association-writer path. Falls back to the lightweight reflection
+    // when polymorphicInverseOf is somehow present on it (test fixtures).
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => unknown;
+    };
+    const refl: any = ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection;
     if (typeof refl.polymorphicInverseOf === "function") {
       return refl.polymorphicInverseOf(record.constructor as typeof Base);
     }

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -94,6 +94,12 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
       const pk = (record.constructor as any).primaryKey;
       if (pk) return Array.isArray(pk) ? pk : [pk];
     }
+    // Polymorphic belongs_to: this.klass is dynamic — resolved at runtime
+    // from the _type column. Preserve the base class's klass-fallback for
+    // scope() / counter-cache paths that hit `associationPrimaryKeys(null)`
+    // once the _type column is set.
+    const pk = (this.klass as any)?.primaryKey;
+    if (pk) return Array.isArray(pk) ? pk : [pk];
     const targetPk = (this.target as any)?.constructor?.primaryKey;
     if (targetPk) return Array.isArray(targetPk) ? targetPk : [targetPk];
     return ["id"];

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -62,7 +62,13 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    * untouched).
    */
   protected override replaceKeys(record: Base | null): void {
-    super.replaceKeys(record);
+    // Write the polymorphic type column FIRST so that the dynamic
+    // `this.klass` resolves via the _type column before
+    // `super.replaceKeys` derives composite foreign-key names via
+    // `foreignKeyNames() → associationPrimaryKeys(null)`. Atomicity
+    // with respect to inverse-validation is unaffected: the
+    // `setInverseInstance` raise happens in `replace()` above us,
+    // before `replaceKeys` runs.
     const typeCol = this.foreignTypeName();
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
     // name (including "::" for namespaced classes). JS class names can't
@@ -81,6 +87,7 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     } else {
       (this.owner as any)[typeCol] = typeName;
     }
+    super.replaceKeys(record);
   }
 
   /**

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -80,6 +80,40 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     super.replace(record);
   }
 
+  /**
+   * Polymorphic belongs_to has no static target class, so when neither an
+   * explicit `primaryKey` option nor an owning record is given we fall
+   * back to the loaded target's class (the generic
+   * `BelongsToAssociation` path can't do this — it has no polymorphic
+   * type column to consult).
+   */
+  protected override associationPrimaryKeys(record: Base | null): string[] {
+    const configured = this.reflection.options.primaryKey;
+    if (configured) return Array.isArray(configured) ? configured : [configured];
+    if (record) {
+      const pk = (record.constructor as any).primaryKey;
+      if (pk) return Array.isArray(pk) ? pk : [pk];
+    }
+    const targetPk = (this.target as any)?.constructor?.primaryKey;
+    if (targetPk) return Array.isArray(targetPk) ? targetPk : [targetPk];
+    return ["id"];
+  }
+
+  /**
+   * Mirrors Rails `BelongsToPolymorphicAssociation#inverse_reflection_for`
+   * (associations/belongs_to_polymorphic_association.rb:35-37) — looks up
+   * the inverse on the assigned record's class via `polymorphic_inverse_of`,
+   * which raises `InverseOfAssociationNotFoundError` when the configured
+   * inverse name does not exist on that class.
+   */
+  protected override inverseReflectionFor(record: Base): unknown {
+    const refl: any = this.reflection;
+    if (typeof refl.polymorphicInverseOf === "function") {
+      return refl.polymorphicInverseOf(record.constructor as typeof Base);
+    }
+    return null;
+  }
+
   protected override async doAsyncFindTarget(): Promise<Base | null> {
     return loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
   }

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1461,6 +1461,36 @@ describe("InversePolymorphicBelongsToTests", () => {
       }),
     ).toThrow(InverseOfAssociationNotFoundError);
   });
+
+  it("association-writer path also raises when polymorphic inverse missing", async () => {
+    // Cover the regular `record.association(name).writer(...)` path —
+    // BelongsToPolymorphicAssociation#inverseReflectionFor must reach
+    // polymorphicInverseOf during setInverseInstance and raise when the
+    // configured inverse name does not exist on the assigned record's
+    // class (Rails belongs_to_polymorphic_association.rb:35-37).
+    class Man extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Tag extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("taggable_id", "integer");
+        this.attribute("taggable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.belongsTo.call(Tag, "taggable", { polymorphic: true, inverseOf: "nonexistent" });
+    registerModel(Man);
+    registerModel(Tag);
+    const m = await Man.create({ name: "Gordon" });
+    const t = await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
+    expect(() => (t as any).association("taggable").writer(m)).toThrow(
+      InverseOfAssociationNotFoundError,
+    );
+  });
 });
 
 describe("InverseCachedPathTests", () => {

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1426,17 +1426,40 @@ describe("InversePolymorphicBelongsToTests", () => {
     expect(parent).not.toBeNull();
   });
 
-  it.skip("trying to set polymorphic inverses that dont exist at all should raise an error", () => {
-    // BLOCKED: associations — inverse-of feature gap
-    // ROOT-CAUSE: associations/inverse-associations.ts or preloader.ts missing inverse-of semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in inverse-associations.test.ts
-    /* needs inverse validation on polymorphic */
+  it("trying to set polymorphic inverses that dont exist at all should raise an error", async () => {
+    const { Man, Tag } = makeModels();
+    const m = await Man.create({ name: "Gordon" });
+    const t = await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
+    // Man has no association named "nonexistent" — set must raise.
+    expect(() =>
+      setBelongsTo(t, "taggable", m, {
+        polymorphic: true,
+        inverseOf: "nonexistent",
+        foreignKey: "taggable_id",
+      }),
+    ).toThrow(InverseOfAssociationNotFoundError);
   });
-  it.skip("trying to set polymorphic inverses that dont exist on the instance being set should raise an error", () => {
-    // BLOCKED: associations — inverse-of feature gap
-    // ROOT-CAUSE: associations/inverse-associations.ts or preloader.ts missing inverse-of semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in inverse-associations.test.ts
-    /* needs inverse validation on polymorphic */
+  it("trying to set polymorphic inverses that dont exist on the instance being set should raise an error", async () => {
+    const { Man, Face, Tag } = makeModels();
+    const m = await Man.create({ name: "Gordon" });
+    const f = await Face.create({ description: "pretty", man_id: m.id });
+    const t = await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
+    // Man has :tags as the inverse; Face does not. Setting a Man passes,
+    // but setting a Face under the same inverseOf must raise.
+    expect(() =>
+      setBelongsTo(t, "taggable", m, {
+        polymorphic: true,
+        inverseOf: "tags",
+        foreignKey: "taggable_id",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      setBelongsTo(t, "taggable", f, {
+        polymorphic: true,
+        inverseOf: "tags",
+        foreignKey: "taggable_id",
+      }),
+    ).toThrow(InverseOfAssociationNotFoundError);
   });
 });
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1015,14 +1015,10 @@ export function isInversePolymorphicAssociationChanged(reflection: any, record: 
   // but the polymorphic _type column points at a different active_record.
   const foreignType: string = inverse.foreignType ?? `${underscore(String(inverse.name))}_type`;
   const className = record._readAttribute(foreignType);
-  // Rails: polymorphic_class_for(nil) raises NameError. Treat a missing
-  // type column as "no inverse parent set" → no change detected, so the
-  // caller's `||` chain falls through to FK-changed / will-save legs.
-  if (className == null) return false;
   const recordClass = record.constructor as {
     polymorphicClassFor: (n: string) => unknown;
   };
-  return reflection.activeRecord !== recordClass.polymorphicClassFor(String(className));
+  return reflection.activeRecord !== recordClass.polymorphicClassFor(className);
 }
 
 /** @internal */

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -14,7 +14,6 @@ import {
 } from "./associations/errors.js";
 import { NestedError as AssociationsNestedError } from "./associations/nested-error.js";
 import type { AssociationDefinition } from "./associations.js";
-import { modelRegistry } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { underscore } from "@blazetrails/activesupport";
 import { included } from "@blazetrails/activesupport";
@@ -1021,13 +1020,9 @@ export function isInversePolymorphicAssociationChanged(reflection: any, record: 
   // caller's `||` chain falls through to FK-changed / will-save legs.
   if (className == null) return false;
   const recordClass = record.constructor as {
-    polymorphicClassFor?: (n: string) => unknown;
+    polymorphicClassFor: (n: string) => unknown;
   };
-  const resolved =
-    typeof recordClass.polymorphicClassFor === "function"
-      ? recordClass.polymorphicClassFor(String(className))
-      : (modelRegistry.get(String(className)) ?? reflection.activeRecord);
-  return reflection.activeRecord !== resolved;
+  return reflection.activeRecord !== recordClass.polymorphicClassFor(String(className));
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Closes three of the four items in [Batch 137 — polymorphic-inverse follow-ups](../blob/main/docs/activerecord-100-plan.md#batch-137--polymorphic-inverse-follow-ups-180-loc-risk-medium) (from #1773).

- Collapse `isInversePolymorphicAssociationChanged` to a single strict `polymorphicClassFor` lookup (Rails parity: unknown type strings raise NameError, not silently equal `activeRecord`).
- Move polymorphic-belongsTo `associationPrimaryKeys` fallback (loaded target → `constructor.primaryKey`) off the generic `BelongsToAssociation` and onto `BelongsToPolymorphicAssociation`. Promotes `associationPrimaryKeys`/`foreignKeyNames`/`inverseReflectionFor` to `protected` so polymorphic overrides can live in the polymorphic class.
- Override `BelongsToPolymorphicAssociation#inverseReflectionFor` to call the existing `Reflection#polymorphicInverseOf(record.class)`, mirroring `belongs_to_polymorphic_association.rb:35-37`.
- Validate polymorphic `inverseOf` at set time in `setBelongsTo` so assigning a record whose class lacks the named inverse raises `InverseOfAssociationNotFoundError` (Rails parity with `polymorphic_inverse_of`). Un-skips the `"trying to set polymorphic inverses that dont exist"` pair in `inverse-associations.test.ts`.

## Follow-ups

- ~50 LOC — Auto-detect `inverseOf` for polymorphic `hasOne` (Rails `Reflection#automatic_inverse_of` for `as:` reflections). Today callers must pass `inverseOf:` explicitly. Deferred from this batch.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/inverse-associations.test.ts` — 2 newly un-skipped polymorphic-validation tests pass; 23 still skipped (unrelated inverse-of clusters).
- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1395 pass / 284 skipped, no regressions.
- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 203 tests, no regressions on the changed `isInversePolymorphicAssociationChanged` path.