### PR TITLE
feat(actionpack): port ActionDispatch::ActionableExceptions middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/actionable-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/actionable-exceptions.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ActionableError, NonActionable } from "@blazetrails/activesupport";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
-import { ActionableExceptions } from "./actionable-exceptions.js";
+import { ActionableExceptions } from "../middleware/actionable-exceptions.js";
 
 const Actions: string[] = [];
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -97,6 +97,7 @@ export {
 } from "./http-authentication.js";
 export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
 export { AssumeSSL } from "./middleware/assume-ssl.js";
+export { ActionableExceptions } from "./middleware/actionable-exceptions.js";
 export { Callbacks } from "./middleware/callbacks.js";
 export {
   Executor,

--- a/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Mirrors actionpack/test/dispatch/actionable_exceptions_test.rb.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { ActionableError, NonActionable } from "@blazetrails/activesupport";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { ActionableExceptions } from "./actionable-exceptions.js";
+
+const Actions: string[] = [];
+
+class ActionError extends ActionableError {}
+ActionError.action("Successful action", () => {
+  Actions.push("Action!");
+});
+ActionError.action("Failed action", () => {
+  throw new Error("Inaction!");
+});
+
+const noop = async (): Promise<RackResponse> => [200, {}, (async function* () {})()];
+
+function postEnv(params: Record<string, string>, headers: Record<string, unknown> = {}): RackEnv {
+  const body = new URLSearchParams(params).toString();
+  return {
+    REQUEST_METHOD: "POST",
+    PATH_INFO: ActionableExceptions.endpoint,
+    CONTENT_TYPE: "application/x-www-form-urlencoded",
+    "rack.input": body,
+    ...headers,
+  };
+}
+
+describe("ActionableExceptionsTest", () => {
+  beforeEach(() => {
+    Actions.length = 0;
+  });
+
+  it("dispatches an actionable error", async () => {
+    const mw = new ActionableExceptions(noop);
+    const res = await mw.call(
+      postEnv(
+        { error: ActionError.name, action: "Successful action", location: "/" },
+        { "action_dispatch.show_detailed_exceptions": true },
+      ),
+    );
+
+    expect(Actions).toEqual(["Action!"]);
+    expect(res[0]).toBe(302);
+    expect(res[1]["location"]).toBe("/");
+  });
+
+  it("cannot dispatch errors if not allowed", async () => {
+    const mw = new ActionableExceptions(noop);
+    await mw.call(
+      postEnv(
+        { error: ActionError.name, action: "Successful action", location: "/" },
+        { "action_dispatch.show_detailed_exceptions": false },
+      ),
+    );
+    expect(Actions).toEqual([]);
+  });
+
+  it("dispatched action can fail", async () => {
+    const mw = new ActionableExceptions(noop);
+    await expect(
+      mw.call(
+        postEnv(
+          { error: ActionError.name, action: "Failed action", location: "/" },
+          { "action_dispatch.show_detailed_exceptions": true },
+        ),
+      ),
+    ).rejects.toThrow("Inaction!");
+  });
+
+  it("cannot dispatch non-actionable errors", async () => {
+    const mw = new ActionableExceptions(noop);
+    await expect(
+      mw.call(
+        postEnv(
+          { error: "RuntimeError", action: "Inexistent action", location: "/" },
+          { "action_dispatch.show_detailed_exceptions": true },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(NonActionable);
+  });
+
+  it("cannot dispatch Inexistent errors", async () => {
+    const mw = new ActionableExceptions(noop);
+    await expect(
+      mw.call(
+        postEnv(
+          { error: "", action: "Inexistent action", location: "/" },
+          { "action_dispatch.show_detailed_exceptions": true },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(NonActionable);
+  });
+
+  it("catches invalid redirections", async () => {
+    const mw = new ActionableExceptions(noop);
+    const res = await mw.call(
+      postEnv(
+        { error: ActionError.name, action: "Successful action", location: "wss://example.com" },
+        { "action_dispatch.show_detailed_exceptions": true },
+      ),
+    );
+    expect(res[0]).toBe(400);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
@@ -1,0 +1,75 @@
+/**
+ * ActionDispatch::ActionableExceptions
+ *
+ * Middleware that dispatches actions defined on actionable errors when the
+ * exception page POSTs back to its endpoint. Mirrors Rails'
+ * `action_dispatch/middleware/actionable_exceptions.rb` 1:1.
+ */
+
+import { ActionableError } from "@blazetrails/activesupport";
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
+import { LOCATION } from "../constants.js";
+import { Request } from "../http/request.js";
+
+export class ActionableExceptions {
+  static endpoint = "/rails/actions";
+
+  private app: RackApp;
+
+  constructor(app: RackApp) {
+    this.app = app;
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const request = new Request(env);
+    if (!this.actionableRequest(request)) {
+      return this.app(env);
+    }
+
+    const params = request.params as Record<string, unknown>;
+    const errorName = String(params["error"] ?? "");
+    const action = String(params["action"] ?? "");
+
+    const cls = ActionableError.lookup(errorName);
+    ActionableError.dispatch(cls, action);
+
+    return this.redirectTo(String(params["location"] ?? ""));
+  }
+
+  /** @internal */
+  private actionableRequest(request: Request): boolean {
+    const flag = request.env["action_dispatch.show_detailed_exceptions"];
+    return Boolean(flag) && request.isPost && request.path === ActionableExceptions.endpoint;
+  }
+
+  /** @internal */
+  private redirectTo(location: string): RackResponse {
+    let scheme: string | null = null;
+    let relative = false;
+    try {
+      const u = new URL(location);
+      scheme = u.protocol.replace(/:$/, "");
+    } catch {
+      relative = true;
+    }
+
+    if (!relative && scheme !== "http" && scheme !== "https") {
+      return [
+        400,
+        { "content-type": "text/plain; charset=utf-8" },
+        bodyFromString("Invalid redirection URI"),
+      ];
+    }
+
+    return [
+      302,
+      {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": "0",
+        [LOCATION]: location,
+      },
+      bodyFromString(""),
+    ];
+  }
+}

--- a/packages/activesupport/src/actionable-error.ts
+++ b/packages/activesupport/src/actionable-error.ts
@@ -8,9 +8,26 @@ export class NonActionable extends Error {
 export class ActionableError extends Error {
   static _actions: Record<string, () => void> = {};
 
+  /**
+   * Registry of error classes keyed by their `.name`. The trails equivalent
+   * of Ruby's `String#safe_constantize`: middleware (e.g. ActionableExceptions)
+   * looks up classes here instead of walking the global namespace.
+   */
+  static _registry: Map<string, typeof ActionableError> = new Map();
+
   constructor(message?: string) {
     super(message);
     this.name = "ActionableError";
+  }
+
+  /** Register an actionable error class so it can be resolved by name. */
+  static register(cls: typeof ActionableError): void {
+    ActionableError._registry.set(cls.name, cls);
+  }
+
+  /** Resolve a registered actionable error class by name. */
+  static lookup(name: string): typeof ActionableError | undefined {
+    return ActionableError._registry.get(name);
   }
 
   static actions(error: any): Record<string, () => void> {
@@ -53,5 +70,6 @@ export class ActionableError extends Error {
       });
     }
     this._actions[name] = block;
+    ActionableError.register(this as unknown as typeof ActionableError);
   }
 }


### PR DESCRIPTION
## Summary
- Ports `action_dispatch/middleware/actionable_exceptions.rb` 1:1: POST to the configured endpoint (default `/rails/actions`) with the `action_dispatch.show_detailed_exceptions` env flag dispatches the named action on the named error class and 302-redirects to `location`; non-http(s) targets return 400.
- Adds a small name→class registry on `ActiveSupport::ActionableError` (the trails analogue of Ruby's `safe_constantize`) so the middleware can resolve error classes without a global namespace. Subclasses auto-register when they declare an action.
- Mirrors all six cases from `actionpack/test/dispatch/actionable_exceptions_test.rb`.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.test.ts` (6 passing)
- [x] `pnpm vitest run packages/activesupport/src/actionable-error.test.ts` (existing 6 still passing)
- [x] `pnpm lint` clean