### PR TITLE
feat(activerecord): CPK AssociationQueryValue Relation subquery path (Batch 71)

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
@@ -90,6 +90,38 @@ describe("AssociationQueryValue", () => {
       expect(av.queries()).toEqual([{ blog_id: 5, blog_post_id: 99 }]);
     });
 
+    it("emits per-column subqueries for a Relation value (Batch 71 deviation)", () => {
+      // Rails synchronously plucks tuples from the relation; our sync queries()
+      // can't await pluck, so we emit one reselected subquery per FK column.
+      const reselected: string[] = [];
+      const fakeRelation = {
+        _modelClass: {},
+        toArel() {
+          return null;
+        },
+        selectValues: [],
+        reselect(col: string) {
+          reselected.push(col);
+          return { tag: `reselect(${col})` };
+        },
+        whereValuesHash() {
+          return {};
+        },
+      };
+      const av = new AssociationQueryValue(
+        {
+          joinForeignKey: ["blog_id", "id"],
+          joinPrimaryKey: ["blog_id", "blog_post_id"],
+        },
+        fakeRelation,
+      );
+      const result = av.queries();
+      expect(result).toEqual([
+        { blog_id: { tag: "reselect(blog_id)" }, id: { tag: "reselect(blog_post_id)" } },
+      ]);
+      expect(reselected).toEqual(["blog_id", "blog_post_id"]);
+    });
+
     it("returns null tuple entries when value is null", () => {
       const av = new AssociationQueryValue(
         {

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -48,10 +48,22 @@ export class AssociationQueryValue {
       // a silently malformed hash.
       const ids = this.ids();
       if (this.isRelation(ids)) {
-        throw new Error(
-          "Composite foreign key with Relation value is not yet supported (Slot B). " +
-            "Use explicit FK conditions instead.",
-        );
+        // Pragmatic deviation from Rails: Rails calls `id_list.pluck(primary_key)`
+        // here, synchronously materializing the relation into tuples. Our pluck is
+        // async and queries() is sync, so instead we emit one IN subquery per FK
+        // column (`fk[i] IN (SELECT pk[i] FROM ...)`, ANDed via PredicateBuilder).
+        // This is broader than Rails' tuple-IN — it matches rows where each FK
+        // component is in its column independently rather than as a tuple — but
+        // mirrors the subquery approach used for non-CPK Relations (Batch 71).
+        const pks = this.primaryKey() as string[];
+        const fkCols = fk as string[];
+        const baseRelation = ids as any;
+        return [
+          fkCols.reduce<Record<string, unknown>>((acc, fkCol, i) => {
+            acc[fkCol] = baseRelation.reselect(pks[i]);
+            return acc;
+          }, {}),
+        ];
       }
       // Rails zips each element of id_list with the FK columns (id_list.map { |ids_set| fk.zip(ids_set).to_h }).
       // Each ids_set must be an array with the same arity as joinForeignKey. Non-tuple values


### PR DESCRIPTION
## Summary

Batch 71 — Relation core gaps bundle B (~30 LOC).

`AssociationQueryValue.queries()` previously threw when the FK was composite and the value was a Relation. This wires up a pragmatic subquery path: emit one `fk[i] IN (SELECT pk[i] FROM ...)` per FK column (ANDed via PredicateBuilder) by reselecting each PK column off the relation.

## Deviation note

Rails calls `id_list.pluck(primary_key)` synchronously to materialize tuples and then emits a tuple-IN. Our `pluck` is async and `queries()` is sync, so we approximate with per-component IN subqueries. This is broader than Rails' tuple-IN (matches rows where each FK component is in its column independently rather than as a tuple) but mirrors the subquery approach already used for non-CPK Relations.

## Test plan
- [x] `association-query-value.test.ts` — new test for CPK + Relation path