### PR TITLE
test(activerecord): batch 25 — upgrade size/empty stubs in has-many-associations

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -996,6 +996,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#empty?
    */
   async isEmpty(): Promise<boolean> {
+    if (this._targetLoaded) return this._target.length === 0;
     return (await this.count()) === 0;
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -998,6 +998,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async isEmpty(): Promise<boolean> {
     if (this._targetLoaded) return this._target.length === 0;
     if (this._target.length > 0) return false;
+    // Through associations currently load the full target in #exists; fall
+    // back to a COUNT query so isEmpty stays non-loading. Mirrors Rails'
+    // intent that `empty?` not materialize the collection when unloaded.
+    if (this._isThrough) return (await this.count()) === 0;
     return !(await this.exists());
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -998,9 +998,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async isEmpty(): Promise<boolean> {
     if (this._targetLoaded) return this._target.length === 0;
     if (this._target.length > 0) return false;
-    // Through associations currently load the full target in #exists; fall
-    // back to a COUNT query so isEmpty stays non-loading. Mirrors Rails'
-    // intent that `empty?` not materialize the collection when unloaded.
+    // Through associations: #exists always loads the full target, so prefer
+    // count() which routes through AssociationScope as a SQL COUNT for the
+    // common shapes (loadHasMany fallback still loads for the rest).
     if (this._isThrough) return (await this.count()) === 0;
     return !(await this.exists());
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -997,7 +997,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   async isEmpty(): Promise<boolean> {
     if (this._targetLoaded) return this._target.length === 0;
-    return (await this.count()) === 0;
+    if (this._target.length > 0) return false;
+    return !(await this.exists());
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -22,6 +22,7 @@ import {
   isAssociationCached,
 } from "../associations.js";
 import { DeleteRestrictionError } from "./errors.js";
+import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
@@ -1715,19 +1716,12 @@ describe("HasManyAssociationsTest", () => {
     const proxy = association(author, "sizeUnPosts");
     const proxy2 = association(author2, "sizeUnPosts");
     expect(proxy.loaded).toBe(false);
-    const sqlQueries: string[] = [];
-    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
-      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
-    });
-    try {
+    await assertQueriesCount(1, false, async () => {
       expect(await proxy.size()).toBe(1);
-      expect(sqlQueries).toHaveLength(1);
-      sqlQueries.length = 0;
+    });
+    await assertQueriesCount(1, false, async () => {
       expect(await proxy2.size()).toBe(0);
-      expect(sqlQueries).toHaveLength(1);
-    } finally {
-      Notifications.unsubscribe(sub);
-    }
+    });
     expect(proxy.loaded).toBe(false);
   });
 
@@ -1760,17 +1754,10 @@ describe("HasManyAssociationsTest", () => {
     await proxy2.load();
     expect(proxy.loaded).toBe(true);
     expect(proxy2.loaded).toBe(true);
-    const sqlQueries: string[] = [];
-    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
-      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
-    });
-    try {
+    await assertNoQueries(false, async () => {
       expect(await proxy.size()).toBe(1);
       expect(await proxy2.size()).toBe(0);
-    } finally {
-      Notifications.unsubscribe(sub);
-    }
-    expect(sqlQueries).toHaveLength(0);
+    });
   });
 
   it("calling empty on an association that has not been loaded performs a query", async () => {
@@ -1799,19 +1786,12 @@ describe("HasManyAssociationsTest", () => {
     const proxy = association(author, "emptyUnPosts");
     const proxy2 = association(author2, "emptyUnPosts");
     expect(proxy.loaded).toBe(false);
-    const sqlQueries: string[] = [];
-    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
-      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
-    });
-    try {
+    await assertQueriesCount(1, false, async () => {
       expect(await proxy.isEmpty()).toBe(false);
-      expect(sqlQueries).toHaveLength(1);
-      sqlQueries.length = 0;
+    });
+    await assertQueriesCount(1, false, async () => {
       expect(await proxy2.isEmpty()).toBe(true);
-      expect(sqlQueries).toHaveLength(1);
-    } finally {
-      Notifications.unsubscribe(sub);
-    }
+    });
     expect(proxy.loaded).toBe(false);
   });
 
@@ -1844,17 +1824,10 @@ describe("HasManyAssociationsTest", () => {
     await proxy2.load();
     expect(proxy.loaded).toBe(true);
     expect(proxy2.loaded).toBe(true);
-    const sqlQueries: string[] = [];
-    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
-      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
-    });
-    try {
+    await assertNoQueries(false, async () => {
       expect(await proxy.isEmpty()).toBe(false);
       expect(await proxy2.isEmpty()).toBe(true);
-    } finally {
-      Notifications.unsubscribe(sub);
-    }
-    expect(sqlQueries).toHaveLength(0);
+    });
   });
 
   it("calling many should return false if none or one", async () => {

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1711,7 +1711,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel("SizeUnPost", SizeUnPost);
     const author = await SizeUnAuthor.create({ name: "Alice" });
     await SizeUnPost.create({ author_id: author.id, title: "A" });
+    const author2 = await SizeUnAuthor.create({ name: "Bob" });
     const proxy = association(author, "sizeUnPosts");
+    const proxy2 = association(author2, "sizeUnPosts");
     expect(proxy.loaded).toBe(false);
     const sqlQueries: string[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: any) => {
@@ -1719,10 +1721,13 @@ describe("HasManyAssociationsTest", () => {
     });
     try {
       expect(await proxy.size()).toBe(1);
+      expect(sqlQueries).toHaveLength(1);
+      sqlQueries.length = 0;
+      expect(await proxy2.size()).toBe(0);
+      expect(sqlQueries).toHaveLength(1);
     } finally {
       Notifications.unsubscribe(sub);
     }
-    expect(sqlQueries.length).toBeGreaterThan(0);
     expect(proxy.loaded).toBe(false);
   });
 
@@ -1748,15 +1753,20 @@ describe("HasManyAssociationsTest", () => {
     registerModel("SizeLdPost", SizeLdPost);
     const author = await SizeLdAuthor.create({ name: "Alice" });
     await SizeLdPost.create({ author_id: author.id, title: "A" });
+    const author2 = await SizeLdAuthor.create({ name: "Bob" });
     const proxy = association(author, "sizeLdPosts");
+    const proxy2 = association(author2, "sizeLdPosts");
     await proxy.load();
+    await proxy2.load();
     expect(proxy.loaded).toBe(true);
+    expect(proxy2.loaded).toBe(true);
     const sqlQueries: string[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: any) => {
       if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
     });
     try {
       expect(await proxy.size()).toBe(1);
+      expect(await proxy2.size()).toBe(0);
     } finally {
       Notifications.unsubscribe(sub);
     }
@@ -1784,18 +1794,24 @@ describe("HasManyAssociationsTest", () => {
     registerModel("EmptyUnAuthor", EmptyUnAuthor);
     registerModel("EmptyUnPost", EmptyUnPost);
     const author = await EmptyUnAuthor.create({ name: "Alice" });
+    await EmptyUnPost.create({ author_id: author.id, title: "A" });
+    const author2 = await EmptyUnAuthor.create({ name: "Bob" });
     const proxy = association(author, "emptyUnPosts");
+    const proxy2 = association(author2, "emptyUnPosts");
     expect(proxy.loaded).toBe(false);
     const sqlQueries: string[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: any) => {
       if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
     });
     try {
-      expect(await proxy.isEmpty()).toBe(true);
+      expect(await proxy.isEmpty()).toBe(false);
+      expect(sqlQueries).toHaveLength(1);
+      sqlQueries.length = 0;
+      expect(await proxy2.isEmpty()).toBe(true);
+      expect(sqlQueries).toHaveLength(1);
     } finally {
       Notifications.unsubscribe(sub);
     }
-    expect(sqlQueries.length).toBeGreaterThan(0);
     expect(proxy.loaded).toBe(false);
   });
 
@@ -1821,15 +1837,20 @@ describe("HasManyAssociationsTest", () => {
     registerModel("EmptyLdPost", EmptyLdPost);
     const author = await EmptyLdAuthor.create({ name: "Alice" });
     await EmptyLdPost.create({ author_id: author.id, title: "A" });
+    const author2 = await EmptyLdAuthor.create({ name: "Bob" });
     const proxy = association(author, "emptyLdPosts");
+    const proxy2 = association(author2, "emptyLdPosts");
     await proxy.load();
+    await proxy2.load();
     expect(proxy.loaded).toBe(true);
+    expect(proxy2.loaded).toBe(true);
     const sqlQueries: string[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: any) => {
       if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
     });
     try {
       expect(await proxy.isEmpty()).toBe(false);
+      expect(await proxy2.isEmpty()).toBe(true);
     } finally {
       Notifications.unsubscribe(sub);
     }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1690,104 +1690,150 @@ describe("HasManyAssociationsTest", () => {
   // -- Calling size/empty --
 
   it("calling size on an association that has not been loaded performs a query", async () => {
-    class Author extends Base {
+    class SizeUnAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class SizeUnPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(SizeUnAuthor, "sizeUnPosts", {
+      className: "SizeUnPost",
       foreignKey: "author_id",
     });
-    expect(posts.length).toBe(1);
+    registerModel("SizeUnAuthor", SizeUnAuthor);
+    registerModel("SizeUnPost", SizeUnPost);
+    const author = await SizeUnAuthor.create({ name: "Alice" });
+    await SizeUnPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "sizeUnPosts");
+    expect(proxy.loaded).toBe(false);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.size()).toBe(1);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries.length).toBeGreaterThan(0);
+    expect(proxy.loaded).toBe(false);
   });
 
   it("calling size on an association that has been loaded does not perform query", async () => {
-    class Author extends Base {
+    class SizeLdAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class SizeLdPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(SizeLdAuthor, "sizeLdPosts", {
+      className: "SizeLdPost",
       foreignKey: "author_id",
     });
-    expect(posts.length).toBe(1);
-    // Second access: still same length
-    expect(posts.length).toBe(1);
+    registerModel("SizeLdAuthor", SizeLdAuthor);
+    registerModel("SizeLdPost", SizeLdPost);
+    const author = await SizeLdAuthor.create({ name: "Alice" });
+    await SizeLdPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "sizeLdPosts");
+    await proxy.load();
+    expect(proxy.loaded).toBe(true);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.size()).toBe(1);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries).toHaveLength(0);
   });
 
   it("calling empty on an association that has not been loaded performs a query", async () => {
-    class Author extends Base {
+    class EmptyUnAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class EmptyUnPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(EmptyUnAuthor, "emptyUnPosts", {
+      className: "EmptyUnPost",
       foreignKey: "author_id",
     });
-    expect(posts.length === 0).toBe(true);
+    registerModel("EmptyUnAuthor", EmptyUnAuthor);
+    registerModel("EmptyUnPost", EmptyUnPost);
+    const author = await EmptyUnAuthor.create({ name: "Alice" });
+    const proxy = association(author, "emptyUnPosts");
+    expect(proxy.loaded).toBe(false);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.isEmpty()).toBe(true);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries.length).toBeGreaterThan(0);
+    expect(proxy.loaded).toBe(false);
   });
 
   it("calling empty on an association that has been loaded does not performs query", async () => {
-    class Author extends Base {
+    class EmptyLdAuthor extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    class Post extends Base {
+    class EmptyLdPost extends Base {
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
+    Associations.hasMany.call(EmptyLdAuthor, "emptyLdPosts", {
+      className: "EmptyLdPost",
       foreignKey: "author_id",
     });
-    expect(posts.length > 0).toBe(true);
+    registerModel("EmptyLdAuthor", EmptyLdAuthor);
+    registerModel("EmptyLdPost", EmptyLdPost);
+    const author = await EmptyLdAuthor.create({ name: "Alice" });
+    await EmptyLdPost.create({ author_id: author.id, title: "A" });
+    const proxy = association(author, "emptyLdPosts");
+    await proxy.load();
+    expect(proxy.loaded).toBe(true);
+    const sqlQueries: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: any) => {
+      if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
+    });
+    try {
+      expect(await proxy.isEmpty()).toBe(false);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(sqlQueries).toHaveLength(0);
   });
 
   it("calling many should return false if none or one", async () => {


### PR DESCRIPTION
## Summary

Batch 25 partial — upgrades the four `size`/`empty` stubs in `has-many-associations.test.ts` (lines ~1691–1791) from trivial `loadHasMany.length` assertions to real `CollectionProxy.size()`/`isEmpty()` calls with Notifications-based SQL-query-count assertions, matching the Rails behavioural contract for loaded vs unloaded associations.

Also fixes `CollectionProxy#isEmpty` to short-circuit when the target is already loaded — previously it always issued a COUNT query, which broke the "does not perform query" contract. Mirrors Rails' `CollectionAssociation#empty?` (`loaded? ? size.zero? : !exists?`).

## Scope notes

Originally batched per the plan with three other items; verified against the current tree:

- "preloads model with query_constraints by explicitly configured fk and pk" — **already shipped**; full body at `associations.test.ts:2640`.
- `reload with query cache` test bodies — **already shipped**; bodies at `has-many-associations.test.ts:3648` and `:3681`.
- Extension test bodies — already shipped in #1778.

That leaves only the size/empty upgrades from the original batch as in-scope here. Remaining Batch 25 items (LoaderQuery.hashKey adapter identity; `Relation#includes!`/`references!` infra) are independent and can land as follow-ups.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts -t "calling size|calling empty"` — 4 passed
- [x] `pnpm typecheck`