### PR TITLE
test(activerecord): TM phase 5 — defineSchema for migration.test.ts

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1182,8 +1182,8 @@ describe("Rails-guided: migrations", () => {
 describe("MigrationTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapterWithSchema();
+  beforeEach(() => {
+    adapter = freshAdapter();
   });
 
   it("migration version matches component version", () => {
@@ -1193,13 +1193,18 @@ describe("MigrationTest", () => {
   });
 
   it("create table raises if already exists", async () => {
+    // Body-level Rails fidelity (second createTable should raise per
+    // activerecord/test/cases/migration_test.rb:158) is blocked by the
+    // shared test adapter, which rewrites every CREATE TABLE into
+    // CREATE TABLE IF NOT EXISTS (test-adapter.ts:812-814). Until that
+    // rewrite is gated, this stays a smoke test for create-then-insert.
+    const adp = await freshAdapterWithSchema();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adapter;
+        this.adapter = adp;
       }
     }
-    // Creating a record works fine
     const post = await Post.create({ title: "first" });
     expect(post.id).toBeDefined();
   });
@@ -1230,10 +1235,11 @@ describe("MigrationTest", () => {
   });
 
   it("instance based migration up", async () => {
+    const adp = await freshAdapterWithSchema();
     class Event extends Base {
       static {
         this.attribute("name", "string");
-        this.adapter = adapter;
+        this.adapter = adp;
       }
     }
     const event = await Event.create({ name: "launch" });
@@ -1242,10 +1248,11 @@ describe("MigrationTest", () => {
   });
 
   it("instance based migration down", async () => {
+    const adp = await freshAdapterWithSchema();
     class Event extends Base {
       static {
         this.attribute("name", "string");
-        this.adapter = adapter;
+        this.adapter = adp;
       }
     }
     const event = await Event.create({ name: "launch" });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -15,6 +15,22 @@ import { Migration } from "./migration.js";
 import { Logger } from "@blazetrails/activesupport";
 import { TableDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import { Schema } from "./schema.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
+
+// Tables some tests rely on existing before any migration runs. Under
+// AR_NO_AUTO_SCHEMA=1 the test adapter no longer auto-creates missing
+// tables, so we materialize them up front via defineSchema().
+const TEST_SCHEMA = {
+  people: { name: "string" },
+  posts: { title: "string" },
+  events: { name: "string" },
+} as const;
+
+async function freshAdapterWithSchema(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 function freshContext(): { adapter: DatabaseAdapter; ctx: MigrationContext } {
   const adapter = createTestAdapter();
@@ -888,7 +904,7 @@ describe("Migration DDL (extended)", () => {
   });
 
   it("reversible renameTable reverses correctly", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapterWithSchema();
     class RenameUsers extends Migration {
       async change() {
         await this.renameTable("people", "users");
@@ -1045,7 +1061,8 @@ describe("Rails-guided: migrations", () => {
     expect(await adapter.execute(`SELECT * FROM "widgets"`)).toHaveLength(1);
 
     await m.run(adapter, "down");
-    expect(await adapter.execute(`SELECT * FROM "widgets"`)).toHaveLength(0);
+    // Auto-reverse of createTable is dropTable, so widgets no longer exists.
+    expect(await m.schema.tableExists("widgets")).toBe(false);
   });
 
   it("reversible removeColumn with type auto-reverses", async () => {
@@ -1165,8 +1182,8 @@ describe("Rails-guided: migrations", () => {
 describe("MigrationTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapterWithSchema();
   });
 
   it("migration version matches component version", () => {


### PR DESCRIPTION
## Summary

Migrates `migration.test.ts` to use `defineSchema()` so it passes under `AR_NO_AUTO_SCHEMA=1`.

- Adds `TEST_SCHEMA` (people / posts / events) + async `freshAdapterWithSchema()` helper.
- Switches the 4 tests that depended on the test adapter auto-creating missing tables to the schema-backed helper:
  - `reversible renameTable reverses correctly`
  - `create table raises if already exists`
  - `instance based migration up`
  - `instance based migration down`
- Fixes `reversible migration change method auto-reverses`: the post-down assertion was `SELECT * FROM widgets → toHaveLength(0)`, which only worked because auto-schema re-created the just-dropped table. Replaced with `tableExists("widgets") === false`, which is what the test name actually asserts.

Most of the file's tests build tables programmatically via migrations, so they continue to use the existing sync `freshAdapter()` unchanged.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/migration.test.ts` → 181 passed / 11 skipped (was 5 failed prior).
- `pnpm vitest run packages/activerecord/src/migration.test.ts` → 181 passed / 11 skipped.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.

## Test plan

- [x] Tests pass under AR_NO_AUTO_SCHEMA=1
- [x] Tests pass without AR_NO_AUTO_SCHEMA
- [x] No test names renamed
- [x] Audit script clean for this file