### PR TITLE
feat(actionpack): processAction forwards extra positional args to the action

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -180,8 +180,12 @@ export class AbstractController {
     return skipped;
   }
 
-  /** Process an action by name. Runs callbacks around the action. */
-  async processAction(action: string): Promise<void> {
+  /**
+   * Process an action by name. Runs callbacks around the action. Extra
+   * `args` are forwarded to the action method (mirrors Rails'
+   * `Controller#process(action, *args)`).
+   */
+  async processAction(action: string, ...args: unknown[]): Promise<void> {
     this.actionName = action;
     this._performed = false;
 
@@ -218,10 +222,10 @@ export class AbstractController {
       if (Constructor.hasAction(action)) {
         const method = (this as any)[action];
         if (typeof method === "function") {
-          await method.call(this);
+          await method.apply(this, args);
         }
       } else if (typeof (this as any).actionMissing === "function") {
-        await (this as any).actionMissing(action);
+        await (this as any).actionMissing(action, ...args);
       } else {
         throw new ActionNotFound(
           `The action '${action}' could not be found for ${this.constructor.name}`,

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -298,11 +298,23 @@ describe("TestHalting", () => {
   });
 });
 
+class CallbacksWithArgs extends AbstractController {
+  text?: string;
+  first() {
+    this.text = "Hello world";
+  }
+  async index(extra: string) {
+    this.responseBody = (this.text ?? "") + extra;
+  }
+}
+CallbacksWithArgs.beforeAction((c) => (c as CallbacksWithArgs).first());
+
 describe("TestCallbacksWithArgs", () => {
-  // BLOCKED: trails' processAction(action: string) does not accept extra
-  // positional args. Rails' Controller#process forwards *args to the
-  // action method. Needs ~30 LOC change to base.ts to thread through.
-  it.skip("callbacks still work when invoking process with multiple arguments", () => {});
+  it("callbacks still work when invoking process with multiple arguments", async () => {
+    const controller = new CallbacksWithArgs();
+    await controller.processAction("index", " Howdy!");
+    expect(controller.responseBody).toBe("Hello world Howdy!");
+  });
 });
 
 describe("TestCallbacksWithMissingConditions", () => {

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -399,9 +399,9 @@ export class Base extends Metal {
    *
    * @internal
    */
-  async processAction(action: string): Promise<void> {
+  async processAction(action: string, ...args: unknown[]): Promise<void> {
     try {
-      await super.processAction(action);
+      await super.processAction(action, ...args);
 
       // Resolve any pending async renders (template/partial)
       if (this._pendingRender && !this.performed) {


### PR DESCRIPTION
## Summary

Mirrors Rails' \`Controller#process(action, *args)\`. The
\`processAction\` signature widens from \`(action: string)\` to
\`(action: string, ...args: unknown[])\`; args flow through to
\`method.apply(this, args)\` at the action invocation, and through to
\`actionMissing(action, ...args)\` when present.

Unblocks \`TestCallbacksWithArgs > callbacks still work when invoking
process with multiple arguments\` (one of the 10 BLOCKED skips landed
in #1814).

### Score

- \`callbacks_test.rb\`: 16/26 → 17/26 (1 fewer skip).
- \`abstractcontroller\` package: 31/52 → 32/52 (59.6% → 61.5%).

### Compatibility

\`actionMissing\` callers using single-arg signatures continue to work
unchanged — JS rest-args ignore extras at call sites. The one existing
trails caller (\`packages/actionpack/src/action-controller/controller/base.test.ts:648\`
declares \`actionMissing(action: string)\` and works as-is.

PR size: 16 LOC net.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/abstract-controller/ packages/actionpack/src/action-controller/controller/base.test.ts\` — 218 passing + 20 skipped. No regressions.
- [x] \`pnpm test:compare --package abstractcontroller\` — callbacks_test.rb shows 17 ok / 9 skip.
- [x] \`tsc --build\` via pre-commit — clean.