### PR TITLE
feat(activerecord): Batch 73 — schema-cache ignored tables + gzip/lazy un-skips

### DIFF
--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -36,7 +36,14 @@ export function setSchemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp
  */
 export function isSchemaCacheIgnoredTable(tableName: string): boolean {
   for (const entry of schemaCacheIgnoredTables) {
-    if (entry instanceof RegExp ? entry.test(tableName) : entry === tableName) return true;
+    if (entry instanceof RegExp) {
+      // Reset lastIndex so /g and /y patterns don't alternate between
+      // matches across calls (same precaution SchemaDumper#isIgnored takes).
+      entry.lastIndex = 0;
+      if (entry.test(tableName)) return true;
+    } else if (entry === tableName) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -12,3 +12,31 @@ export let indexNestedAttributeErrors = false;
 export function setIndexNestedAttributeErrors(value: boolean): void {
   indexNestedAttributeErrors = value;
 }
+
+/**
+ * A list of table names or regular expressions to match tables to ignore
+ * when dumping the schema cache. Mirrors
+ * `ActiveRecord.schema_cache_ignored_tables` (active_record.rb:197).
+ *
+ * @internal
+ */
+export let schemaCacheIgnoredTables: ReadonlyArray<string | RegExp> = [];
+
+/** @internal */
+export function setSchemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp>): void {
+  schemaCacheIgnoredTables = value;
+}
+
+/**
+ * Returns true when `tableName` matches an entry in
+ * `schemaCacheIgnoredTables`. Mirrors
+ * `ActiveRecord.schema_cache_ignored_table?` (active_record.rb:205).
+ *
+ * @internal
+ */
+export function isSchemaCacheIgnoredTable(tableName: string): boolean {
+  for (const entry of schemaCacheIgnoredTables) {
+    if (entry instanceof RegExp ? entry.test(tableName) : entry === tableName) return true;
+  }
+  return false;
+}

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -587,6 +587,18 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
+    // Rails: single combined ALTER TABLE via add_timestamps_for_alter.
+    // SQLite-style adapters that don't support bulk ALTER fall back to
+    // two sequential addColumn calls (sqlite3_adapter.rb#add_timestamps
+    // uses the alter_table rebuild path instead of a combined ALTER).
+    if ((this.adapter as any).supportsBulkAlter?.() === true) {
+      const fragments = this.addTimestampsForAlter(tableName, options);
+      await this.adapter.executeMutation(
+        `ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`,
+      );
+      return;
+    }
+
     const opts: ColumnOptions = { ...options, null: options.null ?? false };
     if (!("precision" in opts) && (this.adapter as any).supportsDatetimeWithPrecision?.()) {
       opts.precision = 6;

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -284,10 +284,12 @@ describe("SchemaCacheTest", () => {
     }
   });
   it("marshal dump and load with gzip", () => {
-    // Trails' marshalDump returns a JSON-serializable array; mirror the
-    // Rails property (gzip-on-disk → load → cached columns survive) by
-    // gzipping the JSON-encoded marshal payload and round-tripping it
-    // through dumpTo / _loadFrom, which understands the .gz suffix.
+    // Rails' equivalent gzips a Marshal payload to a `.dump.gz` file and
+    // round-trips it through `dump_to` / `_load_from`. Trails serializes
+    // via `encodeWith` (JSON) rather than Marshal, but the on-disk
+    // property the Rails test asserts — write a `.gz` file, read it back,
+    // cached columns survive — still applies. `dumpTo(".gz")` gzips the
+    // JSON payload and `_loadFrom` auto-detects the `.gz` suffix.
     const cache = new SchemaCache();
     cache.setColumns("courses", [
       makeColumn("id", "integer", { primaryKey: true }),
@@ -373,20 +375,19 @@ describe("SchemaCacheTest", () => {
     cache.setPrimaryKeys("gadgets", "id");
     cache.dumpTo(cachePath);
 
-    const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
     const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
-    SchemaReflection.lazilyLoadSchemaCache = true;
     SchemaReflection.checkSchemaCacheDumpVersion = false;
     try {
       const reflection = new SchemaReflection(cachePath);
       // Cache starts nil
       expect(reflection.loadedCache).toBeNull();
-      // load! populates it from disk
+      // load! populates it from disk (this is the building block
+      // ConnectionPool.adoptConnection invokes when the lazy-load
+      // flag is enabled).
       await reflection.loadBang(new FakePool({}));
       expect(reflection.loadedCache).not.toBeNull();
       expect(reflection.loadedCache!.isCached("gadgets")).toBe(true);
     } finally {
-      SchemaReflection.lazilyLoadSchemaCache = prevLazy;
       SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
     }
   });

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SchemaCache, SchemaReflection, FakePool } from "./schema-cache.js";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
+import { setSchemaCacheIgnoredTables } from "../ar-config.js";
+import { StatementInvalid } from "../errors.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -86,20 +88,38 @@ describe("SchemaCacheTest", () => {
     expect(loaded!.isCached("posts")).toBe(true);
   });
 
-  it.skip("yaml dump and load with gzip", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+  it("yaml dump and load with gzip", () => {
+    // Trails serializes the schema cache as JSON (not YAML), but the
+    // gzip-round-trip property the Rails test asserts — dump_to a .gz
+    // path and load_from the same path produces a populated cache —
+    // applies to our JSON encoding too. dumpTo(".gz") writes gzipped
+    // JSON; _loadFrom auto-detects the .gz extension and gunzips first.
+    const cache = new SchemaCache();
+    cache.setColumns("courses", [
+      makeColumn("id", "integer", { primaryKey: true, null: false }),
+      makeColumn("name", "varchar(255)"),
+      makeColumn("created_at", "timestamp"),
+    ]);
+    cache.setPrimaryKeys("courses", "id");
+
+    const filename = path.join(tmpDir, "schema_cache.json.gz");
+    cache.dumpTo(filename);
+    expect(fs.existsSync(filename)).toBe(true);
+
+    const loaded = SchemaCache._loadFrom(filename);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.isCached("courses")).toBe(true);
+    const cols = loaded!.getCachedColumnsHash("courses");
+    expect(Object.keys(cols!)).toEqual(["id", "name", "created_at"]);
+    expect(cols!["id"]).toBeInstanceOf(Column);
   });
   it.skip("yaml loads 5 1 dump", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+    // SKIPPED:rails-specific — exercises a fixture written by Rails 5.1's
+    // YAML serializer (test/assets/schema_dump_5_1.yml). Trails uses JSON
+    // throughout the schema cache, so the on-disk shape can't round-trip.
   });
   it.skip("yaml loads 5 1 dump without indexes still queries for indexes", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+    // SKIPPED:rails-specific — see "yaml loads 5 1 dump".
   });
 
   it("primary key for existent table", async () => {
@@ -219,15 +239,69 @@ describe("SchemaCacheTest", () => {
     expect(hash!["title"].sqlType).toBe("text");
   });
 
-  it.skip("marshal dump and load with ignored tables", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+  it("marshal dump and load with ignored tables", async () => {
+    setSchemaCacheIgnoredTables(["professors"]);
+    try {
+      const fakeConn = {
+        primaryKey: async (t: string) => (t === "courses" ? "id" : null),
+        dataSourceExists: async (t: string) => t === "courses" || t === "professors",
+        dataSources: async () => ["courses", "professors"],
+        columns: async (t: string) =>
+          t === "courses"
+            ? [
+                makeColumn("id", "integer", { primaryKey: true }),
+                makeColumn("name", "varchar(255)"),
+                makeColumn("created_at", "timestamp"),
+              ]
+            : [makeColumn("id", "integer")],
+        indexes: async (t: string) =>
+          t === "courses" ? [{ name: "idx_courses_name", columns: ["name"] }] : [],
+      };
+      const pool = new FakePool(fakeConn);
+      const source = new SchemaCache();
+      await source.add(pool, "courses");
+      await source.add(pool, "professors");
+
+      const dumped = JSON.parse(JSON.stringify(source.marshalDump()));
+      const cache = new SchemaCache();
+      cache.marshalLoad(dumped);
+
+      // courses is cached as normal
+      expect((await cache.columns(pool, "courses"))!.length).toBe(3);
+      expect(Object.keys((await cache.columnsHash(pool, "courses"))!)).toHaveLength(3);
+      expect(await cache.dataSourceExists(pool, "courses")).toBe(true);
+      expect(await cache.primaryKeys(pool, "courses")).toBe("id");
+      expect((await cache.indexes(pool, "courses")).length).toBe(1);
+
+      // professors is filtered out — behavior matches a non-existent table
+      expect(await cache.dataSourceExists(pool, "professors")).toBeUndefined();
+      await expect(cache.columns(pool, "professors")).rejects.toBeInstanceOf(StatementInvalid);
+      await expect(cache.columnsHash(pool, "professors")).rejects.toBeInstanceOf(StatementInvalid);
+      expect(await cache.primaryKeys(pool, "professors")).toBeNull();
+      expect(await cache.indexes(pool, "professors")).toEqual([]);
+    } finally {
+      setSchemaCacheIgnoredTables([]);
+    }
   });
-  it.skip("marshal dump and load with gzip", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+  it("marshal dump and load with gzip", () => {
+    // Trails' marshalDump returns a JSON-serializable array; mirror the
+    // Rails property (gzip-on-disk → load → cached columns survive) by
+    // gzipping the JSON-encoded marshal payload and round-tripping it
+    // through dumpTo / _loadFrom, which understands the .gz suffix.
+    const cache = new SchemaCache();
+    cache.setColumns("courses", [
+      makeColumn("id", "integer", { primaryKey: true }),
+      makeColumn("name", "varchar(255)"),
+      makeColumn("created_at", "timestamp"),
+    ]);
+    cache.setPrimaryKeys("courses", "id");
+
+    const filename = path.join(tmpDir, "schema_cache.dump.gz");
+    cache.dumpTo(filename);
+    const loaded = SchemaCache._loadFrom(filename);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.isCached("courses")).toBe(true);
+    expect(loaded!.getCachedColumnsHash("courses")!["id"].primaryKey).toBe(true);
   });
   it("gzip dumps identical", () => {
     // Rails: two .gz dumps of the same cache (with a 1s sleep between) must
@@ -286,10 +360,35 @@ describe("SchemaCacheTest", () => {
     expect(cache.isColumnsHashCached(null, "users")).toBe(false);
   });
 
-  it.skip("when lazily load schema cache is set cache is lazily populated when est connection", () => {
-    // BLOCKED: schema — schema introspection / dumper gap in schema-cache
-    // ROOT-CAUSE: schema-cache.ts or abstract/schema-statements.ts missing Rails parity
-    // SCOPE: ~50–200 LOC fix in schema-dumper.ts or schema-statements.ts; affects ~7–43 tests in schema-cache.test.ts
+  it("when lazily load schema cache is set cache is lazily populated when est connection", async () => {
+    // Rails: when ActiveRecord.lazily_load_schema_cache is on, the
+    // SchemaReflection's @cache stays nil until first access and is
+    // populated from the schema_cache_path on demand. The end-to-end
+    // connection-pool wiring is covered in connection-pool.test.ts
+    // ("lazily loads the schema cache on first connection when enabled");
+    // here we cover the SchemaReflection-level contract that backs it.
+    const cachePath = path.join(tmpDir, "schema_cache.json");
+    const cache = new SchemaCache();
+    cache.setColumns("gadgets", [makeColumn("id", "integer", { primaryKey: true })]);
+    cache.setPrimaryKeys("gadgets", "id");
+    cache.dumpTo(cachePath);
+
+    const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
+    const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
+    SchemaReflection.lazilyLoadSchemaCache = true;
+    SchemaReflection.checkSchemaCacheDumpVersion = false;
+    try {
+      const reflection = new SchemaReflection(cachePath);
+      // Cache starts nil
+      expect(reflection.loadedCache).toBeNull();
+      // load! populates it from disk
+      await reflection.loadBang(new FakePool({}));
+      expect(reflection.loadedCache).not.toBeNull();
+      expect(reflection.loadedCache!.isCached("gadgets")).toBe(true);
+    } finally {
+      SchemaReflection.lazilyLoadSchemaCache = prevLazy;
+      SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
+    }
   });
   it("#init_with skips deduplication if told to", () => {
     // Mirrors Rails: when coder["deduplicated"] is set, init_with uses the

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -10,6 +10,8 @@ import { Gzip } from "@blazetrails/activesupport/gzip";
 import { Column } from "./column.js";
 import type { ColumnJSON } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
+import { isSchemaCacheIgnoredTable } from "../ar-config.js";
+import { StatementInvalid } from "../errors.js";
 
 // ---------------------------------------------------------------------------
 // Helper: run callback inside pool.withConnection if available
@@ -179,6 +181,8 @@ export class SchemaCache {
       return this._primaryKeys.get(tableName);
     }
 
+    if (isSchemaCacheIgnoredTable(tableName)) return null;
+
     return withConnection(pool, async (connection) => {
       if (await this.dataSourceExists(connection, tableName)) {
         const pk =
@@ -193,6 +197,7 @@ export class SchemaCache {
   }
 
   async dataSourceExists(pool: unknown, name: string): Promise<boolean | undefined> {
+    if (isSchemaCacheIgnoredTable(name)) return undefined;
     // Rails: eager-load all data sources on first cache miss
     if (this._dataSourceExists.size === 0) {
       const tables = await this.tablesToCache(pool);
@@ -227,6 +232,10 @@ export class SchemaCache {
   }
 
   async columns(pool: unknown, tableName: string): Promise<Column[] | undefined> {
+    if (isSchemaCacheIgnoredTable(tableName)) {
+      throw new StatementInvalid(`Table '${tableName}' doesn't exist`);
+    }
+
     if (this._columns.has(tableName)) {
       return this._columns.get(tableName);
     }
@@ -277,6 +286,8 @@ export class SchemaCache {
     if (this._indexes.has(tableName)) {
       return this._indexes.get(tableName)!;
     }
+
+    if (isSchemaCacheIgnoredTable(tableName)) return [];
 
     return withConnection(pool, async (connection) => {
       if (typeof connection.indexes === "function") {
@@ -420,11 +431,13 @@ export class SchemaCache {
     this._version = null;
   }
 
-  // Rails: tables_to_cache(pool) — gets data_sources from connection
+  // Rails: tables_to_cache(pool) — gets data_sources from connection,
+  // filtering out anything matched by ActiveRecord.schema_cache_ignored_tables.
   private async tablesToCache(pool: unknown): Promise<string[]> {
     return withConnection(pool, async (connection) => {
       if (typeof connection.dataSources === "function") {
-        return (await connection.dataSources()) as string[];
+        const tables = (await connection.dataSources()) as string[];
+        return tables.filter((t) => !isSchemaCacheIgnoredTable(t));
       }
       return [];
     });
@@ -748,15 +761,13 @@ export function emptyCache(): SchemaCache {
 
 /**
  * Returns true when the table name matches the schema_cache_ignored_tables list.
- * Rails delegates to ActiveRecord.schema_cache_ignored_table?(table_name); trails
- * has no global ignored-tables registry yet so this always returns false.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::SchemaCache#ignored_table? (private)
  *
  * @internal
  */
-export function isIgnoredTable(_tableName: string): boolean {
-  return false;
+export function isIgnoredTable(tableName: string): boolean {
+  return isSchemaCacheIgnoredTable(tableName);
 }
 
 /**

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -118,7 +118,13 @@ export {
   isTriggerTransactionalCallbacks,
 } from "./transactions.js";
 export { delegate } from "./delegate.js";
-export { indexNestedAttributeErrors, setIndexNestedAttributeErrors } from "./ar-config.js";
+export {
+  indexNestedAttributeErrors,
+  setIndexNestedAttributeErrors,
+  schemaCacheIgnoredTables,
+  setSchemaCacheIgnoredTables,
+  isSchemaCacheIgnoredTable,
+} from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export {
   enableSti,


### PR DESCRIPTION
## Summary

Schema Slot J from the activerecord 100% plan (Batch 73). Lands the four achievable items; the two YAML 5.1 fixture tests stay skipped with sharper SKIPPED annotations (Rails-specific on-disk shape).

- `schemaCacheIgnoredTables` registry in `ar-config.ts` + `isSchemaCacheIgnoredTable()`, mirroring `ActiveRecord.schema_cache_ignored_tables` / `?` (active_record.rb:197/205).
- `SchemaCache` honors the registry in `dataSourceExists`, `columns` (throws `StatementInvalid`), `indexes` (`[]`), `primaryKeys` (`null`), and `tablesToCache` (filters out).
- Un-skip:
  - `marshal dump and load with ignored tables` — FakePool round-trip through `marshalDump`/`marshalLoad`.
  - `marshal dump and load with gzip` and `yaml dump and load with gzip` — verify the existing `dumpTo(".gz")` + `_loadFrom` gzip pipeline.
  - `when lazily load schema cache is set …` — SchemaReflection-level contract; end-to-end pool wiring is already covered by `connection-pool.test.ts`.
- Unify abstract `addTimestamps` to route through `addTimestampsForAlter` + a single combined ALTER on adapters that report `supportsBulkAlter()`. SQLite-style adapters keep the sequential `addColumn` pair (Rails sqlite3_adapter.rb overrides the same way).

## Follow-ups (not in this PR)

- The two `yaml loads 5 1 dump …` tests remain skipped — they exercise a fixture written by Rails 5.1's YAML serializer; trails serializes as JSON throughout and would need a JSON-shaped fixture replacement to mean anything.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/schema-cache.test.ts` — 31 passed, 2 skipped (was 27 passed, 6 skipped).
- [x] `pnpm vitest run packages/activerecord/src/active-record-schema.test.ts packages/activerecord/src/migration.test.ts packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts` — 226 passed.
- [ ] CI runs the full PG/MySQL adapter suites to exercise the `supportsBulkAlter()` branch end-to-end.