### PR TITLE
feat(activesupport): add MissingTranslationData + raise option to I18n.translate

### DIFF
--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -94,6 +94,15 @@ describe("TranslationControllerTest", () => {
     expect(controller.t(".twoz", { raise: true, default: [":one.two"] })).toBe("bar");
   });
 
+  it("raises when raise: true and the whole chain (scoped + fallback + defaults-as-keys) misses", () => {
+    controller.actionName = "index";
+    // Both the scoped and all `:`-keyed defaults miss → must throw
+    // MissingTranslationData (not silently return the defaults array).
+    expect(() =>
+      controller.t(".twoz", { raise: true, default: [":also.missing", ":still.gone"] }),
+    ).toThrow(MissingTranslationData);
+  });
+
   it("lazy lookup", () => {
     controller.actionName = "index";
     expect(controller.t(".foo")).toBe("bar");

--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { I18n } from "@blazetrails/activesupport";
+import { I18n, MissingTranslationData } from "@blazetrails/activesupport";
 import {
   l,
   localize,
@@ -81,11 +81,11 @@ describe("TranslationControllerTest", () => {
     expect(typeof controller.l).toBe("function");
   });
 
-  // BLOCKED: `I18n.translate` does not support `{ raise: true }`. It
-  // returns a "Translation missing: ..." string for unknown keys. Adding
-  // a raise option to activesupport I18n is a ~30 LOC follow-up
-  // (introduce `MissingTranslationData` class, threading the option).
-  it.skip("raises missing translation message with raise option", () => {});
+  it("raises missing translation message with raise option", () => {
+    expect(() => controller.t("translations.missing", { raise: true })).toThrow(
+      MissingTranslationData,
+    );
+  });
 
   it("lazy lookup", () => {
     controller.actionName = "index";

--- a/packages/actionpack/src/abstract-controller/translation.test.ts
+++ b/packages/actionpack/src/abstract-controller/translation.test.ts
@@ -87,6 +87,13 @@ describe("TranslationControllerTest", () => {
     );
   });
 
+  it("dot-prefixed lookup with raise: true still honors the user default chain", () => {
+    controller.actionName = "index";
+    // Scoped miss + user default ":one.two" resolves to "bar" — must
+    // NOT throw even though raise: true is set.
+    expect(controller.t(".twoz", { raise: true, default: [":one.two"] })).toBe("bar");
+  });
+
   it("lazy lookup", () => {
     controller.actionName = "index";
     expect(controller.t(".foo")).toBe("bar");

--- a/packages/actionpack/src/abstract-controller/translation.ts
+++ b/packages/actionpack/src/abstract-controller/translation.ts
@@ -43,10 +43,13 @@ export function translate(
     const fallbackKey = `${path}${key}`;
 
     // Forward caller options (interpolation vars, locale, etc.) to
-    // every internal lookup, but strip `default` — the chain below
-    // implements its own default-walking semantics.
-    const passOptions = { ...options };
+    // every internal lookup, but strip `default` and `raise` — the
+    // chain below implements its own default-walking semantics, and
+    // `raise: true` must only fire after the *whole* chain (scoped →
+    // fallback → user defaults) is exhausted, not at the first miss.
+    const passOptions = { ...options } as Record<string, unknown>;
     delete passOptions.default;
+    delete passOptions.raise;
 
     const direct = I18n.translate(scopedKey, passOptions as Parameters<typeof I18n.translate>[1]);
     if (!isMissing(direct)) return direct;
@@ -73,6 +76,11 @@ export function translate(
       }
     }
 
+    // Chain exhausted — honor `raise: true` now (forwarding it to a
+    // final lookup throws `MissingTranslationData` from I18n).
+    if ((options as { raise?: boolean }).raise) {
+      return I18n.translate(scopedKey, options as Parameters<typeof I18n.translate>[1]);
+    }
     return direct; // "Translation missing: ..." from the scoped lookup
   }
   return I18n.translate(key, options as Parameters<typeof I18n.translate>[1]);

--- a/packages/actionpack/src/abstract-controller/translation.ts
+++ b/packages/actionpack/src/abstract-controller/translation.ts
@@ -1,4 +1,4 @@
-import { I18n } from "@blazetrails/activesupport";
+import { I18n, MissingTranslationData } from "@blazetrails/activesupport";
 
 /**
  * Host shape `translate` / `localize` mix into. Trails' `Metal` provides
@@ -76,10 +76,16 @@ export function translate(
       }
     }
 
-    // Chain exhausted — honor `raise: true` now (forwarding it to a
-    // final lookup throws `MissingTranslationData` from I18n).
+    // Chain exhausted — honor `raise: true`. Throw directly rather
+    // than re-entering I18n.translate with the original options:
+    // `default` is still in there and I18n returns it before honoring
+    // raise, so we'd silently return the already-exhausted defaults
+    // array instead of raising.
     if ((options as { raise?: boolean }).raise) {
-      return I18n.translate(scopedKey, options as Parameters<typeof I18n.translate>[1]);
+      const locale =
+        (passOptions as { locale?: string }).locale ??
+        (I18n as unknown as { locale: string }).locale;
+      throw new MissingTranslationData(locale, scopedKey);
     }
     return direct; // "Translation missing: ..." from the scoped lookup
   }

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { I18n } from "./i18n.js";
+import { I18n, MissingTranslationData } from "./i18n.js";
 import { toSentence } from "./array-utils.js";
 
 describe("I18nTest", () => {
@@ -159,5 +159,21 @@ describe("I18nTest", () => {
 
   it("to sentence with empty i18n store", () => {
     expect(toSentence(["a", "b", "c"])).toBe("a, b, and c");
+  });
+
+  it("translate { raise: true } throws MissingTranslationData for unknown keys", () => {
+    expect(() => I18n.translate("nope.never.was", { raise: true })).toThrow(MissingTranslationData);
+    try {
+      I18n.translate("nope.never.was", { raise: true });
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingTranslationData);
+      expect((e as MissingTranslationData).key).toBe("nope.never.was");
+      expect((e as MissingTranslationData).locale).toBe("en");
+      expect((e as Error).message).toBe("Translation missing: en.nope.never.was");
+    }
+  });
+
+  it("translate { raise: true } honors a supplied default (does not throw)", () => {
+    expect(I18n.translate("nope", { raise: true, default: "fallback" })).toBe("fallback");
   });
 });

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -162,15 +162,16 @@ describe("I18nTest", () => {
   });
 
   it("translate { raise: true } throws MissingTranslationData for unknown keys", () => {
-    expect(() => I18n.translate("nope.never.was", { raise: true })).toThrow(MissingTranslationData);
+    let caught: unknown = null;
     try {
       I18n.translate("nope.never.was", { raise: true });
     } catch (e) {
-      expect(e).toBeInstanceOf(MissingTranslationData);
-      expect((e as MissingTranslationData).key).toBe("nope.never.was");
-      expect((e as MissingTranslationData).locale).toBe("en");
-      expect((e as Error).message).toBe("Translation missing: en.nope.never.was");
+      caught = e;
     }
+    expect(caught).toBeInstanceOf(MissingTranslationData);
+    expect((caught as MissingTranslationData).key).toBe("nope.never.was");
+    expect((caught as MissingTranslationData).locale).toBe("en");
+    expect((caught as Error).message).toBe("Translation missing: en.nope.never.was");
   });
 
   it("translate { raise: true } honors a supplied default (does not throw)", () => {

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -205,6 +205,26 @@ interface LocalizeOptions {
 interface TranslateOptions {
   locale?: string;
   default?: TranslationValue;
+  /** When true, raise `MissingTranslationData` instead of returning a
+   * "Translation missing: …" string for unknown keys. Mirrors Rails
+   * `I18n.t(key, raise: true)`. A supplied `default` still wins. */
+  raise?: boolean;
+}
+
+/**
+ * Thrown by `I18n.translate(key, { raise: true })` when the key is
+ * not found and no `default` is supplied. Mirrors Ruby
+ * `I18n::MissingTranslationData`.
+ */
+export class MissingTranslationData extends Error {
+  readonly key: string;
+  readonly locale: string;
+  constructor(locale: string, key: string) {
+    super(`Translation missing: ${locale}.${key}`);
+    this.name = "MissingTranslationData";
+    this.locale = locale;
+    this.key = key;
+  }
 }
 
 class I18nModule {
@@ -255,6 +275,7 @@ class I18nModule {
     const result = this.backend.lookup(locale, keyStr);
     if (result !== undefined) return result;
     if (options.default !== undefined) return options.default;
+    if (options.raise) throw new MissingTranslationData(locale, keyStr);
     return `Translation missing: ${locale}.${keyStr}`;
   }
 

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -479,7 +479,7 @@ export {
 } from "./range-ext.js";
 export type { Range as RangeExt } from "./range-ext.js";
 
-export { I18n } from "./i18n.js";
+export { I18n, MissingTranslationData } from "./i18n.js";
 export { Scalar } from "./duration.js";
 export { NumberHelper } from "./number-helper.js";
 export { NumberConverter } from "./number-helper/number-converter.js";


### PR DESCRIPTION
## Summary

Mirrors Rails \`I18n.t(key, raise: true)\`. When the key is not found,
no \`default\` is supplied, and \`raise: true\` is set, throw a
\`MissingTranslationData\` error instead of returning the
\`\"Translation missing: …\"\` string. A supplied \`default\` still wins
regardless of \`raise\`.

\`MissingTranslationData\` exports from \`@blazetrails/activesupport\`
with \`.key\` / \`.locale\` fields and the canonical
\`\"Translation missing: <locale>.<key>\"\` message.

Unblocks the abstract-controller translation skip:
\`TranslationControllerTest > raises missing translation message with raise option\`
(one of 11 BLOCKED items from #1824).

### Score

- \`translation_test.rb\`: 10/21 → 11/21 ok (1 fewer skip).
- \`abstractcontroller\` package: 32/52 → 33/52 (61.5% → 63.5%).

PR size: 37 LOC net (45 added, 8 removed).

## Test plan

- [x] \`pnpm vitest run packages/activesupport/src/i18n.test.ts packages/actionpack/src/abstract-controller/translation.test.ts\` — 38 passing + 10 skipped.
- [x] \`pnpm test:compare --package abstractcontroller\` — translation_test.rb shows 11 ok / 10 skip.
- [x] \`tsc --build\` via pre-commit — clean.