### PR TITLE
feat(actionpack): port ActionDispatch::ServerTiming middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -98,6 +98,7 @@ export {
 export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
 export { AssumeSSL } from "./middleware/assume-ssl.js";
 export { Callbacks } from "./middleware/callbacks.js";
+export { ServerTiming } from "./middleware/server-timing.js";
 export {
   Executor,
   type ExecutorLike,

--- a/packages/actionpack/src/action-dispatch/middleware/server-timing.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/server-timing.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import { bodyFromString } from "@blazetrails/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { ServerTiming } from "./server-timing.js";
+import { SERVER_TIMING } from "../constants.js";
+
+afterEach(() => {
+  ServerTiming.unsubscribe();
+});
+
+describe("ServerTimingTest", () => {
+  it("server timing header is included in the response", async () => {
+    const inner = async (_env: RackEnv): Promise<RackResponse> => {
+      await Notifications.instrumentAsync("custom.event", {}, async () => {});
+      return [200, {}, bodyFromString("")];
+    };
+    const mw = new ServerTiming(inner);
+    const [, headers] = await mw.call({});
+    expect(headers[SERVER_TIMING]).toMatch(/custom\.event;dur=\d/);
+  });
+
+  it("includes custom active support events duration", async () => {
+    const inner = async (_env: RackEnv): Promise<RackResponse> => {
+      await Notifications.instrumentAsync("custom.event", {}, async () => {});
+      return [200, {}, bodyFromString("")];
+    };
+    const mw = new ServerTiming(inner);
+    const [, headers] = await mw.call({});
+    expect(headers[SERVER_TIMING]).toMatch(/custom\.event;dur=\w+/);
+  });
+
+  it("events are tracked by async context", async () => {
+    const inner = async (env: RackEnv): Promise<RackResponse> => {
+      const proc = env["action_dispatch.test"] as () => Promise<void>;
+      await proc();
+      return [200, {}, bodyFromString("")];
+    };
+    const mw = new ServerTiming(inner);
+
+    const r1 = mw.call({
+      "action_dispatch.test": async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      },
+    });
+    const r2 = mw.call({
+      "action_dispatch.test": async () => {
+        await Notifications.instrumentAsync("custom.event", {}, async () => {});
+      },
+    });
+
+    const [[, h1], [, h2]] = await Promise.all([r1, r2]);
+    expect(h2[SERVER_TIMING]).toMatch(/custom\.event;dur=\w+/);
+    expect(h1[SERVER_TIMING] ?? "").not.toMatch(/custom\.event;dur=\w+/);
+  });
+
+  it("does not overwrite existing header values", async () => {
+    const inner = async (_env: RackEnv): Promise<RackResponse> => {
+      await Notifications.instrumentAsync("custom.event", {}, async () => {});
+      return [200, { [SERVER_TIMING]: 'entry;desc="description"' }, bodyFromString("")];
+    };
+    const mw = new ServerTiming(inner);
+    const [, headers] = await mw.call({});
+    expect(headers[SERVER_TIMING]).toMatch(/entry;desc="description"/);
+    expect(headers[SERVER_TIMING]).toMatch(/custom\.event;dur=\w+/);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
@@ -16,18 +16,13 @@ import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { SERVER_TIMING } from "../constants.js";
 
 /** @internal */
-class Subscriber {
+export class Subscriber {
   private static _instance: Subscriber | null = null;
   private _subscriber: NotificationSubscriber | null = null;
   private _context: AsyncContext<Event[]> | null = null;
 
   static instance(): Subscriber {
     return (this._instance ??= new Subscriber());
-  }
-
-  /** @internal */
-  static resetInstance(): void {
-    this._instance = null;
   }
 
   private _events(): AsyncContext<Event[]> {
@@ -58,6 +53,8 @@ class Subscriber {
 }
 
 export class ServerTiming {
+  static Subscriber = Subscriber;
+
   private app: RackApp;
   private subscriber: Subscriber;
 
@@ -89,7 +86,7 @@ export class ServerTiming {
     }
 
     const existing = headers[SERVER_TIMING];
-    if (existing != null && existing !== "") {
+    if (existing != null && existing.trim() !== "") {
       headerInfo.unshift(existing);
     }
     headers[SERVER_TIMING] = headerInfo.join(", ");

--- a/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
@@ -9,6 +9,7 @@ import {
   Notifications,
   getAsyncContext,
   type AsyncContext,
+  type AsyncContextAdapter,
   type NotificationSubscriber,
   type NotificationEvent as Event,
 } from "@blazetrails/activesupport";
@@ -20,13 +21,19 @@ export class Subscriber {
   private static _instance: Subscriber | null = null;
   private _subscriber: NotificationSubscriber | null = null;
   private _context: AsyncContext<Event[]> | null = null;
+  private _contextAdapter: AsyncContextAdapter | null = null;
 
   static instance(): Subscriber {
     return (this._instance ??= new Subscriber());
   }
 
   private _events(): AsyncContext<Event[]> {
-    return (this._context ??= getAsyncContext().create<Event[]>());
+    const adapter = getAsyncContext();
+    if (!this._context || this._contextAdapter !== adapter) {
+      this._contextAdapter = adapter;
+      this._context = adapter.create<Event[]>();
+    }
+    return this._context;
   }
 
   call(event: Event): void {

--- a/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/server-timing.ts
@@ -1,0 +1,99 @@
+/**
+ * ActionDispatch::ServerTiming
+ *
+ * Collects ActiveSupport::Notifications events fired during a request and
+ * exposes their durations via the `Server-Timing` response header.
+ */
+
+import {
+  Notifications,
+  getAsyncContext,
+  type AsyncContext,
+  type NotificationSubscriber,
+  type NotificationEvent as Event,
+} from "@blazetrails/activesupport";
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+import { SERVER_TIMING } from "../constants.js";
+
+/** @internal */
+class Subscriber {
+  private static _instance: Subscriber | null = null;
+  private _subscriber: NotificationSubscriber | null = null;
+  private _context: AsyncContext<Event[]> | null = null;
+
+  static instance(): Subscriber {
+    return (this._instance ??= new Subscriber());
+  }
+
+  /** @internal */
+  static resetInstance(): void {
+    this._instance = null;
+  }
+
+  private _events(): AsyncContext<Event[]> {
+    return (this._context ??= getAsyncContext().create<Event[]>());
+  }
+
+  call(event: Event): void {
+    const events = this._events().getStore();
+    if (events) events.push(event);
+  }
+
+  async collectEvents(block: () => Promise<void>): Promise<Event[]> {
+    const events: Event[] = [];
+    await this._events().run(events, block);
+    return events;
+  }
+
+  ensureSubscribed(): void {
+    this._subscriber ??= Notifications.subscribe(/^[^!]/, (e) => this.call(e));
+  }
+
+  unsubscribe(): void {
+    if (this._subscriber) {
+      Notifications.unsubscribe(this._subscriber);
+      this._subscriber = null;
+    }
+  }
+}
+
+export class ServerTiming {
+  private app: RackApp;
+  private subscriber: Subscriber;
+
+  static unsubscribe(): void {
+    Subscriber.instance().unsubscribe();
+  }
+
+  constructor(app: RackApp) {
+    this.app = app;
+    this.subscriber = Subscriber.instance();
+    this.subscriber.ensureSubscribed();
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    let response: RackResponse | undefined;
+    const events = await this.subscriber.collectEvents(async () => {
+      response = await this.app(env);
+    });
+
+    const headers = response![1];
+
+    const byName = new Map<string, number>();
+    for (const event of events) {
+      byName.set(event.name, (byName.get(event.name) ?? 0) + event.duration);
+    }
+    const headerInfo: string[] = [];
+    for (const [name, duration] of byName) {
+      headerInfo.push(`${name};dur=${duration.toFixed(2)}`);
+    }
+
+    const existing = headers[SERVER_TIMING];
+    if (existing != null && existing !== "") {
+      headerInfo.unshift(existing);
+    }
+    headers[SERVER_TIMING] = headerInfo.join(", ");
+
+    return response!;
+  }
+}


### PR DESCRIPTION
## Summary
- Ports `ActionDispatch::ServerTiming` (`vendor/rails/actionpack/lib/action_dispatch/middleware/server_timing.rb`) to `packages/actionpack/src/action-dispatch/middleware/server-timing.ts`.
- A module-singleton `Subscriber` subscribes once (via `Notifications.subscribe(/^[^!]/, …)`) and accumulates events into a per-request `AsyncContext<Event[]>` slot — the TS equivalent of Rails' `ActiveSupport::IsolatedExecutionState[KEY]` plumbing.
- The middleware groups collected events by name, formats `name;dur=ms`, and prepends any existing `Server-Timing` header value.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/server-timing.test.ts` (4 tests pass — header inclusion, custom AS::Notifications events, per-async-context isolation under concurrent requests, preservation of pre-existing header)
- [x] `pnpm lint`
- [x] `pnpm api:compare --package actionpack`