### PR TITLE
feat(actionpack): port ActionDispatch::Railtie (top-level)

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -1,6 +1,7 @@
 export const VERSION = "8.0.2";
 
 export { Deprecator, deprecator } from "./deprecator.js";
+export { Trailtie, type ActionDispatchConfig } from "./trailtie.js";
 export { LogSubscriber } from "./log-subscriber.js";
 export * as Constants from "./constants.js";
 export * as Journey from "./journey/index.js";

--- a/packages/actionpack/src/action-dispatch/trailtie.test.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+import { Trailtie, type ActionDispatchConfig } from "./trailtie.js";
+import { URL as HttpURL } from "./http/url.js";
+import { QueryParser } from "./http/query-parser.js";
+import { RequestUtils } from "./request/utils.js";
+import { CacheConfig } from "./http/cache.js";
+import { X_REQUEST_ID } from "./constants.js";
+
+function cfg(): ActionDispatchConfig {
+  return Trailtie.config["actionDispatch"] as ActionDispatchConfig;
+}
+
+describe("ActionDispatch::Trailtie", () => {
+  it("registers itself with the Railtie registry", () => {
+    expect(BaseRailtie.subclasses).toContain(Trailtie);
+  });
+
+  it("seeds Rails-compatible defaults on config.actionDispatch", () => {
+    const c = cfg();
+    expect(c.ipSpoofingCheck).toBe(true);
+    expect(c.showExceptions).toBe("all");
+    expect(c.tldLength).toBe(1);
+    expect(c.performDeepMunge).toBe(true);
+    expect(c.requestIdHeader).toBe(X_REQUEST_ID);
+    expect(c.debugExceptionLogLevel).toBe("fatal");
+    expect(c.httpAuthSalt).toBe("http authentication");
+    expect(c.defaultHeaders["X-Frame-Options"]).toBe("SAMEORIGIN");
+    expect(c.cookiesRotations).toBeNull();
+  });
+
+  it("runInitializers copies config onto framework holders", () => {
+    const c = cfg();
+    c.tldLength = 2;
+    c.strictQueryStringSeparator = true;
+    c.performDeepMunge = false;
+    c.strictFreshness = true;
+
+    Trailtie.runInitializers();
+
+    expect(HttpURL.tldLength).toBe(2);
+    expect(QueryParser.strictQueryStringSeparator).toBe(true);
+    expect(RequestUtils.performDeepMunge).toBe(false);
+    expect(CacheConfig.strictFreshness).toBe(true);
+    expect(BaseRailtie.deprecators["actionDispatch"]).toBeDefined();
+
+    HttpURL.tldLength = 1;
+    QueryParser.strictQueryStringSeparator = null;
+    RequestUtils.performDeepMunge = true;
+    CacheConfig.strictFreshness = false;
+  });
+});

--- a/packages/actionpack/src/action-dispatch/trailtie.test.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { Trailtie, type ActionDispatchConfig } from "./trailtie.js";
 import { URL as HttpURL } from "./http/url.js";
@@ -12,6 +12,31 @@ function cfg(): ActionDispatchConfig {
 }
 
 describe("ActionDispatch::Trailtie", () => {
+  let savedConfig: ActionDispatchConfig;
+  let savedTldLength: number;
+  let savedStrictQuery: boolean | null;
+  let savedPerformDeepMunge: boolean;
+  let savedStrictFreshness: boolean;
+  let hadDeprecator: boolean;
+
+  beforeEach(() => {
+    savedConfig = structuredClone(cfg());
+    savedTldLength = HttpURL.tldLength;
+    savedStrictQuery = QueryParser.strictQueryStringSeparator;
+    savedPerformDeepMunge = RequestUtils.performDeepMunge;
+    savedStrictFreshness = CacheConfig.strictFreshness;
+    hadDeprecator = "actionDispatch" in BaseRailtie.deprecators;
+  });
+
+  afterEach(() => {
+    Trailtie.config["actionDispatch"] = savedConfig;
+    HttpURL.tldLength = savedTldLength;
+    QueryParser.strictQueryStringSeparator = savedStrictQuery;
+    RequestUtils.performDeepMunge = savedPerformDeepMunge;
+    CacheConfig.strictFreshness = savedStrictFreshness;
+    if (!hadDeprecator) delete BaseRailtie.deprecators["actionDispatch"];
+  });
+
   it("registers itself with the Railtie registry", () => {
     expect(BaseRailtie.subclasses).toContain(Trailtie);
   });
@@ -43,10 +68,5 @@ describe("ActionDispatch::Trailtie", () => {
     expect(RequestUtils.performDeepMunge).toBe(false);
     expect(CacheConfig.strictFreshness).toBe(true);
     expect(BaseRailtie.deprecators["actionDispatch"]).toBeDefined();
-
-    HttpURL.tldLength = 1;
-    QueryParser.strictQueryStringSeparator = null;
-    RequestUtils.performDeepMunge = true;
-    CacheConfig.strictFreshness = false;
   });
 });

--- a/packages/actionpack/src/action-dispatch/trailtie.test.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.test.ts
@@ -18,6 +18,7 @@ describe("ActionDispatch::Trailtie", () => {
   let savedPerformDeepMunge: boolean;
   let savedStrictFreshness: boolean;
   let hadDeprecator: boolean;
+  let savedDeprecator: (typeof BaseRailtie.deprecators)[string];
 
   beforeEach(() => {
     savedConfig = structuredClone(cfg());
@@ -26,6 +27,7 @@ describe("ActionDispatch::Trailtie", () => {
     savedPerformDeepMunge = RequestUtils.performDeepMunge;
     savedStrictFreshness = CacheConfig.strictFreshness;
     hadDeprecator = "actionDispatch" in BaseRailtie.deprecators;
+    savedDeprecator = BaseRailtie.deprecators["actionDispatch"];
   });
 
   afterEach(() => {
@@ -34,7 +36,8 @@ describe("ActionDispatch::Trailtie", () => {
     QueryParser.strictQueryStringSeparator = savedStrictQuery;
     RequestUtils.performDeepMunge = savedPerformDeepMunge;
     CacheConfig.strictFreshness = savedStrictFreshness;
-    if (!hadDeprecator) delete BaseRailtie.deprecators["actionDispatch"];
+    if (hadDeprecator) BaseRailtie.deprecators["actionDispatch"] = savedDeprecator;
+    else delete BaseRailtie.deprecators["actionDispatch"];
   });
 
   it("registers itself with the Railtie registry", () => {

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -59,7 +59,7 @@ export interface ActionDispatchConfig {
    * messages rotation-configuration port has not landed yet, so this slot
    * is typed `unknown` and defaults to `null` until that arrives.
    */
-  cookiesRotations: unknown;
+  cookiesRotations: unknown | null;
   alwaysWriteCookie?: boolean;
 }
 

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -1,0 +1,122 @@
+/**
+ * Trailtie — initialization hooks for ActionDispatch.
+ *
+ * Mirrors: ActionDispatch::Railtie < Rails::Railtie (railtie.rb)
+ *
+ * Registers the ActionDispatch config namespace and two initializers:
+ *   - `action_dispatch.deprecator` — installs the ActionDispatch deprecator
+ *     into the shared `deprecators` registry.
+ *   - `action_dispatch.configure` — copies `config.action_dispatch.*` values
+ *     onto the framework-level holders (URL, QueryParser, Request::Utils,
+ *     Cache::Request, ...).
+ *
+ * Unported targets (ExceptionWrapper.rescue_responses/_templates,
+ * CookieJar.always_write_cookie, Mapper.route_source_locations,
+ * Response.default_charset/_headers, Request.ignore_accept_header,
+ * ParamBuilder.ignore_leading_brackets, ActionDispatch.test_app) are left
+ * out of the configure body and will wire in as those classes gain the
+ * matching surface — see actionpack-100-percent.md.
+ */
+import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import { deprecator } from "./deprecator.js";
+import { X_REQUEST_ID } from "./constants.js";
+import { URL as HttpURL } from "./http/url.js";
+import { QueryParser } from "./http/query-parser.js";
+import { RequestUtils } from "./request/utils.js";
+import { CacheConfig } from "./http/cache.js";
+
+/**
+ * Shape of `config.actionDispatch` — mirrors the
+ * `ActiveSupport::OrderedOptions` block at the top of Rails' railtie.rb.
+ */
+export interface ActionDispatchConfig {
+  xSendfileHeader: string | null;
+  ipSpoofingCheck: boolean;
+  showExceptions: "all" | "rescuable" | "none";
+  tldLength: number;
+  ignoreAcceptHeader: boolean;
+  rescueTemplates: Record<string, string>;
+  rescueResponses: Record<string, number | string>;
+  defaultCharset: string | null;
+  rackCache: boolean;
+  httpAuthSalt: string;
+  signedCookieSalt: string;
+  encryptedCookieSalt: string;
+  encryptedSignedCookieSalt: string;
+  authenticatedEncryptedCookieSalt: string;
+  useAuthenticatedCookieEncryption: boolean;
+  useCookiesWithMetadata: boolean;
+  performDeepMunge: boolean;
+  requestIdHeader: string;
+  logRescuedResponses: boolean;
+  debugExceptionLogLevel: "debug" | "info" | "warn" | "error" | "fatal";
+  strictFreshness: boolean;
+  ignoreLeadingBrackets: boolean | null;
+  strictQueryStringSeparator: boolean | null;
+  defaultHeaders: Record<string, string>;
+  /**
+   * Mirrors `ActiveSupport::Messages::RotationConfiguration.new`. The
+   * messages rotation-configuration port has not landed yet, so this slot
+   * is typed `unknown` and defaults to `null` until that arrives.
+   */
+  cookiesRotations: unknown;
+  alwaysWriteCookie?: boolean;
+}
+
+function defaultActionDispatchConfig(): ActionDispatchConfig {
+  return {
+    xSendfileHeader: null,
+    ipSpoofingCheck: true,
+    showExceptions: "all",
+    tldLength: 1,
+    ignoreAcceptHeader: false,
+    rescueTemplates: {},
+    rescueResponses: {},
+    defaultCharset: null,
+    rackCache: false,
+    httpAuthSalt: "http authentication",
+    signedCookieSalt: "signed cookie",
+    encryptedCookieSalt: "encrypted cookie",
+    encryptedSignedCookieSalt: "signed encrypted cookie",
+    authenticatedEncryptedCookieSalt: "authenticated encrypted cookie",
+    useAuthenticatedCookieEncryption: false,
+    useCookiesWithMetadata: false,
+    performDeepMunge: true,
+    requestIdHeader: X_REQUEST_ID,
+    logRescuedResponses: true,
+    debugExceptionLogLevel: "fatal",
+    strictFreshness: false,
+    ignoreLeadingBrackets: null,
+    strictQueryStringSeparator: null,
+    defaultHeaders: {
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Content-Type-Options": "nosniff",
+      "X-Download-Options": "noopen",
+      "X-Permitted-Cross-Domain-Policies": "none",
+      "Referrer-Policy": "strict-origin-when-cross-origin",
+    },
+    cookiesRotations: null,
+  };
+}
+
+export class Trailtie extends BaseRailtie {
+  static {
+    registerRailtie(this);
+
+    this.config["actionDispatch"] = defaultActionDispatchConfig();
+
+    this.initializer("action_dispatch.deprecator", () => {
+      BaseRailtie.deprecators["actionDispatch"] = deprecator;
+    });
+
+    this.initializer("action_dispatch.configure", () => {
+      const cfg = this.config["actionDispatch"] as ActionDispatchConfig;
+
+      HttpURL.tldLength = cfg.tldLength;
+      QueryParser.strictQueryStringSeparator = cfg.strictQueryStringSeparator;
+      RequestUtils.performDeepMunge = cfg.performDeepMunge;
+      CacheConfig.strictFreshness = cfg.strictFreshness;
+    });
+  }
+}

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -6,8 +6,9 @@
  * Registers the ActionDispatch config namespace and two initializers:
  *   - `action_dispatch.deprecator` — installs the ActionDispatch deprecator
  *     into the shared `deprecators` registry.
- *   - `action_dispatch.configure` — copies `config.action_dispatch.*` values
- *     onto the framework-level holders (URL, QueryParser, Request::Utils,
+ *   - `action_dispatch.configure` — copies `config.actionDispatch.*` values
+ *     (trails camelCase mirror of Rails' `config.action_dispatch.*`) onto
+ *     the framework-level holders (URL, QueryParser, Request::Utils,
  *     Cache::Request, ...).
  *
  * Unported targets (ExceptionWrapper.rescue_responses/_templates,


### PR DESCRIPTION
## Summary
- Ports the top-level `action_dispatch/railtie.rb` as `packages/actionpack/src/action-dispatch/trailtie.ts`, following the `trailtie.ts` naming convention.
- Seeds Rails-compatible defaults on `Trailtie.config.actionDispatch` (matches every key from the Rails `OrderedOptions` block), and registers the two named initializers: `action_dispatch.deprecator` and `action_dispatch.configure`.
- The configure body wires the slots whose targets are already ported: `Http::URL.tldLength`, `QueryParser.strictQueryStringSeparator`, `Request::Utils.performDeepMunge`, `Cache::Request.strictFreshness`. Re-exports `Trailtie` + `ActionDispatchConfig` from the action-dispatch barrel.

## Follow-ups
Remaining Rails wirings deferred until their targets land:
- `ExceptionWrapper.rescue_responses` / `rescue_templates`
- `CookieJar.always_write_cookie`
- `Mapper.route_source_locations`
- `Response.default_charset` / `default_headers`
- `Request.ignore_accept_header`
- `ParamBuilder.ignore_leading_brackets`
- `ActionDispatch.test_app`
- `cookies_rotations` (needs `ActiveSupport::Messages::RotationConfiguration` port)

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/trailtie.test.ts`
- [x] `pnpm build` (tsc --build) clean