### PR TITLE
feat(actionpack): port ActionDispatch::Http::FilterParameters + FilterRedirect

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/filter-parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-parameters.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { ParameterFilter } from "@blazetrails/activesupport";
+import {
+  ENV_MATCH,
+  NULL_ENV_FILTER,
+  NULL_PARAM_FILTER,
+  type FilterParametersHost,
+  envFilter,
+  filteredEnv,
+  filteredParameters,
+  filteredPath,
+  parameterFilter,
+  parameterFilterFor,
+} from "./filter-parameters.js";
+import { ParseError } from "./parameters.js";
+
+function makeHost(overrides: Partial<FilterParametersHost> = {}): FilterParametersHost {
+  const headers = new Map<string, unknown>();
+  const env: Record<string, unknown> = {};
+  return {
+    getHeader: (k) => headers.get(k),
+    setHeader: (k, v) => {
+      headers.set(k, v);
+      return v;
+    },
+    deleteHeader: (k) => {
+      headers.delete(k);
+    },
+    hasHeader: (k) => headers.has(k),
+    queryParameters: {},
+    requestParameters: {},
+    contentLength: 0,
+    contentMimeType: null,
+    rawPost: "",
+    env,
+    path: "/",
+    queryString: "",
+    parameters: () => ({}),
+    ...overrides,
+  };
+}
+
+describe("ENV_MATCH", () => {
+  it("matches Rails' static env filter list", () => {
+    expect(ENV_MATCH).toEqual([/RAW_POST_DATA/, "rack.request.form_vars"]);
+  });
+});
+
+describe("filteredParameters", () => {
+  it("returns parameters filtered by the configured filter list", () => {
+    const host = makeHost({
+      parameters: () => ({ password: "secret", username: "alice" }),
+    });
+    host.setHeader("action_dispatch.parameter_filter", ["password"]);
+    expect(filteredParameters.call(host)).toEqual({
+      password: "[FILTERED]",
+      username: "alice",
+    });
+  });
+
+  it("returns an empty hash when parameters() throws ParseError", () => {
+    const host = makeHost({
+      parameters: () => {
+        throw new ParseError("bad");
+      },
+    });
+    expect(filteredParameters.call(host)).toEqual({});
+  });
+
+  it("rethrows non-ParseError exceptions", () => {
+    const host = makeHost({
+      parameters: () => {
+        throw new TypeError("boom");
+      },
+    });
+    expect(() => filteredParameters.call(host)).toThrow(TypeError);
+  });
+
+  it("memoizes the filtered hash", () => {
+    let calls = 0;
+    const host = makeHost({
+      parameters: () => {
+        calls++;
+        return {};
+      },
+    });
+    filteredParameters.call(host);
+    filteredParameters.call(host);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("filteredEnv", () => {
+  it("filters env keys matching the configured filter list plus ENV_MATCH", () => {
+    const host = makeHost({
+      env: { password: "secret", RAW_POST_DATA: "x", safe: "ok" },
+    });
+    host.setHeader("action_dispatch.parameter_filter", ["password"]);
+    const out = filteredEnv.call(host);
+    expect(out["password"]).toBe("[FILTERED]");
+    expect(out["RAW_POST_DATA"]).toBe("[FILTERED]");
+    expect(out["safe"]).toBe("ok");
+  });
+
+  it("uses NULL_ENV_FILTER when no filter header is set", () => {
+    const host = makeHost({ env: { foo: "bar", RAW_POST_DATA: "x" } });
+    const out = filteredEnv.call(host);
+    expect(out["foo"]).toBe("bar");
+    expect(out["RAW_POST_DATA"]).toBe("[FILTERED]");
+  });
+});
+
+describe("filteredPath", () => {
+  it("returns just the path when there is no query string", () => {
+    const host = makeHost({ path: "/users", queryString: "" });
+    expect(filteredPath.call(host)).toBe("/users");
+  });
+
+  it("appends the filtered query string", () => {
+    const host = makeHost({ path: "/users", queryString: "password=hunter2&name=al" });
+    host.setHeader("action_dispatch.parameter_filter", ["password"]);
+    expect(filteredPath.call(host)).toBe("/users?password=[FILTERED]&name=al");
+  });
+});
+
+describe("parameterFilter", () => {
+  it("returns NULL_PARAM_FILTER when the header is unset", () => {
+    expect(parameterFilter.call(makeHost())).toBe(NULL_PARAM_FILTER);
+  });
+
+  it("constructs a ParameterFilter from the header list", () => {
+    const host = makeHost();
+    host.setHeader("action_dispatch.parameter_filter", ["secret"]);
+    const f = parameterFilter.call(host);
+    expect(f).toBeInstanceOf(ParameterFilter);
+    expect(f).not.toBe(NULL_PARAM_FILTER);
+  });
+});
+
+describe("envFilter", () => {
+  it("returns NULL_ENV_FILTER when no header is set", () => {
+    expect(envFilter.call(makeHost())).toBe(NULL_ENV_FILTER);
+  });
+
+  it("appends ENV_MATCH to the user filter list", () => {
+    const host = makeHost({ env: { user_key: "x", RAW_POST_DATA: "y" } });
+    host.setHeader("action_dispatch.parameter_filter", ["user_key"]);
+    const out = envFilter.call(host).filter(host.env);
+    expect(out["user_key"]).toBe("[FILTERED]");
+    expect(out["RAW_POST_DATA"]).toBe("[FILTERED]");
+  });
+});
+
+describe("parameterFilterFor", () => {
+  it("constructs a ParameterFilter from the given list", () => {
+    expect(parameterFilterFor(["x"])).toBeInstanceOf(ParameterFilter);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/filter-parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-parameters.ts
@@ -1,0 +1,126 @@
+/**
+ * ActionDispatch::Http::FilterParameters
+ *
+ * Port of `actionpack/lib/action_dispatch/http/filter_parameters.rb`. Allows
+ * specifying sensitive query string and POST parameters to filter from the
+ * request log. The filter list lives at
+ * `env["action_dispatch.parameter_filter"]`.
+ *
+ * Rails mixes this into `ActionDispatch::Request`. Per CLAUDE.md, we expose
+ * the methods as `this`-typed functions against a {@link FilterParametersHost}
+ * interface so they can be assigned directly onto the host class.
+ */
+
+import { ParameterFilter } from "@blazetrails/activesupport";
+import type { ParametersHost } from "./parameters.js";
+import { ParseError } from "./parameters.js";
+
+/** Patterns Rails always strips from `filtered_env`. */
+export const ENV_MATCH: ReadonlyArray<string | RegExp> = [
+  /RAW_POST_DATA/,
+  "rack.request.form_vars",
+];
+
+/** @internal */
+export const NULL_PARAM_FILTER = new ParameterFilter();
+/** @internal */
+export const NULL_ENV_FILTER = new ParameterFilter([...ENV_MATCH]);
+
+/**
+ * Minimal host surface required by the {@link FilterParameters} mixin.
+ * Mirrors the methods Rails' `Http::FilterParameters` calls on `self`.
+ */
+export interface FilterParametersHost extends ParametersHost {
+  hasHeader(key: string): boolean;
+  env: Record<string, unknown>;
+  path: string;
+  queryString: string;
+  parameters(): Record<string, unknown>;
+}
+
+interface CachedState {
+  _filteredParameters?: Record<string, unknown>;
+  _filteredEnv?: Record<string, unknown>;
+  _filteredPath?: string;
+  _parameterFilter?: ParameterFilter;
+}
+
+/** Returns a hash of parameters with all sensitive data replaced. */
+export function filteredParameters(this: FilterParametersHost): Record<string, unknown> {
+  const host = this as FilterParametersHost & CachedState;
+  if (host._filteredParameters !== undefined) return host._filteredParameters;
+  try {
+    host._filteredParameters = parameterFilter.call(this).filter(this.parameters());
+  } catch (e) {
+    if (e instanceof ParseError) {
+      host._filteredParameters = {};
+    } else {
+      throw e;
+    }
+  }
+  return host._filteredParameters;
+}
+
+/** Returns a hash of request.env with all sensitive data replaced. */
+export function filteredEnv(this: FilterParametersHost): Record<string, unknown> {
+  const host = this as FilterParametersHost & CachedState;
+  if (host._filteredEnv !== undefined) return host._filteredEnv;
+  host._filteredEnv = envFilter.call(this).filter(this.env);
+  return host._filteredEnv;
+}
+
+/** Reconstructs a path with all sensitive GET parameters replaced. */
+export function filteredPath(this: FilterParametersHost): string {
+  const host = this as FilterParametersHost & CachedState;
+  if (host._filteredPath !== undefined) return host._filteredPath;
+  host._filteredPath =
+    this.queryString.length === 0 ? this.path : `${this.path}?${filteredQueryString.call(this)}`;
+  return host._filteredPath;
+}
+
+/** Returns the `ParameterFilter` object used to filter in this request. */
+export function parameterFilter(this: FilterParametersHost): ParameterFilter {
+  const host = this as FilterParametersHost & CachedState;
+  if (host._parameterFilter !== undefined) return host._parameterFilter;
+  if (this.hasHeader("action_dispatch.parameter_filter")) {
+    const list = this.getHeader("action_dispatch.parameter_filter") as Array<string | RegExp>;
+    host._parameterFilter = parameterFilterFor(list);
+  } else {
+    host._parameterFilter = NULL_PARAM_FILTER;
+  }
+  return host._parameterFilter;
+}
+
+/** @internal */
+export function envFilter(this: FilterParametersHost): ParameterFilter {
+  if (!this.hasHeader("action_dispatch.parameter_filter")) return NULL_ENV_FILTER;
+  const userKey = this.getHeader("action_dispatch.parameter_filter") as
+    | Array<string | RegExp>
+    | string
+    | RegExp;
+  const arr = Array.isArray(userKey) ? userKey : [userKey];
+  return parameterFilterFor([...arr, ...ENV_MATCH]);
+}
+
+/** @internal */
+export function parameterFilterFor(filters: Array<string | RegExp>): ParameterFilter {
+  return new ParameterFilter(filters);
+}
+
+/** @internal */
+export function filteredQueryString(this: FilterParametersHost): string {
+  const parts = this.queryString.split(/([&;])/);
+  const filter = parameterFilter.call(this);
+  const filteredParts = parts.map((part) => {
+    if (part.includes("=")) {
+      const eq = part.indexOf("=");
+      const key = part.slice(0, eq);
+      const value = part.slice(eq + 1);
+      const filtered = filter.filter({ [key]: value });
+      const firstKey = Object.keys(filtered)[0];
+      return `${firstKey}=${filtered[firstKey] as string}`;
+    }
+    return part;
+  });
+  return filteredParts.join("");
+}

--- a/packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ParameterFilter } from "@blazetrails/activesupport";
+import {
+  FILTERED,
+  type FilterRedirectHost,
+  type FilterRedirectRequest,
+  filteredLocation,
+} from "./filter-redirect.js";
+
+function makeRequest(
+  redirectFilter: Array<string | RegExp> | undefined,
+  paramFilters: Array<string | RegExp> = [],
+): FilterRedirectRequest {
+  return {
+    getHeader: (k) => (k === "action_dispatch.redirect_filter" ? redirectFilter : undefined),
+    parameterFilter: () => new ParameterFilter(paramFilters),
+  };
+}
+
+function makeHost(
+  location: string,
+  request: FilterRedirectRequest | null = null,
+): FilterRedirectHost {
+  return { location, request };
+}
+
+describe("filteredLocation", () => {
+  it("returns FILTERED when a string redirect_filter substring matches", () => {
+    const host = makeHost("https://example.com/admin/secret", makeRequest(["admin"]));
+    expect(filteredLocation.call(host)).toBe(FILTERED);
+  });
+
+  it("returns FILTERED when a regexp redirect_filter matches", () => {
+    const host = makeHost("https://example.com/u/42", makeRequest([/\/u\/\d+/]));
+    expect(filteredLocation.call(host)).toBe(FILTERED);
+  });
+
+  it("returns FILTERED when the URL cannot be parsed", () => {
+    const host = makeHost("::::not a url::::", makeRequest([]));
+    expect(filteredLocation.call(host)).toBe(FILTERED);
+  });
+
+  it("returns the URL unchanged when there are no filters and no query string", () => {
+    const host = makeHost("https://example.com/path", makeRequest([]));
+    expect(filteredLocation.call(host)).toBe("https://example.com/path");
+  });
+
+  it("filters sensitive query parameters using the request parameter filter", () => {
+    const host = makeHost(
+      "https://example.com/login?password=hunter2&name=alice",
+      makeRequest([], ["password"]),
+    );
+    expect(filteredLocation.call(host)).toBe(
+      "https://example.com/login?password=[FILTERED]&name=alice",
+    );
+  });
+
+  it("returns the URL unchanged when there is no request", () => {
+    const host = makeHost("https://example.com/path?foo=1", null);
+    expect(filteredLocation.call(host)).toBe("https://example.com/path?foo=1");
+  });
+
+  it("treats absent redirect_filter as an empty list", () => {
+    const host = makeHost("https://example.com/path", makeRequest(undefined));
+    expect(filteredLocation.call(host)).toBe("https://example.com/path");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts
@@ -36,7 +36,8 @@ describe("filteredLocation", () => {
   });
 
   it("returns FILTERED when the URL cannot be parsed", () => {
-    const host = makeHost("::::not a url::::", makeRequest([]));
+    // `http://[invalid` triggers a WHATWG URL parse error (invalid IPv6 host).
+    const host = makeHost("http://[invalid", makeRequest([]));
     expect(filteredLocation.call(host)).toBe(FILTERED);
   });
 
@@ -58,6 +59,11 @@ describe("filteredLocation", () => {
   it("returns the URL unchanged when there is no request", () => {
     const host = makeHost("https://example.com/path?foo=1", null);
     expect(filteredLocation.call(host)).toBe("https://example.com/path?foo=1");
+  });
+
+  it("handles relative URLs (Rails URI.parse parity)", () => {
+    const host = makeHost("/login?password=hunter2&name=alice", makeRequest([], ["password"]));
+    expect(filteredLocation.call(host)).toBe("/login?password=[FILTERED]&name=alice");
   });
 
   it("treats absent redirect_filter as an empty list", () => {

--- a/packages/actionpack/src/action-dispatch/http/filter-redirect.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-redirect.ts
@@ -1,0 +1,83 @@
+/**
+ * ActionDispatch::Http::FilterRedirect
+ *
+ * Port of `actionpack/lib/action_dispatch/http/filter_redirect.rb`. Rails
+ * mixes this into `ActionDispatch::Response`; the redirect filter list
+ * lives at `env["action_dispatch.redirect_filter"]`.
+ *
+ * Exposed as `this`-typed mixin functions per CLAUDE.md.
+ */
+
+import type { ParameterFilter } from "@blazetrails/activesupport";
+
+/** @internal */
+export const FILTERED = "[FILTERED]";
+
+/**
+ * Minimal host surface required by the {@link FilterRedirect} mixin.
+ * Mirrors the methods Rails' `Http::FilterRedirect` calls on `self`.
+ */
+export interface FilterRedirectHost {
+  location: string;
+  request: FilterRedirectRequest | null | undefined;
+}
+
+/** Subset of the Request surface needed by {@link FilterRedirect}. */
+export interface FilterRedirectRequest {
+  getHeader(key: string): unknown;
+  parameterFilter(): ParameterFilter;
+}
+
+/** @internal */
+export function filteredLocation(this: FilterRedirectHost): string {
+  return locationFilterMatch.call(this) ? FILTERED : parameterFilteredLocation.call(this);
+}
+
+/** @internal */
+export function locationFilters(this: FilterRedirectHost): Array<string | RegExp> {
+  if (this.request) {
+    return (
+      (this.request.getHeader("action_dispatch.redirect_filter") as
+        | Array<string | RegExp>
+        | undefined) ?? []
+    );
+  }
+  return [];
+}
+
+/** @internal */
+export function locationFilterMatch(this: FilterRedirectHost): boolean {
+  const loc = this.location;
+  return locationFilters.call(this).some((filter) => {
+    if (typeof filter === "string") return loc.includes(filter);
+    if (filter instanceof RegExp) return filter.test(loc);
+    return false;
+  });
+}
+
+/** @internal */
+export function parameterFilteredLocation(this: FilterRedirectHost): string {
+  try {
+    const url = new URL(this.location);
+    if (url.search.length > 1 && this.request) {
+      const filter = this.request.parameterFilter();
+      const query = url.search.slice(1);
+      const parts = query.split(/([&;])/);
+      const filteredParts = parts.map((part) => {
+        if (part.includes("=")) {
+          const eq = part.indexOf("=");
+          const key = part.slice(0, eq);
+          const value = part.slice(eq + 1);
+          const filtered = filter.filter({ [key]: value });
+          const firstKey = Object.keys(filtered)[0];
+          return `${firstKey}=${filtered[firstKey] as string}`;
+        }
+        return part;
+      });
+      url.search = `?${filteredParts.join("")}`;
+    }
+    return url.toString();
+  } catch {
+    return FILTERED;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/http/filter-redirect.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-redirect.ts
@@ -58,7 +58,11 @@ export function locationFilterMatch(this: FilterRedirectHost): boolean {
 /** @internal */
 export function parameterFilteredLocation(this: FilterRedirectHost): string {
   try {
-    const url = new URL(this.location);
+    // Rails' URI.parse accepts both absolute and relative URLs; the
+    // WHATWG URL constructor requires a base for relative URLs.
+    const PLACEHOLDER_BASE = "http://__filter_redirect_placeholder__/";
+    const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(this.location);
+    const url = isAbsolute ? new URL(this.location) : new URL(this.location, PLACEHOLDER_BASE);
     if (url.search.length > 1 && this.request) {
       const filter = this.request.parameterFilter();
       const query = url.search.slice(1);
@@ -75,6 +79,10 @@ export function parameterFilteredLocation(this: FilterRedirectHost): string {
         return part;
       });
       url.search = `?${filteredParts.join("")}`;
+    }
+    if (!isAbsolute) {
+      // Strip the placeholder origin to mirror Rails relative-URL round-trip.
+      return `${url.pathname}${url.search}${url.hash}`;
     }
     return url.toString();
   } catch {

--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -27,3 +27,25 @@ export {
   type ParameterParsers,
   type ParametersHost,
 } from "./parameters.js";
+export {
+  ENV_MATCH,
+  NULL_PARAM_FILTER,
+  NULL_ENV_FILTER,
+  filteredParameters,
+  filteredEnv,
+  filteredPath,
+  parameterFilter,
+  envFilter,
+  parameterFilterFor,
+  filteredQueryString,
+  type FilterParametersHost,
+} from "./filter-parameters.js";
+export {
+  FILTERED,
+  filteredLocation,
+  locationFilters,
+  locationFilterMatch,
+  parameterFilteredLocation,
+  type FilterRedirectHost,
+  type FilterRedirectRequest,
+} from "./filter-redirect.js";


### PR DESCRIPTION
## Summary

- Ports `actionpack/lib/action_dispatch/http/filter_parameters.rb` and `filter_redirect.rb` from Rails 1:1.
- Both modules are mixed into `Request` / `Response` in Rails. Per CLAUDE.md they're exposed as `this`-typed mixin functions against `FilterParametersHost` / `FilterRedirectHost` so they can be assigned onto the host classes when the wiring PRs land.
- `FilterParameters` builds on the already-ported `ActiveSupport::ParameterFilter`; `NULL_PARAM_FILTER` / `NULL_ENV_FILTER` / `ENV_MATCH` constants mirror Rails.
- `FilterRedirect` uses the WHATWG `URL` parser in place of Ruby's `URI`; `URL` constructor failures fall back to `[FILTERED]` (mirrors `rescue URI::Error`).

## Follow-ups

- Wire `filteredParameters` / `filteredEnv` / `filteredPath` / `parameterFilter` onto `Request` (needs `hasHeader` + `setHeader` / `deleteHeader` first — currently only `getHeader` is on Request).
- Wire `filteredLocation` onto `Response` once Response exposes `request` and `location`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/http/filter-parameters.test.ts packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts` — 21 passing
- [x] `pnpm --filter actionpack... build` — clean