### PR TITLE
feat(actionpack): port ActionDispatch::Routing::Endpoint

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/endpoint.ts
+++ b/packages/actionpack/src/action-dispatch/routing/endpoint.ts
@@ -1,0 +1,38 @@
+/**
+ * Port of ActionDispatch::Routing::Endpoint
+ * (Rails actionpack/lib/action_dispatch/routing/endpoint.rb)
+ *
+ * Base class for objects that can serve as the terminating end of a route:
+ * dispatchers (controller#action), redirects, and mounted Rack apps. Subclasses
+ * override the predicates (`dispatcher`, `redirect`, `engine`) and `matches`
+ * to participate in route matching.
+ */
+
+import type { Request } from "../http/request.js";
+
+/** @internal */
+export class Endpoint {
+  dispatcher(): boolean {
+    return false;
+  }
+
+  redirect(): boolean {
+    return false;
+  }
+
+  matches(_req: Request): boolean {
+    return true;
+  }
+
+  app(): unknown {
+    return this;
+  }
+
+  rackApp(): unknown {
+    return this.app();
+  }
+
+  engine(): boolean {
+    return false;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/routing/index.ts
+++ b/packages/actionpack/src/action-dispatch/routing/index.ts
@@ -29,6 +29,7 @@ export {
   type ModelClass,
   type ToModel,
 } from "./polymorphic-routes.js";
+export { Endpoint } from "./endpoint.js";
 export {
   redirect,
   Redirect,

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -13,31 +13,12 @@ import {
   escapeFragment as journeyEscapeFragment,
   escapePath as journeyEscapePath,
 } from "../journey/router/utils.js";
+import { Endpoint } from "./endpoint.js";
 import type { RackEnv } from "@blazetrails/rack";
 
-export type RedirectBlock = (params: Record<string, string>, request: Request) => string;
+export { Endpoint } from "./endpoint.js";
 
-/** @internal */
-export class Endpoint {
-  dispatcher(): boolean {
-    return false;
-  }
-  redirect(): boolean {
-    return false;
-  }
-  matches(_req: Request): boolean {
-    return true;
-  }
-  app(): unknown {
-    return this;
-  }
-  rackApp(): unknown {
-    return this.app();
-  }
-  engine(): boolean {
-    return false;
-  }
-}
+export type RedirectBlock = (params: Record<string, string>, request: Request) => string;
 
 /** Parsed pieces of a URI, mirroring Ruby's URI::Generic. */
 interface ParsedUri {


### PR DESCRIPTION
## Summary

Ports `ActionDispatch::Routing::Endpoint` from Rails (`actionpack/lib/action_dispatch/routing/endpoint.rb`) into its own file at `packages/actionpack/src/action-dispatch/routing/endpoint.ts`, mirroring the Rails source layout so `api:compare` resolves the class to the matching path.

The class was previously inlined in `redirection.ts`. Behavior is unchanged — same six methods (`dispatcher`, `redirect`, `matches`, `app`, `rackApp`, `engine`) — only the file location moves. `redirection.ts` re-exports `Endpoint` so existing imports keep working.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/redirection.test.ts` — 13/13 pass
- [x] `pnpm api:compare --package actionpack` — `routing/endpoint.ts:Endpoint` now matches `routing/endpoint.rb`