### PR TITLE
feat(actionpack): port ActionDispatch::Routing::Redirection

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/index.ts
+++ b/packages/actionpack/src/action-dispatch/routing/index.ts
@@ -29,3 +29,12 @@ export {
   type ModelClass,
   type ToModel,
 } from "./polymorphic-routes.js";
+export {
+  redirect,
+  Redirect,
+  PathRedirect,
+  OptionRedirect,
+  type RedirectBlock,
+  type RedirectCallable,
+  type OptionRedirectOptions,
+} from "./redirection.js";

--- a/packages/actionpack/src/action-dispatch/routing/redirection.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { OptionRedirect, PathRedirect, Redirect, redirect } from "./redirection.js";
+import { Request } from "../http/request.js";
+
+function makeRequest(env: Record<string, unknown> = {}): Request {
+  return new Request({
+    REQUEST_METHOD: "GET",
+    SERVER_NAME: "example.com",
+    SERVER_PORT: "80",
+    PATH_INFO: "/foo",
+    "rack.url_scheme": "http",
+    ...env,
+  });
+}
+
+describe("redirect()", () => {
+  it("returns a PathRedirect for a string path", () => {
+    const r = redirect("/posts");
+    expect(r).toBeInstanceOf(PathRedirect);
+    expect(r.status).toBe(301);
+  });
+
+  it("returns an OptionRedirect when given options", () => {
+    const r = redirect({ subdomain: "stores", path: "/foo" });
+    expect(r).toBeInstanceOf(OptionRedirect);
+  });
+
+  it("accepts a status option", () => {
+    const r = redirect("/foo", { status: 307 });
+    expect(r.status).toBe(307);
+  });
+
+  it("accepts a block", () => {
+    const r = redirect(() => "/dyn");
+    expect(r).toBeInstanceOf(Redirect);
+    expect(r.status).toBe(301);
+  });
+
+  it("raises for unsupported arguments", () => {
+    expect(() => redirect(123 as unknown as string)).toThrow(/not supported/);
+  });
+});
+
+describe("PathRedirect", () => {
+  it("interpolates %{key} placeholders with escaped path values", () => {
+    const r = new PathRedirect(301, "/wiki/%{article}");
+    const req = makeRequest();
+    const res = r.buildResponse(
+      new Request({
+        ...req.env,
+        "action_dispatch.request.path_parameters": { article: "hello world" },
+      }),
+    );
+    expect(res.headers["Location"]).toBe("http://example.com/wiki/hello%20world");
+  });
+
+  it("preserves query and fragment, interpolating each part separately", () => {
+    const r = new PathRedirect(301, "/baz?id=%{id}&foo=?&bar=1#id-%{id}");
+    const req = new Request({
+      REQUEST_METHOD: "GET",
+      SERVER_NAME: "example.com",
+      SERVER_PORT: "80",
+      "rack.url_scheme": "http",
+      "action_dispatch.request.path_parameters": { id: "42" },
+    });
+    const res = r.buildResponse(req);
+    expect(res.headers["Location"]).toBe("http://example.com/baz?id=42&foo=?&bar=1#id-42");
+  });
+
+  it("inspects with status and template", () => {
+    expect(new PathRedirect(302, "/x").inspect()).toBe("redirect(302, /x)");
+  });
+});
+
+describe("Redirect", () => {
+  it("prepends SCRIPT_NAME for relative paths", () => {
+    const r = new Redirect(301, () => "relative");
+    const req = new Request({
+      REQUEST_METHOD: "GET",
+      SERVER_NAME: "example.com",
+      SERVER_PORT: "80",
+      SCRIPT_NAME: "/mount",
+      "rack.url_scheme": "http",
+    });
+    const res = r.buildResponse(req);
+    expect(res.headers["Location"]).toBe("http://example.com/mount/relative");
+  });
+
+  it("call() returns a rack triple", () => {
+    const r = new Redirect(302, () => "/x");
+    const [status, headers] = r.call({
+      REQUEST_METHOD: "GET",
+      SERVER_NAME: "example.com",
+      SERVER_PORT: "80",
+      "rack.url_scheme": "http",
+    });
+    expect(status).toBe(302);
+    expect(headers["Location"]).toBe("http://example.com/x");
+  });
+
+  it("redirect?() is true", () => {
+    expect(new Redirect(301, () => "/x").redirect()).toBe(true);
+  });
+});
+
+describe("OptionRedirect", () => {
+  it("builds a URL from options merged into the request defaults", () => {
+    const r = new OptionRedirect(301, { path: "/documentation/new" });
+    const req = makeRequest({ PATH_INFO: "/new_documentation" });
+    const res = r.buildResponse(req);
+    expect(res.headers["Location"]).toContain("/documentation/new");
+  });
+
+  it("inspect renders option pairs", () => {
+    expect(new OptionRedirect(301, { subdomain: "stores" }).inspect()).toBe(
+      "redirect(301, subdomain: stores)",
+    );
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -1,0 +1,328 @@
+/**
+ * Port of ActionDispatch::Routing::Redirection
+ * (Rails actionpack/lib/action_dispatch/routing/redirection.rb)
+ *
+ * Provides Redirect, PathRedirect, OptionRedirect endpoint classes and a
+ * redirect() factory for building redirect endpoints in route definitions.
+ */
+
+import { Request } from "../http/request.js";
+import { Response } from "../http/response.js";
+import { URL as UrlHelpers, type UrlOptions } from "../http/url.js";
+import {
+  escapeFragment as journeyEscapeFragment,
+  escapePath as journeyEscapePath,
+} from "../journey/router/utils.js";
+import type { RackEnv } from "@blazetrails/rack";
+
+export type RedirectBlock = (params: Record<string, string>, request: Request) => string;
+
+/** @internal */
+export class Endpoint {
+  dispatcher(): boolean {
+    return false;
+  }
+  redirect(): boolean {
+    return false;
+  }
+  matches(_req: Request): boolean {
+    return true;
+  }
+  app(): unknown {
+    return this;
+  }
+  rackApp(): unknown {
+    return this.app();
+  }
+}
+
+/** Parsed pieces of a URI, mirroring Ruby's URI::Generic. */
+interface ParsedUri {
+  scheme: string | null;
+  host: string | null;
+  port: number | null;
+  path: string;
+  query: string | null;
+  fragment: string | null;
+}
+
+const URI_RE =
+  /^(?:([a-zA-Z][a-zA-Z0-9+.-]*):)?(?:\/\/([^/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/;
+
+function parseUri(raw: string): ParsedUri {
+  const m = URI_RE.exec(raw);
+  if (!m) {
+    return { scheme: null, host: null, port: null, path: raw, query: null, fragment: null };
+  }
+  const [, scheme, authority, path, query, fragment] = m;
+  let host: string | null = null;
+  let port: number | null = null;
+  if (authority !== undefined) {
+    const at = authority.lastIndexOf("@");
+    const hostport = at >= 0 ? authority.slice(at + 1) : authority;
+    const colon = hostport.lastIndexOf(":");
+    if (colon >= 0 && /^\d+$/.test(hostport.slice(colon + 1))) {
+      host = hostport.slice(0, colon) || null;
+      port = Number(hostport.slice(colon + 1));
+    } else {
+      host = hostport || null;
+    }
+  }
+  return {
+    scheme: scheme ?? null,
+    host,
+    port,
+    path: path ?? "",
+    query: query ?? null,
+    fragment: fragment ?? null,
+  };
+}
+
+function uriToString(uri: ParsedUri): string {
+  let out = "";
+  if (uri.scheme) out += `${uri.scheme}://`;
+  if (uri.host !== null) {
+    out += uri.host;
+    if (uri.port !== null) out += `:${uri.port}`;
+  }
+  out += uri.path;
+  if (uri.query !== null) out += `?${uri.query}`;
+  if (uri.fragment !== null) out += `#${uri.fragment}`;
+  return out;
+}
+
+/** Rack::Utils.escape — form-encoded value (space → +). */
+function rackEscape(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, "+");
+}
+
+function transformValues(
+  params: Record<string, string>,
+  fn: (v: string) => string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(params)) out[k] = fn(String(v));
+  return out;
+}
+
+/** Ruby's `String % Hash` for `%{key}` interpolation. */
+function interpolate(template: string, params: Record<string, string>): string {
+  return template.replace(/%\{(\w+)\}/g, (_m, key: string) => {
+    if (!(key in params)) {
+      throw new Error(`key{${key}} not found in interpolation params`);
+    }
+    return params[key];
+  });
+}
+
+function scriptName(req: Request): string {
+  return (req.env["SCRIPT_NAME"] as string) ?? "";
+}
+
+export class Redirect extends Endpoint {
+  readonly status: number;
+  readonly block: RedirectBlock;
+
+  constructor(status: number, block: RedirectBlock) {
+    super();
+    this.status = status;
+    this.block = block;
+  }
+
+  override redirect(): boolean {
+    return true;
+  }
+
+  call(env: RackEnv): [number, Record<string, string>, string[]] {
+    const request = new Request(env);
+    const response = this.buildResponse(request);
+    return response.toRack();
+  }
+
+  buildResponse(req: Request): Response {
+    const uri = parseUri(this.path(req.pathParameters, req));
+
+    if (!uri.host) {
+      if (this.relativePath(uri.path)) {
+        uri.path = `${scriptName(req)}/${uri.path}`;
+      } else if (uri.path === "") {
+        uri.path = scriptName(req) === "" ? "/" : scriptName(req);
+      }
+    }
+
+    uri.scheme ??= req.scheme;
+    uri.host ??= req.host;
+    if (uri.port === null && !req.isStandardPort) uri.port = req.port;
+
+    const body = "";
+    const headers = {
+      Location: uriToString(uri),
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Length": String(body.length),
+    };
+    return new Response(this.status, headers, [body]);
+  }
+
+  path(params: Record<string, string>, request: Request): string {
+    return this.block(params, request);
+  }
+
+  inspect(): string {
+    return `redirect(${this.status})`;
+  }
+
+  /** @internal */
+  protected relativePath(path: string): boolean {
+    return !!path && path !== "" && !path.startsWith("/");
+  }
+
+  /** @internal */
+  protected escape(params: Record<string, string>): Record<string, string> {
+    return transformValues(params, rackEscape);
+  }
+
+  /** @internal */
+  protected escapeFragment(params: Record<string, string>): Record<string, string> {
+    return transformValues(params, journeyEscapeFragment);
+  }
+
+  /** @internal */
+  protected escapePath(params: Record<string, string>): Record<string, string> {
+    return transformValues(params, journeyEscapePath);
+  }
+}
+
+const URL_PARTS = /^([^?]+)?(\?[^#]+)?(#.+)?$/;
+
+export class PathRedirect extends Redirect {
+  constructor(status: number, pathTemplate: string) {
+    super(status, () => pathTemplate);
+  }
+
+  get template(): string {
+    return (this.block as () => string)();
+  }
+
+  override path(params: Record<string, string>, _request: Request): string {
+    const tpl = this.template;
+    const m = URL_PARTS.exec(tpl);
+    if (m) {
+      const [, p, q, f] = m;
+      const path = this.interpolationRequired(p, params)
+        ? interpolate(p!, this.escapePath(params))
+        : (p ?? "");
+      const query = this.interpolationRequired(q, params)
+        ? interpolate(q!, this.escape(params))
+        : (q ?? "");
+      const fragment = this.interpolationRequired(f, params)
+        ? interpolate(f!, this.escapeFragment(params))
+        : (f ?? "");
+      return `${path}${query}${fragment}`;
+    }
+    return this.interpolationRequired(tpl, params) ? interpolate(tpl, this.escape(params)) : tpl;
+  }
+
+  override inspect(): string {
+    return `redirect(${this.status}, ${this.template})`;
+  }
+
+  /** @internal */
+  private interpolationRequired(s: string | undefined, params: Record<string, string>): boolean {
+    return Object.keys(params).length > 0 && !!s && /%\{\w*\}/.test(s);
+  }
+}
+
+export interface OptionRedirectOptions {
+  protocol?: string;
+  host?: string;
+  domain?: string;
+  port?: string | number;
+  path?: string;
+  params?: Record<string, unknown>;
+  subdomain?: string;
+  [key: string]: unknown;
+}
+
+export class OptionRedirect extends Redirect {
+  readonly options: OptionRedirectOptions;
+
+  constructor(status: number, options: OptionRedirectOptions) {
+    super(status, () => "");
+    this.options = options;
+  }
+
+  override path(params: Record<string, string>, request: Request): string {
+    const urlOptions: Record<string, unknown> = {
+      protocol: request.protocol,
+      host: request.host,
+      port: request.isStandardPort ? undefined : request.port,
+      path: request.path,
+      params: request.queryParameters,
+      ...this.options,
+    };
+
+    const path = urlOptions["path"];
+    if (Object.keys(params).length > 0 && typeof path === "string" && /%\{\w*\}/.test(path)) {
+      urlOptions["path"] = interpolate(path, this.escapePath(params));
+    }
+
+    if (!this.options.host && !this.options.domain) {
+      const p = urlOptions["path"];
+      if (typeof p === "string" && this.relativePath(p)) {
+        urlOptions["path"] = `/${p}`;
+        urlOptions["scriptName"] = scriptName(request);
+      } else if (typeof p === "string" && p === "") {
+        urlOptions["path"] = scriptName(request) === "" ? "/" : "";
+        urlOptions["scriptName"] = scriptName(request);
+      }
+    }
+
+    return UrlHelpers.urlFor(urlOptions as UrlOptions);
+  }
+
+  override inspect(): string {
+    const pairs = Object.entries(this.options)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(", ");
+    return `redirect(${this.status}, ${pairs})`;
+  }
+}
+
+export interface RedirectCallable {
+  call(params: Record<string, string>, request: Request): string;
+}
+
+/**
+ * Build a Redirect endpoint. Mirrors the `redirect(*args, &block)` factory on
+ * the ActionDispatch::Routing::Redirection module.
+ */
+export function redirect(
+  ...args: Array<
+    string | (OptionRedirectOptions & { status?: number }) | RedirectBlock | RedirectCallable
+  >
+): Redirect {
+  let options: (OptionRedirectOptions & { status?: number }) | undefined;
+  const last = args[args.length - 1];
+  if (last && typeof last === "object" && !("call" in last) && typeof last !== "function") {
+    options = args.pop() as OptionRedirectOptions & { status?: number };
+  }
+  const status = (options?.status as number | undefined) ?? 301;
+  if (options) delete options.status;
+  const path = args.shift();
+
+  if (options && Object.keys(options).length > 0) {
+    return new OptionRedirect(status, options);
+  }
+  if (typeof path === "string") {
+    return new PathRedirect(status, path);
+  }
+  let block: RedirectBlock | undefined;
+  if (typeof path === "function") {
+    block = path as RedirectBlock;
+  } else if (path && typeof (path as RedirectCallable).call === "function") {
+    const callable = path as RedirectCallable;
+    block = (params, request) => callable.call(params, request);
+  }
+  if (!block) throw new Error("redirection argument not supported");
+  return new Redirect(status, block);
+}

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -34,6 +34,9 @@ export class Endpoint {
   rackApp(): unknown {
     return this.app();
   }
+  engine(): boolean {
+    return false;
+  }
 }
 
 /** Parsed pieces of a URI, mirroring Ruby's URI::Generic. */


### PR DESCRIPTION
## Summary

Ports `ActionDispatch::Routing::Redirection` from Rails
(`actionpack/lib/action_dispatch/routing/redirection.rb`) to
`packages/actionpack/src/action-dispatch/routing/redirection.ts`, mirroring
the Rails layout 1:1.

- `Redirect` endpoint class with `call(env)` → rack triple, plus
  `buildResponse` / `path` / `inspect` and the private `escape`,
  `escapeFragment`, `escapePath`, `relativePath` helpers.
- `PathRedirect` with the `URL_PARTS` regex splitting path/query/fragment so
  each segment is interpolated with its own Rack/Journey escaper.
- `OptionRedirect` delegating to `ActionDispatch::Http::URL.urlFor` with the
  same request-driven defaults Rails uses.
- `redirect(...)` factory accepting `(path, opts?)`, `(opts)`, a block, or a
  callable, defaulting to status 301.
- A minimal `Endpoint` base mirroring `action_dispatch/routing/endpoint.rb`
  (no separate port existed yet).

Re-exported from `routing/index.ts`. New `redirection.test.ts` covers the
factory dispatch, path interpolation (path/query/fragment splitting),
`SCRIPT_NAME` relative-path handling, the rack-triple shape, and
`OptionRedirect` URL building / inspect.

## Notes / follow-ups

- `ActiveSupport::Notifications.instrument("redirect.action_dispatch")` is
  not wired (no AS::Notifications port consumer); behavior matches Rails
  apart from emitting the event.
- `req.commitFlash` isn't called — no flash middleware port exists yet.
- The existing in-house `Route.resolveRedirect` path in `route.ts` /
  `route-set.ts` is unchanged; integrating routes with the new
  `Redirect`/`PathRedirect`/`OptionRedirect` endpoint objects is a separate
  follow-up.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/redirection.test.ts` (13 passing)
- [x] `pnpm --filter actionpack build` succeeds with deps prebuilt