### PR TITLE
feat(activerecord): default-on belongs_to autosave + Rails-faithful FK zip

### DIFF
--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -56,9 +56,12 @@ export class BelongsTo extends SingularAssociation {
     if (options.default != null) {
       this.addDefaultCallbacks(model, reflection);
     }
-    if (options.autosave) {
-      addAutosaveAssociationCallbacks(model, reflection);
-    }
+    // Rails registers autosave callbacks for every belongs_to via
+    // AssociationBuilderExtension (autosave_association.rb:143-150) — not
+    // gated on the `autosave` option. The option only steers behavior inside
+    // save_belongs_to_association (validate flag, destroy of marked-for-
+    // destruction targets, save of changed-but-persisted records).
+    addAutosaveAssociationCallbacks(model, reflection);
   }
 
   static addCounterCacheCallbacks(model: any, reflection: any): void {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2489,6 +2489,48 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     expect(post.author_id).toBe(author.id);
   });
 
+  it("belongs_to autosave with mismatched composite FK/PK uses zip semantics", async () => {
+    // Rails autosave_association.rb:563 — `primary_key.zip(foreign_key)`.
+    // When the FK array is longer than the PK array, Ruby Array#zip
+    // drops the extra FK entries; the loop only writes the positions
+    // where both sides exist. No CompositePrimaryKeyMismatchError.
+    const adapter = freshAdapter();
+    class Parent extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Child extends Base {
+      static {
+        this.attribute("parent_id", "integer");
+        this.attribute("region", "string");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("ZipParent", Parent);
+    registerModel("ZipChild", Child);
+    // PK ["id"] (scalar) zipped against FK ["parent_id", "region"] →
+    // pairs [("id", "parent_id")]; the trailing "region" FK is dropped.
+    Associations.belongsTo.call(Child, "parent", {
+      primaryKey: "id",
+      foreignKey: ["parent_id", "region"],
+      className: "ZipParent",
+      autosave: true,
+    });
+
+    const parent = new Parent({ name: "P" });
+    const child = new Child({ label: "c", region: "us-west" });
+    cacheAssoc(child, "parent", parent);
+    await child.save();
+    expect(parent.isNewRecord()).toBe(false);
+    expect(child.parent_id).toBe(parent.id);
+    // Trailing FK "region" was dropped from the zip; the existing
+    // owner value must survive untouched (no overwrite to undefined/null).
+    expect(child.region).toBe("us-west");
+  });
+
   it("should not add the same callbacks multiple times for has one", async () => {
     const adapter = freshAdapter();
     let saveCount = 0;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2454,6 +2454,41 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     expect(post.author_id).toBe(author.id);
   });
 
+  it("default belongs_to saves new associated record and propagates the FK", async () => {
+    // Rails autosave_association.rb:548-572 — `elsif autosave != false`
+    // branch fires even when `autosave` is unset, so default belongs_to
+    // saves a new target during owner save and writes the parent PK back
+    // onto the owner's foreign key.
+    const adapter = freshAdapter();
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("Author", Author);
+    registerModel("Post", Post);
+    // No `autosave:` option — exercises the default-on registration path.
+    Associations.belongsTo.call(Post, "author", {
+      foreignKey: "author_id",
+      className: "Author",
+    });
+
+    const author = new Author({ name: "New Author" });
+    const post = new Post({ title: "Default autosave" });
+    cacheAssoc(post, "author", author);
+    await post.save();
+    expect(author.isNewRecord()).toBe(false);
+    expect(post.author_id).toBe(author.id);
+  });
+
   it("should not add the same callbacks multiple times for has one", async () => {
     const adapter = freshAdapter();
     let saveCount = 0;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2531,6 +2531,88 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     expect(child.region).toBe("us-west");
   });
 
+  it("default belongs_to runs validations on the new target via validate: !autosave", async () => {
+    // Rails autosave_association.rb:553 — `record.save(validate: !autosave)`.
+    // With autosave unset, `!autosave` is truthy → the target's validations
+    // run during owner save. A failing validation makes record.save return
+    // false; Rails' `saved if autosave` clamps the return to nil for the
+    // default branch, so the lambda doesn't `throw(:abort)` and the owner
+    // save still succeeds — the child simply remains unpersisted.
+    const adapter = freshAdapter();
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.validates("name", { presence: true });
+      }
+    }
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("DefaultAutosaveAuthor", Author);
+    registerModel("DefaultAutosavePost", Post);
+    Associations.belongsTo.call(Post, "author", {
+      foreignKey: "author_id",
+      className: "DefaultAutosaveAuthor",
+    });
+
+    const author = new Author({}); // name missing — validation fails
+    const post = new Post({ title: "ok" });
+    cacheAssoc(post, "author", author);
+    const saved = await post.save();
+    // Owner save succeeds — default branch swallows child failure.
+    expect(saved).toBe(true);
+    expect(post.isNewRecord()).toBe(false);
+    // Child remained unsaved because record.save(validate: true) failed.
+    expect(author.isNewRecord()).toBe(true);
+    // Owner.errors stays clean — propagateErrors is gated on autosave.
+    expect(post.errors.size).toBe(0);
+  });
+
+  it("belongs_to autosave with PK longer than FK skips trailing PK positions", async () => {
+    // Rails autosave_association.rb:563 — `primary_key.zip(foreign_key)`.
+    // When PK is longer, the trailing pairs have `foreign_key = nil`;
+    // Ruby's `self[nil] = id` would raise — our impl skips the nil-FK
+    // partner so a misconfigured pair doesn't blow up the owner save.
+    const adapter = freshAdapter();
+    class Parent extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Child extends Base {
+      static {
+        this.attribute("parent_id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("LongPkParent", Parent);
+    registerModel("LongPkChild", Child);
+    // Explicit composite PK ["id", "name"] zipped against scalar FK
+    // ["parent_id"] → only ("id", "parent_id") pairs; ("name", nil) drops.
+    Associations.belongsTo.call(Child, "parent", {
+      primaryKey: ["id", "name"],
+      foreignKey: "parent_id",
+      className: "LongPkParent",
+      autosave: true,
+    });
+
+    const parent = new Parent({ name: "P" });
+    const child = new Child({ label: "c" });
+    cacheAssoc(child, "parent", parent);
+    await child.save();
+    expect(parent.isNewRecord()).toBe(false);
+    expect(child.parent_id).toBe(parent.id);
+    // The dropped ("name", nil) pair didn't attempt to write — no throw,
+    // no spurious column write.
+  });
+
   it("should not add the same callbacks multiple times for has one", async () => {
     const adapter = freshAdapter();
     let saveCount = 0;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2613,6 +2613,45 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // no spurious column write.
   });
 
+  it("default belongs_to populates inferred composite FK columns after autosave", async () => {
+    // Mirrors `BelongsToAssociation#foreignKeyNames` composite-PK
+    // inference: when the target has composite PK and no `foreignKey`
+    // option, the writer fills `${assoc}_${pk}` columns at assignment.
+    // After autosave, FK propagation must hit the same columns so a
+    // newly-saved parent's PK lands on the owner.
+    const adapter = freshAdapter();
+    class CompParent extends Base {
+      static {
+        this.primaryKey = ["region_id", "id"];
+        this.attribute("region_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class CompChild extends Base {
+      static {
+        this.attribute("comp_parent_region_id", "integer");
+        this.attribute("comp_parent_id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("CompParent", CompParent);
+    registerModel("CompChild", CompChild);
+    // No foreignKey/queryConstraints — exercises the composite-PK inference
+    // branch in _resolveBelongsToForeignKey.
+    Associations.belongsTo.call(CompChild, "compParent", { className: "CompParent" });
+
+    const parent = new CompParent({ region_id: 5, id: 11, name: "P" });
+    const child = new CompChild({ label: "c" });
+    cacheAssoc(child, "compParent", parent);
+    await child.save();
+    expect(parent.isNewRecord()).toBe(false);
+    expect(child.comp_parent_region_id).toBe(5);
+    expect(child.comp_parent_id).toBe(11);
+  });
+
   it("should not add the same callbacks multiple times for has one", async () => {
     const adapter = freshAdapter();
     let saveCount = 0;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -726,10 +726,15 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       _setAutosavingBelongsToFor(record, assoc, false);
     }
     if (!saved) {
-      propagateErrors(record, assocRecord, assoc.name);
       // Rails save_belongs_to_association:571 — `saved if autosave`. Only
-      // autosave==true propagates the failure to abort the owner save.
-      return autosave ? false : true;
+      // autosave==true propagates the failure to abort the owner save (and
+      // surfaces child errors via the validate_belongs_to_association path).
+      // Default belongs_to leaves owner.errors untouched on save failure.
+      if (autosave) {
+        propagateErrors(record, assocRecord, assoc.name);
+        return false;
+      }
+      return true;
     }
 
     const foreignKey = _resolveBelongsToForeignKey(assoc);
@@ -1038,10 +1043,16 @@ export async function saveBelongsToAssociation(
   this: AutosaveAssociationHost,
   reflection: any,
 ): Promise<boolean> {
+  // Mirror Rails: `Array(reflection.foreign_key)` (autosave_association.rb:
+  // 545/561). The reflection-resolved FK may differ from the raw option
+  // (e.g. query-constraints-derived composite columns), so forward it
+  // explicitly to override the options.foreignKey fallback.
+  const options = { ...(reflection.options ?? {}) };
+  if (reflection.foreignKey != null) options.foreignKey = reflection.foreignKey;
   return _autosaveBelongsTo(this as unknown as Base, {
     name: reflection.name,
     type: "belongsTo",
-    options: reflection.options ?? {},
+    options,
   });
 }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -671,6 +671,18 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   return true;
 }
 
+/**
+ * Resolve the foreign-key column(s) for a belongs_to association.
+ * Mirrors `Array(reflection.foreign_key)` shape — always returns a list.
+ *
+ * @internal
+ */
+function _resolveBelongsToForeignKey(assoc: AssociationDefinition): string[] {
+  const fk =
+    assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
+  return Array.isArray(fk) ? fk : [fk];
+}
+
 async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
   // Rails save_belongs_to_association:538 — skip when the loaded target is
@@ -683,29 +695,32 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
   if (typeof (assocRecord as any).isDestroyed === "function" && (assocRecord as any).isDestroyed())
     return true;
 
-  if (isMarkedForDestruction(assocRecord)) {
-    // Rails save_belongs_to_association:544-547 — when destroying the
-    // associated record, null out the FK on self first so the owner save
-    // doesn't keep a dangling reference.
-    const foreignKey =
-      assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
-    const fkList: string[] = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
+  const autosave = assoc.options.autosave;
+  // Rails save_belongs_to_association:548 — `elsif autosave != false`.
+  // Explicit `autosave: false` opts out entirely.
+  if (autosave === false) return true;
+
+  if (autosave && isMarkedForDestruction(assocRecord)) {
+    // Rails save_belongs_to_association:544-547 — destroy path is only
+    // reached when `autosave` is truthy; the destruction nulls the FK on
+    // self first so the owner save doesn't keep a dangling reference.
+    const fkList = _resolveBelongsToForeignKey(assoc);
     for (const key of fkList) record._writeAttribute(key, null);
     if (!assocRecord.isNewRecord()) await assocRecord.destroy();
     return true;
   }
+
   // Rails save_belongs_to_association:549 — `record.new_record? || (autosave && record.changed_for_autosave?)`.
-  // autosave is always true on this path (gated in autosaveAssociation).
   const beChangedForSave =
-    typeof (assocRecord as any).changedForAutosave === "function"
+    autosave &&
+    (typeof (assocRecord as any).changedForAutosave === "function"
       ? (assocRecord as any).changedForAutosave()
-      : !!(assocRecord as any).changed;
+      : !!(assocRecord as any).changed);
   if (assocRecord.isNewRecord() || beChangedForSave) {
     _setAutosavingBelongsToFor(record, assoc, true);
     try {
       // Rails save_belongs_to_association:553: `record.save(validate: !autosave)`.
-      // autosave is always true on this code path (gated in autosaveAssociation).
-      const saved = await assocRecord.save({ validate: false });
+      const saved = await assocRecord.save({ validate: !autosave });
       if (!saved) {
         propagateErrors(record, assocRecord, assoc.name);
         return false;
@@ -714,29 +729,20 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       _setAutosavingBelongsToFor(record, assoc, false);
     }
 
-    const foreignKey =
-      assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
-    const primaryKey =
+    const foreignKey = _resolveBelongsToForeignKey(assoc);
+    const rawPk =
       assoc.options.primaryKey ?? (assocRecord.constructor as typeof Base).primaryKey ?? "id";
-    if (Array.isArray(primaryKey) && Array.isArray(foreignKey)) {
-      if (primaryKey.length !== foreignKey.length) {
-        throw new CompositePrimaryKeyMismatchError(
-          (record.constructor as typeof Base).name,
-          assoc.name,
-        );
-      }
-      primaryKey.forEach((pk: string, i: number) => {
-        const pkValue = assocRecord._readAttribute(pk);
-        if (pkValue != null) record._writeAttribute((foreignKey as string[])[i], pkValue);
-      });
-    } else if (!Array.isArray(primaryKey) && !Array.isArray(foreignKey)) {
-      const pkValue = assocRecord._readAttribute(primaryKey);
-      if (pkValue != null) record._writeAttribute(foreignKey, pkValue);
-    } else {
-      throw new CompositePrimaryKeyMismatchError(
-        (record.constructor as typeof Base).name,
-        assoc.name,
-      );
+    const primaryKey = Array.isArray(rawPk) ? rawPk : [rawPk];
+    // Rails save_belongs_to_association:563: `primary_key.zip(foreign_key)`.
+    // Ruby's Array#zip drops trailing args when the argument is longer than
+    // the receiver, and pads with nil when the argument is shorter. Mirror
+    // that here so shape mismatches don't raise — they just don't write FK
+    // columns we have no PK source for (and vice versa).
+    for (let i = 0; i < primaryKey.length; i++) {
+      const fkCol = foreignKey[i];
+      if (fkCol == null) continue;
+      const pkValue = assocRecord._readAttribute(primaryKey[i]);
+      if (pkValue != null) record._writeAttribute(fkCol, pkValue);
     }
     // Rails save_belongs_to_association:559-568: `association.loaded!` only
     // fires inside the `if association.updated?` branch — after the FK write.

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -444,7 +444,10 @@ async function autosaveAssociation(record: Base, assoc: AssociationDefinition): 
   // short-circuits on a null target — no need for a dispatch-level gate.
   if (assoc.type === "hasMany") return autosaveHasMany(record, assoc);
   if (assoc.type === "hasOne") return autosaveHasOne(record, assoc);
-  if (assoc.type === "belongsTo") return _autosaveBelongsTo(record, assoc);
+  if (assoc.type === "belongsTo") {
+    const reflection = (record.constructor as any)._reflectOnAssociation?.(assoc.name);
+    return _autosaveBelongsTo(record, assoc, reflection);
+  }
   if (assoc.type === "hasAndBelongsToMany") return autosaveHabtm(record, assoc);
   return true;
 }
@@ -685,7 +688,11 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
  *
  * @internal
  */
-function _resolveBelongsToForeignKey(assoc: AssociationDefinition, assocRecord?: Base): string[] {
+function _resolveBelongsToForeignKey(
+  assoc: AssociationDefinition,
+  assocRecord?: Base,
+  reflection?: any,
+): string[] {
   if (assoc.options.foreignKey != null) {
     const fk = assoc.options.foreignKey;
     return Array.isArray(fk) ? fk : [fk];
@@ -694,12 +701,28 @@ function _resolveBelongsToForeignKey(assoc: AssociationDefinition, assocRecord?:
     const qc = assoc.options.queryConstraints;
     return Array.isArray(qc) ? qc : [qc];
   }
+  // Composite-PK inference (`${name}_${pk}`) when target has composite
+  // PK — matches `BelongsToAssociation#foreignKeyNames` so autosave FK
+  // propagation writes the same columns the writer populated at
+  // assignment time.
   if (assocRecord) {
     const pk = (assocRecord.constructor as typeof Base).primaryKey;
     if (Array.isArray(pk) && pk.length > 1) {
       const prefix = underscore(assoc.name);
       return pk.map((part) => `${prefix}_${part}`);
     }
+  }
+  // Deferred reflection.foreignKey lookup: the getter runs
+  // `deriveFkQueryConstraints` (reflection.ts), which expands the scalar
+  // `${name}_id` FK into a composite `[fk, qc_key]` pair when the owner
+  // has class-level query_constraints. Without this, owners with
+  // query_constraints would only get the scalar column written and
+  // leave the QC partner stale. The getter can raise
+  // ConfigurationError; that surfaces only on write/null branches that
+  // actually need the FK, never at callback registration.
+  const reflFk = reflection?.foreignKey;
+  if (reflFk != null) {
+    return Array.isArray(reflFk) ? reflFk : [reflFk];
   }
   return [`${underscore(assoc.name)}_id`];
 }
@@ -715,7 +738,11 @@ function _resolveBelongsToForeignKey(assoc: AssociationDefinition, assocRecord?:
  *
  * @internal
  */
-function _resolveBelongsToPrimaryKey(assoc: AssociationDefinition, assocRecord: Base): string[] {
+function _resolveBelongsToPrimaryKey(
+  assoc: AssociationDefinition,
+  assocRecord: Base,
+  reflection?: any,
+): string[] {
   // Composite-PK inference branch: when neither `foreignKey` nor
   // `queryConstraints` is set and the target has composite PK, the
   // writer pairs PK columns 1:1 with the `${name}_${pk}` FK columns.
@@ -725,12 +752,29 @@ function _resolveBelongsToPrimaryKey(assoc: AssociationDefinition, assocRecord: 
   if (assoc.options.foreignKey == null && assoc.options.queryConstraints == null) {
     const pk = (assocRecord.constructor as typeof Base).primaryKey;
     if (Array.isArray(pk) && pk.length > 1) return pk;
+    // QC-derived composite FK branch: reflection.foreignKey came from
+    // `deriveFkQueryConstraints` (owner has class-level
+    // query_constraints, scalar FK got expanded to [fk, qc_key]). The
+    // matching PK side is the target's query_constraints_list, which
+    // shares the QC partner column.
+    const reflFk = reflection?.foreignKey;
+    if (Array.isArray(reflFk) && reflFk.length > 1) {
+      const qcl = queryConstraintsList.call(assocRecord.constructor as any) as
+        | string[]
+        | null
+        | undefined;
+      if (qcl) return qcl;
+    }
   }
   const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });
   return Array.isArray(rawPk) ? rawPk : [rawPk];
 }
 
-async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): Promise<boolean> {
+async function _autosaveBelongsTo(
+  record: Base,
+  assoc: AssociationDefinition,
+  reflection?: any,
+): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
   // Rails save_belongs_to_association:538 — skip when the loaded target is
   // stale (FK changed since the target was cached).
@@ -751,7 +795,7 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
     // Rails save_belongs_to_association:544-547 — destroy path is only
     // reached when `autosave` is truthy; the destruction nulls the FK on
     // self first so the owner save doesn't keep a dangling reference.
-    const fkList = _resolveBelongsToForeignKey(assoc, assocRecord);
+    const fkList = _resolveBelongsToForeignKey(assoc, assocRecord, reflection);
     for (const key of fkList) record._writeAttribute(key, null);
     if (!assocRecord.isNewRecord()) await assocRecord.destroy();
     return true;
@@ -784,11 +828,11 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       return true;
     }
 
-    const foreignKey = _resolveBelongsToForeignKey(assoc, assocRecord);
+    const foreignKey = _resolveBelongsToForeignKey(assoc, assocRecord, reflection);
     // Pair against the target's PK columns in the same shape the writer
     // (BelongsToAssociation#replaceKeys) used, so autosave FK
     // propagation lands on the same columns the writer populated.
-    const primaryKey = _resolveBelongsToPrimaryKey(assoc, assocRecord);
+    const primaryKey = _resolveBelongsToPrimaryKey(assoc, assocRecord, reflection);
     // Rails save_belongs_to_association:563: `primary_key.zip(foreign_key)`.
     // Ruby's Array#zip drops trailing args when the argument is longer than
     // the receiver, and pads with nil when the argument is shorter. Mirror
@@ -1098,11 +1142,15 @@ export async function saveBelongsToAssociation(
   // paths (reflection.ts deriveFkQueryConstraints) on every belongs_to
   // save, even for an unloaded/untouched association — undesirable now
   // that the autosave callback is registered for every belongs_to.
-  return _autosaveBelongsTo(this as unknown as Base, {
-    name: reflection.name,
-    type: "belongsTo",
-    options: reflection.options ?? {},
-  });
+  return _autosaveBelongsTo(
+    this as unknown as Base,
+    {
+      name: reflection.name,
+      type: "belongsTo",
+      options: reflection.options ?? {},
+    },
+    reflection,
+  );
 }
 
 /** @internal */

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -738,8 +738,11 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
     }
 
     const foreignKey = _resolveBelongsToForeignKey(assoc);
-    const rawPk =
-      assoc.options.primaryKey ?? (assocRecord.constructor as typeof Base).primaryKey ?? "id";
+    // Rails save_belongs_to_association:560 — `Array(compute_primary_key(
+    // reflection, record))`. The target record's class drives the lookup
+    // (not the owner's), so query-constraints on the target and the
+    // [tenant_id, id] → "id" inference both go through correctly.
+    const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });
     const primaryKey = Array.isArray(rawPk) ? rawPk : [rawPk];
     // Rails save_belongs_to_association:563: `primary_key.zip(foreign_key)`.
     // Ruby's Array#zip drops trailing args when the argument is longer than
@@ -1228,7 +1231,14 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     beforeSave(
       model,
       (record: any): Promise<void> =>
-        record[saveMethod]().then((ok: boolean) => (ok ? undefined : (false as unknown as void))),
+        // Wrap with Promise.resolve so the re-entrant branch of
+        // defineNonCyclicMethod (returns sync `true` to mirror Rails'
+        // cyclic-guard early return) doesn't blow up on `.then`. Mirrors
+        // Rails' callback chain, which tolerates both throw-abort and
+        // truthy returns.
+        Promise.resolve(record[saveMethod]()).then((ok: boolean) =>
+          ok ? undefined : (false as unknown as void),
+        ),
     );
   }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -752,25 +752,34 @@ function _resolveBelongsToPrimaryKey(
   // Rails' compute_primary_key would collapse [tenant_id, id] → "id"
   // (autosave_association.rb:585) — that collapse only matches when the
   // FK is scalar; with composite-FK inference we need the full PK.
-  if (
-    assoc.options.primaryKey == null &&
-    assoc.options.foreignKey == null &&
-    assoc.options.queryConstraints == null
-  ) {
-    const pk = (assocRecord.constructor as typeof Base).primaryKey;
-    if (Array.isArray(pk) && pk.length > 1) return pk;
-    // QC-derived composite FK branch: reflection.foreignKey came from
-    // `deriveFkQueryConstraints` (owner has class-level
-    // query_constraints, scalar FK got expanded to [fk, qc_key]). The
-    // matching PK side is the target's query_constraints_list, which
-    // shares the QC partner column.
+  if (assoc.options.primaryKey == null) {
+    // Explicit composite foreignKey (or QC-derived composite via
+    // reflection) pairs against the target's full primary key array —
+    // mirrors `BelongsToAssociation#associationPrimaryKeys(record)`
+    // (belongs-to-association.ts) which returns the target class's
+    // primaryKey when no explicit primaryKey option is configured.
+    // Rails' `compute_primary_key` collapse to "id"
+    // (autosave_association.rb:585) only matches a scalar FK; with any
+    // composite FK we need the full PK so the zip pairs up.
+    const explicitFk = assoc.options.foreignKey ?? assoc.options.queryConstraints;
+    const fkIsComposite = Array.isArray(explicitFk) && explicitFk.length > 1;
     const reflFk = reflection?.foreignKey;
-    if (Array.isArray(reflFk) && reflFk.length > 1) {
-      const qcl = queryConstraintsList.call(assocRecord.constructor as any) as
-        | string[]
-        | null
-        | undefined;
-      if (qcl) return qcl;
+    const reflFkIsComposite = Array.isArray(reflFk) && reflFk.length > 1;
+    if (fkIsComposite || reflFkIsComposite || explicitFk == null) {
+      const pk = (assocRecord.constructor as typeof Base).primaryKey;
+      if (Array.isArray(pk) && pk.length > 1) return pk;
+      // QC-derived composite FK branch: reflection.foreignKey came from
+      // `deriveFkQueryConstraints` (owner has class-level
+      // query_constraints, scalar FK got expanded to [fk, qc_key]). The
+      // matching PK side is the target's query_constraints_list, which
+      // shares the QC partner column.
+      if (explicitFk == null && reflFkIsComposite) {
+        const qcl = queryConstraintsList.call(assocRecord.constructor as any) as
+          | string[]
+          | null
+          | undefined;
+        if (qcl) return qcl;
+      }
     }
   }
   const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -718,15 +718,18 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       : !!(assocRecord as any).changed);
   if (assocRecord.isNewRecord() || beChangedForSave) {
     _setAutosavingBelongsToFor(record, assoc, true);
+    let saved: boolean | undefined;
     try {
       // Rails save_belongs_to_association:553: `record.save(validate: !autosave)`.
-      const saved = await assocRecord.save({ validate: !autosave });
-      if (!saved) {
-        propagateErrors(record, assocRecord, assoc.name);
-        return false;
-      }
+      saved = await assocRecord.save({ validate: !autosave });
     } finally {
       _setAutosavingBelongsToFor(record, assoc, false);
+    }
+    if (!saved) {
+      propagateErrors(record, assocRecord, assoc.name);
+      // Rails save_belongs_to_association:571 — `saved if autosave`. Only
+      // autosave==true propagates the failure to abort the owner save.
+      return autosave ? false : true;
     }
 
     const foreignKey = _resolveBelongsToForeignKey(assoc);
@@ -741,11 +744,14 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
     for (let i = 0; i < primaryKey.length; i++) {
       const fkCol = foreignKey[i];
       if (fkCol == null) continue;
-      const pkValue = assocRecord._readAttribute(primaryKey[i]);
-      if (pkValue != null) record._writeAttribute(fkCol, pkValue);
+      const associationId = assocRecord._readAttribute(primaryKey[i]);
+      // Rails save_belongs_to_association:566 — `unless self[fk] == id`.
+      if (record._readAttribute(fkCol) !== associationId) {
+        record._writeAttribute(fkCol, associationId);
+      }
     }
-    // Rails save_belongs_to_association:559-568: `association.loaded!` only
-    // fires inside the `if association.updated?` branch — after the FK write.
+    // Rails save_belongs_to_association:568 — `association.loaded!` fires
+    // inside the `if association.updated?` branch after the FK write.
     if (inst?.isUpdated?.()) inst.loadedBang?.();
   }
   return true;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -672,15 +672,62 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
 }
 
 /**
- * Resolve the foreign-key column(s) for a belongs_to association.
- * Mirrors `Array(reflection.foreign_key)` shape — always returns a list.
+ * Resolve the foreign-key column(s) for a belongs_to association in the
+ * same shape `BelongsToAssociation#foreignKeyNames` produces, so the
+ * autosave path writes to the columns the writer populated at
+ * assignment time. Mirrors `Array(reflection.foreign_key)` plus the
+ * Trails-specific composite-PK inference (`${name}_${pk}`) that the
+ * belongs_to writer applies when the target has a composite PK and no
+ * explicit `foreignKey` was configured (see
+ * `belongs-to-association.ts#foreignKeyNames` and the
+ * `setBelongsTo infers composite foreign key from target primary key`
+ * coverage in `associations.test.ts`).
  *
  * @internal
  */
-function _resolveBelongsToForeignKey(assoc: AssociationDefinition): string[] {
-  const fk =
-    assoc.options.foreignKey ?? assoc.options.queryConstraints ?? `${underscore(assoc.name)}_id`;
-  return Array.isArray(fk) ? fk : [fk];
+function _resolveBelongsToForeignKey(assoc: AssociationDefinition, assocRecord?: Base): string[] {
+  if (assoc.options.foreignKey != null) {
+    const fk = assoc.options.foreignKey;
+    return Array.isArray(fk) ? fk : [fk];
+  }
+  if (assoc.options.queryConstraints != null) {
+    const qc = assoc.options.queryConstraints;
+    return Array.isArray(qc) ? qc : [qc];
+  }
+  if (assocRecord) {
+    const pk = (assocRecord.constructor as typeof Base).primaryKey;
+    if (Array.isArray(pk) && pk.length > 1) {
+      const prefix = underscore(assoc.name);
+      return pk.map((part) => `${prefix}_${part}`);
+    }
+  }
+  return [`${underscore(assoc.name)}_id`];
+}
+
+/**
+ * Resolve the primary-key column(s) on the target side of a belongs_to
+ * association, paired against `_resolveBelongsToForeignKey` so the
+ * autosave FK propagation zips matching columns. Mirrors
+ * `BelongsToAssociation#associationPrimaryKeys` for the no-`foreignKey`
+ * composite-PK branch (each FK position pairs with the matching target
+ * PK column), and Rails' `compute_primary_key(reflection, record)`
+ * otherwise (autosave_association.rb:576-589).
+ *
+ * @internal
+ */
+function _resolveBelongsToPrimaryKey(assoc: AssociationDefinition, assocRecord: Base): string[] {
+  // Composite-PK inference branch: when neither `foreignKey` nor
+  // `queryConstraints` is set and the target has composite PK, the
+  // writer pairs PK columns 1:1 with the `${name}_${pk}` FK columns.
+  // Rails' compute_primary_key would collapse [tenant_id, id] → "id"
+  // (autosave_association.rb:585) — that collapse only matches when the
+  // FK is scalar; with composite-FK inference we need the full PK.
+  if (assoc.options.foreignKey == null && assoc.options.queryConstraints == null) {
+    const pk = (assocRecord.constructor as typeof Base).primaryKey;
+    if (Array.isArray(pk) && pk.length > 1) return pk;
+  }
+  const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });
+  return Array.isArray(rawPk) ? rawPk : [rawPk];
 }
 
 async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): Promise<boolean> {
@@ -704,7 +751,7 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
     // Rails save_belongs_to_association:544-547 — destroy path is only
     // reached when `autosave` is truthy; the destruction nulls the FK on
     // self first so the owner save doesn't keep a dangling reference.
-    const fkList = _resolveBelongsToForeignKey(assoc);
+    const fkList = _resolveBelongsToForeignKey(assoc, assocRecord);
     for (const key of fkList) record._writeAttribute(key, null);
     if (!assocRecord.isNewRecord()) await assocRecord.destroy();
     return true;
@@ -737,13 +784,11 @@ async function _autosaveBelongsTo(record: Base, assoc: AssociationDefinition): P
       return true;
     }
 
-    const foreignKey = _resolveBelongsToForeignKey(assoc);
-    // Rails save_belongs_to_association:560 — `Array(compute_primary_key(
-    // reflection, record))`. The target record's class drives the lookup
-    // (not the owner's), so query-constraints on the target and the
-    // [tenant_id, id] → "id" inference both go through correctly.
-    const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });
-    const primaryKey = Array.isArray(rawPk) ? rawPk : [rawPk];
+    const foreignKey = _resolveBelongsToForeignKey(assoc, assocRecord);
+    // Pair against the target's PK columns in the same shape the writer
+    // (BelongsToAssociation#replaceKeys) used, so autosave FK
+    // propagation lands on the same columns the writer populated.
+    const primaryKey = _resolveBelongsToPrimaryKey(assoc, assocRecord);
     // Rails save_belongs_to_association:563: `primary_key.zip(foreign_key)`.
     // Ruby's Array#zip drops trailing args when the argument is longer than
     // the receiver, and pads with nil when the argument is shorter. Mirror
@@ -1046,16 +1091,17 @@ export async function saveBelongsToAssociation(
   this: AutosaveAssociationHost,
   reflection: any,
 ): Promise<boolean> {
-  // Mirror Rails: `Array(reflection.foreign_key)` (autosave_association.rb:
-  // 545/561). The reflection-resolved FK may differ from the raw option
-  // (e.g. query-constraints-derived composite columns), so forward it
-  // explicitly to override the options.foreignKey fallback.
-  const options = { ...(reflection.options ?? {}) };
-  if (reflection.foreignKey != null) options.foreignKey = reflection.foreignKey;
+  // Pass the raw reflection options through — FK resolution is deferred
+  // to `_resolveBelongsToForeignKey`, which only runs on the branches that
+  // need to write or null columns. Eagerly reading `reflection.foreignKey`
+  // here would trip its query-constraints-derivation ConfigurationError
+  // paths (reflection.ts deriveFkQueryConstraints) on every belongs_to
+  // save, even for an unloaded/untouched association — undesirable now
+  // that the autosave callback is registered for every belongs_to.
   return _autosaveBelongsTo(this as unknown as Base, {
     name: reflection.name,
     type: "belongsTo",
-    options,
+    options: reflection.options ?? {},
   });
 }
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -704,8 +704,11 @@ function _resolveBelongsToForeignKey(
   // Composite-PK inference (`${name}_${pk}`) when target has composite
   // PK — matches `BelongsToAssociation#foreignKeyNames` so autosave FK
   // propagation writes the same columns the writer populated at
-  // assignment time.
-  if (assocRecord) {
+  // assignment time. Skip when the association has an explicit
+  // `primaryKey`: `associationPrimaryKeys()` collapses the configured PK
+  // to a single-element array, so the writer's foreignKeyNames falls
+  // through to the scalar `${name}_id` rather than expanding.
+  if (assoc.options.primaryKey == null && assocRecord) {
     const pk = (assocRecord.constructor as typeof Base).primaryKey;
     if (Array.isArray(pk) && pk.length > 1) {
       const prefix = underscore(assoc.name);
@@ -749,7 +752,11 @@ function _resolveBelongsToPrimaryKey(
   // Rails' compute_primary_key would collapse [tenant_id, id] → "id"
   // (autosave_association.rb:585) — that collapse only matches when the
   // FK is scalar; with composite-FK inference we need the full PK.
-  if (assoc.options.foreignKey == null && assoc.options.queryConstraints == null) {
+  if (
+    assoc.options.primaryKey == null &&
+    assoc.options.foreignKey == null &&
+    assoc.options.queryConstraints == null
+  ) {
     const pk = (assocRecord.constructor as typeof Base).primaryKey;
     if (Array.isArray(pk) && pk.length > 1) return pk;
     // QC-derived composite FK branch: reflection.foreignKey came from

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -753,32 +753,30 @@ function _resolveBelongsToPrimaryKey(
   // (autosave_association.rb:585) — that collapse only matches when the
   // FK is scalar; with composite-FK inference we need the full PK.
   if (assoc.options.primaryKey == null) {
-    // Explicit composite foreignKey (or QC-derived composite via
-    // reflection) pairs against the target's full primary key array —
-    // mirrors `BelongsToAssociation#associationPrimaryKeys(record)`
-    // (belongs-to-association.ts) which returns the target class's
-    // primaryKey when no explicit primaryKey option is configured.
-    // Rails' `compute_primary_key` collapse to "id"
-    // (autosave_association.rb:585) only matches a scalar FK; with any
-    // composite FK we need the full PK so the zip pairs up.
-    const explicitFk = assoc.options.foreignKey ?? assoc.options.queryConstraints;
-    const fkIsComposite = Array.isArray(explicitFk) && explicitFk.length > 1;
-    const reflFk = reflection?.foreignKey;
-    const reflFkIsComposite = Array.isArray(reflFk) && reflFk.length > 1;
-    if (fkIsComposite || reflFkIsComposite || explicitFk == null) {
-      const pk = (assocRecord.constructor as typeof Base).primaryKey;
-      if (Array.isArray(pk) && pk.length > 1) return pk;
-      // QC-derived composite FK branch: reflection.foreignKey came from
-      // `deriveFkQueryConstraints` (owner has class-level
-      // query_constraints, scalar FK got expanded to [fk, qc_key]). The
-      // matching PK side is the target's query_constraints_list, which
-      // shares the QC partner column.
-      if (explicitFk == null && reflFkIsComposite) {
-        const qcl = queryConstraintsList.call(assocRecord.constructor as any) as
-          | string[]
-          | null
-          | undefined;
-        if (qcl) return qcl;
+    // Defer to computePrimaryKey when the target has *explicit*
+    // class-level query_constraints and Rails' compute_primary_key
+    // (steps 2/3 at autosave_association.rb:577-582) would pick that
+    // list: i.e. the assoc has `queryConstraints`, OR the assoc has no
+    // `foreignKey` option. Use hasQueryConstraints (the explicit flag),
+    // not queryConstraintsList — the latter falls back to the
+    // composite-PK array for any composite-PK target, which would
+    // misroute composite-PK-only targets through the QC branch.
+    const targetHasQc = hasQueryConstraints.call(assocRecord.constructor as any);
+    const targetQcWouldApply =
+      targetHasQc && (assoc.options.queryConstraints != null || assoc.options.foreignKey == null);
+    if (!targetQcWouldApply) {
+      // Trails-specific override of Rails' composite-PK collapse-to-"id"
+      // (autosave_association.rb:585): pair the full composite PK
+      // against composite FKs (explicit, queryConstraints array,
+      // reflection-derived, or the no-FK inference path) so the zip
+      // hits every column the writer populates.
+      const explicitFk = assoc.options.foreignKey ?? assoc.options.queryConstraints;
+      const fkIsComposite = Array.isArray(explicitFk) && explicitFk.length > 1;
+      const reflFk = reflection?.foreignKey;
+      const reflFkIsComposite = Array.isArray(reflFk) && reflFk.length > 1;
+      if (fkIsComposite || reflFkIsComposite || explicitFk == null) {
+        const pk = (assocRecord.constructor as typeof Base).primaryKey;
+        if (Array.isArray(pk) && pk.length > 1) return pk;
       }
     }
   }


### PR DESCRIPTION
## Summary

Batch 20 — Associations-core composite-FK autosave (partial).

- Move `addAutosaveAssociationCallbacks` out of the `options.autosave` guard in `builder/belongs-to.ts`. Rails registers the callback on every belongs_to via `AssociationBuilderExtension`; the option only steers behavior inside `save_belongs_to_association`.
- Update `_autosaveBelongsTo` to honor `autosave != false` semantics now that every belongs_to enters this path: opt out on explicit `false`, gate destroy + changed-for-autosave save on truthy autosave, pass `validate: !autosave` to `record.save`.
- Replace the shape-mismatch `CompositePrimaryKeyMismatchError` throw with Ruby-faithful `Array#zip` semantics — drop extra FK columns when `primary_key` is shorter, skip PK positions with no FK partner. Mirrors Rails `autosave_association.rb:563`.
- Extract `_resolveBelongsToForeignKey` + `_resolveBelongsToPrimaryKey` helpers used across the destroy and FK-write branches; both align with `BelongsToAssociation#foreignKeyNames` / `#associationPrimaryKeys` and honor reflection.foreignKey's QC-derivation lazily.

## Followups (deferred)

Unify singular-association accessors in `associations.ts` (`loadHasOne`, `loadBelongsTo`) to consult `owner.association(name).target` when `loaded?` is true, and drop the redundant `_preloadedAssociations.set(...)` in `preloader/association.ts#associateRecordsFromUnscoped`. Listed in `docs/activerecord-100-plan.md` Batch 20 (~30–60 LOC).

## Remaining review concerns (Copilot review #9, max cycles reached)

Both flagged on `_resolveBelongsToPrimaryKey` / `_resolveBelongsToForeignKey` — should be addressed in a follow-up rather than continuing this PR's review loop:

1. **Eager `reflection.foreignKey` read in PK helper** — `_resolveBelongsToPrimaryKey` evaluates `reflection?.foreignKey` even when `explicitFk == null` and the composite-PK inference branch is going to fire anyway. For a default belongs_to to a composite-PK target whose owner has class-level query_constraints that make `reflection.foreignKey` raise during derivation, the helper aborts the save even though the reflection FK is not used. Defer the getter until the composite-reflection-FK check actually needs it.
2. **Configured `primaryKey: ["tenant_id", "id"]` without explicit FK** — current code skips composite-FK inference whenever `primaryKey` is configured, but `BelongsToAssociation#foreignKeyNames` only falls back to the scalar `${name}_id` when the configured PK is *scalar*. With an array `primaryKey`, the writer still infers `${name}_${pk}` columns; autosave currently resolves only the scalar reflection/default FK and writes the wrong/incomplete owner columns. The composite-PK inference gate needs to look at whether the configured `primaryKey` is array-shaped, not whether it's set.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts` + `associations/*`
- [x] `pnpm vitest run` for belongs-to / has-many association tests, dirty, persistence, callbacks, transactions, nested-attributes
- [ ] CI full suite (every belongs_to now registers a beforeSave lambda — broad smoke needed)